### PR TITLE
feat: TUI catalog grid view with toad-inspired architecture

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -19,6 +19,7 @@ import httpx
 from pydantic import BaseModel
 
 from lilbee.config import cfg
+from lilbee.models import ModelTask
 
 log = logging.getLogger(__name__)
 
@@ -85,91 +86,36 @@ class ModelFamily:
     variants: tuple[ModelVariant, ...]
 
 
-FEATURED_CHAT: tuple[CatalogModel, ...] = (
-    CatalogModel(
-        "Qwen3 0.6B",
-        "Qwen/Qwen3-0.6B-GGUF",
-        "*Q4_K_M.gguf",
-        0.5,
-        2,
-        "Tiny — runs on anything",
-        True,
-        0,
-        "chat",
-    ),
-    CatalogModel(
-        "Qwen3 4B",
-        "Qwen/Qwen3-4B-GGUF",
-        "*Q4_K_M.gguf",
-        2.5,
-        8,
-        "Small — good balance for 8 GB RAM",
-        True,
-        0,
-        "chat",
-    ),
-    CatalogModel(
-        "Qwen3 8B",
-        "Qwen/Qwen3-8B-GGUF",
-        "*Q4_K_M.gguf",
-        5.0,
-        8,
-        "Medium — strong general purpose",
-        True,
-        0,
-        "chat",
-    ),
-    CatalogModel(
-        "Mistral 7B Instruct",
-        "MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF",
-        "*Q4_K_M.gguf",
-        4.4,
-        8,
-        "Fast 7B, 32K context",
-        True,
-        0,
-        "chat",
-    ),
-    CatalogModel(
-        "Qwen3-Coder 30B A3B",
-        "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF",
-        "*Q4_K_M.gguf",
-        18.0,
-        32,
-        "Extra large — best quality",
-        True,
-        0,
-        "chat",
-    ),
-)
+def _load_featured() -> tuple[
+    tuple[CatalogModel, ...], tuple[CatalogModel, ...], tuple[CatalogModel, ...]
+]:
+    """Load featured models from the TOML file, cached after first call."""
+    import tomllib
 
-FEATURED_EMBEDDING: tuple[CatalogModel, ...] = (
-    CatalogModel(
-        "Nomic Embed Text v1.5",
-        "nomic-ai/nomic-embed-text-v1.5-GGUF",
-        "nomic-embed-text-v1.5.Q4_K_M.gguf",
-        0.3,
-        2,
-        "Fast, high quality — default for lilbee",
-        True,
-        0,
-        "embedding",
-    ),
-)
+    toml_path = Path(__file__).parent / "featured_models.toml"
+    with open(toml_path, "rb") as f:
+        data = tomllib.load(f)
 
-FEATURED_VISION: tuple[CatalogModel, ...] = (
-    CatalogModel(
-        "LightOnOCR-2",
-        "noctrex/LightOnOCR-2-1B-GGUF",
-        "*Q4_K_M.gguf",
-        1.5,
-        4,
-        "Fast OCR — clean markdown output, small footprint",
-        True,
-        0,
-        "vision",
-    ),
-)
+    def _build(task: ModelTask) -> tuple[CatalogModel, ...]:
+        return tuple(
+            CatalogModel(
+                name=m["name"],
+                hf_repo=m["hf_repo"],
+                gguf_filename=m["gguf_filename"],
+                size_gb=m["size_gb"],
+                min_ram_gb=m["min_ram_gb"],
+                description=m["description"],
+                featured=True,
+                downloads=0,
+                task=task,
+            )
+            for m in data.get(task, [])
+        )
+
+    return _build(ModelTask.CHAT), _build(ModelTask.EMBEDDING), _build(ModelTask.VISION)
+
+
+FEATURED_CHAT, FEATURED_EMBEDDING, FEATURED_VISION = _load_featured()
 
 # Maps vision catalog entries to their mmproj (CLIP projection) filenames.
 # Vision models need both the main GGUF and the mmproj file to work.
@@ -259,9 +205,9 @@ def get_families() -> list[ModelFamily]:
     the largest marked as recommended (for multi-variant families).
     """
     return (
-        _build_families(FEATURED_CHAT, "chat")
-        + _build_families(FEATURED_EMBEDDING, "embedding")
-        + _build_families(FEATURED_VISION, "vision")
+        _build_families(FEATURED_CHAT, ModelTask.CHAT)
+        + _build_families(FEATURED_EMBEDDING, ModelTask.EMBEDDING)
+        + _build_families(FEATURED_VISION, ModelTask.VISION)
     )
 
 
@@ -463,25 +409,25 @@ def get_catalog(
 
 def _task_to_pipeline(task: str | None) -> tuple[str, str | None]:
     """Map task name to HuggingFace pipeline tag and library filter."""
-    mapping = {
-        "chat": ("text-generation", None),
-        "embedding": ("feature-extraction", "sentence-transformers"),
-        "vision": ("image-text-to-text", None),
+    mapping: dict[str, tuple[str, str | None]] = {
+        ModelTask.CHAT: ("text-generation", None),
+        ModelTask.EMBEDDING: ("feature-extraction", "sentence-transformers"),
+        ModelTask.VISION: ("image-text-to-text", None),
     }
-    return mapping.get(task or "chat", ("text-generation", None))
+    return mapping.get(task or ModelTask.CHAT, ("text-generation", None))
 
 
 _PIPELINE_TO_TASK: dict[str, str] = {
-    "text-generation": "chat",
-    "feature-extraction": "embedding",
-    "image-text-to-text": "vision",
-    "image-to-text": "vision",
+    "text-generation": ModelTask.CHAT,
+    "feature-extraction": ModelTask.EMBEDDING,
+    "image-text-to-text": ModelTask.VISION,
+    "image-to-text": ModelTask.VISION,
 }
 
 
 def _pipeline_to_task(pipeline_tag: str) -> str:
     """Map HuggingFace pipeline tag to internal task name."""
-    return _PIPELINE_TO_TASK.get(pipeline_tag, "chat")
+    return _PIPELINE_TO_TASK.get(pipeline_tag, ModelTask.CHAT)
 
 
 def _get_installed_models(model_manager: Any) -> set[str]:
@@ -568,7 +514,7 @@ def download_model(entry: CatalogModel, *, on_progress: Any = None) -> Path:
     _register_model(entry, dest)
 
     # Download mmproj file for vision models
-    if entry.task == "vision":
+    if entry.task == ModelTask.VISION:
         _download_mmproj(entry)
 
     return dest

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -529,7 +529,7 @@ def download_model(entry: CatalogModel, *, on_progress: Any = None) -> Path:
 
     cfg.models_dir.mkdir(parents=True, exist_ok=True)
 
-    filename = _resolve_filename(entry)
+    filename = resolve_filename(entry)
     dest = cfg.models_dir / filename
     if dest.exists():
         log.info("Model already downloaded: %s", dest)
@@ -689,7 +689,7 @@ def find_mmproj_file(model_name: str) -> Path | None:
 _QUANT_PREFERENCE = ("Q4_K_M", "Q4_K_S", "Q5_K_M", "Q5_K_S", "Q8_0", "Q6_K", "Q3_K_M")
 
 
-def _resolve_filename(entry: CatalogModel) -> str:
+def resolve_filename(entry: CatalogModel) -> str:
     """Resolve a GGUF filename pattern to the best concrete filename.
 
     For exact filenames, return as-is. For wildcards, query the HF API

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -8,9 +8,11 @@ from typing import ClassVar
 
 from textual.app import App
 from textual.binding import Binding, BindingType
+from textual.signal import Signal
 
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.commands import LilbeeCommandProvider
+from lilbee.cli.tui.events import ModelChanged
 from lilbee.cli.tui.widgets.nav_bar import NavBar
 from lilbee.config import cfg
 
@@ -59,6 +61,12 @@ class LilbeeApp(App[None]):
         self._auto_sync = auto_sync
         self._active_view = "Chat"
         self._theme_index = 0
+        self.settings_changed_signal: Signal[tuple[str, object]] = Signal(
+            self, "settings_changed"
+        )
+        self.model_changed_signal: Signal[ModelChanged] = Signal(
+            self, "model_changed"
+        )
         from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         self._task_bar = TaskBar(id="app-task-bar")

--- a/src/lilbee/cli/tui/events.py
+++ b/src/lilbee/cli/tui/events.py
@@ -8,10 +8,12 @@ from dataclasses import dataclass
 
 from textual.message import Message
 
+from lilbee.models import ModelTask
+
 
 @dataclass
 class ModelChanged(Message):
     """Fired when the active chat, embedding, or vision model changes."""
 
-    role: str  # "chat" | "embedding" | "vision"
+    role: ModelTask
     name: str

--- a/src/lilbee/cli/tui/events.py
+++ b/src/lilbee/cli/tui/events.py
@@ -1,0 +1,17 @@
+"""Typed Textual Message subclasses for cross-widget communication.
+
+These complement messages.py (which holds user-facing string constants).
+Widgets post these messages for structured, typed event handling.
+"""
+
+from dataclasses import dataclass
+
+from textual.message import Message
+
+
+@dataclass
+class ModelChanged(Message):
+    """Fired when the active chat, embedding, or vision model changes."""
+
+    role: str  # "chat" | "embedding" | "vision"
+    name: str

