### PR TITLE
feat: concept graph + warm model pre-loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
     "litellm",
     "huggingface_hub",
     "httpx",
+    "spacy>=3.8",
+    "networkx>=3.0",
+    "graspologic-native>=1.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "huggingface_hub",
     "httpx",
     "spacy>=3.8",
-    "networkx>=3.0",
     "graspologic-native>=1.2",
 ]
 

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -659,7 +659,7 @@ def topics(
         )
         raise SystemExit(1)
 
-    from lilbee.concepts import ConceptGraph, extract_concepts, get_graph
+    from lilbee.concepts import get_graph
 
     graph = get_graph()
     if graph is None:
@@ -675,7 +675,7 @@ def topics(
         _topics_overview(graph, top_k)
 
 
-def _topics_for_query(graph: "ConceptGraph", query: str) -> None:
+def _topics_for_query(graph: ConceptGraph, query: str) -> None:
     """Show concepts related to a query."""
     from lilbee.concepts import extract_concepts
 
@@ -696,7 +696,7 @@ def _topics_for_query(graph: "ConceptGraph", query: str) -> None:
         console.print(f"  {c}")
 
 
-def _topics_overview(graph: "ConceptGraph", top_k: int) -> None:
+def _topics_overview(graph: ConceptGraph, top_k: int) -> None:
     """Show top concept communities."""
     communities = graph.top_communities(k=top_k)
     if cfg.json_mode:

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -10,6 +10,8 @@ import typer
 
 if TYPE_CHECKING:
     import uvicorn
+
+    from lilbee.concepts import ConceptGraph
 from rich.table import Table
 
 from lilbee import settings
@@ -635,6 +637,84 @@ def serve(
     config = uvicorn.Config(create_app(), host=cfg.server_host, port=cfg.server_port)
     server = uvicorn.Server(config)
     asyncio.run(_run_server(server, config, cfg.server_host))
+
+
+@app.command()
+def topics(
+    query: str = typer.Argument(None, help="Optional query to find related concepts."),
+    top_k: int = typer.Option(10, "--top-k", "-k", help="Number of results."),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = _global_option,
+) -> None:
+    """Show top concept communities or concepts related to a query."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+
+    if not cfg.concept_graph:
+        if cfg.json_mode:
+            json_output({"error": "Concept graph is disabled (LILBEE_CONCEPT_GRAPH=false)"})
+            raise SystemExit(1)
+        console.print(
+            f"[{theme.ERROR}]Concept graph is disabled.[/{theme.ERROR}] "
+            "Enable with LILBEE_CONCEPT_GRAPH=true"
+        )
+        raise SystemExit(1)
+
+    from lilbee.concepts import ConceptGraph, extract_concepts, get_graph
+
+    graph = get_graph()
+    if graph is None:
+        if cfg.json_mode:
+            json_output({"error": "Concept graph not available"})
+            raise SystemExit(1)
+        console.print(f"[{theme.ERROR}]Concept graph not available.[/{theme.ERROR}]")
+        raise SystemExit(1)
+
+    if query:
+        _topics_for_query(graph, query)
+    else:
+        _topics_overview(graph, top_k)
+
+
+def _topics_for_query(graph: "ConceptGraph", query: str) -> None:
+    """Show concepts related to a query."""
+    from lilbee.concepts import extract_concepts
+
+    concepts = extract_concepts(query)
+    related: list[str] = []
+    for c in concepts:
+        related.extend(graph.get_related_concepts(c))
+    all_concepts = concepts + [r for r in related if r not in concepts]
+
+    if cfg.json_mode:
+        json_output({"command": "topics", "query": query, "concepts": all_concepts})
+        return
+    if not all_concepts:
+        console.print("No concepts found for this query.")
+        return
+    console.print(f"Concepts related to [{theme.ACCENT}]{query}[/{theme.ACCENT}]:")
+    for c in all_concepts:
+        console.print(f"  {c}")
+
+
+def _topics_overview(graph: "ConceptGraph", top_k: int) -> None:
+    """Show top concept communities."""
+    communities = graph.top_communities(k=top_k)
+    if cfg.json_mode:
+        json_output({"command": "topics", "communities": communities})
+        return
+    if not communities:
+        console.print("No concept communities found. Try syncing some documents first.")
+        return
+    table = Table(title="Concept Communities")
+    table.add_column("Cluster", justify="right", style=theme.MUTED)
+    table.add_column("Size", justify="right")
+    table.add_column("Top Concepts", style=theme.ACCENT)
+    for comm in communities:
+        preview = ", ".join(comm["concepts"][:5])
+        if len(comm["concepts"]) > 5:
+            preview += f" (+{len(comm['concepts']) - 5} more)"
+        table.add_row(str(comm["cluster_id"]), str(comm["size"]), preview)
+    console.print(table)
 
 
 @app.command(name="mcp")

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -10,8 +10,6 @@ import typer
 
 if TYPE_CHECKING:
     import uvicorn
-
-    from lilbee.concepts import ConceptGraph
 from rich.table import Table
 
 from lilbee import settings
@@ -661,8 +659,7 @@ def topics(
 
     from lilbee.concepts import get_graph
 
-    graph = get_graph()
-    if graph is None:
+    if not get_graph():
         if cfg.json_mode:
             json_output({"error": "Concept graph not available"})
             raise SystemExit(1)
@@ -670,19 +667,17 @@ def topics(
         raise SystemExit(1)
 
     if query:
-        _topics_for_query(graph, query)
+        _topics_for_query(query)
     else:
-        _topics_overview(graph, top_k)
+        _topics_overview(top_k)
 
 
-def _topics_for_query(graph: ConceptGraph, query: str) -> None:
+def _topics_for_query(query: str) -> None:
     """Show concepts related to a query."""
-    from lilbee.concepts import extract_concepts
+    from lilbee.concepts import expand_query, extract_concepts
 
     concepts = extract_concepts(query)
-    related: list[str] = []
-    for c in concepts:
-        related.extend(graph.get_related_concepts(c))
+    related = expand_query(query)
     all_concepts = concepts + [r for r in related if r not in concepts]
 
     if cfg.json_mode:
@@ -696,11 +691,15 @@ def _topics_for_query(graph: ConceptGraph, query: str) -> None:
         console.print(f"  {c}")
 
 
-def _topics_overview(graph: ConceptGraph, top_k: int) -> None:
+def _topics_overview(top_k: int) -> None:
     """Show top concept communities."""
-    communities = graph.top_communities(k=top_k)
+    from dataclasses import asdict
+
+    from lilbee.concepts import top_communities
+
+    communities = top_communities(k=top_k)
     if cfg.json_mode:
-        json_output({"command": "topics", "communities": communities})
+        json_output({"command": "topics", "communities": [asdict(c) for c in communities]})
         return
     if not communities:
         console.print("No concept communities found. Try syncing some documents first.")
@@ -710,10 +709,10 @@ def _topics_overview(graph: ConceptGraph, top_k: int) -> None:
     table.add_column("Size", justify="right")
     table.add_column("Top Concepts", style=theme.ACCENT)
     for comm in communities:
-        preview = ", ".join(comm["concepts"][:5])
-        if len(comm["concepts"]) > 5:
-            preview += f" (+{len(comm['concepts']) - 5} more)"
-        table.add_row(str(comm["cluster_id"]), str(comm["size"]), preview)
+        preview = ", ".join(comm.concepts[:5])
+        if len(comm.concepts) > 5:
+            preview += f" (+{len(comm.concepts) - 5} more)"
+        table.add_row(str(comm.cluster_id), str(comm.size), preview)
     console.print(table)
 
 

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -1,0 +1,388 @@
+"""Concept graph for LazyGraphRAG-style index-time knowledge extraction.
+
+Extracts noun-phrase concepts from chunks via spaCy, builds a PMI-weighted
+co-occurrence graph, and clusters with Leiden (graspologic-native). Used to
+boost search results by concept overlap and expand queries via graph traversal.
+
+Heavy dependencies (spacy, networkx, graspologic) are lazy-imported.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections import Counter
+from typing import Any
+
+import pyarrow as pa
+
+from lilbee.config import (
+    CHUNK_CONCEPTS_TABLE,
+    CONCEPT_EDGES_TABLE,
+    CONCEPT_NODES_TABLE,
+    cfg,
+)
+
+log = logging.getLogger(__name__)
+
+# Minimum concept length (chars) to filter noise like single letters
+_MIN_CONCEPT_LEN = 2
+
+# Smoothing constant for PMI to avoid log(0) and reduce noise from
+# rare co-occurrences (Turney 2001, "Mining the Web for Synonyms")
+_PMI_SMOOTHING = 1.0
+
+
+def _ensure_spacy_model() -> Any:
+    """Load the spaCy model, auto-downloading on first use."""
+    import spacy
+
+    model_name = "en_core_web_sm"
+    try:
+        return spacy.load(model_name)
+    except OSError:
+        log.info("Downloading spaCy model '%s'...", model_name)
+        from spacy.cli import download
+
+        download(model_name)
+        return spacy.load(model_name)
+
+
+_nlp: Any = None
+
+
+def _get_nlp() -> Any:
+    """Lazy-load and cache the spaCy model."""
+    global _nlp
+    if _nlp is None:
+        _nlp = _ensure_spacy_model()
+    return _nlp
+
+
+def extract_concepts(text: str, max_concepts: int | None = None) -> list[str]:
+    """Extract deduplicated noun-phrase concepts from text.
+
+    Returns lowercase concept strings, capped at *max_concepts*
+    (defaults to ``cfg.concept_max_per_chunk``).
+    """
+    if max_concepts is None:
+        max_concepts = cfg.concept_max_per_chunk
+    if not text.strip():
+        return []
+    nlp = _get_nlp()
+    doc = nlp(text)
+    seen: set[str] = set()
+    concepts: list[str] = []
+    for chunk in doc.noun_chunks:
+        concept = chunk.text.lower().strip()
+        if len(concept) < _MIN_CONCEPT_LEN:
+            continue
+        if concept in seen:
+            continue
+        seen.add(concept)
+        concepts.append(concept)
+        if len(concepts) >= max_concepts:
+            break
+    return concepts
+
+
+def extract_concepts_batch(texts: list[str]) -> list[list[str]]:
+    """Batch-extract concepts using spaCy's ``nlp.pipe()`` for efficiency."""
+    if not texts:
+        return []
+    max_concepts = cfg.concept_max_per_chunk
+    nlp = _get_nlp()
+    results: list[list[str]] = []
+    for doc in nlp.pipe(texts):
+        seen: set[str] = set()
+        concepts: list[str] = []
+        for chunk in doc.noun_chunks:
+            concept = chunk.text.lower().strip()
+            if len(concept) < _MIN_CONCEPT_LEN:
+                continue
+            if concept in seen:
+                continue
+            seen.add(concept)
+            concepts.append(concept)
+            if len(concepts) >= max_concepts:
+                break
+        results.append(concepts)
+    return results
+
+
+def _concept_nodes_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("concept", pa.utf8()),
+            pa.field("cluster_id", pa.int32()),
+            pa.field("degree", pa.int32()),
+        ]
+    )
+
+
+def _concept_edges_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("source", pa.utf8()),
+            pa.field("target", pa.utf8()),
+            pa.field("weight", pa.float32()),
+        ]
+    )
+
+
+def _chunk_concepts_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("chunk_source", pa.utf8()),
+            pa.field("chunk_index", pa.int32()),
+            pa.field("concept", pa.utf8()),
+        ]
+    )
+
+
+def _compute_pmi(
+    cooccurrences: Counter[tuple[str, str]],
+    concept_counts: Counter[str],
+    total_chunks: int,
+) -> dict[tuple[str, str], float]:
+    """Compute PMI weights for concept co-occurrence pairs.
+
+    PMI = log2(P(a,b) / (P(a) * P(b))) with additive smoothing.
+    """
+    pmi: dict[tuple[str, str], float] = {}
+    for (a, b), count in cooccurrences.items():
+        p_ab = (count + _PMI_SMOOTHING) / (total_chunks + _PMI_SMOOTHING)
+        p_a = (concept_counts[a] + _PMI_SMOOTHING) / (total_chunks + _PMI_SMOOTHING)
+        p_b = (concept_counts[b] + _PMI_SMOOTHING) / (total_chunks + _PMI_SMOOTHING)
+        pmi[(a, b)] = math.log2(p_ab / (p_a * p_b))
+    return pmi
+
+
+def _leiden_partition(
+    edge_rows: list[dict[str, Any]],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Run Leiden clustering on edge rows. Returns (partition, degree_map).
+
+    Uses graspologic-native's Rust implementation for performance.
+    """
+    from graspologic_native import leiden
+
+    edges: list[tuple[str, str, float]] = [
+        (row["source"], row["target"], max(0.01, row["weight"]))
+        for row in edge_rows
+    ]
+    partition = leiden(edges)
+
+    degree_map: dict[str, int] = Counter()
+    for row in edge_rows:
+        degree_map[row["source"]] += 1
+        degree_map[row["target"]] += 1
+    return partition, dict(degree_map)
+
+
+class ConceptGraph:
+    """Graph of concept co-occurrences backed by LanceDB tables."""
+
+    def build_from_chunks(
+        self,
+        chunk_ids: list[tuple[str, int]],
+        concept_lists: list[list[str]],
+    ) -> None:
+        """Build co-occurrence graph from chunk concepts, compute PMI, store tables."""
+        from lilbee.store import ensure_table, get_db
+
+        if not chunk_ids:
+            return
+
+        cooccurrences: Counter[tuple[str, str]] = Counter()
+        concept_counts: Counter[str] = Counter()
+        chunk_concept_records: list[dict[str, Any]] = []
+
+        for (source, idx), concepts in zip(chunk_ids, concept_lists, strict=True):
+            for c in concepts:
+                concept_counts[c] += 1
+                chunk_concept_records.append(
+                    {"chunk_source": source, "chunk_index": idx, "concept": c}
+                )
+            for i, a in enumerate(concepts):
+                for b in concepts[i + 1 :]:
+                    pair = (min(a, b), max(a, b))
+                    cooccurrences[pair] += 1
+
+        pmi_weights = _compute_pmi(cooccurrences, concept_counts, len(chunk_ids))
+
+        edge_records = [
+            {"source": a, "target": b, "weight": w}
+            for (a, b), w in pmi_weights.items()
+        ]
+
+        node_records = [
+            {"concept": c, "cluster_id": 0, "degree": count}
+            for c, count in concept_counts.items()
+        ]
+
+        db = get_db()
+        if node_records:
+            table = ensure_table(db, CONCEPT_NODES_TABLE, _concept_nodes_schema())
+            table.add(node_records)
+        if edge_records:
+            table = ensure_table(db, CONCEPT_EDGES_TABLE, _concept_edges_schema())
+            table.add(edge_records)
+        if chunk_concept_records:
+            table = ensure_table(db, CHUNK_CONCEPTS_TABLE, _chunk_concepts_schema())
+            table.add(chunk_concept_records)
+
+    def boost_results(
+        self,
+        results: list[Any],
+        query_concepts: list[str],
+    ) -> list[Any]:
+        """Adjust search result scores by concept overlap with query.
+
+        For each result, finds shared concepts between the result's chunk
+        and the query, then boosts the score by overlap ratio times
+        ``cfg.concept_boost_weight``.
+        """
+        if not query_concepts or not results:
+            return results
+        query_set = set(query_concepts)
+        boosted: list[Any] = []
+        for r in results:
+            chunk_concepts = set(self._get_chunk_concepts(r.source, r.chunk_index))
+            overlap = len(query_set & chunk_concepts)
+            if overlap > 0:
+                boost = (overlap / len(query_set)) * cfg.concept_boost_weight
+                r = r.model_copy()
+                if r.relevance_score is not None:
+                    r.relevance_score = r.relevance_score + boost
+                elif r.distance is not None:
+                    r.distance = max(0.0, r.distance - boost)
+            boosted.append(r)
+        return boosted
+
+    def _get_chunk_concepts(self, source: str, chunk_index: int) -> list[str]:
+        """Look up concepts for a specific chunk from the chunk_concepts table."""
+        from lilbee.store import _escape_sql_string, _open_table
+
+        table = _open_table(CHUNK_CONCEPTS_TABLE)
+        if table is None:
+            return []
+        escaped = _escape_sql_string(source)
+        try:
+            rows = (
+                table.search()
+                .where(f"chunk_source = '{escaped}' AND chunk_index = {chunk_index}")
+                .to_list()
+            )
+            return [r["concept"] for r in rows]
+        except Exception:
+            return []
+
+    def expand_query(self, query: str) -> list[str]:
+        """Extract concepts from query and find related concepts via graph."""
+        concepts = extract_concepts(query)
+        if not concepts:
+            return []
+        related: list[str] = []
+        seen = set(concepts)
+        for concept in concepts:
+            for neighbor in self.get_related_concepts(concept):
+                if neighbor not in seen:
+                    related.append(neighbor)
+                    seen.add(neighbor)
+        return related
+
+    def get_related_concepts(self, concept: str, depth: int = 1) -> list[str]:
+        """BFS traversal of edges to find related concepts."""
+        from lilbee.store import _escape_sql_string, _open_table
+
+        table = _open_table(CONCEPT_EDGES_TABLE)
+        if table is None:
+            return []
+        visited: set[str] = {concept}
+        frontier: list[str] = [concept]
+        for _ in range(depth):
+            next_frontier: list[str] = []
+            for node in frontier:
+                escaped = _escape_sql_string(node)
+                try:
+                    rows = (
+                        table.search()
+                        .where(f"source = '{escaped}' OR target = '{escaped}'")
+                        .to_list()
+                    )
+                except Exception:
+                    continue
+                for row in rows:
+                    neighbor = row["target"] if row["source"] == node else row["source"]
+                    if neighbor not in visited:
+                        visited.add(neighbor)
+                        next_frontier.append(neighbor)
+            frontier = next_frontier
+        return [c for c in visited if c != concept]
+
+    def top_communities(self, k: int = 10) -> list[dict[str, Any]]:
+        """Return top-k concept clusters by size."""
+        from lilbee.store import _open_table
+
+        table = _open_table(CONCEPT_NODES_TABLE)
+        if table is None:
+            return []
+        rows = table.to_arrow().to_pylist()
+        clusters: dict[int, list[str]] = {}
+        for row in rows:
+            cid = row["cluster_id"]
+            clusters.setdefault(cid, []).append(row["concept"])
+        sorted_clusters = sorted(clusters.items(), key=lambda x: len(x[1]), reverse=True)
+        return [
+            {"cluster_id": cid, "size": len(concepts), "concepts": concepts}
+            for cid, concepts in sorted_clusters[:k]
+        ]
+
+    def rebuild_clusters(self) -> None:
+        """Re-run Leiden clustering on the full co-occurrence graph."""
+        from lilbee.store import _open_table, ensure_table, get_db, safe_delete
+
+        edges_table = _open_table(CONCEPT_EDGES_TABLE)
+        if edges_table is None:
+            return
+        edge_rows = edges_table.to_arrow().to_pylist()
+        if not edge_rows:
+            return
+
+        partition, degree_map = _leiden_partition(edge_rows)
+
+        node_records = [
+            {
+                "concept": node,
+                "cluster_id": cluster_id,
+                "degree": degree_map.get(node, 0),
+            }
+            for node, cluster_id in partition.items()
+        ]
+
+        db = get_db()
+        nodes_table = ensure_table(db, CONCEPT_NODES_TABLE, _concept_nodes_schema())
+        safe_delete(nodes_table, "concept IS NOT NULL")
+        if node_records:
+            nodes_table.add(node_records)
+
+
+_graph: ConceptGraph | None = None
+
+
+def get_graph() -> ConceptGraph | None:
+    """Return the concept graph singleton, or None if disabled."""
+    global _graph
+    if not cfg.concept_graph:
+        return None
+    if _graph is None:
+        _graph = ConceptGraph()
+    return _graph
+
+
+def reset_graph() -> None:
+    """Clear the graph singleton. For testing only."""
+    global _graph, _nlp
+    _graph = None
+    _nlp = None

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -168,10 +168,9 @@ def _leiden_partition(
     from graspologic_native import leiden
 
     edges: list[tuple[str, str, float]] = [
-        (row["source"], row["target"], max(0.01, row["weight"]))
-        for row in edge_rows
+        (row["source"], row["target"], max(0.01, row["weight"])) for row in edge_rows
     ]
-    partition = leiden(edges)
+    _modularity, partition = leiden(edges=edges)  # type: ignore[call-arg]
 
     degree_map: dict[str, int] = Counter()
     for row in edge_rows:
@@ -212,13 +211,11 @@ class ConceptGraph:
         pmi_weights = _compute_pmi(cooccurrences, concept_counts, len(chunk_ids))
 
         edge_records = [
-            {"source": a, "target": b, "weight": w}
-            for (a, b), w in pmi_weights.items()
+            {"source": a, "target": b, "weight": w} for (a, b), w in pmi_weights.items()
         ]
 
         node_records = [
-            {"concept": c, "cluster_id": 0, "degree": count}
-            for c, count in concept_counts.items()
+            {"concept": c, "cluster_id": 0, "degree": count} for c, count in concept_counts.items()
         ]
 
         db = get_db()

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -1,6 +1,6 @@
 """Concept graph for LazyGraphRAG-style index-time knowledge extraction.
 
-Extracts noun-phrase concepts from chunks via spaCy, builds a PMI-weighted
+Extracts noun-phrase concepts from chunks via spaCy, builds a PPMI-weighted
 co-occurrence graph, and clusters with Leiden (graspologic-native). Used to
 boost search results by concept overlap and expand queries via graph traversal.
 
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import math
 from collections import Counter
+from dataclasses import dataclass
 from typing import Any
 
 import pyarrow as pa
@@ -28,9 +29,18 @@ log = logging.getLogger(__name__)
 # Minimum concept length (chars) to filter noise like single letters
 _MIN_CONCEPT_LEN = 2
 
-# Smoothing constant for PMI to avoid log(0) and reduce noise from
-# rare co-occurrences (Turney 2001, "Mining the Web for Synonyms")
-_PMI_SMOOTHING = 1.0
+# Minimum edge weight for Leiden clustering — avoids zero/negative weights
+# which graspologic-native rejects
+_MIN_LEIDEN_WEIGHT = 0.01
+
+
+@dataclass
+class Community:
+    """A cluster of related concepts from Leiden partitioning."""
+
+    cluster_id: int
+    size: int
+    concepts: list[str]
 
 
 def _ensure_spacy_model() -> Any:
@@ -59,18 +69,8 @@ def _get_nlp() -> Any:
     return _nlp
 
 
-def extract_concepts(text: str, max_concepts: int | None = None) -> list[str]:
-    """Extract deduplicated noun-phrase concepts from text.
-
-    Returns lowercase concept strings, capped at *max_concepts*
-    (defaults to ``cfg.concept_max_per_chunk``).
-    """
-    if max_concepts is None:
-        max_concepts = cfg.concept_max_per_chunk
-    if not text.strip():
-        return []
-    nlp = _get_nlp()
-    doc = nlp(text)
+def _filter_noun_chunks(doc: Any, max_concepts: int) -> list[str]:
+    """Extract deduplicated, filtered noun chunks from a spaCy doc."""
     seen: set[str] = set()
     concepts: list[str] = []
     for chunk in doc.noun_chunks:
@@ -86,28 +86,28 @@ def extract_concepts(text: str, max_concepts: int | None = None) -> list[str]:
     return concepts
 
 
+def extract_concepts(text: str, max_concepts: int | None = None) -> list[str]:
+    """Extract deduplicated noun-phrase concepts from text.
+
+    Returns lowercase concept strings, capped at *max_concepts*
+    (defaults to ``cfg.concept_max_per_chunk``).
+    """
+    if max_concepts is None:
+        max_concepts = cfg.concept_max_per_chunk
+    if not text.strip():
+        return []
+    nlp = _get_nlp()
+    doc = nlp(text)
+    return _filter_noun_chunks(doc, max_concepts)
+
+
 def extract_concepts_batch(texts: list[str]) -> list[list[str]]:
     """Batch-extract concepts using spaCy's ``nlp.pipe()`` for efficiency."""
     if not texts:
         return []
     max_concepts = cfg.concept_max_per_chunk
     nlp = _get_nlp()
-    results: list[list[str]] = []
-    for doc in nlp.pipe(texts):
-        seen: set[str] = set()
-        concepts: list[str] = []
-        for chunk in doc.noun_chunks:
-            concept = chunk.text.lower().strip()
-            if len(concept) < _MIN_CONCEPT_LEN:
-                continue
-            if concept in seen:
-                continue
-            seen.add(concept)
-            concepts.append(concept)
-            if len(concepts) >= max_concepts:
-                break
-        results.append(concepts)
-    return results
+    return [_filter_noun_chunks(doc, max_concepts) for doc in nlp.pipe(texts)]
 
 
 def _concept_nodes_schema() -> pa.Schema:
@@ -145,16 +145,17 @@ def _compute_pmi(
     concept_counts: Counter[str],
     total_chunks: int,
 ) -> dict[tuple[str, str], float]:
-    """Compute PMI weights for concept co-occurrence pairs.
+    """Compute PPMI (Positive PMI) weights for concept co-occurrence pairs.
 
-    PMI = log2(P(a,b) / (P(a) * P(b))) with additive smoothing.
+    PPMI = max(0, log2(P(a,b) / (P(a) * P(b)))).
+    Negative values are clamped to zero to discard anti-correlated pairs.
     """
     pmi: dict[tuple[str, str], float] = {}
     for (a, b), count in cooccurrences.items():
-        p_ab = (count + _PMI_SMOOTHING) / (total_chunks + _PMI_SMOOTHING)
-        p_a = (concept_counts[a] + _PMI_SMOOTHING) / (total_chunks + _PMI_SMOOTHING)
-        p_b = (concept_counts[b] + _PMI_SMOOTHING) / (total_chunks + _PMI_SMOOTHING)
-        pmi[(a, b)] = math.log2(p_ab / (p_a * p_b))
+        p_ab = count / total_chunks
+        p_a = concept_counts[a] / total_chunks
+        p_b = concept_counts[b] / total_chunks
+        pmi[(a, b)] = max(0.0, math.log2(p_ab / (p_a * p_b)))
     return pmi
 
 
@@ -168,7 +169,7 @@ def _leiden_partition(
     from graspologic_native import leiden
 
     edges: list[tuple[str, str, float]] = [
-        (row["source"], row["target"], max(0.01, row["weight"])) for row in edge_rows
+        (row["source"], row["target"], max(_MIN_LEIDEN_WEIGHT, row["weight"])) for row in edge_rows
     ]
     _modularity, partition = leiden(edges=edges)  # type: ignore[call-arg]
 
@@ -179,45 +180,39 @@ def _leiden_partition(
     return partition, dict(degree_map)
 
 
-class ConceptGraph:
-    """Graph of concept co-occurrences backed by LanceDB tables."""
+def build_from_chunks(
+    chunk_ids: list[tuple[str, int]],
+    concept_lists: list[list[str]],
+) -> None:
+    """Build co-occurrence graph from chunk concepts, compute PMI, store tables."""
+    from lilbee.lock import write_lock
+    from lilbee.store import ensure_table, get_db
 
-    def build_from_chunks(
-        self,
-        chunk_ids: list[tuple[str, int]],
-        concept_lists: list[list[str]],
-    ) -> None:
-        """Build co-occurrence graph from chunk concepts, compute PMI, store tables."""
-        from lilbee.store import ensure_table, get_db
+    if not chunk_ids:
+        return
 
-        if not chunk_ids:
-            return
+    cooccurrences: Counter[tuple[str, str]] = Counter()
+    concept_counts: Counter[str] = Counter()
+    chunk_concept_records: list[dict[str, Any]] = []
 
-        cooccurrences: Counter[tuple[str, str]] = Counter()
-        concept_counts: Counter[str] = Counter()
-        chunk_concept_records: list[dict[str, Any]] = []
+    for (source, idx), concepts in zip(chunk_ids, concept_lists, strict=True):
+        for c in concepts:
+            concept_counts[c] += 1
+            chunk_concept_records.append({"chunk_source": source, "chunk_index": idx, "concept": c})
+        for i, a in enumerate(concepts):
+            for b in concepts[i + 1 :]:
+                pair = (min(a, b), max(a, b))
+                cooccurrences[pair] += 1
 
-        for (source, idx), concepts in zip(chunk_ids, concept_lists, strict=True):
-            for c in concepts:
-                concept_counts[c] += 1
-                chunk_concept_records.append(
-                    {"chunk_source": source, "chunk_index": idx, "concept": c}
-                )
-            for i, a in enumerate(concepts):
-                for b in concepts[i + 1 :]:
-                    pair = (min(a, b), max(a, b))
-                    cooccurrences[pair] += 1
+    pmi_weights = _compute_pmi(cooccurrences, concept_counts, len(chunk_ids))
 
-        pmi_weights = _compute_pmi(cooccurrences, concept_counts, len(chunk_ids))
+    edge_records = [{"source": a, "target": b, "weight": w} for (a, b), w in pmi_weights.items()]
 
-        edge_records = [
-            {"source": a, "target": b, "weight": w} for (a, b), w in pmi_weights.items()
-        ]
+    node_records = [
+        {"concept": c, "cluster_id": 0, "degree": count} for c, count in concept_counts.items()
+    ]
 
-        node_records = [
-            {"concept": c, "cluster_id": 0, "degree": count} for c, count in concept_counts.items()
-        ]
-
+    with write_lock():
         db = get_db()
         if node_records:
             table = ensure_table(db, CONCEPT_NODES_TABLE, _concept_nodes_schema())
@@ -229,157 +224,157 @@ class ConceptGraph:
             table = ensure_table(db, CHUNK_CONCEPTS_TABLE, _chunk_concepts_schema())
             table.add(chunk_concept_records)
 
-    def boost_results(
-        self,
-        results: list[Any],
-        query_concepts: list[str],
-    ) -> list[Any]:
-        """Adjust search result scores by concept overlap with query.
 
-        For each result, finds shared concepts between the result's chunk
-        and the query, then boosts the score by overlap ratio times
-        ``cfg.concept_boost_weight``.
-        """
-        if not query_concepts or not results:
-            return results
-        query_set = set(query_concepts)
-        boosted: list[Any] = []
-        for r in results:
-            chunk_concepts = set(self._get_chunk_concepts(r.source, r.chunk_index))
-            overlap = len(query_set & chunk_concepts)
-            if overlap > 0:
-                boost = (overlap / len(query_set)) * cfg.concept_boost_weight
-                r = r.model_copy()
-                if r.relevance_score is not None:
-                    r.relevance_score = r.relevance_score + boost
-                elif r.distance is not None:
-                    r.distance = max(0.0, r.distance - boost)
-            boosted.append(r)
-        return boosted
+def boost_results(
+    results: list[Any],
+    query_concepts: list[str],
+) -> list[Any]:
+    """Adjust search result scores by concept overlap with query.
 
-    def _get_chunk_concepts(self, source: str, chunk_index: int) -> list[str]:
-        """Look up concepts for a specific chunk from the chunk_concepts table."""
-        from lilbee.store import _escape_sql_string, _open_table
+    For each result, finds shared concepts between the result's chunk
+    and the query, then boosts the score by overlap ratio times
+    ``cfg.concept_boost_weight``.
+    """
+    if not query_concepts or not results:
+        return results
+    query_set = set(query_concepts)
+    boosted: list[Any] = []
+    for r in results:
+        chunk_concepts = set(get_chunk_concepts(r.source, r.chunk_index))
+        overlap = len(query_set & chunk_concepts)
+        if overlap > 0:
+            boost = (overlap / len(query_set)) * cfg.concept_boost_weight
+            r = r.model_copy()
+            if r.relevance_score is not None:
+                r.relevance_score = r.relevance_score + boost
+            elif r.distance is not None:
+                r.distance = max(0.0, r.distance - boost)
+        boosted.append(r)
+    return boosted
 
-        table = _open_table(CHUNK_CONCEPTS_TABLE)
-        if table is None:
-            return []
-        escaped = _escape_sql_string(source)
-        try:
-            rows = (
-                table.search()
-                .where(f"chunk_source = '{escaped}' AND chunk_index = {chunk_index}")
-                .to_list()
-            )
-            return [r["concept"] for r in rows]
-        except Exception:
-            return []
 
-    def expand_query(self, query: str) -> list[str]:
-        """Extract concepts from query and find related concepts via graph."""
-        concepts = extract_concepts(query)
-        if not concepts:
-            return []
-        related: list[str] = []
-        seen = set(concepts)
-        for concept in concepts:
-            for neighbor in self.get_related_concepts(concept):
-                if neighbor not in seen:
-                    related.append(neighbor)
-                    seen.add(neighbor)
-        return related
+def get_chunk_concepts(source: str, chunk_index: int) -> list[str]:
+    """Look up concepts for a specific chunk from the chunk_concepts table."""
+    from lilbee.store import escape_sql_string, open_table
 
-    def get_related_concepts(self, concept: str, depth: int = 1) -> list[str]:
-        """BFS traversal of edges to find related concepts."""
-        from lilbee.store import _escape_sql_string, _open_table
+    table = open_table(CHUNK_CONCEPTS_TABLE)
+    if table is None:
+        return []
+    escaped = escape_sql_string(source)
+    try:
+        rows = (
+            table.search()
+            .where(f"chunk_source = '{escaped}' AND chunk_index = {chunk_index}")
+            .to_list()
+        )
+        return [r["concept"] for r in rows]
+    except Exception:
+        return []
 
-        table = _open_table(CONCEPT_EDGES_TABLE)
-        if table is None:
-            return []
-        visited: set[str] = {concept}
-        frontier: list[str] = [concept]
-        for _ in range(depth):
-            next_frontier: list[str] = []
-            for node in frontier:
-                escaped = _escape_sql_string(node)
-                try:
-                    rows = (
-                        table.search()
-                        .where(f"source = '{escaped}' OR target = '{escaped}'")
-                        .to_list()
-                    )
-                except Exception:
-                    continue
-                for row in rows:
-                    neighbor = row["target"] if row["source"] == node else row["source"]
-                    if neighbor not in visited:
-                        visited.add(neighbor)
-                        next_frontier.append(neighbor)
-            frontier = next_frontier
-        return [c for c in visited if c != concept]
 
-    def top_communities(self, k: int = 10) -> list[dict[str, Any]]:
-        """Return top-k concept clusters by size."""
-        from lilbee.store import _open_table
+def expand_query(query: str) -> list[str]:
+    """Extract concepts from query and find related concepts via graph."""
+    concepts = extract_concepts(query)
+    if not concepts:
+        return []
+    related: list[str] = []
+    seen = set(concepts)
+    for concept in concepts:
+        for neighbor in get_related_concepts(concept):
+            if neighbor not in seen:
+                related.append(neighbor)
+                seen.add(neighbor)
+    return related
 
-        table = _open_table(CONCEPT_NODES_TABLE)
-        if table is None:
-            return []
-        rows = table.to_arrow().to_pylist()
-        clusters: dict[int, list[str]] = {}
-        for row in rows:
-            cid = row["cluster_id"]
-            clusters.setdefault(cid, []).append(row["concept"])
-        sorted_clusters = sorted(clusters.items(), key=lambda x: len(x[1]), reverse=True)
-        return [
-            {"cluster_id": cid, "size": len(concepts), "concepts": concepts}
-            for cid, concepts in sorted_clusters[:k]
-        ]
 
-    def rebuild_clusters(self) -> None:
-        """Re-run Leiden clustering on the full co-occurrence graph."""
-        from lilbee.store import _open_table, ensure_table, get_db, safe_delete
+def get_related_concepts(concept: str, depth: int = 1) -> list[str]:
+    """BFS traversal of edges to find related concepts."""
+    from lilbee.store import escape_sql_string, open_table
 
-        edges_table = _open_table(CONCEPT_EDGES_TABLE)
-        if edges_table is None:
-            return
-        edge_rows = edges_table.to_arrow().to_pylist()
-        if not edge_rows:
-            return
+    table = open_table(CONCEPT_EDGES_TABLE)
+    if table is None:
+        return []
+    visited: set[str] = {concept}
+    frontier: list[str] = [concept]
+    for _ in range(depth):
+        next_frontier: list[str] = []
+        for node in frontier:
+            escaped = escape_sql_string(node)
+            try:
+                rows = (
+                    table.search().where(f"source = '{escaped}' OR target = '{escaped}'").to_list()
+                )
+            except Exception:
+                continue
+            for row in rows:
+                neighbor = row["target"] if row["source"] == node else row["source"]
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    next_frontier.append(neighbor)
+        frontier = next_frontier
+    return [c for c in visited if c != concept]
 
-        partition, degree_map = _leiden_partition(edge_rows)
 
-        node_records = [
-            {
-                "concept": node,
-                "cluster_id": cluster_id,
-                "degree": degree_map.get(node, 0),
-            }
-            for node, cluster_id in partition.items()
-        ]
+def top_communities(k: int = 10) -> list[Community]:
+    """Return top-k concept clusters by size."""
+    from lilbee.store import open_table
 
-        db = get_db()
-        nodes_table = ensure_table(db, CONCEPT_NODES_TABLE, _concept_nodes_schema())
-        safe_delete(nodes_table, "concept IS NOT NULL")
+    table = open_table(CONCEPT_NODES_TABLE)
+    if table is None:
+        return []
+    rows = table.to_arrow().to_pylist()
+    clusters: dict[int, list[str]] = {}
+    for row in rows:
+        cid = row["cluster_id"]
+        clusters.setdefault(cid, []).append(row["concept"])
+    sorted_clusters = sorted(clusters.items(), key=lambda x: len(x[1]), reverse=True)
+    return [
+        Community(cluster_id=cid, size=len(concepts), concepts=concepts)
+        for cid, concepts in sorted_clusters[:k]
+    ]
+
+
+def rebuild_clusters() -> None:
+    """Re-run Leiden clustering on the full co-occurrence graph."""
+    from lilbee.lock import write_lock
+    from lilbee.store import ensure_table, get_db, open_table, safe_delete
+
+    edges_table = open_table(CONCEPT_EDGES_TABLE)
+    if edges_table is None:
+        return
+    edge_rows = edges_table.to_arrow().to_pylist()
+    if not edge_rows:
+        return
+
+    partition, degree_map = _leiden_partition(edge_rows)
+
+    node_records = [
+        {
+            "concept": node,
+            "cluster_id": cluster_id,
+            "degree": degree_map.get(node, 0),
+        }
+        for node, cluster_id in partition.items()
+    ]
+
+    db = get_db()
+    nodes_table = ensure_table(db, CONCEPT_NODES_TABLE, _concept_nodes_schema())
+    safe_delete(nodes_table, "concept IS NOT NULL")
+    with write_lock():
         if node_records:
             nodes_table.add(node_records)
 
 
-_graph: ConceptGraph | None = None
-
-
-def get_graph() -> ConceptGraph | None:
-    """Return the concept graph singleton, or None if disabled."""
-    global _graph
+def get_graph() -> bool:
+    """Return whether concept graph tables exist."""
     if not cfg.concept_graph:
-        return None
-    if _graph is None:
-        _graph = ConceptGraph()
-    return _graph
+        return False
+    from lilbee.store import open_table
+
+    return open_table(CONCEPT_NODES_TABLE) is not None
 
 
 def reset_graph() -> None:
-    """Clear the graph singleton. For testing only."""
-    global _graph, _nlp
-    _graph = None
+    """Clear the spaCy model cache. For testing only."""
+    global _nlp
     _nlp = None

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -274,9 +274,7 @@ class Config(BaseModel):
             show_reasoning=_load_setting(
                 data_root, "show_reasoning", "SHOW_REASONING", False, bool
             ),
-            concept_graph=_load_setting(
-                data_root, "concept_graph", "CONCEPT_GRAPH", True, bool
-            ),
+            concept_graph=_load_setting(data_root, "concept_graph", "CONCEPT_GRAPH", True, bool),
             concept_boost_weight=_load_setting(
                 data_root, "concept_boost_weight", "CONCEPT_BOOST_WEIGHT", 0.3, float
             ),

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -32,6 +32,9 @@ DEFAULT_IGNORE_DIRS = frozenset(
 
 CHUNKS_TABLE = "chunks"
 SOURCES_TABLE = "_sources"
+CONCEPT_NODES_TABLE = "concept_nodes"
+CONCEPT_EDGES_TABLE = "concept_edges"
+CHUNK_CONCEPTS_TABLE = "chunk_concepts"
 
 
 class Config(BaseModel):
@@ -135,6 +138,19 @@ class Config(BaseModel):
     # When False, thinking is stripped silently. When True, emitted as
     # separate SSE events (event: reasoning) for UI rendering.
     show_reasoning: bool = False
+
+    # Enable concept graph (LazyGraphRAG-style index). Extracts noun phrases
+    # from chunks, builds a co-occurrence graph, and uses it to boost search
+    # results and expand queries. Requires spacy + networkx + graspologic-native.
+    concept_graph: bool = True
+
+    # Weight for concept overlap boosting in search results (0.0-1.0).
+    # Higher = concept overlap matters more relative to vector similarity.
+    concept_boost_weight: float = Field(default=0.3, ge=0.0, le=1.0)
+
+    # Maximum noun-phrase concepts extracted per chunk.
+    # Caps extraction to avoid noise from very long chunks.
+    concept_max_per_chunk: int = Field(default=10, ge=1)
 
     def generation_options(self, **overrides: Any) -> dict[str, Any]:
         """Build Ollama generation options from config fields and overrides.
@@ -257,6 +273,15 @@ class Config(BaseModel):
             ),
             show_reasoning=_load_setting(
                 data_root, "show_reasoning", "SHOW_REASONING", False, bool
+            ),
+            concept_graph=_load_setting(
+                data_root, "concept_graph", "CONCEPT_GRAPH", True, bool
+            ),
+            concept_boost_weight=_load_setting(
+                data_root, "concept_boost_weight", "CONCEPT_BOOST_WEIGHT", 0.3, float
+            ),
+            concept_max_per_chunk=_load_setting(
+                data_root, "concept_max_per_chunk", "CONCEPT_MAX_PER_CHUNK", 10, int
             ),
         )
 

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -406,12 +406,11 @@ async def _rebuild_concept_clusters() -> None:
     if not cfg.concept_graph:
         return
     try:
