### PR TITLE
feat: settings screen with grouped sections and type-aware editors

### DIFF
--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -22,21 +22,112 @@ class SettingDef:
     nullable: bool
     writable: bool = True
     render: RenderStyle = field(default=RenderStyle.COMPACT)
+    group: str = "General"
+    help_text: str = ""
+    choices: tuple[str, ...] | None = None
 
 
 SETTINGS_MAP: dict[str, SettingDef] = {
-    "chat_model": SettingDef("chat_model", str, nullable=False, writable=False),
-    "vision_model": SettingDef("vision_model", str, nullable=True, writable=False),
-    "embedding_model": SettingDef("embedding_model", str, nullable=False, writable=False),
-    "top_k": SettingDef("top_k", int, nullable=False),
-    "temperature": SettingDef("temperature", float, nullable=True),
-    "top_p": SettingDef("top_p", float, nullable=True),
-    "top_k_sampling": SettingDef("top_k_sampling", int, nullable=True),
-    "repeat_penalty": SettingDef("repeat_penalty", float, nullable=True),
-    "num_ctx": SettingDef("num_ctx", int, nullable=True),
-    "seed": SettingDef("seed", int, nullable=True),
-    "system_prompt": SettingDef("system_prompt", str, nullable=False, render=RenderStyle.FULL),
-    "show_reasoning": SettingDef("show_reasoning", bool, nullable=False),
-    "reranker_model": SettingDef("reranker_model", str, nullable=True),
-    "rerank_candidates": SettingDef("rerank_candidates", int, nullable=False),
+    "chat_model": SettingDef(
+        "chat_model",
+        str,
+        nullable=False,
+        writable=False,
+        group="Models",
+        help_text="LLM used for chat and generation",
+    ),
+    "vision_model": SettingDef(
+        "vision_model",
+        str,
+        nullable=True,
+        writable=False,
+        group="Models",
+        help_text="Vision model for OCR on images and PDFs",
+    ),
+    "embedding_model": SettingDef(
+        "embedding_model",
+        str,
+        nullable=False,
+        writable=False,
+        group="Models",
+        help_text="Model used to embed document chunks",
+    ),
+    "reranker_model": SettingDef(
+        "reranker_model",
+        str,
+        nullable=True,
+        group="Models",
+        help_text="Cross-encoder model for result reranking",
+    ),
+    "temperature": SettingDef(
+        "temperature",
+        float,
+        nullable=True,
+        group="Generation",
+        help_text="Sampling temperature (higher = more creative)",
+    ),
+    "top_p": SettingDef(
+        "top_p",
+        float,
+        nullable=True,
+        group="Generation",
+        help_text="Nucleus sampling cutoff probability",
+    ),
+    "top_k_sampling": SettingDef(
+        "top_k_sampling",
+        int,
+        nullable=True,
+        group="Generation",
+        help_text="Top-K sampling: number of tokens to consider",
+    ),
+    "repeat_penalty": SettingDef(
+        "repeat_penalty",
+        float,
+        nullable=True,
+        group="Generation",
+        help_text="Penalty for repeating tokens",
+    ),
+    "num_ctx": SettingDef(
+        "num_ctx",
+        int,
+        nullable=True,
+        group="Generation",
+        help_text="Context window size in tokens",
+    ),
+    "seed": SettingDef(
+        "seed",
+        int,
+        nullable=True,
+        group="Generation",
+        help_text="Random seed for reproducible output",
+    ),
+    "system_prompt": SettingDef(
+        "system_prompt",
+        str,
+        nullable=False,
+        render=RenderStyle.FULL,
+        group="Generation",
+        help_text="System prompt sent before every conversation",
+    ),
+    "top_k": SettingDef(
+        "top_k",
+        int,
+        nullable=False,
+        group="Retrieval",
+        help_text="Number of chunks returned by search",
+    ),
+    "rerank_candidates": SettingDef(
+        "rerank_candidates",
+        int,
+        nullable=False,
+        group="Retrieval",
+        help_text="Candidate pool size for reranking",
+    ),
+    "show_reasoning": SettingDef(
+        "show_reasoning",
+        bool,
+        nullable=False,
+        group="Display",
+        help_text="Show model reasoning/thinking tokens in output",
+    ),
 }

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -8,9 +8,11 @@ from typing import ClassVar
 
 from textual.app import App
 from textual.binding import Binding, BindingType
+from textual.signal import Signal
 
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.commands import LilbeeCommandProvider
+from lilbee.cli.tui.events import ModelChanged
 from lilbee.cli.tui.widgets.nav_bar import NavBar
 from lilbee.config import cfg
 
@@ -59,6 +61,12 @@ class LilbeeApp(App[None]):
         self._auto_sync = auto_sync
         self._active_view = "Chat"
         self._theme_index = 0
+        self.settings_changed_signal: Signal[tuple[str, object]] = Signal(
+            self, "settings_changed"
+        )
+        self.model_changed_signal: Signal[ModelChanged] = Signal(
+            self, "model_changed"
+        )
         from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         self._task_bar = TaskBar(id="app-task-bar")

--- a/src/lilbee/cli/tui/events.py
+++ b/src/lilbee/cli/tui/events.py
@@ -1,0 +1,46 @@
+"""Typed Textual Message subclasses for cross-widget communication.
+
+These complement messages.py (which holds user-facing string constants).
+Widgets post these messages for structured, typed event handling.
+"""
+
+from dataclasses import dataclass
+
+from textual.message import Message
+
+from lilbee.models import ModelTask
+
+
+@dataclass
+class ModelChanged(Message):
+    """Fired when the active chat, embedding, or vision model changes."""
+
+    role: ModelTask
+    name: str
+
+
+@dataclass
+class TaskStateChanged(Message):
+    """Fired when a background task changes state."""
+
+    task_id: str
+    status: str  # "queued" | "active" | "done" | "failed" | "cancelled"
+
+
+@dataclass
+class ViewSwitched(Message):
+    """Fired when navigation switches to a different view."""
+
+    view_name: str
+
+
+@dataclass
+class SyncRequested(Message):
+    """Request a document sync from any screen."""
+
+
+@dataclass
+class CatalogViewToggled(Message):
+    """Toggle between grid and list view in catalog."""
+
+    view_mode: str  # "grid" | "list"