--- a/src/lilbee/cli/tui/pill.py
+++ b/src/lilbee/cli/tui/pill.py
@@ -5,6 +5,9 @@ Ported from toad (https://github.com/batrachianai/toad).
 
 from textual.content import Content
 
+PILL_LEFT = "\u258c"  # left half block
+PILL_RIGHT = "\u2590"  # right half block
+
 
 def pill(text: Content | str, background: str, foreground: str) -> Content:
     """Format text as a pill badge with rounded half-block ends.
@@ -21,7 +24,7 @@ def pill(text: Content | str, background: str, foreground: str) -> Content:
     main_style = f"{foreground} on {background}"
     end_style = f"{background} on transparent r"
     return Content.assemble(
-        ("\u258c", end_style),
+        (PILL_LEFT, end_style),
         content.stylize(main_style),
-        ("\u2590", end_style),
+        (PILL_RIGHT, end_style),
     )

--- a/src/lilbee/cli/tui/pill.py
+++ b/src/lilbee/cli/tui/pill.py
@@ -1,0 +1,27 @@
+"""Pill badge — colored inline label using half-block characters.
+
+Ported from toad (https://github.com/batrachianai/toad).
+"""
+
+from textual.content import Content
+
+
+def pill(text: Content | str, background: str, foreground: str) -> Content:
+    """Format text as a pill badge with rounded half-block ends.
+
+    Args:
+        text: Pill contents.
+        background: Background color (Textual color string, e.g. "$primary").
+        foreground: Foreground color (Textual color string, e.g. "$text").
+
+    Returns:
+        Styled Content with half-block ends.
+    """
+    content = Content(text) if isinstance(text, str) else text
+    main_style = f"{foreground} on {background}"
+    end_style = f"{background} on transparent r"
+    return Content.assemble(
+        ("\u258c", end_style),
+        content.stylize(main_style),
+        ("\u2590", end_style),
+    )

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -30,11 +30,12 @@ from lilbee.cli.tui.widgets.model_card import ModelCard
 from lilbee.cli.tui.widgets.nav_bar import NavBar
 from lilbee.config import cfg
 from lilbee.model_manager import RemoteModel, get_model_manager
+from lilbee.models import ModelTask
 
 log = logging.getLogger(__name__)
 
 _HF_PAGE_SIZE = 25
-_ALL_TASKS = ("chat", "embedding", "vision")
+_ALL_TASKS = tuple(ModelTask)
 
 COLUMNS = ("Name", "Task", "Params", "Size", "Quant", "Downloads")
 
@@ -693,9 +694,11 @@ def _group_rows_for_grid(
     """Group rows into sections for the grid view."""
     recommended = [r for r in rows if r.featured]
     installed = [r for r in rows if r.installed and not r.featured]
-    chat = [r for r in rows if r.task == "chat" and not r.featured and not r.installed]
-    embedding = [r for r in rows if r.task == "embedding" and not r.featured and not r.installed]
-    vision = [r for r in rows if r.task == "vision" and not r.featured and not r.installed]
+    chat = [r for r in rows if r.task == ModelTask.CHAT and not r.featured and not r.installed]
+    embedding = [
+        r for r in rows if r.task == ModelTask.EMBEDDING and not r.featured and not r.installed
+    ]
+    vision = [r for r in rows if r.task == ModelTask.VISION and not r.featured and not r.installed]
     return [
         ("Recommended", recommended),
         ("Installed", installed),

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -1,4 +1,4 @@
-"""Catalog screen -- browse and install models via a single DataTable."""
+"""Catalog screen -- browse and install models via grid or list view."""
 
 from __future__ import annotations
 
@@ -8,9 +8,10 @@ import re
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
-from textual import work
+from textual import on, work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
+from textual.containers import VerticalScroll
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Header, Input, Static
 from textual.worker import Worker, WorkerState
@@ -24,6 +25,8 @@ from lilbee.catalog import (
     get_families,
 )
 from lilbee.cli.tui import messages as msg
+from lilbee.cli.tui.widgets.grid_select import GridSelect
+from lilbee.cli.tui.widgets.model_card import ModelCard
 from lilbee.cli.tui.widgets.nav_bar import NavBar
 from lilbee.config import cfg
 from lilbee.model_manager import RemoteModel, get_model_manager
@@ -40,21 +43,6 @@ def _parse_param_label(name: str) -> str:
     """Extract parameter count label from model name (e.g. '8B', '0.6B')."""
     match = re.search(r"(\d+\.?\d*)B", name, re.IGNORECASE)
     return f"{match.group(1)}B" if match else "--"
-
-
-def _parse_param_size(name: str) -> str:
-    """Extract parameter size category from model name."""
-    match = re.search(r"(\d+\.?\d*)B", name, re.IGNORECASE)
-    if not match:
-        return "unknown"
-    size = float(match.group(1))
-    if size <= 3:
-        return "Small (<=3B)"
-    if size <= 8:
-        return "Medium (3-8B)"
-    if size <= 30:
-        return "Large (8-30B)"
-    return "Extra Large (30B+)"
 
 
 def _format_downloads(n: int) -> str:
@@ -191,11 +179,14 @@ def _param_sort_value(params: str) -> float:
 
 
 class CatalogScreen(Screen[None]):
-    """Model catalog with a single sortable DataTable."""
+    """Model catalog with grid (default) and list views."""
+
+    CSS_PATH = "catalog.tcss"
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "pop_screen", "Back", show=True),
         Binding("escape", "pop_screen", "Back", show=False),
+        Binding("v", "toggle_view", "View", show=True),
         Binding("slash", "focus_search", "Search", show=True),
         Binding("d", "delete_model", "Delete", show=True),
         Binding("x", "delete_model", "Delete", show=False),
@@ -220,11 +211,14 @@ class CatalogScreen(Screen[None]):
         self._sort_ascending: bool = True
         self._pending_delete: str | None = None
         self._installed_names: set[str] = set()
+        self._grid_view: bool = True
+        self._hf_fetched: bool = False
 
     def compose(self) -> ComposeResult:
         yield NavBar(id="global-nav-bar")
         yield Header()
         yield Static("", id="sort-label", shrink=True)
+        yield VerticalScroll(id="catalog-grid")
         yield DataTable(id="catalog-table", cursor_type="row")
         yield Input(placeholder=msg.CATALOG_FILTER_PLACEHOLDER, id="catalog-search")
         yield Static("", id="model-detail")
@@ -236,8 +230,8 @@ class CatalogScreen(Screen[None]):
         for col in COLUMNS:
             table.add_column(col, key=col)
         self._fetch_installed_names()
-        self._refresh_table()
-        self._fetch_all_hf_models()
+        self.add_class("-grid-view")
+        self._refresh_grid()
         self._fetch_remote_models()
 
     def _fetch_installed_names(self) -> None:
@@ -253,6 +247,24 @@ class CatalogScreen(Screen[None]):
                 if m.source_repo and m.source_filename:
                     self._installed_names.add(f"{m.source_repo}/{m.source_filename}")
 
+    def action_toggle_view(self) -> None:
+        """Toggle between grid and list view."""
+        if self._grid_view:
+            self._grid_view = False
+            self.remove_class("-grid-view")
+            self.add_class("-list-view")
+            if not self._hf_fetched:
+                self._hf_fetched = True
+                self._fetch_all_hf_models()
+            self._refresh_table()
+            with contextlib.suppress(Exception):
+                self.query_one("#catalog-table", DataTable).focus()
+        else:
+            self._grid_view = True
+            self.remove_class("-list-view")
+            self.add_class("-grid-view")
+            self._refresh_grid()
+
     def action_focus_search(self) -> None:
         """Focus the filter input -- bound to / key."""
         filter_input = self.query_one("#catalog-search", Input)
@@ -262,7 +274,7 @@ class CatalogScreen(Screen[None]):
     def on_input_changed(self, event: Input.Changed) -> None:
         """Filter models when input changes."""
         if event.input.id == "catalog-search":
-            self._refresh_table()
+            self._refresh_view()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Close filter on Enter."""
@@ -271,9 +283,8 @@ class CatalogScreen(Screen[None]):
             with contextlib.suppress(Exception):
                 self.query_one("#catalog-table", DataTable).focus()
 
-    @work(thread=True)
-    def _fetch_all_hf_models(self) -> list[CatalogModel]:
-        """Fetch HF models for all task types and merge results."""
+    def _fetch_hf_page(self) -> list[CatalogModel]:
+        """Fetch one page of HF models for all task types (runs in worker thread)."""
         all_models: list[CatalogModel] = []
         seen_repos: set[str] = set()
         for task in _ALL_TASKS:
@@ -289,6 +300,11 @@ class CatalogScreen(Screen[None]):
                     all_models.append(m)
         self._hf_has_more = len(all_models) >= _HF_PAGE_SIZE
         return all_models
+
+    @work(thread=True)
+    def _fetch_all_hf_models(self) -> list[CatalogModel]:
+        """Fetch HF models for all task types (replaces current list)."""
+        return self._fetch_hf_page()
 
     @work(thread=True)
     def _fetch_remote_models(self) -> list[RemoteModel]:
@@ -298,22 +314,8 @@ class CatalogScreen(Screen[None]):
 
     @work(thread=True)
     def _fetch_more_hf(self) -> list[CatalogModel]:
-        """Fetch next page of HF models for all task types."""
-        all_models: list[CatalogModel] = []
-        seen_repos: set[str] = set()
-        for task in _ALL_TASKS:
-            result = get_catalog(
-                task=task,
-                featured=False,
-                limit=_HF_PAGE_SIZE,
-                offset=self._hf_offset,
-            )
-            for m in result.models:
-                if not m.featured and m.hf_repo not in seen_repos:
-                    seen_repos.add(m.hf_repo)
-                    all_models.append(m)
-        self._hf_has_more = len(all_models) >= _HF_PAGE_SIZE
-        return all_models
+        """Fetch next page of HF models for all task types (extends current list)."""
+        return self._fetch_hf_page()
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         if event.state != WorkerState.SUCCESS:
@@ -321,13 +323,13 @@ class CatalogScreen(Screen[None]):
         result = event.worker.result
         if event.worker.name == "_fetch_all_hf_models" and isinstance(result, list):
             self._hf_models = result
-            self._refresh_table()
+            self._refresh_view()
         elif event.worker.name == "_fetch_more_hf" and isinstance(result, list):
             self._hf_models.extend(result)
-            self._refresh_table()
+            self._refresh_view()
         elif event.worker.name == "_fetch_remote_models" and isinstance(result, list):
             self._remote_models = result
-            self._refresh_table()
+            self._refresh_view()
 
     def _get_search_text(self) -> str:
         return self.query_one("#catalog-search", Input).value.strip().lower()
@@ -390,6 +392,38 @@ class CatalogScreen(Screen[None]):
             key=lambda r: (not r.featured, key_fn(r)),
             reverse=not self._sort_ascending,
         )
+
+    def _refresh_view(self) -> None:
+        """Refresh the active view (grid or list)."""
+        if self._grid_view:
+            self._refresh_grid()
+        else:
+            self._refresh_table()
+
+    def _refresh_grid(self) -> None:
+        """Rebuild the grid view from local-only data sources."""
+        search = self._get_search_text()
+        container = self.query_one("#catalog-grid", VerticalScroll)
+        container.remove_children()
+        family_rows = self._build_family_rows(search)
+        remote_rows = self._build_remote_rows(search)
+        hf_rows = self._build_hf_rows(search) if self._hf_fetched else []
+        all_rows = family_rows + remote_rows + hf_rows
+        widgets_to_mount: list[Static | GridSelect] = []
+        for heading, rows in _group_rows_for_grid(all_rows):
+            if not rows:
+                continue
+            widgets_to_mount.append(Static(heading, classes="section-heading"))
+            cards = [ModelCard(row) for row in rows]
+            grid = GridSelect(*cards, min_column_width=30, max_column_width=50)
+            widgets_to_mount.append(grid)
+        container.mount_all(widgets_to_mount)
+
+    @on(GridSelect.Selected)
+    def _on_grid_selected(self, event: GridSelect.Selected) -> None:
+        """Handle model selection from the grid view."""
+        if isinstance(event.widget, ModelCard):
+            self._select_row(event.widget.row)
 
     def _refresh_table(self) -> None:
         """Rebuild the DataTable from current data."""
@@ -465,16 +499,16 @@ class CatalogScreen(Screen[None]):
         self._install_model(entry)
 
     def _install_model(self, model: CatalogModel) -> None:
-        from lilbee.catalog import _resolve_filename
+        from lilbee.catalog import resolve_filename
 
         try:
-            filename = _resolve_filename(model)
+            filename = resolve_filename(model)
             dest = cfg.models_dir / filename
             if dest.exists():
                 self.notify(msg.CATALOG_ALREADY_INSTALLED.format(name=model.name))
                 return
         except Exception:
-            pass  # Can't resolve filename -- proceed with download
+            log.debug("Could not resolve filename", exc_info=True)
 
         self._enqueue_download(model)
 
@@ -510,9 +544,7 @@ class CatalogScreen(Screen[None]):
                     )
                 else:
                     # Total unknown - just show MB downloaded
