### PR TITLE
Keep the task bar visible while you navigate between screens

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -111,9 +111,9 @@ class LilbeeApp(App[None]):
         self.last_quit_time: float = 0.0
         self.settings_changed_signal: Signal[tuple[str, object]] = Signal(self, "settings_changed")
         self.model_changed_signal: Signal[ModelChanged] = Signal(self, "model_changed")
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
+        from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
-        self.task_bar = TaskBar(id="app-task-bar")
+        self.task_bar = TaskBarController(self)
 
     def compose(self) -> ComposeResult:
         yield from ()  # screens compose their own ViewTabs + Footer
@@ -121,7 +121,6 @@ class LilbeeApp(App[None]):
     def on_mount(self) -> None:
         self.title = f"lilbee — {cfg.chat_model}"
         self.theme = _DEFAULT_THEME
-        self.mount(self.task_bar)
 
         from lilbee.cli.tui.screens.chat import ChatScreen
 

--- a/src/lilbee/cli/tui/app.tcss
+++ b/src/lilbee/cli/tui/app.tcss
@@ -1,12 +1,5 @@
 /* lilbee TUI layout — colors come from Textual's built-in theme system */
 
-#task-bar {
-    dock: bottom;
-    height: auto;
-    max-height: 5;
-    padding: 0 1;
-}
-
 ListView {
     height: 1fr;
 }

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -6,7 +6,7 @@ import contextlib
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual import on, work
 from textual.app import ComposeResult
@@ -41,6 +41,9 @@ from lilbee.cli.tui.widgets.model_card import ModelCard
 from lilbee.config import cfg
 from lilbee.model_manager import RemoteModel, get_model_manager
 from lilbee.models import ModelTask
+
+if TYPE_CHECKING:
+    from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
 log = logging.getLogger(__name__)
 
@@ -482,24 +485,20 @@ class CatalogScreen(Screen[None]):
         self.notify(msg.CATALOG_QUEUED_DOWNLOAD.format(name=model.display_name))
         self._run_download(model, task_id, task_bar)
 
-    def _make_progress_callback(self, task_id: str, bar: object) -> Callable[[int, int], None]:
+    def _make_progress_callback(
+        self, task_id: str, bar: TaskBarController
+    ) -> Callable[[int, int], None]:
         """Build a progress callback that reports download progress to the TaskBar."""
-        from lilbee.cli.tui.widgets.task_bar import TaskBarController
-
-        tb: TaskBarController = bar  # type: ignore[assignment]
 
         def _on_update(p: DownloadProgress) -> None:
-            self._safe_call(tb.update_task, task_id, p.percent, p.detail)
+            self._safe_call(bar.update_task, task_id, p.percent, p.detail)
 
         return make_download_callback(_on_update)
 
     @work(thread=True)
-    def _run_download(self, model: CatalogModel, task_id: str, task_bar: object) -> None:
+    def _run_download(self, model: CatalogModel, task_id: str, bar: TaskBarController) -> None:
         """Download a model in a background thread, reporting to TaskBar."""
         from lilbee.catalog import download_model
-        from lilbee.cli.tui.widgets.task_bar import TaskBarController
-
-        bar: TaskBarController = task_bar  # type: ignore[assignment]
 
         try:
             download_model(model, on_progress=self._make_progress_callback(task_id, bar))

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -109,12 +109,14 @@ class CatalogScreen(Screen[None]):
         from textual.widgets import Footer
 
         from lilbee.cli.tui.widgets.status_bar import ViewTabs
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         yield Static("", id="sort-label", shrink=True)
         yield VerticalScroll(id="catalog-grid")
         yield DataTable(id="catalog-table", cursor_type="row")
         yield Input(placeholder=msg.CATALOG_FILTER_PLACEHOLDER, id="catalog-search")
         yield Static("", id="model-detail")
+        yield TaskBar()
         yield ViewTabs()
         yield Footer()
 
@@ -482,9 +484,9 @@ class CatalogScreen(Screen[None]):
 
     def _make_progress_callback(self, task_id: str, bar: object) -> Callable[[int, int], None]:
         """Build a progress callback that reports download progress to the TaskBar."""
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
+        from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
-        tb: TaskBar = bar  # type: ignore[assignment]
+        tb: TaskBarController = bar  # type: ignore[assignment]
 
         def _on_update(p: DownloadProgress) -> None:
             self._safe_call(tb.update_task, task_id, p.percent, p.detail)
@@ -495,9 +497,9 @@ class CatalogScreen(Screen[None]):
     def _run_download(self, model: CatalogModel, task_id: str, task_bar: object) -> None:
         """Download a model in a background thread, reporting to TaskBar."""
         from lilbee.catalog import download_model
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
+        from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
-        bar: TaskBar = task_bar  # type: ignore[assignment]
+        bar: TaskBarController = task_bar  # type: ignore[assignment]
 
         try:
             download_model(model, on_progress=self._make_progress_callback(task_id, bar))

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -36,7 +36,7 @@ from lilbee.query import ChatMessage
 from lilbee.services import get_services, reset_services
 
 if TYPE_CHECKING:
-    from lilbee.cli.tui.widgets.task_bar import TaskBar
+    from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
 log = logging.getLogger(__name__)
 
@@ -113,17 +113,16 @@ class ChatScreen(Screen[None]):
         self._history_index: int = -1
 
     @property
