### PR TITLE
Shrink the setup wizard model cards so they fit on one screen

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog.tcss
+++ b/src/lilbee/cli/tui/screens/catalog.tcss
@@ -61,48 +61,6 @@ GridSelect {
     }
 }
 
-ModelCard {
-    height: auto;
-    border: tall $surface-lighten-2;
-    padding: 0 1;
-    pointer: pointer;
-
-    &:hover {
-        background: $panel;
-    }
-
-    #card-header {
-        grid-size: 3 1;
-        grid-columns: 1fr auto auto;
-        height: auto;
-    }
-
-    #card-name {
-        text-style: bold;
-        text-wrap: nowrap;
-        text-overflow: ellipsis;
-    }
-
-    #card-pick {
-        width: auto;
-        margin: 0 1 0 0;
-    }
-
-    #card-task {
-        text-align: right;
-    }
-
-    #card-info {
-        text-style: dim;
-        text-wrap: nowrap;
-        text-overflow: ellipsis;
-    }
-
-    #card-status {
-        text-style: dim;
-    }
-}
-
 .grid-cta {
     text-align: center;
     text-style: bold;

--- a/src/lilbee/cli/tui/widgets/model_card.py
+++ b/src/lilbee/cli/tui/widgets/model_card.py
@@ -27,6 +27,43 @@ _TASK_COLORS: dict[str, str] = {
 class ModelCard(containers.VerticalGroup):
     """A single model card displaying name, task pill, specs, and status."""
 
+    DEFAULT_CSS = """
+    ModelCard {
+        height: auto;
+        border: tall $surface-lighten-2;
+        padding: 0 1;
+        pointer: pointer;
+    }
+    ModelCard:hover {
+        background: $panel;
+    }
+    ModelCard #card-header {
+        grid-size: 3 1;
+        grid-columns: 1fr auto auto;
+        height: auto;
+    }
+    ModelCard #card-name {
+        text-style: bold;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+    ModelCard #card-pick {
+        width: auto;
+        margin: 0 1 0 0;
+    }
+    ModelCard #card-task {
+        text-align: right;
+    }
+    ModelCard #card-info {
+        text-style: dim;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+    ModelCard #card-status {
+        text-style: dim;
+    }
+    """
+
     selected: reactive[bool] = reactive(False)
 
     def __init__(self, row: TableRow) -> None:

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2290,6 +2290,33 @@ class TestSetupWizardGrid:
                 grids = app.screen.query(GridSelect)
                 assert len(grids) >= 1
 
+    async def test_setup_cards_are_compact(self, _mock_resolve):
+        """SetupWizard cards match the catalog's compact layout.
+
+        Regression guard: before the shared ModelCard stylesheet moved into
+        the widget itself, the wizard cards rendered at ~100+ rows tall
+        because setup.tcss did not reset ModelCard height, so a single row
+        of cards blew through the viewport.
+        """
+        from lilbee.cli.tui.screens.setup import SetupWizard
+        from lilbee.cli.tui.widgets.model_card import ModelCard
+
+        app = ChatTestApp()
+        async with app.run_test(size=(120, 67)) as pilot:
+            await pilot.pause()
+            with mock.patch(
+                "lilbee.cli.tui.screens.setup._scan_installed_models",
+                return_value=([], []),
+            ):
+                app.push_screen(SetupWizard())
+                await pilot.pause()
+                cards = app.screen.query(ModelCard)
+                assert len(cards) > 0
+                max_height = max(c.outer_size.height for c in cards)
+                # The catalog cards render at ~5 rows; give a small slack
+                # but fail loudly if something reintroduces the blow-up.
+                assert max_height <= 8, f"wizard cards are {max_height} rows tall"
+
     async def test_setup_step1_shows_chat_picks(self, _mock_resolve):
         """Setup shows 'Chat Models' heading."""
         from lilbee.cli.tui.screens.setup import SetupWizard


### PR DESCRIPTION
The first-run setup wizard rendered each model card at roughly 113 rows tall, so a single row of cards blew through the viewport. Picking a model meant scrolling through large empty boxes before you could see what was on offer.

The card layout now travels with the ModelCard widget itself instead of living in the catalog screen's stylesheet, so the wizard and the catalog both show the cards at their intended compact size.