-                    self._safe_call(
-                        bar.update_task, task_id, 0, f"{mb_done:.0f} MB"
-                    )
+                    self._safe_call(bar.update_task, task_id, 0, f"{mb_done:.0f} MB")
 
             download_model(model, on_progress=on_progress)
             self._safe_call(bar.complete_task, task_id)
@@ -604,43 +636,43 @@ class CatalogScreen(Screen[None]):
             )
 
     def _refresh_after_delete(self) -> None:
-        """Re-fetch remote models and refresh table after deletion."""
+        """Re-fetch remote models and refresh after deletion."""
         self._fetch_installed_names()
-        self._refresh_table()
+        self._refresh_view()
         self._fetch_remote_models()
 
     def action_page_down(self) -> None:
-        if isinstance(self.focused, Input):
+        if isinstance(self.focused, Input) or self._grid_view:
             return
         table = self.query_one("#catalog-table", DataTable)
         for _ in range(10):
             table.action_cursor_down()
 
     def action_page_up(self) -> None:
-        if isinstance(self.focused, Input):
+        if isinstance(self.focused, Input) or self._grid_view:
             return
         table = self.query_one("#catalog-table", DataTable)
         for _ in range(10):
             table.action_cursor_up()
 
     def action_cursor_down(self) -> None:
-        if isinstance(self.focused, Input):
+        if isinstance(self.focused, Input) or self._grid_view:
             return
         self.query_one("#catalog-table", DataTable).action_cursor_down()
 
     def action_cursor_up(self) -> None:
-        if isinstance(self.focused, Input):
+        if isinstance(self.focused, Input) or self._grid_view:
             return
         self.query_one("#catalog-table", DataTable).action_cursor_up()
 
     def action_jump_top(self) -> None:
-        if isinstance(self.focused, Input):
+        if isinstance(self.focused, Input) or self._grid_view:
             return
         table = self.query_one("#catalog-table", DataTable)
         table.move_cursor(row=0)
 
     def action_jump_bottom(self) -> None:
-        if isinstance(self.focused, Input):
+        if isinstance(self.focused, Input) or self._grid_view:
             return
         table = self.query_one("#catalog-table", DataTable)
         if self._rows:
@@ -653,6 +685,24 @@ class CatalogScreen(Screen[None]):
     def key_right(self) -> None:
         """Navigate to next view instead of switching tabs."""
         self.app.action_nav_next()
+
+
+def _group_rows_for_grid(
+    rows: list[TableRow],
+) -> list[tuple[str, list[TableRow]]]:
+    """Group rows into sections for the grid view."""
+    recommended = [r for r in rows if r.featured]
+    installed = [r for r in rows if r.installed and not r.featured]
+    chat = [r for r in rows if r.task == "chat" and not r.featured and not r.installed]
+    embedding = [r for r in rows if r.task == "embedding" and not r.featured and not r.installed]
+    vision = [r for r in rows if r.task == "vision" and not r.featured and not r.installed]
+    return [
+        ("Recommended", recommended),
+        ("Installed", installed),
+        ("Chat", chat),
+        ("Embedding", embedding),
+        ("Vision", vision),
+    ]
 
 
 def _matches_search(row: TableRow, search: str) -> bool:

--- a/src/lilbee/cli/tui/screens/catalog.tcss
+++ b/src/lilbee/cli/tui/screens/catalog.tcss
@@ -1,0 +1,46 @@
+/* Catalog screen — grid and list views */
+
+#catalog-grid {
+    height: 1fr;
+    overflow-y: auto;
+    padding: 0 1;
+}
+
+#catalog-table {
+    height: 1fr;
+}
+
+#sort-label {
+    height: 1;
+    padding: 0 1;
+    color: $text-muted;
+}
+
+#catalog-search {
+    dock: top;
+    margin: 0 1;
+}
+
+#model-detail {
+    height: 6;
+    padding: 1;
+    border-top: solid $surface-lighten-2;
+}
+
+.section-heading {
+    text-style: bold underline;
+    color: $text-muted;
+    padding: 1 0 0 1;
+}
+
+/* View toggle: hide inactive view */
+CatalogScreen.-grid-view #catalog-table { display: none; }
+CatalogScreen.-grid-view #sort-label { display: none; }
+CatalogScreen.-grid-view #model-detail { display: none; }
+CatalogScreen.-list-view #catalog-grid { display: none; }
+
+GridSelect {
+    height: auto;
+    padding: 0;
+    margin: 0;
+}

--- a/src/lilbee/cli/tui/theme.tcss
+++ b/src/lilbee/cli/tui/theme.tcss
@@ -17,19 +17,10 @@
     padding: 0 1;
 }
 
-#model-detail, #setting-detail {
+#setting-detail {
     height: 6;
     padding: 1;
     border-top: solid $surface-lighten-2;
