### PR TITLE
feat: model management v2 — GGUF metadata, huggingface_hub downloads

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -20,7 +20,6 @@ from lilbee.config import cfg
 log = logging.getLogger(__name__)
 
 HF_API_URL = "https://huggingface.co/api/models"
-HF_DOWNLOAD_URL = "https://huggingface.co/{repo}/resolve/main/{filename}"
 _DEFAULT_TIMEOUT = 30.0
 
 
@@ -144,12 +143,14 @@ _SIZE_RANGES: dict[str, tuple[float, float]] = {
 }
 
 
-def _hf_headers() -> dict[str, str]:
-    """Build HTTP headers for HuggingFace API requests.
+def _hf_token() -> str | None:
+    """Read HuggingFace token from LILBEE_HF_TOKEN or HF_TOKEN env vars."""
+    return os.environ.get("LILBEE_HF_TOKEN") or os.environ.get("HF_TOKEN") or None
 
-    Reads token from LILBEE_HF_TOKEN or HF_TOKEN env vars.
-    """
-    token = os.environ.get("LILBEE_HF_TOKEN") or os.environ.get("HF_TOKEN")
+
+def _hf_headers() -> dict[str, str]:
+    """Build HTTP headers for HuggingFace API requests."""
+    token = _hf_token()
     if token:
         return {"Authorization": f"Bearer {token}"}
     return {}
@@ -185,9 +186,7 @@ def _fetch_hf_models(
         "limit": limit,
     }
     try:
-        resp = httpx.get(
-            HF_API_URL, params=params, timeout=_DEFAULT_TIMEOUT, headers=_hf_headers()
-        )
+        resp = httpx.get(HF_API_URL, params=params, timeout=_DEFAULT_TIMEOUT, headers=_hf_headers())
         if resp.status_code >= 400:
             log.warning("HuggingFace API returned HTTP %d", resp.status_code)
             return []
@@ -364,51 +363,63 @@ def find_catalog_entry(name: str) -> CatalogModel | None:
     return None
 
 
+def _make_progress_tqdm(callback: Any) -> type:
+    """Create a tqdm-compatible class that routes progress to a callback.
+
+    The callback receives (downloaded_bytes, total_bytes).
+    """
+    from tqdm import tqdm
+
+    class _ProgressTqdm(tqdm):  # type: ignore[type-arg]
+        def update(self, n: int = 1) -> bool | None:
+            result: bool | None = super().update(n)
+            if callback and self.total and self.total > 0:
+                callback(self.n, self.total)
+            return result
+
+    return _ProgressTqdm
+
+
 def download_model(entry: CatalogModel, *, on_progress: Any = None) -> Path:
-    """Download a GGUF model from HuggingFace to cfg.models_dir."""
+    """Download a GGUF model from HuggingFace to cfg.models_dir.
+
+    Uses huggingface_hub for resumable downloads, caching, and auth.
+    The optional *on_progress(downloaded, total)* callback receives byte counts.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
+
     cfg.models_dir.mkdir(parents=True, exist_ok=True)
 
-    # Resolve the filename pattern to an actual file
     filename = _resolve_filename(entry)
     dest = cfg.models_dir / filename
-
     if dest.exists():
         log.info("Model already downloaded: %s", dest)
         return dest
 
-    url = HF_DOWNLOAD_URL.format(repo=entry.hf_repo, filename=filename)
-    log.info("Downloading %s → %s", url, dest)
+    log.info("Downloading %s/%s → %s", entry.hf_repo, filename, cfg.models_dir)
+    token = _hf_token()
 
-    import tempfile
+    kwargs: dict[str, Any] = {
+        "repo_id": entry.hf_repo,
+        "filename": filename,
+        "local_dir": cfg.models_dir,
+        "token": token,
+    }
+    if on_progress is not None:
+        kwargs["tqdm_class"] = _make_progress_tqdm(on_progress)
 
-    tmp_name: str | None = None
     try:
-        with tempfile.NamedTemporaryFile(dir=dest.parent, suffix=".tmp", delete=False) as tmp_file:
-            tmp_name = tmp_file.name
-            headers = _hf_headers()
-            with httpx.stream(
-                "GET", url, timeout=None, follow_redirects=True, headers=headers
-            ) as resp:
-                if resp.status_code == 401:
-                    raise PermissionError(
-                        f"{entry.name} requires HuggingFace authentication. "
-                        "Set HF_TOKEN env var or visit the repo page to request access."
-                    )
-                resp.raise_for_status()
-                total = int(resp.headers.get("content-length", 0))
-                downloaded = 0
-                for chunk in resp.iter_bytes(chunk_size=8192):
-                    tmp_file.write(chunk)
-                    downloaded += len(chunk)
-                    if on_progress and total > 0:
-                        on_progress(downloaded, total)
-        Path(tmp_name).replace(dest)
-    except BaseException:
-        if tmp_name is not None:
-            Path(tmp_name).unlink(missing_ok=True)
-        raise
+        path = hf_hub_download(**kwargs)
+    except GatedRepoError:
+        raise PermissionError(
+            f"{entry.name} requires HuggingFace authentication. "
+            "Set HF_TOKEN env var or visit the repo page to request access."
+        ) from None
+    except RepositoryNotFoundError:
+        raise RuntimeError(f"Repository {entry.hf_repo!r} not found on HuggingFace.") from None
 
-    return dest
+    return Path(path)
 
 
 _QUANT_PREFERENCE = ("Q4_K_M", "Q4_K_S", "Q5_K_M", "Q5_K_S", "Q8_0", "Q6_K", "Q3_K_M")

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -131,10 +131,8 @@ class SetupWizard(Screen[str | None]):
                     pct = int(downloaded * 100 / total)
                     self.app.call_from_thread(self._update_progress, pct)
 
-            download_model(model, on_progress=_on_progress)
-            self.app.call_from_thread(
-                self._on_download_complete, model.gguf_filename.rsplit(".", 1)[0]
-            )
+            dest = download_model(model, on_progress=_on_progress)
+            self.app.call_from_thread(self._on_download_complete, dest.stem)
         except Exception as exc:
             log.warning("Download failed for %s", model.name, exc_info=True)
             error_msg = str(exc)

--- a/src/lilbee/embedder.py
+++ b/src/lilbee/embedder.py
@@ -46,12 +46,14 @@ class Embedder:
         return self.embedding_available()
 
     def embedding_available(self) -> bool:
-        """Return True if the embedding model can be resolved."""
+        """Return True if the embedding model can be resolved by the active provider."""
+        model = self._config.embedding_model
+        if not model:
+            return False
         try:
-            from lilbee.providers.llama_cpp_provider import _resolve_model_path
-
-            _resolve_model_path(self._config.embedding_model)
-            return True
+            available = self._provider.list_models()
+            model_base = model.split(":")[0].lower()
+            return any(model_base in m.lower() for m in available)
         except Exception:
             return False
 

--- a/src/lilbee/embedder.py
+++ b/src/lilbee/embedder.py
@@ -55,6 +55,7 @@ class Embedder:
             model_base = model.split(":")[0].lower()
             return any(model_base in m.lower() for m in available)
         except Exception:
+            log.debug("embedding_available check failed", exc_info=True)
             return False
 
     def embed(self, text: str) -> list[float]:

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -465,6 +465,10 @@ async def _rebuild_concept_clusters() -> None:
     """Re-run Leiden clustering after sync. No-op if disabled."""
     if not cfg.concept_graph:
         return
+    from lilbee.concepts import concepts_available
+
+    if not concepts_available():
+        return
     try:
         from lilbee.services import get_services
 
@@ -479,6 +483,10 @@ async def _rebuild_concept_clusters() -> None:
 async def _index_concepts(records: list[ChunkRecord], source_name: str) -> None:
     """Extract and index concepts for ingested chunks. No-op if disabled."""
     if not cfg.concept_graph or not records:
+        return
+    from lilbee.concepts import concepts_available
+
+    if not concepts_available():
         return
     try:
         from lilbee.services import get_services

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -247,7 +247,7 @@ def _read_gguf_metadata(model_path: Path) -> dict[str, str]:
             result["file_type"] = str(raw["general.file_type"])
         if "general.name" in raw:
             result["name"] = str(raw["general.name"])
-        return result
+        return result or None
     finally:
         llm.close()
 

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -74,12 +74,18 @@ class LlamaCppProvider(LLMProvider):
                 break
 
     def _dispatch_batch(self, batch: list[_EmbedRequest]) -> None:
-        """Serialize embedding requests one-by-one and resolve all futures."""
+        """Serialize embedding requests and resolve all futures.
+
+        Embeds one text at a time because some model architectures (e.g.
+        nomic-bert) fail with llama_decode -1 on multi-text batches.
+        """
         llm = self._get_embed_llm()
         for req in batch:
             try:
-                response = llm.create_embedding(input=req.texts)
-                vectors = [item["embedding"] for item in response["data"]]
+                vectors: list[list[float]] = []
+                for text in req.texts:
+                    response = llm.create_embedding(input=[text])
+                    vectors.append(response["data"][0]["embedding"])
                 req.future.set_result(vectors)
             except Exception as exc:
                 if not req.future.done():
@@ -299,4 +305,17 @@ def _load_llama(model_path: Path, *, embedding: bool) -> Any:
         # Without this, llama.cpp defaults to 512 tokens which is too small
         # for most embedding models (e.g. nomic-embed-text trains at 2048).
         kwargs["n_ctx"] = 0
+
+    if embedding:
+        # llama-cpp-python defaults n_batch = min(n_ctx, 512), silently
+        # truncating embeddings to 512 tokens. Set n_batch = n_ctx so each
+        # text can use the model's full context window.
+        if kwargs["n_ctx"] == 0:
+            meta = _read_gguf_metadata(model_path)
+            ctx_len = int(meta.get("context_length", 2048)) if meta else 2048
+        else:
+            ctx_len = kwargs["n_ctx"]
+        kwargs["n_batch"] = ctx_len
+        kwargs["n_ubatch"] = ctx_len
+
     return Llama(**kwargs)

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -84,8 +84,8 @@ class LlamaCppProvider(LLMProvider):
             try:
                 vectors: list[list[float]] = []
                 for text in req.texts:
-                    response = llm.create_embedding(input=[text])
-                    vectors.append(response["data"][0]["embedding"])
+                    response = _embed_one(llm, text)
+                    vectors.append(response)
                 req.future.set_result(vectors)
             except Exception as exc:
                 if not req.future.done():
@@ -224,6 +224,27 @@ class _LockedStreamIterator:
 
     def __del__(self) -> None:  # pragma: no cover
         self._release()
+
+
+def _embed_one(llm: Any, text: str) -> list[float]:
+    """Embed a single text, suppressing llama.cpp C-level stderr noise.
+
+    llama.cpp prints 'init: embeddings required but some input tokens were
+    not marked as outputs -> overriding' on every create_embedding call.
+    This is harmless but spams the terminal.
+    """
+    import os
+
+    devnull = os.open(os.devnull, os.O_WRONLY)
+    old_stderr = os.dup(2)
+    os.dup2(devnull, 2)
+    try:
+        response = llm.create_embedding(input=[text])
+        return response["data"][0]["embedding"]
+    finally:
+        os.dup2(old_stderr, 2)
+        os.close(devnull)
+        os.close(old_stderr)
 
 
 def _read_gguf_metadata(model_path: Path) -> dict[str, str]:

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -226,12 +226,12 @@ class _LockedStreamIterator:
         self._release()
 
 
-def _embed_one(llm: Any, text: str) -> list[float]:
-    """Embed a single text, suppressing llama.cpp C-level stderr noise.
+def _suppress_stderr(fn: Any, *args: Any, **kwargs: Any) -> Any:
+    """Call *fn* with C-level stderr suppressed.
 
-    llama.cpp prints 'init: embeddings required but some input tokens were
-    not marked as outputs -> overriding' on every create_embedding call.
-    This is harmless but spams the terminal.
+    llama.cpp prints noisy messages (e.g. 'init: embeddings required...')
+    that bypass Python logging. This redirects fd 2 to /dev/null for the
+    duration of the call.
     """
     import os
 
