### PR TITLE
Make cfg the source of truth for ModelBar dropdowns

### DIFF
--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -93,15 +93,9 @@ def _collect_remote_models(buckets: dict[str, list[ModelOption]], seen: set[str]
 
 
 def _sync_select(sel: Select, opts: list[ModelOption], default: str = "") -> None:
-    """Set options and value for a model Select widget.
+    """Populate a model Select and set it to *default* (from cfg).
 
-    ``default`` (the configured model from ``cfg``) is the single source of
-    truth. Any in-session manual pick has already been written back to cfg by
-    the Select.Changed handler, so we never preserve ``sel.value`` across a
-    sync. If ``default`` is not in ``opts``, it is prepended so it remains
-    selectable.
-
-    Note: may mutate *opts* by inserting ``default`` at index 0.
+    Prepends *default* if it is not already in *opts*.
     """
     if default and not any(o.ref == default for o in opts):
         opts.insert(0, ModelOption(default, default))
@@ -211,11 +205,7 @@ class ModelBar(Widget, can_focus=False):
         self._populating = False
 
     def _sync_vision_select(self, sel: Select, models: list[ModelOption]) -> None:
-        """Sync vision Select from cfg.vision_model.
-
-        cfg is the source of truth. An empty cfg.vision_model means vision is
-        disabled, so the widget's value is cleared to ``_DISABLED``.
-        """
+        """Populate the vision Select from cfg. Clears to disabled if unset."""
         opts = list(models)
         target = cfg.vision_model
         if target:

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -94,20 +94,20 @@ def _collect_remote_models(buckets: dict[str, list[ModelOption]], seen: set[str]
 
 def _sync_select(sel: Select, opts: list[ModelOption], default: str = "") -> None:
     """Set options and value for a model Select widget.
-    Preserves the current value if it's in the options. Falls back to
-    *default* (typically the configured model from ``cfg``). If the
-    resolved value isn't in *opts*, prepends it so it remains selectable.
 
-    Note: may mutate *opts* by inserting the resolved value at index 0.
+    ``default`` (the configured model from ``cfg``) is the single source of
+    truth. Any in-session manual pick has already been written back to cfg by
+    the Select.Changed handler, so we never preserve ``sel.value`` across a
+    sync. If ``default`` is not in ``opts``, it is prepended so it remains
+    selectable.
+
+    Note: may mutate *opts* by inserting ``default`` at index 0.
     """
+    if default and not any(o.ref == default for o in opts):
+        opts.insert(0, ModelOption(default, default))
     sel.set_options(opts)
-    current = str(sel.value) if sel.value != _DISABLED else ""
-    target = current or default
-    if target:
-        if not any(o.ref == target for o in opts):
-            opts.insert(0, ModelOption(target, target))
-            sel.set_options(opts)
-        sel.value = target
+    if default:
+        sel.value = default
 
 
 _SELECT_IDS = ("#chat-model-select", "#embed-model-select", "#vision-model-select")
@@ -211,10 +211,13 @@ class ModelBar(Widget, can_focus=False):
         self._populating = False
 
     def _sync_vision_select(self, sel: Select, models: list[ModelOption]) -> None:
-        """Sync vision Select with extra fallback to cfg.vision_model."""
+        """Sync vision Select from cfg.vision_model.
+
+        cfg is the source of truth. An empty cfg.vision_model means vision is
+        disabled, so the widget's value is cleared to ``_DISABLED``.
+        """
         opts = list(models)
-        current = str(sel.value) if sel.value != _DISABLED else ""
-        target = current or cfg.vision_model
+        target = cfg.vision_model
         if target:
             if not any(o.ref == target for o in opts):
                 opts.insert(0, ModelOption(target, target))

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2186,25 +2186,25 @@ class TestModelBarAdditional:
 
 
 class TestSyncSelectPrepend:
-    """Cover _sync_select branch: current value not in scanned options."""
+    """Cover _sync_select contract: cfg default is the source of truth."""
 
-    def test_current_value_prepended_when_not_in_options(self) -> None:
-        """When Select holds a value absent from the new options, it's prepended."""
+    def test_default_overrides_stale_current_value(self) -> None:
+        """Stale sel.value is discarded in favor of the configured default."""
         from lilbee.cli.tui.widgets.model_bar import ModelOption, _sync_select
 
-        # Mock a Select widget that retains its value after set_options
         sel = mock.MagicMock()
-        sel.value = "custom:latest"
-        opts = [ModelOption("Qwen3 8B", "qwen3:8b")]
-        _sync_select(sel, opts)
-        # Prepended the missing value and called set_options twice
-        assert sel.set_options.call_count == 2
-        prepended = sel.set_options.call_args_list[1][0][0]
-        assert prepended[0] == ModelOption("custom:latest", "custom:latest")
-        assert sel.value == "custom:latest"
+        sel.value = "mistral:latest"
+        opts = [
+            ModelOption("mistral:latest", "mistral:latest"),
+            ModelOption("smollm2:135m", "smollm2:135m"),
+        ]
+        _sync_select(sel, opts, default="smollm2:135m")
+        assert sel.value == "smollm2:135m"
+        # Single set_options call since default is already in opts
+        assert sel.set_options.call_count == 1
 
-    def test_default_used_when_no_current_value(self) -> None:
-        """When Select has no value, fall back to the configured default."""
+    def test_default_used_when_select_is_disabled(self) -> None:
+        """When Select has no value, use the configured default."""
         from lilbee.cli.tui.widgets.model_bar import _DISABLED, ModelOption, _sync_select
 
         sel = mock.MagicMock()
@@ -2214,20 +2214,20 @@ class TestSyncSelectPrepend:
         assert sel.value == "qwen3:8b"
 
     def test_default_prepended_when_not_in_opts(self) -> None:
-        """When the configured default isn't in opts, it's prepended."""
+        """When the configured default isn't in opts, it's prepended before set_options."""
         from lilbee.cli.tui.widgets.model_bar import _DISABLED, ModelOption, _sync_select
 
         sel = mock.MagicMock()
         sel.value = _DISABLED
         opts = [ModelOption("Qwen3 8B", "qwen3:8b")]
         _sync_select(sel, opts, default="llama3:8b")
-        assert sel.set_options.call_count == 2
-        prepended = sel.set_options.call_args_list[1][0][0]
-        assert prepended[0] == ModelOption("llama3:8b", "llama3:8b")
+        assert sel.set_options.call_count == 1
+        passed = sel.set_options.call_args_list[0][0][0]
+        assert passed[0] == ModelOption("llama3:8b", "llama3:8b")
         assert sel.value == "llama3:8b"
 
-    def test_no_default_no_current_leaves_unset(self) -> None:
-        """When no current value and no default, don't set a value."""
+    def test_no_default_leaves_value_untouched(self) -> None:
+        """When there's no default, don't assign a value."""
         from lilbee.cli.tui.widgets.model_bar import _DISABLED, ModelOption, _sync_select
 
         sel = mock.MagicMock()
@@ -2884,3 +2884,234 @@ class TestModelBarPopulateBranches:
                 await pilot.pause()
                 await pilot.pause()
                 mock_reset.assert_called_once()
+
+
+class TestModelBarCfgSourceOfTruth:
+    """Regression tests for BEE-0gw: dropdown must follow cfg on refresh.
+
+    The bug: _sync_select used to preserve sel.value across set_options even
+    when cfg had changed, so a stale scanner pick would override the configured
+    model. cfg is the single source of truth, and manual user picks already
+    write back to cfg via the Select.Changed handler, so refresh should always
+    re-sync the dropdown to cfg.
+    """
+
+    @pytest.fixture(autouse=True)
+    def mock_classify(self):
+        with mock.patch(
+            "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
+            return_value=([], [], []),
+        ):
+            yield
+
+    async def test_refresh_follows_cfg_chat_model_change(self) -> None:
+        """After cfg.chat_model changes, refresh snaps dropdown to the new value."""
+        from textual.widgets import Select
+
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+
+        cfg.chat_model = "mistral:latest"
+        cfg.embedding_model = "nomic:latest"
+        cfg.vision_model = ""
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(ModelBar)
+            chat_sel = app.query_one("#chat-model-select", Select)
+
+            bar._populate(
+                [
+                    ModelOption("mistral:latest", "mistral:latest"),
+                    ModelOption("smollm2:135m", "smollm2:135m"),
+                ],
+                [ModelOption("nomic:latest", "nomic:latest")],
+                [],
+            )
+            await pilot.pause()
+            assert chat_sel.value == "mistral:latest"
+
+            cfg.chat_model = "smollm2:135m"
+
+            bar._populate(
+                [
+                    ModelOption("mistral:latest", "mistral:latest"),
+                    ModelOption("smollm2:135m", "smollm2:135m"),
+                ],
+                [ModelOption("nomic:latest", "nomic:latest")],
+                [],
+            )
+            await pilot.pause()
+            assert chat_sel.value == "smollm2:135m"
+
+    async def test_refresh_follows_cfg_embedding_model_change(self) -> None:
+        """Embedding dropdown also snaps to cfg on refresh."""
+        from textual.widgets import Select
+
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+
+        cfg.chat_model = "qwen3:8b"
+        cfg.embedding_model = "nomic:latest"
+        cfg.vision_model = ""
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(ModelBar)
+            embed_sel = app.query_one("#embed-model-select", Select)
+
+            bar._populate(
+                [ModelOption("qwen3:8b", "qwen3:8b")],
+                [
+                    ModelOption("nomic:latest", "nomic:latest"),
+                    ModelOption("bge-small:latest", "bge-small:latest"),
+                ],
+                [],
+            )
+            await pilot.pause()
+            assert embed_sel.value == "nomic:latest"
+
+            cfg.embedding_model = "bge-small:latest"
+            bar._populate(
+                [ModelOption("qwen3:8b", "qwen3:8b")],
+                [
+                    ModelOption("nomic:latest", "nomic:latest"),
+                    ModelOption("bge-small:latest", "bge-small:latest"),
+                ],
+                [],
+            )
+            await pilot.pause()
+            assert embed_sel.value == "bge-small:latest"
+
+    async def test_refresh_follows_cfg_vision_model_change(self) -> None:
+        """Vision dropdown also snaps to cfg on refresh."""
+        from textual.widgets import Select
+
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+
+        cfg.chat_model = "qwen3:8b"
+        cfg.embedding_model = "nomic:latest"
+        cfg.vision_model = "llava:7b"
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(ModelBar)
+            vision_sel = app.query_one("#vision-model-select", Select)
+
+            bar._populate(
+                [ModelOption("qwen3:8b", "qwen3:8b")],
+                [ModelOption("nomic:latest", "nomic:latest")],
+                [
+                    ModelOption("llava:7b", "llava:7b"),
+                    ModelOption("moondream:latest", "moondream:latest"),
+                ],
+            )
+            await pilot.pause()
+            assert vision_sel.value == "llava:7b"
+
+            cfg.vision_model = "moondream:latest"
+            bar._populate(
+                [ModelOption("qwen3:8b", "qwen3:8b")],
+                [ModelOption("nomic:latest", "nomic:latest")],
+                [
+                    ModelOption("llava:7b", "llava:7b"),
+                    ModelOption("moondream:latest", "moondream:latest"),
+                ],
+            )
+            await pilot.pause()
+            assert vision_sel.value == "moondream:latest"
+
+    async def test_manual_user_pick_writes_cfg_and_survives_refresh(self) -> None:
+        """A real user pick flows through Select.Changed -> cfg, so refresh keeps it."""
+        from textual.widgets import Select
+
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+
+        cfg.chat_model = "mistral:latest"
+        cfg.embedding_model = "nomic:latest"
+        cfg.vision_model = ""
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(ModelBar)
+            chat_sel = app.query_one("#chat-model-select", Select)
+
+            bar._populate(
+                [
+                    ModelOption("mistral:latest", "mistral:latest"),
+                    ModelOption("smollm2:135m", "smollm2:135m"),
+                ],
+                [ModelOption("nomic:latest", "nomic:latest")],
+                [],
+            )
+            await pilot.pause()
+            assert chat_sel.value == "mistral:latest"
+
+            with (
+                mock.patch("lilbee.cli.tui.widgets.model_bar.settings.set_value"),
+                mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services"),
+            ):
+                chat_sel.value = "smollm2:135m"
+                await pilot.pause()
+
+            assert cfg.chat_model == "smollm2:135m"
+
+            bar._populate(
+                [
+                    ModelOption("mistral:latest", "mistral:latest"),
+                    ModelOption("smollm2:135m", "smollm2:135m"),
+                ],
+                [ModelOption("nomic:latest", "nomic:latest")],
+                [],
+            )
+            await pilot.pause()
+            assert chat_sel.value == "smollm2:135m"
+
+    async def test_chat_changed_ignores_null_event(self) -> None:
+        """A Select.Changed event with NULL value is ignored (no cfg write)."""
+        from textual.widgets import Select
+
+        from lilbee.cli.tui.widgets.model_bar import _DISABLED, ModelBar
+
+        cfg.chat_model = "qwen3:8b"
+        cfg.embedding_model = "nomic:latest"
+        cfg.vision_model = ""
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(ModelBar)
+            bar._populating = False
+            chat_sel = app.query_one("#chat-model-select", Select)
+
+            null_event = mock.MagicMock(spec=Select.Changed)
+            null_event.value = _DISABLED
+            null_event.select = chat_sel
+            bar._on_chat_model_changed(null_event)
+
+            # cfg must not have been mutated (still the original value).
+            assert cfg.chat_model == "qwen3:8b"
+
+    async def test_first_populate_respects_cfg_over_scanner_order(self) -> None:
+        """First populate must honor cfg even when scanner lists other models first."""
+        from textual.widgets import Select
+
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+
+        cfg.chat_model = "smollm2:135m"
+        cfg.embedding_model = "nomic:latest"
+        cfg.vision_model = ""
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(ModelBar)
+            chat_sel = app.query_one("#chat-model-select", Select)
+
+            bar._populate(
+                [
+                    ModelOption("mistral:latest", "mistral:latest"),
+                    ModelOption("smollm2:135m", "smollm2:135m"),
+                    ModelOption("llama3:8b", "llama3:8b"),
+                ],
+                [ModelOption("nomic:latest", "nomic:latest")],
+                [],
+            )
+            await pilot.pause()
+            assert chat_sel.value == "smollm2:135m"

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2186,7 +2186,7 @@ class TestModelBarAdditional:
 
 
 class TestSyncSelectPrepend:
-    """Cover _sync_select contract: cfg default is the source of truth."""
+    """_sync_select always sets the widget value from cfg."""
 
     def test_default_overrides_stale_current_value(self) -> None:
         """Stale sel.value is discarded in favor of the configured default."""
@@ -2887,14 +2887,7 @@ class TestModelBarPopulateBranches:
 
 
 class TestModelBarCfgSourceOfTruth:
-    """Regression tests for BEE-0gw: dropdown must follow cfg on refresh.
-
-    The bug: _sync_select used to preserve sel.value across set_options even
-    when cfg had changed, so a stale scanner pick would override the configured
-    model. cfg is the single source of truth, and manual user picks already
-    write back to cfg via the Select.Changed handler, so refresh should always
-    re-sync the dropdown to cfg.
-    """
+    """Model dropdowns must match cfg after every refresh."""
 
     @pytest.fixture(autouse=True)
     def mock_classify(self):


### PR DESCRIPTION
The model dropdowns at the top of the chat screen would get stuck showing the wrong model after changing it via the setup wizard, settings, or `/model`. The status pill above the input always showed the right one, so the two disagreed.

Now the dropdowns always read from cfg, which is where every other part of the app already looks. Manual dropdown picks still work since those write to cfg immediately.

Regression tests added for all three dropdowns (chat, embed, vision).