-}
-
-#catalog-search {
-    dock: top;
-    margin: 0 1;
-}
-
-.model-row-text {
-    padding: 0 1;
 }
 
 .user-message {

--- a/src/lilbee/cli/tui/widgets/grid_select.py
+++ b/src/lilbee/cli/tui/widgets/grid_select.py
@@ -1,0 +1,195 @@
+"""GridSelect — responsive grid with cursor navigation.
+
+Ported from toad (https://github.com/batrachianai/toad).
+Extends Textual's ItemGrid with keyboard cursor, highlight class, and messages.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from typing import ClassVar
+
+from textual import containers, events
+from textual.binding import Binding, BindingType
+from textual.layouts.grid import GridLayout
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widget import Widget
+
+
+class GridSelect(containers.ItemGrid, can_focus=True):
+    """A responsive grid that supports arrow-key cursor navigation and selection."""
+
+    FOCUS_ON_CLICK = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("up", "cursor_up", "Up", show=False),
+        Binding("down", "cursor_down", "Down", show=False),
+        Binding("left", "cursor_left", "Left", show=False),
+        Binding("right", "cursor_right", "Right", show=False),
+        Binding("enter", "select", "Select", show=False),
+    ]
+
+    highlighted: reactive[int | None] = reactive(None)
+
+    @dataclass
+    class Selected(Message):
+        grid_select: GridSelect
+        widget: Widget
+
+        @property
+        def control(self) -> Widget:
+            return self.grid_select
+
+    @dataclass
+    class Highlighted(Message):
+        grid_select: GridSelect
+        widget: Widget
+
+        @property
+        def control(self) -> Widget:
+            return self.grid_select
+
+    @dataclass
+    class LeaveUp(Message):
+        grid_select: GridSelect
+
+    @dataclass
+    class LeaveDown(Message):
+        grid_select: GridSelect
+
+    def __init__(
+        self,
+        *children: Widget,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        min_column_width: int = 30,
+        max_column_width: int | None = None,
+    ) -> None:
+        super().__init__(
+            *children,
+            name=name,
+            id=id,
+            classes=classes,
+            min_column_width=min_column_width,
+            max_column_width=max_column_width,
+        )
+
+    @property
+    def grid_size(self) -> tuple[int, int] | None:
+        if not isinstance(self.layout, GridLayout):
+            return None
+        return self.layout.grid_size
+
+    def highlight_first(self) -> None:
+        self.highlighted = 0
+
+    def highlight_last(self) -> None:
+        if self.children:
+            self.highlighted = len(self.children) - 1
+
+    def on_focus(self) -> None:
+        if self.highlighted is None:
+            self.highlighted = 0
+        self.reveal_highlight()
+
+    def on_blur(self) -> None:
+        self.highlighted = None
+
+    def reveal_highlight(self) -> None:
+        if self.highlighted is None:
+            return
+        try:
+            widget = self.children[self.highlighted]
+        except IndexError:
+            return
+        if not self.screen.can_view_entire(widget):
+            self.screen.scroll_to_center(widget, origin_visible=True)
+
+    def watch_highlighted(self, old_highlighted: int | None, highlighted: int | None) -> None:
+        if old_highlighted is not None:
+            with contextlib.suppress(IndexError):
+                self.children[old_highlighted].remove_class("-highlight")
+        if highlighted is not None:
+            try:
+                widget = self.children[highlighted]
+                widget.add_class("-highlight")
+                self.post_message(self.Highlighted(self, widget))
+            except IndexError:
+                pass
+        self.reveal_highlight()
+
+    def validate_highlighted(self, highlighted: int | None) -> int | None:
+        if highlighted is None:
+            return None
+        if not self.children:
+            return None
+        if highlighted < 0:
+            return 0
+        if highlighted >= len(self.children):
+            return len(self.children) - 1
+        return highlighted
+
+    def action_cursor_up(self) -> None:
+        if (grid_size := self.grid_size) is None:
+            self.post_message(self.LeaveUp(self))
+            return
+        if self.highlighted is None:
+            self.highlighted = 0
+        else:
+            width, _height = grid_size
+            if self.highlighted >= width:
+                self.highlighted -= width
+            else:
+                self.post_message(self.LeaveUp(self))
+
+    def action_cursor_down(self) -> None:
+        if (grid_size := self.grid_size) is None:
+            self.post_message(self.LeaveDown(self))
+            return
+        if self.highlighted is None:
+            self.highlighted = 0
+        else:
+            width, _height = grid_size
+            if self.highlighted + width < len(self.children):
+                self.highlighted += width
+            else:
+                self.post_message(self.LeaveDown(self))
+
+    def action_cursor_left(self) -> None:
+        if self.highlighted is None:
+            self.highlighted = 0
+        else:
+            self.highlighted -= 1
+
+    def action_cursor_right(self) -> None:
+        if self.highlighted is None:
+            self.highlighted = 0
+        else:
+            self.highlighted += 1
+
+    def on_click(self, event: events.Click) -> None:
+        if event.widget is None:
+            return
+        highlighted_widget: Widget | None = None
+        if self.highlighted is not None:
+            with contextlib.suppress(IndexError):
+                highlighted_widget = self.children[self.highlighted]
+        for widget in event.widget.ancestors_with_self:
+            if widget in self.children:
+                if highlighted_widget is not None and highlighted_widget is widget:
+                    self.action_select()
+                else:
+                    self.highlighted = self.children.index(widget)
+                break
+        self.focus()
+
+    def action_select(self) -> None:
+        if self.highlighted is not None:
+            try:
+                widget = self.children[self.highlighted]
+            except IndexError:
+                pass
+            else:
+                self.post_message(self.Selected(self, widget))

--- a/src/lilbee/cli/tui/widgets/model_card.py
+++ b/src/lilbee/cli/tui/widgets/model_card.py
@@ -9,14 +9,17 @@ from textual.app import ComposeResult
 from textual.content import Content
 
 from lilbee.cli.tui.pill import pill
+from lilbee.models import ModelTask
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.screens.catalog import TableRow
 
+MIDDLE_DOT = "\u00b7"
+
 _TASK_COLORS: dict[str, str] = {
-    "chat": "$primary",
-    "embedding": "$secondary",
-    "vision": "$warning",
+    ModelTask.CHAT: "$primary",
+    ModelTask.EMBEDDING: "$secondary",
+    ModelTask.VISION: "$warning",
 }
 
 
@@ -80,7 +83,7 @@ def _build_specs(params: str, quant: str, size: str) -> Content:
     parts = [p for p in (params, quant, size) if p and p != "--"]
     if not parts:
         return Content("--")
-    return Content(" \u00b7 ".join(parts))
+    return Content(f" {MIDDLE_DOT} ".join(parts))
 
 
 def _build_status(row: TableRow) -> Content | None:

--- a/src/lilbee/cli/tui/widgets/model_card.py
+++ b/src/lilbee/cli/tui/widgets/model_card.py
@@ -1,0 +1,92 @@
+"""ModelCard — compact card widget for the catalog grid view."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual import containers, widgets
+from textual.app import ComposeResult
+from textual.content import Content
+
+from lilbee.cli.tui.pill import pill
+
+if TYPE_CHECKING:
+    from lilbee.cli.tui.screens.catalog import TableRow
+
+_TASK_COLORS: dict[str, str] = {
+    "chat": "$primary",
+    "embedding": "$secondary",
+    "vision": "$warning",
+}
+
+
+class ModelCard(containers.VerticalGroup):
+    """A single model card displaying name, task pill, specs, and status."""
+
+    DEFAULT_CSS = """
+    ModelCard {
+        height: auto;
+        border: tall transparent;
+        padding: 0 1;
+
+        &:hover {
+            background: $panel;
+        }
+
+        &.-highlight {
+            border: tall $primary;
+            background: $panel;
+        }
+
+        Grid {
+            grid-size: 2 1;
+            grid-columns: 1fr auto;
+            height: auto;
+        }
+
+        #card-name {
+            text-style: bold;
+        }
+
+        #card-info {
+            color: $text-muted;
+        }
+    }
+    """
+
+    def __init__(self, row: TableRow) -> None:
+        self._row = row
+        super().__init__()
+
+    @property
+    def row(self) -> TableRow:
+        return self._row
+
+    def compose(self) -> ComposeResult:
+        row = self._row
+        bg = _TASK_COLORS.get(row.task, "$primary")
+        with containers.Grid():
+            yield widgets.Label(row.name, id="card-name")
+            yield widgets.Label(pill(row.task, bg, "$text"), id="card-task")
+        specs = _build_specs(row.params, row.quant, row.size)
+        yield widgets.Label(specs, id="card-info")
+        status = _build_status(row)
+        if status is not None:
+            yield widgets.Label(status, id="card-status")
+
+
+def _build_specs(params: str, quant: str, size: str) -> Content:
+    """Build the specs line: params · quant · size."""
+    parts = [p for p in (params, quant, size) if p and p != "--"]
+    if not parts:
+        return Content("--")
+    return Content(" \u00b7 ".join(parts))
+
+
+def _build_status(row: TableRow) -> Content | None:
+    """Build the status pill for installed or download count."""
+    if row.installed:
+        return pill("installed", "$success", "white")
+    if row.sort_downloads > 0:
+        return Content.styled(f"\u2193 {row.downloads}", "$text-muted")
+    return None

--- a/src/lilbee/featured_models.toml
+++ b/src/lilbee/featured_models.toml
@@ -1,0 +1,55 @@
+[[chat]]
+name = "Qwen3 0.6B"
+hf_repo = "Qwen/Qwen3-0.6B-GGUF"
+gguf_filename = "*Q4_K_M.gguf"
+size_gb = 0.5
+min_ram_gb = 2.0
+description = "Tiny — runs on anything"
+
+[[chat]]
+name = "Qwen3 4B"
+hf_repo = "Qwen/Qwen3-4B-GGUF"
+gguf_filename = "*Q4_K_M.gguf"
+size_gb = 2.5
+min_ram_gb = 8.0
+description = "Small — good balance for 8 GB RAM"
+
+[[chat]]
+name = "Qwen3 8B"
+hf_repo = "Qwen/Qwen3-8B-GGUF"
+gguf_filename = "*Q4_K_M.gguf"
+size_gb = 5.0
+min_ram_gb = 8.0
+description = "Medium — strong general purpose"
+
+[[chat]]
+name = "Mistral 7B Instruct"
+hf_repo = "MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF"
+gguf_filename = "*Q4_K_M.gguf"
+size_gb = 4.4
+min_ram_gb = 8.0
+description = "Fast 7B, 32K context"
+
+[[chat]]
+name = "Qwen3-Coder 30B A3B"
+hf_repo = "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF"
+gguf_filename = "*Q4_K_M.gguf"
+size_gb = 18.0
+min_ram_gb = 32.0
+description = "Extra large — best quality"
+
+[[embedding]]
+name = "Nomic Embed Text v1.5"
+hf_repo = "nomic-ai/nomic-embed-text-v1.5-GGUF"
+gguf_filename = "nomic-embed-text-v1.5.Q4_K_M.gguf"
+size_gb = 0.3
+min_ram_gb = 2.0
+description = "Fast, high quality — default for lilbee"
+
+[[vision]]
+name = "LightOnOCR-2"
+hf_repo = "noctrex/LightOnOCR-2-1B-GGUF"
+gguf_filename = "*Q4_K_M.gguf"
+size_gb = 1.5
+min_ram_gb = 4.0
+description = "Fast OCR — clean markdown output, small footprint"

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import httpx
 
+from lilbee.models import ModelTask
 from lilbee.security import validate_path_within
 
 log = logging.getLogger(__name__)
@@ -227,11 +228,11 @@ def _classify_remote_task(name: str, family: str) -> str:
     """Classify a remote model as chat, embedding, or vision."""
     family_lower = family.lower()
     if any(ef in family_lower for ef in _EMBEDDING_FAMILIES):
-        return "embedding"
+        return ModelTask.EMBEDDING
     name_lower = name.lower()
     if any(vp in name_lower for vp in _VISION_NAME_PATTERNS):
-        return "vision"
-    return "chat"
+        return ModelTask.VISION
+    return ModelTask.CHAT
 
 
 def classify_remote_models(base_url: str = "http://localhost:11434") -> list[RemoteModel]:
@@ -265,7 +266,7 @@ def classify_remote_models(base_url: str = "http://localhost:11434") -> list[Rem
 
 def detect_remote_embedding_models(base_url: str = "http://localhost:11434") -> list[str]:
     """Return names of models classified as embedding from the litellm backend."""
-    return [m.name for m in classify_remote_models(base_url) if m.task == "embedding"]
+    return [m.name for m in classify_remote_models(base_url) if m.task == ModelTask.EMBEDDING]
 
 
 _manager: ModelManager | None = None

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from rich.console import Console
@@ -13,6 +14,15 @@ from rich.table import Table
 
 from lilbee import settings
 from lilbee.config import cfg
+
+
+class ModelTask(StrEnum):
+    """Task classification for models."""
+
+    CHAT = "chat"
+    EMBEDDING = "embedding"
+    VISION = "vision"
+
 
 log = logging.getLogger(__name__)
 
@@ -44,21 +54,36 @@ def _catalog_from_featured(featured: tuple) -> tuple[ModelInfo, ...]:
     return tuple(ModelInfo(m.name, m.size_gb, m.min_ram_gb, m.description) for m in featured)
 
 
-# Derived from catalog.py's featured lists — single source of truth
-def _build_model_catalog() -> tuple[ModelInfo, ...]:
-    from lilbee.catalog import FEATURED_CHAT
-
-    return _catalog_from_featured(FEATURED_CHAT)
-
-
-def _build_vision_catalog() -> tuple[ModelInfo, ...]:
-    from lilbee.catalog import FEATURED_VISION
-
-    return _catalog_from_featured(FEATURED_VISION)
+# Lazy singletons — resolved on first access to break the circular import
+# between models.py (imports ModelTask) and catalog.py (imports from models).
+_model_catalog: tuple[ModelInfo, ...] | None = None
+_vision_catalog: tuple[ModelInfo, ...] | None = None
 
 
-MODEL_CATALOG: tuple[ModelInfo, ...] = _build_model_catalog()
-VISION_CATALOG: tuple[ModelInfo, ...] = _build_vision_catalog()
+def _get_model_catalog() -> tuple[ModelInfo, ...]:
+    global _model_catalog
+    if _model_catalog is None:
+        from lilbee.catalog import FEATURED_CHAT
+
+        _model_catalog = _catalog_from_featured(FEATURED_CHAT)
+    return _model_catalog
+
+
+def _get_vision_catalog() -> tuple[ModelInfo, ...]:
+    global _vision_catalog
+    if _vision_catalog is None:
+        from lilbee.catalog import FEATURED_VISION
+
+        _vision_catalog = _catalog_from_featured(FEATURED_VISION)
+    return _vision_catalog
+
+
+def __getattr__(name: str) -> tuple[ModelInfo, ...]:
+    if name == "MODEL_CATALOG":
+        return _get_model_catalog()
+    if name == "VISION_CATALOG":
+        return _get_vision_catalog()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_system_ram_gb() -> float:
@@ -104,8 +129,8 @@ def get_free_disk_gb(path: Path) -> float:
 
 def pick_default_model(ram_gb: float) -> ModelInfo:
     """Choose the largest catalog model that fits in *ram_gb*."""
-    best = MODEL_CATALOG[0]
-    for model in MODEL_CATALOG:
+    best = _get_model_catalog()[0]
+    for model in _get_model_catalog():
         if model.min_ram_gb <= ram_gb:
             best = model
     return best
@@ -113,7 +138,7 @@ def pick_default_model(ram_gb: float) -> ModelInfo:
 
 def _model_download_size_gb(model: str) -> float:
     """Estimated download size for a model."""
-    catalog_sizes = {m.name: m.size_gb for m in MODEL_CATALOG}
+    catalog_sizes = {m.name: m.size_gb for m in _get_model_catalog()}
     fallback = 5.0  # reasonable default for unknown models
     return catalog_sizes.get(model, fallback)
 
@@ -131,7 +156,7 @@ def display_model_picker(
     table.add_column("Size", justify="right")
     table.add_column("Description")
 
-    for idx, model in enumerate(MODEL_CATALOG, 1):
+    for idx, model in enumerate(_get_model_catalog(), 1):
         num_str = str(idx)
         name = model.name
         size_str = f"{model.size_gb:.1f} GB"
@@ -162,7 +187,7 @@ def display_model_picker(
 
 def pick_default_vision_model() -> ModelInfo:
     """Return the recommended vision model (first catalog entry, best quality)."""
-    return VISION_CATALOG[0]
+    return _get_vision_catalog()[0]
 
 
 def display_vision_picker(
@@ -178,7 +203,7 @@ def display_vision_picker(
     table.add_column("Size", justify="right")
     table.add_column("Description")
 
-    for idx, model in enumerate(VISION_CATALOG, 1):
+    for idx, model in enumerate(_get_vision_catalog(), 1):
         num_str = str(idx)
         name = model.name
         size_str = f"{model.size_gb:.1f} GB"
@@ -211,7 +236,7 @@ def prompt_model_choice(ram_gb: float) -> ModelInfo:
     """Prompt the user to pick a model by number. Returns the chosen ModelInfo."""
     free_disk_gb = get_free_disk_gb(cfg.data_dir)
     recommended = display_model_picker(ram_gb, free_disk_gb)
-    default_idx = list(MODEL_CATALOG).index(recommended) + 1
+    default_idx = list(_get_model_catalog()).index(recommended) + 1
 
     while True:
         try:
@@ -225,13 +250,13 @@ def prompt_model_choice(ram_gb: float) -> ModelInfo:
         try:
             choice = int(raw)
         except ValueError:
-            sys.stderr.write(f"Enter a number 1-{len(MODEL_CATALOG)}.\n")
+            sys.stderr.write(f"Enter a number 1-{len(_get_model_catalog())}.\n")
             continue
 
-        if 1 <= choice <= len(MODEL_CATALOG):
-            return MODEL_CATALOG[choice - 1]
+        if 1 <= choice <= len(_get_model_catalog()):
+            return _get_model_catalog()[choice - 1]
 
-        sys.stderr.write(f"Enter a number 1-{len(MODEL_CATALOG)}.\n")
+        sys.stderr.write(f"Enter a number 1-{len(_get_model_catalog())}.\n")
 
 
 def validate_disk_and_pull(
@@ -328,7 +353,7 @@ def list_installed_models(*, exclude_vision: bool = False) -> list[str]:
         embed_base = cfg.embedding_model.split(":")[0]
         models = [m for m in provider.list_models() if m.split(":")[0] != embed_base]
         if exclude_vision:
-            vision_names = {m.name for m in VISION_CATALOG}
+            vision_names = {m.name for m in _get_vision_catalog()}
             models = [m for m in models if m not in vision_names]
         return models
     except Exception:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 # Add local huggingface_hub for development testing
-_HF_HUB_PATH = '/Users/tobias/projects/huggingface_hub/src'
+_HF_HUB_PATH = "/Users/tobias/projects/huggingface_hub/src"
 if os.path.isdir(_HF_HUB_PATH) and _HF_HUB_PATH not in sys.path:
     sys.path.insert(0, _HF_HUB_PATH)
 
@@ -543,7 +543,7 @@ class TestDownloadModel:
         """progress_updater callback is invoked by hf_hub_download."""
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
 
         def fake_download(**kwargs: Any) -> str:
             result = _fake_download(**kwargs)
@@ -567,7 +567,7 @@ class TestDownloadModel:
         models_dir = tmp_path / "models"
         monkeypatch.setattr(catalog.cfg, "models_dir", models_dir)
         entry = FEATURED_EMBEDDING[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
 
         monkeypatch.setattr("huggingface_hub.hf_hub_download", _fake_download)
         result = download_model(entry)
@@ -576,7 +576,7 @@ class TestDownloadModel:
     def test_calls_progress_callback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
 
         progress_calls: list[tuple[int, int]] = []
 
@@ -601,7 +601,7 @@ class TestDownloadModel:
     ) -> None:
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
 
         from huggingface_hub.utils import GatedRepoError
 
@@ -617,7 +617,7 @@ class TestDownloadModel:
     ) -> None:
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
 
         from huggingface_hub.utils import RepositoryNotFoundError
 
@@ -632,7 +632,7 @@ class TestDownloadModel:
 class TestResolveFilename:
     def test_exact_filename(self, monkeypatch: pytest.MonkeyPatch) -> None:
         entry = FEATURED_EMBEDDING[0]
-        result = catalog._resolve_filename(entry)
+        result = catalog.resolve_filename(entry)
         assert result == entry.gguf_filename
 
     def test_wildcard_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -645,7 +645,7 @@ class TestResolveFilename:
         }
         mock_resp = httpx.Response(200, json=data, request=httpx.Request("GET", "https://x"))
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        result = catalog._resolve_filename(entry)
+        result = catalog.resolve_filename(entry)
         assert result == "Qwen3-0.6B-Q4_K_M.gguf"
 
     def test_wildcard_no_match_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -654,7 +654,7 @@ class TestResolveFilename:
         mock_resp = httpx.Response(200, json=data, request=httpx.Request("GET", "https://x"))
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
         with pytest.raises(RuntimeError, match="No GGUF files found"):
-            catalog._resolve_filename(entry)
+            catalog.resolve_filename(entry)
 
     def test_wildcard_api_error_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         entry = FEATURED_CHAT[0]
@@ -664,14 +664,14 @@ class TestResolveFilename:
 
         monkeypatch.setattr(httpx, "get", raise_connect)
         with pytest.raises(RuntimeError, match="Cannot query files"):
-            catalog._resolve_filename(entry)
+            catalog.resolve_filename(entry)
 
     def test_wildcard_http_error_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         entry = FEATURED_CHAT[0]
         mock_resp = httpx.Response(500)
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
         with pytest.raises(RuntimeError):
-            catalog._resolve_filename(entry)
+            catalog.resolve_filename(entry)
 
     def test_wildcard_401_raises_permission_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """HTTP 401 response raises PermissionError with auth message."""
@@ -679,7 +679,7 @@ class TestResolveFilename:
         mock_resp = httpx.Response(401)
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
         with pytest.raises(PermissionError, match="requires HuggingFace authentication"):
-            catalog._resolve_filename(entry)
+            catalog.resolve_filename(entry)
 
     def test_pick_best_gguf_prefers_q4_k_m(self) -> None:
         files = ["model-Q8_0.gguf", "model-Q4_K_M.gguf", "model-Q5_K_M.gguf"]
@@ -1009,7 +1009,7 @@ class TestVisionMmprojFiles:
         """download_model downloads mmproj file for vision entries."""
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_VISION[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: "model-Q4_K_M.gguf")
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: "model-Q4_K_M.gguf")
 
         download_calls: list[dict] = []
 
@@ -1035,7 +1035,7 @@ class TestVisionMmprojFiles:
         """download_model does NOT download mmproj for chat entries."""
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
 
         download_calls: list[dict] = []
 
@@ -1054,7 +1054,7 @@ class TestVisionMmprojFiles:
         """When mmproj resolution fails, model download still succeeds."""
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_VISION[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: "model-Q4_K_M.gguf")
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: "model-Q4_K_M.gguf")
 
         monkeypatch.setattr("huggingface_hub.hf_hub_download", _fake_download)
         monkeypatch.setattr(catalog, "_resolve_mmproj_filename", lambda repo, pat: None)
@@ -1068,7 +1068,7 @@ class TestVisionMmprojFiles:
         """When mmproj already exists in models_dir, skip re-download."""
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_VISION[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: "model-Q4_K_M.gguf")
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: "model-Q4_K_M.gguf")
 
         mmproj_file = tmp_path / "model-mmproj-f16.gguf"
         mmproj_file.write_bytes(b"existing mmproj")
@@ -1112,7 +1112,7 @@ class TestVisionMmprojFallback:
             0,
             "vision",
         )
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: "custom-Q4_K_M.gguf")
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: "custom-Q4_K_M.gguf")
 
         download_calls: list[dict] = []
 