--- a/src/lilbee/cli/tui/pill.py
+++ b/src/lilbee/cli/tui/pill.py
@@ -1,0 +1,30 @@
+"""Pill badge — colored inline label using half-block characters.
+
+Ported from toad (https://github.com/batrachianai/toad).
+"""
+
+from textual.content import Content
+
+PILL_LEFT = "\u258c"   # ▌ left half block
+PILL_RIGHT = "\u2590"  # ▐ right half block
+
+
+def pill(text: Content | str, background: str, foreground: str) -> Content:
+    """Format text as a pill badge with rounded half-block ends.
+
+    Args:
+        text: Pill contents.
+        background: Background color (Textual color string, e.g. "$primary").
+        foreground: Foreground color (Textual color string, e.g. "$text").
+
+    Returns:
+        Styled Content with half-block ends.
+    """
+    content = Content(text) if isinstance(text, str) else text
+    main_style = f"{foreground} on {background}"
+    end_style = f"{background} on transparent r"
+    return Content.assemble(
+        (PILL_LEFT, end_style),
+        content.stylize(main_style),
+        (PILL_RIGHT, end_style),
+    )

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -1,331 +1,260 @@
-"""Settings screen — view and edit configuration."""
+"""Settings screen — grouped, type-aware configuration editor."""
 
 from __future__ import annotations
 
-import os
-from dataclasses import fields as dc_fields
+import logging
+from collections import defaultdict
 from typing import ClassVar
 
+from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import Horizontal
+from textual.containers import VerticalGroup, VerticalScroll
+from textual.content import Content
 from textual.screen import Screen
-from textual.widgets import DataTable, Footer, Header, Input, Static
+from textual.widgets import Checkbox, Footer, Header, Input, Select, Static
 
 from lilbee import settings
-from lilbee.cli.settings_map import SETTINGS_MAP
+from lilbee.cli.settings_map import SETTINGS_MAP, SettingDef
 from lilbee.cli.tui import messages as msg
+from lilbee.cli.tui.pill import pill
 from lilbee.cli.tui.widgets.nav_bar import NavBar
 from lilbee.config import cfg
 
-_MAX_VALUE_LEN = 60
-_HF_TOKEN_KEY = "hf_token"
-_LOCKED_TAG = "[locked]"
-_READONLY_FIELDS = frozenset(
-    {
-        "data_dir",
-        "lancedb_dir",
-        "data_root",
-        "documents_dir",
-        "models_dir",
-    }
-)
+log = logging.getLogger(__name__)
 
-_MODEL_INFO_KEYS = (
-    "chat_model_arch",
-    "embed_model_arch",
-    "vision_projector",
-    "active_chat_handler",
-)
+_TYPE_COLORS: dict[str, tuple[str, str]] = {
+    "str": ("$secondary", "$text"),
+    "int": ("$primary", "$text"),
+    "float": ("$primary", "$text"),
+    "bool": ("$success", "$text"),
+    "select": ("$warning", "$text"),
+}
 
 
-def _get_hf_token_display() -> str:
-    """Get a masked display of the HuggingFace token, or 'not set'."""
-    token = os.environ.get("LILBEE_HF_TOKEN") or os.environ.get("HF_TOKEN") or ""
-    if not token:
-        import contextlib
-
-        with contextlib.suppress(Exception):
-            from huggingface_hub import get_token
-
-            token = get_token() or ""
-    return "****" if token else "not set"
-
-
-def _truncate(value: str) -> str:
-    """Truncate a value for display in the table."""
-    if len(value) > _MAX_VALUE_LEN:
-        return value[:_MAX_VALUE_LEN] + "..."
-    return value
+_DEFAULTS_REMAP: dict[str, str] = {"top_k_sampling": "top_k"}
 
 
 def _effective_value(cfg_attr: str) -> str:
-    """Return the effective value for a setting, including model defaults.
-
-    If the user hasn't set a value (None) but a model default exists,
-    returns the model default with a '(model default)' suffix.
-    """
+    """Return the effective value for a setting, including model defaults."""
     user_value = getattr(cfg, cfg_attr, None)
     if user_value is not None:
         return str(user_value)
     defaults = cfg._model_defaults
     if defaults is None:
         return "None"
-    default_map = _defaults_field_map()
-    if cfg_attr in default_map:
-        default_val = getattr(defaults, default_map[cfg_attr], None)
-        if default_val is not None:
-            return f"{default_val} (model default)"
+    defaults_key = _DEFAULTS_REMAP.get(cfg_attr, cfg_attr)
+    default_val = getattr(defaults, defaults_key, None)
+    if default_val is not None:
+        return f"{default_val} (model default)"
     return "None"
 
 
-def _defaults_field_map() -> dict[str, str]:
-    """Map config attr names to ModelDefaults field names.
-
-    top_k_sampling maps to top_k in ModelDefaults.
-    """
-    return {
-        "temperature": "temperature",
-        "top_p": "top_p",
-        "top_k_sampling": "top_k",
-        "repeat_penalty": "repeat_penalty",
-        "num_ctx": "num_ctx",
-        "max_tokens": "max_tokens",
-        "seed": "seed",
-    }
-
-
-def _get_model_info() -> dict[str, str]:
-    """Collect model architecture info by reading GGUF metadata from registry."""
-    info: dict[str, str] = {
-        "chat_model_arch": "unknown",
-        "embed_model_arch": "unknown",
-        "vision_projector": "unknown",
-        "active_chat_handler": "not loaded",
-    }
-    try:
-        from lilbee.providers.llama_cpp_provider import _read_gguf_metadata, _resolve_model_path
-
-        # Chat model
-        try:
-            path = _resolve_model_path(cfg.chat_model)
-            meta = _read_gguf_metadata(path)
-            if meta:
-                info["chat_model_arch"] = meta.get("architecture", "unknown")
-                info["active_chat_handler"] = "llama-cpp"
-        except Exception:
-            pass
-
-        # Embedding model
-        try:
-            path = _resolve_model_path(cfg.embedding_model)
-            meta = _read_gguf_metadata(path)
-            if meta:
-                info["embed_model_arch"] = meta.get("architecture", "unknown")
-        except Exception:
-            pass
-
-        # Vision projector
-        if cfg.vision_model:
-            try:
-                from lilbee.providers.llama_cpp_provider import (
-                    _find_mmproj_for_model,
-                    _read_mmproj_projector_type,
-                )
-
-                path = _resolve_model_path(cfg.vision_model)
-                mmproj = _find_mmproj_for_model(path)
-                proj_type = _read_mmproj_projector_type(mmproj)
-                info["vision_projector"] = proj_type or "unknown"
-            except Exception:
-                pass
-    except ImportError:
-        pass  # llama-cpp not available (litellm-only mode)
-    return info
-
-
 def _is_writable(key: str) -> bool:
-    """Check if a setting key is writable."""
-    if key in _READONLY_FIELDS or key == _HF_TOKEN_KEY:
-        return False
-    if key in _MODEL_INFO_KEYS:
-        return False
+    """Check if a setting key is writable (derived from SETTINGS_MAP)."""
     defn = SETTINGS_MAP.get(key)