-        from lilbee.concepts import get_graph
+        from lilbee.concepts import get_graph, rebuild_clusters
 
-        graph = get_graph()
-        if graph is None:
+        if not get_graph():
             return
-        await asyncio.to_thread(graph.rebuild_clusters)
+        await asyncio.to_thread(rebuild_clusters)
     except Exception:
         log.warning("Concept cluster rebuild failed", exc_info=True)
 
@@ -421,15 +420,12 @@ async def _index_concepts(records: list[ChunkRecord], source_name: str) -> None:
     if not cfg.concept_graph or not records:
         return
     try:
-        from lilbee.concepts import extract_concepts_batch, get_graph
+        from lilbee.concepts import build_from_chunks, extract_concepts_batch
 
-        graph = get_graph()
-        if graph is None:
-            return
         texts = [r["chunk"] for r in records]
         concept_lists = await asyncio.to_thread(extract_concepts_batch, texts)
         chunk_ids = [(source_name, r["chunk_index"]) for r in records]
-        await asyncio.to_thread(graph.build_from_chunks, chunk_ids, concept_lists)
+        await asyncio.to_thread(build_from_chunks, chunk_ids, concept_lists)
     except Exception:
         log.warning("Concept indexing failed for %s", source_name, exc_info=True)
 

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -401,6 +401,39 @@ async def ingest_markdown(
     ]
 
 
