### PR TITLE
feat: interactive model catalog browser (Textual TUI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "litellm",
     "huggingface_hub",
     "httpx",
+    "textual>=0.75",
 ]
 
 [project.optional-dependencies]

--- a/src/lilbee/cli/browser.py
+++ b/src/lilbee/cli/browser.py
@@ -1,0 +1,192 @@
+"""Interactive model catalog browser using Textual TUI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from textual import work
+from textual.app import App, ComposeResult
+from textual.binding import Binding, BindingType
+from textual.reactive import reactive
+from textual.widgets import (
+    Footer,
+    Header,
+    Input,
+    Label,
+    ListItem,
+    ListView,
+    Static,
+    TabbedContent,
+    TabPane,
+)
+from textual.worker import Worker, WorkerState
+
+from lilbee.catalog import FEATURED_ALL, CatalogModel, get_catalog
+
+TASK_TABS = ("All", "Chat", "Embedding", "Vision")
+_TAB_TO_TASK: dict[str, str | None] = {
+    "All": None,
+    "Chat": "chat",
+    "Embedding": "embedding",
+    "Vision": "vision",
+}
+
+
+@dataclass
+class BrowserState:
+    """Cached catalog data for the browser."""
+
+    featured: list[CatalogModel]
+    hf_models: list[CatalogModel]
+
+    @property
+    def all_models(self) -> list[CatalogModel]:
+        return self.featured + self.hf_models
+
+
+class ModelRow(ListItem):
+    """A single model row in the catalog list."""
+
+    def __init__(self, model: CatalogModel) -> None:
+        super().__init__()
+        self.model = model
+
+    def compose(self) -> ComposeResult:
+        m = self.model
+        star = " *" if m.featured else "  "
+        size = f"{m.size_gb:.1f} GB"
+        desc = m.description[:60] if m.description else ""
+        yield Static(
+            f"{star} {m.name:<30s} {m.task:<12s} {size:>8s}  {desc}",
+            classes="model-row-text",
+        )
+
+
+class CatalogBrowser(App[CatalogModel | None]):
+    """Full-screen TUI for browsing the model catalog."""
+
+    TITLE = "lilbee model catalog"
+    CSS_PATH = "browser.tcss"
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("q", "quit_browser", "Quit", show=True),
+        Binding("escape", "quit_browser", "Quit", show=False),
+        Binding("slash", "focus_search", "Search", show=True),
+    ]
+
+    search_text: reactive[str] = reactive("", layout=True)
+
+    def __init__(
+        self,
+        initial_task: str | None = None,
+        initial_search: str = "",
+    ) -> None:
+        super().__init__()
+        self._initial_task = initial_task
+        self._initial_search = initial_search
+        self._state = BrowserState(featured=list(FEATURED_ALL), hf_models=[])
+        self._selected: CatalogModel | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Input(placeholder="Type to filter...", id="search-input")
+        with TabbedContent(*TASK_TABS, id="task-tabs"):
+            for tab_label in TASK_TABS:
+                with TabPane(tab_label, id=f"tab-{tab_label.lower()}"):
+                    yield ListView(id=f"list-{tab_label.lower()}")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        if self._initial_search:
+            search_input = self.query_one("#search-input", Input)
+            search_input.value = self._initial_search
+            self.search_text = self._initial_search
+
+        if self._initial_task:
+            tab_id = f"tab-{self._initial_task}"
+            tabs = self.query_one("#task-tabs", TabbedContent)
+            tabs.active = tab_id
+
+        self._refresh_lists()
+        self._fetch_hf_models()
+
+    @work(thread=True)
+    def _fetch_hf_models(self) -> list[CatalogModel]:
+        """Fetch HuggingFace models in a background worker."""
+        result = get_catalog(featured=False, limit=50)
+        hf_only = [m for m in result.models if not m.featured]
+        return hf_only
+
+    def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
+        if event.state == WorkerState.SUCCESS and event.worker.name == "_fetch_hf_models":
+            hf_models = event.worker.result
+            if isinstance(hf_models, list):
+                self._state.hf_models = hf_models
+                self._refresh_lists()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "search-input":
+            self.search_text = event.value
+            self._refresh_lists()
+
+    def on_tabbed_content_tab_activated(self, event: TabbedContent.TabActivated) -> None:
+        self._refresh_lists()
+
+    def _filter_models(self, models: list[CatalogModel], task: str | None) -> list[CatalogModel]:
+        filtered = models
+        if task:
+            filtered = [m for m in filtered if m.task == task]
+        search = self.search_text.strip().lower()
+        if search:
+            filtered = [
+                m
+                for m in filtered
+                if search in m.name.lower()
+                or search in m.hf_repo.lower()
+                or search in m.description.lower()
+            ]
+        return filtered
+
+    def _refresh_lists(self) -> None:
+        """Rebuild every tab's ListView from current state and filters."""
+        for tab_label in TASK_TABS:
+            task = _TAB_TO_TASK[tab_label]
+            list_id = f"list-{tab_label.lower()}"
+            lv = self.query_one(f"#{list_id}", ListView)
+
+            featured = self._filter_models(self._state.featured, task)
+            hf = self._filter_models(self._state.hf_models, task)
+
+            lv.clear()
+
+            if featured:
+                lv.append(ListItem(Label("FEATURED", classes="section-header")))
+                for m in featured:
+                    lv.append(ModelRow(m))
+
+            if hf:
+                lv.append(ListItem(Label("HUGGINGFACE", classes="section-header")))
+                for m in hf:
+                    lv.append(ModelRow(m))
+
+            if not featured and not hf:
+                lv.append(ListItem(Label("No models match your filters.")))
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        item = event.item
+        if isinstance(item, ModelRow):
+            self._selected = item.model
+            self.exit(item.model)
+
+    def action_quit_browser(self) -> None:
+        self.exit(None)
+
+    def action_focus_search(self) -> None:
+        self.query_one("#search-input", Input).focus()
+
+
+def run_browser(task: str | None = None, search: str = "") -> CatalogModel | None:
+    """Launch the catalog browser and return the selected model, or None."""
+    app = CatalogBrowser(initial_task=task, initial_search=search)
+    return app.run()

