### PR TITLE
Let arrow keys escape the SetupWizard grid to the next field

### DIFF
--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -266,6 +266,16 @@ class SetupWizard(Screen[str | None]):
         if task in self._selections:
             self._select_card(card, task)
 
+    @on(GridSelect.LeaveDown)
+    def _on_grid_leave_down(self, event: GridSelect.LeaveDown) -> None:
+        """Arrow-down past the last card walks to the next focusable widget."""
+        self.focus_next()
+
+    @on(GridSelect.LeaveUp)
+    def _on_grid_leave_up(self, event: GridSelect.LeaveUp) -> None:
+        """Arrow-up past the first card walks to the previous focusable widget."""
+        self.focus_previous()
+
     @on(Button.Pressed, "#setup-browse")
     def _on_browse_catalog(self) -> None:
         from lilbee.cli.tui.app import LilbeeApp

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -5232,6 +5232,54 @@ async def test_setup_wizard_on_partial_success():
             assert screen._selections[ModelTask.EMBEDDING] == (None, None)
 
 
+async def test_setup_wizard_grid_leave_down_walks_focus_forward():
+    """Arrow-down past the last card advances focus out of the grid (bb-8epo)."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+    from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            grids = list(screen.query(GridSelect))
+            assert grids, "expected at least one GridSelect in the wizard"
+            last_grid = grids[-1]
+            last_grid.focus()
+            last_grid.highlight_last()
+            await pilot.pause()
+            assert app.focused is last_grid
+            await pilot.press("down")
+            await pilot.pause()
+            assert app.focused is not last_grid
+            assert app.focused is not None
+
+
+async def test_setup_wizard_grid_leave_up_walks_focus_backward():
+    """Arrow-up past the first card walks focus backward (bb-8epo)."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+    from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            grids = list(screen.query(GridSelect))
+            assert len(grids) >= 2, "expected multiple GridSelects in the wizard"
+            second_grid = grids[1]
+            second_grid.focus()
+            second_grid.highlight_first()
+            await pilot.pause()
+            assert app.focused is second_grid
+            await pilot.press("up")
+            await pilot.pause()
+            assert app.focused is not second_grid
+            assert app.focused is not None
+
+
 async def test_setup_wizard_on_download_progress():
     """_on_download_progress updates progress bar and status."""
     from lilbee.cli.tui.screens.setup import SetupWizard

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -5233,7 +5233,7 @@ async def test_setup_wizard_on_partial_success():
 
 
 async def test_setup_wizard_grid_leave_down_walks_focus_forward():
-    """Arrow-down past the last card advances focus out of the grid (bb-8epo)."""
+    """Arrow-down past the last card advances focus out of the grid."""
     from lilbee.cli.tui.screens.setup import SetupWizard
     from lilbee.cli.tui.widgets.grid_select import GridSelect
 
@@ -5257,7 +5257,7 @@ async def test_setup_wizard_grid_leave_down_walks_focus_forward():
 
 
 async def test_setup_wizard_grid_leave_up_walks_focus_backward():
-    """Arrow-up past the first card walks focus backward (bb-8epo)."""
+    """Arrow-up past the first card walks focus backward."""
     from lilbee.cli.tui.screens.setup import SetupWizard
     from lilbee.cli.tui.widgets.grid_select import GridSelect
 


### PR DESCRIPTION
The first-run setup wizard let you highlight a model card with arrow keys, but once the cursor was on the last card of a section, pressing the down arrow did nothing. The same dead-end happened at the top of every grid with the up arrow. The only way to reach the Install/Browse/Skip buttons or walk back into an earlier section was to reach for the mouse or hit Tab, which isn't obvious when you've been driving the page with the arrow keys.

Now arrow-down past the last card and arrow-up past the first card advance focus to the next or previous field in the wizard's natural order, so the entire setup flow can be driven with just the arrow keys.