+async def _rebuild_concept_clusters() -> None:
+    """Re-run Leiden clustering after sync. No-op if disabled."""
+    if not cfg.concept_graph:
+        return
+    try:
+        from lilbee.concepts import get_graph
+
+        graph = get_graph()
+        if graph is None:
+            return
+        await asyncio.to_thread(graph.rebuild_clusters)
+    except Exception:
+        log.warning("Concept cluster rebuild failed", exc_info=True)
+
+
+async def _index_concepts(records: list[ChunkRecord], source_name: str) -> None:
+    """Extract and index concepts for ingested chunks. No-op if disabled."""
+    if not cfg.concept_graph or not records:
+        return
+    try:
+        from lilbee.concepts import extract_concepts_batch, get_graph
+
+        graph = get_graph()
+        if graph is None:
+            return
+        texts = [r["chunk"] for r in records]
+        concept_lists = await asyncio.to_thread(extract_concepts_batch, texts)
+        chunk_ids = [(source_name, r["chunk_index"]) for r in records]
+        await asyncio.to_thread(graph.build_from_chunks, chunk_ids, concept_lists)
+    except Exception:
+        log.warning("Concept indexing failed for %s", source_name, exc_info=True)
+
+
 async def _ingest_file(
     path: Path,
     source_name: str,
@@ -425,7 +458,9 @@ async def _ingest_file(
             quiet=quiet,
             on_progress=on_progress,
         )
-    return await asyncio.to_thread(store.add_chunks, cast(list[dict], records))
+    chunk_count = await asyncio.to_thread(store.add_chunks, cast(list[dict], records))
+    await _index_concepts(records, source_name)
+    return chunk_count
 
 
 async def sync(
@@ -500,6 +535,7 @@ async def sync(
 
     if files_to_process or removed:
         store.ensure_fts_index()
+        await _rebuild_concept_clusters()
 
     result = SyncResult(
         added=added,

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -286,8 +286,8 @@ def _expand_query(question: str) -> list[str]:
             return []
         variants = [line.strip() for line in response.strip().split("\n") if line.strip()]
         variants = variants[:count]
-        variants = _apply_guardrails(variants, question)
         variants.extend(_concept_query_expansion(question))
+        variants = _apply_guardrails(variants, question)
         return variants
     except Exception:
         return []
@@ -421,13 +421,12 @@ def _apply_concept_boost(results: list[SearchChunk], question: str) -> list[Sear
     if not cfg.concept_graph:
         return results
     try:
-        from lilbee.concepts import extract_concepts, get_graph
+        from lilbee.concepts import boost_results, extract_concepts, get_graph
 
-        graph = get_graph()
-        if graph is None:
+        if not get_graph():
             return results
         query_concepts = extract_concepts(question)
-        return graph.boost_results(results, query_concepts)
+        return boost_results(results, query_concepts)
     except Exception:
         return results
 
@@ -437,12 +436,11 @@ def _concept_query_expansion(question: str) -> list[str]:
     if not cfg.concept_graph:
         return []
     try:
-        from lilbee.concepts import get_graph
+        from lilbee.concepts import expand_query, get_graph
 
-        graph = get_graph()
-        if graph is None:
+        if not get_graph():
             return []
-        return graph.expand_query(question)
+        return expand_query(question)
     except Exception:
         return []
 

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -286,7 +286,9 @@ def _expand_query(question: str) -> list[str]:
             return []
         variants = [line.strip() for line in response.strip().split("\n") if line.strip()]
         variants = variants[:count]
-        return _apply_guardrails(variants, question)
+        variants = _apply_guardrails(variants, question)
+        variants.extend(_concept_query_expansion(question))
+        return variants
     except Exception:
         return []
 
@@ -414,6 +416,37 @@ def _search_structured(mode: str, query: str, top_k: int) -> list[SearchChunk]:
     return []
 
 
+def _apply_concept_boost(results: list[SearchChunk], question: str) -> list[SearchChunk]:
+    """Boost search results by concept overlap. No-op if disabled."""
+    if not cfg.concept_graph:
+        return results
+    try:
+        from lilbee.concepts import extract_concepts, get_graph
+
+        graph = get_graph()
+        if graph is None:
+            return results
+        query_concepts = extract_concepts(question)
+        return graph.boost_results(results, query_concepts)
+    except Exception:
+        return results
+
+
+def _concept_query_expansion(question: str) -> list[str]:
+    """Get additional query terms from concept graph. Returns empty on failure."""
+    if not cfg.concept_graph:
+        return []
+    try:
+        from lilbee.concepts import get_graph
+
+        graph = get_graph()
+        if graph is None:
+            return []
+        return graph.expand_query(question)
+    except Exception:
+        return []
+
+
 def search_context(question: str, top_k: int = 0) -> list[SearchChunk]:
     """Embed question and return top-K matching chunks.
 
@@ -458,6 +491,8 @@ def search_context(question: str, top_k: int = 0) -> list[SearchChunk]:
                     r.distance = r.distance / cfg.hyde_weight
                 results.append(r)
                 seen.add(key)
+
+    results = _apply_concept_boost(results, question)
 
     # Cap total results to prevent context overflow from expansion
     return results[: top_k * 2]

--- a/src/lilbee/server/litestar_app.py
+++ b/src/lilbee/server/litestar_app.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+import logging
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 from litestar import Litestar, delete, get, post, put
@@ -240,6 +242,33 @@ async def documents_remove_route(data: dict[str, Any]) -> dict[str, Any]:
     return await handlers.delete_documents(names, delete_files=delete_files)
 
 
+log = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _lifespan(app: Litestar) -> AsyncIterator[None]:
+    """Pre-load LLM provider and embedding model on server startup.
+
+    Each step is wrapped in try/except so a failure logs a warning
+    but never blocks the server from starting.
+    """
+    try:
+        from lilbee.providers.factory import get_provider
+
+        get_provider()
+        log.info("LLM provider pre-loaded")
+    except Exception:
+        log.warning("Failed to pre-load LLM provider", exc_info=True)
+    try:
+        from lilbee import embedder
+
+        embedder.validate_model()
+        log.info("Embedding model validated")
+    except Exception:
+        log.warning("Failed to validate embedding model", exc_info=True)
+    yield
+
+
 def create_app() -> Litestar:
     """Create the Litestar application instance."""
     cors = CORSConfig(
@@ -249,6 +278,7 @@ def create_app() -> Litestar:
         allow_headers=["Content-Type"],
     )
     return Litestar(
+        lifespan=[_lifespan],
         route_handlers=[
             health_route,
             status_route,

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -161,7 +161,7 @@ def ensure_table(db: lancedb.DBConnection, name: str, schema: pa.Schema) -> lanc
         return db.open_table(name)
 
 
-def _open_table(name: str) -> lancedb.table.Table | None:
+def open_table(name: str) -> lancedb.table.Table | None:
     """Open a table if it exists, otherwise return None."""
     db = get_db()
     if name not in _table_names(db):
@@ -183,7 +183,7 @@ def safe_delete(table: lancedb.table.Table, predicate: str) -> None:
         _safe_delete_unlocked(table, predicate)
 
 
-def _escape_sql_string(value: str) -> str:
+def escape_sql_string(value: str) -> str:
     """Escape single quotes for SQL predicates."""
     return value.replace("'", "''")
 
@@ -195,7 +195,7 @@ def ensure_fts_index() -> None:
     on success so hybrid_search can be used.
     """
     with write_lock():
-        table = _open_table(CHUNKS_TABLE)
+        table = open_table(CHUNKS_TABLE)
         if table is None:
             return
         try:
@@ -247,7 +247,7 @@ def _hybrid_search(
 
 def bm25_probe(query_text: str, top_k: int = 5) -> list[SearchChunk]:
     """Quick BM25-only search for confidence checking. Returns up to top_k results."""
-    table = _open_table(CHUNKS_TABLE)
+    table = open_table(CHUNKS_TABLE)
     if table is None:
         return []
     if not _fts.ready:
@@ -277,7 +277,7 @@ def search(
         top_k = cfg.top_k
     if max_distance is None:
         max_distance = cfg.max_distance
-    table = _open_table(CHUNKS_TABLE)
+    table = open_table(CHUNKS_TABLE)
     if table is None:
         return []
 
@@ -331,10 +331,10 @@ def _adaptive_filter(
 
 def get_chunks_by_source(source: str) -> list[SearchChunk]:
     """Return all chunks for a given source file."""
-    table = _open_table(CHUNKS_TABLE)
+    table = open_table(CHUNKS_TABLE)
     if table is None:
         return []
-    escaped = _escape_sql_string(source)
+    escaped = escape_sql_string(source)
     rows = table.search().where(f"source = '{escaped}'").to_list()
     return [SearchChunk(**r) for r in rows]
 
@@ -342,14 +342,14 @@ def get_chunks_by_source(source: str) -> list[SearchChunk]:
 def delete_by_source(source: str) -> None:
     """Delete all chunks from a given source file."""
     with write_lock():
-        table = _open_table(CHUNKS_TABLE)
+        table = open_table(CHUNKS_TABLE)
         if table is not None:
-            _safe_delete_unlocked(table, f"source = '{_escape_sql_string(source)}'")
+            _safe_delete_unlocked(table, f"source = '{escape_sql_string(source)}'")
 
 
 def get_sources() -> list[SourceRecord]:
     """Get all tracked source file records."""
-    table = _open_table(SOURCES_TABLE)
+    table = open_table(SOURCES_TABLE)
     if table is None:
         return []
     result: list[SourceRecord] = table.to_arrow().to_pylist()  # type: ignore[assignment]
@@ -361,7 +361,7 @@ def upsert_source(filename: str, file_hash: str, chunk_count: int) -> None:
     with write_lock():
         db = get_db()
         table = ensure_table(db, SOURCES_TABLE, _sources_schema())
-        _safe_delete_unlocked(table, f"filename = '{_escape_sql_string(filename)}'")
+        _safe_delete_unlocked(table, f"filename = '{escape_sql_string(filename)}'")
         table.add(
             [
                 {
@@ -377,9 +377,9 @@ def upsert_source(filename: str, file_hash: str, chunk_count: int) -> None:
 def delete_source(filename: str) -> None:
     """Remove a source file tracking record."""
     with write_lock():
-        table = _open_table(SOURCES_TABLE)
+        table = open_table(SOURCES_TABLE)
         if table is not None:
-            _safe_delete_unlocked(table, f"filename = '{_escape_sql_string(filename)}'")
+            _safe_delete_unlocked(table, f"filename = '{escape_sql_string(filename)}'")
 
 
 class RemoveResult:

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -23,6 +23,7 @@ def isolated_env(tmp_path: Path):
     cfg.documents_dir = docs
     cfg.data_dir = tmp_path / "data"
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
+    cfg.concept_graph = False
     yield docs
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,7 @@ def isolated_env(tmp_path, monkeypatch):
     cfg.data_dir = tmp_path / "data"
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
     cfg.json_mode = False
+    cfg.concept_graph = False
 
     yield tmp_path
 
@@ -3047,3 +3048,18 @@ class TestTopicsCommand:
         mock_get_graph.return_value = mock_graph
         runner.invoke(app, ["topics", "--top-k", "5"])
         mock_graph.top_communities.assert_called_once_with(k=5)
+
+    @mock.patch("lilbee.concepts.get_graph")
+    def test_large_community_shows_more_count(self, mock_get_graph):
+        cfg.concept_graph = True
+        mock_graph = mock.MagicMock()
+        many_concepts = [f"concept_{i}" for i in range(8)]
+        mock_graph.top_communities.return_value = [
+            {"cluster_id": 0, "size": 8, "concepts": many_concepts},
+        ]
+        mock_get_graph.return_value = mock_graph
+        result = runner.invoke(app, ["topics"])
+        assert result.exit_code == 0
+        # Rich table may wrap text across lines, so check for the key parts
+        assert "concept_0" in result.output
+        assert "more)" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2954,85 +2954,79 @@ class TestTopicsCommand:
         output = json.loads(result.output)
         assert "error" in output
 
-    @mock.patch("lilbee.concepts.get_graph")
-    def test_overview_shows_communities(self, mock_get_graph):
+    @mock.patch("lilbee.concepts.top_communities")
+    @mock.patch("lilbee.concepts.get_graph", return_value=True)
+    def test_overview_shows_communities(self, mock_get_graph, mock_top):
+        from lilbee.concepts import Community
+
         cfg.concept_graph = True
-        mock_graph = mock.MagicMock()
-        mock_graph.top_communities.return_value = [
-            {"cluster_id": 0, "size": 3, "concepts": ["python", "django", "flask"]},
+        mock_top.return_value = [
+            Community(cluster_id=0, size=3, concepts=["python", "django", "flask"]),
         ]
-        mock_get_graph.return_value = mock_graph
         result = runner.invoke(app, ["topics"])
         assert result.exit_code == 0
         assert "python" in result.output
 
-    @mock.patch("lilbee.concepts.get_graph")
-    def test_overview_json_mode(self, mock_get_graph):
+    @mock.patch("lilbee.concepts.top_communities")
+    @mock.patch("lilbee.concepts.get_graph", return_value=True)
+    def test_overview_json_mode(self, mock_get_graph, mock_top):
+        from lilbee.concepts import Community
+
         cfg.concept_graph = True
-        mock_graph = mock.MagicMock()
-        mock_graph.top_communities.return_value = [
-            {"cluster_id": 0, "size": 2, "concepts": ["ml", "ai"]},
+        mock_top.return_value = [
+            Community(cluster_id=0, size=2, concepts=["ml", "ai"]),
         ]
-        mock_get_graph.return_value = mock_graph
         result = runner.invoke(app, ["--json", "topics"])
         assert result.exit_code == 0
         output = json.loads(result.output)
         assert output["command"] == "topics"
         assert len(output["communities"]) == 1
 
+    @mock.patch("lilbee.concepts.expand_query", return_value=["django", "flask"])
     @mock.patch("lilbee.concepts.extract_concepts", return_value=["python"])
-    @mock.patch("lilbee.concepts.get_graph")
-    def test_query_shows_related_concepts(self, mock_get_graph, mock_extract):
+    @mock.patch("lilbee.concepts.get_graph", return_value=True)
+    def test_query_shows_related_concepts(self, mock_get_graph, mock_extract, mock_expand):
         cfg.concept_graph = True
-        mock_graph = mock.MagicMock()
-        mock_graph.get_related_concepts.return_value = ["django", "flask"]
-        mock_get_graph.return_value = mock_graph
         result = runner.invoke(app, ["topics", "python"])
         assert result.exit_code == 0
         assert "django" in result.output
 
+    @mock.patch("lilbee.concepts.expand_query", return_value=["django"])
     @mock.patch("lilbee.concepts.extract_concepts", return_value=["python"])
-    @mock.patch("lilbee.concepts.get_graph")
-    def test_query_json_mode(self, mock_get_graph, mock_extract):
+    @mock.patch("lilbee.concepts.get_graph", return_value=True)
+    def test_query_json_mode(self, mock_get_graph, mock_extract, mock_expand):
         cfg.concept_graph = True
-        mock_graph = mock.MagicMock()
-        mock_graph.get_related_concepts.return_value = ["django"]
-        mock_get_graph.return_value = mock_graph
         result = runner.invoke(app, ["--json", "topics", "python"])
         assert result.exit_code == 0
         output = json.loads(result.output)
         assert "python" in output["concepts"]
         assert "django" in output["concepts"]
 
-    @mock.patch("lilbee.concepts.get_graph")
-    def test_no_communities(self, mock_get_graph):
+    @mock.patch("lilbee.concepts.top_communities", return_value=[])
+    @mock.patch("lilbee.concepts.get_graph", return_value=True)
+    def test_no_communities(self, mock_get_graph, mock_top):
         cfg.concept_graph = True
-        mock_graph = mock.MagicMock()
-        mock_graph.top_communities.return_value = []
-        mock_get_graph.return_value = mock_graph
         result = runner.invoke(app, ["topics"])
         assert result.exit_code == 0
         assert "No concept communities" in result.output
 
+    @mock.patch("lilbee.concepts.expand_query", return_value=[])
     @mock.patch("lilbee.concepts.extract_concepts", return_value=[])
-    @mock.patch("lilbee.concepts.get_graph")
-    def test_query_no_concepts(self, mock_get_graph, mock_extract):
+    @mock.patch("lilbee.concepts.get_graph", return_value=True)
+    def test_query_no_concepts(self, mock_get_graph, mock_extract, mock_expand):
         cfg.concept_graph = True
-        mock_graph = mock.MagicMock()
-        mock_graph.get_related_concepts.return_value = []
-        mock_get_graph.return_value = mock_graph
         result = runner.invoke(app, ["topics", "???"])
         assert result.exit_code == 0
         assert "No concepts found" in result.output
 
-    @mock.patch("lilbee.concepts.get_graph", return_value=None)
+    @mock.patch("lilbee.concepts.get_graph", return_value=False)
     def test_graph_none_shows_error(self, mock_get_graph):
         cfg.concept_graph = True
         result = runner.invoke(app, ["topics"])
         assert result.exit_code == 1
         assert "not available" in result.output.lower()
 
-    @mock.patch("lilbee.concepts.get_graph", return_value=None)
+    @mock.patch("lilbee.concepts.get_graph", return_value=False)
     def test_graph_none_json_mode(self, mock_get_graph):
         cfg.concept_graph = True
         result = runner.invoke(app, ["--json", "topics"])
@@ -3040,24 +3034,23 @@ class TestTopicsCommand:
         output = json.loads(result.output)
         assert "error" in output
 
-    @mock.patch("lilbee.concepts.get_graph")
-    def test_top_k_option(self, mock_get_graph):
+    @mock.patch("lilbee.concepts.top_communities", return_value=[])
+    @mock.patch("lilbee.concepts.get_graph", return_value=True)
+    def test_top_k_option(self, mock_get_graph, mock_top):
         cfg.concept_graph = True
-        mock_graph = mock.MagicMock()
-        mock_graph.top_communities.return_value = []
-        mock_get_graph.return_value = mock_graph
         runner.invoke(app, ["topics", "--top-k", "5"])
-        mock_graph.top_communities.assert_called_once_with(k=5)
+        mock_top.assert_called_once_with(k=5)
 
-    @mock.patch("lilbee.concepts.get_graph")
-    def test_large_community_shows_more_count(self, mock_get_graph):
+    @mock.patch("lilbee.concepts.top_communities")
+    @mock.patch("lilbee.concepts.get_graph", return_value=True)
+    def test_large_community_shows_more_count(self, mock_get_graph, mock_top):
+        from lilbee.concepts import Community
+
         cfg.concept_graph = True
-        mock_graph = mock.MagicMock()
         many_concepts = [f"concept_{i}" for i in range(8)]
-        mock_graph.top_communities.return_value = [
-            {"cluster_id": 0, "size": 8, "concepts": many_concepts},
+        mock_top.return_value = [
+            Community(cluster_id=0, size=8, concepts=many_concepts),
         ]
-        mock_get_graph.return_value = mock_graph
         result = runner.invoke(app, ["topics"])
         assert result.exit_code == 0
         # Rich table may wrap text across lines, so check for the key parts

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2937,3 +2937,113 @@ class TestSlashAddBackground:
         assert len(all_calls) >= 1
         for call in all_calls:
             assert call[1].get("chat_mode") is True
+
+
+class TestTopicsCommand:
+    def test_disabled_shows_error(self):
+        cfg.concept_graph = False
+        result = runner.invoke(app, ["topics"])
+        assert result.exit_code == 1
+        assert "disabled" in result.output.lower()
+
+    def test_disabled_json_mode(self):
+        cfg.concept_graph = False
+        result = runner.invoke(app, ["--json", "topics"])
+        assert result.exit_code == 1
+        output = json.loads(result.output)
+        assert "error" in output
+
+    @mock.patch("lilbee.concepts.get_graph")
+    def test_overview_shows_communities(self, mock_get_graph):
+        cfg.concept_graph = True
+        mock_graph = mock.MagicMock()
+        mock_graph.top_communities.return_value = [
+            {"cluster_id": 0, "size": 3, "concepts": ["python", "django", "flask"]},
+        ]
+        mock_get_graph.return_value = mock_graph
+        result = runner.invoke(app, ["topics"])
+        assert result.exit_code == 0
+        assert "python" in result.output
+
+    @mock.patch("lilbee.concepts.get_graph")
+    def test_overview_json_mode(self, mock_get_graph):
+        cfg.concept_graph = True
+        mock_graph = mock.MagicMock()
+        mock_graph.top_communities.return_value = [
+            {"cluster_id": 0, "size": 2, "concepts": ["ml", "ai"]},
+        ]
+        mock_get_graph.return_value = mock_graph
+        result = runner.invoke(app, ["--json", "topics"])
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["command"] == "topics"
+        assert len(output["communities"]) == 1
+
+    @mock.patch("lilbee.concepts.extract_concepts", return_value=["python"])
+    @mock.patch("lilbee.concepts.get_graph")
+    def test_query_shows_related_concepts(self, mock_get_graph, mock_extract):
+        cfg.concept_graph = True
+        mock_graph = mock.MagicMock()
+        mock_graph.get_related_concepts.return_value = ["django", "flask"]
+        mock_get_graph.return_value = mock_graph
+        result = runner.invoke(app, ["topics", "python"])
+        assert result.exit_code == 0
+        assert "django" in result.output
+
+    @mock.patch("lilbee.concepts.extract_concepts", return_value=["python"])
+    @mock.patch("lilbee.concepts.get_graph")
+    def test_query_json_mode(self, mock_get_graph, mock_extract):
+        cfg.concept_graph = True
+        mock_graph = mock.MagicMock()
+        mock_graph.get_related_concepts.return_value = ["django"]
+        mock_get_graph.return_value = mock_graph
+        result = runner.invoke(app, ["--json", "topics", "python"])
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert "python" in output["concepts"]
+        assert "django" in output["concepts"]
+
+    @mock.patch("lilbee.concepts.get_graph")
+    def test_no_communities(self, mock_get_graph):
+        cfg.concept_graph = True
+        mock_graph = mock.MagicMock()
+        mock_graph.top_communities.return_value = []
+        mock_get_graph.return_value = mock_graph
+        result = runner.invoke(app, ["topics"])
+        assert result.exit_code == 0
+        assert "No concept communities" in result.output
+
+    @mock.patch("lilbee.concepts.extract_concepts", return_value=[])
+    @mock.patch("lilbee.concepts.get_graph")
+    def test_query_no_concepts(self, mock_get_graph, mock_extract):
+        cfg.concept_graph = True
+        mock_graph = mock.MagicMock()
+        mock_graph.get_related_concepts.return_value = []
+        mock_get_graph.return_value = mock_graph
+        result = runner.invoke(app, ["topics", "???"])
+        assert result.exit_code == 0
+        assert "No concepts found" in result.output
+
+    @mock.patch("lilbee.concepts.get_graph", return_value=None)
+    def test_graph_none_shows_error(self, mock_get_graph):
+        cfg.concept_graph = True
+        result = runner.invoke(app, ["topics"])
+        assert result.exit_code == 1
+        assert "not available" in result.output.lower()
+
+    @mock.patch("lilbee.concepts.get_graph", return_value=None)
+    def test_graph_none_json_mode(self, mock_get_graph):
+        cfg.concept_graph = True
+        result = runner.invoke(app, ["--json", "topics"])
+        assert result.exit_code == 1
+        output = json.loads(result.output)
+        assert "error" in output
+
+    @mock.patch("lilbee.concepts.get_graph")
+    def test_top_k_option(self, mock_get_graph):
+        cfg.concept_graph = True
+        mock_graph = mock.MagicMock()
+        mock_graph.top_communities.return_value = []
+        mock_get_graph.return_value = mock_graph
+        runner.invoke(app, ["topics", "--top-k", "5"])
+        mock_graph.top_communities.assert_called_once_with(k=5)

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -1,0 +1,426 @@
+"""Tests for the concept graph module."""
+
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lilbee.config import cfg
+from lilbee.store import SearchChunk
+
+
+@pytest.fixture(autouse=True)
+def isolated_env(tmp_path):
+    """Redirect config paths to temp dir for every test."""
+    snapshot = cfg.model_copy()
+    cfg.documents_dir = tmp_path / "documents"
+    cfg.documents_dir.mkdir()
+    cfg.data_dir = tmp_path / "data"
+    cfg.lancedb_dir = tmp_path / "data" / "lancedb"
+    cfg.concept_graph = True
+    cfg.concept_max_per_chunk = 10
+    cfg.concept_boost_weight = 0.3
+    yield
+    for name in type(cfg).model_fields:
+        setattr(cfg, name, getattr(snapshot, name))
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    """Reset module-level singletons between tests."""
+    from lilbee.concepts import reset_graph
+
+    reset_graph()
+    yield
+    reset_graph()
+
+
+def _make_mock_doc(noun_chunks):
+    """Create a mock spaCy Doc with the given noun chunks."""
+    doc = MagicMock()
+    chunks = []
+    for text in noun_chunks:
+        chunk = MagicMock()
+        chunk.text = text
+        chunks.append(chunk)
+    doc.noun_chunks = chunks
+    return doc
+
+
+def _make_mock_nlp(noun_chunks_per_doc):
+    """Create a mock spaCy nlp that returns docs with specified noun chunks."""
+    nlp = MagicMock()
+
+    def call_fn(text):
+        return _make_mock_doc(noun_chunks_per_doc.get(text, []))
+
+    nlp.side_effect = call_fn
+
+    def pipe_fn(texts):
+        return [_make_mock_doc(noun_chunks_per_doc.get(t, [])) for t in texts]
+
+    nlp.pipe = pipe_fn
+    return nlp
+
+
+def _make_result(
+    source="test.pdf",
+    chunk_index=0,
+    chunk="some text",
+    distance=0.5,
+    relevance_score=None,
+) -> SearchChunk:
+    return SearchChunk(
+        source=source,
+        content_type="pdf",
+        page_start=1,
+        page_end=1,
+        line_start=0,
+        line_end=0,
+        chunk=chunk,
+        chunk_index=chunk_index,
+        distance=distance,
+        relevance_score=relevance_score,
+        vector=[0.1],
+    )
+
+
+class TestExtractConcepts:
+    @patch("lilbee.concepts._get_nlp")
+    def test_basic_extraction(self, mock_get_nlp):
+        mock_get_nlp.return_value = _make_mock_nlp(
+            {"hello world": ["machine learning", "neural networks"]}
+        )
+        from lilbee.concepts import extract_concepts
+
+        result = extract_concepts("hello world")
+        assert result == ["machine learning", "neural networks"]
+
+    @patch("lilbee.concepts._get_nlp")
+    def test_deduplication(self, mock_get_nlp):
+        mock_get_nlp.return_value = _make_mock_nlp(
+            {"text": ["Concept", "concept", "Other"]}
+        )
+        from lilbee.concepts import extract_concepts
+
+        result = extract_concepts("text")
+        assert result == ["concept", "other"]
+
+    @patch("lilbee.concepts._get_nlp")
+    def test_max_cap(self, mock_get_nlp):
+        mock_get_nlp.return_value = _make_mock_nlp(
+            {"text": ["alpha", "beta", "gamma", "delta"]}
+        )
+        from lilbee.concepts import extract_concepts
+
+        result = extract_concepts("text", max_concepts=2)
+        assert len(result) == 2
+
+    @patch("lilbee.concepts._get_nlp")
+    def test_empty_input(self, mock_get_nlp):
+        from lilbee.concepts import extract_concepts
+
+        result = extract_concepts("")
+        assert result == []
+        mock_get_nlp.assert_not_called()
+
+    @patch("lilbee.concepts._get_nlp")
+    def test_filters_short_concepts(self, mock_get_nlp):
+        mock_get_nlp.return_value = _make_mock_nlp(
+            {"text": ["a", "ok", "good concept"]}
+        )
+        from lilbee.concepts import extract_concepts
+
+        result = extract_concepts("text")
+        assert "a" not in result
+        assert "ok" in result
+        assert "good concept" in result
+
+
+class TestExtractConceptsBatch:
+    @patch("lilbee.concepts._get_nlp")
+    def test_batch_extraction(self, mock_get_nlp):
+        mock_get_nlp.return_value = _make_mock_nlp(
+            {"doc1": ["concept a"], "doc2": ["concept b", "concept c"]}
+        )
+        from lilbee.concepts import extract_concepts_batch
+
+        result = extract_concepts_batch(["doc1", "doc2"])
+        assert len(result) == 2
+        assert result[0] == ["concept a"]
+        assert result[1] == ["concept b", "concept c"]
+
+    @patch("lilbee.concepts._get_nlp")
+    def test_empty_input(self, mock_get_nlp):
+        from lilbee.concepts import extract_concepts_batch
+
+        result = extract_concepts_batch([])
+        assert result == []
+        mock_get_nlp.assert_not_called()
+
+
+class TestEnsureSpacyModel:
+    @patch("spacy.load")
+    def test_loads_existing(self, mock_load):
+        mock_load.return_value = MagicMock()
+        from lilbee.concepts import _ensure_spacy_model
+
+        result = _ensure_spacy_model()
+        mock_load.assert_called_once_with("en_core_web_sm")
+        assert result is not None
+
+    @patch("spacy.load")
+    @patch("spacy.cli.download")
+    def test_downloads_on_oserror(self, mock_download, mock_load):
+        mock_load.side_effect = [OSError("not found"), MagicMock()]
+        from lilbee.concepts import _ensure_spacy_model
+
+        result = _ensure_spacy_model()
+        mock_download.assert_called_once_with("en_core_web_sm")
+        assert result is not None
+
+
+class TestConceptGraph:
+    def test_build_from_chunks(self):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        chunk_ids = [("doc.md", 0), ("doc.md", 1)]
+        concept_lists = [["python", "machine learning"], ["python", "deep learning"]]
+        graph.build_from_chunks(chunk_ids, concept_lists)
+
+    def test_build_empty_chunks(self):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        graph.build_from_chunks([], [])
+
+    def test_boost_results_with_overlap(self):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        results = [_make_result(distance=0.5, chunk_index=0)]
+        with patch.object(graph, "_get_chunk_concepts", return_value=["python", "ml"]):
+            boosted = graph.boost_results(results, ["python", "java"])
+        assert boosted[0].distance < 0.5
+
+    def test_boost_results_relevance_score(self):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        results = [_make_result(distance=None, relevance_score=0.8, chunk_index=0)]
+        with patch.object(graph, "_get_chunk_concepts", return_value=["python"]):
+            boosted = graph.boost_results(results, ["python"])
+        assert boosted[0].relevance_score > 0.8
+
+    def test_boost_results_no_overlap(self):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        results = [_make_result(distance=0.5, chunk_index=0)]
+        with patch.object(graph, "_get_chunk_concepts", return_value=["java"]):
+            boosted = graph.boost_results(results, ["python"])
+        assert boosted[0].distance == 0.5
+
+    def test_boost_results_empty_query_concepts(self):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        results = [_make_result()]
+        boosted = graph.boost_results(results, [])
+        assert boosted == results
+
+    def test_boost_results_empty_results(self):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        boosted = graph.boost_results([], ["python"])
+        assert boosted == []
+
+    @patch("lilbee.concepts.extract_concepts", return_value=["python"])
+    def test_expand_query(self, mock_extract):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        with patch.object(graph, "get_related_concepts", return_value=["django", "flask"]):
+            related = graph.expand_query("python frameworks")
+        assert "django" in related
+        assert "flask" in related
+
+    @patch("lilbee.concepts.extract_concepts", return_value=[])
+    def test_expand_query_no_concepts(self, mock_extract):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        assert graph.expand_query("???") == []
+
+    @patch("lilbee.store._open_table")
+    def test_get_related_concepts(self, mock_open):
+        mock_table = MagicMock()
+        mock_table.search.return_value.where.return_value.to_list.return_value = [
+            {"source": "python", "target": "django", "weight": 1.0},
+        ]
+        mock_open.return_value = mock_table
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        related = graph.get_related_concepts("python")
+        assert "django" in related
+
+    @patch("lilbee.store._open_table", return_value=None)
+    def test_get_related_concepts_no_table(self, mock_open):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        assert graph.get_related_concepts("python") == []
+
+    @patch("lilbee.store._open_table")
+    def test_top_communities(self, mock_open):
+        mock_table = MagicMock()
+        mock_table.to_arrow.return_value.to_pylist.return_value = [
+            {"concept": "python", "cluster_id": 0, "degree": 5},
+            {"concept": "ml", "cluster_id": 0, "degree": 3},
+            {"concept": "web", "cluster_id": 1, "degree": 2},
+        ]
+        mock_open.return_value = mock_table
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        communities = graph.top_communities(k=2)
+        assert len(communities) == 2
+        assert communities[0]["size"] == 2
+        assert communities[0]["cluster_id"] == 0
+
+    @patch("lilbee.store._open_table", return_value=None)
+    def test_top_communities_no_table(self, mock_open):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        assert graph.top_communities() == []
+
+    @patch("lilbee.store._open_table")
+    def test_get_chunk_concepts(self, mock_open):
+        mock_table = MagicMock()
+        mock_table.search.return_value.where.return_value.to_list.return_value = [
+            {"concept": "python"},
+            {"concept": "ml"},
+        ]
+        mock_open.return_value = mock_table
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        concepts = graph._get_chunk_concepts("doc.md", 0)
+        assert concepts == ["python", "ml"]
+
+    @patch("lilbee.store._open_table", return_value=None)
+    def test_get_chunk_concepts_no_table(self, mock_open):
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        assert graph._get_chunk_concepts("doc.md", 0) == []
+
+    @patch("lilbee.store._open_table")
+    def test_get_chunk_concepts_exception(self, mock_open):
+        mock_table = MagicMock()
+        mock_table.search.side_effect = RuntimeError("query failed")
+        mock_open.return_value = mock_table
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        assert graph._get_chunk_concepts("doc.md", 0) == []
+
+
+class TestRebuildClusters:
+    @patch("lilbee.store._open_table")
+    def test_rebuild_no_table(self, mock_open):
+        mock_open.return_value = None
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        graph.rebuild_clusters()
+
+    @patch("lilbee.store._open_table")
+    def test_rebuild_empty_edges(self, mock_open):
+        mock_table = MagicMock()
+        mock_table.to_arrow.return_value.to_pylist.return_value = []
+        mock_open.return_value = mock_table
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        graph.rebuild_clusters()
+
+    @patch("lilbee.store.safe_delete")
+    @patch("lilbee.store.ensure_table")
+    @patch("lilbee.store.get_db")
+    @patch("lilbee.concepts._leiden_partition")
+    @patch("lilbee.store._open_table")
+    def test_rebuild_with_edges(
+        self, mock_open, mock_leiden, mock_get_db, mock_ensure, mock_safe_del
+    ):
+        mock_table = MagicMock()
+        edge_rows = [
+            {"source": "python", "target": "ml", "weight": 2.0},
+            {"source": "ml", "target": "deep learning", "weight": 1.5},
+        ]
+        mock_table.to_arrow.return_value.to_pylist.return_value = edge_rows
+        mock_open.return_value = mock_table
+        mock_leiden.return_value = (
+            {"python": 0, "ml": 0, "deep learning": 1},
+            {"python": 1, "ml": 2, "deep learning": 1},
+        )
+        mock_nodes_table = MagicMock()
+        mock_ensure.return_value = mock_nodes_table
+
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        graph.rebuild_clusters()
+        mock_leiden.assert_called_once_with(edge_rows)
+        mock_nodes_table.add.assert_called_once()
+
+
+class TestGetGraph:
+    def test_returns_graph_when_enabled(self):
+        from lilbee.concepts import get_graph
+
+        cfg.concept_graph = True
+        graph = get_graph()
+        assert graph is not None
+
+    def test_returns_none_when_disabled(self):
+        from lilbee.concepts import get_graph
+
+        cfg.concept_graph = False
+        assert get_graph() is None
+
+    def test_singleton(self):
+        from lilbee.concepts import get_graph
+
+        cfg.concept_graph = True
+        g1 = get_graph()
+        g2 = get_graph()
+        assert g1 is g2
+
+
+class TestResetGraph:
+    def test_clears_singleton(self):
+        from lilbee.concepts import get_graph, reset_graph
+
+        cfg.concept_graph = True
+        g1 = get_graph()
+        reset_graph()
+        g2 = get_graph()
+        assert g1 is not g2
+
+
+class TestComputePmi:
+    def test_basic_pmi(self):
+        from collections import Counter
+
+        from lilbee.concepts import _compute_pmi
+
+        cooccurrences = Counter({("a", "b"): 5})
+        concept_counts = Counter({"a": 8, "b": 6})
+        pmi = _compute_pmi(cooccurrences, concept_counts, 10)
+        assert ("a", "b") in pmi
+        assert isinstance(pmi[("a", "b")], float)

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -1,5 +1,6 @@
 """Tests for the concept graph module."""
 
+from dataclasses import fields
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,7 +12,7 @@ from lilbee.store import SearchChunk
 @pytest.fixture(autouse=True)
 def isolated_env(tmp_path):
     """Redirect config paths to temp dir for every test."""
-    snapshot = cfg.model_copy()
+    snapshot = {name: getattr(cfg, name) for name in type(cfg).model_fields}
     cfg.documents_dir = tmp_path / "documents"
     cfg.documents_dir.mkdir()
     cfg.data_dir = tmp_path / "data"
@@ -20,8 +21,8 @@ def isolated_env(tmp_path):
     cfg.concept_max_per_chunk = 10
     cfg.concept_boost_weight = 0.3
     yield
-    for name in type(cfg).model_fields:
-        setattr(cfg, name, getattr(snapshot, name))
+    for name, val in snapshot.items():
+        setattr(cfg, name, val)
 
 
 @pytest.fixture(autouse=True)
@@ -213,114 +214,113 @@ class TestEnsureSpacyModel:
         assert result is not None
 
 
-class TestConceptGraph:
-    def test_build_from_chunks(self):
-        from lilbee.concepts import ConceptGraph
+class TestBuildFromChunks:
+    @patch("lilbee.lock.write_lock")
+    def test_build_from_chunks(self, mock_lock):
+        mock_lock.return_value.__enter__ = MagicMock()
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+        from lilbee.concepts import build_from_chunks
 
-        graph = ConceptGraph()
         chunk_ids = [("doc.md", 0), ("doc.md", 1)]
         concept_lists = [["python", "machine learning"], ["python", "deep learning"]]
-        graph.build_from_chunks(chunk_ids, concept_lists)
+        build_from_chunks(chunk_ids, concept_lists)
 
     def test_build_empty_chunks(self):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import build_from_chunks
 
-        graph = ConceptGraph()
-        graph.build_from_chunks([], [])
+        build_from_chunks([], [])
 
+
+class TestBoostResults:
     def test_boost_results_with_overlap(self):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import boost_results
 
-        graph = ConceptGraph()
         results = [_make_result(distance=0.5, chunk_index=0)]
-        with patch.object(graph, "_get_chunk_concepts", return_value=["python", "ml"]):
-            boosted = graph.boost_results(results, ["python", "java"])
+        with patch("lilbee.concepts.get_chunk_concepts", return_value=["python", "ml"]):
+            boosted = boost_results(results, ["python", "java"])
         assert boosted[0].distance < 0.5
 
     def test_boost_results_relevance_score(self):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import boost_results
 
-        graph = ConceptGraph()
         results = [_make_result(distance=None, relevance_score=0.8, chunk_index=0)]
-        with patch.object(graph, "_get_chunk_concepts", return_value=["python"]):
-            boosted = graph.boost_results(results, ["python"])
+        with patch("lilbee.concepts.get_chunk_concepts", return_value=["python"]):
+            boosted = boost_results(results, ["python"])
         assert boosted[0].relevance_score > 0.8
 
     def test_boost_results_no_overlap(self):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import boost_results
 
-        graph = ConceptGraph()
         results = [_make_result(distance=0.5, chunk_index=0)]
-        with patch.object(graph, "_get_chunk_concepts", return_value=["java"]):
-            boosted = graph.boost_results(results, ["python"])
+        with patch("lilbee.concepts.get_chunk_concepts", return_value=["java"]):
+            boosted = boost_results(results, ["python"])
         assert boosted[0].distance == 0.5
 
     def test_boost_results_empty_query_concepts(self):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import boost_results
 
-        graph = ConceptGraph()
         results = [_make_result()]
-        boosted = graph.boost_results(results, [])
+        boosted = boost_results(results, [])
         assert boosted == results
 
     def test_boost_results_empty_results(self):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import boost_results
 
-        graph = ConceptGraph()
-        boosted = graph.boost_results([], ["python"])
+        boosted = boost_results([], ["python"])
         assert boosted == []
 
-    @patch("lilbee.concepts.extract_concepts", return_value=["python"])
-    def test_expand_query(self, mock_extract):
-        from lilbee.concepts import ConceptGraph
 
-        graph = ConceptGraph()
-        with patch.object(graph, "get_related_concepts", return_value=["django", "flask"]):
-            related = graph.expand_query("python frameworks")
+class TestExpandQuery:
+    @patch("lilbee.concepts.extract_concepts", return_value=["python"])
+    @patch("lilbee.concepts.get_related_concepts", return_value=["django", "flask"])
+    def test_expand_query(self, mock_related, mock_extract):
+        from lilbee.concepts import expand_query
+
+        related = expand_query("python frameworks")
         assert "django" in related
         assert "flask" in related
 
     @patch("lilbee.concepts.extract_concepts", return_value=[])
     def test_expand_query_no_concepts(self, mock_extract):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import expand_query
 
-        graph = ConceptGraph()
-        assert graph.expand_query("???") == []
+        assert expand_query("???") == []
 
-    @patch("lilbee.store._open_table")
+
+class TestGetRelatedConcepts:
+    @patch("lilbee.store.open_table")
     def test_get_related_concepts(self, mock_open):
         mock_table = MagicMock()
         mock_table.search.return_value.where.return_value.to_list.return_value = [
             {"source": "python", "target": "django", "weight": 1.0},
         ]
         mock_open.return_value = mock_table
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import get_related_concepts
 
-        graph = ConceptGraph()
-        related = graph.get_related_concepts("python")
+        related = get_related_concepts("python")
         assert "django" in related
 
-    @patch("lilbee.store._open_table", return_value=None)
+    @patch("lilbee.store.open_table", return_value=None)
     def test_get_related_concepts_no_table(self, mock_open):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import get_related_concepts
 
-        graph = ConceptGraph()
-        assert graph.get_related_concepts("python") == []
+        assert get_related_concepts("python") == []
 
-    @patch("lilbee.store._open_table")
+    @patch("lilbee.store.open_table")
     def test_get_related_concepts_query_exception(self, mock_open):
         mock_table = MagicMock()
         mock_table.search.return_value.where.return_value.to_list.side_effect = RuntimeError(
             "query failed"
         )
         mock_open.return_value = mock_table
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import get_related_concepts
 
-        graph = ConceptGraph()
-        result = graph.get_related_concepts("python")
+        result = get_related_concepts("python")
         assert result == []
 
-    @patch("lilbee.store._open_table")
+
+class TestTopCommunities:
+    @patch("lilbee.store.open_table")
     def test_top_communities(self, mock_open):
         mock_table = MagicMock()
         mock_table.to_arrow.return_value.to_pylist.return_value = [
@@ -329,22 +329,22 @@ class TestConceptGraph:
             {"concept": "web", "cluster_id": 1, "degree": 2},
         ]
         mock_open.return_value = mock_table
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import top_communities
 
-        graph = ConceptGraph()
-        communities = graph.top_communities(k=2)
+        communities = top_communities(k=2)
         assert len(communities) == 2
-        assert communities[0]["size"] == 2
-        assert communities[0]["cluster_id"] == 0
+        assert communities[0].size == 2
+        assert communities[0].cluster_id == 0
 
-    @patch("lilbee.store._open_table", return_value=None)
+    @patch("lilbee.store.open_table", return_value=None)
     def test_top_communities_no_table(self, mock_open):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import top_communities
 
-        graph = ConceptGraph()
-        assert graph.top_communities() == []
+        assert top_communities() == []
 
-    @patch("lilbee.store._open_table")
+
+class TestGetChunkConcepts:
+    @patch("lilbee.store.open_table")
     def test_get_chunk_concepts(self, mock_open):
         mock_table = MagicMock()
         mock_table.search.return_value.where.return_value.to_list.return_value = [
@@ -352,57 +352,55 @@ class TestConceptGraph:
             {"concept": "ml"},
         ]
         mock_open.return_value = mock_table
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import get_chunk_concepts
 
-        graph = ConceptGraph()
-        concepts = graph._get_chunk_concepts("doc.md", 0)
+        concepts = get_chunk_concepts("doc.md", 0)
         assert concepts == ["python", "ml"]
 
-    @patch("lilbee.store._open_table", return_value=None)
+    @patch("lilbee.store.open_table", return_value=None)
     def test_get_chunk_concepts_no_table(self, mock_open):
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import get_chunk_concepts
 
-        graph = ConceptGraph()
-        assert graph._get_chunk_concepts("doc.md", 0) == []
+        assert get_chunk_concepts("doc.md", 0) == []
 
-    @patch("lilbee.store._open_table")
+    @patch("lilbee.store.open_table")
     def test_get_chunk_concepts_exception(self, mock_open):
         mock_table = MagicMock()
         mock_table.search.side_effect = RuntimeError("query failed")
         mock_open.return_value = mock_table
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import get_chunk_concepts
 
-        graph = ConceptGraph()
-        assert graph._get_chunk_concepts("doc.md", 0) == []
+        assert get_chunk_concepts("doc.md", 0) == []
 
 
 class TestRebuildClusters:
-    @patch("lilbee.store._open_table")
+    @patch("lilbee.store.open_table")
     def test_rebuild_no_table(self, mock_open):
         mock_open.return_value = None
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import rebuild_clusters
 
-        graph = ConceptGraph()
-        graph.rebuild_clusters()
+        rebuild_clusters()
 
-    @patch("lilbee.store._open_table")
+    @patch("lilbee.store.open_table")
     def test_rebuild_empty_edges(self, mock_open):
         mock_table = MagicMock()
         mock_table.to_arrow.return_value.to_pylist.return_value = []
         mock_open.return_value = mock_table
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import rebuild_clusters
 
-        graph = ConceptGraph()
-        graph.rebuild_clusters()
+        rebuild_clusters()
 
+    @patch("lilbee.lock.write_lock")
     @patch("lilbee.store.safe_delete")
     @patch("lilbee.store.ensure_table")
     @patch("lilbee.store.get_db")
     @patch("lilbee.concepts._leiden_partition")
-    @patch("lilbee.store._open_table")
+    @patch("lilbee.store.open_table")
     def test_rebuild_with_edges(
-        self, mock_open, mock_leiden, mock_get_db, mock_ensure, mock_safe_del
+        self, mock_open, mock_leiden, mock_get_db, mock_ensure, mock_safe_del, mock_lock
     ):
+        mock_lock.return_value.__enter__ = MagicMock()
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
         mock_table = MagicMock()
         edge_rows = [
             {"source": "python", "target": "ml", "weight": 2.0},
@@ -417,50 +415,48 @@ class TestRebuildClusters:
         mock_nodes_table = MagicMock()
         mock_ensure.return_value = mock_nodes_table
 
-        from lilbee.concepts import ConceptGraph
+        from lilbee.concepts import rebuild_clusters
 
-        graph = ConceptGraph()
-        graph.rebuild_clusters()
+        rebuild_clusters()
         mock_leiden.assert_called_once_with(edge_rows)
         mock_nodes_table.add.assert_called_once()
 
 
 class TestGetGraph:
-    def test_returns_graph_when_enabled(self):
+    @patch("lilbee.store.open_table")
+    def test_returns_true_when_enabled(self, mock_open):
+        mock_open.return_value = MagicMock()
         from lilbee.concepts import get_graph
 
         cfg.concept_graph = True
-        graph = get_graph()
-        assert graph is not None
+        assert get_graph() is True
 
-    def test_returns_none_when_disabled(self):
+    def test_returns_false_when_disabled(self):
         from lilbee.concepts import get_graph
 
         cfg.concept_graph = False
-        assert get_graph() is None
+        assert get_graph() is False
 
-    def test_singleton(self):
+    @patch("lilbee.store.open_table", return_value=None)
+    def test_returns_false_when_no_tables(self, mock_open):
         from lilbee.concepts import get_graph
 
         cfg.concept_graph = True
-        g1 = get_graph()
-        g2 = get_graph()
-        assert g1 is g2
+        assert get_graph() is False
 
 
 class TestResetGraph:
-    def test_clears_singleton(self):
-        from lilbee.concepts import get_graph, reset_graph
+    def test_clears_nlp_cache(self):
+        """reset_graph clears the spaCy model cache."""
+        import lilbee.concepts as concepts_mod
 
-        cfg.concept_graph = True
-        g1 = get_graph()
-        reset_graph()
-        g2 = get_graph()
-        assert g1 is not g2
+        concepts_mod._nlp = MagicMock()
+        concepts_mod.reset_graph()
+        assert concepts_mod._nlp is None
 
 
 class TestComputePmi:
-    def test_basic_pmi(self):
+    def test_basic_ppmi(self):
         from collections import Counter
 
         from lilbee.concepts import _compute_pmi
@@ -469,7 +465,20 @@ class TestComputePmi:
         concept_counts = Counter({"a": 8, "b": 6})
         pmi = _compute_pmi(cooccurrences, concept_counts, 10)
         assert ("a", "b") in pmi
-        assert isinstance(pmi[("a", "b")], float)
+        # PPMI: all values >= 0
+        assert pmi[("a", "b")] >= 0.0
+
+    def test_ppmi_clamps_negative(self):
+        """Anti-correlated pairs should get PPMI = 0."""
+        from collections import Counter
+
+        from lilbee.concepts import _compute_pmi
+
+        # a and b rarely co-occur but each appear often -> negative PMI -> clamped to 0
+        cooccurrences = Counter({("a", "b"): 1})
+        concept_counts = Counter({"a": 9, "b": 9})
+        pmi = _compute_pmi(cooccurrences, concept_counts, 10)
+        assert pmi[("a", "b")] == 0.0
 
 
 class TestLeidenPartition:
@@ -487,3 +496,47 @@ class TestLeidenPartition:
         assert degrees["a"] == 1
         assert degrees["b"] == 2
         assert degrees["c"] == 1
+
+    @patch("graspologic_native.leiden")
+    def test_clamps_low_weights(self, mock_leiden):
+        """Weights below _MIN_LEIDEN_WEIGHT are clamped up."""
+        mock_leiden.return_value = (0.5, {"a": 0, "b": 0})
+        from lilbee.concepts import _MIN_LEIDEN_WEIGHT, _leiden_partition
+
+        edge_rows = [{"source": "a", "target": "b", "weight": 0.0}]
+        _leiden_partition(edge_rows)
+        # Check that the edges passed to leiden have clamped weight
+        call_args = mock_leiden.call_args
+        edges_passed = call_args[1]["edges"]
+        assert edges_passed[0][2] == _MIN_LEIDEN_WEIGHT
+
+
+class TestCommunityDataclass:
+    def test_community_fields(self):
+        from lilbee.concepts import Community
+
+        c = Community(cluster_id=0, size=3, concepts=["a", "b", "c"])
+        assert c.cluster_id == 0
+        assert c.size == 3
+        assert c.concepts == ["a", "b", "c"]
+
+    def test_community_is_dataclass(self):
+        from lilbee.concepts import Community
+
+        assert len(fields(Community)) == 3
+
+
+class TestFilterNounChunks:
+    def test_filter_noun_chunks(self):
+        from lilbee.concepts import _filter_noun_chunks
+
+        doc = _make_mock_doc(["Hello World", "a", "Good Stuff", "Hello World"])
+        result = _filter_noun_chunks(doc, max_concepts=10)
+        assert result == ["hello world", "good stuff"]
+
+    def test_filter_noun_chunks_max(self):
+        from lilbee.concepts import _filter_noun_chunks
+
+        doc = _make_mock_doc(["aa", "bb", "cc"])
+        result = _filter_noun_chunks(doc, max_concepts=2)
+        assert len(result) == 2

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -1,6 +1,5 @@
 """Tests for the concept graph module."""
 
-from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -98,9 +97,7 @@ class TestExtractConcepts:
 
     @patch("lilbee.concepts._get_nlp")
     def test_deduplication(self, mock_get_nlp):
-        mock_get_nlp.return_value = _make_mock_nlp(
-            {"text": ["Concept", "concept", "Other"]}
-        )
+        mock_get_nlp.return_value = _make_mock_nlp({"text": ["Concept", "concept", "Other"]})
         from lilbee.concepts import extract_concepts
 
         result = extract_concepts("text")
@@ -108,9 +105,7 @@ class TestExtractConcepts:
 
     @patch("lilbee.concepts._get_nlp")
     def test_max_cap(self, mock_get_nlp):
-        mock_get_nlp.return_value = _make_mock_nlp(
-            {"text": ["alpha", "beta", "gamma", "delta"]}
-        )
+        mock_get_nlp.return_value = _make_mock_nlp({"text": ["alpha", "beta", "gamma", "delta"]})
         from lilbee.concepts import extract_concepts
 
         result = extract_concepts("text", max_concepts=2)
@@ -126,9 +121,7 @@ class TestExtractConcepts:
 
     @patch("lilbee.concepts._get_nlp")
     def test_filters_short_concepts(self, mock_get_nlp):
-        mock_get_nlp.return_value = _make_mock_nlp(
-            {"text": ["a", "ok", "good concept"]}
-        )
+        mock_get_nlp.return_value = _make_mock_nlp({"text": ["a", "ok", "good concept"]})
         from lilbee.concepts import extract_concepts
 
         result = extract_concepts("text")
@@ -157,6 +150,46 @@ class TestExtractConceptsBatch:
         result = extract_concepts_batch([])
         assert result == []
         mock_get_nlp.assert_not_called()
+
+    @patch("lilbee.concepts._get_nlp")
+    def test_batch_filters_short_concepts(self, mock_get_nlp):
+        mock_get_nlp.return_value = _make_mock_nlp({"text": ["a", "ok", "good"]})
+        from lilbee.concepts import extract_concepts_batch
+
+        result = extract_concepts_batch(["text"])
+        assert result == [["ok", "good"]]
+
+    @patch("lilbee.concepts._get_nlp")
+    def test_batch_deduplicates(self, mock_get_nlp):
+        mock_get_nlp.return_value = _make_mock_nlp({"text": ["Alpha", "alpha", "Beta"]})
+        from lilbee.concepts import extract_concepts_batch
+
+        result = extract_concepts_batch(["text"])
+        assert result == [["alpha", "beta"]]
+
+    @patch("lilbee.concepts._get_nlp")
+    def test_batch_caps_at_max(self, mock_get_nlp):
+        cfg.concept_max_per_chunk = 2
+        mock_get_nlp.return_value = _make_mock_nlp({"text": ["aa", "bb", "cc", "dd"]})
+        from lilbee.concepts import extract_concepts_batch
+
+        result = extract_concepts_batch(["text"])
+        assert len(result[0]) == 2
+
+
+class TestGetNlp:
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_caches_nlp_model(self, mock_ensure):
+        """_get_nlp calls _ensure_spacy_model on first call and caches."""
+        mock_ensure.return_value = MagicMock()
+        from lilbee.concepts import _get_nlp, reset_graph
+
+        reset_graph()
+        nlp1 = _get_nlp()
+        nlp2 = _get_nlp()
+        mock_ensure.assert_called_once()
+        assert nlp1 is nlp2
+        reset_graph()
 
 
 class TestEnsureSpacyModel:
@@ -273,6 +306,19 @@ class TestConceptGraph:
 
         graph = ConceptGraph()
         assert graph.get_related_concepts("python") == []
+
+    @patch("lilbee.store._open_table")
+    def test_get_related_concepts_query_exception(self, mock_open):
+        mock_table = MagicMock()
+        mock_table.search.return_value.where.return_value.to_list.side_effect = RuntimeError(
+            "query failed"
+        )
+        mock_open.return_value = mock_table
+        from lilbee.concepts import ConceptGraph
+
+        graph = ConceptGraph()
+        result = graph.get_related_concepts("python")
+        assert result == []
 
     @patch("lilbee.store._open_table")
     def test_top_communities(self, mock_open):
@@ -424,3 +470,20 @@ class TestComputePmi:
         pmi = _compute_pmi(cooccurrences, concept_counts, 10)
         assert ("a", "b") in pmi
         assert isinstance(pmi[("a", "b")], float)
+
+
+class TestLeidenPartition:
+    @patch("graspologic_native.leiden")
+    def test_returns_partition_and_degrees(self, mock_leiden):
+        mock_leiden.return_value = (0.5, {"a": 0, "b": 0, "c": 1})
+        from lilbee.concepts import _leiden_partition
+
+        edge_rows = [
+            {"source": "a", "target": "b", "weight": 2.0},
+            {"source": "b", "target": "c", "weight": 1.5},
+        ]
+        partition, degrees = _leiden_partition(edge_rows)
+        assert partition == {"a": 0, "b": 0, "c": 1}
+        assert degrees["a"] == 1
+        assert degrees["b"] == 2
+        assert degrees["c"] == 1

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -25,6 +25,7 @@ def isolated_env(tmp_path):
     cfg.documents_dir = docs
     cfg.data_dir = tmp_path / "data"
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
+    cfg.concept_graph = False
 
     yield docs
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1264,14 +1264,14 @@ class TestConceptIndexing:
         cfg.concept_graph = True
         (isolated_env / "test.txt").write_text("Some test content for concepts.")
 
-        with mock.patch(
-            "lilbee.concepts.extract_concepts_batch", return_value=[["test"]]
-        ) as m_ext:
-            with mock.patch("lilbee.concepts.get_graph") as m_graph:
-                m_graph.return_value = mock.MagicMock()
-                from lilbee.ingest import sync
+        with (
+            mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]) as m_ext,
+            mock.patch("lilbee.concepts.get_graph") as m_graph,
+        ):
+            m_graph.return_value = mock.MagicMock()
+            from lilbee.ingest import sync
 
-                await sync(quiet=True)
+            await sync(quiet=True)
         m_ext.assert_called()
 
     @mock.patch("lilbee.embedder.validate_model")
@@ -1304,14 +1304,16 @@ class TestConceptIndexing:
         cfg.concept_graph = True
         (isolated_env / "test.txt").write_text("Some test content.")
 
-        with mock.patch(
-            "lilbee.concepts.extract_concepts_batch", side_effect=RuntimeError("spacy broke")
+        with (
+            mock.patch(
+                "lilbee.concepts.extract_concepts_batch", side_effect=RuntimeError("spacy broke")
+            ),
+            mock.patch("lilbee.concepts.get_graph") as m_graph,
         ):
-            with mock.patch("lilbee.concepts.get_graph") as m_graph:
-                m_graph.return_value = mock.MagicMock()
-                from lilbee.ingest import sync
+            m_graph.return_value = mock.MagicMock()
+            from lilbee.ingest import sync
 
-                result = await sync(quiet=True)
+            result = await sync(quiet=True)
         assert "test.txt" in result.added
 
     @mock.patch("lilbee.embedder.validate_model")
@@ -1327,11 +1329,13 @@ class TestConceptIndexing:
         (isolated_env / "test.txt").write_text("Some test content.")
 
         mock_graph = mock.MagicMock()
-        with mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]):
-            with mock.patch("lilbee.concepts.get_graph", return_value=mock_graph):
-                from lilbee.ingest import sync
+        with (
+            mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]),
+            mock.patch("lilbee.concepts.get_graph", return_value=mock_graph),
+        ):
+            from lilbee.ingest import sync
 
-                await sync(quiet=True)
+            await sync(quiet=True)
         mock_graph.rebuild_clusters.assert_called()
 
     @mock.patch("lilbee.embedder.validate_model")
@@ -1348,9 +1352,29 @@ class TestConceptIndexing:
 
         mock_graph = mock.MagicMock()
         mock_graph.rebuild_clusters.side_effect = RuntimeError("leiden broke")
-        with mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]):
-            with mock.patch("lilbee.concepts.get_graph", return_value=mock_graph):
-                from lilbee.ingest import sync
+        with (
+            mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]),
+            mock.patch("lilbee.concepts.get_graph", return_value=mock_graph),
+        ):
+            from lilbee.ingest import sync
 
-                result = await sync(quiet=True)
+            result = await sync(quiet=True)
+        assert "test.txt" in result.added
+
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch(
+        "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
+    )
+    async def test_graph_none_skips_indexing(
+        self, mock_extract_file, mock_embed_batch, mock_validate_model, isolated_env
+    ):
+        """When get_graph() returns None, concept indexing is skipped gracefully."""
+        cfg.concept_graph = True
+        (isolated_env / "test.txt").write_text("Some test content.")
+
+        with mock.patch("lilbee.concepts.get_graph", return_value=None):
+            from lilbee.ingest import sync
+
+            result = await sync(quiet=True)
         assert "test.txt" in result.added

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1266,9 +1266,10 @@ class TestConceptIndexing:
 
         with (
             mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]) as m_ext,
-            mock.patch("lilbee.concepts.get_graph") as m_graph,
+            mock.patch("lilbee.concepts.build_from_chunks"),
+            mock.patch("lilbee.concepts.get_graph", return_value=True),
+            mock.patch("lilbee.concepts.rebuild_clusters"),
         ):
-            m_graph.return_value = mock.MagicMock()
             from lilbee.ingest import sync
 
             await sync(quiet=True)
@@ -1308,9 +1309,9 @@ class TestConceptIndexing:
             mock.patch(
                 "lilbee.concepts.extract_concepts_batch", side_effect=RuntimeError("spacy broke")
             ),
-            mock.patch("lilbee.concepts.get_graph") as m_graph,
+            mock.patch("lilbee.concepts.get_graph", return_value=True),
+            mock.patch("lilbee.concepts.rebuild_clusters"),
         ):
-            m_graph.return_value = mock.MagicMock()
             from lilbee.ingest import sync
 
             result = await sync(quiet=True)
@@ -1328,15 +1329,16 @@ class TestConceptIndexing:
         cfg.concept_graph = True
         (isolated_env / "test.txt").write_text("Some test content.")
 
-        mock_graph = mock.MagicMock()
         with (
             mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]),
-            mock.patch("lilbee.concepts.get_graph", return_value=mock_graph),
+            mock.patch("lilbee.concepts.build_from_chunks"),
+            mock.patch("lilbee.concepts.get_graph", return_value=True),
+            mock.patch("lilbee.concepts.rebuild_clusters") as mock_rebuild,
         ):
             from lilbee.ingest import sync
 
             await sync(quiet=True)
-        mock_graph.rebuild_clusters.assert_called()
+        mock_rebuild.assert_called()
 
     @mock.patch("lilbee.embedder.validate_model")
     @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
@@ -1350,11 +1352,14 @@ class TestConceptIndexing:
         cfg.concept_graph = True
         (isolated_env / "test.txt").write_text("Some test content.")
 
-        mock_graph = mock.MagicMock()
-        mock_graph.rebuild_clusters.side_effect = RuntimeError("leiden broke")
         with (
             mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]),
