### PR TITLE
Make the setup wizard share the catalog's compact card layout

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog.tcss
+++ b/src/lilbee/cli/tui/screens/catalog.tcss
@@ -61,48 +61,6 @@ GridSelect {
     }
 }
 
-ModelCard {
-    height: auto;
-    border: tall $surface-lighten-2;
-    padding: 0 1;
-    pointer: pointer;
-
-    &:hover {
-        background: $panel;
-    }
-
-    #card-header {
-        grid-size: 3 1;
-        grid-columns: 1fr auto auto;
-        height: auto;
-    }
-
-    #card-name {
-        text-style: bold;
-        text-wrap: nowrap;
-        text-overflow: ellipsis;
-    }
-
-    #card-pick {
-        width: auto;
-        margin: 0 1 0 0;
-    }
-
-    #card-task {
-        text-align: right;
-    }
-
-    #card-info {
-        text-style: dim;
-        text-wrap: nowrap;
-        text-overflow: ellipsis;
-    }
-
-    #card-status {
-        text-style: dim;
-    }
-}
-
 .grid-cta {
     text-align: center;
     text-style: bold;

--- a/src/lilbee/cli/tui/widgets/model_card.py
+++ b/src/lilbee/cli/tui/widgets/model_card.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
 
 from textual import containers, widgets
 from textual.app import ComposeResult
@@ -14,6 +15,8 @@ from lilbee.models import ModelTask
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.screens.catalog import TableRow
+
+_CSS_FILE = Path(__file__).parent / "model_card.tcss"
 
 MIDDLE_DOT = "·"
 
@@ -27,49 +30,11 @@ _TASK_COLORS: dict[str, str] = {
 class ModelCard(containers.VerticalGroup):
     """A single model card displaying name, task pill, specs, and status."""
 
-    DEFAULT_CSS = """
-    ModelCard {
-        height: auto;
-        border: tall $surface-lighten-2;
-        padding: 0 1;
-        pointer: pointer;
-
-        &:hover {
-            background: $panel;
-        }
-
-        #card-header {
-            grid-size: 3 1;
-            grid-columns: 1fr auto auto;
-            height: auto;
-        }
-
-        #card-name {
-            text-style: bold;
-            text-wrap: nowrap;
-            text-overflow: ellipsis;
-        }
-
-        #card-pick {
-            width: auto;
-            margin: 0 1 0 0;
-        }
-
-        #card-task {
-            text-align: right;
-        }
-
-        #card-info {
-            text-style: dim;
-            text-wrap: nowrap;
-            text-overflow: ellipsis;
-        }
-
-        #card-status {
-            text-style: dim;
-        }
-    }
-    """
+    # Widget CSS lives in model_card.tcss so it gets syntax highlighting and
+    # matches the convention used for screens. Textual's Widget class only
+    # supports DEFAULT_CSS (there is no widget-level CSS_PATH), so we load the
+    # file once at import time.
+    DEFAULT_CSS: ClassVar[str] = _CSS_FILE.read_text(encoding="utf-8")
 
     selected: reactive[bool] = reactive(False)
 

--- a/src/lilbee/cli/tui/widgets/model_card.py
+++ b/src/lilbee/cli/tui/widgets/model_card.py
@@ -27,6 +27,50 @@ _TASK_COLORS: dict[str, str] = {
 class ModelCard(containers.VerticalGroup):
     """A single model card displaying name, task pill, specs, and status."""
 
+    DEFAULT_CSS = """
+    ModelCard {
+        height: auto;
+        border: tall $surface-lighten-2;
+        padding: 0 1;
+        pointer: pointer;
+
+        &:hover {
+            background: $panel;
+        }
+
+        #card-header {
+            grid-size: 3 1;
+            grid-columns: 1fr auto auto;
+            height: auto;
+        }
+
+        #card-name {
+            text-style: bold;
+            text-wrap: nowrap;
+            text-overflow: ellipsis;
+        }
+
+        #card-pick {
+            width: auto;
+            margin: 0 1 0 0;
+        }
+
+        #card-task {
+            text-align: right;
+        }
+
+        #card-info {
+            text-style: dim;
+            text-wrap: nowrap;
+            text-overflow: ellipsis;
+        }
+
+        #card-status {
+            text-style: dim;
+        }
+    }
+    """
+
     selected: reactive[bool] = reactive(False)
 
     def __init__(self, row: TableRow) -> None:

--- a/src/lilbee/cli/tui/widgets/model_card.tcss
+++ b/src/lilbee/cli/tui/widgets/model_card.tcss
@@ -1,0 +1,41 @@
+ModelCard {
+    height: auto;
+    border: tall $surface-lighten-2;
+    padding: 0 1;
+    pointer: pointer;
+
+    &:hover {
+        background: $panel;
+    }
+
+    #card-header {
+        grid-size: 3 1;
+        grid-columns: 1fr auto auto;
+        height: auto;
+    }
+
+    #card-name {
+        text-style: bold;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    #card-pick {
+        width: auto;
+        margin: 0 1 0 0;
+    }
+
+    #card-task {
+        text-align: right;
+    }
+
+    #card-info {
+        text-style: dim;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    #card-status {
+        text-style: dim;
+    }
+}

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4732,6 +4732,32 @@ async def test_setup_wizard_mounts_with_recommendations():
             assert screen._selected_embed is not None
 
 
