### PR TITLE
Show a visible focus indicator on SetupWizard model cards

### DIFF
--- a/src/lilbee/cli/tui/screens/setup.tcss
+++ b/src/lilbee/cli/tui/screens/setup.tcss
@@ -72,9 +72,22 @@ SetupWizard.-downloading #setup-progress {
     display: block;
 }
 
+ModelCard {
+    border: tall transparent;
+}
+
 ModelCard.-selected {
     border-left: thick $success;
     background: $success 10%;
+}
+
+GridSelect:focus ModelCard.-highlight {
+    border: tall $primary;
+    background: $panel;
+}
+
+GridSelect:focus ModelCard.-highlight.-selected {
+    border-left: thick $success;
 }
 
 .section-heading {

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2338,6 +2338,68 @@ class TestSetupWizardGrid:
                 await pilot.pause()
                 assert isinstance(app.screen, SetupWizard)
 
+    async def test_setup_grid_highlights_focused_card(self, _mock_resolve):
+        """Focused GridSelect in SetupWizard marks its cursor card with
+        -highlight, and setup.tcss styles that class so users see the
+        focus indicator. Regression test for bb-x075."""
+        from lilbee.cli.tui.screens.setup import SetupWizard
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+        from lilbee.cli.tui.widgets.model_card import ModelCard
+
+        app = ChatTestApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            with mock.patch(
+                "lilbee.cli.tui.screens.setup._scan_installed_models",
+                return_value=([], []),
+            ):
+                app.push_screen(SetupWizard())
+                await pilot.pause()
+                grid = app.screen.query(GridSelect).first()
+                grid.focus()
+                await pilot.pause()
+                await pilot.press("right")
+                await pilot.pause()
+                cards = [c for c in grid.children if isinstance(c, ModelCard)]
+                highlighted = [c for c in cards if c.has_class("-highlight")]
+                others = [c for c in cards if not c.has_class("-highlight")]
+                assert len(highlighted) == 1
+                assert others, "need a non-focused card to compare against"
+                focused_border = highlighted[0].styles.border_top
+                baseline_border = others[0].styles.border_top
+                assert focused_border is not None
+                assert focused_border[0] == "tall"
+                # The focus rule paints a visible color; baseline is transparent.
+                assert focused_border[1] != baseline_border[1]
+
+    async def test_setup_focused_selected_card_keeps_green_bar(self, _mock_resolve):
+        """A card that is both selected and focused keeps its green left bar.
+        Guards against the focus border shorthand clobbering border-left."""
+        from lilbee.cli.tui.screens.setup import SetupWizard
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+        from lilbee.cli.tui.widgets.model_card import ModelCard
+
+        app = ChatTestApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            with mock.patch(
+                "lilbee.cli.tui.screens.setup._scan_installed_models",
+                return_value=([], []),
+            ):
+                app.push_screen(SetupWizard())
+                await pilot.pause()
+                grid = app.screen.query(GridSelect).first()
+                cards = [c for c in grid.children if isinstance(c, ModelCard)]
+                assert cards
+                cards[0].selected = True
+                grid.focus()
+                await pilot.pause()
+                assert cards[0].has_class("-highlight")
+                assert cards[0].has_class("-selected")
+                border_left = cards[0].styles.border_left
+                assert border_left is not None
+                assert border_left[0] == "thick"
+
     async def test_catalog_grid_to_status_preserves_state(self, _mock_resolve):
         """Switching from catalog grid to status and back."""
         from lilbee.cli.tui.app import LilbeeApp

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2339,9 +2339,8 @@ class TestSetupWizardGrid:
                 assert isinstance(app.screen, SetupWizard)
 
     async def test_setup_grid_highlights_focused_card(self, _mock_resolve):
-        """Focused GridSelect in SetupWizard marks its cursor card with
-        -highlight, and setup.tcss styles that class so users see the
-        focus indicator. Regression test for bb-x075."""
+        """The focused card in the SetupWizard grid shows a visible focus
+        indicator so keyboard users can see which card is under the cursor."""
         from lilbee.cli.tui.screens.setup import SetupWizard
         from lilbee.cli.tui.widgets.grid_select import GridSelect
         from lilbee.cli.tui.widgets.model_card import ModelCard


### PR DESCRIPTION
## What was broken

Pressing arrow keys in the setup wizard's model grid moved an invisible cursor. There was no visual indication of which card was focused, so users couldn't tell which model they were about to pick.

## What changed

The setup wizard now paints the focused card with the accent color and gives every card a transparent baseline border so the focus state doesn't shift layout as you move around. Cards that are both selected and focused keep their green left bar so you can tell selection and focus apart.