-            mock.patch("lilbee.concepts.get_graph", return_value=mock_graph),
+            mock.patch("lilbee.concepts.build_from_chunks"),
+            mock.patch("lilbee.concepts.get_graph", return_value=True),
+            mock.patch(
+                "lilbee.concepts.rebuild_clusters",
+                side_effect=RuntimeError("leiden broke"),
+            ),
         ):
             from lilbee.ingest import sync
 
@@ -1373,7 +1378,11 @@ class TestConceptIndexing:
         cfg.concept_graph = True
         (isolated_env / "test.txt").write_text("Some test content.")
 
-        with mock.patch("lilbee.concepts.get_graph", return_value=None):
+        with (
+            mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]),
+            mock.patch("lilbee.concepts.build_from_chunks"),
+            mock.patch("lilbee.concepts.get_graph", return_value=False),
+        ):
             from lilbee.ingest import sync
 
             result = await sync(quiet=True)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -19,6 +19,7 @@ def isolated_env(tmp_path):
     cfg.documents_dir = docs
     cfg.data_dir = tmp_path / "data"
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
+    cfg.concept_graph = False
 
     yield docs
 
@@ -1248,3 +1249,108 @@ class TestChunkViaKreuzberg:
 
         result = chunk_text("Some text that should be chunked.")
         assert len(result) >= 1
+
+
+class TestConceptIndexing:
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch(
+        "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
+    )
+    async def test_concept_extraction_called_during_ingest(
+        self, mock_extract_file, mock_embed_batch, mock_validate_model, isolated_env
+    ):
+        """When concept_graph is enabled, extraction is called after ingest."""
+        cfg.concept_graph = True
+        (isolated_env / "test.txt").write_text("Some test content for concepts.")
+
+        with mock.patch(
+            "lilbee.concepts.extract_concepts_batch", return_value=[["test"]]
+        ) as m_ext:
+            with mock.patch("lilbee.concepts.get_graph") as m_graph:
+                m_graph.return_value = mock.MagicMock()
+                from lilbee.ingest import sync
+
+                await sync(quiet=True)
+        m_ext.assert_called()
+
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch(
+        "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
+    )
+    async def test_concept_disabled_skips_extraction(
+        self, mock_extract_file, mock_embed_batch, mock_validate_model, isolated_env
+    ):
+        """When concept_graph is disabled, extraction is not called."""
+        cfg.concept_graph = False
+        (isolated_env / "test.txt").write_text("Some test content.")
+
+        with mock.patch("lilbee.concepts.extract_concepts_batch") as m_ext:
+            from lilbee.ingest import sync
+
+            await sync(quiet=True)
+        m_ext.assert_not_called()
+
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch(
+        "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
+    )
+    async def test_concept_failure_does_not_break_ingest(
+        self, mock_extract_file, mock_embed_batch, mock_validate_model, isolated_env
+    ):
+        """When concept extraction raises, ingest still succeeds."""
+        cfg.concept_graph = True
+        (isolated_env / "test.txt").write_text("Some test content.")
+
+        with mock.patch(
+            "lilbee.concepts.extract_concepts_batch", side_effect=RuntimeError("spacy broke")
+        ):
+            with mock.patch("lilbee.concepts.get_graph") as m_graph:
+                m_graph.return_value = mock.MagicMock()
+                from lilbee.ingest import sync
+
+                result = await sync(quiet=True)
+        assert "test.txt" in result.added
+
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch(
+        "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
+    )
+    async def test_cluster_rebuild_called_after_sync(
+        self, mock_extract_file, mock_embed_batch, mock_validate_model, isolated_env
+    ):
+        """After sync completes, rebuild_clusters is called."""
+        cfg.concept_graph = True
+        (isolated_env / "test.txt").write_text("Some test content.")
+
+        mock_graph = mock.MagicMock()
+        with mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]):
+            with mock.patch("lilbee.concepts.get_graph", return_value=mock_graph):
+                from lilbee.ingest import sync
+
+                await sync(quiet=True)
+        mock_graph.rebuild_clusters.assert_called()
+
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch)
+    @mock.patch(
+        "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
+    )
+    async def test_cluster_rebuild_failure_does_not_break_sync(
+        self, mock_extract_file, mock_embed_batch, mock_validate_model, isolated_env
+    ):
+        """When cluster rebuild raises, sync still succeeds."""
+        cfg.concept_graph = True
+        (isolated_env / "test.txt").write_text("Some test content.")
+
+        mock_graph = mock.MagicMock()
+        mock_graph.rebuild_clusters.side_effect = RuntimeError("leiden broke")
+        with mock.patch("lilbee.concepts.extract_concepts_batch", return_value=[["test"]]):
+            with mock.patch("lilbee.concepts.get_graph", return_value=mock_graph):
+                from lilbee.ingest import sync
+
+                result = await sync(quiet=True)
+        assert "test.txt" in result.added

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -981,15 +981,26 @@ class TestConceptBoosting:
     @mock.patch("lilbee.store.bm25_probe", return_value=[])
     @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
     def test_boost_failure_returns_original(self, mock_embed, mock_bm25, mock_search):
