### PR TITLE
Unfreeze the catalog screen after closing the search input

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -175,6 +175,15 @@ class CatalogScreen(Screen[None]):
         filter_input.display = True
         filter_input.focus()
 
+    def _close_search(self) -> None:
+        """Hide the search input and return focus to the visible view."""
+        self.query_one("#catalog-search", Input).display = False
+        with contextlib.suppress(Exception):
+            if self._grid_view:
+                self.query_one(GridSelect).focus()
+            else:
+                self.query_one("#catalog-table", DataTable).focus()
+
     @on(Input.Changed, "#catalog-search")
     def _on_search_changed(self, event: Input.Changed) -> None:
         """Filter models when search input changes."""
@@ -186,9 +195,7 @@ class CatalogScreen(Screen[None]):
     @on(Input.Submitted, "#catalog-search")
     def _on_search_submitted(self, event: Input.Submitted) -> None:
         """Close filter on Enter."""
-        event.input.display = False
-        with contextlib.suppress(Exception):
-            self.query_one("#catalog-table", DataTable).focus()
+        self._close_search()
 
     def _fetch_hf_page(self) -> list[CatalogModel]:
         """Fetch one page of HF models for all task types (runs in worker thread)."""
@@ -527,6 +534,11 @@ class CatalogScreen(Screen[None]):
             )
 
     def action_go_back(self) -> None:
+        # Escape closes an open search first, so users aren't trapped.
+        search = self.query_one("#catalog-search", Input)
+        if search.display:
+            self._close_search()
+            return
         from lilbee.cli.tui.app import LilbeeApp
 
         if isinstance(self.app, LilbeeApp):  # test apps aren't LilbeeApp

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1080,6 +1080,101 @@ class TestCatalogInteractions:
                 await pilot.pause()
                 assert search.display is False
 
+    async def test_search_submit_returns_focus_to_grid(self, _mock_resolve):
+        """After submitting search in grid view, focus returns to the visible
+        GridSelect instead of being trapped on the hidden DataTable.
+        Regression for bb-2g12: CatalogScreen freeze after using /."""
+        from textual.widgets import Input
+
+        from lilbee.cli.tui.app import LilbeeApp
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        with _mock_catalog_deps(), _mock_remote_models():
+            app = LilbeeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                app.switch_view("Catalog")
+                await pilot.pause()
+
+                await pilot.press("slash")
+                await pilot.pause()
+                search = app.screen.query_one("#catalog-search", Input)
+                assert search.display is True
+                assert search.has_focus
+
+                search.value = "test"
+                await pilot.press("enter")
+                await pilot.pause()
+
+                assert search.display is False
+                focused = app.focused
+                assert focused is not None
+                assert focused.display
+                assert isinstance(focused, GridSelect)
+
+    async def test_search_submit_returns_focus_to_table_in_list_view(self, _mock_resolve):
+        """After submitting search in list view, focus returns to the
+        DataTable. Covers the list-view branch of _close_search."""
+        from textual.widgets import DataTable, Input
+
+        from lilbee.cli.tui.app import LilbeeApp
+
+        with _mock_catalog_deps(), _mock_remote_models():
+            app = LilbeeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                app.switch_view("Catalog")
+                await pilot.pause()
+                await pilot.press("v")
+                await pilot.pause()
+
+                await pilot.press("slash")
+                await pilot.pause()
+                search = app.screen.query_one("#catalog-search", Input)
+                assert search.display is True
+
+                search.value = "test"
+                await pilot.press("enter")
+                await pilot.pause()
+
+                assert search.display is False
+                focused = app.focused
+                assert isinstance(focused, DataTable)
+
+    async def test_search_escape_closes_and_unfreezes(self, _mock_resolve):
+        """Pressing Escape while the search input is open closes it and
+        restores focus to the grid, so subsequent bindings work again.
+        Regression for bb-2g12."""
+        from textual.widgets import Input
+
+        from lilbee.cli.tui.app import LilbeeApp
+        from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+        with _mock_catalog_deps(), _mock_remote_models():
+            app = LilbeeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                app.switch_view("Catalog")
+                await pilot.pause()
+
+                await pilot.press("slash")
+                await pilot.pause()
+                search = app.screen.query_one("#catalog-search", Input)
+                assert search.display is True
+
+                await pilot.press("escape")
+                await pilot.pause()
+
+                assert search.display is False
+                # Still on the catalog screen -- escape only closed the search,
+                # it didn't pop back to Chat.
+                assert isinstance(app.screen, CatalogScreen)
+
+                # Bindings still work: toggle the view.
+                await pilot.press("v")
+                await pilot.pause()
+                assert app.screen.has_class("-list-view")
+
     async def test_grid_card_count_matches_families(self, _mock_resolve):
         """Verify correct number of cards for featured models."""
         from lilbee.cli.tui.app import LilbeeApp

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1081,9 +1081,7 @@ class TestCatalogInteractions:
                 assert search.display is False
 
     async def test_search_submit_returns_focus_to_grid(self, _mock_resolve):
-        """After submitting search in grid view, focus returns to the visible
-        GridSelect instead of being trapped on the hidden DataTable.
-        Regression for bb-2g12: CatalogScreen freeze after using /."""
+        """Submitting search in grid view returns focus to the GridSelect."""
         from textual.widgets import Input
 
         from lilbee.cli.tui.app import LilbeeApp
@@ -1113,8 +1111,7 @@ class TestCatalogInteractions:
                 assert isinstance(focused, GridSelect)
 
     async def test_search_submit_returns_focus_to_table_in_list_view(self, _mock_resolve):
-        """After submitting search in list view, focus returns to the
-        DataTable. Covers the list-view branch of _close_search."""
+        """Submitting search in list view returns focus to the DataTable."""
         from textual.widgets import DataTable, Input
 
         from lilbee.cli.tui.app import LilbeeApp
@@ -1142,9 +1139,7 @@ class TestCatalogInteractions:
                 assert isinstance(focused, DataTable)
 
     async def test_search_escape_closes_and_unfreezes(self, _mock_resolve):
-        """Pressing Escape while the search input is open closes it and
-        restores focus to the grid, so subsequent bindings work again.
-        Regression for bb-2g12."""
+        """Escape closes the search and restores focus so catalog bindings work again."""
         from textual.widgets import Input
 
         from lilbee.cli.tui.app import LilbeeApp


### PR DESCRIPTION
## What was broken

Opening the catalog search with `/`, typing, and pressing Enter or Escape left the screen unresponsive. Every subsequent keypress — `q`, `v`, `[`, `]`, F1, even Escape again — did nothing, so users had to kill the process to recover.

## What changed

Closing the search now returns focus to whichever view is visible (grid or list), so the screen stays responsive. Pressing Escape while the search is open closes the search first and only leaves the screen on a second press, so users can bail out of the filter without getting trapped.