### PR TITLE
Harden test_tui_e2e.py binding coverage

### DIFF
--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -269,7 +269,6 @@ class TestViewCycling:
             assert app.active_view == "Chat"
 
             # Blur the chat input so the app-level ] binding fires.
-            # Tracked as bb-44fj: nav keys should work from focused inputs.
             await pilot.press("escape")
             await pilot.pause()
 
@@ -522,7 +521,7 @@ class TestScreenTransitions:
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
                 await pilot.pause()
-                # Blur the chat input so the app-level ] binding fires (bb-44fj).
+                # Blur the chat input so the app-level ] binding fires.
                 await pilot.press("escape")
                 await pilot.pause()
                 expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
@@ -573,7 +572,7 @@ class TestScreenTransitions:
             async with app.run_test(size=(120, 40)) as pilot:
                 await pilot.pause()
                 assert app.active_view == "Chat"
-                # Blur the chat input so the app-level ] binding fires (bb-44fj).
+                # Blur the chat input so the app-level ] binding fires.
                 await pilot.press("escape")
                 await pilot.pause()
                 full_cycle = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
@@ -591,7 +590,7 @@ class TestScreenTransitions:
             async with app.run_test(size=(120, 40)) as pilot:
                 await pilot.pause()
                 assert app.active_view == "Chat"
-                # Blur the chat input so the app-level [ binding fires (bb-44fj).
+                # Blur the chat input so the app-level [ binding fires.
                 await pilot.press("escape")
                 await pilot.pause()
                 backward_cycle = ["Wiki", "Tasks", "Settings", "Status", "Catalog", "Chat"]
@@ -627,8 +626,8 @@ class TestScreenTransitions:
                     await pilot.pause()
                     assert app.active_view == view
 
-                    # Use f1 instead of ? because focused inputs swallow
-                    # question_mark (tracked as bb-44fj).
+                    # Use f1 instead of ? because focused inputs still swallow
+                    # question_mark.
                     await pilot.press("f1")
                     await pilot.pause()
                     assert app.screen.query("HelpPanel")

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -251,7 +251,7 @@ class TestModeIndicator:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
             bar = app.screen.query_one(ViewTabs)
             assert "NORMAL" in bar.mode_text
@@ -268,9 +268,14 @@ class TestViewCycling:
             await pilot.pause()
             assert app.active_view == "Chat"
 
+            # Blur the chat input so the app-level ] binding fires.
+            # Tracked as bb-44fj: nav keys should work from focused inputs.
+            await pilot.press("escape")
+            await pilot.pause()
+
             expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
             for view in expected:
-                app.action_nav_next()
+                await pilot.press("right_square_bracket")
                 await pilot.pause()
                 assert app.active_view == view, f"Expected {view}, got {app.active_view}"
 
@@ -517,9 +522,12 @@ class TestScreenTransitions:
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
                 await pilot.pause()
+                # Blur the chat input so the app-level ] binding fires (bb-44fj).
+                await pilot.press("escape")
+                await pilot.pause()
                 expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
                 for view in expected:
-                    app.action_nav_next()
+                    await pilot.press("right_square_bracket")
                     await pilot.pause()
                     assert app.active_view == view
 
@@ -565,9 +573,12 @@ class TestScreenTransitions:
             async with app.run_test(size=(120, 40)) as pilot:
                 await pilot.pause()
                 assert app.active_view == "Chat"
+                # Blur the chat input so the app-level ] binding fires (bb-44fj).
+                await pilot.press("escape")
+                await pilot.pause()
                 full_cycle = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
                 for view in full_cycle:
-                    app.action_nav_next()
+                    await pilot.press("right_square_bracket")
                     await pilot.pause()
                     assert app.active_view == view
 
@@ -580,9 +591,12 @@ class TestScreenTransitions:
             async with app.run_test(size=(120, 40)) as pilot:
                 await pilot.pause()
                 assert app.active_view == "Chat"
+                # Blur the chat input so the app-level [ binding fires (bb-44fj).
+                await pilot.press("escape")
+                await pilot.pause()
                 backward_cycle = ["Wiki", "Tasks", "Settings", "Status", "Catalog", "Chat"]
                 for view in backward_cycle:
-                    app.action_nav_prev()
+                    await pilot.press("left_square_bracket")
                     await pilot.pause()
                     assert app.active_view == view
 
@@ -613,11 +627,13 @@ class TestScreenTransitions:
                     await pilot.pause()
                     assert app.active_view == view
 
-                    app.action_push_help()
+                    # Use f1 instead of ? because focused inputs swallow
+                    # question_mark (tracked as bb-44fj).
+                    await pilot.press("f1")
                     await pilot.pause()
                     assert app.screen.query("HelpPanel")
 
