### PR TITLE
Guard the catalog list-view toggle against silent regressions

### DIFF
--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1007,12 +1007,7 @@ class TestCatalogInteractions:
                 assert app.screen.has_class("-grid-view")
 
     async def test_v_toggles_to_list_and_back(self, _mock_resolve):
-        """Press v: grid->list, v again: list->grid.
-
-        Exercises the actual key binding end-to-end via `pilot.press("v")`
-        so the footer-advertised shortcut is verified, not just the
-        `action_toggle_view` method.
-        """
+        """Pressing v flips the catalog between grid and list views."""
         from textual.widgets import DataTable
 
         from lilbee.cli.tui.app import LilbeeApp
@@ -1045,10 +1040,7 @@ class TestCatalogInteractions:
                 assert table.display is False
 
     async def test_v_toggle_after_bracket_nav_from_chat(self, _mock_resolve):
-        """Regression: the footer advertises `v` as the view toggle, and the
-        bead repro walks in via `]` from ChatScreen. Make sure the keystroke
-        dispatched through the real binding path actually flips the view.
-        """
+        """Pressing v still toggles the view after navigating in from chat via ]."""
         from textual.widgets import DataTable
 
         from lilbee.cli.tui.app import LilbeeApp

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1007,7 +1007,14 @@ class TestCatalogInteractions:
                 assert app.screen.has_class("-grid-view")
 
     async def test_v_toggles_to_list_and_back(self, _mock_resolve):
-        """Press v: grid->list, v again: list->grid."""
+        """Press v: grid->list, v again: list->grid.
+
+        Exercises the actual key binding end-to-end via `pilot.press("v")`
+        so the footer-advertised shortcut is verified, not just the
+        `action_toggle_view` method.
+        """
+        from textual.widgets import DataTable
+
         from lilbee.cli.tui.app import LilbeeApp
 
         with _mock_catalog_deps(), _mock_remote_models():
@@ -1018,16 +1025,57 @@ class TestCatalogInteractions:
                 await pilot.pause()
 
                 assert app.screen.has_class("-grid-view")
+                grid = app.screen.query_one("#catalog-grid")
+                table = app.screen.query_one("#catalog-table", DataTable)
+                assert grid.display is True
+                assert table.display is False
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
                 assert app.screen.has_class("-list-view")
                 assert not app.screen.has_class("-grid-view")
+                assert grid.display is False
+                assert table.display is True
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
                 assert app.screen.has_class("-grid-view")
                 assert not app.screen.has_class("-list-view")
+                assert grid.display is True
+                assert table.display is False
+
+    async def test_v_toggle_after_bracket_nav_from_chat(self, _mock_resolve):
+        """Regression: the footer advertises `v` as the view toggle, and the
+        bead repro walks in via `]` from ChatScreen. Make sure the keystroke
+        dispatched through the real binding path actually flips the view.
+        """
+        from textual.widgets import DataTable
+
+        from lilbee.cli.tui.app import LilbeeApp
+        from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+        with _mock_catalog_deps(), _mock_remote_models():
+            app = LilbeeApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                # ChatScreen auto-focuses the insert-mode input; leave it
+                # before reaching for the screen-level nav keys.
+                await pilot.press("escape")
+                await pilot.press("right_square_bracket")
+                await pilot.pause()
+                assert isinstance(app.screen, CatalogScreen)
+                assert app.screen.has_class("-grid-view")
+
+                grid = app.screen.query_one("#catalog-grid")
+                table = app.screen.query_one("#catalog-table", DataTable)
+                assert grid.display is True
+                assert table.display is False
+
+                await pilot.press("v")
+                await pilot.pause()
+                assert app.screen.has_class("-list-view")
+                assert grid.display is False
+                assert table.display is True
 
     async def test_search_filters_cards_in_grid_view(self, _mock_resolve):
         """Type search text in grid view, verify cards filter by visibility."""
@@ -1107,7 +1155,7 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
 
                 table = app.screen.query_one("#catalog-table", DataTable)
@@ -1134,7 +1182,7 @@ class TestCatalogInteractions:
                 await pilot.pause()
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
                 await pilot.pause()
 
@@ -1162,7 +1210,7 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
 
                 app.screen.action_page_down()
@@ -1182,7 +1230,7 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
 
                 assert app.screen._sort_column == "Name"
@@ -1226,7 +1274,7 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
 
                 table = app.screen.query_one("#catalog-table", DataTable)
@@ -1250,7 +1298,7 @@ class TestCatalogInteractions:
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
                 app.screen.action_delete_model()
                 await pilot.pause()


### PR DESCRIPTION
## What was reported

QA reported that pressing `v` on the catalog screen did nothing. The `v` key should flip the catalog between the card grid and the detailed list view — that behaviour is advertised right there in the footer hint.

## What I found, and what changed

The key itself works correctly on release/next. The reported symptom was most likely a side-effect of the separate catalog freeze bug (fixed elsewhere), which locks out every keystroke once you hit a particular interaction sequence — including `v`.

The real problem was in the test suite: none of the catalog tests actually pressed `v`. They exercised the toggle by calling the underlying method directly, so the shortcut could have quietly broken at any time and every test would still have gone green. That's the gap that let this get reported in the first place.

Now every catalog toggle test genuinely presses `v`, including a new regression test that walks the exact path QA followed (Escape, `]`, `v`) and checks that the grid actually hides and the list actually appears. If someone accidentally rebinds, shadows, or breaks `v` on the catalog screen, CI will fail loudly on the next push.