### PR TITLE
feat: rich status screen with collapsible sections and status pills

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -8,9 +8,11 @@ from typing import ClassVar
 
 from textual.app import App
 from textual.binding import Binding, BindingType
+from textual.signal import Signal
 
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.commands import LilbeeCommandProvider
+from lilbee.cli.tui.events import ModelChanged
 from lilbee.cli.tui.widgets.nav_bar import NavBar
 from lilbee.config import cfg
 
@@ -59,6 +61,12 @@ class LilbeeApp(App[None]):
         self._auto_sync = auto_sync
         self._active_view = "Chat"
         self._theme_index = 0
+        self.settings_changed_signal: Signal[tuple[str, object]] = Signal(
+            self, "settings_changed"
+        )
+        self.model_changed_signal: Signal[ModelChanged] = Signal(
+            self, "model_changed"
+        )
         from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         self._task_bar = TaskBar(id="app-task-bar")

--- a/src/lilbee/cli/tui/events.py
+++ b/src/lilbee/cli/tui/events.py
@@ -1,0 +1,46 @@
+"""Typed Textual Message subclasses for cross-widget communication.
+
+These complement messages.py (which holds user-facing string constants).
+Widgets post these messages for structured, typed event handling.
+"""
+
+from dataclasses import dataclass
+
+from textual.message import Message
+
+from lilbee.models import ModelTask
+
+
+@dataclass
+class ModelChanged(Message):
+    """Fired when the active chat, embedding, or vision model changes."""
+
+    role: ModelTask
+    name: str
+
+
+@dataclass
+class TaskStateChanged(Message):
+    """Fired when a background task changes state."""
+
+    task_id: str
+    status: str  # "queued" | "active" | "done" | "failed" | "cancelled"
+
+
+@dataclass
+class ViewSwitched(Message):
+    """Fired when navigation switches to a different view."""
+
+    view_name: str
+
+
+@dataclass
+class SyncRequested(Message):
+    """Request a document sync from any screen."""
+
+
+@dataclass
+class CatalogViewToggled(Message):
+    """Toggle between grid and list view in catalog."""
+
+    view_mode: str  # "grid" | "list"

--- a/src/lilbee/cli/tui/pill.py
+++ b/src/lilbee/cli/tui/pill.py
@@ -1,0 +1,30 @@
+"""Pill badge — colored inline label using half-block characters.
+
+Ported from toad (https://github.com/batrachianai/toad).
+"""
+
+from textual.content import Content
+
+PILL_LEFT = "\u258c"  # ▌ left half block
+PILL_RIGHT = "\u2590"  # ▐ right half block
+
+
+def pill(text: Content | str, background: str, foreground: str) -> Content:
+    """Format text as a pill badge with rounded half-block ends.
+
+    Args:
+        text: Pill contents.
+        background: Background color (Textual color string, e.g. "$primary").
+        foreground: Foreground color (Textual color string, e.g. "$text").
+
+    Returns:
+        Styled Content with half-block ends.
+    """
+    content = Content(text) if isinstance(text, str) else text
+    main_style = f"{foreground} on {background}"
+    end_style = f"{background} on transparent r"
+    return Content.assemble(
+        (PILL_LEFT, end_style),
+        content.stylize(main_style),
+        (PILL_RIGHT, end_style),
+    )

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from dataclasses import fields as dc_fields
 from typing import ClassVar
 
 from textual.app import ComposeResult
@@ -97,51 +96,15 @@ def _defaults_field_map() -> dict[str, str]:
 
 def _get_model_info() -> dict[str, str]:
     """Collect model architecture info by reading GGUF metadata from registry."""
