### PR TITLE
feat: sensible CORS defaults

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -205,7 +205,8 @@ All settings are configurable via environment variables:
 |----------|---------|-------------|
 | `LILBEE_SERVER_HOST` | `127.0.0.1` | Server bind address |
 | `LILBEE_SERVER_PORT` | `7433` | Server port |
-| `LILBEE_CORS_ORIGINS` | *(none)* | Comma-separated list of allowed CORS origins (e.g. `app://obsidian.md,https://my-app.com`). Localhost is always allowed. |
+| `LILBEE_CORS_ORIGINS` | *(none)* | Comma-separated list of extra allowed CORS origins for remote clients, e.g. `https://my-app.com`. Additive — the default regex below is still applied. |
+| `LILBEE_CORS_ORIGIN_REGEX` | *(see below)* | Regex for allowed origins. Default matches `app://obsidian.md`, `capacitor://localhost`, and any `http(s)://localhost`, `127.0.0.1`, or `[::1]` with any port. Set to `^$` to opt out and rely solely on `LILBEE_CORS_ORIGINS`. |
 
 **Generation** — tune LLM output:
 

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -77,6 +77,20 @@ _DEFAULT_SYSTEM_PROMPT = (
     "elaborate."
 )
 
+# Default regex for the CORS allow-origin filter. Covers:
+#   - Obsidian desktop (Electron renderer uses app://obsidian.md)
+#   - Obsidian iOS (Capacitor webview uses capacitor://localhost)
+#   - Any http(s) localhost origin, including ports (Android Obsidian, local dev tools)
+#   - IPv4 and IPv6 loopback literals
+# Auth is still enforced on mutating endpoints regardless of CORS — see server/auth.py.
+_DEFAULT_CORS_ORIGIN_REGEX = (
+    r"^(app://obsidian\.md"
+    r"|capacitor://localhost"
+    r"|https?://localhost(:\d+)?"
+    r"|https?://127\.0\.0\.1(:\d+)?"
+    r"|https?://\[::1\](:\d+)?)$"
+)
+
 
 class Config(BaseSettings):
     """Runtime configuration — one singleton instance, mutated by CLI overrides."""
@@ -111,6 +125,7 @@ class Config(BaseSettings):
     server_host: str = "127.0.0.1"
     server_port: int = Field(default=0, ge=0, le=65535)
     cors_origins: list[str] = Field(default_factory=list)
