### PR TITLE
refactor: Lilbee class as single entry point with proper DI

### DIFF
--- a/src/lilbee/api.py
+++ b/src/lilbee/api.py
@@ -1,8 +1,4 @@
-"""Programmatic access to lilbee's retrieval pipeline.
-
-Retrieval only -- no LLM chat. Search your indexed documents from Python.
-Optional features (concept graph, reranker) activate automatically when
-their dependencies are installed.
+"""Programmatic access to lilbee's knowledge base pipeline.
 
 Usage::
 
@@ -16,23 +12,28 @@ Usage::
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lilbee.config import Config, cfg
 
 if TYPE_CHECKING:
     from lilbee.ingest import SyncResult
-    from lilbee.store import SearchChunk
+    from lilbee.providers.base import LLMProvider
+    from lilbee.query import AskResult, ChatMessage
+    from lilbee.reasoning import StreamToken
+    from lilbee.store import RemoveResult, SearchChunk
 
 
 @contextmanager
 def _swap_config(target: Config) -> Iterator[None]:
     """Temporarily replace the global cfg fields with *target*'s values.
 
-    Not thread-safe -- sequential use only.
+    Not thread-safe -- sequential use only.  Used by methods that call
+    into sub-modules still reading the global ``cfg`` singleton (e.g.
+    ingest, store).  Will be removed once store/ingest accept explicit config.
     """
     snapshot = {name: getattr(cfg, name) for name in type(cfg).model_fields}
     for name in type(target).model_fields:
@@ -45,11 +46,10 @@ def _swap_config(target: Config) -> Iterator[None]:
 
 
 class Lilbee:
-    """Programmatic access to lilbee's retrieval pipeline.
+    """Single entry point for all lilbee pipeline operations.
 
-    Retrieval only -- no LLM chat. Search your indexed documents from Python.
-    Optional features (concept graph, reranker) activate automatically when
-    their dependencies are installed.
+    Owns a ``Config`` instance and a lazily-created ``LLMProvider``.
+    All pipeline methods use dependency injection internally.
 
     Usage::
 
@@ -58,6 +58,7 @@ class Lilbee:
         bee = Lilbee("./docs")
         bee.sync()
         results = bee.search("authentication")
