### PR TITLE
feat: Lilbee programmatic API for retrieval

### DIFF
--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -1,1 +1,18 @@
 """lilbee — Local RAG knowledge base."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lilbee.api import Lilbee
+
+__all__ = ["Lilbee"]
+
+
+def __getattr__(name: str) -> object:
+    if name == "Lilbee":
+        from lilbee.api import Lilbee
+
+        return Lilbee
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/lilbee/api.py
+++ b/src/lilbee/api.py
@@ -1,0 +1,161 @@
+"""Programmatic access to lilbee's retrieval pipeline.
+
+Retrieval only -- no LLM chat. Search your indexed documents from Python.
+Optional features (concept graph, reranker) activate automatically when
+their dependencies are installed.
+
+Usage::
+
+    from lilbee import Lilbee
+
+    bee = Lilbee("./docs")
+    bee.sync()
+    results = bee.search("authentication")
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lilbee.config import Config, cfg
+
+if TYPE_CHECKING:
+    from lilbee.ingest import SyncResult
+    from lilbee.store import SearchChunk
+
+
+@contextmanager
+def _swap_config(target: Config) -> Iterator[None]:
+    """Temporarily replace the global cfg fields with *target*'s values.
+
+    Not thread-safe -- sequential use only.
+    """
+    snapshot = {name: getattr(cfg, name) for name in type(cfg).model_fields}
+    for name in type(target).model_fields:
+        setattr(cfg, name, getattr(target, name))
+    try:
+        yield
+    finally:
+        for name, val in snapshot.items():
+            setattr(cfg, name, val)
+
+
+class Lilbee:
+    """Programmatic access to lilbee's retrieval pipeline.
+
+    Retrieval only -- no LLM chat. Search your indexed documents from Python.
+    Optional features (concept graph, reranker) activate automatically when
+    their dependencies are installed.
+
+    Usage::
+
+        from lilbee import Lilbee
+
+        bee = Lilbee("./docs")
+        bee.sync()
+        results = bee.search("authentication")
+    """
+
+    def __init__(
+        self,
+        documents_dir: str | Path | None = None,
+        *,
+        config: Config | None = None,
+    ) -> None:
+        """Create a lilbee instance.
+
+        Args:
+            documents_dir: Path to documents folder. Creates a default Config
+                with derived data and lancedb directories.
+            config: Full Config instance for complete control.
+
+        Pass one or the other, not both. If neither is given, uses
+        ``Config.from_env()`` (same defaults as the CLI).
+        """
+        if documents_dir is not None and config is not None:
+            raise ValueError("Pass documents_dir or config, not both")
+
+        if config is not None:
+            self._config = config
+        elif documents_dir is not None:
+            root = Path(documents_dir).resolve()
+            self._config = cfg.model_copy(
+                update={
+                    "data_root": root,
+                    "documents_dir": root / "documents",
+                    "data_dir": root / "data",
+                    "lancedb_dir": root / "data" / "lancedb",
+                },
+            )
+        else:
+            self._config = Config.from_env()
+
+        self._config.documents_dir.mkdir(parents=True, exist_ok=True)
+        self._config.data_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def config(self) -> Config:
+        """The Config instance backing this Lilbee."""
+        return self._config
+
+    def sync(self, *, quiet: bool = True) -> SyncResult:
+        """Sync documents to the vector store. Returns what changed."""
+        from lilbee.ingest import sync as _sync
+
+        with _swap_config(self._config):
+            return asyncio.run(_sync(quiet=quiet))
+
+    def search(self, query: str, *, top_k: int = 0) -> list[SearchChunk]:
+        """Search indexed documents. Returns ranked chunks."""
+        from lilbee.query import search_context
+
+        with _swap_config(self._config):
+            return search_context(query, top_k=top_k)
+
+    def add(self, paths: list[str | Path]) -> SyncResult:
+        """Add files to the knowledge base and sync.
+
+        Copies each path into the documents directory, then syncs.
+        """
+        from lilbee.cli.helpers import copy_files
+        from lilbee.ingest import sync as _sync
+
+        resolved = [Path(p).resolve() for p in paths]
+        with _swap_config(self._config):
+            copy_files(resolved, force=True)
+            return asyncio.run(_sync(quiet=True))
+
+    def remove(self, name: str) -> None:
+        """Remove a document from the index by source name."""
+        from lilbee import store
+
+        with _swap_config(self._config):
+            store.delete_by_source(name)
+            store.delete_source(name)
+            doc_path = self._config.documents_dir / name
+            if doc_path.exists():
+                doc_path.unlink()
+
+    def status(self) -> dict[str, object]:
+        """Return index stats (document count, data directory, etc.)."""
+        from lilbee import store
+
+        with _swap_config(self._config):
+            sources = store.get_sources()
+            return {
+                "documents_dir": str(self._config.documents_dir),
+                "data_dir": str(self._config.data_dir),
+                "document_count": len(sources),
+                "sources": [s["filename"] for s in sources],
+            }
+
+    def rebuild(self) -> SyncResult:
+        """Rebuild the entire index from scratch."""
+        from lilbee.ingest import sync as _sync
+
+        with _swap_config(self._config):
+            return asyncio.run(_sync(force_rebuild=True, quiet=True))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,226 @@
+"""Tests for the Lilbee programmatic API."""
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from lilbee.config import cfg
+
+
+def _fake_embed(text):
+    return [0.1] * 768
+
+
+def _fake_embed_batch(texts, **kwargs):
+    return [[0.1] * 768 for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def _mock_embedder():
+    """Mock embedding calls so tests run without a live model."""
+    with (
+        mock.patch("lilbee.embedder.embed", side_effect=_fake_embed),
+        mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch),
+        mock.patch("lilbee.embedder.validate_model"),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cfg():
+    """Restore global cfg after every test."""
+    snapshot = cfg.model_copy()
+    cfg.concept_graph = False
+    cfg.query_expansion_count = 0
+    cfg.hyde = False
+    yield
+    for name in type(cfg).model_fields:
+        setattr(cfg, name, getattr(snapshot, name))
+
+
+def _write_doc(docs_dir: Path, name: str, content: str) -> Path:
+    """Write a markdown file into a documents directory."""
+    path = docs_dir / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestCreate:
+    def test_create_with_documents_dir(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "myproject")
+        assert bee.config.documents_dir.exists()
+        assert bee.config.data_dir.exists()
+        assert "myproject" in str(bee.config.data_root)
+
+    def test_create_with_config(self, tmp_path):
+        from lilbee import Lilbee
+
+        custom = cfg.model_copy(
+            update={
+                "data_root": tmp_path,
+                "documents_dir": tmp_path / "docs",
+                "data_dir": tmp_path / "data",
+                "lancedb_dir": tmp_path / "data" / "lancedb",
+            },
+        )
+        bee = Lilbee(config=custom)
+        assert bee.config.documents_dir == tmp_path / "docs"
+
+    def test_create_with_both_raises(self, tmp_path):
+        from lilbee import Lilbee
+
+        custom = cfg.model_copy(
+            update={
+                "data_root": tmp_path,
+                "documents_dir": tmp_path / "docs",
+                "data_dir": tmp_path / "data",
+                "lancedb_dir": tmp_path / "data" / "lancedb",
+            },
+        )
+        with pytest.raises(ValueError, match="not both"):
+            Lilbee(tmp_path / "dir", config=custom)
+
+    def test_create_with_neither_uses_env(self, tmp_path, monkeypatch):
+        from lilbee import Lilbee
+
+        monkeypatch.setenv("LILBEE_DATA", str(tmp_path / "envroot"))
+        bee = Lilbee()
+        assert "envroot" in str(bee.config.data_root)
+
+
+class TestSync:
+    def test_sync_indexes_documents(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "proj")
+        _write_doc(bee.config.documents_dir, "notes.md", "# Notes\nThe answer is 42.")
+        result = bee.sync()
+        assert "notes.md" in result.added
+
+    def test_sync_returns_result(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "proj")
+        _write_doc(bee.config.documents_dir, "a.md", "Hello world content here.")
+        result = bee.sync()
+        assert isinstance(result.added, list)
+        assert isinstance(result.unchanged, int)
+
+
+class TestSearch:
+    def test_search_returns_results(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "proj")
+        _write_doc(bee.config.documents_dir, "info.md", "# Auth\nAuthentication uses OAuth2.")
+        bee.sync()
+        results = bee.search("authentication")
+        assert len(results) > 0
+        assert any("OAuth2" in r.chunk for r in results)
+
+    def test_search_empty_index(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "proj")
+        results = bee.search("anything")
+        assert results == []
+
+    def test_search_respects_top_k(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "proj")
+        for i in range(5):
+            _write_doc(
+                bee.config.documents_dir,
+                f"doc{i}.md",
+                f"# Doc {i}\nContent about topic number {i} with enough words to chunk.",
+            )
+        bee.sync()
+        results = bee.search("topic", top_k=2)
+        assert len(results) <= 2
+
+
+class TestAdd:
+    def test_add_copies_and_syncs(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "proj")
+        external = tmp_path / "external.md"
+        external.write_text("# External\nThis file lives outside the project.")
+        result = bee.add([external])
+        assert "external.md" in result.added
+        found = bee.search("external")
+        assert len(found) > 0
+
+
+class TestRemove:
+    def test_remove_deletes_from_index(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "proj")
+        _write_doc(bee.config.documents_dir, "gone.md", "# Gone\nThis will be removed shortly.")
+        bee.sync()
+        assert bee.search("removed") != [] or True  # search may or may not find with fake vecs
+        bee.remove("gone.md")
+        status = bee.status()
+        assert "gone.md" not in status["sources"]
+
+
+class TestStatus:
+    def test_status_returns_info(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "proj")
+        _write_doc(bee.config.documents_dir, "s.md", "# Status\nSome content for status check.")
+        bee.sync()
+        info = bee.status()
+        assert info["document_count"] == 1
+        assert "s.md" in info["sources"]
+        assert "documents_dir" in info
+
+
+class TestRebuild:
+    def test_rebuild_recreates_index(self, tmp_path):
+        from lilbee import Lilbee
+
+        bee = Lilbee(tmp_path / "proj")
+        _write_doc(bee.config.documents_dir, "rb.md", "# Rebuild\nRebuild test document.")
+        bee.sync()
+        result = bee.rebuild()
+        assert "rb.md" in result.added
+
+
+class TestIsolation:
+    def test_config_isolation(self, tmp_path):
+        """Lilbee instance doesn't leak config to global cfg after method call."""
+        from lilbee import Lilbee
+
+        original_docs = cfg.documents_dir
+        bee = Lilbee(tmp_path / "isolated")
+        _write_doc(bee.config.documents_dir, "iso.md", "# Isolation test content here.")
+        bee.sync()
+        assert cfg.documents_dir == original_docs
+
+    def test_multiple_instances_sequential(self, tmp_path):
+        """Two Lilbee instances with different dirs work sequentially."""
+        from lilbee import Lilbee
+
+        bee_a = Lilbee(tmp_path / "a")
+        bee_b = Lilbee(tmp_path / "b")
+
+        _write_doc(bee_a.config.documents_dir, "a.md", "# Alpha\nContent for project A.")
+        _write_doc(bee_b.config.documents_dir, "b.md", "# Beta\nContent for project B.")
+
+        bee_a.sync()
+        bee_b.sync()
+
+        status_a = bee_a.status()
+        status_b = bee_b.status()
+        assert "a.md" in status_a["sources"]
+        assert "b.md" in status_b["sources"]
+        assert "b.md" not in status_a["sources"]
+        assert "a.md" not in status_b["sources"]


### PR DESCRIPTION
## Summary

- Adds `Lilbee` class in `src/lilbee/api.py` for programmatic access to the retrieval pipeline
- Exports `Lilbee` from `lilbee` package via lazy `__getattr__` (avoids loading heavy deps on bare import)
- Retrieval only -- no LLM chat. Methods: `sync()`, `search()`, `add()`, `remove()`, `status()`, `rebuild()`
- 15 test cases covering all methods, config isolation, and multi-instance usage

## Usage

```python
from lilbee import Lilbee

bee = Lilbee("./docs")
bee.sync()
results = bee.search("authentication")
```

Or with explicit config:

```python
from lilbee.config import Config, cfg

custom = cfg.model_copy(update={"documents_dir": "./docs", ...})
bee = Lilbee(config=custom)
```

## Test plan

- [x] 15 unit tests pass covering all public methods
- [x] Config isolation verified (global cfg restored after each method call)
- [x] Multiple sequential instances with different directories work correctly
- [x] 100% test coverage on `api.py`
- [x] Lint, format, typecheck pass