@@ -239,12 +239,17 @@ def _embed_one(llm: Any, text: str) -> list[float]:
     old_stderr = os.dup(2)
     os.dup2(devnull, 2)
     try:
-        response = llm.create_embedding(input=[text])
-        return response["data"][0]["embedding"]
+        return fn(*args, **kwargs)
     finally:
         os.dup2(old_stderr, 2)
         os.close(devnull)
         os.close(old_stderr)
+
+
+def _embed_one(llm: Any, text: str) -> list[float]:
+    """Embed a single text with stderr suppressed."""
+    response = _suppress_stderr(llm.create_embedding, input=[text])
+    return response["data"][0]["embedding"]
 
 
 def _read_gguf_metadata(model_path: Path) -> dict[str, str]:
@@ -318,6 +323,7 @@ def _load_llama(model_path: Path, *, embedding: bool) -> Any:
         "model_path": str(model_path),
         "embedding": embedding,
         "verbose": False,
+        "n_gpu_layers": -1,  # Offload all layers to GPU (Metal/CUDA)
     }
     if cfg.num_ctx is not None:
         kwargs["n_ctx"] = cfg.num_ctx
@@ -339,4 +345,4 @@ def _load_llama(model_path: Path, *, embedding: bool) -> Any:
         kwargs["n_batch"] = ctx_len
         kwargs["n_ubatch"] = ctx_len
 
-    return Llama(**kwargs)
+    return _suppress_stderr(Llama, **kwargs)

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -49,7 +49,17 @@ class LlamaCppProvider(LLMProvider):
         self._worker.start()
 
     def _embed_worker(self) -> None:
-        """Background thread: drain queue, batch, inference, dispatch results."""
+        """Background thread: drain queue, batch, inference, dispatch results.
+
+        Suppresses C-level stderr for the entire thread lifetime because
+        llama.cpp prints noisy messages on every create_embedding call.
+        """
+        import os
+
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull_fd, 2)
+        os.close(devnull_fd)
+
         while True:
             first = self._embed_queue.get()
             if first is None:
@@ -247,8 +257,8 @@ def _suppress_stderr(fn: Any, *args: Any, **kwargs: Any) -> Any:
 
 
 def _embed_one(llm: Any, text: str) -> list[float]:
-    """Embed a single text with stderr suppressed."""
-    response = _suppress_stderr(llm.create_embedding, input=[text])
+    """Embed a single text. Caller must have stderr suppressed."""
+    response = llm.create_embedding(input=[text])
     return response["data"][0]["embedding"]
 
 

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -161,8 +161,12 @@ class LlamaCppProvider(LLMProvider):
         )
 
     def show_model(self, model: str) -> dict[str, str] | None:
-        """llama-cpp doesn't expose model metadata."""
-        return None
+        """Return model metadata from GGUF headers."""
+        try:
+            path = _resolve_model_path(model)
+        except ProviderError:
+            return None
+        return _read_gguf_metadata(path)
 
     def shutdown(self) -> None:
         """Stop the embed worker thread."""
@@ -214,6 +218,38 @@ class _LockedStreamIterator:
 
     def __del__(self) -> None:  # pragma: no cover
         self._release()
+
+
+def _read_gguf_metadata(model_path: Path) -> dict[str, str]:
+    """Read metadata from a GGUF file's headers via llama-cpp-python.
+
+    Returns a dict with keys like 'architecture', 'context_length',
+    'embedding_length', 'chat_template', 'file_type'.
+    """
+    from llama_cpp import Llama
+
+    llm = Llama(model_path=str(model_path), vocab_only=True, verbose=False)
+    try:
+        raw = llm.metadata or {}
+        result: dict[str, str] = {}
+        if "general.architecture" in raw:
+            result["architecture"] = str(raw["general.architecture"])
+        arch = raw.get("general.architecture", "llama")
+        ctx_key = f"{arch}.context_length"
+        if ctx_key in raw:
+            result["context_length"] = str(raw[ctx_key])
+        emb_key = f"{arch}.embedding_length"
+        if emb_key in raw:
+            result["embedding_length"] = str(raw[emb_key])
+        if "tokenizer.chat_template" in raw:
+            result["chat_template"] = str(raw["tokenizer.chat_template"])
+        if "general.file_type" in raw:
+            result["file_type"] = str(raw["general.file_type"])
+        if "general.name" in raw:
+            result["name"] = str(raw["general.name"])
+        return result
+    finally:
+        llm.close()
 
 
 def _resolve_model_path(model: str) -> Path:

--- a/tests/integration/test_pdf_integration.py
+++ b/tests/integration/test_pdf_integration.py
@@ -163,7 +163,7 @@ class TestTesseractOcrFallback:
             phrase in text_lower
             for phrase in ["oil", "maintenance", "filter", "quarts", "engine", "dipstick"]
         )
-        assert recognized, f"No expected phrases found in OCR output: {all_text[:200]}"
+        assert recognized, f"No expected phrases found in OCR output: {text_lower[:200]}"
 
 
 def _vision_model_available() -> bool:

--- a/tests/integration/test_rag_integration.py
+++ b/tests/integration/test_rag_integration.py
@@ -247,6 +247,39 @@ class TestPipelineBasics:
         assert len(vec) == cfg.embedding_dim
         assert any(v != 0.0 for v in vec)
 
+    def test_ingest_realistic_length_document(self, rag_pipeline):
+        """Verify embedding works with realistic text lengths, not just short strings.
+
+        Regression test: llama-cpp-python defaults n_batch=512, silently
+        truncating embeddings. With multiple chunks exceeding this limit,
+        llama_decode returns -1. This test catches that by ingesting a
+        document long enough to produce multiple real-sized chunks.
+        """
+        docs_dir = rag_pipeline["docs_dir"]
+        # ~8000 chars → multiple chunks at 512-token chunk_size
+        content = (
+            "# Vehicle Maintenance Procedures\n\n"
+            "Regular maintenance extends the life of your vehicle and prevents "
+            "costly repairs. This comprehensive guide covers all essential "
+            "maintenance procedures for modern vehicles.\n\n"
+            "## Oil Change Procedure\n\n"
+            "Drain the old oil completely by removing the drain plug. Replace "
+            "the oil filter with a new one, applying a thin film of fresh oil "
+            "to the gasket. Reinstall the drain plug and fill with the correct "
+            "grade of synthetic motor oil. Check the dipstick to verify the "
+            "correct oil level has been reached.\n\n"
+        ) * 10  # Repeat to ensure multiple chunks
+
+        (docs_dir / "maintenance_guide.md").write_text(content)
+        result = asyncio.run(sync(quiet=True))
+        assert result.failed == 0, f"Ingest failed: {result}"
+        assert result.added > 0 or result.updated > 0
+
+        results = get_services().searcher.search("oil change procedure", top_k=3)
+        assert len(results) > 0
+        sources = [r.source for r in results]
+        assert "maintenance_guide.md" in sources
+
 
 # ---------------------------------------------------------------------------
 # Search Quality

--- a/tests/integration/test_tui_integration.py
+++ b/tests/integration/test_tui_integration.py
@@ -29,12 +29,8 @@ def _isolated_cfg(tmp_path):
     cfg.vision_model = ""
     cfg.chunk_size = 512
     with (
-        patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False
-        ),
-        patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=False
-        ),
+        patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=False),
     ):
         yield
     for name in type(cfg).model_fields:
@@ -411,9 +407,7 @@ class TestAutocompleteIntegration:
                 assert inp.value == "/help"
 
     @patch("lilbee.models.list_installed_models", return_value=["qwen3:8b", "mistral:7b"])
