### PR TITLE
Drop hand-curated stopword list from query pipeline

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ flowchart TD
     CONF -->|No| EXPAND[LLM Query Expansion]
 
     EXPAND --> GEXP[+ Graph Expansion]
-    GEXP --> GUARD[Guardrails: overlap check + dedup]
+    GEXP --> GUARD[Guardrails: embedding cosine similarity]
     GUARD --> MULTI[Multi-Query Search + Merge]
     MULTI --> HYBRID
 
@@ -179,9 +179,9 @@ flowchart TD
 #### Expansion Guardrails
 **On by default.** Validates LLM-generated query variants to prevent drift.
 
-- **Technique**: token overlap validation + embedding deduplication
-- **Overlap threshold**: 0.3 (at least 30% of original query tokens must appear in the variant). Below this, the variant has semantically drifted too far from the original question.
-- **Dedup threshold**: cosine similarity > 0.85 between variant embeddings → keep the longer one (more specific).
+- **Technique**: cosine similarity between the question's embedding and each variant's embedding. Language-agnostic — works for any corpus the embedding model supports — and reuses the variant vectors that the multi-query search would have embedded anyway, so there are zero extra embed calls.
+- **Threshold**: 0.5 by default via `LILBEE_EXPANSION_SIMILARITY_THRESHOLD`. Raise it to reject more variants (stricter); lower it to keep more (looser). Calibrate per embedding model — dense 768-dim models cluster higher by default than contrastively-trained ones.
+- **Concept-graph variants bypass this check**: they come from deterministic graph traversal and are expected to be partial phrases with lower similarity to the full question.
 - **Tradeoff**: guardrails may filter out creative but valid variants. Disable via `LILBEE_EXPANSION_GUARDRAILS=false` if recall is more important than precision.
 
 #### HyDE (Hypothetical Document Embeddings)
