### PR TITLE
refactor: llama-cpp core, litellm optional, rename ollama references

### DIFF
--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -23,8 +23,8 @@ Add to your MCP client's MCP server configuration:
 
 ### Tools
 
-| Tool | Description | Requires Ollama |
-|------|-------------|-----------------|
+| Tool | Description | Requires LLM backend |
+|------|-------------|---------------------|
 | `lilbee_search(query, top_k)` | Search for relevant document chunks by vector similarity | No (uses pre-computed embeddings) |
 | `lilbee_status()` | Show indexed documents, config, and chunk counts | No |
 | `lilbee_sync()` | Sync documents directory with the vector store | Yes (for embedding) |
@@ -61,16 +61,16 @@ All commands accept `--json` (or `-j`) before the subcommand for structured outp
 ### Two modes
 
 - **`search`** — Raw chunk retrieval. No LLM call at query time. Use when your agent has its own LLM and just needs relevant document chunks.
-- **`ask`** — Full local RAG via Ollama. Use for fully-local workflows when Ollama is running.
+- **`ask`** — Full local RAG via llama-cpp (or litellm if installed). Use for fully-local workflows.
 
 ### Commands
 
 ```bash
-# Search for relevant chunks (no Ollama needed at query time)
+# Search for relevant chunks (no LLM call at query time)
 lilbee --json search "query" --top-k 5
 # Returns: {"command": "search", "query": "...", "results": [...]}
 
-# Ask a question with local RAG (requires Ollama)
+# Ask a question with local RAG
 lilbee --json ask "question"
 # Returns: {"command": "ask", "question": "...", "answer": "...", "sources": [...]}
 
@@ -105,8 +105,8 @@ SSE events emitted: `crawl_start`, `crawl_page`, `crawl_done`, then `done` (or `
 
 ## Recommendations
 
-- Prefer `search` over `ask` if your agent has its own LLM — it's faster and doesn't need Ollama at query time
+- Prefer `search` over `ask` if your agent has its own LLM — it's faster and skips the LLM call at query time
 - Use MCP when available — it's more direct than shelling out
 - Run `status` / `lilbee_status()` first to check if documents are indexed
 - Run `sync` / `lilbee_sync()` after adding documents to update the index
-- Ollama is needed for two things: (1) embedding during sync/indexing, (2) `ask` for LLM answers. Once indexed, `search` works without Ollama
+- An LLM backend is needed for: (1) embedding during sync/indexing, (2) `ask` for LLM answers. Once indexed, `search` works without an LLM. By default, llama-cpp handles both. Install `lilbee[litellm]` to use external backends like Ollama or OpenAI.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ flowchart LR
     end
 
     subgraph External
-        OLLAMA[Ollama]
+        LITELLM[litellm backends]
         LLAMA[llama-cpp]
         HF[HuggingFace]
     end
@@ -51,7 +51,7 @@ flowchart LR
     SEARCH --> CONCEPT
     SEARCH --> GEN
     GEN --> PROV
-    PROV --> OLLAMA & LLAMA
+    PROV --> LITELLM & LLAMA
     INGEST --> HF
 ```
 
@@ -67,7 +67,7 @@ Documents are chunked, embedded, and stored as vectors for later retrieval.
 - **PDF**: kreuzberg 4.6 extraction with OCR fallback chain (text extraction → Tesseract OCR → vision model). PDF page rasterization delegated to kreuzberg's `PdfPageIterator`.
 - **Structured files**: kreuzberg handles XML, JSON, JSONL, YAML, CSV extraction natively. Language detection delegated to tree-sitter-language-pack's `detect_language()`.
 - **Web pages**: crawl4ai fetches HTML (with JavaScript rendering via Playwright), converts to markdown, saves to `documents/_web/` for indexing
-- **Embedding**: provider-agnostic — works with Ollama, llama-cpp-python, or any configured provider
+- **Embedding**: provider-agnostic — works with llama-cpp-python (default) or any litellm-compatible backend (Ollama, OpenAI, etc.)
 - **Concept extraction**: spaCy noun phrases extracted per chunk, co-occurrence graph built with PPMI weights, Leiden clustering assigns concepts to communities
 - **Storage**: LanceDB with full-text search (FTS) index for hybrid retrieval + concept graph tables (nodes, edges, chunk mappings)
 
@@ -78,18 +78,19 @@ Documents are chunked, embedded, and stored as vectors for later retrieval.
 ```mermaid
 flowchart TD
     APP[Application Code] --> ROUTE[RoutingProvider]
-    ROUTE --> CHECK{Model in Ollama?}
-    CHECK -->|Yes| LIT[LiteLLM → Ollama]
+    ROUTE --> CHECK{litellm installed & model available?}
+    CHECK -->|Yes| LIT[LiteLLM → External Backend]
     CHECK -->|No| LCPP[llama-cpp-python → GGUF]
 
-    APP -->|explicit config| OLLAMA_P[LiteLLM Provider]
+    APP -->|explicit config| LIT_P[LiteLLM Provider]
     APP -->|explicit config| LCPP_P[LlamaCpp Provider]
 ```
 
-- **auto** (default): `RoutingProvider` checks Ollama availability per model. If Ollama has the model, uses it; otherwise falls back to local GGUF.
-- **ollama**: force all calls through LiteLLM → Ollama
-- **llama-cpp**: force local GGUF inference via llama-cpp-python
-- Model downloads always come from HuggingFace. lilbee manages its own GGUF files. Ollama models are used for inference when available but never managed by lilbee.
+- **auto** (default): `RoutingProvider` checks if litellm is installed and the model is available via its API. If so, uses it; otherwise falls back to local GGUF via llama-cpp.
+- **litellm**: force all calls through LiteLLM (Ollama, OpenAI, Azure, etc.). Requires `pip install lilbee[litellm]`.
+- **ollama**: deprecated alias for `litellm`
+- **llama-cpp**: force local GGUF inference via llama-cpp-python (always available)
+- Model downloads come from HuggingFace. lilbee manages its own GGUF files. External models (e.g. Ollama) are used for inference when available but not managed by lilbee.
 
 ---
 
@@ -286,7 +287,7 @@ All settings are configurable via `LILBEE_*` environment variables, `config.toml
 
 | Setting | Default | Description | Caveats |
 |---------|---------|-------------|---------|
-| `LILBEE_CHAT_MODEL` | `qwen3:8b` | LLM used for chat and ask | Must be installed locally or available in Ollama |
+| `LILBEE_CHAT_MODEL` | `qwen3:8b` | LLM used for chat and ask | Must be installed locally or available via litellm backend |
 | `LILBEE_EMBEDDING_MODEL` | `nomic-embed-text` | Model for computing vector embeddings | Changing this requires a full `lilbee rebuild` |
 | `LILBEE_TOP_K` | `10` | Number of search results returned | Higher values provide more context but increase LLM latency and token cost |
 | `LILBEE_MAX_DISTANCE` | `0.7` | Cosine distance cutoff for vector results | Lower values are stricter — may return fewer results but higher precision |
@@ -326,6 +327,6 @@ All settings are configurable via `LILBEE_*` environment variables, `config.toml
 
 | Setting | Default | Description | Caveats |
 |---------|---------|-------------|---------|
-| `LILBEE_LLM_PROVIDER` | `auto` | Backend selection: auto, llama-cpp, ollama, litellm | auto = use Ollama if reachable, otherwise llama-cpp |
-| `LILBEE_OLLAMA_URL` | `http://localhost:11434` | Ollama server endpoint | Also reads `OLLAMA_HOST` for backwards compatibility. Supports remote Ollama servers. |
+| `LILBEE_LLM_PROVIDER` | `auto` | Backend selection: auto, llama-cpp, litellm | auto = use litellm if installed and reachable, otherwise llama-cpp |
+| `LILBEE_LITELLM_BASE_URL` | `http://localhost:11434` | litellm backend endpoint | Also reads `OLLAMA_HOST` for backwards compatibility (deprecated). |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lilbee"
 version = "0.6.0"
-description = "Local knowledge base for documents and code. Search, ask questions, or chat — standalone or as an AI agent backend via MCP. Fully offline with Ollama."
+description = "Local knowledge base for documents and code. Search, ask questions, or chat — standalone or as an AI agent backend via MCP. Runs fully offline with llama-cpp."
 readme = "README.md"
 license = "MIT"
 authors = [{ name = "tobocop2", email = "5562156+tobocop2@users.noreply.github.com" }]
@@ -37,13 +37,13 @@ dependencies = [
     "pillow>=11.3.0",
     "litestar>=2.0",
     "uvicorn>=0.30",
-    "litellm",
+    "llama-cpp-python",
     "huggingface_hub",
     "httpx",
 ]
 
 [project.optional-dependencies]
