### PR TITLE
Show the setup wizard on fresh installs even when models are cached globally

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -160,20 +160,9 @@ class ChatScreen(Screen[None]):
         dismiss()
 
     def _needs_setup(self) -> bool:
-        """Check if the user should see the setup wizard on mount.
-
-        The wizard appears whenever either of two conditions holds:
-
-        1. The LanceDB directory for the current ``LILBEE_DATA`` does not
-           exist as a directory. This is the "fresh install" signal. Even
-           when the default models happen to be installed globally (for
-           example via Ollama or the HuggingFace cache), a brand-new data
-           directory still needs the wizard to onboard the user and trigger
-           the first sync.
-        2. The configured chat or embedding model cannot be resolved, so
-           the user needs to pick models that actually exist before chat
-           can work.
-        """
+        """True when the setup wizard should run: fresh data dir or unresolved models."""
+        # Fresh install: an uninitialized data dir still needs the wizard even
+        # if default models are already cached globally (Ollama, HF cache).
         if not cfg.lancedb_dir.is_dir():
             return True
         try:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -160,7 +160,22 @@ class ChatScreen(Screen[None]):
         dismiss()
 
     def _needs_setup(self) -> bool:
-        """Check if both chat and embedding models are resolvable."""
+        """Check if the user should see the setup wizard on mount.
+
+        The wizard appears whenever either of two conditions holds:
+
+        1. The LanceDB directory for the current ``LILBEE_DATA`` does not
+           exist as a directory. This is the "fresh install" signal. Even
+           when the default models happen to be installed globally (for
+           example via Ollama or the HuggingFace cache), a brand-new data
+           directory still needs the wizard to onboard the user and trigger
+           the first sync.
+        2. The configured chat or embedding model cannot be resolved, so
+           the user needs to pick models that actually exist before chat
+           can work.
+        """
+        if not cfg.lancedb_dir.is_dir():
+            return True
         try:
             from lilbee.providers.llama_cpp_provider import resolve_model_path
 

--- a/tests/test_chat_setup_detection.py
+++ b/tests/test_chat_setup_detection.py
@@ -1,11 +1,4 @@
-"""Tests for ChatScreen._needs_setup fresh-install detection.
-
-Verifies that the setup wizard shows even when the configured models are
-resolvable globally (Ollama, HuggingFace cache) as long as the current data
-directory has not been initialized yet. Prevents a regression where users
-with common models already cached on their machine would silently skip the
-onboarding wizard.
-"""
+"""Tests for ChatScreen._needs_setup: wizard shows on fresh data dirs."""
 
 from __future__ import annotations
 
@@ -33,20 +26,11 @@ def isolated_data_dir(tmp_path):
 
 
 def _make_screen() -> ChatScreen:
-    """Construct a ChatScreen without mounting it in an App.
-
-    ``_needs_setup`` only reads module-level config, so bypassing ``__init__``
-    (which would otherwise require an App context) is safe and keeps these
-    tests narrowly scoped to the setup-detection logic.
-    """
     return ChatScreen.__new__(ChatScreen)
 
 
 def test_needs_setup_true_when_lancedb_dir_missing(isolated_data_dir):