-    def _task_bar(self) -> TaskBar:
-        """The app-level TaskBar (created by LilbeeApp)."""
-        from lilbee.cli.tui.widgets.task_bar import TaskBar as _TaskBar
-
-        bar = getattr(self.app, "task_bar", None)  # test apps lack task_bar
-        if isinstance(bar, _TaskBar):
-            return bar
-        msg_text = "App does not have a TaskBar"
-        raise RuntimeError(msg_text)
+    def _task_bar(self) -> TaskBarController:
+        """The app-level TaskBarController.
+        Always present: LilbeeApp creates one in `__init__`, and the screen's
+        own TaskBar widget lazy-creates one if a bare test harness omits it.
+        """
+        return self.app.task_bar  # type: ignore[attr-defined,no-any-return]
 
     def compose(self) -> ComposeResult:
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
         yield ModelBar(id="model-bar")
         yield Static(msg.CHAT_ONLY_BANNER, id="chat-only-banner")
         yield VerticalScroll(id="chat-log")
@@ -137,6 +136,7 @@ class ChatScreen(Screen[None]):
                 id="chat-input",
                 suggester=SlashSuggester(use_cache=False),
             )
+        yield TaskBar()
         yield ViewTabs()
         yield Footer()
 

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -29,6 +29,7 @@ from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay, get_completio
 from lilbee.cli.tui.widgets.message import AssistantMessage, UserMessage
 from lilbee.cli.tui.widgets.model_bar import ModelBar
 from lilbee.cli.tui.widgets.status_bar import ViewTabs
+from lilbee.cli.tui.widgets.task_bar import TaskBar
 from lilbee.config import cfg
 from lilbee.crawler import crawler_available, is_url, require_valid_crawl_url
 from lilbee.progress import EventType, ProgressEvent
@@ -114,15 +115,10 @@ class ChatScreen(Screen[None]):
 
     @property
     def _task_bar(self) -> TaskBarController:
-        """The app-level TaskBarController.
-        Always present: LilbeeApp creates one in `__init__`, and the screen's
-        own TaskBar widget lazy-creates one if a bare test harness omits it.
-        """
+        """The app-level TaskBarController (always set by LilbeeApp)."""
         return self.app.task_bar  # type: ignore[attr-defined,no-any-return]
 
     def compose(self) -> ComposeResult:
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
         yield ModelBar(id="model-bar")
         yield Static(msg.CHAT_ONLY_BANNER, id="chat-only-banner")
         yield VerticalScroll(id="chat-log")

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -139,6 +139,7 @@ class SettingsScreen(Screen[None]):
         from textual.widgets import Footer
 
         from lilbee.cli.tui.widgets.status_bar import ViewTabs
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         yield Input(
             placeholder="Filter settings...",
@@ -146,6 +147,7 @@ class SettingsScreen(Screen[None]):
         )
         with VerticalScroll(id="settings-scroll"):
             yield from self._compose_groups()
+        yield TaskBar()
         yield ViewTabs()
         yield Footer()
 

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -136,6 +136,8 @@ class SetupWizard(Screen[str | None]):
         return self._selections[ModelTask.EMBEDDING][0]
 
     def compose(self) -> ComposeResult:
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
         yield Static(msg.SETUP_WELCOME, id="setup-title")
         yield Static(msg.SETUP_SUBTITLE, id="setup-subtitle")
         yield VerticalScroll(id="setup-grid-container")
@@ -148,6 +150,7 @@ class SetupWizard(Screen[str | None]):
         yield Button(msg.SETUP_SKIP_BUTTON, id="setup-skip", variant="default")
         yield Label("", id="setup-status")
         yield ProgressBar(total=100, show_eta=False, id="setup-progress")
+        yield TaskBar()
 
     def on_mount(self) -> None:
         self._build_grid()

--- a/src/lilbee/cli/tui/screens/status.py
+++ b/src/lilbee/cli/tui/screens/status.py
@@ -104,6 +104,7 @@ class StatusScreen(Screen[None]):
         from textual.widgets import Footer
 
         from lilbee.cli.tui.widgets.status_bar import ViewTabs
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         yield VerticalScroll(
             Collapsible(Static(id="config-info"), title="Configuration", id="config-section"),
@@ -112,6 +113,7 @@ class StatusScreen(Screen[None]):
             Collapsible(Static(id="storage-info"), title="Storage", id="storage-section"),
             id="status-scroll",
         )
+        yield TaskBar()
         yield ViewTabs()
         yield Footer()
 

--- a/src/lilbee/cli/tui/screens/task_center.py
+++ b/src/lilbee/cli/tui/screens/task_center.py
@@ -62,10 +62,12 @@ class TaskCenter(Screen[None]):
         from textual.widgets import Footer
 
         from lilbee.cli.tui.widgets.status_bar import ViewTabs
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         yield Static("Background Tasks", id="task-center-title")
         yield DataTable(id="task-table", cursor_type="row")
         yield Static("", id="task-detail")
+        yield TaskBar()
         yield ViewTabs()
         yield Footer()
 

--- a/src/lilbee/cli/tui/screens/wiki.py
+++ b/src/lilbee/cli/tui/screens/wiki.py
@@ -74,6 +74,7 @@ class WikiScreen(Screen[None]):
         from textual.widgets import Footer
 
         from lilbee.cli.tui.widgets.status_bar import ViewTabs
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         yield Horizontal(
             Vertical(
@@ -94,6 +95,7 @@ class WikiScreen(Screen[None]):
             ),
             id="wiki-layout",
         )
+        yield TaskBar()
         yield ViewTabs()
         yield Footer()
 

