### PR TITLE
Expose the wiki and clusterer configuration in Settings

### DIFF
--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 
+from lilbee.config import ClustererBackend
+
 
 class RenderStyle(StrEnum):
     """How a setting is displayed in /settings."""
@@ -114,5 +116,54 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         nullable=False,
         group="Display",
         help_text="Show model reasoning/thinking tokens in output",
+    ),
+    "wiki": SettingDef(
+        bool,
+        nullable=False,
+        group="Wiki",
+        help_text="Enable the wiki layer (synthesis pages with citations)",
+    ),
+    "wiki_dir": SettingDef(
+        str,
+        nullable=False,
+        group="Wiki",
+        help_text="Directory under data_root where wiki pages are stored",
+    ),
+    "wiki_prune_raw": SettingDef(
+        bool,
+        nullable=False,
+        group="Wiki",
+        help_text="Delete raw chunks after summarizing into the wiki",
+    ),
+    "wiki_faithfulness_threshold": SettingDef(
+        float,
+        nullable=False,
+        group="Wiki",
+        help_text="Minimum faithfulness score (0-1) to accept a generated page",
+    ),
+    "wiki_stale_citation_threshold": SettingDef(
+        float,
+        nullable=False,
+        group="Wiki",
+        help_text="Fraction of stale citations that triggers page regeneration",
+    ),
+    "wiki_drift_threshold": SettingDef(
+        float,
+        nullable=False,
+        group="Wiki",
+        help_text="Max fraction of changed lines before regeneration requires review",
+    ),
+    "wiki_clusterer": SettingDef(
+        str,
+        nullable=False,
+        group="Wiki",
+        help_text="Synthesis clusterer backend (embedding or concepts)",
+        choices=tuple(b.value for b in ClustererBackend),
+    ),
+    "wiki_clusterer_k": SettingDef(
+        int,
+        nullable=False,
+        group="Wiki",
+        help_text="Mutual-kNN neighborhood size for the clusterer (0 = auto)",
     ),
 }

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -227,6 +227,9 @@ class SettingsScreen(Screen[None]):
         if defn is None:
             return
         value = str(event.value) if event.value != Select.BLANK else ""
+        current = str(getattr(cfg, name, ""))
+        if value == current:
+            return
         self._persist_value(name, defn, value)
 
     def _persist_value(self, key: str, defn: SettingDef, raw: str) -> None:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -342,7 +342,7 @@ async def test_settings_persist_on_change():
 
 
 async def test_settings_exposes_wiki_fields():
-    """Settings screen renders an editor for every new wiki config field (bb-piyt)."""
+    """Settings screen renders an editor for every wiki config field."""
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         wiki_keys = [
@@ -360,7 +360,7 @@ async def test_settings_exposes_wiki_fields():
 
 
 async def test_settings_wiki_clusterer_k_persists():
-    """Editing wiki_clusterer_k writes through to cfg (bb-piyt)."""
+    """Editing wiki_clusterer_k writes through to cfg."""
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         from textual.widgets import Input

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -341,6 +341,38 @@ async def test_settings_persist_on_change():
         assert cfg.top_k == 20
 
 
+async def test_settings_exposes_wiki_fields():
+    """Settings screen renders an editor for every new wiki config field (bb-piyt)."""
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        wiki_keys = [
+            "wiki",
+            "wiki_dir",
+            "wiki_prune_raw",
+            "wiki_faithfulness_threshold",
+            "wiki_stale_citation_threshold",
+            "wiki_drift_threshold",
+            "wiki_clusterer",
+            "wiki_clusterer_k",
+        ]
+        for key in wiki_keys:
+            assert app.screen.query_one(f"#ed-{key}") is not None
+
+
+async def test_settings_wiki_clusterer_k_persists():
+    """Editing wiki_clusterer_k writes through to cfg (bb-piyt)."""
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        from textual.widgets import Input
+
+        editor = app.screen.query_one("#ed-wiki_clusterer_k", Input)
+        editor.focus()
+        editor.value = "8"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert cfg.wiki_clusterer_k == 8
+
+
 async def test_settings_checkbox_persist():
     """Toggling a checkbox persists the boolean value."""
     app = SettingsTestApp()


### PR DESCRIPTION
## What was broken

The wiki layer's configuration — whether wiki generation is enabled, where wiki pages live on disk, the various thresholds, the clusterer backend and its neighborhood size — was not visible in the TUI settings screen at all. The only way to change any of it was to edit config files or set environment variables, which meant the wiki layer was effectively opaque from inside lilbee and the clusterer tuning knobs from the most recent wiki work had no way to be adjusted interactively.

## What changed

A new `Wiki` group in the settings screen exposes every wiki layer field with the right editor for its type: toggles for booleans, numeric fields for the thresholds, and a dropdown for the clusterer backend with its real choices. Any change you make in the screen takes effect immediately and persists to your config the same way the other settings do.