### PR TITLE
Make Tab complete /cat to /catalog in the chat input

### DIFF
--- a/src/lilbee/cli/tui/command_registry.py
+++ b/src/lilbee/cli/tui/command_registry.py
@@ -80,7 +80,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand("/reset", "_cmd_reset", args_hint="confirm", help_text="Factory reset"),
     SlashCommand("/status", "_cmd_status", help_text="Knowledge base status"),
     SlashCommand("/settings", "_cmd_settings", help_text="View/change settings"),
-    SlashCommand("/models", "_cmd_catalog", aliases=("/m",), help_text="Browse catalog"),
+    SlashCommand(
+        "/models",
+        "_cmd_catalog",
+        aliases=("/m", "/catalog"),
+        help_text="Browse catalog",
+    ),
     SlashCommand("/setup", "_cmd_setup", help_text="Run setup wizard"),
     SlashCommand(
         "/remove",
@@ -108,6 +113,10 @@ def build_dispatch_dict() -> dict[str, str]:
     return dispatch
 
 
-def command_names() -> tuple[str, ...]:
-    """All primary command names (excludes aliases), for tab completion."""
-    return tuple(cmd.name for cmd in COMMANDS)
+def completion_names() -> tuple[str, ...]:
+    """All command names including aliases, for tab completion."""
+    names: list[str] = []
+    for cmd in COMMANDS:
+        names.append(cmd.name)
+        names.extend(cmd.aliases)
+    return tuple(names)

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -15,12 +15,12 @@ from textual.widgets.option_list import Option
 
 from lilbee.cli.settings_map import SETTINGS_MAP
 from lilbee.cli.tui.app import DARK_THEMES
-from lilbee.cli.tui.command_registry import command_names
+from lilbee.cli.tui.command_registry import completion_names
 from lilbee.services import get_services
 
 log = logging.getLogger(__name__)
 
-_SLASH_COMMANDS = command_names()
+_SLASH_COMMANDS = completion_names()
 _MAX_VISIBLE = 8  # max dropdown items shown at once
 
 

--- a/src/lilbee/cli/tui/widgets/suggester.py
+++ b/src/lilbee/cli/tui/widgets/suggester.py
@@ -6,10 +6,10 @@ from textual.suggester import Suggester
 
 from lilbee.cli.settings_map import SETTINGS_MAP
 from lilbee.cli.tui.app import DARK_THEMES
-from lilbee.cli.tui.command_registry import command_names
+from lilbee.cli.tui.command_registry import completion_names
 from lilbee.services import get_services
 
-_SLASH_COMMANDS = command_names()
+_SLASH_COMMANDS = completion_names()
 
 
 class SlashSuggester(Suggester):

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -1460,6 +1460,23 @@ async def test_chat_action_complete_cycle():
                 assert "qwen:latest" in inp.value
 
 
+async def test_chat_tab_completes_alias_prefix():
+    """Pressing Tab on '/cat' expands to the /catalog alias (bb-d2tz)."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        from textual.widgets import Input
+
+        inp = app.screen.query_one("#chat-input", Input)
+        inp.focus()
+        for key in ("slash", "c", "a", "t"):
+            await pilot.press(key)
+        await pilot.pause()
+        assert inp.value == "/cat"
+        await pilot.press("tab")
+        await pilot.pause()
+        assert inp.value == "/catalog"
+
+
 async def test_chat_action_complete_cycle_no_selection():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -1461,7 +1461,7 @@ async def test_chat_action_complete_cycle():
 
 
 async def test_chat_tab_completes_alias_prefix():
-    """Pressing Tab on '/cat' expands to the /catalog alias (bb-d2tz)."""
+    """Pressing Tab on '/cat' expands to the /catalog alias."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         from textual.widgets import Input

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -755,6 +755,13 @@ class TestGetCompletions:
         r = get_completions("/model ")
         assert "qwen3:8b" in r
 
+    def test_slash_prefix_includes_aliases(self) -> None:
+        """/cat expands via the /catalog alias for /models."""
+        from lilbee.cli.tui.widgets.autocomplete import get_completions
+
+        r = get_completions("/cat")
+        assert "/catalog" in r
+
     def test_unknown_command_arg_returns_empty(self) -> None:
         from lilbee.cli.tui.widgets.autocomplete import get_completions
 


### PR DESCRIPTION
## What was broken

Typing `/cat` in the chat input and pressing Tab was supposed to expand to `/catalog`, but nothing happened — the completion list didn't know `/catalog` existed as a command name, so there was nothing to complete to. Users had to type out the full command every time.

## What changed

`/catalog` is now a real alias of the models command, so typing `/cat` and pressing Tab expands to `/catalog` the way you'd expect. The command palette and autocomplete both see it, and it routes to the same handler as `/models` so both names continue to work.