### PR TITLE
Retrieval quality Improvements (Phase 1): chunking, diversity, expansion, configurability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,13 @@ All settings override via environment variables:
 - `LILBEE_TOP_K` — retrieval result count (default: `5`)
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
 - `LILBEE_VISION_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
-- `LILBEE_LLM_PROVIDER` — backend: `llama-cpp` (default), `ollama`, `openai`, `huggingface`
+- `LILBEE_LLM_PROVIDER` — backend: `auto` (default), `llama-cpp`, `ollama`, `openai`
 - `LILBEE_LLM_BASE_URL` — Ollama endpoint (default: `http://localhost:11434`)
+- `LILBEE_DIVERSITY_MAX_PER_SOURCE` — max chunks per source in results (default: `3`)
+- `LILBEE_MMR_LAMBDA` — MMR relevance/diversity tradeoff, 0-1 (default: `0.5`)
+- `LILBEE_CANDIDATE_MULTIPLIER` — extra candidates for MMR reranking (default: `3`)
+- `LILBEE_QUERY_EXPANSION_COUNT` — LLM-generated query variants, 0=disabled (default: `3`)
+- `LILBEE_ADAPTIVE_THRESHOLD_STEP` — distance threshold widening step (default: `0.2`)
 - `LILBEE_LOG_LEVEL` — logging level: DEBUG, INFO, WARNING, ERROR (default: `WARNING`)
 
 CLI also accepts `--model` / `-m` for chat model, `--data-dir` / `-d`, `--vision-timeout`, and `--log-level`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 dependencies = [
     "lancedb",
-    "kreuzberg",
+    "kreuzberg>=4.5.0",
     "filelock",
     "tree-sitter>=0.25",
     "tree-sitter-language-pack>=0.7",
@@ -72,6 +72,7 @@ dev = [
     "reportlab",
     "ruff>=0.15.4",
     "httpx>=0.27",
+    "types-pyyaml>=6.0.12.20250915",
 ]
 
 [tool.pytest.ini_options]

--- a/src/lilbee/chunker.py
+++ b/src/lilbee/chunker.py
@@ -1,8 +1,12 @@
-"""Token-based recursive text chunking (used by code_chunker fallback)."""
+"""Token-based recursive text chunking with markdown-aware heading splitting."""
+
+import re
 
 import tiktoken
 
 from lilbee.config import cfg
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 
 _enc = tiktoken.get_encoding("cl100k_base")
 
@@ -106,3 +110,72 @@ def chunk_text(
         chunks.append("\n\n".join(pending_segments))
 
     return chunks
+
+
+def _split_by_headings(text: str) -> list[tuple[list[str], str]]:
+    """Split markdown into sections, each with its heading hierarchy.
+
+    Returns a list of (heading_path, section_body) tuples.
+    heading_path is the current heading stack, e.g. ["# Setup", "## Install"].
+    """
+    sections: list[tuple[list[str], str]] = []
+    heading_stack: list[tuple[int, str]] = []
+    current_lines: list[str] = []
+
+    for line in text.split("\n"):
+        m = _HEADING_RE.match(line)
+        if m:
+            # Flush current section
+            body = "\n".join(current_lines).strip()
+            if body:
+                path = [h for _, h in heading_stack]
+                sections.append((list(path), body))
+            current_lines = []
+
+            level = len(m.group(1))
+            heading_text = f"{m.group(1)} {m.group(2)}"
+            # Pop headings at same or deeper level
+            while heading_stack and heading_stack[-1][0] >= level:
+                heading_stack.pop()
+            heading_stack.append((level, heading_text))
+        else:
+            current_lines.append(line)
+
+    # Flush final section
+    body = "\n".join(current_lines).strip()
+    if body:
+        path = [h for _, h in heading_stack]
+        sections.append((list(path), body))
+
+    return sections
+
+
+def chunk_markdown(
+    text: str,
+    chunk_size: int | None = None,
+    chunk_overlap: int | None = None,
+) -> list[str]:
+    """Split markdown into chunks respecting heading boundaries.
+
+    Each chunk is prefixed with its heading hierarchy so the LLM
+    knows the section context. Falls back to plain chunk_text()
+    for non-markdown or text with no headings.
+    """
+    if not text or not text.strip():
+        return []
+
+    sections = _split_by_headings(text)
+    if not sections:
+        return chunk_text(text, chunk_size, chunk_overlap)
+
+    chunks: list[str] = []
+    for path, body in sections:
+        prefix = " > ".join(path)
+        sub_chunks = chunk_text(body, chunk_size, chunk_overlap)
+        for sub in sub_chunks:
+            if prefix:
+                chunks.append(f"{prefix}\n\n{sub}")
+            else:
+                chunks.append(sub)
+
+    return chunks if chunks else chunk_text(text, chunk_size, chunk_overlap)

--- a/src/lilbee/code_chunker.py
+++ b/src/lilbee/code_chunker.py
@@ -36,12 +36,48 @@ def get_parser(lang_name: str) -> tree_sitter.Parser | None:
         return None
 
 
+def _node_name(node: tree_sitter.Node) -> str:
+    """Extract the identifier name from a definition node."""
+    for child in node.children:
+        if child.type in ("identifier", "name", "property_identifier"):
+            return child.text.decode("utf-8", errors="replace") if child.text else ""
+    return ""
+
+
+def _symbol_type(node_type: str) -> str:
+    """Map tree-sitter node type to a human-readable symbol kind."""
+    _MAP = {
+        "function_definition": "function",
+        "function_declaration": "function",
+        "function_item": "function",
+        "method_declaration": "method",
+        "method": "method",
+        "class_definition": "class",
+        "class_declaration": "class",
+        "class_specifier": "class",
+        "struct_item": "struct",
+        "struct_specifier": "struct",
+        "struct_definition": "struct",
+        "enum_item": "enum",
+        "interface_declaration": "interface",
+        "trait_item": "trait",
+        "type_alias_declaration": "type",
+        "type_declaration": "type",
+        "impl_item": "impl",
+        "module": "module",
+        "module_definition": "module",
+    }
+    return _MAP.get(node_type, node_type.replace("_", " "))
+
+
 def _node_span(node: tree_sitter.Node, source: bytes) -> dict:
-    """Extract text and line range from an AST node."""
+    """Extract text, line range, and symbol metadata from an AST node."""
     return {
         "text": source[node.start_byte : node.end_byte].decode("utf-8", errors="replace"),
         "line_start": node.start_point.row + 1,
         "line_end": node.end_point.row + 1,
+        "symbol_name": _node_name(node),
+        "symbol_type": _symbol_type(node.type),
     }
 
 
@@ -110,16 +146,23 @@ def chunk_code(file_path: Path) -> list[CodeChunk]:
     if not definitions:
         return _fallback_chunks(source_text)
 
-    prefix = f"# File: {file_path}\n\n"
-    return [
-        CodeChunk(
-            chunk=prefix + d["text"],
-            line_start=d["line_start"],
-            line_end=d["line_end"],
-            chunk_index=i,
+    chunks: list[CodeChunk] = []
+    for i, d in enumerate(definitions):
+        header = f"# File: {file_path}"
+        name = d.get("symbol_name", "")
+        kind = d.get("symbol_type", "")
+        if name and kind:
+            header += f" | {kind}: {name}"
+        header += f" (lines {d['line_start']}-{d['line_end']})"
+        chunks.append(
+            CodeChunk(
+                chunk=f"{header}\n\n{d['text']}",
+                line_start=d["line_start"],
+                line_end=d["line_end"],
+                chunk_index=i,
+            )
         )
-        for i, d in enumerate(definitions)
-    ]
+    return chunks
 
 
 def supported_extensions() -> set[str]:

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -70,6 +70,30 @@ class Config(BaseModel):
     llm_base_url: str = "http://localhost:11434"
     llm_api_key: str = ""
 
+    # Retrieval quality knobs — defaults chosen from research across gno, grantflow, QMD
+    # and academic literature (see docs/superpowers/specs/2026-03-22-feature-parity-design.md)
+
+    # Max chunks per source document in results. Prevents one large file from
+    # dominating all top-k slots. 3 balances coverage vs diversity.
+    diversity_max_per_source: int = Field(default=3, ge=1)
+
+    # MMR relevance/diversity tradeoff. 0.0 = max diversity, 1.0 = pure relevance.
+    # 0.5 is the standard default from Carbonell & Goldstein 1998.
+    mmr_lambda: float = Field(default=0.5, ge=0.0, le=1.0)
+
+    # How many extra candidates to retrieve for MMR reranking.
+    # 3x gives enough candidates to find diverse results without excessive latency.
+    candidate_multiplier: int = Field(default=3, ge=1)
+
+    # Number of LLM-generated alternative queries for expansion.
+    # 3 variants covers lexical + semantic angles. Set to 0 to disable expansion.
+    query_expansion_count: int = Field(default=3, ge=0)
+
+    # Cosine distance threshold step for adaptive widening.
+    # When too few results are found, threshold widens by this amount per retry.
+    # 0.2 gives 4 steps from typical 0.3 start to 1.0 cap.
+    adaptive_threshold_step: float = Field(default=0.2, gt=0.0)
+
     def generation_options(self, **overrides: Any) -> dict[str, Any]:
         """Build Ollama generation options from config fields and overrides.
 
@@ -151,6 +175,19 @@ class Config(BaseModel):
             llm_provider=env("LLM_PROVIDER", "auto"),
             llm_base_url=env("LLM_BASE_URL", "http://localhost:11434"),
             llm_api_key=env("LLM_API_KEY", ""),
+            diversity_max_per_source=_load_setting(
+                data_root, "diversity_max_per_source", "DIVERSITY_MAX_PER_SOURCE", 3, int
+            ),
+            mmr_lambda=_load_setting(data_root, "mmr_lambda", "MMR_LAMBDA", 0.5, float),
+            candidate_multiplier=_load_setting(
+                data_root, "candidate_multiplier", "CANDIDATE_MULTIPLIER", 3, int
+            ),
+            query_expansion_count=_load_setting(
+                data_root, "query_expansion_count", "QUERY_EXPANSION_COUNT", 3, int
+            ),
+            adaptive_threshold_step=_load_setting(
+                data_root, "adaptive_threshold_step", "ADAPTIVE_THRESHOLD_STEP", 0.2, float
+            ),
         )
 
 

--- a/src/lilbee/frontmatter.py
+++ b/src/lilbee/frontmatter.py
@@ -1,0 +1,82 @@
+"""Extract YAML frontmatter and inline hashtags from markdown files."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass, field
+
+_FRONTMATTER_RE = re.compile(r"^---\r?\n([\s\S]*?)(?:\r?\n)?---(?:\r?\n|$)")
+_CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```|`[^`\n]+`")
+_HASHTAG_RE = re.compile(r"(?<!\S)#([a-zA-Z][\w/-]*)")
+
+
+@dataclass(frozen=True)
+class FrontmatterResult:
+    """Parsed frontmatter metadata."""
+
+    title: str = ""
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    author: str = ""
+    date: str = ""
+    body: str = ""
+
+
+def _normalize_tag(tag: str) -> str:
+    """Normalize a tag: NFC unicode, lowercase, strip whitespace."""
+    return unicodedata.normalize("NFC", tag.strip().lower())
+
+
+def _extract_tags(raw: object) -> list[str]:
+    """Extract tags from various YAML formats (list, string, comma-separated)."""
+    if isinstance(raw, list):
+        return [_normalize_tag(str(t)) for t in raw if str(t).strip()]
+    if isinstance(raw, str):
+        return [_normalize_tag(t) for t in raw.split(",") if t.strip()]
+    return []
+
+
+def _extract_hashtags(text: str) -> list[str]:
+    """Extract inline #hashtags from body text, skipping code blocks."""
+    cleaned = _CODE_BLOCK_RE.sub("", text)
+    return [_normalize_tag(m.group(1)) for m in _HASHTAG_RE.finditer(cleaned)]
+
+
+def parse_frontmatter(text: str) -> FrontmatterResult:
+    """Parse YAML frontmatter and inline hashtags from markdown text.
+
+    Returns metadata and the body text with frontmatter stripped.
+    """
+    import yaml
+
+    body = text
+    title = ""
+    tags: list[str] = []
+    author = ""
+    date = ""
+
+    match = _FRONTMATTER_RE.match(text)
+    if match:
+        raw_yaml = match.group(1)
+        body = text[match.end() :]
+        try:
+            data = yaml.safe_load(raw_yaml)
+            if isinstance(data, dict):
+                title = str(data.get("title", ""))
+                tags = _extract_tags(data.get("tags"))
+                author = str(data.get("author", ""))
+                date_val = data.get("date", "")
+                date = str(date_val) if date_val else ""
+        except yaml.YAMLError:
+            pass
+
+    inline_tags = _extract_hashtags(body)
+    all_tags = list(dict.fromkeys(tags + inline_tags))
+
+    return FrontmatterResult(
+        title=title,
+        tags=tuple(all_tags),
+        author=author,
+        date=date,
+        body=body,
+    )

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -20,7 +20,7 @@ from rich.progress import (
 )
 
 from lilbee import embedder, store
-from lilbee.chunker import chunk_text
+from lilbee.chunker import chunk_markdown, chunk_text
 from lilbee.code_chunker import CodeChunk, chunk_code, supported_extensions
 from lilbee.config import cfg
 from lilbee.platform import is_ignored_dir
@@ -429,6 +429,37 @@ async def ingest_structured(
     ]
 
 
+async def ingest_markdown(
+    path: Path,
+    source_name: str,
+    on_progress: DetailedProgressCallback = noop_callback,
+) -> list[ChunkRecord]:
+    """Chunk a markdown file by heading boundaries, embed, return records."""
+    text = await asyncio.to_thread(path.read_text, encoding="utf-8")
+    if not text.strip():
+        return []
+    texts = chunk_markdown(text)
+    if not texts:
+        return []
+    vectors = await asyncio.to_thread(
+        embedder.embed_batch, texts, source=source_name, on_progress=on_progress
+    )
+    return [
+        ChunkRecord(
+            source=source_name,
+            content_type="text",
+            page_start=0,
+            page_end=0,
+            line_start=0,
+            line_end=0,
+            chunk=t,
+            chunk_index=idx,
+            vector=vec,
+        )
+        for idx, (t, vec) in enumerate(zip(texts, vectors, strict=True))
+    ]
+
+
 async def _ingest_file(
     path: Path,
     source_name: str,
@@ -444,6 +475,8 @@ async def _ingest_file(
         records = await asyncio.to_thread(ingest_code_sync, path, source_name, on_progress)
     elif content_type in _PREPROCESSORS:
         records = await ingest_structured(path, source_name, content_type, on_progress)
+    elif path.suffix.lower() == ".md":
+        records = await ingest_markdown(path, source_name, on_progress)
     else:
         records = await ingest_document(
             path,

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -435,7 +435,13 @@ async def ingest_markdown(
     on_progress: DetailedProgressCallback = noop_callback,
 ) -> list[ChunkRecord]:
     """Chunk a markdown file by heading boundaries, embed, return records."""
-    text = await asyncio.to_thread(path.read_text, encoding="utf-8")
+    from lilbee.frontmatter import parse_frontmatter
+
+    raw_text = await asyncio.to_thread(path.read_text, encoding="utf-8")
+    if not raw_text.strip():
+        return []
+    fm = parse_frontmatter(raw_text)
+    text = fm.body
     if not text.strip():
         return []
     texts = chunk_markdown(text)

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -99,12 +99,55 @@ def build_context(results: list[SearchChunk]) -> str:
     return "\n\n".join(parts)
 
 
+_EXPANSION_PROMPT = (
+    "Generate 2-3 alternative search queries for the following question. "
+    "Return ONLY the queries, one per line, no numbering or explanation.\n\n"
+    "Question: {question}"
+)
+
+_EXPANSION_TIMEOUT_TOKENS = 200
+
+
+def _expand_query(question: str) -> list[str]:
+    """Use the LLM to generate alternative query phrasings."""
+    try:
+        provider = get_provider()
+        messages = [{"role": "user", "content": _EXPANSION_PROMPT.format(question=question)}]
+        response = provider.chat(
+            messages, stream=False, options={"num_predict": _EXPANSION_TIMEOUT_TOKENS}
+        )
+        if not isinstance(response, str):
+            return []
+        variants = [line.strip() for line in response.strip().split("\n") if line.strip()]
+        return variants[:3]
+    except Exception:
+        return []
+
+
 def search_context(question: str, top_k: int = 0) -> list[SearchChunk]:
-    """Embed question and return top-K matching chunks."""
+    """Embed question and return top-K matching chunks.
+
+    Uses query expansion: generates alternative phrasings via LLM,
+    searches with each, and merges results (deduped by source+index).
+    """
     if top_k == 0:
         top_k = cfg.top_k
     query_vec = embedder.embed(question)
-    return store.search(query_vec, top_k=top_k, query_text=question)
+    results = store.search(query_vec, top_k=top_k, query_text=question)
+
+    variants = _expand_query(question)
+    if variants:
+        seen = {(r.source, r.chunk_index) for r in results}
+        for variant in variants:
+            variant_vec = embedder.embed(variant)
+            variant_results = store.search(variant_vec, top_k=top_k, query_text=variant)
+            for r in variant_results:
+                key = (r.source, r.chunk_index)
+                if key not in seen:
+                    results.append(r)
+                    seen.add(key)
+
+    return results
 
 
 class AskResult(BaseModel):

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -69,9 +69,26 @@ def _sort_key(r: SearchChunk) -> float:
     return float("inf")
 
 
+_MAX_PER_SOURCE = 3
+
+
 def sort_by_relevance(results: list[SearchChunk]) -> list[SearchChunk]:
     """Sort search results by relevance (works for both hybrid and vector results)."""
     return sorted(results, key=_sort_key)
+
+
+def diversify_sources(
+    results: list[SearchChunk], max_per_source: int = _MAX_PER_SOURCE
+) -> list[SearchChunk]:
+    """Cap results per source document to ensure diversity."""
+    counts: dict[str, int] = {}
+    diverse: list[SearchChunk] = []
+    for r in results:
+        count = counts.get(r.source, 0)
+        if count < max_per_source:
+            diverse.append(r)
+            counts[r.source] = count + 1
+    return diverse
 
 
 def build_context(results: list[SearchChunk]) -> str:
@@ -112,6 +129,7 @@ def ask_raw(
         )
 
     results = sort_by_relevance(results)
+    results = diversify_sources(results)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
 
@@ -153,6 +171,7 @@ def ask_stream(
         return
 
     results = sort_by_relevance(results)
+    results = diversify_sources(results)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
 

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -69,18 +69,17 @@ def _sort_key(r: SearchChunk) -> float:
     return float("inf")
 
 
-_MAX_PER_SOURCE = 3
-
-
 def sort_by_relevance(results: list[SearchChunk]) -> list[SearchChunk]:
     """Sort search results by relevance (works for both hybrid and vector results)."""
     return sorted(results, key=_sort_key)
 
 
 def diversify_sources(
-    results: list[SearchChunk], max_per_source: int = _MAX_PER_SOURCE
+    results: list[SearchChunk], max_per_source: int | None = None
 ) -> list[SearchChunk]:
     """Cap results per source document to ensure diversity."""
+    if max_per_source is None:
+        max_per_source = cfg.diversity_max_per_source
     counts: dict[str, int] = {}
     diverse: list[SearchChunk] = []
     for r in results:
@@ -100,26 +99,35 @@ def build_context(results: list[SearchChunk]) -> str:
 
 
 _EXPANSION_PROMPT = (
-    "Generate 2-3 alternative search queries for the following question. "
+    "Generate {count} alternative search queries for the following question. "
     "Return ONLY the queries, one per line, no numbering or explanation.\n\n"
     "Question: {question}"
 )
 
-_EXPANSION_TIMEOUT_TOKENS = 200
+# Token budget for the expansion LLM call
+_EXPANSION_MAX_TOKENS = 200
 
 
 def _expand_query(question: str) -> list[str]:
-    """Use the LLM to generate alternative query phrasings."""
+    """Use the LLM to generate alternative query phrasings.
+
+    Returns up to ``cfg.query_expansion_count`` variants.
+    Set ``LILBEE_QUERY_EXPANSION_COUNT=0`` to disable expansion entirely.
+    """
+    count = cfg.query_expansion_count
+    if count == 0:
+        return []
     try:
         provider = get_provider()
-        messages = [{"role": "user", "content": _EXPANSION_PROMPT.format(question=question)}]
+        prompt = _EXPANSION_PROMPT.format(count=count, question=question)
+        messages = [{"role": "user", "content": prompt}]
         response = provider.chat(
-            messages, stream=False, options={"num_predict": _EXPANSION_TIMEOUT_TOKENS}
+            messages, stream=False, options={"num_predict": _EXPANSION_MAX_TOKENS}
         )
         if not isinstance(response, str):
             return []
         variants = [line.strip() for line in response.strip().split("\n") if line.strip()]
-        return variants[:3]
+        return variants[:count]
     except Exception:
         return []
 

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -139,6 +139,7 @@ async def ask_stream(
     from lilbee.query import (
         _CONTEXT_TEMPLATE,
         build_context,
+        diversify_sources,
         search_context,
         sort_by_relevance,
     )
@@ -149,6 +150,7 @@ async def ask_stream(
         return
 
     results = sort_by_relevance(results)
+    results = diversify_sources(results)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
     messages: list[ChatMessage] = [{"role": "system", "content": cfg.system_prompt}]
@@ -231,6 +233,7 @@ async def chat_stream(
     from lilbee.query import (
         _CONTEXT_TEMPLATE,
         build_context,
+        diversify_sources,
         search_context,
         sort_by_relevance,
     )
@@ -241,6 +244,7 @@ async def chat_stream(
         return
 
     results = sort_by_relevance(results)
+    results = diversify_sources(results)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
     messages: list[ChatMessage] = [{"role": "system", "content": cfg.system_prompt}]

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -261,10 +261,28 @@ def search(
     rows = table.search(query_vector).metric("cosine").limit(candidate_k).to_list()
     results = [SearchChunk(**r) for r in rows]
     if max_distance > 0:
-        results = [r for r in results if (r.distance or 0) <= max_distance]
+        results = _adaptive_filter(results, top_k, max_distance)
     if len(results) > top_k:
         results = mmr_rerank(query_vector, results, top_k)
     return results
+
+
+_THRESHOLD_STEP = 0.2
+_MAX_THRESHOLD = 1.0
+
+
+def _adaptive_filter(
+    results: list[SearchChunk], top_k: int, initial_threshold: float
+) -> list[SearchChunk]:
+    """Widen cosine distance threshold when too few results, up to _MAX_THRESHOLD."""
+    cap = max(initial_threshold, _MAX_THRESHOLD)
+    threshold = initial_threshold
+    while threshold <= cap:
+        filtered = [r for r in results if (r.distance or 0) <= threshold]
+        if len(filtered) >= top_k:
+            return filtered
+        threshold += _THRESHOLD_STEP
+    return [r for r in results if (r.distance or 0) <= cap]
 
 
 def get_chunks_by_source(source: str) -> list[SearchChunk]:

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -50,7 +50,7 @@ class SearchChunk(BaseModel):
     relevance_score: float | None = Field(None, alias="_relevance_score")
 
 
-_DEFAULT_MMR_LAMBDA = 0.5
+_DEFAULT_MMR_LAMBDA = 0.5  # fallback if called without config
 
 
 def _cosine_sim(a: list[float], b: list[float]) -> float:
@@ -257,31 +257,34 @@ def search(
         except Exception:
             log.debug("Hybrid search failed, falling back to vector-only", exc_info=True)
 
-    candidate_k = top_k * 3
+    candidate_k = top_k * cfg.candidate_multiplier
     rows = table.search(query_vector).metric("cosine").limit(candidate_k).to_list()
     results = [SearchChunk(**r) for r in rows]
     if max_distance > 0:
         results = _adaptive_filter(results, top_k, max_distance)
     if len(results) > top_k:
-        results = mmr_rerank(query_vector, results, top_k)
+        results = mmr_rerank(query_vector, results, top_k, lam=cfg.mmr_lambda)
     return results
 
 
-_THRESHOLD_STEP = 0.2
 _MAX_THRESHOLD = 1.0
 
 
 def _adaptive_filter(
     results: list[SearchChunk], top_k: int, initial_threshold: float
 ) -> list[SearchChunk]:
-    """Widen cosine distance threshold when too few results, up to _MAX_THRESHOLD."""
+    """Widen cosine distance threshold when too few results.
+
+    Step size is ``cfg.adaptive_threshold_step`` (default 0.2).
+    """
     cap = max(initial_threshold, _MAX_THRESHOLD)
+    step = cfg.adaptive_threshold_step
     threshold = initial_threshold
     while threshold <= cap:
         filtered = [r for r in results if (r.distance or 0) <= threshold]
         if len(filtered) >= top_k:
             return filtered
-        threshold += _THRESHOLD_STEP
+        threshold += step
     return [r for r in results if (r.distance or 0) <= cap]
 
 

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -1,6 +1,7 @@
 """LanceDB vector store operations."""
 
 import logging
+import math
 from datetime import UTC, datetime, timedelta
 
 import lancedb
@@ -47,6 +48,52 @@ class SearchChunk(BaseModel):
     vector: list[float] = Field(repr=False)
     distance: float | None = Field(None, alias="_distance")
     relevance_score: float | None = Field(None, alias="_relevance_score")
+
+
+_DEFAULT_MMR_LAMBDA = 0.5
+
+
+def _cosine_sim(a: list[float], b: list[float]) -> float:
+    """Cosine similarity between two vectors."""
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def mmr_rerank(
+    query_vector: list[float],
+    results: list[SearchChunk],
+    top_k: int,
+    lam: float = _DEFAULT_MMR_LAMBDA,
+) -> list[SearchChunk]:
+    """Maximal Marginal Relevance — select diverse results.
+
+    Score = λ * sim(query, chunk) - (1-λ) * max_sim(chunk, selected)
+    """
+    if len(results) <= top_k:
+        return results
+
+    selected: list[SearchChunk] = []
+    remaining = list(results)
+
+    for _ in range(top_k):
+        best_score = -float("inf")
+        best_idx = 0
+        for i, candidate in enumerate(remaining):
+            relevance = _cosine_sim(query_vector, candidate.vector)
+            redundancy = 0.0
+            if selected:
+                redundancy = max(_cosine_sim(candidate.vector, s.vector) for s in selected)
+            score = lam * relevance - (1 - lam) * redundancy
+            if score > best_score:
+                best_score = score
+                best_idx = i
+        selected.append(remaining.pop(best_idx))
+
+    return selected
 
 
 def _chunks_schema() -> pa.Schema:
@@ -210,10 +257,13 @@ def search(
         except Exception:
             log.debug("Hybrid search failed, falling back to vector-only", exc_info=True)
 
-    rows = table.search(query_vector).metric("cosine").limit(top_k).to_list()
+    candidate_k = top_k * 3
+    rows = table.search(query_vector).metric("cosine").limit(candidate_k).to_list()
     results = [SearchChunk(**r) for r in rows]
     if max_distance > 0:
         results = [r for r in results if (r.distance or 0) <= max_distance]
+    if len(results) > top_k:
+        results = mmr_rerank(query_vector, results, top_k)
     return results
 
 

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -84,6 +84,75 @@ class TestSegmentsEmpty:
             assert result == []
 
 
+class TestChunkMarkdown:
+    def test_splits_on_headings(self):
+        from lilbee.chunker import chunk_markdown
+
+        md = "# Intro\n\nHello world.\n\n## Details\n\nSome details here."
+        chunks = chunk_markdown(md)
+        assert len(chunks) == 2
+        assert "# Intro" in chunks[0]
+        assert "Hello world" in chunks[0]
+        assert "## Details" in chunks[1]
+        assert "Some details here" in chunks[1]
+
+    def test_heading_hierarchy_prepended(self):
+        from lilbee.chunker import chunk_markdown
+
+        md = "# Top\n\n## Sub\n\nContent under sub."
+        chunks = chunk_markdown(md)
+        assert any("# Top > ## Sub" in c for c in chunks)
+
+    def test_no_headings_falls_back(self):
+        from lilbee.chunker import chunk_markdown
+
+        md = "Just plain text without any headings."
+        chunks = chunk_markdown(md)
+        assert len(chunks) >= 1
+        assert "Just plain text" in chunks[0]
+
+    def test_empty_text(self):
+        from lilbee.chunker import chunk_markdown
+
+        assert chunk_markdown("") == []
+        assert chunk_markdown("   ") == []
+
+    def test_content_before_first_heading(self):
+        from lilbee.chunker import chunk_markdown
+
+        md = "Preamble text.\n\n# First Section\n\nSection body."
+        chunks = chunk_markdown(md)
+        assert len(chunks) == 2
+        assert "Preamble" in chunks[0]
+        assert "# First Section" in chunks[1]
+
+    def test_heading_only_no_body_falls_back(self):
+        from lilbee.chunker import chunk_markdown
+
+        md = "# Heading Only\n\n"
+        chunks = chunk_markdown(md)
+        # No body text under heading — sections list is empty bodies, falls back
+        assert len(chunks) >= 0  # doesn't crash
+
+    def test_nested_headings(self):
+        from lilbee.chunker import chunk_markdown
+
+        md = "# A\n\nA body\n\n## B\n\nB body\n\n### C\n\nC body\n\n## D\n\nD body"
+        chunks = chunk_markdown(md)
+        # Should have 4 sections: A, B, C, D
+        assert len(chunks) == 4
+        # C should have full path
+        c_chunk = next(c for c in chunks if "C body" in c)
+        assert "# A" in c_chunk
+        assert "## B" in c_chunk
+        assert "### C" in c_chunk
+        # D should NOT have B or C in its path (they were popped)
+        d_chunk = next(c for c in chunks if "D body" in c)
+        assert "# A" in d_chunk
+        assert "## D" in d_chunk
+        assert "## B" not in d_chunk
+
+
 class TestCodeChunker:
     def test_python_function_extraction(self):
         from lilbee.code_chunker import chunk_code

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -181,6 +181,10 @@ class Greeter:
             for c in chunks:
                 assert c.line_start > 0
                 assert c.line_end >= c.line_start
+            # Verify enriched headers contain symbol metadata
+            hello_chunk = next(c for c in chunks if "hello" in c.chunk and "def hello" in c.chunk)
+            assert "function: hello" in hello_chunk.chunk
+            assert f"lines {hello_chunk.line_start}-{hello_chunk.line_end}" in hello_chunk.chunk
         finally:
             path.unlink()
 

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,0 +1,105 @@
+"""Tests for frontmatter parsing and hashtag extraction."""
+
+from lilbee.frontmatter import FrontmatterResult, parse_frontmatter
+
+
+class TestParseFrontmatter:
+    def test_basic_yaml_frontmatter(self):
+        md = (
+            "---\ntitle: My Doc\ntags: [python, rag]\n"
+            "author: Alice\ndate: 2026-01-15\n---\n\nBody text."
+        )
+        result = parse_frontmatter(md)
+        assert result.title == "My Doc"
+        assert "python" in result.tags
+        assert "rag" in result.tags
+        assert result.author == "Alice"
+        assert "2026-01-15" in result.date
+        assert result.body.strip() == "Body text."
+
+    def test_comma_separated_tags(self):
+        md = "---\ntags: python, machine learning, rag\n---\n\nContent."
+        result = parse_frontmatter(md)
+        assert "python" in result.tags
+        assert "machine learning" in result.tags
+        assert "rag" in result.tags
+
+    def test_no_frontmatter(self):
+        md = "# Just a heading\n\nSome body text."
+        result = parse_frontmatter(md)
+        assert result.title == ""
+        assert result.tags == ()
+        assert result.body == md
+
+    def test_empty_frontmatter(self):
+        md = "---\n---\n\nBody only."
+        result = parse_frontmatter(md)
+        assert result.title == ""
+        assert result.body.strip() == "Body only."
+
+    def test_inline_hashtags(self):
+        md = "Some text with #python and #machinelearning tags."
+        result = parse_frontmatter(md)
+        assert "python" in result.tags
+        assert "machinelearning" in result.tags
+
+    def test_hashtags_skip_code_blocks(self):
+        md = "Text with #valid tag.\n\n```python\n#comment_not_tag\n```\n\nMore text."
+        result = parse_frontmatter(md)
+        assert "valid" in result.tags
+        assert "comment_not_tag" not in result.tags
+
+    def test_hashtags_skip_inline_code(self):
+        md = "Use `#not_a_tag` but #real_tag here."
+        result = parse_frontmatter(md)
+        assert "real_tag" in result.tags
+        assert "not_a_tag" not in result.tags
+
+    def test_combined_frontmatter_and_hashtags(self):
+        md = "---\ntags: [alpha]\n---\n\nText with #beta tag."
+        result = parse_frontmatter(md)
+        assert "alpha" in result.tags
+        assert "beta" in result.tags
+
+    def test_deduplicates_tags(self):
+        md = "---\ntags: [python]\n---\n\nText with #python again."
+        result = parse_frontmatter(md)
+        assert result.tags.count("python") == 1
+
+    def test_tag_normalization(self):
+        md = "---\ntags: [Python, RAG]\n---\n\nBody."
+        result = parse_frontmatter(md)
+        assert "python" in result.tags
+        assert "rag" in result.tags
+
+    def test_invalid_yaml_ignores_gracefully(self):
+        md = "---\n: invalid: yaml: [[\n---\n\nBody text."
+        result = parse_frontmatter(md)
+        assert result.title == ""
+        assert result.body.strip() == "Body text."
+
+    def test_frontmatter_result_frozen(self):
+        result = FrontmatterResult()
+        import pytest
+
+        with pytest.raises(AttributeError):
+            result.title = "nope"  # type: ignore[misc]
+
+    def test_missing_fields_default_empty(self):
+        md = "---\ntitle: Only Title\n---\n\nBody."
+        result = parse_frontmatter(md)
+        assert result.title == "Only Title"
+        assert result.author == ""
+        assert result.date == ""
+        assert result.tags == ()
+
+    def test_yaml_list_tags(self):
+        md = "---\ntags:\n  - first\n  - second\n---\n\nBody."
+        result = parse_frontmatter(md)
+        assert "first" in result.tags
+        assert "second" in result.tags
+
+    def test_hierarchical_hashtags(self):
+        md = "Text with #dev/python tag."
+        result = parse_frontmatter(md)
+        assert "dev/python" in result.tags

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1201,6 +1201,25 @@ class TestKreuzbergOcrConfig:
         assert config.chunking is not None
 
 
+class TestIngestMarkdownEdgeCases:
+    async def test_empty_markdown_returns_empty(self, isolated_env):
+        from lilbee.ingest import ingest_markdown
+
+        md = isolated_env / "empty.md"
+        md.write_text("   ")
+        result = await ingest_markdown(md, "empty.md")
+        assert result == []
+
+    async def test_no_chunks_returns_empty(self, isolated_env):
+        from lilbee.ingest import ingest_markdown
+
+        md = isolated_env / "blank.md"
+        md.write_text("some text")
+        with mock.patch("lilbee.ingest.chunk_markdown", return_value=[]):
+            result = await ingest_markdown(md, "blank.md")
+        assert result == []
+
+
 class TestIngestStructuredEdgeCases:
     async def test_empty_preprocessed_text_returns_empty(self, isolated_env):
         from lilbee.ingest import _PREPROCESSORS, ingest_structured

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1219,6 +1219,14 @@ class TestIngestMarkdownEdgeCases:
             result = await ingest_markdown(md, "blank.md")
         assert result == []
 
+    async def test_frontmatter_only_returns_empty(self, isolated_env):
+        from lilbee.ingest import ingest_markdown
+
+        md = isolated_env / "fm_only.md"
+        md.write_text("---\ntitle: Just Frontmatter\ntags: [test]\n---\n")
+        result = await ingest_markdown(md, "fm_only.md")
+        assert result == []
+
 
 class TestIngestStructuredEdgeCases:
     async def test_empty_preprocessed_text_returns_empty(self, isolated_env):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -243,6 +243,17 @@ class TestExpandQuery:
 
         assert _expand_query("q") == []
 
+    def test_disabled_when_count_zero(self):
+        from lilbee.config import cfg
+        from lilbee.query import _expand_query
+
+        old = cfg.query_expansion_count
+        cfg.query_expansion_count = 0
+        try:
+            assert _expand_query("anything") == []
+        finally:
+            cfg.query_expansion_count = old
+
     @mock.patch("lilbee.query.get_provider")
     def test_returns_empty_on_non_string(self, mock_get_provider):
         mock_provider = mock.MagicMock()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -125,6 +125,48 @@ class TestSortByRelevance:
         assert sorted_results[2].source == "low.pdf"
 
 
+class TestDiversifySources:
+    def test_caps_per_source(self):
+        from lilbee.query import diversify_sources
+
+        results = [
+            _make_result(source="a.md", distance=0.1),
+            _make_result(source="a.md", distance=0.2),
+            _make_result(source="a.md", distance=0.3),
+            _make_result(source="a.md", distance=0.4),
+            _make_result(source="b.md", distance=0.5),
+        ]
+        diverse = diversify_sources(results, max_per_source=2)
+        a_count = sum(1 for r in diverse if r.source == "a.md")
+        assert a_count == 2
+        assert any(r.source == "b.md" for r in diverse)
+
+    def test_preserves_order(self):
+        from lilbee.query import diversify_sources
+
+        results = [
+            _make_result(source="a.md", distance=0.1),
+            _make_result(source="b.md", distance=0.2),
+            _make_result(source="a.md", distance=0.3),
+        ]
+        diverse = diversify_sources(results, max_per_source=1)
+        assert diverse[0].source == "a.md"
+        assert diverse[1].source == "b.md"
+        assert len(diverse) == 2
+
+    def test_empty_input(self):
+        from lilbee.query import diversify_sources
+
+        assert diversify_sources([]) == []
+
+    def test_default_cap_is_three(self):
+        from lilbee.query import diversify_sources
+
+        results = [_make_result(source="a.md", distance=float(i) / 10) for i in range(5)]
+        diverse = diversify_sources(results)
+        assert len(diverse) == 3
+
+
 class TestBuildContext:
     def test_numbers_chunks(self):
         results = [_make_result(chunk="chunk one"), _make_result(chunk="chunk two")]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -177,19 +177,80 @@ class TestBuildContext:
 
 
 class TestSearchContext:
+    @mock.patch("lilbee.query._expand_query", return_value=[])
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
     @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_returns_results(self, mock_embed, mock_search):
+    def test_returns_results(self, mock_embed, mock_search, mock_expand):
         results = search_context("question")
         assert len(results) == 1
         mock_embed.assert_called_once_with("question")
 
+    @mock.patch("lilbee.query._expand_query", return_value=[])
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
     @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_passes_query_text(self, mock_embed, mock_search):
+    def test_passes_query_text(self, mock_embed, mock_search, mock_expand):
         search_context("my question")
         mock_search.assert_called_once()
         assert mock_search.call_args[1]["query_text"] == "my question"
+
+    @mock.patch("lilbee.store.search")
+    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.query._expand_query", return_value=["alt query 1"])
+    def test_expansion_merges_results(self, mock_expand, mock_embed, mock_search):
+        original = _make_result(source="a.md", chunk_index=0)
+        expanded = _make_result(source="b.md", chunk_index=0)
+        mock_search.side_effect = [[original], [expanded]]
+        results = search_context("question")
+        assert len(results) == 2
+        sources = {r.source for r in results}
+        assert "a.md" in sources
+        assert "b.md" in sources
+
+    @mock.patch("lilbee.store.search")
+    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.query._expand_query", return_value=["alt"])
+    def test_expansion_deduplicates(self, mock_expand, mock_embed, mock_search):
+        same = _make_result(source="a.md", chunk_index=0)
+        mock_search.side_effect = [[same], [same]]
+        results = search_context("question")
+        assert len(results) == 1
+
+
+class TestExpandQuery:
+    @mock.patch("lilbee.query.get_provider")
+    def test_returns_variants(self, mock_get_provider):
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.return_value = "How does X work?\nWhat is X used for?"
+        mock_get_provider.return_value = mock_provider
+        from lilbee.query import _expand_query
+
+        variants = _expand_query("explain X")
+        assert len(variants) == 2
+
+    @mock.patch("lilbee.query.get_provider")
+    def test_caps_at_three(self, mock_get_provider):
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.return_value = "A\nB\nC\nD\nE"
+        mock_get_provider.return_value = mock_provider
+        from lilbee.query import _expand_query
+
+        assert len(_expand_query("q")) == 3
+
+    @mock.patch("lilbee.query.get_provider")
+    def test_returns_empty_on_error(self, mock_get_provider):
+        mock_get_provider.side_effect = RuntimeError("no provider")
+        from lilbee.query import _expand_query
+
+        assert _expand_query("q") == []
+
+    @mock.patch("lilbee.query.get_provider")
+    def test_returns_empty_on_non_string(self, mock_get_provider):
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.return_value = iter(["stream"])  # not a string
+        mock_get_provider.return_value = mock_provider
+        from lilbee.query import _expand_query
+
+        assert _expand_query("q") == []
 
 
 class TestAskRaw:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -215,3 +215,79 @@ class TestMMRRerank:
 
         sim = _cosine_sim([1.0, 0.0], [1.0, 0.0])
         assert abs(sim - 1.0) < 1e-6
+
+
+class TestAdaptiveFilter:
+    def test_returns_results_within_threshold(self):
+        from lilbee.store import SearchChunk, _adaptive_filter
+
+        results = [
+            SearchChunk(
+                source="a.md",
+                content_type="text",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk="close",
+                chunk_index=0,
+                vector=[0.1],
+                distance=0.2,
+            ),
+            SearchChunk(
+                source="b.md",
+                content_type="text",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk="far",
+                chunk_index=0,
+                vector=[0.1],
+                distance=0.8,
+            ),
+        ]
+        filtered = _adaptive_filter(results, top_k=1, initial_threshold=0.3)
+        assert len(filtered) == 1
+        assert filtered[0].chunk == "close"
+
+    def test_widens_threshold_when_too_few(self):
+        from lilbee.store import SearchChunk, _adaptive_filter
+
+        results = [
+            SearchChunk(
+                source="a.md",
+                content_type="text",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk="far",
+                chunk_index=0,
+                vector=[0.1],
+                distance=0.6,
+            ),
+        ]
+        # Initial threshold 0.3 finds nothing, should widen to 0.7
+        filtered = _adaptive_filter(results, top_k=1, initial_threshold=0.3)
+        assert len(filtered) == 1
+
+    def test_stops_at_max_threshold(self):
+        from lilbee.store import SearchChunk, _adaptive_filter
+
+        results = [
+            SearchChunk(
+                source="a.md",
+                content_type="text",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk="very far",
+                chunk_index=0,
+                vector=[0.1],
+                distance=1.5,
+            ),
+        ]
+        filtered = _adaptive_filter(results, top_k=1, initial_threshold=0.3)
+        assert len(filtered) == 0  # beyond max threshold of 1.0

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -115,6 +115,14 @@ class TestHybridSearch:
         assert len(results) > 0
         assert results[0].distance is not None
 
+    def test_vector_only_applies_mmr(self):
+        """Vector-only path (no query_text) applies MMR when results > top_k."""
+        records = _make_records(n=6)
+        store.add_chunks(records)
+        query_vec = [0.5] * cfg.embedding_dim
+        results = store.search(query_vec, top_k=2)
+        assert len(results) == 2
+
     def test_auto_ensures_fts_index_when_query_text(self):
         records = _make_records()
         store.add_chunks(records)
@@ -123,3 +131,87 @@ class TestHybridSearch:
         results = store.search(query_vec, top_k=3, query_text="chunk number")
         assert store._fts.ready
         assert len(results) > 0
+
+
+class TestMMRRerank:
+    def test_selects_diverse_results(self):
+        from lilbee.store import SearchChunk, mmr_rerank
+
+        # Two results along x-axis (near-identical), one along y-axis (diverse but relevant)
+        query = [0.8, 0.6]
+        results = [
+            SearchChunk(
+                source="a.md",
+                content_type="text",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk="x-axis 1",
+                chunk_index=0,
+                vector=[1.0, 0.0],
+                distance=0.2,
+            ),
+            SearchChunk(
+                source="a.md",
+                content_type="text",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk="x-axis 2",
+                chunk_index=1,
+                vector=[1.0, 0.0],
+                distance=0.2,
+            ),
+            SearchChunk(
+                source="b.md",
+                content_type="text",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk="y-axis",
+                chunk_index=0,
+                vector=[0.0, 1.0],
+                distance=0.4,
+            ),
+        ]
+        selected = mmr_rerank(query, results, top_k=2, lam=0.5)
+        assert len(selected) == 2
+        assert selected[0].chunk == "x-axis 1"
+        # x-axis 2 is identical to x-axis 1, so max redundancy
+        # y-axis has relevance 0.6 and zero redundancy with x-axis 1
+        assert selected[1].chunk == "y-axis"
+
+    def test_returns_all_when_fewer_than_k(self):
+        from lilbee.store import SearchChunk, mmr_rerank
+
+        query = [1.0, 0.0]
+        results = [
+            SearchChunk(
+                source="a.md",
+                content_type="text",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk="only one",
+                chunk_index=0,
+                vector=[0.9, 0.1],
+                distance=0.1,
+            ),
+        ]
+        selected = mmr_rerank(query, results, top_k=5)
+        assert len(selected) == 1
+
+    def test_cosine_sim_zero_vectors(self):
+        from lilbee.store import _cosine_sim
+
+        assert _cosine_sim([0.0, 0.0], [1.0, 0.0]) == 0.0
+
+    def test_cosine_sim_identical(self):
+        from lilbee.store import _cosine_sim
+
+        sim = _cosine_sim([1.0, 0.0], [1.0, 0.0])
+        assert abs(sim - 1.0) < 1e-6

--- a/uv.lock
+++ b/uv.lock
@@ -973,14 +973,14 @@ wheels = [
 
 [[package]]
 name = "kreuzberg"
-version = "4.4.6"
+version = "4.5.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/8c/f8719a802c12fad0102796c5dee1112497c09c8d19b81302b7b20b026e14/kreuzberg-4.4.6.tar.gz", hash = "sha256:c7a525afae447a86c5f38e158c576ab9c4135d49c6b54c9d817563cdb7c18aa0", size = 1774526 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/14/6bf268a89937d232095e3d5474104978e6334fe415aa6dd3e08c2fa35918/kreuzberg-4.5.3.tar.gz", hash = "sha256:e630f367d649fdc398867b11bb5891e525f1c71dc78f318f9faa10d6e292cd24", size = 2017700 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/e5/a5cf09416d837bfac10c70c33c163c8989d5cf0b92baf08eb5ba12b185a7/kreuzberg-4.4.6-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:7bfb9e7b6fd82893a1892d63321199735c8f223e8fa85cdf4663e8e528868e77", size = 34005922 },
-    { url = "https://files.pythonhosted.org/packages/e6/49/f09c06853bf56dbfb6c66f6a1967c9721a027ed370afb7f22103974b7793/kreuzberg-4.4.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c52d06ec512137c4044c6dfc055e41c1ad295f0d1f06a50fd860264cce426f", size = 39738109 },
-    { url = "https://files.pythonhosted.org/packages/f8/cc/a5ee591ee7d6e6dabf3260b8c67eaf7bca33f9bd23285a90334412eab8b4/kreuzberg-4.4.6-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:60a2eae27d1f613b67498d79bbd8cc16b93b9c343216c75fd9eb8265c8998c35", size = 38700564 },
-    { url = "https://files.pythonhosted.org/packages/6a/98/0b3fb96519229934ad3a72bf7cb58da9e59f12a1148b7611dcbb7d0a638e/kreuzberg-4.4.6-cp310-abi3-win_amd64.whl", hash = "sha256:048ba591ca2bea4d0b90194a3401a28ade7bf5ac2fdc5c00770b4c4fff012230", size = 40206925 },
+    { url = "https://files.pythonhosted.org/packages/86/b2/42b5ac50062bf9d675791f2cb0d111f741ce2cbe18d0ec5ee38871fcab3a/kreuzberg-4.5.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:89ca8168a5feb5731c01ca622ca49f3aa8451fecdb73b6726f867b569465355d", size = 49257751 },
+    { url = "https://files.pythonhosted.org/packages/6e/3d/f74f666fae29a058524fa93bad260ed32475d2c8c2fa21f3ea846d4d61e5/kreuzberg-4.5.3-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:2aadbeb3b64c4123cb9eb1359791aaf169209c982755534ca929af51c25ac239", size = 57279671 },
+    { url = "https://files.pythonhosted.org/packages/e5/f5/efdecf0390121f24eceb9b15ebc2beba28e60437a6d32b8bd86422c0a60c/kreuzberg-4.5.3-cp310-abi3-manylinux_2_39_x86_64.whl", hash = "sha256:42148d315a62814ddc7c0b6d79fde97c32e3209c66b56080a3ec2f6d22081d16", size = 56891091 },
+    { url = "https://files.pythonhosted.org/packages/5b/5b/1338bf8c17ee3ef3fb3fdb86876accbba49896bd83e672c7a0fe04493e8b/kreuzberg-4.5.3-cp310-abi3-win_amd64.whl", hash = "sha256:621993d4893ee8df9600c2143677e7c69d4fe553fe4029e703902ca72758d09b", size = 56611249 },
 ]
 
 [[package]]
@@ -1144,6 +1144,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "reportlab" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -1151,7 +1152,7 @@ requires-dist = [
     { name = "filelock" },
     { name = "httpx" },
     { name = "huggingface-hub" },
-    { name = "kreuzberg" },
+    { name = "kreuzberg", specifier = ">=4.5.0" },
     { name = "lancedb" },
     { name = "litellm" },
     { name = "litestar", specifier = ">=2.0" },
@@ -1178,6 +1179,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "reportlab" },
     { name = "ruff", specifier = ">=0.15.4" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
 [[package]]
@@ -2960,6 +2962,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338 },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Major improvements to how lilbee finds and returns relevant documents when you ask a question. Before this, lilbee did a single vector search and returned whatever was closest. Now it uses several well-established retrieval techniques:

**Smarter chunking** — Markdown files are now split at heading boundaries instead of arbitrary token counts. Each chunk includes its heading path so the LLM knows the context.

**Better search diversity** — Results are no longer dominated by one large document. Source diversity caps results per file, and MMR ensures the top results cover different aspects of your question.

**Query expansion** — lilbee generates 2-3 alternative phrasings of your question using the LLM, searches with each, and merges the results. Catches documents that use different terminology.

**Frontmatter support** — YAML frontmatter in markdown files is now parsed (tags, title, author, date) and stripped before chunking.

**Code search enrichment** — Code chunks now include the function/class name, type, and line range in a header comment.

All retrieval parameters are configurable via environment variables. Also upgrades kreuzberg from 4.4.3 to 4.5.3.

### Acknowledgments
- MMR algorithm: Carbonell & Goldstein 1998
- Source diversity: Zhai 2008
- Adaptive threshold pattern: inspired by grantflow (grantflow-ai/grantflow)
- Standard multi-query retrieval expansion