+async def test_setup_wizard_model_cards_render_compact():
+    """Wizard ModelCards render compact instead of stretching to fill the grid row.
+
+    Regression: setup.tcss had no ModelCard rules, so cards fell back to grid
+    defaults and rendered ~22 rows tall each, eating almost the whole viewport.
+    The base layout now lives in ModelCard.DEFAULT_CSS so both the setup wizard
+    and the catalog share it.
+    """
+    from lilbee.cli.tui.screens.setup import SetupWizard
+    from lilbee.cli.tui.widgets.model_card import ModelCard
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            cards = list(screen.query(ModelCard))
+            assert cards, "expected model cards in the wizard"
+            for card in cards:
+                assert card.size.height <= 6, (
+                    f"wizard ModelCard is {card.size.height} rows tall, "
+                    "expected compact layout (<=6 rows)"
+                )
+
+
 async def test_setup_wizard_select_chat_updates_slot():
     from lilbee.cli.tui.screens.setup import SetupWizard
     from lilbee.cli.tui.widgets.grid_select import GridSelect

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4733,13 +4733,7 @@ async def test_setup_wizard_mounts_with_recommendations():
 
 
 async def test_setup_wizard_model_cards_render_compact():
-    """Wizard ModelCards render compact instead of stretching to fill the grid row.
-
-    Regression: setup.tcss had no ModelCard rules, so cards fell back to grid
-    defaults and rendered ~22 rows tall each, eating almost the whole viewport.
-    The base layout now lives in ModelCard.DEFAULT_CSS so both the setup wizard
-    and the catalog share it.
-    """
+    """Wizard ModelCards render in the compact layout, not stretched to fill the grid."""
     from lilbee.cli.tui.screens.setup import SetupWizard
     from lilbee.cli.tui.widgets.model_card import ModelCard
 


### PR DESCRIPTION
The first-run setup wizard was hard to look at. Every model card stretched to roughly 22 rows tall in a 40-row terminal, so a single row of three cards ate almost the entire screen. You had to scroll past empty whitespace to see anything below the first section, even though each card only actually displays a name, a task pill, a specs line, and an optional status pill. The catalog screen shows the same cards in about four rows each, and the wizard should have looked the same.

Now the wizard's cards render at the same compact size as the catalog's cards, so all the model sections plus the Install/Browse/Skip buttons fit on one screen without scrolling. Both screens mount the same widget, so this also means any future tweak to the card layout only needs to happen in one place.