--- a/src/lilbee/cli/tui/task_queue.py
+++ b/src/lilbee/cli/tui/task_queue.py
@@ -102,6 +102,25 @@ class TaskQueue:
             return tasks
 
     @property
+    def displayable_tasks(self) -> list[Task]:
+        """Active tasks plus recently-finished (DONE/FAILED) tasks awaiting dismissal.
+        Widgets render this so completed tasks stay visible for their flash period.
+        """
+        with self._lock:
+            result: list[Task] = []
+            active_ids = set(self._active_ids.values())
+            for tid in self._active_ids.values():
+                task = self._tasks.get(tid)
+                if task:
+                    result.append(task)
+            for tid, task in self._tasks.items():
+                if tid in active_ids:
+                    continue
+                if task.status in (TaskStatus.DONE, TaskStatus.FAILED):
+                    result.append(task)
+            return result
+
+    @property
     def queued_tasks(self) -> list[Task]:
         with self._lock:
             result: list[Task] = []
@@ -146,8 +165,9 @@ class TaskQueue:
             if task:
                 task.progress = progress
                 task.detail = detail
-            # Notify while still holding lock to ensure consistency
-            self._notify()
+        # Notify outside the lock so synchronous subscribers (e.g. TaskBar's
+        # same-thread refresh) can acquire the lock again without deadlocking.
+        self._notify()
 
     def complete_task(self, task_id: str) -> None:
         """Mark a task as done and remove it from tracking."""
@@ -191,6 +211,7 @@ class TaskQueue:
         If omitted, advance any type that has no active task.
         Returns None if nothing can advance.
         """
+        advanced: Task | None = None
         with self._lock:
             types = [task_type] if task_type else list(self._queues.keys())
             for tt in types:
@@ -204,8 +225,11 @@ class TaskQueue:
                 if task:
                     task.status = TaskStatus.ACTIVE
                     self._active_ids[tt] = tid
-                    return task
-            return None
+                    advanced = task
+                    break
+        if advanced is not None:
+            self._notify()
+        return advanced
 
     def remove_task(self, task_id: str) -> None:
         """Remove a completed/failed/cancelled task from tracking entirely."""

--- a/src/lilbee/cli/tui/task_queue.py
+++ b/src/lilbee/cli/tui/task_queue.py
@@ -165,8 +165,6 @@ class TaskQueue:
             if task:
                 task.progress = progress
                 task.detail = detail
-        # Notify outside the lock so synchronous subscribers (e.g. TaskBar's
-        # same-thread refresh) can acquire the lock again without deadlocking.
         self._notify()
 
     def complete_task(self, task_id: str) -> None:
@@ -252,5 +250,12 @@ class TaskQueue:
             self._queues[task_type] = [tid for tid in queue if tid != task_id]
 
     def _notify(self) -> None:
-        for callback in self._on_change:
+        # Snapshot under the lock so subscribe/unsubscribe from another thread
+        # (or from inside a callback) cannot mutate the list mid-iteration.
+        # Callbacks run outside the lock so synchronous subscribers that
+        # re-enter the queue (e.g. TaskBar refreshing from displayable_tasks)
+        # do not deadlock on the non-reentrant lock.
+        with self._lock:
+            callbacks = list(self._on_change)
+        for callback in callbacks:
             callback()

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -165,12 +165,18 @@ class TaskBar(Static):
     @property
     def _controller(self) -> TaskBarController:
         """Return the app's TaskBarController, creating one if missing.
-        LilbeeApp wires up a controller in its `__init__`, but minimal test
-        harnesses may instantiate a TaskBar on a plain `App`. In that case we
-        lazily attach a controller so the widget stays self-sufficient.
+        LilbeeApp wires up a controller in its `__init__`. Bare test harnesses
+        that instantiate a TaskBar on a plain `App` (without a controller) get
+        one lazily attached so every screen in the app still shares state. In
+        production this branch is a bug indicator: log a warning so accidental
+        misuse surfaces instead of silently regressing the per-screen fix.
         """
         controller = getattr(self.app, "task_bar", None)
         if not isinstance(controller, TaskBarController):
+            log.warning(
+                "TaskBar mounted on %s without a TaskBarController; creating one lazily",
+                type(self.app).__name__,
+            )
             controller = TaskBarController(self.app)
             self.app.task_bar = controller  # type: ignore[attr-defined]
         return controller
@@ -195,11 +201,6 @@ class TaskBar(Static):
 
     def cancel_task(self, task_id: str) -> None:
         self._controller.cancel_task(task_id)
-
-    def _dismiss_panel(self, task_id: str, task_type: str | None) -> None:
-        """Remove a task from the shared queue; panels rebuild on next refresh."""
-        del task_type
-        self.queue.remove_task(task_id)
 
     @staticmethod
     def _status_icon(status: TaskStatus) -> str:

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -1,14 +1,24 @@
-"""TaskBar widget — browser-style download panels with per-task progress bars.
+"""TaskBar widget and controller.
 
-Each active/completing task gets its own row with a label and progress bar.
-Panels appear when tasks start and disappear shortly after completion.
+The TaskBar is a browser-style docked panel that shows per-task progress bars.
+State ownership is split so the bar can render on every screen:
+
+- `TaskBarController` lives on the app (`app.task_bar`) and owns the single
+  `TaskQueue`. Callers enqueue/update/complete/fail tasks through it.
+- `TaskBar` is a stateless view widget composed by each Screen. It subscribes
+  to the shared queue and re-renders when the queue changes.
+
+This lets progress stay visible as the user navigates between screens,
+because each screen has its own `TaskBar` instance bound to the same queue.
 """
 
 from __future__ import annotations
 
 import contextlib
 import logging
