### PR TITLE
Expose catalog metadata fields on /api/models/catalog response

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -292,14 +292,21 @@ def _extract_quant(filename: str) -> str:
     return m.group(1).upper() if m else ""
 
 
+def _derive_param_count(model: CatalogModel) -> str:
+    """Extract the parameter-count label (e.g. ``7B``) from a catalog model.
+    Falls back to ``model.tag`` when the display name has no numeric suffix
+    (useful for embedding models whose tag is a version like ``v1.5``).
+    """
+    match = PARAM_COUNT_RE.search(model.display_name)
+    return match.group(1) if match else model.tag
+
+
 def _catalog_to_variant(model: CatalogModel) -> ModelVariant:
     """Convert a CatalogModel to a ModelVariant."""
-    m = PARAM_COUNT_RE.search(model.display_name)
-    param_count = m.group(1) if m else model.tag
     return ModelVariant(
         hf_repo=model.hf_repo,
         filename=model.gguf_filename,
-        param_count=param_count,
+        param_count=_derive_param_count(model),
         tag=model.tag,
         quant=_extract_quant(model.gguf_filename),
         size_mb=int(model.size_gb * 1024),
@@ -951,6 +958,7 @@ class EnrichedModel:
     """A catalog model enriched with display metadata and install status."""
 
     name: str
+    tag: str
     hf_repo: str
     gguf_filename: str
     size_gb: float
@@ -960,6 +968,7 @@ class EnrichedModel:
     downloads: int
     task: str
     display_name: str
+    param_count: str
     quality_tier: str
     installed: bool
     source: str
@@ -973,6 +982,7 @@ def enrich_catalog(result: CatalogResult, installed_names: set[str]) -> list[Enr
         enriched.append(
             EnrichedModel(
                 name=m.name,
+                tag=m.tag,
                 hf_repo=m.hf_repo,
                 gguf_filename=m.gguf_filename,
                 size_gb=m.size_gb,
@@ -982,6 +992,7 @@ def enrich_catalog(result: CatalogResult, installed_names: set[str]) -> list[Enr
                 downloads=m.downloads,
                 task=m.task,
                 display_name=m.display_name or clean_display_name(m.hf_repo),
+                param_count=_derive_param_count(m),
                 quality_tier=quant_tier(_extract_quant(m.gguf_filename)),
                 installed=is_installed,
                 source="litellm" if is_installed else "native",

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -643,11 +643,17 @@ async def models_catalog(
         models=[
             CatalogEntryResponse(
                 name=e.name,
+                tag=e.tag,
+                hf_repo=e.hf_repo,
+                task=e.task,
                 display_name=e.display_name,
+                param_count=e.param_count,
                 size_gb=e.size_gb,
                 min_ram_gb=e.min_ram_gb,
                 description=e.description,
                 quality_tier=e.quality_tier,
+                featured=e.featured,
+                downloads=e.downloads,
                 installed=e.installed,
                 source=e.source,
             )

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -172,11 +172,17 @@ class CatalogEntryResponse(BaseModel):
     """A single model in the catalog browser."""
 
     name: str
+    tag: str
+    hf_repo: str
+    task: str
     display_name: str
+    param_count: str
     size_gb: float
     min_ram_gb: float
     description: str
     quality_tier: str
+    featured: bool
+    downloads: int
     installed: bool
     source: str
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1494,12 +1494,44 @@ class TestEnrichCatalog:
         original = result.models[0]
         e = enriched[0]
         assert e.name == original.name
+        assert e.tag == original.tag
         assert e.hf_repo == original.hf_repo
         assert e.size_gb == original.size_gb
         assert e.description == original.description
         assert e.featured == original.featured
         assert e.downloads == original.downloads
         assert e.task == original.task
+
+    def test_param_count_extracted_from_display_name(self) -> None:
+        result = self._make_result()
+        enriched = enrich_catalog(result, set())
+        # "Model-7B-GGUF" -> "7B"; "Qwen3 8B" -> "8B"
+        assert enriched[0].param_count == "7B"
+        assert enriched[1].param_count == "8B"
+
+    def test_param_count_falls_back_to_tag(self) -> None:
+        result = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[
+                CatalogModel(
+                    name="nomic-embed-text",
+                    tag="v1.5",
+                    display_name="Nomic Embed Text v1.5",
+                    hf_repo="nomic-ai/nomic-embed-text-v1.5-GGUF",
+                    gguf_filename="*Q4_K_M.gguf",
+                    size_gb=0.3,
+                    min_ram_gb=1.0,
+                    description="Embedding model",
+                    featured=True,
+                    downloads=42,
+                    task="embedding",
+                )
+            ],
+        )
+        enriched = enrich_catalog(result, set())
+        assert enriched[0].param_count == "v1.5"
 
 
 class TestFormatSizeMb:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -563,6 +563,12 @@ class TestModelsCatalog:
         assert len(result.models) == 1
         m = result.models[0]
         assert m.name == "qwen3"
+        assert m.tag == "8b"
+        assert m.hf_repo == "Qwen/Qwen3-8B-GGUF"
+        assert m.task == "chat"
+        assert m.featured is True
+        assert m.downloads == 1000
+        assert m.param_count == "8B"
         assert m.installed is True
         assert m.source == "litellm"
 


### PR DESCRIPTION
## Summary

This PR widens the response with `hf_repo`, `tag`, `task`, `featured`, `downloads`, and `param_count`. No logic change, response shape stays flat (no family grouping).
