### PR TITLE
feat: task center status pills and chat screen polish

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -8,9 +8,11 @@ from typing import ClassVar
 
 from textual.app import App
 from textual.binding import Binding, BindingType
+from textual.signal import Signal
 
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.commands import LilbeeCommandProvider
+from lilbee.cli.tui.events import ModelChanged
 from lilbee.cli.tui.widgets.nav_bar import NavBar
 from lilbee.config import cfg
 
@@ -59,6 +61,12 @@ class LilbeeApp(App[None]):
         self._auto_sync = auto_sync
         self._active_view = "Chat"
         self._theme_index = 0
+        self.settings_changed_signal: Signal[tuple[str, object]] = Signal(
+            self, "settings_changed"
+        )
+        self.model_changed_signal: Signal[ModelChanged] = Signal(
+            self, "model_changed"
+        )
         from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         self._task_bar = TaskBar(id="app-task-bar")

--- a/src/lilbee/cli/tui/events.py
+++ b/src/lilbee/cli/tui/events.py
@@ -1,0 +1,19 @@
+"""Typed Textual Message subclasses for cross-widget communication.
+
+These complement messages.py (which holds user-facing string constants).
+Widgets post these messages for structured, typed event handling.
+"""
+
+from dataclasses import dataclass
+
+from textual.message import Message
+
+from lilbee.models import ModelTask
+
+
+@dataclass
+class ModelChanged(Message):
+    """Fired when the active chat, embedding, or vision model changes."""
+
+    role: ModelTask
+    name: str

--- a/src/lilbee/cli/tui/pill.py
+++ b/src/lilbee/cli/tui/pill.py
@@ -1,0 +1,30 @@
+"""Pill badge — colored inline label using half-block characters.
+
+Ported from toad (https://github.com/batrachianai/toad).
+"""
+
+from textual.content import Content
+
+PILL_LEFT = "\u258c"  # ▌ left half block
+PILL_RIGHT = "\u2590"  # ▐ right half block
+
+
+def pill(text: Content | str, background: str, foreground: str) -> Content:
+    """Format text as a pill badge with rounded half-block ends.
+
+    Args:
+        text: Pill contents.
+        background: Background color (Textual color string, e.g. "$primary").
+        foreground: Foreground color (Textual color string, e.g. "$text").
+
+    Returns:
+        Styled Content with half-block ends.
+    """
+    content = Content(text) if isinstance(text, str) else text
+    main_style = f"{foreground} on {background}"
+    end_style = f"{background} on transparent r"
+    return Content.assemble(
+        (PILL_LEFT, end_style),
+        content.stylize(main_style),
+        (PILL_RIGHT, end_style),
+    )

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -13,15 +13,17 @@ from typing import TYPE_CHECKING, ClassVar
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import VerticalScroll
+from textual.containers import Vertical, VerticalScroll
+from textual.reactive import var
 from textual.screen import Screen
-from textual.widgets import Input, Static
+from textual.widgets import Input, Label, Static
 
 from lilbee import settings
 from lilbee.cli.helpers import get_version
 from lilbee.cli.settings_map import SETTINGS_MAP
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.command_registry import build_dispatch_dict
+from lilbee.cli.tui.pill import pill
 from lilbee.cli.tui.screens.catalog import CatalogScreen
 from lilbee.cli.tui.screens.settings import SettingsScreen
 from lilbee.cli.tui.screens.status import StatusScreen
@@ -47,8 +49,29 @@ _MAX_HISTORY_MESSAGES = 200
 _FOCUSABLE_IDS = ("model-bar", "chat-log", "chat-input")
 
 
+class ChatStatusLine(Label):
+    """One-line status bar showing the current model as a pill badge."""
+
+    model_name: var[str] = var("")
+
+    def watch_model_name(self, name: str) -> None:
+        """Re-render when model name changes."""
+        if name:
+            self.update(pill(name, "$primary", "$text"))
+        else:
+            self.update("")
+
+
+class PromptArea(Vertical):
+    """Container for chat input that highlights on focus-within."""
+
+    pass
+
+
 class ChatScreen(Screen[None]):
     """Primary chat interface with streaming LLM responses."""
+
+    CSS_PATH = "chat.tcss"
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("slash", "focus_commands", "/ commands", show=True),
@@ -85,17 +108,20 @@ class ChatScreen(Screen[None]):
         yield Static(msg.CHAT_ONLY_BANNER, id="chat-only-banner")
         yield VerticalScroll(id="chat-log")
         yield CompletionOverlay(id="completion-overlay")