-    info: dict[str, str] = {
-        "chat_model_arch": "unknown",
-        "embed_model_arch": "unknown",
-        "vision_projector": "unknown",
-        "active_chat_handler": "not loaded",
+    from lilbee.model_info import get_model_architecture
+
+    arch = get_model_architecture()
+    return {
+        "chat_model_arch": arch.chat_arch,
+        "embed_model_arch": arch.embed_arch,
+        "vision_projector": arch.vision_projector,
+        "active_chat_handler": arch.active_handler,
     }
-    try:
-        from lilbee.providers.llama_cpp_provider import _read_gguf_metadata, _resolve_model_path
-
-        # Chat model
-        try:
-            path = _resolve_model_path(cfg.chat_model)
-            meta = _read_gguf_metadata(path)
-            if meta:
-                info["chat_model_arch"] = meta.get("architecture", "unknown")
-                info["active_chat_handler"] = "llama-cpp"
-        except Exception:
-            pass
-
-        # Embedding model
-        try:
-            path = _resolve_model_path(cfg.embedding_model)
-            meta = _read_gguf_metadata(path)
-            if meta:
-                info["embed_model_arch"] = meta.get("architecture", "unknown")
-        except Exception:
-            pass
-
-        # Vision projector
-        if cfg.vision_model:
-            try:
-                from lilbee.providers.llama_cpp_provider import (
-                    _find_mmproj_for_model,
-                    _read_mmproj_projector_type,
-                )
-
-                path = _resolve_model_path(cfg.vision_model)
-                mmproj = _find_mmproj_for_model(path)
-                proj_type = _read_mmproj_projector_type(mmproj)
-                info["vision_projector"] = proj_type or "unknown"
-            except Exception:
-                pass
-    except ImportError:
-        pass  # llama-cpp not available (litellm-only mode)
-    return info
 
 
 def _is_writable(key: str) -> bool:

--- a/src/lilbee/cli/tui/screens/status.py
+++ b/src/lilbee/cli/tui/screens/status.py
@@ -1,23 +1,87 @@
-"""Status screen — knowledge base info and document listing."""
+"""Status screen — knowledge base info with collapsible sections."""
 
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
+from textual.containers import VerticalScroll
+from textual.content import Content
 from textual.screen import Screen
-from textual.widgets import DataTable, Footer, Header, Static
+from textual.widgets import Collapsible, DataTable, Footer, Header, Static
 
+from lilbee.cli.tui.pill import pill
 from lilbee.cli.tui.widgets.nav_bar import NavBar
 from lilbee.config import cfg
+from lilbee.model_info import ModelArchInfo, get_model_architecture
 
 log = logging.getLogger(__name__)
 
 
+def _model_pill(name: str) -> Content:
+    """Return a green 'loaded' pill if name is set, red 'not set' otherwise."""
+    if name:
+        return pill("loaded", "$success", "$text")
+    return pill("not set", "$error", "$text")
+
+
+def _config_line(label: str, value: str, status: Content) -> Content:
+    """Assemble a single config info line with label, value, and status pill."""
+    return Content.assemble(
+        (f"{label}: ", "bold"),
+        value,
+        " ",
+        status,
+    )
+
+
+def _data_dir_pill() -> Content:
+    """Return a pill based on whether the data directory exists."""
+    if Path(cfg.data_dir).exists():
+        return pill("exists", "$success", "$text")
+    return pill("missing", "$error", "$text")
+
+
+def _build_config_content() -> Content:
+    """Build the configuration section content."""
+    lines = [
+        _config_line("Data dir", str(cfg.data_dir), _data_dir_pill()),
+        _config_line("Chat model", cfg.chat_model, _model_pill(cfg.chat_model)),
+        _config_line("Embed model", cfg.embedding_model, _model_pill(cfg.embedding_model)),
+        _config_line("Vision model", cfg.vision_model or "(none)", _model_pill(cfg.vision_model)),
+    ]
+    return Content("\n").join(lines)
+
+
+def _build_storage_content(doc_count: int) -> Content:
+    """Build the storage section content."""
+    lines = [
+        Content.assemble(("Documents: ", "bold"), str(doc_count)),
+        Content.assemble(("Data dir: ", "bold"), str(cfg.data_dir)),
+        Content.assemble(("Models dir: ", "bold"), str(cfg.models_dir)),
+    ]
+    return Content("\n").join(lines)
+
+
+def _build_arch_content(info: ModelArchInfo) -> Content:
+    """Build the model architecture section from GGUF metadata."""
+    lines = [
+        Content.assemble(("Chat arch: ", "bold"), info.chat_arch),
+        Content.assemble(("Embed arch: ", "bold"), info.embed_arch),
+        Content.assemble(("Handler: ", "bold"), info.active_handler),
+    ]
+    if cfg.vision_model:
+        lines.append(Content.assemble(("Vision proj: ", "bold"), info.vision_projector))
+    return Content("\n").join(lines)
+
+
 class StatusScreen(Screen[None]):
-    """Knowledge base status view."""
+    """Knowledge base status view with collapsible sections."""
+
+    CSS_PATH = "status.tcss"
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "pop_screen", "Back", show=True),
@@ -31,38 +95,59 @@ class StatusScreen(Screen[None]):
     def compose(self) -> ComposeResult:
         yield NavBar(id="global-nav-bar")
         yield Header()
