### PR TITLE
feat: Ollama-style model registry

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -351,42 +351,56 @@ def find_catalog_entry(name: str) -> CatalogModel | None:
 
 
 def download_model(entry: CatalogModel, *, on_progress: Any = None) -> Path:
-    """Download a GGUF model from HuggingFace to cfg.models_dir."""
+    """Download a GGUF model from HuggingFace and register in the model registry."""
     cfg.models_dir.mkdir(parents=True, exist_ok=True)
 
-    # Resolve the filename pattern to an actual file
+    from lilbee.registry import ModelManifest, ModelRef, ModelRegistry
+
+    registry = ModelRegistry(cfg.models_dir)
+    ref = ModelRef.parse(entry.name)
+
+    if registry.is_installed(ref):
+        blob_path = registry.resolve(ref)
+        log.info("Model already installed: %s", blob_path)
+        return blob_path
+
     filename = _resolve_filename(entry)
-    dest = cfg.models_dir / filename
-
-    if dest.exists():
-        log.info("Model already downloaded: %s", dest)
-        return dest
-
     url = HF_DOWNLOAD_URL.format(repo=entry.hf_repo, filename=filename)
-    log.info("Downloading %s → %s", url, dest)
+    log.info("Downloading %s", url)
 
     import tempfile
+    from datetime import UTC, datetime
 
     tmp_name: str | None = None
     try:
-        with tempfile.NamedTemporaryFile(dir=dest.parent, suffix=".tmp", delete=False) as tmp_file:
-            tmp_name = tmp_file.name
+        with tempfile.NamedTemporaryFile(dir=cfg.models_dir, suffix=".tmp", delete=False) as tmp:
+            tmp_name = tmp.name
             with httpx.stream("GET", url, timeout=None, follow_redirects=True) as resp:
                 resp.raise_for_status()
                 total = int(resp.headers.get("content-length", 0))
                 downloaded = 0
                 for chunk in resp.iter_bytes(chunk_size=8192):
-                    tmp_file.write(chunk)
+                    tmp.write(chunk)
                     downloaded += len(chunk)
                     if on_progress and total > 0:
                         on_progress(downloaded, total)
-        Path(tmp_name).replace(dest)
+        tmp_path = Path(tmp_name)
+        manifest = ModelManifest(
+            name=ref.name,
+            tag=ref.tag,
+            size_bytes=tmp_path.stat().st_size,
+            task=entry.task,
+            source_repo=entry.hf_repo,
+            source_filename=filename,
+            downloaded_at=datetime.now(tz=UTC).isoformat(),
+        )
+        blob_path = registry.install(ref, tmp_path, manifest)
     except BaseException:
         if tmp_name is not None:
             Path(tmp_name).unlink(missing_ok=True)
         raise
 
-    return dest
+    return blob_path
 
 
 _QUANT_PREFERENCE = ("Q4_K_M", "Q4_K_S", "Q5_K_M", "Q5_K_S", "Q8_0", "Q6_K", "Q3_K_M")

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -30,6 +30,10 @@ class ModelManager:
         self._models_dir = models_dir
         self._litellm_base_url = litellm_base_url.rstrip("/")
 
+        from lilbee.registry import ModelRegistry
+
+        self._registry = ModelRegistry(self._models_dir)
+
     def list_installed(self, source: ModelSource | None = None) -> list[str]:
         """List installed model names. source=None lists all sources."""
         if source is None:
@@ -41,10 +45,13 @@ class ModelManager:
         return self._list_litellm()
 
     def _list_native(self) -> list[str]:
-        """List .gguf files in the models directory."""
-        if not self._models_dir.is_dir():
-            return []
-        return sorted(p.name for p in self._models_dir.iterdir() if p.suffix == ".gguf")
+        """List native models: registry manifests + legacy .gguf files."""
+        names = [f"{m.name}:{m.tag}" for m in self._registry.list_installed()]
+        if self._models_dir.is_dir():
+            for p in self._models_dir.iterdir():
+                if p.suffix == ".gguf":
+                    names.append(p.name)
+        return sorted(set(names))
 
     def _list_litellm(self) -> list[str]:
         """List models from the litellm backend via its HTTP API."""
@@ -70,6 +77,8 @@ class ModelManager:
         return self._is_litellm(model)
 
     def _is_native(self, model: str) -> bool:
+        if self._registry.is_installed(model):
+            return True
         try:
             validate_path_within(self._models_dir / model, self._models_dir)
         except ValueError:
@@ -150,6 +159,9 @@ class ModelManager:
         return self._remove_litellm(model)
 
     def _remove_native(self, model: str) -> bool:
+        if self._registry.remove(model):
+            log.info("Removed native model %s from registry", model)
+            return True
         try:
             path = validate_path_within(self._models_dir / model, self._models_dir)
         except ValueError:

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -14,14 +14,29 @@ from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lilbee.providers.base import LLMProvider, ProviderError, filter_options
 