+        yield ChatStatusLine(id="chat-status-line")
         from lilbee.cli.tui.widgets.suggester import SlashSuggester
 
-        yield Input(
-            placeholder=msg.CHAT_INPUT_PLACEHOLDER,
-            id="chat-input",
-            suggester=SlashSuggester(use_cache=False),
-        )
+        with PromptArea(id="chat-prompt-area"):
+            yield Input(
+                placeholder=msg.CHAT_INPUT_PLACEHOLDER,
+                id="chat-input",
+                suggester=SlashSuggester(use_cache=False),
+            )
 
     def on_mount(self) -> None:
         self.query_one("#chat-input", Input).focus()
         self._update_input_style()
+        self._refresh_status_line()
         self.query_one("#chat-only-banner", Static).display = False
         if self._needs_setup():
             from lilbee.cli.tui.screens.setup import SetupWizard
@@ -850,8 +876,13 @@ class ChatScreen(Screen[None]):
                 overlay.hide()
 
     def _refresh_model_bar(self) -> None:
-        """Update the model status bar."""
+        """Update the model status bar and status line."""
         self.query_one("#model-bar", ModelBar).refresh_models()
+        self._refresh_status_line()
+
+    def _refresh_status_line(self) -> None:
+        """Update the status line pill with the current chat model."""
+        self.query_one("#chat-status-line", ChatStatusLine).model_name = cfg.chat_model
 
     def key_j(self) -> None:
         """Vim j: cycle focus to next widget in normal mode."""

--- a/src/lilbee/cli/tui/screens/chat.tcss
+++ b/src/lilbee/cli/tui/screens/chat.tcss
@@ -1,0 +1,69 @@
+#chat-log {
+    height: 1fr;
+}
+
+.user-message {
+    text-style: bold;
+    padding: 0 1;
+    margin: 1 0 0 0;
+    height: auto;
+}
+
+.assistant-message {
+    padding: 0 1;
+    height: auto;
+}
+
+.source-citation {
+    padding: 0 1;
+    text-style: italic;
+    color: $text-muted;
+}
+
+.section-header {
+    text-style: bold underline;
+    color: $text-muted;
+    padding: 1 0 0 1;
+}
+
+Markdown {
+    background: transparent;
+    margin: 0 1;
+}
+
+#chat-input.insert-mode {
+    border: tall $accent;
+}
+
+#chat-input.normal-mode {
+    border: tall $surface-lighten-1;
+    opacity: 0.7;
+}
+
+#chat-input:focus {
+    border: tall $accent;
+}
+
+#chat-only-banner {
+    dock: top;
+    height: 1;
+    padding: 0 1;
+    background: $warning;
+    color: $text;
+    text-style: bold;
+}
+
+#chat-status-line {
+    height: 1;
+    padding: 0 1;
+    dock: bottom;
+}
+
+#chat-prompt-area {
+    height: auto;
+    dock: bottom;
+    border: tall transparent;
+    &:focus-within {
+        border: tall $accent;
+    }
+}

--- a/src/lilbee/cli/tui/screens/task_center.py
+++ b/src/lilbee/cli/tui/screens/task_center.py
@@ -2,35 +2,70 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Callable
+import logging
+from typing import ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import VerticalScroll
 from textual.screen import Screen
-from textual.widgets import Collapsible, Footer, Header, ProgressBar, Static
+from textual.widgets import DataTable, Footer, Header, Static
 
-from lilbee.cli.tui.task_queue import Task, TaskStatus
+from lilbee.cli.tui.pill import pill
+from lilbee.cli.tui.task_queue import STATUS_ICONS, Task, TaskStatus
 from lilbee.cli.tui.widgets.nav_bar import NavBar
+
+log = logging.getLogger(__name__)
+
+_STATUS_COLORS: dict[TaskStatus, str] = {
+    TaskStatus.ACTIVE: "$primary",
+    TaskStatus.DONE: "$success",
+    TaskStatus.FAILED: "$error",
+    TaskStatus.QUEUED: "$text-muted",
+    TaskStatus.CANCELLED: "$text-muted",
+}
+
+
+def _status_icon(status: TaskStatus) -> str:
+    """Return a unicode icon for the given task status."""
+    return STATUS_ICONS.get(status, "?")
+
+
+def _status_pill(status: TaskStatus) -> str:
+    """Return a pill-formatted status badge."""
+    color = _STATUS_COLORS.get(status, "$text-muted")
+    badge = pill(status.value, color, "$text")
+    return str(badge)
 
 
 class TaskCenter(Screen[None]):
     """View for monitoring active, queued, and recent background tasks."""
 