-        yield Static("", id="status-info")
-        yield DataTable(id="docs-table")
+        yield VerticalScroll(
+            Collapsible(Static(id="config-info"), title="Configuration", id="config-section"),
+            Collapsible(DataTable(id="docs-table"), title="Documents", id="docs-section"),
+            Collapsible(Static(id="arch-info"), title="Model Architecture", id="arch-section"),
+            Collapsible(Static(id="storage-info"), title="Storage", id="storage-section"),
+            id="status-scroll",
+        )
         yield Footer()
 
     def on_mount(self) -> None:
-        self._load_status()
+        self._load_config()
+        sources = self._fetch_sources()
+        self._load_documents(sources)
+        self._load_arch()
+        self._load_storage(len(sources))
 
-    def _load_status(self) -> None:
-        info_parts = [
-            f"Data: {cfg.data_dir}",
-            f"Model: {cfg.chat_model}",
-            f"Embedding: {cfg.embedding_model}",
-            f"Chunk size: {cfg.chunk_size}",
-        ]
-        self.query_one("#status-info", Static).update("\n".join(info_parts))
-
-        table = self.query_one("#docs-table", DataTable)
-        table.add_columns("Document", "Chunks")
-        table.cursor_type = "row"
-
+    def _fetch_sources(self) -> list[dict[str, object]]:
+        """Fetch sources once from the store."""
         try:
             from lilbee.services import get_services
 
-            sources = get_services().store.get_sources()
-            for src in sources:
-                table.add_row(
-                    src.get("filename", "?"),
-                    str(src.get("chunk_count", 0)),
-                )
+            return get_services().store.get_sources()
         except Exception:
             log.debug("Failed to read store for status screen", exc_info=True)
+            return []
+
+    def _load_config(self) -> None:
+        """Populate the configuration section."""
+        self.query_one("#config-info", Static).update(_build_config_content())
+
+    def _load_documents(self, sources: list[dict[str, object]]) -> None:
+        """Populate the documents table."""
+        table = self.query_one("#docs-table", DataTable)
+        table.add_columns("Document", "Chunks")
+        table.cursor_type = "row"
+        self._fill_doc_rows(table, sources)
+
+    def _fill_doc_rows(self, table: DataTable, sources: list[dict[str, object]]) -> None:
+        """Fill the documents table with source data."""
+        if not sources:
             table.add_row("(unable to read store)", "")
+            return
+        for src in sources:
+            table.add_row(src.get("filename", "?"), str(src.get("chunk_count", 0)))
+
+    def _load_arch(self) -> None:
+        """Populate the model architecture section."""
+        info = get_model_architecture()
+        self.query_one("#arch-info", Static).update(_build_arch_content(info))
+
+    def _load_storage(self, doc_count: int) -> None:
+        """Populate the storage section."""
+        self.query_one("#storage-info", Static).update(_build_storage_content(doc_count))
 
     def action_pop_screen(self) -> None:
         self.app.pop_screen()