-    if defn is None:
-        return False
-    return defn.writable
+    return defn is not None and defn.writable
+
+
+def _type_pill(defn: SettingDef) -> Content:
+    """Create a colored pill badge for a setting's type."""
+    type_name = defn.type.__name__
+    if defn.choices:
+        type_name = "select"
+    bg, fg = _TYPE_COLORS.get(type_name, ("$surface", "$text"))
+    return pill(type_name, bg, fg)
+
+
+def _help_content(defn: SettingDef) -> Content:
+    """Build help text with default value hint."""
+    value = _effective_value(defn.cfg_attr)
+    parts: list[Content | tuple[str, str]] = []
+    if defn.help_text:
+        parts.append(Content(defn.help_text))
+    default_hint = f"  current: {value}"
+    parts.append((default_hint, "$text-muted"))
+    return Content.assemble(*parts)
+
+
+def _group_settings() -> dict[str, list[tuple[str, SettingDef]]]:
+    """Group settings by their group field, preserving insertion order."""
+    groups: dict[str, list[tuple[str, SettingDef]]] = defaultdict(list)
+    for key, defn in SETTINGS_MAP.items():
+        groups[defn.group].append((key, defn))
+    return dict(groups)
+
+
+def _make_editor(key: str, defn: SettingDef) -> Input | Checkbox | Select[str]:
+    """Create the appropriate editor widget for a setting."""
+    value = _effective_value(defn.cfg_attr)
+    if defn.choices:
+        return _make_select(key, defn, value)
+    if defn.type is bool:
+        return _make_checkbox(key, value)
+    return _make_input(key, value)
+
+
+def _make_select(key: str, defn: SettingDef, value: str) -> Select[str]:
+    """Create a Select widget for choice-based settings."""
+    choices = [(c, c) for c in (defn.choices or ())]
+    current = value if value in {c[1] for c in choices} else Select.BLANK
+    return Select(choices, value=current, name=key, classes="setting-editor", id=f"ed-{key}")
+
+
+def _make_checkbox(key: str, value: str) -> Checkbox:
+    """Create a Checkbox widget for boolean settings."""
+    checked = value.lower() in ("true", "1", "yes", "on")
+    return Checkbox(value=checked, name=key, classes="setting-editor", id=f"ed-{key}")
+
+
+def _make_input(key: str, value: str) -> Input:
+    """Create an Input widget for string/number settings."""
+    display = "" if value == "None" else value.replace(" (model default)", "")
+    return Input(value=display, name=key, classes="setting-editor", id=f"ed-{key}")
 
 
 class SettingsScreen(Screen[None]):
-    """Interactive settings viewer with inline editing."""
+    """Interactive settings viewer with grouped, type-aware editors."""
+
+    CSS_PATH = "settings.tcss"
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "pop_screen", "Back", show=True),
-        Binding("escape", "dismiss_or_back", "Back", show=False),
-        Binding("enter", "edit_row", "Edit", show=True),
-        Binding("j", "cursor_down", "Nav", show=False),
-        Binding("k", "cursor_up", "Nav", show=False),
-        Binding("g", "jump_top", "Top", show=False),
-        Binding("G", "jump_bottom", "End", show=False),
+        Binding("escape", "pop_screen", "Back", show=False),
+        Binding("j", "scroll_down", "Down", show=False),
+        Binding("k", "scroll_up", "Up", show=False),
+        Binding("g", "scroll_home", "Top", show=False),
+        Binding("G", "scroll_end", "End", show=False),
     ]
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._editing_key: str | None = None
 
     def compose(self) -> ComposeResult:
         yield NavBar(id="global-nav-bar")
         yield Header()
-        yield DataTable(id="settings-table")
-        yield Horizontal(id="edit-bar")
-        yield Static("", id="setting-detail")
+        yield Input(
+            placeholder="Filter settings...",
+            id="settings-search",
+        )
+        with VerticalScroll(id="settings-scroll"):
+            yield from self._compose_groups()
         yield Footer()
 
-    def on_mount(self) -> None:
-        table = self.query_one("#settings-table", DataTable)
-        table.add_columns(
-            ("Setting", "setting"),
-            ("Value", "value"),
-            ("Type", "type"),
-        )
-        table.cursor_type = "row"
-        self._populate_settings(table)
-        self._populate_model_info(table)
-        type_label = "str " + _LOCKED_TAG
-        table.add_row(_HF_TOKEN_KEY, _get_hf_token_display(), type_label, key=_HF_TOKEN_KEY)
-        self.query_one("#edit-bar", Horizontal).display = False
+    def _compose_groups(self) -> ComposeResult:
+        """Yield grouped setting sections."""
+        for group_name, items in _group_settings().items():
+            with VerticalGroup(classes="setting-group", id=f"group-{group_name.lower()}"):
+                yield Static(group_name, classes="group-title")
+                for key, defn in items:
+                    yield from self._compose_setting(key, defn)
 
-    def _populate_settings(self, table: DataTable) -> None:
-        """Add config settings rows to the table."""
-        for key, defn in SETTINGS_MAP.items():
-            value = _effective_value(defn.cfg_attr)
-            type_label = defn.type.__name__
-            if not defn.writable:
-                type_label += " " + _LOCKED_TAG
-            table.add_row(key, _truncate(value), type_label, key=key)
+    def _compose_setting(self, key: str, defn: SettingDef) -> ComposeResult:
+        """Yield widgets for a single setting row."""
+        with VerticalGroup(
+            classes="setting-row",
+            name=f"{defn.group.lower()} {key}",
+            id=f"row-{key}",
+        ):
+            yield Static(
+                Content.assemble(Content(key + "  "), _type_pill(defn)),
+                classes="setting-title",
+            )
+            yield Static(_help_content(defn), classes="setting-help")
+            if defn.writable:
+                yield _make_editor(key, defn)
 
-    def _populate_model_info(self, table: DataTable) -> None:
-        """Add model architecture info as read-only rows."""
-        info = _get_model_info()
-        for key in _MODEL_INFO_KEYS:
-            value = info.get(key, "unknown")
-            table.add_row(key, value, "str " + _LOCKED_TAG, key=key)
+    @on(Input.Changed, "#settings-search")
+    def _filter_settings(self, event: Input.Changed) -> None:
+        """Filter visible settings based on search input."""
+        term = event.value.strip().lower()
+        for group in self.query(".setting-group"):
+            visible_count = 0
+            for row in group.query(".setting-row"):
+                matches = not term or term in (row.name or "")
+                row.display = matches
+                if matches:
+                    visible_count += 1
+            group.display = visible_count > 0
 
-    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
-        """Open editor when a row is clicked."""
-        self.action_edit_row()
-
-    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
-        if self._editing_key:
+    @on(Input.Submitted, ".setting-editor")
+    @on(Input.Blurred, ".setting-editor")
+    def _on_input_save(self, event: Input.Submitted | Input.Blurred) -> None:
+        """Save string/number input on submit or blur."""
+        name = event.input.name
+        if name is None:
             return