+    CSS_PATH = "task_center.tcss"
+
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "pop_screen", "Back", show=True),
         Binding("escape", "pop_screen", "Back", show=False),
         Binding("r", "refresh_tasks", "Refresh", show=True),
+        Binding("c", "cancel_task", "Cancel", show=True),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
     ]
 
     def compose(self) -> ComposeResult:
         yield NavBar(id="global-nav-bar")
         yield Header()
         yield Static("Background Tasks", id="task-center-title")
-        yield VerticalScroll(id="task-list")
+        yield DataTable(id="task-table", cursor_type="row")
+        yield Static("", id="task-detail")
         yield Footer()
 
+    def action_pop_screen(self) -> None:
+        """Go back to the previous screen."""
+        self.app.pop_screen()
+
     def on_mount(self) -> None:
+        table = self.query_one("#task-table", DataTable)
+        table.add_columns("Status", "Name", "Type", "Progress")
         self._refresh_tasks()
         self._subscribe_to_queue()
 
@@ -52,74 +87,86 @@ class TaskCenter(Screen[None]):
     def _on_queue_change(self) -> None:
         """Called when task queue changes - refresh the display."""
         try:
-            self._refresh_tasks_safe()
-        except Exception:
-            pass
-
-    def _refresh_tasks_safe(self) -> None:
-        """Safely refresh tasks, catching any errors."""
-        try:
             self._refresh_tasks()
         except Exception:
-            pass
+            log.debug("Queue change refresh failed", exc_info=True)
 
     def action_refresh_tasks(self) -> None:
         """Refresh the task list."""
         self._refresh_tasks()
 
-    def _refresh_tasks(self) -> None:
-        """Populate task list from TaskBar's queue."""
-        task_list = self.query_one("#task-list", VerticalScroll)
-        task_list.remove_children()
-
+    def action_cancel_task(self) -> None:
+        """Cancel the currently selected task."""
         task_bar = getattr(self.app, "_task_bar", None)
         if task_bar is None:
-            task_list.mount(Static("No task bar available"))
             return
-
-        queue = task_bar.queue
-        active_list = queue.active_tasks
-        queued = queue.queued_tasks
-        history = queue.history
-
-        if not active_list and not queued and not history:
-            task_list.mount(Static("All quiet. No background tasks."))
+        table = self.query_one("#task-table", DataTable)
+        if table.row_count == 0:
             return
+        row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+        task_bar.queue.cancel(row_key.value)
+        self._refresh_tasks()
 
-        for task in active_list:
-            self._add_task_widget(task_list, task)
+    def action_cursor_down(self) -> None:
+        """Move cursor down in the task table."""
+        self.query_one("#task-table", DataTable).action_cursor_down()
 
-        for task in queued:
-            self._add_task_widget(task_list, task)
+    def action_cursor_up(self) -> None:
+        """Move cursor up in the task table."""
+        self.query_one("#task-table", DataTable).action_cursor_up()
 
