### PR TITLE
Correct default model pick, dedupe installed models, fix wizard re-push

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -22,6 +22,7 @@ from lilbee.services import reset_services
 log = logging.getLogger(__name__)
 
 _DEFAULT_THEME = "gruvbox"  # warm retro CRT aesthetic
+_CHAT_SCREEN_NAME = "chat"
 DARK_THEMES = (
     "monokai",
     "dracula",
@@ -133,10 +134,6 @@ class LilbeeApp(App[None]):
         from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
         self.task_bar = TaskBarController(self)
-        # True once the setup wizard has been shown, skipped, or a first-mount
-        # check determined it wasn't needed. Reset only on a new process, so
-        # re-entering Chat after visiting Catalog never re-pushes the wizard.
-        self.setup_handled: bool = False
 
     def compose(self) -> ComposeResult:
         yield from ()  # screens compose their own ViewTabs + Footer
@@ -147,7 +144,9 @@ class LilbeeApp(App[None]):
 
         from lilbee.cli.tui.screens.chat import ChatScreen
 
-        self.push_screen(ChatScreen(auto_sync=self._auto_sync))
+        chat = ChatScreen(auto_sync=self._auto_sync)
+        self.install_screen(chat, name=_CHAT_SCREEN_NAME)
+        self.push_screen(_CHAT_SCREEN_NAME)
         if self._initial_view and self._initial_view != msg.DEFAULT_VIEW:
             self.switch_view(self._initial_view)
 
@@ -203,7 +202,7 @@ class LilbeeApp(App[None]):
             from lilbee.cli.tui.screens.chat import ChatScreen
 
             if not isinstance(self.screen, ChatScreen):
-                self.switch_screen(ChatScreen(auto_sync=False))
+                self.switch_screen(_CHAT_SCREEN_NAME)
         else:
             factory = get_views().get(view_name)
             if factory is None:

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -133,6 +133,10 @@ class LilbeeApp(App[None]):
         from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
         self.task_bar = TaskBarController(self)
+        # True once the setup wizard has been shown, skipped, or a first-mount
+        # check determined it wasn't needed. Reset only on a new process, so
+        # re-entering Chat after visiting Catalog never re-pushes the wizard.
+        self.setup_handled: bool = False
 
     def compose(self) -> ComposeResult:
         yield from ()  # screens compose their own ViewTabs + Footer

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -151,39 +151,24 @@ class ChatScreen(Screen[None]):
         self._update_input_style()
         self._refresh_status_line()
         self.query_one("#chat-only-banner", Static).display = False
-        # ChatScreen is reinstantiated on every `switch_view("Chat")`, so
-        # wizard state must live on the app. Once setup has been handled in
-        # this session (shown, skipped, or deemed unnecessary on first mount),
-        # never re-push the wizard for the lifetime of this process.
-        setup_handled = bool(getattr(self.app, "setup_handled", False))
-        if not setup_handled and self._needs_setup():
-            self._mark_setup_handled()
+        if self._needs_setup():
             from lilbee.cli.tui.screens.setup import SetupWizard
 
             self.app.push_screen(SetupWizard(), self._on_setup_complete)
-            return
-        self._mark_setup_handled()
-        if not self._embedding_ready():
+        elif not self._embedding_ready():
             self._show_chat_only_banner()
         elif self._auto_sync:
             self._run_sync()
 
-    def _mark_setup_handled(self) -> None:
-        """Record on the app that setup has been resolved for this session."""
-        if hasattr(self.app, "setup_handled"):
-            self.app.setup_handled = True  # type: ignore[attr-defined]
-
     def on_show(self) -> None:
-        """Called when screen becomes visible - signal splash to stop."""
+        """Called when screen becomes visible."""
         from lilbee.splash import dismiss
 
         dismiss()
+        self._refresh_model_bar()
 
     def _needs_setup(self) -> bool:
-        """True when the setup wizard should run: fresh data dir or unresolved models.
-        Any failure inside the model-resolution block is logged at DEBUG so the
-        app-level ``setup_handled`` guard never hides a real regression silently.
-        """
+        """True when the setup wizard should run: fresh data dir or unresolved models."""
         # Fresh install: an uninitialized data dir still needs the wizard even
         # if default models are already cached globally (Ollama, HF cache).
         if not cfg.lancedb_dir.is_dir():
@@ -212,7 +197,6 @@ class ChatScreen(Screen[None]):
 
     def _on_setup_complete(self, result: str | None) -> None:
         """Called when wizard completes or is skipped."""
-        self._mark_setup_handled()
         if result == "skipped":
             self._show_chat_only_banner()
         elif self._auto_sync and self._embedding_ready():

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -151,14 +151,27 @@ class ChatScreen(Screen[None]):
         self._update_input_style()
         self._refresh_status_line()
         self.query_one("#chat-only-banner", Static).display = False
-        if self._needs_setup():
+        # ChatScreen is reinstantiated on every `switch_view("Chat")`, so
+        # wizard state must live on the app. Once setup has been handled in
+        # this session (shown, skipped, or deemed unnecessary on first mount),
+        # never re-push the wizard for the lifetime of this process.
+        setup_handled = bool(getattr(self.app, "setup_handled", False))
+        if not setup_handled and self._needs_setup():
+            self._mark_setup_handled()
             from lilbee.cli.tui.screens.setup import SetupWizard
 
             self.app.push_screen(SetupWizard(), self._on_setup_complete)
-        elif not self._embedding_ready():
+            return
+        self._mark_setup_handled()
+        if not self._embedding_ready():
             self._show_chat_only_banner()
         elif self._auto_sync:
             self._run_sync()
+
+    def _mark_setup_handled(self) -> None:
+        """Record on the app that setup has been resolved for this session."""
+        if hasattr(self.app, "setup_handled"):
+            self.app.setup_handled = True  # type: ignore[attr-defined]
 
     def on_show(self) -> None:
         """Called when screen becomes visible - signal splash to stop."""
@@ -167,19 +180,25 @@ class ChatScreen(Screen[None]):
         dismiss()
 
     def _needs_setup(self) -> bool:
-        """True when the setup wizard should run: fresh data dir or unresolved models."""
+        """True when the setup wizard should run: fresh data dir or unresolved models.
+        Any failure inside the model-resolution block is logged at DEBUG so the
+        app-level ``setup_handled`` guard never hides a real regression silently.
+        """
         # Fresh install: an uninitialized data dir still needs the wizard even
         # if default models are already cached globally (Ollama, HF cache).
         if not cfg.lancedb_dir.is_dir():
+            log.debug("_needs_setup: lancedb_dir missing (%s)", cfg.lancedb_dir)
             return True
-        try:
-            from lilbee.providers.llama_cpp_provider import resolve_model_path
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.llama_cpp_provider import resolve_model_path
 
-            resolve_model_path(cfg.chat_model)
-            resolve_model_path(cfg.embedding_model)
-            return False
-        except Exception:
-            return True
+        for label, model in (("chat", cfg.chat_model), ("embedding", cfg.embedding_model)):
+            try:
+                resolve_model_path(model)
+            except (ProviderError, KeyError, ValueError) as exc:
+                log.debug("_needs_setup: %s model %r unresolved: %s", label, model, exc)
+                return True
+        return False
 
     def _embedding_ready(self) -> bool:
         """Quick check if embedding model exists (no network calls)."""
@@ -193,6 +212,7 @@ class ChatScreen(Screen[None]):
 
     def _on_setup_complete(self, result: str | None) -> None:
         """Called when wizard completes or is skipped."""
+        self._mark_setup_handled()
         if result == "skipped":
             self._show_chat_only_banner()
         elif self._auto_sync and self._embedding_ready():

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -79,14 +79,12 @@ def _installed_name_to_row(name: str, task: str) -> TableRow:
 
 def _pick_recommended(ram_gb: float) -> tuple[CatalogModel, CatalogModel]:
     """Pick chat + embedding models appropriate for system RAM.
-    Selects the largest featured chat model whose min_ram_gb fits,
-    and always picks the first embedding model (Nomic).
+    Selects the largest featured chat model (by ``size_gb``) whose
+    ``min_ram_gb`` fits the host, not just the first entry in authoring
+    order. Always picks the first embedding model (Nomic).
     """
-    chat = FEATURED_CHAT[0]
-    for m in reversed(FEATURED_CHAT):
-        if m.min_ram_gb <= ram_gb:
-            chat = m
-            break
+    eligible = [m for m in FEATURED_CHAT if m.min_ram_gb <= ram_gb]
+    chat = max(eligible, key=lambda m: m.size_gb) if eligible else FEATURED_CHAT[0]
     embed = FEATURED_EMBEDDING[0]
     return chat, embed
 
@@ -167,11 +165,17 @@ class SetupWizard(Screen[str | None]):
         self,
         heading: str,
         models: tuple[CatalogModel, ...],
+        installed_refs: set[str],
         widgets_out: list[Static | GridSelect],
     ) -> list[ModelCard]:
-        """Build a heading + GridSelect for a list of catalog models."""
+        """Build a heading + GridSelect for a list of catalog models.
+        Catalog entries whose canonical ``name:tag`` is already in
+        ``installed_refs`` render with ``installed=True`` so they report a
+        zero download size and don't trigger a redundant download on
+        Install & Go.
+        """
         widgets_out.append(Static(heading, classes="section-heading"))
-        cards = [ModelCard(catalog_to_row(m, installed=False)) for m in models]
+        cards = [ModelCard(catalog_to_row(m, installed=m.ref in installed_refs)) for m in models]
         widgets_out.append(GridSelect(*cards, min_column_width=30, max_column_width=50))
         return cards
 
@@ -184,6 +188,7 @@ class SetupWizard(Screen[str | None]):
 
         container = self.query_one("#setup-grid-container", VerticalScroll)
         widgets_to_mount: list[Static | GridSelect] = []
+        installed_refs = set(self._chat_installed) | set(self._embed_installed)
 
         if self._chat_installed or self._embed_installed:
             widgets_to_mount.append(Static(msg.HEADING_INSTALLED, classes="section-heading"))
@@ -197,9 +202,11 @@ class SetupWizard(Screen[str | None]):
                 GridSelect(*installed_cards, min_column_width=30, max_column_width=50)
             )
 