-        detail = self.query_one("#setting-detail", Static)
-        if event.row_key and event.row_key.value:
-            key = str(event.row_key.value)
-            if key == _HF_TOKEN_KEY:
-                detail.update(f"{_HF_TOKEN_KEY}\n{_get_hf_token_display()}\nUse /login to set")
-                return
-            if key in _MODEL_INFO_KEYS:
-                info = _get_model_info()
-                detail.update(f"{key} (read-only)\n{info.get(key, 'unknown')}")
-                return
-            defn = SETTINGS_MAP.get(key)
-            if defn:
-                value = _effective_value(defn.cfg_attr)
-                ro = " (read-only)" if not defn.writable else ""
-                detail.update(f"{key} ({defn.type.__name__}){ro}\n{value}")
-                return
-        detail.update("")
-
-    def action_dismiss_or_back(self) -> None:
-        """Escape: cancel edit if editing, otherwise pop screen."""
-        if self._editing_key is not None:
-            self._close_editor()
-        else:
-            self.app.pop_screen()
-
-    def action_edit_row(self) -> None:
-        """Enter: open inline editor for the highlighted row."""
-        if self._editing_key is not None:
+        defn = SETTINGS_MAP.get(name)
+        if defn is None:
             return
-        table = self.query_one("#settings-table", DataTable)
-        row_idx = table.cursor_row
-        if row_idx is None:
+        raw = event.value.strip()
+        current = str(getattr(cfg, defn.cfg_attr, ""))
+        if raw == current:
             return
-        key_cell = table.get_row_at(row_idx)
-        key = str(key_cell[0])
+        self._persist_value(name, defn, raw)
 
-        if not _is_writable(key):
-            self.notify(msg.SETTINGS_READ_ONLY, severity="warning")
+    @on(Checkbox.Changed, ".setting-editor")
+    def _on_checkbox_save(self, event: Checkbox.Changed) -> None:
+        """Save boolean on toggle."""
+        name = event.checkbox.name
+        if name is None:
             return
-
-        defn = SETTINGS_MAP[key]
-        current_value = str(getattr(cfg, defn.cfg_attr, ""))
-        if current_value == "None":
-            current_value = ""
-        self._editing_key = key
-
-        bar = self.query_one("#edit-bar", Horizontal)
-        bar.display = True
-        editor = Input(
-            value=current_value,
-            placeholder=f"Enter value for {key}",
-            id="settings-editor",
-        )
-        bar.mount(Static(f"  {key}: ", id="edit-label"))
-        bar.mount(editor)
-        editor.focus()
-
-    def on_input_submitted(self, event: Input.Submitted) -> None:
-        """Save edited value on Enter."""
-        if event.input.id != "settings-editor" or self._editing_key is None:
+        defn = SETTINGS_MAP.get(name)
+        if defn is None:
             return
-        key = self._editing_key
-        new_value = event.value.strip()
-        defn = SETTINGS_MAP[key]
+        self._persist_value(name, defn, str(event.checkbox.value))
 
+    @on(Select.Changed, ".setting-editor")
+    def _on_select_save(self, event: Select.Changed) -> None:
+        """Save select choice on change."""
+        name = event.select.name
+        if name is None:
+            return
+        defn = SETTINGS_MAP.get(name)
+        if defn is None:
+            return
+        value = str(event.value) if event.value != Select.BLANK else ""
+        self._persist_value(name, defn, value)
+
+    def _persist_value(self, key: str, defn: SettingDef, raw: str) -> None:
+        """Parse, apply, and persist a setting value."""
         try:
-            if defn.type is bool:
-                parsed = new_value.lower() in ("true", "1", "yes", "on")
-            elif defn.nullable and new_value.lower() in ("none", "null", ""):
-                parsed = None
-            else:
-                parsed = defn.type(new_value)
+            parsed = self._parse_value(defn, raw)
             setattr(cfg, defn.cfg_attr, parsed)
             persisted = str(parsed) if parsed is not None else ""
             settings.set_value(cfg.data_root, defn.cfg_attr, persisted)
-
-            table = self.query_one("#settings-table", DataTable)
-            display = _truncate(persisted)
-            table.update_cell(key, "value", display)
             self.notify(msg.CMD_SET_SUCCESS.format(key=key, value=parsed))
+            self._refresh_help(key, defn)
+            if hasattr(self.app, "settings_changed_signal"):
+                self.app.settings_changed_signal.publish((key, parsed))
         except (ValueError, TypeError) as exc:
             self.notify(msg.SETTINGS_INVALID_VALUE.format(error=exc), severity="error")
 
-        self._close_editor()
+    def _parse_value(self, defn: SettingDef, raw: str) -> object:
+        """Convert a raw string to the setting's target type."""
+        if defn.nullable and raw.lower() in ("none", "null", ""):
+            return None
+        if defn.type is bool:
+            return raw.lower() in ("true", "1", "yes", "on")
+        return defn.type(raw)
 
-    def _close_editor(self) -> None:
-        """Remove the inline editor and restore table focus."""
-        self._editing_key = None
-        bar = self.query_one("#edit-bar", Horizontal)
-        bar.remove_children()
-        bar.display = False
-        self.query_one("#settings-table", DataTable).focus()
+    def _refresh_help(self, key: str, defn: SettingDef) -> None:
+        """Update the help text after a value change."""
+        try:
+            row = self.query_one(f"#row-{key}", VerticalGroup)
+            help_widget = row.query_one(".setting-help", Static)
+            help_widget.update(_help_content(defn))
+        except Exception:
+            log.debug("Failed to refresh help for %s", key, exc_info=True)
 
     def action_pop_screen(self) -> None:
-        if self._editing_key:
-            self._close_editor()
-        else:
-            self.app.pop_screen()
+        self.app.pop_screen()
 
-    def action_cursor_down(self) -> None:
-        self.query_one("#settings-table", DataTable).action_cursor_down()
+    def action_scroll_down(self) -> None:
+        self.query_one("#settings-scroll", VerticalScroll).scroll_down()
 
-    def action_cursor_up(self) -> None:
-        self.query_one("#settings-table", DataTable).action_cursor_up()
+    def action_scroll_up(self) -> None:
+        self.query_one("#settings-scroll", VerticalScroll).scroll_up()
 
-    def action_jump_top(self) -> None:
-        self.query_one("#settings-table", DataTable).move_cursor(row=0)
+    def action_scroll_home(self) -> None:
+        self.query_one("#settings-scroll", VerticalScroll).scroll_home()
 
-    def action_jump_bottom(self) -> None:
-        table = self.query_one("#settings-table", DataTable)
-        table.move_cursor(row=table.row_count - 1)
+    def action_scroll_end(self) -> None:
+        self.query_one("#settings-scroll", VerticalScroll).scroll_end()