+if TYPE_CHECKING:
+    from lilbee.registry import ModelRegistry
+
 log = logging.getLogger(__name__)
 
-
 _BATCH_WINDOW_S = 0.01  # 10ms — collect concurrent requests before dispatching
+
+_registry: ModelRegistry | None = None
+
+
+def _get_registry() -> ModelRegistry:
+    """Lazy-init and cache a ModelRegistry for the current models_dir."""
+    global _registry
+    if _registry is None:
+        from lilbee.config import cfg
+        from lilbee.registry import ModelRegistry as _Cls
+
+        _registry = _Cls(cfg.models_dir)
+    return _registry
 
 
 @dataclass
@@ -214,14 +229,26 @@ class _LockedStreamIterator:
 
 
 def _resolve_model_path(model: str) -> Path:
-    """Resolve a model name to a .gguf file path."""
+    """Resolve a model name to a .gguf file path.
+
+    Resolution order:
+    1. Registry manifest -> blob
+    2. Direct .gguf filename in models_dir
+    3. Append .gguf extension to model name
+    4. Prefix match (e.g. "nomic-embed-text" -> "nomic-embed-text-v1.5.Q4_K_M.gguf")
+    """
     from lilbee.config import cfg
+
+    registry = _get_registry()
+    try:
+        return registry.resolve(model)
+    except (KeyError, ValueError):
+        pass
 
     models_dir = cfg.models_dir
 
     # Direct path
     if model.endswith(".gguf"):
-        # Try in models_dir first
         candidate = models_dir / Path(model).name
         if candidate.exists():
             from lilbee.security import validate_path_within
@@ -234,6 +261,13 @@ def _resolve_model_path(model: str) -> Path:
         candidate = models_dir / f"{model}{ext}"
         if candidate.exists():
             return candidate
