### PR TITLE
Document deletion, API routes, reasoning support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ All settings override via environment variables:
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
 - `LILBEE_VISION_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
 - `LILBEE_LLM_PROVIDER` — backend: `auto` (default), `llama-cpp`, `ollama`, `openai`
-- `LILBEE_LLM_BASE_URL` — Ollama endpoint (default: `http://localhost:11434`)
+- `LILBEE_OLLAMA_URL` — Ollama endpoint (default: `http://localhost:11434`, also reads `OLLAMA_HOST`)
 - `LILBEE_DIVERSITY_MAX_PER_SOURCE` — max chunks per source in results (default: `3`)
 - `LILBEE_MMR_LAMBDA` — MMR relevance/diversity tradeoff, 0-1 (default: `0.5`)
 - `LILBEE_CANDIDATE_MULTIPLIER` — extra candidates for MMR reranking (default: `3`)

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -8,6 +8,7 @@ Three levels:
 
 import fnmatch
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -143,13 +144,24 @@ _SIZE_RANGES: dict[str, tuple[float, float]] = {
 }
 
 
+# TTL cache for HuggingFace API results (5 minutes)
+_HF_CACHE_TTL = 300
+_hf_cache: dict[str, tuple[float, list["CatalogModel"]]] = {}
+
+
 def _fetch_hf_models(
     pipeline_tag: str = "text-generation",
     tags: str = "gguf",
     sort: str = "downloads",
     limit: int = 50,
 ) -> list[CatalogModel]:
-    """Fetch models from HuggingFace API. Returns empty list on error."""
+    """Fetch models from HuggingFace API with 5-minute cache. Returns empty list on error."""
+    cache_key = f"{pipeline_tag}:{tags}:{sort}:{limit}"
+    now = time.monotonic()
+    cached = _hf_cache.get(cache_key)
+    if cached and now - cached[0] < _HF_CACHE_TTL:
+        return cached[1]
+
     params: dict[str, str | int] = {
         "pipeline_tag": pipeline_tag,
         "tags": tags,
@@ -189,6 +201,7 @@ def _fetch_hf_models(
                 task="chat",
             )
         )
+    _hf_cache[cache_key] = (now, models)
     return models
 
 

--- a/src/lilbee/cli/chat/slash.py
+++ b/src/lilbee/cli/chat/slash.py
@@ -50,6 +50,7 @@ _SETTINGS_MAP: dict[str, _SettingDef] = {
     "num_ctx": _SettingDef("num_ctx", int, nullable=True),
     "seed": _SettingDef("seed", int, nullable=True),
     "system_prompt": _SettingDef("system_prompt", str, nullable=False, render=RenderStyle.FULL),
+    "show_reasoning": _SettingDef("show_reasoning", bool, nullable=False),
 }
 
 

--- a/src/lilbee/cli/chat/slash.py
+++ b/src/lilbee/cli/chat/slash.py
@@ -226,6 +226,42 @@ def handle_slash_version(args: str, con: Console) -> None:
     con.print(f"lilbee [{theme.LABEL}]{get_version()}[/{theme.LABEL}]")
 
 
