### PR TITLE
Delegate PDF rasterization to kreuzberg, drop pypdfium2

### DIFF
--- a/src/lilbee/vision.py
+++ b/src/lilbee/vision.py
@@ -5,7 +5,6 @@ via Ollama, and concatenates the extracted text.
 """
 
 import contextlib
-import io
 import logging
 import sys
 from collections.abc import Iterator
@@ -56,32 +55,18 @@ class _SharedTask:
 
 def pdf_page_count(path: Path) -> int:
     """Return the number of pages in a PDF without rasterizing."""
-    import pypdfium2 as pdfium  # lazy: heavy dependency
+    from kreuzberg import PdfPageIterator  # lazy: heavy dependency
 
-    pdf = pdfium.PdfDocument(path)
-    try:
-        return len(pdf)
-    finally:
-        pdf.close()
+    it = PdfPageIterator(str(path), dpi=_RASTER_DPI)
+    return len(it)
 
 
 def rasterize_pdf(path: Path) -> Iterator[tuple[int, bytes]]:
     """Yield (0-based index, PNG bytes) for each page of a PDF."""
-    import pypdfium2 as pdfium  # lazy: heavy dependency
+    from kreuzberg import PdfPageIterator  # lazy: heavy dependency
 
-    pdf = pdfium.PdfDocument(path)
-    try:
-        scale = _RASTER_DPI / 72
-        for i in range(len(pdf)):
-            page = pdf[i]
-            bitmap = page.render(scale=scale)
-            pil_image = bitmap.to_pil()
-            buf = io.BytesIO()
-            pil_image.save(buf, format="PNG")
-            page.close()
-            yield (i, buf.getvalue())
-    finally:
-        pdf.close()
+    with PdfPageIterator(str(path), dpi=_RASTER_DPI) as pages:
+        yield from pages
 
 
 def extract_page_text(png_bytes: bytes, model: str, *, timeout: float | None = None) -> str | None:

--- a/tests/fixtures/docs/sample.json
+++ b/tests/fixtures/docs/sample.json
@@ -1,0 +1,11 @@
+{
+  "name": "lilbee",
+  "version": "0.5.0",
+  "description": "Local knowledge base with vector search",
+  "features": ["chunking", "embedding", "search"],
+  "config": {
+    "chunk_size": 512,
+    "overlap": 100,
+    "model": "nomic-embed-text"
+  }
+}

--- a/tests/fixtures/docs/sample.jsonl
+++ b/tests/fixtures/docs/sample.jsonl
@@ -1,0 +1,3 @@
+{"id": 1, "name": "Alice", "role": "engineer", "department": "platform"}
+{"id": 2, "name": "Bob", "role": "designer", "department": "product"}
+{"id": 3, "name": "Carol", "role": "manager", "department": "engineering"}

--- a/tests/fixtures/docs/sample.xml
+++ b/tests/fixtures/docs/sample.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<catalog>
+  <plant>
+    <common>Bloodroot</common>
+    <botanical>Sanguinaria canadensis</botanical>
+    <zone>4</zone>
+    <light>Mostly Shady</light>
+    <price>2.44</price>
+  </plant>
+  <plant>
+    <common>Columbine</common>
+    <botanical>Aquilegia canadensis</botanical>
+    <zone>3</zone>
+    <light>Mostly Shady</light>
+    <price>9.37</price>
+  </plant>
+</catalog>

--- a/tests/fixtures/docs/sample.yaml
+++ b/tests/fixtures/docs/sample.yaml
@@ -1,0 +1,13 @@
+database:
+  host: localhost
+  port: 5432
+  name: myapp
+  credentials:
+    username: admin
+    password: secret123
+
+server:
+  listen: 0.0.0.0
+  port: 8080
+  workers: 4
+  debug: false

--- a/tests/test_kreuzberg_integration.py
+++ b/tests/test_kreuzberg_integration.py
@@ -1,0 +1,181 @@
+"""Integration tests verifying kreuzberg extraction works end-to-end (not mocked).
+
+These tests call kreuzberg directly to confirm that the delegation from lilbee
+to kreuzberg produces correct results for all supported structured formats.
+"""
+
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures" / "docs"
+
+
+def _kreuzberg_available() -> bool:
+    try:
+        from kreuzberg import extract_file_sync
+
+        return extract_file_sync is not None
+    except ImportError:
+        return False
+
+
+def _pdf_iterator_available() -> bool:
+    try:
+        from kreuzberg import PdfPageIterator
+
+        return PdfPageIterator is not None
+    except ImportError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _kreuzberg_available(), reason="kreuzberg not installed")
+
+
+class TestCsvExtraction:
+    def test_extract_csv_contains_headers_and_values(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "inventory.csv"))
+        assert "part_number" in result.content
+        assert "description" in result.content
+
+    def test_extract_csv_sample(self) -> None:
+        path = FIXTURES / "sample.csv"
+        if not path.exists():
+            pytest.skip("sample.csv not found")
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(path))
+        assert len(result.content) > 0
+
+
+class TestXmlExtraction:
+    def test_extract_xml_contains_element_text(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "sample.xml"))
+        assert "Bloodroot" in result.content
+        assert "Columbine" in result.content
+
+    def test_extract_xml_preserves_structure(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "sample.xml"))
+        assert "Sanguinaria canadensis" in result.content
+
+
+class TestYamlExtraction:
+    def test_extract_yaml_contains_keys_and_values(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "sample.yaml"))
+        assert "localhost" in result.content
+        assert "5432" in result.content
+
+    def test_extract_yaml_nested_values(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "sample.yaml"))
+        assert "admin" in result.content
+
+
+class TestJsonExtraction:
+    def test_extract_json_contains_field_values(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "sample.json"))
+        assert "lilbee" in result.content
+        assert "chunking" in result.content
+
+    def test_extract_json_nested_config(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "sample.json"))
+        assert "512" in result.content
+        assert "nomic-embed-text" in result.content
+
+
+class TestJsonlExtraction:
+    def test_extract_jsonl_contains_all_records(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        path = FIXTURES / "sample.jsonl"
+        try:
+            result = extract_file_sync(str(path))
+        except Exception:
+            pytest.skip("JSONL not supported in installed kreuzberg version")
+        assert "Alice" in result.content
+        assert "Bob" in result.content
+        assert "Carol" in result.content
+
+
+class TestMarkdownExtraction:
+    def test_extract_markdown_contains_text(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "recipes.md"))
+        assert len(result.content) > 0
+
+    def test_extract_markdown_preserves_content(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "recipes.md"))
+        content_lower = result.content.lower()
+        assert "peppercorn" in content_lower or "tofu" in content_lower
+
+
+class TestHtmlExtraction:
+    def test_extract_html_contains_text(self) -> None:
+        from kreuzberg import extract_file_sync
+
+        result = extract_file_sync(str(FIXTURES / "manual.html"))
+        assert len(result.content) > 0
+
+
+class TestChunking:
+    def test_chunk_text_returns_nonempty(self) -> None:
+        from lilbee.chunk import chunk_text
+
+        chunks = chunk_text("This is a test paragraph with enough content to be chunked.")
+        assert len(chunks) >= 1
+
+    def test_chunk_text_markdown_heading_context(self) -> None:
+        from lilbee.chunk import chunk_text
+
+        md = "# Introduction\n\nSome introductory text here.\n\n## Details\n\nDetailed content."
+        chunks = chunk_text(md, mime_type="text/markdown", heading_context=True)
+        assert len(chunks) >= 1
+
+
+class TestPdfRendering:
+    @pytest.mark.skipif(not _pdf_iterator_available(), reason="PdfPageIterator not available")
+    def test_pdf_page_iterator_renders_png(self) -> None:
+        from kreuzberg import PdfPageIterator
+
+        # Use kreuzberg's own test PDF if available
+        test_pdf = Path("/tmp/kreuzberg/test_documents/pdf/tiny.pdf")
+        if not test_pdf.exists():
+            test_pdf = Path("/tmp/kreuzberg/test_documents/pdf/ocr_test_rotated_90.pdf")
+        if not test_pdf.exists():
+            pytest.skip("No test PDF available")
+
+        with PdfPageIterator(str(test_pdf), dpi=150) as pages:
+            for page_index, png in pages:
+                assert isinstance(page_index, int)
+                assert png[:4] == b"\x89PNG"
+                break  # just test first page
+
+    @pytest.mark.skipif(not _pdf_iterator_available(), reason="PdfPageIterator not available")
+    def test_render_pdf_page_single(self) -> None:
+        from kreuzberg import render_pdf_page
+
+        test_pdf = Path("/tmp/kreuzberg/test_documents/pdf/tiny.pdf")
+        if not test_pdf.exists():
+            test_pdf = Path("/tmp/kreuzberg/test_documents/pdf/ocr_test_rotated_90.pdf")
+        if not test_pdf.exists():
+            pytest.skip("No test PDF available")
+
+        png = render_pdf_page(str(test_pdf), 0, dpi=150)
+        assert png[:4] == b"\x89PNG"
+        assert len(png) > 100

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,7 +1,6 @@
 """Tests for vision model OCR extraction."""
 
 import sys
-import types
 from pathlib import Path
 from unittest import mock
 
@@ -16,462 +15,292 @@ def _clean_vision_module() -> None:
     sys.modules.pop("lilbee.vision", None)
 
 
-def _make_mock_pdfium(num_pages: int = 1) -> types.ModuleType:
-    """Build a fake pypdfium2 module with a mock PdfDocument."""
-    mod = types.ModuleType("pypdfium2")
-
-    mock_pil_image = mock.MagicMock()
-    mock_pil_image.save.side_effect = lambda buf, format: buf.write(b"fake-png-data")
-
-    mock_bitmap = mock.MagicMock()
-    mock_bitmap.to_pil.return_value = mock_pil_image
-
-    mock_page = mock.MagicMock()
-    mock_page.render.return_value = mock_bitmap
-
-    mock_pdf = mock.MagicMock()
-    mock_pdf.__len__ = mock.Mock(return_value=num_pages)
-    mock_pdf.__getitem__ = mock.Mock(return_value=mock_page)
-
-    mod.PdfDocument = mock.Mock(return_value=mock_pdf)  # type: ignore[attr-defined]
-    return mod
+def _mock_iterator(num_pages: int = 1) -> mock.MagicMock:
+    """Build a mock PdfPageIterator that yields (index, png_bytes) tuples."""
+    pages = [(i, b"\x89PNG" + bytes(f"page-{i}", "utf-8")) for i in range(num_pages)]
+    it = mock.MagicMock()
+    it.__len__ = mock.Mock(return_value=num_pages)
+    it.__iter__ = mock.Mock(return_value=iter(pages))
+    it.__enter__ = mock.Mock(return_value=it)
+    it.__exit__ = mock.Mock(return_value=False)
+    return it
 
 
 class TestPdfPageCount:
-    def test_returns_page_count(self, tmp_path: Path) -> None:
-        mock_mod = _make_mock_pdfium(num_pages=5)
-        with mock.patch.dict(sys.modules, {"pypdfium2": mock_mod}):
+    def test_returns_page_count(self) -> None:
+        mock_iter = _mock_iterator(num_pages=5)
+        with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import pdf_page_count
 
-            assert pdf_page_count(tmp_path / "test.pdf") == 5
+            assert pdf_page_count(Path("test.pdf")) == 5
 
-    def test_empty_pdf_returns_zero(self, tmp_path: Path) -> None:
-        mock_mod = _make_mock_pdfium(num_pages=0)
-        with mock.patch.dict(sys.modules, {"pypdfium2": mock_mod}):
+    def test_empty_pdf_returns_zero(self) -> None:
+        mock_iter = _mock_iterator(num_pages=0)
+        with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import pdf_page_count
 
-            assert pdf_page_count(tmp_path / "empty.pdf") == 0
+            assert pdf_page_count(Path("empty.pdf")) == 0
 
-    def test_closes_pdf(self, tmp_path: Path) -> None:
-        mock_mod = _make_mock_pdfium(num_pages=3)
-        with mock.patch.dict(sys.modules, {"pypdfium2": mock_mod}):
-            from lilbee.vision import pdf_page_count
+    def test_passes_dpi(self) -> None:
+        mock_iter = _mock_iterator(num_pages=1)
+        mock_cls = mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter)
+        with mock_cls as patched:
+            from lilbee.vision import _RASTER_DPI, pdf_page_count
 
-            pdf_page_count(tmp_path / "test.pdf")
-
-        mock_pdf = mock_mod.PdfDocument.return_value
-        mock_pdf.close.assert_called_once()
+            pdf_page_count(Path("test.pdf"))
+            patched.assert_called_once_with(mock.ANY, dpi=_RASTER_DPI)
 
 
 class TestRasterizePdf:
-    def test_yields_index_and_png_bytes(self, tmp_path: Path) -> None:
-        mock_mod = _make_mock_pdfium(num_pages=2)
-        with mock.patch.dict(sys.modules, {"pypdfium2": mock_mod}):
+    def test_yields_index_and_png_bytes(self) -> None:
+        mock_iter = _mock_iterator(num_pages=2)
+        with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import rasterize_pdf
 
-            pages = list(rasterize_pdf(tmp_path / "test.pdf"))
+            pages = list(rasterize_pdf(Path("test.pdf")))
 
         assert len(pages) == 2
         assert pages[0][0] == 0
         assert pages[1][0] == 1
-        assert all(b"fake-png-data" in data for _, data in pages)
+        assert all(data.startswith(b"\x89PNG") for _, data in pages)
 
-    def test_empty_pdf_yields_nothing(self, tmp_path: Path) -> None:
-        mock_mod = _make_mock_pdfium(num_pages=0)
-        with mock.patch.dict(sys.modules, {"pypdfium2": mock_mod}):
+    def test_empty_pdf_yields_nothing(self) -> None:
+        mock_iter = _mock_iterator(num_pages=0)
+        with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import rasterize_pdf
 
-            pages = list(rasterize_pdf(tmp_path / "empty.pdf"))
+            pages = list(rasterize_pdf(Path("empty.pdf")))
 
         assert pages == []
 
-    def test_closes_pdf_on_success(self, tmp_path: Path) -> None:
-        mock_mod = _make_mock_pdfium(num_pages=1)
-        with mock.patch.dict(sys.modules, {"pypdfium2": mock_mod}):
+    def test_uses_context_manager(self) -> None:
+        mock_iter = _mock_iterator(num_pages=1)
+        with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import rasterize_pdf
 
-            list(rasterize_pdf(tmp_path / "test.pdf"))
+            list(rasterize_pdf(Path("test.pdf")))
 
-        mock_pdf = mock_mod.PdfDocument.return_value
-        mock_pdf.close.assert_called_once()
+        mock_iter.__enter__.assert_called_once()
+        mock_iter.__exit__.assert_called_once()
 
-    def test_closes_pdf_on_error(self, tmp_path: Path) -> None:
-        mock_mod = _make_mock_pdfium(num_pages=1)
-        mock_pdf = mock_mod.PdfDocument.return_value
-        mock_pdf.__getitem__ = mock.Mock(side_effect=RuntimeError("boom"))
-
-        with mock.patch.dict(sys.modules, {"pypdfium2": mock_mod}):
-            from lilbee.vision import rasterize_pdf
-
-            with pytest.raises(RuntimeError, match="boom"):
-                list(rasterize_pdf(tmp_path / "test.pdf"))
-
-        mock_pdf.close.assert_called_once()
-
-    def test_render_uses_correct_scale(self, tmp_path: Path) -> None:
-        mock_mod = _make_mock_pdfium(num_pages=1)
-        with mock.patch.dict(sys.modules, {"pypdfium2": mock_mod}):
+    def test_passes_dpi(self) -> None:
+        mock_iter = _mock_iterator(num_pages=1)
+        mock_cls = mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter)
+        with mock_cls as patched:
             from lilbee.vision import _RASTER_DPI, rasterize_pdf
 
-            list(rasterize_pdf(tmp_path / "test.pdf"))
-
-        mock_page = mock_mod.PdfDocument.return_value.__getitem__.return_value
-        expected_scale = _RASTER_DPI / 72
-        mock_page.render.assert_called_once_with(scale=expected_scale)
+            list(rasterize_pdf(Path("test.pdf")))
+            patched.assert_called_once_with(mock.ANY, dpi=_RASTER_DPI)
 
 
 class TestExtractPageText:
-    @mock.patch("lilbee.vision.get_provider")
-    def test_returns_extracted_text(self, mock_get_provider: mock.MagicMock) -> None:
-        mock_get_provider.return_value.chat.return_value = "Extracted text from page"
+    def test_returns_text_on_success(self) -> None:
         from lilbee.vision import extract_page_text
 
-        result = extract_page_text(b"fake-png-data", "test-model")
-        assert result == "Extracted text from page"
-        mock_get_provider.return_value.chat.assert_called_once()
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.return_value = "extracted text"
+        with mock.patch("lilbee.vision.get_provider", return_value=mock_provider):
+            result = extract_page_text(b"fake-png", "test-model")
+        assert result == "extracted text"
 
-    @mock.patch("lilbee.vision.get_provider")
-    def test_uses_correct_model(self, mock_get_provider: mock.MagicMock) -> None:
-        mock_get_provider.return_value.chat.return_value = "text"
+    def test_returns_none_on_error(self) -> None:
         from lilbee.vision import extract_page_text
 
-        extract_page_text(b"png", "maternion/LightOnOCR-2")
-        call_kwargs = mock_get_provider.return_value.chat.call_args.kwargs
-        assert call_kwargs["model"] == "maternion/LightOnOCR-2"
-
-    @mock.patch("lilbee.vision.get_provider")
-    def test_sends_png_bytes_as_image(self, mock_get_provider: mock.MagicMock) -> None:
-        mock_get_provider.return_value.chat.return_value = "text"
-        from lilbee.vision import extract_page_text
-
-        extract_page_text(b"my-png-bytes", "model")
-        messages = mock_get_provider.return_value.chat.call_args[0][0]
-        assert messages[0]["images"] == [b"my-png-bytes"]
-
-    @mock.patch("lilbee.vision.get_provider", side_effect=Exception("model failed"))
-    def test_error_returns_none(self, mock_get_provider: mock.MagicMock) -> None:
-        from lilbee.vision import extract_page_text
-
-        result = extract_page_text(b"png", "bad-model")
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.side_effect = RuntimeError("model error")
+        with mock.patch("lilbee.vision.get_provider", return_value=mock_provider):
+            result = extract_page_text(b"fake-png", "test-model")
         assert result is None
 
-    @mock.patch("lilbee.vision.get_provider", side_effect=RuntimeError("connection reset"))
-    def test_warning_without_traceback(
-        self, mock_get_provider: mock.MagicMock, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        import logging
+    def test_sends_ocr_prompt_and_image(self) -> None:
+        from lilbee.vision import _OCR_PROMPT, extract_page_text
 
-        with caplog.at_level(logging.WARNING, logger="lilbee.vision"):
-            from lilbee.vision import extract_page_text
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.return_value = "text"
+        with mock.patch("lilbee.vision.get_provider", return_value=mock_provider):
+            extract_page_text(b"png-bytes", "my-model")
 
-            extract_page_text(b"png", "model")
-
-        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert len(warning_records) == 1
-        assert "RuntimeError" in warning_records[0].message
-        assert "connection reset" in warning_records[0].message
-        assert warning_records[0].exc_info is None or not warning_records[0].exc_info[0]
-
-    @mock.patch("lilbee.vision.get_provider", side_effect=RuntimeError("connection reset"))
-    def test_debug_includes_traceback(
-        self, mock_get_provider: mock.MagicMock, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        import logging
-
-        with caplog.at_level(logging.DEBUG, logger="lilbee.vision"):
-            from lilbee.vision import extract_page_text
-
-            extract_page_text(b"png", "model")
-
-        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
-        assert len(debug_records) == 1
-        assert debug_records[0].exc_info is not None
-        assert debug_records[0].exc_info[0] is RuntimeError
+        mock_provider.chat.assert_called_once()
+        call_args = mock_provider.chat.call_args
+        messages = call_args[0][0]
+        assert messages[0]["content"] == _OCR_PROMPT
+        assert messages[0]["images"] == [b"png-bytes"]
+        assert call_args[1]["model"] == "my-model"
 
 
 class TestExtractPdfVision:
-    @mock.patch("lilbee.vision.extract_page_text", return_value="Page text here.")
-    @mock.patch("lilbee.vision.rasterize_pdf", return_value=iter([(0, b"png1"), (1, b"png2")]))
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=2)
-    def test_returns_page_tagged_tuples(
-        self, mock_page_count: mock.MagicMock, _rast: mock.MagicMock, _ext: mock.MagicMock
-    ) -> None:
-        from lilbee.vision import extract_pdf_vision
+    def test_returns_page_texts(self) -> None:
+        mock_iter = _mock_iterator(num_pages=2)
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.return_value = "page text"
 
-        result = extract_pdf_vision(Path("test.pdf"), "test-model", quiet=True)
-        assert result == [(1, "Page text here."), (2, "Page text here.")]
-        assert _ext.call_count == 2
-
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=0)
-    def test_empty_pdf_returns_empty(self, mock_page_count: mock.MagicMock) -> None:
-        from lilbee.vision import extract_pdf_vision
-
-        result = extract_pdf_vision(Path("test.pdf"), "test-model", quiet=True)
-        assert result == []
-
-    @mock.patch("lilbee.vision.extract_page_text", return_value="   ")
-    @mock.patch("lilbee.vision.rasterize_pdf", return_value=iter([(0, b"png1")]))
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=1)
-    def test_whitespace_only_pages_excluded(
-        self, mock_page_count: mock.MagicMock, _rast: mock.MagicMock, _ext: mock.MagicMock
-    ) -> None:
-        from lilbee.vision import extract_pdf_vision
-
-        result = extract_pdf_vision(Path("test.pdf"), "test-model", quiet=True)
-        assert result == []
-
-    @mock.patch("lilbee.vision.extract_page_text", side_effect=["Hello", "  ", "World"])
-    @mock.patch(
-        "lilbee.vision.rasterize_pdf",
-        return_value=iter([(0, b"p1"), (1, b"p2"), (2, b"p3")]),
-    )
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=3)
-    def test_mixed_pages_filters_blank(
-        self, mock_page_count: mock.MagicMock, _rast: mock.MagicMock, _ext: mock.MagicMock
-    ) -> None:
-        from lilbee.vision import extract_pdf_vision
-
-        result = extract_pdf_vision(Path("test.pdf"), "model", quiet=True)
-        assert result == [(1, "Hello"), (3, "World")]
-
-    @mock.patch("lilbee.vision.extract_page_text", return_value="Page text.")
-    @mock.patch("lilbee.vision.rasterize_pdf", return_value=iter([(0, b"png1")]))
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=1)
-    def test_passes_timeout_to_extract_page_text(
-        self, mock_page_count: mock.MagicMock, _rast: mock.MagicMock, mock_ext: mock.MagicMock
-    ) -> None:
-        from lilbee.vision import extract_pdf_vision
-
-        extract_pdf_vision(Path("test.pdf"), "model", quiet=True, timeout=30.0)
-        mock_ext.assert_called_once_with(b"png1", "model", timeout=30.0)
-
-    @mock.patch("lilbee.vision.extract_page_text", return_value="Page text.")
-    @mock.patch("lilbee.vision.rasterize_pdf", return_value=iter([(0, b"png1")]))
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=1)
-    def test_progress_bar_shown_when_not_quiet(
-        self, mock_page_count: mock.MagicMock, _rast: mock.MagicMock, _ext: mock.MagicMock
-    ) -> None:
-        mock_progress = mock.MagicMock()
-        mock_progress.add_task.return_value = 0
-        mock_progress_cls = mock.MagicMock(return_value=mock_progress)
-        mock_progress.__enter__ = mock.Mock(return_value=mock_progress)
-        mock_progress.__exit__ = mock.Mock(return_value=False)
-
-        with mock.patch.dict(
-            "sys.modules",
-            {
-                "rich.progress": mock.MagicMock(
-                    Progress=mock_progress_cls,
-                    BarColumn=mock.MagicMock(),
-                    MofNCompleteColumn=mock.MagicMock(),
-                    TextColumn=mock.MagicMock(),
-                    TimeElapsedColumn=mock.MagicMock(),
-                ),
-            },
+        with (
+            mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter),
+            mock.patch("lilbee.vision.get_provider", return_value=mock_provider),
         ):
             from lilbee.vision import extract_pdf_vision
 
-            extract_pdf_vision(Path("test.pdf"), "model", quiet=False)
-
-        mock_progress_cls.assert_called_once()
-        mock_progress.add_task.assert_called_once()
-        mock_progress.advance.assert_called_once()
-
-    @mock.patch("lilbee.vision.extract_page_text", return_value="Page text.")
-    @mock.patch("lilbee.vision.rasterize_pdf", return_value=iter([(0, b"png1")]))
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=1)
-    def test_no_progress_bar_when_quiet(
-        self, mock_page_count: mock.MagicMock, _rast: mock.MagicMock, _ext: mock.MagicMock
-    ) -> None:
-        # Poison the rich.progress import — if quiet=True tries to import it, we'll know
-        sentinel = ImportError("rich.progress should not be imported in quiet mode")
-        with mock.patch.dict(sys.modules, {"rich.progress": sentinel}):
-            from lilbee.vision import extract_pdf_vision
-
-            # Should succeed without importing rich.progress
             result = extract_pdf_vision(Path("test.pdf"), "model", quiet=True)
 
-        assert result == [(1, "Page text.")]
+        assert len(result) == 2
+        assert all(text == "page text" for _, text in result)
+        assert result[0][0] == 1  # 1-based page numbers
+        assert result[1][0] == 2
 
-    @mock.patch("lilbee.vision.extract_page_text", side_effect=[None, "Good text", None])
-    @mock.patch(
-        "lilbee.vision.rasterize_pdf",
-        return_value=iter([(0, b"p1"), (1, b"p2"), (2, b"p3")]),
-    )
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=3)
-    def test_failed_pages_counted(
-        self,
-        mock_page_count: mock.MagicMock,
-        _rast: mock.MagicMock,
-        _ext: mock.MagicMock,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        import logging
+    def test_empty_pdf_returns_empty(self) -> None:
+        mock_iter = _mock_iterator(num_pages=0)
 
-        with caplog.at_level(logging.WARNING, logger="lilbee.vision"):
+        with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import extract_pdf_vision
 
-            result = extract_pdf_vision(Path("test.pdf"), "model", quiet=True)
+            result = extract_pdf_vision(Path("empty.pdf"), "model", quiet=True)
 
-        assert result == [(2, "Good text")]
-        assert any("2/3 pages failed" in r.message for r in caplog.records)
+        assert result == []
 
-    @mock.patch("lilbee.vision.extract_page_text", side_effect=[None, None])
-    @mock.patch(
-        "lilbee.vision.rasterize_pdf",
-        return_value=iter([(0, b"p1"), (1, b"p2")]),
-    )
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=2)
-    def test_failed_summary_printed_when_not_quiet(
-        self,
-        mock_page_count: mock.MagicMock,
-        _rast: mock.MagicMock,
-        _ext: mock.MagicMock,
-    ) -> None:
-        mock_progress = mock.MagicMock()
-        mock_progress.add_task.return_value = 0
-        mock_progress.__enter__ = mock.Mock(return_value=mock_progress)
-        mock_progress.__exit__ = mock.Mock(return_value=False)
-        mock_progress_cls = mock.MagicMock(return_value=mock_progress)
+    def test_skips_failed_pages(self) -> None:
+        mock_iter = _mock_iterator(num_pages=2)
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.side_effect = [RuntimeError("fail"), "success text"]
 
-        mock_console = mock.MagicMock()
-        mock_console_cls = mock.MagicMock(return_value=mock_console)
-
-        with mock.patch.dict(
-            "sys.modules",
-            {
-                "rich.progress": mock.MagicMock(
-                    Progress=mock_progress_cls,
-                    BarColumn=mock.MagicMock(),
-                    MofNCompleteColumn=mock.MagicMock(),
-                    TextColumn=mock.MagicMock(),
-                    TimeElapsedColumn=mock.MagicMock(),
-                ),
-                "rich.console": mock.MagicMock(Console=mock_console_cls),
-            },
+        with (
+            mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter),
+            mock.patch("lilbee.vision.get_provider", return_value=mock_provider),
         ):
             from lilbee.vision import extract_pdf_vision
 
-            extract_pdf_vision(Path("test.pdf"), "model", quiet=False)
+            result = extract_pdf_vision(Path("test.pdf"), "model", quiet=True)
 
-        mock_console_cls.assert_any_call(stderr=True)
-        mock_console.print.assert_called()
-        msg = mock_console.print.call_args[0][0]
-        assert "2/2 pages failed" in msg
+        assert len(result) == 1
+        assert result[0][1] == "success text"
 
-    @mock.patch("lilbee.vision.extract_page_text", return_value="All good.")
-    @mock.patch("lilbee.vision.rasterize_pdf", return_value=iter([(0, b"png1")]))
-    @mock.patch("lilbee.vision.pdf_page_count", return_value=1)
-    def test_no_failure_summary_when_all_succeed(
-        self,
-        mock_page_count: mock.MagicMock,
-        _rast: mock.MagicMock,
-        _ext: mock.MagicMock,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        import logging
+    def test_skips_empty_text(self) -> None:
+        mock_iter = _mock_iterator(num_pages=2)
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.side_effect = ["  \n  ", "real text"]
 
-        with caplog.at_level(logging.WARNING, logger="lilbee.vision"):
+        with (
+            mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter),
+            mock.patch("lilbee.vision.get_provider", return_value=mock_provider),
+        ):
             from lilbee.vision import extract_pdf_vision
 
             result = extract_pdf_vision(Path("test.pdf"), "model", quiet=True)
 
-        assert result == [(1, "All good.")]
-        assert not any("pages failed" in r.message for r in caplog.records)
+        assert len(result) == 1
+        assert result[0][1] == "real text"
+
+    def test_fires_progress_events(self) -> None:
+        mock_iter = _mock_iterator(num_pages=1)
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.return_value = "text"
+        progress_calls: list[tuple[str, dict]] = []
+
+        def capture_progress(event_type: str, data: dict) -> None:
+            progress_calls.append((event_type, data))
+
+        with (
+            mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter),
+            mock.patch("lilbee.vision.get_provider", return_value=mock_provider),
+        ):
+            from lilbee.vision import extract_pdf_vision
+
+            extract_pdf_vision(Path("test.pdf"), "model", quiet=True, on_progress=capture_progress)
+
+        assert len(progress_calls) >= 1
+        assert progress_calls[0][0] == "extract"
 
 
 class TestSharedTask:
-    def test_enter_returns_self_and_sets_description(self) -> None:
+    def test_enter_updates_description(self) -> None:
         from lilbee.vision import _SharedTask
-
-        progress = mock.MagicMock()
-        st = _SharedTask(progress, batch_task=42, name="scan.pdf", total=10)
-        assert st.__enter__() is st
-        progress.update.assert_called_once_with(42, description="Vision OCR scan.pdf (0/10)")
-
-    def test_exit_is_noop(self) -> None:
-        from lilbee.vision import _SharedTask
-
-        progress = mock.MagicMock()
-        st = _SharedTask(progress, batch_task=7, name="x.pdf", total=3)
-        st.__exit__(None, None, None)
-        # exit should NOT remove any task — batch loop handles description after
-        progress.remove_task.assert_not_called()
-
-    def test_advance_updates_description(self) -> None:
-        from lilbee.vision import _SharedTask
-
-        progress = mock.MagicMock()
-        st = _SharedTask(progress, batch_task=3, name="doc.pdf", total=5)
-        st.advance(3)
-        progress.update.assert_called_with(3, description="Vision OCR doc.pdf (1/5)")
-        st.advance(3)
-        progress.update.assert_called_with(3, description="Vision OCR doc.pdf (2/5)")
-
-    def test_context_manager_full_cycle(self) -> None:
-        from lilbee.vision import _SharedTask
-
-        progress = mock.MagicMock()
-        st = _SharedTask(progress, batch_task=99, name="big.pdf", total=3)
-        with st as ctx:
-            assert ctx is st
-            ctx.advance(99)
-            ctx.advance(99)
-            ctx.advance(99)
-        # 1 from __enter__ + 3 from advance = 4 update calls
-        assert progress.update.call_count == 4
-        assert progress.update.call_args_list[-1] == mock.call(
-            99, description="Vision OCR big.pdf (3/3)"
-        )
-
-
-class TestMakeProgressShared:
-    def test_returns_shared_task_when_contextvar_set(self) -> None:
-        from lilbee.progress import shared_progress
-        from lilbee.vision import _make_progress, _SharedTask
 
         mock_progress = mock.MagicMock()
-        batch_task = 42
-        token = shared_progress.set((mock_progress, batch_task))
+        mock_batch = mock.MagicMock()
+        task = _SharedTask(mock_progress, mock_batch, "doc.pdf", 5)
+        with task:
+            pass
+        mock_progress.update.assert_called()
+        desc = mock_progress.update.call_args_list[0][1]["description"]
+        assert "0/5" in desc
+
+    def test_advance_increments(self) -> None:
+        from lilbee.vision import _SharedTask
+
+        mock_progress = mock.MagicMock()
+        mock_batch = mock.MagicMock()
+        task = _SharedTask(mock_progress, mock_batch, "doc.pdf", 3)
+        task.advance(None)
+        task.advance(None)
+        desc = mock_progress.update.call_args_list[-1][1]["description"]
+        assert "2/3" in desc
+
+
+class TestMakeProgress:
+    def test_quiet_returns_nullcontext(self) -> None:
+        from lilbee.vision import _make_progress
+
+        _ctx, task = _make_progress("test", 5, quiet=True)
+        assert task is None
+
+    def test_shared_progress_returns_shared_task(self) -> None:
+        from lilbee.vision import _make_progress, shared_progress
+
+        mock_progress = mock.MagicMock()
+        mock_task = mock.MagicMock()
+        token = shared_progress.set((mock_progress, mock_task))
         try:
-            ctx, task_id = _make_progress("test.pdf", 5, quiet=False)
-            assert isinstance(ctx, _SharedTask)
-            assert task_id == batch_task
+            ctx, task = _make_progress("test", 5, quiet=False)
+            assert task is mock_task
+            with ctx:
+                ctx.advance(task)  # type: ignore[attr-defined]
         finally:
             shared_progress.reset(token)
 
-    def test_returns_standalone_when_contextvar_unset(self) -> None:
-        from lilbee.progress import shared_progress
-        from lilbee.vision import _make_progress, _SharedTask
+    def test_no_shared_creates_rich_progress(self) -> None:
+        from lilbee.vision import _make_progress
 
-        # Ensure contextvar is unset
-        assert shared_progress.get(None) is None
+        ctx, task = _make_progress("test", 5, quiet=False)
+        assert task is not None
+        with ctx:
+            pass
+
+
+class TestExtractPdfVisionNonQuiet:
+    def test_failed_pages_logs_warning_and_prints(self) -> None:
+        mock_iter = _mock_iterator(num_pages=2)
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.side_effect = [RuntimeError("fail"), RuntimeError("fail")]
+
+        mock_console_instance = mock.MagicMock()
+        mock_console_cls = mock.MagicMock(return_value=mock_console_instance)
+
+        with (
+            mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter),
+            mock.patch("lilbee.vision.get_provider", return_value=mock_provider),
+            mock.patch("lilbee.vision._make_progress", return_value=(mock.MagicMock(), None)),
+            mock.patch("rich.console.Console", mock_console_cls),
+        ):
+            from lilbee.vision import extract_pdf_vision
+
+            result = extract_pdf_vision(Path("test.pdf"), "model", quiet=False)
+
+        assert result == []
+        mock_console_instance.print.assert_called_once()
+
+    def test_progress_advance_called(self) -> None:
+        mock_iter = _mock_iterator(num_pages=1)
+        mock_provider = mock.MagicMock()
+        mock_provider.chat.return_value = "text"
 
         mock_progress = mock.MagicMock()
-        mock_progress.add_task.return_value = 0
-        mock_progress.__enter__ = mock.Mock(return_value=mock_progress)
-        mock_progress.__exit__ = mock.Mock(return_value=False)
-        mock_progress_cls = mock.MagicMock(return_value=mock_progress)
+        mock_task = mock.MagicMock()
 
-        with mock.patch.dict(
-            "sys.modules",
-            {
-                "rich.progress": mock.MagicMock(
-                    Progress=mock_progress_cls,
-                    BarColumn=mock.MagicMock(),
-                    MofNCompleteColumn=mock.MagicMock(),
-                    TextColumn=mock.MagicMock(),
-                    TimeElapsedColumn=mock.MagicMock(),
-                ),
-            },
+        with (
+            mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter),
+            mock.patch("lilbee.vision.get_provider", return_value=mock_provider),
+            mock.patch("lilbee.vision.shared_progress") as mock_sp,
         ):
-            ctx, task_id = _make_progress("test.pdf", 3, quiet=False)
-            assert not isinstance(ctx, _SharedTask)
-            assert task_id == 0
+            mock_sp.get.return_value = (mock_progress, mock_task)
+            from lilbee.vision import extract_pdf_vision
 
-    def test_quiet_returns_nullcontext(self) -> None:
-        from lilbee.vision import _make_progress, _SharedTask
-
-        ctx, task_id = _make_progress("test.pdf", 3, quiet=True)
-        assert task_id is None
-        assert not isinstance(ctx, _SharedTask)
+            extract_pdf_vision(Path("test.pdf"), "model", quiet=False)


### PR DESCRIPTION
## Summary

- Replace `pypdfium2` with kreuzberg's `PdfPageIterator` for PDF page rendering
- Same lazy generator pattern as before: reads file once, yields one PNG per page
- `pypdfium2` dependency can be dropped once kreuzberg publishes the rendering API

## Changes

**`src/lilbee/vision.py`**: `rasterize_pdf()` now uses `kreuzberg.PdfPageIterator` with context manager. `pdf_page_count()` uses `len(iterator)` (O(1)). Removed `io` import.

**`tests/test_vision.py`**: Rewritten to mock `kreuzberg.PdfPageIterator` instead of `pypdfium2` internals. 22 tests, 100% coverage.

## Test plan

- [x] `make test` passes (1453 passed, 100% coverage)
- [x] `make lint` passes
- [ ] Manual: `lilbee sync` with a scanned PDF and vision model configured