### PR TITLE
Make [ and ] screen nav keys work when the chat input is focused

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -98,13 +98,10 @@ class LilbeeApp(App[None]):
         Binding("f1", "push_help", "Help", show=False),
         Binding("ctrl+h", "push_help", "Help", show=False),
         Binding("ctrl+t", "cycle_theme", "Theme", show=False),
-        # priority=True is required here even though NavAwareInput's
-        # check_consume_key already lets [ and ] bubble past the consume
-        # check. Textual's focused Input still handles printable keys in
-        # its own _on_key path before a non-priority ancestor binding can
-        # fire; marking these bindings priority makes them dispatch before
-        # the Input event handler runs. Removing either NavAwareInput OR
-        # priority=True re-breaks the screen nav (verified via test).
+        # priority=True is required: even though NavAwareInput lets [ and ]
+        # bubble past Input.check_consume_key, Textual's focused Input still
+        # handles printable keys in _on_key before a non-priority ancestor
+        # binding can fire. Both NavAwareInput and priority=True are needed.
         Binding(
             "left_square_bracket",
             "nav_prev",

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -98,8 +98,29 @@ class LilbeeApp(App[None]):
         Binding("f1", "push_help", "Help", show=False),
         Binding("ctrl+h", "push_help", "Help", show=False),
         Binding("ctrl+t", "cycle_theme", "Theme", show=False),
-        Binding("left_square_bracket", "nav_prev", "Prev", show=True, group=_NAV_GROUP),
-        Binding("right_square_bracket", "nav_next", "Next", show=True, group=_NAV_GROUP),
+        # priority=True is required here even though NavAwareInput's
+        # check_consume_key already lets [ and ] bubble past the consume
+        # check. Textual's focused Input still handles printable keys in
+        # its own _on_key path before a non-priority ancestor binding can
+        # fire; marking these bindings priority makes them dispatch before
+        # the Input event handler runs. Removing either NavAwareInput OR
+        # priority=True re-breaks the screen nav (verified via test).
+        Binding(
+            "left_square_bracket",
+            "nav_prev",
+            "Prev",
+            show=True,
+            group=_NAV_GROUP,
+            priority=True,
+        ),
+        Binding(
+            "right_square_bracket",
+            "nav_next",
+            "Next",
+            show=True,
+            group=_NAV_GROUP,
+            priority=True,
+        ),
         Binding("ctrl+c", "quit", "Quit", show=True, priority=True),
     ]
 

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -38,6 +38,7 @@ from lilbee.cli.tui.screens.catalog_utils import (
 )
 from lilbee.cli.tui.widgets.grid_select import GridSelect
 from lilbee.cli.tui.widgets.model_card import ModelCard
+from lilbee.cli.tui.widgets.nav_aware_input import NavAwareInput
 from lilbee.config import cfg
 from lilbee.model_manager import RemoteModel, get_model_manager
 from lilbee.models import ModelTask
@@ -113,7 +114,7 @@ class CatalogScreen(Screen[None]):
         yield Static("", id="sort-label", shrink=True)
         yield VerticalScroll(id="catalog-grid")
         yield DataTable(id="catalog-table", cursor_type="row")
-        yield Input(placeholder=msg.CATALOG_FILTER_PLACEHOLDER, id="catalog-search")
+        yield NavAwareInput(placeholder=msg.CATALOG_FILTER_PLACEHOLDER, id="catalog-search")
         yield Static("", id="model-detail")
         yield ViewTabs()
         yield Footer()

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -28,6 +28,7 @@ from lilbee.cli.tui.pill import pill
 from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay, get_completions
 from lilbee.cli.tui.widgets.message import AssistantMessage, UserMessage
 from lilbee.cli.tui.widgets.model_bar import ModelBar
+from lilbee.cli.tui.widgets.nav_aware_input import NavAwareInput
 from lilbee.cli.tui.widgets.status_bar import ViewTabs
 from lilbee.config import cfg
 from lilbee.crawler import crawler_available, is_url, require_valid_crawl_url
@@ -132,7 +133,7 @@ class ChatScreen(Screen[None]):
         from lilbee.cli.tui.widgets.suggester import SlashSuggester
 
         with PromptArea(id="chat-prompt-area"):