-    async def test_model_name_completion(
-        self, mock_models: MagicMock
-    ) -> None:
+    async def test_model_name_completion(self, mock_models: MagicMock) -> None:
         app = _ChatApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,7 +1,8 @@
 """Tests for catalog.py — model catalog, HF API fetching, filtering, downloading."""
 
 from pathlib import Path
-from typing import ClassVar
+from typing import Any
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -420,26 +421,13 @@ class TestDownloadModel:
         entry = FEATURED_EMBEDDING[0]
         monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
 
-        class FakeStream:
-            headers: ClassVar[dict[str, str]] = {"content-length": "100"}
-            status_code: ClassVar[int] = 200
+        def fake_download(**kwargs: Any) -> str:
+            dest = Path(kwargs["local_dir"]) / kwargs["filename"]
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"x" * 100)
+            return str(dest)
 
-            def __init__(self, *a: object, **kw: object) -> None:
-                pass
-
-            def __enter__(self) -> "FakeStream":
-                return self
-
-            def __exit__(self, *a: object) -> None:
-                pass
-
-            def raise_for_status(self) -> None:
-                pass
-
-            def iter_bytes(self, chunk_size: int = 8192) -> list[bytes]:
-                return [b"x" * 100]
-
-        monkeypatch.setattr(httpx, "stream", lambda *a, **kw: FakeStream())
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_download)
         result = download_model(entry)
         assert result.exists()
         assert result.parent == models_dir
@@ -451,26 +439,18 @@ class TestDownloadModel:
 
         progress_calls: list[tuple[int, int]] = []
 
-        class FakeStream:
-            headers: ClassVar[dict[str, str]] = {"content-length": "100"}
-            status_code: ClassVar[int] = 200
+        def fake_download(**kwargs: Any) -> str:
+            tqdm_cls = kwargs.get("tqdm_class")
+            if tqdm_cls:
+                bar = tqdm_cls(total=100)
+                bar.update(50)
+                bar.update(50)
+                bar.close()
+            dest = Path(kwargs["local_dir"]) / kwargs["filename"]
+            dest.write_bytes(b"x" * 100)
+            return str(dest)
 
-            def __init__(self, *a: object, **kw: object) -> None:
-                pass
-
-            def __enter__(self) -> "FakeStream":
-                return self
-
-            def __exit__(self, *a: object) -> None:
-                pass
-
-            def raise_for_status(self) -> None:
-                pass
-
-            def iter_bytes(self, chunk_size: int = 8192) -> list[bytes]:
-                return [b"x" * 50, b"x" * 50]
-
-        monkeypatch.setattr(httpx, "stream", lambda *a, **kw: FakeStream())
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_download)
 
         def on_progress(downloaded: int, total: int) -> None:
             progress_calls.append((downloaded, total))
@@ -479,40 +459,37 @@ class TestDownloadModel:
         assert len(progress_calls) == 2
         assert progress_calls[-1] == (100, 100)
 
-    def test_http_error_cleans_up_partial(
+    def test_gated_repo_raises_permission_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
         monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
 
-        class FakeStream:
-            headers: ClassVar[dict[str, str]] = {"content-length": "100"}
-            status_code: ClassVar[int] = 200
+        from huggingface_hub.utils import GatedRepoError
 
-            def __init__(self, *a: object, **kw: object) -> None:
-                pass
+        def fake_download(**kwargs: Any) -> str:
+            raise GatedRepoError("Gated repo", response=MagicMock())
 
-            def __enter__(self) -> "FakeStream":
-                return self
-
-            def __exit__(self, *a: object) -> None:
-                pass
-
-            def raise_for_status(self) -> None:
-                pass
-
-            def iter_bytes(self, chunk_size: int = 8192) -> list[bytes]:
-                raise httpx.HTTPStatusError(
-                    "500",
-                    request=httpx.Request("GET", "http://x"),
-                    response=httpx.Response(500),
-                )
-
-        monkeypatch.setattr(httpx, "stream", lambda *a, **kw: FakeStream())
-        with pytest.raises(httpx.HTTPStatusError):
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_download)
+        with pytest.raises(PermissionError, match="requires HuggingFace authentication"):
             download_model(entry)
-        assert not (tmp_path / entry.gguf_filename).exists()
+
+    def test_repo_not_found_raises_runtime_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
+        entry = FEATURED_EMBEDDING[0]
+        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
+
+        from huggingface_hub.utils import RepositoryNotFoundError
+
+        def fake_download(**kwargs: Any) -> str:
+            raise RepositoryNotFoundError("Not found", response=MagicMock())
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_download)
+        with pytest.raises(RuntimeError, match="not found on HuggingFace"):
+            download_model(entry)
 
 
 class TestResolveFilename:

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,6 +1,5 @@
 """Tests for the embedding wrapper (mocked -- no live server needed)."""
 
-from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -112,28 +111,22 @@ class TestValidateVector:
 
 
 class TestValidateModel:
-    def test_validate_returns_true_when_model_available(self, embedder):
-        with mock.patch("lilbee.providers.llama_cpp_provider._resolve_model_path"):
-            assert embedder.validate_model() is True
+    def test_validate_returns_true_when_model_available(self, embedder, mock_provider):
+        mock_provider.list_models.return_value = [cfg.embedding_model]
+        assert embedder.validate_model() is True
 