-llama-cpp = ["llama-cpp-python"]
+litellm = ["litellm"]
 reranker = ["sentence-transformers"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
 crawler = ["crawl4ai>=0.8.0"]

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -330,7 +330,7 @@ def _sort_models(models: list[CatalogModel], sort: str) -> list[CatalogModel]:
     return sorted(models, key=key_fn, reverse=reverse)
 
 
-# Maps Ollama-style names to catalog display names for lookup
+# Maps model names to catalog display names for lookup
 def find_catalog_entry(name: str) -> CatalogModel | None:
     """Find a featured model by display name (case-insensitive)."""
     name_lower = name.lower()

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -74,7 +74,7 @@ def _ensure_vision_model() -> None:
         installed = set(list_installed_models())
     except Exception:
         console.print(
-            f"[{theme.WARNING}]Warning: Cannot connect to Ollama."
+            f"[{theme.WARNING}]Warning: Cannot list models."
             f" Vision OCR disabled.[/{theme.WARNING}]"
         )
         return
@@ -95,7 +95,7 @@ def _validate_configured_vision() -> None:
     try:
         installed = set(list_installed_models())
     except Exception:
-        # Can't reach Ollama — keep the config and let downstream handle errors
+        # Can't reach model backend — keep the config and let downstream handle errors
         return
 
     if tagged in installed:

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -25,7 +25,7 @@ from textual.worker import Worker, WorkerState
 
 from lilbee.catalog import FEATURED_ALL, CatalogModel, get_catalog
 from lilbee.config import cfg
-from lilbee.model_manager import OllamaModel
+from lilbee.model_manager import RemoteModel
 
 log = logging.getLogger(__name__)
 
@@ -99,18 +99,18 @@ class ModelRow(ListItem):
         yield Static(_format_row(self.model), classes="model-row-text")
 
 
-class OllamaRow(ListItem):
-    """An Ollama model (inference-only)."""
+class RemoteRow(ListItem):
+    """A remote model (inference-only, managed by external tool)."""
 
-    def __init__(self, model: OllamaModel) -> None:
+    def __init__(self, model: RemoteModel) -> None:
         super().__init__()
-        self.ollama_model = model
+        self.remote_model = model
 
     def compose(self) -> ComposeResult:
-        m = self.ollama_model
+        m = self.remote_model
         size = m.parameter_size or "?"
         yield Static(
-            f"   {m.name:<30s} {m.task:<10s} {size:>5s}           (Ollama)",
+            f"   {m.name:<30s} {m.task:<10s} {size:>5s}           (remote)",
             classes="model-row-text",
         )
 
@@ -139,7 +139,7 @@ class CatalogScreen(Screen[None]):
         super().__init__()
         self._featured: list[CatalogModel] = list(FEATURED_ALL)
         self._hf_models: list[CatalogModel] = []
-        self._ollama_models: list[OllamaModel] = []
+        self._remote_models: list[RemoteModel] = []
         self._hf_offset = 0
         self._hf_has_more = True
         self._current_sort = "downloads"
@@ -159,7 +159,7 @@ class CatalogScreen(Screen[None]):
     def on_mount(self) -> None:
         self._refresh_lists()
         self._fetch_hf_models()
-        self._fetch_ollama_models()
+        self._fetch_remote_models()
 
     @work(thread=True)
     def _fetch_hf_models(self) -> list[CatalogModel]:
@@ -171,10 +171,10 @@ class CatalogScreen(Screen[None]):
         return new_models
 
     @work(thread=True)
-    def _fetch_ollama_models(self) -> list[OllamaModel]:
-        from lilbee.model_manager import classify_ollama_models
+    def _fetch_remote_models(self) -> list[RemoteModel]:
+        from lilbee.model_manager import classify_remote_models
 
-        return classify_ollama_models(cfg.ollama_url)
+        return classify_remote_models(cfg.litellm_base_url)
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         if event.state != WorkerState.SUCCESS:
@@ -186,8 +186,8 @@ class CatalogScreen(Screen[None]):
         elif event.worker.name == "_fetch_more_hf" and isinstance(result, list):
             self._hf_models.extend(result)
             self._refresh_lists()
-        elif event.worker.name == "_fetch_ollama_models" and isinstance(result, list):
-            self._ollama_models = result
+        elif event.worker.name == "_fetch_remote_models" and isinstance(result, list):
+            self._remote_models = result
             self._refresh_lists()
         elif event.worker.name == "_fetch_model_size" and isinstance(result, tuple):
             repo, size_gb = result
@@ -218,7 +218,7 @@ class CatalogScreen(Screen[None]):
 
             featured = _filter_catalog(self._featured, task, search)
             hf = _filter_catalog(self._hf_models, task, search)
-            ollama = _filter_ollama(self._ollama_models, task, search)
+            remote = _filter_remote(self._remote_models, task, search)
 
             if featured:
                 lv.append(ListItem(Label("★ FEATURED", classes="section-header")))
@@ -237,23 +237,23 @@ class CatalogScreen(Screen[None]):
                 if self._hf_has_more and not search:
                     lv.append(LoadMoreRow())
 
-            if ollama:
-                lv.append(ListItem(Label("INSTALLED (Ollama)", classes="section-header")))
-                for om in ollama:
-                    lv.append(OllamaRow(om))
+            if remote:
+                lv.append(ListItem(Label("INSTALLED (Remote)", classes="section-header")))
+                for rm in remote:
+                    lv.append(RemoteRow(rm))
 
-            if not featured and not ollama and not hf:
+            if not featured and not remote and not hf:
                 lv.append(ListItem(Label("No models match your filters.")))
 
         n_featured = len(self._featured)
         n_hf = len(self._hf_models)
-        n_ollama = len(self._ollama_models)
-        total = n_featured + n_hf + n_ollama
+        n_remote = len(self._remote_models)
+        total = n_featured + n_hf + n_remote
         more = "+" if self._hf_has_more else ""
         self.query_one("#sort-label", Static).update(
             f"Sort: {_SORT_LABELS[self._current_sort]}  |  "
             f"Showing {total}{more} models "
-            f"({n_featured} featured, {n_hf} HF, {n_ollama} Ollama)"
+            f"({n_featured} featured, {n_hf} HF, {n_remote} remote)"
         )
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
@@ -263,10 +263,10 @@ class CatalogScreen(Screen[None]):
             return
         if isinstance(item, ModelRow):
             self._install_model(item.model)
-        elif isinstance(item, OllamaRow):
-            cfg.chat_model = item.ollama_model.name
-            self.notify(f"Using {item.ollama_model.name} (Ollama)")
-            self.app.title = f"lilbee — {item.ollama_model.name}"
+        elif isinstance(item, RemoteRow):
+            cfg.chat_model = item.remote_model.name
+            self.notify(f"Using {item.remote_model.name} (remote)")
+            self.app.title = f"lilbee — {item.remote_model.name}"
 
     def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
         self._update_highlighted_detail(event.item)
@@ -298,9 +298,9 @@ class CatalogScreen(Screen[None]):
             # Lazy-load file size if unknown and not cached
             if m.size_gb <= 0 and m.hf_repo not in self._size_cache:
                 self._fetch_model_size(m.hf_repo)
-        elif isinstance(item, OllamaRow):
-            om = item.ollama_model
-            detail.update(f"{om.name} — {om.task}  Family: {om.family}  {om.parameter_size}")
+        elif isinstance(item, RemoteRow):
+            rm = item.remote_model
+            detail.update(f"{rm.name} — {rm.task}  Family: {rm.family}  {rm.parameter_size}")
         else:
             detail.update("")
 
@@ -403,7 +403,7 @@ def _filter_catalog(
     return filtered
 
 
-def _filter_ollama(models: list[OllamaModel], task: str | None, search: str) -> list[OllamaModel]:
+def _filter_remote(models: list[RemoteModel], task: str | None, search: str) -> list[RemoteModel]:
     filtered = models
     if task:
         filtered = [m for m in filtered if m.task == task]

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -80,20 +80,20 @@ class ChatScreen(Screen[None]):
     @work(thread=True)
     def _check_embedding_model_async(self) -> None:
         """Check for embedding model in a background thread (non-blocking)."""
-        from lilbee.model_manager import detect_ollama_embedding_models, get_model_manager
+        from lilbee.model_manager import detect_remote_embedding_models, get_model_manager
 
         manager = get_model_manager()
         if manager.is_installed(cfg.embedding_model):
             return
 
         embed_base = cfg.embedding_model.split(":")[0]
-        ollama_embeds = detect_ollama_embedding_models(cfg.ollama_url)
-        if any(embed_base in name for name in ollama_embeds):
+        remote_embeds = detect_remote_embedding_models(cfg.litellm_base_url)
+        if any(embed_base in name for name in remote_embeds):
             return
 
-        self.app.call_from_thread(self._show_setup_modal, ollama_embeds)
+        self.app.call_from_thread(self._show_setup_modal, remote_embeds)
 
-    def _show_setup_modal(self, ollama_embeds: list[str]) -> None:
+    def _show_setup_modal(self, remote_embeds: list[str]) -> None:
         from lilbee.cli.tui.widgets.setup_modal import SetupModal
 
         def on_setup_complete(name: str | None) -> None:
@@ -102,7 +102,7 @@ class ChatScreen(Screen[None]):
                 self.notify(msg.EMBEDDING_SET.format(name=name))
                 self._refresh_model_bar()
 
-        self.app.push_screen(SetupModal(ollama_embeddings=ollama_embeds), on_setup_complete)
+        self.app.push_screen(SetupModal(ollama_embeddings=remote_embeds), on_setup_complete)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if event.input.id != "chat-input":

--- a/src/lilbee/cli/tui/widgets/setup_modal.py
+++ b/src/lilbee/cli/tui/widgets/setup_modal.py
@@ -30,15 +30,15 @@ class _EmbeddingRow(ListItem):
         yield Static(f"  {self.model.name}  {self.model.size_gb:.1f} GB{suffix}")
 
 
-class _OllamaRow(ListItem):
-    """An Ollama embedding model (no download needed)."""
+class _RemoteRow(ListItem):
+    """A remote embedding model (no download needed)."""
 
     def __init__(self, name: str) -> None:
         super().__init__()
-        self.ollama_name = name
+        self.remote_name = name
 
     def compose(self) -> ComposeResult:
-        yield Static(f"  {self.ollama_name}  (Ollama, no download)")
+        yield Static(f"  {self.remote_name}  (remote, no download)")
 
 
 class SetupModal(ModalScreen[str | None]):
@@ -50,16 +50,16 @@ class SetupModal(ModalScreen[str | None]):
 
     def __init__(self, ollama_embeddings: list[str] | None = None) -> None:
         super().__init__()
-        self._ollama_embeddings = ollama_embeddings or []
+        self._remote_embeddings = ollama_embeddings or []
         self._downloaded_name: str | None = None
 
     def compose(self) -> ComposeResult:
         items: list[ListItem] = []
 
-        if self._ollama_embeddings:
-            items.append(ListItem(Label("Found in Ollama:")))
-            for name in self._ollama_embeddings:
-                items.append(_OllamaRow(name))
+        if self._remote_embeddings:
+            items.append(ListItem(Label("Found remotely:")))
+            for name in self._remote_embeddings:
+                items.append(_RemoteRow(name))
             items.append(ListItem(Label("\nOr download:")))
 
         for i, model in enumerate(FEATURED_EMBEDDING):
@@ -73,8 +73,8 @@ class SetupModal(ModalScreen[str | None]):
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         item = event.item
-        if isinstance(item, _OllamaRow):
-            self.dismiss(item.ollama_name)
+        if isinstance(item, _RemoteRow):
+            self.dismiss(item.remote_name)
         elif isinstance(item, _EmbeddingRow):
             self._download_model(item.model)
 

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -70,7 +70,7 @@ class Config(BaseModel):
     num_ctx: int | None = Field(default=None, ge=1)
     seed: int | None = None
     llm_provider: str = "auto"
-    ollama_url: str = "http://localhost:11434"
+    litellm_base_url: str = "http://localhost:11434"
     llm_api_key: str = ""
 
     # Retrieval quality knobs — defaults chosen from academic research and grantflow
@@ -169,10 +169,10 @@ class Config(BaseModel):
     concept_max_per_chunk: int = Field(default=10, ge=1)
 
     def generation_options(self, **overrides: Any) -> dict[str, Any]:
-        """Build Ollama generation options from config fields and overrides.
+        """Build LLM generation options from config fields and overrides.
 
-        Remaps ``top_k_sampling`` to Ollama's ``top_k`` key.
-        Filters out ``None`` values so Ollama uses its model defaults.
+        Remaps ``top_k_sampling`` to the provider's ``top_k`` key.
+        Filters out ``None`` values so the provider uses its model defaults.
         """
         mapping: dict[str, Any] = {
             "temperature": self.temperature,
@@ -247,9 +247,9 @@ class Config(BaseModel):
             num_ctx=_load_setting(data_root, "num_ctx", "NUM_CTX", None, int),
             seed=_load_setting(data_root, "seed", "SEED", None, int),
             llm_provider=env("LLM_PROVIDER", "auto"),
-            ollama_url=env(
-                "OLLAMA_URL",
-                # Fall back to OLLAMA_HOST for backwards compat
+            litellm_base_url=env(
+                "LITELLM_BASE_URL",
+                # Fall back to OLLAMA_HOST for backwards compat (deprecated)
                 os.environ.get("OLLAMA_HOST", "http://localhost:11434"),
             ),
             llm_api_key=env("LLM_API_KEY", ""),

--- a/src/lilbee/embedder.py
+++ b/src/lilbee/embedder.py
@@ -40,7 +40,9 @@ def validate_model() -> None:
             log.info("Pulling embedding model '%s'...", cfg.embedding_model)
             get_provider().pull_model(cfg.embedding_model, on_progress=lambda _: None)
     except (ConnectionError, OSError) as exc:
-        raise RuntimeError(f"Cannot connect to Ollama: {exc}. Is Ollama running?") from exc
+        raise RuntimeError(
+            f"Cannot connect to embedding backend: {exc}. Is the server running?"
+        ) from exc
 
 
 def embed(text: str) -> list[float]:

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -73,7 +73,7 @@ async def lilbee_add(
     Args:
         paths: Absolute file/directory paths or URLs to add.
         force: Overwrite files that already exist in the knowledge base.
-        vision_model: Ollama vision model for scanned PDF OCR
+        vision_model: Vision model for scanned PDF OCR
             (e.g. "maternion/LightOnOCR-2:latest"). If empty, uses
             the configured default. If no model is configured,
             scanned PDFs are skipped.

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -1,4 +1,4 @@
-"""Model lifecycle management across native GGUF and Ollama sources."""
+"""Model lifecycle management across native GGUF and litellm-backed sources."""
 
 import json
 import logging
@@ -11,32 +11,32 @@ import httpx
 
 log = logging.getLogger(__name__)
 
-_OLLAMA_TIMEOUT = 30.0
+_LITELLM_TIMEOUT = 30.0
 
 
 class ModelSource(Enum):
     """Where a model is stored."""
 
     NATIVE = "native"  # lilbee's GGUF files in cfg.models_dir
-    OLLAMA = "ollama"  # Ollama's model store
+    LITELLM = "litellm"  # Models managed by an external tool (Ollama, etc.)
 
 
 class ModelManager:
     """Manages model lifecycle with distinct sources."""
 
-    def __init__(self, models_dir: Path, ollama_base_url: str = "http://localhost:11434") -> None:
+    def __init__(self, models_dir: Path, litellm_base_url: str = "http://localhost:11434") -> None:
         self._models_dir = models_dir
-        self._ollama_base_url = ollama_base_url.rstrip("/")
+        self._litellm_base_url = litellm_base_url.rstrip("/")
 
     def list_installed(self, source: ModelSource | None = None) -> list[str]:
         """List installed model names. source=None lists all sources."""
         if source is None:
             native = set(self._list_native())
-            ollama = set(self._list_ollama())
-            return sorted(native | ollama)
+            remote = set(self._list_litellm())
+            return sorted(native | remote)
         if source is ModelSource.NATIVE:
             return self._list_native()
-        return self._list_ollama()
+        return self._list_litellm()
 
     def _list_native(self) -> list[str]:
         """List .gguf files in the models directory."""
@@ -44,41 +44,41 @@ class ModelManager:
             return []
         return sorted(p.name for p in self._models_dir.iterdir() if p.suffix == ".gguf")
 
-    def _list_ollama(self) -> list[str]:
-        """List models from Ollama via its HTTP API."""
-        url = f"{self._ollama_base_url}/api/tags"
+    def _list_litellm(self) -> list[str]:
+        """List models from the litellm backend via its HTTP API."""
+        url = f"{self._litellm_base_url}/api/tags"
         try:
-            resp = httpx.get(url, timeout=_OLLAMA_TIMEOUT)
+            resp = httpx.get(url, timeout=_LITELLM_TIMEOUT)
             resp.raise_for_status()
             data = resp.json()
             return [m["name"] for m in data.get("models", [])]
         except httpx.HTTPStatusError as exc:
-            log.warning("Ollama HTTP error listing models: %s", exc)
+            log.warning("litellm backend HTTP error listing models: %s", exc)
             return []
         except (httpx.ConnectError, httpx.TimeoutException) as exc:
-            log.debug("Ollama not reachable: %s", exc)
+            log.debug("litellm backend not reachable: %s", exc)
             return []
 
     def is_installed(self, model: str, source: ModelSource | None = None) -> bool:
         """Check if model exists in specified source."""
         if source is None:
-            return self._is_native(model) or self._is_ollama(model)
+            return self._is_native(model) or self._is_litellm(model)
         if source is ModelSource.NATIVE:
             return self._is_native(model)
-        return self._is_ollama(model)
+        return self._is_litellm(model)
 
     def _is_native(self, model: str) -> bool:
         return (self._models_dir / model).is_file()
 
-    def _is_ollama(self, model: str) -> bool:
-        return model in self._list_ollama()
+    def _is_litellm(self, model: str) -> bool:
+        return model in self._list_litellm()
 
     def get_source(self, model: str) -> ModelSource | None:
         """Find which source a model lives in. Native takes precedence."""
         if self._is_native(model):
             return ModelSource.NATIVE
-        if self._is_ollama(model):
-            return ModelSource.OLLAMA
+        if self._is_litellm(model):
+            return ModelSource.LITELLM
         return None
 
     def pull(
@@ -90,11 +90,11 @@ class ModelManager:
     ) -> Path | None:
         """Pull/download model to specified source.
 
-        Returns the Path for native downloads, None for Ollama.
+        Returns the Path for native downloads, None for litellm-backed pulls.
         """
         if source is ModelSource.NATIVE:
             return self._pull_native(model)
-        self._pull_ollama(model, on_progress=on_progress)
+        self._pull_litellm(model, on_progress=on_progress)
         return None
 
     def _pull_native(self, model: str) -> Path:
@@ -108,11 +108,11 @@ class ModelManager:
         log.info("Downloaded %s to %s", model, path)
         return path
 
-    def _pull_ollama(
+    def _pull_litellm(
         self, model: str, *, on_progress: Callable[[dict], None] | None = None
     ) -> None:
-        """Pull model via Ollama's HTTP API with streaming progress."""
-        url = f"{self._ollama_base_url}/api/pull"
+        """Pull model via the litellm backend's HTTP API with streaming progress."""
+        url = f"{self._litellm_base_url}/api/pull"
         try:
             with (
                 httpx.Client(timeout=None) as client,
@@ -128,18 +128,20 @@ class ModelManager:
                     if on_progress is not None:
                         on_progress(data)
         except httpx.ConnectError as exc:
-            raise RuntimeError(f"Cannot connect to Ollama: {exc}. Is Ollama running?") from exc
-        log.info("Pulled %s via Ollama", model)
+            raise RuntimeError(
+                f"Cannot connect to litellm backend: {exc}. Is the server running?"
+            ) from exc
+        log.info("Pulled %s via litellm backend", model)
 
     def remove(self, model: str, source: ModelSource | None = None) -> bool:
         """Remove installed model. Returns True if removed."""
         if source is None:
             native_removed = self._remove_native(model)
-            ollama_removed = self._remove_ollama(model)
-            return native_removed or ollama_removed
+            litellm_removed = self._remove_litellm(model)
+            return native_removed or litellm_removed
         if source is ModelSource.NATIVE:
             return self._remove_native(model)
-        return self._remove_ollama(model)
+        return self._remove_litellm(model)
 
     def _remove_native(self, model: str) -> bool:
         path = self._models_dir / model
@@ -149,25 +151,27 @@ class ModelManager:
             return True
         return False
 
-    def _remove_ollama(self, model: str) -> bool:
-        url = f"{self._ollama_base_url}/api/delete"
+    def _remove_litellm(self, model: str) -> bool:
+        url = f"{self._litellm_base_url}/api/delete"
         try:
             resp = httpx.request(
                 "DELETE",
                 url,
                 content=json.dumps({"model": model}).encode(),
                 headers={"Content-Type": "application/json"},
-                timeout=_OLLAMA_TIMEOUT,
+                timeout=_LITELLM_TIMEOUT,
             )
             if resp.status_code == 200:
-                log.info("Removed Ollama model %s", model)
+                log.info("Removed litellm model %s", model)
                 return True
             if resp.status_code == 404:
                 return False
             log.warning("Unexpected status %d removing %s", resp.status_code, model)
             return False
         except httpx.ConnectError as exc:
-            raise RuntimeError(f"Cannot connect to Ollama: {exc}. Is Ollama running?") from exc
+            raise RuntimeError(
+                f"Cannot connect to litellm backend: {exc}. Is the server running?"
+            ) from exc
 
 
 _EMBEDDING_FAMILIES = frozenset({"bert", "nomic-bert", "e5", "bge"})
@@ -175,8 +179,8 @@ _VISION_NAME_PATTERNS = frozenset({"llava", "vision", "moondream", "ocr", "minic
 
 
 @dataclass
-class OllamaModel:
-    """An Ollama model with inferred task classification."""
+class RemoteModel:
+    """A model from the litellm backend with inferred task classification."""
 
     name: str
     task: str  # "chat", "embedding", "vision"
@@ -184,8 +188,12 @@ class OllamaModel:
     parameter_size: str
 
 
-def _classify_ollama_task(name: str, family: str) -> str:
-    """Classify an Ollama model as chat, embedding, or vision."""
+# Backwards-compatible alias
+OllamaModel = RemoteModel
+
+
+def _classify_remote_task(name: str, family: str) -> str:
+    """Classify a remote model as chat, embedding, or vision."""
     family_lower = family.lower()
     if any(ef in family_lower for ef in _EMBEDDING_FAMILIES):
         return "embedding"
@@ -195,33 +203,41 @@ def _classify_ollama_task(name: str, family: str) -> str:
     return "chat"
 
 
-def classify_ollama_models(ollama_url: str = "http://localhost:11434") -> list[OllamaModel]:
-    """Discover and classify all Ollama models by task.
+def classify_remote_models(base_url: str = "http://localhost:11434") -> list[RemoteModel]:
+    """Discover and classify all models from the litellm backend by task.
 
     Uses /api/tags family metadata for embedding detection and
     name patterns for vision detection.
     """
     try:
-        resp = httpx.get(f"{ollama_url}/api/tags", timeout=5.0)
+        resp = httpx.get(f"{base_url}/api/tags", timeout=5.0)
         resp.raise_for_status()
         raw_models = resp.json().get("models", [])
     except Exception:
         return []
 
-    result: list[OllamaModel] = []
+    result: list[RemoteModel] = []
     for model in raw_models:
         name = model.get("name", "")
         details = model.get("details", {})
         family = details.get("family", "")
         param_size = details.get("parameter_size", "")
-        task = _classify_ollama_task(name, family)
-        result.append(OllamaModel(name=name, task=task, family=family, parameter_size=param_size))
+        task = _classify_remote_task(name, family)
+        result.append(RemoteModel(name=name, task=task, family=family, parameter_size=param_size))
     return result
 
 
-def detect_ollama_embedding_models(ollama_url: str = "http://localhost:11434") -> list[str]:
-    """Return names of Ollama models classified as embedding."""
-    return [m.name for m in classify_ollama_models(ollama_url) if m.task == "embedding"]
+# Backwards-compatible alias
+classify_ollama_models = classify_remote_models
+
+
+def detect_remote_embedding_models(base_url: str = "http://localhost:11434") -> list[str]:
+    """Return names of models classified as embedding from the litellm backend."""
+    return [m.name for m in classify_remote_models(base_url) if m.task == "embedding"]
+
+
+# Backwards-compatible alias
+detect_ollama_embedding_models = detect_remote_embedding_models
 
 
 _manager: ModelManager | None = None
@@ -233,7 +249,7 @@ def get_model_manager() -> ModelManager:
     if _manager is None:
         from lilbee.config import cfg
 
-        _manager = ModelManager(cfg.models_dir, cfg.ollama_url)
+        _manager = ModelManager(cfg.models_dir, cfg.litellm_base_url)
     return _manager
 
 

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 # Extra headroom required beyond model size (GB)
 _DISK_HEADROOM_GB = 2
 
-OLLAMA_MODELS_URL = "https://ollama.com/library"
+MODELS_BROWSE_URL = "https://ollama.com/library"
 
 
 def ensure_tag(name: str) -> str:
@@ -152,7 +152,7 @@ def display_model_picker(
     console.print(table)
     console.print(f"\n  System: {ram_gb:.0f} GB RAM, {free_disk_gb:.1f} GB free disk")
     console.print("  \u2605 = recommended for your system")
-    console.print(f"  Browse more models at {OLLAMA_MODELS_URL}\n")
+    console.print(f"  Browse more models at {MODELS_BROWSE_URL}\n")
 
     return recommended
 
@@ -199,7 +199,7 @@ def display_vision_picker(
     console.print(table)
     console.print(f"\n  System: {ram_gb:.0f} GB RAM, {free_disk_gb:.1f} GB free disk")
     console.print("  \u2605 = recommended for your system")
-    console.print(f"  Browse more models at {OLLAMA_MODELS_URL}\n")
+    console.print(f"  Browse more models at {MODELS_BROWSE_URL}\n")
 
     return recommended
 

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -28,14 +28,18 @@ def get_provider() -> LLMProvider:
         from lilbee.providers.llama_cpp_provider import LlamaCppProvider
 
         _provider = LlamaCppProvider()
-    elif provider_name == "ollama":
+    elif provider_name in ("litellm", "ollama"):
         from lilbee.providers.litellm_provider import LiteLLMProvider
 
-        _provider = LiteLLMProvider(base_url=cfg.ollama_url)
-    elif provider_name == "litellm":
-        from lilbee.providers.litellm_provider import LiteLLMProvider
+        if not LiteLLMProvider.available():
+            from lilbee.providers.base import ProviderError
 
-        _provider = LiteLLMProvider(base_url=cfg.ollama_url, api_key=cfg.llm_api_key)
+            raise ProviderError(
+                "litellm is not installed. Install with: pip install 'lilbee[litellm]'"
+            )
+        _provider = LiteLLMProvider(
+            base_url=cfg.litellm_base_url, api_key=cfg.llm_api_key
+        )
     else:
         from lilbee.providers.base import ProviderError
 

--- a/src/lilbee/providers/litellm_provider.py
+++ b/src/lilbee/providers/litellm_provider.py
@@ -1,4 +1,9 @@
-"""LiteLLM provider for Ollama, OpenAI, and other backends."""
+"""LiteLLM provider for external LLM backends.
+
+For users who manage models with external tools like Ollama, or want to connect
+to frontier AI APIs (OpenAI, Anthropic, Azure). Install with ``pip install
+lilbee[litellm]``. By default, lilbee manages its own models via llama-cpp.
+"""
 
 from __future__ import annotations
 
@@ -13,19 +18,34 @@ from lilbee.providers.base import LLMProvider, ProviderError
 
 log = logging.getLogger(__name__)
 
-# HTTP timeout for Ollama API calls (seconds)
+# HTTP timeout for litellm API calls (seconds)
 _HTTP_TIMEOUT = 30
 
 
+def litellm_available() -> bool:
+    """Return True if litellm is installed."""
+    try:
+        import litellm  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 class LiteLLMProvider(LLMProvider):
-    """Provider backed by litellm for Ollama/cloud APIs."""
+    """Provider backed by litellm for external APIs (Ollama, OpenAI, Azure, etc.)."""
+
+    @staticmethod
+    def available() -> bool:
+        """Return True if litellm is installed."""
+        return litellm_available()
 
     def __init__(self, *, base_url: str = "http://localhost:11434", api_key: str = "") -> None:
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
 
     def _model_name(self, model: str | None = None) -> str:
-        """Prefix model name with ollama/ for litellm routing."""
+        """Prefix model name with ollama/ for litellm routing when needed."""
         from lilbee.config import cfg
 
         resolved = model or cfg.chat_model
@@ -34,7 +54,7 @@ class LiteLLMProvider(LLMProvider):
         return resolved
 
     def _embed_model_name(self) -> str:
-        """Prefix embedding model with ollama/ for litellm routing."""
+        """Prefix embedding model with ollama/ for litellm routing when needed."""
         from lilbee.config import cfg
 
         name = cfg.embedding_model
@@ -90,7 +110,7 @@ class LiteLLMProvider(LLMProvider):
         return response.choices[0].message.content or ""
 
     def list_models(self) -> list[str]:
-        """List models via Ollama's /api/tags endpoint."""
+        """List models via the /api/tags endpoint."""
         try:
             resp = httpx.get(f"{self._base_url}/api/tags", timeout=_HTTP_TIMEOUT)
             resp.raise_for_status()
@@ -100,7 +120,7 @@ class LiteLLMProvider(LLMProvider):
             raise ProviderError(f"Cannot list models: {exc}", provider="litellm") from exc
 
     def pull_model(self, model: str, *, on_progress: Callable[..., Any] | None = None) -> None:
-        """Pull a model via Ollama's /api/pull endpoint."""
+        """Pull a model via the /api/pull endpoint."""
         try:
             with (
                 httpx.Client(timeout=None) as client,
@@ -125,7 +145,7 @@ class LiteLLMProvider(LLMProvider):
             raise ProviderError(f"Cannot pull model {model!r}: {exc}", provider="litellm") from exc
 
     def show_model(self, model: str) -> dict[str, str] | None:
-        """Get model info via Ollama's /api/show endpoint."""
+        """Get model info via the /api/show endpoint."""
         try:
             resp = httpx.post(
                 f"{self._base_url}/api/show",

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -14,14 +14,14 @@ log = logging.getLogger(__name__)
 class RoutingProvider(LLMProvider):
     """Routes each call to the correct backend based on model source.
 
-    If a model exists in Ollama, uses litellm (Ollama backend).
+    If litellm is installed and models are reachable via its API, uses litellm.
     Otherwise, uses llama-cpp for local GGUF files.
     """
 
     def __init__(self) -> None:
         self._llama_cpp: LLMProvider | None = None
         self._litellm: LLMProvider | None = None
-        self._ollama_models: set[str] | None = None
+        self._remote_models: set[str] | None = None
 
     def _get_llama_cpp(self) -> LLMProvider:
         if self._llama_cpp is None:
@@ -35,26 +35,32 @@ class RoutingProvider(LLMProvider):
             from lilbee.config import cfg
             from lilbee.providers.litellm_provider import LiteLLMProvider
 
-            self._litellm = LiteLLMProvider(base_url=cfg.ollama_url)
+            self._litellm = LiteLLMProvider(base_url=cfg.litellm_base_url)
         return self._litellm
 
-    def _ollama_available(self) -> set[str]:
-        """Return set of models available in Ollama, cached per provider lifetime."""
-        if self._ollama_models is not None:
-            return self._ollama_models
-        try:
-            self._ollama_models = set(self._get_litellm().list_models())
-        except (ProviderError, Exception):
-            log.debug("Ollama not reachable, using local models only")
-            self._ollama_models = set()
-        return self._ollama_models
+    def _litellm_models(self) -> set[str]:
+        """Return set of models available via litellm, cached per provider lifetime."""
+        if self._remote_models is not None:
+            return self._remote_models
 
-    def _is_in_ollama(self, model: str) -> bool:
-        return model in self._ollama_available()
+        from lilbee.providers.litellm_provider import litellm_available
+
+        if not litellm_available():
+            self._remote_models = set()
+            return self._remote_models
+        try:
+            self._remote_models = set(self._get_litellm().list_models())
+        except (ProviderError, Exception):
+            log.debug("litellm backend not reachable, using local models only")
+            self._remote_models = set()
+        return self._remote_models
+
+    def _is_in_litellm(self, model: str) -> bool:
+        return model in self._litellm_models()
 
     def _provider_for(self, model: str) -> LLMProvider:
         """Pick the right provider for a given model name."""
-        if self._is_in_ollama(model):
+        if self._is_in_litellm(model):
             return self._get_litellm()
         return self._get_llama_cpp()
 
@@ -81,18 +87,18 @@ class RoutingProvider(LLMProvider):
         )
 
     def list_models(self) -> list[str]:
-        """Return the union of Ollama and native GGUF models."""
+        """Return the union of litellm and native GGUF models."""
         import contextlib
 
         native: set[str] = set()
         with contextlib.suppress(Exception):
             native = set(self._get_llama_cpp().list_models())
-        ollama = self._ollama_available()
-        return sorted(native | ollama)
+        remote = self._litellm_models()
+        return sorted(native | remote)
 
     def pull_model(self, model: str, *, on_progress: Callable[..., Any] | None = None) -> None:
-        """Pull via Ollama if available, otherwise raise."""
-        if self._ollama_available() is not None:
+        """Pull via litellm if available, otherwise raise."""
+        if self._litellm_models() is not None:
             try:
                 self._get_litellm().pull_model(model, on_progress=on_progress)
                 self.invalidate_cache()
@@ -102,11 +108,11 @@ class RoutingProvider(LLMProvider):
         raise ProviderError(f"Cannot pull model {model!r}: no pull-capable backend available")
 
     def show_model(self, model: str) -> dict[str, str] | None:
-        """Try Ollama first (has metadata), fall back to llama-cpp (returns None)."""
-        if self._is_in_ollama(model):
+        """Try litellm first (has metadata), fall back to llama-cpp (returns None)."""
+        if self._is_in_litellm(model):
             return self._get_litellm().show_model(model)
         return self._get_llama_cpp().show_model(model)
 
     def invalidate_cache(self) -> None:
-        """Clear cached Ollama model list (after pull/delete)."""
-        self._ollama_models = None
+        """Clear cached litellm model list (after pull/delete)."""
+        self._remote_models = None

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -438,7 +438,7 @@ async def get_config() -> dict[str, Any]:
         "chat_model": cfg.chat_model,
         "embedding_model": cfg.embedding_model,
         "vision_model": cfg.vision_model,
-        "ollama_url": cfg.ollama_url,
+        "litellm_base_url": cfg.litellm_base_url,
         "system_prompt": cfg.system_prompt,
         "top_k": cfg.top_k,
         "max_distance": cfg.max_distance,
@@ -506,7 +506,7 @@ async def models_catalog(
 
     models = []
     for m in result.models:
-        source = "ollama" if m.name in installed_names else "native"
+        source = "litellm" if m.name in installed_names else "native"
         models.append(
             {
                 "name": m.name,
@@ -535,7 +535,7 @@ async def models_installed() -> dict[str, Any]:
     models = []
     for name in names:
         src = manager.get_source(name)
-        source_str = src.value if src is not None else ModelSource.OLLAMA.value
+        source_str = src.value if src is not None else ModelSource.LITELLM.value
         models.append({"name": name, "source": source_str})
     return {"models": models}
 
@@ -560,7 +560,7 @@ async def models_pull(model: str, *, source: str = "native") -> AsyncGenerator[s
         yield sse_error(str(exc))
 
 
-async def models_delete(model: str, *, source: str = "ollama") -> dict[str, Any]:
+async def models_delete(model: str, *, source: str = "litellm") -> dict[str, Any]:
     """Delete a model. Returns {deleted, model, freed_gb}."""
     from lilbee.model_manager import get_model_manager
 

--- a/src/lilbee/server/litestar_app.py
+++ b/src/lilbee/server/litestar_app.py
@@ -150,7 +150,7 @@ async def add_route(data: AddRequest) -> Stream:
 
 @get("/api/models")
 async def models_list_route() -> dict[str, Any]:
-    """Available chat and vision models from Ollama."""
+    """Available chat and vision models."""
     return await handlers.list_models()
 
 
@@ -192,7 +192,7 @@ async def models_catalog_route(
 
 @get("/api/models/installed")
 async def models_installed_route() -> dict[str, Any]:
-    """List installed models with their source (native or ollama)."""
+    """List installed models with their source (native or litellm)."""
     return await handlers.models_installed()
 
 

--- a/src/lilbee/vision.py
+++ b/src/lilbee/vision.py
@@ -1,7 +1,7 @@
 """Vision model OCR extraction for scanned PDFs.
 
 Rasterizes PDF pages to PNG, sends each to a local vision model
-via Ollama, and concatenates the extracted text.
+via the configured LLM provider, and concatenates the extracted text.
 """
 
 import contextlib

--- a/tests/integration/test_rag_integration.py
+++ b/tests/integration/test_rag_integration.py
@@ -1,7 +1,7 @@
 """RAG pipeline integration tests with real models.
 
 Uses llama-cpp-python with real GGUF models downloaded from HuggingFace.
-No Ollama required. Marked slow — excluded from default test runs.
+No external server required. Marked slow — excluded from default test runs.
 
 Run with:
     uv run pytest tests/test_rag_integration.py -v -m slow

--- a/tests/integration/test_tui_integration.py
+++ b/tests/integration/test_tui_integration.py
@@ -251,7 +251,7 @@ class TestSlashCommandIntegration:
             await pilot.pause()
             with (
                 patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-                patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+                patch("lilbee.model_manager.classify_remote_models", return_value=[]),
             ):
                 app.screen._handle_slash("/model")
                 await pilot.pause()
@@ -471,7 +471,7 @@ class TestGlobalKeybindings:
             await pilot.pause()
             with (
                 patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-                patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+                patch("lilbee.model_manager.classify_remote_models", return_value=[]),
             ):
                 app.action_push_catalog()
                 await pilot.pause()
@@ -588,7 +588,7 @@ class TestCatalogKeybindings:
         async with app.run_test(size=(120, 40)) as pilot:
             with (
                 patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-                patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+                patch("lilbee.model_manager.classify_remote_models", return_value=[]),
             ):
                 screen = CatalogScreen()
                 app.push_screen(screen)
@@ -604,7 +604,7 @@ class TestCatalogKeybindings:
         async with app.run_test(size=(120, 40)) as pilot:
             with (
                 patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-                patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+                patch("lilbee.model_manager.classify_remote_models", return_value=[]),
             ):
                 screen = CatalogScreen()
                 app.push_screen(screen)
@@ -621,7 +621,7 @@ class TestCatalogKeybindings:
         async with app.run_test(size=(120, 40)) as pilot:
             with (
                 patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-                patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+                patch("lilbee.model_manager.classify_remote_models", return_value=[]),
             ):
                 screen = CatalogScreen()
                 app.push_screen(screen)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,7 +31,7 @@ def _mock_stream(*texts: str):
 
 @pytest.fixture(autouse=True)
 def _skip_model_validation():
-    """CLI tests never need real Ollama model validation or chat model checks."""
+    """CLI tests never need real model validation or chat model checks."""
     with (
         mock.patch("lilbee.embedder.validate_model"),
         mock.patch("lilbee.models.ensure_chat_model"),
@@ -1253,61 +1253,61 @@ class TestAskModelNotFound:
         assert "not found" in data["error"]
 
 
-class TestOllamaUnavailable:
-    """CLI commands should show friendly errors when Ollama is unreachable."""
+class TestBackendUnavailable:
+    """CLI commands should show friendly errors when the backend is unreachable."""
 
-    _ERR = RuntimeError("Cannot connect to Ollama: Connection refused")
+    _ERR = RuntimeError("Connection refused")
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, side_effect=_ERR)
-    def test_sync_ollama_unavailable(self, mock_sync):
+    def test_sync_backend_unavailable(self, mock_sync):
         result = runner.invoke(app, ["sync"])
         assert result.exit_code == 1
-        assert "Cannot connect to Ollama" in result.output
+        assert "Connection refused" in result.output
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, side_effect=_ERR)
-    def test_sync_ollama_unavailable_json(self, mock_sync):
+    def test_sync_backend_unavailable_json(self, mock_sync):
         result = runner.invoke(app, ["--json", "sync"])
         assert result.exit_code == 1
         data = json.loads(result.output.strip())
-        assert "Cannot connect to Ollama" in data["error"]
+        assert "Connection refused" in data["error"]
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, side_effect=_ERR)
-    def test_rebuild_ollama_unavailable(self, mock_sync):
+    def test_rebuild_backend_unavailable(self, mock_sync):
         result = runner.invoke(app, ["rebuild"])
         assert result.exit_code == 1
-        assert "Cannot connect to Ollama" in result.output
+        assert "Connection refused" in result.output
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, side_effect=_ERR)
-    def test_rebuild_ollama_unavailable_json(self, mock_sync):
+    def test_rebuild_backend_unavailable_json(self, mock_sync):
         result = runner.invoke(app, ["--json", "rebuild"])
         assert result.exit_code == 1
         data = json.loads(result.output.strip())
-        assert "Cannot connect to Ollama" in data["error"]
+        assert "Connection refused" in data["error"]
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, side_effect=_ERR)
-    def test_add_ollama_unavailable(self, mock_sync, isolated_env, tmp_path):
+    def test_add_backend_unavailable(self, mock_sync, isolated_env, tmp_path):
         src = tmp_path / "source" / "test.txt"
         src.parent.mkdir()
         src.write_text("content")
         result = runner.invoke(app, ["add", str(src)])
         assert result.exit_code == 1
-        assert "Cannot connect to Ollama" in result.output
+        assert "Connection refused" in result.output
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, side_effect=_ERR)
-    def test_add_ollama_unavailable_json(self, mock_sync, isolated_env, tmp_path):
+    def test_add_backend_unavailable_json(self, mock_sync, isolated_env, tmp_path):
         src = tmp_path / "source" / "test.txt"
         src.parent.mkdir()
         src.write_text("content")
         result = runner.invoke(app, ["--json", "add", str(src)])
         assert result.exit_code == 1
         data = json.loads(result.output.strip())
-        assert "Cannot connect to Ollama" in data["error"]
+        assert "Connection refused" in data["error"]
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, side_effect=_ERR)
-    def test_auto_sync_ollama_unavailable(self, mock_sync):
+    def test_auto_sync_backend_unavailable(self, mock_sync):
         result = runner.invoke(app, ["ask", "hello"])
         assert result.exit_code == 1
-        assert "Cannot connect to Ollama" in result.output
+        assert "Connection refused" in result.output
 
 
 class TestEnsureChatModelWiring:
@@ -1356,7 +1356,7 @@ class TestEnsureVisionModel:
             assert cfg.vision_model == "saved-model"
             mock_val.assert_called_once()
 
-    def test_ollama_unreachable_disables_vision(self) -> None:
+    def test_backend_unreachable_disables_vision(self) -> None:
         from lilbee.cli.commands import _ensure_vision_model
 
         cfg.vision_model = ""
@@ -1427,7 +1427,7 @@ class TestValidateConfiguredVision:
             _validate_configured_vision()
             assert cfg.vision_model == ""
 
-    def test_ollama_unreachable_keeps_config(self) -> None:
+    def test_backend_unreachable_keeps_config(self) -> None:
         from lilbee.cli.commands import _validate_configured_vision
 
         cfg.vision_model = "llava:7b"

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,7 +1,7 @@
 """Real-file format tests — full sync() pipeline with actual files on disk.
 
 All document formats go through kreuzberg. Code files still use tree-sitter.
-Embeddings are mocked (no Ollama needed). kreuzberg is mocked for document
+Embeddings are mocked (no live LLM server needed). kreuzberg is mocked for document
 extraction since we're testing the pipeline, not kreuzberg itself.
 """
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -53,7 +53,7 @@ def _no_dns():
 
 @pytest.fixture(autouse=True)
 def _skip_model_validation():
-    """MCP tests never need real Ollama model validation."""
+    """MCP tests never need real model validation."""
     with mock.patch("lilbee.embedder.validate_model"):
         yield
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -18,11 +18,11 @@ class TestModelSource:
     def test_native_value(self) -> None:
         assert ModelSource.NATIVE.value == "native"
 
-    def test_ollama_value(self) -> None:
-        assert ModelSource.OLLAMA.value == "ollama"
+    def test_litellm_value(self) -> None:
+        assert ModelSource.LITELLM.value == "litellm"
 
     def test_members(self) -> None:
-        assert set(ModelSource) == {ModelSource.NATIVE, ModelSource.OLLAMA}
+        assert set(ModelSource) == {ModelSource.NATIVE, ModelSource.LITELLM}
 
 
 class TestModelManagerListInstalled:
@@ -51,7 +51,7 @@ class TestModelManagerListInstalled:
         mgr = ModelManager(models_dir, "http://localhost:11434")
         assert mgr.list_installed(ModelSource.NATIVE) == []
 
-    def test_ollama_lists_models(self) -> None:
+    def test_litellm_lists_models(self) -> None:
         mock_response = mock.Mock()
         mock_response.json.return_value = {
             "models": [
@@ -63,26 +63,26 @@ class TestModelManagerListInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response) as mock_get:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.list_installed(ModelSource.OLLAMA)
+            result = mgr.list_installed(ModelSource.LITELLM)
 
         mock_get.assert_called_once_with("http://localhost:11434/api/tags", timeout=30.0)
         assert set(result) == {"llama3:latest", "nomic-embed-text:latest"}
 
-    def test_ollama_connection_error(self) -> None:
+    def test_litellm_connection_error(self) -> None:
         with mock.patch("httpx.get", side_effect=httpx.ConnectError("Connection refused")):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.list_installed(ModelSource.OLLAMA)
+            result = mgr.list_installed(ModelSource.LITELLM)
 
         assert result == []
 
-    def test_ollama_empty_response(self) -> None:
+    def test_litellm_empty_response(self) -> None:
         mock_response = mock.Mock()
         mock_response.json.return_value = {"models": []}
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.list_installed(ModelSource.OLLAMA)
+            result = mgr.list_installed(ModelSource.LITELLM)
 
         assert result == []
 
@@ -92,14 +92,14 @@ class TestModelManagerListInstalled:
         (models_dir / "native-model.gguf").touch()
 
         mock_response = mock.Mock()
-        mock_response.json.return_value = {"models": [{"name": "ollama-model:latest"}]}
+        mock_response.json.return_value = {"models": [{"name": "remote-model:latest"}]}
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(models_dir, "http://localhost:11434")
             result = mgr.list_installed(None)
 
-        assert set(result) == {"native-model.gguf", "ollama-model:latest"}
+        assert set(result) == {"native-model.gguf", "remote-model:latest"}
 
     def test_none_source_deduplicates(self, tmp_path: Path) -> None:
         """If same model appears in both sources, it should appear once."""
@@ -134,25 +134,25 @@ class TestModelManagerIsInstalled:
         mgr = ModelManager(models_dir, "http://localhost:11434")
         assert mgr.is_installed("missing.gguf", ModelSource.NATIVE) is False
 
-    def test_ollama_installed(self) -> None:
+    def test_litellm_installed(self) -> None:
         mock_response = mock.Mock()
         mock_response.json.return_value = {"models": [{"name": "llama3:latest"}]}
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.is_installed("llama3:latest", ModelSource.OLLAMA)
+            result = mgr.is_installed("llama3:latest", ModelSource.LITELLM)
 
         assert result is True
 
-    def test_ollama_not_installed(self) -> None:
+    def test_litellm_not_installed(self) -> None:
         mock_response = mock.Mock()
         mock_response.json.return_value = {"models": []}
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.is_installed("missing:latest", ModelSource.OLLAMA)
+            result = mgr.is_installed("missing:latest", ModelSource.LITELLM)
 
         assert result is False
 
@@ -168,7 +168,7 @@ class TestModelManagerIsInstalled:
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(models_dir, "http://localhost:11434")
             assert mgr.is_installed("native-model.gguf", None) is True
-            assert mgr.is_installed("ollama-model:latest", None) is False
+            assert mgr.is_installed("remote-model:latest", None) is False
 
 
 class TestModelManagerGetSource:
@@ -180,7 +180,7 @@ class TestModelManagerGetSource:
         mgr = ModelManager(models_dir, "http://localhost:11434")
         assert mgr.get_source("my-model.gguf") == ModelSource.NATIVE
 
-    def test_ollama_model(self) -> None:
+    def test_litellm_model(self) -> None:
         mock_response = mock.Mock()
         mock_response.json.return_value = {"models": [{"name": "llama3:latest"}]}
         mock_response.raise_for_status = mock.Mock()
@@ -189,7 +189,7 @@ class TestModelManagerGetSource:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
             result = mgr.get_source("llama3:latest")
 
-        assert result == ModelSource.OLLAMA
+        assert result == ModelSource.LITELLM
 
     def test_native_takes_precedence(self, tmp_path: Path) -> None:
         """When model exists in both sources, NATIVE takes precedence."""
@@ -258,7 +258,7 @@ class TestModelManagerPull:
         ):
             mgr.pull("nonexistent-model", ModelSource.NATIVE)
 
-    def test_ollama_pull_success(self, tmp_path: Path) -> None:
+    def test_litellm_pull_success(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
@@ -287,17 +287,17 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.OLLAMA, on_progress=on_progress)
+            result = mgr.pull("llama3:latest", ModelSource.LITELLM, on_progress=on_progress)
 
         mock_client.stream.assert_called_once()
         call_args = mock_client.stream.call_args
         assert call_args[0] == ("POST", "http://localhost:11434/api/pull")
         assert call_args[1]["json"] == {"name": "llama3:latest", "stream": True}
 
-        assert result is None  # Ollama pull doesn't return a path
+        assert result is None  # litellm pull doesn't return a path
         assert len(progress_calls) > 0
 
-    def test_ollama_pull_error(self, tmp_path: Path) -> None:
+    def test_litellm_pull_error(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
@@ -317,9 +317,9 @@ class TestModelManagerPull:
             mock.patch("httpx.Client", return_value=mock_client),
             pytest.raises(RuntimeError, match="model not found"),
         ):
-            mgr.pull("nonexistent:model", ModelSource.OLLAMA)
+            mgr.pull("nonexistent:model", ModelSource.LITELLM)
 
-    def test_ollama_connection_error_during_pull(self, tmp_path: Path) -> None:
+    def test_litellm_connection_error_during_pull(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
@@ -331,11 +331,11 @@ class TestModelManagerPull:
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with (
             mock.patch("httpx.Client", return_value=mock_client),
-            pytest.raises(RuntimeError, match="Cannot connect to Ollama"),
+            pytest.raises(RuntimeError, match="Cannot connect to litellm backend"),
         ):
-            mgr.pull("llama3:latest", ModelSource.OLLAMA)
+            mgr.pull("llama3:latest", ModelSource.LITELLM)
 
-    def test_ollama_pull_without_progress_callback(self, tmp_path: Path) -> None:
+    def test_litellm_pull_without_progress_callback(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
@@ -357,11 +357,11 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.OLLAMA)
+            result = mgr.pull("llama3:latest", ModelSource.LITELLM)
 
         assert result is None
 
-    def test_ollama_pull_skips_empty_lines(self, tmp_path: Path) -> None:
+    def test_litellm_pull_skips_empty_lines(self, tmp_path: Path) -> None:
         """Empty strings from iter_lines are skipped."""
         models_dir = tmp_path / "models"
         models_dir.mkdir()
@@ -379,7 +379,7 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.OLLAMA)
+            result = mgr.pull("llama3:latest", ModelSource.LITELLM)
 
         assert result is None
 
@@ -402,13 +402,13 @@ class TestModelManagerRemove:
         mgr = ModelManager(models_dir, "http://localhost:11434")
         assert mgr.remove("missing.gguf", ModelSource.NATIVE) is False
 
-    def test_ollama_remove_success(self) -> None:
+    def test_litellm_remove_success(self) -> None:
         mock_response = mock.Mock()
         mock_response.status_code = 200
 
         with mock.patch("httpx.request", return_value=mock_response) as mock_req:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("llama3:latest", ModelSource.OLLAMA)
+            result = mgr.remove("llama3:latest", ModelSource.LITELLM)
 
         mock_req.assert_called_once()
         call_kwargs = mock_req.call_args[1]
@@ -416,34 +416,34 @@ class TestModelManagerRemove:
         assert call_kwargs["headers"]["Content-Type"] == "application/json"
         assert result is True
 
-    def test_ollama_remove_not_found(self) -> None:
+    def test_litellm_remove_not_found(self) -> None:
         mock_response = mock.Mock()
         mock_response.status_code = 404
 
         with mock.patch("httpx.request", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("nonexistent:latest", ModelSource.OLLAMA)
+            result = mgr.remove("nonexistent:latest", ModelSource.LITELLM)
 
         assert result is False
 
-    def test_ollama_connection_error_during_remove(self) -> None:
+    def test_litellm_connection_error_during_remove(self) -> None:
         with mock.patch("httpx.request", side_effect=httpx.ConnectError("Connection refused")):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            with pytest.raises(RuntimeError, match="Cannot connect to Ollama"):
-                mgr.remove("llama3:latest", ModelSource.OLLAMA)
+            with pytest.raises(RuntimeError, match="Cannot connect to litellm backend"):
+                mgr.remove("llama3:latest", ModelSource.LITELLM)
 
-    def test_ollama_remove_unexpected_status(self) -> None:
+    def test_litellm_remove_unexpected_status(self) -> None:
         mock_response = mock.Mock()
         mock_response.status_code = 500
 
         with mock.patch("httpx.request", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("llama3:latest", ModelSource.OLLAMA)
+            result = mgr.remove("llama3:latest", ModelSource.LITELLM)
 
         assert result is False
 
     def test_none_source_removes_from_all(self, tmp_path: Path) -> None:
-        """source=None tries native first, then ollama."""
+        """source=None tries native first, then litellm."""
         models_dir = tmp_path / "models"
         models_dir.mkdir()
         model_file = models_dir / "my-model.gguf"
@@ -470,14 +470,14 @@ class TestSingleton:
     def test_creates_singleton(self) -> None:
         with mock.patch("lilbee.config.cfg") as mock_cfg:
             mock_cfg.models_dir = Path("/tmp/models")
-            mock_cfg.ollama_url = "http://localhost:11434"
+            mock_cfg.litellm_base_url = "http://localhost:11434"
             mgr = get_model_manager()
             assert isinstance(mgr, ModelManager)
 
     def test_returns_same_instance(self) -> None:
         with mock.patch("lilbee.config.cfg") as mock_cfg:
             mock_cfg.models_dir = Path("/tmp/models")
-            mock_cfg.ollama_url = "http://localhost:11434"
+            mock_cfg.litellm_base_url = "http://localhost:11434"
             mgr1 = get_model_manager()
             mgr2 = get_model_manager()
             assert mgr1 is mgr2
@@ -485,15 +485,15 @@ class TestSingleton:
     def test_reset_creates_new_instance(self) -> None:
         with mock.patch("lilbee.config.cfg") as mock_cfg:
             mock_cfg.models_dir = Path("/tmp/models")
-            mock_cfg.ollama_url = "http://localhost:11434"
+            mock_cfg.litellm_base_url = "http://localhost:11434"
             mgr1 = get_model_manager()
             reset_model_manager()
             mgr2 = get_model_manager()
             assert mgr1 is not mgr2
 
 
-class TestOllamaEdgeCases:
-    def test_ollama_http_error(self, tmp_path: Path) -> None:
+class TestLitellmEdgeCases:
+    def test_litellm_http_error(self, tmp_path: Path) -> None:
         mock_response = mock.Mock()
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
@@ -502,14 +502,14 @@ class TestOllamaEdgeCases:
         )
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir=tmp_path, ollama_base_url="http://localhost:11434")
-            result = mgr.list_installed(ModelSource.OLLAMA)
+            mgr = ModelManager(models_dir=tmp_path, litellm_base_url="http://localhost:11434")
+            result = mgr.list_installed(ModelSource.LITELLM)
 
         assert result == []
 
-    def test_ollama_timeout(self, tmp_path: Path) -> None:
+    def test_litellm_timeout(self, tmp_path: Path) -> None:
         with mock.patch("httpx.get", side_effect=httpx.TimeoutException("timeout")):
-            mgr = ModelManager(models_dir=tmp_path, ollama_base_url="http://localhost:11434")
-            result = mgr.list_installed(ModelSource.OLLAMA)
+            mgr = ModelManager(models_dir=tmp_path, litellm_base_url="http://localhost:11434")
+            result = mgr.list_installed(ModelSource.LITELLM)
 
         assert result == []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -156,7 +156,7 @@ class TestDisplayModelPicker:
     def test_shows_browse_link(self, capsys):
         models.display_model_picker(8.0, 50.0)
         captured = capsys.readouterr()
-        assert models.OLLAMA_MODELS_URL in captured.err
+        assert models.MODELS_BROWSE_URL in captured.err
 
 
 class TestPromptModelChoice:
@@ -399,7 +399,7 @@ class TestDisplayVisionPicker:
     def test_shows_browse_link(self, capsys: pytest.CaptureFixture[str]) -> None:
         models.display_vision_picker(8.0, 50.0)
         captured = capsys.readouterr()
-        assert models.OLLAMA_MODELS_URL in captured.err
+        assert models.MODELS_BROWSE_URL in captured.err
 
 
 class TestEnsureTag:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,6 @@
 """Tests for embedder + store round-trip.
 
-Requires a running Ollama instance with nomic-embed-text model.
+Requires a running embedding model backend with nomic-embed-text model.
 """
 
 import pytest
@@ -109,7 +109,7 @@ class TestStoreRoundTrip:
 
 
 class TestStoreOperations:
-    """Cover store paths that don't need Ollama."""
+    """Cover store paths that don't need a live backend."""
 
     def test_add_chunks_and_search_empty_table(self):
         """add_chunks with data + search on that table."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -699,7 +699,7 @@ class TestFactory:
         provider = get_provider()
         assert isinstance(provider, LlamaCppProvider)
 
-    def test_ollama_provider(self) -> None:
+    def test_ollama_alias_provider(self) -> None:
         from lilbee.providers.factory import get_provider
         from lilbee.providers.litellm_provider import LiteLLMProvider
 
@@ -747,8 +747,8 @@ class TestFactory:
         from lilbee.providers.factory import get_provider
         from lilbee.providers.litellm_provider import LiteLLMProvider
 
-        cfg.llm_provider = "ollama"
-        cfg.ollama_url = "http://custom:11434"
+        cfg.llm_provider = "litellm"
+        cfg.litellm_base_url = "http://custom:11434"
         provider = get_provider()
         assert isinstance(provider, LiteLLMProvider)
         assert provider._base_url == "http://custom:11434"
@@ -770,7 +770,7 @@ class TestConfigProvider:
 
             c = Config.from_env()
             assert c.llm_provider == "auto"
-            assert c.ollama_url == "http://localhost:11434"
+            assert c.litellm_base_url == "http://localhost:11434"
             assert c.llm_api_key == ""
 
     def test_provider_env_override(self) -> None:
@@ -779,16 +779,16 @@ class TestConfigProvider:
         with mock.patch.dict(
             os.environ,
             {
-                "LILBEE_LLM_PROVIDER": "ollama",
-                "LILBEE_OLLAMA_URL": "http://myhost:11434",
+                "LILBEE_LLM_PROVIDER": "litellm",
+                "LILBEE_LITELLM_BASE_URL": "http://myhost:11434",
                 "LILBEE_LLM_API_KEY": "sk-key",
             },
         ):
             from lilbee.config import Config
 
             c = Config.from_env()
-            assert c.llm_provider == "ollama"
-            assert c.ollama_url == "http://myhost:11434"
+            assert c.llm_provider == "litellm"
+            assert c.litellm_base_url == "http://myhost:11434"
             assert c.llm_api_key == "sk-key"
 
     def test_models_dir_is_canonical(self) -> None:
@@ -815,7 +815,7 @@ class TestRoutingProvider:
 
         return RoutingProvider()
 
-    def test_routes_chat_to_ollama_when_model_in_ollama(self) -> None:
+    def test_routes_chat_to_litellm_when_model_in_litellm(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.list_models.return_value = ["qwen3:8b"]
@@ -827,7 +827,7 @@ class TestRoutingProvider:
         assert result == "hello"
         mock_litellm.chat.assert_called_once()
 
-    def test_routes_chat_to_llama_cpp_when_not_in_ollama(self) -> None:
+    def test_routes_chat_to_llama_cpp_when_not_in_litellm(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.list_models.return_value = []
@@ -842,7 +842,7 @@ class TestRoutingProvider:
         assert result == "local"
         mock_llama.chat.assert_called_once()
 
-    def test_routes_embed_to_ollama_when_model_available(self) -> None:
+    def test_routes_embed_to_litellm_when_model_available(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.list_models.return_value = ["nomic-embed-text:latest"]
@@ -854,7 +854,7 @@ class TestRoutingProvider:
         assert result == [[0.1, 0.2]]
         mock_litellm.embed.assert_called_once()
 
-    def test_routes_embed_to_llama_cpp_when_not_in_ollama(self) -> None:
+    def test_routes_embed_to_llama_cpp_when_not_in_litellm(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.list_models.return_value = []
@@ -883,7 +883,7 @@ class TestRoutingProvider:
         assert "local.gguf" in result
         assert len(result) == 3
 
-    def test_ollama_unreachable_falls_back_to_llama_cpp(self) -> None:
+    def test_litellm_unreachable_falls_back_to_llama_cpp(self) -> None:
         from lilbee.providers.base import ProviderError
 
         rp = self._make_provider()
@@ -899,7 +899,7 @@ class TestRoutingProvider:
         result = rp.chat([{"role": "user", "content": "hi"}])
         assert result == "fallback"
 
-    def test_show_model_delegates_to_ollama(self) -> None:
+    def test_show_model_delegates_to_litellm(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.list_models.return_value = ["qwen3:8b"]
@@ -923,20 +923,20 @@ class TestRoutingProvider:
         result = rp.show_model("local.gguf")
         assert result is None
 
-    def test_invalidate_cache_clears_ollama_list(self) -> None:
+    def test_invalidate_cache_clears_litellm_list(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.list_models.return_value = ["qwen3:8b"]
         rp._litellm = mock_litellm
 
         # First call caches
-        assert rp._is_in_ollama("qwen3:8b")
-        assert rp._ollama_models is not None
+        assert rp._is_in_litellm("qwen3:8b")
+        assert rp._remote_models is not None
 
         rp.invalidate_cache()
-        assert rp._ollama_models is None
+        assert rp._remote_models is None
 
-    def test_pull_model_delegates_to_ollama(self) -> None:
+    def test_pull_model_delegates_to_litellm(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.list_models.return_value = ["qwen3:8b"]
@@ -946,9 +946,9 @@ class TestRoutingProvider:
         rp.pull_model("qwen3:8b")
         mock_litellm.pull_model.assert_called_once()
         # Cache should be invalidated after pull
-        assert rp._ollama_models is None
+        assert rp._remote_models is None
 
-    def test_pull_model_raises_when_ollama_fails(self) -> None:
+    def test_pull_model_raises_when_litellm_fails(self) -> None:
         from lilbee.providers.base import ProviderError
 
         rp = self._make_provider()
@@ -974,3 +974,48 @@ class TestRoutingProvider:
         )
         assert result == "saw it"
         mock_litellm.chat.assert_called_once()
+
+    def test_litellm_not_installed_skips_remote(self) -> None:
+        """When litellm is not installed, routing provider skips remote models."""
+        rp = self._make_provider()
+
+        with mock.patch(
+            "lilbee.providers.litellm_provider.litellm_available", return_value=False
+        ):
+            models = rp._litellm_models()
+        assert models == set()
+
+
+# ---------------------------------------------------------------------------
+# litellm_available guard
+# ---------------------------------------------------------------------------
+
+
+class TestLitellmAvailable:
+    def test_returns_true_when_installed(self) -> None:
+        from lilbee.providers.litellm_provider import litellm_available
+
+        assert litellm_available() is True
+
+    def test_returns_false_when_not_installed(self) -> None:
+        from lilbee.providers.litellm_provider import litellm_available
+
+        with mock.patch.dict("sys.modules", {"litellm": None}):
+            assert litellm_available() is False
+
+    def test_provider_static_method(self) -> None:
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        assert LiteLLMProvider.available() is True
+
+    def test_factory_raises_when_litellm_unavailable(self) -> None:
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.factory import get_provider
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        cfg.llm_provider = "litellm"
+        with (
+            mock.patch.object(LiteLLMProvider, "available", return_value=False),
+            pytest.raises(ProviderError, match="litellm is not installed"),
+        ):
+            get_provider()

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -591,19 +591,19 @@ class TestModelsInstalled:
         mock_manager.list_installed.return_value = ["qwen3:8b", "mistral:7b"]
         from lilbee.model_manager import ModelSource
 
-        mock_manager.get_source.return_value = ModelSource.OLLAMA
+        mock_manager.get_source.return_value = ModelSource.LITELLM
         with patch("lilbee.model_manager.get_model_manager", return_value=mock_manager):
             result = await handlers.models_installed()
         assert len(result["models"]) == 2
-        assert result["models"][0]["source"] == "ollama"
+        assert result["models"][0]["source"] == "litellm"
 
-    async def test_unknown_source_defaults_to_ollama(self):
+    async def test_unknown_source_defaults_to_litellm(self):
         mock_manager = MagicMock()
         mock_manager.list_installed.return_value = ["unknown"]
         mock_manager.get_source.return_value = None
         with patch("lilbee.model_manager.get_model_manager", return_value=mock_manager):
             result = await handlers.models_installed()
-        assert result["models"][0]["source"] == "ollama"
+        assert result["models"][0]["source"] == "litellm"
 
 
 class TestModelsPull:
@@ -637,7 +637,7 @@ class TestModelsDelete:
         mock_manager = MagicMock()
         mock_manager.remove.return_value = True
         with patch("lilbee.model_manager.get_model_manager", return_value=mock_manager):
-            result = await handlers.models_delete("test", source="ollama")
+            result = await handlers.models_delete("test", source="litellm")
         assert result["deleted"] is True
         assert result["model"] == "test"
 
@@ -705,7 +705,7 @@ class TestGetConfig:
         result = await handlers.get_config()
         assert "chat_model" in result
         assert "system_prompt" in result
-        assert "ollama_url" in result
+        assert "litellm_base_url" in result
         assert "diversity_max_per_source" in result
         assert "mmr_lambda" in result
         assert "query_expansion_count" in result

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 
 from lilbee.catalog import CatalogModel, CatalogResult
-from lilbee.cli.tui.screens.catalog import _TAB_TO_TASK, ModelRow, OllamaRow
+from lilbee.cli.tui.screens.catalog import _TAB_TO_TASK, ModelRow, RemoteRow
 from lilbee.cli.tui.widgets.help_modal import HelpModal
 from lilbee.cli.tui.widgets.message import AssistantMessage, UserMessage
 from lilbee.cli.tui.widgets.sync_bar import SyncBar
@@ -102,10 +102,10 @@ class TestHelpModal:
         assert modal is not None
 
 
-class TestOllamaClassification:
+class TestRemoteClassification:
     @mock.patch("httpx.get")
     def test_classifies_models(self, mock_get: mock.MagicMock) -> None:
-        from lilbee.model_manager import classify_ollama_models
+        from lilbee.model_manager import classify_remote_models
 
         mock_get.return_value = mock.MagicMock(
             status_code=200,
@@ -124,7 +124,7 @@ class TestOllamaClassification:
             },
         )
         mock_get.return_value.raise_for_status = lambda: None
-        result = classify_ollama_models()
+        result = classify_remote_models()
         by_task = {m.task: m.name for m in result}
         assert by_task["embedding"] == "nomic-embed-text:latest"
         assert by_task["chat"] == "qwen3:8b"
@@ -508,10 +508,10 @@ class TestThemes:
             assert app.theme == "gruvbox"
 
 
-class TestDetectOllamaEmbeddings:
+class TestDetectRemoteEmbeddings:
     @mock.patch("httpx.get")
     def test_detects_bert_family(self, mock_get: mock.MagicMock) -> None:
-        from lilbee.model_manager import detect_ollama_embedding_models
+        from lilbee.model_manager import detect_remote_embedding_models
 
         mock_get.return_value = mock.MagicMock(
             status_code=200,
@@ -523,28 +523,28 @@ class TestDetectOllamaEmbeddings:
             },
         )
         mock_get.return_value.raise_for_status = lambda: None
-        result = detect_ollama_embedding_models()
+        result = detect_remote_embedding_models()
         assert result == ["nomic-embed-text:latest"]
 
     @mock.patch("httpx.get", side_effect=Exception("connection refused"))
     def test_returns_empty_on_error(self, mock_get: mock.MagicMock) -> None:
-        from lilbee.model_manager import detect_ollama_embedding_models
+        from lilbee.model_manager import detect_remote_embedding_models
 
-        assert detect_ollama_embedding_models() == []
+        assert detect_remote_embedding_models() == []
 
 
 class TestSetupModal:
-    def test_creates_without_ollama(self) -> None:
+    def test_creates_without_remote(self) -> None:
         from lilbee.cli.tui.widgets.setup_modal import SetupModal
 
         modal = SetupModal()
         assert modal is not None
 
-    def test_creates_with_ollama(self) -> None:
+    def test_creates_with_remote(self) -> None:
         from lilbee.cli.tui.widgets.setup_modal import SetupModal
 
         modal = SetupModal(ollama_embeddings=["nomic-embed-text:latest"])
-        assert modal._ollama_embeddings == ["nomic-embed-text:latest"]
+        assert modal._remote_embeddings == ["nomic-embed-text:latest"]
 
 
 class TestCanonicalModelsDir:
@@ -556,13 +556,13 @@ class TestCanonicalModelsDir:
         assert "lilbee" in str(result)
 
 
-class TestOllamaRow:
+class TestRemoteRow:
     def test_creates(self) -> None:
-        from lilbee.model_manager import OllamaModel
+        from lilbee.model_manager import RemoteModel
 
-        om = OllamaModel(name="mistral:latest", task="chat", family="llama", parameter_size="7.2B")
-        row = OllamaRow(om)
-        assert row.ollama_model.name == "mistral:latest"
+        rm = RemoteModel(name="mistral:latest", task="chat", family="llama", parameter_size="7.2B")
+        row = RemoteRow(rm)
+        assert row.remote_model.name == "mistral:latest"
 
 
 class TestSlashSuggester:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -12,9 +12,9 @@ from lilbee.catalog import CatalogModel, CatalogResult
 from lilbee.cli.tui.screens.catalog import (
     LoadMoreRow,
     ModelRow,
-    OllamaRow,
+    RemoteRow,
     _filter_catalog,
-    _filter_ollama,
+    _filter_remote,
     _format_downloads,
     _format_row,
     _group_by_size,
@@ -22,7 +22,7 @@ from lilbee.cli.tui.screens.catalog import (
     _parse_param_size,
 )
 from lilbee.config import cfg
-from lilbee.model_manager import OllamaModel
+from lilbee.model_manager import RemoteModel
 
 _EMPTY_CATALOG = CatalogResult(total=0, limit=25, offset=0, models=[])
 
@@ -65,13 +65,13 @@ def _make_catalog_model(
     )
 
 
-def _make_ollama_model(
-    name: str = "ollama-test:latest",
+def _make_remote_model(
+    name: str = "remote-test:latest",
     task: str = "chat",
     family: str = "llama",
     parameter_size: str = "7B",
-) -> OllamaModel:
-    return OllamaModel(name=name, task=task, family=family, parameter_size=parameter_size)
+) -> RemoteModel:
+    return RemoteModel(name=name, task=task, family=family, parameter_size=parameter_size)
 
 
 # ---------------------------------------------------------------------------
@@ -225,25 +225,25 @@ class TestFilterCatalog:
         assert _filter_catalog([], "chat", "test") == []
 
 
-class TestFilterOllama:
+class TestFilterRemote:
     def test_no_filters(self):
-        models = [_make_ollama_model(task="chat"), _make_ollama_model(task="embedding")]
-        assert len(_filter_ollama(models, None, "")) == 2
+        models = [_make_remote_model(task="chat"), _make_remote_model(task="embedding")]
+        assert len(_filter_remote(models, None, "")) == 2
 
     def test_task_filter(self):
-        models = [_make_ollama_model(task="chat"), _make_ollama_model(task="embedding")]
-        assert len(_filter_ollama(models, "chat", "")) == 1
+        models = [_make_remote_model(task="chat"), _make_remote_model(task="embedding")]
+        assert len(_filter_remote(models, "chat", "")) == 1
 
     def test_search_filter(self):
         models = [
-            _make_ollama_model(name="qwen:latest"),
-            _make_ollama_model(name="llama:latest"),
+            _make_remote_model(name="qwen:latest"),
+            _make_remote_model(name="llama:latest"),
         ]
-        result = _filter_ollama(models, None, "qwen")
+        result = _filter_remote(models, None, "qwen")
         assert len(result) == 1
 
     def test_empty_list(self):
-        assert _filter_ollama([], None, "") == []
+        assert _filter_remote([], None, "") == []
 
 
 class TestGroupBySize:
@@ -286,16 +286,16 @@ class TestModelRow:
         assert row.model is m
 
 
-class TestOllamaRow:
+class TestRemoteRow:
     def test_stores_model(self):
-        m = _make_ollama_model()
-        row = OllamaRow(m)
-        assert row.ollama_model is m
+        m = _make_remote_model()
+        row = RemoteRow(m)
+        assert row.remote_model is m
 
     def test_none_parameter_size(self):
-        m = _make_ollama_model(parameter_size="")
-        row = OllamaRow(m)
-        assert row.ollama_model.parameter_size == ""
+        m = _make_remote_model(parameter_size="")
+        row = RemoteRow(m)
+        assert row.remote_model.parameter_size == ""
 
 
 # ---------------------------------------------------------------------------
@@ -515,7 +515,7 @@ async def test_app_push_catalog(mock_check):
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+            patch("lilbee.model_manager.classify_remote_models", return_value=[]),
         ):
             app.action_push_catalog()
             await _pilot.pause()
@@ -626,7 +626,7 @@ async def test_chat_slash_model_no_arg(mock_check):
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+            patch("lilbee.model_manager.classify_remote_models", return_value=[]),
         ):
             app.screen._handle_slash("/model")
             await _pilot.pause()
@@ -885,7 +885,7 @@ async def test_chat_slash_models(mock_check):
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+            patch("lilbee.model_manager.classify_remote_models", return_value=[]),
         ):
             app.screen._handle_slash("/models")
             await _pilot.pause()
@@ -1055,7 +1055,7 @@ async def test_chat_slash_m(mock_check):
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+            patch("lilbee.model_manager.classify_remote_models", return_value=[]),
         ):
             app.screen._handle_slash("/m")
             await _pilot.pause()
@@ -1484,7 +1484,7 @@ def _patch_catalog():
     """Context manager to patch catalog screen's network calls."""
     return (
         patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-        patch("lilbee.model_manager.classify_ollama_models", return_value=[]),
+        patch("lilbee.model_manager.classify_remote_models", return_value=[]),
     )
 
 
@@ -1661,7 +1661,7 @@ async def test_catalog_install_new_model():
                 await _pilot.pause()
 
 
-async def test_catalog_select_ollama_row():
+async def test_catalog_select_remote_row():
     from lilbee.cli.tui.screens.catalog import CatalogScreen
 
     app = CatalogTestApp()
@@ -1670,12 +1670,12 @@ async def test_catalog_select_ollama_row():
             screen = CatalogScreen()
             app.push_screen(screen)
             await _pilot.pause()
-            om = _make_ollama_model(name="ollama-chat:latest")
-            row = OllamaRow(om)
+            om = _make_remote_model(name="remote-chat:latest")
+            row = RemoteRow(om)
             event = MagicMock()
             event.item = row
             screen.on_list_view_selected(event)
-            assert cfg.chat_model == "ollama-chat:latest"
+            assert cfg.chat_model == "remote-chat:latest"
 
 
 async def test_catalog_select_load_more():
@@ -1712,7 +1712,7 @@ async def test_catalog_highlight_model_row():
             assert "test-7B" in str(detail.render())
 
 
-async def test_catalog_highlight_ollama_row():
+async def test_catalog_highlight_remote_row():
     from lilbee.cli.tui.screens.catalog import CatalogScreen
 
     app = CatalogTestApp()
@@ -1721,11 +1721,11 @@ async def test_catalog_highlight_ollama_row():
             screen = CatalogScreen()
             app.push_screen(screen)
             await _pilot.pause()
-            om = _make_ollama_model(name="ollama-test:latest")
-            row = OllamaRow(om)
+            om = _make_remote_model(name="remote-test:latest")
+            row = RemoteRow(om)
             screen._update_highlighted_detail(row)
             detail = screen.query_one("#model-detail", Static)
-            assert "ollama-test" in str(detail.render())
+            assert "remote-test" in str(detail.render())
 
 
 async def test_catalog_highlight_unknown_row():
@@ -1812,7 +1812,7 @@ async def test_catalog_worker_hf_success():
             assert len(screen._hf_models) == 1
 
 
-async def test_catalog_worker_ollama_success():
+async def test_catalog_worker_remote_success():
     from lilbee.cli.tui.screens.catalog import CatalogScreen
 
     app = CatalogTestApp()
@@ -1825,13 +1825,13 @@ async def test_catalog_worker_ollama_success():
             from textual.worker import WorkerState
 
             mock_worker = MagicMock()
-            mock_worker.name = "_fetch_ollama_models"
-            mock_worker.result = [_make_ollama_model()]
+            mock_worker.name = "_fetch_remote_models"
+            mock_worker.result = [_make_remote_model()]
             mock_event = MagicMock()
             mock_event.state = WorkerState.SUCCESS
             mock_event.worker = mock_worker
             screen.on_worker_state_changed(mock_event)
-            assert len(screen._ollama_models) == 1
+            assert len(screen._remote_models) == 1
 
 
 async def test_catalog_worker_more_hf_success():
@@ -2037,18 +2037,18 @@ async def test_model_row_compose():
         assert "compose-test-7B" in str(text.render())
 
 
-class OllamaRowTestApp(App[None]):
+class RemoteRowTestApp(App[None]):
     CSS = ""
 
     def compose(self) -> ComposeResult:
-        yield OllamaRow(_make_ollama_model(name="ollama-compose:latest", parameter_size=""))
+        yield RemoteRow(_make_remote_model(name="remote-compose:latest", parameter_size=""))
 
 
-async def test_ollama_row_compose():
-    app = OllamaRowTestApp()
+async def test_remote_row_compose():
+    app = RemoteRowTestApp()
     async with app.run_test(size=(120, 10)) as _pilot:
         text = app.query_one(Static)
-        assert "ollama-compose:latest" in str(text.render())
+        assert "remote-compose:latest" in str(text.render())
 
 
 # ---------------------------------------------------------------------------
@@ -2266,7 +2266,7 @@ async def test_chat_cancel_stream_with_streaming_workers(mock_check):
             assert app.screen._streaming is False
 
 
-@patch("lilbee.model_manager.detect_ollama_embedding_models", return_value=[])
+@patch("lilbee.model_manager.detect_remote_embedding_models", return_value=[])
 @patch("lilbee.model_manager.get_model_manager")
 async def test_chat_check_embedding_model_async_installed(mock_get_mgr, mock_detect):
     """Cover _check_embedding_model_async lines 61-65 (model installed)."""
@@ -2293,10 +2293,10 @@ async def test_chat_check_embedding_model_async_installed(mock_get_mgr, mock_det
         mock_mgr.is_installed.assert_called_with(cfg.embedding_model)
 
 
-@patch("lilbee.model_manager.detect_ollama_embedding_models", return_value=["test-embed"])
+@patch("lilbee.model_manager.detect_remote_embedding_models", return_value=["test-embed"])
 @patch("lilbee.model_manager.get_model_manager")
-async def test_chat_check_embedding_model_async_ollama(mock_get_mgr, mock_detect):
-    """Cover _check_embedding_model_async lines 67-70 (model in Ollama)."""
+async def test_chat_check_embedding_model_async_remote(mock_get_mgr, mock_detect):
+    """Cover _check_embedding_model_async lines 67-70 (model in remote backend)."""
     from lilbee.cli.tui.screens.chat import ChatScreen
 
     class EmbedTestApp(App[None]):
@@ -2320,7 +2320,7 @@ async def test_chat_check_embedding_model_async_ollama(mock_get_mgr, mock_detect
         mock_detect.assert_called()
 
 
-@patch("lilbee.model_manager.detect_ollama_embedding_models", return_value=[])
+@patch("lilbee.model_manager.detect_remote_embedding_models", return_value=[])
 @patch("lilbee.model_manager.get_model_manager")
 async def test_chat_check_embedding_model_async_not_found(mock_get_mgr, mock_detect):
     """Cover _check_embedding_model_async line 72 (shows setup modal)."""
@@ -2484,7 +2484,7 @@ async def test_catalog_refresh_lists_with_search_and_load_more():
             # Clear all models and set search to something that won't match
             screen._featured = []
             screen._hf_models = []
-            screen._ollama_models = []
+            screen._remote_models = []
             screen._refresh_lists()
             # Should show "No models match" in at least the All tab
             from textual.widgets import ListView
@@ -2622,25 +2622,25 @@ def test_check_embedding_model_installed():
         assert manager.is_installed(cfg.embedding_model) is True
 
 
-def test_check_embedding_model_ollama_available():
-    """Cover _check_embedding_model_async lines 67-70 (model in ollama)."""
+def test_check_embedding_model_remote_available():
+    """Cover _check_embedding_model_async lines 67-70 (model in remote backend)."""
     mock_mgr = MagicMock()
     mock_mgr.is_installed.return_value = False
     with (
         patch("lilbee.model_manager.get_model_manager", return_value=mock_mgr),
         patch(
-            "lilbee.model_manager.detect_ollama_embedding_models",
+            "lilbee.model_manager.detect_remote_embedding_models",
             return_value=["test-embed"],
         ),
     ):
-        from lilbee.model_manager import detect_ollama_embedding_models, get_model_manager
+        from lilbee.model_manager import detect_remote_embedding_models, get_model_manager
 
         manager = get_model_manager()
         assert not manager.is_installed(cfg.embedding_model)
 
         embed_base = cfg.embedding_model.split(":")[0]
-        ollama_embeds = detect_ollama_embedding_models(cfg.ollama_url)
-        assert any(embed_base in name for name in ollama_embeds)
+        remote_embeds = detect_remote_embedding_models(cfg.litellm_base_url)
+        assert any(embed_base in name for name in remote_embeds)
 
 
 def test_check_embedding_model_not_found():
@@ -2649,17 +2649,17 @@ def test_check_embedding_model_not_found():
     mock_mgr.is_installed.return_value = False
     with (
         patch("lilbee.model_manager.get_model_manager", return_value=mock_mgr),
-        patch("lilbee.model_manager.detect_ollama_embedding_models", return_value=[]),
+        patch("lilbee.model_manager.detect_remote_embedding_models", return_value=[]),
     ):
-        from lilbee.model_manager import detect_ollama_embedding_models, get_model_manager
+        from lilbee.model_manager import detect_remote_embedding_models, get_model_manager
 
         manager = get_model_manager()
         assert not manager.is_installed(cfg.embedding_model)
 
         embed_base = cfg.embedding_model.split(":")[0]
-        ollama_embeds = detect_ollama_embedding_models(cfg.ollama_url)
-        assert not any(embed_base in name for name in ollama_embeds)
-        # Would call self.app.call_from_thread(self._show_setup_modal, ollama_embeds)
+        remote_embeds = detect_remote_embedding_models(cfg.litellm_base_url)
+        assert not any(embed_base in name for name in remote_embeds)
+        # Would call self.app.call_from_thread(self._show_setup_modal, remote_embeds)
 
 
 @patch("lilbee.cli.tui.screens.chat.ChatScreen._check_embedding_model_async")

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -821,19 +821,19 @@ class _SetupApp(App):
 
 
 class TestSetupModal:
-    def test_creates_without_ollama(self) -> None:
+    def test_creates_without_remote(self) -> None:
         from lilbee.cli.tui.widgets.setup_modal import SetupModal
 
         modal = SetupModal()
-        assert modal._ollama_embeddings == []
+        assert modal._remote_embeddings == []
 
-    def test_creates_with_ollama(self) -> None:
+    def test_creates_with_remote(self) -> None:
         from lilbee.cli.tui.widgets.setup_modal import SetupModal
 
         modal = SetupModal(ollama_embeddings=["nomic:latest"])
-        assert modal._ollama_embeddings == ["nomic:latest"]
+        assert modal._remote_embeddings == ["nomic:latest"]
 
-    async def test_compose_with_ollama(self) -> None:
+    async def test_compose_with_remote(self) -> None:
         from lilbee.cli.tui.widgets.setup_modal import SetupModal
 
         app = _SetupApp()
@@ -842,7 +842,7 @@ class TestSetupModal:
             await pilot.pause()
             assert len(app.screen_stack) == 2
 
-    async def test_compose_without_ollama(self) -> None:
+    async def test_compose_without_remote(self) -> None:
         from lilbee.cli.tui.widgets.setup_modal import SetupModal
 
         app = _SetupApp()
@@ -863,7 +863,7 @@ class TestSetupModal:
             await pilot.pause()
         assert None in results
 
-    async def test_ollama_row_selection_dismisses(self) -> None:
+    async def test_remote_row_selection_dismisses(self) -> None:
         from lilbee.cli.tui.widgets.setup_modal import SetupModal
 
         app = _SetupApp()
@@ -874,11 +874,11 @@ class TestSetupModal:
                 callback=lambda r: results.append(r),
             )
             await pilot.pause()
-            # Find the list and select the ollama row (index 1 — first is header label)
+            # Find the list and select the remote row (index 1 -- first is header label)
             from textual.widgets import ListView
 
             lv = app.screen.query_one("#embed-picker", ListView)
-            lv.index = 1  # OllamaRow
+            lv.index = 1  # _RemoteRow
             await pilot.pause()
             # Simulate selection via action
             lv.action_select_cursor()
@@ -952,11 +952,11 @@ class TestEmbeddingRow:
         assert len(children) == 1
 
 
-class TestOllamaSetupRow:
+class TestRemoteSetupRow:
     def test_compose(self) -> None:
-        from lilbee.cli.tui.widgets.setup_modal import _OllamaRow
+        from lilbee.cli.tui.widgets.setup_modal import _RemoteRow
 
-        row = _OllamaRow("nomic:latest")
-        assert row.ollama_name == "nomic:latest"
+        row = _RemoteRow("nomic:latest")
+        assert row.remote_name == "nomic:latest"
         children = list(row.compose())
         assert len(children) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1593,8 +1593,8 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "kreuzberg" },
     { name = "lancedb" },
-    { name = "litellm" },
     { name = "litestar" },
+    { name = "llama-cpp-python" },
     { name = "mcp" },
     { name = "pillow" },
     { name = "textual" },
@@ -1612,8 +1612,8 @@ graph = [
     { name = "graspologic-native" },
     { name = "spacy" },
 ]
-llama-cpp = [
-    { name = "llama-cpp-python" },
+litellm = [
+    { name = "litellm" },
 ]
 reranker = [
     { name = "sentence-transformers" },
@@ -1641,9 +1641,9 @@ requires-dist = [
     { name = "huggingface-hub" },
     { name = "kreuzberg", specifier = ">=4.6.2" },
     { name = "lancedb" },
-    { name = "litellm" },
+    { name = "litellm", marker = "extra == 'litellm'" },
     { name = "litestar", specifier = ">=2.0" },
-    { name = "llama-cpp-python", marker = "extra == 'llama-cpp'" },
+    { name = "llama-cpp-python" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "sentence-transformers", marker = "extra == 'reranker'" },
@@ -1654,7 +1654,7 @@ requires-dist = [
     { name = "typer" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
-provides-extras = ["llama-cpp", "reranker", "graph", "crawler"]
+provides-extras = ["litellm", "reranker", "graph", "crawler"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
llama-cpp-python is now a core dependency. lilbee works out of the box with local GGUF models.

litellm moved to optional: `pip install lilbee[litellm]` for Ollama, OpenAI, Azure, or any litellm-supported provider. positioned as a convenience for users who manage models externally or want frontier AI access.

all "ollama" references renamed throughout the codebase:
- config: `ollama_url` → `litellm_base_url`, env var `LILBEE_LITELLM_BASE_URL`
- provider: `"ollama"` still accepted as deprecated alias for `"litellm"`
- model manager: `ModelSource.OLLAMA` → `ModelSource.LITELLM`, `OllamaModel` → `RemoteModel`
- docs and tests updated throughout