--- a/src/lilbee/cli/tui/screens/status.tcss
+++ b/src/lilbee/cli/tui/screens/status.tcss
@@ -1,0 +1,19 @@
+#status-scroll {
+    height: 1fr;
+    padding: 0 1;
+}
+
+Collapsible {
+    margin: 0 0 1 0;
+    padding: 0 1;
+}
+
+#config-info, #arch-info, #storage-info {
+    padding: 1 1;
+    height: auto;
+}
+
+#docs-table {
+    height: auto;
+    max-height: 20;
+}

--- a/src/lilbee/model_info.py
+++ b/src/lilbee/model_info.py
@@ -1,0 +1,88 @@
+"""Public API for reading model architecture metadata from GGUF files."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from lilbee.config import cfg
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelArchInfo:
+    """Architecture metadata for installed models."""
+
+    chat_arch: str = "unknown"
+    embed_arch: str = "unknown"
+    vision_projector: str = "unknown"
+    active_handler: str = "not loaded"
+
+
+def get_model_architecture() -> ModelArchInfo:
+    """Return architecture metadata for the currently configured models.
+
+    Reads GGUF headers for chat, embedding, and (optionally) vision models.
+    Falls back gracefully if llama-cpp-python is not installed or models
+    are not available.
+    """
+    info = ModelArchInfo()
+    try:
+        import lilbee.providers.llama_cpp_provider  # noqa: F401
+
+        info = _read_chat_arch(info)
+        info = _read_embed_arch(info)
+        info = _read_vision_arch(info)
+    except ImportError:
+        pass
+    return info
+
+
+def _read_chat_arch(info: ModelArchInfo) -> ModelArchInfo:
+    """Read chat model architecture from GGUF metadata."""
+    try:
+        from lilbee.providers.llama_cpp_provider import _read_gguf_metadata, _resolve_model_path
+
+        path = _resolve_model_path(cfg.chat_model)
+        meta = _read_gguf_metadata(path)
+        if meta:
+            info.chat_arch = meta.get("architecture", "unknown")
+            info.active_handler = "llama-cpp"
+    except Exception:
+        log.debug("Failed to read chat model architecture", exc_info=True)
+    return info
+
+
+def _read_embed_arch(info: ModelArchInfo) -> ModelArchInfo:
+    """Read embedding model architecture from GGUF metadata."""
+    try:
+        from lilbee.providers.llama_cpp_provider import _read_gguf_metadata, _resolve_model_path
+
+        path = _resolve_model_path(cfg.embedding_model)
+        meta = _read_gguf_metadata(path)
+        if meta:
+            info.embed_arch = meta.get("architecture", "unknown")
+    except Exception:
+        log.debug("Failed to read embedding model architecture", exc_info=True)
+    return info
+
+
+def _read_vision_arch(info: ModelArchInfo) -> ModelArchInfo:
+    """Read vision projector type from GGUF metadata."""
+    if not cfg.vision_model:
+        return info
+    try:
+        from lilbee.providers.llama_cpp_provider import (
+            _find_mmproj_for_model,
+            _read_mmproj_projector_type,
+            _resolve_model_path,
+        )
+
+        path = _resolve_model_path(cfg.vision_model)
+        mmproj = _find_mmproj_for_model(path)
+        proj_type = _read_mmproj_projector_type(mmproj)
+        info.vision_projector = proj_type or "unknown"
+    except Exception:
+        log.debug("Failed to read vision projector type", exc_info=True)
+    return info

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from rich.console import Console
@@ -15,6 +16,15 @@ from lilbee import settings
 from lilbee.config import cfg
 
 log = logging.getLogger(__name__)
+
+
+class ModelTask(StrEnum):
+    """Role a model serves in the pipeline."""
+
+    CHAT = "chat"
+    EMBEDDING = "embedding"
+    VISION = "vision"
+
 
 # Extra headroom required beyond model size (GB)
 _DISK_HEADROOM_GB = 2

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -711,3 +711,60 @@ class TestLoginCommand:
             await pilot.press("enter")
             await pilot.pause()
             mock_wb.assert_called_once_with("https://huggingface.co/settings/tokens")
+
+
+# ---------------------------------------------------------------------------
+# App signals
+# ---------------------------------------------------------------------------
+
+
+class TestAppSignals:
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_settings_changed_signal_exists(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert hasattr(app, "settings_changed_signal")
+
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_model_changed_signal_exists(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert hasattr(app, "model_changed_signal")
+
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_signal_subscribe_and_publish(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            received: list[tuple[str, object]] = []
+            app.settings_changed_signal.subscribe(app, lambda val: received.append(val))
+            app.settings_changed_signal.publish(("chat_model", "new-model"))
+            await pilot.pause()
+            assert len(received) == 1
+            assert received[0] == ("chat_model", "new-model")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -105,11 +105,6 @@ def _make_remote_model(
     return RemoteModel(name=name, task=task, family=family, parameter_size=parameter_size)
 
 
-# ---------------------------------------------------------------------------
-# Pure function tests: catalog helpers
-# ---------------------------------------------------------------------------
-
-
 class TestParseParamLabel:
     def test_extracts_integer(self):
         assert _parse_param_label("qwen-8B-instruct") == "8B"
@@ -268,11 +263,6 @@ class TestRemoteToRow:
         rm = _make_remote_model(parameter_size="")
         row = _remote_to_row(rm)
         assert row.params == "--"
-
-
-# ---------------------------------------------------------------------------
-# Settings screen (Textual integration)
-# ---------------------------------------------------------------------------
 
 
 class SettingsTestApp(App[None]):
@@ -602,32 +592,21 @@ async def test_settings_model_info_values():
 
 
 async def test_settings_model_info_loaded():
-    """Model info shows 'loaded' when model defaults are available."""
-    from dataclasses import dataclass
-
+    """Model info shows 'llama-cpp' handler when model is resolvable."""
     from lilbee.cli.tui.screens.settings import _get_model_info
 
-    @dataclass(frozen=True)
-    class FakeDefaults:
-        temperature: float | None = 0.7
-        top_p: float | None = None
-        top_k: int | None = None
-        repeat_penalty: float | None = None
-        num_ctx: int | None = None
-        max_tokens: int | None = None
-
-    old_defaults = cfg._model_defaults
-    try:
-        cfg.apply_model_defaults(FakeDefaults())
+    with (
+        patch(
+            "lilbee.providers.llama_cpp_provider._resolve_model_path",
+            return_value="/fake/path",
+        ),
+        patch(
+            "lilbee.providers.llama_cpp_provider._read_gguf_metadata",
+            return_value={"architecture": "llama"},
+        ),
+    ):
         info = _get_model_info()
-        assert info["active_chat_handler"] == "loaded"
-    finally:
-        object.__setattr__(cfg, "_model_defaults", old_defaults)
-
-
-# ---------------------------------------------------------------------------
-# Status screen (Textual integration)
-# ---------------------------------------------------------------------------
+    assert info["active_chat_handler"] == "llama-cpp"
 
 
 class StatusTestApp(App[None]):
@@ -648,10 +627,38 @@ async def test_status_screen_renders_info(mock_svc):
     ]
     app = StatusTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        info = app.screen.query_one("#status-info", Static)
+        info = app.screen.query_one("#config-info", Static)
         rendered = str(info.render())
         assert "test-model:latest" in rendered
         assert "test-embed:latest" in rendered
+
+
+async def test_status_screen_has_collapsible_sections(mock_svc):
+    app = StatusTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        from textual.widgets import Collapsible
+
+        sections = app.screen.query(Collapsible)
+        assert len(sections) == 4
+
+
+async def test_status_screen_config_shows_models(mock_svc):
+    app = StatusTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        info = app.screen.query_one("#config-info", Static)
+        rendered = str(info.render())
+        assert "Chat model" in rendered
+        assert "Embed model" in rendered
+        assert "Vision model" in rendered
+
+
+async def test_status_screen_config_pills_render(mock_svc):
+    cfg.vision_model = ""
+    app = StatusTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        info = app.screen.query_one("#config-info", Static)
+        rendered = str(info.render())
+        assert "loaded" in rendered or "not set" in rendered
 
 
 async def test_status_screen_shows_documents(mock_svc):
@@ -670,10 +677,137 @@ async def test_status_screen_store_error(mock_svc):
     mock_svc.store.get_sources.side_effect = Exception("no table")
     app = StatusTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        from textual.widgets import DataTable
-
         table = app.screen.query_one("#docs-table", DataTable)
         assert table.row_count == 1
+
+
+async def test_status_screen_storage_section(mock_svc):
+    mock_svc.store.get_sources.return_value = [
+        {"source": "a.md", "chunk_count": 1, "content_type": "text/markdown"},
+    ]
+    app = StatusTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        info = app.screen.query_one("#storage-info", Static)
+        rendered = str(info.render())
+        assert "Documents" in rendered
+        assert "Data dir" in rendered
+        assert "Models dir" in rendered
+
+
+async def test_status_screen_arch_section(mock_svc):
+    app = StatusTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        info = app.screen.query_one("#arch-info", Static)
+        rendered = str(info.render())
+        assert "Chat arch" in rendered
+        assert "Handler" in rendered
+
+
+def test_status_model_pill_truthy():
+    from lilbee.cli.tui.screens.status import _model_pill
+
+    result = _model_pill("qwen3:8b")
+    assert "loaded" in str(result)
+
+
+def test_status_model_pill_empty():
+    from lilbee.cli.tui.screens.status import _model_pill
+
+    result = _model_pill("")
+    assert "not set" in str(result)
+
+
+def test_status_read_chat_arch_success():
+    from lilbee.model_info import ModelArchInfo, _read_chat_arch
+
+    info = ModelArchInfo()
+    with (
+        patch(
+            "lilbee.providers.llama_cpp_provider._resolve_model_path",
+            return_value="/fake/path",
+        ),
+        patch(
+            "lilbee.providers.llama_cpp_provider._read_gguf_metadata",
+            return_value={"architecture": "llama"},
+        ),
+    ):
+        result = _read_chat_arch(info)
+    assert result.chat_arch == "llama"
+    assert result.active_handler == "llama-cpp"
+
+
+def test_status_read_embed_arch_success():
+    from lilbee.model_info import ModelArchInfo, _read_embed_arch
+
+    info = ModelArchInfo()
+    with (
+        patch(
+            "lilbee.providers.llama_cpp_provider._resolve_model_path",
+            return_value="/fake/path",
+        ),
+        patch(
+            "lilbee.providers.llama_cpp_provider._read_gguf_metadata",
+            return_value={"architecture": "bert"},
+        ),
+    ):
+        result = _read_embed_arch(info)
+    assert result.embed_arch == "bert"
+
+
+def test_status_read_vision_arch_success():
+    from lilbee.model_info import ModelArchInfo, _read_vision_arch
+
+    cfg.vision_model = "test-vision:latest"
+    info = ModelArchInfo()
+    with (
+        patch(
+            "lilbee.providers.llama_cpp_provider._resolve_model_path",
+            return_value="/fake/path",
+        ),
+        patch(
+            "lilbee.providers.llama_cpp_provider._find_mmproj_for_model",
+            return_value="/fake/mmproj",
+        ),
+        patch(
+            "lilbee.providers.llama_cpp_provider._read_mmproj_projector_type",
+            return_value="resampler",
+        ),
+    ):
+        result = _read_vision_arch(info)
+    assert result.vision_projector == "resampler"
+
+
+def test_status_read_vision_arch_skips_when_no_model():
+    from lilbee.model_info import ModelArchInfo, _read_vision_arch
+
+    cfg.vision_model = ""
+    info = ModelArchInfo()
+    result = _read_vision_arch(info)
+    assert result.vision_projector == "unknown"
+
+
+def test_status_read_model_arch_import_error():
+    from lilbee.model_info import get_model_architecture
+
+    with patch(
+        "builtins.__import__",
+        side_effect=lambda name, *a, **kw: (
+            (_ for _ in ()).throw(ImportError("no llama-cpp"))
+            if "llama_cpp" in name
+            else __import__(name, *a, **kw)
+        ),
+    ):
+        result = get_model_architecture()
+    assert result.chat_arch == "unknown"
+
+
+async def test_status_screen_arch_with_vision(mock_svc):
+    cfg.vision_model = "test-vision:latest"
+    app = StatusTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        info = app.screen.query_one("#arch-info", Static)
+        rendered = str(info.render())
+        assert "Vision proj" in rendered
 
 
 async def test_status_screen_vim_keys(mock_svc):
@@ -695,11 +829,6 @@ async def test_status_screen_escape_pops():
     app = StatusTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         await _pilot.press("escape")
-
-
-# ---------------------------------------------------------------------------
-# LilbeeApp tests
-# ---------------------------------------------------------------------------
 
 
 async def test_app_mounts_chat_screen():
@@ -799,11 +928,6 @@ async def test_app_auto_sync_flag():
 
     app = LilbeeApp(auto_sync=True)
     assert app._auto_sync is True
-
-
-# ---------------------------------------------------------------------------
-# ChatScreen slash command tests
-# ---------------------------------------------------------------------------
 
 
 class ChatTestApp(App[None]):
@@ -1277,11 +1401,6 @@ async def test_chat_slash_delete_dispatch():
         app.screen._handle_slash("/delete")
 
 
-# ---------------------------------------------------------------------------
-# ChatScreen action_complete tests
-# ---------------------------------------------------------------------------
-
-
 async def test_chat_action_complete_no_options():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -1357,11 +1476,6 @@ async def test_chat_action_complete_cycle_no_selection():
             app.screen.action_complete()
 
 
-# ---------------------------------------------------------------------------
-# ChatScreen on_input_submitted (non-slash = send message)
-# ---------------------------------------------------------------------------
-
-
 async def test_chat_send_message():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -1415,11 +1529,6 @@ async def test_chat_trim_history_when_over_limit():
         app.screen._trim_history()
         assert len(app.screen._history) == _MAX_HISTORY_MESSAGES
         assert app.screen._history[0]["content"] == "msg-10"
-
-
-# ---------------------------------------------------------------------------
-# CommandProvider tests
-# ---------------------------------------------------------------------------
 
 
 async def test_command_provider_discover():
@@ -1631,11 +1740,6 @@ async def test_command_provider_document_commands_empty_name():
         provider = LilbeeCommandProvider(app.screen, match_style=None)
         cmds = provider._document_commands()
         assert cmds == []
-
-
-# ---------------------------------------------------------------------------
-# CatalogScreen tests
-# ---------------------------------------------------------------------------
 
 
 class CatalogTestApp(App[None]):
@@ -2031,11 +2135,6 @@ async def test_catalog_row_selected_out_of_range():
             screen.on_data_table_row_selected(event)
 
 
-# ---------------------------------------------------------------------------
-# Direct worker body tests (call underlying fn, not @work decorator)
-# ---------------------------------------------------------------------------
-
-
 async def test_catalog_fetch_more_hf_worker():
     """Cover _fetch_more_hf worker body."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -2269,11 +2368,6 @@ async def test_chat_embedding_ready_false_no_sync():
             mock_sync.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# Additional coverage: chat.py lines