-        from lilbee.config import cfg
-
         old = cfg.concept_graph
         cfg.concept_graph = True
         cfg.query_expansion_count = 0
         try:
-            with mock.patch(
-                "lilbee.concepts.get_graph", side_effect=RuntimeError("broken")
-            ):
+            with mock.patch("lilbee.concepts.get_graph", side_effect=RuntimeError("broken")):
+                results = search_context("python code")
+            assert results[0].distance == 0.5
+        finally:
+            cfg.concept_graph = old
+            cfg.query_expansion_count = 3
+
+    @mock.patch("lilbee.store.search", return_value=[_make_result(distance=0.5)])
+    @mock.patch("lilbee.store.bm25_probe", return_value=[])
+    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    def test_boost_graph_none_returns_original(self, mock_embed, mock_bm25, mock_search):
+        old = cfg.concept_graph
+        cfg.concept_graph = True
+        cfg.query_expansion_count = 0
+        try:
+            with mock.patch("lilbee.concepts.get_graph", return_value=None):
                 results = search_context("python code")
             assert results[0].distance == 0.5
         finally:
@@ -1035,15 +1046,24 @@ class TestConceptQueryExpansion:
             cfg.concept_graph = old
 
     def test_expansion_failure_returns_empty(self):
-        from lilbee.config import cfg
         from lilbee.query import _concept_query_expansion
 
         old = cfg.concept_graph
         cfg.concept_graph = True
         try:
-            with mock.patch(
-                "lilbee.concepts.get_graph", side_effect=RuntimeError("broken")
-            ):
+            with mock.patch("lilbee.concepts.get_graph", side_effect=RuntimeError("broken")):
+                result = _concept_query_expansion("test query")
+            assert result == []
+        finally:
+            cfg.concept_graph = old
+
+    def test_expansion_graph_none_returns_empty(self):
+        from lilbee.query import _concept_query_expansion
+
+        old = cfg.concept_graph
+        cfg.concept_graph = True
+        try:
+            with mock.patch("lilbee.concepts.get_graph", return_value=None):
                 result = _concept_query_expansion("test query")
             assert result == []
         finally:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from lilbee.config import cfg
 from lilbee.query import (
     ask,
     ask_raw,
@@ -15,6 +16,15 @@ from lilbee.query import (
     sort_by_relevance,
 )
 from lilbee.store import SearchChunk
+
+
+@pytest.fixture(autouse=True)
+def _disable_concepts():
+    """Disable concept graph by default in query tests to avoid spaCy loads."""
+    old = cfg.concept_graph
+    cfg.concept_graph = False
+    yield
+    cfg.concept_graph = old
 
 
 def _make_result(
@@ -923,3 +933,118 @@ class TestAskStreamWithReranker:
                 mock_rerank.assert_called_once()
         finally:
             cfg.reranker_model = old
+
+
+class TestConceptBoosting:
+    @mock.patch("lilbee.store.search", return_value=[_make_result(distance=0.5)])
+    @mock.patch("lilbee.store.bm25_probe", return_value=[])
+    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    def test_boost_applied_when_enabled(self, mock_embed, mock_bm25, mock_search):
+        from lilbee.config import cfg
+
+        old = cfg.concept_graph
+        cfg.concept_graph = True
+        cfg.query_expansion_count = 0
+        try:
+            mock_graph = mock.MagicMock()
+            mock_graph.boost_results.return_value = [_make_result(distance=0.3)]
+            with (
+                mock.patch("lilbee.concepts.get_graph", return_value=mock_graph),
+                mock.patch("lilbee.concepts.extract_concepts", return_value=["python"]),
+            ):
+                results = search_context("python code")
+            mock_graph.boost_results.assert_called_once()
+            assert results[0].distance == 0.3
+        finally:
+            cfg.concept_graph = old
+            cfg.query_expansion_count = 3
+
+    @mock.patch("lilbee.store.search", return_value=[_make_result(distance=0.5)])
+    @mock.patch("lilbee.store.bm25_probe", return_value=[])
+    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    def test_boost_skipped_when_disabled(self, mock_embed, mock_bm25, mock_search):
+        from lilbee.config import cfg
+
+        old = cfg.concept_graph
+        cfg.concept_graph = False
+        cfg.query_expansion_count = 0
+        try:
+            with mock.patch("lilbee.concepts.get_graph") as m_graph:
+                results = search_context("python code")
+            m_graph.assert_not_called()
+            assert results[0].distance == 0.5
+        finally:
+            cfg.concept_graph = old
+            cfg.query_expansion_count = 3
+
+    @mock.patch("lilbee.store.search", return_value=[_make_result(distance=0.5)])
+    @mock.patch("lilbee.store.bm25_probe", return_value=[])
+    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    def test_boost_failure_returns_original(self, mock_embed, mock_bm25, mock_search):
+        from lilbee.config import cfg
+
+        old = cfg.concept_graph
+        cfg.concept_graph = True
+        cfg.query_expansion_count = 0
+        try:
+            with mock.patch(
+                "lilbee.concepts.get_graph", side_effect=RuntimeError("broken")
+            ):
+                results = search_context("python code")
+            assert results[0].distance == 0.5
+        finally:
+            cfg.concept_graph = old
+            cfg.query_expansion_count = 3
+
+
+class TestConceptQueryExpansion:
+    @mock.patch("lilbee.query.get_provider")
+    @mock.patch("lilbee.store.search", return_value=[_make_result()])
+    @mock.patch("lilbee.store.bm25_probe", return_value=[])
+    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    def test_expansion_includes_concept_terms(
+        self, mock_embed, mock_bm25, mock_search, mock_provider
+    ):
+        from lilbee.config import cfg
+        from lilbee.query import _expand_query
+
+        old_graph = cfg.concept_graph
+        cfg.concept_graph = True
+        mock_provider.return_value.chat.return_value = "variant query about python"
+        try:
+            mock_graph = mock.MagicMock()
+            mock_graph.expand_query.return_value = ["django", "flask"]
+            with (
+                mock.patch("lilbee.concepts.get_graph", return_value=mock_graph),
+            ):
+                variants = _expand_query("python frameworks")
+            assert "django" in variants or "flask" in variants
+        finally:
+            cfg.concept_graph = old_graph
+
+    def test_expansion_disabled_returns_empty(self):
+        from lilbee.config import cfg
+        from lilbee.query import _concept_query_expansion
+
+        old = cfg.concept_graph
+        cfg.concept_graph = False
+        try:
+            result = _concept_query_expansion("test query")
+            assert result == []
+        finally:
+            cfg.concept_graph = old
+
+    def test_expansion_failure_returns_empty(self):
+        from lilbee.config import cfg
+        from lilbee.query import _concept_query_expansion
+
+        old = cfg.concept_graph
+        cfg.concept_graph = True
+        try:
+            with mock.patch(
+                "lilbee.concepts.get_graph", side_effect=RuntimeError("broken")
+            ):
+                result = _concept_query_expansion("test query")
+            assert result == []
+        finally:
+            cfg.concept_graph = old

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -946,14 +946,16 @@ class TestConceptBoosting:
         cfg.concept_graph = True
         cfg.query_expansion_count = 0
         try:
-            mock_graph = mock.MagicMock()
-            mock_graph.boost_results.return_value = [_make_result(distance=0.3)]
             with (
-                mock.patch("lilbee.concepts.get_graph", return_value=mock_graph),
+                mock.patch("lilbee.concepts.get_graph", return_value=True),
                 mock.patch("lilbee.concepts.extract_concepts", return_value=["python"]),
+                mock.patch(
+                    "lilbee.concepts.boost_results",
+                    return_value=[_make_result(distance=0.3)],
+                ) as mock_boost,
             ):
                 results = search_context("python code")
-            mock_graph.boost_results.assert_called_once()
+            mock_boost.assert_called_once()
             assert results[0].distance == 0.3
         finally:
             cfg.concept_graph = old
@@ -1000,7 +1002,7 @@ class TestConceptBoosting:
         cfg.concept_graph = True
         cfg.query_expansion_count = 0
         try:
-            with mock.patch("lilbee.concepts.get_graph", return_value=None):
+            with mock.patch("lilbee.concepts.get_graph", return_value=False):
                 results = search_context("python code")
             assert results[0].distance == 0.5
         finally:
@@ -1023,13 +1025,17 @@ class TestConceptQueryExpansion:
         cfg.concept_graph = True
         mock_provider.return_value.chat.return_value = "variant query about python"
         try:
-            mock_graph = mock.MagicMock()
-            mock_graph.expand_query.return_value = ["django", "flask"]
+            # Use concept terms that share tokens with the original query
+            # so they survive the guardrails overlap check
             with (
-                mock.patch("lilbee.concepts.get_graph", return_value=mock_graph),
+                mock.patch("lilbee.concepts.get_graph", return_value=True),
+                mock.patch(
+                    "lilbee.concepts.expand_query",
+                    return_value=["python web frameworks"],
+                ),
             ):
                 variants = _expand_query("python frameworks")
-            assert "django" in variants or "flask" in variants
+            assert "python web frameworks" in variants
         finally:
             cfg.concept_graph = old_graph
 

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -412,3 +412,39 @@ class TestCreateAppReexport:
 
         create_app()
         mock_create.assert_called_once()
+
+
+class TestLifespan:
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch("lilbee.providers.factory.get_provider")
+    async def test_calls_both(self, mock_provider, mock_validate):
+        from lilbee.server.litestar_app import _lifespan
+
+        async with _lifespan(mock.MagicMock()):
+            pass
+        mock_provider.assert_called_once()
+        mock_validate.assert_called_once()
+
+    @mock.patch("lilbee.embedder.validate_model")
+    @mock.patch(
+        "lilbee.providers.factory.get_provider",
+        side_effect=RuntimeError("no provider"),
+    )
+    async def test_provider_failure_does_not_block(self, mock_provider, mock_validate):
+        from lilbee.server.litestar_app import _lifespan
+
+        async with _lifespan(mock.MagicMock()):
+            pass
+        mock_validate.assert_called_once()
+
+    @mock.patch(
+        "lilbee.embedder.validate_model",
+        side_effect=RuntimeError("no model"),
+    )
+    @mock.patch("lilbee.providers.factory.get_provider")
+    async def test_validate_model_failure_does_not_block(self, mock_provider, mock_validate):
+        from lilbee.server.litestar_app import _lifespan
+
+        async with _lifespan(mock.MagicMock()):
+            pass
+        mock_provider.assert_called_once()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -49,7 +49,7 @@ class TestEnsureFtsIndex:
 
     def test_handles_exception_gracefully(self):
         store.add_chunks(_make_records())
-        table = store._open_table(store.CHUNKS_TABLE)
+        table = store.open_table(store.CHUNKS_TABLE)
         assert table is not None
         with mock.patch.object(
             type(table),

--- a/uv.lock
+++ b/uv.lock
@@ -171,6 +171,54 @@ wheels = [
 ]
 
 [[package]]
+name = "blis"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/0a/a4c8736bc497d386b0ffc76d321f478c03f1a4725e52092f93b38beb3786/blis-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e10c8d3e892b1dbdff365b9d00e08291876fc336915bf1a5e9f188ed087e1a91", size = 6925522 },
+    { url = "https://files.pythonhosted.org/packages/83/5a/3437009282f23684ecd3963a8b034f9307cdd2bf4484972e5a6b096bf9ac/blis-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66e6249564f1db22e8af1e0513ff64134041fa7e03c8dd73df74db3f4d8415a7", size = 1232787 },
+    { url = "https://files.pythonhosted.org/packages/d1/0e/82221910d16259ce3017c1442c468a3f206a4143a96fbba9f5b5b81d62e8/blis-1.3.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7260da065958b4e5475f62f44895ef9d673b0f47dcf61b672b22b7dae1a18505", size = 2844596 },
+    { url = "https://files.pythonhosted.org/packages/6c/93/ab547f1a5c23e20bca16fbcf04021c32aac3f969be737ea4980509a7ca90/blis-1.3.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9327a6ca67de8ae76fe071e8584cc7f3b2e8bfadece4961d40f2826e1cda2df", size = 11377746 },
+    { url = "https://files.pythonhosted.org/packages/6e/a6/7733820aa62da32526287a63cd85c103b2b323b186c8ee43b7772ff7017c/blis-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c4ae70629cf302035d268858a10ca4eb6242a01b2dc8d64422f8e6dcb8a8ee74", size = 3041954 },
+    { url = "https://files.pythonhosted.org/packages/87/53/e39d67fd3296b649772780ca6aab081412838ecb54e0b0c6432d01626a50/blis-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45866a9027d43b93e8b59980a23c5d7358b6536fc04606286e39fdcfce1101c2", size = 14251222 },
+    { url = "https://files.pythonhosted.org/packages/ea/44/b749f8777b020b420bceaaf60f66432fc30cc904ca5b69640ec9cbef11ed/blis-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:27f82b8633030f8d095d2b412dffa7eb6dbc8ee43813139909a20012e54422ea", size = 6171233 },
+    { url = "https://files.pythonhosted.org/packages/16/d1/429cf0cf693d4c7dc2efed969bd474e315aab636e4a95f66c4ed7264912d/blis-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2a1c74e100665f8e918ebdbae2794576adf1f691680b5cdb8b29578432f623ef", size = 6929663 },
+    { url = "https://files.pythonhosted.org/packages/11/69/363c8df8d98b3cc97be19aad6aabb2c9c53f372490d79316bdee92d476e7/blis-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3f6c595185176ce021316263e1a1d636a3425b6c48366c1fd712d08d0b71849a", size = 1230939 },
+    { url = "https://files.pythonhosted.org/packages/96/2a/fbf65d906d823d839076c5150a6f8eb5ecbc5f9135e0b6510609bda1e6b7/blis-1.3.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d734b19fba0be7944f272dfa7b443b37c61f9476d9ab054a9ac53555ceadd2e0", size = 2818835 },
+    { url = "https://files.pythonhosted.org/packages/d5/ad/58deaa3ad856dd3cc96493e40ffd2ed043d18d4d304f85a65cde1ccbf644/blis-1.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ef6d6e2b599a3a2788eb6d9b443533961265aa4ec49d574ed4bb846e548dcdb", size = 11366550 },
+    { url = "https://files.pythonhosted.org/packages/78/82/816a7adfe1f7acc8151f01ec86ef64467a3c833932d8f19f8e06613b8a4e/blis-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8c888438ae99c500422d50698e3028b65caa8ebb44e24204d87fda2df64058f7", size = 3023686 },
+    { url = "https://files.pythonhosted.org/packages/1e/e2/0e93b865f648b5519360846669a35f28ee8f4e1d93d054f6850d8afbabde/blis-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8177879fd3590b5eecdd377f9deafb5dc8af6d684f065bd01553302fb3fcf9a7", size = 14250939 },
+    { url = "https://files.pythonhosted.org/packages/20/07/fb43edc2ff0a6a367e4a94fc39eb3b85aa1e55e24cc857af2db145ce9f0d/blis-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:f20f7ad69aaffd1ce14fe77de557b6df9b61e0c9e582f75a843715d836b5c8af", size = 6192759 },
+    { url = "https://files.pythonhosted.org/packages/e6/f7/d26e62d9be3d70473a63e0a5d30bae49c2fe138bebac224adddcdef8a7ce/blis-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1e647341f958421a86b028a2efe16ce19c67dba2a05f79e8f7e80b1ff45328aa", size = 6928322 },
+    { url = "https://files.pythonhosted.org/packages/4a/78/750d12da388f714958eb2f2fd177652323bbe7ec528365c37129edd6eb84/blis-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d563160f874abb78a57e346f07312c5323f7ad67b6370052b6b17087ef234a8e", size = 1229635 },
+    { url = "https://files.pythonhosted.org/packages/e8/36/eac4199c5b200a5f3e93cad197da8d26d909f218eb444c4f552647c95240/blis-1.3.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:30b8a5b90cb6cb81d1ada9ae05aa55fb8e70d9a0ae9db40d2401bb9c1c8f14c4", size = 2815650 },
+    { url = "https://files.pythonhosted.org/packages/bf/51/472e7b36a6bedb5242a9757e7486f702c3619eff76e256735d0c8b1679c6/blis-1.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9f5c53b277f6ac5b3ca30bc12ebab7ea16c8f8c36b14428abb56924213dc127", size = 11359008 },
+    { url = "https://files.pythonhosted.org/packages/84/da/d0dfb6d6e6321ae44df0321384c32c322bd07b15740d7422727a1a49fc5d/blis-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6297e7616c158b305c9a8a4e47ca5fc9b0785194dd96c903b1a1591a7ca21ddf", size = 3011959 },
+    { url = "https://files.pythonhosted.org/packages/20/c5/2b0b5e556fa0364ed671051ea078a6d6d7b979b1cfef78d64ad3ca5f0c7f/blis-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3f966ca74f89f8a33e568b9a1d71992fc9a0d29a423e047f0a212643e21b5458", size = 14232456 },
+    { url = "https://files.pythonhosted.org/packages/31/07/4cdc81a47bf862c0b06d91f1bc6782064e8b69ac9b5d4ff51d97e4ff03da/blis-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:7a0fc4b237a3a453bdc3c7ab48d91439fcd2d013b665c46948d9eaf9c3e45a97", size = 6192624 },
+    { url = "https://files.pythonhosted.org/packages/5f/8a/80f7c68fbc24a76fc9c18522c46d6d69329c320abb18e26a707a5d874083/blis-1.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c3e33cfbf22a418373766816343fcfcd0556012aa3ffdf562c29cddec448a415", size = 6934081 },
+    { url = "https://files.pythonhosted.org/packages/e5/52/d1aa3a51a7fc299b0c89dcaa971922714f50b1202769eebbdaadd1b5cff7/blis-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6f165930e8d3a85c606d2003211497e28d528c7416fbfeafb6b15600963f7c9b", size = 1231486 },
+    { url = "https://files.pythonhosted.org/packages/99/4f/badc7bd7f74861b26c10123bba7b9d16f99cd9535ad0128780360713820f/blis-1.3.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:878d4d96d8f2c7a2459024f013f2e4e5f46d708b23437dae970d998e7bff14a0", size = 2814944 },
+    { url = "https://files.pythonhosted.org/packages/72/a6/f62a3bd814ca19ec7e29ac889fd354adea1217df3183e10217de51e2eb8b/blis-1.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f36c0ca84a05ee5d3dbaa38056c4423c1fc29948b17a7923dd2fed8967375d74", size = 11345825 },
+    { url = "https://files.pythonhosted.org/packages/d4/6c/671af79ee42bc4c968cae35c091ac89e8721c795bfa4639100670dc59139/blis-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e5a662c48cd4aad5dae1a950345df23957524f071315837a4c6feb7d3b288990", size = 3008771 },
+    { url = "https://files.pythonhosted.org/packages/be/92/7cd7f8490da7c98ee01557f2105885cc597217b0e7fd2eeb9e22cdd4ef23/blis-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9de26fbd72bac900c273b76d46f0b45b77a28eace2e01f6ac6c2239531a413bb", size = 14219213 },
+    { url = "https://files.pythonhosted.org/packages/0a/de/acae8e9f9a1f4bb393d41c8265898b0f29772e38eac14e9f69d191e2c006/blis-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:9e5fdf4211b1972400f8ff6dafe87cb689c5d84f046b4a76b207c0bd2270faaf", size = 6324695 },
+]
+
+[[package]]
+name = "catalogue"
+version = "2.0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/b4/244d58127e1cdf04cf2dc7d9566f0d24ef01d5ce21811bab088ecc62b5ea/catalogue-2.0.10.tar.gz", hash = "sha256:4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15", size = 19561 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/96/d32b941a501ab566a16358d68b6eb4e4acc373fab3c3c4d7d9e649f7b4bb/catalogue-2.0.10-py3-none-any.whl", hash = "sha256:58c2de0020aa90f4a2da7dfad161bf7b3b054c86a5f09fcedc0b2b740c109a9f", size = 17325 },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -335,12 +383,30 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpathlib"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/18/2ac35d6b3015a0c74e923d94fc69baf8307f7c3233de015d69f99e17afa8/cloudpathlib-0.23.0.tar.gz", hash = "sha256:eb38a34c6b8a048ecfd2b2f60917f7cbad4a105b7c979196450c2f541f4d6b4b", size = 53126 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8a/c4bb04426d608be4a3171efa2e233d2c59a5c8937850c10d098e126df18e/cloudpathlib-0.23.0-py3-none-any.whl", hash = "sha256:8520b3b01468fee77de37ab5d50b1b524ea6b4a8731c35d1b7407ac0cd716002", size = 62755 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "confection"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/65/efd0fe8a936fc8ca2978cb7b82581fb20d901c6039e746a808f746b7647b/confection-1.3.3.tar.gz", hash = "sha256:f0f6810d567ff73993fe74d218ca5e1ffb6a44fb03f391257fc5d033546cbfaa", size = 54895 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/e4/d66708bdf0d92fb4d49b22cdff4b10cec38aca5dcd7e81d909bb55c65cd7/confection-1.3.3-py3-none-any.whl", hash = "sha256:b9fef9ee84b237ef4611ec3eb5797b70e13063e6310ad9f15536373f5e313c82", size = 35902 },
 ]
 
 [[package]]
