### PR TITLE
fix: Windows install no longer requires a C compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --all-extras
-        env:
-          CMAKE_ARGS: "-DGGML_METAL=OFF -DGGML_NATIVE=OFF"
 
       - name: Lint
         run: make lint
@@ -63,8 +61,6 @@ jobs:
 
       - name: Install dependencies
         run: uv sync
-        env:
-          CMAKE_ARGS: "-DGGML_METAL=OFF -DGGML_NATIVE=OFF -DGGML_BLAS=OFF -DGGML_CUDA=OFF"
 
       - name: Run unit tests with coverage
         run: make test-ci
@@ -132,8 +128,6 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --all-extras
-        env:
-          CMAKE_ARGS: "-DGGML_METAL=OFF -DGGML_NATIVE=OFF"
 
       - name: Build dev portal (coverage + API docs)
         run: make docs-site
@@ -148,3 +142,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/deploy-pages@v4
+
+  pip-install-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install lilbee with prebuilt llama-cpp-python wheels
+        run: pip install . --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu/
+
+      - name: Smoke test
+        run: |
+          lilbee --version
+          lilbee --help

--- a/README.md
+++ b/README.md
@@ -148,7 +148,15 @@ No external services needed. lilbee downloads and runs GGUF models locally via l
 ### Install
 
 ```bash
-pip install lilbee        # or: uv tool install lilbee
+pip install lilbee --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu/
+```
+
+The `--extra-index-url` flag fetches prebuilt `llama-cpp-python` wheels so no C compiler (CMake, MSVC) is needed. This works on **Windows, macOS, and Linux**. If you already have cmake installed, plain `pip install lilbee` also works.
+
+With [uv](https://docs.astral.sh/uv/), prebuilt wheels resolve automatically:
+
+```bash
+uv tool install lilbee
 ```
 
 ### Optional extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,14 @@ select = [
     "RUF",   # ruff-specific
 ]
 
+[tool.uv.sources]
+llama-cpp-python = { index = "llama-cpp-prebuilt" }
+
+[[tool.uv.index]]
+name = "llama-cpp-prebuilt"
+url = "https://abetlen.github.io/llama-cpp-python/whl/cpu/"
+explicit = true
+
 [tool.mypy]
 python_version = "3.11"
 warn_return_any = true

--- a/uv.lock
+++ b/uv.lock
@@ -1645,7 +1645,7 @@ requires-dist = [
     { name = "lancedb" },
     { name = "litellm", marker = "extra == 'litellm'" },
     { name = "litestar", specifier = ">=2.0" },
-    { name = "llama-cpp-python" },
+    { name = "llama-cpp-python", index = "https://abetlen.github.io/llama-cpp-python/whl/cpu/" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "psutil", specifier = ">=5.9" },
@@ -1743,15 +1743,34 @@ wheels = [
 
 [[package]]
 name = "llama-cpp-python"
-version = "0.3.16"
-source = { registry = "https://pypi.org/simple" }
+version = "0.3.18"
+source = { registry = "https://abetlen.github.io/llama-cpp-python/whl/cpu/" }
 dependencies = [
     { name = "diskcache" },
     { name = "jinja2" },
     { name = "numpy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/b4/c8cd17629ced0b9644a71d399a91145aedef109c0333443bef015e45b704/llama_cpp_python-0.3.16.tar.gz", hash = "sha256:34ed0f9bd9431af045bb63d9324ae620ad0536653740e9bb163a2e1fcb973be6", size = 50688636 }
+wheels = [
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp311-cp311-linux_aarch64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp311-cp311-linux_riscv64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp311-cp311-linux_x86_64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp311-cp311-macosx_11_0_arm64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp311-cp311-win32.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp311-cp311-win_amd64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp312-cp312-linux_aarch64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp312-cp312-linux_riscv64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp312-cp312-linux_x86_64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp312-cp312-macosx_11_0_arm64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp312-cp312-win32.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp312-cp312-win_amd64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp313-cp313-linux_riscv64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp313-cp313-linux_x86_64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp313-cp313-macosx_11_0_arm64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp313-cp313-win32.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp313-cp313-win_amd64.whl" },
+    { url = "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.18/llama_cpp_python-0.3.18-cp314-cp314-linux_riscv64.whl" },
+]
 
 [[package]]
 name = "lxml"


### PR DESCRIPTION
Windows users can now pip install lilbee without Visual Studio Build Tools. macOS and Linux installs also simplified — no more CMAKE_ARGS needed. Adds CI smoke test on Windows.