-# ---------------------------------------------------------------------------
-
-
 async def test_chat_on_input_submitted_slash():
     """Cover the on_input_submitted slash dispatch (line 94-95)."""
     app = ChatTestApp()
@@ -2381,11 +2475,6 @@ async def test_chat_cancel_with_active_worker(mock_svc):
         await _pilot.pause()
 
 
-# ---------------------------------------------------------------------------
-# Additional coverage: catalog.py worker body lines
-# ---------------------------------------------------------------------------
-
-
 async def test_catalog_refresh_table_empty():
     """Cover empty table case."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -2490,11 +2579,6 @@ async def test_catalog_jump_top_bottom():
             await _pilot.pause()
             screen.action_jump_bottom()
             screen.action_jump_top()
-
-
-# ---------------------------------------------------------------------------
-# Additional coverage: commands.py vision catalog exception (lines 91-92)
-# ---------------------------------------------------------------------------
 
 
 async def test_chat_vim_j_cycles_focus_from_chat_log():
@@ -2853,11 +2937,6 @@ async def test_chat_bindings_include_half_page():
     assert "ctrl+u" in keys
 
 
-# ---------------------------------------------------------------------------
-# Catalog: delete model (d key)
-# ---------------------------------------------------------------------------
-
-
 async def test_catalog_delete_installed_model_confirmation():
     """First press of d shows confirmation notification."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -2997,11 +3076,6 @@ async def test_catalog_delete_in_input_ignored():
             screen.query_one("#catalog-search", Input).focus()
             screen.action_delete_model()
             assert screen._pending_delete is None