+import threading
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
@@ -16,6 +26,9 @@ from textual.css.query import NoMatches
 from textual.widgets import Label, ProgressBar, Static
 
 from lilbee.cli.tui.task_queue import STATUS_ICONS, Task, TaskQueue, TaskStatus
+
+if TYPE_CHECKING:
+    from textual.app import App
 
 log = logging.getLogger(__name__)
 
@@ -57,10 +70,65 @@ class _TaskPanel(Static):
         yield ProgressBar(total=100, show_eta=False)
 
 
+class TaskBarController:
+    """App-level coordinator for background tasks.
+
+    Owns the shared `TaskQueue` and schedules the brief post-completion flash
+    period before finished tasks are removed. `TaskBar` view widgets subscribe
+    to `queue.on_change` and re-render whenever this controller mutates state.
+    """
+
+    def __init__(self, app: App[None]) -> None:
+        self._app = app
+        self.queue = TaskQueue()
+
+    def add_task(self, name: str, task_type: str, fn: Callable[[], None] | None = None) -> str:
+        """Enqueue a task. Returns the new task_id."""
+        return self.queue.enqueue(fn or (lambda: None), name, task_type)
+
+    def update_task(self, task_id: str, progress: int, detail: str = "") -> None:
+        """Update progress and detail text for a task."""
+        self.queue.update_task(task_id, progress, detail)
+
+    def complete_task(self, task_id: str) -> None:
+        """Mark a task done; keep it visible for a brief flash, then remove."""
+        self.queue.complete_task(task_id)
+        self._app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id))
+
+    def fail_task(self, task_id: str, detail: str = "") -> None:
+        """Mark a task failed; keep it visible for a brief flash, then remove."""
+        self.queue.fail_task(task_id, detail)
+        self._app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id))
+
+    def cancel_task(self, task_id: str) -> None:
+        """Cancel and immediately remove a task."""
+        task = self.queue.get_task(task_id)
+        task_type = task.task_type if task else None
+        self.queue.cancel(task_id)
+        self.queue.remove_task(task_id)
+        self._advance_all(task_type)
+
+    def _dismiss(self, task_id: str) -> None:
+        """Final cleanup after the flash period: remove and advance the queue."""
+        task = self.queue.get_task(task_id)
+        task_type = task.task_type if task else None
+        self.queue.remove_task(task_id)
+        self._advance_all(task_type)
+
+    def _advance_all(self, task_type: str | None) -> None:
+        """Try to advance the freed type first, then any other idle type."""
+        if task_type:
+            self.queue.advance(task_type)
+        while self.queue.advance() is not None:
+            pass
+
+
 class TaskBar(Static):
-    """Docked panel showing browser-style download progress bars.
-    Each task gets its own panel with a label and progress bar.
-    Panels auto-hide when complete. Auto-hides when no tasks are present.
+    """Docked view of the app's TaskBarController.
+
+    Each Screen composes its own `TaskBar` instance. All instances subscribe
+    to the app-level `TaskBarController.queue` and render its displayable
+    tasks, so progress is visible regardless of which screen is on top.
     """
 
     DEFAULT_CSS = """
@@ -79,7 +147,6 @@ class TaskBar(Static):
 
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)  # type: ignore[arg-type]
-        self._queue = TaskQueue(on_change=self._on_queue_change)
         self._spinner_index = 0
         self._panels: dict[str, _TaskPanel] = {}
 
@@ -88,111 +155,90 @@ class TaskBar(Static):
         yield Label("", id="task-queued-label", classes="task-queued-label")
 
     def on_mount(self) -> None:
+        self.queue.subscribe(self._on_queue_change)
         self._refresh_display()
         self.set_interval(_SPINNER_INTERVAL, self._tick_spinner)
 
+    def on_unmount(self) -> None:
+        self.queue.unsubscribe(self._on_queue_change)
+
+    @property
+    def _controller(self) -> TaskBarController:
+        """Return the app's TaskBarController, creating one if missing.
+        LilbeeApp wires up a controller in its `__init__`, but minimal test
+        harnesses may instantiate a TaskBar on a plain `App`. In that case we
+        lazily attach a controller so the widget stays self-sufficient.
+        """
+        controller = getattr(self.app, "task_bar", None)
+        if not isinstance(controller, TaskBarController):
+            controller = TaskBarController(self.app)
+            self.app.task_bar = controller  # type: ignore[attr-defined]
+        return controller
+
     @property
     def queue(self) -> TaskQueue:
-        """Expose the queue for external use."""
-        return self._queue
+        """Expose the shared queue for callers that iterate or advance it."""
+        return self._controller.queue
 
     def add_task(self, name: str, task_type: str, fn: Callable[[], None] | None = None) -> str:
-        """Add a task to the queue. Returns task_id."""
-        task_id = self._queue.enqueue(fn or (lambda: None), name, task_type)
-        self._refresh_display()
-        return task_id
+        """Enqueue a task via the app's controller. Returns the task_id."""
+        return self._controller.add_task(name, task_type, fn)
 
     def update_task(self, task_id: str, progress: int, detail: str = "") -> None:
-        """Update progress (0-100) and optional detail text."""
-        self._queue.update_task(task_id, progress, detail)
-        self._refresh_display()
+        self._controller.update_task(task_id, progress, detail)
 
     def complete_task(self, task_id: str) -> None:
-        """Mark task done, flash briefly, then remove panel."""
-        task = self._queue.get_task(task_id)
-        task_type = task.task_type if task else None
-        self._queue.complete_task(task_id)
-        panel = self._panels.get(task_id)
-        if panel:
-            panel.add_class("task-done")
-            self._render_task_panel(task_id, task)
-        self._refresh_display()
-        self.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss_panel(task_id, task_type))
+        self._controller.complete_task(task_id)
 
     def fail_task(self, task_id: str, detail: str = "") -> None:
-        """Mark task failed, flash briefly, then remove panel."""
-        task = self._queue.get_task(task_id)
-        task_type = task.task_type if task else None
-        self._queue.fail_task(task_id, detail)
-        panel = self._panels.get(task_id)
-        if panel:
-            panel.add_class("task-failed")
-            self._render_task_panel(task_id, task)
-        self._refresh_display()
-        self.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss_panel(task_id, task_type))
+        self._controller.fail_task(task_id, detail)
 
     def cancel_task(self, task_id: str) -> None:
-        """Cancel and immediately remove a task panel."""
-        task = self._queue.get_task(task_id)
-        task_type = task.task_type if task else None
-        self._queue.cancel(task_id)
-        self._queue.remove_task(task_id)
-        self._remove_panel(task_id)
-        self._try_advance(task_type)
-        self._refresh_display()
+        self._controller.cancel_task(task_id)
 
     def _dismiss_panel(self, task_id: str, task_type: str | None) -> None:
-        """Remove a completed/failed panel after the flash period."""
-        self._queue.remove_task(task_id)
-        self._remove_panel(task_id)
-        self._try_advance(task_type)
-        self._refresh_display()
+        """Remove a task from the shared queue; panels rebuild on next refresh."""
+        del task_type
+        self.queue.remove_task(task_id)
 
-    def _remove_panel(self, task_id: str) -> None:
-        """Unmount and forget a task panel."""
-        panel = self._panels.pop(task_id, None)
-        if panel:
-            panel.remove()
-
-    def _ensure_panel(self, task_id: str) -> _TaskPanel:
-        """Get or create a panel for a task."""
-        if task_id not in self._panels:
-            panel = _TaskPanel(task_id)
-            self._panels[task_id] = panel
-            container = self.query_one("#task-bar-panels", Vertical)
-            container.mount(panel)
-        return self._panels[task_id]
-
-    def _try_advance(self, task_type: str | None = None) -> None:
-        """Advance the queue for a specific type, then try all other types too."""
-        if task_type:
-            self._queue.advance(task_type)
-        while self._queue.advance() is not None:
-            pass
-
-    def _tick_spinner(self) -> None:
-        """Advance the spinner frame and refresh if there are active tasks."""
-        if self._queue.active_tasks:
-            self._spinner_index = (self._spinner_index + 1) % len(_SPINNER_FRAMES)
-            self._refresh_display()
+    @staticmethod
+    def _status_icon(status: TaskStatus) -> str:
+        return STATUS_ICONS.get(status, "▸")
 
     def _on_queue_change(self) -> None:
-        """Called by TaskQueue when state changes (may be from worker thread)."""
+        """Queue callback. May fire on either the main or a worker thread."""
+        if threading.current_thread() is threading.main_thread():
+            with contextlib.suppress(Exception):
+                self._refresh_display()
+            return
         with contextlib.suppress(Exception):
             self.app.call_from_thread(self._refresh_display)
 
-    def _refresh_display(self) -> None:
-        """Update all task panels based on current queue state."""
-        active_list = self._queue.active_tasks
-        queued = self._queue.queued_tasks
+    def _tick_spinner(self) -> None:
+        if self.queue.active_tasks:
+            self._spinner_index = (self._spinner_index + 1) % len(_SPINNER_FRAMES)
+            self._refresh_display()
 
-        if not active_list and not queued and not self._panels:
+    def _refresh_display(self) -> None:
+        """Rebuild panels from the shared queue's displayable tasks."""
+        queue = self.queue
+        displayable = queue.displayable_tasks[:_MAX_VISIBLE_PANELS]
+        queued = queue.queued_tasks
+
+        if not displayable and not queued:
             self.display = False
+            self._clear_panels()
             return
 
         self.display = True
 
-        for task in active_list[:_MAX_VISIBLE_PANELS]:
+        visible_ids = {task.task_id for task in displayable}
+        for tid in list(self._panels.keys()):
+            if tid not in visible_ids:
+                panel = self._panels.pop(tid)
+                panel.remove()
+
+        for task in displayable:
             self._ensure_panel(task.task_id)
             self._render_task_panel(task.task_id, task)
 
@@ -207,11 +253,26 @@ class TaskBar(Static):
 
         self.refresh()
 
+    def _clear_panels(self) -> None:
+        for panel in self._panels.values():
+            panel.remove()
+        self._panels.clear()
+
+    def _ensure_panel(self, task_id: str) -> _TaskPanel:
+        if task_id not in self._panels:
+            panel = _TaskPanel(task_id)
+            self._panels[task_id] = panel
+            container = self.query_one("#task-bar-panels", Vertical)
+            container.mount(panel)
+        return self._panels[task_id]
+
     def _render_task_panel(self, task_id: str, task: Task | None) -> None:
-        """Render a task's current state into its panel."""
         panel = self._panels.get(task_id)
