### PR TITLE
fix interactive CLI issues as well as release packaging issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
             asset_name: lilbee-linux-x86_64
           - os: macos-latest
             asset_name: lilbee-macos-arm64
+          - os: macos-13
+            asset_name: lilbee-macos-x86_64
           - os: windows-latest
             asset_name: lilbee-windows-x86_64.exe
 
@@ -61,7 +63,11 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync && uv pip install pyinstaller
+        run: |
+          uv sync && uv pip install pyinstaller
+          # python-multipart's `multipart/` package shadows the real `multipart.py`
+          # in frozen PyInstaller builds, causing an ImportError. Nothing uses it.
+          uv pip uninstall python-multipart
 
       - name: Build executable
         run: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lilbee"
-version = "0.5.0"
+version = "0.5.1"
 description = "Local knowledge base for documents and code. Search, ask questions, or chat — standalone or as an AI agent backend via MCP. Fully offline with Ollama."
 readme = "README.md"
 license = "MIT"
@@ -13,6 +13,7 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
+    "Environment :: Web Environment",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -23,6 +24,7 @@ classifiers = [
     "Topic :: Text Processing :: Indexing",
     "Typing :: Typed",
 ]
+
 dependencies = [
     "ollama",
     "lancedb",
@@ -41,7 +43,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/tobocop2/lilbee"
+Homepage = "https://tobocop2.github.io/lilbee/"
 Repository = "https://github.com/tobocop2/lilbee"
 Issues = "https://github.com/tobocop2/lilbee/issues"
 

--- a/src/lilbee/cli/chat/sync.py
+++ b/src/lilbee/cli/chat/sync.py
@@ -11,7 +11,8 @@ from typing import TYPE_CHECKING, Any
 from rich.console import Console
 
 from lilbee.cli import theme
-from lilbee.progress import EventType
+from lilbee.ingest import sync
+from lilbee.progress import EventType, ExtractEvent, FileStartEvent, SyncDoneEvent
 
 if TYPE_CHECKING:
     from lilbee.progress import DetailedProgressCallback
@@ -26,7 +27,6 @@ def _format_sync_summary(added: int, updated: int, removed: int, failed: int) ->
 
 def _sync_progress_printer(con: Console) -> DetailedProgressCallback:
     """Return a callback that prints one-line status for FILE_START and DONE events."""
-    from lilbee.progress import FileStartEvent, SyncDoneEvent
 
     def _callback(event_type: EventType, data: dict[str, Any]) -> None:
         if event_type == EventType.FILE_START:
@@ -99,6 +99,7 @@ class SyncStatus:
 
     def __init__(self) -> None:
         self.text: str = ""
+        self.pending: int = 0
 
     def clear(self) -> None:
         self.text = ""
@@ -111,14 +112,19 @@ def _chat_sync_callback(status: SyncStatus) -> DetailedProgressCallback:
     toolbar).  On DONE the status is cleared and the summary is printed via
     ``print()`` (goes through StdoutProxy → appears above the prompt).
     """
-    from lilbee.progress import FileStartEvent, SyncDoneEvent
 
     status.clear()
 
     def _callback(event_type: EventType, data: dict[str, Any]) -> None:
+        queue_suffix = f" (+{status.pending} queued)" if status.pending > 0 else ""
         if event_type == EventType.FILE_START:
             ev = FileStartEvent(**data)
-            status.text = f"⟳ Syncing [{ev.current_file}/{ev.total_files}]: {ev.file}"
+            status.text = f"⟳ Syncing [{ev.current_file}/{ev.total_files}]: {ev.file}{queue_suffix}"
+        elif event_type == EventType.EXTRACT:
+            ev_ext = ExtractEvent(**data)
+            status.text = (
+                f"⟳ Vision OCR [{ev_ext.page}/{ev_ext.total_pages}]: {ev_ext.file}{queue_suffix}"
+            )
         elif event_type == EventType.DONE:
             status.clear()
             ev_done = SyncDoneEvent(**data)
@@ -139,15 +145,18 @@ def run_sync_background(
     sync_status: SyncStatus | None = None,
 ) -> Future[object]:
     """Submit sync to a background thread. Returns the Future."""
-    from lilbee.ingest import sync
 
-    if chat_mode:
-        callback = _chat_sync_callback(sync_status or SyncStatus())
-    else:
-        callback = _sync_progress_printer(con)
+    status = sync_status or SyncStatus()
+
+    callback = _chat_sync_callback(status) if chat_mode else _sync_progress_printer(con)
 
     def _run() -> object:
+        if chat_mode:
+            status.pending -= 1
         return asyncio.run(sync(quiet=True, on_progress=callback, force_vision=force_vision))
+
+    if chat_mode:
+        status.pending += 1
 
     future = _get_executor().submit(_run)
     future.add_done_callback(lambda f: _on_sync_done(con, f, chat_mode=chat_mode))

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -10,7 +10,14 @@ from pathlib import Path
 from typing import Any, TypedDict, cast
 
 from pydantic import BaseModel
-from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
 
 from lilbee import embedder, store
 from lilbee.chunker import chunk_text
@@ -26,7 +33,9 @@ from lilbee.progress import (
     FileStartEvent,
     SyncDoneEvent,
     noop_callback,
+    shared_progress,
 )
+from lilbee.vision import extract_pdf_vision
 
 log = logging.getLogger(__name__)
 
@@ -248,15 +257,16 @@ async def _vision_fallback(
     source_name: str,
     content_type: str,
     on_progress: DetailedProgressCallback = noop_callback,
+    *,
+    quiet: bool = False,
 ) -> list[ChunkRecord]:
     """OCR a scanned PDF via vision model, chunk, and embed."""
-    from lilbee.vision import extract_pdf_vision
 
     page_texts = await asyncio.to_thread(
         extract_pdf_vision,
         path,
         cfg.vision_model,
-        quiet=cfg.json_mode,
+        quiet=quiet,
         timeout=cfg.vision_timeout,
         on_progress=on_progress,
     )
@@ -293,6 +303,7 @@ async def ingest_document(
     content_type: str,
     *,
     force_vision: bool = False,
+    quiet: bool = False,
     on_progress: DetailedProgressCallback = noop_callback,
 ) -> list[ChunkRecord]:
     """Extract and chunk a document via kreuzberg, embed, return records.