@@ -528,6 +594,62 @@ version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/59/911a1a597264f1fb7ac176995a0f0b6062e37f8c1b6e0f23071a76838507/cuda_pathfinder-1.4.3-py3-none-any.whl", hash = "sha256:4345d8ead1f701c4fb8a99be6bc1843a7348b6ba0ef3b031f5a2d66fb128ae4c", size = 47951 },
+]
+
+[[package]]
+name = "cymem"
+version = "2.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/2f0fbb32535c3731b7c2974c569fb9325e0a38ed5565a08e1139a3b71e82/cymem-2.0.13.tar.gz", hash = "sha256:1c91a92ae8c7104275ac26bd4d29b08ccd3e7faff5893d3858cb6fadf1bc1588", size = 12320 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/64/1db41f7576a6b69f70367e3c15e968fd775ba7419e12059c9966ceb826f8/cymem-2.0.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:673183466b0ff2e060d97ec5116711d44200b8f7be524323e080d215ee2d44a5", size = 43587 },
+    { url = "https://files.pythonhosted.org/packages/81/13/57f936fc08551323aab3f92ff6b7f4d4b89d5b4e495c870a67cb8d279757/cymem-2.0.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bee2791b3f6fc034ce41268851462bf662ff87e8947e35fb6dd0115b4644a61f", size = 43139 },
+    { url = "https://files.pythonhosted.org/packages/32/a6/9345754be51e0479aa387b7b6cffc289d0fd3201aaeb8dade4623abd1e02/cymem-2.0.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f3aee3adf16272bca81c5826eed55ba3c938add6d8c9e273f01c6b829ecfde22", size = 245063 },
+    { url = "https://files.pythonhosted.org/packages/d6/01/6bc654101526fa86e82bf6b05d99b2cd47c30a333cfe8622c26c0592beb2/cymem-2.0.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:30c4e75a3a1d809e89106b0b21803eb78e839881aa1f5b9bd27b454bc73afde3", size = 244496 },
+    { url = "https://files.pythonhosted.org/packages/c4/fb/853b7b021e701a1f41687f3704d5f469aeb2a4f898c3fbb8076806885955/cymem-2.0.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ec99efa03cf8ec11c8906aa4d4cc0c47df393bc9095c9dd64b89b9b43e220b04", size = 243287 },
+    { url = "https://files.pythonhosted.org/packages/d4/2b/0e4664cafc581de2896d75000651fd2ce7094d33263f466185c28ffc96e4/cymem-2.0.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c90a6ecba994a15b17a3f45d7ec74d34081df2f73bd1b090e2adc0317e4e01b6", size = 248287 },
+    { url = "https://files.pythonhosted.org/packages/21/0f/f94c6950edbfc2aafb81194fc40b6cacc8e994e9359d3cb4328c5705b9b5/cymem-2.0.13-cp311-cp311-win_amd64.whl", hash = "sha256:ce821e6ba59148ed17c4567113b8683a6a0be9c9ac86f14e969919121efb61a5", size = 40116 },
+    { url = "https://files.pythonhosted.org/packages/00/df/2455eff6ac0381ff165db6883b311f7016e222e3dd62185517f8e8187ed0/cymem-2.0.13-cp311-cp311-win_arm64.whl", hash = "sha256:0dca715e708e545fd1d97693542378a00394b20a37779c1ae2c8bdbb43acef79", size = 36349 },
+    { url = "https://files.pythonhosted.org/packages/c9/52/478a2911ab5028cb710b4900d64aceba6f4f882fcb13fd8d40a456a1b6dc/cymem-2.0.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8afbc5162a0fe14b6463e1c4e45248a1b2fe2cbcecc8a5b9e511117080da0eb", size = 43745 },
+    { url = "https://files.pythonhosted.org/packages/f9/71/f0f8adee945524774b16af326bd314a14a478ed369a728a22834e6785a18/cymem-2.0.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c9251d889348fe79a75e9b3e4d1b5fa651fca8a64500820685d73a3acc21b6a8", size = 42927 },
+    { url = "https://files.pythonhosted.org/packages/62/6d/159780fe162ff715d62b809246e5fc20901cef87ca28b67d255a8d741861/cymem-2.0.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:742fc19764467a49ed22e56a4d2134c262d73a6c635409584ae3bf9afa092c33", size = 258346 },
+    { url = "https://files.pythonhosted.org/packages/eb/12/678d16f7aa1996f947bf17b8cfb917ea9c9674ef5e2bd3690c04123d5680/cymem-2.0.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f190a92fe46197ee64d32560eb121c2809bb843341733227f51538ce77b3410d", size = 260843 },
+    { url = "https://files.pythonhosted.org/packages/31/5d/0dd8c167c08cd85e70d274b7235cfe1e31b3cebc99221178eaf4bbb95c6f/cymem-2.0.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d670329ee8dbbbf241b7c08069fe3f1d3a1a3e2d69c7d05ea008a7010d826298", size = 254607 },
+    { url = "https://files.pythonhosted.org/packages/b7/c9/d6514a412a1160aa65db539836b3d47f9b59f6675f294ec34ae32f867c82/cymem-2.0.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a84ba3178d9128b9ffb52ce81ebab456e9fe959125b51109f5b73ebdfc6b60d6", size = 262421 },
+    { url = "https://files.pythonhosted.org/packages/dd/fe/3ee37d02ca4040f2fb22d34eb415198f955862b5dd47eee01df4c8f5454c/cymem-2.0.13-cp312-cp312-win_amd64.whl", hash = "sha256:2ff1c41fd59b789579fdace78aa587c5fc091991fa59458c382b116fc36e30dc", size = 40176 },
+    { url = "https://files.pythonhosted.org/packages/94/fb/1b681635bfd5f2274d0caa8f934b58435db6c091b97f5593738065ddb786/cymem-2.0.13-cp312-cp312-win_arm64.whl", hash = "sha256:6bbd701338df7bf408648191dff52472a9b334f71bcd31a21a41d83821050f67", size = 35959 },
+    { url = "https://files.pythonhosted.org/packages/ce/0f/95a4d1e3bebfdfa7829252369357cf9a764f67569328cd9221f21e2c952e/cymem-2.0.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:891fd9030293a8b652dc7fb9fdc79a910a6c76fc679cd775e6741b819ffea476", size = 43478 },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/8fc929cc29ae466b7b4efc23ece99cbd3ea34992ccff319089c624d667fd/cymem-2.0.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:89c4889bd16513ce1644ccfe1e7c473ba7ca150f0621e66feac3a571bde09e7e", size = 42695 },
+    { url = "https://files.pythonhosted.org/packages/4a/b3/deeb01354ebaf384438083ffe0310209ef903db3e7ba5a8f584b06d28387/cymem-2.0.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:45dcaba0f48bef9cc3d8b0b92058640244a95a9f12542210b51318da97c2cf28", size = 250573 },
+    { url = "https://files.pythonhosted.org/packages/36/36/bc980b9a14409f3356309c45a8d88d58797d02002a9d794dd6c84e809d3a/cymem-2.0.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e96848faaafccc0abd631f1c5fb194eac0caee4f5a8777fdbb3e349d3a21741c", size = 254572 },
+    { url = "https://files.pythonhosted.org/packages/fd/dd/a12522952624685bd0f8968e26d2ed6d059c967413ce6eb52292f538f1b0/cymem-2.0.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e02d3e2c3bfeb21185d5a4a70790d9df40629a87d8d7617dc22b4e864f665fa3", size = 248060 },
+    { url = "https://files.pythonhosted.org/packages/08/11/5dc933ddfeb2dfea747a0b935cb965b9a7580b324d96fc5f5a1b5ff8df29/cymem-2.0.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fece5229fd5ecdcd7a0738affb8c59890e13073ae5626544e13825f26c019d3c", size = 254601 },
+    { url = "https://files.pythonhosted.org/packages/70/66/d23b06166864fa94e13a98e5922986ce774832936473578febce64448d75/cymem-2.0.13-cp313-cp313-win_amd64.whl", hash = "sha256:38aefeb269597c1a0c2ddf1567dd8605489b661fa0369c6406c1acd433b4c7ba", size = 40103 },
+    { url = "https://files.pythonhosted.org/packages/2f/9e/c7b21271ab88a21760f3afdec84d2bc09ffa9e6c8d774ad9d4f1afab0416/cymem-2.0.13-cp313-cp313-win_arm64.whl", hash = "sha256:717270dcfd8c8096b479c42708b151002ff98e434a7b6f1f916387a6c791e2ad", size = 36016 },
+    { url = "https://files.pythonhosted.org/packages/7f/28/d3b03427edc04ae04910edf1c24b993881c3ba93a9729a42bcbb816a1808/cymem-2.0.13-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7e1a863a7f144ffb345397813701509cfc74fc9ed360a4d92799805b4b865dd1", size = 46429 },
+    { url = "https://files.pythonhosted.org/packages/35/a9/7ed53e481f47ebfb922b0b42e980cec83e98ccb2137dc597ea156642440c/cymem-2.0.13-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c16cb80efc017b054f78998c6b4b013cef509c7b3d802707ce1f85a1d68361bf", size = 46205 },
+    { url = "https://files.pythonhosted.org/packages/61/39/a3d6ad073cf7f0fbbb8bbf09698c3c8fac11be3f791d710239a4e8dd3438/cymem-2.0.13-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0d78a27c88b26c89bd1ece247d1d5939dba05a1dae6305aad8fd8056b17ddb51", size = 296083 },
+    { url = "https://files.pythonhosted.org/packages/36/0c/20697c8bc19f624a595833e566f37d7bcb9167b0ce69de896eba7cfc9c2d/cymem-2.0.13-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6d36710760f817194dacb09d9fc45cb6a5062ed75e85f0ef7ad7aeeb13d80cc3", size = 286159 },
+    { url = "https://files.pythonhosted.org/packages/82/d4/9326e3422d1c2d2b4a8fb859bdcce80138f6ab721ddafa4cba328a505c71/cymem-2.0.13-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c8f30971cadd5dcf73bcfbbc5849b1f1e1f40db8cd846c4aa7d3b5e035c7b583", size = 288186 },
+    { url = "https://files.pythonhosted.org/packages/ed/bc/68da7dd749b72884dc22e898562f335002d70306069d496376e5ff3b6153/cymem-2.0.13-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:9d441d0e45798ec1fd330373bf7ffa6b795f229275f64016b6a193e6e2a51522", size = 290353 },
+    { url = "https://files.pythonhosted.org/packages/50/23/dbf2ad6ecd19b99b3aab6203b1a06608bbd04a09c522d836b854f2f30f73/cymem-2.0.13-cp313-cp313t-win_amd64.whl", hash = "sha256:d1c950eebb9f0f15e3ef3591313482a5a611d16fc12d545e2018cd607f40f472", size = 44764 },
+    { url = "https://files.pythonhosted.org/packages/54/3f/35701c13e1fc7b0895198c8b20068c569a841e0daf8e0b14d1dc0816b28f/cymem-2.0.13-cp313-cp313t-win_arm64.whl", hash = "sha256:042e8611ef862c34a97b13241f5d0da86d58aca3cecc45c533496678e75c5a1f", size = 38964 },
+    { url = "https://files.pythonhosted.org/packages/a7/2e/f0e1596010a9a57fa9ebd124a678c07c5b2092283781ae51e79edcf5cb98/cymem-2.0.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d2a4bf67db76c7b6afc33de44fb1c318207c3224a30da02c70901936b5aafdf1", size = 43812 },
+    { url = "https://files.pythonhosted.org/packages/bc/45/8ccc21df08fcbfa6aa3efeb7efc11a1c81c90e7476e255768bb9c29ba02a/cymem-2.0.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:92a2ce50afa5625fb5ce7c9302cee61e23a57ccac52cd0410b4858e572f8614b", size = 42951 },
+    { url = "https://files.pythonhosted.org/packages/01/8c/fe16531631f051d3d1226fa42e2d76fd2c8d5cfa893ec93baee90c7a9d90/cymem-2.0.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bc116a70cc3a5dc3d1684db5268eff9399a0be8603980005e5b889564f1ea42f", size = 249878 },
+    { url = "https://files.pythonhosted.org/packages/47/4b/39d67b80ffb260457c05fcc545de37d82e9e2dbafc93dd6b64f17e09b933/cymem-2.0.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68489bf0035c4c280614067ab6a82815b01dc9fcd486742a5306fe9f68deb7ef", size = 252571 },
+    { url = "https://files.pythonhosted.org/packages/53/0e/76f6531f74dfdfe7107899cce93ab063bb7ee086ccd3910522b31f623c08/cymem-2.0.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:03cb7bdb55718d5eb6ef0340b1d2430ba1386db30d33e9134d01ba9d6d34d705", size = 248555 },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/eee56757db81f0aefc2615267677ae145aff74228f529838425057003c0d/cymem-2.0.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1710390e7fb2510a8091a1991024d8ae838fd06b02cdfdcd35f006192e3c6b0e", size = 254177 },
+    { url = "https://files.pythonhosted.org/packages/77/e0/a4b58ec9e53c836dce07ef39837a64a599f4a21a134fc7ca57a3a8f9a4b5/cymem-2.0.13-cp314-cp314-win_amd64.whl", hash = "sha256:ac699c8ec72a3a9de8109bd78821ab22f60b14cf2abccd970b5ff310e14158ed", size = 40853 },
+    { url = "https://files.pythonhosted.org/packages/61/81/9931d1f83e5aeba175440af0b28f0c2e6f71274a5a7b688bc3e907669388/cymem-2.0.13-cp314-cp314-win_arm64.whl", hash = "sha256:90c2d0c04bcda12cd5cebe9be93ce3af6742ad8da96e1b1907e3f8e00291def1", size = 36970 },
+    { url = "https://files.pythonhosted.org/packages/b7/ef/af447c2184dec6dec973be14614df8ccb4d16d1c74e0784ab4f02538433c/cymem-2.0.13-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ff036bbc1464993552fd1251b0a83fe102af334b301e3896d7aa05a4999ad042", size = 46804 },
+    { url = "https://files.pythonhosted.org/packages/8c/95/e10f33a8d4fc17f9b933d451038218437f9326c2abb15a3e7f58ce2a06ec/cymem-2.0.13-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fb8291691ba7ff4e6e000224cc97a744a8d9588418535c9454fd8436911df612", size = 46254 },
+    { url = "https://files.pythonhosted.org/packages/e7/7a/5efeb2d2ea6ebad2745301ad33a4fa9a8f9a33b66623ee4d9185683007a6/cymem-2.0.13-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d8d06ea59006b1251ad5794bcc00121e148434826090ead0073c7b7fedebe431", size = 296061 },
+    { url = "https://files.pythonhosted.org/packages/0b/28/2a3f65842cc8443c2c0650cf23d525be06c8761ab212e0a095a88627be1b/cymem-2.0.13-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c0046a619ecc845ccb4528b37b63426a0cbcb4f14d7940add3391f59f13701e6", size = 285784 },
+    { url = "https://files.pythonhosted.org/packages/98/73/dd5f9729398f0108c2e71d942253d0d484d299d08b02e474d7cfc43ed0b0/cymem-2.0.13-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:18ad5b116a82fa3674bc8838bd3792891b428971e2123ae8c0fd3ca472157c5e", size = 288062 },
+    { url = "https://files.pythonhosted.org/packages/5a/01/ffe51729a8f961a437920560659073e47f575d4627445216c1177ecd4a41/cymem-2.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:666ce6146bc61b9318aa70d91ce33f126b6344a25cf0b925621baed0c161e9cc", size = 290465 },
+    { url = "https://files.pythonhosted.org/packages/fd/ac/c9e7d68607f71ef978c81e334ab2898b426944c71950212b1467186f69f9/cymem-2.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:84c1168c563d9d1e04546cb65e3e54fde2bf814f7c7faf11fc06436598e386d1", size = 46665 },
+    { url = "https://files.pythonhosted.org/packages/66/66/150e406a2db5535533aa3c946de58f0371f2e412e23f050c704588023e6e/cymem-2.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:e9027764dc5f1999fb4b4cabee1d0322c59e330c0a6485b436a68275f614277f", size = 39715 },
 ]
 
 [[package]]
@@ -745,6 +867,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505 },
+]
+
+[[package]]
+name = "graspologic-native"
+version = "1.2.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/2d/62b30d89533643ccf4778a18eb023f291b8877b5d85de3342f07b2d363a7/graspologic_native-1.2.5.tar.gz", hash = "sha256:27ea7e01fa44466c0b4cdd678d4561e5d3dc0cb400015683b7ae1386031257a0", size = 2512729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/86/10748f4c474b0c8f6060dd379bb0c4da5d42779244bb13a58656ffb44a03/graspologic_native-1.2.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bf05f2e162ae2a2a8d6e8cfccbe3586d1faa0b808159ff950478348df557c61e", size = 648437 },
+    { url = "https://files.pythonhosted.org/packages/42/cc/b75ea35755340bedda29727e5388390c639ea533f55b9249f5ac3003f656/graspologic_native-1.2.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a7fff06ed49c3875cf351bb09a92ae7cbc169ce92dcc4c3439e28e801f822ae", size = 352044 },
+    { url = "https://files.pythonhosted.org/packages/8e/55/15e6e4f18bf249b529ac4cd1522b03f5c9ef9284a2f7bfaa1fd1f96464fe/graspologic_native-1.2.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53e7e993e7d70fe0d860773fc62812fbb8cb4ef2d11d8661a1f06f8772593915", size = 364644 },
+    { url = "https://files.pythonhosted.org/packages/3b/51/21097af79f3d68626539ab829bdbf6cc42933f020e161972927d916e394c/graspologic_native-1.2.5-cp38-abi3-win_amd64.whl", hash = "sha256:c3ef2172d774083d7e2c8e77daccd218571ddeebeb2c1703cebb1a2cc4c56e07", size = 210438 },
 ]
 
 [[package]]
@@ -1149,6 +1283,7 @@ version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },
+    { name = "graspologic-native" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "kreuzberg" },
@@ -1158,6 +1293,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pillow" },
     { name = "prompt-toolkit" },
+    { name = "spacy" },
     { name = "tiktoken" },
     { name = "tree-sitter-language-pack" },
     { name = "typer" },
@@ -1187,6 +1323,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "filelock" },
+    { name = "graspologic-native", specifier = ">=1.2" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "kreuzberg", specifier = ">=4.6.2" },
@@ -1198,6 +1335,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "sentence-transformers", marker = "extra == 'reranker'" },
+    { name = "spacy", specifier = ">=3.8" },
     { name = "tiktoken" },
     { name = "tree-sitter-language-pack", specifier = ">=1.3.2" },
     { name = "typer" },
@@ -1586,6 +1724,62 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/d6/9c4f366d6f9bb8f8fb5eae3acac471335c39510c42b537fd515213d7d8c3/multipart-1.3.1.tar.gz", hash = "sha256:211d7cfc1a7a43e75c4d24ee0e8e0f4f61d522f1a21575303ae85333dea687bf", size = 38929 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/ed/e1f03200ee1f0bf4a2b9b72709afefbf5319b68df654e0b84b35c65613ee/multipart-1.3.1-py3-none-any.whl", hash = "sha256:a82b59e1befe74d3d30b3d3f70efd5a2eba4d938f845dcff9faace968888ff29", size = 15061 },
+]
+
+[[package]]
+name = "murmurhash"
+version = "1.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/2e/88c147931ea9725d634840d538622e94122bceaf346233349b7b5c62964b/murmurhash-1.0.15.tar.gz", hash = "sha256:58e2b27b7847f9e2a6edf10b47a8c8dd70a4705f45dccb7bf76aeadacf56ba01", size = 13291 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/ca/77d3e69924a8eb4508bb4f0ad34e46adbeedeb93616a71080e61e53dad71/murmurhash-1.0.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f32307fb9347680bb4fe1cbef6362fb39bd994f1b59abd8c09ca174e44199081", size = 27397 },
+    { url = "https://files.pythonhosted.org/packages/e6/53/a936f577d35b245d47b310f29e5e9f09fcac776c8c992f1ab51a9fb0cee2/murmurhash-1.0.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:539d8405885d1d19c005f3a2313b47e8e54b0ee89915eb8dfbb430b194328e6c", size = 27692 },
+    { url = "https://files.pythonhosted.org/packages/4d/64/5f8cfd1fd9cbeb43fcff96672f5bd9e7e1598d1c970f808ecd915490dc20/murmurhash-1.0.15-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4cd739a00f5a4602201b74568ddabae46ec304719d9be752fd8f534a9464b5e", size = 128396 },
+    { url = "https://files.pythonhosted.org/packages/ac/10/d9ce29d559a75db0d8a3f13ea12c7f541ec9de2afca38dc70418b890eedb/murmurhash-1.0.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44d211bcc3ec203c47dac06f48ee871093fcbdffa6652a6cc5ea7180306680a8", size = 128687 },
+    { url = "https://files.pythonhosted.org/packages/48/cd/dc97ab7e68cdfa1537a56e36dbc846c5a66701cc39ecee2d4399fe61996c/murmurhash-1.0.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f9bf47101354fb1dc4b2e313192566f04ba295c28a37e2f71c692759acc1ba3c", size = 128198 },
+    { url = "https://files.pythonhosted.org/packages/53/73/32f2aaa22c1e4afae337106baf0c938abf36a6cc879cfee83a00461bbbf7/murmurhash-1.0.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3c69b4d3bcd6233782a78907fe10b9b7a796bdc5d28060cf097d067bec280a5d", size = 127214 },
+    { url = "https://files.pythonhosted.org/packages/82/ed/812103a7f353eba2d83655b08205e13a38c93b4db0692f94756e1eb44516/murmurhash-1.0.15-cp311-cp311-win_amd64.whl", hash = "sha256:e43a69496342ce530bdd670264cb7c8f45490b296e4764c837ce577e3c7ebd53", size = 25241 },
+    { url = "https://files.pythonhosted.org/packages/eb/5f/2c511bdd28f7c24da37a00116ffd0432b65669d098f0d0260c66ac0ffdc2/murmurhash-1.0.15-cp311-cp311-win_arm64.whl", hash = "sha256:f3e99a6ee36ef5372df5f138e3d9c801420776d3641a34a49e5c2555f44edba7", size = 23216 },
+    { url = "https://files.pythonhosted.org/packages/b6/46/be8522d3456fdccf1b8b049c6d82e7a3c1114c4fc2cfe14b04cba4b3e701/murmurhash-1.0.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d37e3ae44746bca80b1a917c2ea625cf216913564ed43f69d2888e5df97db0cb", size = 27884 },
+    { url = "https://files.pythonhosted.org/packages/ed/cc/630449bf4f6178d7daf948ce46ad00b25d279065fc30abd8d706be3d87e0/murmurhash-1.0.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0861cb11039409eaf46878456b7d985ef17b6b484103a6fc367b2ecec846891d", size = 27855 },
+    { url = "https://files.pythonhosted.org/packages/ff/30/ea8f601a9bf44db99468696efd59eb9cff1157cd55cb586d67116697583f/murmurhash-1.0.15-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5a301decfaccfec70fe55cb01dde2a012c3014a874542eaa7cc73477bb749616", size = 134088 },
+    { url = "https://files.pythonhosted.org/packages/c9/de/c40ce8c0877d406691e735b8d6e9c815f36a82b499d358313db5dbe219d7/murmurhash-1.0.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32c6fde7bd7e9407003370a07b5f4addacabe1556ad3dc2cac246b7a2bba3400", size = 133978 },
+    { url = "https://files.pythonhosted.org/packages/47/84/bd49963ecd84ebab2fe66595e2d1ed41d5e8b5153af5dc930f0bd827007c/murmurhash-1.0.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5d8b43a7011540dc3c7ce66f2134df9732e2bc3bbb4a35f6458bc755e48bde26", size = 132956 },
+    { url = "https://files.pythonhosted.org/packages/4f/7c/2530769c545074417c862583f05f4245644599f1e9ff619b3dfe2969aafc/murmurhash-1.0.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43bf4541892ecd95963fcd307bf1c575fc0fee1682f41c93007adee71ca2bb40", size = 134184 },
+    { url = "https://files.pythonhosted.org/packages/84/a4/b249b042f5afe34d14ada2dc4afc777e883c15863296756179652e081c44/murmurhash-1.0.15-cp312-cp312-win_amd64.whl", hash = "sha256:f4ac15a2089dc42e6eb0966622d42d2521590a12c92480aafecf34c085302cca", size = 25647 },
+    { url = "https://files.pythonhosted.org/packages/13/bf/028179259aebc18fd4ba5cae2601d1d47517427a537ab44336446431a215/murmurhash-1.0.15-cp312-cp312-win_arm64.whl", hash = "sha256:4a70ca4ae19e600d9be3da64d00710e79dde388a4d162f22078d64844d0ebdda", size = 23338 },
+    { url = "https://files.pythonhosted.org/packages/29/2f/ba300b5f04dae0409202d6285668b8a9d3ade43a846abee3ef611cb388d5/murmurhash-1.0.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fe50dc70e52786759358fd1471e309b94dddfffb9320d9dfea233c7684c894ba", size = 27861 },
+    { url = "https://files.pythonhosted.org/packages/34/02/29c19d268e6f4ea1ed2a462c901eed1ed35b454e2cbc57da592fad663ac6/murmurhash-1.0.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1349a7c23f6092e7998ddc5bd28546cc31a595afc61e9fdb3afc423feec3d7ad", size = 27840 },
+    { url = "https://files.pythonhosted.org/packages/e2/63/58e2de2b5232cd294c64092688c422196e74f9fa8b3958bdf02d33df24b9/murmurhash-1.0.15-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ba6d05de2613535b5a9227d4ad8ef40a540465f64660d4a8800634ae10e04f", size = 133080 },
+    { url = "https://files.pythonhosted.org/packages/aa/9a/d13e2e9f8ba1ced06840921a50f7cece0a475453284158a3018b72679761/murmurhash-1.0.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fa1b70b3cc2801ab44179c65827bbd12009c68b34e9d9ce7125b6a0bd35af63c", size = 132648 },
+    { url = "https://files.pythonhosted.org/packages/b2/e1/47994f1813fa205c84977b0ff51ae6709f8539af052c7491a5f863d82bdc/murmurhash-1.0.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:213d710fb6f4ef3bc11abbfad0fa94a75ffb675b7dc158c123471e5de869f9af", size = 131502 },
+    { url = "https://files.pythonhosted.org/packages/b9/ea/90c1fd00b4aeb704fb5e84cd666b33ffd7f245155048071ffbb51d2bb57d/murmurhash-1.0.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b65a5c4e7f5d71f7ccac2d2b60bdf7092d7976270878cfec59d5a66a533db823", size = 132736 },
+    { url = "https://files.pythonhosted.org/packages/00/db/da73462dbfa77f6433b128d2120ba7ba300f8c06dc4f4e022c38d240a5f5/murmurhash-1.0.15-cp313-cp313-win_amd64.whl", hash = "sha256:9aba94c5d841e1904cd110e94ceb7f49cfb60a874bbfb27e0373622998fb7c7c", size = 25682 },
+    { url = "https://files.pythonhosted.org/packages/bb/83/032729ef14971b938fbef41ee125fc8800020ee229bd35178b6ede8ee934/murmurhash-1.0.15-cp313-cp313-win_arm64.whl", hash = "sha256:263807eca40d08c7b702413e45cca75ecb5883aa337237dc5addb660f1483378", size = 23370 },
+    { url = "https://files.pythonhosted.org/packages/10/83/7547d9205e9bd2f8e5dfd0b682cc9277594f98909f228eb359489baec1df/murmurhash-1.0.15-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:694fd42a74b7ce257169d14c24aa616aa6cd4ccf8abe50eca0557e08da99d055", size = 29955 },
+    { url = "https://files.pythonhosted.org/packages/b7/c7/3afd5de7a5b3ae07fe2d3a3271b327ee1489c58ba2b2f2159bd31a25edb9/murmurhash-1.0.15-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a2ea4546ba426390beff3cd10db8f0152fdc9072c4f2583ec7d8aa9f3e4ac070", size = 30108 },
+    { url = "https://files.pythonhosted.org/packages/02/69/d6637ee67d78ebb2538c00411f28ea5c154886bbe1db16c49435a8a4ab16/murmurhash-1.0.15-cp313-cp313t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:34e5a91139c40b10f98d0b297907f5d5267b4b1b2e5dd2eb74a021824f751b98", size = 164054 },
+    { url = "https://files.pythonhosted.org/packages/ab/4c/89e590165b4c7da6bf941441212a721a270195332d3aacfdfdf527d466ca/murmurhash-1.0.15-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dc35606868a5961cf42e79314ca0bddf5a400ce377b14d83192057928d6252ec", size = 168153 },
+    { url = "https://files.pythonhosted.org/packages/07/7a/95c42df0c21d2e413b9fcd17317a7587351daeb264dc29c6aec1fdbd26f8/murmurhash-1.0.15-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:43cc6ac3b91ca0f7a5ae9c063ba4d6c26972c97fd7c25280ecc666413e4c5535", size = 164345 },
+    { url = "https://files.pythonhosted.org/packages/d0/22/9d02c880a88b83bb3ce7d6a38fb727373ab78d82e5f3d8d9fc5612219f90/murmurhash-1.0.15-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:847d712136cb462f0e4bd6229ee2d9eb996d8854eb8312dff3d20c8f5181fda5", size = 161990 },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/750232524e0dc262e8dcede6536dafc766faadd9a52f1d23746b02948ad8/murmurhash-1.0.15-cp313-cp313t-win_amd64.whl", hash = "sha256:2680851af6901dbe66cc4aa7ef8e263de47e6e1b425ae324caa571bdf18f8d58", size = 28812 },
+    { url = "https://files.pythonhosted.org/packages/ff/89/4ad9d215ef6ade89f27a72dc4e86b98ef1a43534cc3e6a6900a362a0bf0a/murmurhash-1.0.15-cp313-cp313t-win_arm64.whl", hash = "sha256:189a8de4d657b5da9efd66601b0636330b08262b3a55431f2379097c986995d0", size = 25398 },
+    { url = "https://files.pythonhosted.org/packages/1c/69/726df275edf07688146966e15eaaa23168100b933a2e1a29b37eb56c6db8/murmurhash-1.0.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c4280136b738e85ff76b4bdc4341d0b867ee753e73fd8b6994288080c040d0b", size = 28029 },
+    { url = "https://files.pythonhosted.org/packages/59/8f/24ecf9061bc2b20933df8aba47c73e904274ea8811c8300cab92f6f82372/murmurhash-1.0.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d4d681f474830489e2ec1d912095cfff027fbaf2baa5414c7e9d25b89f0fab68", size = 27912 },
+    { url = "https://files.pythonhosted.org/packages/ba/26/fff3caba25aa3c0622114e03c69fb66c839b22335b04d7cce91a3a126d44/murmurhash-1.0.15-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7e47c5746785db6a43b65fac47b9e63dd71dfbd89a8c92693425b9715e68c6e", size = 131847 },
+    { url = "https://files.pythonhosted.org/packages/df/e4/0f2b9fc533467a27afb4e906c33f32d5f637477de87dd94690e0c44335a6/murmurhash-1.0.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e8e674f02a99828c8a671ba99cd03299381b2f0744e6f25c29cadfc6151dc724", size = 132267 },
+    { url = "https://files.pythonhosted.org/packages/da/bf/9d1c107989728ec46e25773d503aa54070b32822a18cfa7f9d5f41bc17a5/murmurhash-1.0.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:26fd7c7855ac4850ad8737991d7b0e3e501df93ebaf0cf45aa5954303085fdba", size = 131894 },
+    { url = "https://files.pythonhosted.org/packages/0d/81/dcf27c71445c0e993b10e33169a098ca60ee702c5c58fcbde205fa6332a6/murmurhash-1.0.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb8ebafae60d5f892acff533cc599a359954d8c016a829514cb3f6e9ee10f322", size = 132054 },
+    { url = "https://files.pythonhosted.org/packages/bc/32/e874a14b2d2246bd2d16f80f49fad393a3865d4ee7d66d2cae939a67a29a/murmurhash-1.0.15-cp314-cp314-win_amd64.whl", hash = "sha256:898a629bf111f1aeba4437e533b5b836c0a9d2dd12d6880a9c75f6ca13e30e22", size = 26579 },
+    { url = "https://files.pythonhosted.org/packages/af/8e/4fca051ed8ae4d23a15aaf0a82b18cb368e8cf84f1e3b474d5749ec46069/murmurhash-1.0.15-cp314-cp314-win_arm64.whl", hash = "sha256:88dc1dd53b7b37c0df1b8b6bce190c12763014492f0269ff7620dc6027f470f4", size = 24341 },
+    { url = "https://files.pythonhosted.org/packages/38/9c/c72c2a4edd86aac829337ab9f83cf04cdb15e5d503e4c9a3a243f30a261c/murmurhash-1.0.15-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6cb4e962ec4f928b30c271b2d84e6707eff6d942552765b663743cfa618b294b", size = 30146 },
+    { url = "https://files.pythonhosted.org/packages/ac/d7/72b47ebc86436cd0aa1fd4c6e8779521ec389397ac11389990278d0f7a47/murmurhash-1.0.15-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5678a3ea4fbf0cbaaca2bed9b445f556f294d5f799c67185d05ffcb221a77faf", size = 30141 },
+    { url = "https://files.pythonhosted.org/packages/64/bb/6d2f09135079c34dc2d26e961c52742d558b320c61503f273eab6ba743d9/murmurhash-1.0.15-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ef19f38c6b858eef83caf710773db98c8f7eb2193b4c324650c74f3d8ba299e0", size = 163898 },
+    { url = "https://files.pythonhosted.org/packages/b9/e2/9c1b462e33f9cb2d632056f07c90b502fc20bd7da50a15d0557343bd2fed/murmurhash-1.0.15-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22aa3ceaedd2e57078b491ed08852d512b84ff4ff9bb2ff3f9bf0eec7f214c9e", size = 168040 },
+    { url = "https://files.pythonhosted.org/packages/e8/73/8694db1408fcdfa73589f7df6c445437ea146986fa1e393ec60d26d6e30c/murmurhash-1.0.15-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bba0e0262c0d08682b028cb963ac477bd9839029486fa1333fc5c01fb6072749", size = 164239 },
+    { url = "https://files.pythonhosted.org/packages/2d/f9/8e360bdfc3c44e267e7e046f0e0b9922766da92da26959a6963f597e6bb5/murmurhash-1.0.15-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4fd8189ee293a09f30f4931408f40c28ccd42d9de4f66595f8814879339378bc", size = 161811 },
+    { url = "https://files.pythonhosted.org/packages/f9/31/97649680595b1096803d877ababb9a67c07f4378f177ec885eea28b9db6d/murmurhash-1.0.15-cp314-cp314t-win_amd64.whl", hash = "sha256:66395b1388f7daa5103db92debe06842ae3be4c0749ef6db68b444518666cdcc", size = 29817 },
+    { url = "https://files.pythonhosted.org/packages/76/66/4fce8755f25d77324401886c00017c556be7ca3039575b94037aff905385/murmurhash-1.0.15-cp314-cp314t-win_arm64.whl", hash = "sha256:c22e56c6a0b70598a66e456de5272f76088bc623688da84ef403148a6d41851d", size = 26219 },
 ]
 
 [[package]]
