### PR TITLE
feat: PATCH /api/config and PUT /api/models/embedding

### DIFF
--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -12,6 +12,30 @@ from typing import Any, ClassVar
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
+def ConfigField(
+    *args: Any,
+    writable: bool = False,
+    reindex: bool = False,
+    write_only: bool = False,
+    public: bool = True,
+    **kwargs: Any,
+) -> Any:
+    """Wrap pydantic ``Field`` and attach metadata via ``json_schema_extra``."""
+    extra: dict[str, bool] = {}
+    if writable:
+        extra["writable"] = True
+    if reindex:
+        extra["reindex"] = True
+    if write_only:
+        extra["write_only"] = True
+    if not public:
+        extra["public"] = False
+    if extra:
+        kwargs["json_schema_extra"] = extra
+    return Field(*args, **kwargs)
+
+
 log = logging.getLogger(__name__)
 
 DEFAULT_IGNORE_DIRS = frozenset(
@@ -65,12 +89,12 @@ class Config(BaseSettings):
     chat_model: str = Field(default="qwen3:8b", min_length=1)
     embedding_model: str = Field(default="nomic-embed-text", min_length=1)
     embedding_dim: int = Field(default=768, ge=1)
-    chunk_size: int = Field(default=512, ge=1)
-    chunk_overlap: int = Field(default=100, ge=0)
+    chunk_size: int = ConfigField(default=512, ge=1, writable=True, reindex=True)
+    chunk_overlap: int = ConfigField(default=100, ge=0, writable=True, reindex=True)
     max_embed_chars: int = Field(default=2000, ge=1)
-    top_k: int = Field(default=10, ge=1)
-    max_distance: float = Field(default=0.7, ge=0.0)
-    system_prompt: str = Field(default=_DEFAULT_SYSTEM_PROMPT, min_length=1)
+    top_k: int = ConfigField(default=10, ge=1, writable=True)
+    max_distance: float = ConfigField(default=0.7, ge=0.0, writable=True)
+    system_prompt: str = ConfigField(default=_DEFAULT_SYSTEM_PROMPT, min_length=1, writable=True)
     ignore_dirs: frozenset[str] = Field(default=DEFAULT_IGNORE_DIRS)
     vision_model: str = ""
     vision_timeout: float = Field(default=120.0, ge=0.0)
@@ -78,39 +102,39 @@ class Config(BaseSettings):
     server_port: int = Field(default=0, ge=0, le=65535)
     cors_origins: list[str] = Field(default_factory=list)
     json_mode: bool = False
-    temperature: float | None = Field(default=None, ge=0.0)
-    top_p: float | None = Field(default=None, ge=0.0, le=1.0)
-    top_k_sampling: int | None = Field(default=None, ge=1)
-    repeat_penalty: float | None = Field(default=None, ge=0.0)
-    num_ctx: int | None = Field(default=None, ge=1)
-    seed: int | None = None
-    llm_provider: str = "auto"
-    litellm_base_url: str = "http://localhost:11434"
-    llm_api_key: str = ""
+    temperature: float | None = ConfigField(default=None, ge=0.0, writable=True)
+    top_p: float | None = ConfigField(default=None, ge=0.0, le=1.0, writable=True)
+    top_k_sampling: int | None = ConfigField(default=None, ge=1, writable=True)
+    repeat_penalty: float | None = ConfigField(default=None, ge=0.0, writable=True)
+    num_ctx: int | None = ConfigField(default=None, ge=1, writable=True)
+    seed: int | None = ConfigField(default=None, writable=True)
+    llm_provider: str = ConfigField(default="auto", writable=True)
+    litellm_base_url: str = ConfigField(default="http://localhost:11434", writable=True)
+    llm_api_key: str = ConfigField(default="", writable=True, write_only=True)
 
     # Retrieval quality knobs — defaults chosen from academic research and grantflow
     # and academic literature (see docs/superpowers/specs/2026-03-22-feature-parity-design.md)
 
     # Max chunks per source document in results. Prevents one large file from
     # dominating all top-k slots. 3 balances coverage vs diversity.
-    diversity_max_per_source: int = Field(default=3, ge=1)
+    diversity_max_per_source: int = ConfigField(default=3, ge=1, writable=True)
 
     # MMR relevance/diversity tradeoff. 0.0 = max diversity, 1.0 = pure relevance.
     # 0.5 is the standard default from Carbonell & Goldstein 1998.
-    mmr_lambda: float = Field(default=0.5, ge=0.0, le=1.0)
+    mmr_lambda: float = ConfigField(default=0.5, ge=0.0, le=1.0, writable=True)
 
     # How many extra candidates to retrieve for MMR reranking.
     # 3x gives enough candidates to find diverse results without excessive latency.
-    candidate_multiplier: int = Field(default=3, ge=1)
+    candidate_multiplier: int = ConfigField(default=3, ge=1, writable=True)
 
     # Number of LLM-generated alternative queries for expansion.
     # 3 variants covers lexical + semantic angles. Set to 0 to disable expansion.
-    query_expansion_count: int = Field(default=3, ge=0)
+    query_expansion_count: int = ConfigField(default=3, ge=0, writable=True)
 
     # Cosine distance threshold step for adaptive widening.
     # When too few results are found, threshold widens by this amount per retry.
     # 0.2 gives 4 steps from typical 0.3 start to 1.0 cap.
-    adaptive_threshold_step: float = Field(default=0.2, gt=0.0)
+    adaptive_threshold_step: float = ConfigField(default=0.2, gt=0.0, writable=True)
 
     # Validate LLM-generated expansion variants to prevent query drift.
     # Checks token overlap with original query (>= 0.3) and deduplicates
@@ -128,15 +152,15 @@ class Config(BaseSettings):
 
     # Maximum chunks included in LLM context after adaptive selection.
     # More = more complete answers but higher latency and token cost.
-    max_context_sources: int = Field(default=5, ge=1)
+    max_context_sources: int = ConfigField(default=5, ge=1, writable=True)
 
     # Enable HyDE (Hypothetical Document Embeddings) for search.
     # Gao et al. 2022. Adds ~500ms per query. Best for vague queries.
-    hyde: bool = False
+    hyde: bool = ConfigField(default=False, writable=True)
 
     # Weight for HyDE results relative to original search (0.0-1.0).
     # Lower = less trust in hypothetical documents.
-    hyde_weight: float = Field(default=0.7, ge=0.0, le=1.0)
+    hyde_weight: float = ConfigField(default=0.7, ge=0.0, le=1.0, writable=True)
 
     # HyDE prompt template. Must contain {question} placeholder.
     hyde_prompt: str = (
@@ -147,48 +171,48 @@ class Config(BaseSettings):
 
     # Cross-encoder model for reranking. Empty = disabled.
     # Requires sentence-transformers installed.
-    reranker_model: str = ""
+    reranker_model: str = ConfigField(default="", writable=True, public=False)
 
     # Number of candidates to rerank with cross-encoder.
-    rerank_candidates: int = Field(default=20, ge=1)
+    rerank_candidates: int = ConfigField(default=20, ge=1, writable=True, public=False)
 
     # Enable temporal filtering (date-based result filtering).
     # Only activates when temporal keywords detected in query.
-    temporal_filtering: bool = True
+    temporal_filtering: bool = ConfigField(default=True, writable=True)
 
     # Show reasoning model thinking process (<think>...</think> tags).
     # When False, thinking is stripped silently. When True, emitted as
     # separate SSE events (event: reasoning) for UI rendering.
-    show_reasoning: bool = False
+    show_reasoning: bool = ConfigField(default=False, writable=True)
 
     # Web crawling settings
     # Maximum link-following depth for recursive crawls.
-    crawl_max_depth: int = Field(default=2, ge=0)
+    crawl_max_depth: int = ConfigField(default=2, ge=0, writable=True)
 
     # Maximum pages to fetch in a single crawl operation.
-    crawl_max_pages: int = Field(default=50, ge=1)
+    crawl_max_pages: int = ConfigField(default=50, ge=1, writable=True)
 
     # Per-page timeout in seconds for fetching a URL.
-    crawl_timeout: int = Field(default=30, ge=1)
+    crawl_timeout: int = ConfigField(default=30, ge=1, writable=True)
 
     # Maximum concurrent crawl operations (0 = unlimited, default = CPU count).
     crawl_max_concurrent: int = Field(default=0, ge=0)
 
     # Seconds between periodic syncs during crawl (0 = sync only at end).
-    crawl_sync_interval: int = Field(default=30, ge=0)
+    crawl_sync_interval: int = ConfigField(default=30, ge=0, writable=True)
 
     # Enable concept graph (LazyGraphRAG-style index). Extracts noun phrases
     # from chunks, builds a co-occurrence graph, and uses it to boost search
     # results and expand queries. Requires spacy + networkx + graspologic-native.
-    concept_graph: bool = True
+    concept_graph: bool = ConfigField(default=True, writable=True)
 
     # Weight for concept overlap boosting in search results (0.0-1.0).
     # Higher = concept overlap matters more relative to vector similarity.
-    concept_boost_weight: float = Field(default=0.3, ge=0.0, le=1.0)
+    concept_boost_weight: float = ConfigField(default=0.3, ge=0.0, le=1.0, writable=True)
 
     # Maximum noun-phrase concepts extracted per chunk.
     # Caps extraction to avoid noise from very long chunks.
-    concept_max_per_chunk: int = Field(default=10, ge=1)
+    concept_max_per_chunk: int = ConfigField(default=10, ge=1, writable=True)
 
     # Class variable — not a settings field
     _toml_cache: ClassVar[dict[str, Any]] = {}

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -25,7 +25,12 @@ from lilbee.server.routes.documents import (
     documents_remove_route,
     sync_route,
 )
-from lilbee.server.routes.general import config_route, health_route, status_route
+from lilbee.server.routes.general import (
+    config_route,
+    config_update_route,
+    health_route,
+    status_route,
+)
 from lilbee.server.routes.models import (
     models_catalog_route,
     models_delete_route,
@@ -33,6 +38,7 @@ from lilbee.server.routes.models import (
     models_list_route,
     models_pull_route,
     models_set_chat_route,
+    models_set_embedding_route,
     models_set_vision_route,
     models_show_route,
 )
@@ -73,7 +79,7 @@ def create_app() -> Litestar:
     """Create the Litestar application instance."""
     cors = CORSConfig(
         allow_origins=cfg.cors_origins,
-        allow_methods=["GET", "POST", "PUT", "DELETE"],
+        allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
         allow_headers=["Content-Type", "Authorization"],
     )
     return Litestar(
@@ -83,6 +89,7 @@ def create_app() -> Litestar:
             health_route,
             status_route,
             config_route,
+            config_update_route,
             search_route,
             ask_route,
             ask_stream_route,
@@ -92,6 +99,7 @@ def create_app() -> Litestar:
             add_route,
             models_list_route,
             models_set_chat_route,
+            models_set_embedding_route,
             models_set_vision_route,
             models_catalog_route,
             models_installed_route,

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -12,7 +12,7 @@ import logging
 import threading
 from collections.abc import AsyncGenerator, Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import BaseModel
 
@@ -55,8 +55,57 @@ _PUBLIC_CONFIG_FIELDS: frozenset[str] = frozenset(
         "query_expansion_count",
         "adaptive_threshold_step",
         "show_reasoning",
+        "crawl_max_depth",
+        "crawl_max_pages",
+        "crawl_timeout",
+        "crawl_sync_interval",
+        "max_context_sources",
+        "hyde",
+        "hyde_weight",
+        "temporal_filtering",
+        "concept_graph",
+        "concept_boost_weight",
+        "concept_max_per_chunk",
     }
 )
+
+WRITABLE_CONFIG_FIELDS: dict[str, bool] = {
+    # bool value = nullable (True means null resets to model default)
+    "temperature": True,
+    "top_p": True,
+    "top_k_sampling": True,
+    "repeat_penalty": True,
+    "num_ctx": True,
+    "seed": True,
+    "system_prompt": False,
+    "show_reasoning": False,
+    "top_k": False,
+    "max_distance": False,
+    "diversity_max_per_source": False,
+    "mmr_lambda": False,
+    "candidate_multiplier": False,
+    "query_expansion_count": False,
+    "adaptive_threshold_step": False,
+    "max_context_sources": False,
+    "hyde": False,
+    "hyde_weight": False,
+    "temporal_filtering": False,
+    "reranker_model": False,
+    "rerank_candidates": False,
+    "chunk_size": False,
+    "chunk_overlap": False,
+    "crawl_max_depth": False,
+    "crawl_max_pages": False,
+    "crawl_timeout": False,
+    "crawl_sync_interval": False,
+    "concept_graph": False,
+    "concept_boost_weight": False,
+    "concept_max_per_chunk": False,
+    "llm_provider": False,
+    "litellm_base_url": False,
+    "llm_api_key": False,
+}
+REINDEX_FIELDS: frozenset[str] = frozenset({"chunk_size", "chunk_overlap"})
 
 
 class ModelCatalogEntry(BaseModel):
@@ -418,21 +467,64 @@ async def list_models() -> dict[str, Any]:
     return response.model_dump()
 
 
+async def _set_model(
+    field: Literal["chat_model", "vision_model", "embedding_model"],
+    model: str,
+    *,
+    normalize: bool = False,
+) -> dict[str, str]:
+    """Shared helper for switching a model field. Returns {model}."""
+    if normalize:
+        from lilbee.models import ensure_tag
+
+        model = ensure_tag(model)
+    setattr(cfg, field, model)
+    settings.set_value(cfg.data_root, field, model)
+    return {"model": model}
+
+
 async def set_chat_model(model: str) -> dict[str, str]:
     """Switch active chat model. Returns {model}."""
-    from lilbee.models import ensure_tag
-
-    tagged = ensure_tag(model)
-    cfg.chat_model = tagged
-    settings.set_value(cfg.data_root, "chat_model", tagged)
-    return {"model": tagged}
+    return await _set_model("chat_model", model, normalize=True)
 
 
 async def set_vision_model(model: str) -> dict[str, str]:
     """Switch active vision model. Pass empty string to disable. Returns {model}."""
-    cfg.vision_model = model
-    settings.set_value(cfg.data_root, "vision_model", model)
-    return {"model": model}
+    return await _set_model("vision_model", model)
+
+
+async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
+    """Partial update of writable config fields. Returns updated keys + reindex flag.
+
+    Validates all fields before applying any, so a bad field in a multi-field
+    PATCH won't leave config in a partially-updated state.
+    """
+    # Phase 1: validate all keys and values before mutating anything.
+    for key, value in updates.items():
+        if key not in WRITABLE_CONFIG_FIELDS:
+            raise ValueError(f"Unknown or read-only config field: {key}")
+        nullable = WRITABLE_CONFIG_FIELDS[key]
+        if value is None and not nullable:
+            raise ValueError(f"Field '{key}' does not accept null")
+
+    # Phase 2: apply — all keys are known-valid, apply and persist.
+    updated = []
+    for key, value in updates.items():
+        nullable = WRITABLE_CONFIG_FIELDS[key]
+        if value is None and nullable:
+            settings.delete_value(cfg.data_root, key)
+            setattr(cfg, key, None)
+        else:
+            setattr(cfg, key, value)  # pydantic validates type
+            settings.set_value(cfg.data_root, key, str(value))
+        updated.append(key)
+    reindex_required = bool(REINDEX_FIELDS & set(updated))
+    return {"updated": updated, "reindex_required": reindex_required}
+
+
+async def set_embedding_model(model: str) -> dict[str, str]:
+    """Switch embedding model. Same pattern as set_chat_model."""
+    return await _set_model("embedding_model", model)
 
 
 async def delete_documents(names: list[str], *, delete_files: bool = False) -> dict[str, Any]:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -10,15 +10,17 @@ import asyncio
 import json
 import logging
 import threading
+import types
 from collections.abc import AsyncGenerator, Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, Union, cast, get_args, get_origin
 
 from pydantic import BaseModel
+from pydantic.fields import FieldInfo
 
 from lilbee import settings
 from lilbee.cli.helpers import clean_result, copy_files, gather_status, get_version
-from lilbee.config import cfg
+from lilbee.config import Config, cfg
 from lilbee.progress import DetailedProgressCallback, EventType, SseEvent
 from lilbee.results import group, to_dicts
 from lilbee.security import validate_path_within
@@ -31,81 +33,51 @@ log = logging.getLogger(__name__)
 
 MAX_ADD_FILES = 100
 
-_PUBLIC_CONFIG_FIELDS: frozenset[str] = frozenset(
-    {
+
+# ---------------------------------------------------------------------------
+# Helpers for deriving field sets from Config metadata
+# ---------------------------------------------------------------------------
+
+
+def _get_extra(info: FieldInfo, key: str, default: bool = False) -> bool:
+    """Read a boolean flag from a field's ``json_schema_extra``."""
+    extra = info.json_schema_extra
+    if isinstance(extra, dict):
+        return bool(extra.get(key, default))
+    return default
+
+
+def _is_nullable(info: FieldInfo) -> bool:
+    """Return True if ``None`` is part of the field's type union."""
+    origin = get_origin(info.annotation)
+    if origin is Union or origin is types.UnionType:
+        return type(None) in get_args(info.annotation)
+    return False
+
+
+# Derive WRITABLE_CONFIG_FIELDS, REINDEX_FIELDS, _PUBLIC_CONFIG_FIELDS from metadata
+_writable: dict[str, bool] = {}
+_reindex: set[str] = set()
+_public: set[str] = set()
+
+for _name, _info in Config.model_fields.items():
+    if _get_extra(_info, "writable"):
+        _writable[_name] = _is_nullable(_info)
+        if not _get_extra(_info, "write_only") and _get_extra(_info, "public", default=True):
+            _public.add(_name)
+        if _get_extra(_info, "reindex"):
+            _reindex.add(_name)
+    elif _name in {
         "chat_model",
         "embedding_model",
         "vision_model",
-        "litellm_base_url",
-        "system_prompt",
-        "top_k",
-        "max_distance",
-        "chunk_size",
-        "chunk_overlap",
-        "temperature",
-        "top_p",
-        "top_k_sampling",
-        "repeat_penalty",
-        "num_ctx",
-        "seed",
-        "llm_provider",
-        "diversity_max_per_source",
-        "mmr_lambda",
-        "candidate_multiplier",
-        "query_expansion_count",
-        "adaptive_threshold_step",
-        "show_reasoning",
-        "crawl_max_depth",
-        "crawl_max_pages",
-        "crawl_timeout",
-        "crawl_sync_interval",
-        "max_context_sources",
-        "hyde",
-        "hyde_weight",
-        "temporal_filtering",
-        "concept_graph",
-        "concept_boost_weight",
-        "concept_max_per_chunk",
-    }
-)
+    }:
+        # Model fields are public but not directly writable via update_config
+        _public.add(_name)
 
-WRITABLE_CONFIG_FIELDS: dict[str, bool] = {
-    # bool value = nullable (True means null resets to model default)
-    "temperature": True,
-    "top_p": True,
-    "top_k_sampling": True,
-    "repeat_penalty": True,
-    "num_ctx": True,
-    "seed": True,
-    "system_prompt": False,
-    "show_reasoning": False,
-    "top_k": False,
-    "max_distance": False,
-    "diversity_max_per_source": False,
-    "mmr_lambda": False,
-    "candidate_multiplier": False,
-    "query_expansion_count": False,
-    "adaptive_threshold_step": False,
-    "max_context_sources": False,
-    "hyde": False,
-    "hyde_weight": False,
-    "temporal_filtering": False,
-    "reranker_model": False,
-    "rerank_candidates": False,
-    "chunk_size": False,
-    "chunk_overlap": False,
-    "crawl_max_depth": False,
-    "crawl_max_pages": False,
-    "crawl_timeout": False,
-    "crawl_sync_interval": False,
-    "concept_graph": False,
-    "concept_boost_weight": False,
-    "concept_max_per_chunk": False,
-    "llm_provider": False,
-    "litellm_base_url": False,
-    "llm_api_key": False,
-}
-REINDEX_FIELDS: frozenset[str] = frozenset({"chunk_size", "chunk_overlap"})
+WRITABLE_CONFIG_FIELDS: types.MappingProxyType[str, bool] = types.MappingProxyType(_writable)
+REINDEX_FIELDS: frozenset[str] = frozenset(_reindex)
+_PUBLIC_CONFIG_FIELDS: frozenset[str] = frozenset(_public)
 
 
 class ModelCatalogEntry(BaseModel):
@@ -507,17 +479,29 @@ async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
         if value is None and not nullable:
             raise ValueError(f"Field '{key}' does not accept null")
 
-    # Phase 2: apply — all keys are known-valid, apply and persist.
-    updated = []
-    for key, value in updates.items():
-        nullable = WRITABLE_CONFIG_FIELDS[key]
-        if value is None and nullable:
-            settings.delete_value(cfg.data_root, key)
-            setattr(cfg, key, None)
-        else:
-            setattr(cfg, key, value)  # pydantic validates type
-            settings.set_value(cfg.data_root, key, str(value))
-        updated.append(key)
+    # Phase 2: apply with snapshot/rollback (S2) and batch persistence (S4).
+    snapshot = {k: getattr(cfg, k) for k in updates}
+    updated: list[str] = []
+    to_persist: dict[str, str] = {}
+    to_delete: list[str] = []
+    try:
+        for key, value in updates.items():
+            nullable = WRITABLE_CONFIG_FIELDS[key]
+            if value is None and nullable:
+                setattr(cfg, key, None)
+                to_delete.append(key)
+            else:
+                setattr(cfg, key, value)  # pydantic validates type
+                to_persist[key] = str(getattr(cfg, key))  # coerced value (S3)
+            updated.append(key)
+    except Exception:
+        for k, v in snapshot.items():
+            setattr(cfg, k, v)
+        raise
+    if to_persist:
+        settings.update_values(cfg.data_root, to_persist)
+    if to_delete:
+        settings.delete_values(cfg.data_root, to_delete)
     reindex_required = bool(REINDEX_FIELDS & set(updated))
     return {"updated": updated, "reindex_required": reindex_required}
 

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -462,44 +462,65 @@ async def set_embedding_model(model: str) -> dict[str, str]:
     return await _set_model("embedding_model", model)
 
 
-async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
-    """Partial update of writable config fields. Returns updated keys + reindex flag.
-
-    Validates all fields before applying any, so a bad field in a multi-field
-    PATCH won't leave config in a partially-updated state.
-    """
+def _validate_config_updates(updates: dict[str, Any]) -> None:
+    """Reject unknown fields and null values on non-nullable fields."""
     for key, value in updates.items():
         if key not in WRITABLE_CONFIG_FIELDS:
             raise ValueError(f"Unknown or read-only config field: {key}")
-        nullable = WRITABLE_CONFIG_FIELDS[key]
-        if value is None and not nullable:
+        if value is None and not WRITABLE_CONFIG_FIELDS[key]:
             raise ValueError(f"Field '{key}' does not accept null")
 
-    # Apply with snapshot for rollback on type errors.
+
+def _apply_config_updates(updates: dict[str, Any]) -> tuple[dict[str, str], list[str]]:
+    """Apply updates to the in-memory config, rolling back on error.
+
+    Returns (fields_to_persist, fields_to_delete) for disk write.
+    """
     snapshot = {k: getattr(cfg, k) for k in updates}
-    updated: list[str] = []
     to_persist: dict[str, str] = {}
     to_delete: list[str] = []
     try:
         for key, value in updates.items():
-            nullable = WRITABLE_CONFIG_FIELDS[key]
-            if value is None and nullable:
+            if value is None:
                 setattr(cfg, key, None)
                 to_delete.append(key)
             else:
-                setattr(cfg, key, value)  # pydantic validates type
+                setattr(cfg, key, value)
                 to_persist[key] = str(getattr(cfg, key))
-            updated.append(key)
     except Exception:
         for k, v in snapshot.items():
             setattr(cfg, k, v)
         raise
+    return to_persist, to_delete
+
+
+async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
+    """Partial update of writable config fields. Returns updated keys + reindex flag.
+
+    Algorithm: validate-then-apply with rollback.
+
+    1. Validate all keys and null-acceptability upfront (no mutations yet).
+       This catches typos and bad input before anything changes.
+    2. Snapshot current values, then apply each update via setattr (pydantic's
+       validate_assignment catches type errors). If any field fails type
+       validation, roll back ALL fields from the snapshot so the config
+       stays consistent — no half-applied updates.
+    3. Persist to disk in batch (one file write for sets, one for deletes)
+       rather than per-field, avoiding partial writes on crash.
+
+    Why not just setattr-and-save per field? A multi-field PATCH like
+    {"chunk_size": 1024, "chunk_overlap": "bad"} would leave chunk_size
+    changed but chunk_overlap unchanged — the caller gets an error but
+    the config is silently modified. The snapshot/rollback prevents that.
+    """
+    _validate_config_updates(updates)
+    to_persist, to_delete = _apply_config_updates(updates)
     if to_persist:
         settings.update_values(cfg.data_root, to_persist)
     if to_delete:
         settings.delete_values(cfg.data_root, to_delete)
-    reindex_required = bool(REINDEX_FIELDS & set(updated))
-    return {"updated": updated, "reindex_required": reindex_required}
+    reindex_required = bool(REINDEX_FIELDS & set(updates))
+    return {"updated": list(updates), "reindex_required": reindex_required}
 
 
 async def delete_documents(names: list[str], *, delete_files: bool = False) -> dict[str, Any]:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -34,11 +34,6 @@ log = logging.getLogger(__name__)
 MAX_ADD_FILES = 100
 
 
-# ---------------------------------------------------------------------------
-# Helpers for deriving field sets from Config metadata
-# ---------------------------------------------------------------------------
-
-
 def _get_extra(info: FieldInfo, key: str, default: bool = False) -> bool:
     """Read a boolean flag from a field's ``json_schema_extra``."""
     extra = info.json_schema_extra
@@ -55,29 +50,26 @@ def _is_nullable(info: FieldInfo) -> bool:
     return False
 
 
-# Derive WRITABLE_CONFIG_FIELDS, REINDEX_FIELDS, _PUBLIC_CONFIG_FIELDS from metadata
-_writable: dict[str, bool] = {}
-_reindex: set[str] = set()
-_public: set[str] = set()
+def _derive_field_sets() -> tuple[
+    types.MappingProxyType[str, bool], frozenset[str], frozenset[str]
+]:
+    """Derive writable, reindex, and public field sets from Config metadata."""
+    writable: dict[str, bool] = {}
+    reindex: set[str] = set()
+    public: set[str] = set()
+    for name, info in Config.model_fields.items():
+        if _get_extra(info, "writable"):
+            writable[name] = _is_nullable(info)
+            if not _get_extra(info, "write_only") and _get_extra(info, "public", default=True):
+                public.add(name)
+            if _get_extra(info, "reindex"):
+                reindex.add(name)
+        elif name in {"chat_model", "embedding_model", "vision_model"}:
+            public.add(name)
+    return types.MappingProxyType(writable), frozenset(reindex), frozenset(public)
 
-for _name, _info in Config.model_fields.items():
-    if _get_extra(_info, "writable"):
-        _writable[_name] = _is_nullable(_info)
-        if not _get_extra(_info, "write_only") and _get_extra(_info, "public", default=True):
-            _public.add(_name)
-        if _get_extra(_info, "reindex"):
-            _reindex.add(_name)
-    elif _name in {
-        "chat_model",
-        "embedding_model",
-        "vision_model",
-    }:
-        # Model fields are public but not directly writable via update_config
-        _public.add(_name)
 
-WRITABLE_CONFIG_FIELDS: types.MappingProxyType[str, bool] = types.MappingProxyType(_writable)
-REINDEX_FIELDS: frozenset[str] = frozenset(_reindex)
-_PUBLIC_CONFIG_FIELDS: frozenset[str] = frozenset(_public)
+WRITABLE_CONFIG_FIELDS, REINDEX_FIELDS, _PUBLIC_CONFIG_FIELDS = _derive_field_sets()
 
 
 class ModelCatalogEntry(BaseModel):
@@ -465,13 +457,17 @@ async def set_vision_model(model: str) -> dict[str, str]:
     return await _set_model("vision_model", model)
 
 
+async def set_embedding_model(model: str) -> dict[str, str]:
+    """Switch embedding model. Returns {model}."""
+    return await _set_model("embedding_model", model)
+
+
 async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
     """Partial update of writable config fields. Returns updated keys + reindex flag.
 
     Validates all fields before applying any, so a bad field in a multi-field
     PATCH won't leave config in a partially-updated state.
     """
-    # Phase 1: validate all keys and values before mutating anything.
     for key, value in updates.items():
         if key not in WRITABLE_CONFIG_FIELDS:
             raise ValueError(f"Unknown or read-only config field: {key}")
@@ -479,7 +475,7 @@ async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
         if value is None and not nullable:
             raise ValueError(f"Field '{key}' does not accept null")
 
-    # Phase 2: apply with snapshot/rollback (S2) and batch persistence (S4).
+    # Apply with snapshot for rollback on type errors.
     snapshot = {k: getattr(cfg, k) for k in updates}
     updated: list[str] = []
     to_persist: dict[str, str] = {}
@@ -492,7 +488,7 @@ async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
                 to_delete.append(key)
             else:
                 setattr(cfg, key, value)  # pydantic validates type
-                to_persist[key] = str(getattr(cfg, key))  # coerced value (S3)
+                to_persist[key] = str(getattr(cfg, key))
             updated.append(key)
     except Exception:
         for k, v in snapshot.items():
@@ -504,11 +500,6 @@ async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
         settings.delete_values(cfg.data_root, to_delete)
     reindex_required = bool(REINDEX_FIELDS & set(updated))
     return {"updated": updated, "reindex_required": reindex_required}
-
-
-async def set_embedding_model(model: str) -> dict[str, str]:
-    """Switch embedding model. Same pattern as set_chat_model."""
-    return await _set_model("embedding_model", model)
 
 
 async def delete_documents(names: list[str], *, delete_files: bool = False) -> dict[str, Any]:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -24,6 +24,7 @@ from lilbee.config import Config, cfg
 from lilbee.progress import DetailedProgressCallback, EventType, SseEvent
 from lilbee.results import group, to_dicts
 from lilbee.security import validate_path_within
+from lilbee.server.models import ConfigUpdateResponse
 
 if TYPE_CHECKING:
     from lilbee.model_manager import ModelSource
@@ -494,8 +495,8 @@ def _apply_config_updates(updates: dict[str, Any]) -> tuple[dict[str, str], list
     return to_persist, to_delete
 
 
-async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
-    """Partial update of writable config fields. Returns updated keys + reindex flag.
+async def update_config(updates: dict[str, Any]) -> ConfigUpdateResponse:
+    """Partial update of writable config fields.
 
     Algorithm: validate-then-apply with rollback.
 
@@ -520,7 +521,7 @@ async def update_config(updates: dict[str, Any]) -> dict[str, Any]:
     if to_delete:
         settings.delete_values(cfg.data_root, to_delete)
     reindex_required = bool(REINDEX_FIELDS & set(updates))
-    return {"updated": list(updates), "reindex_required": reindex_required}
+    return ConfigUpdateResponse(updated=list(updates), reindex_required=reindex_required)
 
 
 async def delete_documents(names: list[str], *, delete_files: bool = False) -> dict[str, Any]:

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -89,6 +89,13 @@ class SetModelResponse(BaseModel):
     model: str
 
 
+class ConfigUpdateResponse(BaseModel):
+    """Response for PATCH /api/config."""
+
+    updated: list[str]
+    reindex_required: bool
+
+
 class CrawlRequest(BaseModel):
     """Request body for /api/crawl."""
 

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from litestar import get
+from litestar import get, patch
+from pydantic import ValidationError
 
 from lilbee.server.auth import read_only
 from lilbee.server.models import HealthResponse
@@ -36,3 +37,16 @@ async def config_route() -> dict[str, Any]:
     from lilbee.server import handlers
 
     return await handlers.get_config()
+
+
+@patch("/api/config")
+async def config_update_route(data: dict[str, Any]) -> dict[str, Any]:
+    """Partial update of writable configuration fields."""
+    from lilbee.server import handlers
+
+    try:
+        return await handlers.update_config(data)
+    except (ValueError, ValidationError) as exc:
+        from litestar.exceptions import ValidationException
+
+        raise ValidationException(str(exc)) from exc

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -8,7 +8,7 @@ from litestar import get, patch
 from pydantic import ValidationError
 
 from lilbee.server.auth import read_only
-from lilbee.server.models import HealthResponse
+from lilbee.server.models import ConfigUpdateResponse, HealthResponse
 
 
 @get("/api/health")
@@ -40,7 +40,7 @@ async def config_route() -> dict[str, Any]:
 
 
 @patch("/api/config")
-async def config_update_route(data: dict[str, Any]) -> dict[str, Any]:
+async def config_update_route(data: dict[str, Any]) -> ConfigUpdateResponse:
     """Partial update of writable configuration fields."""
     from lilbee.server import handlers
 

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -42,6 +42,13 @@ async def models_set_vision_route(data: SetModelRequest) -> SetModelResponse:
     return SetModelResponse(**raw)
 
 
+@put("/api/models/embedding")
+async def models_set_embedding_route(data: SetModelRequest) -> SetModelResponse:
+    """Switch the active embedding model."""
+    raw = await handlers.set_embedding_model(model=data.model)
+    return SetModelResponse(**raw)
+
+
 @get("/api/models/catalog")
 @read_only
 async def models_catalog_route(

--- a/src/lilbee/settings.py
+++ b/src/lilbee/settings.py
@@ -1,5 +1,6 @@
 """Persistent settings stored in config.toml alongside the data directory."""
 
+import sys
 import threading
 import tomllib
 from pathlib import Path
@@ -39,6 +40,8 @@ def save(data_root: Path, settings: dict[str, str]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = [f'{k} = "{_escape_toml_string(v)}"\n' for k, v in sorted(settings.items())]
     path.write_text("".join(lines))
+    if sys.platform != "win32":
+        path.chmod(0o600)
 
 
 def get(data_root: Path, key: str) -> str | None:
@@ -59,4 +62,21 @@ def delete_value(data_root: Path, key: str) -> None:
     with _settings_lock:
         current = load(data_root)
         current.pop(key, None)
+        save(data_root, current)
+
+
+def update_values(data_root: Path, updates: dict[str, str]) -> None:
+    """Batch update multiple keys in config.toml (single write)."""
+    with _settings_lock:
+        current = load(data_root)
+        current.update(updates)
+        save(data_root, current)
+
+
+def delete_values(data_root: Path, keys: list[str]) -> None:
+    """Batch delete multiple keys from config.toml (single write)."""
+    with _settings_lock:
+        current = load(data_root)
+        for key in keys:
+            current.pop(key, None)
         save(data_root, current)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -677,19 +677,19 @@ class TestDeleteDocuments:
 class TestUpdateConfig:
     async def test_update_config_valid(self, tmp_path):
         result = await handlers.update_config({"temperature": 0.7})
-        assert result["updated"] == ["temperature"]
-        assert result["reindex_required"] is False
+        assert result.updated == ["temperature"]
+        assert result.reindex_required is False
         assert cfg.temperature == 0.7
 
     async def test_update_config_reindex(self, tmp_path):
         result = await handlers.update_config({"chunk_size": 1024})
-        assert result["reindex_required"] is True
+        assert result.reindex_required is True
         assert cfg.chunk_size == 1024
 
     async def test_update_config_null_reset(self, tmp_path):
         cfg.temperature = 0.5
         result = await handlers.update_config({"temperature": None})
-        assert result["updated"] == ["temperature"]
+        assert result.updated == ["temperature"]
         assert cfg.temperature is None
         # Verify delete_value was called (file should not contain temperature)
         from lilbee import settings as s
@@ -707,7 +707,8 @@ class TestUpdateConfig:
 
     async def test_empty_dict_returns_no_updates(self):
         result = await handlers.update_config({})
-        assert result == {"updated": [], "reindex_required": False}
+        assert result.updated == []
+        assert result.reindex_required is False
 
     async def test_invalid_type_raises(self):
         from pydantic import ValidationError
@@ -718,7 +719,7 @@ class TestUpdateConfig:
     async def test_llm_api_key_write_only(self, tmp_path):
         """llm_api_key can be written via PATCH but is excluded from GET."""
         result = await handlers.update_config({"llm_api_key": "sk-test123"})
-        assert result["updated"] == ["llm_api_key"]
+        assert result.updated == ["llm_api_key"]
         assert cfg.llm_api_key == "sk-test123"
         # Verify it's excluded from GET /api/config
         config = await handlers.get_config()
@@ -735,8 +736,8 @@ class TestUpdateConfig:
     async def test_multi_field_success(self, tmp_path):
         """Multiple valid fields are applied and persisted in one call."""
         result = await handlers.update_config({"temperature": 0.7, "top_k": 5})
-        assert set(result["updated"]) == {"temperature", "top_k"}
-        assert result["reindex_required"] is False
+        assert set(result.updated) == {"temperature", "top_k"}
+        assert result.reindex_required is False
         assert cfg.temperature == 0.7
         assert cfg.top_k == 5
         # Verify both persisted

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -674,6 +674,82 @@ class TestDeleteDocuments:
         assert not f.exists()
 
 
+class TestUpdateConfig:
+    async def test_update_config_valid(self, tmp_path):
+        result = await handlers.update_config({"temperature": 0.7})
+        assert result["updated"] == ["temperature"]
+        assert result["reindex_required"] is False
+        assert cfg.temperature == 0.7
+
+    async def test_update_config_reindex(self, tmp_path):
+        result = await handlers.update_config({"chunk_size": 1024})
+        assert result["reindex_required"] is True
+        assert cfg.chunk_size == 1024
+
+    async def test_update_config_null_reset(self, tmp_path):
+        cfg.temperature = 0.5
+        result = await handlers.update_config({"temperature": None})
+        assert result["updated"] == ["temperature"]
+        assert cfg.temperature is None
+        # Verify delete_value was called (file should not contain temperature)
+        from lilbee import settings as s
+
+        stored = s.load(cfg.data_root)
+        assert "temperature" not in stored
+
+    async def test_update_config_unknown_field(self):
+        with pytest.raises(ValueError, match="Unknown or read-only config field"):
+            await handlers.update_config({"bogus_field": 123})
+
+    async def test_non_nullable_field_rejects_null(self):
+        with pytest.raises(ValueError, match="does not accept null"):
+            await handlers.update_config({"system_prompt": None})
+
+    async def test_empty_dict_returns_no_updates(self):
+        result = await handlers.update_config({})
+        assert result == {"updated": [], "reindex_required": False}
+
+    async def test_invalid_type_raises(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            await handlers.update_config({"chunk_size": "not_a_number"})
+
+    async def test_llm_api_key_write_only(self, tmp_path):
+        """llm_api_key can be written via PATCH but is excluded from GET."""
+        result = await handlers.update_config({"llm_api_key": "sk-test123"})
+        assert result["updated"] == ["llm_api_key"]
+        assert cfg.llm_api_key == "sk-test123"
+        # Verify it's excluded from GET /api/config
+        config = await handlers.get_config()
+        assert "llm_api_key" not in config
+
+    async def test_multi_field_bad_second_no_partial_apply(self):
+        """If second field is invalid, first field should NOT be applied."""
+        original_temp = cfg.temperature
+        with pytest.raises(ValueError, match="does not accept null"):
+            await handlers.update_config({"temperature": 0.9, "system_prompt": None})
+        # temperature should be unchanged — validation happens before apply
+        assert cfg.temperature == original_temp
+
+
+class TestSetEmbeddingModel:
+    async def test_updates_config_and_persists(self, tmp_path):
+        result = await handlers.set_embedding_model("nomic-embed-text:latest")
+        assert result["model"] == "nomic-embed-text:latest"
+        assert cfg.embedding_model == "nomic-embed-text:latest"
+        from lilbee import settings as s
+
+        stored = s.load(cfg.data_root)
+        assert stored["embedding_model"] == "nomic-embed-text:latest"
+
+    async def test_empty_string_rejected(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            await handlers.set_embedding_model("")
+
+
 class TestGetConfig:
     async def test_returns_all_config_keys(self):
         result = await handlers.get_config()
@@ -685,6 +761,14 @@ class TestGetConfig:
         assert "query_expansion_count" in result
         assert "adaptive_threshold_step" in result
         assert "temperature" in result
+        assert "max_context_sources" in result
+        assert "hyde" in result
+        assert "hyde_weight" in result
+        assert "temporal_filtering" in result
+        assert "concept_graph" in result
+        assert "concept_boost_weight" in result
+        assert "concept_max_per_chunk" in result
+        assert "llm_api_key" not in result
 
 
 class TestListDocuments:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -732,6 +732,20 @@ class TestUpdateConfig:
         # temperature should be unchanged — validation happens before apply
         assert cfg.temperature == original_temp
 
+    async def test_multi_field_success(self, tmp_path):
+        """Multiple valid fields are applied and persisted in one call."""
+        result = await handlers.update_config({"temperature": 0.7, "top_k": 5})
+        assert set(result["updated"]) == {"temperature", "top_k"}
+        assert result["reindex_required"] is False
+        assert cfg.temperature == 0.7
+        assert cfg.top_k == 5
+        # Verify both persisted
+        from lilbee import settings as s
+
+        stored = s.load(cfg.data_root)
+        assert stored["temperature"] == "0.7"
+        assert stored["top_k"] == "5"
+
 
 class TestSetEmbeddingModel:
     async def test_updates_config_and_persists(self, tmp_path):
@@ -748,6 +762,12 @@ class TestSetEmbeddingModel:
 
         with pytest.raises(ValidationError):
             await handlers.set_embedding_model("")
+
+    async def test_embedding_model_without_tag(self, tmp_path):
+        """Setting embedding model without a tag stores it as-is (no :latest append)."""
+        result = await handlers.set_embedding_model("nomic-embed-text")
+        assert result["model"] == "nomic-embed-text"
+        assert cfg.embedding_model == "nomic-embed-text"
 
 
 class TestGetConfig:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -306,6 +306,63 @@ class TestConfigRoute:
         assert "system_prompt" in resp.json()
 
 
+class TestConfigUpdateRoute:
+    @mock.patch(
+        "lilbee.server.handlers.update_config",
+        new_callable=AsyncMock,
+        return_value={"updated": ["temperature"], "reindex_required": False},
+    )
+    def test_returns_json(self, mock_update, client):
+        resp = client.patch("/api/config", json={"temperature": 0.7})
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == ["temperature"]
+
+    @mock.patch(
+        "lilbee.server.handlers.update_config",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Unknown or read-only config field: bogus"),
+    )
+    def test_unknown_field_returns_error(self, mock_update, client):
+        resp = client.patch("/api/config", json={"bogus": 1})
+        assert resp.status_code == 400
+
+    def test_pydantic_validation_error_returns_400(self, client):
+        from pydantic import ValidationError
+
+        @mock.patch(
+            "lilbee.server.handlers.update_config",
+            new_callable=AsyncMock,
+            side_effect=ValidationError.from_exception_data(
+                "Config",
+                [
+                    {
+                        "type": "int_parsing",
+                        "loc": ("chunk_size",),
+                        "msg": "Input should be a valid integer",
+                        "input": "not_a_number",
+                    }
+                ],
+            ),
+        )
+        def _inner(mock_update):
+            resp = client.patch("/api/config", json={"chunk_size": "not_a_number"})
+            assert resp.status_code == 400
+
+        _inner()
+
+
+class TestModelsSetEmbeddingRoute:
+    @mock.patch(
+        "lilbee.server.handlers.set_embedding_model",
+        new_callable=AsyncMock,
+        return_value={"model": "nomic-embed-text:latest"},
+    )
+    def test_returns_model(self, mock_set, client):
+        resp = client.put("/api/models/embedding", json={"model": "nomic-embed-text:latest"})
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "nomic-embed-text:latest"
+
+
 class TestDocumentsListRoute:
     @mock.patch(
         "lilbee.server.handlers.list_documents",
@@ -552,3 +609,25 @@ class TestAuthMiddleware:
                 await middleware(scope, AsyncMock(), AsyncMock())
         finally:
             auth_mod._session_token = old
+
+
+class TestAuthRequiredRoutes:
+    """Verify mutating endpoints return 401 without a valid bearer token."""
+
+    @pytest.fixture()
+    def auth_client(self):
+        import lilbee.server.auth as auth_mod
+        from lilbee.server.app import create_app
+
+        auth_mod._session_token = "test-secret"
+        app = create_app()
+        yield TestClient(app)
+        auth_mod._session_token = None
+
+    def test_patch_config_requires_auth(self, auth_client):
+        resp = auth_client.patch("/api/config", json={"temperature": 0.5})
+        assert resp.status_code == 401
+
+    def test_put_models_embedding_requires_auth(self, auth_client):
+        resp = auth_client.put("/api/models/embedding", json={"model": "nomic-embed-text:latest"})
+        assert resp.status_code == 401


### PR DESCRIPTION
Adds two new endpoints so  consumers can update server config and switch embedding models.

**PATCH /api/config** — partial config updates.

**PUT /api/models/embedding** — switch the active embedding model, same pattern as the existing chat/vision endpoints.
