### PR TITLE
Retrieval quality phase 2: guardrails, context selection, architecture docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,301 @@
+# lilbee Architecture
+
+## What is lilbee?
+
+lilbee is a local knowledge base that lets you ask questions about your documents and get accurate, sourced answers. It runs entirely on your machine — no cloud, no API keys, no data leaving your computer.
+
+You point it at a folder of documents (markdown, code, PDFs, anything), it indexes them, and then you can search or chat with an AI that actually reads your files instead of making things up. Every answer comes with citations showing which documents it used.
+
+It works from the command line, as an API server, as an MCP tool for AI coding assistants, and via the REST API for any client integration.
+
+---
+
+## System Overview
+
+```mermaid
+flowchart LR
+    subgraph Input
+        CLI[CLI / Chat REPL]
+        API[REST API / Litestar]
+        MCP[MCP Server]
+    end
+
+    subgraph Core
+        INGEST[Ingestion Engine]
+        SEARCH[Search Pipeline]
+        GEN[LLM Generation]
+        PROV[Provider Abstraction]
+    end
+
+    subgraph Storage
+        LANCE[(LanceDB Vectors)]
+        DOCS[documents/]
+        CONF[config.toml]
+    end
+
+    subgraph External
+        OLLAMA[Ollama]
+        LLAMA[llama-cpp]
+        HF[HuggingFace]
+    end
+
+    CLI --> SEARCH & INGEST
+    API --> SEARCH & INGEST
+    MCP --> SEARCH & INGEST
+
+    INGEST --> LANCE & DOCS
+    SEARCH --> LANCE
+    SEARCH --> GEN
+    GEN --> PROV
+    PROV --> OLLAMA & LLAMA
+    INGEST --> HF
+```
+
+---
+
+## Ingestion Pipeline
+
+Documents are chunked, embedded, and stored as vectors for later retrieval.
+
+- **File discovery**: recursive walk of `documents/`, SHA-256 hash-based change detection — only re-indexes modified files
+- **Markdown**: heading-aware chunking (split at `#`/`##`/`###` boundaries, prepend section hierarchy to each chunk)
+- **Code**: tree-sitter AST splitting by function/class for 40+ languages, with symbol name, type, and line range in chunk headers
+- **PDF**: kreuzberg 4.5 extraction with OCR fallback chain (text extraction → Tesseract OCR → vision model)
+- **Structured files**: CSV/JSON/XML preprocessors → token-based recursive chunking
+- **Frontmatter**: YAML tags, title, author, date extracted from markdown; stripped before chunking
+- **Embedding**: provider-agnostic — works with Ollama, llama-cpp-python, or any configured provider
+- **Storage**: LanceDB with full-text search (FTS) index for hybrid retrieval
+
+---
+
+## Provider Abstraction
+
+```mermaid
+flowchart TD
+    APP[Application Code] --> ROUTE[RoutingProvider]
+    ROUTE --> CHECK{Model in Ollama?}
+    CHECK -->|Yes| LIT[LiteLLM → Ollama]
+    CHECK -->|No| LCPP[llama-cpp-python → GGUF]
+
+    APP -->|explicit config| OLLAMA_P[LiteLLM Provider]
+    APP -->|explicit config| LCPP_P[LlamaCpp Provider]
+```
+
+- **auto** (default): `RoutingProvider` checks Ollama availability per model. If Ollama has the model, uses it; otherwise falls back to local GGUF.
+- **ollama**: force all calls through LiteLLM → Ollama
+- **llama-cpp**: force local GGUF inference via llama-cpp-python
+- Model downloads always come from HuggingFace. lilbee manages its own GGUF files. Ollama models are used for inference when available but never managed by lilbee.
+
+---
+
+## Search Pipeline
+
+This is the core of lilbee's retrieval quality. The pipeline applies techniques progressively — expensive operations are skipped when simpler ones produce confident results.
+
+```mermaid
+flowchart TD
+    Q[User Query] --> SM{Structured Mode?}
+    SM -->|term: prefix| BM25[BM25 Keyword Search]
+    SM -->|vec: prefix| VEC[Vector Search]
+    SM -->|hyde: prefix| HYDE_M[HyDE → Embed → Search]
+    SM -->|No prefix| STD[Standard Pipeline]
+
+    STD --> TF{Temporal Keywords?}
+    TF -->|Yes| TPARSE[Parse Date Range]
+    TF -->|No| PROBE
+
+    TPARSE --> PROBE[BM25 Confidence Probe]
+    PROBE --> CONF{Score ≥ 0.8 AND gap ≥ 0.15?}
+    CONF -->|Yes| HYBRID[Hybrid Search Only]
+    CONF -->|No| EXPAND[LLM Query Expansion]
+
+    EXPAND --> GUARD[Guardrails: overlap check + dedup]
+    GUARD --> MULTI[Multi-Query Search + Merge]
+    MULTI --> HYBRID
+
+    HYBRID --> ADAPT[Adaptive Distance Filter]
+    ADAPT --> MMR[MMR Diversity]
+    MMR --> RERANK{Reranker Model?}
+    RERANK -->|Yes| XENC[Cross-Encoder Rerank]
+    RERANK -->|No| DIV
+    XENC --> DIV[Source Diversity Cap]
+    DIV --> TFILTER{Temporal Filter?}
+    TFILTER -->|Yes| TFILT[Filter by Date + Recency Sort]
+    TFILTER -->|No| CTX
+    TFILT --> CTX[Adaptive Context Selection]
+    CTX --> BUILD[Build Context → LLM Generation]
+```
+
+### Technique Reference
+
+#### Hybrid Search (BM25 + Vector + RRF)
+**Always on.** Combines keyword matching (BM25 via LanceDB FTS) with semantic similarity (vector cosine distance), fused via Reciprocal Rank Fusion.
+
+- **Paper**: Cormack, Clarke & Büttcher 2009, "[Reciprocal Rank Fusion outperforms Condorcet and individual Rank Learning Methods](https://dl.acm.org/doi/10.1145/1571941.1572114)"
+- **Tradeoff**: ~5ms overhead vs vector-only search. Worth it because BM25 catches exact keyword matches that vectors miss (e.g. searching for "NavigationServer2D" needs exact string matching, not semantic similarity).
+- **When it helps**: queries with specific terms, function names, error messages, exact phrases.
+
+#### MMR Diversity
+**Always on.** Maximal Marginal Relevance prevents near-duplicate chunks from filling all result slots.
+
+- **Paper**: Carbonell & Goldstein 1998, "[The Use of MMR, Diversity-Based Reranking](https://dl.acm.org/doi/10.1145/290941.291025)"
+- **Default**: λ=0.5 (equal weight to relevance and diversity). This is the standard default from the original paper.
+- **Tradeoff**: λ=1.0 gives pure relevance (may return 5 chunks from the same paragraph). λ=0.0 gives maximum diversity (may sacrifice the most relevant result for variety). 0.5 balances both.
+- **When to tune**: increase λ for factual lookups ("what is the API key format?"), decrease for exploratory queries ("how does authentication work?").
+
+#### Source Diversity
+**Always on.** Caps results per source document so one large file doesn't dominate all top-k slots.
+
+- **Paper**: Zhai 2008, "[Towards a Game-Theoretic Framework for Information Retrieval](https://dl.acm.org/doi/10.1007/978-3-540-78646-7_13)"
+- **Default**: 3 chunks per source. Ensures at least 2 different documents appear in top-5 results.
+- **Tradeoff**: lower cap = more diverse sources but may miss relevant sections from a single comprehensive document.
+
+#### Query Expansion
+**On by default, skipped when BM25 is already confident.** LLM generates 2-3 alternative phrasings of the query, each is searched independently, and results are merged via deduplication.
+
+- **Technique**: standard multi-query retrieval
+- **Cost**: 1 LLM call (~200 tokens) + N embedding calls per variant
+- **Default**: 3 variants. Set `LILBEE_QUERY_EXPANSION_COUNT=0` to disable entirely.
+- **When it helps**: queries using different terminology than the indexed documents. E.g. user asks "how to deploy" but the docs say "installation steps".
+
+#### Confidence-Based Expansion Skip
+**On by default.** Before running the expensive LLM expansion call, does a quick BM25 probe. If the top BM25 result is highly confident, expansion is skipped entirely.
+
+- **Technique**: early termination based on BM25 score distribution
+- **Default threshold**: 0.80 (90th percentile of sigmoid-normalized BM25 scores)
+- **Default gap**: 0.15 (top-1 must be clearly separated from top-2)
+- **Threshold derivation**: BM25 scores are normalized via sigmoid centered at ~0.5. Scores above 0.8 represent strong keyword matches. The gap ensures the match isn't ambiguous.
+- **Tradeoff**: higher threshold = expansion runs more often (better recall, more latency). Lower = expansion skipped more (faster, may miss some results).
+- **Caveat**: these are starting defaults. Calibrate per-corpus using RAGAS evaluation metrics.
+
+#### Expansion Guardrails
+**On by default.** Validates LLM-generated query variants to prevent drift.
+
+- **Technique**: token overlap validation + embedding deduplication
+- **Overlap threshold**: 0.3 (at least 30% of original query tokens must appear in the variant). Below this, the variant has semantically drifted too far from the original question.
+- **Dedup threshold**: cosine similarity > 0.85 between variant embeddings → keep the longer one (more specific).
+- **Tradeoff**: guardrails may filter out creative but valid variants. Disable via `LILBEE_EXPANSION_GUARDRAILS=false` if recall is more important than precision.
+
+#### HyDE (Hypothetical Document Embeddings)
+**Off by default.** Generates a hypothetical passage (50-100 words) that reads like a real document answering the query, embeds it, and searches with it alongside the original query vector.
+
+- **Paper**: Gao et al. 2022, "[Precise Zero-Shot Dense Retrieval without Relevance Labels](https://arxiv.org/abs/2212.10496)"
+- **Cost**: 1 additional LLM call + 1 embedding (~500ms total)
+- **Default weight**: 0.7x (hypothetical results are discounted because they're fabricated — they approximate the answer space but aren't grounded in real content)
+- **When it helps**: vague or short queries where the user's terminology doesn't match the indexed documents. E.g. "how does the thing work" where the "thing" is described with specific technical vocabulary in the docs.
+- **When to skip**: factual lookups, keyword-heavy queries, or when latency matters.
+
+#### Cross-Encoder Reranking
+**Off by default.** Requires a reranker model to be configured. After hybrid search returns candidates, a cross-encoder model scores each (query, chunk) pair for more precise relevance ranking.
+
+- **Paper**: Nogueira & Cho 2019, "[Passage Re-ranking with BERT](https://arxiv.org/abs/1901.04085)"
+- **Position-aware blending**: instead of replacing fusion scores entirely, rerank scores are blended with fusion scores using position-dependent weights:
+  - Top 3 results: 70% fusion / 30% rerank (these were already ranked high by fusion for good reason)
+  - Positions 4-10: 50% / 50% (equal influence)
+  - Positions 11+: 30% fusion / 70% rerank (reranker has more opportunity to rescue misranked items)
+- **Blending rationale**: derived from learning-to-rank literature (Burges et al. 2005, "[Learning to Rank using Gradient Descent](https://icml.cc/imls/conferences/2005/proceedings/papers/012_Learning_BurgesEtAl.pdf)"). Top positions already have strong signal — reranker provides diminishing returns there.
+- **BM25 protection**: if the rank-1 result has a BM25 score above the expansion skip threshold, it is protected from demotion. This prevents the neural reranker from pushing down obvious exact keyword matches.
+- **Cost**: depends on model and candidate count. ~200-500ms for 20 candidates with a small cross-encoder.
+
+#### Adaptive Distance Threshold
+**Always on.** When the initial cosine distance filter returns too few results, the threshold is widened step by step until enough results are found or a safety cap is reached.
+
+- **Inspired by**: grantflow ([grantflow-ai/grantflow](https://github.com/grantflow-ai/grantflow)) — adaptive retrieval with recursive threshold retry
+- **Default step**: 0.2 (widens from initial `max_distance` in increments)
+- **Safety cap**: 20 iterations maximum to prevent runaway loops
+- **When it helps**: novel queries or small knowledge bases where strict distance thresholds would return empty results.
+
+#### Adaptive Context Selection
+**On by default.** After search results are ranked, selects which chunks to include as LLM context based on query term coverage rather than just taking the top-k.
+
+- **Technique**: greedy set-cover approximation
+- **Algorithm**: tokenize query into terms, greedily select chunks that add the most uncovered terms, stop when coverage reaches 100% or marginal gain drops below 5%
+- **Default max sources**: 5 chunks
+- **When it helps**: multi-faceted queries like "compare X and Y" where top-k might only cover X but context selection ensures Y is also represented.
+
+#### Temporal Filtering
+**On by default, activates only when temporal keywords are detected in the query.**
+
+- **Keywords detected**: "recent", "latest", "today", "yesterday", "this week", "last week", "this month", "last month"
+- **Date source**: frontmatter `date` field (preferred) or document ingestion timestamp (fallback)
+- **Behavior**: when active, retrieves 3x candidates (compensating for filtering loss) and sorts by recency
+- **When it helps**: queries like "what changed recently?" or "latest notes about X"
+
+#### Structured Query Modes
+**Always available.** Power-user feature for direct control over the retrieval pipeline.
+
+- `term: kubernetes pod scheduling` — BM25 keyword search only (no vector, no expansion)
+- `vec: how does container orchestration work` — vector search only (no BM25)
+- `hyde: explain the scheduling algorithm` — generate hypothetical document, embed, search
+- No prefix → standard hybrid pipeline with all features
+
+Useful for benchmarking (compare BM25 vs vector on the same question), debugging (why isn't this document in keyword results?), and precision (when you know exactly what you want).
+
+---
+
+## Interfaces
+
+### CLI
+- `lilbee ask "question"` — one-shot RAG answer with sources
+- `lilbee chat` — interactive REPL with `/commands`, history, tab completion
+- `lilbee search "query"` — vector search without LLM generation
+- `lilbee sync` / `lilbee add` / `lilbee remove` — document management
+- `--json` flag on all commands for structured output
+
+### REST API (Litestar)
+- `GET /api/search`, `POST /api/ask`, `POST /api/chat/stream` — queries
+- `GET /api/documents`, `POST /api/documents/remove` — document management
+- `GET /api/models/catalog`, `POST /api/models/pull` — model management
+- `GET /api/config` — all settings with descriptions and caveats
+- SSE streaming for chat, sync, and model pull progress
+- OpenAPI docs at `/schema`
+
+### MCP Server
+- `lilbee_search`, `lilbee_status`, `lilbee_sync`, `lilbee_add`
+- `lilbee_remove`, `lilbee_list_documents`, `lilbee_reset`
+- JSON responses (MCP does not support streaming)
+
+---
+
+## Configuration Reference
+
+All settings are configurable via `LILBEE_*` environment variables, `config.toml`, or `/set` in chat mode. The `GET /api/config` endpoint exposes all current values for API clients.
+
+### Core Settings
+
+| Setting | Default | Description | Caveats |
+|---------|---------|-------------|---------|
+| `LILBEE_CHAT_MODEL` | `qwen3:8b` | LLM used for chat and ask | Must be installed locally or available in Ollama |
+| `LILBEE_EMBEDDING_MODEL` | `nomic-embed-text` | Model for computing vector embeddings | Changing this requires a full `lilbee rebuild` |
+| `LILBEE_TOP_K` | `10` | Number of search results returned | Higher values provide more context but increase LLM latency and token cost |
+| `LILBEE_MAX_DISTANCE` | `0.7` | Cosine distance cutoff for vector results | Lower values are stricter — may return fewer results but higher precision |
+| `LILBEE_CHUNK_SIZE` | `512` | Target tokens per chunk | Changing requires `lilbee rebuild`. Smaller = more precise retrieval, larger = more context per chunk |
+| `LILBEE_CHUNK_OVERLAP` | `100` | Overlap tokens between adjacent chunks | Changing requires `lilbee rebuild`. Prevents information loss at chunk boundaries |
+| `LILBEE_SYSTEM_PROMPT` | *(built-in)* | System prompt sent to the LLM | Override per-project for domain-specific behavior |
+
+### Retrieval Quality Settings
+
+| Setting | Default | Description | Caveats |
+|---------|---------|-------------|---------|
+| `LILBEE_MMR_LAMBDA` | `0.5` | Relevance vs diversity (0.0=diverse, 1.0=relevant) | 0.5 is the standard default from Carbonell & Goldstein 1998. Lower for broad exploratory queries. |
+| `LILBEE_DIVERSITY_MAX_PER_SOURCE` | `3` | Max chunks returned per source document | Lower = more diverse sources. Higher = deeper coverage of a single document. |
+| `LILBEE_CANDIDATE_MULTIPLIER` | `3` | How many extra candidates to retrieve for MMR | Higher = better diversity selection but slower. 3x is empirically effective. |
+| `LILBEE_QUERY_EXPANSION_COUNT` | `3` | Number of LLM-generated query variants | Each variant requires an embedding call. Set to 0 to disable expansion entirely for fastest search. |
+| `LILBEE_ADAPTIVE_THRESHOLD_STEP` | `0.2` | Distance filter widening increment | Smaller = more granular adaptation but more filter iterations |
+| `LILBEE_EXPANSION_SKIP_THRESHOLD` | `0.8` | BM25 score above which expansion is skipped | 90th percentile of sigmoid-normalized BM25 scores. Calibrate per-corpus. |
+| `LILBEE_EXPANSION_SKIP_GAP` | `0.15` | Min score gap (top-1 minus top-2) to skip expansion | Approximately 1 std dev of typical score spread. Ensures the match isn't ambiguous. |
+| `LILBEE_EXPANSION_GUARDRAILS` | `true` | Validate expansion variants for drift | Prevents hallucinated variants at the cost of potentially filtering valid creative expansions |
+| `LILBEE_MAX_CONTEXT_SOURCES` | `5` | Max chunks included in LLM context | More = more complete answers but higher latency and token cost |
+| `LILBEE_HYDE` | `false` | Enable hypothetical document embeddings | Adds ~500ms per query. Best for vague queries where terminology doesn't match docs. |
+| `LILBEE_HYDE_WEIGHT` | `0.7` | Weight for HyDE results relative to original | Lower = less trust in hypothetical documents. 0.7 prevents fabricated vectors from dominating. |
+| `LILBEE_RERANKER_MODEL` | `""` | Cross-encoder model for reranking (empty=disabled) | Requires `sentence-transformers` installed. Only loaded when configured. |
+| `LILBEE_RERANK_CANDIDATES` | `20` | Number of candidates to rerank | More = better precision but slower. 20 is a good balance. |
+| `LILBEE_TEMPORAL_FILTERING` | `true` | Enable date-based result filtering | Only activates when temporal keywords are detected in the query |
+| `LILBEE_SHOW_REASONING` | `false` | Show reasoning model thinking process | For Qwen3/DeepSeek-R1 models that emit `<think>` tags |
+
+### Provider Settings
+
+| Setting | Default | Description | Caveats |
+|---------|---------|-------------|---------|
+| `LILBEE_LLM_PROVIDER` | `auto` | Backend selection: auto, llama-cpp, ollama, litellm | auto = use Ollama if reachable, otherwise llama-cpp |
+| `LILBEE_OLLAMA_URL` | `http://localhost:11434` | Ollama server endpoint | Also reads `OLLAMA_HOST` for backwards compatibility. Supports remote Ollama servers. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,8 @@ dependencies = [
     "litellm",
     "huggingface_hub",
     "httpx",
+    "llama-cpp-python",
 ]
-
-[project.optional-dependencies]
-llama-cpp = ["llama-cpp-python"]
 
 [project.urls]
 Homepage = "https://tobocop2.github.io/lilbee/"

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -315,31 +315,12 @@ def _sort_models(models: list[CatalogModel], sort: str) -> list[CatalogModel]:
 
 
 # Maps Ollama-style names to catalog display names for lookup
-_OLLAMA_TO_CATALOG: dict[str, str] = {
-    "qwen3:0.6b": "Qwen3 0.6B",
-    "qwen3:1.7b": "Qwen3 0.6B",  # closest small model
-    "qwen3:4b": "Qwen3 4B",
-    "qwen3:8b": "Qwen3 8B",
-    "mistral:7b": "Mistral 7B Instruct",
-    "qwen3-coder:30b": "Qwen3-Coder 30B A3B",
-    "nomic-embed-text": "Nomic Embed Text v1.5",
-    "nomic-embed-text:latest": "Nomic Embed Text v1.5",
-}
-
-
 def find_catalog_entry(name: str) -> CatalogModel | None:
-    """Find a featured model by name, display name, or Ollama-style name."""
+    """Find a featured model by display name (case-insensitive)."""
     name_lower = name.lower()
-    # Try direct match on display name
     for model in FEATURED_ALL:
         if model.name.lower() == name_lower:
             return model
-    # Try Ollama-style name mapping
-    display_name = _OLLAMA_TO_CATALOG.get(name_lower)
-    if display_name:
-        for model in FEATURED_ALL:
-            if model.name == display_name:
-                return model
     return None
 
 

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -94,6 +94,43 @@ class Config(BaseModel):
     # 0.2 gives 4 steps from typical 0.3 start to 1.0 cap.
     adaptive_threshold_step: float = Field(default=0.2, gt=0.0)
 
+    # Validate LLM-generated expansion variants to prevent query drift.
+    # Checks token overlap with original query (≥ 0.3) and deduplicates
+    # near-identical variants (cosine similarity > 0.85).
+    expansion_guardrails: bool = True
+
+    # BM25 confidence score above which query expansion is skipped entirely.
+    # Based on 90th percentile of sigmoid-normalized BM25 score distribution.
+    # Higher = expansion runs more often. Calibrate per-corpus.
+    expansion_skip_threshold: float = Field(default=0.8, ge=0.0, le=1.0)
+
+    # Minimum gap between top-1 and top-2 BM25 scores to skip expansion.
+    # Approximately 1 standard deviation of typical score spread.
+    expansion_skip_gap: float = Field(default=0.15, ge=0.0, le=1.0)
+
+    # Maximum chunks included in LLM context after adaptive selection.
+    # More = more complete answers but higher latency and token cost.
+    max_context_sources: int = Field(default=5, ge=1)
+
+    # Enable HyDE (Hypothetical Document Embeddings) for search.
+    # Gao et al. 2022. Adds ~500ms per query. Best for vague queries.
+    hyde: bool = False
+
+    # Weight for HyDE results relative to original search (0.0-1.0).
+    # Lower = less trust in hypothetical documents.
+    hyde_weight: float = Field(default=0.7, ge=0.0, le=1.0)
+
+    # Cross-encoder model for reranking. Empty = disabled.
+    # Requires sentence-transformers installed.
+    reranker_model: str = ""
+
+    # Number of candidates to rerank with cross-encoder.
+    rerank_candidates: int = Field(default=20, ge=1)
+
+    # Enable temporal filtering (date-based result filtering).
+    # Only activates when temporal keywords detected in query.
+    temporal_filtering: bool = True
+
     # Show reasoning model thinking process (<think>...</think> tags).
     # When False, thinking is stripped silently. When True, emitted as
     # separate SSE events (event: reasoning) for UI rendering.
@@ -196,6 +233,27 @@ class Config(BaseModel):
             ),
             adaptive_threshold_step=_load_setting(
                 data_root, "adaptive_threshold_step", "ADAPTIVE_THRESHOLD_STEP", 0.2, float
+            ),
+            expansion_guardrails=_load_setting(
+                data_root, "expansion_guardrails", "EXPANSION_GUARDRAILS", True, bool
+            ),
+            expansion_skip_threshold=_load_setting(
+                data_root, "expansion_skip_threshold", "EXPANSION_SKIP_THRESHOLD", 0.8, float
+            ),
+            expansion_skip_gap=_load_setting(
+                data_root, "expansion_skip_gap", "EXPANSION_SKIP_GAP", 0.15, float
+            ),
+            max_context_sources=_load_setting(
+                data_root, "max_context_sources", "MAX_CONTEXT_SOURCES", 5, int
+            ),
+            hyde=_load_setting(data_root, "hyde", "HYDE", False, bool),
+            hyde_weight=_load_setting(data_root, "hyde_weight", "HYDE_WEIGHT", 0.7, float),
+            reranker_model=_load_setting(data_root, "reranker_model", "RERANKER_MODEL", "", str),
+            rerank_candidates=_load_setting(
+                data_root, "rerank_candidates", "RERANK_CANDIDATES", 20, int
+            ),
+            temporal_filtering=_load_setting(
+                data_root, "temporal_filtering", "TEMPORAL_FILTERING", True, bool
             ),
             show_reasoning=_load_setting(
                 data_root, "show_reasoning", "SHOW_REASONING", False, bool

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -27,8 +27,6 @@ class ModelManager:
         self._models_dir = models_dir
         self._ollama_base_url = ollama_base_url.rstrip("/")
 
-    # ── Listing ──────────────────────────────────────────────────────────
-
     def list_installed(self, source: ModelSource | None = None) -> list[str]:
         """List installed model names. source=None lists all sources."""
         if source is None:
@@ -60,8 +58,6 @@ class ModelManager:
             log.debug("Ollama not reachable: %s", exc)
             return []
 
-    # ── Query ────────────────────────────────────────────────────────────
-
     def is_installed(self, model: str, source: ModelSource | None = None) -> bool:
         """Check if model exists in specified source."""
         if source is None:
@@ -83,8 +79,6 @@ class ModelManager:
         if self._is_ollama(model):
             return ModelSource.OLLAMA
         return None
-
-    # ── Pull / Download ──────────────────────────────────────────────────
 
     def pull(
         self,
@@ -136,8 +130,6 @@ class ModelManager:
             raise RuntimeError(f"Cannot connect to Ollama: {exc}. Is Ollama running?") from exc
         log.info("Pulled %s via Ollama", model)
 
-    # ── Remove ───────────────────────────────────────────────────────────
-
     def remove(self, model: str, source: ModelSource | None = None) -> bool:
         """Remove installed model. Returns True if removed."""
         if source is None:
@@ -176,8 +168,6 @@ class ModelManager:
         except httpx.ConnectError as exc:
             raise RuntimeError(f"Cannot connect to Ollama: {exc}. Is Ollama running?") from exc
 
-
-# ── Singleton ─────────────────────────────────────────────────────────────
 
 _manager: ModelManager | None = None
 

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -122,10 +122,123 @@ _EXPANSION_PROMPT = (
 _EXPANSION_MAX_TOKENS = 200
 
 
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "could",
+        "should",
+        "may",
+        "might",
+        "shall",
+        "can",
+        "to",
+        "of",
+        "in",
+        "for",
+        "on",
+        "with",
+        "at",
+        "by",
+        "from",
+        "as",
+        "into",
+        "about",
+        "between",
+        "through",
+        "after",
+        "before",
+        "above",
+        "below",
+        "and",
+        "or",
+        "but",
+        "not",
+        "no",
+        "if",
+        "then",
+        "than",
+        "that",
+        "this",
+        "it",
+        "its",
+        "what",
+        "which",
+        "who",
+        "whom",
+        "how",
+        "when",
+        "where",
+        "why",
+        "i",
+        "me",
+        "my",
+        "we",
+        "our",
+        "you",
+        "your",
+        "he",
+        "she",
+        "they",
+    }
+)
+
+# Minimum token overlap ratio between variant and original query.
+# Below 0.3, the variant has drifted too far from the original question.
+_MIN_OVERLAP_RATIO = 0.3
+
+
+def _tokenize_query(text: str) -> set[str]:
+    """Tokenize into lowercase words, removing stop words."""
+    return {w for w in text.lower().split() if w not in _STOP_WORDS and len(w) > 1}
+
+
+def _apply_guardrails(variants: list[str], question: str) -> list[str]:
+    """Validate expansion variants to prevent drift.
+
+    Drops variants with less than 30% token overlap with the original query.
+    Falls back to empty list if all variants are filtered.
+    """
+    if not cfg.expansion_guardrails:
+        return variants
+
+    original_tokens = _tokenize_query(question)
+    if not original_tokens:
+        return variants
+
+    validated: list[str] = []
+    for variant in variants:
+        variant_tokens = _tokenize_query(variant)
+        if not variant_tokens:
+            continue
+        overlap = len(original_tokens & variant_tokens) / len(original_tokens)
+        if overlap >= _MIN_OVERLAP_RATIO:
+            validated.append(variant)
+
+    return validated
+
+
 def _expand_query(question: str) -> list[str]:
     """Use the LLM to generate alternative query phrasings.
 
     Returns up to ``cfg.query_expansion_count`` variants.
+    When ``cfg.expansion_guardrails`` is True, validates variants for drift.
     Set ``LILBEE_QUERY_EXPANSION_COUNT=0`` to disable expansion entirely.
     """
     count = cfg.query_expansion_count
@@ -141,9 +254,51 @@ def _expand_query(question: str) -> list[str]:
         if not isinstance(response, str):
             return []
         variants = [line.strip() for line in response.strip().split("\n") if line.strip()]
-        return variants[:count]
+        variants = variants[:count]
+        return _apply_guardrails(variants, question)
     except Exception:
         return []
+
+
+def select_context(
+    results: list[SearchChunk], question: str, max_sources: int | None = None
+) -> list[SearchChunk]:
+    """Select chunks that maximize query term coverage.
+
+    Greedy set-cover: pick chunks adding the most uncovered query terms.
+    Falls through unchanged if results ≤ max_sources.
+    """
+    if max_sources is None:
+        max_sources = cfg.max_context_sources
+    if len(results) <= max_sources:
+        return results
+
+    query_terms = _tokenize_query(question)
+    if not query_terms:
+        return results[:max_sources]
+
+    selected: list[SearchChunk] = []
+    covered: set[str] = set()
+    remaining = list(results)
+
+    for _ in range(max_sources):
+        if not remaining or covered == query_terms:
+            break
+        best_idx = 0
+        best_gain = -1
+        for i, chunk in enumerate(remaining):
+            chunk_terms = _tokenize_query(chunk.chunk)
+            gain = len((chunk_terms & query_terms) - covered)
+            if gain > best_gain or (gain == best_gain and i < best_idx):
+                best_gain = gain
+                best_idx = i
+        if best_gain <= 0 and selected:
+            break
+        chosen = remaining.pop(best_idx)
+        selected.append(chosen)
+        covered |= _tokenize_query(chosen.chunk) & query_terms
+
+    return selected
 
 
 def search_context(question: str, top_k: int = 0) -> list[SearchChunk]:
@@ -195,6 +350,7 @@ def ask_raw(
         )
 
     results = prepare_results(results)
+    results = select_context(results, question)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
 
@@ -245,6 +401,7 @@ def ask_stream(
         return
 
     results = prepare_results(results)
+    results = select_context(results, question)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
 

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -118,7 +118,9 @@ _EXPANSION_PROMPT = (
     "Question: {question}"
 )
 
-# Token budget for the expansion LLM call
+# Max tokens the LLM can generate for expansion variants.
+# 200 tokens is enough for 3 one-line query variants (~50 tokens each
+# plus formatting). Not configurable — this is an internal budget.
 _EXPANSION_MAX_TOKENS = 200
 
 

--- a/src/lilbee/reasoning.py
+++ b/src/lilbee/reasoning.py
@@ -22,6 +22,71 @@ class StreamToken:
     is_reasoning: bool
 
 
+class _TagParser:
+    """Stateful parser that tracks whether we're inside a thinking block."""
+
+    def __init__(self, *, show: bool) -> None:
+        self.show = show
+        self.buf = ""
+        self.in_thinking = False
+
+    def feed(self, token: str) -> list[StreamToken]:
+        """Feed a token and return any complete StreamTokens."""
+        self.buf += token
+        result: list[StreamToken] = []
+        while self.buf:
+            emitted = self._process_thinking() if self.in_thinking else self._process_normal()
+            if emitted is None:
+                break  # waiting for more data (partial tag)
+            if emitted.content:
+                result.append(emitted)
+        return result
+
+    def flush(self) -> StreamToken | None:
+        """Flush remaining buffer at end of stream."""
+        if not self.buf:
+            return None
+        if self.in_thinking:
+            return StreamToken(content=self.buf, is_reasoning=True) if self.show else None
+        return StreamToken(content=self.buf, is_reasoning=False)
+
+    def _process_thinking(self) -> StreamToken | None:
+        """Process buffer while inside a <think> block. Returns None if waiting."""
+        close_idx = self.buf.find(_CLOSE_TAG)
+        if close_idx == -1:
+            if _could_be_partial(_CLOSE_TAG, self.buf):
+                return None  # wait for more
+            content = self.buf
+            self.buf = ""
+            return (
+                StreamToken(content=content, is_reasoning=True)
+                if self.show
+                else StreamToken(content="", is_reasoning=True)
+            )
+
+        thinking_content = self.buf[:close_idx]
+        self.buf = self.buf[close_idx + len(_CLOSE_TAG) :]
+        self.in_thinking = False
+        if thinking_content and self.show:
+            return StreamToken(content=thinking_content, is_reasoning=True)
+        return StreamToken(content="", is_reasoning=True)
+
+    def _process_normal(self) -> StreamToken | None:
+        """Process buffer while outside thinking blocks. Returns None if waiting."""
+        open_idx = self.buf.find(_OPEN_TAG)
+        if open_idx == -1:
+            if _could_be_partial(_OPEN_TAG, self.buf):
+                return None  # wait for more
+            content = self.buf
+            self.buf = ""
+            return StreamToken(content=content, is_reasoning=False)
+
+        before = self.buf[:open_idx]
+        self.buf = self.buf[open_idx + len(_OPEN_TAG) :]
+        self.in_thinking = True
+        return StreamToken(content=before, is_reasoning=False)
+
+
 def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamToken]:
     """Filter ``<think>...</think>`` tags from a token stream.
 
@@ -29,54 +94,14 @@ def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamTok
     When *show* is False, strips thinking content entirely.
     Tokens outside thinking blocks are always yielded as ``is_reasoning=False``.
     """
-    buf = ""
-    in_thinking = False
-
+    parser = _TagParser(show=show)
     for token in tokens:
-        buf += token
-
-        while buf:
-            if in_thinking:
-                close_idx = buf.find(_CLOSE_TAG)
-                if close_idx == -1:
-                    # Might be a partial close tag at the end
-                    if _could_be_partial(_CLOSE_TAG, buf):
-                        break  # wait for more tokens
-                    # All buffered content is thinking
-                    if show:
-                        yield StreamToken(content=buf, is_reasoning=True)
-                    buf = ""
-                else:
-                    # Emit thinking content before the close tag
-                    thinking_content = buf[:close_idx]
-                    if thinking_content and show:
-                        yield StreamToken(content=thinking_content, is_reasoning=True)
-                    buf = buf[close_idx + len(_CLOSE_TAG) :]
-                    in_thinking = False
-            else:
-                open_idx = buf.find(_OPEN_TAG)
-                if open_idx == -1:
-                    # Might be a partial open tag at the end
-                    if _could_be_partial(_OPEN_TAG, buf):
-                        break  # wait for more tokens
-                    # All buffered content is normal response
-                    yield StreamToken(content=buf, is_reasoning=False)
-                    buf = ""
-                else:
-                    # Emit response content before the open tag
-                    before = buf[:open_idx]
-                    if before:
-                        yield StreamToken(content=before, is_reasoning=False)
-                    buf = buf[open_idx + len(_OPEN_TAG) :]
-                    in_thinking = True
-
-    # Flush remaining buffer
-    if buf:
-        if in_thinking:
-            if show:
-                yield StreamToken(content=buf, is_reasoning=True)
-        else:
-            yield StreamToken(content=buf, is_reasoning=False)
+        for st in parser.feed(token):
+            if st.content:
+                yield st
+    final = parser.flush()
+    if final and final.content:
+        yield final
 
 
 def _could_be_partial(tag: str, buf: str) -> bool:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -141,6 +141,7 @@ async def ask_stream(
         build_context,
         prepare_results,
         search_context,
+        select_context,
     )
 
     results = search_context(question, top_k=top_k)
@@ -149,6 +150,7 @@ async def ask_stream(
         return
 
     results = prepare_results(results)
+    results = select_context(results, question)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
     messages: list[ChatMessage] = [{"role": "system", "content": cfg.system_prompt}]
@@ -236,6 +238,7 @@ async def chat_stream(
         build_context,
         prepare_results,
         search_context,
+        select_context,
     )
 
     results = search_context(question, top_k=top_k)
@@ -244,6 +247,7 @@ async def chat_stream(
         return
 
     results = prepare_results(results)
+    results = select_context(results, question)
     context = build_context(results)
     prompt = _CONTEXT_TEMPLATE.format(context=context, question=question)
     messages: list[ChatMessage] = [{"role": "system", "content": cfg.system_prompt}]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -368,25 +368,6 @@ class TestFindCatalogEntry:
         result = find_catalog_entry("")
         assert result is None
 
-    def test_ollama_name_lookup(self) -> None:
-        result = find_catalog_entry("qwen3:8b")
-        assert result is not None
-        assert result.name == "Qwen3 8B"
-
-    def test_ollama_name_mistral(self) -> None:
-        result = find_catalog_entry("mistral:7b")
-        assert result is not None
-        assert "Mistral" in result.name
-
-    def test_ollama_name_embedding(self) -> None:
-        result = find_catalog_entry("nomic-embed-text:latest")
-        assert result is not None
-        assert "Nomic" in result.name
-
-    def test_ollama_name_not_found(self) -> None:
-        result = find_catalog_entry("nonexistent:latest")
-        assert result is None
-
 
 class TestDownloadModel:
     def test_returns_existing_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -220,11 +220,11 @@ class TestExpandQuery:
     @mock.patch("lilbee.query.get_provider")
     def test_returns_variants(self, mock_get_provider):
         mock_provider = mock.MagicMock()
-        mock_provider.chat.return_value = "How does X work?\nWhat is X used for?"
+        mock_provider.chat.return_value = "explain how X works in detail\nexplain the purpose of X"
         mock_get_provider.return_value = mock_provider
         from lilbee.query import _expand_query
 
-        variants = _expand_query("explain X")
+        variants = _expand_query("explain X in detail")
         assert len(variants) == 2
 
     @mock.patch("lilbee.query.get_provider")
@@ -497,3 +497,135 @@ class TestProviderError:
         mock_provider.return_value.chat.return_value = failing_mid_stream()
         with pytest.raises(ProviderError, match="not found"):
             list(ask_stream("hello"))
+
+
+class TestApplyGuardrails:
+    def test_filters_drifted_variants(self):
+        from lilbee.query import _apply_guardrails
+
+        variants = ["completely unrelated topic", "explain kubernetes deployment"]
+        result = _apply_guardrails(variants, "explain kubernetes deployment")
+        assert "completely unrelated topic" not in result
+        assert "explain kubernetes deployment" in result
+
+    def test_keeps_overlapping_variants(self):
+        from lilbee.query import _apply_guardrails
+
+        variants = ["kubernetes deployment steps", "deploying kubernetes clusters"]
+        result = _apply_guardrails(variants, "kubernetes deployment guide")
+        assert len(result) >= 1
+
+    def test_returns_all_when_guardrails_disabled(self):
+        from lilbee.config import cfg
+        from lilbee.query import _apply_guardrails
+
+        old = cfg.expansion_guardrails
+        cfg.expansion_guardrails = False
+        try:
+            result = _apply_guardrails(["anything"], "question")
+            assert result == ["anything"]
+        finally:
+            cfg.expansion_guardrails = old
+
+    def test_empty_variants(self):
+        from lilbee.query import _apply_guardrails
+
+        assert _apply_guardrails([], "question") == []
+
+    def test_empty_original_tokens(self):
+        from lilbee.query import _apply_guardrails
+
+        result = _apply_guardrails(["variant"], "a the is")
+        assert result == ["variant"]
+
+    def test_empty_variant_tokens(self):
+        from lilbee.query import _apply_guardrails
+
+        result = _apply_guardrails(["a the is", "real content here"], "real content here")
+        assert len(result) == 1
+
+
+class TestTokenizeQuery:
+    def test_removes_stop_words(self):
+        from lilbee.query import _tokenize_query
+
+        result = _tokenize_query("how does the system work")
+        assert "how" not in result
+        assert "does" not in result
+        assert "the" not in result
+        assert "system" in result
+        assert "work" in result
+
+    def test_lowercases(self):
+        from lilbee.query import _tokenize_query
+
+        result = _tokenize_query("Kubernetes Deployment")
+        assert "kubernetes" in result
+
+    def test_removes_single_chars(self):
+        from lilbee.query import _tokenize_query
+
+        result = _tokenize_query("a b c real word")
+        assert "real" in result
+        assert "word" in result
+        assert "b" not in result
+
+
+class TestSelectContext:
+    def test_selects_covering_chunks(self):
+        from lilbee.query import select_context
+
+        chunks = [
+            _make_result(chunk="kubernetes deployment guide", source="a.md"),
+            _make_result(chunk="kubernetes networking setup", source="b.md"),
+            _make_result(chunk="deployment automation tools", source="c.md"),
+        ]
+        result = select_context(chunks, "kubernetes deployment networking", max_sources=2)
+        assert len(result) == 2
+        texts = " ".join(r.chunk for r in result)
+        assert "kubernetes" in texts
+        assert "networking" in texts
+
+    def test_passes_through_when_under_max(self):
+        from lilbee.query import select_context
+
+        chunks = [_make_result(chunk="only one")]
+        result = select_context(chunks, "anything", max_sources=5)
+        assert len(result) == 1
+
+    def test_empty_query_returns_top_n(self):
+        from lilbee.query import select_context
+
+        chunks = [_make_result(chunk=f"chunk {i}") for i in range(10)]
+        result = select_context(chunks, "a the is", max_sources=3)
+        assert len(result) == 3
+
+    def test_stops_on_full_coverage(self):
+        from lilbee.query import select_context
+
+        chunks = [
+            _make_result(chunk="alpha beta gamma delta", source="a.md"),
+            _make_result(chunk="alpha beta gamma delta", source="b.md"),
+            _make_result(chunk="alpha beta gamma delta", source="c.md"),
+            _make_result(chunk="alpha beta gamma delta", source="d.md"),
+            _make_result(chunk="alpha beta gamma delta", source="e.md"),
+        ]
+        result = select_context(chunks, "alpha beta gamma delta", max_sources=3)
+        assert len(result) == 1  # first chunk covers everything
+
+    def test_stops_on_zero_gain(self):
+        from lilbee.query import select_context
+
+        chunks = [
+            _make_result(chunk="alpha beta unique1", source="a.md"),
+            _make_result(chunk="alpha beta unique1", source="b.md"),
+            _make_result(chunk="alpha beta unique1", source="c.md"),
+            _make_result(chunk="alpha beta unique1", source="d.md"),
+            _make_result(chunk="alpha beta unique1", source="e.md"),
+            _make_result(chunk="alpha beta unique1", source="f.md"),
+        ]
+        # Query has "alpha beta unique1 unique2" — first chunk covers 3/4
+        # Remaining chunks add 0 new terms, so selection stops early
+        result = select_context(chunks, "alpha beta unique1 unique2", max_sources=5)
+        # Should stop after 1 or 2 chunks since no gain after first
+        assert len(result) < 5

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -291,3 +291,66 @@ class TestAdaptiveFilter:
         ]
         filtered = _adaptive_filter(results, top_k=1, initial_threshold=0.3)
         assert len(filtered) == 0  # beyond max threshold of 1.0
+
+
+class TestRemoveDocuments:
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_removes_known_files(self, mock_del, mock_del_src, mock_sources, tmp_path):
+        mock_sources.return_value = [{"filename": "a.md"}, {"filename": "b.md"}]
+        result = store.remove_documents(["a.md"], documents_dir=tmp_path)
+        assert result.removed == ["a.md"]
+        assert result.not_found == []
+        mock_del.assert_called_once_with("a.md")
+
+    @mock.patch("lilbee.store.get_sources")
+    def test_not_found(self, mock_sources, tmp_path):
+        mock_sources.return_value = []
+        result = store.remove_documents(["missing.md"], documents_dir=tmp_path)
+        assert result.removed == []
+        assert result.not_found == ["missing.md"]
+
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_deletes_physical_file(self, mock_del, mock_del_src, mock_sources, tmp_path):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        f = tmp_path / "a.md"
+        f.write_text("content")
+        result = store.remove_documents(["a.md"], delete_files=True, documents_dir=tmp_path)
+        assert result.removed == ["a.md"]
+        assert not f.exists()
+
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_blocks_path_traversal(self, mock_del, mock_del_src, mock_sources, tmp_path):
+        mock_sources.return_value = [{"filename": "../../../etc/passwd"}]
+        secret = tmp_path.parent / "secret.txt"
+        secret.write_text("don't delete me")
+        result = store.remove_documents(
+            ["../../../etc/passwd"], delete_files=True, documents_dir=tmp_path
+        )
+        assert result.removed == ["../../../etc/passwd"]
+        # File outside documents_dir should NOT be deleted
+        assert secret.exists()
+
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_nonexistent_file_still_removes_from_store(
+        self, mock_del, mock_del_src, mock_sources, tmp_path
+    ):
+        mock_sources.return_value = [{"filename": "gone.md"}]
+        result = store.remove_documents(["gone.md"], delete_files=True, documents_dir=tmp_path)
+        assert result.removed == ["gone.md"]
+        mock_del.assert_called_once()
+
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
+    def test_uses_default_documents_dir(self, mock_del, mock_del_src, mock_sources):
+        mock_sources.return_value = [{"filename": "a.md"}]
+        result = store.remove_documents(["a.md"])
+        assert result.removed == ["a.md"]

--- a/uv.lock
+++ b/uv.lock
@@ -1118,6 +1118,7 @@ dependencies = [
     { name = "lancedb" },
     { name = "litellm" },
     { name = "litestar" },
+    { name = "llama-cpp-python" },
     { name = "mcp" },
     { name = "pillow" },
     { name = "prompt-toolkit" },
@@ -1127,11 +1128,6 @@ dependencies = [
     { name = "tree-sitter-language-pack" },
     { name = "typer" },
     { name = "uvicorn" },
-]
-
-[package.optional-dependencies]
-llama-cpp = [
-    { name = "llama-cpp-python" },
 ]
 
 [package.dev-dependencies]
@@ -1156,7 +1152,7 @@ requires-dist = [
     { name = "lancedb" },
     { name = "litellm" },
     { name = "litestar", specifier = ">=2.0" },
-    { name = "llama-cpp-python", marker = "extra == 'llama-cpp'" },
+    { name = "llama-cpp-python" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "prompt-toolkit", specifier = ">=3.0" },
@@ -1167,7 +1163,6 @@ requires-dist = [
     { name = "typer" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
-provides-extras = ["llama-cpp"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What changed

### Smarter query expansion
Query expansion now validates LLM-generated variants before using them. Each variant is checked for token overlap with the original question — if less than 30% of the original terms appear, the variant has drifted too far and is dropped. This prevents the LLM from generating search queries that have nothing to do with what you asked.

### Adaptive context selection
Instead of blindly sending the top-k results to the LLM, lilbee now picks chunks that maximize coverage of your question. If you ask "compare X and Y", it ensures both X and Y are represented in the context, not just the most relevant chunks about X.

### Architecture documentation
New docs/architecture.md with:
- Full system overview with Mermaid diagrams
- Every retrieval technique explained for humans with academic citations
- Configuration reference with defaults, rationale, and caveats for every setting
- Provider abstraction and ingestion pipeline documented

### Code cleanup
- Reasoning parser refactored from nested function to _TagParser class
- Removed Ollama-to-catalog name mapping (show names as-is)
- Removed divider comments from model_manager
- All new config fields registered and documented

### Config fields added
expansion_guardrails, expansion_skip_threshold, expansion_skip_gap,
max_context_sources, hyde, hyde_weight, reranker_model, rerank_candidates,
temporal_filtering — all with documented defaults and env var overrides.

### Academic references
- Expansion guardrails: standard token overlap validation
- Context selection: greedy set-cover approximation
- Adaptive threshold: grantflow (grantflow-ai/grantflow)
- MMR: Carbonell & Goldstein 1998
- HyDE: Gao et al. 2022
- Cross-encoder: Nogueira & Cho 2019