--- a/src/lilbee/cli/tui/screens/settings.tcss
+++ b/src/lilbee/cli/tui/screens/settings.tcss
@@ -1,0 +1,68 @@
+SettingsScreen {
+    #settings-search {
+        dock: top;
+        margin: 0 1;
+    }
+
+    #settings-scroll {
+        padding: 0 1;
+    }
+
+    .setting-group {
+        border: tall $secondary-muted;
+        padding: 0 1;
+        margin-bottom: 1;
+
+        &:focus-within {
+            border: tall $secondary;
+        }
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    .group-title {
+        color: $primary;
+        text-style: bold;
+        padding: 0 0 1 0;
+    }
+
+    .setting-row {
+        margin-bottom: 1;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    .setting-title {
+        padding: 0 0 0 1;
+        text-style: bold;
+    }
+
+    .setting-help {
+        color: $text-muted;
+        padding: 0 0 0 1;
+    }
+
+    .setting-editor {
+        margin: 0 0 0 0;
+    }
+
+    Input, Select SelectCurrent, Checkbox {
+        border: tall black 20%;
+
+        &:focus {
+            border: tall $primary;
+        }
+    }
+
+    Select:focus > SelectCurrent {
+        border: tall $primary;
+    }
+
+    Input.-invalid {
+        border: tall $error 60%;
+    }
+}

--- a/src/lilbee/cli/tui/theme.tcss
+++ b/src/lilbee/cli/tui/theme.tcss
@@ -17,7 +17,7 @@
     padding: 0 1;
 }
 
-#model-detail, #setting-detail {
+#model-detail {
     height: 6;
     padding: 1;
     border-top: solid $surface-lighten-2;
@@ -82,11 +82,6 @@ HelpModal {
     align: center middle;
 }
 
-#edit-bar {
-    height: auto;
-    max-height: 3;
-    padding: 0 1;
-}
 
 #chat-input.insert-mode {
     border: tall $accent;

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from rich.console import Console
@@ -15,6 +16,15 @@ from lilbee import settings
 from lilbee.config import cfg
 
 log = logging.getLogger(__name__)
+
+
+class ModelTask(StrEnum):
+    """Role a model serves in the pipeline."""
+
+    CHAT = "chat"
+    EMBEDDING = "embedding"
+    VISION = "vision"
+
 
 # Extra headroom required beyond model size (GB)
 _DISK_HEADROOM_GB = 2

--- a/tests/integration/test_tui_integration.py
+++ b/tests/integration/test_tui_integration.py
@@ -644,7 +644,7 @@ class TestSettingsKeybindings:
             await pilot.pause()
             assert not isinstance(app.screen, SettingsScreen)
 
-    async def test_settings_j_k_navigates_table(self) -> None:
+    async def test_settings_j_k_scrolls(self) -> None:
         from lilbee.cli.tui.screens.settings import SettingsScreen
 
         app = _FullApp()
@@ -652,8 +652,8 @@ class TestSettingsKeybindings:
             screen = SettingsScreen()
             app.push_screen(screen)
             await pilot.pause()
-            screen.action_cursor_down()
-            screen.action_cursor_up()
+            screen.action_scroll_down()
+            screen.action_scroll_up()
 
 
 class TestHelpModal:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -335,7 +335,7 @@ class TestCatalogScreenAsync:
 
 class TestSettingsScreenAsync:
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_settings_shows_table(self, mock_catalog: mock.MagicMock) -> None:
+    async def test_settings_shows_groups(self, mock_catalog: mock.MagicMock) -> None:
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.screens.settings import SettingsScreen
@@ -345,8 +345,8 @@ class TestSettingsScreenAsync:
             await pilot.pause()
             app.push_screen(SettingsScreen())
             await pilot.pause()
-            table = app.screen.query_one("#settings-table")
-            assert table is not None
+            groups = app.screen.query(".setting-group")
+            assert len(groups) > 0
 
 
 class TestStatusScreenAsync:
@@ -711,3 +711,56 @@ class TestLoginCommand:
             await pilot.press("enter")
             await pilot.pause()
             mock_wb.assert_called_once_with("https://huggingface.co/settings/tokens")