-                    app.action_push_help()
+                    await pilot.press("f1")
                     await pilot.pause()
                     assert not app.screen.query("HelpPanel")
 
@@ -652,9 +668,11 @@ class TestScreenTransitions:
                 assert isinstance(app.screen, ChatScreen)
 
     async def test_pop_from_settings_returns_to_chat(self, _mock_resolve):
-        """From Settings, action_go_back returns to Chat.
-        Note: 'q' keystroke is consumed by the search Input when focused,
-        so we test the action directly.
+        """From Settings, pressing escape returns to Chat.
+
+        Note: 'q' is consumed when the search Input has focus (tracked as
+        a separate binding bug). Escape is bound to go_back on SettingsScreen
+        and also removes Input focus, so it exercises the binding path.
         """
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.screens.chat import ChatScreen
@@ -665,8 +683,12 @@ class TestScreenTransitions:
                 await pilot.pause()
                 app.switch_view("Settings")
                 await pilot.pause()
-                app.screen.action_go_back()
+                await pilot.press("escape")
                 await pilot.pause()
+                # If the search input was focused, the first escape just blurs it.
+                if not isinstance(app.screen, ChatScreen):
+                    await pilot.press("escape")
+                    await pilot.pause()
                 assert isinstance(app.screen, ChatScreen)
 
     async def test_q_from_tasks_returns_to_chat(self, _mock_resolve):
@@ -696,8 +718,12 @@ class TestScreenTransitions:
                 for view in ["Catalog", "Status", "Settings", "Tasks"]:
                     app.switch_view(view)
                     await pilot.pause()
-                    app.screen.action_go_back()
+                    await pilot.press("escape")
                     await pilot.pause()
+                    if not isinstance(app.screen, ChatScreen):
+                        # Settings search input consumes the first escape (blur).
+                        await pilot.press("escape")
+                        await pilot.pause()
                     assert isinstance(app.screen, ChatScreen)
 
     async def test_theme_cycling(self, _mock_resolve):
@@ -708,7 +734,7 @@ class TestScreenTransitions:
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
             initial_theme = app.theme
-            app.action_cycle_theme()
+            await pilot.press("ctrl+t")
             await pilot.pause()
             assert app.theme != initial_theme
             assert app.theme in DARK_THEMES
@@ -733,7 +759,7 @@ class TestChatInteractions:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
             assert app.screen._insert_mode is False
 
@@ -742,7 +768,7 @@ class TestChatInteractions:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
             assert app.screen._insert_mode is False
             app.screen._enter_insert_mode()
@@ -754,10 +780,10 @@ class TestChatInteractions:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
 
-            app.screen.action_vim_scroll_down()
+            await pilot.press("j")
             await pilot.pause()
             new_focus = app.screen.focused.id if app.screen.focused else None
             assert new_focus is not None
@@ -769,9 +795,9 @@ class TestChatInteractions:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
-            app.screen.action_vim_scroll_home()
+            await pilot.press("g")
             await pilot.pause()
             assert app.screen._insert_mode is False
 
@@ -780,9 +806,9 @@ class TestChatInteractions:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
-            app.screen.action_vim_scroll_end()
+            await pilot.press("G")
             await pilot.pause()
             assert app.screen._insert_mode is False
 
@@ -791,9 +817,9 @@ class TestChatInteractions:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_scroll_up()
+            await pilot.press("pageup")
             await pilot.pause()
-            app.screen.action_scroll_down()
+            await pilot.press("pagedown")
             await pilot.pause()
             assert app.screen.is_current
 
@@ -802,9 +828,9 @@ class TestChatInteractions:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_half_page_down()
+            await pilot.press("ctrl+d")
             await pilot.pause()
-            app.screen.action_half_page_up()
+            await pilot.press("ctrl+u")
             await pilot.pause()
             assert app.screen.is_current
 
@@ -815,7 +841,12 @@ class TestChatInteractions:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_focus_commands()
+            # Blur chat input (escape -> normal mode focuses chat-log) so the
+            # slash key reaches the screen-level binding instead of being
+            # consumed as a literal character by the input.
+            await pilot.press("escape")
+            await pilot.pause()
+            await pilot.press("slash")
             await pilot.pause()
             inp = app.screen.query_one("#chat-input", Input)
             assert inp.has_focus
@@ -872,7 +903,7 @@ class TestChatInteractions:
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
             app.screen.streaming = True
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
             assert app.screen.streaming is False
 
@@ -901,7 +932,7 @@ class TestChatInteractions:
             await pilot.pause()
             inp = app.screen.query_one("#chat-input", Input)
             inp.value = "Hello test"
-            await inp.action_submit()
+            await pilot.press("enter")
             await pilot.pause()
             messages = app.screen.query(UserMessage)
             assert len(messages) >= 1
@@ -917,28 +948,28 @@ class TestChatInteractions:
 
             # Submit two messages
             inp.value = "first message"
-            await inp.action_submit()
+            await pilot.press("enter")
             await pilot.pause()
             inp.value = "second message"
-            await inp.action_submit()
+            await pilot.press("enter")
             await pilot.pause()
 
             # Navigate up through history
-            app.screen.action_history_prev()
+            await pilot.press("up")
             await pilot.pause()
             assert inp.value == "second message"
 
-            app.screen.action_history_prev()
+            await pilot.press("up")
             await pilot.pause()
             assert inp.value == "first message"
 
             # Navigate down
-            app.screen.action_history_next()
+            await pilot.press("down")
             await pilot.pause()
             assert inp.value == "second message"
 
             # Past end clears
-            app.screen.action_history_next()
+            await pilot.press("down")
             await pilot.pause()
             assert inp.value == ""
 
@@ -948,11 +979,11 @@ class TestChatInteractions:
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
             initial = cfg.markdown_rendering
-            await app.screen.action_toggle_markdown()
+            await pilot.press("ctrl+r")
             await pilot.pause()
             assert cfg.markdown_rendering != initial
             # Toggle back
-            await app.screen.action_toggle_markdown()
+            await pilot.press("ctrl+r")
             await pilot.pause()
             assert cfg.markdown_rendering == initial
 
@@ -961,7 +992,7 @@ class TestChatInteractions:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
             assert app.screen._insert_mode is False
             # Simulate enter key event in normal mode
@@ -973,13 +1004,19 @@ class TestChatInteractions:
             assert app.screen._insert_mode is True
 
     async def test_history_actions_skip_in_normal_mode(self, _mock_resolve):
-        """In normal mode, up/down raise SkipAction (no focus cycling)."""
+        """In normal mode, the history action guards raise SkipAction.
+
+        This is a unit assertion on the action methods' guard clauses -
+        the key bindings already delegate here, so pilot.press would
+        swallow the SkipAction via the binding dispatcher. Calling the
+        action directly is the correct way to assert the guard raises.
+        """
         from textual.actions import SkipAction
 
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
             with pytest.raises(SkipAction):
                 app.screen.action_history_prev()
@@ -1019,12 +1056,12 @@ class TestCatalogInteractions:
 
                 assert app.screen.has_class("-grid-view")
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
                 assert app.screen.has_class("-list-view")
                 assert not app.screen.has_class("-grid-view")
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
                 assert app.screen.has_class("-grid-view")
                 assert not app.screen.has_class("-list-view")
@@ -1070,13 +1107,13 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_focus_search()
+                await pilot.press("slash")
                 await pilot.pause()
                 search = app.screen.query_one("#catalog-search", Input)
                 assert search.display is True
 
                 search.value = "test"
-                await search.action_submit()
+                await pilot.press("enter")
                 await pilot.pause()
                 assert search.display is False
 
@@ -1107,17 +1144,19 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
 
                 table = app.screen.query_one("#catalog-table", DataTable)
+                table.focus()
+                await pilot.pause()
                 if table.row_count > 1:
                     initial_row = table.cursor_row
-                    app.screen.action_cursor_down()
+                    await pilot.press("j")
                     await pilot.pause()
                     assert table.cursor_row >= initial_row
 
-                    app.screen.action_cursor_up()
+                    await pilot.press("k")
                     await pilot.pause()
 
     async def test_list_view_g_G_jump(self, _mock_resolve):
@@ -1134,7 +1173,7 @@ class TestCatalogInteractions:
                 await pilot.pause()
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
                 await pilot.pause()
 
@@ -1153,6 +1192,8 @@ class TestCatalogInteractions:
 
     async def test_list_view_page_down_up(self, _mock_resolve):
         """In list view, space/ctrl-d pages down, ctrl-u pages up."""
+        from textual.widgets import DataTable
+
         from lilbee.cli.tui.app import LilbeeApp
 
         with _mock_catalog_deps(), _mock_remote_models():
@@ -1162,12 +1203,15 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
 
-                app.screen.action_page_down()
+                table = app.screen.query_one("#catalog-table", DataTable)
+                table.focus()
                 await pilot.pause()
-                app.screen.action_page_up()
+                await pilot.press("space")
+                await pilot.pause()
+                await pilot.press("ctrl+u")
                 await pilot.pause()
                 assert app.screen.is_current
 
@@ -1182,7 +1226,7 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
 
                 assert app.screen._sort_column == "Name"
@@ -1226,7 +1270,7 @@ class TestCatalogInteractions:
                 app.switch_view("Catalog")
                 await pilot.pause()
 
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
 
                 table = app.screen.query_one("#catalog-table", DataTable)
@@ -1250,9 +1294,14 @@ class TestCatalogInteractions:
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
-                app.screen.action_toggle_view()
+                await pilot.press("v")
                 await pilot.pause()
-                app.screen.action_delete_model()
+                from textual.widgets import DataTable
+
+                table = app.screen.query_one("#catalog-table", DataTable)
+                table.focus()
+                await pilot.pause()
+                await pilot.press("d")
                 await pilot.pause()
                 assert app.screen.is_current
 
@@ -1281,13 +1330,13 @@ class TestCatalogInteractions:
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
-                # These actions should be no-ops or safe in grid mode
-                app.screen.action_cursor_down()
-                app.screen.action_cursor_up()
-                app.screen.action_jump_top()
-                app.screen.action_jump_bottom()
-                app.screen.action_page_down()
-                app.screen.action_page_up()
+                # These key bindings should delegate to the grid safely.
+                await pilot.press("j")
+                await pilot.press("k")
+                await pilot.press("g")
+                await pilot.press("G")
+                await pilot.press("space")
+                await pilot.press("ctrl+u")
                 assert app.screen.is_current
                 await pilot.pause()
 
@@ -1431,9 +1480,12 @@ class TestSettingsInteractions:
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
-            app.screen.action_scroll_down()
+            # Move focus off the search input so screen bindings receive j/k.
+            app.screen.focus_next()
             await pilot.pause()
-            app.screen.action_scroll_up()
+            await pilot.press("j")
+            await pilot.pause()
+            await pilot.press("k")
             await pilot.pause()
             assert app.screen.is_current
 
@@ -1446,14 +1498,17 @@ class TestSettingsInteractions:
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
-            app.screen.action_scroll_end()
+            # Move focus off the search input so screen bindings receive g/G.
+            app.screen.focus_next()
             await pilot.pause()
-            app.screen.action_scroll_home()
+            await pilot.press("G")
+            await pilot.pause()
+            await pilot.press("g")
             await pilot.pause()
             assert app.screen.is_current
 
     async def test_pop_screen_returns_to_chat(self, _mock_resolve):
-        """action_go_back returns to chat."""
+        """Pressing escape on settings returns to chat."""
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.screens.chat import ChatScreen
 
@@ -1462,8 +1517,12 @@ class TestSettingsInteractions:
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
-            app.screen.action_go_back()
+            await pilot.press("escape")
             await pilot.pause()
+            if not isinstance(app.screen, ChatScreen):
+                # Settings search input consumes the first escape (blur).
+                await pilot.press("escape")
+                await pilot.pause()
             assert isinstance(app.screen, ChatScreen)
 
     async def test_settings_changed_signal_fires(self, _mock_resolve):
@@ -1547,9 +1606,9 @@ class TestStatusInteractions:
                 await pilot.pause()
                 app.switch_view("Status")
                 await pilot.pause()
-                app.screen.action_cursor_down()
+                await pilot.press("j")
                 await pilot.pause()
-                app.screen.action_cursor_up()
+                await pilot.press("k")
                 await pilot.pause()
                 assert app.screen.is_current
 
@@ -1563,9 +1622,9 @@ class TestStatusInteractions:
                 await pilot.pause()
                 app.switch_view("Status")
                 await pilot.pause()
-                app.screen.action_jump_bottom()
+                await pilot.press("G")
                 await pilot.pause()
-                app.screen.action_jump_top()
+                await pilot.press("g")
                 await pilot.pause()
                 assert app.screen.is_current
 
@@ -1690,9 +1749,9 @@ class TestTaskCenterInteractions:
 
             app.switch_view("Tasks")
             await pilot.pause()
-            app.screen.action_cursor_down()
+            await pilot.press("j")
             await pilot.pause()
-            app.screen.action_cursor_up()
+            await pilot.press("k")
             await pilot.pause()
             assert app.screen.is_current
 
@@ -1737,7 +1796,7 @@ class TestTaskCenterInteractions:
             await pilot.pause()
 
             app.task_bar.add_task("Late Task", "download")
-            app.screen.action_refresh_tasks()
+            await pilot.press("r")
             await pilot.pause()
 
             table = app.screen.query_one("#task-table", DataTable)
@@ -1754,7 +1813,7 @@ class TestTaskCenterInteractions:
 
             app.switch_view("Tasks")
             await pilot.pause()
-            app.screen.action_cancel_task()
+            await pilot.press("c")
             await pilot.pause()
             assert app.screen.is_current
 
@@ -1781,7 +1840,7 @@ class TestTaskCenterInteractions:
             await pilot.pause()
             app.switch_view("Tasks")
             await pilot.pause()
-            app.screen.action_cancel_task()
+            await pilot.press("c")
             await pilot.pause()
             assert app.screen.is_current
 
@@ -1807,7 +1866,7 @@ class TestChatPromptBorder:
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            app.screen.action_enter_normal_mode()
+            await pilot.press("escape")
             await pilot.pause()
             inp = app.screen.query_one("#chat-input")
             area = app.screen.query_one("#chat-prompt-area")
@@ -1826,7 +1885,8 @@ class TestAppQuit:
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
             with mock.patch.object(app, "exit") as mock_exit:
-                await app.action_quit()
+                await pilot.press("ctrl+c")
+                await pilot.pause()
                 mock_exit.assert_called_once()
 
     async def test_quit_cancels_active_task_first(self, _mock_resolve):
@@ -1839,7 +1899,8 @@ class TestAppQuit:
             app.task_bar.add_task("Active Task", "download")
             app.task_bar.queue.advance("download")
             with mock.patch.object(app, "exit") as mock_exit:
-                await app.action_quit()
+                await pilot.press("ctrl+c")
+                await pilot.pause()
                 mock_exit.assert_not_called()
 
     async def test_quit_cancels_stream_if_on_chat(self, _mock_resolve):
@@ -1854,7 +1915,8 @@ class TestAppQuit:
                 mock.patch.object(app.screen, "action_cancel_stream") as mock_cancel,
                 mock.patch.object(app, "exit") as mock_exit,
             ):
-                await app.action_quit()
+                await pilot.press("ctrl+c")
+                await pilot.pause()
                 mock_cancel.assert_called_once()
                 mock_exit.assert_not_called()
 
@@ -2046,7 +2108,7 @@ class TestChatCompletions:
 
             inp = app.screen.query_one("#chat-input", Input)
             inp.value = "/"
-            app.screen.action_complete()
+            await pilot.press("tab")
             await pilot.pause()
             assert app.screen.is_current
 
@@ -2059,7 +2121,7 @@ class TestChatCompletions:
 
             inp = app.screen.query_one("#chat-input", Input)
             inp.value = "/"
-            app.screen.action_complete_next()
+            await pilot.press("ctrl+n")
             await pilot.pause()
             assert app.screen.is_current
 
@@ -2072,7 +2134,7 @@ class TestChatCompletions:
 
             inp = app.screen.query_one("#chat-input", Input)
             inp.value = "/"
-            app.screen.action_complete_prev()
+            await pilot.press("ctrl+p")
             await pilot.pause()
             assert app.screen.is_current
 
@@ -2087,7 +2149,7 @@ class TestChatCompletions:
 
             inp = app.screen.query_one("#chat-input", Input)
             inp.value = "/"
-            app.screen.action_complete()
+            await pilot.press("tab")
             await pilot.pause()
 
             overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
@@ -2119,11 +2181,11 @@ class TestGridSelectWidget:
             await pilot.pause()
             assert grid.highlighted == 0
 
-            grid.action_cursor_right()
+            await pilot.press("right")
             await pilot.pause()
             assert grid.highlighted == 1
 
-            grid.action_cursor_left()
+            await pilot.press("left")
             await pilot.pause()
             assert grid.highlighted == 0
 
@@ -2149,7 +2211,7 @@ class TestGridSelectWidget:
             grid = app.query_one("#test-grid", GridSelect)
             grid.focus()
             await pilot.pause()
-            grid.action_select()
+            await pilot.press("enter")
             await pilot.pause()
             assert len(selections) == 1
 


### PR DESCRIPTION
The TUI e2e suite had drifted into calling screen/widget `action_*()` methods directly. That pattern bypasses Textual's key-to-binding-to-action dispatcher, so bugs in the binding layer itself (like the catalog `v` toggle regression we recently hit) were invisible to the tests.

This sweep rewrites the affected tests to use `pilot.press()` with the real bound key. Assertions are unchanged. Two sites keep direct action calls and are now annotated with their reason: a mock assignment, and a guard-clause that raises `SkipAction` (which the dispatcher would otherwise swallow).

The sweep also surfaced a genuine binding bug: app-level nav and help keys (`]`, `[`, `?`) are consumed by a focused chat input because they lack `priority=True`. Tests work around it by blurring the input first. The underlying fix is tracked separately.