-        if not panel or not task:
+        if not panel or task is None:
             return
+
+        panel.set_class(task.status == TaskStatus.DONE, "task-done")
+        panel.set_class(task.status == TaskStatus.FAILED, "task-failed")
 
         if task.status == TaskStatus.ACTIVE:
             icon = _SPINNER_FRAMES[self._spinner_index]
@@ -225,8 +286,4 @@ class TaskBar(Static):
             progress_bar = panel.query_one(ProgressBar)
             progress_bar.update(total=100, progress=task.progress)
         except NoMatches:
-            pass  # panel children not yet composed — next refresh will catch up
-
-    @staticmethod
-    def _status_icon(status: TaskStatus) -> str:
-        return STATUS_ICONS.get(status, "▸")
+            pass  # panel children not yet composed, next refresh will catch up

--- a/tests/integration/test_tui_integration.py
+++ b/tests/integration/test_tui_integration.py
@@ -25,17 +25,14 @@ class _IntegrationChatApp(App[None]):
 
     CSS = ""
 
+    def __init__(self) -> None:
+        super().__init__()
+        from lilbee.cli.tui.widgets.task_bar import TaskBarController
+
+        self.task_bar = TaskBarController(self)
+
     def compose(self) -> ComposeResult:
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        yield TaskBar(id="app-task-bar")
         yield Footer()
-
-    @property
-    def task_bar(self):
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        return self.query_one("#app-task-bar", TaskBar)
 
     def on_mount(self) -> None:
         from lilbee.cli.tui.screens.chat import ChatScreen

--- a/tests/test_task_bar_per_screen.py
+++ b/tests/test_task_bar_per_screen.py
@@ -1,0 +1,226 @@
+"""Regression tests for the per-screen TaskBar mount.
+
+Every lilbee screen must compose its own `TaskBar` so background progress
+(downloads, syncs, crawls) stays visible as the user navigates. Before this
+fix the TaskBar was mounted once on the app and was hidden behind every
+pushed screen.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Footer
+
+from lilbee.catalog import CatalogResult
+from lilbee.cli.tui.widgets.task_bar import TaskBar, TaskBarController
+from lilbee.config import cfg
+from lilbee.services import set_services
+
+_EMPTY_CATALOG = CatalogResult(total=0, limit=25, offset=0, models=[])
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cfg(tmp_path):
+    snapshot = cfg.model_copy()
+    cfg.data_root = tmp_path
+    cfg.data_dir = tmp_path / "data"
+    cfg.documents_dir = tmp_path / "documents"
+    cfg.lancedb_dir = tmp_path / "lancedb"
+    cfg.chat_model = "test-model:latest"
+    cfg.embedding_model = "test-embed:latest"
+    cfg.vision_model = ""
+    yield
+    for name in type(cfg).model_fields:
+        setattr(cfg, name, getattr(snapshot, name))
+
+
+@pytest.fixture(autouse=True)
+def _mock_services():
+    from tests.conftest import make_mock_services
+
+    store = MagicMock()
+    store.search.return_value = []
+    store.bm25_probe.return_value = []
+    store.get_sources.return_value = []
+    store.add_chunks.side_effect = lambda records: len(records)
+    set_services(make_mock_services(store=store))
+    yield
+    set_services(None)
+
+
+@pytest.fixture(autouse=True)
+def _patch_chat_setup():
+    with (
+        patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        patch(
+            "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
+            return_value=False,
+        ),
+        patch(
+            "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
+            return_value=([], [], []),
+        ),
+        patch(
+            "lilbee.cli.tui.screens.catalog.CatalogScreen._fetch_remote_models",
+            return_value=None,
+        ),
+        patch(
+            "lilbee.cli.tui.screens.catalog.CatalogScreen._fetch_installed_names",
+            return_value=None,
+        ),
+    ):
+        yield
+
+
+class _ControllerApp(App[None]):
+    """Test harness that exposes a real TaskBarController plus a single screen."""
+
+    CSS = ""
+
+    def __init__(self, screen_factory) -> None:
+        super().__init__()
+        self.task_bar = TaskBarController(self)
+        self._screen_factory = screen_factory
+
+    def compose(self) -> ComposeResult:
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.push_screen(self._screen_factory())
+
+
+def _chat_screen():
+    from lilbee.cli.tui.screens.chat import ChatScreen
+
+    return ChatScreen()
+
+
+def _catalog_screen():
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+    return CatalogScreen()
+
+
+def _settings_screen():
+    from lilbee.cli.tui.screens.settings import SettingsScreen
+
+    return SettingsScreen()
+
+
+def _status_screen():
+    from lilbee.cli.tui.screens.status import StatusScreen
+
+    return StatusScreen()
+
+
+def _task_center_screen():
+    from lilbee.cli.tui.screens.task_center import TaskCenter
+
+    return TaskCenter()
+
+
+def _wiki_screen():
+    from lilbee.cli.tui.screens.wiki import WikiScreen
+
+    return WikiScreen()
+
+
+def _setup_screen():
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    return SetupWizard()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        _chat_screen,
+        _catalog_screen,
+        _settings_screen,
+        _status_screen,
+        _task_center_screen,
+        _wiki_screen,
+        _setup_screen,
+    ],
+    ids=[
+        "chat",
+        "catalog",
+        "settings",
+        "status",
+        "task_center",
+        "wiki",
+        "setup",
+    ],
+)
+async def test_every_screen_mounts_a_task_bar(factory) -> None:
+    """Each top-level screen must compose its own TaskBar instance."""
+    app = _ControllerApp(factory)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        bars = list(app.screen.query(TaskBar))
+        assert len(bars) == 1, (
+            f"{factory.__name__} should mount exactly one TaskBar, found {len(bars)}"
+        )
+
+
+async def test_task_bar_shows_active_task_on_catalog_screen() -> None:
+    """A task added via the controller is rendered by the screen's TaskBar."""
+    app = _ControllerApp(_catalog_screen)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        bar = app.screen.query_one(TaskBar)
+        assert bar.display is False  # idle: hidden
+        task_id = app.task_bar.add_task("Download test-model", "download")
+        app.task_bar.queue.advance()
+        await pilot.pause()
+        assert bar.display is True
+        assert task_id in bar._panels
+
+
+async def test_task_bar_state_shared_across_screens() -> None:
+    """Switching screens keeps tasks visible because they share one queue."""
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+    from lilbee.cli.tui.screens.chat import ChatScreen
+
+    app = _ControllerApp(_chat_screen)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.task_bar.add_task("Background sync", "sync")
+        app.task_bar.queue.advance()
+        await pilot.pause()
+
+        chat_bar = app.screen.query_one(TaskBar)
+        assert chat_bar.display is True
+        assert isinstance(app.screen, ChatScreen)
+
+        app.switch_screen(CatalogScreen())
+        await pilot.pause()
+        assert isinstance(app.screen, CatalogScreen)
+        catalog_bar = app.screen.query_one(TaskBar)
+        assert catalog_bar is not chat_bar
+        assert catalog_bar.display is True
+        # Same underlying queue → same active task
+        assert catalog_bar.queue is chat_bar.queue
+        assert catalog_bar.queue.active_task is not None
+        assert catalog_bar.queue.active_task.name == "Background sync"
+
+
+async def test_task_bar_auto_hides_when_queue_drains() -> None:
+    """When all tasks finish, every screen's TaskBar should hide again."""
+    app = _ControllerApp(_chat_screen)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        bar = app.screen.query_one(TaskBar)
+        task_id = app.task_bar.add_task("Download", "download")
+        app.task_bar.queue.advance()
+        await pilot.pause()
+        assert bar.display is True
+
+        app.task_bar.complete_task(task_id)
+        await pilot.pause(delay=1.2)  # wait out the flash
+        await pilot.pause()
+        assert app.task_bar.queue.is_empty
+        assert bar.display is False