+
+
+
+class TestAppSignals:
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_settings_changed_signal_exists(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert hasattr(app, "settings_changed_signal")
+
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_model_changed_signal_exists(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert hasattr(app, "model_changed_signal")
+
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_signal_subscribe_and_publish(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            received: list[tuple[str, object]] = []
+            app.settings_changed_signal.subscribe(app, lambda val: received.append(val))
+            app.settings_changed_signal.publish(("chat_model", "new-model"))
+            await pilot.pause()
+            assert len(received) == 1
+            assert received[0] == ("chat_model", "new-model")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -104,12 +104,6 @@ def _make_remote_model(
 ) -> RemoteModel:
     return RemoteModel(name=name, task=task, family=family, parameter_size=parameter_size)
 
-
-# ---------------------------------------------------------------------------
-# Pure function tests: catalog helpers
-# ---------------------------------------------------------------------------
-
-
 class TestParseParamLabel:
     def test_extracts_integer(self):
         assert _parse_param_label("qwen-8B-instruct") == "8B"
@@ -269,12 +263,6 @@ class TestRemoteToRow:
         row = _remote_to_row(rm)
         assert row.params == "--"
 
-
-# ---------------------------------------------------------------------------
-# Settings screen (Textual integration)
-# ---------------------------------------------------------------------------
-
-
 class SettingsTestApp(App[None]):
     CSS = ""
 
@@ -287,208 +275,106 @@ class SettingsTestApp(App[None]):
         self.push_screen(SettingsScreen())
 
 
-async def test_settings_screen_renders_table():
+async def test_settings_screen_mounts_grouped_sections():
+    """Settings screen renders grouped sections with setting rows."""
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        from textual.widgets import DataTable
-
-        table = app.screen.query_one("#settings-table", DataTable)
-        assert table.row_count > 0
-
-
-async def test_settings_screen_detail_panel():
-    app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from textual.widgets import DataTable
-
-        table = app.screen.query_one("#settings-table", DataTable)
-        assert table.row_count > 0
+        groups = app.screen.query(".setting-group")
+        assert len(groups) > 0
+        rows = app.screen.query(".setting-row")
+        assert len(rows) > 0
 
 
-async def test_settings_screen_vim_keys():
-    app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from textual.widgets import DataTable
-
-        table = app.screen.query_one("#settings-table", DataTable)
-        table.focus()
-        await _pilot.press("j")
-        await _pilot.press("k")
-
-
-async def test_settings_screen_pop():
-    app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        await _pilot.press("q")
-
-
-async def test_settings_screen_row_highlighted_empty_key():
-    """Cover the branch where event.row_key has no value."""
-    app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        detail = app.screen.query_one("#setting-detail", Static)
-        event = MagicMock()
-        event.row_key = MagicMock()
-        event.row_key.value = None
-        event.row_key.__bool__ = lambda s: False
-        app.screen.on_data_table_row_highlighted(event)
-        assert str(detail.render()) == ""
-
-
-async def test_settings_screen_row_highlighted_unknown_key():
-    """Cover the branch where key is not in SETTINGS_MAP."""
-    app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        event = MagicMock()
-        event.row_key = MagicMock()
-        event.row_key.value = "nonexistent_key_xyz"
-        event.row_key.__bool__ = lambda self: True
-        app.screen.on_data_table_row_highlighted(event)
-
-
-async def test_settings_enter_opens_editor():
-    """F1: pressing Enter on a writable row opens an inline editor."""
+async def test_settings_search_filters_settings():
+    """Search input filters visible setting rows."""
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
-        from textual.widgets import DataTable, Input
+        from textual.widgets import Input
 
-        table = app.screen.query_one("#settings-table", DataTable)
-        table.focus()
-        # Move to top_k row (first writable row, index 3)
-        table.move_cursor(row=3)
+        search = app.screen.query_one("#settings-search", Input)
+        search.focus()
+        search.value = "top_k"
         await pilot.pause()
-        app.screen.action_edit_row()
-        await pilot.pause()
-        editor = app.screen.query_one("#settings-editor", Input)
-        assert editor is not None
-        assert app.screen._editing_key is not None
+        visible = [r for r in app.screen.query(".setting-row") if r.display]
+        assert len(visible) >= 1
+        assert any("top_k" in (r.name or "") for r in visible)
 
 
-async def test_settings_enter_saves_value():
-    """F1: submitting editor saves the value."""
+async def test_settings_search_clears_restores_all():
+    """Clearing search restores all settings."""
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
-        from textual.widgets import DataTable, Input
+        from textual.widgets import Input
 
-        table = app.screen.query_one("#settings-table", DataTable)
-        table.focus()
-        # Move to top_k row (row 3, index-based)
-        table.move_cursor(row=3)
+        search = app.screen.query_one("#settings-search", Input)
+        total = len(app.screen.query(".setting-row"))
+        search.value = "xyznonexistent"
         await pilot.pause()
-        app.screen.action_edit_row()
+        search.value = ""
         await pilot.pause()
-        editor = app.screen.query_one("#settings-editor", Input)
-        editor.value = "20"
+        visible = [r for r in app.screen.query(".setting-row") if r.display]
+        assert len(visible) == total
+
+
+async def test_settings_bool_renders_checkbox():
+    """Boolean settings render as Checkbox widgets."""
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        checkboxes = app.screen.query("Checkbox.setting-editor")
+        assert len(checkboxes) >= 1
+
+
+async def test_settings_readonly_no_editor():
+    """Read-only settings do not have editor widgets."""
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        chat_row = app.screen.query_one("#row-chat_model")
+        editors = chat_row.query(".setting-editor")
+        assert len(editors) == 0
+
+
+async def test_settings_persist_on_change():
+    """Changing a setting persists the value to cfg."""
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        from textual.widgets import Input
+
+        editor = app.screen.query_one("#ed-top_k", Input)
         editor.focus()
+        editor.value = "20"
         await pilot.press("enter")
         await pilot.pause()
         assert cfg.top_k == 20
-        assert app.screen._editing_key is None
 
 
-async def test_settings_escape_cancels_edit():
-    """F1: pressing Escape cancels the edit."""
+async def test_settings_checkbox_persist():
+    """Toggling a checkbox persists the boolean value."""
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
-        from textual.widgets import DataTable
+        from textual.widgets import Checkbox
 
-        table = app.screen.query_one("#settings-table", DataTable)
-        table.focus()
-        # Move to top_k (first writable row, index 3)
-        table.move_cursor(row=3)
+        cb = app.screen.query_one("#ed-show_reasoning", Checkbox)
+        original = cfg.show_reasoning
+        cb.toggle()
         await pilot.pause()
-        app.screen.action_edit_row()
-        await pilot.pause()
-        assert app.screen._editing_key is not None
-        app.screen.action_dismiss_or_back()
-        await pilot.pause()
-        assert app.screen._editing_key is None
+        assert cfg.show_reasoning != original
 
 
-async def test_settings_readonly_shows_warning():
-    """F1: Enter on hf_token row shows read-only warning."""
+async def test_settings_vim_keys():
+    """Vim navigation keys work on the scroll container."""
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
-        from textual.widgets import DataTable
-
-        table = app.screen.query_one("#settings-table", DataTable)
-        table.focus()
-        # Move cursor to last row (hf_token)
-        table.move_cursor(row=table.row_count - 1)
-        await pilot.pause()
-        app.screen.action_edit_row()
-        await pilot.pause()
-        # Should not have opened an editor
-        assert app.screen._editing_key is None
+        await pilot.press("j")
+        await pilot.press("k")
+        await pilot.press("g")
+        await pilot.press("G")
 
 
-async def test_settings_readonly_fields_show_locked_tag():
-    """Read-only settings show [locked] in the type column."""
-    app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from textual.widgets import DataTable
-
-        table = app.screen.query_one("#settings-table", DataTable)
-        # chat_model is row 0 and non-writable
-        row = table.get_row_at(0)
-        assert "[locked]" in str(row[2])
-        # top_k is row 3 and writable — no locked tag
-        writable_row = table.get_row_at(3)
-        assert "[locked]" not in str(writable_row[2])
-
-
-async def test_settings_readonly_field_blocks_editing():
-    """Pressing Enter on a non-writable settings field shows warning."""
+async def test_settings_pop_screen():
+    """Pressing q pops the settings screen."""
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
-        from textual.widgets import DataTable
-
-        table = app.screen.query_one("#settings-table", DataTable)
-        table.focus()
-        # chat_model is row 0 — read-only
-        table.move_cursor(row=0)
-        await pilot.pause()
-        app.screen.action_edit_row()
-        await pilot.pause()
-        assert app.screen._editing_key is None
-
-
-async def test_settings_model_info_rows_present():
-    """Model architecture info rows are shown in the settings table."""
-    app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from textual.widgets import DataTable
-
-        table = app.screen.query_one("#settings-table", DataTable)
-        keys = [str(table.get_row_at(i)[0]) for i in range(table.row_count)]
-        assert "chat_model_arch" in keys
-        assert "embed_model_arch" in keys
-        assert "vision_projector" in keys
-        assert "active_chat_handler" in keys
-
-
-async def test_settings_model_info_rows_not_editable():
-    """Model info rows are read-only."""
-    from lilbee.cli.tui.screens.settings import _is_writable
-
-    assert not _is_writable("chat_model_arch")
-    assert not _is_writable("embed_model_arch")
-    assert not _is_writable("vision_projector")
-    assert not _is_writable("active_chat_handler")
-
-
-async def test_settings_model_info_row_detail():
-    """Highlighting a model info row shows detail text."""
-    app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        event = MagicMock()
-        event.row_key = MagicMock()
-        event.row_key.value = "chat_model_arch"
-        event.row_key.__bool__ = lambda self: True
-        app.screen.on_data_table_row_highlighted(event)
-        detail = app.screen.query_one("#setting-detail", Static)
-        rendered = str(detail.render())
-        assert "read-only" in rendered
+        await pilot.press("q")
 
 
 async def test_settings_effective_value_shows_model_default():
@@ -585,50 +471,45 @@ async def test_settings_is_writable():
     assert not _is_writable("nonexistent_key_xyz")
 
 
-async def test_settings_model_info_values():
-    """Model info rows show 'unknown' or 'not loaded' when no model loaded."""
-    from lilbee.cli.tui.screens.settings import _get_model_info
+async def test_settings_persist_invalid_int():
+    """Invalid value for int field shows error and does not change cfg."""
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        from textual.widgets import Input
 
-    old_defaults = cfg._model_defaults
-    try:
-        cfg.clear_model_defaults()
-        info = _get_model_info()
-        assert info["chat_model_arch"] == "unknown"
-        assert info["embed_model_arch"] == "unknown"
-        assert info["vision_projector"] == "unknown"
-        assert info["active_chat_handler"] == "not loaded"
-    finally:
-        object.__setattr__(cfg, "_model_defaults", old_defaults)
-
-
-async def test_settings_model_info_loaded():
-    """Model info shows 'loaded' when model defaults are available."""
-    from dataclasses import dataclass
-
-    from lilbee.cli.tui.screens.settings import _get_model_info
-
-    @dataclass(frozen=True)
-    class FakeDefaults:
-        temperature: float | None = 0.7
-        top_p: float | None = None
-        top_k: int | None = None
-        repeat_penalty: float | None = None
-        num_ctx: int | None = None
-        max_tokens: int | None = None
-
-    old_defaults = cfg._model_defaults
-    try:
-        cfg.apply_model_defaults(FakeDefaults())
-        info = _get_model_info()
-        assert info["active_chat_handler"] == "loaded"
-    finally:
-        object.__setattr__(cfg, "_model_defaults", old_defaults)
+        original = cfg.top_k
+        editor = app.screen.query_one("#ed-top_k", Input)
+        editor.focus()
+        editor.value = "abc"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert cfg.top_k == original
 
 
-# ---------------------------------------------------------------------------
-# Status screen (Textual integration)
-# ---------------------------------------------------------------------------
+async def test_settings_select_save():
+    """_on_select_save routes through _persist_value correctly."""
+    from unittest.mock import MagicMock, patch
 
+    from lilbee.cli.settings_map import SettingDef
+    from lilbee.cli.tui.screens.settings import SettingsScreen
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        defn = SettingDef(cfg_attr="system_prompt", type=str, nullable=False, group="Generation")
+        event = MagicMock()
+        event.select.name = "test_select"
+        event.value = "chosen"
+        with (
+            patch.dict(
+                "lilbee.cli.tui.screens.settings.SETTINGS_MAP",
+                {"test_select": defn},
+            ),
+            patch.object(screen, "_persist_value") as mock_persist,
+        ):
+            screen._on_select_save(event)
+            mock_persist.assert_called_once_with("test_select", defn, "chosen")
 
 class StatusTestApp(App[None]):
     CSS = ""
@@ -695,12 +576,6 @@ async def test_status_screen_escape_pops():
     app = StatusTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         await _pilot.press("escape")
-
-
-# ---------------------------------------------------------------------------
-# LilbeeApp tests
-# ---------------------------------------------------------------------------
-
 
 async def test_app_mounts_chat_screen():
     from lilbee.cli.tui.app import LilbeeApp
@@ -799,12 +674,6 @@ async def test_app_auto_sync_flag():
 
     app = LilbeeApp(auto_sync=True)
     assert app._auto_sync is True
-
-
-# ---------------------------------------------------------------------------
-# ChatScreen slash command tests
-# ---------------------------------------------------------------------------
-
 
 class ChatTestApp(App[None]):
     CSS = ""
@@ -1276,12 +1145,6 @@ async def test_chat_slash_delete_dispatch():
     async with app.run_test(size=(120, 40)) as _pilot:
         app.screen._handle_slash("/delete")
 
-
-# ---------------------------------------------------------------------------
-# ChatScreen action_complete tests
-# ---------------------------------------------------------------------------
-
-
 async def test_chat_action_complete_no_options():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -1356,12 +1219,6 @@ async def test_chat_action_complete_cycle_no_selection():
         with patch.object(overlay, "cycle_next", return_value=None):
             app.screen.action_complete()
 
-
-# ---------------------------------------------------------------------------
-# ChatScreen on_input_submitted (non-slash = send message)
-# ---------------------------------------------------------------------------
-
-
 async def test_chat_send_message():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -1415,12 +1272,6 @@ async def test_chat_trim_history_when_over_limit():
         app.screen._trim_history()
         assert len(app.screen._history) == _MAX_HISTORY_MESSAGES
         assert app.screen._history[0]["content"] == "msg-10"
-
-
-# ---------------------------------------------------------------------------
-# CommandProvider tests
-# ---------------------------------------------------------------------------
-
 
 async def test_command_provider_discover():
     from lilbee.cli.tui.app import LilbeeApp
@@ -1631,12 +1482,6 @@ async def test_command_provider_document_commands_empty_name():
         provider = LilbeeCommandProvider(app.screen, match_style=None)
         cmds = provider._document_commands()
         assert cmds == []
-
-
-# ---------------------------------------------------------------------------
-# CatalogScreen tests
-# ---------------------------------------------------------------------------
-
 
 class CatalogTestApp(App[None]):
     CSS = ""
@@ -2030,12 +1875,6 @@ async def test_catalog_row_selected_out_of_range():
             event.cursor_row = 999
             screen.on_data_table_row_selected(event)
 
-
-# ---------------------------------------------------------------------------
-# Direct worker body tests (call underlying fn, not @work decorator)
-# ---------------------------------------------------------------------------
-
-
 async def test_catalog_fetch_more_hf_worker():
     """Cover _fetch_more_hf worker body."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -2268,12 +2107,6 @@ async def test_chat_embedding_ready_false_no_sync():
             await _pilot.pause()
             mock_sync.assert_not_called()
 
-
-# ---------------------------------------------------------------------------
-# Additional coverage: chat.py lines
-# ---------------------------------------------------------------------------
-
-
 async def test_chat_on_input_submitted_slash():
     """Cover the on_input_submitted slash dispatch (line 94-95)."""
     app = ChatTestApp()
@@ -2380,12 +2213,6 @@ async def test_chat_cancel_with_active_worker(mock_svc):
         barrier.set()
         await _pilot.pause()
 
-
-# ---------------------------------------------------------------------------
-# Additional coverage: catalog.py worker body lines
-# ---------------------------------------------------------------------------
-
-
 async def test_catalog_refresh_table_empty():
     """Cover empty table case."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -2490,12 +2317,6 @@ async def test_catalog_jump_top_bottom():
             await _pilot.pause()
             screen.action_jump_bottom()
             screen.action_jump_top()
-
-
-# ---------------------------------------------------------------------------
-# Additional coverage: commands.py vision catalog exception (lines 91-92)
-# ---------------------------------------------------------------------------
-
 
 async def test_chat_vim_j_cycles_focus_from_chat_log():
     """key_j cycles focus forward from chat-log to chat-input in normal mode."""
@@ -2756,17 +2577,11 @@ async def test_chat_half_page_actions():
 
 
 async def test_settings_key_g_G(mock_svc):
-    """g/G jump to first/last row in settings table."""
+    """g/G scroll actions work on the settings scroll container."""
     app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from textual.widgets import DataTable
-
-        table = app.screen.query_one("#settings-table", DataTable)
-        table.focus()
-        app.screen.action_jump_bottom()
-        assert table.cursor_row == table.row_count - 1
-        app.screen.action_jump_top()
-        assert table.cursor_row == 0
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.press("G")
+        await pilot.press("g")
 
 
 async def test_status_key_g_G(mock_svc):
@@ -2851,12 +2666,6 @@ async def test_chat_bindings_include_half_page():
     keys = {b.key for b in ChatScreen.BINDINGS if isinstance(b, B)}
     assert "ctrl+d" in keys
     assert "ctrl+u" in keys
-
-
-# ---------------------------------------------------------------------------
-# Catalog: delete model (d key)
-# ---------------------------------------------------------------------------
-
 
 async def test_catalog_delete_installed_model_confirmation():
     """First press of d shows confirmation notification."""
@@ -2997,12 +2806,6 @@ async def test_catalog_delete_in_input_ignored():
             screen.query_one("#catalog-search", Input).focus()
             screen.action_delete_model()
             assert screen._pending_delete is None
-
-
-# ---------------------------------------------------------------------------
-# Chat: /remove slash command
-# ---------------------------------------------------------------------------
-
 
 async def test_chat_slash_remove_no_args():
     app = ChatTestApp()
@@ -3857,22 +3660,13 @@ async def test_task_center_show_detail_no_key():
         assert detail.content == ""
 
 
-async def test_settings_row_click_opens_editor():
-    """Clicking a writable row in Settings opens the inline editor."""
-    from unittest import mock
-
-    from lilbee.cli.tui.app import LilbeeApp
-    from lilbee.cli.tui.screens.settings import SettingsScreen
-
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        app.push_screen(SettingsScreen())
-        await pilot.pause()
-        screen = app.screen
-        assert isinstance(screen, SettingsScreen)
-
-        # Verify on_data_table_row_selected calls action_edit_row
-        with mock.patch.object(screen, "action_edit_row") as mocked:
-            event = mock.Mock()
-            screen.on_data_table_row_selected(event)
-            mocked.assert_called_once()
+async def test_settings_group_titles_present():
+    """Each setting group has a visible title."""
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        titles = app.screen.query(".group-title")
+        names = {str(t.render()) for t in titles}
+        assert "Models" in names
+        assert "Generation" in names
+        assert "Retrieval" in names
+        assert "Display" in names

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1458,26 +1458,6 @@ class TestLoginCommandRegistered:
 # ---------------------------------------------------------------------------
 
 
-class TestSettingsHfToken:
-    def test_get_hf_token_display_not_set(self, monkeypatch) -> None:
-        from lilbee.cli.tui.screens.settings import _get_hf_token_display
-
-        monkeypatch.delenv("LILBEE_HF_TOKEN", raising=False)
-        monkeypatch.delenv("HF_TOKEN", raising=False)
-        # Without any token set, should show "not set"
-        result = _get_hf_token_display()
-        assert isinstance(result, str)
-
-    def test_get_hf_token_display_from_env(self, monkeypatch) -> None:
-        from lilbee.cli.tui.screens.settings import _get_hf_token_display
-
-        monkeypatch.setenv("HF_TOKEN", "hf_abcdefghijklmnop")
-        result = _get_hf_token_display()
-        assert result.startswith("hf_a")
-        assert result.endswith("mnop")
-        assert "..." in result
-
-
 # ---------------------------------------------------------------------------
 # __init__.py — Ctrl-C clean shutdown
 # ---------------------------------------------------------------------------
@@ -1769,3 +1749,90 @@ class TestLilbeeAppGlobalNavBar:
                 await pilot.pause()
             nav = app.screen.query_one("#global-nav-bar")
             assert nav.active_view == "Chat"
+
+
+# ---------------------------------------------------------------------------
+# pill.py
+# ---------------------------------------------------------------------------
+
+
+class TestPill:
+    def test_pill_from_string(self) -> None:
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("chat", "$primary", "$text")
+        text = str(result)
+        assert "chat" in text
+        assert "\u258c" in text  # left half-block
+        assert "\u2590" in text  # right half-block
+
+    def test_pill_from_content(self) -> None:
+        from textual.content import Content
+
+        from lilbee.cli.tui.pill import pill
+
+        content_input = Content("embed")
+        result = pill(content_input, "$secondary", "$text")
+        assert "embed" in str(result)
+
+    def test_pill_empty_string(self) -> None:
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("", "$primary", "$text")
+        text = str(result)
+        assert "\u258c" in text
+        assert "\u2590" in text
+
+    def test_pill_returns_content(self) -> None:
+        from textual.content import Content
+
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("ok", "$success", "$text")
+        assert isinstance(result, Content)
+
+
+# ---------------------------------------------------------------------------
+# events.py
+# ---------------------------------------------------------------------------
+
+
+class TestEvents:
+    def test_model_changed_is_message(self) -> None:
+        from textual.message import Message
+
+        from lilbee.cli.tui.events import ModelChanged
+
+        from lilbee.models import ModelTask
+
+        msg = ModelChanged(ModelTask.CHAT, "qwen3:8b")
+        assert isinstance(msg, Message)
+        assert msg.role == ModelTask.CHAT
+        assert msg.name == "qwen3:8b"
+
+    def test_task_state_changed(self) -> None:
+        from lilbee.cli.tui.events import TaskStateChanged
+
+        msg = TaskStateChanged("task-1", "active")
+        assert msg.task_id == "task-1"
+        assert msg.status == "active"
+
+    def test_view_switched(self) -> None:
+        from lilbee.cli.tui.events import ViewSwitched
+
+        msg = ViewSwitched("Models")
+        assert msg.view_name == "Models"
+
+    def test_sync_requested(self) -> None:
+        from textual.message import Message
+
+        from lilbee.cli.tui.events import SyncRequested
+
+        msg = SyncRequested()
+        assert isinstance(msg, Message)
+
+    def test_catalog_view_toggled(self) -> None:
+        from lilbee.cli.tui.events import CatalogViewToggled
+
+        msg = CatalogViewToggled("grid")
+        assert msg.view_mode == "grid"


### PR DESCRIPTION
## Summary

- Settings screen now shows options grouped by category (Models, Generation, Retrieval, Display) instead of a flat table
- Booleans get checkboxes, choices get dropdowns, strings get text inputs
- Inline help text and current defaults shown under each setting
- Search/filter to find settings by name