### PR TITLE
feat: lilbee model CLI + MCP tools

### DIFF
--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -35,6 +35,10 @@ Add to your MCP client's MCP server configuration:
 | `lilbee_remove(names, delete_files)` | Remove documents from the index (optionally delete source files) | No |
 | `lilbee_list_documents()` | List all indexed documents with chunk counts | No |
 | `lilbee_reset()` | Delete all documents and data (factory reset) | No |
+| `lilbee_model_list(source, task)` | List installed models, optionally filtered by source or task | No |
+| `lilbee_model_show(model)` | Show catalog and installed metadata for a model ref | No |
+| `lilbee_model_pull(model, source)` | Download a model, streaming progress via MCP progress notifications | Yes (download) |
+| `lilbee_model_rm(model, source)` | Remove an installed model | No |
 
 ### Example responses
 

--- a/src/lilbee/cli/__init__.py
+++ b/src/lilbee/cli/__init__.py
@@ -14,6 +14,9 @@ from lilbee.cli.helpers import (
     perform_reset,
     sync_result_to_json,
 )
+from lilbee.cli.model import model_app
+
+app.add_typer(model_app)
 
 __all__ = [
     "CHUNK_PREVIEW_LEN",

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -107,6 +107,17 @@ class ListModelsResult(BaseModel):
     models: list[ModelEntry]
     total: int
 
+    def __rich__(self) -> Table:
+        table = Table(title="Installed models")
+        table.add_column("Name", style=theme.ACCENT)
+        table.add_column("Source", style=theme.MUTED)
+        table.add_column("Task")
+        table.add_column("Size", justify="right")
+        for entry in self.models:
+            size = f"{entry.size_gb:.2f} GB" if entry.size_gb is not None else ""
+            table.add_row(entry.name, entry.source, entry.task or "", size)
+        return table
+
 
 class CatalogEntryData(BaseModel):
     name: str
@@ -170,6 +181,28 @@ class ShowModelResult(BaseModel):
     source: str | None = None
     path: str | None = None
     manifest: ManifestData | None = None
+
+    def __rich__(self) -> str:
+        lines = [f"[{theme.ACCENT}]{self.model}[/{theme.ACCENT}]"]
+        if self.catalog is not None:
+            lines.extend(
+                [
+                    f"  display_name: {self.catalog.display_name}",
+                    f"  task:         {self.catalog.task}",
+                    f"  size_gb:      {self.catalog.size_gb}",
+                    f"  min_ram_gb:   {self.catalog.min_ram_gb}",
+                    f"  hf_repo:      {self.catalog.hf_repo}",
+                    f"  description:  {self.catalog.description}",
+                ]
+            )
+        lines.append(f"  installed:    {self.installed}")
+        if self.source:
+            lines.append(f"  source:       {self.source}")
+        if self.path:
+            lines.append(f"  path:         {self.path}")
+        if self.manifest is not None:
+            lines.append(f"  downloaded:   {self.manifest.downloaded_at}")
+        return "\n".join(lines)
 
 
 class PullResult(BaseModel):
@@ -357,37 +390,6 @@ def remove_model_data(
     )
 
 
-def _render_list_table(models: list[ModelEntry]) -> None:
-    table = Table(title="Installed models")
-    table.add_column("Name", style=theme.ACCENT)
-    table.add_column("Source", style=theme.MUTED)
-    table.add_column("Task")
-    table.add_column("Size", justify="right")
-    for entry in models:
-        size = f"{entry.size_gb:.2f} GB" if entry.size_gb is not None else ""
-        table.add_row(entry.name, entry.source, entry.task or "", size)
-    console.print(table)
-
-
-def _render_show_human(ref: str, data: ShowModelResult) -> None:
-    console.print(f"[{theme.ACCENT}]{ref}[/{theme.ACCENT}]")
-    cat = data.catalog
-    if cat is not None:
-        console.print(f"  display_name: {cat.display_name}")
-        console.print(f"  task:         {cat.task}")
-        console.print(f"  size_gb:      {cat.size_gb}")
-        console.print(f"  min_ram_gb:   {cat.min_ram_gb}")
-        console.print(f"  hf_repo:      {cat.hf_repo}")
-        console.print(f"  description:  {cat.description}")
-    console.print(f"  installed:    {data.installed}")
-    if data.source:
-        console.print(f"  source:       {data.source}")
-    if data.path:
-        console.print(f"  path:         {data.path}")
-    if data.manifest is not None:
-        console.print(f"  downloaded:   {data.manifest.downloaded_at}")
-
-
 model_app = typer.Typer(
     name="model",
     help="Manage installed and available models (pull / list / show / rm / browse).",
@@ -440,7 +442,7 @@ def list_cmd(
     if not data.models:
         console.print("No models installed.")
         return
-    _render_list_table(data.models)
+    console.print(data)
 
 
 @model_app.command("show")
@@ -464,7 +466,7 @@ def show_cmd(
     if cfg.json_mode:
         json_output(data.model_dump())
         return
-    _render_show_human(ref, data)
+    console.print(data)
 
 
 def _run_pull(

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -1,0 +1,612 @@
+"""`lilbee model` sub-app: list/show/pull/rm/browse for installed models.
+
+Thin CLI and shared data helpers over
+:class:`lilbee.model_manager.ModelManager`. The ``*_data`` functions
+return Pydantic models so MCP tools and CLI commands share a single,
+typed implementation.
+
+Heavy imports (:mod:`lilbee.catalog`, :mod:`lilbee.model_manager`,
+:mod:`lilbee.registry`, :mod:`lilbee.cli.tui`) are deferred to function
+bodies so importing this module at CLI startup stays cheap.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import typer
+from pydantic import BaseModel, Field
+from rich.console import Console
+from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
+from rich.table import Table
+
+from lilbee.cli import theme
+from lilbee.cli.app import (
+    apply_overrides,
+    console,
+    data_dir_option,
+    global_option,
+)
+from lilbee.cli.helpers import json_output
+from lilbee.config import cfg
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from lilbee.catalog import CatalogModel, DownloadProgress
+    from lilbee.model_manager import ModelSource, RemoteModel
+    from lilbee.registry import ModelManifest
+
+
+_BYTES_PER_GB = 1024**3  # Model sizes are reported to users in GiB.
+_LITELLM_LIST_TIMEOUT_S = 2.0  # Keep `model list` snappy when backend is down.
+
+
+def _bytes_to_gb(n: int) -> float:
+    """Convert bytes to GiB rounded to 2 decimals for user display."""
+    return round(n / _BYTES_PER_GB, 2)
+
+
+class ModelCommand(StrEnum):
+    """Command field values for model sub-app JSON output."""
+
+    LIST = "model list"
+    SHOW = "model show"
+    PULL = "model pull"
+    RM = "model rm"
+
+
+class PullStatus(StrEnum):
+    OK = "ok"
+    ALREADY_INSTALLED = "already_installed"
+
+
+class PullEvent(StrEnum):
+    PROGRESS = "progress"
+    DONE = "done"
+
+
+class ModelEntry(BaseModel):
+    """One row of `lilbee model list` output."""
+
+    name: str
+    source: str
+    task: str | None = None
+    size_gb: float | None = None
+    display_name: str = ""
+
+    @classmethod
+    def from_native(cls, ref: str, manifest: ModelManifest | None) -> ModelEntry:
+        from lilbee.model_manager import ModelSource
+
+        return cls(
+            name=ref,
+            source=ModelSource.NATIVE.value,
+            task=manifest.task if manifest else None,
+            size_gb=_bytes_to_gb(manifest.size_bytes) if manifest else None,
+            display_name=manifest.display_name if manifest else "",
+        )
+
+    @classmethod
+    def from_litellm(cls, ref: str, remote: RemoteModel | None) -> ModelEntry:
+        from lilbee.model_manager import ModelSource
+
+        return cls(
+            name=ref,
+            source=ModelSource.LITELLM.value,
+            task=remote.task if remote else None,
+            size_gb=None,
+            display_name=remote.parameter_size if remote else "",
+        )
+
+
+class ListModelsResult(BaseModel):
+    command: str = ModelCommand.LIST
+    models: list[ModelEntry]
+    total: int
+
+
+class CatalogEntryData(BaseModel):
+    name: str
+    tag: str
+    ref: str
+    display_name: str
+    hf_repo: str
+    size_gb: float
+    min_ram_gb: float
+    description: str
+    task: str
+    featured: bool
+    recommended: bool
+
+    @classmethod
+    def from_catalog_model(cls, entry: CatalogModel) -> CatalogEntryData:
+        return cls(
+            name=entry.name,
+            tag=entry.tag,
+            ref=entry.ref,
+            display_name=entry.display_name,
+            hf_repo=entry.hf_repo,
+            size_gb=entry.size_gb,
+            min_ram_gb=entry.min_ram_gb,
+            description=entry.description,
+            task=entry.task,
+            featured=entry.featured,
+            recommended=entry.recommended,
+        )
+
+
+class ManifestData(BaseModel):
+    name: str
+    display_name: str
+    task: str
+    size_gb: float
+    size_bytes: int
+    source_repo: str
+    source_filename: str
+    downloaded_at: str
+
+    @classmethod
+    def from_manifest(cls, manifest: ModelManifest) -> ManifestData:
+        return cls(
+            name=f"{manifest.name}:{manifest.tag}",
+            display_name=manifest.display_name,
+            task=manifest.task,
+            size_gb=_bytes_to_gb(manifest.size_bytes),
+            size_bytes=manifest.size_bytes,
+            source_repo=manifest.source_repo,
+            source_filename=manifest.source_filename,
+            downloaded_at=manifest.downloaded_at,
+        )
+
+
+class ShowModelResult(BaseModel):
+    command: str = ModelCommand.SHOW
+    model: str
+    catalog: CatalogEntryData | None = None
+    installed: bool = False
+    source: str | None = None
+    path: str | None = None
+    manifest: ManifestData | None = None
+
+
+class PullResult(BaseModel):
+    command: str = ModelCommand.PULL
+    model: str
+    source: str
+    status: str
+    path: str | None = None
+
+
+class PullProgressEvent(BaseModel):
+    command: str = ModelCommand.PULL
+    event: str = PullEvent.PROGRESS
+    model: str
+    percent: int
+    detail: str
+    cache_hit: bool
+
+
+class RemoveResult(BaseModel):
+    command: str = ModelCommand.RM
+    model: str
+    deleted: bool
+    freed_gb: float = Field(default=0.0)
+
+
+def _native_manifest_index() -> dict[str, ModelManifest]:
+    """Map 'name:tag' to manifest for every installed native model."""
+    from lilbee.registry import ModelRegistry
+
+    registry = ModelRegistry(cfg.models_dir)
+    return {f"{m.name}:{m.tag}": m for m in registry.list_installed()}
+
+
+def _resolve_native_path(ref: str) -> str | None:
+    """Return the on-disk path of an installed native model, if resolvable.
+
+    Swallows ``KeyError`` (manifest present but blob missing) and
+    ``ValueError`` (malformed ref) so callers can treat the path as
+    optional metadata.
+    """
+    from lilbee.registry import ModelRegistry
+
+    try:
+        return str(ModelRegistry(cfg.models_dir).resolve(ref))
+    except (KeyError, ValueError):
+        return None
+
+
+def _collect_native_entries() -> list[ModelEntry]:
+    from lilbee.model_manager import ModelSource, get_model_manager
+
+    manifests = _native_manifest_index()
+    refs = get_model_manager().list_installed(source=ModelSource.NATIVE)
+    return [ModelEntry.from_native(ref, manifests.get(ref)) for ref in refs]
+
+
+def _collect_litellm_entries() -> list[ModelEntry]:
+    from lilbee.model_manager import classify_remote_models
+
+    remote_list = classify_remote_models(cfg.litellm_base_url, timeout=_LITELLM_LIST_TIMEOUT_S)
+    remote_by_name = {rm.name: rm for rm in remote_list}
+    return [ModelEntry.from_litellm(ref, remote_by_name[ref]) for ref in sorted(remote_by_name)]
+
+
+def list_models_data(
+    source: ModelSource | None = None,
+    task: str | None = None,
+) -> ListModelsResult:
+    """Build the list of installed models with source and task metadata.
+
+    Discovers remote (litellm) models via a single HTTP call with a
+    short timeout so the command stays responsive when the backend is
+    down.
+    """
+    from lilbee.model_manager import ModelSource
+
+    entries: list[ModelEntry] = []
+    if source is None or source is ModelSource.NATIVE:
+        entries.extend(_collect_native_entries())
+    if source is None or source is ModelSource.LITELLM:
+        entries.extend(_collect_litellm_entries())
+    if task:
+        entries = [e for e in entries if e.task == task]
+    return ListModelsResult(models=entries, total=len(entries))
+
+
+def show_model_data(ref: str) -> ShowModelResult:
+    """Return catalog and install metadata for *ref*.
+
+    Raises :class:`~lilbee.model_manager.ModelNotFoundError` if the ref
+    is unknown to both the catalog and the installed set.
+    """
+    from lilbee.catalog import find_catalog_entry
+    from lilbee.model_manager import ModelNotFoundError, get_model_manager
+
+    entry = find_catalog_entry(ref)
+    source = get_model_manager().get_source(ref)
+    if entry is None and source is None:
+        raise ModelNotFoundError(f"model not found: {ref}")
+    manifest = _native_manifest_index().get(ref)
+    return ShowModelResult(
+        model=ref,
+        catalog=CatalogEntryData.from_catalog_model(entry) if entry else None,
+        installed=source is not None,
+        source=source.value if source else None,
+        manifest=ManifestData.from_manifest(manifest) if manifest else None,
+        path=_resolve_native_path(ref) if manifest is not None else None,
+    )
+
+
+def _litellm_event_to_progress(
+    on_update: Callable[[DownloadProgress], None],
+    event: dict[str, Any],
+) -> None:
+    """Adapt an Ollama-style dict event into a DownloadProgress call."""
+    from lilbee.catalog import DownloadProgress
+
+    total = event.get("total", 0) or 0
+    completed = event.get("completed", 0) or 0
+    detail = event.get("status", "") or ""
+    pct = int(completed * 100 / total) if total > 0 else 0
+    on_update(DownloadProgress(percent=pct, detail=detail, is_cache_hit=False))
+
+
+def _build_pull_callbacks(
+    on_update: Callable[[DownloadProgress], None] | None,
+) -> tuple[Callable[[dict[str, Any]], None] | None, Callable[[int, int], None] | None]:
+    """Build the (dict_cb, bytes_cb) pair for ModelManager.pull from on_update."""
+    import functools
+
+    from lilbee.catalog import make_download_callback
+
+    if on_update is None:
+        return None, None
+    dict_cb = functools.partial(_litellm_event_to_progress, on_update)
+    bytes_cb = make_download_callback(on_update)
+    return dict_cb, bytes_cb
+
+
+def pull_model_data(
+    ref: str,
+    source: ModelSource,
+    *,
+    on_update: Callable[[DownloadProgress], None] | None = None,
+) -> PullResult:
+    """Pull *ref* from *source* and return a typed result.
+
+    Progress updates are throttled by
+    :func:`~lilbee.catalog.make_download_callback`, so callers see at
+    most roughly 10 Hz of progress events.
+    """
+    from lilbee.model_manager import get_model_manager
+
+    manager = get_model_manager()
+
+    if manager.is_installed(ref, source):
+        return PullResult(model=ref, source=source.value, status=PullStatus.ALREADY_INSTALLED)
+
+    dict_cb, bytes_cb = _build_pull_callbacks(on_update)
+    path = manager.pull(ref, source, on_progress=dict_cb, on_bytes=bytes_cb)
+    return PullResult(
+        model=ref,
+        source=source.value,
+        status=PullStatus.OK,
+        path=str(path) if path is not None else None,
+    )
+
+
+def remove_model_data(
+    ref: str,
+    source: ModelSource | None = None,
+) -> RemoveResult:
+    """Remove *ref* and return a typed result with freed size."""
+    from lilbee.model_manager import get_model_manager
+
+    manager = get_model_manager()
+    manifests = _native_manifest_index()
+    size_bytes = manifests[ref].size_bytes if ref in manifests else 0
+    removed = manager.remove(ref, source=source)
+    return RemoveResult(
+        model=ref,
+        deleted=removed,
+        freed_gb=_bytes_to_gb(size_bytes),
+    )
+
+
+def _render_list_table(models: list[ModelEntry]) -> None:
+    table = Table(title="Installed models")
+    table.add_column("Name", style=theme.ACCENT)
+    table.add_column("Source", style=theme.MUTED)
+    table.add_column("Task")
+    table.add_column("Size", justify="right")
+    for entry in models:
+        size = f"{entry.size_gb:.2f} GB" if entry.size_gb is not None else ""
+        table.add_row(entry.name, entry.source, entry.task or "", size)
+    console.print(table)
+
+
+def _render_show_human(ref: str, data: ShowModelResult) -> None:
+    console.print(f"[{theme.ACCENT}]{ref}[/{theme.ACCENT}]")
+    cat = data.catalog
+    if cat is not None:
+        console.print(f"  display_name: {cat.display_name}")
+        console.print(f"  task:         {cat.task}")
+        console.print(f"  size_gb:      {cat.size_gb}")
+        console.print(f"  min_ram_gb:   {cat.min_ram_gb}")
+        console.print(f"  hf_repo:      {cat.hf_repo}")
+        console.print(f"  description:  {cat.description}")
+    console.print(f"  installed:    {data.installed}")
+    if data.source:
+        console.print(f"  source:       {data.source}")
+    if data.path:
+        console.print(f"  path:         {data.path}")
+    if data.manifest is not None:
+        console.print(f"  downloaded:   {data.manifest.downloaded_at}")
+
+
+model_app = typer.Typer(
+    name="model",
+    help="Manage installed and available models (pull / list / show / rm / browse).",
+    no_args_is_help=True,
+)
+
+_source_option = typer.Option(
+    None,
+    "--source",
+    "-s",
+    help="Filter by source: 'native' or 'litellm' (default: all).",
+)
+_task_option = typer.Option(
+    None,
+    "--task",
+    "-t",
+    help="Filter by task: 'chat', 'embedding', or 'vision'.",
+)
+_yes_option = typer.Option(
+    False,
+    "--yes",
+    "-y",
+    help="Skip confirmation prompt.",
+)
+
+
+def _parse_source_or_bad_param(value: str | None) -> ModelSource | None:
+    """Parse a CLI --source value, raising typer.BadParameter on bad input."""
+    from lilbee.model_manager import ModelSource
+
+    try:
+        return ModelSource.parse(value)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+@model_app.command("list")
+def list_cmd(
+    source: str | None = _source_option,
+    task: str | None = _task_option,
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """List installed models across all sources."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    data = list_models_data(source=_parse_source_or_bad_param(source), task=task)
+    if cfg.json_mode:
+        json_output(data.model_dump())
+        return
+    if not data.models:
+        console.print("No models installed.")
+        return
+    _render_list_table(data.models)
+
+
+@model_app.command("show")
+def show_cmd(
+    ref: str = typer.Argument(..., help="Model ref (e.g. 'qwen3:0.6b')."),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Show catalog and installed metadata for a model."""
+    from lilbee.model_manager import ModelNotFoundError
+
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    try:
+        data = show_model_data(ref)
+    except ModelNotFoundError as exc:
+        if cfg.json_mode:
+            json_output({"error": str(exc)})
+        else:
+            console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(1) from None
+    if cfg.json_mode:
+        json_output(data.model_dump())
+        return
+    _render_show_human(ref, data)
+
+
+def _run_pull(
+    ref: str,
+    src: ModelSource,
+    on_update: Callable[[DownloadProgress], None],
+) -> PullResult:
+    """Invoke ``pull_model_data`` and translate known errors to typer.Exit."""
+    try:
+        return pull_model_data(ref, src, on_update=on_update)
+    except (RuntimeError, PermissionError) as exc:
+        if cfg.json_mode:
+            json_output({"error": str(exc)})
+        else:
+            console.print(f"[{theme.ERROR}]Error:[/{theme.ERROR}] {exc}")
+        raise typer.Exit(1) from None
+
+
+def _pull_json_stream(ref: str, src: ModelSource) -> None:
+    """Emit newline-delimited JSON progress events, then the final result."""
+
+    def on_update(p: DownloadProgress) -> None:
+        event = PullProgressEvent(
+            model=ref, percent=p.percent, detail=p.detail, cache_hit=p.is_cache_hit
+        )
+        json_output(event.model_dump())
+
+    final = _run_pull(ref, src, on_update)
+    json_output({**final.model_dump(), "event": PullEvent.DONE.value})
+
+
+def _pull_rich_progress(ref: str, src: ModelSource) -> None:
+    """Drive a Rich progress bar during a native HuggingFace download."""
+    err_console = Console(stderr=True)
+    with Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("{task.percentage:>3.0f}%"),
+        TextColumn("{task.fields[detail]}"),
+        TimeRemainingColumn(),
+        console=err_console,
+        transient=False,
+    ) as progress:
+        task_id = progress.add_task(f"Downloading {ref}", total=100, detail="")
+
+        def on_update(p: DownloadProgress) -> None:
+            progress.update(task_id, completed=p.percent, detail=p.detail)
+
+        final = _run_pull(ref, src, on_update)
+
+    if final.status == PullStatus.ALREADY_INSTALLED:
+        console.print(f"{ref} is already installed.")
+    else:
+        console.print(f"Pulled [{theme.ACCENT}]{ref}[/{theme.ACCENT}].")
+
+
+@model_app.command("pull")
+def pull_cmd(
+    ref: str = typer.Argument(..., help="Model ref to download (e.g. 'qwen3:0.6b')."),
+    source: str = typer.Option(
+        "native",
+        "--source",
+        "-s",
+        help="Pull from 'native' (HuggingFace GGUF) or 'litellm' (remote backend).",
+    ),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Download a model."""
+    from lilbee.model_manager import ModelSource
+
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    src = _parse_source_or_bad_param(source) or ModelSource.NATIVE
+    if cfg.json_mode:
+        _pull_json_stream(ref, src)
+    else:
+        _pull_rich_progress(ref, src)
+
+
+def _confirm_remove_or_exit(ref: str, yes: bool) -> None:
+    if yes or cfg.json_mode:
+        return
+    if not typer.confirm(f"Remove {ref}?", default=False):
+        console.print("Aborted.")
+        raise typer.Exit(0)
+
+
+@model_app.command("rm")
+def rm_cmd(
+    ref: str = typer.Argument(..., help="Model ref to remove."),
+    source: str | None = _source_option,
+    yes: bool = _yes_option,
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Remove an installed model."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    src = _parse_source_or_bad_param(source)
+    _confirm_remove_or_exit(ref, yes)
+    data = remove_model_data(ref, source=src)
+    if cfg.json_mode:
+        json_output(data.model_dump())
+        return
+    if not data.deleted:
+        console.print(f"[{theme.WARNING}]Not found: {ref}[/{theme.WARNING}]")
+        raise typer.Exit(1)
+    suffix = f" ({data.freed_gb:.2f} GB freed)" if data.freed_gb else ""
+    console.print(f"Removed [{theme.ACCENT}]{ref}[/{theme.ACCENT}]{suffix}.")
+
+
+def _is_interactive_terminal() -> bool:
+    """Return True when both stdin and stdout are connected to a TTY.
+
+    Extracted as a module-level helper so tests can patch it deterministically;
+    CliRunner replaces ``sys.stdin`` during invoke which makes direct
+    monkey-patching of ``sys.stdin.isatty`` unreliable.
+    """
+    import sys
+
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+@model_app.command("browse")
+def browse_cmd(
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Open the Textual TUI directly on the model catalog screen.
+
+    Exit codes follow the project convention: 2 for invalid flag
+    combinations (``--json`` with an interactive-only command), 1 for
+    runtime environment failures (no TTY).
+    """
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    if cfg.json_mode:
+        json_output({"error": "model browse is interactive, not available in --json mode"})
+        raise typer.Exit(2)
+    if not _is_interactive_terminal():
+        console.print(f"[{theme.ERROR}]Error:[/{theme.ERROR}] model browse requires a terminal.")
+        raise typer.Exit(1)
+
+    # Browsing the catalog does not depend on documents, so skip auto-sync.
+    from lilbee.cli.tui import run_tui
+
+    run_tui(auto_sync=False, initial_view="Catalog")

--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -6,13 +6,17 @@ from lilbee.cli.sync import shutdown_executor
 from lilbee.services import reset_services
 
 
-def run_tui(*, auto_sync: bool = False) -> None:
-    """Launch the full-screen Textual TUI."""
+def run_tui(*, auto_sync: bool = False, initial_view: str | None = None) -> None:
+    """Launch the full-screen Textual TUI.
+
+    *initial_view* deep-links to a named view (e.g. ``"Catalog"``) after
+    the default chat screen is mounted. Used by ``lilbee model browse``.
+    """
     import os
 
     from lilbee.cli.tui.app import LilbeeApp
 
-    app = LilbeeApp(auto_sync=auto_sync)
+    app = LilbeeApp(auto_sync=auto_sync, initial_view=initial_view)
     try:
         app.run()
     except KeyboardInterrupt:

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -103,9 +103,10 @@ class LilbeeApp(App[None]):
         Binding("ctrl+c", "quit", "Quit", show=True, priority=True),
     ]
 
-    def __init__(self, *, auto_sync: bool = False) -> None:
+    def __init__(self, *, auto_sync: bool = False, initial_view: str | None = None) -> None:
         super().__init__()
         self._auto_sync = auto_sync
+        self._initial_view = initial_view
         self.active_view = msg.DEFAULT_VIEW
         self._theme_index = 0
         self.last_quit_time: float = 0.0
@@ -126,6 +127,8 @@ class LilbeeApp(App[None]):
         from lilbee.cli.tui.screens.chat import ChatScreen
 
         self.push_screen(ChatScreen(auto_sync=self._auto_sync))
+        if self._initial_view and self._initial_view != msg.DEFAULT_VIEW:
+            self.switch_view(self._initial_view)
 
     def action_cycle_theme(self) -> None:
         self._theme_index = (self._theme_index + 1) % len(DARK_THEMES)

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 
 from lilbee.config import cfg
 from lilbee.crawl_task import get_task, start_crawl
@@ -15,6 +18,8 @@ from lilbee.services import get_services
 
 if TYPE_CHECKING:
     from lilbee.store import SearchChunk
+
+log = logging.getLogger(__name__)
 
 mcp = FastMCP("lilbee", instructions="Local RAG knowledge base. Search indexed documents.")
 
@@ -351,6 +356,105 @@ def lilbee_wiki_prune() -> dict[str, Any]:
         "archived": report.archived_count,
         "flagged": report.flagged_count,
     }
+
+
+@mcp.tool()
+def lilbee_model_list(source: str = "", task: str = "") -> dict[str, Any]:
+    """List installed models across native and litellm sources.
+
+    Args:
+        source: Filter by source: "native", "litellm", or "" for all.
+        task: Filter by task: "chat", "embedding", "vision", or "" for all.
+    """
+    from lilbee.cli.model import list_models_data
+    from lilbee.model_manager import ModelSource
+
+    try:
+        src = ModelSource.parse(source)
+    except ValueError as exc:
+        return {"error": str(exc)}
+    return list_models_data(source=src, task=task or None).model_dump()
+
+
+@mcp.tool()
+def lilbee_model_show(model: str) -> dict[str, Any]:
+    """Show catalog and installed metadata for a model ref (e.g. 'qwen3:0.6b')."""
+    from lilbee.cli.model import show_model_data
+    from lilbee.model_manager import ModelNotFoundError
+
+    try:
+        return show_model_data(model).model_dump()
+    except ModelNotFoundError as exc:
+        return {"error": str(exc)}
+
+
+def _log_progress_failure(future: concurrent.futures.Future[None]) -> None:
+    """Log report_progress failures without raising.
+
+    Progress notifications are best-effort: a failure should not abort
+    an in-flight pull.
+    """
+    try:
+        future.result()
+    except Exception:
+        log.warning("MCP report_progress failed", exc_info=True)
+
+
+@mcp.tool()
+async def lilbee_model_pull(
+    model: str,
+    source: str = "native",
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """Download a model, streaming progress via MCP notifications.
+
+    Args:
+        model: Model ref to pull (e.g. "qwen3:0.6b").
+        source: "native" (HuggingFace GGUF) or "litellm" (remote backend).
+    """
+    from lilbee.catalog import DownloadProgress
+    from lilbee.cli.model import pull_model_data
+    from lilbee.model_manager import ModelSource
+
+    try:
+        src = ModelSource.parse(source) or ModelSource.NATIVE
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    loop = asyncio.get_running_loop()
+
+    def on_update(p: DownloadProgress) -> None:
+        if ctx is None:
+            return
+        future = asyncio.run_coroutine_threadsafe(
+            ctx.report_progress(progress=float(p.percent), total=100.0, message=p.detail),
+            loop,
+        )
+        future.add_done_callback(_log_progress_failure)
+
+    try:
+        result = await asyncio.to_thread(pull_model_data, model, src, on_update=on_update)
+    except (RuntimeError, PermissionError) as exc:
+        return {"error": str(exc)}
+    return result.model_dump()
+
+
+@mcp.tool()
+def lilbee_model_rm(model: str, source: str = "") -> dict[str, Any]:
+    """Remove an installed model.
+
+    Args:
+        model: Model ref to remove.
+        source: Restrict to "native" or "litellm"; empty = both.
+    """
+    from lilbee.cli.model import remove_model_data
+    from lilbee.model_manager import ModelSource
+
+    try:
+        src = ModelSource.parse(source)
+    except ValueError as exc:
+        return {"error": str(exc)}
+    return remove_model_data(model, source=src).model_dump()
 
 
 def clean(result: SearchChunk) -> dict[str, object]:

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -24,6 +24,29 @@ class ModelSource(Enum):
     NATIVE = "native"  # lilbee's GGUF files in cfg.models_dir
     LITELLM = "litellm"  # Models managed by an external backend
 
+    @classmethod
+    def parse(cls, value: str | None) -> "ModelSource | None":
+        """Parse a user-supplied source string. Empty or None means 'all'.
+
+        Raises ValueError on any other non-empty input so callers get a
+        consistent error type regardless of entry point (CLI, MCP, server).
+        """
+        if value is None or value == "":
+            return None
+        try:
+            return cls(value)
+        except ValueError as exc:
+            valid = ", ".join(s.value for s in cls)
+            raise ValueError(f"invalid source {value!r}; expected one of: {valid}") from exc
+
+
+class ModelNotFoundError(RuntimeError):
+    """Raised when a model ref is not found in any source or the catalog.
+
+    Subclasses RuntimeError so pre-existing `except RuntimeError` call
+    sites still catch it.
+    """
+
 
 class ModelManager:
     """Manages model lifecycle with distinct sources."""
@@ -99,23 +122,35 @@ class ModelManager:
         source: ModelSource,
         *,
         on_progress: Callable[[dict], None] | None = None,
+        on_bytes: Callable[[int, int], None] | None = None,
     ) -> Path | None:
         """Pull/download model to specified source.
+
         Returns the Path for native downloads, None for litellm-backed pulls.
+
+        *on_progress* receives dict events from the litellm backend.
+        *on_bytes* receives (downloaded_bytes, total_bytes) from native
+        HuggingFace downloads. The two sources report progress in different
+        shapes, so callers pass whichever matches the chosen source.
         """
         if source is ModelSource.NATIVE:
-            return self._pull_native(model)
+            return self._pull_native(model, on_bytes=on_bytes)
         self._pull_litellm(model, on_progress=on_progress)
         return None
 
-    def _pull_native(self, model: str) -> Path:
+    def _pull_native(
+        self,
+        model: str,
+        *,
+        on_bytes: Callable[[int, int], None] | None = None,
+    ) -> Path:
         """Download model to the native GGUF directory via catalog."""
         from lilbee.catalog import download_model, find_catalog_entry
 
         entry = find_catalog_entry(model)
         if entry is None:
-            raise RuntimeError(f"Model '{model}' not found in catalog")
-        path = download_model(entry)
+            raise ModelNotFoundError(f"Model '{model}' not found in catalog")
+        path = download_model(entry, on_progress=on_bytes)
         log.info("Downloaded %s to %s", model, path)
         return path
 
@@ -235,13 +270,23 @@ def _classify_remote_task(name: str, family: str) -> str:
     return ModelTask.CHAT
 
 
-def classify_remote_models(base_url: str = "http://localhost:11434") -> list[RemoteModel]:
+_CLASSIFY_DEFAULT_TIMEOUT_S = 5.0
+
+
+def classify_remote_models(
+    base_url: str = "http://localhost:11434",
+    *,
+    timeout: float = _CLASSIFY_DEFAULT_TIMEOUT_S,
+) -> list[RemoteModel]:
     """Discover and classify all models from the litellm backend by task.
-    Uses /api/tags family metadata for embedding detection and
-    name patterns for vision detection.
+
+    Uses /api/tags family metadata for embedding detection and name
+    patterns for vision detection. Returns an empty list on any error
+    (including timeout) so callers in read-only code paths can stay
+    responsive when the backend is down.
     """
     try:
-        resp = httpx.get(f"{base_url}/api/tags", timeout=5.0)
+        resp = httpx.get(f"{base_url}/api/tags", timeout=timeout)
         resp.raise_for_status()
         raw_models = resp.json().get("models", [])
     except Exception:

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -1,0 +1,542 @@
+"""Tests for the `lilbee model` CLI sub-app and its typed data helpers."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from lilbee.cli import app
+from lilbee.cli import model as model_mod
+from lilbee.cli.model import (
+    CatalogEntryData,
+    ListModelsResult,
+    ManifestData,
+    ModelEntry,
+    PullEvent,
+    PullResult,
+    PullStatus,
+    RemoveResult,
+    ShowModelResult,
+)
+from lilbee.model_manager import ModelNotFoundError, ModelSource
+from lilbee.registry import ModelManifest
+
+runner = CliRunner()
+
+
+def _manifest(name: str, tag: str, *, size: int, task: str) -> ModelManifest:
+    return ModelManifest(
+        name=name,
+        tag=tag,
+        size_bytes=size,
+        task=task,
+        source_repo=f"org/{name}-GGUF",
+        source_filename=f"{name}.gguf",
+        downloaded_at="2026-04-11T00:00:00+00:00",
+        display_name=f"{name} {tag}",
+    )
+
+
+def _remote(name: str, task: str, parameter_size: str = "8B") -> MagicMock:
+    rm = MagicMock()
+    rm.name = name
+    rm.task = task
+    rm.parameter_size = parameter_size
+    return rm
+
+
+def _catalog_model(*, name: str = "qwen3", tag: str = "0.6b", task: str = "chat") -> MagicMock:
+    entry = MagicMock()
+    entry.name = name
+    entry.tag = tag
+    entry.ref = f"{name}:{tag}"
+    entry.display_name = f"Qwen3 {tag.upper()}"
+    entry.hf_repo = f"Qwen/Qwen3-{tag.upper()}-GGUF"
+    entry.size_gb = 0.5
+    entry.min_ram_gb = 2.0
+    entry.description = "Tiny chat model"
+    entry.task = task
+    entry.featured = True
+    entry.recommended = True
+    return entry
+
+
+class _FakeManager:
+    """Minimal ModelManager test double with recorded call sites."""
+
+    def __init__(
+        self,
+        *,
+        native: list[str] | None = None,
+        litellm: list[str] | None = None,
+    ) -> None:
+        self._native = list(native or [])
+        self._litellm = list(litellm or [])
+        self.pull_calls: list[tuple[str, ModelSource]] = []
+        self.remove_calls: list[tuple[str, ModelSource | None]] = []
+
+    def list_installed(self, source: ModelSource | None = None) -> list[str]:
+        if source is None:
+            return sorted({*self._native, *self._litellm})
+        if source is ModelSource.NATIVE:
+            return list(self._native)
+        return list(self._litellm)
+
+    def is_installed(self, model: str, source: ModelSource | None = None) -> bool:
+        if source is None:
+            return model in self._native or model in self._litellm
+        if source is ModelSource.NATIVE:
+            return model in self._native
+        return model in self._litellm
+
+    def get_source(self, model: str) -> ModelSource | None:
+        if model in self._native:
+            return ModelSource.NATIVE
+        if model in self._litellm:
+            return ModelSource.LITELLM
+        return None
+
+    def pull(self, model, source, *, on_progress=None, on_bytes=None):
+        self.pull_calls.append((model, source))
+        if on_bytes is not None:
+            on_bytes(50, 100)
+        return f"/fake/{model}.gguf"
+
+    def remove(self, model, source=None) -> bool:
+        self.remove_calls.append((model, source))
+        if (source is ModelSource.NATIVE or source is None) and model in self._native:
+            self._native.remove(model)
+            return True
+        if (source is ModelSource.LITELLM or source is None) and model in self._litellm:
+            self._litellm.remove(model)
+            return True
+        return False
+
+
+@pytest.fixture
+def fake_manager():
+    manager = _FakeManager(native=["qwen3:0.6b"], litellm=["llama3:latest"])
+    with patch("lilbee.model_manager.get_model_manager", return_value=manager):
+        yield manager
+
+
+@pytest.fixture
+def empty_manager():
+    manager = _FakeManager()
+    with patch("lilbee.model_manager.get_model_manager", return_value=manager):
+        yield manager
+
+
+@pytest.fixture
+def native_manifests():
+    manifests = {
+        "qwen3:0.6b": _manifest("qwen3", "0.6b", size=5 * 1024**3, task="chat"),
+    }
+    with patch("lilbee.cli.model._native_manifest_index", return_value=manifests):
+        yield manifests
+
+
+@pytest.fixture
+def no_remote_classify():
+    with patch("lilbee.model_manager.classify_remote_models", return_value=[]):
+        yield
+
+
+@pytest.fixture
+def with_remote_classify():
+    remote = [_remote("llama3:latest", task="chat", parameter_size="8B")]
+    with patch("lilbee.model_manager.classify_remote_models", return_value=remote):
+        yield remote
+
+
+class TestModelEntryFactories:
+    def test_from_native_populates_size_and_task(self):
+        manifest = _manifest("qwen3", "0.6b", size=2 * 1024**3, task="chat")
+        entry = ModelEntry.from_native("qwen3:0.6b", manifest)
+        assert entry.source == "native"
+        assert entry.size_gb == 2.0
+        assert entry.task == "chat"
+        assert entry.display_name == "qwen3 0.6b"
+
+    def test_from_native_missing_manifest(self):
+        entry = ModelEntry.from_native("qwen3:8b", None)
+        assert entry.source == "native"
+        assert entry.task is None
+        assert entry.size_gb is None
+        assert entry.display_name == ""
+
+    def test_from_litellm_with_remote(self):
+        remote = _remote("llama3:latest", task="chat", parameter_size="8B")
+        entry = ModelEntry.from_litellm("llama3:latest", remote)
+        assert entry.source == "litellm"
+        assert entry.task == "chat"
+        assert entry.display_name == "8B"
+
+    def test_from_litellm_missing_remote(self):
+        entry = ModelEntry.from_litellm("llama3:latest", None)
+        assert entry.task is None
+        assert entry.display_name == ""
+
+
+class TestListModelsData:
+    def test_default_lists_both_sources(self, fake_manager, native_manifests, with_remote_classify):
+        data = model_mod.list_models_data()
+        assert isinstance(data, ListModelsResult)
+        assert data.total == 2
+        sources = {e.source for e in data.models}
+        assert sources == {"native", "litellm"}
+
+    def test_filter_source_native_skips_litellm_http(self, fake_manager, native_manifests):
+        with patch("lilbee.model_manager.classify_remote_models") as classify:
+            data = model_mod.list_models_data(source=ModelSource.NATIVE)
+        classify.assert_not_called()
+        assert data.total == 1
+        assert data.models[0].name == "qwen3:0.6b"
+
+    def test_filter_source_litellm(self, fake_manager, native_manifests, with_remote_classify):
+        data = model_mod.list_models_data(source=ModelSource.LITELLM)
+        assert data.total == 1
+        assert data.models[0].source == "litellm"
+
+    def test_task_filter_drops_entries_without_matching_task(
+        self, fake_manager, native_manifests, with_remote_classify
+    ):
+        data = model_mod.list_models_data(task="chat")
+        assert {e.name for e in data.models} == {"qwen3:0.6b", "llama3:latest"}
+        empty = model_mod.list_models_data(task="embedding")
+        assert empty.total == 0
+
+    def test_empty_when_no_models_installed(self, empty_manager, no_remote_classify):
+        with patch("lilbee.cli.model._native_manifest_index", return_value={}):
+            data = model_mod.list_models_data()
+        assert data.total == 0
+
+
+class TestListCmd:
+    def test_human_output(self, fake_manager, native_manifests, with_remote_classify):
+        result = runner.invoke(app, ["model", "list"])
+        assert result.exit_code == 0, result.output
+        assert "qwen3:0.6b" in result.output
+        assert "llama3:latest" in result.output
+
+    def test_json_output_roundtrips(self, fake_manager, native_manifests, with_remote_classify):
+        result = runner.invoke(app, ["--json", "model", "list"])
+        assert result.exit_code == 0, result.output
+        parsed = ListModelsResult.model_validate_json(result.output)
+        assert parsed.total == 2
+        assert {e.name for e in parsed.models} == {"qwen3:0.6b", "llama3:latest"}
+
+    def test_empty_human_message(self, empty_manager, no_remote_classify):
+        with patch("lilbee.cli.model._native_manifest_index", return_value={}):
+            result = runner.invoke(app, ["model", "list"])
+        assert result.exit_code == 0
+        assert "No models installed" in result.output
+
+    def test_invalid_source_raises_bad_param(self, fake_manager):
+        result = runner.invoke(app, ["model", "list", "--source", "bogus"])
+        assert result.exit_code != 0
+        assert "bogus" in result.output
+
+
+class TestShowModelData:
+    def test_catalog_and_installed_merged(self, fake_manager, native_manifests):
+        entry = _catalog_model()
+        with (
+            patch("lilbee.catalog.find_catalog_entry", return_value=entry),
+            patch(
+                "lilbee.cli.model._resolve_native_path",
+                return_value="/fake/path.gguf",
+            ),
+        ):
+            data = model_mod.show_model_data("qwen3:0.6b")
+        assert isinstance(data, ShowModelResult)
+        assert data.installed is True
+        assert data.source == "native"
+        assert data.path == "/fake/path.gguf"
+        assert data.catalog is not None
+        assert data.catalog.display_name == "Qwen3 0.6B"
+        assert data.manifest is not None
+        assert data.manifest.task == "chat"
+
+    def test_catalog_only_not_installed(self, empty_manager):
+        entry = _catalog_model(name="qwen3", tag="8b")
+        with (
+            patch("lilbee.cli.model._native_manifest_index", return_value={}),
+            patch("lilbee.catalog.find_catalog_entry", return_value=entry),
+        ):
+            data = model_mod.show_model_data("qwen3:8b")
+        assert data.installed is False
+        assert data.catalog is not None
+        assert data.manifest is None
+
+    def test_unknown_ref_raises_not_found(self, empty_manager):
+        with (
+            patch("lilbee.cli.model._native_manifest_index", return_value={}),
+            patch("lilbee.catalog.find_catalog_entry", return_value=None),
+            pytest.raises(ModelNotFoundError, match="model not found: ghost"),
+        ):
+            model_mod.show_model_data("ghost:latest")
+
+
+class TestResolveNativePath:
+    def test_returns_path_when_registry_resolves(self, tmp_path):
+        fake_registry = MagicMock()
+        fake_registry.resolve.return_value = tmp_path / "blob.gguf"
+        with patch("lilbee.registry.ModelRegistry", return_value=fake_registry):
+            path = model_mod._resolve_native_path("qwen3:0.6b")
+        assert path == str(tmp_path / "blob.gguf")
+
+    def test_suppresses_key_error_from_missing_blob(self):
+        fake_registry = MagicMock()
+        fake_registry.resolve.side_effect = KeyError("no blob")
+        with patch("lilbee.registry.ModelRegistry", return_value=fake_registry):
+            path = model_mod._resolve_native_path("qwen3:0.6b")
+        assert path is None
+
+    def test_suppresses_value_error_from_invalid_ref(self):
+        fake_registry = MagicMock()
+        fake_registry.resolve.side_effect = ValueError("bad ref")
+        with patch("lilbee.registry.ModelRegistry", return_value=fake_registry):
+            path = model_mod._resolve_native_path("qwen3:0.6b")
+        assert path is None
+
+
+class TestShowCmd:
+    def test_human_output_installed(self, fake_manager, native_manifests):
+        entry = _catalog_model()
+        with (
+            patch("lilbee.catalog.find_catalog_entry", return_value=entry),
+            patch(
+                "lilbee.cli.model._resolve_native_path",
+                return_value="/fake/path.gguf",
+            ),
+        ):
+            result = runner.invoke(app, ["model", "show", "qwen3:0.6b"])
+        assert result.exit_code == 0, result.output
+        assert "source:" in result.output
+        assert "/fake/path.gguf" in result.output
+        assert "downloaded:" in result.output
+
+    def test_json_output_roundtrips(self, fake_manager, native_manifests):
+        entry = _catalog_model()
+        with (
+            patch("lilbee.catalog.find_catalog_entry", return_value=entry),
+            patch("lilbee.cli.model._resolve_native_path", return_value="/p.gguf"),
+        ):
+            result = runner.invoke(app, ["--json", "model", "show", "qwen3:0.6b"])
+        assert result.exit_code == 0, result.output
+        parsed = ShowModelResult.model_validate_json(result.output)
+        assert parsed.installed is True
+        assert parsed.catalog is not None
+        assert parsed.catalog.display_name == "Qwen3 0.6B"
+        assert parsed.path == "/p.gguf"
+
+    def test_json_not_found_exits_1(self, empty_manager):
+        with (
+            patch("lilbee.cli.model._native_manifest_index", return_value={}),
+            patch("lilbee.catalog.find_catalog_entry", return_value=None),
+        ):
+            result = runner.invoke(app, ["--json", "model", "show", "ghost:1"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert "model not found" in payload["error"]
+
+    def test_human_not_found_exits_1(self, empty_manager):
+        with (
+            patch("lilbee.cli.model._native_manifest_index", return_value={}),
+            patch("lilbee.catalog.find_catalog_entry", return_value=None),
+        ):
+            result = runner.invoke(app, ["model", "show", "ghost:1"])
+        assert result.exit_code == 1
+        assert "model not found" in result.output
+
+
+class TestPullModelData:
+    def test_already_installed_short_circuits(self, fake_manager, native_manifests):
+        result = model_mod.pull_model_data("qwen3:0.6b", ModelSource.NATIVE)
+        assert isinstance(result, PullResult)
+        assert result.status == PullStatus.ALREADY_INSTALLED
+        assert fake_manager.pull_calls == []
+
+    def test_pull_native_invokes_manager_and_callbacks(self, fake_manager, native_manifests):
+        events = []
+        result = model_mod.pull_model_data("qwen3:8b", ModelSource.NATIVE, on_update=events.append)
+        assert result.status == PullStatus.OK
+        assert result.path == "/fake/qwen3:8b.gguf"
+        assert events
+        assert events[0].percent == 50
+        assert fake_manager.pull_calls == [("qwen3:8b", ModelSource.NATIVE)]
+
+    def test_build_pull_callbacks_none_when_no_on_update(self):
+        dict_cb, bytes_cb = model_mod._build_pull_callbacks(None)
+        assert dict_cb is None
+        assert bytes_cb is None
+
+    def test_pull_litellm_adapts_dict_events(self, native_manifests):
+        events = []
+
+        class _Litellm(_FakeManager):
+            def pull(self, model, source, *, on_progress=None, on_bytes=None):
+                self.pull_calls.append((model, source))
+                if on_progress is not None:
+                    on_progress({"status": "pulling", "completed": 25, "total": 100})
+                return None
+
+        manager = _Litellm()
+        with patch("lilbee.model_manager.get_model_manager", return_value=manager):
+            result = model_mod.pull_model_data(
+                "llama3:latest", ModelSource.LITELLM, on_update=events.append
+            )
+        assert result.status == PullStatus.OK
+        assert result.path is None
+        assert events
+        assert events[0].percent == 25
+        assert events[0].detail == "pulling"
+
+
+class TestPullCmd:
+    def test_json_stream_emits_done_event(self, fake_manager, native_manifests):
+        result = runner.invoke(app, ["--json", "model", "pull", "qwen3:8b"])
+        assert result.exit_code == 0, result.output
+        lines = [line for line in result.output.splitlines() if line.strip()]
+        parsed = [json.loads(line) for line in lines]
+        assert parsed[-1]["event"] == PullEvent.DONE.value
+        assert parsed[-1]["status"] == PullStatus.OK.value
+        assert parsed[-1]["model"] == "qwen3:8b"
+
+    def test_human_mode_prints_pulled(self, fake_manager, native_manifests):
+        result = runner.invoke(app, ["model", "pull", "qwen3:8b"])
+        assert result.exit_code == 0, result.output
+        assert "Pulled" in result.output
+
+    def test_human_already_installed_message(self, fake_manager, native_manifests):
+        result = runner.invoke(app, ["model", "pull", "qwen3:0.6b"])
+        assert result.exit_code == 0
+        assert "already installed" in result.output
+
+    def test_runtime_error_json(self, native_manifests):
+        manager = _FakeManager()
+        manager.pull = MagicMock(side_effect=RuntimeError("no network"))
+        with patch("lilbee.model_manager.get_model_manager", return_value=manager):
+            result = runner.invoke(app, ["--json", "model", "pull", "qwen3:8b"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output.strip().splitlines()[-1])
+        assert payload == {"error": "no network"}
+
+    def test_runtime_error_human(self, native_manifests):
+        manager = _FakeManager()
+        manager.pull = MagicMock(side_effect=RuntimeError("boom"))
+        with patch("lilbee.model_manager.get_model_manager", return_value=manager):
+            result = runner.invoke(app, ["model", "pull", "qwen3:8b"])
+        assert result.exit_code == 1
+        assert "boom" in result.output
+
+    def test_invalid_source(self, fake_manager):
+        result = runner.invoke(app, ["model", "pull", "qwen3:8b", "--source", "bad"])
+        assert result.exit_code != 0
+
+
+class TestRemoveModelData:
+    def test_removes_and_reports_freed(self, fake_manager, native_manifests):
+        result = model_mod.remove_model_data("qwen3:0.6b")
+        assert isinstance(result, RemoveResult)
+        assert result.deleted is True
+        assert result.freed_gb == 5.0
+        assert fake_manager.remove_calls == [("qwen3:0.6b", None)]
+
+    def test_missing_manifest_returns_zero_freed(self, fake_manager):
+        with patch("lilbee.cli.model._native_manifest_index", return_value={}):
+            result = model_mod.remove_model_data("qwen3:0.6b")
+        assert result.deleted is True
+        assert result.freed_gb == 0.0
+
+
+class TestRmCmd:
+    def test_confirm_declined(self, fake_manager, native_manifests):
+        result = runner.invoke(app, ["model", "rm", "qwen3:0.6b"], input="n\n")
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+        assert fake_manager.remove_calls == []
+
+    def test_confirm_accepted(self, fake_manager, native_manifests):
+        result = runner.invoke(app, ["model", "rm", "qwen3:0.6b"], input="y\n")
+        assert result.exit_code == 0
+        assert "5.00 GB freed" in result.output
+        assert fake_manager.remove_calls == [("qwen3:0.6b", None)]
+
+    def test_yes_flag_skips_prompt(self, fake_manager, native_manifests):
+        result = runner.invoke(app, ["model", "rm", "--yes", "qwen3:0.6b"])
+        assert result.exit_code == 0
+        assert "Removed" in result.output
+
+    def test_not_found_exits_1(self, fake_manager, native_manifests):
+        result = runner.invoke(app, ["model", "rm", "--yes", "ghost:1.0"])
+        assert result.exit_code == 1
+        assert "Not found" in result.output
+
+    def test_json_output_serializes_remove_result(self, fake_manager, native_manifests):
+        result = runner.invoke(app, ["--json", "model", "rm", "qwen3:0.6b"])
+        assert result.exit_code == 0
+        parsed = RemoveResult.model_validate_json(result.output)
+        assert parsed.deleted is True
+        assert parsed.freed_gb == 5.0
+
+    def test_invalid_source(self, fake_manager):
+        result = runner.invoke(app, ["model", "rm", "--yes", "qwen3:0.6b", "--source", "bad"])
+        assert result.exit_code != 0
+
+
+class TestBrowseCmd:
+    def test_json_mode_rejected_exit_2(self, fake_manager):
+        result = runner.invoke(app, ["--json", "model", "browse"])
+        assert result.exit_code == 2
+        payload = json.loads(result.output)
+        assert "interactive" in payload["error"]
+
+    def test_non_tty_rejected_exit_1(self, fake_manager):
+        result = runner.invoke(app, ["model", "browse"])
+        assert result.exit_code == 1
+        assert "terminal" in result.output
+
+    def test_tty_launches_tui_with_catalog(self, fake_manager):
+        with (
+            patch("lilbee.cli.model._is_interactive_terminal", return_value=True),
+            patch("lilbee.cli.tui.run_tui") as run_tui,
+        ):
+            result = runner.invoke(app, ["model", "browse"])
+        assert result.exit_code == 0, result.output
+        run_tui.assert_called_once_with(auto_sync=False, initial_view="Catalog")
+
+
+class TestCatalogEntryDataFactory:
+    def test_from_catalog_model_maps_fields(self):
+        entry = _catalog_model()
+        data = CatalogEntryData.from_catalog_model(entry)
+        assert data.ref == "qwen3:0.6b"
+        assert data.hf_repo == "Qwen/Qwen3-0.6B-GGUF"
+        assert data.featured is True
+        assert data.recommended is True
+
+
+class TestManifestDataFactory:
+    def test_from_manifest_computes_size_gb(self):
+        manifest = _manifest("qwen3", "0.6b", size=3 * 1024**3, task="chat")
+        data = ManifestData.from_manifest(manifest)
+        assert data.size_gb == 3.0
+        assert data.name == "qwen3:0.6b"
+        assert data.source_repo == "org/qwen3-GGUF"
+
+
+class TestNativeManifestIndex:
+    def test_indexes_by_ref(self, tmp_path):
+        fake_registry = MagicMock()
+        fake_registry.list_installed.return_value = [
+            _manifest("qwen3", "0.6b", size=1024, task="chat"),
+        ]
+        with patch("lilbee.registry.ModelRegistry", return_value=fake_registry):
+            index = model_mod._native_manifest_index()
+        assert "qwen3:0.6b" in index
+        assert index["qwen3:0.6b"].task == "chat"

--- a/tests/test_mcp_model_tools.py
+++ b/tests/test_mcp_model_tools.py
@@ -1,0 +1,183 @@
+"""Tests for MCP model management tools."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from concurrent.futures import Future
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lilbee.catalog import DownloadProgress
+from lilbee.cli.model import (
+    ListModelsResult,
+    PullResult,
+    PullStatus,
+    RemoveResult,
+    ShowModelResult,
+)
+from lilbee.mcp import (
+    _log_progress_failure,
+    lilbee_model_list,
+    lilbee_model_pull,
+    lilbee_model_rm,
+    lilbee_model_show,
+)
+from lilbee.model_manager import ModelNotFoundError, ModelSource
+
+
+class TestMcpList:
+    def test_native_source_forwarded(self):
+        expected = ListModelsResult(models=[], total=0)
+        with patch("lilbee.cli.model.list_models_data", return_value=expected) as fn:
+            result = lilbee_model_list(source="native", task="chat")
+        assert result == expected.model_dump()
+        fn.assert_called_once_with(source=ModelSource.NATIVE, task="chat")
+
+    def test_empty_strings_mean_all(self):
+        expected = ListModelsResult(models=[], total=0)
+        with patch("lilbee.cli.model.list_models_data", return_value=expected) as fn:
+            lilbee_model_list()
+        fn.assert_called_once_with(source=None, task=None)
+
+    def test_invalid_source_returns_explicit_error(self):
+        with patch("lilbee.cli.model.list_models_data") as fn:
+            result = lilbee_model_list(source="bogus")
+        assert result == {"error": "invalid source 'bogus'; expected one of: native, litellm"}
+        fn.assert_not_called()
+
+
+class TestMcpShow:
+    def test_delegates_and_serializes(self):
+        expected = ShowModelResult(model="qwen3:0.6b", installed=True, source="native")
+        with patch("lilbee.cli.model.show_model_data", return_value=expected) as fn:
+            result = lilbee_model_show("qwen3:0.6b")
+        fn.assert_called_once_with("qwen3:0.6b")
+        assert result == expected.model_dump()
+
+    def test_not_found_returns_error_dict(self):
+        with patch(
+            "lilbee.cli.model.show_model_data",
+            side_effect=ModelNotFoundError("model not found: ghost"),
+        ):
+            result = lilbee_model_show("ghost")
+        assert result == {"error": "model not found: ghost"}
+
+
+class TestMcpRemove:
+    def test_default_source_is_none(self):
+        expected = RemoveResult(model="qwen3:0.6b", deleted=True, freed_gb=5.0)
+        with patch("lilbee.cli.model.remove_model_data", return_value=expected) as fn:
+            result = lilbee_model_rm("qwen3:0.6b")
+        fn.assert_called_once_with("qwen3:0.6b", source=None)
+        assert result == expected.model_dump()
+
+    def test_native_source(self):
+        expected = RemoveResult(model="qwen3:0.6b", deleted=True)
+        with patch("lilbee.cli.model.remove_model_data", return_value=expected) as fn:
+            lilbee_model_rm("qwen3:0.6b", source="native")
+        fn.assert_called_once_with("qwen3:0.6b", source=ModelSource.NATIVE)
+
+    def test_invalid_source_explicit_error(self):
+        with patch("lilbee.cli.model.remove_model_data") as fn:
+            result = lilbee_model_rm("qwen3:0.6b", source="bogus")
+        assert result == {"error": "invalid source 'bogus'; expected one of: native, litellm"}
+        fn.assert_not_called()
+
+
+class TestMcpPull:
+    @staticmethod
+    def _fake_ctx() -> MagicMock:
+        ctx = MagicMock()
+        ctx.report_progress = AsyncMock()
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_streams_progress_and_returns_final_dict(self):
+        ctx = self._fake_ctx()
+        final = PullResult(model="qwen3:0.6b", source="native", status=PullStatus.OK)
+
+        def fake_pull(model, source, *, on_update):
+            on_update(DownloadProgress(percent=10, detail="10 MB", is_cache_hit=False))
+            on_update(DownloadProgress(percent=50, detail="50 MB", is_cache_hit=False))
+            return final
+
+        with patch("lilbee.cli.model.pull_model_data", side_effect=fake_pull):
+            result = await lilbee_model_pull("qwen3:0.6b", source="native", ctx=ctx)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert result == final.model_dump()
+        assert ctx.report_progress.await_count == 2
+        first = ctx.report_progress.await_args_list[0]
+        assert first.kwargs == {
+            "progress": 10.0,
+            "total": 100.0,
+            "message": "10 MB",
+        }
+
+    @pytest.mark.asyncio
+    async def test_pull_without_ctx_does_not_report_progress(self):
+        final = PullResult(model="qwen3:0.6b", source="native", status=PullStatus.OK)
+
+        def fake_pull(model, source, *, on_update):
+            on_update(DownloadProgress(percent=30, detail="", is_cache_hit=False))
+            return final
+
+        with patch("lilbee.cli.model.pull_model_data", side_effect=fake_pull):
+            result = await lilbee_model_pull("qwen3:0.6b")
+        assert result == final.model_dump()
+
+    @pytest.mark.asyncio
+    async def test_pull_litellm_source(self):
+        captured: list[ModelSource] = []
+        final = PullResult(model="llama3:latest", source="litellm", status=PullStatus.OK)
+
+        def fake_pull(model, source, *, on_update):
+            captured.append(source)
+            return final
+
+        with patch("lilbee.cli.model.pull_model_data", side_effect=fake_pull):
+            await lilbee_model_pull("llama3:latest", source="litellm")
+        assert captured == [ModelSource.LITELLM]
+
+    @pytest.mark.asyncio
+    async def test_pull_runtime_error_returned_as_dict(self):
+        with patch(
+            "lilbee.cli.model.pull_model_data",
+            side_effect=RuntimeError("no network"),
+        ):
+            result = await lilbee_model_pull("qwen3:0.6b")
+        assert result == {"error": "no network"}
+
+    @pytest.mark.asyncio
+    async def test_pull_permission_error_returned_as_dict(self):
+        with patch(
+            "lilbee.cli.model.pull_model_data",
+            side_effect=PermissionError("gated"),
+        ):
+            result = await lilbee_model_pull("qwen3:0.6b")
+        assert result == {"error": "gated"}
+
+    @pytest.mark.asyncio
+    async def test_pull_invalid_source(self):
+        result = await lilbee_model_pull("qwen3:0.6b", source="bogus")
+        assert result == {"error": "invalid source 'bogus'; expected one of: native, litellm"}
+
+
+class TestLogProgressFailure:
+    def test_success_is_silent(self, caplog):
+        fut: Future[None] = Future()
+        fut.set_result(None)
+        with caplog.at_level(logging.WARNING, logger="lilbee.mcp"):
+            _log_progress_failure(fut)
+        assert "report_progress failed" not in caplog.text
+
+    def test_exception_is_logged_at_warning(self, caplog):
+        fut: Future[None] = Future()
+        fut.set_exception(RuntimeError("notify failed"))
+        with caplog.at_level(logging.WARNING, logger="lilbee.mcp"):
+            _log_progress_failure(fut)
+        assert "report_progress failed" in caplog.text
+        assert "notify failed" in caplog.text

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -26,6 +26,20 @@ class TestModelSource:
     def test_members(self) -> None:
         assert set(ModelSource) == {ModelSource.NATIVE, ModelSource.LITELLM}
 
+    def test_parse_none_and_empty_return_none(self) -> None:
+        assert ModelSource.parse(None) is None
+        assert ModelSource.parse("") is None
+
+    def test_parse_valid_values(self) -> None:
+        assert ModelSource.parse("native") is ModelSource.NATIVE
+        assert ModelSource.parse("litellm") is ModelSource.LITELLM
+
+    def test_parse_invalid_raises_value_error(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="invalid source 'bogus'"):
+            ModelSource.parse("bogus")
+
 
 def _install_registry_model(
     models_dir: Path,
@@ -266,7 +280,7 @@ class TestModelManagerPull:
         fake_entry = mock.Mock()
         fake_entry.name = "test-model"
 
-        def fake_download(entry: object) -> Path:
+        def fake_download(entry: object, *, on_progress: object = None) -> Path:
             path = models_dir / f"{entry.name}.gguf"
             path.write_text("fake model")
             return path
@@ -279,7 +293,7 @@ class TestModelManagerPull:
             result = mgr.pull("test-model", ModelSource.NATIVE)
 
         mock_find.assert_called_once_with("test-model")
-        mock_dl.assert_called_once_with(fake_entry)
+        mock_dl.assert_called_once_with(fake_entry, on_progress=None)
         assert result is not None
         assert result.name == "test-model.gguf"
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -50,6 +50,25 @@ class TestRunTui:
         run_tui()
         mock_run.assert_called_once()
 
+    @mock.patch("lilbee.cli.tui.app.LilbeeApp.run")
+    def test_run_tui_forwards_initial_view(self, mock_run: mock.MagicMock) -> None:
+        from lilbee.cli.tui import run_tui
+
+        with mock.patch("lilbee.cli.tui.app.LilbeeApp.__init__", return_value=None) as init:
+            run_tui(initial_view="Catalog")
+        init.assert_called_once_with(auto_sync=False, initial_view="Catalog")
+
+    @pytest.mark.asyncio
+    @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
+    async def test_initial_view_switches_to_catalog(self, mock_catalog: mock.MagicMock) -> None:
+        mock_catalog.return_value = _EMPTY_CATALOG
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp(initial_view="Catalog")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.active_view == "Catalog"
+
 
 class TestUserMessage:
     def test_creates_with_text(self) -> None:


### PR DESCRIPTION
## Summary

Adds a `lilbee model` command group and matching MCP tools so you can manage installed models without opening the TUI or shelling out to Ollama.

- `lilbee model list [--source native|litellm] [--task chat|embedding|vision]`
- `lilbee model show <ref>`
- `lilbee model pull <ref> [--source ...]` (Rich progress bar; newline-delimited JSON events under `--json`)
- `lilbee model rm <ref> [--yes]`
- `lilbee model browse` (deep-links the TUI to the catalog screen)

MCP gets `lilbee_model_list`, `lilbee_model_show`, `lilbee_model_pull`, `lilbee_model_rm`. The pull tool streams real-time progress via MCP `notifications/progress`, so agents see live download feedback.

CLI and MCP share typed Pydantic data helpers (`ListModelsResult`, `ShowModelResult`, `PullResult`, `RemoveResult`, etc.) in `cli/model.py`. No download or registry logic is duplicated.