--- a/tests/test_task_bar_per_screen.py
+++ b/tests/test_task_bar_per_screen.py
@@ -15,6 +15,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Footer
 
 from lilbee.catalog import CatalogResult
+from lilbee.cli.tui.widgets import task_bar as task_bar_module
 from lilbee.cli.tui.widgets.task_bar import TaskBar, TaskBarController
 from lilbee.config import cfg
 from lilbee.services import set_services
@@ -220,7 +221,8 @@ async def test_task_bar_auto_hides_when_queue_drains() -> None:
         assert bar.display is True
 
         app.task_bar.complete_task(task_id)
-        await pilot.pause(delay=1.2)  # wait out the flash
+        # Wait out the post-completion flash window before the panel is dropped.
+        await pilot.pause(delay=task_bar_module._DONE_FLASH_SECONDS + 0.2)
         await pilot.pause()
         assert app.task_bar.queue.is_empty
         assert bar.display is False

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -92,6 +92,30 @@ class TestTaskBarUnit:
         assert isinstance(task_id, str)
         assert len(task_id) == 8
 
+    def test_update_task_does_not_deadlock_reentrant_subscriber(self) -> None:
+        """Regression: a subscriber that reads the queue inside its callback
+        must not deadlock on the non-reentrant lock held by `update_task`.
+        """
+        from lilbee.cli.tui.task_queue import TaskQueue
+
+        q = TaskQueue()
+        task_id = q.enqueue(lambda: None, "Test", "sync")
+        q.advance()
+
+        observed: list[int] = []
+
+        def _on_change() -> None:
+            # Re-enter the queue from inside the callback (TaskBar does this
+            # via `displayable_tasks` during `_refresh_display`). If `_notify`
+            # fired while still holding the lock, this would hang forever.
+            task = q.get_task(task_id)
+            if task is not None:
+                observed.append(task.progress)
+
+        q.subscribe(_on_change)
+        q.update_task(task_id, 42, "halfway")
+        assert observed == [42]
+
 
 class TestRemoteClassification:
     @mock.patch("httpx.get")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -837,9 +837,9 @@ class ChatTestApp(App[None]):
 
     def __init__(self) -> None:
         super().__init__()
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
+        from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
-        self.task_bar = TaskBar(id="app-task-bar")
+        self.task_bar = TaskBarController(self)
 
     def compose(self) -> ComposeResult:
         yield from ()
@@ -847,7 +847,6 @@ class ChatTestApp(App[None]):
     def on_mount(self) -> None:
         from lilbee.cli.tui.screens.chat import ChatScreen
 
-        self.mount(self.task_bar)
         self.push_screen(ChatScreen())
 
 
@@ -5725,26 +5724,6 @@ async def test_catalog_run_download_generic_error():
 # ---------------------------------------------------------------------------
 
 