@@ -324,7 +335,7 @@ async def ingest_document(
                 )
                 return []
             log.info("PDF text extraction empty, falling back to vision OCR: %s", source_name)
-            return await _vision_fallback(path, source_name, content_type, on_progress)
+            return await _vision_fallback(path, source_name, content_type, on_progress, quiet=quiet)
 
         log.info(
             "Scanned PDF detected — extracted with Tesseract OCR: %s. "
@@ -424,6 +435,7 @@ async def _ingest_file(
     content_type: str,
     *,
     force_vision: bool = False,
+    quiet: bool = False,
     on_progress: DetailedProgressCallback = noop_callback,
 ) -> int:
     """Ingest a single file. Returns chunk count."""
@@ -438,6 +450,7 @@ async def _ingest_file(
             source_name,
             content_type,
             force_vision=force_vision,
+            quiet=quiet,
             on_progress=on_progress,
         )
     return await asyncio.to_thread(store.add_chunks, cast(list[dict], records))
@@ -569,6 +582,7 @@ async def ingest_batch(
                     name,
                     content_type,
                     force_vision=force_vision,
+                    quiet=quiet,
                     on_progress=on_progress,
                 )
                 on_progress(
@@ -589,15 +603,33 @@ async def ingest_batch(
                 )
                 return _IngestResult(name, path, 0, error=exc)
 
-    tasks = [
-        asyncio.ensure_future(_process_one(name, path, ct, idx))
-        for idx, (name, path, ct) in enumerate(files_to_process, 1)
-    ]
-
     if quiet:
+        tasks = [
+            asyncio.ensure_future(_process_one(name, path, ct, idx))
+            for idx, (name, path, ct) in enumerate(files_to_process, 1)
+        ]
         await _collect_results(tasks, added, updated, failed, on_progress=on_progress)
     else:
-        await _collect_results_with_progress(tasks, added, updated, failed, on_progress=on_progress)
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            transient=True,
+        ) as progress:
+            ptask = progress.add_task("Ingesting documents...", total=total_files)
+            token = shared_progress.set((progress, ptask))
+            try:
+                tasks = [
+                    asyncio.ensure_future(_process_one(name, path, ct, idx))
+                    for idx, (name, path, ct) in enumerate(files_to_process, 1)
+                ]
+                await _collect_results_with_progress(
+                    progress, ptask, tasks, added, updated, failed, on_progress=on_progress
+                )
+            finally:
+                shared_progress.reset(token)
 
 
 async def _collect_results(
@@ -625,6 +657,8 @@ async def _collect_results(
 
 
 async def _collect_results_with_progress(
+    progress: Progress,
+    ptask: Any,
     tasks: list[asyncio.Task[_IngestResult]],
     added: list[str],
     updated: list[str],
@@ -632,29 +666,23 @@ async def _collect_results_with_progress(
     *,
     on_progress: DetailedProgressCallback = noop_callback,
 ) -> None:
-    """Collect task results with Rich progress bar."""
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("{task.description}"),
-        transient=True,
-    ) as progress:
-        ptask = progress.add_task("Ingesting documents...", total=len(tasks))
-        for completed_count, fut in enumerate(asyncio.as_completed(tasks), 1):
-            result = await fut
-            _apply_result(result, added, updated, failed)
-            desc = f"Ingested {result.name}" if result.error is None else f"Failed {result.name}"
-            progress.update(ptask, description=desc)
-            progress.advance(ptask)
-            progress_status = "failed" if result.error is not None else "ingested"
-            on_progress(
-                EventType.BATCH_PROGRESS,
-                BatchProgressEvent(
-                    file=result.name,
-                    status=progress_status,
-                    current=completed_count,
-                    total=len(tasks),
-                ).model_dump(),
-            )
+    """Collect task results, updating an existing Rich progress bar."""
+    for completed_count, fut in enumerate(asyncio.as_completed(tasks), 1):
+        result = await fut
+        _apply_result(result, added, updated, failed)
+        desc = f"Ingested {result.name}" if result.error is None else f"Failed {result.name}"
+        progress.update(ptask, description=desc)
+        progress.advance(ptask)
+        progress_status = "failed" if result.error is not None else "ingested"
+        on_progress(
+            EventType.BATCH_PROGRESS,
+            BatchProgressEvent(
+                file=result.name,
+                status=progress_status,
+                current=completed_count,
+                total=len(tasks),
+            ).model_dump(),
+        )
 
 
 def _apply_result(

--- a/src/lilbee/progress.py
+++ b/src/lilbee/progress.py
@@ -1,6 +1,7 @@
 """Granular progress callback protocol for streaming pipeline events."""
 
 from collections.abc import Callable
+from contextvars import ContextVar
 from enum import StrEnum
 from typing import Any
 
@@ -19,6 +20,10 @@ class EventType(StrEnum):
 
 
 DetailedProgressCallback = Callable[[EventType, dict[str, Any]], None]
+
+# When set, vision updates the batch task's description instead of creating its own bar.
+# Value is (Progress, batch_task_id).
+shared_progress: ContextVar[tuple[Any, Any] | None] = ContextVar("shared_progress", default=None)
 
 
 def noop_callback(event_type: EventType, data: dict[str, Any]) -> None:
@@ -48,6 +53,14 @@ class BatchProgressEvent(BaseModel):
     status: str
     current: int
     total: int
+
+
+class ExtractEvent(BaseModel):
+    """Emitted per page during vision OCR extraction."""
+
+    file: str
+    page: int
+    total_pages: int
 
 
 class SyncDoneEvent(BaseModel):

--- a/src/lilbee/vision.py
+++ b/src/lilbee/vision.py
@@ -13,7 +13,7 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any
 
-from lilbee.progress import DetailedProgressCallback, EventType, noop_callback
+from lilbee.progress import DetailedProgressCallback, EventType, noop_callback, shared_progress
 
 log = logging.getLogger(__name__)
 
@@ -24,6 +24,33 @@ _OCR_PROMPT = (
 )
 
 _RASTER_DPI = 150
+
+
+class _SharedTask:
+    """Updates the batch task's description with per-page vision progress."""
+
+    def __init__(self, progress: Any, batch_task: Any, name: str, total: int) -> None:
+        self._progress = progress
+        self._batch_task = batch_task
+        self._name = name
+        self._total = total
+        self._current = 0
+
+    def __enter__(self) -> "_SharedTask":
+        self._progress.update(
+            self._batch_task, description=f"Vision OCR {self._name} (0/{self._total})"
+        )
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        pass  # batch loop updates the description after each file completes
+
+    def advance(self, _task_id: Any) -> None:
+        self._current += 1
+        self._progress.update(
+            self._batch_task,
+            description=f"Vision OCR {self._name} ({self._current}/{self._total})",
+        )
 
 
 def pdf_page_count(path: Path) -> int:
@@ -78,6 +105,12 @@ def _make_progress(name: str, total: int, quiet: bool) -> tuple[AbstractContextM
     """Return (context_manager, task_id | None) for optional Rich progress."""
     if quiet:
         return contextlib.nullcontext(), None
+
+    parent = shared_progress.get(None)
+    if parent is not None:
+        progress, batch_task = parent
+        return _SharedTask(progress, batch_task, name, total), batch_task
+
     from rich.console import Console
     from rich.progress import (  # lazy: heavy dependency
         BarColumn,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -470,6 +470,18 @@ class TestSyncToolbar:
         status = SyncStatus()
         assert sync_toolbar(status) == ""
 
+    def test_extract_event_updates_toolbar(self):
+        from lilbee.cli.chat.sync import SyncStatus, _chat_sync_callback
+        from lilbee.progress import EventType
+
+        status = SyncStatus()
+        callback = _chat_sync_callback(status)
+        callback(
+            EventType.EXTRACT,
+            {"file": "scan.pdf", "page": 2, "total_pages": 5},
+        )
+        assert status.text == "⟳ Vision OCR [2/5]: scan.pdf"
+
     def test_returns_empty_after_clear(self):
         from lilbee.cli.chat.loop import sync_toolbar
         from lilbee.cli.chat.sync import SyncStatus
@@ -478,3 +490,35 @@ class TestSyncToolbar:
         status.text = "something"
         status.clear()
         assert sync_toolbar(status) == ""
+
+    def test_pending_defaults_to_zero(self):
+        from lilbee.cli.chat.sync import SyncStatus
+
+        status = SyncStatus()
+        assert status.pending == 0
+
+    def test_toolbar_shows_queued_count(self):
+        from lilbee.cli.chat.sync import SyncStatus, _chat_sync_callback
+        from lilbee.progress import EventType
+
+        status = SyncStatus()
+        status.pending = 2
+        callback = _chat_sync_callback(status)
+        callback(
+            EventType.FILE_START,
+            {"file": "a.pdf", "current_file": 1, "total_files": 1},
+        )
+        assert "(+2 queued)" in status.text
+
+    def test_toolbar_no_queued_suffix_when_zero(self):
+        from lilbee.cli.chat.sync import SyncStatus, _chat_sync_callback
+        from lilbee.progress import EventType
+
+        status = SyncStatus()
+        status.pending = 0
+        callback = _chat_sync_callback(status)
+        callback(
+            EventType.FILE_START,
+            {"file": "a.pdf", "current_file": 1, "total_files": 1},
+        )
+        assert "queued" not in status.text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2527,7 +2527,7 @@ class TestSyncProgressPrinter:
 
 
 class TestRunSyncBackground:
-    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    @mock.patch("lilbee.cli.chat.sync.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_returns_immediately(self, _sync):
         from lilbee.cli.chat.sync import run_sync_background
 
@@ -2540,7 +2540,7 @@ class TestRunSyncBackground:
         _sync.assert_called_once()
 
     @mock.patch(
-        "lilbee.ingest.sync",
+        "lilbee.cli.chat.sync.sync",
         new_callable=AsyncMock,
         side_effect=RuntimeError("Ollama down"),
     )
@@ -2557,7 +2557,7 @@ class TestRunSyncBackground:
         assert "Background sync error" in con.print.call_args[0][0]
 
     @mock.patch(
-        "lilbee.ingest.sync",
+        "lilbee.cli.chat.sync.sync",
         new_callable=AsyncMock,
         side_effect=RuntimeError("Ollama down"),
     )
@@ -2572,7 +2572,7 @@ class TestRunSyncBackground:
         con.print.assert_not_called()
         assert "Background sync error" in capsys.readouterr().out
 
-    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    @mock.patch("lilbee.cli.chat.sync.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_passes_force_vision(self, mock_sync):
         from lilbee.cli.chat.sync import run_sync_background
 
@@ -2582,7 +2582,7 @@ class TestRunSyncBackground:
         mock_sync.assert_called_once()
         assert mock_sync.call_args[1]["force_vision"] is True
 
-    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    @mock.patch("lilbee.cli.chat.sync.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_chat_mode_uses_status_callback(self, mock_sync):
         from lilbee.cli.chat.sync import SyncStatus, run_sync_background
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -703,7 +703,6 @@ class TestVisionFallback:
         """When PDF extraction is empty and vision_model is set, fall back to vision."""
         cfg.vision_model = "test-vision"
         cfg.vision_timeout = 45.0
-        cfg.json_mode = True
         # Called twice: initial extraction + Tesseract OCR (both empty)
         empty = _make_empty_result()
         mock_kf.side_effect = [empty, empty]
@@ -717,13 +716,59 @@ class TestVisionFallback:
         ) as mock_vision:
             from lilbee.ingest import ingest_document
 
-            result = await ingest_document(f, "scanned.pdf", "pdf")
+            result = await ingest_document(f, "scanned.pdf", "pdf", quiet=True)
         mock_vision.assert_called_once_with(
             f, "test-vision", quiet=True, timeout=45.0, on_progress=mock.ANY
         )
         assert len(result) > 0
         assert result[0]["content_type"] == "pdf"
         assert result[0]["page_start"] == 1
+
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
+    async def test_vision_fallback_quiet_false_by_default(self, mock_kf, _eb, isolated_env):
+        """Without quiet=True, vision fallback passes quiet=False."""
+        cfg.vision_model = "test-vision"
+        cfg.vision_timeout = 120.0
+        empty = _make_empty_result()
+        mock_kf.side_effect = [empty, empty]
+
+        f = isolated_env / "scanned.pdf"
+        f.write_bytes(b"fake pdf")
+
+        vision_pages = [(1, "Vision extracted text. " * 10)]
+        with mock.patch(
+            "lilbee.vision.extract_pdf_vision", return_value=vision_pages
+        ) as mock_vision:
+            from lilbee.ingest import ingest_document
+
+            await ingest_document(f, "scanned.pdf", "pdf")
+        mock_vision.assert_called_once_with(
+            f, "test-vision", quiet=False, timeout=120.0, on_progress=mock.ANY
+        )
+
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
+    async def test_ingest_file_threads_quiet_to_vision(self, mock_kf, _eb, isolated_env):
+        """quiet=True flows from _ingest_file through ingest_document to vision."""
+        cfg.vision_model = "test-vision"
+        cfg.vision_timeout = 120.0
+        empty = _make_empty_result()
+        mock_kf.return_value = empty
+
+        f = isolated_env / "scanned.pdf"
+        f.write_bytes(b"fake pdf")
+
+        vision_pages = [(1, "Vision extracted text. " * 10)]
+        with mock.patch(
+            "lilbee.vision.extract_pdf_vision", return_value=vision_pages
+        ) as mock_vision:
+            from lilbee.ingest import _ingest_file
+
+            await _ingest_file(f, "scanned.pdf", "pdf", quiet=True)
+        mock_vision.assert_called_once_with(
+            f, "test-vision", quiet=True, timeout=120.0, on_progress=mock.ANY
+        )
 
     @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
@@ -846,7 +891,6 @@ class TestTesseractOcrMiddleTier:
         """When Tesseract OCR also yields < 50 chars, fall through to vision."""
         cfg.vision_model = "test-vision"
         cfg.vision_timeout = 120.0
-        cfg.json_mode = False
         empty = _make_empty_result()
         # Called twice: initial extraction + Tesseract OCR (both empty)
         mock_kf.side_effect = [empty, empty]
@@ -902,7 +946,6 @@ class TestTesseractOcrMiddleTier:
         """When force_vision=True, Tesseract OCR tier is skipped entirely."""
         cfg.vision_model = "test-vision"
         cfg.vision_timeout = 120.0
-        cfg.json_mode = False
         empty = _make_empty_result()
         mock_kf.return_value = empty
 
@@ -940,7 +983,6 @@ class TestTesseractOcrMiddleTier:
         """With vision_model set, Tesseract is skipped — vision takes precedence."""
         cfg.vision_model = "test-vision"
         cfg.vision_timeout = 120.0
-        cfg.json_mode = False
         empty = _make_empty_result()
         mock_kf.return_value = empty
 
@@ -955,6 +997,73 @@ class TestTesseractOcrMiddleTier:
         # extract_file called only once (initial extraction), Tesseract skipped
         assert mock_kf.call_count == 1
         assert len(result) > 0
+
+
+class TestSharedProgress:
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch(
+        "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
+    )
+    async def test_contextvar_set_during_progress(self, _kf, _eb, _vm, isolated_env):
+        """shared_progress contextvar is set inside _collect_results_with_progress."""
+        from lilbee.progress import shared_progress
+
+        (isolated_env / "a.txt").write_text("Content for shared progress test.")
+
+        captured: list[tuple] = []
+
+        # Use on_progress callback to capture the contextvar value during ingestion
+        def capture_progress(event_type, data):
+            val = shared_progress.get(None)
+            if val is not None and val not in captured:
+                captured.append(val)
+
+        from lilbee.ingest import sync
+
+        await sync(quiet=False, on_progress=capture_progress)
+        assert len(captured) > 0, "shared_progress was never set during progress bar"
+        progress_obj, task_id = captured[0]
+        assert progress_obj is not None
+        assert task_id is not None
+
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch(
+        "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
+    )
+    async def test_contextvar_not_set_in_quiet_mode(self, _kf, _eb, _vm, isolated_env):
+        """shared_progress contextvar is NOT set in quiet mode (no progress bar)."""
+        from lilbee.progress import shared_progress
+
+        (isolated_env / "b.txt").write_text("Content for quiet mode test.")
+
+        captured: list[object] = []
+
+        def capture_progress(event_type, data):
+            val = shared_progress.get(None)
+            if val is not None:
+                captured.append(val)
+
+        from lilbee.ingest import sync
+
+        await sync(quiet=True, on_progress=capture_progress)
+        assert len(captured) == 0, "shared_progress should not be set in quiet mode"
+
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch(
+        "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
+    )
+    async def test_contextvar_reset_after_progress(self, _kf, _eb, _vm, isolated_env):
+        """shared_progress is reset to None after _collect_results_with_progress completes."""
+        from lilbee.progress import shared_progress
+
+        (isolated_env / "c.txt").write_text("Content for reset test.")
+        from lilbee.ingest import sync
+
+        await sync(quiet=False)
+        assert shared_progress.get(None) is None
 
 
 class TestKreuzbergOcrConfig:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -712,7 +712,7 @@ class TestVisionFallback:
 
         vision_pages = [(1, "Vision extracted text. " * 10)]
         with mock.patch(
-            "lilbee.vision.extract_pdf_vision", return_value=vision_pages
+            "lilbee.ingest.extract_pdf_vision", return_value=vision_pages
         ) as mock_vision:
             from lilbee.ingest import ingest_document
 
@@ -738,7 +738,7 @@ class TestVisionFallback:
 
         vision_pages = [(1, "Vision extracted text. " * 10)]
         with mock.patch(
-            "lilbee.vision.extract_pdf_vision", return_value=vision_pages
+            "lilbee.ingest.extract_pdf_vision", return_value=vision_pages
         ) as mock_vision:
             from lilbee.ingest import ingest_document
 
@@ -761,7 +761,7 @@ class TestVisionFallback:
 
         vision_pages = [(1, "Vision extracted text. " * 10)]
         with mock.patch(
-            "lilbee.vision.extract_pdf_vision", return_value=vision_pages
+            "lilbee.ingest.extract_pdf_vision", return_value=vision_pages
         ) as mock_vision:
             from lilbee.ingest import _ingest_file
 
@@ -779,7 +779,7 @@ class TestVisionFallback:
         f = isolated_env / "scanned.pdf"
         f.write_bytes(b"fake pdf")
 
-        with mock.patch("lilbee.vision.extract_pdf_vision") as mock_vision:
+        with mock.patch("lilbee.ingest.extract_pdf_vision") as mock_vision:
             from lilbee.ingest import ingest_document
 
             result = await ingest_document(f, "scanned.pdf", "pdf")
@@ -795,7 +795,7 @@ class TestVisionFallback:
         f = isolated_env / "doc.txt"
         f.write_text("")
 
-        with mock.patch("lilbee.vision.extract_pdf_vision") as mock_vision:
+        with mock.patch("lilbee.ingest.extract_pdf_vision") as mock_vision:
             from lilbee.ingest import ingest_document
 
             result = await ingest_document(f, "doc.txt", "text")
@@ -815,7 +815,7 @@ class TestVisionFallback:
         f = isolated_env / "blank.pdf"
         f.write_bytes(b"fake pdf")
 
-        with mock.patch("lilbee.vision.extract_pdf_vision", return_value=[]):
+        with mock.patch("lilbee.ingest.extract_pdf_vision", return_value=[]):
             from lilbee.ingest import ingest_document
 
             result = await ingest_document(f, "blank.pdf", "pdf")
@@ -832,7 +832,7 @@ class TestVisionFallback:
         f = isolated_env / "good.pdf"
         f.write_bytes(b"fake pdf")
 
-        with mock.patch("lilbee.vision.extract_pdf_vision") as mock_vision:
+        with mock.patch("lilbee.ingest.extract_pdf_vision") as mock_vision:
             from lilbee.ingest import ingest_document
 
             result = await ingest_document(f, "good.pdf", "pdf")
@@ -851,7 +851,7 @@ class TestVisionFallback:
         f.write_bytes(b"fake pdf")
 
         with (
-            mock.patch("lilbee.vision.extract_pdf_vision", return_value=[(1, "Some text")]),
+            mock.patch("lilbee.ingest.extract_pdf_vision", return_value=[(1, "Some text")]),
             mock.patch("lilbee.ingest.chunk_text", return_value=[]),
         ):
             from lilbee.ingest import ingest_document
@@ -877,7 +877,7 @@ class TestTesseractOcrMiddleTier:
         f = isolated_env / "scanned.pdf"
         f.write_bytes(b"fake pdf")
 
-        with mock.patch("lilbee.vision.extract_pdf_vision") as mock_vision:
+        with mock.patch("lilbee.ingest.extract_pdf_vision") as mock_vision:
             from lilbee.ingest import ingest_document
 
             result = await ingest_document(f, "scanned.pdf", "pdf")
@@ -900,7 +900,7 @@ class TestTesseractOcrMiddleTier:
 
         vision_pages = [(1, "Vision extracted text. " * 10)]
         with mock.patch(
-            "lilbee.vision.extract_pdf_vision", return_value=vision_pages
+            "lilbee.ingest.extract_pdf_vision", return_value=vision_pages
         ) as mock_vision:
             from lilbee.ingest import ingest_document
 
@@ -953,7 +953,7 @@ class TestTesseractOcrMiddleTier:
         f.write_bytes(b"fake pdf")
 
         vision_pages = [(1, "Vision extracted text. " * 10)]
-        with mock.patch("lilbee.vision.extract_pdf_vision", return_value=vision_pages):
+        with mock.patch("lilbee.ingest.extract_pdf_vision", return_value=vision_pages):
             from lilbee.ingest import ingest_document
 
             result = await ingest_document(f, "scanned.pdf", "pdf", force_vision=True)
@@ -990,7 +990,7 @@ class TestTesseractOcrMiddleTier:
         f.write_bytes(b"fake pdf")
 
         vision_pages = [(1, "Vision extracted text. " * 10)]
-        with mock.patch("lilbee.vision.extract_pdf_vision", return_value=vision_pages):
+        with mock.patch("lilbee.ingest.extract_pdf_vision", return_value=vision_pages):
             from lilbee.ingest import ingest_document
 
             result = await ingest_document(f, "scanned.pdf", "pdf")

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -410,3 +410,100 @@ class TestExtractPdfVision:
 
         assert result == [(1, "All good.")]
         assert not any("pages failed" in r.message for r in caplog.records)
+
+
+class TestSharedTask:
+    def test_enter_returns_self_and_sets_description(self) -> None:
+        from lilbee.vision import _SharedTask
+
+        progress = mock.MagicMock()
+        st = _SharedTask(progress, batch_task=42, name="scan.pdf", total=10)
+        assert st.__enter__() is st
+        progress.update.assert_called_once_with(42, description="Vision OCR scan.pdf (0/10)")
+
+    def test_exit_is_noop(self) -> None:
+        from lilbee.vision import _SharedTask
+
+        progress = mock.MagicMock()
+        st = _SharedTask(progress, batch_task=7, name="x.pdf", total=3)
+        st.__exit__(None, None, None)
+        # exit should NOT remove any task — batch loop handles description after
+        progress.remove_task.assert_not_called()
+
+    def test_advance_updates_description(self) -> None:
+        from lilbee.vision import _SharedTask
+
+        progress = mock.MagicMock()
+        st = _SharedTask(progress, batch_task=3, name="doc.pdf", total=5)
+        st.advance(3)
+        progress.update.assert_called_with(3, description="Vision OCR doc.pdf (1/5)")
+        st.advance(3)
+        progress.update.assert_called_with(3, description="Vision OCR doc.pdf (2/5)")
+
+    def test_context_manager_full_cycle(self) -> None:
+        from lilbee.vision import _SharedTask
+
+        progress = mock.MagicMock()
+        st = _SharedTask(progress, batch_task=99, name="big.pdf", total=3)
+        with st as ctx:
+            assert ctx is st
+            ctx.advance(99)
+            ctx.advance(99)
+            ctx.advance(99)
+        # 1 from __enter__ + 3 from advance = 4 update calls
+        assert progress.update.call_count == 4
+        assert progress.update.call_args_list[-1] == mock.call(
+            99, description="Vision OCR big.pdf (3/3)"
+        )
+
+
+class TestMakeProgressShared:
+    def test_returns_shared_task_when_contextvar_set(self) -> None:
+        from lilbee.progress import shared_progress
+        from lilbee.vision import _make_progress, _SharedTask
+
+        mock_progress = mock.MagicMock()
+        batch_task = 42
+        token = shared_progress.set((mock_progress, batch_task))
+        try:
+            ctx, task_id = _make_progress("test.pdf", 5, quiet=False)
+            assert isinstance(ctx, _SharedTask)
+            assert task_id == batch_task
+        finally:
+            shared_progress.reset(token)
+
+    def test_returns_standalone_when_contextvar_unset(self) -> None:
+        from lilbee.progress import shared_progress
+        from lilbee.vision import _make_progress, _SharedTask
+
+        # Ensure contextvar is unset
+        assert shared_progress.get(None) is None
+
+        mock_progress = mock.MagicMock()
+        mock_progress.add_task.return_value = 0
+        mock_progress.__enter__ = mock.Mock(return_value=mock_progress)
+        mock_progress.__exit__ = mock.Mock(return_value=False)
+        mock_progress_cls = mock.MagicMock(return_value=mock_progress)
+
+        with mock.patch.dict(
+            "sys.modules",
+            {
+                "rich.progress": mock.MagicMock(
+                    Progress=mock_progress_cls,
+                    BarColumn=mock.MagicMock(),
+                    MofNCompleteColumn=mock.MagicMock(),
+                    TextColumn=mock.MagicMock(),
+                    TimeElapsedColumn=mock.MagicMock(),
+                ),
+            },
+        ):
+            ctx, task_id = _make_progress("test.pdf", 3, quiet=False)
+            assert not isinstance(ctx, _SharedTask)
+            assert task_id == 0
+
+    def test_quiet_returns_nullcontext(self) -> None:
+        from lilbee.vision import _make_progress, _SharedTask
+
+        ctx, task_id = _make_progress("test.pdf", 3, quiet=True)
+        assert task_id is None
+        assert not isinstance(ctx, _SharedTask)

--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "lilbee"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## What does this PR do?

The interactive CLI had some weirdness with multiple progress bars overwriting each other. This was specific to vision models. This has now been fixed and the vision model progress is in the grey bar at the bottom in interactive mode.

Next, the non interactive flags for add using say `lilbee add` had an issue for vision models as well and there were two progress bars stepping on each other. 

Finally, the release was broken due to an issue with a `multipart` package in python, Two packages both claim the name multipart. When Python runs normally it can tell them apart, but when we freeze the app into a single executable, it grabs the wrong one and crashes. This has been resolved in the release workflow. 


## Checklist

- [ ] `make check` passes (lint, format, typecheck, tests)
- [ ] Tests added or updated for new/changed code
- [ ] 100% test coverage maintained