-
-
-# ---------------------------------------------------------------------------
-# Chat: /remove slash command
-# ---------------------------------------------------------------------------
 
 
 async def test_chat_slash_remove_no_args():

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1769,3 +1769,88 @@ class TestLilbeeAppGlobalNavBar:
                 await pilot.pause()
             nav = app.screen.query_one("#global-nav-bar")
             assert nav.active_view == "Chat"
+
+
+# ---------------------------------------------------------------------------
+# pill.py
+# ---------------------------------------------------------------------------
+
+
+class TestPill:
+    def test_pill_from_string(self) -> None:
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("chat", "$primary", "$text")
+        text = str(result)
+        assert "chat" in text
+        assert "\u258c" in text  # left half-block
+        assert "\u2590" in text  # right half-block
+
+    def test_pill_from_content(self) -> None:
+        from textual.content import Content
+
+        from lilbee.cli.tui.pill import pill
+
+        content_input = Content("embed")
+        result = pill(content_input, "$secondary", "$text")
+        assert "embed" in str(result)
+
+    def test_pill_empty_string(self) -> None:
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("", "$primary", "$text")
+        text = str(result)
+        assert "\u258c" in text
+        assert "\u2590" in text
+
+    def test_pill_returns_content(self) -> None:
+        from textual.content import Content
+
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("ok", "$success", "$text")
+        assert isinstance(result, Content)
+
+
+# ---------------------------------------------------------------------------
+# events.py
+# ---------------------------------------------------------------------------
+
+
+class TestEvents:
+    def test_model_changed_is_message(self) -> None:
+        from textual.message import Message
+
+        from lilbee.cli.tui.events import ModelChanged
+
+        msg = ModelChanged("chat", "qwen3:8b")
+        assert isinstance(msg, Message)
+        assert msg.role == "chat"
+        assert msg.name == "qwen3:8b"
+
+    def test_task_state_changed(self) -> None:
+        from lilbee.cli.tui.events import TaskStateChanged
+
+        msg = TaskStateChanged("task-1", "active")
+        assert msg.task_id == "task-1"
+        assert msg.status == "active"
+
+    def test_view_switched(self) -> None:
+        from lilbee.cli.tui.events import ViewSwitched
+
+        msg = ViewSwitched("Models")
+        assert msg.view_name == "Models"
+
+    def test_sync_requested(self) -> None:
+        from textual.message import Message
+
+        from lilbee.cli.tui.events import SyncRequested
+
+        msg = SyncRequested()
+        assert isinstance(msg, Message)
+
+    def test_catalog_view_toggled(self) -> None:
+        from lilbee.cli.tui.events import CatalogViewToggled
+
+        msg = CatalogViewToggled("grid")
+        assert msg.view_mode == "grid"


### PR DESCRIPTION
## Summary

- Status screen now shows collapsible sections instead of a flat text dump
- Model names display with colored pills showing loaded/not-set state
- GGUF architecture metadata visible at a glance
- Documents table with chunk counts, storage info section

## Test plan

- [ ] Navigate to Status — see 4 collapsible sections
- [ ] Model pills show green for loaded models, red for missing
- [ ] Collapse/expand sections work
- [ ] Vim keybindings still work (j/k/g/G)