+        answer = bee.ask_raw("How does auth work?")
     """
 
     def __init__(
@@ -66,16 +67,6 @@ class Lilbee:
         *,
         config: Config | None = None,
     ) -> None:
-        """Create a lilbee instance.
-
-        Args:
-            documents_dir: Path to documents folder. Creates a default Config
-                with derived data and lancedb directories.
-            config: Full Config instance for complete control.
-
-        Pass one or the other, not both. If neither is given, uses
-        ``Config.from_env()`` (same defaults as the CLI).
-        """
         if documents_dir is not None and config is not None:
             raise ValueError("Pass documents_dir or config, not both")
 
@@ -96,38 +87,109 @@ class Lilbee:
 
         self._config.documents_dir.mkdir(parents=True, exist_ok=True)
         self._config.data_dir.mkdir(parents=True, exist_ok=True)
+        self._provider: LLMProvider | None = None
 
     @property
     def config(self) -> Config:
         """The Config instance backing this Lilbee."""
         return self._config
 
-    def sync(self, *, quiet: bool = True) -> SyncResult:
-        """Sync documents to the vector store. Returns what changed."""
-        from lilbee.ingest import sync as _sync
+    @property
+    def provider(self) -> LLMProvider:
+        """Lazily-created LLM provider."""
+        if self._provider is None:
+            from lilbee.providers.factory import create_provider
 
-        with _swap_config(self._config):
-            return asyncio.run(_sync(quiet=quiet))
+            self._provider = create_provider(self._config)
+        return self._provider
 
     def search(self, query: str, *, top_k: int = 0) -> list[SearchChunk]:
         """Search indexed documents. Returns ranked chunks."""
-        from lilbee.query import search_context
+        from lilbee.query import _search_context
 
         with _swap_config(self._config):
-            return search_context(query, top_k=top_k)
+            return _search_context(query, top_k=top_k, config=self._config, provider=self.provider)
 
-    def add(self, paths: list[str | Path]) -> SyncResult:
-        """Add files to the knowledge base and sync.
+    def ask_raw(
+        self,
+        question: str,
+        *,
+        top_k: int = 0,
+        history: list[ChatMessage] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> AskResult:
+        """One-shot question returning structured answer + raw sources."""
+        from lilbee.query import _ask_raw
 
-        Copies each path into the documents directory, then syncs.
-        """
+        with _swap_config(self._config):
+            return _ask_raw(
+                question,
+                top_k=top_k,
+                history=history,
+                options=options,
+                config=self._config,
+                provider=self.provider,
+            )
+
+    def ask_stream(
+        self,
+        question: str,
+        *,
+        top_k: int = 0,
+        history: list[ChatMessage] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> Generator[StreamToken, None, None]:
+        """Streaming question: yields classified tokens, then source citations."""
+        from lilbee.query import _ask_stream
+
+        with _swap_config(self._config):
+            yield from _ask_stream(
+                question,
+                top_k=top_k,
+                history=history,
+                options=options,
+                config=self._config,
+                provider=self.provider,
+            )
+
+    def sync(
+        self,
+        *,
+        quiet: bool = True,
+        force_rebuild: bool = False,
+        force_vision: bool = False,
+        on_progress: Any = None,
+    ) -> SyncResult:
+        """Sync documents to the vector store. Returns what changed."""
+        from lilbee.ingest import sync as _sync
+        from lilbee.progress import noop_callback
+
+        callback = on_progress if on_progress is not None else noop_callback
+        with _swap_config(self._config):
+            return asyncio.run(
+                _sync(
+                    force_rebuild=force_rebuild,
+                    quiet=quiet,
+                    force_vision=force_vision,
+                    on_progress=callback,
+                )
+            )
+
+    def add(
+        self,
+        paths: list[str | Path],
+        *,
+        force: bool = True,
+        force_vision: bool = False,
+    ) -> SyncResult:
+        """Add files to the knowledge base and sync."""
         from lilbee.cli.helpers import copy_files
         from lilbee.ingest import sync as _sync
 
         resolved = [Path(p).resolve() for p in paths]
         with _swap_config(self._config):
-            copy_files(resolved, force=True)
-            return asyncio.run(_sync(quiet=True))
+            copy_files(resolved, force=force)
+            return asyncio.run(_sync(quiet=True, force_vision=force_vision))
 
     def remove(self, name: str) -> None:
         """Remove a document from the index by source name."""
@@ -139,6 +201,15 @@ class Lilbee:
             doc_path = self._config.documents_dir / name
             if doc_path.exists():
                 doc_path.unlink()
+
+    def remove_documents(self, names: list[str], *, delete_files: bool = False) -> RemoveResult:
+        """Remove documents from the knowledge base by source name."""
+        from lilbee.store import remove_documents
+
+        with _swap_config(self._config):
+            return remove_documents(
+                names, delete_files=delete_files, documents_dir=self._config.documents_dir
+            )
 
     def status(self) -> dict[str, object]:
         """Return index stats (document count, data directory, etc.)."""
@@ -155,7 +226,4 @@ class Lilbee:
 
     def rebuild(self) -> SyncResult:
         """Rebuild the entire index from scratch."""
-        from lilbee.ingest import sync as _sync
-
-        with _swap_config(self._config):
-            return asyncio.run(_sync(force_rebuild=True, quiet=True))
+        return self.sync(force_rebuild=True, quiet=True)

--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -1,9 +1,12 @@
 """App creation, console, and global callback."""
 
+from __future__ import annotations
+
 import logging
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
@@ -12,6 +15,9 @@ from lilbee.cli.helpers import get_version
 from lilbee.cli.helpers import json_output as json_out
 from lilbee.config import cfg
 from lilbee.models import ensure_tag
+
+if TYPE_CHECKING:
+    from lilbee.api import Lilbee
 
 app = typer.Typer(help="lilbee — Local RAG knowledge base", invoke_without_command=True)
 console = Console()
@@ -56,6 +62,23 @@ top_k_sampling_option = typer.Option(None, "--top-k-sampling", help="Top-k sampl
 repeat_penalty_option = typer.Option(None, "--repeat-penalty", help="Repeat penalty factor.")
 num_ctx_option = typer.Option(None, "--num-ctx", help="Context window size (tokens).")
 seed_option = typer.Option(None, "--seed", help="Random seed for reproducibility.")
+
+_bee = None
+
+
+def get_bee() -> Lilbee:
+    """Return a Lilbee instance backed by the global cfg singleton.
+
+    The instance is created lazily and cached for the process lifetime.
+    CLI overrides mutate ``cfg`` before any command runs, so the Lilbee
+    instance always sees the current config.
+    """
+    global _bee
+    if _bee is None:
+        from lilbee.api import Lilbee as _LilbeeCls
+
+        _bee = _LilbeeCls(config=cfg)
+    return _bee
 
 
 def _apply_data_root(root: Path) -> None:

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -21,6 +21,7 @@ from lilbee.cli.app import (
     apply_overrides,
     console,
     data_dir_option,
+    get_bee,
     model_option,
     num_ctx_option,
     repeat_penalty_option,
@@ -43,7 +44,7 @@ from lilbee.cli.helpers import (
 )
 from lilbee.config import cfg
 from lilbee.crawler import is_url
-from lilbee.store import delete_by_source, delete_source, get_chunks_by_source, get_sources
+from lilbee.store import get_chunks_by_source
 
 CHUNK_PREVIEW_LEN = 80  # characters shown in human-readable search output
 
@@ -188,9 +189,8 @@ def search(
 ) -> None:
     """Search the knowledge base for relevant chunks."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    from lilbee.query import search_context
-
-    results = search_context(query, top_k=top_k or cfg.top_k)
+    bee = get_bee()
+    results = bee.search(query, top_k=top_k or cfg.top_k)
     cleaned = [clean_result(r) for r in results]
 
     if cfg.json_mode:
@@ -231,10 +231,9 @@ def sync_cmd(
         cfg.vision_timeout = vision_timeout
     if vision:
         _ensure_vision_model()
-    from lilbee.ingest import sync
-
+    bee = get_bee()
     try:
-        result = asyncio.run(sync(quiet=cfg.json_mode, force_vision=vision))
+        result = bee.sync(quiet=cfg.json_mode, force_vision=vision)
     except RuntimeError as exc:
         if cfg.json_mode:
             json_output({"error": str(exc)})
@@ -260,10 +259,9 @@ def rebuild(
         cfg.vision_timeout = vision_timeout
     if vision:
         _ensure_vision_model()
-    from lilbee.ingest import sync
-
+    bee = get_bee()
     try:
-        result = asyncio.run(sync(force_rebuild=True, quiet=cfg.json_mode, force_vision=vision))
+        result = bee.sync(force_rebuild=True, quiet=cfg.json_mode, force_vision=vision)
     except RuntimeError as exc:
         if cfg.json_mode:
             json_output({"error": str(exc)})
@@ -388,13 +386,12 @@ def add(
                     f" from {len(urls)} URL(s)[/{theme.MUTED}]"
                 )
 
+        bee = get_bee()
         if cfg.json_mode:
-            from lilbee.ingest import sync
-
             copied: list[str] = []
             if file_paths:
                 copied = copy_paths(file_paths, console, force=force)
-            result = asyncio.run(sync(quiet=True, force_vision=vision))
+            result = bee.sync(quiet=True, force_vision=vision)
             json_output(
                 {
                     "command": "add",
@@ -408,10 +405,7 @@ def add(
         if file_paths:
             add_paths(file_paths, console, force=force, force_vision=vision)
         elif urls:
-            # URLs already saved; just trigger sync
-            from lilbee.ingest import sync
-
-            result = asyncio.run(sync(force_vision=vision))
+            result = bee.sync(force_vision=vision)
             console.print(result)
     except RuntimeError as exc:
         if cfg.json_mode:
@@ -432,6 +426,7 @@ def chunks(
 ) -> None:
     """Show chunks a document was split into (useful for debugging retrieval)."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
+    from lilbee.store import get_sources
 
     known = {s["filename"] for s in get_sources()}
     if source not in known:
@@ -481,22 +476,10 @@ def remove(
 ) -> None:
     """Remove documents from the knowledge base by source name."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
-
-    known = {s["filename"] for s in get_sources()}
-    removed: list[str] = []
-    not_found: list[str] = []
-
-    for name in names:
-        if name not in known:
-            not_found.append(name)
-            continue
-        delete_by_source(name)
-        delete_source(name)
-        removed.append(name)
-        if delete_file:
-            path = cfg.documents_dir / name
-            if path.exists():
-                path.unlink()
+    bee = get_bee()
+    result = bee.remove_documents(names, delete_files=delete_file)
+    removed = result.removed
+    not_found = result.not_found
 
     if cfg.json_mode:
         payload: dict = {"command": "remove", "removed": removed}
@@ -546,11 +529,10 @@ def ask(
     validate_model()
     auto_sync(console)
 
+    bee = get_bee()
     try:
         if cfg.json_mode:
-            from lilbee.query import ask_raw
-
-            result = ask_raw(question)
+            result = bee.ask_raw(question)
             json_output(
                 {
                     "command": "ask",
@@ -561,9 +543,7 @@ def ask(
             )
             return
 
-        from lilbee.query import ask_stream
-
-        for token in ask_stream(question):
+        for token in bee.ask_stream(question):
             console.print(token, end="")
         console.print()
     except RuntimeError as exc:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -16,6 +16,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Input
 
 from lilbee import settings
+from lilbee.cli.app import get_bee
 from lilbee.cli.helpers import get_version
 from lilbee.cli.settings_map import SETTINGS_MAP
 from lilbee.cli.tui import messages as msg
@@ -32,7 +33,6 @@ from lilbee.config import cfg
 from lilbee.crawler import is_url, require_valid_crawl_url
 from lilbee.progress import EventType
 from lilbee.query import ChatMessage
-from lilbee.store import delete_by_source, delete_source, get_sources
 
 log = logging.getLogger(__name__)
 
@@ -223,14 +223,16 @@ class ChatScreen(Screen[None]):
         self.app.push_screen(CatalogScreen())
 
     def _cmd_delete(self, args: str) -> None:
+        bee = get_bee()
         try:
-            sources = get_sources()
+            status = bee.status()
+            source_names: list[str] = status["sources"]  # type: ignore[assignment]
+            known = set(source_names)
         except Exception:
             log.debug("Failed to list documents for /delete", exc_info=True)
             self.notify(msg.CMD_DELETE_NO_DOCS, severity="warning")
             return
 
-        known = {s.get("filename", s.get("source", "?")) for s in sources}
         if not known:
             self.notify(msg.CMD_DELETE_NO_DOCS, severity="warning")
             return
@@ -244,8 +246,7 @@ class ChatScreen(Screen[None]):
             self.notify(msg.CMD_DELETE_NOT_FOUND.format(name=name), severity="error")
             return
 
-        delete_by_source(name)
-        delete_source(name)
+        bee.remove(name)
         self.notify(msg.CMD_DELETE_SUCCESS.format(name=name))
 
     def _cmd_help(self, _args: str) -> None:
@@ -355,13 +356,12 @@ class ChatScreen(Screen[None]):
     @work(thread=True)
     def _stream_response(self, question: str, widget: AssistantMessage) -> None:
         """Stream LLM response in a background thread."""
-        from lilbee.query import ask_stream
-
+        bee = get_bee()
         response_parts: list[str] = []
         sources: list[str] = []
 
         try:
-            stream = ask_stream(question, history=self._history[:-1])
+            stream = bee.ask_stream(question, history=self._history[:-1])
             for token in stream:
                 if token.is_reasoning:
                     self.app.call_from_thread(widget.append_reasoning, token.content)
@@ -404,15 +404,12 @@ class ChatScreen(Screen[None]):
     def _run_sync(self) -> None:
         """Run background document sync.
 
-        Uses asyncio.run() because Textual workers run in threads, not the
-        async event loop, so we need a fresh loop for the async sync() call.
+        Uses bee.sync() which internally calls asyncio.run() for the async
+        ingest pipeline.
         """
-        import asyncio
-
         sync_bar = self.query_one("#sync-bar", SyncBar)
         try:
-            from lilbee.ingest import sync
-
+            bee = get_bee()
             self.app.call_from_thread(sync_bar.set_status, msg.SYNC_STATUS_SYNCING)
 
             def on_progress(event_type: EventType, data: dict[str, object]) -> None:
@@ -424,8 +421,8 @@ class ChatScreen(Screen[None]):
                     )
                     self.app.call_from_thread(sync_bar.set_status, status)
 
-            result = asyncio.run(sync(on_progress=on_progress))
-            added = result.get("added", 0) if isinstance(result, dict) else 0
+            result = bee.sync(on_progress=on_progress)
+            added = len(result.added)
             self.app.call_from_thread(sync_bar.set_status, msg.SYNC_STATUS_DONE.format(count=added))
         except Exception:
             log.warning("Background sync failed", exc_info=True)

--- a/src/lilbee/embedder.py
+++ b/src/lilbee/embedder.py
@@ -1,34 +1,51 @@
 """Thin wrapper around LLM provider embeddings API."""
 
+from __future__ import annotations
+
 import logging
 import math
+from typing import TYPE_CHECKING
 
 from lilbee.config import cfg
 from lilbee.progress import DetailedProgressCallback, EventType, noop_callback
 from lilbee.providers import get_provider
+
+if TYPE_CHECKING:
+    from lilbee.config import Config
+    from lilbee.providers.base import LLMProvider
 
 log = logging.getLogger(__name__)
 
 MAX_BATCH_CHARS = 6000
 
 
+def _truncate(text: str, max_chars: int) -> str:
+    """Truncate text to *max_chars*."""
+    if len(text) <= max_chars:
+        return text
+    log.debug("Truncating chunk from %d to %d chars for embedding", len(text), max_chars)
+    return text[:max_chars]
+
+
 def truncate(text: str) -> str:
     """Truncate text to stay within the embedding model's context window."""
-    if len(text) <= cfg.max_embed_chars:
-        return text
-    log.debug("Truncating chunk from %d to %d chars for embedding", len(text), cfg.max_embed_chars)
-    return text[: cfg.max_embed_chars]
+    return _truncate(text, cfg.max_embed_chars)
 
 
-def validate_vector(vector: list[float]) -> None:
+def _validate_vector(vector: list[float], expected_dim: int) -> None:
     """Validate embedding vector dimension and values."""
-    if len(vector) != cfg.embedding_dim:
+    if len(vector) != expected_dim:
         raise ValueError(
-            f"Embedding dimension mismatch: expected {cfg.embedding_dim}, got {len(vector)}"
+            f"Embedding dimension mismatch: expected {expected_dim}, got {len(vector)}"
         )
     for i, v in enumerate(vector):
         if math.isnan(v) or math.isinf(v):
             raise ValueError(f"Embedding contains invalid value at index {i}: {v}")
+
+
+def validate_vector(vector: list[float]) -> None:
+    """Validate embedding vector dimension and values (uses global cfg)."""
+    _validate_vector(vector, cfg.embedding_dim)
 
 
 def validate_model() -> None:
@@ -45,6 +62,28 @@ def validate_model() -> None:
         ) from exc
 
 
+def validate_model_di(*, config: Config, provider: LLMProvider) -> None:
+    """Ensure the configured embedding model is available (DI version)."""
+    from lilbee.model_manager import get_model_manager
+
+    try:
+        if not get_model_manager().is_installed(config.embedding_model):
+            log.info("Pulling embedding model '%s'...", config.embedding_model)
+            provider.pull_model(config.embedding_model, on_progress=lambda _: None)
+    except (ConnectionError, OSError) as exc:
+        raise RuntimeError(
+            f"Cannot connect to embedding backend: {exc}. Is the server running?"
+        ) from exc
+
+
+def embed_di(text: str, *, provider: LLMProvider, config: Config) -> list[float]:
+    """Embed a single text string with explicit provider and config."""
+    vectors = provider.embed([_truncate(text, config.max_embed_chars)])
+    result: list[float] = vectors[0]
+    _validate_vector(result, config.embedding_dim)
+    return result
+
+
 def embed(text: str) -> list[float]:
     """Embed a single text string, return vector."""
     provider = get_provider()
@@ -52,6 +91,46 @@ def embed(text: str) -> list[float]:
     result: list[float] = vectors[0]
     validate_vector(result)
     return result
+
+
+def embed_batch_di(
+    texts: list[str],
+    *,
+    provider: LLMProvider,
+    config: Config,
+    source: str = "",
+    on_progress: DetailedProgressCallback = noop_callback,
+) -> list[list[float]]:
+    """Embed multiple texts with explicit provider and config."""
+    if not texts:
+        return []
+    total_chunks = len(texts)
+    max_chars = config.max_embed_chars
+    vectors: list[list[float]] = []
+    batch: list[str] = []
+    batch_chars = 0
+    for text in texts:
+        truncated = _truncate(text, max_chars)
+        chunk_len = len(truncated)
+        if batch and batch_chars + chunk_len > MAX_BATCH_CHARS:
+            vectors.extend(provider.embed(batch))
+            on_progress(
+                EventType.EMBED,
+                {"file": source, "chunk": len(vectors), "total_chunks": total_chunks},
+            )
+            batch = []
+            batch_chars = 0
+        batch.append(truncated)
+        batch_chars += chunk_len
+    if batch:
+        vectors.extend(provider.embed(batch))
+        on_progress(
+            EventType.EMBED,
+            {"file": source, "chunk": len(vectors), "total_chunks": total_chunks},
+        )
+    for vec in vectors:
+        _validate_vector(vec, config.embedding_dim)
+    return vectors
 
 
 def embed_batch(

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 if TYPE_CHECKING:
     from kreuzberg import ExtractionConfig, ExtractionResult
 
+
 from pydantic import BaseModel
 from rich.progress import (
     BarColumn,

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -10,30 +10,43 @@ from mcp.server.fastmcp import FastMCP
 from lilbee.config import cfg
 from lilbee.crawl_task import get_task, start_crawl
 from lilbee.crawler import is_url, require_valid_crawl_url
-from lilbee.store import delete_by_source, delete_source, get_sources
 
 if TYPE_CHECKING:
+    from lilbee.api import Lilbee
     from lilbee.store import SearchChunk
 
 mcp = FastMCP("lilbee", instructions="Local RAG knowledge base. Search indexed documents.")
+
+_bee: Lilbee | None = None
+
+
+def _get_bee() -> Lilbee:
+    """Return a module-level Lilbee instance backed by the global cfg."""
+    global _bee
+    if _bee is None:
+        from lilbee.api import Lilbee
+
+        _bee = Lilbee(config=cfg)
+    return _bee
 
 
 @mcp.tool()
 def lilbee_search(query: str, top_k: int = 5) -> list[dict]:
     """Search the knowledge base for relevant document chunks.
 
-    Returns chunks sorted by relevance. No LLM call — uses pre-computed embeddings.
+    Returns chunks sorted by relevance. No LLM call -- uses pre-computed embeddings.
     """
-    from lilbee.query import search_context
-
-    results = search_context(query, top_k=top_k)
+    bee = _get_bee()
+    results = bee.search(query, top_k=top_k)
     return [clean(r) for r in results]
 
 
 @mcp.tool()
 def lilbee_status() -> dict:
     """Show indexed documents, configuration, and chunk counts."""
-    sources = get_sources()
+    from lilbee.store import SourceRecord, get_sources
+
+    sources: list[SourceRecord] = get_sources()
     return {
         "config": {
             "documents_dir": str(cfg.documents_dir),
@@ -79,7 +92,6 @@ async def lilbee_add(
             scanned PDFs are skipped.
     """
     from lilbee.cli.helpers import copy_files
-    from lilbee.ingest import sync
 
     errors: list[str] = []
     valid: list[Path] = []
@@ -94,7 +106,6 @@ async def lilbee_add(
             else:
                 valid.append(p)
 
-    # Crawl URLs
     crawled_count = 0
     if urls:
         from lilbee.crawler import crawler_available
@@ -117,6 +128,8 @@ async def lilbee_add(
     old_vision = cfg.vision_model
     if vision_model:
         cfg.vision_model = vision_model
+    from lilbee.ingest import sync
+
     try:
         sync_result = (await sync(quiet=True, force_vision=bool(vision_model))).model_dump()
     finally:
@@ -212,26 +225,16 @@ def lilbee_remove(names: list[str], delete_files: bool = False) -> dict:
         names: Source filenames to remove (as shown by lilbee_status).
         delete_files: Also delete the physical files from the documents directory.
     """
-    known = {s["filename"] for s in get_sources()}
-    removed: list[str] = []
-    not_found: list[str] = []
-    for name in names:
-        if name not in known:
-            not_found.append(name)
-            continue
-        delete_by_source(name)
-        delete_source(name)
-        removed.append(name)
-        if delete_files:
-            path = cfg.documents_dir / name
-            if path.exists():
-                path.unlink()
-    return {"command": "remove", "removed": removed, "not_found": not_found}
+    bee = _get_bee()
+    result = bee.remove_documents(names, delete_files=delete_files)
+    return {"command": "remove", "removed": result.removed, "not_found": result.not_found}
 
 
 @mcp.tool()
 def lilbee_list_documents() -> dict:
     """List all indexed documents with their chunk counts."""
+    from lilbee.store import get_sources
+
     sources = get_sources()
     return {
         "documents": [

--- a/src/lilbee/providers/__init__.py
+++ b/src/lilbee/providers/__init__.py
@@ -1,6 +1,6 @@
 """Pluggable LLM provider abstraction."""
 
 from lilbee.providers.base import LLMProvider, ProviderError
-from lilbee.providers.factory import get_provider, reset_provider
+from lilbee.providers.factory import create_provider, get_provider, reset_provider
 
-__all__ = ["LLMProvider", "ProviderError", "get_provider", "reset_provider"]
+__all__ = ["LLMProvider", "ProviderError", "create_provider", "get_provider", "reset_provider"]

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -1,34 +1,32 @@
-"""Factory for creating LLM provider singletons."""
+"""Factory for creating LLM provider instances."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from lilbee.config import Config
     from lilbee.providers.base import LLMProvider
 
 _provider: LLMProvider | None = None
 
 
-def get_provider() -> LLMProvider:
-    """Return the configured LLM provider singleton."""
-    global _provider
-    if _provider is not None:
-        return _provider
+def create_provider(config: Config) -> LLMProvider:
+    """Create a new LLM provider instance from explicit config.
 
-    from lilbee.config import cfg
-
-    provider_name = cfg.llm_provider
+    Does NOT cache — the caller owns the lifecycle. Used by ``Lilbee``.
+    """
+    provider_name = config.llm_provider
 
     if provider_name == "auto":
         from lilbee.providers.routing_provider import RoutingProvider
 
-        _provider = RoutingProvider()
-    elif provider_name == "llama-cpp":
+        return RoutingProvider()
+    if provider_name == "llama-cpp":
         from lilbee.providers.llama_cpp_provider import LlamaCppProvider
 
-        _provider = LlamaCppProvider()
-    elif provider_name in ("litellm", "ollama"):
+        return LlamaCppProvider()
+    if provider_name in ("litellm", "ollama"):
         from lilbee.providers.litellm_provider import LiteLLMProvider
 
         if not LiteLLMProvider.available():
@@ -37,12 +35,22 @@ def get_provider() -> LLMProvider:
             raise ProviderError(
                 "litellm is not installed. Install with: pip install 'lilbee[litellm]'"
             )
-        _provider = LiteLLMProvider(base_url=cfg.litellm_base_url, api_key=cfg.llm_api_key)
-    else:
-        from lilbee.providers.base import ProviderError
+        return LiteLLMProvider(base_url=config.litellm_base_url, api_key=config.llm_api_key)
 
-        raise ProviderError(f"Unknown LLM provider: {provider_name!r}")
+    from lilbee.providers.base import ProviderError
 
+    raise ProviderError(f"Unknown LLM provider: {provider_name!r}")
+
+
+def get_provider() -> LLMProvider:
+    """Return the configured LLM provider singleton (uses global cfg)."""
+    global _provider
+    if _provider is not None:
+        return _provider
+
+    from lilbee.config import cfg
+
+    _provider = create_provider(cfg)
     return _provider
 
 

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -1,4 +1,9 @@
-"""RAG query pipeline — embed question, search, generate answer with citations."""
+"""RAG query pipeline — embed question, search, generate answer with citations.
+
+All pipeline functions are private (prefixed ``_``) and accept explicit
+``config`` and ``provider`` parameters.  The public entry point is the
+:class:`~lilbee.api.Lilbee` facade.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +12,8 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
+    from lilbee.config import Config
+    from lilbee.providers.base import LLMProvider
     from lilbee.reasoning import StreamToken
 
 from pydantic import BaseModel
@@ -14,7 +21,6 @@ from typing_extensions import TypedDict
 
 from lilbee import embedder, store
 from lilbee.config import cfg
-from lilbee.providers import get_provider
 from lilbee.store import SearchChunk
 
 
@@ -63,8 +69,8 @@ def deduplicate_sources(results: list[SearchChunk], max_citations: int = 5) -> l
 def _sort_key(r: SearchChunk) -> float:
     """Sort key: lower = more relevant.
 
-    Hybrid results have relevance_score (higher = better) → negate.
-    Vector results have distance (lower = better) → use directly.
+    Hybrid results have relevance_score (higher = better) -> negate.
+    Vector results have distance (lower = better) -> use directly.
     """
     if r.relevance_score is not None:
         return -r.relevance_score
@@ -108,8 +114,6 @@ def _apply_temporal_filter(results: list[SearchChunk], question: str) -> list[Se
     if keyword is None:
         return results
     date_range = resolve_date_range(keyword)
-    # Filter by ingestion date (stored in sources table, not on chunks directly).
-    # Since chunks don't carry dates, we filter by source ingestion time via store.
     source_dates = {s["filename"]: s.get("ingested_at", "") for s in store.get_sources()}
     filtered: list[SearchChunk] = []
     for r in results:
@@ -149,7 +153,7 @@ _EXPANSION_PROMPT = (
 
 # Max tokens the LLM can generate for expansion variants.
 # 200 tokens is enough for 3 one-line query variants (~50 tokens each
-# plus formatting). Not configurable — this is an internal budget.
+# plus formatting). Not configurable -- this is an internal budget.
 _EXPANSION_MAX_TOKENS = 200
 
 
@@ -265,34 +269,6 @@ def _apply_guardrails(variants: list[str], question: str) -> list[str]:
     return validated
 
 
-def _expand_query(question: str) -> list[str]:
-    """Use the LLM to generate alternative query phrasings.
-
-    Returns up to ``cfg.query_expansion_count`` variants.
-    When ``cfg.expansion_guardrails`` is True, validates variants for drift.
-    Set ``LILBEE_QUERY_EXPANSION_COUNT=0`` to disable expansion entirely.
-    """
-    count = cfg.query_expansion_count
-    if count == 0:
-        return []
-    try:
-        provider = get_provider()
-        prompt = _EXPANSION_PROMPT.format(count=count, question=question)
-        messages = [{"role": "user", "content": prompt}]
-        response = provider.chat(
-            messages, stream=False, options={"num_predict": _EXPANSION_MAX_TOKENS}
-        )
-        if not isinstance(response, str):
-            return []
-        variants = [line.strip() for line in response.strip().split("\n") if line.strip()]
-        variants = variants[:count]
-        variants.extend(_concept_query_expansion(question))
-        variants = _apply_guardrails(variants, question)
-        return variants
-    except Exception:
-        return []
-
-
 def _should_skip_expansion(question: str) -> bool:
     """Check if BM25 results are confident enough to skip query expansion.
 
@@ -325,7 +301,7 @@ def select_context(
     """Select chunks that maximize query term coverage.
 
     Greedy set-cover: pick chunks adding the most uncovered query terms.
-    Falls through unchanged if results ≤ max_sources.
+    Falls through unchanged if results <= max_sources.
     """
     if max_sources is None:
         max_sources = cfg.max_context_sources
@@ -367,31 +343,6 @@ _HYDE_PROMPT = (
 )
 
 
-def _hyde_search(question: str, top_k: int) -> list[SearchChunk]:
-    """HyDE: generate a hypothetical document, embed it, search with it.
-
-    Gao et al. 2022, "Precise Zero-Shot Dense Retrieval without
-    Relevance Labels" (https://arxiv.org/abs/2212.10496).
-
-    Returns results from the hypothetical embedding search, or empty
-    list on failure. Results should be weighted at ``cfg.hyde_weight``
-    relative to original search results.
-    """
-    try:
-        provider = get_provider()
-        response = provider.chat(
-            [{"role": "user", "content": _HYDE_PROMPT.format(question=question)}],
-            stream=False,
-            options={"num_predict": _EXPANSION_MAX_TOKENS},
-        )
-        if not isinstance(response, str) or not response.strip():
-            return []
-        hyde_vec = embedder.embed(response.strip())
-        return store.search(hyde_vec, top_k=top_k, query_text=None)
-    except Exception:
-        return []
-
-
 def _parse_structured_query(question: str) -> tuple[str | None, str]:
     """Parse structured query mode prefix.
 
@@ -401,19 +352,6 @@ def _parse_structured_query(question: str) -> tuple[str | None, str]:
         if question.strip().lower().startswith(prefix):
             return prefix[:-1], question.strip()[len(prefix) :].strip()
     return None, question
-
-
-def _search_structured(mode: str, query: str, top_k: int) -> list[SearchChunk]:
-    """Execute a structured query mode search."""
-    if mode == "term":
-        return store.bm25_probe(query, top_k=top_k)
-    if mode == "vec":
-        query_vec = embedder.embed(query)
-        return store.search(query_vec, top_k=top_k, query_text=None)
-    if mode == "hyde":
-        hyde_results = _hyde_search(query, top_k)
-        return hyde_results
-    return []
 
 
 def _apply_concept_boost(results: list[SearchChunk], question: str) -> list[SearchChunk]:
@@ -445,32 +383,113 @@ def _concept_query_expansion(question: str) -> list[str]:
         return []
 
 
-def search_context(question: str, top_k: int = 0) -> list[SearchChunk]:
+class AskResult(BaseModel):
+    """Structured result from ask_raw -- answer text + raw search results."""
+
+    answer: str
+    sources: list[SearchChunk]
+
+
+def _search_structured(
+    mode: str,
+    query: str,
+    top_k: int,
+    *,
+    config: Config,
+    provider: LLMProvider,
+) -> list[SearchChunk]:
+    """Execute a structured query mode search."""
+    if mode == "term":
+        return store.bm25_probe(query, top_k=top_k)
+    if mode == "vec":
+        query_vec = embedder.embed_di(query, provider=provider, config=config)
+        return store.search(query_vec, top_k=top_k, query_text=None)
+    if mode == "hyde":
+        return _hyde_search(query, top_k, config=config, provider=provider)
+    return []
+
+
+def _expand_query(question: str, *, config: Config, provider: LLMProvider) -> list[str]:
+    """Use the LLM to generate alternative query phrasings.
+
+    Returns up to ``config.query_expansion_count`` variants.
+    """
+    count = config.query_expansion_count
+    if count == 0:
+        return []
+    try:
+        prompt = _EXPANSION_PROMPT.format(count=count, question=question)
+        messages = [{"role": "user", "content": prompt}]
+        response = provider.chat(
+            messages, stream=False, options={"num_predict": _EXPANSION_MAX_TOKENS}
+        )
+        if not isinstance(response, str):
+            return []
+        variants = [line.strip() for line in response.strip().split("\n") if line.strip()]
+        variants = variants[:count]
+        variants.extend(_concept_query_expansion(question))
+        variants = _apply_guardrails(variants, question)
+        return variants
+    except Exception:
+        return []
+
+
+def _hyde_search(
+    question: str,
+    top_k: int,
+    *,
+    config: Config,
+    provider: LLMProvider,
+) -> list[SearchChunk]:
+    """HyDE: generate a hypothetical document, embed it, search with it.
+
+    Gao et al. 2022, "Precise Zero-Shot Dense Retrieval without
+    Relevance Labels" (https://arxiv.org/abs/2212.10496).
+    """
+    try:
+        response = provider.chat(
+            [{"role": "user", "content": _HYDE_PROMPT.format(question=question)}],
+            stream=False,
+            options={"num_predict": _EXPANSION_MAX_TOKENS},
+        )
+        if not isinstance(response, str) or not response.strip():
+            return []
+        hyde_vec = embedder.embed_di(response.strip(), provider=provider, config=config)
+        return store.search(hyde_vec, top_k=top_k, query_text=None)
+    except Exception:
+        return []
+
+
+def _search_context(
+    question: str,
+    top_k: int = 0,
+    *,
+    config: Config,
+    provider: LLMProvider,
+) -> list[SearchChunk]:
     """Embed question and return top-K matching chunks.
 
     Supports structured query modes (``term:``, ``vec:``, ``hyde:`` prefixes)
     and query expansion with confidence-based skipping.
     """
     if top_k == 0:
-        top_k = cfg.top_k
+        top_k = config.top_k
 
-    # Check for structured query mode
     mode, clean_query = _parse_structured_query(question)
     if mode is not None:
-        return _search_structured(mode, clean_query, top_k)
+        return _search_structured(mode, clean_query, top_k, config=config, provider=provider)
 
-    query_vec = embedder.embed(question)
+    query_vec = embedder.embed_di(question, provider=provider, config=config)
     results = store.search(query_vec, top_k=top_k, query_text=question)
 
-    # Skip expansion if BM25 already found a confident match
     if _should_skip_expansion(question):
         return results[: top_k * 2]
 
     seen = {(r.source, r.chunk_index) for r in results}
-    variants = _expand_query(question)
+    variants = _expand_query(question, config=config, provider=provider)
     if variants:
         for variant in variants:
-            variant_vec = embedder.embed(variant)
+            variant_vec = embedder.embed_di(variant, provider=provider, config=config)
             variant_results = store.search(variant_vec, top_k=top_k, query_text=variant)
             for r in variant_results:
                 key = (r.source, r.chunk_index)
@@ -478,46 +497,38 @@ def search_context(question: str, top_k: int = 0) -> list[SearchChunk]:
                     results.append(r)
                     seen.add(key)
 
-    # HyDE: search with hypothetical document embedding (if enabled).
-    # Discount distances by hyde_weight since these are from a fabricated passage.
-    if cfg.hyde:
-        hyde_results = _hyde_search(question, top_k)
+    if config.hyde:
+        hyde_results = _hyde_search(question, top_k, config=config, provider=provider)
         for r in hyde_results:
             key = (r.source, r.chunk_index)
             if key not in seen:
-                if r.distance is not None and cfg.hyde_weight > 0:
-                    r.distance = r.distance / cfg.hyde_weight
+                if r.distance is not None and config.hyde_weight > 0:
+                    r.distance = r.distance / config.hyde_weight
                 results.append(r)
                 seen.add(key)
 
     results = _apply_concept_boost(results, question)
-
-    # Cap total results to prevent context overflow from expansion
     return results[: top_k * 2]
 
 
-class AskResult(BaseModel):
-    """Structured result from ask_raw — answer text + raw search results."""
-
-    answer: str
-    sources: list[SearchChunk]
-
-
-def build_rag_context(
+def _build_rag_context(
     question: str,
     top_k: int = 0,
     history: list[ChatMessage] | None = None,
+    *,
+    config: Config,
+    provider: LLMProvider,
 ) -> tuple[list[SearchChunk], list[ChatMessage]] | None:
-    """Shared RAG pipeline: search → prepare → rerank → filter → select → build.
+    """Shared RAG pipeline: search -> prepare -> rerank -> filter -> select -> build.
 
     Returns (results, messages) or None if no results found.
     """
-    results = search_context(question, top_k=top_k)
+    results = _search_context(question, top_k=top_k, config=config, provider=provider)
     if not results:
         return None
 
     results = prepare_results(results)
-    if cfg.reranker_model:
+    if config.reranker_model:
         from lilbee.reranker import rerank
 
         results = rerank(question, results)
@@ -526,21 +537,26 @@ def build_rag_context(
     context = build_context(results)
     prompt = CONTEXT_TEMPLATE.format(context=context, question=question)
 
-    messages: list[ChatMessage] = [{"role": "system", "content": cfg.system_prompt}]
+    messages: list[ChatMessage] = [{"role": "system", "content": config.system_prompt}]
     if history:
         messages.extend(history)
     messages.append({"role": "user", "content": prompt})
     return results, messages
 
 
-def ask_raw(
+def _ask_raw(
     question: str,
     top_k: int = 0,
     history: list[ChatMessage] | None = None,
     options: dict[str, Any] | None = None,
+    *,
+    config: Config,
+    provider: LLMProvider,
 ) -> AskResult:
     """One-shot question returning structured answer + raw sources."""
-    rag = build_rag_context(question, top_k=top_k, history=history)
+    rag = _build_rag_context(
+        question, top_k=top_k, history=history, config=config, provider=provider
+    )
     if rag is None:
         return AskResult(
             answer="No relevant documents found. Try ingesting some documents first.",
@@ -548,40 +564,54 @@ def ask_raw(
         )
 
     results, messages = rag
-    opts = options if options is not None else cfg.generation_options()
-    provider = get_provider()
+    opts = options if options is not None else config.generation_options()
     answer = provider.chat(cast(list[dict[str, Any]], messages), options=opts or None)
     return AskResult(answer=str(answer) or "", sources=results)
 
 
-def ask(
+def _ask(
     question: str,
     top_k: int = 0,
     history: list[ChatMessage] | None = None,
     options: dict[str, Any] | None = None,
+    *,
+    config: Config,
+    provider: LLMProvider,
 ) -> str:
     """One-shot question: returns full answer with source citations."""
-    result = ask_raw(question, top_k=top_k, history=history, options=options)
+    result = _ask_raw(
+        question,
+        top_k=top_k,
+        history=history,
+        options=options,
+        config=config,
+        provider=provider,
+    )
     if not result.sources:
         return result.answer
     citations = deduplicate_sources(result.sources)
     return f"{result.answer}\n\nSources:\n" + "\n".join(citations)
 
 
-def ask_stream(
+def _ask_stream(
     question: str,
     top_k: int = 0,
     history: list[ChatMessage] | None = None,
     options: dict[str, Any] | None = None,
+    *,
+    config: Config,
+    provider: LLMProvider,
 ) -> Generator[StreamToken, None, None]:
     """Streaming question: yields classified tokens, then source citations.
 
     Each yielded ``StreamToken`` has ``.content`` (text) and ``.is_reasoning``
-    (True for ``<think>...</think>`` blocks when ``cfg.show_reasoning`` is True).
+    (True for ``<think>...</think>`` blocks when ``config.show_reasoning`` is True).
     """
     from lilbee.reasoning import StreamToken, filter_reasoning
 
-    rag = build_rag_context(question, top_k=top_k, history=history)
+    rag = _build_rag_context(
+        question, top_k=top_k, history=history, config=config, provider=provider
+    )
     if rag is None:
         yield StreamToken(
             content="No relevant documents found. Try ingesting some documents first.",
@@ -590,14 +620,13 @@ def ask_stream(
         return
 
     results, messages = rag
-    opts = options if options is not None else cfg.generation_options()
-    provider = get_provider()
+    opts = options if options is not None else config.generation_options()
     raw_stream = provider.chat(
         cast(list[dict[str, Any]], messages), stream=True, options=opts or None
     )
 
     try:
-        for st in filter_reasoning(cast(Iterator[str], raw_stream), show=cfg.show_reasoning):
+        for st in filter_reasoning(cast(Iterator[str], raw_stream), show=config.show_reasoning):
             if st.content:
                 yield st
     except (ConnectionError, OSError) as exc:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -20,14 +20,26 @@ from lilbee import settings
 from lilbee.cli.helpers import clean_result, copy_files, gather_status, get_version
 from lilbee.config import cfg
 from lilbee.progress import DetailedProgressCallback, EventType, SseEvent
-from lilbee.providers import get_provider
-from lilbee.query import build_rag_context, search_context
 from lilbee.results import group, to_dicts
 from lilbee.store import get_sources, remove_documents
 
 if TYPE_CHECKING:
+    from lilbee.api import Lilbee
     from lilbee.model_manager import ModelSource
     from lilbee.query import ChatMessage
+
+_bee: Lilbee | None = None
+
+
+def _get_bee() -> Lilbee:
+    """Return a module-level Lilbee instance backed by the global cfg."""
+    global _bee
+    if _bee is None:
+        from lilbee.api import Lilbee
+
+        _bee = Lilbee(config=cfg)
+    return _bee
+
 
 log = logging.getLogger(__name__)
 
@@ -122,7 +134,8 @@ async def status() -> dict[str, Any]:
 
 async def search(q: str, top_k: int = 5) -> list[dict[str, Any]]:
     """Search and return grouped DocumentResults as dicts."""
-    results = search_context(q, top_k=top_k)
+    bee = _get_bee()
+    results = bee.search(q, top_k=top_k)
     grouped = group(results)
     return to_dicts(grouped)
 
@@ -131,10 +144,9 @@ async def ask(
     question: str, top_k: int = 0, options: dict[str, Any] | None = None
 ) -> dict[str, Any]:
     """One-shot RAG answer. Returns {answer, sources[]}."""
-    from lilbee.query import ask_raw
-
+    bee = _get_bee()
     opts = _resolve_generation_options(options)
-    result = ask_raw(question, top_k=top_k, options=opts)
+    result = bee.ask_raw(question, top_k=top_k, options=opts)
     return {
         "answer": result.answer,
         "sources": [clean_result(s) for s in result.sources],
@@ -152,8 +164,8 @@ def _run_llm_stream(
     from lilbee.reasoning import filter_reasoning
 
     try:
-        provider = get_provider()
-        stream = provider.chat(
+        bee = _get_bee()
+        stream = bee.provider.chat(
             cast("list[dict[str, Any]]", messages),
             stream=True,
             options=opts or None,
@@ -188,8 +200,16 @@ async def _stream_rag_response(
 ) -> AsyncGenerator[str, None]:
     """Shared SSE streaming for ask_stream and chat_stream."""
     yield ""  # force generator
+    from lilbee.query import _build_rag_context
 
-    rag = build_rag_context(question, top_k=top_k, history=history)
+    bee = _get_bee()
+    rag = _build_rag_context(
+        question,
+        top_k=top_k,
+        history=history,
+        config=bee.config,
+        provider=bee.provider,
+    )
     if rag is None:
         yield sse_error("No relevant documents found.")
         return
@@ -233,10 +253,9 @@ async def chat(
     options: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Chat with history. Returns {answer, sources[]}."""
-    from lilbee.query import ask_raw
-
+    bee = _get_bee()
     opts = _resolve_generation_options(options)
-    result = ask_raw(question, top_k=top_k, history=history, options=opts)
+    result = bee.ask_raw(question, top_k=top_k, history=history, options=opts)
     return {
         "answer": result.answer,
         "sources": [clean_result(s) for s in result.sources],
@@ -466,8 +485,8 @@ async def get_config() -> dict[str, Any]:
 
 async def models_show(model: str) -> dict[str, Any]:
     """Return model metadata/parameters. Returns empty dict if unavailable."""
-    provider = get_provider()
-    result = provider.show_model(model)
+    bee = _get_bee()
+    result = bee.provider.show_model(model)
     return result if result is not None else {}
 
 
@@ -501,8 +520,8 @@ async def models_catalog(
         limit=limit,
         offset=offset,
     )
-    provider = get_provider()
-    installed_names = set(provider.list_models())
+    bee = _get_bee()
+    installed_names = set(bee.provider.list_models())
 
     models = []
     for m in result.models:

--- a/src/lilbee/server/litestar_app.py
+++ b/src/lilbee/server/litestar_app.py
@@ -260,9 +260,10 @@ log = logging.getLogger(__name__)
 async def _lifespan(app: Litestar) -> AsyncIterator[None]:
     """Pre-load LLM provider and embedding model on server startup."""
     try:
-        from lilbee.providers.factory import get_provider
+        from lilbee.server.handlers import _get_bee
 
-        get_provider()
+        bee = _get_bee()
+        _ = bee.provider  # force lazy init
         log.info("LLM provider pre-loaded")
     except Exception:
         log.warning("Failed to pre-load LLM provider", exc_info=True)

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -139,11 +139,14 @@ def _sources_schema() -> pa.Schema:
     )
 
 
+def get_db_at(lancedb_dir: Path) -> lancedb.DBConnection:
+    """Open a LanceDB connection at an explicit path."""
+    lancedb_dir.mkdir(parents=True, exist_ok=True)
+    return lancedb.connect(str(lancedb_dir), read_consistency_interval=READ_CONSISTENCY_INTERVAL)
+
+
 def get_db() -> lancedb.DBConnection:
-    cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
-    return lancedb.connect(
-        str(cfg.lancedb_dir), read_consistency_interval=READ_CONSISTENCY_INTERVAL
-    )
+    return get_db_at(cfg.lancedb_dir)
 
 
 def _table_names(db: lancedb.DBConnection) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,32 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 
+import pytest
+
 from lilbee.config import cfg
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _reset_bee_singletons() -> None:
+    """Reset all cached Lilbee instances and provider singletons."""
+    import lilbee.cli.app as cli_app
+    import lilbee.mcp as mcp_mod
+    import lilbee.providers.factory as factory_mod
+    import lilbee.server.handlers as handlers_mod
+
+    cli_app._bee = None
+    mcp_mod._bee = None
+    handlers_mod._bee = None
+    factory_mod._provider = None
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    """Reset cached Lilbee singletons before and after every test."""
+    _reset_bee_singletons()
+    yield
+    _reset_bee_singletons()
 
 
 @contextmanager

--- a/tests/integration/test_rag_integration.py
+++ b/tests/integration/test_rag_integration.py
@@ -23,7 +23,8 @@ from lilbee.config import cfg  # noqa: E402
 from lilbee.ingest import sync  # noqa: E402
 from lilbee.model_manager import reset_model_manager  # noqa: E402
 from lilbee.providers.factory import reset_provider  # noqa: E402
-from lilbee.query import ask_raw, search_context  # noqa: E402
+from lilbee.query import _ask_raw as ask_raw  # noqa: E402
+from lilbee.query import _search_context as search_context  # noqa: E402
 
 pytestmark = pytest.mark.slow
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -17,14 +17,19 @@ from lilbee.server.handlers import MAX_ADD_FILES
 @pytest.fixture(autouse=True)
 def isolated_env(tmp_path: Path):
     """Redirect config paths to temp dir for every test."""
+    from lilbee.server import handlers as h
+
+    h._bee = None
     snapshot = cfg.model_copy()
     docs = tmp_path / "documents"
     docs.mkdir()
     cfg.documents_dir = docs
     cfg.data_dir = tmp_path / "data"
+    cfg.data_root = tmp_path
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
     cfg.concept_graph = False
     yield docs
+    h._bee = None
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))
 
@@ -281,6 +286,7 @@ class TestOptionsPassthrough:
 
         with (
             mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768),
+            mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768),
             mock.patch("lilbee.store.search", return_value=[]),
         ):
             async with AsyncTestClient(create_app()) as client:
@@ -297,6 +303,7 @@ class TestOptionsPassthrough:
 
         with (
             mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768),
+            mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768),
             mock.patch("lilbee.store.search", return_value=[]),
         ):
             async with AsyncTestClient(create_app()) as client:
@@ -318,6 +325,7 @@ class TestOptionsPassthrough:
 
         with (
             mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768),
+            mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768),
             mock.patch("lilbee.store.search", return_value=[]),
         ):
             async with AsyncTestClient(create_app()) as client:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ import pytest
 from lilbee.config import cfg
 
 
-def _fake_embed(text):
+def _fake_embed(text, **kwargs):
     return [0.1] * 768
 
 
@@ -16,13 +16,25 @@ def _fake_embed_batch(texts, **kwargs):
     return [[0.1] * 768 for _ in texts]
 
 
+def _fake_provider():
+    """Create a mock provider that handles embed and chat calls."""
+    p = mock.MagicMock()
+    p.embed.side_effect = lambda texts: [[0.1] * 768 for _ in texts]
+    p.chat.return_value = "mock answer"
+    return p
+
+
 @pytest.fixture(autouse=True)
 def _mock_embedder():
     """Mock embedding calls so tests run without a live model."""
     with (
         mock.patch("lilbee.embedder.embed", side_effect=_fake_embed),
+        mock.patch("lilbee.embedder.embed_di", side_effect=_fake_embed),
         mock.patch("lilbee.embedder.embed_batch", side_effect=_fake_embed_batch),
+        mock.patch("lilbee.embedder.embed_batch_di", side_effect=_fake_embed_batch),
         mock.patch("lilbee.embedder.validate_model"),
+        mock.patch("lilbee.embedder.validate_model_di"),
+        mock.patch("lilbee.providers.factory.create_provider", return_value=_fake_provider()),
     ):
         yield
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,8 @@ def _skip_model_validation():
 @pytest.fixture(autouse=True)
 def isolated_env(tmp_path, monkeypatch):
     """Redirect config paths for all CLI tests."""
+    import lilbee.cli.app as cli_app
+
     monkeypatch.delenv("LILBEE_DATA", raising=False)
     monkeypatch.delenv("LILBEE_LOG_LEVEL", raising=False)
     snapshot = cfg.model_copy()
@@ -57,8 +59,12 @@ def isolated_env(tmp_path, monkeypatch):
     cfg.json_mode = False
     cfg.concept_graph = False
 
+    # Reset the cached Lilbee singleton so each test gets a fresh one
+    cli_app._bee = None
+
     yield tmp_path
 
+    cli_app._bee = None
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))
     root.setLevel(old_level)
@@ -252,14 +258,14 @@ class TestAddIgnoresDirs:
 
 
 class TestAsk:
-    @mock.patch("lilbee.query.ask_stream")
+    @mock.patch("lilbee.query._ask_stream")
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_prints_response(self, mock_sync, mock_stream):
         mock_stream.return_value = iter(["Hello", " world"])
         result = runner.invoke(app, ["ask", "test question"])
         assert result.exit_code == 0
 
-    @mock.patch("lilbee.query.ask_stream")
+    @mock.patch("lilbee.query._ask_stream")
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_with_model_flag(self, mock_sync, mock_stream):
         mock_stream.return_value = _mock_stream("answer")
@@ -291,7 +297,7 @@ class TestAutoSync:
         new_callable=AsyncMock,
         return_value=SyncResult(added=["new.pdf"]),
     )
-    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("answer"))
+    @mock.patch("lilbee.query._ask_stream", return_value=_mock_stream("answer"))
     def test_auto_sync_prints_summary(self, mock_ask_stream, mock_sync):
         result = runner.invoke(app, ["ask", "test"])
         assert result.exit_code == 0
@@ -689,7 +695,7 @@ _MOCK_SEARCH_RESULTS = [
 
 
 class TestSearch:
-    @mock.patch("lilbee.query.search_context", return_value=_MOCK_SEARCH_RESULTS)
+    @mock.patch("lilbee.query._search_context", return_value=_MOCK_SEARCH_RESULTS)
     def test_search_json_with_results(self, mock_search):
         result = runner.invoke(app, ["--json", "search", "engine oil"])
         assert result.exit_code == 0
@@ -700,21 +706,21 @@ class TestSearch:
         assert "vector" not in data["results"][0]
         assert "distance" in data["results"][0]
 
-    @mock.patch("lilbee.query.search_context", return_value=[])
+    @mock.patch("lilbee.query._search_context", return_value=[])
     def test_search_json_empty_results(self, mock_search):
         result = runner.invoke(app, ["--json", "search", "nothing"])
         assert result.exit_code == 0
         data = json.loads(result.output.strip())
         assert data["results"] == []
 
-    @mock.patch("lilbee.query.search_context", return_value=_MOCK_SEARCH_RESULTS)
+    @mock.patch("lilbee.query._search_context", return_value=_MOCK_SEARCH_RESULTS)
     def test_search_human_output(self, mock_search):
         result = runner.invoke(app, ["search", "engine oil"])
         assert result.exit_code == 0
         assert "manual.pdf" in result.output
 
     @mock.patch(
-        "lilbee.query.search_context",
+        "lilbee.query._search_context",
         return_value=[_MOCK_SEARCH_RESULTS[0].model_copy(update={"chunk": "x" * 100})],
     )
     def test_search_human_truncates_long_chunks(self, mock_search):
@@ -723,14 +729,14 @@ class TestSearch:
         # Chunk is truncated (100 chars doesn't all appear, Rich truncates with …)
         assert result.output.count("x") < 100
 
-    @mock.patch("lilbee.query.search_context", return_value=[])
+    @mock.patch("lilbee.query._search_context", return_value=[])
     def test_search_human_no_results(self, mock_search):
         result = runner.invoke(app, ["search", "nothing"])
         assert result.exit_code == 0
         assert "No results found" in result.output
 
     @mock.patch(
-        "lilbee.query.search_context",
+        "lilbee.query._search_context",
         return_value=[
             _MOCK_SEARCH_RESULTS[0].model_copy(update={"relevance_score": 0.85, "distance": None})
         ],
@@ -742,7 +748,7 @@ class TestSearch:
         assert "0.85" in result.output
 
     @mock.patch(
-        "lilbee.query.search_context",
+        "lilbee.query._search_context",
         return_value=[
             _MOCK_SEARCH_RESULTS[0].model_copy(update={"relevance_score": 0.85, "distance": None})
         ],
@@ -1189,7 +1195,7 @@ class TestAddJson:
 
 
 class TestAskJson:
-    @mock.patch("lilbee.query.ask_raw")
+    @mock.patch("lilbee.query._ask_raw")
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_json(self, mock_sync, mock_ask_raw):
         from lilbee.query import AskResult
@@ -1221,7 +1227,7 @@ class TestAskJson:
         assert "vector" not in data["sources"][0]
         assert "distance" in data["sources"][0]
 
-    @mock.patch("lilbee.query.ask_raw")
+    @mock.patch("lilbee.query._ask_raw")
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_json_no_results(self, mock_sync, mock_ask_raw):
         from lilbee.query import AskResult
@@ -1237,14 +1243,14 @@ class TestAskJson:
 class TestAskModelNotFound:
     """CLI should show a friendly error when the model doesn't exist."""
 
-    @mock.patch("lilbee.query.ask_stream", side_effect=RuntimeError("Model 'bad' not found"))
+    @mock.patch("lilbee.query._ask_stream", side_effect=RuntimeError("Model 'bad' not found"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_model_not_found_human(self, mock_sync, mock_ask_stream):
         result = runner.invoke(app, ["ask", "hello"])
         assert result.exit_code == 1
         assert "not found" in result.output
 
-    @mock.patch("lilbee.query.ask_raw", side_effect=RuntimeError("Model 'bad' not found"))
+    @mock.patch("lilbee.query._ask_raw", side_effect=RuntimeError("Model 'bad' not found"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_model_not_found_json(self, mock_sync, mock_ask_raw):
         result = runner.invoke(app, ["--json", "ask", "hello"])
@@ -1313,14 +1319,14 @@ class TestBackendUnavailable:
 class TestEnsureChatModelWiring:
     """Verify that ask and chat call ensure_chat_model before running."""
 
-    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("answer"))
+    @mock.patch("lilbee.query._ask_stream", return_value=_mock_stream("answer"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_calls_ensure_chat_model(self, mock_sync, mock_ask_stream):
         with mock.patch("lilbee.models.ensure_chat_model") as mock_ensure:
             runner.invoke(app, ["ask", "test"])
             mock_ensure.assert_called_once()
 
-    @mock.patch("lilbee.query.ask_stream", return_value=_mock_stream("answer"))
+    @mock.patch("lilbee.query._ask_stream", return_value=_mock_stream("answer"))
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_calls_validate_model(self, mock_sync, mock_ask_stream):
         with mock.patch("lilbee.embedder.validate_model") as mock_val:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -28,15 +28,20 @@ from lilbee.store import SearchChunk
 @pytest.fixture(autouse=True)
 def isolated_env(tmp_path):
     """Redirect config paths for all MCP tests."""
+    import lilbee.mcp as mcp_mod
+
+    mcp_mod._bee = None
     snapshot = cfg.model_copy()
 
     cfg.documents_dir = tmp_path / "documents"
     cfg.documents_dir.mkdir(exist_ok=True)
     cfg.data_dir = tmp_path / "data"
+    cfg.data_root = tmp_path
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
 
     yield tmp_path
 
+    mcp_mod._bee = None
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))
 
@@ -97,7 +102,7 @@ class TestClean:
 
 
 class TestLilbeeSearch:
-    @mock.patch("lilbee.query.search_context")
+    @mock.patch("lilbee.query._search_context")
     def test_returnscleaned_results(self, mock_search):
         mock_search.return_value = [
             SearchChunk(
@@ -117,9 +122,12 @@ class TestLilbeeSearch:
         assert len(results) == 1
         assert "vector" not in results[0]
         assert results[0]["distance"] == 0.3
-        mock_search.assert_called_once_with("test query", top_k=3)
+        mock_search.assert_called_once()
+        args, kwargs = mock_search.call_args
+        assert args[0] == "test query"
+        assert kwargs["top_k"] == 3
 
-    @mock.patch("lilbee.query.search_context", return_value=[])
+    @mock.patch("lilbee.query._search_context", return_value=[])
     def test_empty_results(self, mock_search):
         assert lilbee_search("nothing") == []
 
@@ -170,24 +178,24 @@ class TestLilbeeSync:
 
 
 class TestLilbeeRemove:
-    @mock.patch("lilbee.mcp.get_sources")
-    @mock.patch("lilbee.mcp.delete_source")
-    @mock.patch("lilbee.mcp.delete_by_source")
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
     def test_removes_known_file(self, mock_del, mock_del_src, mock_sources):
         mock_sources.return_value = [{"filename": "a.md"}]
         result = lilbee_remove(["a.md"])
         assert result["removed"] == ["a.md"]
         assert result["not_found"] == []
 
-    @mock.patch("lilbee.mcp.get_sources")
+    @mock.patch("lilbee.store.get_sources")
     def test_not_found(self, mock_sources):
         mock_sources.return_value = []
         result = lilbee_remove(["missing.md"])
         assert result["not_found"] == ["missing.md"]
 
-    @mock.patch("lilbee.mcp.get_sources")
-    @mock.patch("lilbee.mcp.delete_source")
-    @mock.patch("lilbee.mcp.delete_by_source")
+    @mock.patch("lilbee.store.get_sources")
+    @mock.patch("lilbee.store.delete_source")
+    @mock.patch("lilbee.store.delete_by_source")
     def test_delete_files_removes_from_disk(self, mock_del, mock_del_src, mock_sources):
         mock_sources.return_value = [{"filename": "a.md"}]
         f = cfg.documents_dir / "a.md"
@@ -199,14 +207,14 @@ class TestLilbeeRemove:
 
 
 class TestLilbeeListDocuments:
-    @mock.patch("lilbee.mcp.get_sources")
+    @mock.patch("lilbee.store.get_sources")
     def test_returns_documents(self, mock_sources):
         mock_sources.return_value = [{"filename": "a.md", "chunk_count": 3}]
         result = lilbee_list_documents()
         assert result["total"] == 1
         assert result["documents"][0]["filename"] == "a.md"
 
-    @mock.patch("lilbee.mcp.get_sources")
+    @mock.patch("lilbee.store.get_sources")
     def test_empty(self, mock_sources):
         mock_sources.return_value = []
         result = lilbee_list_documents()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,4 @@
-"""Tests for the RAG query pipeline (mocked — no live server needed)."""
+"""Tests for the RAG query pipeline (mocked -- no live server needed)."""
 
 from unittest import mock
 
@@ -6,13 +6,16 @@ import pytest
 
 from lilbee.config import cfg
 from lilbee.query import (
-    ask,
-    ask_raw,
-    ask_stream,
+    _ask,
+    _ask_raw,
+    _ask_stream,
+    _expand_query,
+    _hyde_search,
+    _search_context,
+    _search_structured,
     build_context,
     deduplicate_sources,
     format_source,
-    search_context,
     sort_by_relevance,
 )
 from lilbee.store import SearchChunk
@@ -25,6 +28,14 @@ def _disable_concepts():
     cfg.concept_graph = False
     yield
     cfg.concept_graph = old
+
+
+def _make_provider(chat_return=None):
+    """Create a mock LLM provider."""
+    p = mock.MagicMock()
+    p.chat.return_value = chat_return
+    p.embed.return_value = [[0.1] * 768]
+    return p
 
 
 def _make_result(
@@ -189,223 +200,199 @@ class TestBuildContext:
 class TestSearchContext:
     @mock.patch("lilbee.query._expand_query", return_value=[])
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_returns_results(self, mock_embed, mock_search, mock_expand):
-        results = search_context("question")
+        provider = _make_provider()
+        results = _search_context("question", config=cfg, provider=provider)
         assert len(results) == 1
-        mock_embed.assert_called_once_with("question")
+        mock_embed.assert_called_once_with("question", provider=provider, config=cfg)
 
     @mock.patch("lilbee.query._expand_query", return_value=[])
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_passes_query_text(self, mock_embed, mock_search, mock_expand):
-        search_context("my question")
+        provider = _make_provider()
+        _search_context("my question", config=cfg, provider=provider)
         mock_search.assert_called_once()
         assert mock_search.call_args[1]["query_text"] == "my question"
 
     @mock.patch("lilbee.store.search")
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     @mock.patch("lilbee.query._expand_query", return_value=["alt query 1"])
     def test_expansion_merges_results(self, mock_expand, mock_embed, mock_search):
         original = _make_result(source="a.md", chunk_index=0)
         expanded = _make_result(source="b.md", chunk_index=0)
         mock_search.side_effect = [[original], [expanded]]
-        results = search_context("question")
+        provider = _make_provider()
+        results = _search_context("question", config=cfg, provider=provider)
         assert len(results) == 2
         sources = {r.source for r in results}
         assert "a.md" in sources
         assert "b.md" in sources
 
     @mock.patch("lilbee.store.search")
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     @mock.patch("lilbee.query._expand_query", return_value=["alt"])
     def test_expansion_deduplicates(self, mock_expand, mock_embed, mock_search):
         same = _make_result(source="a.md", chunk_index=0)
         mock_search.side_effect = [[same], [same]]
-        results = search_context("question")
+        provider = _make_provider()
+        results = _search_context("question", config=cfg, provider=provider)
         assert len(results) == 1
 
 
 class TestExpandQuery:
-    @mock.patch("lilbee.query.get_provider")
-    def test_returns_variants(self, mock_get_provider):
-        mock_provider = mock.MagicMock()
-        mock_provider.chat.return_value = "explain how X works in detail\nexplain the purpose of X"
-        mock_get_provider.return_value = mock_provider
-        from lilbee.query import _expand_query
-
-        variants = _expand_query("explain X in detail")
+    def test_returns_variants(self):
+        provider = _make_provider("explain how X works in detail\nexplain the purpose of X")
+        variants = _expand_query("explain X in detail", config=cfg, provider=provider)
         assert len(variants) == 2
 
-    @mock.patch("lilbee.query.get_provider")
-    def test_caps_at_three(self, mock_get_provider):
-        mock_provider = mock.MagicMock()
-        mock_provider.chat.return_value = "A\nB\nC\nD\nE"
-        mock_get_provider.return_value = mock_provider
-        from lilbee.query import _expand_query
+    def test_caps_at_three(self):
+        provider = _make_provider("A\nB\nC\nD\nE")
+        assert len(_expand_query("q", config=cfg, provider=provider)) == 3
 
-        assert len(_expand_query("q")) == 3
-
-    @mock.patch("lilbee.query.get_provider")
-    def test_returns_empty_on_error(self, mock_get_provider):
-        mock_get_provider.side_effect = RuntimeError("no provider")
-        from lilbee.query import _expand_query
-
-        assert _expand_query("q") == []
+    def test_returns_empty_on_error(self):
+        provider = _make_provider()
+        provider.chat.side_effect = RuntimeError("no provider")
+        assert _expand_query("q", config=cfg, provider=provider) == []
 
     def test_disabled_when_count_zero(self):
-        from lilbee.config import cfg
-        from lilbee.query import _expand_query
-
         old = cfg.query_expansion_count
         cfg.query_expansion_count = 0
         try:
-            assert _expand_query("anything") == []
+            provider = _make_provider()
+            assert _expand_query("anything", config=cfg, provider=provider) == []
         finally:
             cfg.query_expansion_count = old
 
-    @mock.patch("lilbee.query.get_provider")
-    def test_returns_empty_on_non_string(self, mock_get_provider):
-        mock_provider = mock.MagicMock()
-        mock_provider.chat.return_value = iter(["stream"])  # not a string
-        mock_get_provider.return_value = mock_provider
-        from lilbee.query import _expand_query
-
-        assert _expand_query("q") == []
+    def test_returns_empty_on_non_string(self):
+        provider = _make_provider(iter(["stream"]))  # not a string
+        assert _expand_query("q", config=cfg, provider=provider) == []
 
 
 class TestAskRaw:
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result(chunk="oil is 5 quarts")])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_returns_structured_result(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = "5 quarts."
-        result = ask_raw("oil capacity?")
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_returns_structured_result(self, mock_embed, mock_search):
+        provider = _make_provider("5 quarts.")
+        result = _ask_raw("oil capacity?", config=cfg, provider=provider)
         assert result.answer == "5 quarts."
         assert len(result.sources) == 1
         assert result.sources[0].source == "test.pdf"
 
     @mock.patch("lilbee.store.search", return_value=[])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_no_results(self, mock_embed, mock_search):
-        result = ask_raw("anything")
+        provider = _make_provider()
+        result = _ask_raw("anything", config=cfg, provider=provider)
         assert "No relevant documents" in result.answer
         assert result.sources == []
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_raw_with_history(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = "answer"
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_raw_with_history(self, mock_embed, mock_search):
+        provider = _make_provider("answer")
         history = [{"role": "user", "content": "prev"}]
-        ask_raw("new q", history=history)
-        messages = mock_provider.return_value.chat.call_args[0][0]
+        _ask_raw("new q", history=history, config=cfg, provider=provider)
+        messages = provider.chat.call_args[0][0]
         assert len(messages) == 3  # system + history + user
 
 
 class TestAsk:
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result(chunk="oil is 5 quarts")])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_returns_answer_with_citations(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = "The oil capacity is 5 quarts."
-        answer = ask("oil capacity?")
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_returns_answer_with_citations(self, mock_embed, mock_search):
+        provider = _make_provider("The oil capacity is 5 quarts.")
+        answer = _ask("oil capacity?", config=cfg, provider=provider)
         assert "5 quarts" in answer
         assert "Sources:" in answer
         assert "test.pdf" in answer
 
     @mock.patch("lilbee.store.search", return_value=[])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_no_results_message(self, mock_embed, mock_search):
-        answer = ask("anything")
+        provider = _make_provider()
+        answer = _ask("anything", config=cfg, provider=provider)
         assert "No relevant documents" in answer
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_with_history(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = "answer"
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_with_history(self, mock_embed, mock_search):
+        provider = _make_provider("answer")
         history = [
             {"role": "user", "content": "prev q"},
             {"role": "assistant", "content": "prev a"},
         ]
-        ask("new q", history=history)
-        messages = mock_provider.return_value.chat.call_args[0][0]
+        _ask("new q", history=history, config=cfg, provider=provider)
+        messages = provider.chat.call_args[0][0]
         # System + 2 history + user = 4
         assert len(messages) == 4
         assert messages[1]["content"] == "prev q"
 
 
 class TestAskStream:
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_yields_tokens_then_citations(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = iter(["Hello", " world"])
-        stream_tokens = list(ask_stream("test"))
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_yields_tokens_then_citations(self, mock_embed, mock_search):
+        provider = _make_provider(iter(["Hello", " world"]))
+        stream_tokens = list(_ask_stream("test", config=cfg, provider=provider))
         combined = "".join(st.content for st in stream_tokens)
         assert "Hello world" in combined
         assert "Sources:" in combined
 
     @mock.patch("lilbee.store.search", return_value=[])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_empty_results_yields_message(self, mock_embed, mock_search):
-        stream_tokens = list(ask_stream("anything"))
+        provider = _make_provider()
+        stream_tokens = list(_ask_stream("anything", config=cfg, provider=provider))
         assert any("No relevant documents" in st.content for st in stream_tokens)
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_stream_with_history(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = iter(["response"])
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_stream_with_history(self, mock_embed, mock_search):
+        provider = _make_provider(iter(["response"]))
         history = [
             {"role": "user", "content": "previous question"},
             {"role": "assistant", "content": "previous answer"},
         ]
-        list(ask_stream("new question", history=history))
-        call_args = mock_provider.return_value.chat.call_args
+        list(_ask_stream("new question", history=history, config=cfg, provider=provider))
+        call_args = provider.chat.call_args
         messages = call_args[0][0]
         assert len(messages) == 4
         assert messages[1]["role"] == "user"
         assert messages[1]["content"] == "previous question"
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_skips_empty_tokens(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = iter(["", "data"])
-        stream_tokens = list(ask_stream("test"))
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_skips_empty_tokens(self, mock_embed, mock_search):
+        provider = _make_provider(iter(["", "data"]))
+        stream_tokens = list(_ask_stream("test", config=cfg, provider=provider))
         non_source = [st for st in stream_tokens if "Sources:" not in st.content]
         assert all(st.content != "" for st in non_source)
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_reasoning_stripped_by_default(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = iter(["<think>reasoning</think>answer"])
-        stream_tokens = list(ask_stream("test"))
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_reasoning_stripped_by_default(self, mock_embed, mock_search):
+        provider = _make_provider(iter(["<think>reasoning</think>answer"]))
+        stream_tokens = list(_ask_stream("test", config=cfg, provider=provider))
         combined = "".join(st.content for st in stream_tokens if not st.is_reasoning)
         assert "reasoning" not in combined
         assert "answer" in combined
 
 
 class TestGenerationOptions:
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_raw_passes_options(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = "answer"
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_raw_passes_options(self, mock_embed, mock_search):
+        provider = _make_provider("answer")
         opts = {"temperature": 0.3, "seed": 42}
-        ask_raw("q", options=opts)
-        assert mock_provider.return_value.chat.call_args[1]["options"] == opts
+        _ask_raw("q", options=opts, config=cfg, provider=provider)
+        assert provider.chat.call_args[1]["options"] == opts
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_raw_defaults_to_cfg_options(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = "answer"
-        from lilbee.config import cfg
-
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_raw_defaults_to_cfg_options(self, mock_embed, mock_search):
+        provider = _make_provider("answer")
         cfg.temperature = 0.7
         cfg.seed = None
         cfg.top_p = None
@@ -413,58 +400,52 @@ class TestGenerationOptions:
         cfg.repeat_penalty = None
         cfg.num_ctx = None
         try:
-            ask_raw("q")
-            assert mock_provider.return_value.chat.call_args[1]["options"] == {"temperature": 0.7}
+            _ask_raw("q", config=cfg, provider=provider)
+            assert provider.chat.call_args[1]["options"] == {"temperature": 0.7}
         finally:
             cfg.temperature = None
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_stream_passes_options(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = iter(["token"])
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_stream_passes_options(self, mock_embed, mock_search):
+        provider = _make_provider(iter(["token"]))
         opts = {"temperature": 0.1}
-        list(ask_stream("q", options=opts))
-        assert mock_provider.return_value.chat.call_args[1]["options"] == opts
+        list(_ask_stream("q", options=opts, config=cfg, provider=provider))
+        assert provider.chat.call_args[1]["options"] == opts
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_passes_options_through(self, mock_embed, mock_search, mock_provider):
-        mock_provider.return_value.chat.return_value = "answer"
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_passes_options_through(self, mock_embed, mock_search):
+        provider = _make_provider("answer")
         opts = {"num_ctx": 4096}
-        ask("q", options=opts)
-        assert mock_provider.return_value.chat.call_args[1]["options"] == opts
+        _ask("q", options=opts, config=cfg, provider=provider)
+        assert provider.chat.call_args[1]["options"] == opts
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_raw_empty_options_passes_none(self, mock_embed, mock_search, mock_provider):
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_raw_empty_options_passes_none(self, mock_embed, mock_search):
         """When cfg has no generation options set, passes None to provider."""
-        mock_provider.return_value.chat.return_value = "answer"
-        from lilbee.config import cfg
-
+        provider = _make_provider("answer")
         cfg.temperature = None
         cfg.top_p = None
         cfg.top_k_sampling = None
         cfg.repeat_penalty = None
         cfg.num_ctx = None
         cfg.seed = None
-        ask_raw("q")
-        assert mock_provider.return_value.chat.call_args[1]["options"] is None
+        _ask_raw("q", config=cfg, provider=provider)
+        assert provider.chat.call_args[1]["options"] is None
 
 
 class TestAskStreamError:
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_stream_handles_disconnect(self, mock_embed, mock_search, mock_provider):
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_stream_handles_disconnect(self, mock_embed, mock_search):
         def failing_stream():
             yield "partial"
             raise ConnectionError("lost connection")
 
-        mock_provider.return_value.chat.return_value = failing_stream()
-        stream_tokens = list(ask_stream("test"))
+        provider = _make_provider(failing_stream())
+        stream_tokens = list(_ask_stream("test", config=cfg, provider=provider))
         combined = "".join(st.content for st in stream_tokens)
         assert "partial" in combined
         assert "Connection lost" in combined
@@ -473,30 +454,29 @@ class TestAskStreamError:
 class TestProviderError:
     """ProviderError from the provider should propagate."""
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_raw_provider_error(self, mock_embed, mock_search, mock_provider):
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_raw_provider_error(self, mock_embed, mock_search):
         from lilbee.providers.base import ProviderError
 
-        mock_provider.return_value.chat.side_effect = ProviderError("model 'bad' not found")
+        provider = _make_provider()
+        provider.chat.side_effect = ProviderError("model 'bad' not found")
         with pytest.raises(ProviderError, match="not found"):
-            ask_raw("hello")
+            _ask_raw("hello", config=cfg, provider=provider)
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_stream_provider_error(self, mock_embed, mock_search, mock_provider):
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_stream_provider_error(self, mock_embed, mock_search):
         from lilbee.providers.base import ProviderError
 
-        mock_provider.return_value.chat.side_effect = ProviderError("model 'bad' not found")
+        provider = _make_provider()
+        provider.chat.side_effect = ProviderError("model 'bad' not found")
         with pytest.raises(ProviderError, match="not found"):
-            list(ask_stream("hello"))
+            list(_ask_stream("hello", config=cfg, provider=provider))
 
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_ask_stream_provider_error_mid_stream(self, mock_embed, mock_search, mock_provider):
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_ask_stream_provider_error_mid_stream(self, mock_embed, mock_search):
         """ProviderError raised during iteration should propagate."""
         from lilbee.providers.base import ProviderError
 
@@ -504,9 +484,9 @@ class TestProviderError:
             yield "partial"
             raise ProviderError("model 'bad' not found")
 
-        mock_provider.return_value.chat.return_value = failing_mid_stream()
+        provider = _make_provider(failing_mid_stream())
         with pytest.raises(ProviderError, match="not found"):
-            list(ask_stream("hello"))
+            list(_ask_stream("hello", config=cfg, provider=provider))
 
 
 class TestApplyGuardrails:
@@ -526,7 +506,6 @@ class TestApplyGuardrails:
         assert len(result) >= 1
 
     def test_returns_all_when_guardrails_disabled(self):
-        from lilbee.config import cfg
         from lilbee.query import _apply_guardrails
 
         old = cfg.expansion_guardrails
@@ -634,7 +613,7 @@ class TestSelectContext:
             _make_result(chunk="alpha beta unique1", source="e.md"),
             _make_result(chunk="alpha beta unique1", source="f.md"),
         ]
-        # Query has "alpha beta unique1 unique2" — first chunk covers 3/4
+        # Query has "alpha beta unique1 unique2" -- first chunk covers 3/4
         # Remaining chunks add 0 new terms, so selection stops early
         result = select_context(chunks, "alpha beta unique1 unique2", max_sources=5)
         # Should stop after 1 or 2 chunks since no gain after first
@@ -687,7 +666,6 @@ class TestShouldSkipExpansion:
         assert _should_skip_expansion("test") is False
 
     def test_disabled_when_threshold_zero(self):
-        from lilbee.config import cfg
         from lilbee.query import _should_skip_expansion
 
         old = cfg.expansion_skip_threshold
@@ -734,36 +712,25 @@ class TestParseStructuredQuery:
 
 
 class TestHydeSearch:
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_returns_results(self, mock_embed, mock_search, mock_provider):
-        from lilbee.query import _hyde_search
-
-        mock_provider.return_value.chat.return_value = "hypothetical document about X"
-        results = _hyde_search("explain X", top_k=5)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_returns_results(self, mock_embed, mock_search):
+        provider = _make_provider("hypothetical document about X")
+        results = _hyde_search("explain X", top_k=5, config=cfg, provider=provider)
         assert len(results) >= 1
 
-    @mock.patch("lilbee.query.get_provider")
-    def test_returns_empty_on_error(self, mock_provider):
-        from lilbee.query import _hyde_search
+    def test_returns_empty_on_error(self):
+        provider = _make_provider()
+        provider.chat.side_effect = RuntimeError("fail")
+        assert _hyde_search("test", top_k=5, config=cfg, provider=provider) == []
 
-        mock_provider.return_value.chat.side_effect = RuntimeError("fail")
-        assert _hyde_search("test", top_k=5) == []
+    def test_returns_empty_on_non_string(self):
+        provider = _make_provider(iter(["stream"]))
+        assert _hyde_search("test", top_k=5, config=cfg, provider=provider) == []
 
-    @mock.patch("lilbee.query.get_provider")
-    def test_returns_empty_on_non_string(self, mock_provider):
-        from lilbee.query import _hyde_search
-
-        mock_provider.return_value.chat.return_value = iter(["stream"])
-        assert _hyde_search("test", top_k=5) == []
-
-    @mock.patch("lilbee.query.get_provider")
-    def test_returns_empty_on_blank(self, mock_provider):
-        from lilbee.query import _hyde_search
-
-        mock_provider.return_value.chat.return_value = "   "
-        assert _hyde_search("test", top_k=5) == []
+    def test_returns_empty_on_blank(self):
+        provider = _make_provider("   ")
+        assert _hyde_search("test", top_k=5, config=cfg, provider=provider) == []
 
 
 class TestTemporalFilter:
@@ -789,7 +756,6 @@ class TestTemporalFilter:
         assert _apply_temporal_filter(results, "how does auth work") == results
 
     def test_disabled_via_config(self):
-        from lilbee.config import cfg
         from lilbee.query import _apply_temporal_filter
 
         old = cfg.temporal_filtering
@@ -833,50 +799,48 @@ class TestTemporalFilter:
 class TestSearchStructured:
     @mock.patch("lilbee.store.bm25_probe", return_value=[_make_result()])
     def test_term_mode(self, mock_probe):
-        from lilbee.query import _search_structured
-
-        results = _search_structured("term", "test query", 5)
+        provider = _make_provider()
+        results = _search_structured("term", "test query", 5, config=cfg, provider=provider)
         assert len(results) == 1
         mock_probe.assert_called_once_with("test query", top_k=5)
 
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_vec_mode(self, mock_embed, mock_search):
-        from lilbee.query import _search_structured
-
-        results = _search_structured("vec", "semantic query", 5)
+        provider = _make_provider()
+        results = _search_structured("vec", "semantic query", 5, config=cfg, provider=provider)
         assert len(results) == 1
 
     @mock.patch("lilbee.query._hyde_search", return_value=[_make_result()])
     def test_hyde_mode(self, mock_hyde):
-        from lilbee.query import _search_structured
-
-        results = _search_structured("hyde", "vague question", 5)
+        provider = _make_provider()
+        results = _search_structured("hyde", "vague question", 5, config=cfg, provider=provider)
         assert len(results) == 1
 
     def test_unknown_mode_returns_empty(self):
-        from lilbee.query import _search_structured
-
-        assert _search_structured("unknown", "test", 5) == []
+        provider = _make_provider()
+        assert _search_structured("unknown", "test", 5, config=cfg, provider=provider) == []
 
 
 class TestSearchContextIntegration:
     @mock.patch("lilbee.query._expand_query", return_value=[])
     @mock.patch("lilbee.store.bm25_probe", return_value=[])
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_structured_term_mode(self, mock_embed, mock_search, mock_probe, mock_expand):
         mock_probe.return_value = [_make_result()]
-        results = search_context("term: kubernetes pods")
+        provider = _make_provider()
+        results = _search_context("term: kubernetes pods", config=cfg, provider=provider)
         mock_probe.assert_called_once()
         assert len(results) >= 1
 
     @mock.patch("lilbee.query._expand_query", return_value=[])
     @mock.patch("lilbee.query._should_skip_expansion", return_value=True)
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_skips_expansion_when_confident(self, mock_embed, mock_search, mock_skip, mock_expand):
-        results = search_context("exact match query")
+        provider = _make_provider()
+        results = _search_context("exact match query", config=cfg, provider=provider)
         mock_expand.assert_not_called()
         assert len(results) >= 1
 
@@ -884,14 +848,13 @@ class TestSearchContextIntegration:
     @mock.patch("lilbee.query._expand_query", return_value=[])
     @mock.patch("lilbee.query._should_skip_expansion", return_value=False)
     @mock.patch("lilbee.store.search", return_value=[_make_result(source="normal.md")])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_hyde_merges_results(self, mock_embed, mock_search, mock_skip, mock_expand, mock_hyde):
-        from lilbee.config import cfg
-
         old = cfg.hyde
         cfg.hyde = True
         try:
-            results = search_context("vague question")
+            provider = _make_provider()
+            results = _search_context("vague question", config=cfg, provider=provider)
             sources = {r.source for r in results}
             assert "hyde.md" in sources
         finally:
@@ -899,18 +862,15 @@ class TestSearchContextIntegration:
 
 
 class TestAskRawWithReranker:
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_reranker_called_when_configured(self, mock_embed, mock_search, mock_provider):
-        from lilbee.config import cfg
-
-        mock_provider.return_value.chat.return_value = "answer"
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_reranker_called_when_configured(self, mock_embed, mock_search):
+        provider = _make_provider("answer")
         old = cfg.reranker_model
         cfg.reranker_model = "test-reranker"
         try:
             with mock.patch("lilbee.reranker.rerank", return_value=[_make_result()]) as mock_rerank:
-                result = ask_raw("question")
+                result = _ask_raw("question", config=cfg, provider=provider)
                 mock_rerank.assert_called_once()
                 assert result.answer == "answer"
         finally:
@@ -918,18 +878,15 @@ class TestAskRawWithReranker:
 
 
 class TestAskStreamWithReranker:
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_reranker_called_when_configured(self, mock_embed, mock_search, mock_provider):
-        from lilbee.config import cfg
-
-        mock_provider.return_value.chat.return_value = iter(["token"])
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_reranker_called_when_configured(self, mock_embed, mock_search):
+        provider = _make_provider(iter(["token"]))
         old = cfg.reranker_model
         cfg.reranker_model = "test-reranker"
         try:
             with mock.patch("lilbee.reranker.rerank", return_value=[_make_result()]) as mock_rerank:
-                list(ask_stream("question"))
+                list(_ask_stream("question", config=cfg, provider=provider))
                 mock_rerank.assert_called_once()
         finally:
             cfg.reranker_model = old
@@ -938,10 +895,8 @@ class TestAskStreamWithReranker:
 class TestConceptBoosting:
     @mock.patch("lilbee.store.search", return_value=[_make_result(distance=0.5)])
     @mock.patch("lilbee.store.bm25_probe", return_value=[])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_boost_applied_when_enabled(self, mock_embed, mock_bm25, mock_search):
-        from lilbee.config import cfg
-
         old = cfg.concept_graph
         cfg.concept_graph = True
         cfg.query_expansion_count = 0
@@ -954,7 +909,8 @@ class TestConceptBoosting:
                     return_value=[_make_result(distance=0.3)],
                 ) as mock_boost,
             ):
-                results = search_context("python code")
+                provider = _make_provider()
+                results = _search_context("python code", config=cfg, provider=provider)
             mock_boost.assert_called_once()
             assert results[0].distance == 0.3
         finally:
@@ -963,16 +919,15 @@ class TestConceptBoosting:
 
     @mock.patch("lilbee.store.search", return_value=[_make_result(distance=0.5)])
     @mock.patch("lilbee.store.bm25_probe", return_value=[])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_boost_skipped_when_disabled(self, mock_embed, mock_bm25, mock_search):
-        from lilbee.config import cfg
-
         old = cfg.concept_graph
         cfg.concept_graph = False
         cfg.query_expansion_count = 0
         try:
             with mock.patch("lilbee.concepts.get_graph") as m_graph:
-                results = search_context("python code")
+                provider = _make_provider()
+                results = _search_context("python code", config=cfg, provider=provider)
             m_graph.assert_not_called()
             assert results[0].distance == 0.5
         finally:
@@ -981,14 +936,15 @@ class TestConceptBoosting:
 
     @mock.patch("lilbee.store.search", return_value=[_make_result(distance=0.5)])
     @mock.patch("lilbee.store.bm25_probe", return_value=[])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_boost_failure_returns_original(self, mock_embed, mock_bm25, mock_search):
         old = cfg.concept_graph
         cfg.concept_graph = True
         cfg.query_expansion_count = 0
         try:
             with mock.patch("lilbee.concepts.get_graph", side_effect=RuntimeError("broken")):
-                results = search_context("python code")
+                provider = _make_provider()
+                results = _search_context("python code", config=cfg, provider=provider)
             assert results[0].distance == 0.5
         finally:
             cfg.concept_graph = old
@@ -996,14 +952,15 @@ class TestConceptBoosting:
 
     @mock.patch("lilbee.store.search", return_value=[_make_result(distance=0.5)])
     @mock.patch("lilbee.store.bm25_probe", return_value=[])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
     def test_boost_graph_none_returns_original(self, mock_embed, mock_bm25, mock_search):
         old = cfg.concept_graph
         cfg.concept_graph = True
         cfg.query_expansion_count = 0
         try:
             with mock.patch("lilbee.concepts.get_graph", return_value=False):
-                results = search_context("python code")
+                provider = _make_provider()
+                results = _search_context("python code", config=cfg, provider=provider)
             assert results[0].distance == 0.5
         finally:
             cfg.concept_graph = old
@@ -1011,22 +968,14 @@ class TestConceptBoosting:
 
 
 class TestConceptQueryExpansion:
-    @mock.patch("lilbee.query.get_provider")
     @mock.patch("lilbee.store.search", return_value=[_make_result()])
     @mock.patch("lilbee.store.bm25_probe", return_value=[])
-    @mock.patch("lilbee.embedder.embed", return_value=[0.1] * 768)
-    def test_expansion_includes_concept_terms(
-        self, mock_embed, mock_bm25, mock_search, mock_provider
-    ):
-        from lilbee.config import cfg
-        from lilbee.query import _expand_query
-
+    @mock.patch("lilbee.embedder.embed_di", return_value=[0.1] * 768)
+    def test_expansion_includes_concept_terms(self, mock_embed, mock_bm25, mock_search):
         old_graph = cfg.concept_graph
         cfg.concept_graph = True
-        mock_provider.return_value.chat.return_value = "variant query about python"
+        provider = _make_provider("variant query about python")
         try:
-            # Use concept terms that share tokens with the original query
-            # so they survive the guardrails overlap check
             with (
                 mock.patch("lilbee.concepts.get_graph", return_value=True),
                 mock.patch(
@@ -1034,13 +983,12 @@ class TestConceptQueryExpansion:
                     return_value=["python web frameworks"],
                 ),
             ):
-                variants = _expand_query("python frameworks")
+                variants = _expand_query("python frameworks", config=cfg, provider=provider)
             assert "python web frameworks" in variants
         finally:
             cfg.concept_graph = old_graph
 
     def test_expansion_disabled_returns_empty(self):
-        from lilbee.config import cfg
         from lilbee.query import _concept_query_expansion
 
         old = cfg.concept_graph

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,8 +12,20 @@ from lilbee.ingest import SyncResult
 from lilbee.server import handlers
 from lilbee.store import SearchChunk
 
-PATCH_PROVIDER = "lilbee.server.handlers.get_provider"
-PATCH_RAG = "lilbee.server.handlers.build_rag_context"
+PATCH_RAG = "lilbee.query._build_rag_context"
+
+
+@contextmanager
+def _provider_override(mock_provider):
+    """Temporarily set the provider on the handler's Lilbee instance."""
+    bee = handlers._get_bee()
+    old = bee._provider
+    bee._provider = mock_provider
+    try:
+        yield
+    finally:
+        bee._provider = old
+
 
 _SAMPLE_CHUNK = SearchChunk(
     source="a.pdf",
@@ -41,13 +54,24 @@ def isolated_env(tmp_path):
     from lilbee.providers import reset_provider
 
     reset_provider()
+    handlers._bee = None
     snapshot = cfg.model_copy()
     cfg.documents_dir = tmp_path / "documents"
     cfg.documents_dir.mkdir(exist_ok=True)
     cfg.data_dir = tmp_path / "data"
     cfg.data_root = tmp_path
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
+
+    # Ensure Lilbee is pre-created with a mock provider so tests
+    # don't fail when coverage changes module load ordering.
+    from lilbee.api import Lilbee
+
+    bee = Lilbee(config=cfg)
+    bee._provider = MagicMock()
+    handlers._bee = bee
+
     yield tmp_path
+    handlers._bee = None
     reset_provider()
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))
@@ -95,7 +119,7 @@ class TestStatus:
 
 
 class TestSearch:
-    @patch("lilbee.server.handlers.search_context")
+    @patch("lilbee.query._search_context")
     async def test_returns_grouped_results(self, mock_search):
         mock_search.return_value = [
             SearchChunk(
@@ -114,16 +138,19 @@ class TestSearch:
         result = await handlers.search("test", top_k=3)
         assert len(result) == 1
         assert result[0]["source"] == "doc.pdf"
-        mock_search.assert_called_once_with("test", top_k=3)
+        mock_search.assert_called_once()
+        args, kwargs = mock_search.call_args
+        assert args[0] == "test"
+        assert kwargs["top_k"] == 3
 
-    @patch("lilbee.server.handlers.search_context", return_value=[])
+    @patch("lilbee.query._search_context", return_value=[])
     async def test_empty_results(self, mock_search):
         result = await handlers.search("nothing")
         assert result == []
 
 
 class TestAsk:
-    @patch("lilbee.query.ask_raw")
+    @patch("lilbee.query._ask_raw")
     async def test_returns_answer_and_sources(self, mock_ask):
         from lilbee.query import AskResult
 
@@ -150,7 +177,7 @@ class TestAsk:
         assert "vector" not in result["sources"][0]
         assert result["sources"][0]["distance"] == 0.1
 
-    @patch("lilbee.query.ask_raw")
+    @patch("lilbee.query._ask_raw")
     async def test_no_sources(self, mock_ask):
         from lilbee.query import AskResult
 
@@ -161,7 +188,7 @@ class TestAsk:
 
 
 class TestAskStream:
-    @patch("lilbee.server.handlers.build_rag_context", return_value=None)
+    @patch(PATCH_RAG, return_value=None)
     async def test_no_results_yields_error(self, mock_search):
         events = [e async for e in handlers.ask_stream("test")]
         # First event is the empty yield, then the error
@@ -174,7 +201,7 @@ class TestAskStream:
     async def test_yields_token_sources_done(self, mock_rag):
         mock_provider = MagicMock()
         mock_provider.chat.return_value = iter(["answer"])
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             events = [e async for e in handlers.ask_stream("question")]
 
         non_empty = [e for e in events if e]
@@ -187,7 +214,7 @@ class TestAskStream:
     async def test_provider_error_yields_error_event(self, mock_rag):
         mock_provider = MagicMock()
         mock_provider.chat.side_effect = RuntimeError("model missing")
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             events = [e async for e in handlers.ask_stream("question")]
 
         non_empty = [e for e in events if e]
@@ -209,7 +236,7 @@ class TestAskStream:
 
         mock_provider = MagicMock()
         mock_provider.chat.side_effect = blocking_chat
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             gen = handlers.ask_stream("question")
             events = []
             async for event in gen:
@@ -239,7 +266,7 @@ class TestAskStream:
         mock_provider.chat.side_effect = blocking_chat
         with (
             caplog.at_level(logging.INFO, logger="lilbee.server.handlers"),
-            patch(PATCH_PROVIDER, return_value=mock_provider),
+            _provider_override(mock_provider),
         ):
             gen = handlers.ask_stream("question")
             async for event in gen:
@@ -255,7 +282,7 @@ class TestAskStream:
         """Empty strings from provider are not emitted."""
         mock_provider = MagicMock()
         mock_provider.chat.return_value = iter(["", "answer"])
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             events = [e async for e in handlers.ask_stream("question")]
 
         non_empty = [e for e in events if e]
@@ -265,7 +292,7 @@ class TestAskStream:
 
 
 class TestChat:
-    @patch("lilbee.query.ask_raw")
+    @patch("lilbee.query._ask_raw")
     async def test_passes_history(self, mock_ask):
         from lilbee.query import AskResult
 
@@ -273,11 +300,13 @@ class TestChat:
         history = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
         result = await handlers.chat("follow up", history)
         assert result["answer"] == "ok"
-        mock_ask.assert_called_once_with("follow up", top_k=0, history=history, options=None)
+        mock_ask.assert_called_once()
+        _, kwargs = mock_ask.call_args
+        assert kwargs["history"] == history
 
 
 class TestChatStream:
-    @patch("lilbee.server.handlers.build_rag_context", return_value=None)
+    @patch(PATCH_RAG, return_value=None)
     async def test_no_results_yields_error(self, mock_rag):
         events = [e async for e in handlers.chat_stream("test", [])]
         non_empty = [e for e in events if e]
@@ -287,7 +316,7 @@ class TestChatStream:
     async def test_yields_events_with_history(self, mock_rag):
         mock_provider = MagicMock()
         mock_provider.chat.return_value = iter(["reply"])
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             history = [{"role": "user", "content": "hi"}]
             events = [e async for e in handlers.chat_stream("follow up", history)]
 
@@ -300,7 +329,7 @@ class TestChatStream:
     async def test_provider_error_yields_error_event(self, mock_rag):
         mock_provider = MagicMock()
         mock_provider.chat.side_effect = ConnectionError("provider down")
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             events = [e async for e in handlers.chat_stream("q", [])]
 
         non_empty = [e for e in events if e]
@@ -322,7 +351,7 @@ class TestChatStream:
 
         mock_provider = MagicMock()
         mock_provider.chat.side_effect = blocking_chat
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             gen = handlers.chat_stream("question", [])
             events = []
             async for event in gen:
@@ -352,7 +381,7 @@ class TestChatStream:
         mock_provider.chat.side_effect = blocking_chat
         with (
             caplog.at_level(logging.INFO, logger="lilbee.server.handlers"),
-            patch(PATCH_PROVIDER, return_value=mock_provider),
+            _provider_override(mock_provider),
         ):
             gen = handlers.chat_stream("question", [])
             async for event in gen:
@@ -368,7 +397,7 @@ class TestChatStream:
         """Empty strings from provider are not emitted."""
         mock_provider = MagicMock()
         mock_provider.chat.return_value = iter(["", "reply"])
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             events = [e async for e in handlers.chat_stream("question", [])]
 
         non_empty = [e for e in events if e]
@@ -517,7 +546,7 @@ class TestModelsCatalog:
         )
         mock_provider = MagicMock()
         mock_provider.list_models.return_value = ["qwen3:8b"]
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             result = await handlers.models_catalog()
 
         assert result["total"] == 1
@@ -534,7 +563,7 @@ class TestModelsCatalog:
         mock_get_catalog.return_value = CatalogResult(total=0, limit=10, offset=5, models=[])
         mock_provider = MagicMock()
         mock_provider.list_models.return_value = []
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             await handlers.models_catalog(
                 task="chat",
                 search="qwen",
@@ -580,7 +609,7 @@ class TestModelsCatalog:
         )
         mock_provider = MagicMock()
         mock_provider.list_models.return_value = ["qwen3:8b"]
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             result = await handlers.models_catalog()
         assert result["models"][0]["installed"] is True
 
@@ -654,14 +683,14 @@ class TestModelsShow:
     async def test_returns_params(self):
         mock_provider = MagicMock()
         mock_provider.show_model.return_value = {"parameters": "temp 0.7"}
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             result = await handlers.models_show("qwen3:8b")
         assert result == {"parameters": "temp 0.7"}
 
     async def test_returns_empty_when_none(self):
         mock_provider = MagicMock()
         mock_provider.show_model.return_value = None
-        with patch(PATCH_PROVIDER, return_value=mock_provider):
+        with _provider_override(mock_provider):
             result = await handlers.models_show("unknown")
         assert result == {}
 

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -436,36 +436,47 @@ class TestCreateAppReexport:
 
 
 class TestLifespan:
+    def _reset_bee(self):
+        from lilbee.server import handlers
+
+        handlers._bee = None
+
     @mock.patch("lilbee.embedder.validate_model")
-    @mock.patch("lilbee.providers.factory.get_provider")
+    @mock.patch("lilbee.providers.factory.create_provider")
     async def test_calls_both(self, mock_provider, mock_validate):
+        self._reset_bee()
         from lilbee.server.litestar_app import _lifespan
 
         async with _lifespan(mock.MagicMock()):
             pass
         mock_provider.assert_called_once()
         mock_validate.assert_called_once()
+        self._reset_bee()
 
     @mock.patch("lilbee.embedder.validate_model")
     @mock.patch(
-        "lilbee.providers.factory.get_provider",
+        "lilbee.providers.factory.create_provider",
         side_effect=RuntimeError("no provider"),
     )
     async def test_provider_failure_does_not_block(self, mock_provider, mock_validate):
+        self._reset_bee()
         from lilbee.server.litestar_app import _lifespan
 
         async with _lifespan(mock.MagicMock()):
             pass
         mock_validate.assert_called_once()
+        self._reset_bee()
 
     @mock.patch(
         "lilbee.embedder.validate_model",
         side_effect=RuntimeError("no model"),
     )
-    @mock.patch("lilbee.providers.factory.get_provider")
+    @mock.patch("lilbee.providers.factory.create_provider")
     async def test_validate_model_failure_does_not_block(self, mock_provider, mock_validate):
+        self._reset_bee()
         from lilbee.server.litestar_app import _lifespan
 
         async with _lifespan(mock.MagicMock()):
             pass
         mock_provider.assert_called_once()
+        self._reset_bee()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -692,9 +692,9 @@ async def test_chat_slash_delete_with_match(mock_check):
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
-            patch("lilbee.cli.tui.screens.chat.get_sources") as mock_get,
-            patch("lilbee.cli.tui.screens.chat.delete_by_source") as mock_del_chunks,
-            patch("lilbee.cli.tui.screens.chat.delete_source") as mock_del_src,
+            patch("lilbee.store.get_sources") as mock_get,
+            patch("lilbee.store.delete_by_source") as mock_del_chunks,
+            patch("lilbee.store.delete_source") as mock_del_src,
         ):
             mock_get.return_value = [{"filename": "notes.md", "source": "notes.md"}]
             app.screen._cmd_delete("notes.md")
@@ -707,7 +707,7 @@ async def test_chat_slash_delete_not_found(mock_check):
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         with patch(
-            "lilbee.cli.tui.screens.chat.get_sources",
+            "lilbee.store.get_sources",
             return_value=[{"filename": "notes.md", "source": "notes.md"}],
         ):
             app.screen._cmd_delete("nonexistent.md")
@@ -718,7 +718,7 @@ async def test_chat_slash_delete_no_arg(mock_check):
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         with patch(
-            "lilbee.cli.tui.screens.chat.get_sources",
+            "lilbee.store.get_sources",
             return_value=[{"filename": "notes.md", "source": "notes.md"}],
         ):
             app.screen._cmd_delete("")
@@ -728,7 +728,7 @@ async def test_chat_slash_delete_no_arg(mock_check):
 async def test_chat_slash_delete_store_error(mock_check):
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        with patch("lilbee.cli.tui.screens.chat.get_sources", side_effect=Exception("no store")):
+        with patch("lilbee.store.get_sources", side_effect=Exception("no store")):
             app.screen._cmd_delete("x")
 
 
@@ -736,7 +736,7 @@ async def test_chat_slash_delete_store_error(mock_check):
 async def test_chat_slash_delete_empty_sources(mock_check):
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        with patch("lilbee.cli.tui.screens.chat.get_sources", return_value=[]):
+        with patch("lilbee.store.get_sources", return_value=[]):
             app.screen._cmd_delete("x")
 
 
@@ -2140,7 +2140,7 @@ async def test_chat_stream_response_worker(mock_check):
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         tokens = [FakeToken("Hello"), FakeToken(" world")]
-        with patch("lilbee.query.ask_stream", return_value=iter(tokens)):
+        with patch("lilbee.query._ask_stream", return_value=iter(tokens)):
             from textual.widgets import Input
 
             inp = app.screen.query_one("#chat-input", Input)
@@ -2158,7 +2158,7 @@ async def test_chat_stream_response_error_worker(mock_check):
     """Cover the error branch in _stream_response."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        with patch("lilbee.query.ask_stream", side_effect=Exception("LLM error")):
+        with patch("lilbee.query._ask_stream", side_effect=Exception("LLM error")):
             from textual.widgets import Input
 
             inp = app.screen.query_one("#chat-input", Input)
@@ -2182,7 +2182,7 @@ async def test_chat_stream_response_reasoning_worker(mock_check):
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         tokens = [FakeToken("thinking", is_reasoning=True), FakeToken("answer")]
-        with patch("lilbee.query.ask_stream", return_value=iter(tokens)):
+        with patch("lilbee.query._ask_stream", return_value=iter(tokens)):
             from textual.widgets import Input
 
             inp = app.screen.query_one("#chat-input", Input)
@@ -2253,7 +2253,7 @@ async def test_chat_cancel_stream_with_streaming_workers(mock_check):
             time.sleep(5)  # long enough to cancel
             yield FakeToken("end")
 
-        with patch("lilbee.query.ask_stream", side_effect=slow_stream):
+        with patch("lilbee.query._ask_stream", side_effect=slow_stream):
             from textual.widgets import Input
 
             inp = app.screen.query_one("#chat-input", Input)
@@ -2452,7 +2452,7 @@ async def test_chat_cancel_with_active_worker(mock_check):
             barrier.wait(timeout=5)
             yield FakeToken("end")
 
-        with patch("lilbee.query.ask_stream", side_effect=slow_stream):
+        with patch("lilbee.query._ask_stream", side_effect=slow_stream):
             from textual.widgets import Input
 
             inp = app.screen.query_one("#chat-input", Input)


### PR DESCRIPTION
all pipeline operations go through the Lilbee class. no more public module-level functions for search/ask/sync. proper dependency injection throughout.

- query.py: public functions removed, private _search_context/_ask_raw/_ask_stream accept explicit config and provider
- api.py: Lilbee methods call private functions with explicit config/provider
- cli: get_bee() singleton, all commands go through it
- server: _get_bee() singleton, handlers receive Lilbee instance
- mcp: _get_bee() singleton, tools go through it
- tui: uses get_bee() from cli app

no compatibility shims. old function names are private. tests updated to match.