-        chat_cards = self._build_section(msg.SETUP_HEADING_CHAT, FEATURED_CHAT, widgets_to_mount)
+        chat_cards = self._build_section(
+            msg.SETUP_HEADING_CHAT, FEATURED_CHAT, installed_refs, widgets_to_mount
+        )
         embed_cards = self._build_section(
-            msg.SETUP_HEADING_EMBED, FEATURED_EMBEDDING, widgets_to_mount
+            msg.SETUP_HEADING_EMBED, FEATURED_EMBEDDING, installed_refs, widgets_to_mount
         )
 
         container.mount_all(widgets_to_mount)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,6 +160,7 @@ def make_test_catalog_model(
     description: str = "A test model",
     tag: str = "latest",
     display_name: str = "",
+    min_ram_gb: float = 4,
 ) -> CatalogModel:
     """Build a CatalogModel with sensible test defaults."""
     return CatalogModel(
@@ -169,7 +170,7 @@ def make_test_catalog_model(
         hf_repo=f"test/{name.lower().replace(' ', '-')}",
         gguf_filename="*.gguf",
         size_gb=size_gb,
-        min_ram_gb=4,
+        min_ram_gb=min_ram_gb,
         description=description,
         featured=featured,
         downloads=100,

--- a/tests/test_chat_setup_detection.py
+++ b/tests/test_chat_setup_detection.py
@@ -89,86 +89,12 @@ def mock_services():
         set_services(None)
 
 
-async def test_wizard_not_repushed_after_skip_and_nav(isolated_data_dir, mock_services):
-    """After the wizard is skipped, navigating to Catalog and back must not
-    re-push it. Regression test for the setup-wizard-flapping bug."""
+async def test_chat_screen_cached_across_navigation(isolated_data_dir, mock_services):
+    """Navigating away from Chat and back reuses the same instance.
+    ChatScreen is installed via install_screen, so on_mount (and therefore
+    _needs_setup) runs only on first mount, not on every revisit."""
     from lilbee.cli.tui.app import LilbeeApp
     from lilbee.cli.tui.screens.catalog import CatalogScreen
-    from lilbee.cli.tui.screens.chat import ChatScreen
-    from lilbee.cli.tui.screens.setup import SetupWizard
-
-    cfg.lancedb_dir.mkdir(parents=True)
-    cfg.models_dir = isolated_data_dir / "models"
-    cfg.models_dir.mkdir()
-    cfg.chat_model = "ghost:latest"
-    cfg.embedding_model = "ghost-embed:latest"
-
-    # _needs_setup returns True on first mount (models unresolvable), then we
-    # simulate flip-flop by making it True again on the re-entry mount. The
-    # app-level flag must still prevent the wizard from being re-pushed.
-    with mock.patch(
-        "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
-        return_value=True,
-    ):
-        app = LilbeeApp()
-        async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
-            # First mount: wizard is pushed.
-            assert isinstance(app.screen, SetupWizard)
-            # User skips the wizard.
-            app.screen.dismiss("skipped")
-            await pilot.pause()
-            assert isinstance(app.screen, ChatScreen)
-            assert app.setup_handled is True
-
-            # Navigate to Catalog and back to Chat. _needs_setup still says
-            # True but the flag must prevent the wizard from being re-pushed.
-            app.switch_view("Catalog")
-            await pilot.pause()
-            assert isinstance(app.screen, CatalogScreen)
-            app.switch_view("Chat")
-            await pilot.pause()
-            assert isinstance(app.screen, ChatScreen)
-
-
-async def test_wizard_not_repushed_after_completion(isolated_data_dir, mock_services):
-    """After the wizard is completed, navigating away and back must not
-    re-push it either."""
-    from lilbee.cli.tui.app import LilbeeApp
-    from lilbee.cli.tui.screens.catalog import CatalogScreen
-    from lilbee.cli.tui.screens.chat import ChatScreen
-    from lilbee.cli.tui.screens.setup import SetupWizard
-
-    cfg.lancedb_dir.mkdir(parents=True)
-    cfg.models_dir = isolated_data_dir / "models"
-    cfg.models_dir.mkdir()
-    cfg.chat_model = "ghost:latest"
-    cfg.embedding_model = "ghost-embed:latest"
-
-    with mock.patch(
-        "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
-        return_value=True,
-    ):
-        app = LilbeeApp()
-        async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
-            assert isinstance(app.screen, SetupWizard)
-            app.screen.dismiss("completed")
-            await pilot.pause()
-            assert isinstance(app.screen, ChatScreen)
-
-            app.switch_view("Catalog")
-            await pilot.pause()
-            assert isinstance(app.screen, CatalogScreen)
-            app.switch_view("Chat")
-            await pilot.pause()
-            assert isinstance(app.screen, ChatScreen)
-
-
-async def test_first_mount_no_wizard_marks_handled(isolated_data_dir, mock_services):
-    """When the first chat mount decides setup isn't needed, the app flag must
-    be set so any later flakiness in _needs_setup can't resurrect the wizard."""
-    from lilbee.cli.tui.app import LilbeeApp
     from lilbee.cli.tui.screens.chat import ChatScreen
 
     cfg.lancedb_dir.mkdir(parents=True)
@@ -186,5 +112,13 @@ async def test_first_mount_no_wizard_marks_handled(isolated_data_dir, mock_servi
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            assert isinstance(app.screen, ChatScreen)
-            assert app.setup_handled is True
+            chat = app.screen
+            assert isinstance(chat, ChatScreen)
+
+            app.switch_view("Catalog")
+            await pilot.pause()
+            assert isinstance(app.screen, CatalogScreen)
+
+            app.switch_view("Chat")
+            await pilot.pause()
+            assert app.screen is chat  # same instance, not a new one

--- a/tests/test_chat_setup_detection.py
+++ b/tests/test_chat_setup_detection.py
@@ -52,10 +52,12 @@ def test_needs_setup_false_when_initialized_and_models_resolve(isolated_data_dir
 
 def test_needs_setup_true_when_initialized_but_model_missing(isolated_data_dir):
     """Unresolvable chat/embedding model still triggers the wizard."""
+    from lilbee.providers.base import ProviderError
+
     cfg.lancedb_dir.mkdir(parents=True)
     with mock.patch(
         "lilbee.providers.llama_cpp_provider.resolve_model_path",
-        side_effect=FileNotFoundError("no such model"),
+        side_effect=ProviderError("no such model", provider="llama-cpp"),
     ):
         assert _make_screen()._needs_setup() is True
 
@@ -71,3 +73,118 @@ def test_needs_setup_true_when_lancedb_path_is_a_file(isolated_data_dir):
         return_value="/some/resolved/path",
     ):
         assert _make_screen()._needs_setup() is True
+
+
+@pytest.fixture
+def mock_services():
+    from lilbee.services import set_services
+
+    svc = mock.MagicMock()
+    svc.provider.list_models.return_value = []
+    svc.searcher._embedder.embedding_available.return_value = True
+    set_services(svc)
+    try:
+        yield svc
+    finally:
+        set_services(None)
+
+
+async def test_wizard_not_repushed_after_skip_and_nav(isolated_data_dir, mock_services):
+    """After the wizard is skipped, navigating to Catalog and back must not
+    re-push it. Regression test for the setup-wizard-flapping bug."""
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+    from lilbee.cli.tui.screens.chat import ChatScreen
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    cfg.lancedb_dir.mkdir(parents=True)
+    cfg.models_dir = isolated_data_dir / "models"
+    cfg.models_dir.mkdir()
+    cfg.chat_model = "ghost:latest"
+    cfg.embedding_model = "ghost-embed:latest"
+
+    # _needs_setup returns True on first mount (models unresolvable), then we
+    # simulate flip-flop by making it True again on the re-entry mount. The
+    # app-level flag must still prevent the wizard from being re-pushed.
+    with mock.patch(
+        "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
+        return_value=True,
+    ):
+        app = LilbeeApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            # First mount: wizard is pushed.
+            assert isinstance(app.screen, SetupWizard)
+            # User skips the wizard.
+            app.screen.dismiss("skipped")
+            await pilot.pause()
+            assert isinstance(app.screen, ChatScreen)
+            assert app.setup_handled is True
+
+            # Navigate to Catalog and back to Chat. _needs_setup still says
+            # True but the flag must prevent the wizard from being re-pushed.
+            app.switch_view("Catalog")
+            await pilot.pause()
+            assert isinstance(app.screen, CatalogScreen)
+            app.switch_view("Chat")
+            await pilot.pause()
+            assert isinstance(app.screen, ChatScreen)
+
+
+async def test_wizard_not_repushed_after_completion(isolated_data_dir, mock_services):
+    """After the wizard is completed, navigating away and back must not
+    re-push it either."""
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+    from lilbee.cli.tui.screens.chat import ChatScreen
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    cfg.lancedb_dir.mkdir(parents=True)
+    cfg.models_dir = isolated_data_dir / "models"
+    cfg.models_dir.mkdir()
+    cfg.chat_model = "ghost:latest"
+    cfg.embedding_model = "ghost-embed:latest"
+
+    with mock.patch(
+        "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
+        return_value=True,
+    ):
+        app = LilbeeApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert isinstance(app.screen, SetupWizard)
+            app.screen.dismiss("completed")
+            await pilot.pause()
+            assert isinstance(app.screen, ChatScreen)
+
+            app.switch_view("Catalog")
+            await pilot.pause()
+            assert isinstance(app.screen, CatalogScreen)
+            app.switch_view("Chat")
+            await pilot.pause()
+            assert isinstance(app.screen, ChatScreen)
+
+
+async def test_first_mount_no_wizard_marks_handled(isolated_data_dir, mock_services):
+    """When the first chat mount decides setup isn't needed, the app flag must
+    be set so any later flakiness in _needs_setup can't resurrect the wizard."""
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.chat import ChatScreen
+
+    cfg.lancedb_dir.mkdir(parents=True)
+
+    with (
+        mock.patch(
+            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
+            return_value=False,
+        ),
+        mock.patch(
+            "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
+            return_value=True,
+        ),
+    ):
+        app = LilbeeApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert isinstance(app.screen, ChatScreen)
+            assert app.setup_handled is True

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -86,6 +86,10 @@ def _patch_chat_setup():
             "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
             return_value=([], [], []),
         ),
+        patch(
+            "lilbee.cli.tui.widgets.model_bar.ModelBar._scan_models",
+            return_value=None,
+        ),
     ):
         yield
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1407,6 +1407,77 @@ class TestSetupWizard:
         assert card.row.featured is True
         assert card.row.task == "chat"
 
+    def test_pick_recommended_picks_largest_fitting_not_first(self) -> None:
+        """Default pick is the biggest-size-gb model whose min_ram_gb fits."""
+        from lilbee.cli.tui.screens import setup as setup_mod
+
+        tiny = _make_model("Tiny", size_gb=0.4, min_ram_gb=0.5, featured=True)
+        small = _make_model("Small", size_gb=2.5, min_ram_gb=4, featured=True)
+        medium = _make_model("Medium", size_gb=5.0, min_ram_gb=8, featured=True)
+        large = _make_model("Large", size_gb=18.0, min_ram_gb=16, featured=True)
+        embed = _make_model("Embed", task="embedding", size_gb=0.3, min_ram_gb=1)
+        with (
+            mock.patch.object(setup_mod, "FEATURED_CHAT", (tiny, small, medium, large)),
+            mock.patch.object(setup_mod, "FEATURED_EMBEDDING", (embed,)),
+        ):
+            # 64 GB: everything fits, largest wins.
+            chat, picked_embed = setup_mod._pick_recommended(64.0)
+            assert chat is large
+            assert picked_embed is embed
+            # 16 GB: large just fits, still wins.
+            assert setup_mod._pick_recommended(16.0)[0] is large
+            # 8 GB: medium is the largest that fits.
+            assert setup_mod._pick_recommended(8.0)[0] is medium
+            # 4 GB: small is the largest that fits.
+            assert setup_mod._pick_recommended(4.0)[0] is small
+            # 1 GB: only tiny fits.
+            assert setup_mod._pick_recommended(1.0)[0] is tiny
+
+    def test_pick_recommended_falls_back_when_nothing_fits(self) -> None:
+        """If no featured model fits, fall back to the first entry."""
+        from lilbee.cli.tui.screens import setup as setup_mod
+
+        big = _make_model("BigOnly", size_gb=40.0, min_ram_gb=64, featured=True)
+        embed = _make_model("Embed", task="embedding", size_gb=0.3, min_ram_gb=1)
+        with (
+            mock.patch.object(setup_mod, "FEATURED_CHAT", (big,)),
+            mock.patch.object(setup_mod, "FEATURED_EMBEDDING", (embed,)),
+        ):
+            assert setup_mod._pick_recommended(4.0)[0] is big
+
+    def test_build_section_marks_installed_catalog_cards(self) -> None:
+        """Catalog cards whose name:tag is already installed come back with
+        ``installed=True`` so they report a zero download size."""
+        from lilbee.cli.tui.screens.setup import SetupWizard, _card_download_size
+
+        a = _make_model("Qwen3 0.6B", tag="0.6b", featured=True, size_gb=0.6)
+        b = _make_model("Qwen3 4B", tag="4b", featured=True, size_gb=2.5)
+        wizard = SetupWizard.__new__(SetupWizard)
+        widgets: list = []
+        cards = SetupWizard._build_section(wizard, "Chat", (a, b), {"qwen3-0.6b:0.6b"}, widgets)
+        assert cards[0].row.installed is True
+        assert cards[1].row.installed is False
+        assert _card_download_size(cards[0]) == 0.0
+        assert _card_download_size(cards[1]) == 2.5
+
+    def test_scan_installed_feeds_build_grid_installed_refs(self, tmp_path) -> None:
+        """_scan_installed_models output must be usable as installed refs for the
+        catalog grid so the same model never appears with a phantom download."""
+        from lilbee.cli.tui.screens.setup import _scan_installed_models
+        from lilbee.models import ModelTask
+
+        cfg.models_dir = tmp_path / "models"
+        cfg.models_dir.mkdir()
+        fake_chat = mock.Mock(name="qwen3-0.6b", tag="0.6b", task=ModelTask.CHAT)
+        fake_chat.name = "qwen3-0.6b"
+        fake_embed = mock.Mock(name="nomic", tag="v1.5", task=ModelTask.EMBEDDING)
+        fake_embed.name = "nomic"
+        with mock.patch("lilbee.registry.ModelRegistry") as MockRegistry:
+            MockRegistry.return_value.list_installed.return_value = [fake_chat, fake_embed]
+            chat, embed = _scan_installed_models()
+        assert "qwen3-0.6b:0.6b" in chat
+        assert "nomic:v1.5" in embed
+
 
 class TestAllTasksFetched:
     def test_all_tasks_constant(self) -> None:


### PR DESCRIPTION
Three related setup-wizard bugs caught in QA.

- First-run wizard was defaulting to the 135M toy model on machines with plenty of RAM, which then produced nonsense answers. It now picks the biggest featured chat model that actually fits your system.
- A model that was already installed globally could show up twice in the wizard grid and claim it still needed to be downloaded. The grid now honours the installed scan.
- After dismissing the wizard, navigating to the catalog and back to chat could re-pop the wizard in the same session. The chat screen now remembers, on the app, that setup was already handled.
- Narrowed the catch-all in the chat-screen setup check and added debug logging so future flakiness is visible instead of silently triggering the wizard.