### PR TITLE
Always show the catalog filter input

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -119,7 +119,6 @@ class CatalogScreen(Screen[None]):
         yield Footer()
 
     def on_mount(self) -> None:
-        self.query_one("#catalog-search", Input).display = False
         table = self.query_one("#catalog-table", DataTable)
         for col in COLUMNS:
             table.add_column(col, key=col)
@@ -171,9 +170,7 @@ class CatalogScreen(Screen[None]):
 
     def action_focus_search(self) -> None:
         """Focus the filter input -- bound to / key."""
-        filter_input = self.query_one("#catalog-search", Input)
-        filter_input.display = True
-        filter_input.focus()
+        self.query_one("#catalog-search", Input).focus()
 
     @on(Input.Changed, "#catalog-search")
     def _on_search_changed(self, event: Input.Changed) -> None:
@@ -185,10 +182,12 @@ class CatalogScreen(Screen[None]):
 
     @on(Input.Submitted, "#catalog-search")
     def _on_search_submitted(self, event: Input.Submitted) -> None:
-        """Close filter on Enter."""
-        event.input.display = False
+        """Return focus to the visible view on Enter."""
         with contextlib.suppress(Exception):
-            self.query_one("#catalog-table", DataTable).focus()
+            if self._grid_view:
+                self.query_one(GridSelect).focus()
+            else:
+                self.query_one("#catalog-table", DataTable).focus()
 
     def _fetch_hf_page(self) -> list[CatalogModel]:
         """Fetch one page of HF models for all task types (runs in worker thread)."""

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1057,7 +1057,7 @@ class TestCatalogInteractions:
                 assert len(hidden) >= 1
 
     async def test_search_input_is_visible_when_opened(self, _mock_resolve):
-        """Pressing / focuses a visible search input. Regression for bb-lufk."""
+        """Pressing / focuses a visible search input ready for text entry."""
         from textual.widgets import Input
 
         from lilbee.cli.tui.app import LilbeeApp

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1046,7 +1046,6 @@ class TestCatalogInteractions:
                 assert initial_count > 0
 
                 search = app.screen.query_one("#catalog-search")
-                search.display = True
                 search.value = "TestChat"
                 await pilot.pause()
 
@@ -1057,8 +1056,8 @@ class TestCatalogInteractions:
                 assert len(visible) >= 1
                 assert len(hidden) >= 1
 
-    async def test_search_submit_closes_search(self, _mock_resolve):
-        """Pressing Enter in search closes the search input."""
+    async def test_search_input_is_visible_when_opened(self, _mock_resolve):
+        """Pressing / focuses a visible search input. Regression for bb-lufk."""
         from textual.widgets import Input
 
         from lilbee.cli.tui.app import LilbeeApp
@@ -1070,15 +1069,64 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_focus_search()
+                await pilot.press("slash")
                 await pilot.pause()
                 search = app.screen.query_one("#catalog-search", Input)
                 assert search.display is True
+                assert search.region.width > 0
+                assert search.region.height > 0
+                assert search.has_focus
 
+                await pilot.press("q", "w", "e", "n")
+                await pilot.pause()
+                assert search.value == "qwen"
+
+    async def test_search_submit_returns_focus_to_grid(self, _mock_resolve):
+        """Pressing Enter in search returns focus to the visible grid."""
+        from textual.widgets import Input
+
+        from lilbee.cli.tui.app import LilbeeApp
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        with _mock_catalog_deps(), _mock_remote_models():
+            app = LilbeeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                app.switch_view("Catalog")
+                await pilot.pause()
+
+                await pilot.press("slash")
+                await pilot.pause()
+                search = app.screen.query_one("#catalog-search", Input)
                 search.value = "test"
                 await search.action_submit()
                 await pilot.pause()
-                assert search.display is False
+                grid = app.screen.query_one(GridSelect)
+                assert grid.has_focus
+
+    async def test_search_submit_returns_focus_to_table_in_list_view(self, _mock_resolve):
+        """In list view, pressing Enter in search returns focus to the DataTable."""
+        from textual.widgets import DataTable, Input
+
+        from lilbee.cli.tui.app import LilbeeApp
+
+        with _mock_catalog_deps(), _mock_remote_models():
+            app = LilbeeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                app.switch_view("Catalog")
+                await pilot.pause()
+                app.screen.action_toggle_view()
+                await pilot.pause()
+
+                await pilot.press("slash")
+                await pilot.pause()
+                search = app.screen.query_one("#catalog-search", Input)
+                search.value = "test"
+                await search.action_submit()
+                await pilot.pause()
+                table = app.screen.query_one("#catalog-table", DataTable)
+                assert table.has_focus
 
     async def test_grid_card_count_matches_families(self, _mock_resolve):
         """Verify correct number of cards for featured models."""
@@ -1233,7 +1281,6 @@ class TestCatalogInteractions:
                 initial_rows = table.row_count
 
                 search = app.screen.query_one("#catalog-search")
-                search.display = True
                 search.value = "TestChat"
                 await pilot.pause()
 

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -1866,7 +1866,6 @@ async def test_catalog_vim_keys_in_input():
             from textual.widgets import Input
 
             inp = screen.query_one("#catalog-search", Input)
-            inp.display = True
             inp.focus()
             await _pilot.pause()
             screen.action_cursor_down()
@@ -1901,7 +1900,6 @@ async def test_catalog_page_down_no_focus():
             from textual.widgets import Input
 
             inp = screen.query_one("#catalog-search", Input)
-            inp.display = True
             inp.focus()
             await _pilot.pause()
             screen.action_page_down()
@@ -3018,7 +3016,6 @@ async def test_catalog_key_g_G_noop_in_input():
             from textual.widgets import Input
 
             inp = screen.query_one("#catalog-search", Input)
-            inp.display = True
             inp.focus()
             await _pilot.pause()
             screen.action_jump_top()


### PR DESCRIPTION
## What was broken

Pressing `/` on the catalog screen was supposed to open a filter input, but nothing visible happened. Users saw the footer hint advertising `/ to search` and then pressed it to no effect — there was no way to narrow the catalog down to a specific model.

## What changed

The filter input now lives permanently at the top of the catalog screen, right where the footer hint says it is. Typing filters the list as you type, and pressing Enter drops focus back into whichever view is active (grid or list) so you can pick a model without having to tab around.