-    """A fresh LILBEE_DATA (no lancedb dir) must always show the wizard,
-    even when the configured models are globally resolvable. The check must
-    also short-circuit model resolution because the answer is already known.
-    """
+    """Fresh data dir must trigger the wizard even when models resolve globally."""
     assert not cfg.lancedb_dir.exists()
     with mock.patch(
         "lilbee.providers.llama_cpp_provider.resolve_model_path",
@@ -57,9 +41,7 @@ def test_needs_setup_true_when_lancedb_dir_missing(isolated_data_dir):
 
 
 def test_needs_setup_false_when_initialized_and_models_resolve(isolated_data_dir):
-    """After first sync (lancedb dir exists) and both models resolve, the
-    user should skip the wizard and go straight to chat.
-    """
+    """Initialized data dir plus resolvable models skips the wizard."""
     cfg.lancedb_dir.mkdir(parents=True)
     with mock.patch(
         "lilbee.providers.llama_cpp_provider.resolve_model_path",
@@ -69,9 +51,7 @@ def test_needs_setup_false_when_initialized_and_models_resolve(isolated_data_dir
 
 
 def test_needs_setup_true_when_initialized_but_model_missing(isolated_data_dir):
-    """An initialized data directory but a missing chat or embedding model
-    should still show the wizard so the user can pick a valid one.
-    """
+    """Unresolvable chat/embedding model still triggers the wizard."""
     cfg.lancedb_dir.mkdir(parents=True)
     with mock.patch(
         "lilbee.providers.llama_cpp_provider.resolve_model_path",
@@ -81,9 +61,7 @@ def test_needs_setup_true_when_initialized_but_model_missing(isolated_data_dir):
 
 
 def test_needs_setup_true_when_lancedb_path_is_a_file(isolated_data_dir):
-    """A stray file at the lancedb path is not a real data directory,
-    so the wizard must still show. This exercises the ``is_dir`` check.
-    """
+    """A stray file at the lancedb path is not a real data directory."""
     cfg.lancedb_dir.parent.mkdir(parents=True, exist_ok=True)
     cfg.lancedb_dir.write_text("not a directory")
     assert cfg.lancedb_dir.exists()

--- a/tests/test_chat_setup_detection.py
+++ b/tests/test_chat_setup_detection.py
@@ -1,0 +1,95 @@
+"""Tests for ChatScreen._needs_setup fresh-install detection.
+
+Verifies that the setup wizard shows even when the configured models are
+resolvable globally (Ollama, HuggingFace cache) as long as the current data
+directory has not been initialized yet. Prevents a regression where users
+with common models already cached on their machine would silently skip the
+onboarding wizard.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from lilbee.cli.tui.screens.chat import ChatScreen
+from lilbee.config import cfg
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path):
+    """Point cfg at a per-test data directory and restore the full snapshot."""
+    snapshot = cfg.model_copy()
+    cfg.data_root = tmp_path
+    cfg.documents_dir = tmp_path / "documents"
+    cfg.data_dir = tmp_path / "data"
+    cfg.lancedb_dir = tmp_path / "data" / "lancedb"
+    try:
+        yield tmp_path
+    finally:
+        for field_name in type(snapshot).model_fields:
+            setattr(cfg, field_name, getattr(snapshot, field_name))
+
+
+def _make_screen() -> ChatScreen:
+    """Construct a ChatScreen without mounting it in an App.
+
+    ``_needs_setup`` only reads module-level config, so bypassing ``__init__``
+    (which would otherwise require an App context) is safe and keeps these
+    tests narrowly scoped to the setup-detection logic.
+    """
+    return ChatScreen.__new__(ChatScreen)
+
+
+def test_needs_setup_true_when_lancedb_dir_missing(isolated_data_dir):
+    """A fresh LILBEE_DATA (no lancedb dir) must always show the wizard,
+    even when the configured models are globally resolvable. The check must
+    also short-circuit model resolution because the answer is already known.
+    """
+    assert not cfg.lancedb_dir.exists()
+    with mock.patch(
+        "lilbee.providers.llama_cpp_provider.resolve_model_path",
+        return_value="/some/resolved/path",
+    ) as resolve:
+        assert _make_screen()._needs_setup() is True
+        resolve.assert_not_called()
+
+
+def test_needs_setup_false_when_initialized_and_models_resolve(isolated_data_dir):
+    """After first sync (lancedb dir exists) and both models resolve, the
+    user should skip the wizard and go straight to chat.
+    """
+    cfg.lancedb_dir.mkdir(parents=True)
+    with mock.patch(
+        "lilbee.providers.llama_cpp_provider.resolve_model_path",
+        return_value="/some/resolved/path",
+    ):
+        assert _make_screen()._needs_setup() is False
+
+
+def test_needs_setup_true_when_initialized_but_model_missing(isolated_data_dir):
+    """An initialized data directory but a missing chat or embedding model
+    should still show the wizard so the user can pick a valid one.
+    """
+    cfg.lancedb_dir.mkdir(parents=True)
+    with mock.patch(
+        "lilbee.providers.llama_cpp_provider.resolve_model_path",
+        side_effect=FileNotFoundError("no such model"),
+    ):
+        assert _make_screen()._needs_setup() is True
+
+
+def test_needs_setup_true_when_lancedb_path_is_a_file(isolated_data_dir):
+    """A stray file at the lancedb path is not a real data directory,
+    so the wizard must still show. This exercises the ``is_dir`` check.
+    """
+    cfg.lancedb_dir.parent.mkdir(parents=True, exist_ok=True)
+    cfg.lancedb_dir.write_text("not a directory")
+    assert cfg.lancedb_dir.exists()
+    assert not cfg.lancedb_dir.is_dir()
+    with mock.patch(
+        "lilbee.providers.llama_cpp_provider.resolve_model_path",
+        return_value="/some/resolved/path",
+    ):
+        assert _make_screen()._needs_setup() is True

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -31,6 +31,9 @@ def _isolated_cfg(tmp_path):
     cfg.data_dir.mkdir(parents=True, exist_ok=True)
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
     cfg.models_dir.mkdir(parents=True, exist_ok=True)
+    # Simulate "already-initialized" state so ChatScreen._needs_setup()
+    # doesn't push the SetupWizard during tests that exercise chat.
+    cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     yield
     for field_name in type(snapshot).model_fields:
         setattr(cfg, field_name, getattr(snapshot, field_name))

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -37,6 +37,9 @@ def _isolated_cfg(tmp_path):
     cfg.data_dir.mkdir(parents=True, exist_ok=True)
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
     cfg.models_dir.mkdir(parents=True, exist_ok=True)
+    # Simulate "already-initialized" state so ChatScreen._needs_setup()
+    # doesn't push the SetupWizard during tests that exercise chat.
+    cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     yield
     for field_name in type(snapshot).model_fields:
         setattr(cfg, field_name, getattr(snapshot, field_name))

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -47,6 +47,9 @@ def _isolated_cfg(tmp_path):
     cfg.embedding_model = "test-embed:latest"
     cfg.vision_model = ""
     cfg.chunk_size = 512
+    # Simulate "already-initialized" state so ChatScreen._needs_setup()
+    # doesn't push the SetupWizard during tests that exercise chat.
+    cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     yield
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))


### PR DESCRIPTION
## What was broken

A first-time user running lilbee with a pristine `LILBEE_DATA` would skip the setup wizard entirely if they happened to already have common models (mistral, nomic-embed-text) cached by Ollama or by the HuggingFace cache on their machine. The onboarding flow was invisible to the majority of users who run any AI tooling, so they landed on an empty chat screen with no guidance about how lilbee works or how to add documents to it.

## What changed

The setup wizard now shows whenever the data root for the current `LILBEE_DATA` has not been initialized yet, regardless of whether the configured models happen to resolve in a global cache. If you already have an initialized data directory, nothing changes — the wizard still only shows when a model is actually missing.