-    def test_validate_returns_false_when_model_missing(self, embedder):
-        from lilbee.providers.base import ProviderError
+    def test_validate_returns_false_when_model_missing(self, embedder, mock_provider):
+        mock_provider.list_models.return_value = []
+        assert embedder.validate_model() is False
 
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider._resolve_model_path",
-            side_effect=ProviderError("not found"),
-        ):
-            assert embedder.validate_model() is False
+    def test_validate_returns_false_on_provider_error(self, embedder, mock_provider):
+        mock_provider.list_models.side_effect = RuntimeError("no connection")
+        assert embedder.validate_model() is False
 
-    def test_embedding_available_true(self, embedder):
-        with mock.patch("lilbee.providers.llama_cpp_provider._resolve_model_path"):
-            assert embedder.embedding_available() is True
+    def test_embedding_available_true(self, embedder, mock_provider):
+        mock_provider.list_models.return_value = [cfg.embedding_model]
+        assert embedder.embedding_available() is True
 
-    def test_embedding_available_false(self, embedder):
-        from lilbee.providers.base import ProviderError
-
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider._resolve_model_path",
-            side_effect=ProviderError("not found"),
-        ):
-            assert embedder.embedding_available() is False
+    def test_embedding_available_false(self, embedder, mock_provider):
+        mock_provider.list_models.return_value = []
+        assert embedder.embedding_available() is False

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1180,6 +1180,11 @@ class TestChunkViaKreuzberg:
 
 
 class TestConceptIndexing:
+    @pytest.fixture(autouse=True)
+    def _mock_concepts_available(self):
+        with mock.patch("lilbee.concepts.concepts_available", return_value=True):
+            yield
+
     @mock.patch(
         "kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result()
     )

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -56,14 +56,17 @@ class TestEmbedQueue:
         from lilbee.providers.llama_cpp_provider import LlamaCppProvider
 
         instance = mock.MagicMock()
-        instance.create_embedding.return_value = _make_embed_response([[0.1, 0.2], [0.3, 0.4]])
+        instance.create_embedding.side_effect = [
+            _make_embed_response([[0.1, 0.2]]),
+            _make_embed_response([[0.3, 0.4]]),
+        ]
         mock_llama_cpp.Llama.return_value = instance
 
         provider = LlamaCppProvider()
         result = provider.embed(["hello", "world"])
 
         assert result == [[0.1, 0.2], [0.3, 0.4]]