+def handle_slash_delete(args: str, con: Console, *, sync_status: SyncStatus | None = None) -> None:
+    """Delete documents from the knowledge base. Interactive picker if no arg given."""
+    from lilbee.store import delete_by_source, delete_source, get_sources
+
+    known = {s["filename"] for s in get_sources()}
+    if not known:
+        con.print(f"[{theme.MUTED}]No documents indexed.[/{theme.MUTED}]")
+        return
+
+    name = args.strip()
+    if not name:
+        try:
+            from prompt_toolkit import prompt as pt_prompt
+            from prompt_toolkit.completion import WordCompleter
+
+            completer = WordCompleter(sorted(known), sentence=True)
+            name = pt_prompt("delete file: ", completer=completer).strip()
+        except (ImportError, EOFError, KeyboardInterrupt):
+            return
+    if not name:
+        return
+
+    if name not in known:
+        con.print(f"[{theme.ERROR}]Not found:[/{theme.ERROR}] {name}")
+        return
+
+    delete_by_source(name)
+    delete_source(name)
+    path = cfg.documents_dir / name
+    if path.exists():
+        path.unlink()
+    if sync_status is not None:
+        sync_status.clear()
+    con.print(f"Deleted [{theme.ACCENT}]{name}[/{theme.ACCENT}]")
+
+
 def handle_slash_reset(args: str, con: Console, *, sync_status: SyncStatus | None = None) -> None:
     con.print(
         f"[{theme.ERROR_BOLD}]This will delete ALL documents and data.[/{theme.ERROR_BOLD}]"
@@ -381,6 +417,7 @@ _SLASH_COMMANDS: dict[str, Callable[[str, Console], None]] = {
     "settings": handle_slash_settings,
     "set": handle_slash_set,
     "version": handle_slash_version,
+    "delete": handle_slash_delete,
     "reset": handle_slash_reset,
     "help": handle_slash_help,
     "quit": handle_slash_quit,
@@ -401,6 +438,8 @@ def dispatch_slash(raw_input: str, con: Console, *, sync_status: SyncStatus | No
         return True
     if cmd == "add":
         handle_slash_add(args, con, sync_status=sync_status)
+    elif cmd == "delete":
+        handle_slash_delete(args, con, sync_status=sync_status)
     elif cmd == "reset":
         handle_slash_reset(args, con, sync_status=sync_status)
     else:

--- a/src/lilbee/cli/chat/stream.py
+++ b/src/lilbee/cli/chat/stream.py
@@ -31,6 +31,7 @@ def stream_response(
     stream = ask_stream(question, history=history)
     response_parts: list[str] = []
     cancelled = False
+    in_reasoning = False
 
     # In chat mode, use chat_console (bypasses StdoutProxy) for all output.
     out_con = chat_console if chat_mode and chat_console else con
@@ -43,23 +44,37 @@ def stream_response(
             ctx = con.status("Thinking...")
 
         with ctx:
-            first_token = next(stream, None)
+            first_st = next(stream, None)
 
-        if first_token is not None:
-            out_con.print(first_token, end="")
-            response_parts.append(first_token)
+        if first_st is not None:
+            if first_st.is_reasoning:
+                out_con.print(first_st.content, end="", style=theme.MUTED)
+                in_reasoning = True
+            else:
+                out_con.print(first_st.content, end="")
+                response_parts.append(first_st.content)
 
-        for token in stream:
-            out_con.print(token, end="")
-            response_parts.append(token)
+        for st in stream:
+            if st.is_reasoning:
+                if not in_reasoning:
+                    in_reasoning = True
+                out_con.print(st.content, end="", style=theme.MUTED, markup=False)
+            else:
+                if in_reasoning:
+                    out_con.print()  # newline after reasoning block
+                    in_reasoning = False
+                out_con.print(st.content, end="")
+                response_parts.append(st.content)
     except KeyboardInterrupt:
         cancelled = True
         stream.close()
-        out_con.print(f"\n[{theme.MUTED}](stopped)[/{theme.MUTED}]")
+        out_con.print("\n(stopped)", style=theme.MUTED, markup=False)
     except RuntimeError as exc:
-        out_con.print(f"\n[{theme.ERROR}]Error:[/{theme.ERROR}] {exc}")
+        out_con.print(f"\nError: {exc}", style=theme.ERROR)
         return
 
+    if in_reasoning:
+        out_con.print(f"[/{theme.MUTED}]", end="")
     if not cancelled:
         out_con.print("\n")
     full = "".join(response_parts)

--- a/src/lilbee/code_chunker.py
+++ b/src/lilbee/code_chunker.py
@@ -16,6 +16,17 @@ _CONTAINERS = frozenset({"class_body", "block", "declaration_list", "impl_body"}
 
 
 @dataclass
+class NodeSpan:
+    """Text and metadata extracted from a single AST definition node."""
+
+    text: str
+    line_start: int
+    line_end: int
+    symbol_name: str
+    symbol_type: str
+
+
+@dataclass
 class CodeChunk:
     """A chunk of source code with line location metadata."""
 
@@ -44,50 +55,52 @@ def _node_name(node: tree_sitter.Node) -> str:
     return ""
 
 
+_SYMBOL_TYPE_MAP: dict[str, str] = {
+    "function_definition": "function",
+    "function_declaration": "function",
+    "function_item": "function",
+    "method_declaration": "method",
+    "method": "method",
+    "class_definition": "class",
+    "class_declaration": "class",
+    "class_specifier": "class",
+    "struct_item": "struct",
+    "struct_specifier": "struct",
+    "struct_definition": "struct",
+    "enum_item": "enum",
+    "interface_declaration": "interface",
+    "trait_item": "trait",
+    "type_alias_declaration": "type",
+    "type_declaration": "type",
+    "impl_item": "impl",
+    "module": "module",
+    "module_definition": "module",
+}
+
+
 def _symbol_type(node_type: str) -> str:
     """Map tree-sitter node type to a human-readable symbol kind."""
-    _MAP = {
-        "function_definition": "function",
-        "function_declaration": "function",
-        "function_item": "function",
-        "method_declaration": "method",
-        "method": "method",
-        "class_definition": "class",
-        "class_declaration": "class",
-        "class_specifier": "class",
-        "struct_item": "struct",
-        "struct_specifier": "struct",
-        "struct_definition": "struct",
-        "enum_item": "enum",
-        "interface_declaration": "interface",
-        "trait_item": "trait",
-        "type_alias_declaration": "type",
-        "type_declaration": "type",
-        "impl_item": "impl",
-        "module": "module",
-        "module_definition": "module",
-    }
-    return _MAP.get(node_type, node_type.replace("_", " "))
+    return _SYMBOL_TYPE_MAP.get(node_type, node_type.replace("_", " "))
 
 
-def _node_span(node: tree_sitter.Node, source: bytes) -> dict:
-    """Extract text, line range, and symbol metadata from an AST node."""
-    return {
-        "text": source[node.start_byte : node.end_byte].decode("utf-8", errors="replace"),
-        "line_start": node.start_point.row + 1,
-        "line_end": node.end_point.row + 1,
-        "symbol_name": _node_name(node),
-        "symbol_type": _symbol_type(node.type),
-    }
+def _node_span(node: tree_sitter.Node, source: bytes) -> NodeSpan:
+    """Extract text, line range, and symbol metadata from an AST definition node."""
+    return NodeSpan(
+        text=source[node.start_byte : node.end_byte].decode("utf-8", errors="replace"),
+        line_start=node.start_point.row + 1,
+        line_end=node.end_point.row + 1,
+        symbol_name=_node_name(node),
+        symbol_type=_symbol_type(node.type),
+    )
 
 
 def collect_definitions(
     root: tree_sitter.Node,
     source: bytes,
     def_types: frozenset[str],
-) -> list[dict]:
+) -> list[NodeSpan]:
     """Walk top-level children + one level of containers for definitions."""
-    results: list[dict] = []
+    results: list[NodeSpan] = []
     for child in root.children:
         if child.type in def_types:
             results.append(_node_span(child, source))
@@ -147,18 +160,16 @@ def chunk_code(file_path: Path) -> list[CodeChunk]:
         return _fallback_chunks(source_text)
 
     chunks: list[CodeChunk] = []
-    for i, d in enumerate(definitions):
+    for i, defn in enumerate(definitions):
         header = f"# File: {file_path}"
-        name = d.get("symbol_name", "")
-        kind = d.get("symbol_type", "")
-        if name and kind:
-            header += f" | {kind}: {name}"
-        header += f" (lines {d['line_start']}-{d['line_end']})"
+        if defn.symbol_name and defn.symbol_type:
+            header += f" | {defn.symbol_type}: {defn.symbol_name}"
+        header += f" (lines {defn.line_start}-{defn.line_end})"
         chunks.append(
             CodeChunk(
-                chunk=f"{header}\n\n{d['text']}",
-                line_start=d["line_start"],
-                line_end=d["line_end"],
+                chunk=f"{header}\n\n{defn.text}",
+                line_start=defn.line_start,
+                line_end=defn.line_end,
                 chunk_index=i,
             )
         )

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -94,6 +94,11 @@ class Config(BaseModel):
     # 0.2 gives 4 steps from typical 0.3 start to 1.0 cap.
     adaptive_threshold_step: float = Field(default=0.2, gt=0.0)
 
+    # Show reasoning model thinking process (<think>...</think> tags).
+    # When False, thinking is stripped silently. When True, emitted as
+    # separate SSE events (event: reasoning) for UI rendering.
+    show_reasoning: bool = False
+
     def generation_options(self, **overrides: Any) -> dict[str, Any]:
         """Build Ollama generation options from config fields and overrides.
 
@@ -191,6 +196,9 @@ class Config(BaseModel):
             ),
             adaptive_threshold_step=_load_setting(
                 data_root, "adaptive_threshold_step", "ADAPTIVE_THRESHOLD_STEP", 0.2, float
+            ),
+            show_reasoning=_load_setting(
+                data_root, "show_reasoning", "SHOW_REASONING", False, bool
             ),
         )
 

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -70,7 +70,7 @@ class Config(BaseModel):
     ollama_url: str = "http://localhost:11434"
     llm_api_key: str = ""
 
-    # Retrieval quality knobs — defaults chosen from research across gno, grantflow, QMD
+    # Retrieval quality knobs — defaults chosen from academic research and grantflow
     # and academic literature (see docs/superpowers/specs/2026-03-22-feature-parity-design.md)
 
     # Max chunks per source document in results. Prevents one large file from

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -67,7 +67,7 @@ class Config(BaseModel):
     num_ctx: int | None = Field(default=None, ge=1)
     seed: int | None = None
     llm_provider: str = "auto"
-    llm_base_url: str = "http://localhost:11434"
+    ollama_url: str = "http://localhost:11434"
     llm_api_key: str = ""
 
     # Retrieval quality knobs — defaults chosen from research across gno, grantflow, QMD
@@ -173,7 +173,11 @@ class Config(BaseModel):
             num_ctx=_load_setting(data_root, "num_ctx", "NUM_CTX", None, int),
             seed=_load_setting(data_root, "seed", "SEED", None, int),
             llm_provider=env("LLM_PROVIDER", "auto"),
-            llm_base_url=env("LLM_BASE_URL", "http://localhost:11434"),
+            ollama_url=env(
+                "OLLAMA_URL",
+                # Fall back to OLLAMA_HOST for backwards compat
+                os.environ.get("OLLAMA_HOST", "http://localhost:11434"),
+            ),
             llm_api_key=env("LLM_API_KEY", ""),
             diversity_max_per_source=_load_setting(
                 data_root, "diversity_max_per_source", "DIVERSITY_MAX_PER_SOURCE", 3, int

--- a/src/lilbee/frontmatter.py
+++ b/src/lilbee/frontmatter.py
@@ -1,10 +1,17 @@
-"""Extract YAML frontmatter and inline hashtags from markdown files."""
+"""Extract YAML frontmatter and inline hashtags from markdown files.
+
+Parsing approach inspired by gno (gmickel/gno) frontmatter.ts which
+supports YAML frontmatter, Logseq properties, and inline hashtags
+with code-block-aware extraction and NFC tag normalization.
+"""
 
 from __future__ import annotations
 
 import re
 import unicodedata
 from dataclasses import dataclass, field
+
+import yaml
 
 _FRONTMATTER_RE = re.compile(r"^---\r?\n([\s\S]*?)(?:\r?\n)?---(?:\r?\n|$)")
 _CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```|`[^`\n]+`")
@@ -47,7 +54,6 @@ def parse_frontmatter(text: str) -> FrontmatterResult:
 
     Returns metadata and the body text with frontmatter stripped.
     """
-    import yaml
 
     body = text
     title = ""

--- a/src/lilbee/frontmatter.py
+++ b/src/lilbee/frontmatter.py
@@ -1,9 +1,7 @@
 """Extract YAML frontmatter and inline hashtags from markdown files.
 
-Parsing approach inspired by gno (gmickel/gno) frontmatter.ts which
-supports YAML frontmatter, Logseq properties, and inline hashtags
-with code-block-aware extraction and NFC tag normalization.
-"""
+Standard YAML frontmatter extraction with code-block-aware
+hashtag parsing and NFC unicode tag normalization."""
 
 from __future__ import annotations
 

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -23,6 +23,7 @@ from lilbee import embedder, store
 from lilbee.chunker import chunk_markdown, chunk_text
 from lilbee.code_chunker import CodeChunk, chunk_code, supported_extensions
 from lilbee.config import cfg
+from lilbee.frontmatter import parse_frontmatter
 from lilbee.platform import is_ignored_dir
 from lilbee.preprocessors import preprocess_csv, preprocess_json, preprocess_xml
 from lilbee.progress import (
@@ -435,7 +436,6 @@ async def ingest_markdown(
     on_progress: DetailedProgressCallback = noop_callback,
 ) -> list[ChunkRecord]:
     """Chunk a markdown file by heading boundaries, embed, return records."""
-    from lilbee.frontmatter import parse_frontmatter
 
     raw_text = await asyncio.to_thread(path.read_text, encoding="utf-8")
     if not raw_text.strip():

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -126,6 +126,48 @@ def lilbee_init(path: str = "") -> dict:
 
 
 @mcp.tool()
+def lilbee_remove(names: list[str], delete_files: bool = False) -> dict:
+    """Remove documents from the knowledge base by source name.
+
+    Args:
+        names: Source filenames to remove (as shown by lilbee_status).
+        delete_files: Also delete the physical files from the documents directory.
+    """
+    from lilbee.config import cfg
+    from lilbee.store import delete_by_source, delete_source, get_sources
+
+    known = {s["filename"] for s in get_sources()}
+    removed: list[str] = []
+    not_found: list[str] = []
+    for name in names:
+        if name not in known:
+            not_found.append(name)
+            continue
+        delete_by_source(name)
+        delete_source(name)
+        removed.append(name)
+        if delete_files:
+            path = cfg.documents_dir / name
+            if path.exists():
+                path.unlink()
+    return {"command": "remove", "removed": removed, "not_found": not_found}
+
+
+@mcp.tool()
+def lilbee_list_documents() -> dict:
+    """List all indexed documents with their chunk counts."""
+    from lilbee.store import get_sources
+
+    sources = get_sources()
+    return {
+        "documents": [
+            {"filename": s["filename"], "chunk_count": s.get("chunk_count", 0)} for s in sources
+        ],
+        "total": len(sources),
+    }
+
+
+@mcp.tool()
 def lilbee_reset() -> dict:
     """Delete all documents and data (full factory reset).
 

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -188,7 +188,7 @@ def get_model_manager() -> ModelManager:
     if _manager is None:
         from lilbee.config import cfg
 
-        _manager = ModelManager(cfg.models_dir, cfg.llm_base_url)
+        _manager = ModelManager(cfg.models_dir, cfg.ollama_url)
     return _manager
 
 

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -31,11 +31,11 @@ def get_provider() -> LLMProvider:
     elif provider_name == "ollama":
         from lilbee.providers.litellm_provider import LiteLLMProvider
 
-        _provider = LiteLLMProvider(base_url=cfg.llm_base_url)
+        _provider = LiteLLMProvider(base_url=cfg.ollama_url)
     elif provider_name == "litellm":
         from lilbee.providers.litellm_provider import LiteLLMProvider
 
-        _provider = LiteLLMProvider(base_url=cfg.llm_base_url, api_key=cfg.llm_api_key)
+        _provider = LiteLLMProvider(base_url=cfg.ollama_url, api_key=cfg.llm_api_key)
     else:
         from lilbee.providers.base import ProviderError
 

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -35,7 +35,7 @@ class RoutingProvider(LLMProvider):
             from lilbee.config import cfg
             from lilbee.providers.litellm_provider import LiteLLMProvider
 
-            self._litellm = LiteLLMProvider(base_url=cfg.llm_base_url)
+            self._litellm = LiteLLMProvider(base_url=cfg.ollama_url)
         return self._litellm
 
     def _ollama_available(self) -> set[str]:

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
-from typing import Any, cast
+from collections.abc import Generator, Iterator
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from lilbee.reasoning import StreamToken
 
 from pydantic import BaseModel
 from typing_extensions import TypedDict
@@ -214,11 +217,20 @@ def ask_stream(
     top_k: int = 0,
     history: list[ChatMessage] | None = None,
     options: dict[str, Any] | None = None,
-) -> Generator[str, None, None]:
-    """Streaming question: yields answer tokens, then source citations."""
+) -> Generator[StreamToken, None, None]:
+    """Streaming question: yields classified tokens, then source citations.
+
+    Each yielded ``StreamToken`` has ``.content`` (text) and ``.is_reasoning``
+    (True for ``<think>...</think>`` blocks when ``cfg.show_reasoning`` is True).
+    """
+    from lilbee.reasoning import StreamToken, filter_reasoning
+
     results = search_context(question, top_k=top_k)
     if not results:
-        yield "No relevant documents found. Try ingesting some documents first."
+        yield StreamToken(
+            content="No relevant documents found. Try ingesting some documents first.",
+            is_reasoning=False,
+        )
         return
 
     results = sort_by_relevance(results)
@@ -233,14 +245,16 @@ def ask_stream(
 
     opts = options if options is not None else cfg.generation_options()
     provider = get_provider()
-    stream = provider.chat(cast(list[dict[str, Any]], messages), stream=True, options=opts or None)
+    raw_stream = provider.chat(
+        cast(list[dict[str, Any]], messages), stream=True, options=opts or None
+    )
 
     try:
-        for token in stream:
-            if token:
-                yield token
+        for st in filter_reasoning(cast(Iterator[str], raw_stream), show=cfg.show_reasoning):
+            if st.content:
+                yield st
     except (ConnectionError, OSError) as exc:
-        yield f"\n\n[Connection lost: {exc}]"
+        yield StreamToken(content=f"\n\n[Connection lost: {exc}]", is_reasoning=False)
 
     citations = deduplicate_sources(results)
-    yield "\n\nSources:\n" + "\n".join(citations)
+    yield StreamToken(content="\n\nSources:\n" + "\n".join(citations), is_reasoning=False)

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -80,7 +80,11 @@ def sort_by_relevance(results: list[SearchChunk]) -> list[SearchChunk]:
 def diversify_sources(
     results: list[SearchChunk], max_per_source: int | None = None
 ) -> list[SearchChunk]:
-    """Cap results per source document to ensure diversity."""
+    """Cap results per source document to ensure diversity.
+
+    Standard IR diversity technique; see Zhai 2008,
+    "Towards a Game-Theoretic Framework for Information Retrieval."
+    """
     if max_per_source is None:
         max_per_source = cfg.diversity_max_per_source
     counts: dict[str, int] = {}
@@ -93,6 +97,11 @@ def diversify_sources(
     return diverse
 
 
+def prepare_results(results: list[SearchChunk]) -> list[SearchChunk]:
+    """Sort by relevance and apply source diversity cap."""
+    return diversify_sources(sort_by_relevance(results))
+
+
 def build_context(results: list[SearchChunk]) -> str:
     """Build context block from search results."""
     parts: list[str] = []
@@ -101,6 +110,9 @@ def build_context(results: list[SearchChunk]) -> str:
     return "\n\n".join(parts)
 
 
+# Multi-query expansion inspired by gno (gmickel/gno) which generates
+# lexical + semantic variants with guardrails. Simplified here to LLM-generated
+# alternative phrasings merged via deduplication.
 _EXPANSION_PROMPT = (
     "Generate {count} alternative search queries for the following question. "
     "Return ONLY the queries, one per line, no numbering or explanation.\n\n"
@@ -158,7 +170,8 @@ def search_context(question: str, top_k: int = 0) -> list[SearchChunk]:
                     results.append(r)
                     seen.add(key)
 
-    return results
+    # Cap total results to prevent context overflow from expansion
+    return results[: top_k * 2]
 
 
 class AskResult(BaseModel):
@@ -182,8 +195,7 @@ def ask_raw(
             sources=[],
         )
 
-    results = sort_by_relevance(results)
-    results = diversify_sources(results)
+    results = prepare_results(results)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
 
@@ -233,8 +245,7 @@ def ask_stream(
         )
         return
 
-    results = sort_by_relevance(results)
-    results = diversify_sources(results)
+    results = prepare_results(results)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
 

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -110,9 +110,8 @@ def build_context(results: list[SearchChunk]) -> str:
     return "\n\n".join(parts)
 
 
-# Multi-query expansion inspired by gno (gmickel/gno) which generates
-# lexical + semantic variants with guardrails. Simplified here to LLM-generated
-# alternative phrasings merged via deduplication.
+# Multi-query expansion generates alternative search phrasings to
+# improve recall. Based on standard multi-query retrieval techniques.
 _EXPANSION_PROMPT = (
     "Generate {count} alternative search queries for the following question. "
     "Return ONLY the queries, one per line, no numbering or explanation.\n\n"

--- a/src/lilbee/reasoning.py
+++ b/src/lilbee/reasoning.py
@@ -1,0 +1,84 @@
+"""Reasoning token filter — detects <think>...</think> tags in streaming output.
+
+Reasoning models (Qwen3, DeepSeek-R1) wrap their thinking process in
+``<think>...</think>`` tags. This module provides a stateful filter that
+classifies tokens as reasoning or response content.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+_OPEN_TAG = "<think>"
+_CLOSE_TAG = "</think>"
+
+
+@dataclass
+class StreamToken:
+    """A classified token from the stream."""
+
+    content: str
+    is_reasoning: bool
+
+
+def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamToken]:
+    """Filter ``<think>...</think>`` tags from a token stream.
+
+    When *show* is True, yields thinking content as ``StreamToken(is_reasoning=True)``.
+    When *show* is False, strips thinking content entirely.
+    Tokens outside thinking blocks are always yielded as ``is_reasoning=False``.
+    """
+    buf = ""
+    in_thinking = False
+
+    for token in tokens:
+        buf += token
+
+        while buf:
+            if in_thinking:
+                close_idx = buf.find(_CLOSE_TAG)
+                if close_idx == -1:
+                    # Might be a partial close tag at the end
+                    if _could_be_partial(_CLOSE_TAG, buf):
+                        break  # wait for more tokens
+                    # All buffered content is thinking
+                    if show:
+                        yield StreamToken(content=buf, is_reasoning=True)
+                    buf = ""
+                else:
+                    # Emit thinking content before the close tag
+                    thinking_content = buf[:close_idx]
+                    if thinking_content and show:
+                        yield StreamToken(content=thinking_content, is_reasoning=True)
+                    buf = buf[close_idx + len(_CLOSE_TAG) :]
+                    in_thinking = False
+            else:
+                open_idx = buf.find(_OPEN_TAG)
+                if open_idx == -1:
+                    # Might be a partial open tag at the end
+                    if _could_be_partial(_OPEN_TAG, buf):
+                        break  # wait for more tokens
+                    # All buffered content is normal response
+                    yield StreamToken(content=buf, is_reasoning=False)
+                    buf = ""
+                else:
+                    # Emit response content before the open tag
+                    before = buf[:open_idx]
+                    if before:
+                        yield StreamToken(content=before, is_reasoning=False)
+                    buf = buf[open_idx + len(_OPEN_TAG) :]
+                    in_thinking = True
+
+    # Flush remaining buffer
+    if buf:
+        if in_thinking:
+            if show:
+                yield StreamToken(content=buf, is_reasoning=True)
+        else:
+            yield StreamToken(content=buf, is_reasoning=False)
+
+
+def _could_be_partial(tag: str, buf: str) -> bool:
+    """Check if the end of buf could be the start of the given tag."""
+    return any(buf.endswith(tag[:length]) for length in range(1, len(tag)))

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -473,11 +473,20 @@ async def delete_documents(names: list[str], *, delete_files: bool = False) -> d
     return {"removed": removed, "not_found": not_found}
 
 
-async def list_documents() -> dict[str, Any]:
-    """Return all indexed documents with metadata."""
+async def list_documents(
+    search: str = "",
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Return indexed documents with metadata, paginated and filterable."""
     from lilbee.store import get_sources
 
     sources = get_sources()
+    if search:
+        search_lower = search.lower()
+        sources = [s for s in sources if search_lower in s["filename"].lower()]
+    total = len(sources)
+    page = sources[offset : offset + limit]
     return {
         "documents": [
             {
@@ -485,9 +494,11 @@ async def list_documents() -> dict[str, Any]:
                 "chunk_count": s.get("chunk_count", 0),
                 "ingested_at": s.get("ingested_at", ""),
             }
-            for s in sources
+            for s in page
         ],
-        "total": len(sources),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
     }
 
 

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 import threading
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -162,6 +162,8 @@ async def ask_stream(
     error_holder: list[str] = []
 
     def _generate() -> None:
+        from lilbee.reasoning import filter_reasoning
+
         try:
             provider = get_provider()
             stream = provider.chat(
@@ -170,11 +172,12 @@ async def ask_stream(
                 options=opts or None,
                 model=cfg.chat_model,
             )
-            for token in stream:
+            for st in filter_reasoning(cast(Iterator[str], stream), show=cfg.show_reasoning):
                 if cancel.is_set():
                     break
-                if token:
-                    queue.put_nowait(sse_event("token", {"token": token}))
+                if st.content:
+                    event_type = "reasoning" if st.is_reasoning else "token"
+                    queue.put_nowait(sse_event(event_type, {"token": st.content}))
         except Exception as exc:
             error_holder.append(str(exc))
         finally:
@@ -257,6 +260,8 @@ async def chat_stream(
     error_holder: list[str] = []
 
     def _generate() -> None:
+        from lilbee.reasoning import filter_reasoning
+
         try:
             provider = get_provider()
             stream = provider.chat(
@@ -265,11 +270,12 @@ async def chat_stream(
                 options=opts or None,
                 model=cfg.chat_model,
             )
-            for token in stream:
+            for st in filter_reasoning(cast(Iterator[str], stream), show=cfg.show_reasoning):
                 if cancel.is_set():
                     break
-                if token:
-                    queue.put_nowait(sse_event("token", {"token": token}))
+                if st.content:
+                    event_type = "reasoning" if st.is_reasoning else "token"
+                    queue.put_nowait(sse_event(event_type, {"token": st.content}))
         except Exception as exc:
             error_holder.append(str(exc))
         finally:
@@ -528,6 +534,7 @@ async def get_config() -> dict[str, Any]:
         "candidate_multiplier": cfg.candidate_multiplier,
         "query_expansion_count": cfg.query_expansion_count,
         "adaptive_threshold_step": cfg.adaptive_threshold_step,
+        "show_reasoning": cfg.show_reasoning,
     }
 
 

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -502,6 +502,35 @@ async def list_documents(
     }
 
 
+async def get_config() -> dict[str, Any]:
+    """Return all user-facing configuration values."""
+    from lilbee.config import cfg
+
+    return {
+        "chat_model": cfg.chat_model,
+        "embedding_model": cfg.embedding_model,
+        "vision_model": cfg.vision_model,
+        "ollama_url": cfg.ollama_url,
+        "system_prompt": cfg.system_prompt,
+        "top_k": cfg.top_k,
+        "max_distance": cfg.max_distance,
+        "chunk_size": cfg.chunk_size,
+        "chunk_overlap": cfg.chunk_overlap,
+        "temperature": cfg.temperature,
+        "top_p": cfg.top_p,
+        "top_k_sampling": cfg.top_k_sampling,
+        "repeat_penalty": cfg.repeat_penalty,
+        "num_ctx": cfg.num_ctx,
+        "seed": cfg.seed,
+        "llm_provider": cfg.llm_provider,
+        "diversity_max_per_source": cfg.diversity_max_per_source,
+        "mmr_lambda": cfg.mmr_lambda,
+        "candidate_multiplier": cfg.candidate_multiplier,
+        "query_expansion_count": cfg.query_expansion_count,
+        "adaptive_threshold_step": cfg.adaptive_threshold_step,
+    }
+
+
 async def models_show(model: str) -> dict[str, Any]:
     """Return model metadata/parameters. Returns empty dict if unavailable."""
     provider = get_provider()

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -449,6 +449,48 @@ async def set_vision_model(model: str) -> dict[str, str]:
     return {"model": model}
 
 
+async def delete_documents(names: list[str], *, delete_files: bool = False) -> dict[str, Any]:
+    """Remove documents from the knowledge base by source name."""
+    from lilbee.config import cfg
+    from lilbee.store import delete_by_source, delete_source, get_sources
+
+    known = {s["filename"] for s in get_sources()}
+    removed: list[str] = []
+    not_found: list[str] = []
+
+    for name in names:
+        if name not in known:
+            not_found.append(name)
+            continue
+        delete_by_source(name)
+        delete_source(name)
+        removed.append(name)
+        if delete_files:
+            path = cfg.documents_dir / name
+            if path.exists():
+                path.unlink()
+
+    return {"removed": removed, "not_found": not_found}
+
+
+async def list_documents() -> dict[str, Any]:
+    """Return all indexed documents with metadata."""
+    from lilbee.store import get_sources
+
+    sources = get_sources()
+    return {
+        "documents": [
+            {
+                "filename": s["filename"],
+                "chunk_count": s.get("chunk_count", 0),
+                "ingested_at": s.get("ingested_at", ""),
+            }
+            for s in sources
+        ],
+        "total": len(sources),
+    }
+
+
 def _parse_source(source: str) -> ModelSource:
     """Convert a source string to ModelSource enum."""
     from lilbee.model_manager import ModelSource

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -139,9 +139,8 @@ async def ask_stream(
     from lilbee.query import (
         _CONTEXT_TEMPLATE,
         build_context,
-        diversify_sources,
+        prepare_results,
         search_context,
-        sort_by_relevance,
     )
 
     results = search_context(question, top_k=top_k)
@@ -149,8 +148,7 @@ async def ask_stream(
         yield sse_event("error", {"message": "No relevant documents found."})
         return
 
-    results = sort_by_relevance(results)
-    results = diversify_sources(results)
+    results = prepare_results(results)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
     messages: list[ChatMessage] = [{"role": "system", "content": cfg.system_prompt}]
@@ -236,9 +234,8 @@ async def chat_stream(
     from lilbee.query import (
         _CONTEXT_TEMPLATE,
         build_context,
-        diversify_sources,
+        prepare_results,
         search_context,
-        sort_by_relevance,
     )
 
     results = search_context(question, top_k=top_k)
@@ -246,8 +243,7 @@ async def chat_stream(
         yield sse_event("error", {"message": "No relevant documents found."})
         return
 
-    results = sort_by_relevance(results)
-    results = diversify_sources(results)
+    results = prepare_results(results)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
     messages: list[ChatMessage] = [{"role": "system", "content": cfg.system_prompt}]

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -491,6 +491,13 @@ async def list_documents() -> dict[str, Any]:
     }
 
 
+async def models_show(model: str) -> dict[str, Any]:
+    """Return model metadata/parameters. Returns empty dict if unavailable."""
+    provider = get_provider()
+    result = provider.show_model(model)
+    return result if result is not None else {}
+
+
 def _parse_source(source: str) -> ModelSource:
     """Convert a source string to ModelSource enum."""
     from lilbee.model_manager import ModelSource

--- a/src/lilbee/server/litestar_app.py
+++ b/src/lilbee/server/litestar_app.py
@@ -217,9 +217,13 @@ async def models_delete_route(model: str, source: str = "native") -> dict[str, A
 
 
 @get("/api/documents")
-async def documents_list_route() -> dict[str, Any]:
-    """List all indexed documents with metadata."""
-    return await handlers.list_documents()
+async def documents_list_route(
+    search: str = Parameter(query="search", default=""),
+    limit: int = Parameter(query="limit", default=50),
+    offset: int = Parameter(query="offset", default=0),
+) -> dict[str, Any]:
+    """List indexed documents with metadata, paginated and searchable."""
+    return await handlers.list_documents(search=search, limit=limit, offset=offset)
 
 
 @post("/api/documents/remove")

--- a/src/lilbee/server/litestar_app.py
+++ b/src/lilbee/server/litestar_app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from litestar import Litestar, get, post, put
+from litestar import Litestar, delete, get, post, put
 from litestar.config.cors import CORSConfig
 from litestar.exceptions import ValidationException
 from litestar.openapi import OpenAPIConfig
@@ -165,12 +165,77 @@ async def models_set_vision_route(data: SetModelRequest) -> SetModelResponse:
     return SetModelResponse(**raw)
 
 
+@get("/api/models/catalog")
+async def models_catalog_route(
+    task: str | None = Parameter(query="task", default=None),
+    search: str = Parameter(query="search", default=""),
+    size: str | None = Parameter(query="size", default=None),
+    featured: bool | None = Parameter(query="featured", default=None),
+    sort: str = Parameter(query="sort", default="featured"),
+    limit: int = Parameter(query="limit", default=20),
+    offset: int = Parameter(query="offset", default=0),
+) -> dict[str, Any]:
+    """Browse the model catalog with optional filters."""
+    return await handlers.models_catalog(
+        task=task,
+        search=search,
+        size=size,
+        featured=featured,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@get("/api/models/installed")
+async def models_installed_route() -> dict[str, Any]:
+    """List installed models with their source (native or ollama)."""
+    return await handlers.models_installed()
+
+
+@post("/api/models/pull")
+async def models_pull_route(data: dict[str, Any]) -> Stream:
+    """Pull a model with streaming SSE progress events."""
+    model = data.get("model", "")
+    source = data.get("source", "native")
+    return Stream(
+        handlers.models_pull(model, source=source),
+        media_type="text/event-stream",
+    )
+
+
+@post("/api/models/show")
+async def models_show_route(data: SetModelRequest) -> dict[str, Any]:
+    """Get model metadata and parameter defaults."""
+    return await handlers.models_show(model=data.model)
+
+
+@delete("/api/models/{model:str}", status_code=200)
+async def models_delete_route(model: str, source: str = "native") -> dict[str, Any]:
+    """Delete a model from the specified source."""
+    return await handlers.models_delete(model, source=source)
+
+
+@get("/api/documents")
+async def documents_list_route() -> dict[str, Any]:
+    """List all indexed documents with metadata."""
+    return await handlers.list_documents()
+
+
+@post("/api/documents/remove")
+async def documents_remove_route(data: dict[str, Any]) -> dict[str, Any]:
+    """Remove documents from the knowledge base by source name."""
+    names = data.get("names", [])
+    delete_files = data.get("delete_files", False)
+    return await handlers.delete_documents(names, delete_files=delete_files)
+
+
 def create_app() -> Litestar:
     """Create the Litestar application instance."""
     cors = CORSConfig(
         allow_origins=cfg.cors_origins,
         allow_origin_regex=r"^http://localhost(:\d+)?$",
-        allow_methods=["GET", "POST", "PUT"],
+        allow_methods=["GET", "POST", "PUT", "DELETE"],
         allow_headers=["Content-Type"],
     )
     return Litestar(
@@ -187,6 +252,13 @@ def create_app() -> Litestar:
             models_list_route,
             models_set_chat_route,
             models_set_vision_route,
+            models_catalog_route,
+            models_installed_route,
+            models_pull_route,
+            models_show_route,
+            models_delete_route,
+            documents_list_route,
+            documents_remove_route,
         ],
         cors_config=cors,
         openapi_config=OpenAPIConfig(

--- a/src/lilbee/server/litestar_app.py
+++ b/src/lilbee/server/litestar_app.py
@@ -216,6 +216,12 @@ async def models_delete_route(model: str, source: str = "native") -> dict[str, A
     return await handlers.models_delete(model, source=source)
 
 
+@get("/api/config")
+async def config_route() -> dict[str, Any]:
+    """Return all user-facing configuration values."""
+    return await handlers.get_config()
+
+
 @get("/api/documents")
 async def documents_list_route(
     search: str = Parameter(query="search", default=""),
@@ -256,6 +262,7 @@ def create_app() -> Litestar:
             models_list_route,
             models_set_chat_route,
             models_set_vision_route,
+            config_route,
             models_catalog_route,
             models_installed_route,
             models_pull_route,

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -281,8 +281,8 @@ def _adaptive_filter(
 ) -> list[SearchChunk]:
     """Widen cosine distance threshold when too few results.
 
-    Inspired by grantflow (grantflow-ai/grantflow) which uses
-    ``threshold = 0.3 + 0.2 * iteration`` with recursive retry.
+    Adapts the recursive threshold widening pattern described in
+    adaptive retrieval literature. Step size and cap are configurable.
 
     Step size is ``cfg.adaptive_threshold_step`` (default 0.2).
     Stops after ``_MAX_FILTER_ITERATIONS`` to prevent runaway loops.
@@ -351,6 +351,53 @@ def delete_source(filename: str) -> None:
         table = _open_table(SOURCES_TABLE)
         if table is not None:
             _safe_delete_unlocked(table, f"filename = '{_escape_sql_string(filename)}'")
+
+
+class RemoveResult:
+    """Result of a remove_documents operation."""
+
+    def __init__(self, removed: list[str], not_found: list[str]) -> None:
+        self.removed = removed
+        self.not_found = not_found
+
+
+def remove_documents(
+    names: list[str],
+    *,
+    delete_files: bool = False,
+    documents_dir: Path | None = None,
+) -> RemoveResult:
+    """Remove documents from the knowledge base by source name.
+
+    Looks up known sources, deletes chunks and source records for each.
+    If *delete_files* is True, resolves the path and verifies it is
+    contained within *documents_dir* before unlinking (path traversal guard).
+
+    Returns a RemoveResult with removed and not_found lists.
+    """
+    if documents_dir is None:
+        documents_dir = cfg.documents_dir
+
+    known = {s["filename"] for s in get_sources()}
+    removed: list[str] = []
+    not_found: list[str] = []
+
+    for name in names:
+        if name not in known:
+            not_found.append(name)
+            continue
+        delete_by_source(name)
+        delete_source(name)
+        removed.append(name)
+        if delete_files:
+            path = (documents_dir / name).resolve()
+            if not path.is_relative_to(documents_dir.resolve()):
+                log.warning("Path traversal blocked: %s escapes %s", name, documents_dir)
+                continue
+            if path.exists():
+                path.unlink()
+
+    return RemoveResult(removed=removed, not_found=not_found)
 
 
 def drop_all() -> None:

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -3,6 +3,7 @@
 import logging
 import math
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import lancedb
 import pyarrow as pa
@@ -281,8 +282,9 @@ def _adaptive_filter(
 ) -> list[SearchChunk]:
     """Widen cosine distance threshold when too few results.
 
-    Adapts the recursive threshold widening pattern described in
-    adaptive retrieval literature. Step size and cap are configurable.
+    Inspired by grantflow's (grantflow-ai/grantflow) adaptive retrieval
+    pattern which widens thresholds on recursive retry. Step size and
+    cap are configurable via ``cfg.adaptive_threshold_step``.
 
     Step size is ``cfg.adaptive_threshold_step`` (default 0.2).
     Stops after ``_MAX_FILTER_ITERATIONS`` to prevent runaway loops.

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -50,9 +50,6 @@ class SearchChunk(BaseModel):
     relevance_score: float | None = Field(None, alias="_relevance_score")
 
 
-_DEFAULT_MMR_LAMBDA = 0.5  # fallback if called without config
-
-
 def _cosine_sim(a: list[float], b: list[float]) -> float:
     """Cosine similarity between two vectors."""
     dot = sum(x * y for x, y in zip(a, b, strict=True))
@@ -67,12 +64,20 @@ def mmr_rerank(
     query_vector: list[float],
     results: list[SearchChunk],
     top_k: int,
-    lam: float = _DEFAULT_MMR_LAMBDA,
+    mmr_lambda: float | None = None,
 ) -> list[SearchChunk]:
     """Maximal Marginal Relevance — select diverse results.
 
-    Score = λ * sim(query, chunk) - (1-λ) * max_sim(chunk, selected)
+    Algorithm: Carbonell & Goldstein 1998,
+    "The Use of MMR, Diversity-Based Reranking for Reordering Documents
+    and Producing Summaries."
+
+    ``mmr_lambda`` controls the relevance/diversity tradeoff:
+    0.0 = maximum diversity, 1.0 = pure relevance.
+    Defaults to ``cfg.mmr_lambda`` (0.5).
     """
+    if mmr_lambda is None:
+        mmr_lambda = cfg.mmr_lambda
     if len(results) <= top_k:
         return results
 
@@ -87,7 +92,7 @@ def mmr_rerank(
             redundancy = 0.0
             if selected:
                 redundancy = max(_cosine_sim(candidate.vector, s.vector) for s in selected)
-            score = lam * relevance - (1 - lam) * redundancy
+            score = mmr_lambda * relevance - (1 - mmr_lambda) * redundancy
             if score > best_score:
                 best_score = score
                 best_idx = i
@@ -263,11 +268,12 @@ def search(
     if max_distance > 0:
         results = _adaptive_filter(results, top_k, max_distance)
     if len(results) > top_k:
-        results = mmr_rerank(query_vector, results, top_k, lam=cfg.mmr_lambda)
+        results = mmr_rerank(query_vector, results, top_k)
     return results
 
 
 _MAX_THRESHOLD = 1.0
+_MAX_FILTER_ITERATIONS = 20  # safety cap to prevent runaway loops
 
 
 def _adaptive_filter(
@@ -275,12 +281,18 @@ def _adaptive_filter(
 ) -> list[SearchChunk]:
     """Widen cosine distance threshold when too few results.
 
+    Inspired by grantflow (grantflow-ai/grantflow) which uses
+    ``threshold = 0.3 + 0.2 * iteration`` with recursive retry.
+
     Step size is ``cfg.adaptive_threshold_step`` (default 0.2).
+    Stops after ``_MAX_FILTER_ITERATIONS`` to prevent runaway loops.
     """
     cap = max(initial_threshold, _MAX_THRESHOLD)
     step = cfg.adaptive_threshold_step
     threshold = initial_threshold
-    while threshold <= cap:
+    for _ in range(_MAX_FILTER_ITERATIONS):
+        if threshold > cap:
+            break
         filtered = [r for r in results if (r.distance or 0) <= threshold]
         if len(filtered) >= top_k:
             return filtered

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -20,6 +20,14 @@ from lilbee.catalog import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_hf_cache():
+    """Clear the HuggingFace API cache between tests."""
+    catalog._hf_cache.clear()
+    yield
+    catalog._hf_cache.clear()
+
+
 class TestCatalogModelDataclass:
     def test_frozen(self) -> None:
         m = FEATURED_CHAT[0]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -448,11 +448,13 @@ class TestSetTabCompletion:
 
 class TestStreamResponseCancellation:
     def test_keyboard_interrupt_prints_stopped(self):
+        from lilbee.reasoning import StreamToken
+
         con, buf = _make_console()
         history: list[dict] = []
 
         def interrupted_stream(*_args, **_kwargs):
-            yield "partial "
+            yield StreamToken(content="partial ", is_reasoning=False)
             raise KeyboardInterrupt
 
         with mock.patch("lilbee.query.ask_stream", side_effect=interrupted_stream):
@@ -467,9 +469,11 @@ class TestStreamResponseCancellation:
         con, _buf = _make_console()
         history: list[dict] = []
 
+        from lilbee.reasoning import StreamToken
+
         def interrupted_stream(*_args, **_kwargs):
-            yield "partial "
-            yield "answer"
+            yield StreamToken(content="partial ", is_reasoning=False)
+            yield StreamToken(content="answer", is_reasoning=False)
             raise KeyboardInterrupt
 
         with mock.patch("lilbee.query.ask_stream", side_effect=interrupted_stream):
@@ -516,13 +520,135 @@ class TestStreamResponseCancellation:
         con, _buf = _make_console()
         history: list[dict] = []
 
-        with mock.patch("lilbee.query.ask_stream", return_value=iter(["Hello", " world"])):
+        from lilbee.reasoning import StreamToken
+
+        tokens = iter(
+            [
+                StreamToken(content="Hello", is_reasoning=False),
+                StreamToken(content=" world", is_reasoning=False),
+            ]
+        )
+        with mock.patch("lilbee.query.ask_stream", return_value=tokens):
             from lilbee.cli.chat.stream import stream_response
 
             stream_response("test", history, con)
 
         assert len(history) == 2
         assert history[1]["content"] == "Hello world"
+
+
+class TestStreamResponseReasoning:
+    def test_reasoning_rendered_dim(self):
+        from lilbee.config import cfg
+        from lilbee.reasoning import StreamToken
+
+        old = cfg.show_reasoning
+        cfg.show_reasoning = True
+        try:
+            con, buf = _make_console()
+            history: list[dict] = []
+            tokens = iter(
+                [
+                    StreamToken(content="thinking...", is_reasoning=True),
+                    StreamToken(content="answer", is_reasoning=False),
+                ]
+            )
+            with mock.patch("lilbee.query.ask_stream", return_value=tokens):
+                from lilbee.cli.chat.stream import stream_response
+
+                stream_response("test", history, con)
+            output = buf.getvalue()
+            assert "answer" in output
+        finally:
+            cfg.show_reasoning = old
+
+    def test_reasoning_then_response_transition(self):
+        from lilbee.reasoning import StreamToken
+
+        con = RichConsole(force_terminal=False, no_color=True, markup=False)
+        history: list[dict] = []
+        tokens = iter(
+            [
+                StreamToken(content="thought", is_reasoning=True),
+                StreamToken(content="more thought", is_reasoning=True),
+                StreamToken(content="answer", is_reasoning=False),
+            ]
+        )
+        with mock.patch("lilbee.query.ask_stream", return_value=tokens):
+            from lilbee.cli.chat.stream import stream_response
+
+            stream_response("test", history, con)
+        assert history[1]["content"] == "answer"
+
+    def test_response_then_reasoning_then_response(self):
+        from lilbee.reasoning import StreamToken
+
+        con = RichConsole(force_terminal=False, no_color=True, markup=False)
+        history: list[dict] = []
+        tokens = iter(
+            [
+                StreamToken(content="intro ", is_reasoning=False),
+                StreamToken(content="thinking", is_reasoning=True),
+                StreamToken(content="answer", is_reasoning=False),
+            ]
+        )
+        with mock.patch("lilbee.query.ask_stream", return_value=tokens):
+            from lilbee.cli.chat.stream import stream_response
+
+            stream_response("test", history, con)
+        assert history[1]["content"] == "intro answer"
+
+    def test_reasoning_only_response_parts_in_history(self):
+        from lilbee.reasoning import StreamToken
+
+        con, _buf = _make_console()
+        history: list[dict] = []
+        tokens = iter(
+            [
+                StreamToken(content="thinking...", is_reasoning=True),
+                StreamToken(content="answer", is_reasoning=False),
+            ]
+        )
+        with mock.patch("lilbee.query.ask_stream", return_value=tokens):
+            from lilbee.cli.chat.stream import stream_response
+
+            stream_response("test", history, con)
+        # Only non-reasoning content goes into history
+        assert history[1]["content"] == "answer"
+
+    def test_keyboard_interrupt_during_reasoning(self):
+        from lilbee.reasoning import StreamToken
+
+        con = RichConsole(force_terminal=False, no_color=True, markup=False)
+        history: list[dict] = []
+
+        def interrupted_reasoning(*_args, **_kwargs):
+            yield StreamToken(content="thinking", is_reasoning=True)
+            raise KeyboardInterrupt
+
+        with mock.patch("lilbee.query.ask_stream", side_effect=interrupted_reasoning):
+            from lilbee.cli.chat.stream import stream_response
+
+            stream_response("test", history, con)
+        # No crash — interrupt during reasoning handled gracefully
+        assert len(history) == 0
+
+    def test_error_during_reasoning(self):
+        from lilbee.reasoning import StreamToken
+
+        con = RichConsole(force_terminal=False, no_color=True, markup=False)
+        history: list[dict] = []
+
+        def error_reasoning(*_args, **_kwargs):
+            yield StreamToken(content="thinking", is_reasoning=True)
+            raise RuntimeError("boom")
+
+        with mock.patch("lilbee.query.ask_stream", side_effect=error_reasoning):
+            from lilbee.cli.chat.stream import stream_response
+
+            stream_response("test", history, con)
+        # No crash — error during reasoning handled gracefully
+        assert len(history) == 0
 
 
 class TestSyncToolbar:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -339,6 +339,77 @@ class TestSlashSetValidation:
         assert "saved" in buf.getvalue()
 
 
+class TestSlashDelete:
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_deletes_known_file(self, mock_del, mock_del_src, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        con, buf = _make_console()
+        dispatch_slash("/delete a.md", con)
+        output = buf.getvalue()
+        assert "Deleted" in output
+        assert "a.md" in output
+
+    @mock.patch("lilbee.store.get_sources")
+    def test_not_found(self, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        con, buf = _make_console()
+        dispatch_slash("/delete missing.md", con)
+        output = buf.getvalue()
+        assert "Not found" in output
+
+    @mock.patch("lilbee.store.get_sources")
+    def test_no_documents(self, mock_sources):
+        mock_sources.return_value = []
+        con, buf = _make_console()
+        dispatch_slash("/delete", con)
+        output = buf.getvalue()
+        assert "No documents" in output
+
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_deletes_physical_file(self, mock_del, mock_del_src, mock_sources, tmp_path):
+        from lilbee.config import cfg
+
+        mock_sources.return_value = [{"filename": "a.md"}]
+        cfg.documents_dir = tmp_path
+        f = tmp_path / "a.md"
+        f.write_text("content")
+        con, _buf = _make_console()
+        dispatch_slash("/delete a.md", con)
+        assert not f.exists()
+
+    @mock.patch("lilbee.store.get_sources")
+    def test_interactive_picker_eof(self, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        con, _buf = _make_console()
+        with mock.patch("prompt_toolkit.prompt", side_effect=EOFError):
+            dispatch_slash("/delete", con)
+        # Should not crash, just return silently
+
+    @mock.patch("lilbee.store.get_sources")
+    def test_interactive_empty_input(self, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        con, _buf = _make_console()
+        with mock.patch("prompt_toolkit.prompt", return_value="   "):
+            dispatch_slash("/delete", con)
+        # Empty input after strip — should return silently
+
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_clears_sync_status(self, mock_del, mock_del_src, mock_sources):
+        from lilbee.cli.chat.slash import handle_slash_delete
+        from lilbee.cli.chat.sync import SyncStatus
+
+        mock_sources.return_value = [{"filename": "a.md"}]
+        con, _buf = _make_console()
+        ss = SyncStatus()
+        handle_slash_delete("a.md", con, sync_status=ss)
+
+
 class TestSlashHelpIncludesNewCommands:
     def test_help_shows_settings(self):
         con, buf = _make_console()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,12 @@ runner = CliRunner()
 _SYNC_NOOP = SyncResult()
 
 
+def _mock_stream(*texts: str):
+    from lilbee.reasoning import StreamToken
+
+    return iter([StreamToken(content=t, is_reasoning=False) for t in texts])
+
+
 @pytest.fixture(autouse=True)
 def _skip_model_validation():
     """CLI tests never need real Ollama model validation or chat model checks."""
@@ -258,7 +264,7 @@ class TestAsk:
     @mock.patch("lilbee.query.ask_stream")
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_with_model_flag(self, mock_sync, mock_stream):
-        mock_stream.return_value = iter(["answer"])
+        mock_stream.return_value = _mock_stream("answer")
         result = runner.invoke(app, ["ask", "question", "--model", "llama3"])
         assert result.exit_code == 0
 
@@ -287,7 +293,7 @@ class TestAutoSync:
         new_callable=AsyncMock,
         return_value=SyncResult(added=["new.pdf"]),
     )
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["answer"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("answer"))
     def test_auto_sync_prints_summary(self, mock_ask_stream, mock_sync):
         result = runner.invoke(app, ["ask", "test"])
         assert result.exit_code == 0
@@ -295,20 +301,20 @@ class TestAutoSync:
 
 
 class TestChat:
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["Hello", " world"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("Hello", " world"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_chat_quit(self, mock_sync, mock_ask_stream):
         result = runner.invoke(app, ["chat"], input="question\n/quit\n")
         assert result.exit_code == 0
 
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["Hello"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("Hello"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_chat_slash_quit(self, mock_sync, mock_ask_stream):
         """Bare /quit exits immediately."""
         result = runner.invoke(app, ["chat"], input="/quit\n")
         assert result.exit_code == 0
 
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["Hello"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("Hello"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_chat_empty_input_skipped(self, mock_sync, mock_ask_stream):
         result = runner.invoke(app, ["chat"], input="\n/quit\n")
@@ -339,7 +345,7 @@ class TestChat:
                 assert len(history) == 2
                 assert history[0]["role"] == "user"
                 assert history[1]["role"] == "assistant"
-            return iter(["answer"])
+            return _mock_stream("answer")
 
         mock_stream.side_effect = fake_stream
         result = runner.invoke(app, ["chat"], input="first\nsecond\n/quit\n")
@@ -1166,7 +1172,7 @@ class TestSlashUnknown:
 class TestDefaultInvokesChatLoop:
     """Invoking `lilbee` with no subcommand enters chat mode."""
 
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["Hello"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("Hello"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_default_chat(self, mock_sync, mock_ask_stream):
         result = runner.invoke(app, [], input="question\n/quit\n")
@@ -2088,7 +2094,7 @@ class TestOllamaUnavailable:
 class TestEnsureChatModelWiring:
     """Verify that ask and chat call ensure_chat_model before running."""
 
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["answer"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("answer"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_calls_ensure_chat_model(self, mock_sync, mock_ask_stream):
         with mock.patch("lilbee.models.ensure_chat_model") as mock_ensure:
@@ -2108,7 +2114,7 @@ class TestEnsureChatModelWiring:
             runner.invoke(app, [], input="/quit\n")
             mock_ensure.assert_called_once()
 
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["answer"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("answer"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_calls_validate_model(self, mock_sync, mock_ask_stream):
         with mock.patch("lilbee.embedder.validate_model") as mock_val:
@@ -2615,7 +2621,7 @@ class TestRunSyncBackground:
 
 
 class TestStreamResponseChatMode:
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["Hello"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("Hello"))
     def test_chat_mode_uses_chat_console(self, mock_ask_stream):
         from lilbee.cli.chat.stream import stream_response
 
@@ -2627,7 +2633,7 @@ class TestStreamResponseChatMode:
         stream_response("test", history, con, chat_mode=True, chat_console=chat_con)
         chat_con.status.assert_called_once_with("Thinking...")
 
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["Hello"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("Hello"))
     def test_chat_mode_fallback_creates_console(self, mock_ask_stream):
         from lilbee.cli.chat.stream import stream_response
 
@@ -2644,7 +2650,7 @@ class TestStreamResponseChatMode:
 
             assert mock_console_cls.call_args[1]["file"] is sys.__stdout__
 
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["Hello"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("Hello"))
     def test_non_chat_mode_uses_con(self, mock_ask_stream):
         from lilbee.cli.chat.stream import stream_response
 
@@ -2897,7 +2903,7 @@ class TestChatBackgroundSync:
             mock_bg.assert_called_once()
             assert mock_bg.call_args[1].get("chat_mode") is True
 
-    @mock.patch("lilbee.query.ask_stream", return_value=iter(["answer"]))
+    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("answer"))
     @mock.patch(
         "lilbee.ingest.sync",
         new_callable=AsyncMock,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -11,6 +11,8 @@ from lilbee.mcp import (
     clean,
     lilbee_add,
     lilbee_init,
+    lilbee_list_documents,
+    lilbee_remove,
     lilbee_reset,
     lilbee_search,
     lilbee_status,
@@ -152,6 +154,50 @@ class TestLilbeeSync:
         (cfg.documents_dir / "test.txt").write_text("Hello world content.")
         result = await lilbee_sync()
         assert "test.txt" in result["added"]
+
+
+class TestLilbeeRemove:
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_removes_known_file(self, mock_del, mock_del_src, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        result = lilbee_remove(["a.md"])
+        assert result["removed"] == ["a.md"]
+        assert result["not_found"] == []
+
+    @mock.patch("lilbee.store.get_sources")
+    def test_not_found(self, mock_sources):
+        mock_sources.return_value = []
+        result = lilbee_remove(["missing.md"])
+        assert result["not_found"] == ["missing.md"]
+
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_delete_files_removes_from_disk(self, mock_del, mock_del_src, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        f = cfg.documents_dir / "a.md"
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("content")
+        result = lilbee_remove(["a.md"], delete_files=True)
+        assert result["removed"] == ["a.md"]
+        assert not f.exists()
+
+
+class TestLilbeeListDocuments:
+    @mock.patch("lilbee.store.get_sources")
+    def test_returns_documents(self, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md", "chunk_count": 3}]
+        result = lilbee_list_documents()
+        assert result["total"] == 1
+        assert result["documents"][0]["filename"] == "a.md"
+
+    @mock.patch("lilbee.store.get_sources")
+    def test_empty(self, mock_sources):
+        mock_sources.return_value = []
+        result = lilbee_list_documents()
+        assert result["total"] == 0
 
 
 class TestLilbeeReset:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -470,14 +470,14 @@ class TestSingleton:
     def test_creates_singleton(self) -> None:
         with mock.patch("lilbee.config.cfg") as mock_cfg:
             mock_cfg.models_dir = Path("/tmp/models")
-            mock_cfg.llm_base_url = "http://localhost:11434"
+            mock_cfg.ollama_url = "http://localhost:11434"
             mgr = get_model_manager()
             assert isinstance(mgr, ModelManager)
 
     def test_returns_same_instance(self) -> None:
         with mock.patch("lilbee.config.cfg") as mock_cfg:
             mock_cfg.models_dir = Path("/tmp/models")
-            mock_cfg.llm_base_url = "http://localhost:11434"
+            mock_cfg.ollama_url = "http://localhost:11434"
             mgr1 = get_model_manager()
             mgr2 = get_model_manager()
             assert mgr1 is mgr2
@@ -485,7 +485,7 @@ class TestSingleton:
     def test_reset_creates_new_instance(self) -> None:
         with mock.patch("lilbee.config.cfg") as mock_cfg:
             mock_cfg.models_dir = Path("/tmp/models")
-            mock_cfg.llm_base_url = "http://localhost:11434"
+            mock_cfg.ollama_url = "http://localhost:11434"
             mgr1 = get_model_manager()
             reset_model_manager()
             mgr2 = get_model_manager()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -748,7 +748,7 @@ class TestFactory:
         from lilbee.providers.litellm_provider import LiteLLMProvider
 
         cfg.llm_provider = "ollama"
-        cfg.llm_base_url = "http://custom:11434"
+        cfg.ollama_url = "http://custom:11434"
         provider = get_provider()
         assert isinstance(provider, LiteLLMProvider)
         assert provider._base_url == "http://custom:11434"
@@ -770,7 +770,7 @@ class TestConfigProvider:
 
             c = Config.from_env()
             assert c.llm_provider == "auto"
-            assert c.llm_base_url == "http://localhost:11434"
+            assert c.ollama_url == "http://localhost:11434"
             assert c.llm_api_key == ""
 
     def test_provider_env_override(self) -> None:
@@ -780,7 +780,7 @@ class TestConfigProvider:
             os.environ,
             {
                 "LILBEE_LLM_PROVIDER": "ollama",
-                "LILBEE_LLM_BASE_URL": "http://myhost:11434",
+                "LILBEE_OLLAMA_URL": "http://myhost:11434",
                 "LILBEE_LLM_API_KEY": "sk-key",
             },
         ):
@@ -788,7 +788,7 @@ class TestConfigProvider:
 
             c = Config.from_env()
             assert c.llm_provider == "ollama"
-            assert c.llm_base_url == "http://myhost:11434"
+            assert c.ollama_url == "http://myhost:11434"
             assert c.llm_api_key == "sk-key"
 
     def test_models_dir_computed(self) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -332,16 +332,16 @@ class TestAskStream:
     @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
     def test_yields_tokens_then_citations(self, mock_embed, mock_search, mock_provider):
         mock_provider.return_value.chat.return_value = iter(["Hello", " world"])
-        tokens = list(ask_stream("test"))
-        combined = "".join(tokens)
+        stream_tokens = list(ask_stream("test"))
+        combined = "".join(st.content for st in stream_tokens)
         assert "Hello world" in combined
         assert "Sources:" in combined
 
     @mock.patch("lilbee.store.search", return_value=[])
     @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
     def test_empty_results_yields_message(self, mock_embed, mock_search):
-        tokens = list(ask_stream("anything"))
-        assert any("No relevant documents" in t for t in tokens)
+        stream_tokens = list(ask_stream("anything"))
+        assert any("No relevant documents" in st.content for st in stream_tokens)
 
     @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
@@ -355,7 +355,6 @@ class TestAskStream:
         list(ask_stream("new question", history=history))
         call_args = mock_provider.return_value.chat.call_args
         messages = call_args[0][0]
-        # System + 2 history + user = 4 messages
         assert len(messages) == 4
         assert messages[1]["role"] == "user"
         assert messages[1]["content"] == "previous question"
@@ -365,10 +364,19 @@ class TestAskStream:
     @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
     def test_skips_empty_tokens(self, mock_embed, mock_search, mock_provider):
         mock_provider.return_value.chat.return_value = iter(["", "data"])
-        tokens = list(ask_stream("test"))
-        # Empty string token should not appear as a separate yield
-        non_source_tokens = [t for t in tokens if "Sources:" not in t]
-        assert all(t != "" for t in non_source_tokens if t.strip())
+        stream_tokens = list(ask_stream("test"))
+        non_source = [st for st in stream_tokens if "Sources:" not in st.content]
+        assert all(st.content != "" for st in non_source)
+
+    @mock.patch("lilbee.query.get_provider")
+    @mock.patch("lilbee.store.search", return_value=[_make_result()])
+    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    def test_reasoning_stripped_by_default(self, mock_embed, mock_search, mock_provider):
+        mock_provider.return_value.chat.return_value = iter(["<think>reasoning</think>answer"])
+        stream_tokens = list(ask_stream("test"))
+        combined = "".join(st.content for st in stream_tokens if not st.is_reasoning)
+        assert "reasoning" not in combined
+        assert "answer" in combined
 
 
 class TestGenerationOptions:
@@ -446,8 +454,8 @@ class TestAskStreamError:
             raise ConnectionError("lost connection")
 
         mock_provider.return_value.chat.return_value = failing_stream()
-        tokens = list(ask_stream("test"))
-        combined = "".join(tokens)
+        stream_tokens = list(ask_stream("test"))
+        combined = "".join(st.content for st in stream_tokens)
         assert "partial" in combined
         assert "Connection lost" in combined
 

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,0 +1,139 @@
+"""Tests for reasoning token filter — <think>...</think> tag detection."""
+
+from lilbee.reasoning import StreamToken, filter_reasoning
+
+
+def _collect(tokens: list[str], *, show: bool) -> list[StreamToken]:
+    return list(filter_reasoning(iter(tokens), show=show))
+
+
+class TestFilterReasoningShowFalse:
+    def test_clean_text_passes_through(self):
+        result = _collect(["Hello ", "world"], show=False)
+        assert len(result) == 2
+        assert all(not st.is_reasoning for st in result)
+        assert "".join(st.content for st in result) == "Hello world"
+
+    def test_strips_thinking_block(self):
+        result = _collect(["<think>reasoning</think>answer"], show=False)
+        content = "".join(st.content for st in result)
+        assert "<think>" not in content
+        assert "reasoning" not in content
+        assert "answer" in content
+
+    def test_strips_thinking_across_tokens(self):
+        result = _collect(["<thi", "nk>deep thought</thi", "nk>final"], show=False)
+        content = "".join(st.content for st in result)
+        assert "deep thought" not in content
+        assert "final" in content
+
+    def test_content_before_and_after(self):
+        result = _collect(["before<think>middle</think>after"], show=False)
+        content = "".join(st.content for st in result)
+        assert content == "beforeafter"
+
+    def test_empty_thinking_block(self):
+        result = _collect(["<think></think>answer"], show=False)
+        content = "".join(st.content for st in result)
+        assert content == "answer"
+
+    def test_no_tokens(self):
+        result = _collect([], show=False)
+        assert result == []
+
+
+class TestFilterReasoningShowTrue:
+    def test_clean_text_not_reasoning(self):
+        result = _collect(["Hello"], show=True)
+        assert len(result) == 1
+        assert result[0].content == "Hello"
+        assert result[0].is_reasoning is False
+
+    def test_thinking_yielded_as_reasoning(self):
+        result = _collect(["<think>reasoning</think>answer"], show=True)
+        reasoning = [st for st in result if st.is_reasoning]
+        response = [st for st in result if not st.is_reasoning]
+        assert len(reasoning) >= 1
+        assert "reasoning" in "".join(st.content for st in reasoning)
+        assert "answer" in "".join(st.content for st in response)
+
+    def test_thinking_across_token_boundaries(self):
+        tokens = ["<th", "ink>", "deep ", "thought", "</th", "ink>", "answer"]
+        result = _collect(tokens, show=True)
+        reasoning_text = "".join(st.content for st in result if st.is_reasoning)
+        response_text = "".join(st.content for st in result if not st.is_reasoning)
+        assert "deep thought" in reasoning_text
+        assert "answer" in response_text
+
+    def test_content_before_thinking(self):
+        result = _collect(["before<think>thinking</think>after"], show=True)
+        parts = [(st.content, st.is_reasoning) for st in result]
+        before = [c for c, r in parts if not r and "before" in c]
+        assert len(before) >= 1
+
+    def test_empty_thinking_block(self):
+        result = _collect(["<think></think>answer"], show=True)
+        response = "".join(st.content for st in result if not st.is_reasoning)
+        assert "answer" in response
+
+    def test_multiple_thinking_blocks(self):
+        result = _collect(["<think>first</think>mid<think>second</think>end"], show=True)
+        reasoning = "".join(st.content for st in result if st.is_reasoning)
+        response = "".join(st.content for st in result if not st.is_reasoning)
+        assert "first" in reasoning
+        assert "second" in reasoning
+        assert "mid" in response
+        assert "end" in response
+
+
+class TestCouldBePartial:
+    def test_partial_open_tag(self):
+        """Token ending with '<thi' should wait for more data."""
+        result = _collect(["text<thi", "nk>reasoning</think>done"], show=False)
+        content = "".join(st.content for st in result)
+        assert "reasoning" not in content
+        assert "text" in content
+        assert "done" in content
+
+    def test_partial_close_tag(self):
+        """Token ending with '</thi' inside thinking should wait."""
+        result = _collect(["<think>thought</thi", "nk>done"], show=True)
+        reasoning = "".join(st.content for st in result if st.is_reasoning)
+        assert "thought" in reasoning
+
+    def test_false_partial_not_tag(self):
+        """'<' at end that doesn't match tag prefix should not stall."""
+        result = _collect(["text<", "b>not a tag"], show=False)
+        content = "".join(st.content for st in result)
+        assert "text" in content
+
+    def test_unterminated_thinking_flushed_when_show(self):
+        """Thinking block never closed — buffer flushed as reasoning at end."""
+        result = _collect(["<think>unterminated"], show=True)
+        reasoning = [st for st in result if st.is_reasoning]
+        assert len(reasoning) >= 1
+        assert "unterminated" in "".join(st.content for st in reasoning)
+
+    def test_unterminated_thinking_with_partial_close(self):
+        """Thinking with partial close tag at end — flushed as reasoning."""
+        result = _collect(["<think>deep thought</thi"], show=True)
+        reasoning = "".join(st.content for st in result if st.is_reasoning)
+        assert "deep thought" in reasoning
+
+    def test_unterminated_thinking_stripped_when_hidden(self):
+        """Thinking block never closed — buffer discarded when show=False."""
+        result = _collect(["<think>unterminated"], show=False)
+        content = "".join(st.content for st in result)
+        assert content == ""
+
+    def test_trailing_text_after_thinking(self):
+        """Normal text at end of stream flushed correctly."""
+        result = _collect(["<think>thought</think>trailing"], show=True)
+        response = "".join(st.content for st in result if not st.is_reasoning)
+        assert "trailing" in response
+
+    def test_normal_text_ending_with_partial_tag(self):
+        """Buffer has normal text ending with '<t' — flushed as normal at end."""
+        result = _collect(["hello<t"], show=False)
+        content = "".join(st.content for st in result)
+        assert "hello<t" in content

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -838,3 +838,26 @@ class TestListDocuments:
         result = await handlers.list_documents()
         assert result["total"] == 0
         assert result["documents"] == []
+
+    @patch("lilbee.store.get_sources")
+    async def test_pagination(self, mock_sources):
+        mock_sources.return_value = [
+            {"filename": f"doc{i}.md", "chunk_count": i} for i in range(10)
+        ]
+        result = await handlers.list_documents(limit=3, offset=2)
+        assert result["total"] == 10
+        assert len(result["documents"]) == 3
+        assert result["documents"][0]["filename"] == "doc2.md"
+        assert result["limit"] == 3
+        assert result["offset"] == 2
+
+    @patch("lilbee.store.get_sources")
+    async def test_search_filter(self, mock_sources):
+        mock_sources.return_value = [
+            {"filename": "readme.md", "chunk_count": 3},
+            {"filename": "setup.py", "chunk_count": 1},
+            {"filename": "readme_dev.md", "chunk_count": 2},
+        ]
+        result = await handlers.list_documents(search="readme")
+        assert result["total"] == 2
+        assert all("readme" in d["filename"] for d in result["documents"])

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -771,6 +771,22 @@ class TestModelsDelete:
         assert result["freed_gb"] == 0.0
 
 
+class TestModelsShow:
+    async def test_returns_params(self):
+        mock_provider = MagicMock()
+        mock_provider.show_model.return_value = {"parameters": "temp 0.7"}
+        with patch(PATCH_PROVIDER, return_value=mock_provider):
+            result = await handlers.models_show("qwen3:8b")
+        assert result == {"parameters": "temp 0.7"}
+
+    async def test_returns_empty_when_none(self):
+        mock_provider = MagicMock()
+        mock_provider.show_model.return_value = None
+        with patch(PATCH_PROVIDER, return_value=mock_provider):
+            result = await handlers.models_show("unknown")
+        assert result == {}
+
+
 class TestDeleteDocuments:
     @patch("lilbee.store.get_sources")
     @patch("lilbee.store.delete_source")

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -821,6 +821,19 @@ class TestDeleteDocuments:
         assert not f.exists()
 
 
+class TestGetConfig:
+    async def test_returns_all_config_keys(self):
+        result = await handlers.get_config()
+        assert "chat_model" in result
+        assert "system_prompt" in result
+        assert "ollama_url" in result
+        assert "diversity_max_per_source" in result
+        assert "mmr_lambda" in result
+        assert "query_expansion_count" in result
+        assert "adaptive_threshold_step" in result
+        assert "temperature" in result
+
+
 class TestListDocuments:
     @patch("lilbee.store.get_sources")
     async def test_returns_documents(self, mock_sources):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -769,3 +769,56 @@ class TestModelsDelete:
             result = await handlers.models_delete("missing", source="native")
         assert result["deleted"] is False
         assert result["freed_gb"] == 0.0
+
+
+class TestDeleteDocuments:
+    @patch("lilbee.store.get_sources")
+    @patch("lilbee.store.delete_source")
+    @patch("lilbee.store.delete_by_source")
+    async def test_removes_known_documents(self, mock_del, mock_del_src, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md"}, {"filename": "b.md"}]
+        result = await handlers.delete_documents(["a.md"])
+        assert result["removed"] == ["a.md"]
+        assert result["not_found"] == []
+        mock_del.assert_called_once_with("a.md")
+        mock_del_src.assert_called_once_with("a.md")
+
+    @patch("lilbee.store.get_sources")
+    async def test_not_found(self, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        result = await handlers.delete_documents(["missing.md"])
+        assert result["removed"] == []
+        assert result["not_found"] == ["missing.md"]
+
+    @patch("lilbee.store.get_sources")
+    @patch("lilbee.store.delete_source")
+    @patch("lilbee.store.delete_by_source")
+    async def test_delete_files_removes_from_disk(
+        self, mock_del, mock_del_src, mock_sources, tmp_path
+    ):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        cfg.documents_dir = tmp_path
+        f = tmp_path / "a.md"
+        f.write_text("content")
+        result = await handlers.delete_documents(["a.md"], delete_files=True)
+        assert result["removed"] == ["a.md"]
+        assert not f.exists()
+
+
+class TestListDocuments:
+    @patch("lilbee.store.get_sources")
+    async def test_returns_documents(self, mock_sources):
+        mock_sources.return_value = [
+            {"filename": "a.md", "chunk_count": 5, "ingested_at": "2026-01-01"},
+        ]
+        result = await handlers.list_documents()
+        assert result["total"] == 1
+        assert result["documents"][0]["filename"] == "a.md"
+        assert result["documents"][0]["chunk_count"] == 5
+
+    @patch("lilbee.store.get_sources")
+    async def test_empty(self, mock_sources):
+        mock_sources.return_value = []
+        result = await handlers.list_documents()
+        assert result["total"] == 0
+        assert result["documents"] == []

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -289,6 +289,19 @@ class TestModelsDeleteRoute:
         assert resp.json()["deleted"] is True
 
 
+class TestConfigRoute:
+    @mock.patch(
+        "lilbee.server.handlers.get_config",
+        new_callable=AsyncMock,
+        return_value={"chat_model": "qwen3:8b", "system_prompt": "You are helpful."},
+    )
+    def test_returns_json(self, mock_cfg, client):
+        resp = client.get("/api/config")
+        assert resp.status_code == 200
+        assert resp.json()["chat_model"] == "qwen3:8b"
+        assert "system_prompt" in resp.json()
+
+
 class TestDocumentsListRoute:
     @mock.patch(
         "lilbee.server.handlers.list_documents",

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -233,6 +233,86 @@ class TestModelsSetVisionRoute:
         assert resp.json()["model"] == "llava:13b"
 
 
+class TestModelsCatalogRoute:
+    @mock.patch(
+        "lilbee.server.handlers.models_catalog",
+        new_callable=AsyncMock,
+        return_value={"total": 0, "limit": 20, "offset": 0, "models": []},
+    )
+    def test_returns_json(self, mock_cat, client):
+        resp = client.get("/api/models/catalog")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+
+class TestModelsInstalledRoute:
+    @mock.patch(
+        "lilbee.server.handlers.models_installed",
+        new_callable=AsyncMock,
+        return_value={"models": []},
+    )
+    def test_returns_json(self, mock_inst, client):
+        resp = client.get("/api/models/installed")
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+
+
+class TestModelsPullRoute:
+    @mock.patch("lilbee.server.handlers.models_pull")
+    def test_returns_sse(self, mock_pull, client):
+        mock_pull.return_value = mock_async_gen("event: progress\ndata: {}\n\n")
+        resp = client.post("/api/models/pull", json={"model": "test", "source": "native"})
+        assert resp.status_code == 201
+
+
+class TestModelsShowRoute:
+    @mock.patch(
+        "lilbee.server.handlers.models_show",
+        new_callable=AsyncMock,
+        return_value={"parameters": "temp 0.7"},
+    )
+    def test_returns_json(self, mock_show, client):
+        resp = client.post("/api/models/show", json={"model": "test"})
+        assert resp.status_code == 201
+        assert resp.json()["parameters"] == "temp 0.7"
+
+
+class TestModelsDeleteRoute:
+    @mock.patch(
+        "lilbee.server.handlers.models_delete",
+        new_callable=AsyncMock,
+        return_value={"deleted": True, "model": "test", "freed_gb": 0.0},
+    )
+    def test_returns_json(self, mock_del, client):
+        resp = client.delete("/api/models/test")
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] is True
+
+
+class TestDocumentsListRoute:
+    @mock.patch(
+        "lilbee.server.handlers.list_documents",
+        new_callable=AsyncMock,
+        return_value={"documents": [], "total": 0},
+    )
+    def test_returns_json(self, mock_list, client):
+        resp = client.get("/api/documents")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+
+class TestDocumentsRemoveRoute:
+    @mock.patch(
+        "lilbee.server.handlers.delete_documents",
+        new_callable=AsyncMock,
+        return_value={"removed": ["a.md"], "not_found": []},
+    )
+    def test_returns_json(self, mock_remove, client):
+        resp = client.post("/api/documents/remove", json={"names": ["a.md"]})
+        assert resp.status_code == 201
+        assert resp.json()["removed"] == ["a.md"]
+
+
 class TestOpenAPISchema:
     def test_schema_endpoint_returns_json(self, client):
         resp = client.get("/schema/openapi.json")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -177,7 +177,7 @@ class TestMMRRerank:
                 distance=0.4,
             ),
         ]
-        selected = mmr_rerank(query, results, top_k=2, lam=0.5)
+        selected = mmr_rerank(query, results, top_k=2, mmr_lambda=0.5)
         assert len(selected) == 2
         assert selected[0].chunk == "x-axis 1"
         # x-axis 2 is identical to x-axis 1, so max redundancy


### PR DESCRIPTION
## What changed

### Document management
You can now delete documents from lilbee — not just add them. This works everywhere:
- `/delete` in the chat REPL with interactive file picker and tab completion
- REST API: `GET /api/documents` (paginated, searchable) + `POST /api/documents/remove`
- MCP: `lilbee_remove` and `lilbee_list_documents` tools

All deletion paths use a shared `remove_documents()` function with path traversal protection.

### Reasoning model support
Models like Qwen3 and DeepSeek-R1 wrap their thinking in `<think>...</think>` tags. lilbee now handles this:
- **Default (off):** Thinking is stripped — you see a clean answer
- **Enabled:** `LILBEE_SHOW_REASONING=true` — thinking appears in a muted style (CLI) or collapsible block (Obsidian)
- Settable via `/set show_reasoning true` in chat, env var, or config.toml

### API completeness
All server handlers now have HTTP routes:
- `GET /api/config` — all user-facing settings
- `GET /api/documents` — paginated document list with search
- Model catalog, install, show, delete endpoints

### Code quality
- Shared `remove_documents()` helper with path traversal guard
- Named types (`NodeSpan`, `RemoveResult`) replace inline dicts
- Algorithm citations reference academic papers
- HuggingFace API responses cached for 5 minutes
- Pagination bounds validation