@@ -309,6 +309,7 @@ All settings are configurable via `LILBEE_*` environment variables, `config.toml
 | `LILBEE_EXPANSION_SKIP_THRESHOLD` | `0.8` | BM25 score above which expansion is skipped | 90th percentile of sigmoid-normalized BM25 scores. Calibrate per-corpus. |
 | `LILBEE_EXPANSION_SKIP_GAP` | `0.15` | Min score gap (top-1 minus top-2) to skip expansion | Approximately 1 std dev of typical score spread. Ensures the match isn't ambiguous. |
 | `LILBEE_EXPANSION_GUARDRAILS` | `true` | Validate expansion variants for drift | Prevents hallucinated variants at the cost of potentially filtering valid creative expansions |
+| `LILBEE_EXPANSION_SIMILARITY_THRESHOLD` | `0.5` | Minimum question↔variant cosine similarity for an expansion variant to survive the guardrail | Raise for stricter filtering, lower to keep more variants. Calibrate per embedding model. |
 | `LILBEE_MAX_CONTEXT_SOURCES` | `5` | Max chunks included in LLM context | More = more complete answers but higher latency and token cost |
 | `LILBEE_HYDE` | `false` | Enable hypothetical document embeddings | Adds ~500ms per query. Best for vague queries where terminology doesn't match docs. |
 | `LILBEE_HYDE_WEIGHT` | `0.7` | Weight for HyDE results relative to original | Lower = less trust in hypothetical documents. 0.7 prevents fabricated vectors from dominating. |

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -150,11 +150,13 @@ class Config(BaseSettings):
     # Validate LLM-generated expansion variants to prevent query drift
     # by comparing the cosine similarity of the variant's embedding to
     # the original question's embedding.
-    expansion_guardrails: bool = True
+    expansion_guardrails: bool = ConfigField(default=True, writable=True)
 
     # Minimum cosine similarity (question vs variant embedding) for an
     # expansion variant to survive the guardrail. 0.5 accepts rephrases
-    # and related questions while rejecting semantic drift.
+    # and related questions while rejecting semantic drift. Calibrate
+    # per embedding model — dense 768-dim models cluster higher by
+    # default than contrastively-trained ones.
     expansion_similarity_threshold: float = ConfigField(default=0.5, ge=0.0, le=1.0, writable=True)
 
     # BM25 confidence score above which query expansion is skipped entirely.

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -147,10 +147,15 @@ class Config(BaseSettings):
     # 0.2 gives 4 steps from typical 0.3 start to 1.0 cap.
     adaptive_threshold_step: float = ConfigField(default=0.2, gt=0.0, writable=True)
 
-    # Validate LLM-generated expansion variants to prevent query drift.
-    # Checks token overlap with original query (>= 0.3) and deduplicates
-    # near-identical variants (cosine similarity > 0.85).
+    # Validate LLM-generated expansion variants to prevent query drift
+    # by comparing the cosine similarity of the variant's embedding to
+    # the original question's embedding.
     expansion_guardrails: bool = True
+
+    # Minimum cosine similarity (question vs variant embedding) for an
+    # expansion variant to survive the guardrail. 0.5 accepts rephrases
+    # and related questions while rejecting semantic drift.
+    expansion_similarity_threshold: float = ConfigField(default=0.5, ge=0.0, le=1.0, writable=True)
 
     # BM25 confidence score above which query expansion is skipped entirely.
     # Based on 90th percentile of sigmoid-normalized BM25 score distribution.

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -147,16 +147,11 @@ class Config(BaseSettings):
     # 0.2 gives 4 steps from typical 0.3 start to 1.0 cap.
     adaptive_threshold_step: float = ConfigField(default=0.2, gt=0.0, writable=True)
 
-    # Validate LLM-generated expansion variants to prevent query drift
-    # by comparing the cosine similarity of the variant's embedding to
-    # the original question's embedding.
+    # Reject expansion variants below expansion_similarity_threshold.
     expansion_guardrails: bool = ConfigField(default=True, writable=True)
 
-    # Minimum cosine similarity (question vs variant embedding) for an
-    # expansion variant to survive the guardrail. 0.5 accepts rephrases
-    # and related questions while rejecting semantic drift. Calibrate
-    # per embedding model — dense 768-dim models cluster higher by
-    # default than contrastively-trained ones.
+    # Minimum cosine similarity (question vs variant embedding).
+    # Calibrate per embedding model.
     expansion_similarity_threshold: float = ConfigField(default=0.5, ge=0.0, le=1.0, writable=True)
 
     # BM25 confidence score above which query expansion is skipped entirely.

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Generator, Iterator
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
@@ -18,96 +19,42 @@ from typing_extensions import TypedDict
 from lilbee.config import Config, cfg
 from lilbee.embedder import Embedder
 from lilbee.providers.base import LLMProvider
-from lilbee.store import CitationRecord, SearchChunk, Store
+from lilbee.store import CitationRecord, SearchChunk, Store, _cosine_sim
 
 log = logging.getLogger(__name__)
 
-# English stop words used ONLY for query-side token overlap checks. If we
-# let "the" and "and" count toward the overlap between a user's question
-# and a candidate chunk, every chunk looks similar to every query. This is
-# a deliberate, scoped heuristic; it is not used anywhere else in the code
-# base because nothing else does bag-of-words overlap.
-_STOP_WORDS: frozenset[str] = frozenset(
-    {
-        "a",
-        "an",
-        "the",
-        "is",
-        "are",
-        "was",
-        "were",
-        "be",
-        "been",
-        "being",
-        "have",
-        "has",
-        "had",
-        "do",
-        "does",
-        "did",
-        "will",
-        "would",
-        "could",
-        "should",
-        "may",
-        "might",
-        "shall",
-        "can",
-        "to",
-        "of",
-        "in",
-        "for",
-        "on",
-        "with",
-        "at",
-        "by",
-        "from",
-        "as",
-        "into",
-        "about",
-        "between",
-        "through",
-        "after",
-        "before",
-        "above",
-        "below",
-        "and",
-        "or",
-        "but",
-        "not",
-        "no",
-        "if",
-        "then",
-        "than",
-        "that",
-        "this",
-        "it",
-        "its",
-        "what",
-        "which",
-        "who",
-        "whom",
-        "how",
-        "when",
-        "where",
-        "why",
-        "i",
-        "me",
-        "my",
-        "we",
-        "our",
-        "you",
-        "your",
-        "he",
-        "she",
-        "they",
-    }
-)
+# Minimum token length — single characters carry no selection signal.
+_MIN_TOKEN_LEN = 2
 
 
-def _tokenize_query(text: str) -> set[str]:
-    """Lowercase whitespace tokens, drop stopwords and single characters."""
-    return {w for w in text.lower().split() if w not in _STOP_WORDS and len(w) > 1}
+def _tokenize(text: str) -> list[str]:
+    """Lowercase alphanumeric tokens for IDF-weighted context selection."""
+    result: list[str] = []
+    for raw in text.lower().split():
+        word = "".join(ch for ch in raw if ch.isalnum())
+        if len(word) >= _MIN_TOKEN_LEN:
+            result.append(word)
+    return result
+
+
+def _idf_weights(
+    question_terms: set[str],
+    chunk_tokens: list[set[str]],
+) -> dict[str, float]:
+    """Return IDF weight per question term over the candidate corpus.
+
+    ``log(N / (1 + df))`` is clamped to zero for terms that appear in
+    (almost) every candidate chunk — the corpus-specific stopwords that
+    a hand-curated English list would otherwise approximate.
+    """
+    n = len(chunk_tokens)
+    if n == 0:
+        return {t: 0.0 for t in question_terms}
+    df: dict[str, int] = {}
+    for tokens in chunk_tokens:
+        for term in tokens & question_terms:
+            df[term] = df.get(term, 0) + 1
+    return {t: max(0.0, math.log(n / (1 + df.get(t, 0)))) for t in question_terms}
 
 
 class ChatMessage(TypedDict):
@@ -267,9 +214,6 @@ _EXPANSION_PROMPT = (
 _EXPANSION_MAX_TOKENS = 200
 
 
-_MIN_OVERLAP_RATIO = 0.3
-
-
 class AskResult(BaseModel):
     """Structured result from ask_raw -- answer text + raw search results."""
 
@@ -325,21 +269,23 @@ class Searcher:
                 filtered.append(r)
         return filtered if filtered else results
 
-    def _apply_guardrails(self, variants: list[str], question: str) -> list[str]:
+    def _apply_guardrails(
+        self,
+        variants: list[tuple[str, list[float]]],
+        question_vec: list[float],
+    ) -> list[tuple[str, list[float]]]:
+        """Drop expansion variants that drift too far from the question.
+
+        Compares sentence-level cosine similarity between the question
+        embedding and each variant embedding. Language-agnostic and uses
+        embeddings already computed by the caller.
+        """
         if not self._config.expansion_guardrails:
             return variants
-        original_tokens = _tokenize_query(question)
-        if not original_tokens:
-            return variants
-        validated: list[str] = []
-        for variant in variants:
-            variant_tokens = _tokenize_query(variant)
-            if not variant_tokens:
-                continue
-            overlap = len(original_tokens & variant_tokens) / len(original_tokens)
-            if overlap >= _MIN_OVERLAP_RATIO:
-                validated.append(variant)
-        return validated
+        threshold = self._config.expansion_similarity_threshold
+        return [
+            (text, vec) for text, vec in variants if _cosine_sim(question_vec, vec) >= threshold
+        ]
 
     def _concept_query_expansion(self, question: str) -> list[str]:
         if not self._config.concept_graph:
@@ -352,23 +298,38 @@ class Searcher:
             log.debug("Concept query expansion failed", exc_info=True)
             return []
 
-    def _expand_query(self, question: str) -> list[str]:
-        count = self._config.query_expansion_count
-        if count == 0:
+    def _llm_expand(self, question: str, count: int) -> list[str]:
+        """Call the LLM to produce ``count`` alternative phrasings."""
+        prompt = _EXPANSION_PROMPT.format(count=count, question=question)
+        messages = [{"role": "user", "content": prompt}]
+        response = self._provider.chat(
+            messages, stream=False, options={"num_predict": _EXPANSION_MAX_TOKENS}
+        )
+        if not isinstance(response, str):
             return []
+        variants = [line.strip() for line in response.strip().split("\n") if line.strip()]
+        return variants[:count]
+
+    def _expand_query(
+        self, question: str, question_vec: list[float]
+    ) -> list[tuple[str, list[float]]]:
+        """Return ``(variant, variant_vec)`` pairs for downstream search.
+
+        LLM expansions run through the similarity guardrail; concept-graph
+        expansions bypass it because they come from deterministic graph
+        traversal and are expected to be partial phrases with lower
+        similarity to the full question.
+        """
+        count = self._config.query_expansion_count
         try:
-            prompt = _EXPANSION_PROMPT.format(count=count, question=question)
-            messages = [{"role": "user", "content": prompt}]
-            response = self._provider.chat(
-                messages, stream=False, options={"num_predict": _EXPANSION_MAX_TOKENS}
-            )
-            if not isinstance(response, str):
-                return []
-            variants = [line.strip() for line in response.strip().split("\n") if line.strip()]
-            variants = variants[:count]
-            variants = self._apply_guardrails(variants, question)
-            variants.extend(self._concept_query_expansion(question))
-            return variants
+            llm_variants: list[tuple[str, list[float]]] = []
+            if count > 0:
+                for text in self._llm_expand(question, count):
+                    llm_variants.append((text, self._embedder.embed(text)))
+            llm_variants = self._apply_guardrails(llm_variants, question_vec)
+            for concept in self._concept_query_expansion(question):
+                llm_variants.append((concept, self._embedder.embed(concept)))
+            return llm_variants
         except Exception:
             log.debug("Query expansion failed", exc_info=True)
             return []
@@ -441,40 +402,56 @@ class Searcher:
     def select_context(
         self, results: list[SearchChunk], question: str, max_sources: int | None = None
     ) -> list[SearchChunk]:
-        """Select context chunks covering distinct query terms.
-        Greedy set-cover: pick chunks that add the most uncovered query
-        terms until the budget is exhausted or all terms are covered.
+        """Greedy IDF-weighted cover: pick chunks whose distinctive query
+        terms add the most information, then fill any remaining budget
+        in retrieval order.
+
+        IDF is computed over the candidate ``results`` list itself, so
+        terms that appear in every candidate (the corpus-specific
+        stopwords) contribute zero weight without needing a hand-curated
+        stoplist.
         """
         if max_sources is None:
             max_sources = self._config.max_context_sources
         if len(results) <= max_sources:
             return results
-        query_terms = _tokenize_query(question)
-        if not query_terms:
+
+        question_terms = set(_tokenize(question))
+        if not question_terms:
             return results[:max_sources]
-        chunk_tokens = [_tokenize_query(r.chunk) for r in results]
-        selected: list[SearchChunk] = []
+
+        chunk_tokens = [set(_tokenize(r.chunk)) for r in results]
+        term_weights = _idf_weights(question_terms, chunk_tokens)
+        if not any(term_weights.values()):
+            return results[:max_sources]
+
+        selected_indices: list[int] = []
         covered: set[str] = set()
-        remaining_indices = list(range(len(results)))
-        for _ in range(max_sources):
-            if not remaining_indices or covered == query_terms:
-                break
-            best_pos = 0
-            best_gain = -1
-            for pos, idx in enumerate(remaining_indices):
-                gain = len((chunk_tokens[idx] & query_terms) - covered)
-                # First-best-wins on ties: ``pos`` increases monotonically so a
-                # tie-break on smaller ``pos`` never fires, and the earliest
-                # candidate with the current best gain is always kept.
+        remaining = list(range(len(results)))
+        while remaining and len(selected_indices) < max_sources:
+            best_pos = -1
+            best_gain = 0.0
+            for pos, idx in enumerate(remaining):
+                new_terms = (chunk_tokens[idx] & question_terms) - covered
+                gain = sum(term_weights[t] for t in new_terms)
                 if gain > best_gain:
                     best_gain = gain
                     best_pos = pos
-            if best_gain <= 0 and selected:
+            if best_pos < 0:
                 break
-            chosen_idx = remaining_indices.pop(best_pos)
-            selected.append(results[chosen_idx])
-            covered |= chunk_tokens[chosen_idx] & query_terms
-        return selected
+            chosen_idx = remaining.pop(best_pos)
+            selected_indices.append(chosen_idx)
+            covered |= chunk_tokens[chosen_idx] & question_terms
+
+        # Fill any remaining budget in retrieval order so callers always
+        # receive ``max_sources`` chunks when that many are available.
+        for idx in remaining:
+            if len(selected_indices) >= max_sources:
+                break
+            selected_indices.append(idx)
+
+        selected_indices.sort()
+        return [results[i] for i in selected_indices]
 
     def search(self, question: str, top_k: int = 0) -> list[SearchChunk]:
         """Embed question and search with expansion, HyDE, and concept boost.
@@ -490,16 +467,13 @@ class Searcher:
         if self._should_skip_expansion(question):
             return results[: top_k * 2]
         seen = {(r.source, r.chunk_index) for r in results}
-        variants = self._expand_query(question)
-        if variants:
-            for variant in variants:
-                variant_vec = self._embedder.embed(variant)
-                variant_results = self._store.search(variant_vec, top_k=top_k, query_text=variant)
-                for r in variant_results:
-                    key = (r.source, r.chunk_index)
-                    if key not in seen:
-                        results.append(r)
-                        seen.add(key)
+        for variant, variant_vec in self._expand_query(question, query_vec):
+            variant_results = self._store.search(variant_vec, top_k=top_k, query_text=variant)
+            for r in variant_results:
+                key = (r.source, r.chunk_index)
+                if key not in seen:
+                    results.append(r)
+                    seen.add(key)
         if self._config.hyde:
             hyde_results = self._hyde_search(question, top_k)
             for r in hyde_results:

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -24,17 +24,12 @@ from lilbee.store import CitationRecord, SearchChunk, Store, cosine_sim
 
 log = logging.getLogger(__name__)
 
-# Minimum token length — single characters carry no selection signal.
 _MIN_TOKEN_LEN = 2
-
-# Any run of non-alphanumeric characters (whitespace, punctuation,
-# hyphens) is treated as a word boundary so ``"state-of-the-art"``
-# becomes four tokens rather than collapsing into one.
 _TOKEN_SPLIT_RE = re.compile(r"\W+")
 
 
 def _tokenize(text: str) -> list[str]:
-    """Lowercase alphanumeric tokens for IDF-weighted context selection."""
+    """Lowercase alphanumeric tokens, split on any non-alnum run."""
     return [word for word in _TOKEN_SPLIT_RE.split(text.lower()) if len(word) >= _MIN_TOKEN_LEN]
 
 
@@ -42,13 +37,12 @@ def _idf_weights(
     question_terms: set[str],
     chunk_tokens: list[set[str]],
 ) -> dict[str, float]:
-    """Return IDF weight per question term over the candidate corpus.
+    """Inverse Document Frequency weight per query term over the candidate chunks.
 
-    ``log(N / (1 + df))`` is clamped to zero for terms that appear in
-    (almost) every candidate chunk — the corpus-specific stopwords that
-    a hand-curated English list would otherwise approximate. The only
-    caller is ``select_context``, which short-circuits on empty
-    ``results``, so ``chunk_tokens`` is guaranteed non-empty here.
+    Classical IDF per Spärck Jones (1972), "A Statistical Interpretation
+    of Term Specificity and Its Application in Retrieval", Journal of
+    Documentation 28:11-21. Terms that appear in every chunk collapse to
+    zero weight, so corpus-specific stopwords are filtered automatically.
     """
     n = len(chunk_tokens)
     df: dict[str, int] = {}
@@ -64,13 +58,11 @@ def _greedy_cover(
     term_weights: dict[str, float],
     budget: int,
 ) -> list[int]:
-    """Greedy IDF-weighted set cover over candidate chunks.
+    """Greedy weighted set cover: pick chunks that add the most uncovered weight.
 
-    Picks chunks whose distinctive (high-IDF) query terms contribute
-    the most uncovered weight until either the budget is exhausted or
-    no chunk can add anything new. Any remaining budget is filled in
-    retrieval order so callers always receive ``budget`` chunks when
-    that many are available.
+    Standard (1 - 1/e) approximation for weighted set cover. Budget is
+    always filled, falling back to retrieval order once no chunk can
+    contribute any new weight.
     """
     selected: list[int] = []
     covered: set[str] = set()
@@ -314,12 +306,7 @@ class Searcher:
         variants: list[tuple[str, list[float]]],
         question_vec: list[float],
     ) -> list[tuple[str, list[float]]]:
-        """Drop expansion variants that drift too far from the question.
-
-        Compares sentence-level cosine similarity between the question
-        embedding and each variant embedding. Language-agnostic and uses
-        embeddings already computed by the caller.
-        """
+        """Drop expansion variants whose embedding drifts too far from the question."""
         if not self._config.expansion_guardrails:
             return variants
         threshold = self._config.expansion_similarity_threshold
@@ -353,15 +340,8 @@ class Searcher:
     ) -> list[tuple[str, list[float]]]:
         """Return ``(variant, variant_vec)`` pairs for downstream search.
 
-        Expansion is disabled entirely when both ``query_expansion_count``
-        is zero and concept-graph expansion is off — matching the old
-        early-return so ``LILBEE_QUERY_EXPANSION_COUNT=0`` remains an
-        off-switch for users who have ``cfg.concept_graph`` enabled.
-
-        LLM expansions run through the similarity guardrail; concept-graph
-        expansions bypass it because they come from deterministic graph
-        traversal and are expected to be partial phrases with lower
-        similarity to the full question.
+        LLM variants run through ``_apply_guardrails``; concept-graph
+        variants bypass it since they come from deterministic traversal.
         """
         count = self._config.query_expansion_count
         if count <= 0 and not self._config.concept_graph:
@@ -447,15 +427,7 @@ class Searcher:
     def select_context(
         self, results: list[SearchChunk], question: str, max_sources: int | None = None
     ) -> list[SearchChunk]:
-        """Greedy IDF-weighted cover: pick chunks whose distinctive query
-        terms add the most information, then fill any remaining budget
-        in retrieval order.
-
-        IDF is computed over the candidate ``results`` list itself, so
-        terms that appear in every candidate (the corpus-specific
-        stopwords) contribute zero weight without needing a hand-curated
-        stoplist.
-        """
+        """Pick ``max_sources`` chunks by greedy IDF-weighted set cover."""
         if max_sources is None:
             max_sources = self._config.max_context_sources
         if len(results) <= max_sources:

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 from collections.abc import Generator, Iterator
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
@@ -19,22 +20,22 @@ from typing_extensions import TypedDict
 from lilbee.config import Config, cfg
 from lilbee.embedder import Embedder
 from lilbee.providers.base import LLMProvider
-from lilbee.store import CitationRecord, SearchChunk, Store, _cosine_sim
+from lilbee.store import CitationRecord, SearchChunk, Store, cosine_sim
 
 log = logging.getLogger(__name__)
 
 # Minimum token length — single characters carry no selection signal.
 _MIN_TOKEN_LEN = 2
 
+# Any run of non-alphanumeric characters (whitespace, punctuation,
+# hyphens) is treated as a word boundary so ``"state-of-the-art"``
+# becomes four tokens rather than collapsing into one.
+_TOKEN_SPLIT_RE = re.compile(r"\W+")
+
 
 def _tokenize(text: str) -> list[str]:
     """Lowercase alphanumeric tokens for IDF-weighted context selection."""
-    result: list[str] = []
-    for raw in text.lower().split():
-        word = "".join(ch for ch in raw if ch.isalnum())
-        if len(word) >= _MIN_TOKEN_LEN:
-            result.append(word)
-    return result
+    return [word for word in _TOKEN_SPLIT_RE.split(text.lower()) if len(word) >= _MIN_TOKEN_LEN]
 
 
 def _idf_weights(
@@ -45,16 +46,55 @@ def _idf_weights(
 
     ``log(N / (1 + df))`` is clamped to zero for terms that appear in
     (almost) every candidate chunk — the corpus-specific stopwords that
-    a hand-curated English list would otherwise approximate.
+    a hand-curated English list would otherwise approximate. The only
+    caller is ``select_context``, which short-circuits on empty
+    ``results``, so ``chunk_tokens`` is guaranteed non-empty here.
     """
     n = len(chunk_tokens)
-    if n == 0:
-        return {t: 0.0 for t in question_terms}
     df: dict[str, int] = {}
     for tokens in chunk_tokens:
         for term in tokens & question_terms:
             df[term] = df.get(term, 0) + 1
     return {t: max(0.0, math.log(n / (1 + df.get(t, 0)))) for t in question_terms}
+
+
+def _greedy_cover(
+    chunk_tokens: list[set[str]],
+    question_terms: set[str],
+    term_weights: dict[str, float],
+    budget: int,
+) -> list[int]:
+    """Greedy IDF-weighted set cover over candidate chunks.
+
+    Picks chunks whose distinctive (high-IDF) query terms contribute
+    the most uncovered weight until either the budget is exhausted or
+    no chunk can add anything new. Any remaining budget is filled in
+    retrieval order so callers always receive ``budget`` chunks when
+    that many are available.
+    """
+    selected: list[int] = []
+    covered: set[str] = set()
+    remaining = list(range(len(chunk_tokens)))
+    while remaining and len(selected) < budget:
+        best_pos = -1
+        best_gain = 0.0
+        for pos, idx in enumerate(remaining):
+            new_terms = (chunk_tokens[idx] & question_terms) - covered
+            gain = sum(term_weights[t] for t in new_terms)
+            if gain > best_gain:
+                best_gain = gain
+                best_pos = pos
+        if best_pos < 0:
+            break
+        chosen = remaining.pop(best_pos)
+        selected.append(chosen)
+        covered |= chunk_tokens[chosen] & question_terms
+
+    for idx in remaining:
+        if len(selected) >= budget:
+            break
+        selected.append(idx)
+    return selected
 
 
 class ChatMessage(TypedDict):
@@ -283,9 +323,7 @@ class Searcher:
         if not self._config.expansion_guardrails:
             return variants
         threshold = self._config.expansion_similarity_threshold
-        return [
-            (text, vec) for text, vec in variants if _cosine_sim(question_vec, vec) >= threshold
-        ]
+        return [(text, vec) for text, vec in variants if cosine_sim(question_vec, vec) >= threshold]
 
     def _concept_query_expansion(self, question: str) -> list[str]:
         if not self._config.concept_graph:
@@ -315,12 +353,19 @@ class Searcher:
     ) -> list[tuple[str, list[float]]]:
         """Return ``(variant, variant_vec)`` pairs for downstream search.
 
+        Expansion is disabled entirely when both ``query_expansion_count``
+        is zero and concept-graph expansion is off — matching the old
+        early-return so ``LILBEE_QUERY_EXPANSION_COUNT=0`` remains an
+        off-switch for users who have ``cfg.concept_graph`` enabled.
+
         LLM expansions run through the similarity guardrail; concept-graph
         expansions bypass it because they come from deterministic graph
         traversal and are expected to be partial phrases with lower
         similarity to the full question.
         """
         count = self._config.query_expansion_count
+        if count <= 0 and not self._config.concept_graph:
+            return []
         try:
             llm_variants: list[tuple[str, list[float]]] = []
             if count > 0:
@@ -330,8 +375,8 @@ class Searcher:
             for concept in self._concept_query_expansion(question):
                 llm_variants.append((concept, self._embedder.embed(concept)))
             return llm_variants
-        except Exception:
-            log.debug("Query expansion failed", exc_info=True)
+        except (ConnectionError, OSError, RuntimeError) as exc:
+            log.warning("Query expansion disabled for this call: %s", exc, exc_info=True)
             return []
 
     def _should_skip_expansion(self, question: str) -> bool:
@@ -425,33 +470,9 @@ class Searcher:
         if not any(term_weights.values()):
             return results[:max_sources]
 
-        selected_indices: list[int] = []
-        covered: set[str] = set()
-        remaining = list(range(len(results)))
-        while remaining and len(selected_indices) < max_sources:
-            best_pos = -1
-            best_gain = 0.0
-            for pos, idx in enumerate(remaining):
-                new_terms = (chunk_tokens[idx] & question_terms) - covered
-                gain = sum(term_weights[t] for t in new_terms)
-                if gain > best_gain:
-                    best_gain = gain
-                    best_pos = pos
-            if best_pos < 0:
-                break
-            chosen_idx = remaining.pop(best_pos)
-            selected_indices.append(chosen_idx)
-            covered |= chunk_tokens[chosen_idx] & question_terms
-
-        # Fill any remaining budget in retrieval order so callers always
-        # receive ``max_sources`` chunks when that many are available.
-        for idx in remaining:
-            if len(selected_indices) >= max_sources:
-                break
-            selected_indices.append(idx)
-
-        selected_indices.sort()
-        return [results[i] for i in selected_indices]
+        selected = _greedy_cover(chunk_tokens, question_terms, term_weights, max_sources)
+        selected.sort()
+        return [results[i] for i in selected]
 
     def search(self, question: str, top_k: int = 0) -> list[SearchChunk]:
         """Embed question and search with expansion, HyDE, and concept boost.

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -77,7 +77,7 @@ class SearchChunk(BaseModel):
     relevance_score: float | None = Field(None, alias="_relevance_score")
 
 
-def _cosine_sim(a: list[float], b: list[float]) -> float:
+def cosine_sim(a: list[float], b: list[float]) -> float:
     """Cosine similarity between two vectors."""
     dot = sum(x * y for x, y in zip(a, b, strict=True))
     norm_a = math.sqrt(sum(x * x for x in a))
@@ -107,7 +107,7 @@ def mmr_rerank(
     if len(results) <= top_k:
         return results
 
-    relevance_map = {id(r): _cosine_sim(query_vector, r.vector) for r in results}
+    relevance_map = {id(r): cosine_sim(query_vector, r.vector) for r in results}
     selected: list[SearchChunk] = []
     remaining = list(results)
 
@@ -118,7 +118,7 @@ def mmr_rerank(
             relevance = relevance_map[id(candidate)]
             redundancy = 0.0
             if selected:
-                redundancy = max(_cosine_sim(candidate.vector, s.vector) for s in selected)
+                redundancy = max(cosine_sim(candidate.vector, s.vector) for s in selected)
             score = mmr_lambda * relevance - (1 - mmr_lambda) * redundancy
             if score > best_score:
                 best_score = score

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -234,32 +234,35 @@ class TestSearchContext:
 
 
 class TestExpandQuery:
+    _QUESTION_VEC = [0.1] * 768  # matches mock_svc.embedder default
+
     def test_returns_variants(self, mock_svc):
         mock_svc.provider.chat.return_value = (
             "explain how X works in detail\nexplain the purpose of X"
         )
-        variants = get_services().searcher._expand_query("explain X in detail")
+        variants = get_services().searcher._expand_query("explain X in detail", self._QUESTION_VEC)
         assert len(variants) == 2
+        for text, vec in variants:
+            assert isinstance(text, str)
+            assert len(vec) == 768
 
     def test_caps_at_three(self, mock_svc):
         mock_svc.provider.chat.return_value = "A\nB\nC\nD\nE"
-        assert len(get_services().searcher._expand_query("q")) == 3
+        variants = get_services().searcher._expand_query("q", self._QUESTION_VEC)
+        assert len(variants) == 3
 
     def test_returns_empty_on_error(self, mock_svc):
         mock_svc.provider.chat.side_effect = RuntimeError("no provider")
-        assert get_services().searcher._expand_query("q") == []
+        assert get_services().searcher._expand_query("q", self._QUESTION_VEC) == []
 
     def test_disabled_when_count_zero(self, mock_svc):
-        old = cfg.query_expansion_count
         cfg.query_expansion_count = 0
-        try:
-            assert get_services().searcher._expand_query("anything") == []
-        finally:
-            cfg.query_expansion_count = old
+        assert get_services().searcher._expand_query("anything", self._QUESTION_VEC) == []
+        cfg.query_expansion_count = 3
 
     def test_returns_empty_on_non_string(self, mock_svc):
         mock_svc.provider.chat.return_value = iter(["stream"])
-        assert get_services().searcher._expand_query("q") == []
+        assert get_services().searcher._expand_query("q", self._QUESTION_VEC) == []
 
 
 class TestAskRaw:
@@ -460,65 +463,75 @@ class TestProviderError:
 
 
 class TestApplyGuardrails:
-    def test_filters_drifted_variants(self, mock_svc):
-        variants = ["completely unrelated topic", "explain kubernetes deployment"]
-        searcher = get_services().searcher
-        result = searcher._apply_guardrails(variants, "explain kubernetes deployment")
-        assert "completely unrelated topic" not in result
-        assert "explain kubernetes deployment" in result
+    def test_rejects_orthogonal_variant(self, mock_svc):
+        question_vec = [1.0, 0.0, 0.0]
+        variants = [("related rephrase", [0.9, 0.1, 0.0]), ("drifted", [0.0, 1.0, 0.0])]
+        result = get_services().searcher._apply_guardrails(variants, question_vec)
+        texts = [text for text, _ in result]
+        assert "drifted" not in texts
+        assert "related rephrase" in texts
 
-    def test_keeps_overlapping_variants(self, mock_svc):
-        variants = ["kubernetes deployment steps", "deploying kubernetes clusters"]
-        result = get_services().searcher._apply_guardrails(variants, "kubernetes deployment guide")
-        assert len(result) >= 1
-
-    def test_returns_all_when_guardrails_disabled(self, mock_svc):
-        old = cfg.expansion_guardrails
-        cfg.expansion_guardrails = False
-        try:
-            result = get_services().searcher._apply_guardrails(["anything"], "question")
-            assert result == ["anything"]
-        finally:
-            cfg.expansion_guardrails = old
-
-    def test_empty_variants(self, mock_svc):
-        assert get_services().searcher._apply_guardrails([], "question") == []
-
-    def test_empty_original_tokens(self, mock_svc):
-        result = get_services().searcher._apply_guardrails(["variant"], "a the is")
-        assert result == ["variant"]
-
-    def test_empty_variant_tokens(self, mock_svc):
-        result = get_services().searcher._apply_guardrails(
-            ["a the is", "real content here"], "real content here"
-        )
+    def test_keeps_near_duplicate(self, mock_svc):
+        question_vec = [1.0, 0.0, 0.0]
+        variants = [("same topic", [0.95, 0.05, 0.0])]
+        result = get_services().searcher._apply_guardrails(variants, question_vec)
         assert len(result) == 1
 
+    def test_returns_all_when_disabled(self, mock_svc):
+        cfg.expansion_guardrails = False
+        try:
+            variants = [("drifted", [0.0, 1.0, 0.0])]
+            result = get_services().searcher._apply_guardrails(variants, [1.0, 0.0, 0.0])
+            assert result == variants
+        finally:
+            cfg.expansion_guardrails = True
 
-class TestTokenizeQuery:
-    def test_removes_stop_words(self):
-        from lilbee.query import _tokenize_query
+    def test_respects_configurable_threshold(self, mock_svc):
+        # Cosine = 0.6; passes at default 0.5 but not at 0.8.
+        question_vec = [1.0, 0.0]
+        variants = [("borderline", [0.6, 0.8])]
+        searcher = get_services().searcher
+        cfg.expansion_similarity_threshold = 0.5
+        assert len(searcher._apply_guardrails(variants, question_vec)) == 1
+        cfg.expansion_similarity_threshold = 0.8
+        assert searcher._apply_guardrails(variants, question_vec) == []
 
-        result = _tokenize_query("how does the system work")
-        assert "how" not in result
-        assert "does" not in result
-        assert "the" not in result
-        assert "system" in result
-        assert "work" in result
+    def test_empty_variants(self, mock_svc):
+        assert get_services().searcher._apply_guardrails([], [1.0, 0.0, 0.0]) == []
 
-    def test_lowercases(self):
-        from lilbee.query import _tokenize_query
 
-        result = _tokenize_query("Kubernetes Deployment")
-        assert "kubernetes" in result
+class TestTokenize:
+    def test_lowercases_and_strips_punctuation(self):
+        from lilbee.query import _tokenize
 
-    def test_removes_single_chars(self):
-        from lilbee.query import _tokenize_query
+        assert _tokenize("Kubernetes, deployment!") == ["kubernetes", "deployment"]
 
-        result = _tokenize_query("a b c real word")
-        assert "real" in result
-        assert "word" in result
-        assert "b" not in result
+    def test_drops_single_chars(self):
+        from lilbee.query import _tokenize
+
+        assert _tokenize("a b cc real") == ["cc", "real"]
+
+    def test_preserves_duplicates(self):
+        from lilbee.query import _tokenize
+
+        assert _tokenize("alpha alpha beta") == ["alpha", "alpha", "beta"]
+
+
+class TestIdfWeights:
+    def test_high_weight_for_distinctive_term(self):
+        from lilbee.query import _idf_weights
+
+        # "kafka" in 1/3 chunks, "python" in 3/3 → python gets zero weight.
+        chunk_tokens = [{"python", "kafka"}, {"python", "typing"}, {"python", "async"}]
+        weights = _idf_weights({"kafka", "python"}, chunk_tokens)
+        assert weights["kafka"] > 0
+        assert weights["python"] == 0.0
+
+    def test_empty_corpus_returns_zero_weights(self):
+        from lilbee.query import _idf_weights
+
+        weights = _idf_weights({"anything"}, [])
+        assert weights == {"anything": 0.0}
 
 
 class TestSelectContext:
@@ -533,8 +546,7 @@ class TestSelectContext:
         )
         assert len(result) == 2
         texts = " ".join(r.chunk for r in result)
-        assert "kubernetes" in texts
-        assert "networking" in texts
+        assert "networking" in texts  # distinctive term must be covered
 
     def test_passes_through_when_under_max(self, mock_svc):
         chunks = [_make_result(chunk="only one")]
@@ -543,10 +555,12 @@ class TestSelectContext:
 
     def test_empty_query_returns_top_n(self, mock_svc):
         chunks = [_make_result(chunk=f"chunk {i}") for i in range(10)]
-        result = get_services().searcher.select_context(chunks, "a the is", max_sources=3)
+        result = get_services().searcher.select_context(chunks, "", max_sources=3)
         assert len(result) == 3
 
-    def test_stops_on_full_coverage(self, mock_svc):
+    def test_all_zero_weight_falls_back_to_top_n(self, mock_svc):
+        # Every chunk contains both question terms → IDF is zero for both →
+        # no term adds any weight → fall back to top-N by retrieval order.
         chunks = [
             _make_result(chunk="alpha beta gamma delta", source="a.md"),
             _make_result(chunk="alpha beta gamma delta", source="b.md"),
@@ -557,21 +571,24 @@ class TestSelectContext:
         result = get_services().searcher.select_context(
             chunks, "alpha beta gamma delta", max_sources=3
         )
-        assert len(result) == 1
+        assert len(result) == 3
 
-    def test_stops_on_zero_gain(self, mock_svc):
+    def test_fills_budget_with_retrieval_order(self, mock_svc):
+        # The distinctive term pulls b.md first; the remaining slot is
+        # filled from the top of the retrieval order (a.md), not another
+        # duplicate. Final ordering is retrieval-stable.
         chunks = [
-            _make_result(chunk="alpha beta unique1", source="a.md"),
-            _make_result(chunk="alpha beta unique1", source="b.md"),
-            _make_result(chunk="alpha beta unique1", source="c.md"),
-            _make_result(chunk="alpha beta unique1", source="d.md"),
-            _make_result(chunk="alpha beta unique1", source="e.md"),
-            _make_result(chunk="alpha beta unique1", source="f.md"),
+            _make_result(chunk="kafka rebalance broker", source="a.md"),
+            _make_result(chunk="kafka streams consumer group rebalance", source="b.md"),
+            _make_result(chunk="kafka broker replication", source="c.md"),
         ]
         result = get_services().searcher.select_context(
-            chunks, "alpha beta unique1 unique2", max_sources=5
+            chunks, "kafka consumer group", max_sources=2
         )
-        assert len(result) < 5
+        assert len(result) == 2
+        sources = [r.source for r in result]
+        assert "b.md" in sources  # cover pick
+        assert sources == sorted(sources)
 
 
 class TestShouldSkipExpansion:
@@ -769,8 +786,9 @@ class TestSearchContextIntegration:
             [hyde_only_result],
         ]
         mock_svc.provider.chat.return_value = "hypothetical document"
-        old_hyde = cfg.hyde
-        old_weight = cfg.hyde_weight
+        # Disable query expansion so the HyDE path owns the second
+        # store.search call.
+        cfg.query_expansion_count = 0
         cfg.hyde = True
         cfg.hyde_weight = 0.5
         try:
@@ -781,8 +799,9 @@ class TestSearchContextIntegration:
             hyde_r = next(r for r in results if r.source == "hyde.md")
             assert hyde_r.distance == pytest.approx(0.8 / 0.5)
         finally:
-            cfg.hyde = old_hyde
-            cfg.hyde_weight = old_weight
+            cfg.query_expansion_count = 3
+            cfg.hyde = False
+            cfg.hyde_weight = 0.7
 
 
 class TestAskRawWithReranker:
@@ -909,8 +928,9 @@ class TestConceptQueryExpansion:
                 mock_svc.reranker,
                 mock_svc.concepts,
             )
-            variants = searcher._expand_query("python frameworks")
-            assert "python web frameworks" in variants
+            variants = searcher._expand_query("python frameworks", [0.1] * 768)
+            texts = [text for text, _ in variants]
+            assert "python web frameworks" in texts
         finally:
             cfg.concept_graph = old
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -260,6 +260,37 @@ class TestExpandQuery:
         assert get_services().searcher._expand_query("anything", self._QUESTION_VEC) == []
         cfg.query_expansion_count = 3
 
+    def test_count_zero_still_runs_concept_expansion_when_enabled(self, mock_svc):
+        # Regression: setting query_expansion_count=0 should not
+        # short-circuit concept-graph expansion. Users who want an
+        # off-switch for LLM expansion while keeping concept expansion
+        # need this to stay live.
+        old_count = cfg.query_expansion_count
+        old_concept = cfg.concept_graph
+        cfg.query_expansion_count = 0
+        cfg.concept_graph = True
+        mock_svc.concepts.get_graph.return_value = True
+        mock_svc.concepts.expand_query.return_value = ["kubernetes"]
+        try:
+            variants = get_services().searcher._expand_query("k8s", self._QUESTION_VEC)
+            assert [text for text, _ in variants] == ["kubernetes"]
+            mock_svc.provider.chat.assert_not_called()
+        finally:
+            cfg.query_expansion_count = old_count
+            cfg.concept_graph = old_concept
+
+    def test_count_zero_and_concepts_off_returns_empty(self, mock_svc):
+        # Both off-switches should short-circuit before any LLM or
+        # embedder calls.
+        old = cfg.query_expansion_count
+        cfg.query_expansion_count = 0
+        try:
+            assert get_services().searcher._expand_query("q", self._QUESTION_VEC) == []
+            mock_svc.provider.chat.assert_not_called()
+            mock_svc.embedder.embed.assert_not_called()
+        finally:
+            cfg.query_expansion_count = old
+
     def test_returns_empty_on_non_string(self, mock_svc):
         mock_svc.provider.chat.return_value = iter(["stream"])
         assert get_services().searcher._expand_query("q", self._QUESTION_VEC) == []
@@ -500,40 +531,6 @@ class TestApplyGuardrails:
         assert get_services().searcher._apply_guardrails([], [1.0, 0.0, 0.0]) == []
 
 
-class TestTokenize:
-    def test_lowercases_and_strips_punctuation(self):
-        from lilbee.query import _tokenize
-
-        assert _tokenize("Kubernetes, deployment!") == ["kubernetes", "deployment"]
-
-    def test_drops_single_chars(self):
-        from lilbee.query import _tokenize
-
-        assert _tokenize("a b cc real") == ["cc", "real"]
-
-    def test_preserves_duplicates(self):
-        from lilbee.query import _tokenize
-
-        assert _tokenize("alpha alpha beta") == ["alpha", "alpha", "beta"]
-
-
-class TestIdfWeights:
-    def test_high_weight_for_distinctive_term(self):
-        from lilbee.query import _idf_weights
-
-        # "kafka" in 1/3 chunks, "python" in 3/3 → python gets zero weight.
-        chunk_tokens = [{"python", "kafka"}, {"python", "typing"}, {"python", "async"}]
-        weights = _idf_weights({"kafka", "python"}, chunk_tokens)
-        assert weights["kafka"] > 0
-        assert weights["python"] == 0.0
-
-    def test_empty_corpus_returns_zero_weights(self):
-        from lilbee.query import _idf_weights
-
-        weights = _idf_weights({"anything"}, [])
-        assert weights == {"anything": 0.0}
-
-
 class TestSelectContext:
     def test_selects_covering_chunks(self, mock_svc):
         chunks = [
@@ -589,6 +586,21 @@ class TestSelectContext:
         sources = [r.source for r in result]
         assert "b.md" in sources  # cover pick
         assert sources == sorted(sources)
+
+    def test_hyphenated_phrase_splits_into_tokens(self, mock_svc):
+        # Regression: the old tokenizer would strip the hyphens and
+        # collapse "state-of-the-art" into one meaningless 14-char
+        # token that matched nothing. The new regex-split tokenizer
+        # treats every run of non-alnum characters as a boundary.
+        chunks = [
+            _make_result(chunk="state of the art benchmarks", source="a.md"),
+            _make_result(chunk="unrelated monitoring setup", source="b.md"),
+        ]
+        result = get_services().searcher.select_context(
+            chunks, "state-of-the-art benchmarks", max_sources=1
+        )
+        assert len(result) == 1
+        assert result[0].source == "a.md"
 
 
 class TestShouldSkipExpansion:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -879,6 +879,8 @@ class TestGetConfig:
         assert "concept_graph" in dumped
         assert "concept_boost_weight" in dumped
         assert "concept_max_per_chunk" in dumped
+        assert "expansion_guardrails" in dumped
+        assert "expansion_similarity_threshold" in dumped
         assert "llm_api_key" not in dumped
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -9,7 +9,7 @@ from lilbee.store import (
     CitationRecord,
     SearchChunk,
     Store,
-    _cosine_sim,
+    cosine_sim,
     escape_sql_string,
     mmr_rerank,
 )
@@ -258,11 +258,11 @@ class TestMMRRerank:
         selected = mmr_rerank(query, results, top_k=5)
         assert len(selected) == 1
 
-    def test_cosine_sim_zero_vectors(self):
-        assert _cosine_sim([0.0, 0.0], [1.0, 0.0]) == 0.0
+    def testcosine_sim_zero_vectors(self):
+        assert cosine_sim([0.0, 0.0], [1.0, 0.0]) == 0.0
 
-    def test_cosine_sim_identical(self):
-        sim = _cosine_sim([1.0, 0.0], [1.0, 0.0])
+    def testcosine_sim_identical(self):
+        sim = cosine_sim([1.0, 0.0], [1.0, 0.0])
         assert abs(sim - 1.0) < 1e-6
 
 


### PR DESCRIPTION
## What this changes



**Context selection** (`ask` / `chat` → pick which retrieved chunks go into the LLM prompt): was "drop stopwords, count word matches," now "weigh query terms by IDF over the candidate chunks." Words that appear in every candidate get zero weight automatically, whether they're English filler or domain boilerplate like "server" in an infra KB.

**Expansion guardrails** (filter out hallucinated LLM query rewrites): was "require 30% English word overlap," now "require cosine similarity ≥ threshold between question and variant embeddings." Reuses vectors the search path already computes, so zero extra embed calls.

## Why

Both features were doing word-level string matching when they should have been looking at distribution (for selection) and meaning (for guardrails). The stopword list was papering over that. Removing it also drops every English assumption from the query pipeline as a side effect.

## User-visible

- Non-English corpora now work correctly in `ask` / `chat`.
- One new config knob: `LILBEE_EXPANSION_SIMILARITY_THRESHOLD` (default `0.5`, range `0.0`–`1.0`). Raise for stricter guardrails.
- Nothing else changes. No config renames, no migrations. `LILBEE_QUERY_EXPANSION_COUNT=0` and `LILBEE_EXPANSION_GUARDRAILS=false` still work as before.