### PR TITLE
feat: hybrid search with LanceDB FTS + RRF reranking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,6 @@ jobs:
 
   test-with-ollama:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,11 @@ permissions:
   contents: write
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   build:
+    needs: ci
     strategy:
       fail-fast: false
       matrix:

--- a/site/index.html
+++ b/site/index.html
@@ -3,207 +3,161 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>lilbee — chat with your documents locally, or plug into AI agents via MCP</title>
+<title>lilbee — local knowledge base for your documents</title>
 <style>
   :root {
-    --bg: #0a0a0a;
-    --surface: #141414;
-    --border: #2a2a2a;
-    --gold: #f5a623;
-    --gold-dim: #c4841d;
-    --text: #e0e0e0;
-    --text-dim: #888;
-    --code-bg: #1a1a1a;
+    --bg: #0a0800;
+    --amber: #ffb000;
+    --dim: #996a00;
+    --faint: #4d3500;
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
-    font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', monospace;
+    font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Courier New', monospace;
     background: var(--bg);
-    color: var(--text);
+    color: var(--amber);
     min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-  .hero {
-    text-align: center;
-    padding: 4rem 2rem 2rem;
-    max-width: 700px;
-  }
-  .logo {
-    font-size: 4rem;
-    margin-bottom: 0.5rem;
-  }
-  h1 {
-    font-size: 2.5rem;
-    font-weight: 900;
-    letter-spacing: -0.02em;
-    color: var(--gold);
-    text-transform: uppercase;
-  }
-  .tagline {
-    font-size: 1.1rem;
-    color: var(--text-dim);
-    margin-top: 0.5rem;
-    font-weight: 400;
-  }
-  .honeycomb {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: center;
-    margin: 2rem 0;
-  }
-  .hex {
-    width: 12px;
-    height: 12px;
-    background: var(--gold-dim);
-    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
-    opacity: 0.6;
-  }
-  .hex:nth-child(odd) { opacity: 0.3; }
-  .hex:nth-child(3) { opacity: 1; background: var(--gold); }
-
-  .links {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-    max-width: 700px;
-    width: 100%;
-    padding: 0 2rem;
-    margin: 1rem 0 2rem;
-  }
-  .links a {
-    display: block;
-    padding: 1.2rem;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    color: var(--text);
-    text-decoration: none;
-    font-size: 0.9rem;
-    font-weight: 600;
-    transition: border-color 0.15s, color 0.15s;
-  }
-  .links a:hover {
-    border-color: var(--gold);
-    color: var(--gold);
-  }
-  .links .label {
-    display: block;
-    font-size: 0.7rem;
-    color: var(--text-dim);
-    margin-top: 0.3rem;
-    font-weight: 400;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
-  .features {
-    max-width: 700px;
-    width: 100%;
-    padding: 0 2rem;
-    margin-bottom: 2rem;
-  }
-  .features ul {
-    list-style: none;
-    display: grid;
-    gap: 0.6rem;
-  }
-  .features li {
-    font-size: 0.85rem;
-    color: var(--text-dim);
-    padding-left: 1.2rem;
-    position: relative;
-  }
-  .features li::before {
-    content: "\25B8";
-    position: absolute;
-    left: 0;
-    color: var(--gold-dim);
-  }
-
-  .install {
-    max-width: 700px;
-    width: 100%;
-    padding: 0 2rem;
-    margin-bottom: 3rem;
-  }
-  .install code {
-    display: block;
-    background: var(--code-bg);
-    border: 1px solid var(--border);
-    padding: 1rem 1.2rem;
-    font-size: 0.85rem;
-    color: var(--gold);
-    overflow-x: auto;
-  }
-
-  footer {
     padding: 2rem;
-    text-align: center;
-    color: var(--text-dim);
-    font-size: 0.7rem;
-    border-top: 1px solid var(--border);
-    width: 100%;
-    margin-top: auto;
+    font-size: 14px;
+    line-height: 1.4;
   }
-  footer a { color: var(--gold-dim); text-decoration: none; }
-  footer a:hover { color: var(--gold); }
+  body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      rgba(0, 0, 0, 0.12) 2px,
+      rgba(0, 0, 0, 0.12) 4px
+    );
+    pointer-events: none;
+    z-index: 999;
+  }
+  pre { font: inherit; white-space: pre; }
+  a { color: var(--amber); text-decoration: none; }
+  a:hover { text-shadow: 0 0 8px rgba(255, 176, 0, 0.5); }
+  .dim { color: var(--dim); }
+  .faint { color: var(--faint); }
+  .cursor {
+    display: inline-block;
+    width: 0.6em;
+    height: 1.1em;
+    background: var(--amber);
+    vertical-align: text-bottom;
+    animation: blink 1s step-end infinite;
+  }
+  @keyframes blink { 50% { opacity: 0; } }
+  h1 {
+    position: absolute;
+    width: 1px; height: 1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+  }
+
+  .layout {
+    display: flex;
+    gap: 3rem;
+    align-items: flex-start;
+  }
+  .main { flex: 0 1 auto; min-width: 0; }
+  .bee-art {
+    flex: 0 0 auto;
+    font-size: 7px;
+    line-height: 1.1;
+    color: var(--dim);
+    text-shadow: 0 0 4px rgba(255, 176, 0, 0.15);
+    user-select: none;
+    padding-top: 1rem;
+  }
+
+  @media (max-width: 900px) {
+    .bee-art { display: none; }
+  }
 </style>
 </head>
 <body>
+<h1>lilbee</h1>
+<div class="layout">
+<div class="main"><pre>
+888 d8b 888 888
+888 Y8P 888 888
+888     888 888
+888 888 888 88888b.  .d88b.  .d88b.
+888 888 888 888 "88bd8P  Y8bd8P  Y8b
+888 888 888 888  88888888888888888888
+888 888 888 888 d88PY8b.    Y8b.
+888 888 888 88888P"  "Y8888  "Y8888
 
-<div class="hero">
-  <div class="logo">&#x1F41D;</div>
-  <h1>lilbee</h1>
-  <p class="tagline">chat with your documents locally, or plug into AI agents via MCP</p>
+<span class="dim">a knowledge base — local or agent-ready</span>
+
+<span class="faint">════════════════════════════════════════════</span>
+
+ <a href="https://github.com/tobocop2/lilbee">[1] GitHub</a> <span class="faint">··············</span> <span class="dim">source code</span>
+ <a href="https://pypi.org/project/lilbee/">[2] PyPI</a> <span class="faint">················</span> <span class="dim">package</span>
+ <a href="api/">[3] API docs</a> <span class="faint">············</span> <span class="dim">OpenAPI / Redoc</span>
+ <a href="coverage/">[4] Coverage</a> <span class="faint">············</span> <span class="dim">100% tested</span>
+
+<span class="faint">──── built with lilbee ─────────────────────</span>
+
+ <a href="https://github.com/tobocop2/obsidian-lilbee">Obsidian Plugin</a> <span class="faint">········</span> <span class="dim">chat, search, sync your vault</span>
+
+<span class="faint">════════════════════════════════════════════</span>
+
+ <span class="dim">&gt;</span> local document chat via Ollama
+ <span class="dim">&gt;</span> MCP server + JSON CLI for agents
+ <span class="dim">&gt;</span> REST API with streaming SSE
+ <span class="dim">&gt;</span> PDFs, Office docs, images, 150+ code langs
+ <span class="dim">&gt;</span> per-project databases (.lilbee/)
+ <span class="dim">&gt;</span> AST-aware code chunking via tree-sitter
+ <span class="dim">&gt;</span> no cloud, no Docker — fully local
+
+ <span class="faint">$</span> pip install lilbee<span class="cursor"></span>
+
+<span class="faint">════════════════════════════════════════════</span>
+ <span class="faint"><a href="https://github.com/tobocop2/lilbee">lilbee</a> — MIT License</span>
+</pre></div>
+<aside class="bee-art" aria-hidden="true"><pre>
+     %           %
+         %           %
+            %           %
+               %          %
+                 %          %
+                   %          %                   :::
+                    %          %                ::::::
+                 %%%%%%  %%%%%%%%%            ::::::::
+              %%%%%ZZZZ%%%%%%   %%%ZZZZ     ::::::::::         ::::::
+             %%%ZZZZZ%%%%%%%%%%%%%%ZZZZZZ  :::::::::::    :::::::::::::::::
+             ZZZ%ZZZ%%%%%%%%%%%%%%%ZZZZZZZ::::::::::***:::::::::::::::::::::
+          ZZZ%ZZZZZZ%%%%%%%%%%%%%%ZZZZZZZZZ::::::***:::::::::::::::::::::::
+        ZZZ%ZZZZZZZZZZ%%%%%%%%%%ZZZZZZ%ZZZZ:::***:::::::::::::::::::::::
+       ZZ%ZZZZZZZZZZZZZZZZZZZZZZZ%%%%% %ZZZ:**::::::::::::::::::::::
+      ZZ%ZZZZZZZZZZZZZZZZZZZ%%%%% | | %ZZZ *:::::::::::::::::::
+      Z%ZZZZZZZZZZZZZZZ%%%%%%%%%%%%%%%ZZZ::::::::::::::::::::::::::
+       ZZZZZZZZZZZ%%%%%ZZZZZZZZZZZZZZZZZ%%%%:::ZZZZ:::::::::::::::::
+         ZZZZ%%%%%ZZZZZZZZZZZZZZZZZZ%%%%%ZZZ%%ZZZ%ZZ%%*:::::::::::
+            ZZZZZZZZZZZZZZZZZZ%%%%%%%%%ZZZZZZZZZZ%ZZ%:::*:::::::
+            *:::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZZZZZZ%%%*::::*::::
+          *:::::::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZ%%      *:::Z
+         **:ZZZZ:::%%%%%%%%%%%%%%%%%%%%%%%%%%%ZZ      ZZZZZ
+        *:ZZZZZZZ       %%%%%%%%%%%%%%%%%%%%%ZZZZ    ZZZZZZZ
+       *::::ZZZZZZ         %%%%%%%%%%%%%%%ZZZZZZZ      ZZZ
+        *::ZZZZZZ           Z%%%%%%%%%%%ZZZZZZZ%%
+          ZZZZ              ZZZZZZZZZZZZZZZZ%%%%%
+                           %%%ZZZZZZZZZZZ%%%%%%%%
+                          Z%%%%%%%%%%%%%%%%%%%%%
+                          ZZ%%%%%%%%%%%%%%%%%%%
+                          %ZZZZZZZZZZZZZZZZZZZ
+                          %%ZZZZZZZZZZZZZZZZZ
+                           %%%%%%%%%%%%%%%%
+                            %%%%%%%%%%%%%
+                             %%%%%%%%%
+                              ZZZZ
+                              ZZZ
+                             ZZ
+                            Z
+</pre></aside>
 </div>