@@ -2023,6 +2217,58 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/68/7717bd9e63ed254617a7d3dc9260904fb736d6ea203e58ffddcb186c64e4/polyfactory-3.3.0.tar.gz", hash = "sha256:237258b6ff43edf362ffd1f68086bb796466f786adfa002b0ac256dbf2246e9a", size = 348668 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/34/b6f19941adcdaf415b5e8a8d577499f5b6a76b59cbae37f9b125a9ffe9f2/polyfactory-3.3.0-py3-none-any.whl", hash = "sha256:686abcaa761930d3df87b91e95b26b8d8cb9fdbbbe0b03d5f918acff5c72606e", size = 62707 },
+]
+
+[[package]]
+name = "preshed"
+version = "3.0.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cymem" },
+    { name = "murmurhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/75/fe6b7bbd0dea530a001b0e24c331b21a0be2786e402abf3c57f5dce43d4b/preshed-3.0.13.tar.gz", hash = "sha256:d75f718bbfd97e992f7827e0fa7faf6a91bdd9c922d5baa4b50d62731396cb89", size = 18338 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/d1/7bc39738388b38ff48cecbb326a9b2bb3f422bb32097be92e010f3162395/preshed-3.0.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5268c0e6fa96f50cdf87f516c2d4b32563c12706ee768e75c00e8d0098acd545", size = 136718 },
+    { url = "https://files.pythonhosted.org/packages/f6/65/de465b6801740140c2b5d2db6c312ca7937dcfd0442f1ae7d50dee529544/preshed-3.0.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:df642547a1a94079978a0ea8f4593ab4b8d3bd43f767bef0ef64d9a214f8c4c9", size = 137261 },
+    { url = "https://files.pythonhosted.org/packages/89/83/478ee078746a4a413c841542caebd2ea74b659475b8bf5f2e3724b6fe655/preshed-3.0.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09397592d333a77f88454e72b7f1f941b2afaf040b392b9e74898dbc4648cdf5", size = 821010 },
+    { url = "https://files.pythonhosted.org/packages/ee/2e/1ac761e973966893cd3a0ad3256360365276e2d1e779e351448981a1156a/preshed-3.0.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8e6fe0620ed0f96a246d46447055c447e071cd8222731a045c235e8a758c918", size = 823096 },
+    { url = "https://files.pythonhosted.org/packages/3c/51/7824cfd85dd7fe547888de20228ebd87d9acd3708206d30b82211e382d23/preshed-3.0.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:502f93f49a22788203f02d3067d4ea077a0cca3864de6a792eae12e7ce589e14", size = 1812148 },
+    { url = "https://files.pythonhosted.org/packages/34/48/32160a24705d56179de6af838c10a0c735c955dae5f9e4bb344750b79bc2/preshed-3.0.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:acd4d89abeca3678c5d8c89b3cd351314465bc67c7fa053d2644f8513e543386", size = 1881154 },
+    { url = "https://files.pythonhosted.org/packages/ed/22/0344b50f8b1ad9e3aac08099c47e1aba91c81602fd117d2673f6606ecae6/preshed-3.0.13-cp311-cp311-win_amd64.whl", hash = "sha256:de87fbabb0f37c3c92d4dd9b94fc82ab73cdab4247cdfbd57ab3926caa983919", size = 122219 },
+    { url = "https://files.pythonhosted.org/packages/33/c4/812eeaa568510f396e27edab01100ca71418f032fd7098b107f12e572361/preshed-3.0.13-cp311-cp311-win_arm64.whl", hash = "sha256:5e2753779832e411e93eb727f3d409c0a6b7408e5ce4dd868076d8ece48c7693", size = 109308 },
+    { url = "https://files.pythonhosted.org/packages/39/fb/ccff23c44c04088c248539005fcda78b9014512a34d170c5360f02ad908b/preshed-3.0.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5d14eea14bd01291388928991d7df7d60b9fd19ae970e55006eb4d29b0c1e8eb", size = 138497 },
+    { url = "https://files.pythonhosted.org/packages/8e/ce/cad5a8145881a771e6c0d002f2e585fc19b962f120860b54d32af5baa342/preshed-3.0.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f05b08ce92399c0655b5e0eb5a1cc1f9e295703ed3aabdfaf6538dfa8ae23d57", size = 138010 },
+    { url = "https://files.pythonhosted.org/packages/a7/a2/c5fed4fb3e946699259d11e4036a3cfdd8c89b3e542e3077d46781642425/preshed-3.0.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:62cf7f3113132891d6bba70ff547ad81c6fe50a31930bbbb8499f1d47cd122b7", size = 861498 },
+    { url = "https://files.pythonhosted.org/packages/51/94/8c9bc48a6ea4903f53a1a0031ce8e35687526949f25821762ef21493c007/preshed-3.0.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b8de3f58043070a354477995acdd98626ce43e4193c708ebd0f694e467f5155", size = 868988 },
+    { url = "https://files.pythonhosted.org/packages/b6/df/ecd2f40055ff52527ca117ffbfafb888c1a3079b59fbabe03c5b8f9b7240/preshed-3.0.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:183b339956a9e1d7a4a00038a3b9587a734db9e8bd915939a49791bd1b372156", size = 1847382 },
+    { url = "https://files.pythonhosted.org/packages/e6/88/bdb244e40284ded3632a9f88c23bc80230bd7b2ae4a8b7f2cc91adead7a8/preshed-3.0.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2e77bed56aded7cbe5d28d6bd2178bc5b13eda0e0e464dab205fb578fa915000", size = 1919236 },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/c91ea56342e6c364fc69b444a1ac5432327857199c44032c9cc9dc4c3a23/preshed-3.0.13-cp312-cp312-win_amd64.whl", hash = "sha256:04d8f13f2986e5d11af5ac51f55ce3106c70c41b483d20ea392e6180bdd0f870", size = 122938 },
+    { url = "https://files.pythonhosted.org/packages/b2/0b/6a99d99619fd83b14c696e2489caed7070647488d4d3ac0b723d35db2de0/preshed-3.0.13-cp312-cp312-win_arm64.whl", hash = "sha256:19318dc1cd8cac6663c6c830bf7e0002d2de853769fb03e056774e97c21bedfd", size = 109194 },
+    { url = "https://files.pythonhosted.org/packages/0e/2a/401158195d6dc7f6aef0b354d74d0e95c9da124499448c2b3dbb95b71204/preshed-3.0.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0d0c14187dc0078d8a63bf190ec045a4d13e7748b6caeb557a7d575e411410b", size = 137289 },
+    { url = "https://files.pythonhosted.org/packages/88/8f/e20e64573988528785447a6893b2e7ab287ecfd85b3888e978b28812fd20/preshed-3.0.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7770987c2e57497cd26124a9be5f652b5b3ccd0def89859ab0da8bca6144a3de", size = 136847 },
+    { url = "https://files.pythonhosted.org/packages/b9/72/18168f881359c4482d312f8dc196371bdd61c1583a52b34390da4c88bbea/preshed-3.0.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4a7bc48220de579be6bdb0a8715482cf36e2a625a6fd5ad26c9f43485a4a23b5", size = 831478 },
+    { url = "https://files.pythonhosted.org/packages/fd/3a/3543476091087102775568cea9885dde3453569e9aeee365809108de572f/preshed-3.0.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5c8462472f790c16708306aef3a102a762bd19dfe3d2f8ee08bd5e12f51b835", size = 839913 },
+    { url = "https://files.pythonhosted.org/packages/cf/65/b13f01329decc44ef53cfb6b4601ba85382dcb2a4ec78d9250f03a418066/preshed-3.0.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c046736239cc8d72670749b79b526e4111839a2fc461a58545d212797649129c", size = 1816452 },
+    { url = "https://files.pythonhosted.org/packages/d1/c7/f1a996c6832234efd4d543041b582418d41ac480ee55c557ec9e65344637/preshed-3.0.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7c333f18e9a81c8a6de0603fd8781e17115324b117c445ca91abdf7bfb1abe49", size = 1888978 },
+    { url = "https://files.pythonhosted.org/packages/e3/b9/96fb71499049885ce19545903fdd38877bbc2be0da47e37c04d01f3e9f66/preshed-3.0.13-cp313-cp313-win_amd64.whl", hash = "sha256:461327f8dd36520dcf1fd55a671e0c3c2c97a2d95e22fc85faa31173f4785dda", size = 122134 },
+    { url = "https://files.pythonhosted.org/packages/ef/a7/32a4903019d936a2316fdd330bedddac287ac26326107d24fb76a1fbc60a/preshed-3.0.13-cp313-cp313-win_arm64.whl", hash = "sha256:35d6c5acb3ee3b12b87a551913063f0cec784055c2af16e028c19fe875f079d0", size = 108497 },
+    { url = "https://files.pythonhosted.org/packages/bb/b5/993886c98f5caaa6f07a648cac97a7c62a3093091cad65e1e43a1bd41cc4/preshed-3.0.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d2f1efae396cadab5f3890a2fd43d2ee65373ef9096ccbb805e51e8d8bcc563b", size = 137882 },
+    { url = "https://files.pythonhosted.org/packages/c6/86/b7fd137cbf140afd6c45e895946068a15f5b55642916de0075e6eb18581c/preshed-3.0.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8d6acc1f5031a535a55a6f7148e2f274554a8343a16309c700cebea0fe7aee8c", size = 138233 },
+    { url = "https://files.pythonhosted.org/packages/8b/ca/21a7e79625614134273dfed32bca5bb4c2ec1313e33fbd12d41657536f1f/preshed-3.0.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7da9d931e7660dcdd757e5870269f0c159126d682ed73ed313971d199eb0f334", size = 834835 },
+    { url = "https://files.pythonhosted.org/packages/8f/3a/2dbd299516461831ae90e0d5b0637137bf28520c4e6dd0b01d6f1886659a/preshed-3.0.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4ae5cfe075bb7a07982e382bca44f41ddf041f4d24cbd358e8cccfc049259b8", size = 834928 },
+    { url = "https://files.pythonhosted.org/packages/7c/d3/af654eba4f6587c4ee02c5043e62c194b0a1c4431ffef0c67b9518f6b61c/preshed-3.0.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7557963d0125a3a7bcdb2eb6948f3e45da31b5a7f066b55320de3dea22d7557f", size = 1820368 },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/ebcb2b9e8cb881e40b55b0bf450f8a6b187e2ef3ae0c685cce81d2d85026/preshed-3.0.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c4bc60dc994864095d784b7e4d77dba3e64188d169ac88722b699d175561fddb", size = 1888251 },
+    { url = "https://files.pythonhosted.org/packages/97/f7/c6c012779edcaa6e2cd092c554e98dc53e77f41205b07208655ba77e2327/preshed-3.0.13-cp314-cp314-win_amd64.whl", hash = "sha256:208dcebbe294bf1881ce33fb015d56ab2a7587aece85a09147727174207892e4", size = 125211 },
+    { url = "https://files.pythonhosted.org/packages/f8/82/390ef87d732ef64e673ef6bf9e5d898453986e979efa50fb3a400e2c0766/preshed-3.0.13-cp314-cp314-win_arm64.whl", hash = "sha256:cf8e1a7a1823b2a7765121446c630140ac6e8650c07a6efbf375e168d1fef4f7", size = 111942 },
+    { url = "https://files.pythonhosted.org/packages/80/3a/a9dde3167bcecb27ae82ce4567b5ab1aa3989113ae6814c092ce223cc4ef/preshed-3.0.13-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9ca43ecbc3783eda4d6ab3416ae2ecd9ef23dca5f53995843f69f7457bcd0677", size = 144997 },
+    { url = "https://files.pythonhosted.org/packages/74/d4/22d9355b50b6a13b407dcad0a81df83fb1d5602092d1f05834674dde8fda/preshed-3.0.13-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c8596e41a258ff213553a441e0bb3eb388fd8158e84a7bf3aae6d8ede2c166d3", size = 147294 },
+    { url = "https://files.pythonhosted.org/packages/70/42/a225ee83fdb306d2a503f21a627953b820f4e079c90c8a84338957cb8ff5/preshed-3.0.13-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f8856ca3d88e9b250630d70abb4f260d8933151ddfb413024784b25b009868e", size = 952110 },
+    { url = "https://files.pythonhosted.org/packages/40/ba/09a9dfe3d22d7e745483fd5d7f2a82cd4d39c161f7d2daa0faa4bd6402be/preshed-3.0.13-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e5b2865aecbd2e1e10e5d19bb8bfad765863c1307c6c3e51f2a08bd64122409", size = 932217 },
+    { url = "https://files.pythonhosted.org/packages/6c/5c/e10e2e05133e7fcbd7c40536af1148c82dd24357b8f5726e2c7bc51cfd53/preshed-3.0.13-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:09f96b477c987755b3c945df214ea1c1c80bfb350e9f34e78da89585535b77e8", size = 1896542 },
+    { url = "https://files.pythonhosted.org/packages/37/aa/51e5b4109a4cdfae28c3613eeeb10764a3794ebef8de93ffbb109465bea3/preshed-3.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:670db59a52e1823b5f088c764df474e65b686592d4093adbeef14581c95ee2cb", size = 1959473 },
+    { url = "https://files.pythonhosted.org/packages/0e/6a/1d966f367a14c703dde629d150d996c1b727d442f620300b21c9ec1a24d1/preshed-3.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:b03e21b0bf95eb56e23973f32cabb930e94f352228652f81c0955dbd6967d904", size = 146229 },
+    { url = "https://files.pythonhosted.org/packages/22/80/368139067603e590a000122355f9c8576c8ebed4fb0b8849feaa2698489d/preshed-3.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:b980f3ea9bb74b7f94464bc3d6eb3c9162b6b79b531febd14c6465c24344d2cc", size = 119339 },
 ]
 
 [[package]]
@@ -2996,12 +3242,154 @@ wheels = [
 ]
 
 [[package]]