+
+    # Prefix match: "nomic-embed-text" matches "nomic-embed-text-v1.5.Q4_K_M.gguf"
+    # Uses *.gguf glob + startswith filter to avoid glob injection
+    if models_dir.exists():
+        candidates = sorted(p for p in models_dir.glob("*.gguf") if p.name.startswith(model))
+        if candidates:
+            return candidates[0]
 
     raise ProviderError(
         f"Model {model!r} not found in {models_dir}. "

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -14,29 +14,13 @@ from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from lilbee.providers.base import LLMProvider, ProviderError, filter_options
-
-if TYPE_CHECKING:
-    from lilbee.registry import ModelRegistry
 
 log = logging.getLogger(__name__)
 
 _BATCH_WINDOW_S = 0.01  # 10ms — collect concurrent requests before dispatching
-
-_registry: ModelRegistry | None = None
-
-
-def _get_registry() -> ModelRegistry:
-    """Lazy-init and cache a ModelRegistry for the current models_dir."""
-    global _registry
-    if _registry is None:
-        from lilbee.config import cfg
-        from lilbee.registry import ModelRegistry as _Cls
-
-        _registry = _Cls(cfg.models_dir)
-    return _registry
 
 
 @dataclass
@@ -238,8 +222,9 @@ def _resolve_model_path(model: str) -> Path:
     4. Prefix match (e.g. "nomic-embed-text" -> "nomic-embed-text-v1.5.Q4_K_M.gguf")
     """
     from lilbee.config import cfg
+    from lilbee.services import get_services
 
-    registry = _get_registry()
+    registry = get_services().registry
     try:
         return registry.resolve(model)
     except (KeyError, ValueError):

--- a/src/lilbee/registry.py
+++ b/src/lilbee/registry.py
@@ -1,0 +1,281 @@
+"""Model registry -- content-addressable storage with manifest-based resolution.
+
+Inspired by Ollama's model management. Model names (e.g., "nomic-embed-text")
+resolve through manifests to content-addressed .gguf blobs.
+
+Storage layout::
+
+    models_dir/
+    +-- manifests/
+    |   +-- nomic-embed-text/
+    |   |   +-- latest.json
+    |   +-- qwen3/
+    |       +-- latest.json
+    |       +-- 0.6b.json
+    +-- blobs/
+        +-- sha256-abc123...
+        +-- sha256-def456...
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lilbee.security import validate_path_within
+
+log = logging.getLogger(__name__)
+
+_HASH_ALGORITHM = "sha256"
+_HASH_CHUNK_SIZE = 8192  # bytes read per iteration when hashing
+_REF_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9 ._/-]+$")
+
+
+def _validate_ref_segment(segment: str, label: str) -> str:
+    """Validate that a model ref segment contains only safe characters.
+
+    Allows alphanumeric, hyphens, dots, underscores, slashes (namespaced models),
+    and spaces (display names). Rejects path traversal sequences.
+    """
+    if not segment or not _REF_SEGMENT_RE.match(segment):
+        raise ValueError(f"Invalid model {label}: {segment!r}")
+    if ".." in segment:
+        raise ValueError(f"Invalid model {label}: {segment!r}")
+    return segment
+
+
+@dataclass(frozen=True)
+class ModelRef:
+    """Parsed model reference like 'qwen3:8b' or 'nomic-embed-text:latest'."""
+
+    name: str
+    tag: str = "latest"
+
+    @classmethod
+    def parse(cls, s: str) -> ModelRef:
+        """Parse 'name:tag' string. Default tag is 'latest'."""
+        if ":" in s:
+            name, tag = s.rsplit(":", 1)
+            return cls(
+                name=_validate_ref_segment(name, "name"),
+                tag=_validate_ref_segment(tag, "tag"),
+            )
+        return cls(name=_validate_ref_segment(s, "name"))
+
+    def __str__(self) -> str:
+        return f"{self.name}:{self.tag}"
+
+
+@dataclass
+class ModelManifest:
+    """Manifest for an installed model version."""
+
+    name: str
+    tag: str
+    size_bytes: int
+    task: str  # "chat", "embedding", or "vision"
+    source_repo: str  # HuggingFace repo
+    source_filename: str  # original .gguf filename
+    downloaded_at: str  # ISO 8601 timestamp
+    blob: str = ""  # SHA-256 hash (filename in blobs/), set by install()
+
+
+def _coerce_ref(ref: str | ModelRef) -> ModelRef:
+    """Normalize a string or ModelRef into a ModelRef."""
+    if isinstance(ref, str):
+        return ModelRef.parse(ref)
+    return ref
+
+
+def _sha256_file(path: Path) -> str:
+    """Compute SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(_HASH_CHUNK_SIZE)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+class ModelRegistry:
+    """Content-addressable model storage with manifest resolution."""
+
+    def __init__(self, models_dir: Path) -> None:
+        self._root = models_dir
+        self._manifests_dir = models_dir / "manifests"
+        self._blobs_dir = models_dir / "blobs"
+
+    def resolve(self, ref: str | ModelRef) -> Path:
+        """Resolve model name to blob file path.
+
+        Raises ``KeyError`` if the model is not installed.
+        """
+        r = _coerce_ref(ref)
+        manifest = self._read_manifest(r)
+        if manifest is None:
+            raise KeyError(f"Model {r} not installed")
+        blob_path = self._blobs_dir / f"{_HASH_ALGORITHM}-{manifest.blob}"
+        if not blob_path.exists():
+            raise KeyError(f"Blob missing for {r}: {blob_path.name}")
+        return blob_path
+
+    def is_installed(self, ref: str | ModelRef) -> bool:
+        """Check if a model is installed (manifest exists and blob is present)."""
+        try:
+            self.resolve(ref)
+            return True
+        except (KeyError, ValueError):
+            return False
+
+    def install(self, ref: ModelRef, source_path: Path, manifest: ModelManifest) -> Path:
+        """Move a downloaded file into blob storage and write manifest.
+
+        Returns the blob path.
+        """
+        self._blobs_dir.mkdir(parents=True, exist_ok=True)
+        digest = _sha256_file(source_path)
+        blob_path = self._blobs_dir / f"{_HASH_ALGORITHM}-{digest}"
+        os.replace(source_path, blob_path)
+        updated = ModelManifest(
+            name=manifest.name,
+            tag=manifest.tag,
+            size_bytes=manifest.size_bytes,
+            task=manifest.task,
+            source_repo=manifest.source_repo,
+            source_filename=manifest.source_filename,
+            downloaded_at=manifest.downloaded_at,
+            blob=digest,
+        )
+        self._write_manifest(ref, updated)
+        return blob_path
+
+    def remove(self, ref: str | ModelRef) -> bool:
+        """Remove a model manifest. Delete blob if no other manifests reference it."""
+        try:
+            r = _coerce_ref(ref)
+            manifest = self._read_manifest(r)
+        except ValueError:
+            return False
+        if manifest is None:
+            return False
+        manifest_path = self._manifest_path(r)
+        manifest_path.unlink()
+        # Remove empty name directory
+        name_dir = manifest_path.parent
+        if name_dir.exists() and not any(name_dir.iterdir()):
+            name_dir.rmdir()
+        # Garbage-collect blob if unreferenced
+        if not self._blob_referenced(manifest.blob):
+            blob_path = self._blobs_dir / f"{_HASH_ALGORITHM}-{manifest.blob}"
+            blob_path.unlink(missing_ok=True)
+            log.info("Deleted unreferenced blob %s", blob_path.name)
+        return True
+
+    def list_installed(self) -> list[ModelManifest]:
+        """List all installed models."""
+        manifests: list[ModelManifest] = []
+        if not self._manifests_dir.exists():
+            return manifests
+        for name_dir in sorted(self._manifests_dir.iterdir()):
+            if not name_dir.is_dir():
+                continue
+            for tag_file in sorted(name_dir.glob("*.json")):
+                manifest = self._load_manifest_file(tag_file)
+                if manifest is not None:
+                    manifests.append(manifest)
+        return manifests
+
+    def migrate_legacy(self) -> int:
+        """Scan for .gguf files in root dir and register them.
+
+        On first run, finds existing .gguf files and creates manifests.
+        Uses catalog to match display names. Returns the number of models migrated.
+        """
+        if not self._root.exists():
+            return 0
+        gguf_files = sorted(self._root.glob("*.gguf"))
+        if not gguf_files:
+            return 0
+        count = 0
+        for path in gguf_files:
+            name, task, repo = _match_catalog_entry(path.name)
+            ref = ModelRef.parse(name)
+            manifest = ModelManifest(
+                name=name,
+                tag="latest",
+                size_bytes=path.stat().st_size,
+                task=task,
+                source_repo=repo,
+                source_filename=path.name,
+                downloaded_at=datetime.now(tz=UTC).isoformat(),
+            )
+            self.install(ref, path, manifest)
+            log.info("Migrated legacy model %s -> %s", path.name, ref)
+            count += 1
+        return count
+
+    def _manifest_path(self, ref: ModelRef) -> Path:
+        path = self._manifests_dir / ref.name / f"{ref.tag}.json"
+        validate_path_within(path, self._manifests_dir)
+        return path
+
+    def _read_manifest(self, ref: ModelRef) -> ModelManifest | None:
+        return self._load_manifest_file(self._manifest_path(ref))
+
+    def _write_manifest(self, ref: ModelRef, manifest: ModelManifest) -> None:
+        path = self._manifest_path(ref)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = json.dumps(asdict(manifest), indent=2)
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=path.parent, suffix=".tmp", mode="w", delete=False
+            ) as tmp:
+                tmp_path = tmp.name
+                tmp.write(data)
+            os.replace(tmp_path, path)
+        except BaseException:
+            if tmp_path is not None:
+                Path(tmp_path).unlink(missing_ok=True)
+            raise
+
+    def _load_manifest_file(self, path: Path) -> ModelManifest | None:
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+            return ModelManifest(**data)
+        except (json.JSONDecodeError, TypeError, KeyError):
+            log.warning("Corrupt manifest: %s", path)
+            return None
+
+    def _blob_referenced(self, digest: str) -> bool:
+        """Check if any manifest still references the given blob digest."""
+        return any(manifest.blob == digest for manifest in self.list_installed())
+
+
+def _match_catalog_entry(filename: str) -> tuple[str, str, str]:
+    """Match a .gguf filename to a catalog entry, returning (name, task, repo).
+
+    Falls back to deriving a name from the filename itself.
+    """
+    from lilbee.catalog import FEATURED_ALL
+
+    filename_lower = filename.lower()
+    for entry in FEATURED_ALL:
+        # Match on repo name fragment or exact filename
+        repo_stem = entry.hf_repo.split("/")[-1].lower()
+        if filename_lower.startswith(repo_stem) or entry.gguf_filename == filename:
+            return entry.name, entry.task, entry.hf_repo
+    # Fallback: strip extension and quant suffix for a reasonable name
+    stem = filename.rsplit(".", 1)[0]
+    return stem, "chat", ""

--- a/src/lilbee/services.py
+++ b/src/lilbee/services.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from lilbee.embedder import Embedder
     from lilbee.providers.base import LLMProvider
     from lilbee.query import Searcher
+    from lilbee.registry import ModelRegistry
     from lilbee.reranker import Reranker
     from lilbee.store import Store
 
@@ -29,6 +30,7 @@ class Services:
     reranker: Reranker
     concepts: ConceptGraph
     searcher: Searcher
+    registry: ModelRegistry
 
 
 _svc: Services | None = None
@@ -45,6 +47,7 @@ def get_services() -> Services:
     from lilbee.embedder import Embedder
     from lilbee.providers.factory import create_provider
     from lilbee.query import Searcher
+    from lilbee.registry import ModelRegistry
     from lilbee.reranker import Reranker
     from lilbee.store import Store
 
@@ -53,6 +56,7 @@ def get_services() -> Services:
     embedder = Embedder(cfg, provider)
     reranker = Reranker(cfg)
     concepts = ConceptGraph(cfg, store)
+    registry = ModelRegistry(cfg.models_dir)
     searcher = Searcher(cfg, provider, store, embedder, reranker, concepts)
     _svc = Services(
         provider=provider,
@@ -61,6 +65,7 @@ def get_services() -> Services:
         reranker=reranker,
         concepts=concepts,
         searcher=searcher,
+        registry=registry,
     )
     return _svc
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -409,10 +409,25 @@ class TestDownloadModel:
     def test_returns_existing_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
-        existing = tmp_path / entry.gguf_filename
-        existing.write_bytes(b"fake model")
+        from lilbee.registry import ModelManifest, ModelRef, ModelRegistry
+
+        registry = ModelRegistry(tmp_path)
+        source = tmp_path / entry.gguf_filename
+        source.write_bytes(b"fake model")
+        ref = ModelRef.parse(entry.name)
+        manifest = ModelManifest(
+            name=ref.name,
+            tag=ref.tag,
+            blob="",
+            size_bytes=10,
+            task=entry.task,
+            source_repo=entry.hf_repo,
+            source_filename=entry.gguf_filename,
+            downloaded_at="2026-01-01T00:00:00+00:00",
+        )
+        blob_path = registry.install(ref, source, manifest)
         result = download_model(entry)
-        assert result == existing
+        assert result == blob_path
 
     def test_creates_models_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         models_dir = tmp_path / "models"
@@ -441,7 +456,7 @@ class TestDownloadModel:
         monkeypatch.setattr(httpx, "stream", lambda *a, **kw: FakeStream())
         result = download_model(entry)
         assert result.exists()
-        assert result.parent == models_dir
+        assert result.parent == models_dir / "blobs"
 
     def test_calls_progress_callback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -527,3 +527,59 @@ class TestIsNativePathTraversal:
         """_is_native returns False for path traversal attempts."""
         mgr = ModelManager(models_dir=tmp_path, litellm_base_url="http://localhost:11434")
         assert not mgr._is_native("../../etc/passwd")
+
+
+class TestIsNativeRegistry:
+    def test_is_native_true_when_in_registry(self, tmp_path: Path) -> None:
+        """_is_native returns True when model exists in registry."""
+
+        from lilbee.registry import ModelManifest, ModelRef, ModelRegistry
+
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        source = tmp_path / "model.gguf"
+        source.write_bytes(b"registry-model-data")
+        ref = ModelRef(name="my-reg-model")
+        manifest = ModelManifest(
+            name="my-reg-model",
+            tag="latest",
+            size_bytes=len(b"registry-model-data"),
+            task="chat",
+            source_repo="org/repo",
+            source_filename="model.gguf",
+            downloaded_at="2026-01-01T00:00:00+00:00",
+        )
+        registry.install(ref, source, manifest)
+
+        mgr = ModelManager(models_dir, "http://localhost:11434")
+        assert mgr._is_native("my-reg-model") is True
+
+
+class TestRemoveNativeRegistry:
+    def test_remove_native_from_registry(self, tmp_path: Path) -> None:
+        """_remove_native removes model from registry."""
+        from lilbee.registry import ModelManifest, ModelRef, ModelRegistry
+
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        source = tmp_path / "model.gguf"
+        source.write_bytes(b"registry-model-data")
+        ref = ModelRef(name="removable")
+        manifest = ModelManifest(
+            name="removable",
+            tag="latest",
+            size_bytes=len(b"registry-model-data"),
+            task="chat",
+            source_repo="org/repo",
+            source_filename="model.gguf",
+            downloaded_at="2026-01-01T00:00:00+00:00",
+        )
+        registry.install(ref, source, manifest)
+
+        mgr = ModelManager(models_dir, "http://localhost:11434")
+        assert mgr._remove_native("removable") is True
+        assert not registry.is_installed("removable")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -23,11 +23,14 @@ if TYPE_CHECKING:
 @pytest.fixture(autouse=True)
 def _reset_provider() -> None:
     """Reset provider singleton between tests."""
+    import lilbee.providers.llama_cpp_provider as lcp
     from lilbee.services import reset_services
 
     reset_services()
+    lcp._registry = None
     yield
     reset_services()
+    lcp._registry = None
 
 
 @pytest.fixture()
@@ -266,6 +269,31 @@ class TestLlamaCppProvider:
         cfg.models_dir = models_dir
         with pytest.raises(ProviderError, match="Model file not found"):
             _resolve_model_path("/nonexistent/model.gguf")
+
+    def test_resolve_model_path_prefix_match(self, models_dir: Path) -> None:
+        from lilbee.providers.llama_cpp_provider import _resolve_model_path
+
+        cfg.models_dir = models_dir
+        # "test-model.gguf" already exists from fixture; prefix "test-" should match it
+        path = _resolve_model_path("test-")
+        assert path.name == "test-model.gguf"
+
+    def test_resolve_model_path_prefix_match_picks_first_sorted(self, models_dir: Path) -> None:
+        from lilbee.providers.llama_cpp_provider import _resolve_model_path
+
+        cfg.models_dir = models_dir
+        (models_dir / "alpha-v1.gguf").touch()
+        (models_dir / "alpha-v2.gguf").touch()
+        path = _resolve_model_path("alpha-")
+        assert path.name == "alpha-v1.gguf"
+
+    def test_resolve_model_path_prefix_no_match(self, models_dir: Path) -> None:
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.llama_cpp_provider import _resolve_model_path
+
+        cfg.models_dir = models_dir
+        with pytest.raises(ProviderError, match="not found"):
+            _resolve_model_path("nonexistent-prefix-")
 
     def test_embed_caches_llm(self, models_dir: Path, mock_llama_cpp: mock.MagicMock) -> None:
         from lilbee.providers.llama_cpp_provider import LlamaCppProvider

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,461 @@
+"""Tests for registry.py -- content-addressable model storage."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from lilbee.registry import (
+    ModelManifest,
+    ModelRef,
+    ModelRegistry,
+    _coerce_ref,
+    _match_catalog_entry,
+    _sha256_file,
+    _validate_ref_segment,
+)
+
+
+class TestModelRef:
+    def test_parse_name_only(self) -> None:
+        ref = ModelRef.parse("nomic-embed-text")
+        assert ref.name == "nomic-embed-text"
+        assert ref.tag == "latest"
+
+    def test_parse_name_and_tag(self) -> None:
+        ref = ModelRef.parse("qwen3:8b")
+        assert ref.name == "qwen3"
+        assert ref.tag == "8b"
+
+    def test_parse_name_with_multiple_colons(self) -> None:
+        ref = ModelRef.parse("org/repo:v1.0")
+        assert ref.name == "org/repo"
+        assert ref.tag == "v1.0"
+
+    def test_str_representation(self) -> None:
+        ref = ModelRef(name="qwen3", tag="8b")
+        assert str(ref) == "qwen3:8b"
+
+    def test_str_latest(self) -> None:
+        ref = ModelRef(name="nomic-embed-text")
+        assert str(ref) == "nomic-embed-text:latest"
+
+    def test_frozen(self) -> None:
+        ref = ModelRef(name="test")
+        with pytest.raises(AttributeError):
+            ref.name = "other"  # type: ignore[misc]
+
+    def test_default_tag(self) -> None:
+        ref = ModelRef(name="test")
+        assert ref.tag == "latest"
+
+    def test_parse_rejects_path_traversal_in_name(self) -> None:
+        with pytest.raises(ValueError, match="Invalid model name"):
+            ModelRef.parse("../etc/passwd")
+
+    def test_parse_rejects_empty_name(self) -> None:
+        with pytest.raises(ValueError, match="Invalid model name"):
+            ModelRef.parse("")
+
+    def test_parse_rejects_path_traversal_in_tag(self) -> None:
+        with pytest.raises(ValueError, match="Invalid model tag"):
+            ModelRef.parse("model:../../evil")
+
+    def test_parse_allows_namespaced_models(self) -> None:
+        ref = ModelRef.parse("org/repo:v1.0")
+        assert ref.name == "org/repo"
+        assert ref.tag == "v1.0"
+
+
+class TestValidateRefSegment:
+    def test_valid_segment(self) -> None:
+        assert _validate_ref_segment("qwen3-8B", "name") == "qwen3-8B"
+
+    def test_rejects_dotdot(self) -> None:
+        with pytest.raises(ValueError, match="Invalid model name"):
+            _validate_ref_segment("..", "name")
+
+    def test_allows_spaces(self) -> None:
+        assert _validate_ref_segment("Nomic Embed Text v1.5", "name") == "Nomic Embed Text v1.5"
+
+    def test_rejects_special_chars(self) -> None:
+        with pytest.raises(ValueError, match="Invalid model tag"):
+            _validate_ref_segment("bad;tag", "tag")
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match="Invalid model name"):
+            _validate_ref_segment("", "name")
+
+
+class TestCoerceRef:
+    def test_string_input(self) -> None:
+        ref = _coerce_ref("qwen3:8b")
+        assert ref == ModelRef(name="qwen3", tag="8b")
+
+    def test_model_ref_passthrough(self) -> None:
+        original = ModelRef(name="test", tag="v1")
+        assert _coerce_ref(original) is original
+
+
+class TestSha256File:
+    def test_computes_hash(self, tmp_path: Path) -> None:
+        p = tmp_path / "test.bin"
+        p.write_bytes(b"hello world")
+        expected = hashlib.sha256(b"hello world").hexdigest()
+        assert _sha256_file(p) == expected
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.bin"
+        p.write_bytes(b"")
+        expected = hashlib.sha256(b"").hexdigest()
+        assert _sha256_file(p) == expected
+
+
+def _make_manifest(
+    name: str = "test-model",
+    tag: str = "latest",
+    size_bytes: int = 1000,
+    task: str = "chat",
+    source_repo: str = "org/repo",
+    source_filename: str = "model.gguf",
+    downloaded_at: str = "2026-01-01T00:00:00+00:00",
+    blob: str = "abc123",
+) -> ModelManifest:
+    return ModelManifest(
+        name=name,
+        tag=tag,
+        size_bytes=size_bytes,
+        task=task,
+        source_repo=source_repo,
+        source_filename=source_filename,
+        downloaded_at=downloaded_at,
+        blob=blob,
+    )
+
+
+class TestModelRegistry:
+    def test_resolve_not_installed(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        with pytest.raises(KeyError, match="not installed"):
+            registry.resolve("missing-model")
+
+    def test_resolve_missing_blob(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        manifest = _make_manifest(blob="deadbeef")
+        ref = ModelRef(name="test-model")
+        registry._write_manifest(ref, manifest)
+        with pytest.raises(KeyError, match="Blob missing"):
+            registry.resolve(ref)
+
+    def test_install_and_resolve_roundtrip(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        source = tmp_path / "model.gguf"
+        source.write_bytes(b"fake model data")
+        digest = hashlib.sha256(b"fake model data").hexdigest()
+
+        ref = ModelRef(name="test-model", tag="latest")
+        manifest = _make_manifest(size_bytes=len(b"fake model data"))
+
+        blob_path = registry.install(ref, source, manifest)
+
+        assert blob_path == models_dir / "blobs" / f"sha256-{digest}"
+        assert blob_path.exists()
+        assert not source.exists()  # moved, not copied
+
+        resolved = registry.resolve(ref)
+        assert resolved == blob_path
+
+    def test_install_deduplicates_blobs(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        content = b"same content"
+        source1 = tmp_path / "model1.gguf"
+        source1.write_bytes(content)
+        source2 = tmp_path / "model2.gguf"
+        source2.write_bytes(content)
+
+        ref1 = ModelRef(name="model-a", tag="latest")
+        ref2 = ModelRef(name="model-b", tag="latest")
+        manifest1 = _make_manifest(name="model-a")
+        manifest2 = _make_manifest(name="model-b")
+
+        blob1 = registry.install(ref1, source1, manifest1)
+        blob2 = registry.install(ref2, source2, manifest2)
+
+        assert blob1 == blob2
+        assert not source2.exists()  # cleaned up since blob already existed
+
+    def test_is_installed_true(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        source = tmp_path / "model.gguf"
+        source.write_bytes(b"data")
+        ref = ModelRef(name="test")
+        registry.install(ref, source, _make_manifest())
+
+        assert registry.is_installed("test") is True
+        assert registry.is_installed("test:latest") is True
+
+    def test_is_installed_false(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        assert registry.is_installed("nonexistent") is False
+
+    def test_remove_unique_blob(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        source = tmp_path / "model.gguf"
+        source.write_bytes(b"unique data")
+        ref = ModelRef(name="removeme")
+        blob_path = registry.install(ref, source, _make_manifest(name="removeme"))
+
+        assert registry.remove("removeme") is True
+        assert not blob_path.exists()  # blob deleted (no other refs)
+        assert registry.is_installed("removeme") is False
+
+    def test_remove_shared_blob_keeps_blob(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        content = b"shared blob data"
+        source1 = tmp_path / "m1.gguf"
+        source1.write_bytes(content)
+        source2 = tmp_path / "m2.gguf"
+        source2.write_bytes(content)
+
+        ref1 = ModelRef(name="model-a")
+        ref2 = ModelRef(name="model-b")
+        blob = registry.install(ref1, source1, _make_manifest(name="model-a"))
+        registry.install(ref2, source2, _make_manifest(name="model-b"))
+
+        assert registry.remove("model-a") is True
+        assert blob.exists()  # still referenced by model-b
+        assert registry.is_installed("model-b") is True
+
+    def test_remove_nonexistent(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        assert registry.remove("ghost") is False
+
+    def test_list_installed_empty(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        assert registry.list_installed() == []
+
+    def test_list_installed_multiple(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        for name in ("alpha", "beta"):
+            source = tmp_path / f"{name}.gguf"
+            source.write_bytes(f"data-{name}".encode())
+            ref = ModelRef(name=name)
+            registry.install(ref, source, _make_manifest(name=name))
+
+        installed = registry.list_installed()
+        names = [m.name for m in installed]
+        assert "alpha" in names
+        assert "beta" in names
+        assert len(installed) == 2
+
+    def test_list_installed_skips_non_dir(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        # Install one real model
+        source = tmp_path / "real.gguf"
+        source.write_bytes(b"data")
+        registry.install(ModelRef(name="real"), source, _make_manifest(name="real"))
+
+        # Place a stray file in manifests/
+        (models_dir / "manifests" / "stray.txt").write_text("junk")
+
+        installed = registry.list_installed()
+        assert len(installed) == 1
+        assert installed[0].name == "real"
+
+    def test_tag_support(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        source_latest = tmp_path / "latest.gguf"
+        source_latest.write_bytes(b"latest-data")
+        source_v2 = tmp_path / "v2.gguf"
+        source_v2.write_bytes(b"v2-data")
+
+        ref_latest = ModelRef(name="qwen3", tag="latest")
+        ref_v2 = ModelRef(name="qwen3", tag="0.6b")
+
+        registry.install(ref_latest, source_latest, _make_manifest(name="qwen3", tag="latest"))
+        registry.install(ref_v2, source_v2, _make_manifest(name="qwen3", tag="0.6b"))
+
+        assert registry.is_installed("qwen3:latest")
+        assert registry.is_installed("qwen3:0.6b")
+
+        path_latest = registry.resolve("qwen3:latest")
+        path_v2 = registry.resolve("qwen3:0.6b")
+        assert path_latest != path_v2
+
+    def test_resolve_with_string(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        source = tmp_path / "model.gguf"
+        source.write_bytes(b"content")
+        registry.install(ModelRef(name="mymodel"), source, _make_manifest(name="mymodel"))
+
+        path = registry.resolve("mymodel:latest")
+        assert path.exists()
+
+    def test_corrupt_manifest_skipped(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        manifest_dir = models_dir / "manifests" / "broken"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "latest.json").write_text("not valid json {{{")
+
+        assert registry.list_installed() == []
+
+    def test_manifest_path_traversal_blocked(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        # Directly constructed ref with traversal (bypassing parse validation)
+        evil_ref = ModelRef.__new__(ModelRef)
+        object.__setattr__(evil_ref, "name", "../../etc")
+        object.__setattr__(evil_ref, "tag", "passwd")
+        with pytest.raises(ValueError, match="Path escapes"):
+            registry._manifest_path(evil_ref)
+
+    def test_corrupt_manifest_missing_fields(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        manifest_dir = models_dir / "manifests" / "broken"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "latest.json").write_text(json.dumps({"name": "broken"}))
+
+        assert registry.list_installed() == []
+
+    def test_remove_cleans_empty_name_dir(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+
+        source = tmp_path / "model.gguf"
+        source.write_bytes(b"data")
+        ref = ModelRef(name="cleanup-test")
+        registry.install(ref, source, _make_manifest(name="cleanup-test"))
+
+        name_dir = models_dir / "manifests" / "cleanup-test"
+        assert name_dir.exists()
+
+        registry.remove("cleanup-test")
+        assert not name_dir.exists()
+
+
+class TestMigrateLegacy:
+    def test_migrates_gguf_files(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        (models_dir / "some-model.gguf").write_bytes(b"model-bytes")
+
+        registry = ModelRegistry(models_dir)
+        count = registry.migrate_legacy()
+
+        assert count == 1
+        assert not (models_dir / "some-model.gguf").exists()  # moved to blobs
+        assert registry.list_installed()[0].source_filename == "some-model.gguf"
+
+    def test_migrates_known_catalog_model(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        (models_dir / "nomic-embed-text-v1.5-GGUF-Q4_K_M.gguf").write_bytes(b"embed-bytes")
+
+        registry = ModelRegistry(models_dir)
+        count = registry.migrate_legacy()
+
+        assert count == 1
+        installed = registry.list_installed()
+        assert len(installed) == 1
+        assert installed[0].task == "embedding"
+        assert installed[0].source_repo == "nomic-ai/nomic-embed-text-v1.5-GGUF"
+
+    def test_no_gguf_files(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        (models_dir / "readme.txt").write_text("nothing here")
+
+        registry = ModelRegistry(models_dir)
+        assert registry.migrate_legacy() == 0
+
+    def test_missing_root_dir(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path / "nonexistent")
+        assert registry.migrate_legacy() == 0
+
+    def test_migrates_multiple(self, tmp_path: Path) -> None:
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        (models_dir / "a.gguf").write_bytes(b"aaa")
+        (models_dir / "b.gguf").write_bytes(b"bbb")
+
+        registry = ModelRegistry(models_dir)
+        assert registry.migrate_legacy() == 2
+        assert len(registry.list_installed()) == 2
+
+
+class TestMatchCatalogEntry:
+    def test_matches_featured_embedding(self) -> None:
+        _name, task, repo = _match_catalog_entry("nomic-embed-text-v1.5-GGUF-Q4_K_M.gguf")
+        assert task == "embedding"
+        assert "nomic" in repo.lower()
+
+    def test_matches_featured_chat(self) -> None:
+        _name, task, repo = _match_catalog_entry("Qwen3-8B-GGUF-Q4_K_M.gguf")
+        assert task == "chat"
+        assert "Qwen" in repo
+
+    def test_fallback_unknown_model(self) -> None:
+        name, task, repo = _match_catalog_entry("totally-custom-model.gguf")
+        assert name == "totally-custom-model"
+        assert task == "chat"
+        assert repo == ""
+
+
+class TestWriteManifestErrorPath:
+    def test_temp_file_cleaned_up_on_replace_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When os.replace raises, the temp file is cleaned up."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+        ref = ModelRef(name="fail-model")
+        manifest = _make_manifest(name="fail-model")
+
+        def failing_replace(src: str, dst: str) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr("os.replace", failing_replace)
+
+        with pytest.raises(OSError, match="disk full"):
+            registry._write_manifest(ref, manifest)
+
+        # Verify no temp files left behind
+        manifest_dir = models_dir / "manifests" / "fail-model"
+        if manifest_dir.exists():
+            tmp_files = list(manifest_dir.glob("*.tmp"))
+            assert tmp_files == []


### PR DESCRIPTION
Adds a model registry to lilbee. Right now it's bound to filenames directly, but this doesn't scale well and this system needs to improve. Ollama does it perfectly in a straight forward way and that's the inspiration here. 