@@ -1268,7 +1268,7 @@ class TestGatedRepoShowsLoginMessage:
     ) -> None:
         monkeypatch.setattr(catalog.cfg, "models_dir", tmp_path)
         entry = FEATURED_VISION[0]
-        monkeypatch.setattr(catalog, "_resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
 
         from huggingface_hub.utils import GatedRepoError
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -711,3 +711,60 @@ class TestLoginCommand:
             await pilot.press("enter")
             await pilot.pause()
             mock_wb.assert_called_once_with("https://huggingface.co/settings/tokens")
+
+
+# ---------------------------------------------------------------------------
+# App signals
+# ---------------------------------------------------------------------------
+
+
+class TestAppSignals:
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_settings_changed_signal_exists(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert hasattr(app, "settings_changed_signal")
+
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_model_changed_signal_exists(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert hasattr(app, "model_changed_signal")
+
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_signal_subscribe_and_publish(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            received: list[tuple[str, object]] = []
+            app.settings_changed_signal.subscribe(app, lambda val: received.append(val))
+            app.settings_changed_signal.publish(("chat_model", "new-model"))
+            await pilot.pause()
+            assert len(received) == 1
+            assert received[0] == ("chat_model", "new-model")

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -408,7 +408,7 @@ class TestDownloadProgress:
         (cfg.models_dir / "test.gguf").write_bytes(b"\0" * 100)
 
         with (
-            mock.patch("lilbee.catalog._resolve_filename", return_value="test.gguf"),
+            mock.patch("lilbee.catalog.resolve_filename", return_value="test.gguf"),
             mock.patch("lilbee.catalog.hf_hub_download", side_effect=fake_download),
             mock.patch("lilbee.catalog._register_model"),
         ):
@@ -450,7 +450,9 @@ class TestTaskCenter:
 
             # Should have at least one collapsible
             collapsibles = app.screen.query(Collapsible)
-            assert len(collapsibles) >= 1, f"Expected at least 1 Collapsible, got {len(collapsibles)}"
+            assert len(collapsibles) >= 1, (
+                f"Expected at least 1 Collapsible, got {len(collapsibles)}"
+            )
 
     async def test_task_center_renders_empty_state(self, _mock_resolve):
         """Task Center shows 'All quiet' when no tasks."""
@@ -468,7 +470,9 @@ class TestTaskCenter:
             # The task-list VerticalScroll should have children
             task_list = app.screen.query_one("#task-list")
             # Should have at least one child (the empty state Static)
-            assert len(task_list.children) >= 1, f"Expected at least 1 child, got {len(task_list.children)}"
+            assert len(task_list.children) >= 1, (
+                f"Expected at least 1 child, got {len(task_list.children)}"
+            )
 
 
 class TestDownloadProgress:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -104,12 +104,6 @@ def _make_remote_model(
 ) -> RemoteModel:
     return RemoteModel(name=name, task=task, family=family, parameter_size=parameter_size)
 
-
-# ---------------------------------------------------------------------------
-# Pure function tests: catalog helpers
-# ---------------------------------------------------------------------------
-
-
 class TestParseParamLabel:
     def test_extracts_integer(self):
         assert _parse_param_label("qwen-8B-instruct") == "8B"
@@ -281,12 +275,6 @@ class TestRemoteToRow:
         rm = _make_remote_model(parameter_size="")
         row = _remote_to_row(rm)
         assert row.params == "--"
-
-
-# ---------------------------------------------------------------------------
-# Settings screen (Textual integration)
-# ---------------------------------------------------------------------------
-
 
 class SettingsTestApp(App[None]):
     CSS = ""
@@ -637,12 +625,6 @@ async def test_settings_model_info_loaded():
     finally:
         object.__setattr__(cfg, "_model_defaults", old_defaults)
 
-
-# ---------------------------------------------------------------------------
-# Status screen (Textual integration)
-# ---------------------------------------------------------------------------
-
-
 class StatusTestApp(App[None]):
     CSS = ""
 
@@ -708,12 +690,6 @@ async def test_status_screen_escape_pops():
     app = StatusTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         await _pilot.press("escape")
-
-
-# ---------------------------------------------------------------------------
-# LilbeeApp tests
-# ---------------------------------------------------------------------------
-
 
 async def test_app_mounts_chat_screen():
     from lilbee.cli.tui.app import LilbeeApp
@@ -812,12 +788,6 @@ async def test_app_auto_sync_flag():
 
     app = LilbeeApp(auto_sync=True)
     assert app._auto_sync is True
-
-
-# ---------------------------------------------------------------------------
-# ChatScreen slash command tests
-# ---------------------------------------------------------------------------
-
 
 class ChatTestApp(App[None]):
     CSS = ""
@@ -1289,12 +1259,6 @@ async def test_chat_slash_delete_dispatch():
     async with app.run_test(size=(120, 40)) as _pilot:
         app.screen._handle_slash("/delete")
 
-
-# ---------------------------------------------------------------------------
-# ChatScreen action_complete tests
-# ---------------------------------------------------------------------------
-
-
 async def test_chat_action_complete_no_options():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -1369,12 +1333,6 @@ async def test_chat_action_complete_cycle_no_selection():
         with patch.object(overlay, "cycle_next", return_value=None):
             app.screen.action_complete()
 
-
-# ---------------------------------------------------------------------------
-# ChatScreen on_input_submitted (non-slash = send message)
-# ---------------------------------------------------------------------------
-
-
 async def test_chat_send_message():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -1428,12 +1386,6 @@ async def test_chat_trim_history_when_over_limit():
         app.screen._trim_history()
         assert len(app.screen._history) == _MAX_HISTORY_MESSAGES
         assert app.screen._history[0]["content"] == "msg-10"
-
-
-# ---------------------------------------------------------------------------
-# CommandProvider tests
-# ---------------------------------------------------------------------------
-
 
 async def test_command_provider_discover():
     from lilbee.cli.tui.app import LilbeeApp
@@ -1644,12 +1596,6 @@ async def test_command_provider_document_commands_empty_name():
         provider = LilbeeCommandProvider(app.screen, match_style=None)
         cmds = provider._document_commands()
         assert cmds == []
-
-
-# ---------------------------------------------------------------------------
-# CatalogScreen tests
-# ---------------------------------------------------------------------------
-
 
 class CatalogTestApp(App[None]):
     CSS = ""
@@ -2098,12 +2044,6 @@ async def test_catalog_row_selected_out_of_range():
             event.cursor_row = 999
             screen.on_data_table_row_selected(event)
 
-
-# ---------------------------------------------------------------------------
-# Direct worker body tests (call underlying fn, not @work decorator)
-# ---------------------------------------------------------------------------
-
-
 async def test_catalog_fetch_more_hf_worker():
     """Cover _fetch_more_hf worker body."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -2336,12 +2276,6 @@ async def test_chat_embedding_ready_false_no_sync():
             await _pilot.pause()
             mock_sync.assert_not_called()
 
-
-# ---------------------------------------------------------------------------
-# Additional coverage: chat.py lines
-# ---------------------------------------------------------------------------
-
-
 async def test_chat_on_input_submitted_slash():
     """Cover the on_input_submitted slash dispatch (line 94-95)."""
     app = ChatTestApp()
@@ -2448,12 +2382,6 @@ async def test_chat_cancel_with_active_worker(mock_svc):
         barrier.set()
         await _pilot.pause()
 
-
-# ---------------------------------------------------------------------------
-# Additional coverage: catalog.py worker body lines
-# ---------------------------------------------------------------------------
-
-
 async def test_catalog_refresh_table_empty():
     """Cover empty table case."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -2558,12 +2486,6 @@ async def test_catalog_jump_top_bottom():
             await _pilot.pause()
             screen.action_jump_bottom()
             screen.action_jump_top()
-
-
-# ---------------------------------------------------------------------------
-# Additional coverage: commands.py vision catalog exception (lines 91-92)
-# ---------------------------------------------------------------------------
-
 
 async def test_chat_vim_j_cycles_focus_from_chat_log():
     """key_j cycles focus forward from chat-log to chat-input in normal mode."""
@@ -2920,12 +2842,6 @@ async def test_chat_bindings_include_half_page():
     assert "ctrl+d" in keys
     assert "ctrl+u" in keys
 
-
-# ---------------------------------------------------------------------------
-# Catalog: delete model (d key)
-# ---------------------------------------------------------------------------
-
-
 async def test_catalog_delete_installed_model_confirmation():
     """First press of d shows confirmation notification."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -3065,12 +2981,6 @@ async def test_catalog_delete_in_input_ignored():
             screen.query_one("#catalog-search", Input).focus()
             screen.action_delete_model()
             assert screen._pending_delete is None
-
-
-# ---------------------------------------------------------------------------
-# Chat: /remove slash command
-# ---------------------------------------------------------------------------
-
 
 async def test_chat_slash_remove_no_args():
     app = ChatTestApp()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -14,9 +14,9 @@ from lilbee.cli.tui.screens.catalog import (
     _catalog_to_row,
     _format_downloads,
     _format_size_gb,
+    _group_rows_for_grid,
     _matches_search,
     _parse_param_label,
-    _parse_param_size,
     _remote_to_row,
     _row_display_name,
 )
@@ -124,32 +124,6 @@ class TestParseParamLabel:
         assert _parse_param_label("model-3b-chat") == "3B"
 
 
-class TestParseParamSize:
-    def test_small(self):
-        assert _parse_param_size("model-1.5B") == "Small (<=3B)"
-
-    def test_medium(self):
-        assert _parse_param_size("model-7B") == "Medium (3-8B)"
-
-    def test_large(self):
-        assert _parse_param_size("model-14B") == "Large (8-30B)"
-
-    def test_extra_large(self):
-        assert _parse_param_size("model-70B") == "Extra Large (30B+)"
-
-    def test_unknown(self):
-        assert _parse_param_size("nomic-embed") == "unknown"
-
-    def test_boundary_3b(self):
-        assert _parse_param_size("model-3B") == "Small (<=3B)"
-
-    def test_boundary_8b(self):
-        assert _parse_param_size("model-8B") == "Medium (3-8B)"
-
-    def test_boundary_30b(self):
-        assert _parse_param_size("model-30B") == "Large (8-30B)"
-
-
 class TestFormatDownloads:
     def test_millions(self):
         assert _format_downloads(2_500_000) == "2.5M"
@@ -218,6 +192,45 @@ class TestCatalogToRow:
         m = _make_catalog_model(downloads=5000)
         row = _catalog_to_row(m, installed=False)
         assert row.downloads == "5K"
+
+
+class TestGroupRowsForGrid:
+    def _row(self, task: str = "chat", featured: bool = False, installed: bool = False) -> TableRow:
+        return TableRow(
+            name="test",
+            task=task,
+            params="7B",
+            size="4 GB",
+            quant="Q4",
+            downloads="--",
+            featured=featured,
+            installed=installed,
+            sort_downloads=0,
+            sort_size=4.0,
+        )
+
+    def test_groups_featured_as_recommended(self) -> None:
+        rows = [self._row(featured=True), self._row(featured=False)]
+        groups = dict(_group_rows_for_grid(rows))
+        assert len(groups["Recommended"]) == 1
+        assert len(groups["Chat"]) == 1
+
+    def test_groups_installed_separately(self) -> None:
+        rows = [self._row(installed=True)]
+        groups = dict(_group_rows_for_grid(rows))
+        assert len(groups["Installed"]) == 1
+        assert len(groups["Chat"]) == 0
+
+    def test_groups_by_task(self) -> None:
+        rows = [self._row(task="chat"), self._row(task="embedding"), self._row(task="vision")]
+        groups = dict(_group_rows_for_grid(rows))
+        assert len(groups["Chat"]) == 1
+        assert len(groups["Embedding"]) == 1
+        assert len(groups["Vision"]) == 1
+
+    def test_empty_rows(self) -> None:
+        groups = _group_rows_for_grid([])
+        assert all(len(rows) == 0 for _, rows in groups)
 
 
 class TestMatchesSearch:
@@ -1993,7 +2006,7 @@ async def test_catalog_input_changed_refreshes():
             from textual.widgets import Input
 
             inp = screen.query_one("#catalog-search", Input)
-            with patch.object(screen, "_refresh_table") as mock_refresh:
+            with patch.object(screen, "_refresh_view") as mock_refresh:
                 event = MagicMock()
                 event.input = inp
                 screen.on_input_changed(event)
@@ -2009,12 +2022,67 @@ async def test_catalog_input_changed_other_input_ignored():
             screen = CatalogScreen()
             app.push_screen(screen)
             await _pilot.pause()
-            with patch.object(screen, "_refresh_table") as mock_refresh:
+            with patch.object(screen, "_refresh_view") as mock_refresh:
                 event = MagicMock()
                 event.input = MagicMock()
                 event.input.id = "other-input"
                 screen.on_input_changed(event)
                 mock_refresh.assert_not_called()
+
+
+async def test_catalog_default_grid_view():
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+    app = CatalogTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with _patch_catalog()[0], _patch_catalog()[1], _patch_catalog()[2]:
+            screen = CatalogScreen()
+            app.push_screen(screen)
+            await _pilot.pause()
+            assert screen._grid_view is True
+            assert screen.has_class("-grid-view")
+            assert not screen.has_class("-list-view")
+
+
+async def test_catalog_toggle_to_list_and_back():
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+    app = CatalogTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with _patch_catalog()[0], _patch_catalog()[1], _patch_catalog()[2]:
+            screen = CatalogScreen()
+            app.push_screen(screen)
+            await _pilot.pause()
+            # Toggle to list
+            screen.action_toggle_view()
+            await _pilot.pause()
+            assert screen._grid_view is False
+            assert screen.has_class("-list-view")
+            assert not screen.has_class("-grid-view")
+            # Toggle back to grid
+            screen.action_toggle_view()
+            await _pilot.pause()
+            assert screen._grid_view is True
+            assert screen.has_class("-grid-view")
+
+
+async def test_catalog_lazy_hf_fetch():
+    """HF API not called on mount, only on first list view switch."""
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+    app = CatalogTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with _patch_catalog()[0] as mock_cat, _patch_catalog()[1], _patch_catalog()[2]:
+            screen = CatalogScreen()
+            app.push_screen(screen)
+            await _pilot.pause()
+            # Grid view on mount — no HF fetch
+            assert not screen._hf_fetched
+            mock_cat.assert_not_called()
+            # Switch to list triggers fetch
+            screen.action_toggle_view()
+            await _pilot.pause()
+            assert screen._hf_fetched
 
 
 async def test_catalog_row_selected_out_of_range():

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -44,12 +44,6 @@ def _make_model(
         task=task,
     )
 
-
-# ---------------------------------------------------------------------------
-# message.py
-# ---------------------------------------------------------------------------
-
-
 class _MsgApp(App):
     def compose(self) -> ComposeResult:
         from lilbee.cli.tui.widgets.message import AssistantMessage, UserMessage
@@ -175,12 +169,6 @@ class TestAssistantMessageAsync:
             await am.rebuild_content_widget(use_markdown=False)
             assert am._content_widget is None
 
-
-# ---------------------------------------------------------------------------
-# help_modal.py
-# ---------------------------------------------------------------------------
-
-
 class _HelpApp(App):
     def compose(self) -> ComposeResult:
         yield Static("bg")
@@ -212,12 +200,6 @@ class TestHelpModal:
             app.screen.action_close()
             await pilot.pause()
             assert len(app.screen_stack) == 1
-
-
-# ---------------------------------------------------------------------------
-# task_bar.py
-# ---------------------------------------------------------------------------
-
 
 class _TaskBarApp(App):
     def compose(self) -> ComposeResult:
@@ -347,12 +329,6 @@ class TestTaskBar:
             bar = app.query_one(TaskBar)
             app._task_bar = bar  # type: ignore[attr-defined]
             assert getattr(app, "_task_bar", None) is bar
-
-
-# ---------------------------------------------------------------------------
-# model_bar.py
-# ---------------------------------------------------------------------------
-
 
 class _ModelBarApp(App):
     def compose(self) -> ComposeResult:
@@ -583,12 +559,6 @@ class TestClassifyInstalledModels:
 
         assert "custom-model.gguf" in chat
 
-
-# ---------------------------------------------------------------------------
-# suggester.py
-# ---------------------------------------------------------------------------
-
-
 class TestSlashSuggester:
     async def test_empty_returns_none(self) -> None:
         from lilbee.cli.tui.widgets.suggester import SlashSuggester
@@ -739,12 +709,6 @@ class TestSlashSuggester:
         s = SlashSuggester(use_cache=False)
         with mock.patch("lilbee.services.get_services", side_effect=Exception("err")):
             assert s._get_document_names() == []
-
-
-# ---------------------------------------------------------------------------
-# autocomplete.py — pure functions
-# ---------------------------------------------------------------------------
-
 
 class TestGetCompletions:
     def test_non_slash_returns_empty(self) -> None:
@@ -964,12 +928,6 @@ class TestPathOptions:
         r = _path_options(str(tmp_path) + "/")
         assert len(r) == 20
 
-
-# ---------------------------------------------------------------------------
-# autocomplete.py — CompletionOverlay widget
-# ---------------------------------------------------------------------------
-
-
 class _OverlayApp(App):
     def compose(self) -> ComposeResult:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -1065,12 +1023,6 @@ class TestCompletionOverlay:
             many = [f"/opt{i}" for i in range(20)]
             overlay.show_completions(many)
             assert len(overlay._options) == _MAX_VISIBLE
-
-
-# ---------------------------------------------------------------------------
-# task_queue.py (unit tests for queue logic)
-# ---------------------------------------------------------------------------
-
 
 class TestTaskQueue:
     def test_enqueue_and_advance(self) -> None:
@@ -1305,12 +1257,6 @@ class TestTaskQueue:
         assert len(q.active_tasks) == 1
         assert q.active_tasks[0].task_id == t2
 
-
-# ---------------------------------------------------------------------------
-# CompletionOverlay.cycle_prev
-# ---------------------------------------------------------------------------
-
-
 class TestCompletionOverlayCyclePrev:
     async def test_cycle_prev_wraps(self) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -1331,12 +1277,6 @@ class TestCompletionOverlayCyclePrev:
             await pilot.pause()
             overlay = app.query_one(CompletionOverlay)
             assert overlay.cycle_prev() is None
-
-
-# ---------------------------------------------------------------------------
-# setup_modal.py
-# ---------------------------------------------------------------------------
-
 
 class _SetupApp(App):
     def compose(self) -> ComposeResult:
@@ -1407,12 +1347,6 @@ class TestSetupWizard:
         children = list(row.compose())
         assert len(children) == 1
 
-
-# ---------------------------------------------------------------------------
-# catalog.py screen — HF grouping, empty tabs, size grouping
-# ---------------------------------------------------------------------------
-
-
 class TestAllTasksFetched:
     def test_all_tasks_constant(self) -> None:
         from lilbee.cli.tui.screens.catalog import _ALL_TASKS
@@ -1437,12 +1371,6 @@ class TestMatchesSearchWidget:
         row = _catalog_to_row(m, installed=False)
         assert _matches_search(row, "llama") is False
 
-
-# ---------------------------------------------------------------------------
-# command_registry.py — /login command
-# ---------------------------------------------------------------------------
-
-
 class TestLoginCommandRegistered:
     def test_login_in_registry(self) -> None:
         from lilbee.cli.tui.command_registry import COMMANDS, build_dispatch_dict
@@ -1451,12 +1379,6 @@ class TestLoginCommandRegistered:
         assert "/login" in names
         dispatch = build_dispatch_dict()
         assert dispatch["/login"] == "_cmd_login"
-
-
-# ---------------------------------------------------------------------------
-# settings.py — HF token field
-# ---------------------------------------------------------------------------
-
 
 class TestSettingsHfToken:
     def test_get_hf_token_display_not_set(self, monkeypatch) -> None:
@@ -1476,12 +1398,6 @@ class TestSettingsHfToken:
         assert result.startswith("hf_a")
         assert result.endswith("mnop")
         assert "..." in result
-
-
-# ---------------------------------------------------------------------------
-# __init__.py — Ctrl-C clean shutdown
-# ---------------------------------------------------------------------------
-
 
 class TestRunTuiKeyboardInterrupt:
     def test_keyboard_interrupt_does_not_raise(self) -> None:
@@ -1507,12 +1423,6 @@ class TestRunTuiKeyboardInterrupt:
                 run_tui()
                 mock_shutdown.assert_called_once()
                 mock_reset.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# nav_bar.py — global docked navigation bar
-# ---------------------------------------------------------------------------
-
 
 class _NavBarApp(App):
     def compose(self) -> ComposeResult:
@@ -1730,12 +1640,6 @@ class TestNavBarClickSupport:
             # App has no _switch_view -- should not raise
             bar.on_click(mock.Mock(x=0, y=0))
 
-
-# ---------------------------------------------------------------------------
-# app.py — global NavBar composition and key bindings
-# ---------------------------------------------------------------------------
-
-
 class TestLilbeeAppGlobalNavBar:
     async def test_screen_composes_global_nav_bar(self) -> None:
         cfg.chat_model = "test-model"
@@ -1769,12 +1673,6 @@ class TestLilbeeAppGlobalNavBar:
                 await pilot.pause()
             nav = app.screen.query_one("#global-nav-bar")
             assert nav.active_view == "Chat"
-
-
-# ---------------------------------------------------------------------------
-# pill.py
-# ---------------------------------------------------------------------------
-
 
 class TestPill:
     def test_pill_from_string(self) -> None:
@@ -1811,28 +1709,18 @@ class TestPill:
         result = pill("ok", "$success", "$text")
         assert isinstance(result, Content)
 
-
-# ---------------------------------------------------------------------------
-# events.py
-# ---------------------------------------------------------------------------
-
-
 class TestEvents:
     def test_model_changed_is_message(self) -> None:
         from textual.message import Message
 
         from lilbee.cli.tui.events import ModelChanged
 
-        msg = ModelChanged("chat", "qwen3:8b")
+        from lilbee.models import ModelTask
+
+        msg = ModelChanged(ModelTask.CHAT, "qwen3:8b")
         assert isinstance(msg, Message)
-        assert msg.role == "chat"
+        assert msg.role == ModelTask.CHAT
         assert msg.name == "qwen3:8b"
-
-
-# ---------------------------------------------------------------------------
-# grid_select.py
-# ---------------------------------------------------------------------------
-
 
 class _GridApp(App):
     def compose(self) -> ComposeResult:
@@ -1928,12 +1816,6 @@ class TestGridSelect:
             await pilot.pause()
             assert len(messages) == 1
             assert messages[0].widget is gs.children[0]
-
-
-# ---------------------------------------------------------------------------
-# model_card.py
-# ---------------------------------------------------------------------------
-
 
 class TestModelCard:
     def test_card_has_row_property(self) -> None:

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1769,3 +1769,247 @@ class TestLilbeeAppGlobalNavBar:
                 await pilot.pause()
             nav = app.screen.query_one("#global-nav-bar")
             assert nav.active_view == "Chat"
+
+
+# ---------------------------------------------------------------------------
+# pill.py
+# ---------------------------------------------------------------------------
+
+
+class TestPill:
+    def test_pill_from_string(self) -> None:
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("chat", "$primary", "$text")
+        text = str(result)
+        assert "chat" in text
+        assert "\u258c" in text  # left half-block
+        assert "\u2590" in text  # right half-block
+
+    def test_pill_from_content(self) -> None:
+        from textual.content import Content
+
+        from lilbee.cli.tui.pill import pill
+
+        content_input = Content("embed")
+        result = pill(content_input, "$secondary", "$text")
+        assert "embed" in str(result)
+
+    def test_pill_empty_string(self) -> None:
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("", "$primary", "$text")
+        text = str(result)
+        assert "\u258c" in text
+        assert "\u2590" in text
+
+    def test_pill_returns_content(self) -> None:
+        from textual.content import Content
+
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("ok", "$success", "$text")
+        assert isinstance(result, Content)
+
+
+# ---------------------------------------------------------------------------
+# events.py
+# ---------------------------------------------------------------------------
+
+
+class TestEvents:
+    def test_model_changed_is_message(self) -> None:
+        from textual.message import Message
+
+        from lilbee.cli.tui.events import ModelChanged
+
+        msg = ModelChanged("chat", "qwen3:8b")
+        assert isinstance(msg, Message)
+        assert msg.role == "chat"
+        assert msg.name == "qwen3:8b"
+
+
+# ---------------------------------------------------------------------------
+# grid_select.py
+# ---------------------------------------------------------------------------
+
+
+class _GridApp(App):
+    def compose(self) -> ComposeResult:
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        items = [Static(f"Item {i}", classes="grid-item") for i in range(6)]
+        yield GridSelect(*items, id="gs", min_column_width=20)
+
+
+class TestGridSelect:
+    async def test_focus_sets_highlighted_zero(self) -> None:
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            gs = app.query_one("#gs", GridSelect)
+            gs.focus()
+            await pilot.pause()
+            assert gs.highlighted == 0
+
+    async def test_blur_clears_highlighted(self) -> None:
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            gs = app.query_one("#gs", GridSelect)
+            gs.focus()
+            await pilot.pause()
+            gs.blur()
+            await pilot.pause()
+            assert gs.highlighted is None
+
+    async def test_cursor_right_increments(self) -> None:
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            gs = app.query_one("#gs", GridSelect)
+            gs.focus()
+            await pilot.pause()
+            gs.action_cursor_right()
+            assert gs.highlighted == 1
+
+    async def test_validate_clamps(self) -> None:
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            gs = app.query_one("#gs", GridSelect)
+            assert gs.validate_highlighted(-5) == 0
+            assert gs.validate_highlighted(999) == 5
+            assert gs.validate_highlighted(None) is None
+
+    async def test_highlight_class_toggled(self) -> None:
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            gs = app.query_one("#gs", GridSelect)
+            gs.focus()
+            await pilot.pause()
+            assert "-highlight" in gs.children[0].classes
+            gs.action_cursor_right()
+            await pilot.pause()
+            assert "-highlight" not in gs.children[0].classes
+            assert "-highlight" in gs.children[1].classes
+
+    async def test_action_select_posts_selected(self) -> None:
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        messages: list[GridSelect.Selected] = []
+
+        class _SelectApp(App):
+            def compose(self_app) -> ComposeResult:
+                items = [Static(f"Item {i}", classes="grid-item") for i in range(3)]
+                yield GridSelect(*items, id="gs", min_column_width=20)
+
+            def on_grid_select_selected(self_app, event: GridSelect.Selected) -> None:
+                messages.append(event)
+
+        app = _SelectApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            gs = app.query_one("#gs", GridSelect)
+            gs.focus()
+            await pilot.pause()
+            gs.action_select()
+            await pilot.pause()
+            assert len(messages) == 1
+            assert messages[0].widget is gs.children[0]
+
+
+# ---------------------------------------------------------------------------
+# model_card.py
+# ---------------------------------------------------------------------------
+
+
+class TestModelCard:
+    def test_card_has_row_property(self) -> None:
+        from lilbee.cli.tui.screens.catalog import TableRow
+        from lilbee.cli.tui.widgets.model_card import ModelCard
+
+        row = TableRow(
+            name="Qwen3 8B",
+            task="chat",
+            params="8B",
+            size="4.9 GB",
+            quant="Q4_K_M",
+            downloads="2.1M",
+            featured=True,
+            installed=False,
+            sort_downloads=2_100_000,
+            sort_size=4.9,
+        )
+        card = ModelCard(row)
+        assert card.row is row
+        assert card.row.name == "Qwen3 8B"
+
+    async def test_card_composes_labels(self) -> None:
+        from lilbee.cli.tui.screens.catalog import TableRow
+        from lilbee.cli.tui.widgets.model_card import ModelCard
+
+        row = TableRow(
+            name="TestModel",
+            task="chat",
+            params="7B",
+            size="4.0 GB",
+            quant="Q4_K_M",
+            downloads="100K",
+            featured=False,
+            installed=True,
+            sort_downloads=100_000,
+            sort_size=4.0,
+        )
+
+        class _CardApp(App):
+            def compose(self_app) -> ComposeResult:
+                yield ModelCard(row)
+
+        app = _CardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            card = app.query_one(ModelCard)
+            assert card.query_one("#card-name") is not None
+            assert card.query_one("#card-task") is not None
+            assert card.query_one("#card-info") is not None
+            # installed → status pill
+            assert card.query_one("#card-status") is not None
+
+    async def test_card_without_installed_no_status(self) -> None:
+        from lilbee.cli.tui.screens.catalog import TableRow
+        from lilbee.cli.tui.widgets.model_card import ModelCard
+
+        row = TableRow(
+            name="NewModel",
+            task="chat",
+            params="7B",
+            size="4.0 GB",
+            quant="Q4_K_M",
+            downloads="--",
+            featured=False,
+            installed=False,
+            sort_downloads=0,
+            sort_size=4.0,
+        )
+
+        class _CardApp(App):
+            def compose(self_app) -> ComposeResult:
+                yield ModelCard(row)
+
+        app = _CardApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            card = app.query_one(ModelCard)
+            assert len(card.query("#card-status")) == 0


### PR DESCRIPTION
## Summary

- Card grid view is now the default when browsing models — responsive layout with task badges, specs, and install status at a glance
- Press `v` to toggle between the grid and the existing flat list
- Model catalog no longer hits the HuggingFace API on open — featured and installed models load instantly, HF results load lazily when you search or switch to list view

## Test plan

- [ ] Open the TUI, navigate to Models — grid view with cards
- [ ] Press `v` — switches to flat table, press again to go back
- [ ] Search with `/` filters cards in both views
- [ ] Select a model card to install