-            yield Input(
+            yield NavAwareInput(
                 placeholder=msg.CHAT_INPUT_PLACEHOLDER,
                 id="chat-input",
                 suggester=SlashSuggester(use_cache=False),

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -18,6 +18,7 @@ from lilbee import settings
 from lilbee.cli.settings_map import SETTINGS_MAP, SettingDef
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.pill import pill
+from lilbee.cli.tui.widgets.nav_aware_input import NavAwareInput
 from lilbee.config import cfg
 
 log = logging.getLogger(__name__)
@@ -107,10 +108,10 @@ def _make_checkbox(key: str, value: str) -> Checkbox:
     return Checkbox(value=checked, name=key, classes="setting-editor", id=f"ed-{key}")
 
 
-def _make_input(key: str, value: str) -> Input:
+def _make_input(key: str, value: str) -> NavAwareInput:
     """Create an Input widget for string/number settings."""
     display = "" if value == "None" else value.replace(" (model default)", "")
-    return Input(value=display, name=key, classes="setting-editor", id=f"ed-{key}")
+    return NavAwareInput(value=display, name=key, classes="setting-editor", id=f"ed-{key}")
 
 
 class SettingsScreen(Screen[None]):
@@ -140,7 +141,7 @@ class SettingsScreen(Screen[None]):
 
         from lilbee.cli.tui.widgets.status_bar import ViewTabs
 
-        yield Input(
+        yield NavAwareInput(
             placeholder="Filter settings...",
             id="settings-search",
         )

--- a/src/lilbee/cli/tui/screens/wiki.py
+++ b/src/lilbee/cli/tui/screens/wiki.py
@@ -19,6 +19,7 @@ from textual.widgets import Input, Markdown, OptionList, Static
 from textual.widgets.option_list import Option
 
 from lilbee.cli.tui import messages as msg
+from lilbee.cli.tui.widgets.nav_aware_input import NavAwareInput
 from lilbee.config import cfg
 
 log = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ class WikiScreen(Screen[None]):
 
         yield Horizontal(
             Vertical(
-                Input(
+                NavAwareInput(
                     placeholder=msg.WIKI_SEARCH_PLACEHOLDER,
                     id="wiki-search",
                 ),

--- a/src/lilbee/cli/tui/widgets/nav_aware_input.py
+++ b/src/lilbee/cli/tui/widgets/nav_aware_input.py
@@ -1,0 +1,28 @@
+"""Input subclass that lets screen-nav keys ([ and ]) bubble up.
+
+Textual's default `Input.check_consume_key` returns True for every printable
+character, which tells the binding dispatcher to skip any ancestor binding for
+those keys even if that binding is marked `priority=True`. That means the
+app-level screen navigation keys declared as `[` / `]` silently get typed into
+the focused input instead of switching screens.
+
+This subclass exempts `left_square_bracket` and `right_square_bracket` from the
+consume check so those keys bubble up to the screen/app bindings unchanged.
+All other printable characters are still captured normally, preserving the
+full Input behavior for regular text entry.
+"""
+
+from __future__ import annotations
+
+from textual.widgets import Input
+
+_BUBBLE_KEYS: frozenset[str] = frozenset({"left_square_bracket", "right_square_bracket"})
+
+
+class NavAwareInput(Input):
+    """Input that does not consume the `[` / `]` screen-nav keys."""
+
+    def check_consume_key(self, key: str, character: str | None) -> bool:
+        if key in _BUBBLE_KEYS:
+            return False
+        return super().check_consume_key(key, character)

--- a/tests/test_nav_aware_input.py
+++ b/tests/test_nav_aware_input.py
@@ -1,10 +1,4 @@
-"""Unit tests for the NavAwareInput Input subclass.
-
-Pins the contract that `[` and `]` bubble up while every other printable
-character is still captured as text. Also includes a guard test that fails if
-any TUI screen reintroduces a bare `Input(` instantiation, which would silently
-revive the [/] screen-nav bug.
-"""
+"""Tests for NavAwareInput: [ and ] bubble up, other printables stay captured."""
 
 from __future__ import annotations
 
@@ -56,11 +50,7 @@ def _is_bare_input_call(node: ast.AST) -> bool:
 
 
 def test_tui_screens_do_not_reintroduce_bare_input():
-    """Guard against regressions: any TUI screen that needs a focusable
-    text input must use NavAwareInput, not the base Input class. A bare
-    ``Input(...)`` instantiation inside a screen silently re-breaks the
-    screen-nav bug for that widget.
-    """
+    """TUI screens must use NavAwareInput, not the base Input class."""
     screens_dir = Path(__file__).parent.parent / "src" / "lilbee" / "cli" / "tui" / "screens"
     offenders: list[str] = []
     for path in sorted(screens_dir.glob("*.py")):

--- a/tests/test_nav_aware_input.py
+++ b/tests/test_nav_aware_input.py
@@ -1,0 +1,74 @@
+"""Unit tests for the NavAwareInput Input subclass.
+
+Pins the contract that `[` and `]` bubble up while every other printable
+character is still captured as text. Also includes a guard test that fails if
+any TUI screen reintroduces a bare `Input(` instantiation, which would silently
+revive the [/] screen-nav bug.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from lilbee.cli.tui.widgets.nav_aware_input import NavAwareInput
+
+
+def test_check_consume_key_bubbles_nav_bindings():
+    """NavAwareInput must not claim [ or ] so they reach screen bindings."""
+    widget = NavAwareInput()
+    assert widget.check_consume_key("left_square_bracket", "[") is False
+    assert widget.check_consume_key("right_square_bracket", "]") is False
+
+
+def test_check_consume_key_still_captures_printable_chars():
+    """Every other printable character must still be captured as text."""
+    widget = NavAwareInput()
+    for key, char in [
+        ("a", "a"),
+        ("A", "A"),
+        ("space", " "),
+        ("slash", "/"),
+        ("full_stop", "."),
+    ]:
+        assert widget.check_consume_key(key, char) is True, (
+            f"Expected NavAwareInput to consume {key!r}"
+        )
+
+
+def test_check_consume_key_ignores_non_printable_keys():
+    """Non-printable keys (no character) must not be captured."""
+    widget = NavAwareInput()
+    assert widget.check_consume_key("tab", None) is False
+    assert widget.check_consume_key("escape", None) is False
+
+
+def _is_bare_input_call(node: ast.AST) -> bool:
+    """True if ``node`` is a call whose callee resolves to the name ``Input``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == "Input"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "Input"
+    return False
+
+
+def test_tui_screens_do_not_reintroduce_bare_input():
+    """Guard against regressions: any TUI screen that needs a focusable
+    text input must use NavAwareInput, not the base Input class. A bare
+    ``Input(...)`` instantiation inside a screen silently re-breaks the
+    screen-nav bug for that widget.
+    """
+    screens_dir = Path(__file__).parent.parent / "src" / "lilbee" / "cli" / "tui" / "screens"
+    offenders: list[str] = []
+    for path in sorted(screens_dir.glob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if _is_bare_input_call(node):
+                offenders.append(f"{path.name}:{node.lineno}")
+    assert not offenders, (
+        "TUI screens must instantiate NavAwareInput, not Input. "
+        "Bare `Input(...)` calls found at: " + ", ".join(offenders)
+    )

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1388,7 +1388,15 @@ class TestSettingsInteractions:
             assert cfg.system_prompt == "test system prompt"
 
     async def test_toggle_boolean_checkbox(self, _mock_resolve):
-        """Toggling a boolean checkbox updates cfg."""
+        """Toggling a boolean checkbox updates cfg.
+
+        This dispatches ``Checkbox.Changed`` synchronously rather than flipping
+        the reactive and waiting for ``pilot.pause()`` to drain the message
+        queue. ``pilot.pause()`` uses ``wait_for_idle(0)`` which can return
+        before a message posted from a reactive watcher has propagated to the
+        ancestor screen's ``@on`` handler on slower runners (observed on
+        Windows Python 3.11 and 3.12), leading to flaky failures.
+        """
         from textual.widgets import Checkbox
 
         from lilbee.cli.tui.app import LilbeeApp
@@ -1401,9 +1409,13 @@ class TestSettingsInteractions:
 
             checkbox = app.screen.query_one("#ed-show_reasoning", Checkbox)
             initial = checkbox.value
-            checkbox.toggle()
+            with checkbox.prevent(Checkbox.Changed):
+                checkbox.value = not initial
+            event = Checkbox.Changed(checkbox, checkbox.value)
+            app.screen._on_checkbox_save(event)
             await pilot.pause()
             assert cfg.show_reasoning != initial
+            assert cfg.show_reasoning == checkbox.value
 
     async def test_read_only_fields_have_no_editor(self, _mock_resolve):
         """Read-only settings do not have an editor widget."""

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1390,32 +1390,33 @@ class TestSettingsInteractions:
     async def test_toggle_boolean_checkbox(self, _mock_resolve):
         """Toggling a boolean checkbox updates cfg.
 
-        This dispatches ``Checkbox.Changed`` synchronously rather than flipping
-        the reactive and waiting for ``pilot.pause()`` to drain the message
-        queue. ``pilot.pause()`` uses ``wait_for_idle(0)`` which can return
-        before a message posted from a reactive watcher has propagated to the
-        ancestor screen's ``@on`` handler on slower runners (observed on
-        Windows Python 3.11 and 3.12), leading to flaky failures.
+        Drives the real user gesture: focus the Checkbox and press space.
+        This covers the full binding path (keyboard dispatch -> Checkbox
+        toggle -> reactive watcher -> Checkbox.Changed bubbles to
+        SettingsScreen -> ``_on_checkbox_save`` writes cfg). Uses a tall
+        enough test size so the widget is in the visible scroll region.
         """
         from textual.widgets import Checkbox
 
         from lilbee.cli.tui.app import LilbeeApp
 
         app = LilbeeApp()
-        async with app.run_test(size=(120, 40)) as pilot:
+        async with app.run_test(size=(120, 120)) as pilot:
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
 
             checkbox = app.screen.query_one("#ed-show_reasoning", Checkbox)
             initial = checkbox.value
-            with checkbox.prevent(Checkbox.Changed):
-                checkbox.value = not initial
-            event = Checkbox.Changed(checkbox, checkbox.value)
-            app.screen._on_checkbox_save(event)
+            checkbox.focus()
             await pilot.pause()
-            assert cfg.show_reasoning != initial
+
+            await pilot.press("space")
+            await pilot.pause()
+
+            assert checkbox.value != initial
             assert cfg.show_reasoning == checkbox.value
+            assert cfg.show_reasoning != initial
 
     async def test_read_only_fields_have_no_editor(self, _mock_resolve):
         """Read-only settings do not have an editor widget."""

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -91,6 +91,37 @@ async def test_bracket_keys_cycle_all_screens():
             )
 
 
+async def test_bracket_keys_work_with_chat_input_focused():
+    """Pressing ] with the chat input focused (insert mode) should switch
+    screens instead of being typed as a literal character into the input.
+
+    Regression: Textual's default Input.check_consume_key returns True for all
+    printable chars, so without a NavAwareInput subclass the focused chat input
+    swallows [ and ] as text instead of letting them bubble to the app-level
+    nav bindings.
+    """
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, ChatScreen)
+
+        chat_input = app.screen.query_one("#chat-input", Input)
+        assert chat_input.has_focus, "Chat input should auto-focus on mount"
+        assert chat_input.value == ""
+
+        await pilot.press("right_square_bracket")
+        await pilot.pause()
+
+        assert isinstance(app.screen, CatalogScreen), (
+            f"Expected CatalogScreen after ], got {type(app.screen).__name__}"
+        )
+        # The original chat_input reference must still be unchanged — the ]
+        # keypress must not have been typed into it before the screen switched.
+        assert chat_input.value == "", (
+            f"] was typed into chat input instead of navigating (value={chat_input.value!r})"
+        )
+
+
 async def test_bracket_keys_cycle_backward():
     """Press [ to go backward through views."""
     app = LilbeeApp()

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -92,14 +92,7 @@ async def test_bracket_keys_cycle_all_screens():
 
 
 async def test_bracket_keys_work_with_chat_input_focused():
-    """Pressing ] with the chat input focused (insert mode) should switch
-    screens instead of being typed as a literal character into the input.
-
-    Regression: Textual's default Input.check_consume_key returns True for all
-    printable chars, so without a NavAwareInput subclass the focused chat input
-    swallows [ and ] as text instead of letting them bubble to the app-level
-    nav bindings.
-    """
+    """Pressing ] with the chat input focused must switch screens, not insert text."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()


### PR DESCRIPTION
## What was broken

On the chat screen, the input field auto-focuses when the TUI opens. Pressing `[` or `]` there typed the bracket character into the input instead of switching to the previous or next view. The screen-nav keys that the footer advertises on every screen were effectively unusable without first pressing Escape to leave insert mode, which most users wouldn't know to do.

## What changed

`[` and `]` now reliably switch screens regardless of where focus is. The fix also covers the equivalent search and filter inputs on the catalog, settings, and wiki screens, so opening a filter with `/` no longer traps the user on that screen.