-        for task in reversed(history):
-            self._add_task_widget(task_list, task)
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Show detail for the highlighted row."""
+        key = event.row_key.value if event.row_key is not None else None
+        self._show_task_detail(key)
 
-    def _add_task_widget(self, container: VerticalScroll, task: Task) -> None:
-        """Add a collapsible task widget with progress bar."""
-        title = f"{task.name} ({task.progress}%)"
-
-        collapsible = Collapsible(
-            title=title,
-            collapsed=True,
-            id=f"task-{task.task_id}",
-        )
-
-        # Mount collapsible to container FIRST, then add children
-        container.mount(collapsible)
-
-        # Now add children to the already-mounted collapsible
-        collapsible.mount(Static(f"Type: {task.task_type}"))
-        collapsible.mount(Static(f"Status: {task.status.value}"))
-
+    def _show_task_detail(self, task_id: str | None) -> None:
+        """Update the detail panel with info about the given task."""
+        detail = self.query_one("#task-detail", Static)
+        if task_id is None:
+            detail.update("")
+            return
+        task = self._find_task(task_id)
+        if task is None:
+            detail.update("")
+            return
+        text = f"{task.name} ({task.task_type}) — {task.progress}%"
         if task.detail:
-            collapsible.mount(Static(f"Detail: {task.detail}"))
+            text += f"\n{task.detail}"
+        detail.update(text)
 
-        if task.status == TaskStatus.ACTIVE:
-            progress = ProgressBar(
-                total=100,
-                show_eta=False,
-                id=f"task-progress-{task.task_id}",
-            )
-            progress.update(progress=task.progress)
-            collapsible.mount(progress)
+    def _find_task(self, task_id: str) -> Task | None:
+        """Look up a task by ID across all queue lists."""
+        task_bar = getattr(self.app, "_task_bar", None)
+        if task_bar is None:
+            return None
+        for task in self._all_tasks():
+            if task.task_id == task_id:
+                return task
+        return None
+
+    def _all_tasks(self) -> list[Task]:
+        """Gather all tasks: active, queued, and history."""
+        task_bar = getattr(self.app, "_task_bar", None)
+        if task_bar is None:
+            return []
+        queue = task_bar.queue
+        return queue.active_tasks + queue.queued_tasks + list(reversed(queue.history))
+
+    def _refresh_tasks(self) -> None:
+        """Populate task table from TaskBar's queue."""
+        table = self.query_one("#task-table", DataTable)
+        table.clear()
+        for task in self._all_tasks():
+            self._add_task_row(table, task)
+
+    def _add_task_row(self, table: DataTable, task: Task) -> None:
+        """Add a single task as a row in the data table."""
+        status_badge = _status_pill(task.status)
+        table.add_row(
+            status_badge,
+            task.name,
+            task.task_type,
+            f"{task.progress}%",
+            key=task.task_id,
+        )

--- a/src/lilbee/cli/tui/screens/task_center.tcss
+++ b/src/lilbee/cli/tui/screens/task_center.tcss
@@ -1,0 +1,16 @@
+#task-center-title {
+    text-style: bold;
+    padding: 0 1;
+    height: 1;
+}
+
+#task-table {
+    height: 1fr;
+}
+
+#task-detail {
+    height: auto;
+    max-height: 5;
+    padding: 0 1;
+    border-top: solid $surface-lighten-2;
+}

--- a/src/lilbee/cli/tui/task_queue.py
+++ b/src/lilbee/cli/tui/task_queue.py
@@ -26,6 +26,15 @@ class TaskStatus(StrEnum):
     CANCELLED = "cancelled"
 
 
+STATUS_ICONS: dict[TaskStatus, str] = {
+    TaskStatus.QUEUED: "\u23f3",
+    TaskStatus.ACTIVE: "\u25b6",
+    TaskStatus.DONE: "\u2713",
+    TaskStatus.FAILED: "\u2717",
+    TaskStatus.CANCELLED: "\u2298",
+}
+
+
 @dataclass
 class Task:
     """A single unit of work in the queue."""

--- a/src/lilbee/cli/tui/theme.tcss
+++ b/src/lilbee/cli/tui/theme.tcss
@@ -6,10 +6,6 @@
     width: 100%;
 }
 
-#chat-log {
-    height: 1fr;
-}
-
 #task-bar {
     dock: bottom;
     height: auto;
@@ -32,35 +28,6 @@
     padding: 0 1;
 }
 
-.user-message {
-    text-style: bold;
-    padding: 0 1;
-    margin: 1 0 0 0;
-    height: auto;
-}
-
-.assistant-message {
-    padding: 0 1;
-    height: auto;
-}
-
-.source-citation {
-    padding: 0 1;
-    text-style: italic;
-    color: $text-muted;
-}
-
-.section-header {
-    text-style: bold underline;
-    color: $text-muted;
-    padding: 1 0 0 1;
-}
-
-Markdown {
-    background: transparent;
-    margin: 0 1;
-}
-
 ListView {
     height: 1fr;
 }
@@ -69,7 +36,6 @@ TabbedContent > ContentSwitcher {
     height: 1fr;
 }
 
-/* Modal screens */
 HelpModal > Vertical {
     width: 70;
     height: auto;
@@ -88,27 +54,6 @@ HelpModal {
     padding: 0 1;
 }
 
-#chat-input.insert-mode {
-    border: tall $accent;
-}
-
-#chat-input.normal-mode {
-    border: tall $surface-lighten-1;
-    opacity: 0.7;
-}
-
-#chat-input:focus {
-    border: tall $accent;
-}
-
-#chat-only-banner {
-    dock: top;
-    height: 1;
-    padding: 0 1;
-    background: $warning;
-    color: $text;
-    text-style: bold;
-}
 #setup-title {
     text-style: bold;
     padding: 1 0;

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -10,7 +10,7 @@ from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.widgets import Label, ProgressBar, Static
 