--- a/src/lilbee/cli/browser.tcss
+++ b/src/lilbee/cli/browser.tcss
@@ -1,0 +1,31 @@
+CatalogBrowser {
+    background: $surface;
+}
+
+#search-input {
+    dock: top;
+    margin: 0 1;
+    width: 100%;
+}
+
+ListView {
+    height: 1fr;
+}
+
+.section-header {
+    color: $text-muted;
+    text-style: bold underline;
+    padding: 1 0 0 1;
+}
+
+.model-row-text {
+    padding: 0 1;
+}
+
+ModelRow.--highlight {
+    background: $accent;
+}
+
+Footer {
+    dock: bottom;
+}

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -643,3 +643,8 @@ def mcp_cmd() -> None:
     from lilbee.mcp import main
 
     main()
+
+
+from lilbee.cli.models_cmd import models_app  # noqa: E402  # must be after app definition
+
+app.add_typer(models_app, name="models")

--- a/src/lilbee/cli/models_cmd.py
+++ b/src/lilbee/cli/models_cmd.py
@@ -1,0 +1,243 @@
+"""CLI subcommands for model management — browse, install, remove, list."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+from rich.table import Table
+
+from lilbee.cli.app import (
+    _global_option,
+    apply_overrides,
+    console,
+    data_dir_option,
+)
+from lilbee.cli.helpers import json_output
+from lilbee.cli.theme import ACCENT, ERROR, LABEL, MUTED
+from lilbee.config import cfg
+
+models_app = typer.Typer(help="Browse, install, and remove models.")
+
+
+@models_app.command(name="list")
+def list_cmd(
+    source: str | None = typer.Option(None, help="Filter by source: native, ollama"),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = _global_option,
+) -> None:
+    """List installed models."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    from lilbee.model_manager import ModelSource, get_model_manager
+
+    manager = get_model_manager()
+    src = ModelSource(source) if source else None
+    names = manager.list_installed(src)
+
+    if cfg.json_mode:
+        items = []
+        for name in names:
+            s = manager.get_source(name)
+            items.append({"name": name, "source": s.value if s else "unknown"})
+        json_output({"command": "models list", "models": items})
+        return
+
+    if not names:
+        console.print(f"[{MUTED}]No models installed.[/{MUTED}]")
+        return
+
+    table = Table(title="Installed Models")
+    table.add_column("Model", style=ACCENT)
+    table.add_column("Source", style=MUTED)
+    for name in names:
+        s = manager.get_source(name)
+        table.add_row(name, s.value if s else "unknown")
+    console.print(table)
+
+
+@models_app.command()
+def browse(
+    task: str | None = typer.Option(None, help="Filter: chat, embedding, vision"),
+    search: str = typer.Option("", "--search", "-s", help="Search query"),
+    size: str | None = typer.Option(None, help="Size filter: small, medium, large"),
+    featured: bool = typer.Option(False, "--featured", "-f", help="Show featured only"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Results per page"),
+    offset: int = typer.Option(0, "--offset", help="Skip N results"),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = _global_option,
+) -> None:
+    """Browse the model catalog (featured + HuggingFace)."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+
+    if not cfg.json_mode and sys.stdin.isatty() and sys.stdout.isatty():
+        _browse_interactive(task=task, search=search)
+        return
+
+    _browse_static(
+        task=task,
+        search=search,
+        size=size,
+        featured=featured,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def _browse_interactive(task: str | None, search: str) -> None:
+    """Launch the Textual TUI browser and optionally install the selected model."""
+    from lilbee.cli.browser import run_browser
+
+    selected = run_browser(task=task, search=search)
+    if selected is None:
+        return
+    _install_from_catalog(selected.name)
+
+
+def _install_from_catalog(name: str) -> None:
+    """Install a model by catalog name, with progress display."""
+    from lilbee.catalog import find_catalog_entry
+    from lilbee.model_manager import ModelSource, get_model_manager
+
+    manager = get_model_manager()
+    if manager.is_installed(name):
+        if cfg.json_mode:
+            json_output({"command": "models install", "model": name, "already_installed": True})
+        else:
+            console.print(f"[{LABEL}]{name}[/{LABEL}] is already installed.")
+        return
+
+    entry = find_catalog_entry(name)
+    if entry is not None:
+        from lilbee.models import pull_with_progress
+
+        pull_with_progress(name)
+        if cfg.json_mode:
+            json_output({"command": "models install", "model": name, "source": "native"})
+        return
+
+    try:
+        manager.pull(name, ModelSource.OLLAMA)
+        if cfg.json_mode:
+            json_output({"command": "models install", "model": name, "source": "ollama"})
+        else:
+            console.print(f"[{LABEL}]{name}[/{LABEL}] installed via Ollama.")
+    except RuntimeError as exc:
+        if cfg.json_mode:
+            json_output({"error": str(exc)})
+        else:
+            console.print(f"[{ERROR}]Error:[/{ERROR}] {exc}")
+        raise SystemExit(1) from None
+
+
+def _browse_static(
+    task: str | None,
+    search: str,
+    size: str | None,
+    featured: bool,
+    limit: int,
+    offset: int,
+) -> None:
+    """Show a static Rich table of catalog models (for --json or non-TTY)."""
+    from lilbee.catalog import get_catalog
+
+    result = get_catalog(
+        task=task,
+        search=search,
+        size=size,
+        featured=featured or None,
+        sort="featured",
+        limit=limit,
+        offset=offset,
+    )
+
+    if cfg.json_mode:
+        json_output(
+            {
+                "command": "models browse",
+                "total": result.total,
+                "limit": result.limit,
+                "offset": result.offset,
+                "models": [
+                    {
+                        "name": m.name,
+                        "repo": m.hf_repo,
+                        "size_gb": m.size_gb,
+                        "task": m.task,
+                        "description": m.description,
+                        "featured": m.featured,
+                    }
+                    for m in result.models
+                ],
+            }
+        )
+        return
+
+    if not result.models:
+        console.print(f"[{MUTED}]No models found.[/{MUTED}]")
+        return
+
+    title = "Model Catalog"
+    if task:
+        title = f"{task.title()} Models"
+
+    table = Table(title=title)
+    table.add_column("#", justify="right", style="bold")
+    table.add_column("Model", style=ACCENT)
+    table.add_column("Task", style=MUTED)
+    table.add_column("Size", justify="right")
+    table.add_column("Description")
+
+    for idx, m in enumerate(result.models, offset + 1):
+        star = " \u2605" if m.featured else ""
+        table.add_row(
+            str(idx),
+            f"{m.name}{star}",
+            m.task,
+            f"{m.size_gb:.1f} GB",
+            m.description[:80],
+        )
+
+    console.print(table)
+    if result.total > offset + limit:
+        console.print(
+            f"\n[{MUTED}]Showing {offset + 1}-{offset + len(result.models)} "
+            f"of {result.total}. Use --offset to see more.[/{MUTED}]"
+        )
+
+
+@models_app.command()
+def install(
+    name: str = typer.Argument(..., help="Model name (catalog name or Ollama name)"),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = _global_option,
+) -> None:
+    """Install a model by catalog name or Ollama name."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    _install_from_catalog(name)
+
+
+@models_app.command()
+def remove(
+    name: str = typer.Argument(..., help="Model name to remove"),
+    source: str | None = typer.Option(None, help="Source: native, ollama"),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = _global_option,
+) -> None:
+    """Remove an installed model."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    from lilbee.model_manager import ModelSource, get_model_manager
+
+    manager = get_model_manager()
+    src = ModelSource(source) if source else None
+    deleted = manager.remove(name, src)
+
+    if cfg.json_mode:
+        json_output({"command": "models remove", "model": name, "deleted": deleted})
+        return
+
+    if deleted:
+        console.print(f"Removed [{ACCENT}]{name}[/{ACCENT}]")
+    else:
+        console.print(f"[{ERROR}]Not found:[/{ERROR}] {name}")
+        raise SystemExit(1)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,0 +1,417 @@
+"""Tests for the interactive model catalog browser (Textual TUI)."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from lilbee.catalog import CatalogModel, CatalogResult
+from lilbee.cli.browser import (
+    _TAB_TO_TASK,
+    BrowserState,
+    CatalogBrowser,
+    ModelRow,
+    run_browser,
+)
+
+
+def _make_model(
+    name: str = "TestModel",
+    task: str = "chat",
+    featured: bool = False,
+    size_gb: float = 2.0,
+    description: str = "A test model",
+) -> CatalogModel:
+    return CatalogModel(
+        name=name,
+        hf_repo=f"test/{name.lower().replace(' ', '-')}",
+        gguf_filename="*.gguf",
+        size_gb=size_gb,
+        min_ram_gb=4,
+        description=description,
+        featured=featured,
+        downloads=100,
+        task=task,
+    )
+
+
+def _list_children(app: CatalogBrowser, list_id: str) -> list:
+    """Get children of a ListView by ID."""
+    lv = app.query_one(f"#{list_id}")
+    return list(lv.children)
+
+
+def _model_rows(app: CatalogBrowser, list_id: str) -> list[ModelRow]:
+    """Get only ModelRow children from a ListView."""
+    return [c for c in _list_children(app, list_id) if isinstance(c, ModelRow)]
+
+
+class TestBrowserState:
+    def test_all_models_combines_featured_and_hf(self) -> None:
+        f = [_make_model("F1", featured=True)]
+        h = [_make_model("H1")]
+        state = BrowserState(featured=f, hf_models=h)
+        assert len(state.all_models) == 2
+        assert state.all_models[0].name == "F1"
+        assert state.all_models[1].name == "H1"
+
+    def test_empty_state(self) -> None:
+        state = BrowserState(featured=[], hf_models=[])
+        assert state.all_models == []
+
+
+class TestModelRow:
+    def test_stores_model(self) -> None:
+        m = _make_model("Qwen3 8B", featured=True)
+        row = ModelRow(m)
+        assert row.model is m
+
+    def test_compose_yields_static(self) -> None:
+        m = _make_model("TestModel", task="chat", size_gb=5.0)
+        row = ModelRow(m)
+        children = list(row.compose())
+        assert len(children) == 1
+
+
+class TestTabToTask:
+    def test_all_tab_maps_to_none(self) -> None:
+        assert _TAB_TO_TASK["All"] is None
+
+    def test_chat_tab_maps_to_chat(self) -> None:
+        assert _TAB_TO_TASK["Chat"] == "chat"
+
+    def test_embedding_tab_maps_to_embedding(self) -> None:
+        assert _TAB_TO_TASK["Embedding"] == "embedding"
+
+    def test_vision_tab_maps_to_vision(self) -> None:
+        assert _TAB_TO_TASK["Vision"] == "vision"
+
+
+class TestCatalogBrowserCompose:
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_browse_shows_featured(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            rows = _model_rows(app, "list-all")
+            assert len(rows) > 0
+            # At least one should be featured
+            assert any(r.model.featured for r in rows)
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_tab_filters_by_task(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            rows = _model_rows(app, "list-embedding")
+            for row in rows:
+                assert row.model.task == "embedding"
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_search_filters_models(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            search_input = app.query_one("#search-input")
+            search_input.value = "nomic"
+            await pilot.pause()
+            rows = _model_rows(app, "list-all")
+            for row in rows:
+                combined = (
+                    row.model.name.lower()
+                    + row.model.hf_repo.lower()
+                    + row.model.description.lower()
+                )
+                assert "nomic" in combined
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_enter_selects_model(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            all_list = app.query_one("#list-all")
+            all_list.focus()
+            await pilot.pause()
+            rows = _model_rows(app, "list-all")
+            if rows:
+                idx = list(all_list.children).index(rows[0])
+                all_list.index = idx
+                await pilot.press("enter")
+                assert app.return_value is not None
+                assert isinstance(app.return_value, CatalogModel)
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_quit_returns_none(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.press("q")
+            assert app.return_value is None
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_escape_returns_none(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.press("escape")
+            assert app.return_value is None
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_slash_focuses_search(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.press("slash")
+            assert app.query_one("#search-input").has_focus
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_initial_task_sets_tab(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser(initial_task="embedding")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tabs = app.query_one("#task-tabs")
+            assert tabs.active == "tab-embedding"
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_initial_search_populates_input(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser(initial_search="qwen")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            search_input = app.query_one("#search-input")
+            assert search_input.value == "qwen"
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_hf_models_appear_after_worker(self, mock_catalog: mock.MagicMock) -> None:
+        hf_model = _make_model("HF-Model", featured=False)
+        mock_catalog.return_value = CatalogResult(total=1, limit=50, offset=0, models=[hf_model])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            # State should be updated with HF models
+            assert isinstance(app._state.hf_models, list)
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_no_matches_shows_fallback(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            search_input = app.query_one("#search-input")
+            search_input.value = "zzzznonexistent"
+            await pilot.pause()
+            # All tabs should have at least a fallback "no models" message
+            children = _list_children(app, "list-all")
+            assert len(children) > 0
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_vision_tab_shows_vision_models(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            rows = _model_rows(app, "list-vision")
+            for row in rows:
+                assert row.model.task == "vision"
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_chat_tab_shows_chat_models(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            rows = _model_rows(app, "list-chat")
+            assert len(rows) > 0
+            for row in rows:
+                assert row.model.task == "chat"
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_action_focus_search_directly(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.action_focus_search()
+            await pilot.pause()
+            assert app.query_one("#search-input").has_focus
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_action_quit_browser_directly(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.action_quit_browser()
+            assert app.return_value is None
+
+    @mock.patch("lilbee.cli.browser.get_catalog")
+    async def test_select_non_model_row_noop(self, mock_catalog: mock.MagicMock) -> None:
+        """Selecting a header row (not a ModelRow) should not exit."""
+        mock_catalog.return_value = CatalogResult(total=0, limit=50, offset=0, models=[])
+        app = CatalogBrowser()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            all_list = app.query_one("#list-all")
+            all_list.focus()
+            await pilot.pause()
+            # Select the first item which is the FEATURED header, not a ModelRow
+            if all_list.children:
+                all_list.index = 0
+                await pilot.press("enter")
+                # App should still be running (not exited with a model)
+                assert app._selected is None
+
+
+class TestRunBrowser:
+    @mock.patch("lilbee.cli.browser.CatalogBrowser.run")
+    def test_returns_selected_model(self, mock_run: mock.MagicMock) -> None:
+        model = _make_model("SelectedModel")
+        mock_run.return_value = model
+        result = run_browser()
+        assert result is model
+
+    @mock.patch("lilbee.cli.browser.CatalogBrowser.run")
+    def test_returns_none_on_quit(self, mock_run: mock.MagicMock) -> None:
+        mock_run.return_value = None
+        result = run_browser()
+        assert result is None
+
+    @mock.patch("lilbee.cli.browser.CatalogBrowser.run")
+    def test_passes_task_and_search(self, mock_run: mock.MagicMock) -> None:
+        mock_run.return_value = None
+        run_browser(task="embedding", search="nomic")
+        mock_run.assert_called_once()
+
+
+class TestBrowseInteractiveCLI:
+    """Test the CLI integration path through models_cmd._browse_interactive."""
+
+    @mock.patch("lilbee.cli.browser.run_browser")
+    def test_non_tty_uses_static(self, mock_browser: mock.MagicMock) -> None:
+        """CliRunner is not a TTY, so browse should use static table path."""
+        from typer.testing import CliRunner
+
+        from lilbee.cli.app import app
+
+        runner = CliRunner()
+        with mock.patch("lilbee.catalog.get_catalog") as mock_catalog:
+            mock_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+            result = runner.invoke(app, ["models", "browse"])
+            assert result.exit_code == 0
+            mock_browser.assert_not_called()
+
+    @mock.patch("lilbee.cli.models_cmd._install_from_catalog")
+    @mock.patch("lilbee.cli.browser.run_browser")
+    def test_interactive_installs_on_select(
+        self, mock_browser: mock.MagicMock, mock_install: mock.MagicMock
+    ) -> None:
+        from lilbee.cli.models_cmd import _browse_interactive
+
+        selected = _make_model("PickedModel")
+        mock_browser.return_value = selected
+        _browse_interactive(task=None, search="")
+        mock_install.assert_called_once_with("PickedModel")
+
+    @mock.patch("lilbee.cli.browser.run_browser")
+    def test_interactive_noop_on_quit(self, mock_browser: mock.MagicMock) -> None:
+        from lilbee.cli.models_cmd import _browse_interactive
+
+        mock_browser.return_value = None
+        _browse_interactive(task=None, search="")
+
+    @mock.patch("lilbee.cli.models_cmd._browse_interactive")
+    @mock.patch("lilbee.cli.models_cmd.sys")
+    def test_tty_calls_browse_interactive(
+        self, mock_sys: mock.MagicMock, mock_interactive: mock.MagicMock
+    ) -> None:
+        """When stdin/stdout are TTY and not json_mode, browse calls _browse_interactive."""
+        from lilbee.cli.models_cmd import browse
+
+        mock_sys.stdin.isatty.return_value = True
+        mock_sys.stdout.isatty.return_value = True
+
+        from lilbee.config import cfg
+
+        orig_json = cfg.json_mode
+        cfg.json_mode = False
+        try:
+            # Call the internal logic directly — the TTY check uses sys module
+            # which we've patched above. We still need to avoid apply_overrides.
+            with mock.patch("lilbee.cli.models_cmd.apply_overrides"):
+                browse(
+                    task="chat",
+                    search="test",
+                    size=None,
+                    featured=False,
+                    limit=20,
+                    offset=0,
+                    data_dir=None,
+                    use_global=False,
+                )
+                mock_interactive.assert_called_once_with(task="chat", search="test")
+        finally:
+            cfg.json_mode = orig_json
+
+
+class TestInstallFromCatalog:
+    """Test _install_from_catalog helper in models_cmd."""
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_already_installed(self, mock_get: mock.MagicMock) -> None:
+        from lilbee.cli.models_cmd import _install_from_catalog
+
+        manager = mock.MagicMock()
+        manager.is_installed.return_value = True
+        mock_get.return_value = manager
+        _install_from_catalog("TestModel")
+        manager.pull.assert_not_called()
+
+    @mock.patch("lilbee.models.pull_with_progress")
+    @mock.patch("lilbee.catalog.find_catalog_entry")
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_catalog_entry_found(
+        self,
+        mock_get: mock.MagicMock,
+        mock_find: mock.MagicMock,
+        mock_pull: mock.MagicMock,
+    ) -> None:
+        from lilbee.cli.models_cmd import _install_from_catalog
+
+        manager = mock.MagicMock()
+        manager.is_installed.return_value = False
+        mock_get.return_value = manager
+        mock_find.return_value = _make_model("CatalogModel")
+        _install_from_catalog("CatalogModel")
+        mock_pull.assert_called_once_with("CatalogModel")
+
+    @mock.patch("lilbee.catalog.find_catalog_entry", return_value=None)
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_ollama_fallback(self, mock_get: mock.MagicMock, mock_find: mock.MagicMock) -> None:
+        from lilbee.cli.models_cmd import _install_from_catalog
+        from lilbee.model_manager import ModelSource
+
+        manager = mock.MagicMock()
+        manager.is_installed.return_value = False
+        mock_get.return_value = manager
+        _install_from_catalog("OllamaModel")
+        manager.pull.assert_called_once_with("OllamaModel", ModelSource.OLLAMA)
+
+    @mock.patch("lilbee.catalog.find_catalog_entry", return_value=None)
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_ollama_failure_raises_exit(
+        self, mock_get: mock.MagicMock, mock_find: mock.MagicMock
+    ) -> None:
+        import pytest
+
+        from lilbee.cli.models_cmd import _install_from_catalog
+
+        manager = mock.MagicMock()
+        manager.is_installed.return_value = False
+        manager.pull.side_effect = RuntimeError("Connection refused")
+        mock_get.return_value = manager
+        with pytest.raises(SystemExit):
+            _install_from_catalog("BadModel")

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -1,0 +1,340 @@
+"""Tests for the ``lilbee models`` CLI command group."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from typer.testing import CliRunner
+
+from lilbee.cli.app import app
+
+runner = CliRunner()
+
+
+def _mock_manager(
+    installed: list[str] | None = None,
+    source_map: dict[str, str] | None = None,
+) -> mock.MagicMock:
+    """Create a mock ModelManager with common defaults."""
+    from lilbee.model_manager import ModelSource
+
+    manager = mock.MagicMock()
+    manager.list_installed.return_value = installed or []
+
+    source_map = source_map or {}
+    source_enum_map = {name: ModelSource(src) for name, src in source_map.items()}
+    manager.get_source.side_effect = lambda name: source_enum_map.get(name)
+    manager.is_installed.side_effect = lambda name, source=None: name in (installed or [])
+    return manager
+
+
+class TestModelsList:
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_empty_list(self, mock_get: mock.MagicMock) -> None:
+        mock_get.return_value = _mock_manager()
+        result = runner.invoke(app, ["models", "list"])
+        assert result.exit_code == 0
+        assert "No models installed" in result.output
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_shows_installed(self, mock_get: mock.MagicMock) -> None:
+        mock_get.return_value = _mock_manager(
+            installed=["qwen3:8b", "nomic.gguf"],
+            source_map={"qwen3:8b": "ollama", "nomic.gguf": "native"},
+        )
+        result = runner.invoke(app, ["models", "list"])
+        assert result.exit_code == 0
+        assert "qwen3:8b" in result.output
+        assert "nomic.gguf" in result.output
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_json_mode(self, mock_get: mock.MagicMock) -> None:
+        mock_get.return_value = _mock_manager(
+            installed=["qwen3:8b"],
+            source_map={"qwen3:8b": "ollama"},
+        )
+        result = runner.invoke(app, ["--json", "models", "list"])
+        assert result.exit_code == 0
+        assert '"models list"' in result.output
+        assert "qwen3:8b" in result.output
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_source_filter(self, mock_get: mock.MagicMock) -> None:
+        from lilbee.model_manager import ModelSource
+
+        manager = _mock_manager(installed=["qwen3:8b"])
+        manager.list_installed.side_effect = lambda src=None: (
+            ["qwen3:8b"] if src == ModelSource.OLLAMA else []
+        )
+        mock_get.return_value = manager
+        result = runner.invoke(app, ["models", "list", "--source", "ollama"])
+        assert result.exit_code == 0
+
+
+class TestModelsBrowse:
+    @mock.patch("lilbee.catalog.get_catalog")
+    def test_shows_catalog(self, mock_catalog: mock.MagicMock) -> None:
+        from lilbee.catalog import CatalogModel, CatalogResult
+
+        mock_catalog.return_value = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[
+                CatalogModel(
+                    "TestModel",
+                    "test/repo",
+                    "*.gguf",
+                    2.0,
+                    4,
+                    "A test model",
+                    True,
+                    100,
+                    "chat",
+                ),
+            ],
+        )
+        result = runner.invoke(app, ["models", "browse"])
+        assert result.exit_code == 0
+        assert "TestModel" in result.output
+
+    @mock.patch("lilbee.catalog.get_catalog")
+    def test_empty_catalog(self, mock_catalog: mock.MagicMock) -> None:
+        from lilbee.catalog import CatalogResult
+
+        mock_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        result = runner.invoke(app, ["models", "browse"])
+        assert result.exit_code == 0
+        assert "No models found" in result.output
+
+    @mock.patch("lilbee.catalog.get_catalog")
+    def test_task_filter(self, mock_catalog: mock.MagicMock) -> None:
+        from lilbee.catalog import CatalogResult
+
+        mock_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        runner.invoke(app, ["models", "browse", "--task", "embedding"])
+        mock_catalog.assert_called_once()
+        assert mock_catalog.call_args.kwargs.get("task") == "embedding"
+
+    @mock.patch("lilbee.catalog.get_catalog")
+    def test_json_mode(self, mock_catalog: mock.MagicMock) -> None:
+        from lilbee.catalog import CatalogModel, CatalogResult
+
+        mock_catalog.return_value = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[
+                CatalogModel(
+                    "TestModel",
+                    "test/repo",
+                    "*.gguf",
+                    2.0,
+                    4,
+                    "A test",
+                    True,
+                    100,
+                    "chat",
+                ),
+            ],
+        )
+        result = runner.invoke(app, ["--json", "models", "browse"])
+        assert result.exit_code == 0
+        assert '"models browse"' in result.output
+        assert "TestModel" in result.output
+
+    @mock.patch("lilbee.catalog.get_catalog")
+    def test_pagination_hint(self, mock_catalog: mock.MagicMock) -> None:
+        from lilbee.catalog import CatalogModel, CatalogResult
+
+        models = [
+            CatalogModel(f"m{i}", "r/r", "*.gguf", 1.0, 2, "d", False, 0, "chat") for i in range(3)
+        ]
+        mock_catalog.return_value = CatalogResult(total=10, limit=3, offset=0, models=models)
+        result = runner.invoke(app, ["models", "browse", "--limit", "3"])
+        assert result.exit_code == 0
+        assert "--offset" in result.output
+
+    @mock.patch("lilbee.catalog.get_catalog")
+    def test_search_filter(self, mock_catalog: mock.MagicMock) -> None:
+        from lilbee.catalog import CatalogResult
+
+        mock_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        runner.invoke(app, ["models", "browse", "--search", "nomic"])
+        assert mock_catalog.call_args.kwargs.get("search") == "nomic"
+
+    @mock.patch("lilbee.catalog.get_catalog")
+    def test_featured_flag(self, mock_catalog: mock.MagicMock) -> None:
+        from lilbee.catalog import CatalogResult
+
+        mock_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        runner.invoke(app, ["models", "browse", "--featured"])
+        assert mock_catalog.call_args.kwargs.get("featured") is True
+
+    @mock.patch("lilbee.catalog.get_catalog")
+    def test_task_title(self, mock_catalog: mock.MagicMock) -> None:
+        from lilbee.catalog import CatalogModel, CatalogResult
+
+        mock_catalog.return_value = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[CatalogModel("m", "r/r", "*.gguf", 1.0, 2, "d", True, 0, "embedding")],
+        )
+        result = runner.invoke(app, ["models", "browse", "--task", "embedding"])
+        assert "Embedding Models" in result.output
+
+
+class TestModelsInstall:
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_already_installed(self, mock_get: mock.MagicMock) -> None:
+        mock_get.return_value = _mock_manager(installed=["qwen3:8b"])
+        result = runner.invoke(app, ["models", "install", "qwen3:8b"])
+        assert result.exit_code == 0
+        assert "already installed" in result.output
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_already_installed_json(self, mock_get: mock.MagicMock) -> None:
+        mock_get.return_value = _mock_manager(installed=["qwen3:8b"])
+        result = runner.invoke(app, ["--json", "models", "install", "qwen3:8b"])
+        assert result.exit_code == 0
+        assert "already_installed" in result.output
+
+    @mock.patch("lilbee.models.pull_with_progress")
+    @mock.patch("lilbee.catalog.find_catalog_entry")
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_catalog_install(
+        self,
+        mock_get: mock.MagicMock,
+        mock_find: mock.MagicMock,
+        mock_pull: mock.MagicMock,
+    ) -> None:
+        from lilbee.catalog import CatalogModel
+
+        mock_get.return_value = _mock_manager()
+        mock_find.return_value = CatalogModel(
+            "Nomic Embed Text v1.5",
+            "nomic-ai/repo",
+            "nomic.gguf",
+            0.3,
+            2,
+            "desc",
+            True,
+            0,
+            "embedding",
+        )
+        result = runner.invoke(app, ["models", "install", "Nomic Embed Text v1.5"])
+        assert result.exit_code == 0
+        mock_pull.assert_called_once_with("Nomic Embed Text v1.5")
+
+    @mock.patch("lilbee.models.pull_with_progress")
+    @mock.patch("lilbee.catalog.find_catalog_entry")
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_catalog_install_json(
+        self,
+        mock_get: mock.MagicMock,
+        mock_find: mock.MagicMock,
+        mock_pull: mock.MagicMock,
+    ) -> None:
+        from lilbee.catalog import CatalogModel
+
+        mock_get.return_value = _mock_manager()
+        mock_find.return_value = CatalogModel(
+            "Nomic Embed Text v1.5",
+            "nomic-ai/repo",
+            "nomic.gguf",
+            0.3,
+            2,
+            "desc",
+            True,
+            0,
+            "embedding",
+        )
+        result = runner.invoke(app, ["--json", "models", "install", "Nomic Embed Text v1.5"])
+        assert result.exit_code == 0
+        assert '"native"' in result.output
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    @mock.patch("lilbee.catalog.find_catalog_entry", return_value=None)
+    def test_ollama_fallback_json(
+        self, mock_find: mock.MagicMock, mock_get: mock.MagicMock
+    ) -> None:
+        from lilbee.model_manager import ModelSource
+
+        manager = _mock_manager()
+        mock_get.return_value = manager
+        result = runner.invoke(app, ["--json", "models", "install", "nomic-embed-text"])
+        assert result.exit_code == 0
+        assert '"ollama"' in result.output
+        manager.pull.assert_called_once_with("nomic-embed-text", ModelSource.OLLAMA)
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    @mock.patch("lilbee.catalog.find_catalog_entry", return_value=None)
+    def test_ollama_fallback(self, mock_find: mock.MagicMock, mock_get: mock.MagicMock) -> None:
+        from lilbee.model_manager import ModelSource
+
+        manager = _mock_manager()
+        mock_get.return_value = manager
+        result = runner.invoke(app, ["models", "install", "nomic-embed-text"])
+        assert result.exit_code == 0
+        manager.pull.assert_called_once_with("nomic-embed-text", ModelSource.OLLAMA)
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    @mock.patch("lilbee.catalog.find_catalog_entry", return_value=None)
+    def test_ollama_failure(self, mock_find: mock.MagicMock, mock_get: mock.MagicMock) -> None:
+        manager = _mock_manager()
+        manager.pull.side_effect = RuntimeError("Connection refused")
+        mock_get.return_value = manager
+        result = runner.invoke(app, ["models", "install", "bad-model"])
+        assert result.exit_code == 1
+        assert "Connection refused" in result.output
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    @mock.patch("lilbee.catalog.find_catalog_entry", return_value=None)
+    def test_ollama_failure_json(self, mock_find: mock.MagicMock, mock_get: mock.MagicMock) -> None:
+        manager = _mock_manager()
+        manager.pull.side_effect = RuntimeError("Connection refused")
+        mock_get.return_value = manager
+        result = runner.invoke(app, ["--json", "models", "install", "bad-model"])
+        assert result.exit_code == 1
+        assert "Connection refused" in result.output
+
+
+class TestModelsRemove:
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_removes_model(self, mock_get: mock.MagicMock) -> None:
+        manager = mock.MagicMock()
+        manager.remove.return_value = True
+        mock_get.return_value = manager
+        result = runner.invoke(app, ["models", "remove", "qwen3:8b"])
+        assert result.exit_code == 0
+        assert "Removed" in result.output
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_not_found(self, mock_get: mock.MagicMock) -> None:
+        manager = mock.MagicMock()
+        manager.remove.return_value = False
+        mock_get.return_value = manager
+        result = runner.invoke(app, ["models", "remove", "nonexistent"])
+        assert result.exit_code == 1
+        assert "Not found" in result.output
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_json_mode(self, mock_get: mock.MagicMock) -> None:
+        manager = mock.MagicMock()
+        manager.remove.return_value = True
+        mock_get.return_value = manager
+        result = runner.invoke(app, ["--json", "models", "remove", "qwen3:8b"])
+        assert result.exit_code == 0
+        assert '"deleted": true' in result.output
+
+    @mock.patch("lilbee.model_manager.get_model_manager")
+    def test_source_filter(self, mock_get: mock.MagicMock) -> None:
+        from lilbee.model_manager import ModelSource
+
+        manager = mock.MagicMock()
+        manager.remove.return_value = True
+        mock_get.return_value = manager
+        result = runner.invoke(app, ["models", "remove", "qwen3:8b", "--source", "ollama"])
+        assert result.exit_code == 0
+        manager.remove.assert_called_once_with("qwen3:8b", ModelSource.OLLAMA)

--- a/uv.lock
+++ b/uv.lock
@@ -1159,6 +1159,7 @@ dependencies = [
     { name = "pillow" },
     { name = "prompt-toolkit" },
     { name = "pypdfium2" },
+    { name = "textual" },
     { name = "tiktoken" },
     { name = "tree-sitter-language-pack" },
     { name = "typer" },
@@ -1201,6 +1202,7 @@ requires-dist = [
     { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "pypdfium2", specifier = ">=5.6.0" },
     { name = "sentence-transformers", marker = "extra == 'reranker'" },
+    { name = "textual", specifier = ">=0.75" },
     { name = "tiktoken" },
     { name = "tree-sitter-language-pack", specifier = ">=1.0.0" },
     { name = "typer" },
@@ -1219,6 +1221,18 @@ dev = [
     { name = "reportlab" },
     { name = "ruff", specifier = ">=0.15.4" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878 },
 ]
 
 [[package]]
@@ -1299,6 +1313,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321 },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -1398,6 +1417,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615 },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205 },
 ]
 
 [[package]]
@@ -2005,6 +2036,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/00/98/fc53ab36da80b88df0967896b6c4b4cd948a0dc5aa40a754266aa3ae48b3/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f975aa7ef9684ce7e2c18a3aa8f8e2106ce1e46b94ab713d156b2898811651d3", size = 5313850 },
     { url = "https://files.pythonhosted.org/packages/30/02/00fa585abfd9fe9d73e5f6e554dc36cc2b842898cbfc46d70353dae227f8/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8089c852a56c2966cf18835db62d9b34fef7ba74c726ad943928d494fa7f4735", size = 5963343 },
     { url = "https://files.pythonhosted.org/packages/f2/26/c56ce33ca856e358d27fda9676c055395abddb82c35ac0f593877ed4562e/pillow-12.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cb9bb857b2d057c6dfc72ac5f3b44836924ba15721882ef103cecb40d002d80e", size = 7029880 },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216 },
 ]
 
 [[package]]
@@ -3076,6 +3116,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/23/8c709655c5f2208ee82ab81b8104802421865535c278a7649b842b129db1/textual-8.1.1.tar.gz", hash = "sha256:eef0256a6131f06a20ad7576412138c1f30f92ddeedd055953c08d97044bc317", size = 1843002 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/21/421b02bf5943172b7a9320712a5e0d74a02a8f7597284e3f8b5b06c70b8d/textual-8.1.1-py3-none-any.whl", hash = "sha256:6712f96e335cd782e76193dee16b9c8875fe0699d923bc8d3f1228fd23e773a6", size = 719598 },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3431,6 +3488,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521 },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383 },
 ]
 
 [[package]]


### PR DESCRIPTION
adds `lilbee models browse` — a full-screen terminal UI for browsing and installing models.

featured models load instantly, HuggingFace results stream in via a background worker. keyboard-driven: arrow keys to navigate, Tab to switch task filters (All/Chat/Embedding/Vision), / to search, Enter to install, q to quit.

falls back to static Rich table for --json or non-TTY.

also adds `lilbee models list`, `install`, and `remove` subcommands. removes dead `src/lilbee/cli/setup.py` (broken imports, never used). DRYs install logic into shared `_install_from_catalog` helper.

1338 tests passed, 100% coverage.