### PR TITLE
fix: cancel long-running operations without data loss

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -696,6 +696,11 @@ class ChatScreen(Screen[None]):
 
             asyncio.run(sync(quiet=True, on_progress=on_progress))
             self.app.call_from_thread(task_bar.complete_task, task_id)
+        except asyncio.CancelledError:
+            self._auto_sync = False
+            self.app.call_from_thread(
+                task_bar.fail_task, task_id, "Sync cancelled. Use /sync to resume."
+            )
         except Exception:
             log.warning("Background sync failed", exc_info=True)
             self.app.call_from_thread(task_bar.fail_task, task_id, msg.SYNC_STATUS_FAILED)

--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -416,11 +416,13 @@ async def crawl_and_save(
     depth: int = 0,
     max_pages: int = 0,
     on_progress: DetailedProgressCallback | None = None,
+    cancel: threading.Event | None = None,
 ) -> list[Path]:
     """Crawl URL(s), save as markdown, update metadata. Returns paths written.
 
     Uses hash-based change detection: always fetches, but only saves files
     whose content has changed (or is new).
+    When *cancel* is set, returns early with an empty list.
     """
     max_pages = min(max_pages if max_pages > 0 else cfg.crawl_max_pages, cfg.crawl_max_pages)
 
@@ -440,6 +442,9 @@ async def crawl_and_save(
             results = [result]
             if on_progress:
                 on_progress(EventType.CRAWL_PAGE, CrawlPageEvent(url=url, current=1, total=1))
+
+        if cancel and cancel.is_set():
+            return []
 
         changed = _filter_changed(results)
         paths = save_crawl_results(changed)

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -7,6 +7,7 @@ import contextlib
 import hashlib
 import logging
 import os
+import threading
 from collections.abc import Generator
 from dataclasses import dataclass
 from pathlib import Path
@@ -538,11 +539,13 @@ async def sync(
     *,
     force_vision: bool = False,
     on_progress: DetailedProgressCallback = noop_callback,
+    cancel: threading.Event | None = None,
 ) -> SyncResult:
     """Sync documents/ with the vector store.
 
     Returns summary dict with keys: added, updated, removed, unchanged, failed.
     When *quiet* is True, the Rich progress bar is suppressed (for JSON output).
+    When *cancel* is set, processing stops between files without data loss.
     """
     from lilbee.services import get_services
 
@@ -569,10 +572,13 @@ async def sync(
             _store.delete_source(name)
             removed.append(name)
 
-    # Process files on disk — (name, path, content_type, hash)
-    files_to_process: list[tuple[str, Path, str, str]] = []
+    # Process files on disk — (name, path, content_type, hash, needs_cleanup)
+    files_to_process: list[tuple[str, Path, str, str, bool]] = []
 
     for name, path in sorted(disk_files.items()):
+        if cancel and cancel.is_set():
+            break
+
         content_type = classify_file(path)
         assert content_type is not None, f"Unsupported file slipped through discovery: {name}"
 
@@ -584,13 +590,12 @@ async def sync(
             continue
 
         if old_hash is not None:
-            # Modified -- remove old data
-            _store.delete_by_source(name)
-            _store.delete_source(name)
-            files_to_process.append((name, path, content_type, current_hash))
+            # Modified — defer old chunk deletion to ingest_batch so
+            # delete + re-ingest are atomic per file (no data loss on cancel).
+            files_to_process.append((name, path, content_type, current_hash, True))
             updated.append(name)
         else:
-            files_to_process.append((name, path, content_type, current_hash))
+            files_to_process.append((name, path, content_type, current_hash, False))
             added.append(name)
 
     # Ingest files (with optional progress bar)
@@ -604,6 +609,7 @@ async def sync(
             quiet=quiet,
             force_vision=force_vision,
             on_progress=on_progress,
+            cancel=cancel,
         )
 
     if files_to_process or removed:
@@ -634,7 +640,7 @@ _MAX_CONCURRENT = os.cpu_count() or 4
 
 
 async def ingest_batch(
-    files_to_process: list[tuple[str, Path, str, str]],
+    files_to_process: list[tuple[str, Path, str, str, bool]],
     added: list[str],
     updated: list[str],
     failed: list[str],
@@ -642,20 +648,39 @@ async def ingest_batch(
     quiet: bool = False,
     force_vision: bool = False,
     on_progress: DetailedProgressCallback = noop_callback,
+    cancel: threading.Event | None = None,
 ) -> None:
-    """Ingest a batch of files, optionally showing a Rich progress bar."""
+    """Ingest a batch of files, optionally showing a Rich progress bar.
+
+    Each tuple is (name, path, content_type, file_hash, needs_cleanup).
+    When *needs_cleanup* is True, old chunks are deleted immediately before
+    ingesting new ones so the two operations are atomic per file.
+    When *cancel* is set, pending files raise CancelledError before starting.
+    """
     semaphore = asyncio.Semaphore(_MAX_CONCURRENT)
     total_files = len(files_to_process)
 
     async def _process_one(
-        name: str, path: Path, content_type: str, fhash: str, file_index: int
+        name: str,
+        path: Path,
+        content_type: str,
+        fhash: str,
+        needs_cleanup: bool,
+        file_index: int,
     ) -> _IngestResult:
         async with semaphore:
+            if cancel and cancel.is_set():
+                raise asyncio.CancelledError
+
             on_progress(
                 EventType.FILE_START,
                 FileStartEvent(file=name, total_files=total_files, current_file=file_index),
             )
             try:
+                if needs_cleanup:
+                    from lilbee.services import get_services
+
+                    get_services().store.delete_by_source(name)
                 chunk_count = await _ingest_file(
                     path,
                     name,
@@ -684,8 +709,8 @@ async def ingest_batch(
 
     if quiet:
         tasks = [
-            asyncio.ensure_future(_process_one(name, path, ct, fh, idx))
-            for idx, (name, path, ct, fh) in enumerate(files_to_process, 1)
+            asyncio.ensure_future(_process_one(name, path, ct, fh, cleanup, idx))
+            for idx, (name, path, ct, fh, cleanup) in enumerate(files_to_process, 1)
         ]
         await _collect_results(tasks, added, updated, failed, on_progress=on_progress)
     else:
@@ -701,8 +726,8 @@ async def ingest_batch(
             token = shared_progress.set((progress, ptask))
             try:
                 tasks = [
-                    asyncio.ensure_future(_process_one(name, path, ct, fh, idx))
-                    for idx, (name, path, ct, fh) in enumerate(files_to_process, 1)
+                    asyncio.ensure_future(_process_one(name, path, ct, fh, cleanup, idx))
+                    for idx, (name, path, ct, fh, cleanup) in enumerate(files_to_process, 1)
                 ]
                 await _collect_results(
                     tasks,

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -325,23 +325,35 @@ def chat_stream(
 
 
 async def sync_stream(*, force_vision: bool = False) -> AsyncGenerator[str, None]:
-    """Trigger sync, yield SSE progress events, then done event."""
+    """Trigger sync, yield SSE progress events, then done event.
+
+    Sets a cancel event on client disconnect so the sync stops between files.
+    """
     from lilbee.ingest import SyncResult, sync
 
     queue: asyncio.Queue[str | None] = asyncio.Queue()
     callback = _make_sse_callback(queue)
+    cancel = threading.Event()
 
     async def run_sync() -> SyncResult:
-        return await sync(quiet=True, on_progress=callback, force_vision=force_vision)
+        return await sync(
+            quiet=True, on_progress=callback, force_vision=force_vision, cancel=cancel
+        )
 
     task = asyncio.create_task(run_sync())
-    while not task.done() or not queue.empty():
-        try:
-            item = await asyncio.wait_for(queue.get(), timeout=0.1)
-        except TimeoutError:
-            continue
-        if item is not None:
-            yield item
+    try:
+        while not task.done() or not queue.empty():
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=0.1)
+            except TimeoutError:
+                continue
+            if item is not None:
+                yield item
+    except (asyncio.CancelledError, GeneratorExit):
+        log.info("Sync stream cancelled by client")
+        cancel.set()
+        task.cancel()
+        return
     yield sse_done(task.result().model_dump())
 
 
@@ -350,6 +362,7 @@ async def _run_add(
     force: bool,
     vision_model: str,
     queue: asyncio.Queue[str | None],
+    cancel: threading.Event,
 ) -> None:
     """Copy files and sync, pushing SSE events to the queue."""
     from lilbee.ingest import sync
@@ -367,10 +380,16 @@ async def _run_add(
 
     copy_result = copy_files(valid, force=force)
 
+    if cancel.is_set():
+        queue.put_nowait(None)
+        return
+
     from lilbee.cli.helpers import temporary_vision_model
 
     with temporary_vision_model(vision_model):
-        sync_result = await sync(quiet=True, force_vision=bool(vision_model), on_progress=callback)
+        sync_result = await sync(
+            quiet=True, force_vision=bool(vision_model), on_progress=callback, cancel=cancel
+        )
 
     summary = {
         "copied": copy_result.copied,
@@ -383,13 +402,14 @@ async def _run_add(
     queue.put_nowait(None)  # sentinel
 
 
-AddResult = tuple[list[str], asyncio.Queue[str | None], asyncio.Task[None]]
+AddResult = tuple[list[str], asyncio.Queue[str | None], asyncio.Task[None], threading.Event]
 
 
 async def add_files(data: dict[str, Any]) -> AddResult:
     """Validate and start the add-files operation.
 
-    Returns (paths, queue, task) for the Litestar adapter to stream.
+    Returns (paths, queue, task, cancel) for the Litestar adapter to stream.
+    The cancel event should be set on client disconnect to stop the sync.
     Raises ValueError on validation failure.
     """
     paths = data.get("paths")
@@ -404,10 +424,11 @@ async def add_files(data: dict[str, Any]) -> AddResult:
 
     force = bool(data.get("force", False))
     vision_model = str(data.get("vision_model", "") or "")
+    cancel = threading.Event()
 
     queue: asyncio.Queue[str | None] = asyncio.Queue()
-    task = asyncio.create_task(_run_add(paths, force, vision_model, queue))
-    return paths, queue, task
+    task = asyncio.create_task(_run_add(paths, force, vision_model, queue, cancel))
+    return paths, queue, task, cancel
 
 
 async def list_models() -> ModelsResponse:
@@ -674,16 +695,22 @@ async def models_installed() -> ModelsInstalledResponse:
 
 
 async def models_pull(model: str, *, source: str = "native") -> AsyncGenerator[str, None]:
-    """Yield SSE progress events while pulling a model in real time."""
+    """Yield SSE progress events while pulling a model in real time.
+
+    Sets a cancel event on client disconnect so the pull stops.
+    """
     from lilbee.model_manager import get_model_manager
 
     manager = get_model_manager()
     src = _parse_source(source)
     queue: asyncio.Queue[str | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
+    cancel = threading.Event()
 
     def _pull_blocking() -> None:
         def _on_progress(data: dict[str, Any]) -> None:
+            if cancel.is_set():
+                return
             payload = sse_event(SseEvent.PROGRESS, data)
             loop.call_soon_threadsafe(queue.put_nowait, payload)
 
@@ -695,14 +722,19 @@ async def models_pull(model: str, *, source: str = "native") -> AsyncGenerator[s
             loop.call_soon_threadsafe(queue.put_nowait, None)
 
     task = asyncio.ensure_future(asyncio.to_thread(_pull_blocking))
-    while not task.done() or not queue.empty():
-        try:
-            item = await asyncio.wait_for(queue.get(), timeout=0.1)
-        except TimeoutError:  # pragma: no cover — async polling race
-            continue
-        if item is None:
-            break
-        yield item
+    try:
+        while not task.done() or not queue.empty():
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=0.1)
+            except TimeoutError:  # pragma: no cover -- async polling race
+                continue
+            if item is None:
+                break
+            yield item
+    except (asyncio.CancelledError, GeneratorExit):
+        log.info("Model pull stream cancelled by client")
+        cancel.set()
+        return
 
 
 async def models_delete(model: str, *, source: str = "litellm") -> ModelsDeleteResponse:
@@ -720,6 +752,7 @@ async def crawl_stream(url: str, depth: int = 0, max_pages: int = 50) -> AsyncGe
 
     Emits crawl_start, crawl_page, crawl_done events, then a final done event
     with the list of files written. On error emits crawl_error.
+    Sets a cancel event on client disconnect so the crawl stops between pages.
     """
     from lilbee.crawler import require_valid_crawl_url
 
@@ -727,20 +760,29 @@ async def crawl_stream(url: str, depth: int = 0, max_pages: int = 50) -> AsyncGe
 
     queue: asyncio.Queue[str | None] = asyncio.Queue()
     callback = _make_sse_callback(queue)
+    cancel = threading.Event()
 
     async def _run_crawl() -> list[Path]:
         from lilbee.crawler import crawl_and_save
 
-        return await crawl_and_save(url, depth=depth, max_pages=max_pages, on_progress=callback)
+        return await crawl_and_save(
+            url, depth=depth, max_pages=max_pages, on_progress=callback, cancel=cancel
+        )
 
     task = asyncio.create_task(_run_crawl())
-    while not task.done() or not queue.empty():
-        try:
-            item = await asyncio.wait_for(queue.get(), timeout=0.1)
-        except TimeoutError:
-            continue
-        if item is not None:
-            yield item
+    try:
+        while not task.done() or not queue.empty():
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=0.1)
+            except TimeoutError:
+                continue
+            if item is not None:
+                yield item
+    except (asyncio.CancelledError, GeneratorExit):
+        log.info("Crawl stream cancelled by client")
+        cancel.set()
+        task.cancel()
+        return
 
     exc = task.exception()
     if exc is not None:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -118,6 +118,16 @@ class ModelsResponse(BaseModel):
     vision: ModelCatalogSection
 
 
+@dataclass
+class AddFilesResult:
+    """Result of starting an add-files operation."""
+
+    paths: list[str]
+    queue: asyncio.Queue[str | None]
+    task: asyncio.Task[None]
+    cancel: threading.Event
+
+
 def sse_event(event: str, data: Any) -> str:
     """Format a single Server-Sent Event string."""
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
@@ -417,16 +427,6 @@ async def _run_add(
     payload = f"event: summary\ndata: {json.dumps(summary)}\n\n"
     queue.put_nowait(payload)
     queue.put_nowait(None)  # sentinel
-
-
-@dataclass
-class AddFilesResult:
-    """Result of starting an add-files operation."""
-
-    paths: list[str]
-    queue: asyncio.Queue[str | None]
-    task: asyncio.Task[None]
-    cancel: threading.Event
 
 
 async def add_files(data: dict[str, Any]) -> AddFilesResult:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -137,6 +137,32 @@ def _resolve_generation_options(options: dict[str, Any] | None) -> dict[str, Any
     return cfg.generation_options(**options) if options else None
 
 
+async def _drain_sse_queue(
+    queue: asyncio.Queue[str | None],
+    task: asyncio.Task[Any],
+) -> AsyncGenerator[str, None]:
+    """Drain SSE events from *queue* until *task* completes or sentinel received."""
+    while not task.done() or not queue.empty():
+        try:
+            item = await asyncio.wait_for(queue.get(), timeout=0.1)
+        except TimeoutError:
+            continue
+        if item is None:
+            break
+        yield item
+
+
+def _on_stream_cancel(
+    cancel: threading.Event,
+    task: asyncio.Task[Any],
+    label: str,
+) -> None:
+    """Signal cancellation and log when a client disconnects mid-stream."""
+    log.info("%s cancelled by client", label)
+    cancel.set()
+    task.cancel()
+
+
 def _make_sse_callback(queue: asyncio.Queue[str | None]) -> DetailedProgressCallback:
     """Return a progress callback that serializes events into an asyncio queue.
 
@@ -325,36 +351,24 @@ def chat_stream(
 
 
 async def sync_stream(*, force_vision: bool = False) -> AsyncGenerator[str, None]:
-    """Trigger sync, yield SSE progress events, then done event.
-
-    Sets a cancel event on client disconnect so the sync stops between files.
-    """
-    from lilbee.ingest import SyncResult, sync
+    """Trigger sync, yield SSE progress events, then done event."""
+    from lilbee.ingest import sync
 
     queue: asyncio.Queue[str | None] = asyncio.Queue()
-    callback = _make_sse_callback(queue)
     cancel = threading.Event()
+    callback = _make_sse_callback(queue)
 
-    async def run_sync() -> SyncResult:
-        return await sync(
-            quiet=True, on_progress=callback, force_vision=force_vision, cancel=cancel
-        )
-
-    task = asyncio.create_task(run_sync())
+    task = asyncio.create_task(
+        sync(quiet=True, on_progress=callback, force_vision=force_vision, cancel=cancel)
+    )
     try:
-        while not task.done() or not queue.empty():
-            try:
-                item = await asyncio.wait_for(queue.get(), timeout=0.1)
-            except TimeoutError:
-                continue
-            if item is not None:
-                yield item
+        async for event in _drain_sse_queue(queue, task):
+            yield event
     except (asyncio.CancelledError, GeneratorExit):
-        log.info("Sync stream cancelled by client")
-        cancel.set()
-        task.cancel()
+        _on_stream_cancel(cancel, task, "Sync stream")
         return
-    yield sse_done(task.result().model_dump())
+    if not cancel.is_set() and task.done() and not task.cancelled():
+        yield sse_done(task.result().model_dump())
 
 
 async def _run_add(
@@ -723,17 +737,10 @@ async def models_pull(model: str, *, source: str = "native") -> AsyncGenerator[s
 
     task = asyncio.ensure_future(asyncio.to_thread(_pull_blocking))
     try:
-        while not task.done() or not queue.empty():
-            try:
-                item = await asyncio.wait_for(queue.get(), timeout=0.1)
-            except TimeoutError:  # pragma: no cover -- async polling race
-                continue
-            if item is None:
-                break
-            yield item
+        async for event in _drain_sse_queue(queue, task):
+            yield event
     except (asyncio.CancelledError, GeneratorExit):
-        log.info("Model pull stream cancelled by client")
-        cancel.set()
+        _on_stream_cancel(cancel, task, "Model pull stream")
         return
 
 
@@ -771,17 +778,10 @@ async def crawl_stream(url: str, depth: int = 0, max_pages: int = 50) -> AsyncGe
 
     task = asyncio.create_task(_run_crawl())
     try:
-        while not task.done() or not queue.empty():
-            try:
-                item = await asyncio.wait_for(queue.get(), timeout=0.1)
-            except TimeoutError:
-                continue
-            if item is not None:
-                yield item
+        async for event in _drain_sse_queue(queue, task):
+            yield event
     except (asyncio.CancelledError, GeneratorExit):
-        log.info("Crawl stream cancelled by client")
-        cancel.set()
-        task.cancel()
+        _on_stream_cancel(cancel, task, "Crawl stream")
         return
 
     exc = task.exception()

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -13,6 +13,7 @@ import threading
 import time
 import types
 from collections.abc import AsyncGenerator, Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Union, cast, get_args, get_origin
 
@@ -22,6 +23,7 @@ from pydantic.fields import FieldInfo
 from lilbee import settings
 from lilbee.cli.helpers import clean_result, copy_files, gather_status, get_version
 from lilbee.config import Config, cfg
+from lilbee.model_manager import ModelSource, get_model_manager
 from lilbee.progress import DetailedProgressCallback, EventType, ProgressEvent, SseEvent
 from lilbee.results import group, to_dicts
 from lilbee.security import validate_path_within
@@ -46,7 +48,6 @@ from lilbee.server.models import (
 )
 
 if TYPE_CHECKING:
-    from lilbee.model_manager import ModelSource
     from lilbee.query import ChatMessage
 
 log = logging.getLogger(__name__)
@@ -137,30 +138,31 @@ def _resolve_generation_options(options: dict[str, Any] | None) -> dict[str, Any
     return cfg.generation_options(**options) if options else None
 
 
-async def _drain_sse_queue(
+async def _stream_with_cancellation(
     queue: asyncio.Queue[str | None],
     task: asyncio.Task[Any],
-) -> AsyncGenerator[str, None]:
-    """Drain SSE events from *queue* until *task* completes or sentinel received."""
-    while not task.done() or not queue.empty():
-        try:
-            item = await asyncio.wait_for(queue.get(), timeout=0.1)
-        except TimeoutError:
-            continue
-        if item is None:
-            break
-        yield item
-
-
-def _on_stream_cancel(
     cancel: threading.Event,
-    task: asyncio.Task[Any],
     label: str,
-) -> None:
-    """Signal cancellation and log when a client disconnects mid-stream."""
-    log.info("%s cancelled by client", label)
-    cancel.set()
-    task.cancel()
+) -> AsyncGenerator[str, None]:
+    """Drain SSE events from a queue, cancelling on client disconnect.
+
+    Wraps the drain-and-cancel pattern: yields SSE strings from *queue* until
+    *task* completes or a sentinel is received.  On ``GeneratorExit`` /
+    ``CancelledError`` (client disconnect), sets *cancel* and cancels *task*.
+    """
+    try:
+        while not task.done() or not queue.empty():
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=0.1)
+            except TimeoutError:
+                continue
+            if item is None:
+                break
+            yield item
+    except (asyncio.CancelledError, GeneratorExit):
+        log.info("%s cancelled by client", label)
+        cancel.set()
+        task.cancel()
 
 
 def _make_sse_callback(queue: asyncio.Queue[str | None]) -> DetailedProgressCallback:
@@ -361,11 +363,12 @@ async def sync_stream(*, force_vision: bool = False) -> AsyncGenerator[str, None
     task = asyncio.create_task(
         sync(quiet=True, on_progress=callback, force_vision=force_vision, cancel=cancel)
     )
+    stream = _stream_with_cancellation(queue, task, cancel, "Sync stream")
     try:
-        async for event in _drain_sse_queue(queue, task):
+        async for event in stream:
             yield event
     except (asyncio.CancelledError, GeneratorExit):
-        _on_stream_cancel(cancel, task, "Sync stream")
+        await stream.aclose()
         return
     if not cancel.is_set() and task.done() and not task.cancelled():
         yield sse_done(task.result().model_dump())
@@ -416,13 +419,20 @@ async def _run_add(
     queue.put_nowait(None)  # sentinel
 
 
-AddResult = tuple[list[str], asyncio.Queue[str | None], asyncio.Task[None], threading.Event]
+@dataclass
+class AddFilesResult:
+    """Result of starting an add-files operation."""
+
+    paths: list[str]
+    queue: asyncio.Queue[str | None]
+    task: asyncio.Task[None]
+    cancel: threading.Event
 
 
-async def add_files(data: dict[str, Any]) -> AddResult:
+async def add_files(data: dict[str, Any]) -> AddFilesResult:
     """Validate and start the add-files operation.
 
-    Returns (paths, queue, task, cancel) for the Litestar adapter to stream.
+    Returns an AddFilesResult for the Litestar adapter to stream.
     The cancel event should be set on client disconnect to stop the sync.
     Raises ValueError on validation failure.
     """
@@ -442,7 +452,7 @@ async def add_files(data: dict[str, Any]) -> AddResult:
 
     queue: asyncio.Queue[str | None] = asyncio.Queue()
     task = asyncio.create_task(_run_add(paths, force, vision_model, queue, cancel))
-    return paths, queue, task, cancel
+    return AddFilesResult(paths=paths, queue=queue, task=task, cancel=cancel)
 
 
 async def list_models() -> ModelsResponse:
@@ -640,8 +650,6 @@ async def models_show(model: str) -> ModelsShowResponse:
 
 def _parse_source(source: str) -> ModelSource:
     """Convert a source string to ModelSource enum."""
-    from lilbee.model_manager import ModelSource
-
     return ModelSource(source)
 
 
@@ -696,8 +704,6 @@ async def models_catalog(
 
 async def models_installed() -> ModelsInstalledResponse:
     """Return list of installed models with their source."""
-    from lilbee.model_manager import ModelSource, get_model_manager
-
     manager = get_model_manager()
     names = manager.list_installed()
     models = []
@@ -713,8 +719,6 @@ async def models_pull(model: str, *, source: str = "native") -> AsyncGenerator[s
 
     Sets a cancel event on client disconnect so the pull stops.
     """
-    from lilbee.model_manager import get_model_manager
-
     manager = get_model_manager()
     src = _parse_source(source)
     queue: asyncio.Queue[str | None] = asyncio.Queue()
@@ -736,18 +740,17 @@ async def models_pull(model: str, *, source: str = "native") -> AsyncGenerator[s
             loop.call_soon_threadsafe(queue.put_nowait, None)
 
     task = asyncio.ensure_future(asyncio.to_thread(_pull_blocking))
+    stream = _stream_with_cancellation(queue, task, cancel, "Model pull stream")
     try:
-        async for event in _drain_sse_queue(queue, task):
+        async for event in stream:
             yield event
     except (asyncio.CancelledError, GeneratorExit):
-        _on_stream_cancel(cancel, task, "Model pull stream")
+        await stream.aclose()
         return
 
 
 async def models_delete(model: str, *, source: str = "litellm") -> ModelsDeleteResponse:
     """Delete a model. Returns deletion status, model name, and freed space."""
-    from lilbee.model_manager import get_model_manager
-
     manager = get_model_manager()
     src = _parse_source(source)
     deleted = manager.remove(model, src)
@@ -777,20 +780,21 @@ async def crawl_stream(url: str, depth: int = 0, max_pages: int = 50) -> AsyncGe
         )
 
     task = asyncio.create_task(_run_crawl())
+    stream = _stream_with_cancellation(queue, task, cancel, "Crawl stream")
     try:
-        async for event in _drain_sse_queue(queue, task):
+        async for event in stream:
             yield event
     except (asyncio.CancelledError, GeneratorExit):
-        _on_stream_cancel(cancel, task, "Crawl stream")
+        await stream.aclose()
         return
 
-    exc = task.exception()
-    if exc is not None:
-        yield sse_error(str(exc))
-        return
-
-    paths = task.result()
-    yield sse_done({"files_written": [str(p) for p in paths]})
+    if not cancel.is_set() and task.done() and not task.cancelled():
+        exc = task.exception()
+        if exc is not None:
+            yield sse_error(str(exc))
+            return
+        paths = task.result()
+        yield sse_done({"files_written": [str(p) for p in paths]})
 
 
 _EXTERNAL_MODELS_TTL = 60
@@ -800,7 +804,6 @@ _external_cache: tuple[float, str, ExternalModelsResponse | None] = (0.0, "", No
 async def list_external_models() -> ExternalModelsResponse:
     """Query the provider for available models via its list_models() API."""
     global _external_cache
-    import asyncio
 
     cache_time, cache_key, cache_result = _external_cache
     key = f"{cfg.litellm_base_url}:{cfg.llm_api_key or ''}"

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -42,14 +42,17 @@ async def sync_route(data: SyncRequest | None = None) -> Stream:
 async def add_route(data: AddRequest) -> Stream:
     """Add files to the knowledge base with streaming SSE progress."""
     try:
-        _paths, queue, task = await handlers.add_files(data.model_dump())
+        _paths, queue, task, cancel = await handlers.add_files(data.model_dump())
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
 
     async def _stream() -> AsyncGenerator[bytes, None]:
-        async for chunk in sse_generator(queue):
-            yield chunk
-        await task
+        try:
+            async for chunk in sse_generator(queue):
+                yield chunk
+            await task
+        except (GeneratorExit, Exception):
+            cancel.set()
 
     return Stream(_stream(), media_type="text/event-stream", status_code=201)
 

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -42,17 +42,17 @@ async def sync_route(data: SyncRequest | None = None) -> Stream:
 async def add_route(data: AddRequest) -> Stream:
     """Add files to the knowledge base with streaming SSE progress."""
     try:
-        _paths, queue, task, cancel = await handlers.add_files(data.model_dump())
+        result = await handlers.add_files(data.model_dump())
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
 
     async def _stream() -> AsyncGenerator[bytes, None]:
         try:
-            async for chunk in sse_generator(queue):
+            async for chunk in sse_generator(result.queue):
                 yield chunk
-            await task
+            await result.task
         except (GeneratorExit, Exception):
-            cancel.set()
+            result.cancel.set()
 
     return Stream(_stream(), media_type="text/event-stream", status_code=201)
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -678,6 +678,19 @@ class TestCrawlAndSave:
         assert _get_crawl_semaphore() is None
         crawler_mod._state.semaphore = None
 
+    @patch("lilbee.crawler.crawl_single")
+    async def test_cancel_returns_empty(self, mock_crawl_single, isolated_env):
+        """Setting cancel event causes crawl_and_save to return empty list."""
+        import threading
+
+        mock_crawl_single.return_value = CrawlResult(
+            url="https://example.com", markdown="# Hello"
+        )
+        cancel = threading.Event()
+        cancel.set()
+        paths = await crawl_and_save("https://example.com", cancel=cancel)
+        assert paths == []
+
 
 class TestPeriodicSync:
     async def test_sync_disabled_when_interval_zero(self, isolated_env):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -348,6 +348,86 @@ class TestSync:
         assert "qflaky.txt" not in result.updated
 
 
+@mock.patch("kreuzberg.extract_file", new_callable=AsyncMock, return_value=_make_kreuzberg_result())
+class TestSyncCancellation:
+    """Tests for cancel support and atomic per-file delete in sync."""
+
+    async def test_cancel_stops_file_discovery(self, mock_extract_file, isolated_env):
+        """Setting cancel before sync starts prevents any file processing."""
+        import threading
+
+        (isolated_env / "a.txt").write_text("file a")
+        (isolated_env / "b.txt").write_text("file b")
+        from lilbee.ingest import sync
+
+        cancel = threading.Event()
+        cancel.set()
+        result = await sync(quiet=True, cancel=cancel)
+        # Cancel was set before the loop, so no files should be processed
+        assert result.added == []
+        assert result.unchanged == 0
+
+    async def test_cancel_during_ingest_batch(self, mock_extract_file, isolated_env, mock_svc):
+        """Cancel set mid-batch raises CancelledError for pending files."""
+        import asyncio
+        import threading
+
+        from lilbee.ingest import ingest_batch
+
+        (isolated_env / "a.txt").write_text("file a")
+        (isolated_env / "b.txt").write_text("file b")
+
+        cancel = threading.Event()
+        cancel.set()
+
+        added = ["a.txt", "b.txt"]
+        files = [
+            ("a.txt", isolated_env / "a.txt", "text", "hash_a", False),
+            ("b.txt", isolated_env / "b.txt", "text", "hash_b", False),
+        ]
+        with pytest.raises(asyncio.CancelledError):
+            await ingest_batch(files, added, [], [], quiet=True, cancel=cancel)
+
+    async def test_atomic_delete_for_modified_file(self, mock_extract_file, isolated_env, mock_svc):
+        """Modified file: old chunks deleted in _process_one, not in sync() loop."""
+        from lilbee.ingest import sync
+
+        f = isolated_env / "doc.txt"
+        f.write_text("Version 1")
+        await sync(quiet=True)
+
+        # Reset call tracking
+        mock_svc.store.delete_by_source.reset_mock()
+
+        f.write_text("Version 2 — modified content")
+        await sync(quiet=True)
+
+        # delete_by_source should be called (from _process_one), not from the sync loop
+        mock_svc.store.delete_by_source.assert_called_with("doc.txt")
+
+    async def test_cancel_preserves_old_chunks_for_modified_file(
+        self, mock_extract_file, isolated_env, mock_svc
+    ):
+        """If cancel is set before a modified file is processed, old chunks remain."""
+        import threading
+
+        from lilbee.ingest import sync
+
+        f = isolated_env / "doc.txt"
+        f.write_text("Version 1")
+        await sync(quiet=True)
+
+        mock_svc.store.delete_by_source.reset_mock()
+
+        f.write_text("Version 2 — modified content")
+        cancel = threading.Event()
+        cancel.set()
+        await sync(quiet=True, cancel=cancel)
+
+        # Old chunks should NOT have been deleted since cancel was set before processing
+        mock_svc.store.delete_by_source.assert_not_called()
+
+
 class TestIngestHelpers:
     """Cover edge cases in ingest_document and ingest_code_sync."""
 
@@ -408,7 +488,7 @@ class TestCancellation:
             added = ["cancel.txt"]
             with pytest.raises(asyncio.CancelledError):
                 await ingest_batch(
-                    [("cancel.txt", isolated_env / "cancel.txt", "text", "abc123")],
+                    [("cancel.txt", isolated_env / "cancel.txt", "text", "abc123", False)],
                     added,
                     [],
                     [],

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -459,7 +459,7 @@ class TestSyncStream:
                     break
 
         assert captured_cancel and captured_cancel[0].is_set()
-        assert any("Sync stream cancelled" in r.message for r in caplog.records)
+        assert any("Sync stream cancelled by client" in r.message for r in caplog.records)
 
 
 class TestAddFiles:
@@ -693,7 +693,7 @@ class TestModelsPull:
                     barrier.set()
                     break
 
-        assert any("Model pull stream cancelled" in r.message for r in caplog.records)
+        assert any("Model pull stream cancelled by client" in r.message for r in caplog.records)
 
 
 class TestModelsDelete:
@@ -998,7 +998,7 @@ class TestCrawlStream:
                     barrier.set()
                     break
 
-        assert any("Crawl stream cancelled" in r.message for r in caplog.records)
+        assert any("Crawl stream cancelled by client" in r.message for r in caplog.records)
 
 
 class TestSseHelpers:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -474,12 +474,10 @@ class TestAddFiles:
             return SyncResult()
 
         with patch("lilbee.ingest.sync", side_effect=fake_sync):
-            _paths, _queue, _task, cancel = await handlers.add_files(
-                {"paths": [str(test_file)]}
-            )
-            assert isinstance(cancel, threading.Event)
-            assert not cancel.is_set()
-            _task.cancel()
+            result = await handlers.add_files({"paths": [str(test_file)]})
+            assert isinstance(result.cancel, threading.Event)
+            assert not result.cancel.is_set()
+            result.task.cancel()
 
 
 class TestListModels:
@@ -628,7 +626,7 @@ class TestModelsInstalled:
         from lilbee.model_manager import ModelSource
 
         mock_manager.get_source.return_value = ModelSource.LITELLM
-        with patch("lilbee.model_manager.get_model_manager", return_value=mock_manager):
+        with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             result = await handlers.models_installed()
         assert len(result.models) == 2
         assert result.models[0].source == "litellm"
@@ -637,7 +635,7 @@ class TestModelsInstalled:
         mock_manager = MagicMock()
         mock_manager.list_installed.return_value = ["unknown"]
         mock_manager.get_source.return_value = None
-        with patch("lilbee.model_manager.get_model_manager", return_value=mock_manager):
+        with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             result = await handlers.models_installed()
         assert result.models[0].source == "litellm"
 
@@ -653,7 +651,7 @@ class TestModelsPull:
             return None
 
         mock_manager.pull.side_effect = fake_pull
-        with patch("lilbee.model_manager.get_model_manager", return_value=mock_manager):
+        with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             events = [e async for e in handlers.models_pull("test", source="native")]
         non_empty = [e for e in events if e]
         assert any("downloading" in e for e in non_empty)
@@ -662,7 +660,7 @@ class TestModelsPull:
     async def test_error_yields_error_event(self):
         mock_manager = MagicMock()
         mock_manager.pull.side_effect = RuntimeError("fail")
-        with patch("lilbee.model_manager.get_model_manager", return_value=mock_manager):
+        with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             events = [e async for e in handlers.models_pull("bad", source="native")]
         non_empty = [e for e in events if e]
         assert any("error" in e and "fail" in e for e in non_empty)
@@ -683,7 +681,7 @@ class TestModelsPull:
 
         mock_manager.pull.side_effect = blocking_pull
         with (
-            patch("lilbee.model_manager.get_model_manager", return_value=mock_manager),
+            patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager),
             caplog.at_level(logging.INFO, logger="lilbee.server.handlers"),
         ):
             gen = handlers.models_pull("test", source="native")
@@ -700,7 +698,7 @@ class TestModelsDelete:
     async def test_returns_deleted_true(self):
         mock_manager = MagicMock()
         mock_manager.remove.return_value = True
-        with patch("lilbee.model_manager.get_model_manager", return_value=mock_manager):
+        with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             result = await handlers.models_delete("test", source="litellm")
         assert result.deleted is True
         assert result.model == "test"
@@ -708,7 +706,7 @@ class TestModelsDelete:
     async def test_returns_deleted_false(self):
         mock_manager = MagicMock()
         mock_manager.remove.return_value = False
-        with patch("lilbee.model_manager.get_model_manager", return_value=mock_manager):
+        with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             result = await handlers.models_delete("missing", source="native")
         assert result.deleted is False
         assert result.freed_gb == 0.0

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -363,7 +363,7 @@ class TestSyncStream:
         sync_result = SyncResult(added=["a.txt"], unchanged=0)
 
         async def fake_sync(
-            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None
+            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None, cancel=None
         ):
             if on_progress:
                 from lilbee.progress import FileDoneEvent, SyncDoneEvent
@@ -387,7 +387,7 @@ class TestSyncStream:
         sync_result = SyncResult(added=["b.txt"])
 
         async def fake_sync(
-            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None
+            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None, cancel=None
         ):
             if on_progress:
                 from lilbee.progress import FileDoneEvent, FileStartEvent, SyncDoneEvent
@@ -416,7 +416,7 @@ class TestSyncStream:
         sync_result = SyncResult()
 
         async def slow_sync(
-            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None
+            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None, cancel=None
         ):
             await asyncio.sleep(0.2)  # force at least one timeout iteration
             return sync_result
@@ -426,6 +426,60 @@ class TestSyncStream:
 
         done_events = [e for e in events if e.startswith("event: done")]
         assert len(done_events) == 1
+
+    async def test_cancel_sets_cancel_event(self, caplog):
+        """Closing the sync_stream generator signals cancel to the sync task."""
+        import threading
+
+        barrier = threading.Event()
+        captured_cancel: list[threading.Event] = []
+
+        async def blocking_sync(
+            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None, cancel=None
+        ):
+            captured_cancel.append(cancel)
+            if on_progress:
+                from lilbee.progress import FileStartEvent
+
+                on_progress(
+                    "file_start", FileStartEvent(file="a.txt", total_files=1, current_file=1)
+                )
+            barrier.wait(timeout=2)
+            return SyncResult()
+
+        with (
+            patch("lilbee.ingest.sync", side_effect=blocking_sync),
+            caplog.at_level(logging.INFO, logger="lilbee.server.handlers"),
+        ):
+            gen = handlers.sync_stream()
+            async for event in gen:
+                if event and "file_start" in event:
+                    await gen.aclose()
+                    barrier.set()
+                    break
+
+        assert captured_cancel and captured_cancel[0].is_set()
+        assert any("Sync stream cancelled" in r.message for r in caplog.records)
+
+
+class TestAddFiles:
+    async def test_returns_cancel_event(self, isolated_env):
+        """add_files returns a cancel event as the fourth element."""
+        import threading
+
+        test_file = isolated_env / "documents" / "test.txt"
+        test_file.write_text("test content")
+
+        async def fake_sync(**kwargs):
+            return SyncResult()
+
+        with patch("lilbee.ingest.sync", side_effect=fake_sync):
+            _paths, _queue, _task, cancel = await handlers.add_files(
+                {"paths": [str(test_file)]}
+            )
+            assert isinstance(cancel, threading.Event)
+            assert not cancel.is_set()
+            _task.cancel()
 
 
 class TestListModels:
@@ -612,6 +666,34 @@ class TestModelsPull:
             events = [e async for e in handlers.models_pull("bad", source="native")]
         non_empty = [e for e in events if e]
         assert any("error" in e and "fail" in e for e in non_empty)
+
+    async def test_cancel_stops_pull(self, caplog):
+        """Closing the pull generator mid-stream sets cancel and logs."""
+        import threading
+
+        barrier = threading.Event()
+        mock_manager = MagicMock()
+
+        def blocking_pull(model, source, *, on_progress=None):
+            if on_progress:
+                on_progress({"status": "downloading"})
+            barrier.wait(timeout=2)
+            if on_progress:
+                on_progress({"status": "done"})
+
+        mock_manager.pull.side_effect = blocking_pull
+        with (
+            patch("lilbee.model_manager.get_model_manager", return_value=mock_manager),
+            caplog.at_level(logging.INFO, logger="lilbee.server.handlers"),
+        ):
+            gen = handlers.models_pull("test", source="native")
+            async for event in gen:
+                if event and "downloading" in event:
+                    await gen.aclose()
+                    barrier.set()
+                    break
+
+        assert any("Model pull stream cancelled" in r.message for r in caplog.records)
 
 
 class TestModelsDelete:
@@ -868,7 +950,7 @@ class TestCrawlStream:
     async def test_streams_events_and_done(self, _mock_validate, mock_crawl):
         from pathlib import Path
 
-        async def fake_crawl(url, *, depth, max_pages, on_progress):
+        async def fake_crawl(url, *, depth, max_pages, on_progress, cancel=None):
             from lilbee.progress import CrawlDoneEvent, CrawlPageEvent, CrawlStartEvent
 
             on_progress("crawl_start", CrawlStartEvent(url=url, depth=depth))
@@ -891,6 +973,32 @@ class TestCrawlStream:
         async for event in handlers.crawl_stream("https://example.com"):
             events.append(event)
         assert any("error" in e and "network fail" in e for e in events)
+
+    @patch("lilbee.crawler.crawl_and_save")
+    @patch("lilbee.crawler.validate_crawl_url")
+    async def test_cancel_stops_crawl(self, _mock_validate, mock_crawl, caplog):
+        """Closing the crawl generator mid-stream sets cancel and logs."""
+        import threading
+
+        barrier = threading.Event()
+
+        async def blocking_crawl(url, *, depth, max_pages, on_progress, cancel=None):
+            from lilbee.progress import CrawlStartEvent
+
+            on_progress("crawl_start", CrawlStartEvent(url=url, depth=depth))
+            barrier.wait(timeout=2)
+            return []
+
+        mock_crawl.side_effect = blocking_crawl
+        with caplog.at_level(logging.INFO, logger="lilbee.server.handlers"):
+            gen = handlers.crawl_stream("https://example.com")
+            async for event in gen:
+                if event and "crawl_start" in event:
+                    await gen.aclose()
+                    barrier.set()
+                    break
+
+        assert any("Crawl stream cancelled" in r.message for r in caplog.records)
 
 
 class TestSseHelpers:


### PR DESCRIPTION
Sync, add, pull, and crawl now stop cleanly when the client disconnects. Old chunks stay searchable until new ones are ready — no more gaps during sync. Auto-sync suppressed after cancellation.