-from lilbee.cli.tui.task_queue import Task, TaskQueue, TaskStatus
+from lilbee.cli.tui.task_queue import STATUS_ICONS, Task, TaskQueue, TaskStatus
 
 log = logging.getLogger(__name__)
 
@@ -189,11 +189,4 @@ class TaskBar(Static):
 
     @staticmethod
     def _status_icon(status: TaskStatus) -> str:
-        icons = {
-            TaskStatus.ACTIVE: "\u25b8",
-            TaskStatus.DONE: "\u2713",
-            TaskStatus.FAILED: "\u2717",
-            TaskStatus.CANCELLED: "\u2212",
-            TaskStatus.QUEUED: "\u2022",
-        }
-        return icons.get(status, "\u25b8")
+        return STATUS_ICONS.get(status, "\u25b8")

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from rich.console import Console
@@ -15,6 +16,13 @@ from lilbee import settings
 from lilbee.config import cfg
 
 log = logging.getLogger(__name__)
+
+
+class ModelTask(StrEnum):
+    CHAT = "chat"
+    EMBEDDING = "embedding"
+    VISION = "vision"
+
 
 # Extra headroom required beyond model size (GB)
 _DISK_HEADROOM_GB = 2

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -711,3 +711,60 @@ class TestLoginCommand:
             await pilot.press("enter")
             await pilot.pause()
             mock_wb.assert_called_once_with("https://huggingface.co/settings/tokens")