+    cors_origin_regex: str = Field(default=_DEFAULT_CORS_ORIGIN_REGEX)
     json_mode: bool = False
     temperature: float | None = ConfigField(default=None, ge=0.0, writable=True)
     top_p: float | None = ConfigField(default=None, ge=0.0, le=1.0, writable=True)

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -86,6 +86,7 @@ def create_app() -> Litestar:
     """Create the Litestar application instance."""
     cors = CORSConfig(
         allow_origins=cfg.cors_origins,
+        allow_origin_regex=cfg.cors_origin_regex,
         allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
         allow_headers=["Content-Type", "Authorization"],
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,14 @@
 """Tests for Config (pydantic-settings BaseSettings) and env var overrides."""
 
 import os
+import re
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from lilbee.config import (
+    _DEFAULT_CORS_ORIGIN_REGEX,
     CHUNKS_TABLE,
     DEFAULT_IGNORE_DIRS,
     SOURCES_TABLE,
@@ -301,6 +303,83 @@ class TestCorsOriginsConfig:
         with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
             c = Config()
             assert c.cors_origins == []
+
+
+class TestCorsOriginRegexConfig:
+    def test_cors_origin_regex_default_matches_obsidian_desktop(self, tmp_path) -> None:
+
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            pat = re.compile(c.cors_origin_regex)
+            assert pat.fullmatch("app://obsidian.md")
+
+    def test_cors_origin_regex_default_matches_capacitor_localhost(self, tmp_path) -> None:
+
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            pat = re.compile(c.cors_origin_regex)
+            assert pat.fullmatch("capacitor://localhost")
+
+    def test_cors_origin_regex_default_matches_http_localhost_any_port(self, tmp_path) -> None:
+
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            pat = re.compile(c.cors_origin_regex)
+            assert pat.fullmatch("http://localhost")
+            assert pat.fullmatch("http://localhost:3000")
+            assert pat.fullmatch("http://localhost:7433")
+            assert pat.fullmatch("https://localhost:8443")
+
+    def test_cors_origin_regex_default_matches_loopback_ipv4(self, tmp_path) -> None:
+
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            pat = re.compile(c.cors_origin_regex)
+            assert pat.fullmatch("http://127.0.0.1:7433")
+            assert pat.fullmatch("https://127.0.0.1")
+
+    def test_cors_origin_regex_default_matches_loopback_ipv6(self, tmp_path) -> None:
+
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            pat = re.compile(c.cors_origin_regex)
+            assert pat.fullmatch("http://[::1]:7433")
+            assert pat.fullmatch("https://[::1]")
+
+    def test_cors_origin_regex_default_rejects_random_remote(self, tmp_path) -> None:
+
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            pat = re.compile(c.cors_origin_regex)
+            assert not pat.fullmatch("https://evil.example.com")
+            assert not pat.fullmatch("http://not-localhost.example")
+            assert not pat.fullmatch("app://some-other-app.md")
+
+    def test_cors_origin_regex_from_env_overrides_default(self, tmp_path) -> None:
+        env = _clean_env(tmp_path)
+        env["LILBEE_CORS_ORIGIN_REGEX"] = r"^https://only-this\.example$"
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.cors_origin_regex == r"^https://only-this\.example$"
+
+    def test_cors_origin_regex_from_env_match_nothing_disables_default(self, tmp_path) -> None:
+        # Empty env vars are ignored by _PlainEnvSource, so the documented opt-out is
+        # to set a regex that matches nothing — e.g. ^$.
+        env = _clean_env(tmp_path)
+        env["LILBEE_CORS_ORIGIN_REGEX"] = "^$"
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.cors_origin_regex == "^$"
+
+    def test_cors_origin_regex_default_compiles(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            re.compile(c.cors_origin_regex)
+
+    def test_cors_origin_regex_default_equals_constant(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            assert c.cors_origin_regex == _DEFAULT_CORS_ORIGIN_REGEX
 
 
 class TestLocalDotLilbee:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -484,6 +484,101 @@ class TestCors:
         assert resp.headers.get("access-control-allow-origin") == "http://localhost:7433"
 
 
+class TestCorsDefaultRegex:
+    """Default cors_origin_regex should allow Obsidian (desktop + mobile) and any
+    localhost origin out of the box, without any config or env var."""
+
+    @staticmethod
+    def _preflight(origin: str) -> str | None:
+        from lilbee.server.app import create_app
+
+        with TestClient(create_app()) as c:
+            resp = c.options(
+                "/api/health",
+                headers={
+                    "Origin": origin,
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+        return resp.headers.get("access-control-allow-origin")
+
+    @mock.patch(
+        "lilbee.server.handlers.health",
+        new_callable=AsyncMock,
+        return_value={"status": "ok", "version": "1.0.0"},
+    )
+    def test_allows_obsidian_desktop(self, mock_patched):
+        assert self._preflight("app://obsidian.md") == "app://obsidian.md"
+
+    @mock.patch(
+        "lilbee.server.handlers.health",
+        new_callable=AsyncMock,
+        return_value={"status": "ok", "version": "1.0.0"},
+    )
+    def test_allows_obsidian_mobile_capacitor(self, mock_patched):
+        assert self._preflight("capacitor://localhost") == "capacitor://localhost"
+
+    @mock.patch(
+        "lilbee.server.handlers.health",
+        new_callable=AsyncMock,
+        return_value={"status": "ok", "version": "1.0.0"},
+    )
+    def test_allows_http_localhost_any_port(self, mock_patched):
+        assert self._preflight("http://localhost:3000") == "http://localhost:3000"
+        assert self._preflight("http://localhost:8080") == "http://localhost:8080"
+        assert self._preflight("https://localhost:8443") == "https://localhost:8443"
+
+    @mock.patch(
+        "lilbee.server.handlers.health",
+        new_callable=AsyncMock,
+        return_value={"status": "ok", "version": "1.0.0"},
+    )
+    def test_allows_loopback_ipv4(self, mock_patched):
+        assert self._preflight("http://127.0.0.1:7433") == "http://127.0.0.1:7433"
+
+    @mock.patch(
+        "lilbee.server.handlers.health",
+        new_callable=AsyncMock,
+        return_value={"status": "ok", "version": "1.0.0"},
+    )
+    def test_allows_loopback_ipv6(self, mock_patched):
+        assert self._preflight("http://[::1]:7433") == "http://[::1]:7433"
+
+    @mock.patch(
+        "lilbee.server.handlers.health",
+        new_callable=AsyncMock,
+        return_value={"status": "ok", "version": "1.0.0"},
+    )
+    def test_rejects_random_remote(self, mock_patched):
+        assert self._preflight("https://evil.example.com") is None
+        assert self._preflight("app://some-other-app.md") is None
+
+    @mock.patch(
+        "lilbee.server.handlers.health",
+        new_callable=AsyncMock,
+        return_value={"status": "ok", "version": "1.0.0"},
+    )
+    def test_regex_and_explicit_list_combine(self, mock_patched):
+        # User adds an explicit remote origin; default regex is untouched.
+        cfg.cors_origins = ["https://my-remote-app.example"]
+        assert self._preflight("https://my-remote-app.example") == "https://my-remote-app.example"
+        # Default regex still applies on top.
+        assert self._preflight("app://obsidian.md") == "app://obsidian.md"
+
+    @mock.patch(
+        "lilbee.server.handlers.health",
+        new_callable=AsyncMock,
+        return_value={"status": "ok", "version": "1.0.0"},
+    )
+    def test_match_nothing_regex_disables_default(self, mock_patched):
+        # Documented opt-out: set regex to ^$ so only the explicit list is consulted.
+        cfg.cors_origin_regex = "^$"
+        cfg.cors_origins = ["https://only-this.example"]
+        assert self._preflight("https://only-this.example") == "https://only-this.example"
+        assert self._preflight("app://obsidian.md") is None
+        assert self._preflight("http://localhost:3000") is None
+
+
 class TestCrawlRoute:
     @mock.patch("lilbee.server.handlers.crawl_stream")
     def test_post_crawl_streams_sse(self, mock_stream, client):


### PR DESCRIPTION
External-mode Obsidian connections were silently blocked because the server shipped with an empty CORS allow-list. No `Access-Control-Allow-Origin` header was ever sent back.

Now the server defaults to a regex that covers Obsidian (desktop and mobile) plus any localhost origin. Auth is unchanged — bearer tokens are still required on mutating endpoints.

Users who need additional remote origins can add them via `LILBEE_CORS_ORIGINS`. The default regex is overridable via `LILBEE_CORS_ORIGIN_REGEX`.