+name = "smart-open"
+version = "7.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/be/a66598b305763861a9ab15ff0f2fbc44e47b1ce7a776797337a4eef37c66/smart_open-7.5.1.tar.gz", hash = "sha256:3f08e16827c4733699e6b2cc40328a3568f900cb12ad9a3ad233ba6c872d9fe7", size = 54034 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/ea/dcdecd68acebb49d3fd560473a43499b1635076f7f1ae8641c060fe7ce74/smart_open-7.5.1-py3-none-any.whl", hash = "sha256:3e07cbbd9c8a908bcb8e25d48becf1a5cbb4886fa975e9f34c672ed171df2318", size = 64108 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "spacy"
+version = "3.8.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "jinja2" },
+    { name = "murmurhash" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "spacy-legacy" },
+    { name = "spacy-loggers" },
+    { name = "srsly" },
+    { name = "thinc" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "wasabi" },
+    { name = "weasel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/d7/1924f32272f50d2f13275f16d6f869fcec47b2b676b64f91fa206bd30ef4/spacy-3.8.13.tar.gz", hash = "sha256:eb7c03c2bb16593c34d4c91974118f0931c6e6969dbfe895b1a026c6714176cf", size = 1328016 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/a8/21f5b9c3998c7a9cdd28715248e489ebd9300b1d349d5220166b951c3df4/spacy-3.8.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3fb3ec2a78a72bb87ca1cc22ad9fea2d37a3d88ec68ee6b4a02c967f35c8b0cb", size = 6617511 },
+    { url = "https://files.pythonhosted.org/packages/0c/24/0da6c637b3d25a37db605f836e53226cae65f035e865d2909ddf66b89185/spacy-3.8.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1c7d719ff171aad00a9aac31e7c7f6e1871be08b0be50c362885c632826d41ce", size = 6441498 },
+    { url = "https://files.pythonhosted.org/packages/17/64/1eeb854dc194dde91582eedf523d38c8caa209fce45c79b175e3e7a00b9f/spacy-3.8.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:95c2bf7d0afbf699df89cca5431527dff4950a823fd093680618057aa2affff8", size = 32050555 },
+    { url = "https://files.pythonhosted.org/packages/05/5b/7de5aae98f0a4547b9e44fd41e3f5820c199d67c78148782a08df83d19a8/spacy-3.8.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b118c9ca4250cba8a39c7fc73641820086d476dafb54b5d1f306a3f60098d3cd", size = 32296475 },
+    { url = "https://files.pythonhosted.org/packages/96/33/624d0025097b6b26a2c6d1b3dd7e24dec5da495e8c2a0f379bcc3ec26d15/spacy-3.8.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:53a6ff574a4505339375e31ba3280ff7235e82e120377614210750fa66cb63df", size = 32288426 },
+    { url = "https://files.pythonhosted.org/packages/c2/be/93eec7f8266a6d96fb5229d4588d64bb6dfa037604b5121a703cad35debb/spacy-3.8.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cf07faad25a301efbd90da1343c1f62e35185d064c5e087bd0d11a5a6b3358fe", size = 33113494 },
+    { url = "https://files.pythonhosted.org/packages/26/3d/0bd7d780642635e662b32fcd530ed5bed1844dbf977bc5eed43efefa034c/spacy-3.8.13-cp311-cp311-win_amd64.whl", hash = "sha256:740cafd3cb2331c48057f6689ed6be5652d35db92aa2980f32f3d78a9aba6300", size = 15359637 },
+    { url = "https://files.pythonhosted.org/packages/be/78/11896d5b5987cd37ae498ef1ce795e0dd551f984fffa9cf6a7887655617e/spacy-3.8.13-cp311-cp311-win_arm64.whl", hash = "sha256:189bdd05cfd66fd3d1f79449d38ba4e2d0270743f762db1304617ccad9dd321c", size = 14717010 },
+    { url = "https://files.pythonhosted.org/packages/d8/e1/e8f6dc7fc00582b8dcbf40fac5bce6c0ff366cf6db212decdacfaf13e584/spacy-3.8.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:dd8ab0deefe9d2c7dccce1be1e65660a32cfc3cc114d0aa222ff52ae11be58ba", size = 6218311 },
+    { url = "https://files.pythonhosted.org/packages/31/fe/517de9e25a6ec469738c9e886c15cd96649b338c6ae475b9b3e4c4f5e03d/spacy-3.8.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eab059bc668336d0034f3f69aed6b661b626c174e97cc1b52296d0d923c24405", size = 6033843 },
+    { url = "https://files.pythonhosted.org/packages/2c/a8/9a33c69f772f5c32a57c9ef7e692293b558e7bad202264d5586ab087fd29/spacy-3.8.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:96a8e141fd7ff749fa6693c9c72187f802d334bcadf48b6b9d6ca9bff315ca73", size = 32725183 },
+    { url = "https://files.pythonhosted.org/packages/ba/cf/dcc0ea61270cb23a46d3efc437fe760e7a9c3cabcfaa770591329d1430f2/spacy-3.8.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:32c16f5be8c8006197554da3647d83311fb89bb31bb417d38f0d1da585877b0d", size = 33205816 },
+    { url = "https://files.pythonhosted.org/packages/90/6b/ce94ba2a166add3376aa2c976cb1a34d6387e9dc61103cfbe9192675d0b6/spacy-3.8.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7402154eae9d2c34d097f3f7f2bf3ed4ce6ef9d44e3035af15ccc7f357d122cb", size = 32090348 },
+    { url = "https://files.pythonhosted.org/packages/4d/20/df5076a162bda36b04cdfa9cd544ac2be4b47aed957b3922e4c8f75dc25a/spacy-3.8.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:879f467578569db73b5811aa0f0b9a3b3fb81a125c2f7a433dd5626bcaca53f6", size = 32991911 },
+    { url = "https://files.pythonhosted.org/packages/41/17/316dfdf5f8d1dd33a205e4f5e7190b67db73802180f7d08c8b306eb44375/spacy-3.8.13-cp312-cp312-win_amd64.whl", hash = "sha256:a0c849b5c9cee5a930a5e8a63d0b07e095d4e3d371af6a70c496efa1d0851257", size = 14226861 },
+    { url = "https://files.pythonhosted.org/packages/be/a8/a794d5bbf7bc2df6770df2b14cd6811420d0e10fe81830920bf0e891c19a/spacy-3.8.13-cp312-cp312-win_arm64.whl", hash = "sha256:5d7f660f64c7d09778600b27b881a367075fe792cb5cc6932737aeda71a9aa09", size = 13628855 },
+    { url = "https://files.pythonhosted.org/packages/a7/2d/dc15440fa58c12bab25cbd368bbf3b754eb11d1d3cc37f3aee47caa63695/spacy-3.8.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6db8903cf3fd8b40db9dab669c1e823a8884100f223dc8ec63c3744ff505d5fd", size = 6202080 },
+    { url = "https://files.pythonhosted.org/packages/1b/27/6d723fa0c3c9872d7b8c3fb1c76edef65c1db2de441ee87d119128cb82f7/spacy-3.8.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c26258bfed2f3bf5563c5994ee752ea8662bbac70924d28fbea4d1c10df48fd0", size = 6015435 },
+    { url = "https://files.pythonhosted.org/packages/c0/36/d13f36204290e7753ce849106fb732a1a1ff6c1af0a200f2c2f493a56e60/spacy-3.8.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a5f02eab8e6e8e9e790b1e8da05b70b3b1d4b1fb10dc4f44203da96939fdb977", size = 32510675 },
+    { url = "https://files.pythonhosted.org/packages/19/37/f2a0c986bc2d59b18547d5ffaabf57fd9d88e129ad7df5ebc9ccdc91e643/spacy-3.8.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17b14f28d83fe85390f420f89760ae36d515f3e0a236f8266c46335549806e3a", size = 32841103 },
+    { url = "https://files.pythonhosted.org/packages/37/31/b4a86cc013e4ac3c3c290ecade748c4623709a78db8a368ee0e152931c0b/spacy-3.8.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:10fffb387e6afeba582e01efd9b5e0c5431ac323af134f4a71a749255182f4c8", size = 31763223 },
+    { url = "https://files.pythonhosted.org/packages/4f/fa/b3a406bdc2636aaa315b8539b88f262e78ca391afc4083e3e9806953b24a/spacy-3.8.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:500f6eb9e4711e75fc07d517962dbfb553ba144ccf1b1e8ffc71b014c9ad91b2", size = 32717863 },
+    { url = "https://files.pythonhosted.org/packages/d9/97/11ed2a980e7225b0a1a4041cb1cba44f40bd83682a08e450dd6171f054e4/spacy-3.8.13-cp313-cp313-win_amd64.whl", hash = "sha256:1e679a8c5dd86c564a1185d894b1b8e50b52fa81bee518120fc2f86349d1879c", size = 14220413 },
+    { url = "https://files.pythonhosted.org/packages/ca/e2/06633e779486f62b3ec7ddeeb4accc10fb9a356b59f5bed3771dfb89931b/spacy-3.8.13-cp313-cp313-win_arm64.whl", hash = "sha256:c086bff909d73be892b4eb6883070dd3e328592b8933f0059a6569c8c7904928", size = 13619060 },
+    { url = "https://files.pythonhosted.org/packages/f2/02/bf2943f61a8bd21cca90e4fe19c4da8752c386f02a76e326b33199e09953/spacy-3.8.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:edcdd4f99e2711fc90c6ba3e8e07f7dc9753d111377ba7b7b5eb0d7259b0d211", size = 6209920 },
+    { url = "https://files.pythonhosted.org/packages/e7/87/fa5e4eb2ccb660d5042eb9144134dc6238c132ec812131bb0aca296bcdd9/spacy-3.8.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b8fd0188f78e032ac58f70a00748d591e244f3d4718e0ead2d9418b4148c744d", size = 6040696 },
+    { url = "https://files.pythonhosted.org/packages/ed/f3/9132878e0c18d627adffc1d23129a3706385d4f0fbe2ea5839523519452c/spacy-3.8.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0dc2d058cb919102bf0634b1b41aff64b867d9bab36bd35979ab658b5b2e4c27", size = 32431416 },
+    { url = "https://files.pythonhosted.org/packages/80/73/396c5c3aaef5004d04abbda4ec736ce4d33944aff6722e974cebdd4023fd/spacy-3.8.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ef884df658d3b60d91cbc1e9b62a6d932589d2fa3f322c3f739b6ffdf3303e0c", size = 32483676 },
+    { url = "https://files.pythonhosted.org/packages/71/01/15ceb2097a817c2912297eac29f801bd71d895e93d7557110937c88f7c77/spacy-3.8.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:86f58d686d1ba6f0dc818005ee6ad87ade8dde7224012f1870a0d31abccd349e", size = 31732468 },
+    { url = "https://files.pythonhosted.org/packages/03/c4/b4c39083df6209414faec7d7471994316dc6fca68c4d2f1f8f099f25c2e3/spacy-3.8.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbcb411b9749a1cd5e4325953212b3984d8c0f60b4976943e77fb0c7d5027383", size = 32473870 },
+    { url = "https://files.pythonhosted.org/packages/f2/5c/9b0fa420b01809c0170b3cf0bf509ec06b4da96214995360815615b8e8fa/spacy-3.8.13-cp314-cp314-win_amd64.whl", hash = "sha256:bf9b6879d70201acb73fc5f07d550ff488d3b5f15a959e9896717b2635c8e137", size = 14405303 },
+    { url = "https://files.pythonhosted.org/packages/fa/58/0001fd8124b62a2a9984278d793e3abfa1b70e969fc26a8668755178db84/spacy-3.8.13-cp314-cp314-win_arm64.whl", hash = "sha256:b2a402f229fcb5dba5454c346468757bd3a5215809e784b85d739ca84916f05b", size = 13834663 },
+]
+
+[[package]]
+name = "spacy-legacy"
+version = "3.0.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/79/91f9d7cc8db5642acad830dcc4b49ba65a7790152832c4eceb305e46d681/spacy-legacy-3.0.12.tar.gz", hash = "sha256:b37d6e0c9b6e1d7ca1cf5bc7152ab64a4c4671f59c85adaf7a3fcb870357a774", size = 23806 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/55/12e842c70ff8828e34e543a2c7176dac4da006ca6901c9e8b43efab8bc6b/spacy_legacy-3.0.12-py2.py3-none-any.whl", hash = "sha256:476e3bd0d05f8c339ed60f40986c07387c0a71479245d6d0f4298dbd52cda55f", size = 29971 },
+]
+
+[[package]]
+name = "spacy-loggers"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/3d/926db774c9c98acf66cb4ed7faf6c377746f3e00b84b700d0868b95d0712/spacy-loggers-1.0.5.tar.gz", hash = "sha256:d60b0bdbf915a60e516cc2e653baeff946f0cfc461b452d11a4d5458c6fe5f24", size = 20811 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/78/d1a1a026ef3af911159398c939b1509d5c36fe524c7b644f34a5146c4e16/spacy_loggers-1.0.5-py3-none-any.whl", hash = "sha256:196284c9c446cc0cdb944005384270d775fdeaf4f494d8e269466cfa497ef645", size = 22343 },
+]
+
+[[package]]
+name = "srsly"
+version = "2.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "catalogue" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/db/f794f219a6c788b881252d2536a8c4a97d2bdaadc690391e1cb53d123d71/srsly-2.5.3.tar.gz", hash = "sha256:08f98dbecbff3a31466c4ae7c833131f59d3655a0ad8ac749e6e2c149e2b0680", size = 490881 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/36/5d7bb412d52e9cca787f9bfe838b596367189b254e50bf90f234a97184bf/srsly-2.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:785a09216ac31570fb301ddb9f61ee73d1f18f8b9561f712dce0b8ac8628bc88", size = 656760 },
+    { url = "https://files.pythonhosted.org/packages/d6/dc/124f008cd2be3e887e972cbdeb17c5aee0f42093eca02c7cfd63bb5daf19/srsly-2.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0017c7d2a0cd9a4f1bdc00d946b45edcf90bb0e271e8f084c1ce542bf6708c32", size = 657503 },
+    { url = "https://files.pythonhosted.org/packages/35/8a/2c97244ebab125d55f1bfb7bb94e9572b3e819410dffd6a040eca1112350/srsly-2.5.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:66ebae2c70305987341519ec1a720072a3cb3e4b1d52ac0e9e841f4d02658d3d", size = 1139161 },
+    { url = "https://files.pythonhosted.org/packages/fc/ea/ecd396188f7591d80b89665f7af9e3ae02e42683daef57033ad7993ad3f9/srsly-2.5.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4ca4a068f6e14d84113a02fcb875c6b50a6285a12938c0e7a157eb3a63c50a86", size = 1142438 },
+    { url = "https://files.pythonhosted.org/packages/9c/65/143e2e143c53d498ad0956f69d0e09189aa7a6e0ee6017758c285ba1ab2d/srsly-2.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e283fa2a8f7350fb9fb70ecdee28d59d39c92f4c7f1cc90a44d6b86db3b3a8b3", size = 1101783 },
+    { url = "https://files.pythonhosted.org/packages/6b/86/1392a5593de0cd3d08c2d6c071b877c84358a37f63172c4e9cb71706842d/srsly-2.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9ffc97e22730ea97b00f7c303ccc60b1305e786afadb2a4a46578dafa4d29da0", size = 1115876 },
+    { url = "https://files.pythonhosted.org/packages/d4/a5/6193aa4c08e488821538fcbce2282449e228fd2183ed67d118bb5ccd8b54/srsly-2.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:f09b551f6c3e334652831ac68c770ee4284741ce0a3895bf1ccf2a1178d66cdd", size = 651733 },
+    { url = "https://files.pythonhosted.org/packages/66/a8/a73181743b6d237026615ca75c3fb3e4780736f1390550a7350d0c7f1149/srsly-2.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:21cf09e417d3e4f3fbf7dd337fd6d948c97abd01896b9b4cb80e81cd9778a73a", size = 639124 },
+    { url = "https://files.pythonhosted.org/packages/02/cc/e9f7fcec4cc92ad8bad6316c4241638b8cf7380382d4489d94ec6c436452/srsly-2.5.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:71e51c046ccbeefb86524c6b1e17574f579c6ac4dc8ea4a09437d3e8f88342d3", size = 658379 },
+    { url = "https://files.pythonhosted.org/packages/21/e4/fea4512e9785f58509b2cf67d993323848e583161b5fcfdc7dd9d7c1f3df/srsly-2.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f73c0db911552e94fe2016e1759d261d2f47926f68826664cada3723c87006a", size = 658513 },
+    { url = "https://files.pythonhosted.org/packages/20/b1/53591681b6ff2699a4f97b2d5552ba196eaa6a979b0873605f4c04b5f7ee/srsly-2.5.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c1ac27ae5f4bb9163c7d2c45fc8ec173aac3d92e32086d9472b326c5c6e570e", size = 1172265 },
+    { url = "https://files.pythonhosted.org/packages/4e/c9/741e29f534919a944a16da4184924b1d3404c4bf60716ab2b91be771d1e3/srsly-2.5.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:99026bcd9cbd3211cc36517400b04ca0fc5d3e412b14daf84ee6e65f67d9a2d8", size = 1180873 },
+    { url = "https://files.pythonhosted.org/packages/89/57/5554f786eccf78b2750d6ac63be126e1b67badec2cb409dd611cf6f8c52b/srsly-2.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:07d682679e639eb46ff7e6da4a92714f4d5ffe351d088ee66f221e9b1f8865bb", size = 1120437 },
+    { url = "https://files.pythonhosted.org/packages/eb/95/9b4f73b1be3692f86d72ccc131c8e50f26f824d5c8830a59390bcc5b60ef/srsly-2.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8e0542d85d6b55cf2934050d6ffcb1cd76c768dcf9572e7467002cf087bb366d", size = 1137376 },
+    { url = "https://files.pythonhosted.org/packages/5a/de/89ca640ca1953c4612279ce515d0af35658df3c06cdb324329bc91b4a7e1/srsly-2.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:598f1e494c18cacb978299d77125415a586417081959f8ec3f068b32d97f8933", size = 652459 },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/7ab6d49e36d9cc72ee15746cabd116eb6f338be8a06c1882968ee9d6c7d7/srsly-2.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:4b1b721cd3ad1a9b2343519aadc786a4d09d5c0666962d49852eb12d6ec3fe26", size = 638411 },
+    { url = "https://files.pythonhosted.org/packages/9d/5c/12901e3794f4158abc6da750725aad6c2afddb1e4227b300fe7c71f66957/srsly-2.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e67b6bbacbfadea5e100266d2797f2d4cec9883ea4dc84a5537673850036a8d8", size = 656750 },
+    { url = "https://files.pythonhosted.org/packages/04/61/181c26370995f96f56f1b64b801e3ca1e0d703fc36506ae28606d62369fb/srsly-2.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:348c231b4477d8fe86603131d0f166d2feac9c372704dfc4398be71cc5b6fb07", size = 656746 },
+    { url = "https://files.pythonhosted.org/packages/77/c6/35876c78889f8ffe11ed3521644e666c3aef20ea31527b70f47456cf35c2/srsly-2.5.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b0938c2978c91ae1ef9c1f2ba35abb86330e198fb23469e356eba311e02233ee", size = 1155762 },
+    { url = "https://files.pythonhosted.org/packages/3e/da/40b71ca9906c8eb8f8feb6ac11d33dad458c85a56e1de764b96d402168a0/srsly-2.5.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f6a837954429ecbe6dcdd27390d2fb4c7d01a3f99c9ffcf9ce66b2a6dd1b738", size = 1161092 },
+    { url = "https://files.pythonhosted.org/packages/dc/14/c0dd30cc8b93ce8137ff4766f743c882440ce49195fffc5d50eaeef311a6/srsly-2.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3576c125c486ce2958c2047e8858fe3cfc9ea877adfa05203b0986f9badee355", size = 1109984 },
+    { url = "https://files.pythonhosted.org/packages/08/f3/34354f183d8faafc631585571224b54d1b4b67e796972c36519c074ca355/srsly-2.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5fb59c42922e095d1ea36085c55bc16e2adb06a7bfe57b24d381e0194ae699f2", size = 1128409 },
+    { url = "https://files.pythonhosted.org/packages/a4/d9/5531f8a19492060b4e76e4ab06aca6f096fb5128fe18cc813d1772daf653/srsly-2.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:111805927f05f5db440aeeacb85ce43da0b19ce7b2a09567a9ef8d30f3cc4d83", size = 650820 },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/62fb7a971eca29e12f03fb9ddacb058548c14d33e5b5675ff0f85839cc7b/srsly-2.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:0f106b0a700ab56e4a7c431b0f1444009ab6cb332edc7bbf6811c2a43f4722cb", size = 637278 },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/e4ef43c2a381711230af98d4c94a5323df48d6a7899ee652e05bf889290e/srsly-2.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:39c13d552a9f9674a12cdcdc66b0c2f02f3430d0cd04c5f9cf598824c2bd3d65", size = 661294 },
+    { url = "https://files.pythonhosted.org/packages/92/2d/ebce7f3717e52cd0a01f4ec570f388f3b7098526794fcf1ad734e0b8f852/srsly-2.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:14c930767cc169611a2dc14e23bc7638cfb616d6f79029700ade033607343540", size = 660952 },
+    { url = "https://files.pythonhosted.org/packages/22/47/a8f3e9b214be2624c8e8a78d38ca7b1d4e26b92d57018412e4bfc4abe89a/srsly-2.5.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2f2d464f0d0237e32fb53f0ec6f05418652c550e772b50e9918e83a1577cba4d", size = 1154554 },
+    { url = "https://files.pythonhosted.org/packages/d6/71/2a89dc3180a51e633a87a079ca064225f4aaf46c7b2a5fc720e28f261d98/srsly-2.5.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d18933248a5bb0ad56a1bae6003a9a7f37daac2ecb0c5bcbfaaf081b317e1c84", size = 1155746 },
+    { url = "https://files.pythonhosted.org/packages/b8/36/72e5ce3153927ca404b6f5bf5280e6ff3399c11557df472b153945468e0a/srsly-2.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7ea5412ea229e571ac9738cbe14f845cc06c8e4e956afb5f42061ccd087ef31f", size = 1112374 },
+    { url = "https://files.pythonhosted.org/packages/04/b2/0895de109c28eca0d41a811ab7c076d4e4a505e8466f06bae22f5180a1dd/srsly-2.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8d3988970b4cf7d03bdd5b5169302ff84562dd2e1e0f84aeb34df3e5b5dc19bf", size = 1127732 },
+    { url = "https://files.pythonhosted.org/packages/c7/79/a37fa7759797fbdfe0a2e029ab13e78b1e81e191220d2bb8ff57d869aefb/srsly-2.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:6a02d7dcc16126c8fae1c1c09b2072798a1dc482ab5f9c52b12c7114dac47325", size = 656467 },
+    { url = "https://files.pythonhosted.org/packages/d7/25/0dae019b3b90ad9037f91de4c390555cdaac9460a93ad62b02b03babdff5/srsly-2.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:1c9129c4abe31903ff7996904a51afdd5428060de6c3d12af49a4da5e8df2821", size = 643040 },
+    { url = "https://files.pythonhosted.org/packages/3a/44/72dd5285b2e05435d98b0797f101d91d9b345d491ddc1fdb9bd09e27ccb8/srsly-2.5.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:29d5d01ba4c2e9c01f936e5e6d5babc4a47b38c9cbd6e1ec23f6d5a49df32605", size = 666200 },
+    { url = "https://files.pythonhosted.org/packages/d2/ad/002c71b87fc3f648c9bf0ec47de0c3822bf2c95c8896a589dd03e7fd3977/srsly-2.5.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c8df4039426d99f0148b5743542842ab96b82daded0b342555e15a639927757", size = 667409 },
+    { url = "https://files.pythonhosted.org/packages/2a/35/2cea3d5e80aeecfc4ece9e7e1783e7792cc3bad7ab85ab585882e1db4e38/srsly-2.5.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:06a43d63bde2e8cccadb953d7fff70b18196ca286b65dd2ad16006d65f3f8166", size = 1265941 },
+    { url = "https://files.pythonhosted.org/packages/aa/38/8a4d7e86dd0370a2e5af251b646000197bb5b7e0f9aa360c71bbfb253d0d/srsly-2.5.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:808cfafc047f0dec507a34c8fa8e4cda5722737fd33577df73452f52f7aca644", size = 1250693 },
+    { url = "https://files.pythonhosted.org/packages/99/05/340129de5ea7b237271b12f8a6962cfa7eb0c5a3056794626d348c5ae7c7/srsly-2.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:71d4cbe2b2a1335c76ed0acae2dc862163787d8b01a705e1949796907ed94ccd", size = 1242408 },
+    { url = "https://files.pythonhosted.org/packages/01/cb/d7fee7ab27c6aa2e3f865fb7b50ba18c81a4c763bba12bdf53df246441bc/srsly-2.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:565f69083d33cb329cfc74317da937fb3270c0f40fabc1b4488702d8074b4a3e", size = 1242749 },
+    { url = "https://files.pythonhosted.org/packages/d8/d1/9bad3a0f2fa7b72f4e0cf1d267b00513092d20ef538c47f72823ae4f7656/srsly-2.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:8ac016ffaeac35bc010992b71bf8afdd39d458f201c8138d84cf78778a936e6c", size = 673783 },
+    { url = "https://files.pythonhosted.org/packages/2a/ae/57d1d7af907e20c077e113e0e4976f87b82c0a415403d99284a262229dd0/srsly-2.5.3-cp314-cp314t-win_arm64.whl", hash = "sha256:d822083fe26ec6728bd8c273ac121fc4ab3864a0fdf0cf0ff3efb188fcd209ed", size = 650229 },
 ]
 
 [[package]]
@@ -3040,6 +3428,60 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353 },
+]
+
+[[package]]
+name = "thinc"
+version = "8.3.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blis" },
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "murmurhash" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "setuptools" },
+    { name = "srsly" },
+    { name = "wasabi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/46/76df95f2c327f9a9cef30c1523bf285627897097163584dcf5f77b2ebce2/thinc-8.3.13.tar.gz", hash = "sha256:68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9", size = 194640 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/72/ca06842a007e8c794e8c59462f242cdfd6167d7cc9d0155ad004b194b015/thinc-8.3.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4565102638038a01a2193c7f5d41ccbd6233fbdcb1f1b184322a06add4f51f18", size = 844359 },
+    { url = "https://files.pythonhosted.org/packages/48/44/e6aef092f478d263f72eb3933b55a6f37ba97c6a0ea0a61d13fbf9bf0c19/thinc-8.3.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:859fbd9d9b16af5278da23589b4afbe2ab6b0dd615df4d3229b7c4e67cd3107e", size = 812089 },
+    { url = "https://files.pythonhosted.org/packages/ff/8a/9ce0424d456cd3580cc3a855b23a7ff86b81d5299fceb496a2f56f06c1c0/thinc-8.3.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a518d5c761a0f2341e530e867de133dc3ed814558365b2a68ec53b89c482a43f", size = 4101388 },
+    { url = "https://files.pythonhosted.org/packages/ad/51/ec91c0434bd9a1096ab874bbd6dc110c5089d7fc513137e6af59bd051eec/thinc-8.3.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:81337dfbee37f58f36c0c70f9a819dce1b32cdc13d959181e10de079621f6ac6", size = 4131972 },
+    { url = "https://files.pythonhosted.org/packages/ff/67/e30dea753c90cff5cb9e5feb34948fdb89a6774b84d849585b49e16a730e/thinc-8.3.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fbc0ee16edd260c6a4a9e365ff36d0a682c9e7ca6d7b985682659ef2e3e73826", size = 5101283 },
+    { url = "https://files.pythonhosted.org/packages/00/e9/b7544eddababa16e548b26a96fff29eeb307ce938df5fa4af9371fe8ed5d/thinc-8.3.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0355c37e40d1a9fc2a1b8e9c2e294d8586f6baa97bcac6b9002f2dddb4b82ae9", size = 5264488 },
+    { url = "https://files.pythonhosted.org/packages/4c/a9/49391a40d703efc0f7a451310373261835f71fd3e6e2e8cfc08ee02f78ad/thinc-8.3.13-cp311-cp311-win_amd64.whl", hash = "sha256:0a0fa13dcfe4b319c3a396432c1dbff30d3de37dbbdee559e76600ee2b9486df", size = 1795058 },
+    { url = "https://files.pythonhosted.org/packages/c1/31/fd5348d44beda12a3ee415cbba9ed4fd0b17ce65db1d473c38a29a8d6153/thinc-8.3.13-cp311-cp311-win_arm64.whl", hash = "sha256:cd8a2b714c061969eee65802965167a6ada1fe708d82fe176d98dcb95ebe182a", size = 1721215 },
+    { url = "https://files.pythonhosted.org/packages/3e/af/f7c1ebfe92eb5d27d7f2f3da67a11e2eb57bc30ab1553279af6dc65b65a8/thinc-8.3.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:77a41f66285321d20aaedaea1e87d7cd48dca6d2427bed1867ec7cba7109fc8d", size = 821097 },
+    { url = "https://files.pythonhosted.org/packages/45/8f/69d7338575d98df85d0b54c0f5fc277dba72587fe9ab846ecdd12a998bcb/thinc-8.3.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3710d318b4e5460cf366a6f7b5ddbefb5d39dbd4cfa408222750fdc6c27c4411", size = 791932 },
+    { url = "https://files.pythonhosted.org/packages/4b/a5/21d010c81e81e1589e5ccb4950e521804d13726e541e87f644c51815673b/thinc-8.3.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a08c87143a6d20177652dca1ec0dc815d88216d8fc62594a57e8bc45bf5ed49", size = 3854219 },
+    { url = "https://files.pythonhosted.org/packages/f9/ff/6914bf370bd1d604d89e6dfb46b97d10cd9b00d42ff8c036283e92314a8c/thinc-8.3.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b5ec9ff313819e7d8667794a3559463fa89ff45aaa73e3fd8d6273b1e0d7a7f", size = 3903307 },
+    { url = "https://files.pythonhosted.org/packages/f3/3d/5572b47fa155fb3388c071515b74024fa17a6efd1df9406da378f0aa84ef/thinc-8.3.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5c9a48f2bc1e04f138240ed5f9b815a9141a5de26accd0f08fa0137fcefed258", size = 4836882 },
+    { url = "https://files.pythonhosted.org/packages/f0/f0/a8d77c7bac089697c6df302cc3c936a1ab36a4720deae889e6f1dbcbd0eb/thinc-8.3.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:79a29a44d76bd02f5ac0624268c6e42b3576ae472c791a8ae9c2d813ae789b59", size = 5033398 },
+    { url = "https://files.pythonhosted.org/packages/21/82/5651bb1f904d04220fc7670035ada921bf0638e2cff6444d67c12887a968/thinc-8.3.13-cp312-cp312-win_amd64.whl", hash = "sha256:ed1dc709ac4f2f03b710457889e4e02f05de51bc8456980c241d0b28798bc7cb", size = 1721248 },
+    { url = "https://files.pythonhosted.org/packages/94/8d/683703de021ffbe46833d722b70f49ffbbca8e5bd6876256977555d92d7d/thinc-8.3.13-cp312-cp312-win_arm64.whl", hash = "sha256:c6a049703a6011c8fe26ee41af7e70272145594140d82f79bb23de619c6a6525", size = 1645777 },
+    { url = "https://files.pythonhosted.org/packages/af/b9/7b46942176df459d1804a9e77b0976f7c56f3abf3ec7485d0e5f836a0382/thinc-8.3.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2811dfd8d46d8b5d3b39051b23e64006b2994a5143b1978b436938018792af8", size = 817337 },
+    { url = "https://files.pythonhosted.org/packages/a7/79/53085a72cd8f4fc4e6e313d05ea5aa98e870684f4a0fb318a9875fc0a964/thinc-8.3.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5593e6300cb1ebe0c0e546e9c9fb49e7c2627a0aa688795cd4f995a8b820d2ec", size = 788120 },
+    { url = "https://files.pythonhosted.org/packages/9e/3e/d61b462b16da95ac6885f95bb395e672040ee594833e571a6edcffd234f5/thinc-8.3.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f697174d3fb474966ce50b430bbafa101a6d2f7ffb559dac4b5c59389ef72d22", size = 3844666 },
+    { url = "https://files.pythonhosted.org/packages/78/4c/898cc654bb123734c71ec5a425c02ca34439517d01ce1c95a6563295580e/thinc-8.3.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9c7c5c104737b414c8c4ec578e67d78b6c859afe25cbc0684402e721415bd7f", size = 3890658 },
+    { url = "https://files.pythonhosted.org/packages/cd/56/1abdbf0a4ad628e8a05d6516fe0745969649d805367a3dccad8ee872981b/thinc-8.3.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7a99d0e242d1ccd23f9ae6bea7cd502f8626efa65c156b91d84581d0356696c3", size = 4819933 },
+    { url = "https://files.pythonhosted.org/packages/f1/22/b84dbdc6be5055bbdb2a7352e2c393f67e8593c137f1b83c82bf1e062b6e/thinc-8.3.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e676edd21a747afbe3e6b9f3fca8b962e36d146ded03b070cb0c28e2dfbe9499", size = 5018099 },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/763cd7ba949334c9d2cddc92dadb68b344cb9546dc01b8d4a733dcaa16c1/thinc-8.3.13-cp313-cp313-win_amd64.whl", hash = "sha256:8ad40307f20e83f77af28ff5c6be0b86af7a8b251d1231c545508d2763157d8f", size = 1720309 },
+    { url = "https://files.pythonhosted.org/packages/f5/15/a11f7bb3cbc97dfecf32a90552f5a8f8a5c99316a99c6c17bdabf5baf256/thinc-8.3.13-cp313-cp313-win_arm64.whl", hash = "sha256:723949cab11d1925c15447928513a718276316cec6e0de28337cca0a62be0521", size = 1644606 },
+    { url = "https://files.pythonhosted.org/packages/80/40/f4937d113912c6d669ffe982356ab29dcb6c7fe3be926a15981dbbb6a91c/thinc-8.3.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7badb0be4825535e6362c19e8a41872b65409e9da46d3453a391b843a0720865", size = 817024 },
+    { url = "https://files.pythonhosted.org/packages/d2/00/4d4ed1a11ba2920b85a03a0683b16d97dc5beb2e78078dbf0e13e43bcea7/thinc-8.3.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:565300b7e13de799e5abff00d445f537e9256cf7da4dcb0d0f005fc16748a29e", size = 792096 },
+    { url = "https://files.pythonhosted.org/packages/44/5d/dc33d6932be8721af2ef76b4a3a6e8020648630eabae61fb916d2a861d1d/thinc-8.3.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c17cef1900a1aba7e1487493d16b8aa0a8633116f1b2a51c6649a4000697f17b", size = 3842215 },
+    { url = "https://files.pythonhosted.org/packages/af/bc/a6d37d8dadc2c5b524f51192413481160c42c9dd6105e8d5551531623225/thinc-8.3.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f4f26d1eec9b2a6a8f2e0298a5515d13eb06d70730d0d9e1040bb329e12bf3fb", size = 3849253 },
+    { url = "https://files.pythonhosted.org/packages/7a/59/ce9c7067f1dfe5985875927de9cf7a79f9dae3e69487fd650dfba558029d/thinc-8.3.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a61a31fd0ce3c2771cf4901ba6df70e774ffe32febf1024c5b43d63575cd58fe", size = 4831163 },
+    { url = "https://files.pythonhosted.org/packages/4f/a8/f57819347fc4d8bef2204d15fcbb9d7dff2d6cdd5f83d5ed91456ddacc55/thinc-8.3.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba8119daf84a12259ae4d251d36426417bafa0b34108890b4b7e2b50966bd990", size = 4986051 },
+    { url = "https://files.pythonhosted.org/packages/05/ef/a82214bb7c7c1e2d92b69e1a7654be90cfab180082c6108e45a98af2422c/thinc-8.3.13-cp314-cp314-win_amd64.whl", hash = "sha256:433e3826e018da489f1a8068e6de677f6eff3cc93991a599d90f12cd1bc26cdc", size = 1740382 },
+    { url = "https://files.pythonhosted.org/packages/9f/ef/1648fda54e9689058335ff54f650a7a314db2a42e21af1b83949b2dc748e/thinc-8.3.13-cp314-cp314-win_arm64.whl", hash = "sha256:11754fada9ad5ba2e02d5f3f234f940e24015b82333db58372f4a6aedad9b43f", size = 1667687 },
 ]
 
 [[package]]
@@ -3414,12 +3856,119 @@ wheels = [
 ]
 
 [[package]]
+name = "wasabi"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/7c/34330a89da55610daa5f245ddce5aab81244321101614751e7537f125133/wasabi-1.1.3-py3-none-any.whl", hash = "sha256:f76e16e8f7e79f8c4c8be49b4024ac725713ab10cd7f19350ad18a8e3f71728c", size = 27880 },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189 },
+]
+
+[[package]]
+name = "weasel"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpathlib" },
+    { name = "confection" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "smart-open" },
+    { name = "srsly" },
+    { name = "typer" },
+    { name = "wasabi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/07/57ebf7a6798b016c064bd0ca81b4c6a99daa4dc377b898bc7b41eb6b5af0/weasel-1.0.0-py3-none-any.whl", hash = "sha256:89518acee027f49d743126c3502d35e6dd14f5768be5c37c9af47c171b6005cc", size = 50713 },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666 },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601 },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057 },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099 },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457 },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351 },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748 },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783 },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977 },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336 },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756 },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255 },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848 },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433 },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013 },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326 },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444 },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237 },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563 },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198 },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441 },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836 },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259 },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851 },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446 },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056 },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359 },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479 },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271 },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573 },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205 },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452 },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842 },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075 },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719 },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643 },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805 },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990 },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670 },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357 },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269 },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894 },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197 },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363 },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418 },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914 },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417 },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797 },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350 },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223 },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287 },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593 },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631 },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875 },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164 },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163 },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723 },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652 },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807 },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061 },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667 },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392 },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296 },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539 },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969 },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554 },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993 },
 ]
 
 [[package]]


### PR DESCRIPTION
## warm model pre-loading

server pre-loads LLM provider and embedding model at startup. no more cold-start on first request.

## concept graph

builds a concept co-occurrence graph at index time using spacy noun phrases + leiden clustering. zero LLM calls, on by default.

- concept-boosted search — related chunks score higher
- graph-aware query expansion — supplements LLM-generated variants
- `lilbee topics` command — browse concept clusters in your knowledge base

1301 tests, 100% coverage.