-async def test_chat_task_bar_property_raises_when_missing():
-    """_task_bar raises RuntimeError when app has no task_bar attribute."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
-
-    class NoTaskBarApp(App[None]):
-        CSS = ""
-
-        def compose(self) -> ComposeResult:
-            yield Footer()
-
-        def on_mount(self) -> None:
-            self.push_screen(ChatScreen())
-
-    app = NoTaskBarApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        with pytest.raises(RuntimeError, match="TaskBar"):
-            _ = app.screen._task_bar
-
-
 async def test_chat_on_show_calls_dismiss():
     """on_show calls splash.dismiss() to signal splash stop."""
     app = ChatTestApp()
@@ -6077,9 +6056,9 @@ class TaskCenterTestApp(App[None]):
 
     def __init__(self) -> None:
         super().__init__()
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
+        from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
-        self.task_bar = TaskBar(id="app-task-bar")
+        self.task_bar = TaskBarController(self)
 
     def compose(self) -> ComposeResult:
         yield Footer()
@@ -6087,7 +6066,6 @@ class TaskCenterTestApp(App[None]):
     def on_mount(self) -> None:
         from lilbee.cli.tui.screens.task_center import TaskCenter
 
-        self.mount(self.task_bar)
         self.push_screen(TaskCenter())
 
 
@@ -6510,11 +6488,14 @@ async def test_chat_auto_sync_on_mount_runs_sync():
     class SyncApp(App[None]):
         CSS = ""
 
-        def compose(self) -> ComposeResult:
-            from lilbee.cli.tui.widgets.task_bar import TaskBar
+        def __init__(self) -> None:
+            super().__init__()
+            from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
-            self.task_bar = TaskBar(id="app-task-bar")
-            yield self.task_bar
+            self.task_bar = TaskBarController(self)
+
+        def compose(self) -> ComposeResult:
+            yield from ()
 
         def on_mount(self) -> None:
             self.push_screen(ChatScreen(auto_sync=True))

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -183,6 +183,12 @@ class TestHelpPanel:
 
 
 class _TaskBarApp(App):
+    def __init__(self) -> None:
+        super().__init__()
+        from lilbee.cli.tui.widgets.task_bar import TaskBarController
+
+        self.task_bar = TaskBarController(self)
+
     def compose(self) -> ComposeResult:
         from lilbee.cli.tui.widgets.task_bar import TaskBar
 
@@ -301,15 +307,15 @@ class TestTaskBar:
             assert bar.queue.is_empty
 
     async def test_app_task_bar_ref(self) -> None:
-        """TaskBar is accessible via app.task_bar from other screens."""
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
+        """TaskBarController is accessible via app.task_bar from other screens."""
+        from lilbee.cli.tui.widgets.task_bar import TaskBar, TaskBarController
 
         app = _TaskBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             bar = app.query_one(TaskBar)
-            app.task_bar = bar
-            assert app.task_bar is bar
+            assert isinstance(app.task_bar, TaskBarController)
+            assert bar.queue is app.task_bar.queue
 
 
 class _ModelBarApp(App):
@@ -2455,6 +2461,29 @@ class TestTaskBarAdditional:
             )
             bar._render_task_panel("nonexistent", task)  # should not raise
             bar._render_task_panel("nonexistent", None)  # should not raise
+
+    async def test_on_queue_change_from_worker_thread(self) -> None:
+        """Queue notifications fired from a background thread must marshal back."""
+        import threading
+
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+
+            called = threading.Event()
+
+            def worker() -> None:
+                bar._on_queue_change()
+                called.set()
+
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join(timeout=2)
+            await pilot.pause()
+            assert called.is_set()
 
     async def test_render_task_panel_queued_status(self) -> None:
         """_render_task_panel with QUEUED status uses fallback icon."""

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 from textual.app import App, ComposeResult
+from textual.css.query import NoMatches
 from textual.widgets import Static
 
 from conftest import make_test_catalog_model as _make_model
@@ -2382,8 +2383,8 @@ class TestTaskBarAdditional:
             assert t1 in bar._panels
             assert t2 in bar._panels
 
-    async def test_panel_removed_on_dismiss(self) -> None:
-        """Panel is removed from DOM after dismiss."""
+    async def test_panel_removed_when_task_removed_from_queue(self) -> None:
+        """Removing a task from the shared queue drops its panel on next refresh."""
         from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         app = _TaskBarApp()
@@ -2392,12 +2393,12 @@ class TestTaskBarAdditional:
             bar = app.query_one(TaskBar)
             task_id = bar.add_task("Download", "download")
             bar.queue.advance()
-            bar._refresh_display()
             await pilot.pause()
-            assert task_id in bar._panels
-            bar._dismiss_panel(task_id, "download")
+            bar.query_one(f"#task-panel-{task_id}")  # raises NoMatches if absent
+            bar.queue.remove_task(task_id)
             await pilot.pause()
-            assert task_id not in bar._panels
+            with pytest.raises(NoMatches):
+                bar.query_one(f"#task-panel-{task_id}")
 
     async def test_fail_task_adds_failed_class_to_panel(self) -> None:
         """fail_task marks the panel with task-failed CSS class."""


### PR DESCRIPTION
## What was broken

The task bar that shows downloads, syncs, and crawls was mounted once at app level, so every screen that pushed on top of it hid it behind its own viewport. The moment you navigated away from chat, any in-progress task silently disappeared — a download you kicked off from the catalog had no visible progress once you left the catalog, and coming back didn't bring it back.

## What changed

The task bar is now visible on every TUI screen. Whatever you're doing — browsing the catalog, editing settings, looking at status, generating a wiki page — you can see active downloads, syncs, and crawls in the same place, with the same progress, the whole time they run. Switching screens no longer hides them.