+
+
+# ---------------------------------------------------------------------------
+# App signals
+# ---------------------------------------------------------------------------
+
+
+class TestAppSignals:
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_settings_changed_signal_exists(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert hasattr(app, "settings_changed_signal")
+
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_model_changed_signal_exists(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert hasattr(app, "model_changed_signal")
+
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_families", return_value=[])
+    async def test_signal_subscribe_and_publish(
+        self,
+        _fam: mock.MagicMock,
+        _cat: mock.MagicMock,
+    ) -> None:
+        _cat.return_value = CatalogResult(total=0, limit=25, offset=0, models=[])
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            received: list[tuple[str, object]] = []
+            app.settings_changed_signal.subscribe(app, lambda val: received.append(val))
+            app.settings_changed_signal.publish(("chat_model", "new-model"))
+            await pilot.pause()
+            assert len(received) == 1
+            assert received[0] == ("chat_model", "new-model")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -105,9 +105,7 @@ def _make_remote_model(
     return RemoteModel(name=name, task=task, family=family, parameter_size=parameter_size)
 
 
-# ---------------------------------------------------------------------------
 # Pure function tests: catalog helpers
-# ---------------------------------------------------------------------------
 
 
 class TestParseParamLabel:
@@ -270,9 +268,7 @@ class TestRemoteToRow:
         assert row.params == "--"
 
 
-# ---------------------------------------------------------------------------
 # Settings screen (Textual integration)
-# ---------------------------------------------------------------------------
 
 
 class SettingsTestApp(App[None]):
@@ -625,9 +621,7 @@ async def test_settings_model_info_loaded():
         object.__setattr__(cfg, "_model_defaults", old_defaults)
 
 
-# ---------------------------------------------------------------------------
 # Status screen (Textual integration)
-# ---------------------------------------------------------------------------
 
 
 class StatusTestApp(App[None]):
@@ -697,9 +691,7 @@ async def test_status_screen_escape_pops():
         await _pilot.press("escape")
 
 
-# ---------------------------------------------------------------------------
 # LilbeeApp tests
-# ---------------------------------------------------------------------------
 
 
 async def test_app_mounts_chat_screen():
@@ -801,9 +793,7 @@ async def test_app_auto_sync_flag():
     assert app._auto_sync is True
 
 
-# ---------------------------------------------------------------------------
 # ChatScreen slash command tests
-# ---------------------------------------------------------------------------
 
 
 class ChatTestApp(App[None]):
@@ -1277,9 +1267,7 @@ async def test_chat_slash_delete_dispatch():
         app.screen._handle_slash("/delete")
 
 
-# ---------------------------------------------------------------------------
 # ChatScreen action_complete tests
-# ---------------------------------------------------------------------------
 
 
 async def test_chat_action_complete_no_options():
@@ -1357,9 +1345,7 @@ async def test_chat_action_complete_cycle_no_selection():
             app.screen.action_complete()
 
 
-# ---------------------------------------------------------------------------
 # ChatScreen on_input_submitted (non-slash = send message)
-# ---------------------------------------------------------------------------
 
 
 async def test_chat_send_message():
@@ -1417,9 +1403,7 @@ async def test_chat_trim_history_when_over_limit():
         assert app.screen._history[0]["content"] == "msg-10"
 
 
-# ---------------------------------------------------------------------------
 # CommandProvider tests
-# ---------------------------------------------------------------------------
 
 
 async def test_command_provider_discover():
@@ -1633,9 +1617,7 @@ async def test_command_provider_document_commands_empty_name():
         assert cmds == []
 
 
-# ---------------------------------------------------------------------------
 # CatalogScreen tests
-# ---------------------------------------------------------------------------
 
 
 class CatalogTestApp(App[None]):
@@ -2031,9 +2013,7 @@ async def test_catalog_row_selected_out_of_range():
             screen.on_data_table_row_selected(event)
 
 
-# ---------------------------------------------------------------------------
 # Direct worker body tests (call underlying fn, not @work decorator)
-# ---------------------------------------------------------------------------
 
 
 async def test_catalog_fetch_more_hf_worker():
@@ -2269,9 +2249,7 @@ async def test_chat_embedding_ready_false_no_sync():
             mock_sync.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
 # Additional coverage: chat.py lines
-# ---------------------------------------------------------------------------
 
 
 async def test_chat_on_input_submitted_slash():
@@ -2381,9 +2359,7 @@ async def test_chat_cancel_with_active_worker(mock_svc):
         await _pilot.pause()
 
 
-# ---------------------------------------------------------------------------
 # Additional coverage: catalog.py worker body lines
-# ---------------------------------------------------------------------------
 
 
 async def test_catalog_refresh_table_empty():
@@ -2492,9 +2468,7 @@ async def test_catalog_jump_top_bottom():
             screen.action_jump_top()
 
 
-# ---------------------------------------------------------------------------
 # Additional coverage: commands.py vision catalog exception (lines 91-92)
-# ---------------------------------------------------------------------------
 
 
 async def test_chat_vim_j_cycles_focus_from_chat_log():
@@ -2853,9 +2827,7 @@ async def test_chat_bindings_include_half_page():
     assert "ctrl+u" in keys
 
 
-# ---------------------------------------------------------------------------
 # Catalog: delete model (d key)
-# ---------------------------------------------------------------------------
 
 
 async def test_catalog_delete_installed_model_confirmation():
@@ -2999,9 +2971,7 @@ async def test_catalog_delete_in_input_ignored():
             assert screen._pending_delete is None
 
 
-# ---------------------------------------------------------------------------
 # Chat: /remove slash command
-# ---------------------------------------------------------------------------
 
 
 async def test_chat_slash_remove_no_args():
@@ -3813,7 +3783,7 @@ async def test_task_center_row_click_shows_detail():
         row_key.value = tid
         event = mock.Mock()
         event.row_key = row_key
-        screen.on_data_table_row_selected(event)
+        screen.on_data_table_row_highlighted(event)
         await pilot.pause()
         text = detail.content
         assert "Download X" in text
@@ -3855,6 +3825,110 @@ async def test_task_center_show_detail_no_key():
         await pilot.pause()
         detail = screen.query_one("#task-detail", Static)
         assert detail.content == ""
+
+
+async def test_task_center_has_css_path():
+    """TaskCenter declares a CSS_PATH for task-specific styles."""
+    from lilbee.cli.tui.screens.task_center import TaskCenter
+
+    assert TaskCenter.CSS_PATH == "task_center.tcss"
+
+
+def test_task_center_status_pill():
+    """_status_pill returns a pill string for each status."""
+    from lilbee.cli.tui.screens.task_center import _status_pill
+    from lilbee.cli.tui.task_queue import TaskStatus
+
+    for status in TaskStatus:
+        result = _status_pill(status)
+        assert status.value in result
+
+
+async def test_chat_screen_has_css_path():
+    """ChatScreen declares a CSS_PATH for chat-specific styles."""
+    from lilbee.cli.tui.screens.chat import ChatScreen
+
+    assert ChatScreen.CSS_PATH == "chat.tcss"
+
+
+async def test_chat_status_line_updates_on_model_change():
+    """ChatStatusLine renders a pill when model_name is set."""
+    from textual.app import App
+
+    from lilbee.cli.tui.screens.chat import ChatStatusLine
+
+    class StatusApp(App[None]):
+        def compose(self):  # type: ignore[override]
+            yield ChatStatusLine(id="status")
+
+    app = StatusApp()
+    async with app.run_test(size=(80, 10)) as pilot:
+        widget = app.query_one("#status", ChatStatusLine)
+        widget.model_name = "qwen3:8b"
+        await pilot.pause()
+        assert widget.model_name == "qwen3:8b"
+        # Label.content holds the plain-text form of the last update() call
+        assert "qwen3:8b" in str(widget.content)
+
+
+async def test_chat_status_line_empty_model():
+    """ChatStatusLine renders empty when model_name is empty."""
+    from textual.app import App
+
+    from lilbee.cli.tui.screens.chat import ChatStatusLine
+
+    class StatusApp(App[None]):
+        def compose(self):  # type: ignore[override]
+            yield ChatStatusLine(id="status")
+
+    app = StatusApp()
+    async with app.run_test(size=(80, 10)) as pilot:
+        widget = app.query_one("#status", ChatStatusLine)
+        widget.model_name = ""
+        await pilot.pause()
+        assert widget.model_name == ""
+
+
+async def test_chat_screen_has_status_line():
+    """ChatScreen compose includes a ChatStatusLine widget."""
+    cfg.chat_model = "test-model"
+    cfg.embedding_model = "test-embed"
+    cfg.vision_model = ""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        from lilbee.cli.tui.screens.chat import ChatStatusLine
+
+        status = app.screen.query_one("#chat-status-line", ChatStatusLine)
+        assert status is not None
+
+
+async def test_chat_screen_has_prompt_area():
+    """ChatScreen compose wraps input in a PromptArea container."""
+    cfg.chat_model = "test-model"
+    cfg.embedding_model = "test-embed"
+    cfg.vision_model = ""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        from lilbee.cli.tui.screens.chat import PromptArea
+
+        prompt_area = app.screen.query_one("#chat-prompt-area", PromptArea)
+        assert prompt_area is not None
+
+
+async def test_chat_refresh_status_line():
+    """_refresh_status_line sets the model name on the status widget."""
+    cfg.chat_model = "my-model"
+    cfg.embedding_model = "test-embed"
+    cfg.vision_model = ""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        from lilbee.cli.tui.screens.chat import ChatStatusLine
+
+        status = app.screen.query_one("#chat-status-line", ChatStatusLine)
+        assert status.model_name == "my-model"
 
 
 async def test_settings_row_click_opens_editor():

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -45,9 +45,7 @@ def _make_model(
     )
 
 
-# ---------------------------------------------------------------------------
 # message.py
-# ---------------------------------------------------------------------------
 
 
 class _MsgApp(App):
@@ -176,9 +174,7 @@ class TestAssistantMessageAsync:
             assert am._content_widget is None
 
 
-# ---------------------------------------------------------------------------
 # help_modal.py
-# ---------------------------------------------------------------------------
 
 
 class _HelpApp(App):
@@ -214,9 +210,7 @@ class TestHelpModal:
             assert len(app.screen_stack) == 1
 
 
-# ---------------------------------------------------------------------------
 # task_bar.py
-# ---------------------------------------------------------------------------
 
 
 class _TaskBarApp(App):
@@ -349,9 +343,7 @@ class TestTaskBar:
             assert getattr(app, "_task_bar", None) is bar
 
 
-# ---------------------------------------------------------------------------
 # model_bar.py
-# ---------------------------------------------------------------------------
 
 
 class _ModelBarApp(App):
@@ -584,9 +576,7 @@ class TestClassifyInstalledModels:
         assert "custom-model.gguf" in chat
 
 
-# ---------------------------------------------------------------------------
 # suggester.py
-# ---------------------------------------------------------------------------
 
 
 class TestSlashSuggester:
@@ -741,9 +731,7 @@ class TestSlashSuggester:
             assert s._get_document_names() == []
 
 
-# ---------------------------------------------------------------------------
 # autocomplete.py — pure functions
-# ---------------------------------------------------------------------------
 
 
 class TestGetCompletions:
@@ -965,9 +953,7 @@ class TestPathOptions:
         assert len(r) == 20
 
 
-# ---------------------------------------------------------------------------
 # autocomplete.py — CompletionOverlay widget
-# ---------------------------------------------------------------------------
 
 
 class _OverlayApp(App):
@@ -1067,9 +1053,7 @@ class TestCompletionOverlay:
             assert len(overlay._options) == _MAX_VISIBLE
 
 
-# ---------------------------------------------------------------------------
 # task_queue.py (unit tests for queue logic)
-# ---------------------------------------------------------------------------
 
 
 class TestTaskQueue:
@@ -1306,9 +1290,7 @@ class TestTaskQueue:
         assert q.active_tasks[0].task_id == t2
 
 
-# ---------------------------------------------------------------------------
 # CompletionOverlay.cycle_prev
-# ---------------------------------------------------------------------------
 
 
 class TestCompletionOverlayCyclePrev:
@@ -1333,9 +1315,7 @@ class TestCompletionOverlayCyclePrev:
             assert overlay.cycle_prev() is None
 
 
-# ---------------------------------------------------------------------------
 # setup_modal.py
-# ---------------------------------------------------------------------------
 
 
 class _SetupApp(App):
@@ -1408,9 +1388,7 @@ class TestSetupWizard:
         assert len(children) == 1
 
 
-# ---------------------------------------------------------------------------
 # catalog.py screen — HF grouping, empty tabs, size grouping
-# ---------------------------------------------------------------------------
 
 
 class TestAllTasksFetched:
@@ -1438,9 +1416,7 @@ class TestMatchesSearchWidget:
         assert _matches_search(row, "llama") is False
 
 
-# ---------------------------------------------------------------------------
 # command_registry.py — /login command
-# ---------------------------------------------------------------------------
 
 
 class TestLoginCommandRegistered:
@@ -1453,9 +1429,7 @@ class TestLoginCommandRegistered:
         assert dispatch["/login"] == "_cmd_login"
 
 
-# ---------------------------------------------------------------------------
 # settings.py — HF token field
-# ---------------------------------------------------------------------------
 
 
 class TestSettingsHfToken:
@@ -1478,9 +1452,7 @@ class TestSettingsHfToken:
         assert "..." in result
 
 
-# ---------------------------------------------------------------------------
 # __init__.py — Ctrl-C clean shutdown
-# ---------------------------------------------------------------------------
 
 
 class TestRunTuiKeyboardInterrupt:
@@ -1509,9 +1481,7 @@ class TestRunTuiKeyboardInterrupt:
                 mock_reset.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
 # nav_bar.py — global docked navigation bar
-# ---------------------------------------------------------------------------
 
 
 class _NavBarApp(App):
@@ -1731,9 +1701,7 @@ class TestNavBarClickSupport:
             bar.on_click(mock.Mock(x=0, y=0))
 
 
-# ---------------------------------------------------------------------------
 # app.py — global NavBar composition and key bindings
-# ---------------------------------------------------------------------------
 
 
 class TestLilbeeAppGlobalNavBar:
@@ -1769,3 +1737,58 @@ class TestLilbeeAppGlobalNavBar:
                 await pilot.pause()
             nav = app.screen.query_one("#global-nav-bar")
             assert nav.active_view == "Chat"
+
+
+# pill.py
+
+
+class TestPill:
+    def test_pill_from_string(self) -> None:
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("chat", "$primary", "$text")
+        text = str(result)
+        assert "chat" in text
+        assert "\u258c" in text  # left half-block
+        assert "\u2590" in text  # right half-block
+
+    def test_pill_from_content(self) -> None:
+        from textual.content import Content
+
+        from lilbee.cli.tui.pill import pill
+
+        content_input = Content("embed")
+        result = pill(content_input, "$secondary", "$text")
+        assert "embed" in str(result)
+
+    def test_pill_empty_string(self) -> None:
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("", "$primary", "$text")
+        text = str(result)
+        assert "\u258c" in text
+        assert "\u2590" in text
+
+    def test_pill_returns_content(self) -> None:
+        from textual.content import Content
+
+        from lilbee.cli.tui.pill import pill
+
+        result = pill("ok", "$success", "$text")
+        assert isinstance(result, Content)
+
+
+# events.py
+
+
+class TestEvents:
+    def test_model_changed_is_message(self) -> None:
+        from textual.message import Message
+
+        from lilbee.cli.tui.events import ModelChanged
+        from lilbee.models import ModelTask
+
+        msg = ModelChanged(ModelTask.CHAT, "qwen3:8b")
+        assert isinstance(msg, Message)
+        assert msg.role == ModelTask.CHAT
+        assert msg.name == "qwen3:8b"


### PR DESCRIPTION
## Summary

- Task center shows colored status pills (active, done, failed, queued) and a detail panel
- Chat screen gets a status line showing the current model, and focus highlighting on the prompt area
- Chat and task center CSS extracted from the monolithic theme file into per-screen stylesheets