-        instance.create_embedding.assert_called_once_with(input=["hello", "world"])
+        assert instance.create_embedding.call_count == 2
         provider.shutdown()
 
     def test_concurrent_embeds_batched(
@@ -365,31 +368,39 @@ class TestLockedStreamIteratorExceptionRelease:
 
 class TestLoadLlamaNCtx:
     def test_default_n_ctx(self, models_dir: Path, mock_llama_cpp: mock.MagicMock) -> None:
-        """When num_ctx is None, _load_llama passes n_ctx=0 (use model's training context)."""
+        """When num_ctx is None, _load_llama passes n_ctx=0 and n_batch from metadata."""
         from lilbee.providers.llama_cpp_provider import _load_llama
 
         cfg.num_ctx = None
+        mock_llama_cpp.Llama.return_value.metadata = {
+            "general.architecture": "nomic-bert",
+            "nomic-bert.context_length": "2048",
+        }
         _load_llama(models_dir / "test-model.gguf", embedding=True)
 
-        mock_llama_cpp.Llama.assert_called_once()
+        # Called twice: once for metadata (vocab_only), once for model
+        assert mock_llama_cpp.Llama.call_count == 2
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         assert call_kwargs["n_ctx"] == 0
+        assert call_kwargs["n_batch"] == 2048
 
     def test_custom_n_ctx(self, models_dir: Path, mock_llama_cpp: mock.MagicMock) -> None:
-        """When num_ctx is set, _load_llama uses it for n_ctx."""
+        """When num_ctx is set, _load_llama uses it for n_ctx and n_batch."""
         from lilbee.providers.llama_cpp_provider import _load_llama
 
         cfg.num_ctx = 8192
         _load_llama(models_dir / "test-model.gguf", embedding=True)
 
-        mock_llama_cpp.Llama.assert_called_once()
+        # No metadata read needed when n_ctx is explicit
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         assert call_kwargs["n_ctx"] == 8192
+        assert call_kwargs["n_batch"] == 8192
 
     def test_embedding_flag_passed(self, models_dir: Path, mock_llama_cpp: mock.MagicMock) -> None:
         """_load_llama passes embedding flag correctly."""
         from lilbee.providers.llama_cpp_provider import _load_llama
 
+        mock_llama_cpp.Llama.return_value.metadata = {}
         _load_llama(models_dir / "test-model.gguf", embedding=True)
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         assert call_kwargs["embedding"] is True

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -81,16 +81,17 @@ class TestLlamaCppProvider:
         cfg.models_dir = models_dir
 
         mock_llama_instance = mock.MagicMock()
-        mock_llama_instance.create_embedding.return_value = {
-            "data": [{"embedding": [0.1, 0.2, 0.3]}, {"embedding": [0.4, 0.5, 0.6]}]
-        }
+        mock_llama_instance.create_embedding.side_effect = [
+            {"data": [{"embedding": [0.1, 0.2, 0.3]}]},
+            {"data": [{"embedding": [0.4, 0.5, 0.6]}]},
+        ]
         mock_llama_cpp.Llama.return_value = mock_llama_instance
 
         provider = LlamaCppProvider()
         result = provider.embed(["hello", "world"])
 
         assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
-        mock_llama_instance.create_embedding.assert_called_once_with(input=["hello", "world"])
+        assert mock_llama_instance.create_embedding.call_count == 2
 
     def test_chat_non_stream(self, models_dir: Path, mock_llama_cpp: mock.MagicMock) -> None:
         from lilbee.providers.llama_cpp_provider import LlamaCppProvider
@@ -264,6 +265,37 @@ class TestLlamaCppProvider:
             result = _read_gguf_metadata(models_dir / "test-model.gguf")
         assert result is None
 
+    def test_load_llama_sets_n_batch_for_embedding(self, models_dir: Path) -> None:
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import _load_llama
+
+        cfg.num_ctx = None
+        with (
+            patch("llama_cpp.Llama") as mock_llama_cls,
+            patch(
+                "lilbee.providers.llama_cpp_provider._read_gguf_metadata",
+                return_value={"context_length": "2048"},
+            ),
+        ):
+            _load_llama(models_dir / "test-model.gguf", embedding=True)
+            call_kwargs = mock_llama_cls.call_args[1]
+            assert call_kwargs["n_batch"] == 2048
+            assert call_kwargs["n_ubatch"] == 2048
+            assert call_kwargs["embedding"] is True
+
+    def test_load_llama_no_n_batch_for_chat(self, models_dir: Path) -> None:
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import _load_llama
+
+        with patch("llama_cpp.Llama"):
+            _load_llama(models_dir / "test-model.gguf", embedding=False)
+            import llama_cpp
+
+            call_kwargs = llama_cpp.Llama.call_args[1]
+            assert "n_batch" not in call_kwargs
+
     def test_resolve_model_path_direct(self, models_dir: Path) -> None:
         from lilbee.providers.llama_cpp_provider import _resolve_model_path
 
@@ -311,11 +343,13 @@ class TestLlamaCppProvider:
         mock_llama_instance.create_embedding.return_value = {"data": [{"embedding": [0.1] * 3}]}
         mock_llama_cpp.Llama.return_value = mock_llama_instance
 
+        cfg.num_ctx = 4096  # Explicit ctx skips metadata read
         provider = LlamaCppProvider()
         provider.embed(["a"])
         provider.embed(["b"])
 
-        # Llama should only be instantiated once for embeddings
+        # With explicit num_ctx, no metadata read needed — only 1 Llama call.
+        # Second embed reuses the cached instance.
         assert mock_llama_cpp.Llama.call_count == 1
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -230,6 +230,40 @@ class TestLlamaCppProvider:
         provider = LlamaCppProvider()
         assert provider.show_model("some-model") is None
 
+    def test_read_gguf_metadata(self, models_dir: Path) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from lilbee.providers.llama_cpp_provider import _read_gguf_metadata
+
+        mock_llm = MagicMock()
+        mock_llm.metadata = {
+            "general.architecture": "qwen3",
+            "general.name": "Qwen3 8B",
+            "general.file_type": "15",
+            "qwen3.context_length": "32768",
+            "qwen3.embedding_length": "4096",
+            "tokenizer.chat_template": "{% if messages %}...",
+        }
+        with patch("llama_cpp.Llama", return_value=mock_llm):
+            result = _read_gguf_metadata(models_dir / "test-model.gguf")
+        assert result["architecture"] == "qwen3"
+        assert result["context_length"] == "32768"
+        assert result["embedding_length"] == "4096"
+        assert result["chat_template"] == "{% if messages %}..."
+        assert result["name"] == "Qwen3 8B"
+        mock_llm.close.assert_called_once()
+
+    def test_read_gguf_metadata_empty(self, models_dir: Path) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from lilbee.providers.llama_cpp_provider import _read_gguf_metadata
+
+        mock_llm = MagicMock()
+        mock_llm.metadata = {}
+        with patch("llama_cpp.Llama", return_value=mock_llm):
+            result = _read_gguf_metadata(models_dir / "test-model.gguf")
+        assert result == {}
+
     def test_resolve_model_path_direct(self, models_dir: Path) -> None:
         from lilbee.providers.llama_cpp_provider import _resolve_model_path
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -262,7 +262,7 @@ class TestLlamaCppProvider:
         mock_llm.metadata = {}
         with patch("llama_cpp.Llama", return_value=mock_llm):
             result = _read_gguf_metadata(models_dir / "test-model.gguf")
-        assert result == {}
+        assert result is None
 
     def test_resolve_model_path_direct(self, models_dir: Path) -> None:
         from lilbee.providers.llama_cpp_provider import _resolve_model_path

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -29,9 +29,7 @@ def _isolated_cfg(tmp_path):
 def _patch_chat_setup():
     """Patch out embedding model checks so ChatScreen mounts cleanly."""
     with (
-        mock.patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False
-        ),
+        mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
         mock.patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,
@@ -175,9 +173,7 @@ class TestModelRow:
 
 class TestChatScreenAsync:
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_app_launches(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_app_launches(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -187,9 +183,7 @@ class TestChatScreenAsync:
             assert app.title.startswith("lilbee")
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_chat_input_exists(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_chat_input_exists(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -201,9 +195,7 @@ class TestChatScreenAsync:
             assert inp is not None
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_quit_keybinding(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_quit_keybinding(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -212,9 +204,7 @@ class TestChatScreenAsync:
             await pilot.press("ctrl+q")
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_help_modal(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_help_modal(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -226,9 +216,7 @@ class TestChatScreenAsync:
             assert len(app.screen_stack) > 1
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_catalog_push(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_catalog_push(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -240,9 +228,7 @@ class TestChatScreenAsync:
             assert len(app.screen_stack) > 1
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_slash_help(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_slash_help(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -256,9 +242,7 @@ class TestChatScreenAsync:
             assert len(app.screen_stack) > 1
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_slash_unknown_notifies(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_slash_unknown_notifies(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -271,9 +255,7 @@ class TestChatScreenAsync:
             await pilot.pause()
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_slash_model_changes_model(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_slash_model_changes_model(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -287,9 +269,7 @@ class TestChatScreenAsync:
             assert cfg.chat_model == "new-model:latest"
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_slash_set_changes_setting(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_slash_set_changes_setting(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -303,9 +283,7 @@ class TestChatScreenAsync:
             assert cfg.top_k == 10
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_slash_set_invalid_key(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_slash_set_invalid_key(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -318,9 +296,7 @@ class TestChatScreenAsync:
             await pilot.pause()
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_empty_input_ignored(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_empty_input_ignored(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -335,9 +311,7 @@ class TestChatScreenAsync:
 
 class TestCatalogScreenAsync:
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_catalog_shows_featured(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_catalog_shows_featured(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -349,9 +323,7 @@ class TestCatalogScreenAsync:
             await pilot.pause()
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_catalog_quit(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_catalog_quit(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -370,9 +342,7 @@ class TestCatalogScreenAsync:
 
 class TestSettingsScreenAsync:
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_settings_shows_table(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_settings_shows_table(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.screens.settings import SettingsScreen
@@ -465,9 +435,7 @@ class TestThemes:
         assert "dracula" in DARK_THEMES
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_cycle_theme(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_cycle_theme(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -478,9 +446,7 @@ class TestThemes:
             assert app.theme != "gruvbox"  # cycled to next
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_set_theme(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_set_theme(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -491,9 +457,7 @@ class TestThemes:
             assert app.theme == "dracula"
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_set_invalid_theme_noop(
-        self, mock_catalog: mock.MagicMock
-    ) -> None:
+    async def test_set_invalid_theme_noop(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -66,9 +66,7 @@ def mock_svc():
 def _patch_chat_setup():
     """Patch out embedding model checks so ChatScreen mounts cleanly."""
     with (
-        patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False
-        ),
+        patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
         patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,
@@ -953,9 +951,7 @@ async def test_chat_vim_j_k_in_input():
 async def test_chat_needs_setup_false_when_models_exist():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        with patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False
-        ):
+        with patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False):
             assert not app.screen._needs_setup()
 
 
@@ -2204,9 +2200,7 @@ async def test_chat_needs_setup_true_pushes_wizard():
             self.push_screen(ChatScreen())
 
     app = SetupTestApp()
-    with patch(
-        "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=True
-    ):
+    with patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=True):
         async with app.run_test(size=(120, 40)) as _pilot:
             await _pilot.pause()
             assert isinstance(app.screen, SetupWizard)
@@ -2227,15 +2221,9 @@ async def test_chat_embedding_ready_false_no_sync():
 
     app = NoSyncApp()
     with (
-        patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False
-        ),
-        patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=False
-        ),
-        patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._run_sync"
-        ) as mock_sync,
+        patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=False),
+        patch("lilbee.cli.tui.screens.chat.ChatScreen._run_sync") as mock_sync,
     ):
         async with app.run_test(size=(120, 40)) as _pilot:
             await _pilot.pause()


### PR DESCRIPTION
## Summary

- Use `huggingface_hub` for model downloads (resumable, cached, authenticated)
- Read model metadata (chat template, context window, architecture) from GGUF file headers
- Make embedding model detection work with any provider, not just llama-cpp

## Why

GGUF files are self-describing — they already contain chat templates, context windows, and architecture info. lilbee was ignoring this metadata and hand-rolling download logic that `huggingface_hub` handles better.