-
-<div class="honeycomb">
-  <div class="hex"></div>
-  <div class="hex"></div>
-  <div class="hex"></div>
-  <div class="hex"></div>
-  <div class="hex"></div>
-</div>
-
-<div class="links">
-  <a href="https://github.com/tobocop2/lilbee">
-    GitHub
-    <span class="label">Source code</span>
-  </a>
-  <a href="https://pypi.org/project/lilbee/">
-    PyPI
-    <span class="label">pip install lilbee</span>
-  </a>
-  <a href="api/">
-    API Reference
-    <span class="label">OpenAPI / Redoc</span>
-  </a>
-  <a href="coverage/">
-    Coverage
-    <span class="label">100% test coverage</span>
-  </a>
-</div>
-
-<div class="features">
-  <ul>
-    <li>Chat with documents locally using Ollama</li>
-    <li>MCP server + JSON CLI for AI agent integration</li>
-    <li>HTTP REST API with streaming SSE</li>
-    <li>PDFs, Office docs, images (vision OCR), 150+ code languages</li>
-    <li>Per-project databases (git-like .lilbee/ model)</li>
-    <li>AST-aware code chunking via tree-sitter</li>
-    <li>No cloud APIs, no Docker — fully local</li>
-  </ul>
-</div>
-
-<div class="install">
-  <code>pip install lilbee</code>
-</div>
-
-<footer>
-  <a href="https://github.com/tobocop2/lilbee">lilbee</a> &mdash; MIT License
-</footer>
-
 </body>
 </html>

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -193,20 +193,22 @@ def search(
         console.print("No results found.")
         return
 
+    has_relevance = any("relevance_score" in r for r in cleaned)
     table = Table(title="Search Results")
     table.add_column("Source", style="cyan")
     table.add_column("Chunk", max_width=80)
-    table.add_column("Distance", justify="right", style="dim")
+    score_label = "Score" if has_relevance else "Distance"
+    table.add_column(score_label, justify="right", style="dim")
 
     for r in cleaned:
         preview = r.get("chunk", "")[:CHUNK_PREVIEW_LEN]
         if len(r.get("chunk", "")) > CHUNK_PREVIEW_LEN:
             preview += "..."
-        table.add_row(
-            r.get("source", ""),
-            preview,
-            f"{r.get('distance', 0):.4f}",
-        )
+        if has_relevance:
+            score_str = f"{r.get('relevance_score', 0):.4f}"
+        else:
+            score_str = f"{r.get('distance', 0):.4f}"
+        table.add_row(r.get("source", ""), preview, score_str)
     console.print(table)
 
 

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -201,14 +201,12 @@ def search(
     table.add_column(score_label, justify="right", style="dim")
 
     for r in cleaned:
-        preview = r.get("chunk", "")[:CHUNK_PREVIEW_LEN]
-        if len(r.get("chunk", "")) > CHUNK_PREVIEW_LEN:
+        chunk_text = r["chunk"]
+        preview = chunk_text[:CHUNK_PREVIEW_LEN]
+        if len(chunk_text) > CHUNK_PREVIEW_LEN:
             preview += "..."
-        if has_relevance:
-            score_str = f"{r.get('relevance_score', 0):.4f}"
-        else:
-            score_str = f"{r.get('distance', 0):.4f}"
-        table.add_row(r.get("source", ""), preview, score_str)
+        score = r.get("relevance_score") or r.get("distance") or 0
+        table.add_row(r["source"], preview, f"{score:.4f}")
     console.print(table)
 
 

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -111,9 +111,12 @@ def json_output(data: dict) -> None:
 
 
 def clean_result(result: SearchChunk) -> dict:
-    """Strip vector field and rename _distance for JSON output."""
+    """Strip vector field and normalize score fields for JSON output."""
     cleaned = {k: v for k, v in result.items() if k != "vector"}
-    if "_distance" in cleaned:
+    if "_relevance_score" in cleaned:
+        cleaned["relevance_score"] = cleaned.pop("_relevance_score")
+        cleaned.pop("_distance", None)
+    elif "_distance" in cleaned:
         cleaned["distance"] = cleaned.pop("_distance")
     return cleaned
 

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -111,14 +111,8 @@ def json_output(data: dict) -> None:
 
 
 def clean_result(result: SearchChunk) -> dict:
-    """Strip vector field and normalize score fields for JSON output."""
-    cleaned = {k: v for k, v in result.items() if k != "vector"}
-    if "_relevance_score" in cleaned:
-        cleaned["relevance_score"] = cleaned.pop("_relevance_score")
-        cleaned.pop("_distance", None)
-    elif "_distance" in cleaned:
-        cleaned["distance"] = cleaned.pop("_distance")
-    return cleaned
+    """Convert SearchChunk to a JSON-friendly dict (no vector, no None scores)."""
+    return result.model_dump(exclude={"vector"}, exclude_none=True)
 
 
 def gather_status() -> StatusResult:

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -509,6 +509,9 @@ async def sync(
             on_progress=on_progress,
         )
 
+    if files_to_process or removed:
+        store.ensure_fts_index()
+
     result = SyncResult(
         added=added,
         updated=updated,

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -137,11 +137,8 @@ def lilbee_reset() -> dict:
 
 
 def clean(result: SearchChunk) -> dict[str, object]:
-    """Strip vector field and rename _distance for output."""
-    cleaned = {k: v for k, v in result.items() if k != "vector"}
-    if "_distance" in cleaned:
-        cleaned["distance"] = cleaned.pop("_distance")
-    return cleaned
+    """Convert SearchChunk to a JSON-friendly dict."""
+    return result.model_dump(exclude={"vector"}, exclude_none=True)
 
 
 def main() -> None:

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -29,20 +29,17 @@ Question: {question}"""
 
 def format_source(result: SearchChunk) -> str:
     """Format a search result as a source citation line."""
-    source = result["source"]
-    content_type = result["content_type"]
-
-    if content_type == "pdf":
-        ps, pe = result["page_start"], result["page_end"]
+    if result.content_type == "pdf":
+        ps, pe = result.page_start, result.page_end
         pages = f"page {ps}" if ps == pe else f"pages {ps}-{pe}"
-        return f"  → {source}, {pages}"
+        return f"  → {result.source}, {pages}"
 
-    if content_type == "code":
-        ls, le = result["line_start"], result["line_end"]
+    if result.content_type == "code":
+        ls, le = result.line_start, result.line_end
         lines = f"line {ls}" if ls == le else f"lines {ls}-{le}"
-        return f"  → {source}, {lines}"
+        return f"  → {result.source}, {lines}"
 
-    return f"  → {source}"
+    return f"  → {result.source}"
 
 
 def deduplicate_sources(results: list[SearchChunk], max_citations: int = 5) -> list[str]:
@@ -62,12 +59,14 @@ def deduplicate_sources(results: list[SearchChunk], max_citations: int = 5) -> l
 def _sort_key(r: SearchChunk) -> float:
     """Sort key: lower = more relevant.
 
-    Hybrid results have _relevance_score (higher = better) → negate.
-    Vector results have _distance (lower = better) → use directly.
+    Hybrid results have relevance_score (higher = better) → negate.
+    Vector results have distance (lower = better) → use directly.
     """
-    if "_relevance_score" in r:
-        return -r["_relevance_score"]
-    return r.get("_distance", float("inf"))
+    if r.relevance_score is not None:
+        return -r.relevance_score
+    if r.distance is not None:
+        return r.distance
+    return float("inf")
 
 
 def sort_by_relevance(results: list[SearchChunk]) -> list[SearchChunk]:
@@ -79,7 +78,7 @@ def build_context(results: list[SearchChunk]) -> str:
     """Build context block from search results."""
     parts: list[str] = []
     for i, r in enumerate(results, 1):
-        parts.append(f"[{i}] {r['chunk']}")
+        parts.append(f"[{i}] {r.chunk}")
     return "\n\n".join(parts)
 
 

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -59,9 +59,20 @@ def deduplicate_sources(results: list[SearchChunk], max_citations: int = 5) -> l
     return citations
 
 
+def _sort_key(r: SearchChunk) -> float:
+    """Sort key: lower = more relevant.
+
+    Hybrid results have _relevance_score (higher = better) → negate.
+    Vector results have _distance (lower = better) → use directly.
+    """
+    if "_relevance_score" in r:
+        return -r["_relevance_score"]
+    return r.get("_distance", float("inf"))
+
+
 def sort_by_relevance(results: list[SearchChunk]) -> list[SearchChunk]:
-    """Sort search results by distance (lower = more relevant)."""
-    return sorted(results, key=lambda r: r.get("_distance", float("inf")))
+    """Sort search results by relevance (works for both hybrid and vector results)."""
+    return sorted(results, key=_sort_key)
 
 
 def build_context(results: list[SearchChunk]) -> str:
@@ -77,7 +88,7 @@ def search_context(question: str, top_k: int = 0) -> list[SearchChunk]:
     if top_k == 0:
         top_k = cfg.top_k
     query_vec = embedder.embed(question)
-    return store.search(query_vec, top_k=top_k)
+    return store.search(query_vec, top_k=top_k, query_text=question)
 
 
 class AskResult(BaseModel):

--- a/src/lilbee/results.py
+++ b/src/lilbee/results.py
@@ -26,17 +26,16 @@ def _zero_to_none(val: int) -> int | None:
 
 
 def _to_excerpt(chunk: SearchChunk) -> Excerpt:
-    if "_relevance_score" in chunk:
-        relevance = float(chunk["_relevance_score"])
+    if chunk.relevance_score is not None:
+        relevance = chunk.relevance_score
     else:
-        distance = float(chunk["_distance"])
-        relevance = 1.0 / (1.0 + distance)
+        relevance = 1.0 / (1.0 + (chunk.distance or 0))
     return Excerpt(
-        content=str(chunk["chunk"]),
-        page_start=_zero_to_none(chunk["page_start"]),
-        page_end=_zero_to_none(chunk["page_end"]),
-        line_start=_zero_to_none(chunk["line_start"]),
-        line_end=_zero_to_none(chunk["line_end"]),
+        content=chunk.chunk,
+        page_start=_zero_to_none(chunk.page_start),
+        page_end=_zero_to_none(chunk.page_end),
+        line_start=_zero_to_none(chunk.line_start),
+        line_end=_zero_to_none(chunk.line_end),
         relevance=relevance,
     )
 
@@ -45,7 +44,7 @@ def group(chunks: list[SearchChunk]) -> list[DocumentResult]:
     """Group raw LanceDB chunks into document-centric results."""
     by_source: dict[str, list[SearchChunk]] = {}
     for chunk in chunks:
-        source = str(chunk["source"])
+        source = chunk.source
         by_source.setdefault(source, []).append(chunk)
 
     results: list[DocumentResult] = []
@@ -58,7 +57,7 @@ def group(chunks: list[SearchChunk]) -> list[DocumentResult]:
         results.append(
             DocumentResult(
                 source=source,
-                content_type=str(source_chunks[0]["content_type"]),
+                content_type=source_chunks[0].content_type,
                 excerpts=excerpts,
                 best_relevance=excerpts[0].relevance,
             )

--- a/src/lilbee/results.py
+++ b/src/lilbee/results.py
@@ -26,8 +26,11 @@ def _zero_to_none(val: int) -> int | None:
 
 
 def _to_excerpt(chunk: SearchChunk) -> Excerpt:
-    distance = float(chunk["_distance"])
-    relevance = 1.0 / (1.0 + distance)
+    if "_relevance_score" in chunk:
+        relevance = float(chunk["_relevance_score"])
+    else:
+        distance = float(chunk["_distance"])
+        relevance = 1.0 / (1.0 + distance)
     return Excerpt(
         content=str(chunk["chunk"]),
         page_start=_zero_to_none(chunk["page_start"]),

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import UTC, datetime
+from typing import Required
 
 import lancedb
 import pyarrow as pa
@@ -11,20 +12,30 @@ from lilbee.config import CHUNKS_TABLE, SOURCES_TABLE, cfg
 
 log = logging.getLogger(__name__)
 
+# Ephemeral runtime flag — resets on process start, correct since FTS index
+# may not exist yet.  Set True after ensure_fts_index() succeeds.
+_fts_index_ready = False
 
-class SearchChunk(TypedDict):
-    """A search result row from LanceDB — chunk fields plus distance."""
 
-    source: str
-    content_type: str
-    page_start: int
-    page_end: int
-    line_start: int
-    line_end: int
-    chunk: str
-    chunk_index: int
-    vector: list[float]
+class SearchChunk(TypedDict, total=False):
+    """A search result row from LanceDB — chunk fields plus score/distance.
+
+    Core fields are Required (always present).  Score fields are optional
+    because hybrid results carry ``_relevance_score`` while vector-only
+    results carry ``_distance``.
+    """
+
+    source: Required[str]
+    content_type: Required[str]
+    page_start: Required[int]
+    page_end: Required[int]
+    line_start: Required[int]
+    line_end: Required[int]
+    chunk: Required[str]
+    chunk_index: Required[int]
+    vector: Required[list[float]]
     _distance: float
+    _relevance_score: float
 
 
 def _chunks_schema() -> pa.Schema:
@@ -95,8 +106,28 @@ def _escape_sql_string(value: str) -> str:
     return value.replace("'", "''")
 
 
+def ensure_fts_index() -> None:
+    """Create or replace the FTS index on the chunks table.
+
+    No-op when the table doesn't exist or is empty.  Sets _fts_index_ready
+    on success so hybrid_search can be used.
+    """
+    global _fts_index_ready
+    table = _open_table(CHUNKS_TABLE)
+    if table is None:
+        return
+    try:
+        table.create_fts_index("chunk", replace=True)
+        _fts_index_ready = True
+        log.debug("FTS index created/replaced on '%s'", CHUNKS_TABLE)
+    except Exception:
+        log.debug("FTS index creation failed (empty table?)", exc_info=True)
+
+
 def add_chunks(records: list[dict]) -> int:
     """Add chunk records to the store. Returns count added."""
+    global _fts_index_ready
+    _fts_index_ready = False
     if not records:
         return 0
     for rec in records:
@@ -112,14 +143,35 @@ def add_chunks(records: list[dict]) -> int:
     return len(records)
 
 
+def _hybrid_search(
+    table: lancedb.table.Table,
+    query_text: str,
+    query_vector: list[float],
+    top_k: int,
+) -> list[SearchChunk]:
+    """Run hybrid (vector + FTS) search with RRF reranking."""
+    from lancedb.rerankers import RRFReranker
+
+    results: list[SearchChunk] = (
+        table.search(query_type="hybrid")
+        .vector(query_vector)
+        .text(query_text)
+        .rerank(RRFReranker())
+        .limit(top_k)
+        .to_list()
+    )
+    return results
+
+
 def search(
     query_vector: list[float],
     top_k: int | None = None,
     max_distance: float | None = None,
+    query_text: str | None = None,
 ) -> list[SearchChunk]:
-    """Search for similar chunks by vector similarity.
+    """Search for similar chunks — hybrid when FTS index is available, else vector-only.
 
-    Results with distance > max_distance are filtered out.
+    Results with distance > max_distance are filtered out (vector-only path).
     Pass max_distance=0 to disable filtering.
     """
     if top_k is None:
@@ -129,6 +181,16 @@ def search(
     table = _open_table(CHUNKS_TABLE)
     if table is None:
         return []
+
+    if query_text and not _fts_index_ready:
+        ensure_fts_index()
+
+    if query_text and _fts_index_ready:
+        try:
+            return _hybrid_search(table, query_text, query_vector, top_k)
+        except Exception:
+            log.debug("Hybrid search failed, falling back to vector-only", exc_info=True)
+
     results: list[SearchChunk] = table.search(query_vector).metric("cosine").limit(top_k).to_list()
     if max_distance > 0:
         results = [r for r in results if r["_distance"] <= max_distance]
@@ -187,6 +249,8 @@ def delete_source(filename: str) -> None:
 
 def drop_all() -> None:
     """Drop all tables — used by rebuild."""
+    global _fts_index_ready
+    _fts_index_ready = False
     db = get_db()
     for name in _table_names(db):
         db.drop_table(name)

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -2,40 +2,45 @@
 
 import logging
 from datetime import UTC, datetime
-from typing import Required
 
 import lancedb
 import pyarrow as pa
-from typing_extensions import TypedDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from lilbee.config import CHUNKS_TABLE, SOURCES_TABLE, cfg
 
 log = logging.getLogger(__name__)
 
-# Ephemeral runtime flag — resets on process start, correct since FTS index
-# may not exist yet.  Set True after ensure_fts_index() succeeds.
-_fts_index_ready = False
+
+class _FtsState:
+    """Ephemeral FTS index state — resets on process start."""
+
+    ready: bool = False
 
 
-class SearchChunk(TypedDict, total=False):
-    """A search result row from LanceDB — chunk fields plus score/distance.
+_fts = _FtsState()
 
-    Core fields are Required (always present).  Score fields are optional
-    because hybrid results carry ``_relevance_score`` while vector-only
-    results carry ``_distance``.
+
+class SearchChunk(BaseModel):
+    """A search result from LanceDB.
+
+    Hybrid results have ``relevance_score`` set (higher = better).
+    Vector-only results have ``distance`` set (lower = better).
     """
 
-    source: Required[str]
-    content_type: Required[str]
-    page_start: Required[int]
-    page_end: Required[int]
-    line_start: Required[int]
-    line_end: Required[int]
-    chunk: Required[str]
-    chunk_index: Required[int]
-    vector: Required[list[float]]
-    _distance: float
-    _relevance_score: float
+    model_config = ConfigDict(populate_by_name=True)
+
+    source: str
+    content_type: str
+    page_start: int
+    page_end: int
+    line_start: int
+    line_end: int
+    chunk: str
+    chunk_index: int
+    vector: list[float] = Field(repr=False)
+    distance: float | None = Field(None, alias="_distance")
+    relevance_score: float | None = Field(None, alias="_relevance_score")
 
 
 def _chunks_schema() -> pa.Schema:
@@ -109,16 +114,15 @@ def _escape_sql_string(value: str) -> str:
 def ensure_fts_index() -> None:
     """Create or replace the FTS index on the chunks table.
 
-    No-op when the table doesn't exist or is empty.  Sets _fts_index_ready
+    No-op when the table doesn't exist or is empty.  Sets _fts.ready
     on success so hybrid_search can be used.
     """
-    global _fts_index_ready
     table = _open_table(CHUNKS_TABLE)
     if table is None:
         return
     try:
         table.create_fts_index("chunk", replace=True)
-        _fts_index_ready = True
+        _fts.ready = True
         log.debug("FTS index created/replaced on '%s'", CHUNKS_TABLE)
     except Exception:
         log.debug("FTS index creation failed (empty table?)", exc_info=True)
@@ -126,8 +130,7 @@ def ensure_fts_index() -> None:
 
 def add_chunks(records: list[dict]) -> int:
     """Add chunk records to the store. Returns count added."""
-    global _fts_index_ready
-    _fts_index_ready = False
+    _fts.ready = False
     if not records:
         return 0
     for rec in records:
@@ -152,7 +155,7 @@ def _hybrid_search(
     """Run hybrid (vector + FTS) search with RRF reranking."""
     from lancedb.rerankers import RRFReranker
 
-    results: list[SearchChunk] = (
+    rows = (
         table.search(query_type="hybrid")
         .vector(query_vector)
         .text(query_text)
@@ -160,7 +163,7 @@ def _hybrid_search(
         .limit(top_k)
         .to_list()
     )
-    return results
+    return [SearchChunk(**r) for r in rows]
 
 
 def search(
@@ -182,18 +185,19 @@ def search(
     if table is None:
         return []
 
-    if query_text and not _fts_index_ready:
+    if query_text and not _fts.ready:
         ensure_fts_index()
 
-    if query_text and _fts_index_ready:
+    if query_text and _fts.ready:
         try:
             return _hybrid_search(table, query_text, query_vector, top_k)
         except Exception:
             log.debug("Hybrid search failed, falling back to vector-only", exc_info=True)
 
-    results: list[SearchChunk] = table.search(query_vector).metric("cosine").limit(top_k).to_list()
+    rows = table.search(query_vector).metric("cosine").limit(top_k).to_list()
+    results = [SearchChunk(**r) for r in rows]
     if max_distance > 0:
-        results = [r for r in results if r["_distance"] <= max_distance]
+        results = [r for r in results if (r.distance or 0) <= max_distance]
     return results
 
 
@@ -203,8 +207,8 @@ def get_chunks_by_source(source: str) -> list[SearchChunk]:
     if table is None:
         return []
     escaped = _escape_sql_string(source)
-    rows: list[SearchChunk] = table.search().where(f"source = '{escaped}'").to_list()
-    return rows
+    rows = table.search().where(f"source = '{escaped}'").to_list()
+    return [SearchChunk(**r) for r in rows]
 
 
 def delete_by_source(source: str) -> None:
@@ -249,8 +253,7 @@ def delete_source(filename: str) -> None:
 
 def drop_all() -> None:
     """Drop all tables — used by rebuild."""
-    global _fts_index_ready
-    _fts_index_ready = False
+    _fts.ready = False
     db = get_db()
     for name in _table_names(db):
         db.drop_table(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def copy_fixtures_to(subdir: str, dest: Path) -> None:
             shutil.copy2(item, dest / item.name)
 
 
-def batch_search(queries: list[str], top_k: int = 10) -> dict[str, list[dict]]:
+def batch_search(queries: list[str], top_k: int = 10) -> dict[str, list]:
     """Embed all queries in one batch call, then search for each. Returns {query: results}."""
     from lilbee.embedder import embed_batch
     from lilbee.store import search

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -137,5 +137,5 @@ class TestRAGAccuracy:
 
         results = search_context("oil capacity")
         assert len(results) > 0
-        chunks_text = " ".join(r["chunk"] for r in results)
+        chunks_text = " ".join(r.chunk for r in results)
         assert "6.5 quarts" in chunks_text

--- a/tests/test_accuracy_code.py
+++ b/tests/test_accuracy_code.py
@@ -83,13 +83,13 @@ class TestCodeAccuracy:
         matching = [
             r
             for r in results
-            if r["source"].endswith(expected_source)
-            and any(term in r["chunk"] for term in expected_terms)
+            if r.source.endswith(expected_source)
+            and any(term in r.chunk for term in expected_terms)
         ]
         assert matching, (
             f"No chunk from '{expected_source}' containing {expected_terms} "
             f"for query '{query}'. Got sources: "
-            f"{[r['source'] for r in results]}"
+            f"{[r.source for r in results]}"
         )
 
     def test_code_chunks_have_valid_line_metadata(self, code_data):
@@ -100,14 +100,14 @@ class TestCodeAccuracy:
             chunks = get_chunks_by_source(source)
             assert chunks, f"No chunks found for {source}"
             for chunk in chunks:
-                assert chunk["line_start"] > 0, (
-                    f"{source}: line_start must be > 0, got {chunk['line_start']}"
+                assert chunk.line_start > 0, (
+                    f"{source}: line_start must be > 0, got {chunk.line_start}"
                 )
-                assert chunk["line_end"] >= chunk["line_start"], (
-                    f"{source}: line_end ({chunk['line_end']}) < line_start ({chunk['line_start']})"
+                assert chunk.line_end >= chunk.line_start, (
+                    f"{source}: line_end ({chunk.line_end}) < line_start ({chunk.line_start})"
                 )
-                assert chunk["content_type"] == "code", (
-                    f"{source}: expected content_type 'code', got '{chunk['content_type']}'"
+                assert chunk.content_type == "code", (
+                    f"{source}: expected content_type 'code', got '{chunk.content_type}'"
                 )
 
     def test_code_source_attribution(self, code_data):

--- a/tests/test_accuracy_docs.py
+++ b/tests/test_accuracy_docs.py
@@ -82,13 +82,13 @@ class TestDocumentAccuracy:
         matching = [
             r
             for r in results
-            if r["source"].endswith(expected_source)
-            and any(term in r["chunk"] for term in expected_terms)
+            if r.source.endswith(expected_source)
+            and any(term in r.chunk for term in expected_terms)
         ]
         assert matching, (
             f"No result from '{expected_source}' containing {expected_terms} "
             f"for query '{query}'. Got sources: "
-            f"{[r['source'] for r in results]}"
+            f"{[r.source for r in results]}"
         )
 
     @pytest.mark.parametrize(
@@ -99,11 +99,11 @@ class TestDocumentAccuracy:
         self, doc_data, query, expected_source, expected_terms, expected_type
     ):
         results = doc_data.search_results[query]
-        matching = [r for r in results if r["source"].endswith(expected_source)]
+        matching = [r for r in results if r.source.endswith(expected_source)]
         assert matching, f"No result from '{expected_source}' for query '{query}'"
-        assert matching[0]["content_type"] == expected_type, (
+        assert matching[0].content_type == expected_type, (
             f"Expected content_type '{expected_type}' for '{expected_source}', "
-            f"got '{matching[0]['content_type']}'"
+            f"got '{matching[0].content_type}'"
         )
 
     def test_document_source_attribution(self, doc_data):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1302,6 +1302,21 @@ class TestCleanResult:
         result = clean_result({"source": "a.pdf", "chunk": "hi", "page_start": 1})
         assert result == {"source": "a.pdf", "chunk": "hi", "page_start": 1}
 
+    def test_renames_relevance_score(self):
+        result = clean_result({"_relevance_score": 0.85, "chunk": "hi", "vector": [0.1]})
+        assert "relevance_score" in result
+        assert "_relevance_score" not in result
+        assert "vector" not in result
+        assert result["relevance_score"] == 0.85
+
+    def test_relevance_score_strips_distance(self):
+        result = clean_result(
+            {"_relevance_score": 0.85, "_distance": 0.3, "chunk": "hi", "vector": [0.1]}
+        )
+        assert "relevance_score" in result
+        assert "distance" not in result
+        assert "_distance" not in result
+
 
 class TestJsonFlag:
     def test_json_no_subcommand_returns_error(self):
@@ -1378,6 +1393,27 @@ class TestSearch:
         result = runner.invoke(app, ["search", "nothing"])
         assert result.exit_code == 0
         assert "No results found" in result.output
+
+    @mock.patch(
+        "lilbee.query.search_context",
+        return_value=[{**_MOCK_SEARCH_RESULTS[0], "_relevance_score": 0.85}],
+    )
+    def test_search_human_hybrid_shows_score(self, _search):
+        result = runner.invoke(app, ["search", "engine oil"])
+        assert result.exit_code == 0
+        assert "Score" in result.output
+        assert "0.85" in result.output
+
+    @mock.patch(
+        "lilbee.query.search_context",
+        return_value=[{**_MOCK_SEARCH_RESULTS[0], "_relevance_score": 0.85}],
+    )
+    def test_search_json_hybrid_has_relevance_score(self, _search):
+        result = runner.invoke(app, ["--json", "search", "engine oil"])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert "relevance_score" in data["results"][0]
+        assert "distance" not in data["results"][0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ from lilbee.cli import (
 )
 from lilbee.config import cfg
 from lilbee.ingest import SyncResult
+from lilbee.store import SearchChunk
 
 runner = CliRunner()
 
@@ -1286,36 +1287,40 @@ class TestPromptSessionBranch:
 # ---------------------------------------------------------------------------
 
 
+def _search_chunk(**overrides) -> SearchChunk:
+    defaults = dict(
+        source="a.pdf",
+        content_type="pdf",
+        page_start=0,
+        page_end=0,
+        line_start=0,
+        line_end=0,
+        chunk="hi",
+        chunk_index=0,
+        vector=[0.1, 0.2],
+    )
+    return SearchChunk(**(defaults | overrides))
+
+
 class TestCleanResult:
     def test_strips_vector(self):
-        result = clean_result({"source": "a.pdf", "vector": [0.1, 0.2], "chunk": "hi"})
+        result = clean_result(_search_chunk(distance=0.5))
         assert "vector" not in result
         assert result["source"] == "a.pdf"
 
-    def test_renames_distance(self):
-        result = clean_result({"_distance": 0.42, "chunk": "hi"})
-        assert "distance" in result
-        assert "_distance" not in result
+    def test_has_distance(self):
+        result = clean_result(_search_chunk(distance=0.42))
         assert result["distance"] == 0.42
 
-    def test_passthrough_other_fields(self):
-        result = clean_result({"source": "a.pdf", "chunk": "hi", "page_start": 1})
-        assert result == {"source": "a.pdf", "chunk": "hi", "page_start": 1}
+    def test_excludes_none_scores(self):
+        result = clean_result(_search_chunk(distance=0.5))
+        assert "relevance_score" not in result
 
-    def test_renames_relevance_score(self):
-        result = clean_result({"_relevance_score": 0.85, "chunk": "hi", "vector": [0.1]})
-        assert "relevance_score" in result
-        assert "_relevance_score" not in result
-        assert "vector" not in result
+    def test_has_relevance_score(self):
+        result = clean_result(_search_chunk(relevance_score=0.85))
         assert result["relevance_score"] == 0.85
-
-    def test_relevance_score_strips_distance(self):
-        result = clean_result(
-            {"_relevance_score": 0.85, "_distance": 0.3, "chunk": "hi", "vector": [0.1]}
-        )
-        assert "relevance_score" in result
+        assert "vector" not in result
         assert "distance" not in result
-        assert "_distance" not in result
 
 
 class TestJsonFlag:
@@ -1338,18 +1343,18 @@ class TestJsonFlag:
 # ---------------------------------------------------------------------------
 
 _MOCK_SEARCH_RESULTS = [
-    {
-        "source": "manual.pdf",
-        "content_type": "pdf",
-        "page_start": 5,
-        "page_end": 5,
-        "line_start": 0,
-        "line_end": 0,
-        "chunk": "The engine oil capacity is 5 quarts.",
-        "chunk_index": 0,
-        "_distance": 0.25,
-        "vector": [0.1] * 768,
-    },
+    SearchChunk(
+        source="manual.pdf",
+        content_type="pdf",
+        page_start=5,
+        page_end=5,
+        line_start=0,
+        line_end=0,
+        chunk="The engine oil capacity is 5 quarts.",
+        chunk_index=0,
+        distance=0.25,
+        vector=[0.1] * 768,
+    ),
 ]
 
 
@@ -1380,7 +1385,7 @@ class TestSearch:
 
     @mock.patch(
         "lilbee.query.search_context",
-        return_value=[{**_MOCK_SEARCH_RESULTS[0], "chunk": "x" * 100}],
+        return_value=[_MOCK_SEARCH_RESULTS[0].model_copy(update={"chunk": "x" * 100})],
     )
     def test_search_human_truncates_long_chunks(self, _search):
         result = runner.invoke(app, ["search", "test"])
@@ -1396,7 +1401,9 @@ class TestSearch:
 
     @mock.patch(
         "lilbee.query.search_context",
-        return_value=[{**_MOCK_SEARCH_RESULTS[0], "_relevance_score": 0.85}],
+        return_value=[
+            _MOCK_SEARCH_RESULTS[0].model_copy(update={"relevance_score": 0.85, "distance": None})
+        ],
     )
     def test_search_human_hybrid_shows_score(self, _search):
         result = runner.invoke(app, ["search", "engine oil"])
@@ -1406,7 +1413,9 @@ class TestSearch:
 
     @mock.patch(
         "lilbee.query.search_context",
-        return_value=[{**_MOCK_SEARCH_RESULTS[0], "_relevance_score": 0.85}],
+        return_value=[
+            _MOCK_SEARCH_RESULTS[0].model_copy(update={"relevance_score": 0.85, "distance": None})
+        ],
     )
     def test_search_json_hybrid_has_relevance_score(self, _search):
         result = runner.invoke(app, ["--json", "search", "engine oil"])
@@ -1899,18 +1908,18 @@ class TestAskJson:
         mock_ask_raw.return_value = AskResult(
             answer="5 quarts",
             sources=[
-                {
-                    "source": "manual.pdf",
-                    "content_type": "pdf",
-                    "page_start": 1,
-                    "page_end": 1,
-                    "line_start": 0,
-                    "line_end": 0,
-                    "chunk": "oil",
-                    "chunk_index": 0,
-                    "_distance": 0.3,
-                    "vector": [0.1],
-                }
+                SearchChunk(
+                    source="manual.pdf",
+                    content_type="pdf",
+                    page_start=1,
+                    page_end=1,
+                    line_start=0,
+                    line_end=0,
+                    chunk="oil",
+                    chunk_index=0,
+                    distance=0.3,
+                    vector=[0.1],
+                )
             ],
         )
         result = runner.invoke(app, ["--json", "ask", "oil capacity?"])

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -17,6 +17,7 @@ from lilbee.mcp import (
     lilbee_sync,
     main,
 )
+from lilbee.store import SearchChunk
 
 
 @pytest.fixture(autouse=True)
@@ -47,21 +48,55 @@ _SYNC_NOOP = SyncResult()
 
 class TestClean:
     def test_strips_vector(self):
-        result = clean({"source": "a.pdf", "vector": [0.1], "chunk": "hi"})
+        chunk = SearchChunk(
+            source="a.pdf",
+            content_type="text",
+            page_start=0,
+            page_end=0,
+            line_start=0,
+            line_end=0,
+            chunk="hi",
+            chunk_index=0,
+            vector=[0.1],
+            distance=0.5,
+        )
+        result = clean(chunk)
         assert "vector" not in result
         assert result["source"] == "a.pdf"
 
-    def test_renames_distance(self):
-        result = clean({"_distance": 0.42, "chunk": "hi"})
+    def test_has_distance(self):
+        chunk = SearchChunk(
+            source="a.pdf",
+            content_type="text",
+            page_start=0,
+            page_end=0,
+            line_start=0,
+            line_end=0,
+            chunk="hi",
+            chunk_index=0,
+            vector=[0.1],
+            distance=0.42,
+        )
+        result = clean(chunk)
         assert result["distance"] == 0.42
-        assert "_distance" not in result
 
 
 class TestLilbeeSearch:
     @mock.patch("lilbee.query.search_context")
     def test_returnscleaned_results(self, mock_search):
         mock_search.return_value = [
-            {"source": "doc.pdf", "chunk": "content", "_distance": 0.3, "vector": [0.1] * 768},
+            SearchChunk(
+                source="doc.pdf",
+                content_type="pdf",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk="content",
+                chunk_index=0,
+                vector=[0.1] * 768,
+                distance=0.3,
+            ),
         ]
         results = lilbee_search("test query", top_k=3)
         assert len(results) == 1

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -80,7 +80,7 @@ class TestStoreRoundTrip:
 
         results = search(embed("how much oil does it need?"), top_k=1)
         assert len(results) == 1
-        assert "5 quarts" in results[0]["chunk"]
+        assert "5 quarts" in results[0].chunk
 
     def test_delete_by_source_removes_chunks(self):
         from lilbee.embedder import embed
@@ -105,7 +105,7 @@ class TestStoreRoundTrip:
 
         delete_by_source("delete_me.pdf")
         for r in search(embed("tire pressure"), top_k=5):
-            assert r["source"] != "delete_me.pdf"
+            assert r.source != "delete_me.pdf"
 
 
 class TestStoreOperations:
@@ -134,7 +134,7 @@ class TestStoreOperations:
         assert count == 1
         results = search(vec, top_k=1)
         assert len(results) == 1
-        assert "5 quarts" in results[0]["chunk"]
+        assert "5 quarts" in results[0].chunk
 
     def test_add_chunks_empty_returns_zero(self):
         from lilbee.store import add_chunks
@@ -195,7 +195,7 @@ class TestStoreOperations:
         )
         delete_by_source("remove_me.txt")
         results = search(vec, top_k=5)
-        assert all(r["source"] != "remove_me.txt" for r in results)
+        assert all(r.source != "remove_me.txt" for r in results)
 
     def test_delete_by_source_with_single_quote(self):
         from lilbee.store import add_chunks, delete_by_source, search
@@ -218,7 +218,7 @@ class TestStoreOperations:
         )
         delete_by_source("it's_a_file.txt")
         results = search(vec, top_k=5)
-        assert all(r["source"] != "it's_a_file.txt" for r in results)
+        assert all(r.source != "it's_a_file.txt" for r in results)
 
     def test_delete_by_source_no_table(self):
         from lilbee.store import delete_by_source
@@ -297,7 +297,7 @@ class TestGetChunksBySource:
         )
         chunks = get_chunks_by_source("doc.txt")
         assert len(chunks) == 1
-        assert chunks[0]["chunk"] == "Hello world"
+        assert chunks[0].chunk == "Hello world"
 
     def test_empty_store_returns_empty(self):
         from lilbee.store import get_chunks_by_source
@@ -336,7 +336,7 @@ class TestGetChunksBySource:
         )
         chunks = get_chunks_by_source("a.txt")
         assert len(chunks) == 1
-        assert chunks[0]["source"] == "a.txt"
+        assert chunks[0].source == "a.txt"
 
 
 class TestSourceTracking:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -111,6 +111,17 @@ class TestSortByRelevance:
         assert sorted_results[0]["source"] == "has_dist.pdf"
         assert sorted_results[1]["source"] == "no_dist.pdf"
 
+    def test_sorts_by_relevance_score_when_present(self):
+        results = [
+            {**_make_result(source="low.pdf"), "_relevance_score": 0.2},
+            {**_make_result(source="high.pdf"), "_relevance_score": 0.9},
+            {**_make_result(source="mid.pdf"), "_relevance_score": 0.5},
+        ]
+        sorted_results = sort_by_relevance(results)
+        assert sorted_results[0]["source"] == "high.pdf"
+        assert sorted_results[1]["source"] == "mid.pdf"
+        assert sorted_results[2]["source"] == "low.pdf"
+
 
 class TestBuildContext:
     def test_numbers_chunks(self):
@@ -128,6 +139,13 @@ class TestSearchContext:
         results = search_context("question")
         assert len(results) == 1
         mock_embed.assert_called_once_with("question")
+
+    @mock.patch("lilbee.store.search", return_value=[_make_result()])
+    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    def test_passes_query_text(self, mock_embed, mock_search):
+        search_context("my question")
+        mock_search.assert_called_once()
+        assert mock_search.call_args[1]["query_text"] == "my question"
 
 
 class TestAskRaw:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -15,6 +15,7 @@ from lilbee.query import (
     search_context,
     sort_by_relevance,
 )
+from lilbee.store import SearchChunk
 
 
 def _make_result(
@@ -26,21 +27,23 @@ def _make_result(
     line_end=0,
     chunk="some text",
     chunk_index=0,
-    _distance=0.5,
+    distance=0.5,
+    relevance_score=None,
     vector=None,
-):
-    return {
-        "source": source,
-        "content_type": content_type,
-        "page_start": page_start,
-        "page_end": page_end,
-        "line_start": line_start,
-        "line_end": line_end,
-        "chunk": chunk,
-        "chunk_index": chunk_index,
-        "_distance": _distance,
-        "vector": vector or [0.1],
-    }
+) -> SearchChunk:
+    return SearchChunk(
+        source=source,
+        content_type=content_type,
+        page_start=page_start,
+        page_end=page_end,
+        line_start=line_start,
+        line_end=line_end,
+        chunk=chunk,
+        chunk_index=chunk_index,
+        distance=distance,
+        relevance_score=relevance_score,
+        vector=vector or [0.1],
+    )
 
 
 class TestFormatSource:
@@ -93,34 +96,34 @@ class TestDeduplicateSources:
 class TestSortByRelevance:
     def test_sorts_by_distance(self):
         results = [
-            _make_result(source="far.pdf", _distance=0.9),
-            _make_result(source="close.pdf", _distance=0.1),
-            _make_result(source="mid.pdf", _distance=0.5),
+            _make_result(source="far.pdf", distance=0.9),
+            _make_result(source="close.pdf", distance=0.1),
+            _make_result(source="mid.pdf", distance=0.5),
         ]
         sorted_results = sort_by_relevance(results)
-        assert sorted_results[0]["source"] == "close.pdf"
-        assert sorted_results[1]["source"] == "mid.pdf"
-        assert sorted_results[2]["source"] == "far.pdf"
+        assert sorted_results[0].source == "close.pdf"
+        assert sorted_results[1].source == "mid.pdf"
+        assert sorted_results[2].source == "far.pdf"
 
     def test_missing_distance_sorts_last(self):
         results = [
-            {"source": "no_dist.pdf", "chunk": "text"},
-            _make_result(source="has_dist.pdf", _distance=0.3),
+            _make_result(source="no_dist.pdf", distance=None),
+            _make_result(source="has_dist.pdf", distance=0.3),
         ]
         sorted_results = sort_by_relevance(results)
-        assert sorted_results[0]["source"] == "has_dist.pdf"
-        assert sorted_results[1]["source"] == "no_dist.pdf"
+        assert sorted_results[0].source == "has_dist.pdf"
+        assert sorted_results[1].source == "no_dist.pdf"
 
     def test_sorts_by_relevance_score_when_present(self):
         results = [
-            {**_make_result(source="low.pdf"), "_relevance_score": 0.2},
-            {**_make_result(source="high.pdf"), "_relevance_score": 0.9},
-            {**_make_result(source="mid.pdf"), "_relevance_score": 0.5},
+            _make_result(source="low.pdf", relevance_score=0.2),
+            _make_result(source="high.pdf", relevance_score=0.9),
+            _make_result(source="mid.pdf", relevance_score=0.5),
         ]
         sorted_results = sort_by_relevance(results)
-        assert sorted_results[0]["source"] == "high.pdf"
-        assert sorted_results[1]["source"] == "mid.pdf"
-        assert sorted_results[2]["source"] == "low.pdf"
+        assert sorted_results[0].source == "high.pdf"
+        assert sorted_results[1].source == "mid.pdf"
+        assert sorted_results[2].source == "low.pdf"
 
 
 class TestBuildContext:
@@ -157,7 +160,7 @@ class TestAskRaw:
         result = ask_raw("oil capacity?")
         assert result.answer == "5 quarts."
         assert len(result.sources) == 1
-        assert result.sources[0]["source"] == "test.pdf"
+        assert result.sources[0].source == "test.pdf"
 
     @mock.patch("lilbee.store.search", return_value=[])
     @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -135,3 +135,43 @@ def test_best_relevance_matches_top_excerpt() -> None:
     ]
     results = group(chunks)
     assert results[0].best_relevance == results[0].excerpts[0].relevance
+
+
+def _hybrid_chunk(
+    source: str = "doc.md",
+    content_type: str = "text/markdown",
+    chunk: str = "hello world",
+    relevance_score: float = 0.8,
+    page_start: int = 0,
+    page_end: int = 0,
+    line_start: int = 0,
+    line_end: int = 0,
+    chunk_index: int = 0,
+) -> dict[str, object]:
+    return {
+        "source": source,
+        "content_type": content_type,
+        "chunk": chunk,
+        "_relevance_score": relevance_score,
+        "page_start": page_start,
+        "page_end": page_end,
+        "line_start": line_start,
+        "line_end": line_end,
+        "chunk_index": chunk_index,
+        "vector": [0.1, 0.2, 0.3],
+    }
+
+
+def test_relevance_score_used_directly() -> None:
+    results = group([_hybrid_chunk(relevance_score=0.75)])
+    assert results[0].excerpts[0].relevance == 0.75
+
+
+def test_hybrid_results_sorted_by_relevance_score() -> None:
+    chunks = [
+        _hybrid_chunk(source="a.md", relevance_score=0.3, chunk="low"),
+        _hybrid_chunk(source="a.md", relevance_score=0.9, chunk="high"),
+    ]
+    results = group(chunks)
+    assert results[0].excerpts[0].content == "high"
+    assert results[0].excerpts[1].content == "low"

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -3,31 +3,34 @@ from __future__ import annotations
 import json
 
 from lilbee.results import group, to_dicts
+from lilbee.store import SearchChunk
 
 
 def _chunk(
     source: str = "doc.md",
     content_type: str = "text/markdown",
     chunk: str = "hello world",
-    distance: float = 0.5,
+    distance: float | None = 0.5,
+    relevance_score: float | None = None,
     page_start: int = 0,
     page_end: int = 0,
     line_start: int = 0,
     line_end: int = 0,
     chunk_index: int = 0,
-) -> dict[str, object]:
-    return {
-        "source": source,
-        "content_type": content_type,
-        "chunk": chunk,
-        "_distance": distance,
-        "page_start": page_start,
-        "page_end": page_end,
-        "line_start": line_start,
-        "line_end": line_end,
-        "chunk_index": chunk_index,
-        "vector": [0.1, 0.2, 0.3],
-    }
+) -> SearchChunk:
+    return SearchChunk(
+        source=source,
+        content_type=content_type,
+        chunk=chunk,
+        distance=distance,
+        relevance_score=relevance_score,
+        page_start=page_start,
+        page_end=page_end,
+        line_start=line_start,
+        line_end=line_end,
+        chunk_index=chunk_index,
+        vector=[0.1, 0.2, 0.3],
+    )
 
 
 def test_empty_input() -> None:
@@ -137,40 +140,15 @@ def test_best_relevance_matches_top_excerpt() -> None:
     assert results[0].best_relevance == results[0].excerpts[0].relevance
 
 
-def _hybrid_chunk(
-    source: str = "doc.md",
-    content_type: str = "text/markdown",
-    chunk: str = "hello world",
-    relevance_score: float = 0.8,
-    page_start: int = 0,
-    page_end: int = 0,
-    line_start: int = 0,
-    line_end: int = 0,
-    chunk_index: int = 0,
-) -> dict[str, object]:
-    return {
-        "source": source,
-        "content_type": content_type,
-        "chunk": chunk,
-        "_relevance_score": relevance_score,
-        "page_start": page_start,
-        "page_end": page_end,
-        "line_start": line_start,
-        "line_end": line_end,
-        "chunk_index": chunk_index,
-        "vector": [0.1, 0.2, 0.3],
-    }
-
-
 def test_relevance_score_used_directly() -> None:
-    results = group([_hybrid_chunk(relevance_score=0.75)])
+    results = group([_chunk(distance=None, relevance_score=0.75)])
     assert results[0].excerpts[0].relevance == 0.75
 
 
 def test_hybrid_results_sorted_by_relevance_score() -> None:
     chunks = [
-        _hybrid_chunk(source="a.md", relevance_score=0.3, chunk="low"),
-        _hybrid_chunk(source="a.md", relevance_score=0.9, chunk="high"),
+        _chunk(source="a.md", distance=None, relevance_score=0.3, chunk="low"),
+        _chunk(source="a.md", distance=None, relevance_score=0.9, chunk="high"),
     ]
     results = group(chunks)
     assert results[0].excerpts[0].content == "high"

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -9,6 +9,7 @@ import pytest
 from lilbee.config import cfg
 from lilbee.ingest import SyncResult
 from lilbee.server import handlers
+from lilbee.store import SearchChunk
 
 
 @pytest.fixture(autouse=True)
@@ -70,16 +71,18 @@ class TestSearch:
     @patch("lilbee.query.search_context")
     async def test_returns_grouped_results(self, mock_search):
         mock_search.return_value = [
-            {
-                "source": "doc.pdf",
-                "content_type": "pdf",
-                "chunk": "hello",
-                "_distance": 0.2,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="doc.pdf",
+                content_type="pdf",
+                chunk="hello",
+                distance=0.2,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         result = await handlers.search("test", top_k=3)
         assert len(result) == 1
@@ -100,18 +103,18 @@ class TestAsk:
         mock_ask.return_value = AskResult(
             answer="42",
             sources=[
-                {
-                    "source": "doc.pdf",
-                    "content_type": "pdf",
-                    "page_start": 1,
-                    "page_end": 1,
-                    "line_start": 0,
-                    "line_end": 0,
-                    "chunk": "c",
-                    "chunk_index": 0,
-                    "_distance": 0.1,
-                    "vector": [0.1],
-                }
+                SearchChunk(
+                    source="doc.pdf",
+                    content_type="pdf",
+                    page_start=1,
+                    page_end=1,
+                    line_start=0,
+                    line_end=0,
+                    chunk="c",
+                    chunk_index=0,
+                    distance=0.1,
+                    vector=[0.1],
+                )
             ],
         )
         result = await handlers.ask("what?")
@@ -143,16 +146,18 @@ class TestAskStream:
     @patch("lilbee.query.search_context")
     async def test_yields_token_sources_done(self, mock_search):
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         mock_chunk = MagicMock()
         mock_chunk.message.content = "answer"
@@ -169,16 +174,18 @@ class TestAskStream:
     @patch("lilbee.query.search_context")
     async def test_ollama_error_yields_error_event(self, mock_search):
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
 
         with patch("ollama.chat", side_effect=RuntimeError("model missing")):
@@ -195,16 +202,18 @@ class TestAskStream:
         import threading
 
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         barrier = threading.Event()
 
@@ -237,16 +246,18 @@ class TestAskStream:
         import threading
 
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         barrier = threading.Event()
 
@@ -276,16 +287,18 @@ class TestAskStream:
     async def test_skips_empty_tokens(self, mock_search):
         """Chunks with empty content are not emitted."""
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         empty_chunk = MagicMock()
         empty_chunk.message.content = ""
@@ -323,16 +336,18 @@ class TestChatStream:
     @patch("lilbee.query.search_context")
     async def test_yields_events_with_history(self, mock_search):
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         mock_chunk = MagicMock()
         mock_chunk.message.content = "reply"
@@ -350,16 +365,18 @@ class TestChatStream:
     @patch("lilbee.query.search_context")
     async def test_ollama_error_yields_error_event(self, mock_search):
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         with patch("ollama.chat", side_effect=ConnectionError("ollama down")):
             events = [e async for e in handlers.chat_stream("q", [])]
@@ -375,16 +392,18 @@ class TestChatStream:
         import threading
 
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         barrier = threading.Event()
 
@@ -417,16 +436,18 @@ class TestChatStream:
         import threading
 
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         barrier = threading.Event()
 
@@ -456,16 +477,18 @@ class TestChatStream:
     async def test_skips_empty_tokens(self, mock_search):
         """Chunks with empty content are not emitted."""
         mock_search.return_value = [
-            {
-                "source": "a.pdf",
-                "content_type": "pdf",
-                "chunk": "text",
-                "_distance": 0.1,
-                "page_start": 1,
-                "page_end": 1,
-                "line_start": 0,
-                "line_end": 0,
-            }
+            SearchChunk(
+                source="a.pdf",
+                content_type="pdf",
+                chunk="text",
+                distance=0.1,
+                page_start=1,
+                page_end=1,
+                line_start=0,
+                line_end=0,
+                chunk_index=0,
+                vector=[0.1],
+            )
         ]
         empty_chunk = MagicMock()
         empty_chunk.message.content = ""

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,125 @@
+"""Tests for LanceDB store operations — hybrid search + FTS index lifecycle."""
+
+from unittest import mock
+
+import pytest
+
+from lilbee import store
+from lilbee.config import cfg
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path):
+    """Point store at a temp directory and reset FTS flag."""
+    original = cfg.lancedb_dir
+    cfg.lancedb_dir = tmp_path / "lancedb_test"
+    store._fts_index_ready = False
+    yield
+    cfg.lancedb_dir = original
+    store._fts_index_ready = False
+
+
+def _make_records(n=3):
+    dim = cfg.embedding_dim
+    return [
+        {
+            "source": f"doc{i}.md",
+            "content_type": "text",
+            "page_start": 0,
+            "page_end": 0,
+            "line_start": 0,
+            "line_end": 0,
+            "chunk": f"chunk number {i} with some text",
+            "chunk_index": i,
+            "vector": [float(i) / n] * dim,
+        }
+        for i in range(n)
+    ]
+
+
+class TestEnsureFtsIndex:
+    def test_noop_when_no_table(self):
+        store.ensure_fts_index()
+        assert not store._fts_index_ready
+
+    def test_creates_index_after_add(self):
+        store.add_chunks(_make_records())
+        store.ensure_fts_index()
+        assert store._fts_index_ready
+
+    def test_handles_exception_gracefully(self):
+        store.add_chunks(_make_records())
+        table = store._open_table(store.CHUNKS_TABLE)
+        assert table is not None
+        with mock.patch.object(
+            type(table),
+            "create_fts_index",
+            side_effect=RuntimeError("boom"),
+        ):
+            store.ensure_fts_index()
+            assert not store._fts_index_ready
+
+
+class TestFtsIndexStaleFlag:
+    def test_add_chunks_marks_stale(self):
+        store.add_chunks(_make_records())
+        store.ensure_fts_index()
+        assert store._fts_index_ready
+        store.add_chunks(_make_records(1))
+        assert not store._fts_index_ready
+
+    def test_drop_all_marks_stale(self):
+        store.add_chunks(_make_records())
+        store.ensure_fts_index()
+        assert store._fts_index_ready
+        store.drop_all()
+        assert not store._fts_index_ready
+
+
+class TestHybridSearch:
+    def test_hybrid_search_with_fts_index(self):
+        records = _make_records()
+        store.add_chunks(records)
+        store.ensure_fts_index()
+        query_vec = [0.5] * cfg.embedding_dim
+        results = store.search(query_vec, top_k=3, query_text="chunk number")
+        assert len(results) > 0
+        assert "_relevance_score" in results[0]
+
+    def test_fallback_to_vector_when_no_query_text(self):
+        records = _make_records()
+        store.add_chunks(records)
+        store.ensure_fts_index()
+        query_vec = [0.5] * cfg.embedding_dim
+        results = store.search(query_vec, top_k=3)
+        assert len(results) > 0
+        assert "_distance" in results[0]
+
+    def test_fallback_to_vector_when_no_fts_index(self):
+        records = _make_records()
+        store.add_chunks(records)
+        # Don't call ensure_fts_index, but patch it to not actually create
+        with mock.patch("lilbee.store.ensure_fts_index"):
+            query_vec = [0.5] * cfg.embedding_dim
+            results = store.search(query_vec, top_k=3, query_text="chunk")
+        assert len(results) > 0
+        assert "_distance" in results[0]
+
+    def test_hybrid_fallback_on_exception(self):
+        records = _make_records()
+        store.add_chunks(records)
+        store.ensure_fts_index()
+        query_vec = [0.5] * cfg.embedding_dim
+        with mock.patch("lilbee.store._hybrid_search", side_effect=RuntimeError("boom")):
+            results = store.search(query_vec, top_k=3, query_text="chunk")
+        assert len(results) > 0
+        assert "_distance" in results[0]
+
+    def test_auto_ensures_fts_index_when_query_text(self):
+        records = _make_records()
+        store.add_chunks(records)
+        assert not store._fts_index_ready
+        query_vec = [0.5] * cfg.embedding_dim
+        results = store.search(query_vec, top_k=3, query_text="chunk number")
+        assert store._fts_index_ready
+        assert len(results) > 0

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -13,10 +13,10 @@ def isolated_db(tmp_path):
     """Point store at a temp directory and reset FTS flag."""
     original = cfg.lancedb_dir
     cfg.lancedb_dir = tmp_path / "lancedb_test"
-    store._fts_index_ready = False
+    store._fts.ready = False
     yield
     cfg.lancedb_dir = original
-    store._fts_index_ready = False
+    store._fts.ready = False
 
 
 def _make_records(n=3):
@@ -40,12 +40,12 @@ def _make_records(n=3):
 class TestEnsureFtsIndex:
     def test_noop_when_no_table(self):
         store.ensure_fts_index()
-        assert not store._fts_index_ready
+        assert not store._fts.ready
 
     def test_creates_index_after_add(self):
         store.add_chunks(_make_records())
         store.ensure_fts_index()
-        assert store._fts_index_ready
+        assert store._fts.ready
 
     def test_handles_exception_gracefully(self):
         store.add_chunks(_make_records())
@@ -57,23 +57,23 @@ class TestEnsureFtsIndex:
             side_effect=RuntimeError("boom"),
         ):
             store.ensure_fts_index()
-            assert not store._fts_index_ready
+            assert not store._fts.ready
 
 
 class TestFtsIndexStaleFlag:
     def test_add_chunks_marks_stale(self):
         store.add_chunks(_make_records())
         store.ensure_fts_index()
-        assert store._fts_index_ready
+        assert store._fts.ready
         store.add_chunks(_make_records(1))
-        assert not store._fts_index_ready
+        assert not store._fts.ready
 
     def test_drop_all_marks_stale(self):
         store.add_chunks(_make_records())
         store.ensure_fts_index()
-        assert store._fts_index_ready
+        assert store._fts.ready
         store.drop_all()
-        assert not store._fts_index_ready
+        assert not store._fts.ready
 
 
 class TestHybridSearch:
@@ -84,7 +84,7 @@ class TestHybridSearch:
         query_vec = [0.5] * cfg.embedding_dim
         results = store.search(query_vec, top_k=3, query_text="chunk number")
         assert len(results) > 0
-        assert "_relevance_score" in results[0]
+        assert results[0].relevance_score is not None
 
     def test_fallback_to_vector_when_no_query_text(self):
         records = _make_records()
@@ -93,7 +93,7 @@ class TestHybridSearch:
         query_vec = [0.5] * cfg.embedding_dim
         results = store.search(query_vec, top_k=3)
         assert len(results) > 0
-        assert "_distance" in results[0]
+        assert results[0].distance is not None
 
     def test_fallback_to_vector_when_no_fts_index(self):
         records = _make_records()
@@ -103,7 +103,7 @@ class TestHybridSearch:
             query_vec = [0.5] * cfg.embedding_dim
             results = store.search(query_vec, top_k=3, query_text="chunk")
         assert len(results) > 0
-        assert "_distance" in results[0]
+        assert results[0].distance is not None
 
     def test_hybrid_fallback_on_exception(self):
         records = _make_records()
@@ -113,13 +113,13 @@ class TestHybridSearch:
         with mock.patch("lilbee.store._hybrid_search", side_effect=RuntimeError("boom")):
             results = store.search(query_vec, top_k=3, query_text="chunk")
         assert len(results) > 0
-        assert "_distance" in results[0]
+        assert results[0].distance is not None
 
     def test_auto_ensures_fts_index_when_query_text(self):
         records = _make_records()
         store.add_chunks(records)
-        assert not store._fts_index_ready
+        assert not store._fts.ready
         query_vec = [0.5] * cfg.embedding_dim
         results = store.search(query_vec, top_k=3, query_text="chunk number")
-        assert store._fts_index_ready
+        assert store._fts.ready
         assert len(results) > 0


### PR DESCRIPTION
Hybrid search using LanceDB's built-in tantivy FTS index and `RRFReranker`. No new dependencies or config needed.

- Combines vector similarity with keyword matching via RRF reranking
- FTS index rebuilds automatically after `sync`
- Falls back to vector-only when FTS index is unavailable or hybrid search fails
- Replaces `SearchChunk` TypedDict with a Pydantic model — dot access everywhere, no more underscore-prefixed LanceDB field names leaking through


Also, redesign website 😬 