### PR TITLE
fix: apply hyde_weight to HyDE results, document missing MCP tools

### DIFF
--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -28,7 +28,10 @@ Add to your MCP client's MCP server configuration:
 | `lilbee_search(query, top_k)` | Search for relevant document chunks by vector similarity | No (uses pre-computed embeddings) |
 | `lilbee_status()` | Show indexed documents, config, and chunk counts | No |
 | `lilbee_sync()` | Sync documents directory with the vector store | Yes (for embedding) |
+| `lilbee_add(paths, force, vision_model)` | Add files/dirs and sync them into the vector store | Yes (for embedding) |
 | `lilbee_init(path)` | Initialize a local `.lilbee/` knowledge base in a directory | No |
+| `lilbee_remove(names, delete_files)` | Remove documents from the index (optionally delete source files) | No |
+| `lilbee_list_documents()` | List all indexed documents with chunk counts | No |
 | `lilbee_reset()` | Delete all documents and data (factory reset) | No |
 
 ### Example responses

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -447,12 +447,15 @@ def search_context(question: str, top_k: int = 0) -> list[SearchChunk]:
                     results.append(r)
                     seen.add(key)
 
-    # HyDE: search with hypothetical document embedding (if enabled)
+    # HyDE: search with hypothetical document embedding (if enabled).
+    # Discount distances by hyde_weight since these are from a fabricated passage.
     if cfg.hyde:
         hyde_results = _hyde_search(question, top_k)
         for r in hyde_results:
             key = (r.source, r.chunk_index)
             if key not in seen:
+                if r.distance is not None and cfg.hyde_weight > 0:
+                    r.distance = r.distance / cfg.hyde_weight
                 results.append(r)
                 seen.add(key)
 


### PR DESCRIPTION
found during a codebase audit

### hyde_weight not applied

`cfg.hyde_weight` (0.7) was defined but never used — HyDE search results were appended at full relevance. now divides distance by hyde_weight so fabricated-passage results rank lower than direct matches.

### undocumented MCP tools

`lilbee_remove`, `lilbee_list_documents`, and `lilbee_add` existed in mcp.py but were missing from the tools table in agent-integration.md 