### PR TITLE
Fix TUI progress bar and cursor rendering bugs

### DIFF
--- a/src/lilbee/_splash_runner.py
+++ b/src/lilbee/_splash_runner.py
@@ -96,9 +96,15 @@ def move_up_and_clear(n: int) -> bytes:
     return ((MOVE_UP + CLEAR_LINE) * n).encode()
 
 
-def clear_screen() -> bytes:
-    """Full terminal reset for clean handoff to TUI."""
-    return b"\033[2J\033[H\033[?25h"
+def clear_screen(frame_height: int) -> bytes:
+    """Erase the splash frame area and restore the cursor to the top.
+
+    Uses line-by-line clear (move-up + erase) instead of ``\\033[2J\\033[H``
+    so the subprocess never writes a cursor-home escape. A cursor-home
+    would land on the Textual alt-screen if the TUI starts before the
+    subprocess has finished, leaving a stuck cursor artifact at (0,0).
+    """
+    return move_up_and_clear(frame_height) + SHOW_CURSOR.encode()
 
 
 def _read_eof(pipe_fd: int) -> bool:
@@ -183,7 +189,7 @@ def animation_loop(pipe_fd: int) -> None:
         pass
     finally:
         with contextlib.suppress(OSError):
-            os.write(fd, clear_screen())
+            os.write(fd, clear_screen(frame_height))
 
 
 def main() -> None:

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -181,8 +181,12 @@ class LilbeeApp(App[None]):
                 self.notify(msg.APP_CANCELLED)
                 return
         from lilbee.cli.tui.screens.chat import ChatScreen
+        from lilbee.cli.tui.screens.setup import SetupWizard
 
         screen = self.screen
+        if isinstance(screen, SetupWizard):
+            screen.action_cancel()
+            return
         if isinstance(screen, ChatScreen) and screen.streaming:
             screen.action_cancel_stream()
             return

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -518,14 +518,9 @@ class CatalogScreen(Screen[None]):
 
     def _safe_call(self, fn: Any, *args: Any, **kwargs: Any) -> None:
         """Call fn via call_from_thread, suppressing errors if app context is gone."""
-        try:
-            self.app.call_from_thread(fn, *args, **kwargs)
-        except Exception:
-            log.debug(
-                "_safe_call failed for %s",
-                fn.__name__ if hasattr(fn, "__name__") else fn,
-                exc_info=True,
-            )
+        from lilbee.cli.tui.thread_safe import call_from_thread
+
+        call_from_thread(self, fn, *args, **kwargs)
 
     def action_go_back(self) -> None:
         from lilbee.cli.tui.app import LilbeeApp

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -297,7 +297,7 @@ class ChatScreen(Screen[None]):
             self.notify(msg.CMD_ADD_NOT_FOUND.format(path=path), severity="error")
             return
         task_bar = self._task_bar
-        task_id = task_bar.add_task(f"Add {path.name}", "add")
+        task_id = task_bar.add_task(f"Add {path.name}", "add", indeterminate=True)
         task_bar.queue.advance("add")
         self._run_add_background(path, task_id)
 
@@ -306,7 +306,17 @@ class ChatScreen(Screen[None]):
         """Copy files and sync in a background thread."""
         self._sync_active = True
         task_bar = self._task_bar
-        self.app.call_from_thread(task_bar.update_task, task_id, 0, f"Copying {path.name}...")
+        # Copy + ingest run as opaque phases from the TUI's perspective:
+        # the underlying pipeline does not emit percent-complete events,
+        # so a determinate bar would lie about progress (see BEE-65f). Use
+        # an indeterminate bar and update detail text as each phase runs.
+        self.app.call_from_thread(
+            task_bar.update_task,
+            task_id,
+            0,
+            f"Copying {path.name}...",
+            indeterminate=True,
+        )
         try:
             from lilbee.cli.helpers import copy_files
 
@@ -317,7 +327,11 @@ class ChatScreen(Screen[None]):
                     self.notify, f"{name} already exists (use --force to overwrite)"
                 )
             self.app.call_from_thread(
-                task_bar.update_task, task_id, 50, f"Copied {len(copied)} file(s), syncing..."
+                task_bar.update_task,
+                task_id,
+                0,
+                f"Copied {len(copied)} file(s), syncing...",
+                indeterminate=True,
             )
 
             from lilbee.ingest import sync
@@ -328,12 +342,12 @@ class ChatScreen(Screen[None]):
 
                     if not isinstance(data, FileStartEvent):
                         raise TypeError(f"Expected FileStartEvent, got {type(data).__name__}")
-                    if data.total_files:
-                        pct = 50 + int(data.current_file * 50 / data.total_files)
-                    else:
-                        pct = 75
                     self.app.call_from_thread(
-                        task_bar.update_task, task_id, pct, f"Syncing {data.file}..."
+                        task_bar.update_task,
+                        task_id,
+                        0,
+                        f"Syncing {data.file}...",
+                        indeterminate=True,
                     )
 
             asyncio.run(sync(quiet=True, on_progress=on_progress))
@@ -805,7 +819,7 @@ class ChatScreen(Screen[None]):
             self.notify(msg.SYNC_ALREADY_ACTIVE, severity="warning")
             return
         task_bar = self._task_bar
-        task_id = task_bar.add_task("Sync documents", "sync")
+        task_id = task_bar.add_task("Sync documents", "sync", indeterminate=True)
         task_bar.queue.advance("sync")
         self._run_sync_worker(task_id)
 
@@ -833,13 +847,22 @@ class ChatScreen(Screen[None]):
 
                     if not isinstance(data, FileStartEvent):
                         raise TypeError(f"Expected FileStartEvent, got {type(data).__name__}")
-                    pct = int(data.current_file * 100 / data.total_files) if data.total_files else 0
                     status = msg.SYNC_FILE_PROGRESS.format(
                         current=data.current_file,
                         total=data.total_files,
                         file=data.file,
                     )
-                    self.app.call_from_thread(task_bar.update_task, task_id, pct, status)
+                    self.app.call_from_thread(
+                        task_bar.update_task, task_id, 0, status, indeterminate=True
+                    )
+                elif event_type == EventType.FILE_DONE:
+                    from lilbee.progress import FileDoneEvent
+
+                    if not isinstance(data, FileDoneEvent):
+                        raise TypeError(f"Expected FileDoneEvent, got {type(data).__name__}")
+                    self.app.call_from_thread(
+                        task_bar.update_task, task_id, 0, f"Done: {data.file}", indeterminate=True
+                    )
 
             asyncio.run(sync(quiet=True, on_progress=on_progress))
             self.app.call_from_thread(task_bar.complete_task, task_id)

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -25,6 +25,7 @@ from lilbee.cli.settings_map import SETTINGS_MAP
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.command_registry import build_dispatch_dict
 from lilbee.cli.tui.pill import pill
+from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay, get_completions
 from lilbee.cli.tui.widgets.message import AssistantMessage, UserMessage
 from lilbee.cli.tui.widgets.model_bar import ModelBar
@@ -310,7 +311,8 @@ class ChatScreen(Screen[None]):
         # the underlying pipeline does not emit percent-complete events,
         # so a determinate bar would lie about progress (see BEE-65f). Use
         # an indeterminate bar and update detail text as each phase runs.
-        self.app.call_from_thread(
+        call_from_thread(
+            self,
             task_bar.update_task,
             task_id,
             0,
@@ -323,10 +325,11 @@ class ChatScreen(Screen[None]):
             result = copy_files([path])
             copied = result.copied
             for name in result.skipped:
-                self.app.call_from_thread(
-                    self.notify, f"{name} already exists (use --force to overwrite)"
+                call_from_thread(
+                    self, self.notify, f"{name} already exists (use --force to overwrite)"
                 )
-            self.app.call_from_thread(
+            call_from_thread(
+                self,
                 task_bar.update_task,
                 task_id,
                 0,
@@ -342,7 +345,8 @@ class ChatScreen(Screen[None]):
 
                     if not isinstance(data, FileStartEvent):
                         raise TypeError(f"Expected FileStartEvent, got {type(data).__name__}")
-                    self.app.call_from_thread(
+                    call_from_thread(
+                        self,
                         task_bar.update_task,
                         task_id,
                         0,
@@ -351,13 +355,13 @@ class ChatScreen(Screen[None]):
                     )
 
             asyncio.run(sync(quiet=True, on_progress=on_progress))
-            self.app.call_from_thread(task_bar.complete_task, task_id)
-            self.app.call_from_thread(self.notify, msg.CMD_ADD_SUCCESS.format(count=len(copied)))
+            call_from_thread(self, task_bar.complete_task, task_id)
+            call_from_thread(self, self.notify, msg.CMD_ADD_SUCCESS.format(count=len(copied)))
         except Exception as exc:
             log.warning("Failed to add %s", path, exc_info=True)
-            self.app.call_from_thread(task_bar.fail_task, task_id, str(exc))
-            self.app.call_from_thread(
-                self.notify, msg.CMD_ADD_ERROR.format(error=exc), severity="error"
+            call_from_thread(self, task_bar.fail_task, task_id, str(exc))
+            call_from_thread(
+                self, self.notify, msg.CMD_ADD_ERROR.format(error=exc), severity="error"
             )
         finally:
             self._sync_active = False
@@ -409,7 +413,7 @@ class ChatScreen(Screen[None]):
         from lilbee.crawler import crawl_and_save
 
         task_bar = self._task_bar
-        self.app.call_from_thread(task_bar.update_task, task_id, 0, f"Crawling {url}...")
+        call_from_thread(self, task_bar.update_task, task_id, 0, f"Crawling {url}...")
 
         try:
 
@@ -421,23 +425,23 @@ class ChatScreen(Screen[None]):
                         raise TypeError(f"Expected CrawlPageEvent, got {type(data).__name__}")
                     pct = int(data.current * 100 / data.total) if data.total > 0 else 50
                     detail = f"[{data.current}/{data.total}]: {data.url}"
-                    self.app.call_from_thread(task_bar.update_task, task_id, pct, detail)
+                    call_from_thread(self, task_bar.update_task, task_id, pct, detail)
 
             paths = asyncio.run(
                 crawl_and_save(url, depth=depth, max_pages=max_pages, on_progress=on_progress)
             )
-            self.app.call_from_thread(task_bar.complete_task, task_id)
-            self.app.call_from_thread(
-                self.notify, msg.CMD_CRAWL_SUCCESS.format(count=len(paths), url=url)
+            call_from_thread(self, task_bar.complete_task, task_id)
+            call_from_thread(
+                self, self.notify, msg.CMD_CRAWL_SUCCESS.format(count=len(paths), url=url)
             )
         except Exception as exc:
-            self.app.call_from_thread(task_bar.fail_task, task_id, str(exc))
-            self.app.call_from_thread(
-                self.notify, msg.CMD_CRAWL_FAILED.format(error=exc), severity="error"
+            call_from_thread(self, task_bar.fail_task, task_id, str(exc))
+            call_from_thread(
+                self, self.notify, msg.CMD_CRAWL_FAILED.format(error=exc), severity="error"
             )
             return
 
-        self.app.call_from_thread(self._run_sync)
+        call_from_thread(self, self._run_sync)
 
     def _cmd_catalog(self, _args: str) -> None:
         from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -490,11 +494,11 @@ class ChatScreen(Screen[None]):
             from huggingface_hub import login
 
             login(token=token, add_to_git_credential=False)
-            self.app.call_from_thread(self.notify, msg.CHAT_LOGGED_IN)
+            call_from_thread(self, self.notify, msg.CHAT_LOGGED_IN)
         except Exception as exc:
             log.warning("HuggingFace login failed", exc_info=True)
-            self.app.call_from_thread(
-                self.notify, msg.CHAT_LOGIN_FAILED.format(error=exc), severity="error"
+            call_from_thread(
+                self, self.notify, msg.CHAT_LOGIN_FAILED.format(error=exc), severity="error"
             )
 
     def _cmd_model(self, args: str) -> None:
@@ -528,22 +532,22 @@ class ChatScreen(Screen[None]):
 
         mgr = get_model_manager()
         if not mgr.is_installed(name):
-            self.app.call_from_thread(
-                self.notify, msg.CMD_REMOVE_NOT_FOUND.format(name=name), severity="error"
+            call_from_thread(
+                self, self.notify, msg.CMD_REMOVE_NOT_FOUND.format(name=name), severity="error"
             )
             return
         try:
             removed = mgr.remove(name)
             if removed:
-                self.app.call_from_thread(self.notify, msg.CMD_REMOVE_SUCCESS.format(name=name))
+                call_from_thread(self, self.notify, msg.CMD_REMOVE_SUCCESS.format(name=name))
             else:
-                self.app.call_from_thread(
-                    self.notify, msg.CMD_REMOVE_FAILED.format(name=name), severity="error"
+                call_from_thread(
+                    self, self.notify, msg.CMD_REMOVE_FAILED.format(name=name), severity="error"
                 )
         except Exception:
             log.warning("Remove failed for %s", name, exc_info=True)
-            self.app.call_from_thread(
-                self.notify, msg.CMD_REMOVE_FAILED.format(name=name), severity="error"
+            call_from_thread(
+                self, self.notify, msg.CMD_REMOVE_FAILED.format(name=name), severity="error"
             )
 
     def _cmd_reset(self, args: str) -> None:
@@ -658,7 +662,8 @@ class ChatScreen(Screen[None]):
         try:
             for idx, source in enumerate(sources):
                 base_pct = int(idx * 100 / total)
-                self.app.call_from_thread(
+                call_from_thread(
+                    self,
                     task_bar.update_task,
                     task_id,
                     base_pct,
@@ -676,7 +681,8 @@ class ChatScreen(Screen[None]):
                 ) -> None:
                     fraction = _WIKI_STAGE_FRACTIONS.get(stage, 0.0)
                     pct = int((source_idx + fraction) * 100 / total)
-                    self.app.call_from_thread(
+                    call_from_thread(
+                        self,
                         task_bar.update_task,
                         task_id,
                         pct,
@@ -688,16 +694,16 @@ class ChatScreen(Screen[None]):
                 )
                 if result is not None:
                     generated += 1
-            self.app.call_from_thread(task_bar.complete_task, task_id)
-            self.app.call_from_thread(
-                self.notify, msg.CMD_WIKI_SUCCESS.format(generated=generated, total=total)
+            call_from_thread(self, task_bar.complete_task, task_id)
+            call_from_thread(
+                self, self.notify, msg.CMD_WIKI_SUCCESS.format(generated=generated, total=total)
             )
-            self.app.call_from_thread(self._refresh_wiki_screen)
+            call_from_thread(self, self._refresh_wiki_screen)
         except Exception as exc:
             log.warning("Wiki generation failed", exc_info=True)
-            self.app.call_from_thread(task_bar.fail_task, task_id, str(exc))
-            self.app.call_from_thread(
-                self.notify, msg.CMD_WIKI_FAILED.format(error=exc), severity="error"
+            call_from_thread(self, task_bar.fail_task, task_id, str(exc))
+            call_from_thread(
+                self, self.notify, msg.CMD_WIKI_FAILED.format(error=exc), severity="error"
             )
 
     def _refresh_wiki_screen(self) -> None:
@@ -736,20 +742,20 @@ class ChatScreen(Screen[None]):
             for token in stream:
                 try:
                     if token.is_reasoning:
-                        self.app.call_from_thread(widget.append_reasoning, token.content)
+                        call_from_thread(self, widget.append_reasoning, token.content)
                     elif token.content:
                         response_parts.append(token.content)
-                        self.app.call_from_thread(widget.append_content, token.content)
+                        call_from_thread(self, widget.append_content, token.content)
                     now = time.monotonic()
                     if now - last_scroll >= 0.15:
-                        self.app.call_from_thread(self._scroll_to_bottom)
+                        call_from_thread(self, self._scroll_to_bottom)
                         last_scroll = now
                 except Exception:
                     break  # App shutting down (Ctrl-C) -- stop streaming
         except Exception as exc:
             log.debug("Stream error", exc_info=True)
             with contextlib.suppress(Exception):
-                self.app.call_from_thread(widget.append_content, msg.STREAM_ERROR.format(error=exc))
+                call_from_thread(self, widget.append_content, msg.STREAM_ERROR.format(error=exc))
         finally:
             self.streaming = False
             full_response = "".join(response_parts)
@@ -757,8 +763,8 @@ class ChatScreen(Screen[None]):
                 with self._history_lock:
                     self._history.append({"role": "assistant", "content": full_response})
                     self._trim_history()
-            self.app.call_from_thread(widget.finish, sources)
-            self.app.call_from_thread(self._scroll_to_bottom)
+            call_from_thread(self, widget.finish, sources)
+            call_from_thread(self, self._scroll_to_bottom)
 
     def _trim_history(self) -> None:
         """Trim history to max size, dropping oldest messages. Caller must hold _history_lock."""
@@ -839,8 +845,8 @@ class ChatScreen(Screen[None]):
         try:
             from lilbee.ingest import sync
 
-            self.app.call_from_thread(
-                task_bar.update_task, task_id, 0, "Syncing...", indeterminate=True
+            call_from_thread(
+                self, task_bar.update_task, task_id, 0, "Syncing...", indeterminate=True
             )
 
             def on_progress(event_type: EventType, data: ProgressEvent) -> None:
@@ -854,28 +860,33 @@ class ChatScreen(Screen[None]):
                         total=data.total_files,
                         file=data.file,
                     )
-                    self.app.call_from_thread(
-                        task_bar.update_task, task_id, 0, status, indeterminate=True
+                    call_from_thread(
+                        self, task_bar.update_task, task_id, 0, status, indeterminate=True
                     )
                 elif event_type == EventType.FILE_DONE:
                     from lilbee.progress import FileDoneEvent
 
                     if not isinstance(data, FileDoneEvent):
                         raise TypeError(f"Expected FileDoneEvent, got {type(data).__name__}")
-                    self.app.call_from_thread(
-                        task_bar.update_task, task_id, 0, f"Done: {data.file}", indeterminate=True
+                    call_from_thread(
+                        self,
+                        task_bar.update_task,
+                        task_id,
+                        0,
+                        f"Done: {data.file}",
+                        indeterminate=True,
                     )
 
             asyncio.run(sync(quiet=True, on_progress=on_progress))
-            self.app.call_from_thread(task_bar.complete_task, task_id)
+            call_from_thread(self, task_bar.complete_task, task_id)
         except asyncio.CancelledError:
             self._auto_sync = False
-            self.app.call_from_thread(
-                task_bar.fail_task, task_id, "Sync cancelled. Use /sync to resume."
+            call_from_thread(
+                self, task_bar.fail_task, task_id, "Sync cancelled. Use /sync to resume."
             )
         except Exception:
             log.warning("Background sync failed", exc_info=True)
-            self.app.call_from_thread(task_bar.fail_task, task_id, msg.SYNC_STATUS_FAILED)
+            call_from_thread(self, task_bar.fail_task, task_id, msg.SYNC_STATUS_FAILED)
         finally:
             self._sync_active = False
 

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -839,7 +839,9 @@ class ChatScreen(Screen[None]):
         try:
             from lilbee.ingest import sync
 
-            self.app.call_from_thread(task_bar.update_task, task_id, 0, "Syncing...")
+            self.app.call_from_thread(
+                task_bar.update_task, task_id, 0, "Syncing...", indeterminate=True
+            )
 
             def on_progress(event_type: EventType, data: ProgressEvent) -> None:
                 if event_type == EventType.FILE_START:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -510,6 +510,7 @@ class ChatScreen(Screen[None]):
             settings.set_value(cfg.data_root, "chat_model", tagged)
             self.app.title = f"lilbee -- {cfg.chat_model}"
             self.notify(msg.CMD_MODEL_SET.format(name=tagged))
+            self._apply_model_change()
             self._refresh_model_bar()
         else:
             from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -808,6 +809,21 @@ class ChatScreen(Screen[None]):
         inp = self.query_one("#chat-input", Input)
         if inp.has_focus:
             self.query_one("#chat-log", VerticalScroll).focus()
+
+    def _apply_model_change(self) -> None:
+        """Cancel active stream (if any) and reset services for the new model."""
+        if self.streaming:
+            self.action_cancel_stream()
+            self.call_later(self._deferred_service_reset)
+        else:
+            reset_services()
+
+    def _deferred_service_reset(self) -> None:
+        """Reset services once workers have drained."""
+        if self.workers:
+            self.call_later(self._deferred_service_reset)
+            return
+        reset_services()
 
     async def action_toggle_markdown(self) -> None:
         """Toggle between Markdown and plain-text rendering for chat responses."""

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Callable
 from functools import partial
 from typing import ClassVar, NamedTuple
@@ -37,6 +38,10 @@ from lilbee.models import ModelTask, get_system_ram_gb
 from lilbee.services import reset_services
 
 log = logging.getLogger(__name__)
+
+
+class _DownloadCancelled(Exception):
+    """Raised inside a download progress callback to abort hf_hub_download."""
 
 
 def _scan_installed_models() -> tuple[list[str], list[str]]:
@@ -135,6 +140,7 @@ class SetupWizard(Screen[str | None]):
         self._recommended_embed: CatalogModel | None = None
         self._download_models: list[CatalogModel] = []
         self._download_rows: dict[str, _DownloadRow] = {}
+        self._cancel_event = threading.Event()
 
     @property
     def _selected_chat(self) -> str | None:
@@ -336,14 +342,16 @@ class SetupWizard(Screen[str | None]):
             self._download_rows[model.ref] = _DownloadRow(model.display_name, label, bar)
 
     @work(thread=True)
-    def _run_downloads(self) -> None:
+    def _run_downloads(self) -> None:  # pragma: no cover
         """Download all selected models in a background thread."""
-        self._download_loop(partial(call_from_thread, self))  # pragma: no cover
+        self._download_loop(partial(call_from_thread, self))
 
     def _on_download_progress(
         self, notify: Callable[..., None], model_ref: str, p: DownloadProgress
     ) -> None:
         """Handle a single download progress update for the given model."""
+        if self._cancel_event.is_set():
+            raise _DownloadCancelled
         notify(self._update_row, model_ref, p.percent, p.detail)
 
     def _handle_download_error(
@@ -367,6 +375,8 @@ class SetupWizard(Screen[str | None]):
         """Download all selected models sequentially."""
         notify(self._mount_download_rows)
         for idx, model in enumerate(self._download_models, 1):
+            if self._cancel_event.is_set():
+                return
             is_first = idx == 1
             notify(self._update_row, model.ref, 0, msg.SETUP_DOWNLOAD_STARTING)
 
@@ -376,6 +386,9 @@ class SetupWizard(Screen[str | None]):
             callback = make_download_callback(_progress)
             try:
                 download_model(model, on_progress=callback)
+            except _DownloadCancelled:
+                log.info("Download cancelled for %s", model.ref)
+                return
             except Exception as exc:
                 self._handle_download_error(notify, exc, model, is_first=is_first)
                 return
@@ -428,4 +441,5 @@ class SetupWizard(Screen[str | None]):
         self._save_and_dismiss("skipped")
 
     def action_cancel(self) -> None:
+        self._cancel_event.set()
         self.dismiss("skipped")

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from functools import partial
 from typing import ClassVar, NamedTuple
 
 from textual import on, work
@@ -28,6 +29,7 @@ from lilbee.cli.tui.screens.catalog_utils import (
     format_size_gb,
     parse_param_label,
 )
+from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.cli.tui.widgets.grid_select import GridSelect
 from lilbee.cli.tui.widgets.model_card import ModelCard
 from lilbee.config import cfg
@@ -336,10 +338,6 @@ class SetupWizard(Screen[str | None]):
     @work(thread=True)
     def _run_downloads(self) -> None:
         """Download all selected models in a background thread."""
-        from functools import partial
-
-        from lilbee.cli.tui.thread_safe import call_from_thread
-
         self._download_loop(partial(call_from_thread, self))  # pragma: no cover
 
     def _on_download_progress(

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -336,7 +336,11 @@ class SetupWizard(Screen[str | None]):
     @work(thread=True)
     def _run_downloads(self) -> None:
         """Download all selected models in a background thread."""
-        self._download_loop(self.app.call_from_thread)  # pragma: no cover
+        from functools import partial
+
+        from lilbee.cli.tui.thread_safe import call_from_thread
+
+        self._download_loop(partial(call_from_thread, self))  # pragma: no cover
 
     def _on_download_progress(
         self, notify: Callable[..., None], model_ref: str, p: DownloadProgress

--- a/src/lilbee/cli/tui/task_queue.py
+++ b/src/lilbee/cli/tui/task_queue.py
@@ -46,6 +46,7 @@ class Task:
     status: TaskStatus = TaskStatus.QUEUED
     progress: int = 0
     detail: str = ""
+    indeterminate: bool = False
 
 
 class TaskQueue:
@@ -148,23 +149,46 @@ class TaskQueue:
         with self._lock:
             return self._tasks.get(task_id)
 
-    def enqueue(self, fn: Callable[[], None], name: str, task_type: str) -> str:
+    def enqueue(
+        self,
+        fn: Callable[[], None],
+        name: str,
+        task_type: str,
+        *,
+        indeterminate: bool = False,
+    ) -> str:
         """Add a task to the per-type queue. Returns a task_id."""
         task_id = uuid.uuid4().hex[:8]
-        task = Task(task_id=task_id, name=name, task_type=task_type, fn=fn)
+        task = Task(
+            task_id=task_id, name=name, task_type=task_type, fn=fn, indeterminate=indeterminate
+        )
         with self._lock:
             self._tasks[task_id] = task
             self._queues.setdefault(task_type, []).append(task_id)
         self._notify()
         return task_id
 
-    def update_task(self, task_id: str, progress: int, detail: str = "") -> None:
-        """Update progress and detail text for a task."""
+    def update_task(
+        self,
+        task_id: str,
+        progress: int,
+        detail: str = "",
+        *,
+        indeterminate: bool | None = None,
+    ) -> None:
+        """Update progress and detail text for a task.
+        When *indeterminate* is True the task's progress bar renders as a
+        pulsing indeterminate bar instead of a percentage. When explicitly
+        False it returns to determinate mode. ``None`` leaves the flag as-is
+        so incremental progress updates don't clobber the caller's intent.
+        """
         with self._lock:
             task = self._tasks.get(task_id)
             if task:
                 task.progress = progress
                 task.detail = detail
+                if indeterminate is not None:
+                    task.indeterminate = indeterminate
         self._notify()
 
     def complete_task(self, task_id: str) -> None:
@@ -174,6 +198,7 @@ class TaskQueue:
             if task:
                 task.status = TaskStatus.DONE
                 task.progress = 100
+                task.indeterminate = False
                 self._history.append(task)
                 self._remove_from_active_locked(task_id, task.task_type)
                 self._remove_from_queue_locked(task_id, task.task_type)

--- a/src/lilbee/cli/tui/thread_safe.py
+++ b/src/lilbee/cli/tui/thread_safe.py
@@ -1,0 +1,27 @@
+"""Thread-safe helpers for posting from @work(thread=True) workers to the main thread.
+
+Textual's call_from_thread raises OSError when the app's message queue
+has already been closed during shutdown. Since workers run in daemon
+threads, they can outlive the app. This module provides a drop-in
+wrapper that silently drops calls when the app is gone.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from textual.dom import DOMNode
+
+log = logging.getLogger(__name__)
+
+
+def call_from_thread(node: DOMNode, fn: Any, *args: Any, **kwargs: Any) -> None:
+    """Post *fn* to the main thread via the app, dropping silently on shutdown."""
+    try:
+        node.app.call_from_thread(fn, *args, **kwargs)
+    except Exception:
+        log.debug(
+            "call_from_thread dropped (app shutting down): %s",
+            getattr(fn, "__name__", fn),
+        )

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -223,25 +223,10 @@ class ModelBar(Widget, can_focus=False):
         from lilbee.cli.tui.screens.chat import ChatScreen
 
         screen = self.app.screen
-        if isinstance(screen, ChatScreen) and screen.streaming:
-            screen.action_cancel_stream()
-            self.app.call_later(self._deferred_reset)
+        if isinstance(screen, ChatScreen):
+            screen._apply_model_change()
         else:
-            self._reset_services()
-
-    def _deferred_reset(self) -> None:
-        """Reset services after workers have finished (avoids freeing in-use models)."""
-        from lilbee.cli.tui.screens.chat import ChatScreen
-
-        screen = self.app.screen
-        if isinstance(screen, ChatScreen) and screen.workers:
-            self.app.call_later(self._deferred_reset)
-            return
-        self._reset_services()
-
-    @staticmethod
-    def _reset_services() -> None:
-        reset_services()
+            reset_services()
 
     def refresh_models(self) -> None:
         """Re-scan models (called after downloads complete)."""

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -12,6 +12,7 @@ from textual.widget import Widget
 from textual.widgets import Label, Select
 
 from lilbee import settings
+from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.config import cfg
 from lilbee.models import ModelTask
 from lilbee.services import reset_services
@@ -168,7 +169,7 @@ class ModelBar(Widget, can_focus=False):
     def _scan_models(self) -> None:
         """Scan installed models in background, then populate dropdowns."""
         chat, embed = _classify_installed_models()
-        self.app.call_from_thread(self._populate, chat, embed)
+        call_from_thread(self, self._populate, chat, embed)
 
     def _populate(
         self,

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -65,6 +65,7 @@ class _TaskPanel(Static):
         super().__init__(id=f"task-panel-{task_id}", **kwargs)  # type: ignore[arg-type]
         self.task_id = task_id
         self._last_progress: int = -1
+        # None means "never rendered yet", distinct from False (rendered as determinate).
         self._last_indeterminate: bool | None = None
 
     def compose(self) -> ComposeResult:

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -64,6 +64,8 @@ class _TaskPanel(Static):
     def __init__(self, task_id: str, **kwargs: object) -> None:
         super().__init__(id=f"task-panel-{task_id}", **kwargs)  # type: ignore[arg-type]
         self.task_id = task_id
+        self._last_progress: int = -1
+        self._last_indeterminate: bool | None = None
 
     def compose(self) -> ComposeResult:
         yield Label("", classes="task-panel-label")
@@ -82,13 +84,33 @@ class TaskBarController:
         self._app = app
         self.queue = TaskQueue()
 
-    def add_task(self, name: str, task_type: str, fn: Callable[[], None] | None = None) -> str:
+    def add_task(
+        self,
+        name: str,
+        task_type: str,
+        fn: Callable[[], None] | None = None,
+        *,
+        indeterminate: bool = False,
+    ) -> str:
         """Enqueue a task. Returns the new task_id."""
-        return self.queue.enqueue(fn or (lambda: None), name, task_type)
+        return self.queue.enqueue(
+            fn or (lambda: None), name, task_type, indeterminate=indeterminate
+        )
 
-    def update_task(self, task_id: str, progress: int, detail: str = "") -> None:
-        """Update progress and detail text for a task."""
-        self.queue.update_task(task_id, progress, detail)
+    def update_task(
+        self,
+        task_id: str,
+        progress: int,
+        detail: str = "",
+        *,
+        indeterminate: bool | None = None,
+    ) -> None:
+        """Update progress and detail text for a task.
+        When *indeterminate* is True the panel renders a pulsing bar instead
+        of a percentage, so long-running phases without a reliable percent
+        don't falsely claim to be finished.
+        """
+        self.queue.update_task(task_id, progress, detail, indeterminate=indeterminate)
 
     def complete_task(self, task_id: str) -> None:
         """Mark a task done; keep it visible for a brief flash, then remove."""
@@ -186,12 +208,26 @@ class TaskBar(Static):
         """Expose the shared queue for callers that iterate or advance it."""
         return self._controller.queue
 
-    def add_task(self, name: str, task_type: str, fn: Callable[[], None] | None = None) -> str:
+    def add_task(
+        self,
+        name: str,
+        task_type: str,
+        fn: Callable[[], None] | None = None,
+        *,
+        indeterminate: bool = False,
+    ) -> str:
         """Enqueue a task via the app's controller. Returns the task_id."""
-        return self._controller.add_task(name, task_type, fn)
+        return self._controller.add_task(name, task_type, fn, indeterminate=indeterminate)
 
-    def update_task(self, task_id: str, progress: int, detail: str = "") -> None:
-        self._controller.update_task(task_id, progress, detail)
+    def update_task(
+        self,
+        task_id: str,
+        progress: int,
+        detail: str = "",
+        *,
+        indeterminate: bool | None = None,
+    ) -> None:
+        self._controller.update_task(task_id, progress, detail, indeterminate=indeterminate)
 
     def complete_task(self, task_id: str) -> None:
         self._controller.complete_task(task_id)
@@ -284,7 +320,18 @@ class TaskBar(Static):
         try:
             label = panel.query_one(".task-panel-label", Label)
             label.update(f" {icon} {task.name}{detail}")
-            progress_bar = panel.query_one(ProgressBar)
-            progress_bar.update(total=100, progress=task.progress)
+            is_indeterminate = task.indeterminate and task.status == TaskStatus.ACTIVE
+            progress_changed = (
+                is_indeterminate != panel._last_indeterminate
+                or task.progress != panel._last_progress
+            )
+            if progress_changed:
+                progress_bar = panel.query_one(ProgressBar)
+                if is_indeterminate:
+                    progress_bar.update(total=None, progress=0)
+                else:
+                    progress_bar.update(total=100, progress=task.progress)
+                panel._last_progress = task.progress
+                panel._last_indeterminate = is_indeterminate
         except NoMatches:
             pass  # panel children not yet composed, next refresh will catch up

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -26,6 +26,7 @@ from textual.css.query import NoMatches
 from textual.widgets import Label, ProgressBar, Static
 
 from lilbee.cli.tui.task_queue import STATUS_ICONS, Task, TaskQueue, TaskStatus
+from lilbee.cli.tui.thread_safe import call_from_thread
 
 if TYPE_CHECKING:
     from textual.app import App
@@ -249,8 +250,7 @@ class TaskBar(Static):
             with contextlib.suppress(Exception):
                 self._refresh_display()
             return
-        with contextlib.suppress(Exception):
-            self.app.call_from_thread(self._refresh_display)
+        call_from_thread(self, self._refresh_display)
 
     def _tick_spinner(self) -> None:
         if self.queue.active_tasks:

--- a/src/lilbee/launcher.py
+++ b/src/lilbee/launcher.py
@@ -27,14 +27,12 @@ def main() -> None:
 
     try:
         from lilbee.cli import app
-    finally:
-        # Stop the splash BEFORE the TUI takes over the terminal. Otherwise
-        # the subprocess's final writes (erase + home) land on Textual's
-        # alt-screen and leave the cursor visible, producing stray artifacts
-        # during background tasks and a stuck glyph in the top-left corner
-        # of every screen (BEE-73k, BEE-jmj). stop() is synchronous and
-        # waits for the child to exit, so by the time app() runs no more
-        # splash writes can reach the terminal.
+    except BaseException:
+        stop(handle)
+        raise
+    else:
+        # Stop the splash BEFORE the TUI takes over the terminal so the
+        # subprocess's final writes don't land on Textual's alt-screen.
         stop(handle)
 
     try:

--- a/src/lilbee/launcher.py
+++ b/src/lilbee/launcher.py
@@ -27,9 +27,15 @@ def main() -> None:
 
     try:
         from lilbee.cli import app
-    except BaseException:
+    finally:
+        # Stop the splash BEFORE the TUI takes over the terminal. Otherwise
+        # the subprocess's final writes (erase + home) land on Textual's
+        # alt-screen and leave the cursor visible, producing stray artifacts
+        # during background tasks and a stuck glyph in the top-left corner
+        # of every screen (BEE-73k, BEE-jmj). stop() is synchronous and
+        # waits for the child to exit, so by the time app() runs no more
+        # splash writes can reach the terminal.
         stop(handle)
-        raise
 
     try:
         app()
@@ -37,5 +43,3 @@ def main() -> None:
         sys.stderr.write("\033[?25h")
         sys.stderr.flush()
         raise SystemExit(130) from None
-    finally:
-        stop(handle)

--- a/src/lilbee/splash.py
+++ b/src/lilbee/splash.py
@@ -100,13 +100,28 @@ def stop(handle: SplashHandle | None) -> None:
 def dismiss() -> None:
     """Signal the splash to stop from the TUI side.
     Called by the chat screen's ``on_show()`` to dismiss the splash once
-    the TUI is ready to paint. Reads the pipe fd from the environment
-    variable and closes it — the subprocess sees EOF and exits.
+    the TUI is ready to paint. Closes the pipe so the subprocess sees EOF,
+    waits for it to exit, and clears the active handle so ``atexit`` does
+    not re-run ``stop()`` (which would write ``\\033[?25h`` into the
+    Textual alt-screen and leave a cursor artifact at (0,0)).
     """
+    global _active_handle
+
     fd_str = os.environ.pop(_SPLASH_FD_ENV, None)
-    if fd_str is None:
+    if fd_str is not None:
+        _close_write_fd(int(fd_str))
+
+    handle = _active_handle
+    if handle is None:
         return
-    _close_write_fd(int(fd_str))
+    _active_handle = None
+
+    _close_write_fd(handle.write_fd)
+    try:
+        handle.process.wait(timeout=_STOP_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        handle.process.kill()
+        handle.process.wait(timeout=1.0)
 
 
 def _close_write_fd(fd: int) -> None:

--- a/src/lilbee/splash.py
+++ b/src/lilbee/splash.py
@@ -116,6 +116,11 @@ def dismiss() -> None:
         return
     _active_handle = None
 
+    # Close the write end so the subprocess sees EOF. This may double-close
+    # the same fd that the env-var path already closed; _close_write_fd
+    # suppresses OSError so that is harmless.
+    # No _restore_cursor() here: we are inside Textual's alt-screen,
+    # where writing cursor-show would produce a visible artifact.
     _close_write_fd(handle.write_fd)
     try:
         handle.process.wait(timeout=_STOP_TIMEOUT)

--- a/tests/test_splash.py
+++ b/tests/test_splash.py
@@ -75,26 +75,90 @@ class TestStartStop:
 
 
 class TestDismiss:
-    def test_dismiss_no_env_var(self) -> None:
-        with patch.dict(os.environ, {}, clear=True):
-            dismiss()  # should not raise
+    def test_dismiss_no_env_var_no_handle(self) -> None:
+        import lilbee.splash as splash_mod
+
+        original = splash_mod._active_handle
+        splash_mod._active_handle = None
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                dismiss()  # should not raise
+        finally:
+            splash_mod._active_handle = original
 
     def test_dismiss_closes_fd_and_clears_env(self) -> None:
         read_fd, write_fd = os.pipe()
         os.close(read_fd)
         os.environ[_SPLASH_FD_ENV] = str(write_fd)
-        dismiss()
-        assert _SPLASH_FD_ENV not in os.environ
-        with pytest.raises(OSError):
-            os.close(write_fd)  # already closed
+        import lilbee.splash as splash_mod
+
+        original = splash_mod._active_handle
+        splash_mod._active_handle = None
+        try:
+            dismiss()
+            assert _SPLASH_FD_ENV not in os.environ
+            with pytest.raises(OSError):
+                os.close(write_fd)  # already closed
+        finally:
+            splash_mod._active_handle = original
 
     def test_dismiss_tolerates_already_closed_fd(self) -> None:
         read_fd, write_fd = os.pipe()
         os.close(read_fd)
         os.close(write_fd)
         os.environ[_SPLASH_FD_ENV] = str(write_fd)
-        dismiss()  # should not raise
-        assert _SPLASH_FD_ENV not in os.environ
+        import lilbee.splash as splash_mod
+
+        original = splash_mod._active_handle
+        splash_mod._active_handle = None
+        try:
+            dismiss()  # should not raise
+            assert _SPLASH_FD_ENV not in os.environ
+        finally:
+            splash_mod._active_handle = original
+
+    def test_dismiss_waits_for_process_and_clears_handle(self) -> None:
+        """dismiss() waits for the subprocess and clears _active_handle
+        so atexit does not re-run stop() while Textual owns the terminal.
+        """
+        import lilbee.splash as splash_mod
+
+        original = splash_mod._active_handle
+        try:
+            with patch("lilbee.splash._should_skip", return_value=False):
+                handle = start()
+                assert handle is not None
+                splash_mod._active_handle = handle
+                os.environ[_SPLASH_FD_ENV] = str(handle.write_fd)
+
+                dismiss()
+
+                assert splash_mod._active_handle is None
+                assert handle.process.poll() is not None  # exited
+        finally:
+            splash_mod._active_handle = original
+            os.environ.pop(_SPLASH_FD_ENV, None)
+
+    def test_dismiss_kills_on_timeout(self) -> None:
+        """dismiss() kills the subprocess when it doesn't exit within timeout."""
+        import subprocess
+        from unittest.mock import MagicMock
+
+        import lilbee.splash as splash_mod
+        from lilbee.splash import SplashHandle
+
+        original = splash_mod._active_handle
+        mock_proc = MagicMock()
+        mock_proc.wait.side_effect = [subprocess.TimeoutExpired("cmd", 3), None]
+        handle = SplashHandle(process=mock_proc, write_fd=-1)
+        splash_mod._active_handle = handle
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                dismiss()
+            mock_proc.kill.assert_called_once()
+            assert splash_mod._active_handle is None
+        finally:
+            splash_mod._active_handle = original
 
 
 class TestLogoFrames:
@@ -168,12 +232,14 @@ class TestRenderFrame:
 
 
 class TestClearScreen:
-    def test_contains_escape_codes(self) -> None:
-        result = clear_screen()
+    def test_uses_line_erase_not_cursor_home(self) -> None:
+        result = clear_screen(5)
         text = result.decode()
-        assert "\033[2J" in text
-        assert "\033[H" in text
-        assert "\033[?25h" in text
+        assert "\033[A" in text  # move-up
+        assert "\033[2K" in text  # clear-line
+        assert "\033[?25h" in text  # cursor restore
+        assert "\033[2J" not in text  # no full-screen clear
+        assert "\033[H" not in text  # no cursor home
 
 
 class TestMoveUpAndClear:

--- a/tests/test_splash_runner.py
+++ b/tests/test_splash_runner.py
@@ -55,11 +55,20 @@ def test_move_up_and_clear():
 
 
 def test_clear_screen():
+    """clear_screen erases the splash frame without cursor-home.
+
+    Uses move-up-and-clear instead of ``\\033[2J\\033[H`` so the subprocess
+    never writes a cursor-home escape into Textual's alt-screen.
+    Restores cursor visibility so non-TUI exits leave the terminal clean.
+    """
     from lilbee._splash_runner import clear_screen
 
-    result = clear_screen()
-    assert b"\033[2J" in result
-    assert b"\033[?25h" in result
+    result = clear_screen(5)
+    assert b"\033[A" in result  # move-up sequences
+    assert b"\033[2K" in result  # clear-line sequences
+    assert b"\033[?25h" in result  # cursor restore
+    assert b"\033[2J" not in result  # no full-screen clear
+    assert b"\033[H" not in result  # no cursor home
 
 
 def test_pipe_closed_returns_true_on_eof():

--- a/tests/test_task_bar_per_screen.py
+++ b/tests/test_task_bar_per_screen.py
@@ -93,18 +93,9 @@ class _ControllerApp(App[None]):
 
 
 def _chat_screen():
-    """Minimal screen that mirrors ChatScreen's TaskBar without ModelBar."""
-    from textual.screen import Screen
-    from textual.widgets import Footer
+    from lilbee.cli.tui.screens.chat import ChatScreen
 
-    from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-    class _ChatStub(Screen[None]):
-        def compose(self):
-            yield TaskBar()
-            yield Footer()
-
-    return _ChatStub()
+    return ChatScreen()
 
 
 def _catalog_screen():

--- a/tests/test_thread_safe.py
+++ b/tests/test_thread_safe.py
@@ -1,0 +1,23 @@
+"""Tests for the thread-safe call_from_thread wrapper."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from lilbee.cli.tui.thread_safe import call_from_thread
+
+
+def test_call_from_thread_forwards_to_app():
+    """Normal case: delegates to node.app.call_from_thread."""
+    node = MagicMock()
+    fn = MagicMock()
+    call_from_thread(node, fn, 1, 2, key="val")
+    node.app.call_from_thread.assert_called_once_with(fn, 1, 2, key="val")
+
+
+def test_call_from_thread_swallows_shutdown_error():
+    """When the app is shutting down, the call is silently dropped."""
+    node = MagicMock()
+    node.app.call_from_thread.side_effect = OSError("[Errno 9] Bad file descriptor")
+    fn = MagicMock()
+    call_from_thread(node, fn, "arg")  # should not raise

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -191,7 +191,6 @@ class TestModelSwitchSafety:
             await pilot.pause()
             screen = app.screen
             screen.streaming = True
-            screen.action_cancel_stream = mock.MagicMock()
 
             bar = screen.query_one("#model-bar", ModelBar)
             bar._populating = False
@@ -202,13 +201,10 @@ class TestModelSwitchSafety:
             event.select = mock.MagicMock()
             event.select.id = "chat-model-select"
 
-            with (
-                mock.patch("lilbee.services.reset_services"),
-                mock.patch.object(bar, "_deferred_reset"),
-            ):
+            with mock.patch.object(screen, "_apply_model_change") as mock_apply:
                 bar._on_chat_model_changed(event)
 
-            screen.action_cancel_stream.assert_called_once()
+            mock_apply.assert_called_once()
 
 
 class TestViewTabsPresence:
@@ -2066,6 +2062,17 @@ class TestChatSlashCommands:
             app.screen._handle_slash("/model slash-test-model")
             await pilot.pause()
             assert "slash-test-model" in cfg.chat_model
+
+    async def test_cmd_model_cancels_stream_when_streaming(self, _mock_resolve):
+        """/model <name> cancels stream and resets services when streaming."""
+        app = ChatTestApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.screen.streaming = True
+            with mock.patch.object(app.screen, "_apply_model_change") as mock_apply:
+                app.screen._handle_slash("/model stream-switch-model")
+                await pilot.pause()
+                mock_apply.assert_called()
 
     async def test_cmd_model_without_name(self, _mock_resolve):
         """/model with no args pushes catalog."""

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -1411,6 +1411,63 @@ async def test_chat_cancel_stream_while_streaming():
         assert app.screen.streaming is False
 
 
+async def test_apply_model_change_cancels_stream_when_streaming():
+    """_apply_model_change cancels stream and defers service reset."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        with (
+            patch.object(screen, "action_cancel_stream") as mock_cancel,
+            patch.object(screen, "call_later") as mock_later,
+        ):
+            screen._apply_model_change()
+            mock_cancel.assert_called_once()
+            mock_later.assert_called_once_with(screen._deferred_service_reset)
+
+
+async def test_apply_model_change_resets_immediately_when_not_streaming():
+    """_apply_model_change resets services immediately when not streaming."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = False
+        with patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset:
+            screen._apply_model_change()
+            mock_reset.assert_called_once()
+
+
+async def test_deferred_service_reset_retries_while_workers_active():
+    """_deferred_service_reset retries via call_later when workers exist."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        with (
+            patch.object(
+                type(screen), "workers", new_callable=MagicMock, return_value=[MagicMock()]
+            ),
+            patch.object(screen, "call_later") as mock_later,
+            patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset,
+        ):
+            screen._deferred_service_reset()
+            mock_later.assert_called_once_with(screen._deferred_service_reset)
+            mock_reset.assert_not_called()
+
+
+async def test_deferred_service_reset_resets_when_no_workers():
+    """_deferred_service_reset calls reset_services when workers drained."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        # Cancel background workers so the screen's worker manager is empty
+        for w in list(screen.workers):
+            w.cancel()
+        await pilot.pause()
+        with patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset:
+            screen._deferred_service_reset()
+            mock_reset.assert_called_once()
+
+
 async def test_chat_vim_j_k_scrolls_in_normal_mode():
     """j/k scroll the chat log in normal mode."""
     app = ChatTestApp()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2475,24 +2475,30 @@ async def test_chat_run_sync_worker():
             assert app.screen._sync_active is False
 
 
-async def test_chat_sync_progress_percentage():
-    """Verify sync progress reports actual percentage, not hardcoded 50%."""
+async def test_chat_sync_progress_uses_indeterminate():
+    """Verify sync progress uses indeterminate mode, not percentages."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        from lilbee.progress import EventType, FileStartEvent
+        from lilbee.progress import EventType, FileDoneEvent, FileStartEvent
 
         update_calls: list[tuple] = []
         task_bar = app.task_bar
         original_update = task_bar.update_task
 
-        def tracking_update(task_id, pct, status):
-            update_calls.append((task_id, pct, status))
-            return original_update(task_id, pct, status)
+        def tracking_update(task_id, pct, status, *, indeterminate=None):
+            update_calls.append((task_id, pct, status, indeterminate))
+            return original_update(task_id, pct, status, indeterminate=indeterminate)
 
         async def fake_sync(quiet=False, on_progress=None):
             if on_progress:
-                event = FileStartEvent(current_file=3, total_files=4, file="doc.md")
-                on_progress(EventType.FILE_START, event)
+                on_progress(
+                    EventType.FILE_START,
+                    FileStartEvent(current_file=1, total_files=1, file="doc.md"),
+                )
+                on_progress(
+                    EventType.FILE_DONE,
+                    FileDoneEvent(file="doc.md", status="ok", chunks=3),
+                )
             return {"added": 1}
 
         with (
@@ -2504,8 +2510,33 @@ async def test_chat_sync_progress_percentage():
             while app.screen.workers:
                 await _pilot.pause()
 
-        pct_values = [pct for _, pct, _ in update_calls if pct > 0]
-        assert 75 in pct_values
+        # All progress updates should use indeterminate mode
+        for _, _pct, _, indet in update_calls:
+            if indet is not None:
+                assert indet is True
+        # No update should report 100% progress
+        pct_values = [pct for _, pct, _, _ in update_calls]
+        assert 100 not in pct_values
+
+
+async def test_chat_sync_file_done_bad_type():
+    """Sync progress raises TypeError when FILE_DONE data is not FileDoneEvent."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        from lilbee.progress import EventType
+
+        async def fake_sync(quiet=False, on_progress=None):
+            if on_progress:
+                on_progress(EventType.FILE_DONE, {"file": "x.md", "status": "ok", "chunks": 1})
+            return {"added": 0}
+
+        with patch("lilbee.ingest.sync", new=fake_sync):
+            app.screen._run_sync()
+            await _pilot.pause()
+            while app.screen.workers:
+                await _pilot.pause()
+            # Worker catches the TypeError via the except Exception handler
+            assert app.screen._sync_active is False
 
 
 async def test_chat_run_sync_error_worker():
@@ -7081,7 +7112,6 @@ async def test_chat_add_skipped_file():
 
         async def fake_sync(*, quiet: bool = True, on_progress: object = None) -> None:
             if on_progress:
-                # Trigger with total_files=0 to cover pct=75 path
                 on_progress(
                     EventType.FILE_START,
                     FileStartEvent(file="test.txt", total_files=0, current_file=0),
@@ -7092,36 +7122,6 @@ async def test_chat_add_skipped_file():
             patch("lilbee.ingest.sync", new=fake_sync),
         ):
             app.screen._run_add_background(_Path("test.txt"), "task-1")
-            while app.screen.workers:
-                await _pilot.pause()
-            assert app.screen._sync_active is False
-
-
-async def test_chat_add_sync_progress_with_total_files():
-    """_run_add_background computes percentage when total_files > 0."""
-    from pathlib import Path as _Path
-
-    from lilbee.cli.helpers import CopyResult
-
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        await _pilot.pause()
-        mock_result = CopyResult(copied=[_Path("new.txt")], skipped=[])
-
-        from lilbee.progress import EventType, FileStartEvent
-
-        async def fake_sync(*, quiet=True, on_progress=None):
-            if on_progress:
-                on_progress(
-                    EventType.FILE_START,
-                    FileStartEvent(file="doc.md", total_files=4, current_file=2),
-                )
-
-        with (
-            patch("lilbee.cli.helpers.copy_files", return_value=mock_result),
-            patch("lilbee.ingest.sync", new=fake_sync),
-        ):
-            app.screen._run_add_background(_Path("doc.md"), "task-pct")
             while app.screen.workers:
                 await _pilot.pause()
             assert app.screen._sync_active is False
@@ -7502,3 +7502,116 @@ async def test_catalog_grid_selected_with_model_card():
             with patch.object(screen, "_select_row") as mock_sel:
                 screen._on_grid_selected(event)
                 mock_sel.assert_called_once_with(row)
+
+
+async def test_cmd_add_uses_indeterminate_progress_during_ingest(tmp_path):
+    """BEE-65f: /add must not claim determinate progress while ingest runs.
+    Before the fix, the task bar jumped 0 -> 50 -> 100 for a single-file add,
+    falsely showing "done" while parse/chunk/embed/store were still running
+    for tens of seconds. The TaskBarController must flip the task to
+    indeterminate mode during copy and sync so the bar pulses instead of
+    lying about completion.
+    """
+    from pathlib import Path as _Path
+
+    from lilbee.cli.helpers import CopyResult
+    from lilbee.progress import EventType, FileStartEvent
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        await _pilot.pause()
+        test_file = tmp_path / "note.md"
+        test_file.write_text("hello")
+
+        task_id = app.task_bar.add_task("Add note.md", "add")
+        app.task_bar.queue.advance("add")
+
+        snapshots: list[tuple[bool, int]] = []
+
+        def on_change() -> None:
+            task = app.task_bar.queue.get_task(task_id)
+            if task is not None:
+                snapshots.append((task.indeterminate, task.progress))
+
+        app.task_bar.queue.subscribe(on_change)
+
+        async def fake_sync(*, quiet=True, on_progress=None):
+            if on_progress:
+                on_progress(
+                    EventType.FILE_START,
+                    FileStartEvent(file="note.md", total_files=1, current_file=1),
+                )
+
+        try:
+            with (
+                patch(
+                    "lilbee.cli.helpers.copy_files",
+                    return_value=CopyResult(copied=[_Path("note.md")], skipped=[]),
+                ),
+                patch("lilbee.ingest.sync", new=fake_sync),
+            ):
+                app.screen._run_add_background(test_file, task_id)
+                while app.screen.workers:
+                    await _pilot.pause()
+                await _pilot.pause()
+        finally:
+            app.task_bar.queue.unsubscribe(on_change)
+
+        # Drop the final DONE entry. The task bar flips indeterminate off at
+        # completion; everything BEFORE that must be indeterminate and must
+        # not claim 100% progress.
+        running_snapshots = [s for s in snapshots if s != (False, 100)]
+        assert running_snapshots, f"expected progress updates, got {snapshots}"
+        assert all(indet for indet, _ in running_snapshots), (
+            f"task should stay indeterminate until completion, got {running_snapshots}"
+        )
+        assert all(p < 100 for _, p in running_snapshots), (
+            f"no update should claim 100% progress while running, got {running_snapshots}"
+        )
+
+
+async def test_task_bar_indeterminate_renders_total_none():
+    """BEE-65f: indeterminate tasks render the Textual ProgressBar with total=None.
+    Setting total=None is how Textual draws an indeterminate pulsing bar.
+    A task flagged indeterminate=True must not leak a total=100 update.
+    """
+    from textual.widgets import ProgressBar
+
+    from lilbee.cli.tui.task_queue import TaskStatus
+    from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+    class _Harness(App[None]):
+        def __init__(self) -> None:
+            super().__init__()
+            from lilbee.cli.tui.widgets.task_bar import TaskBarController
+
+            self.task_bar = TaskBarController(self)
+
+        def compose(self) -> ComposeResult:
+            yield TaskBar(id="tbar")
+
+    app = _Harness()
+    async with app.run_test(size=(80, 24)) as _pilot:
+        task_id = app.task_bar.add_task("indet", "add")
+        app.task_bar.queue.advance("add")
+        app.task_bar.update_task(task_id, 0, "working", indeterminate=True)
+        # Panel compose + the spinner tick need a few frames to settle.
+        for _ in range(5):
+            await _pilot.pause()
+
+        task = app.task_bar.queue.get_task(task_id)
+        assert task is not None
+        assert task.indeterminate is True
+        assert task.status == TaskStatus.ACTIVE
+
+        bar = app.screen.query_one("#tbar", TaskBar)
+        pb = bar.query_one(ProgressBar)
+        # total=None is Textual's indeterminate mode
+        assert pb.total is None
+
+        # Completing flips indeterminate off and drives the bar to 100
+        app.task_bar.complete_task(task_id)
+        await _pilot.pause()
+        task = app.task_bar.queue.get_task(task_id)
+        if task is not None:
+            assert task.indeterminate is False

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -5141,6 +5141,112 @@ async def test_setup_wizard_partial_download():
                     await pilot.pause()
 
 
+async def test_setup_wizard_download_cancel():
+    """Setting _cancel_event aborts the download loop via _DownloadCancelled."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            download_started = False
+
+            def fake_download(model, on_progress=None):
+                nonlocal download_started
+                download_started = True
+                # Simulate progress callbacks; the cancel event is set before
+                # the first callback so _on_download_progress raises.
+                if on_progress:
+                    on_progress(100, 1000)
+                return MagicMock(stem="cancelled-model")
+
+            # Populate at least one model so the for-loop body executes
+            screen._download_models = [MagicMock(ref="chat:model", display_name="Test Model")]
+            screen._cancel_event.set()
+            with (
+                patch(
+                    "lilbee.cli.tui.screens.setup.download_model",
+                    side_effect=fake_download,
+                ),
+                patch("lilbee.settings.set_value"),
+                patch("lilbee.services.reset_services"),
+            ):
+                screen._download_loop(lambda fn, *a: fn(*a))
+                await pilot.pause()
+            # Download should not have started because the loop checks the
+            # event before each model.
+            assert not download_started
+
+
+async def test_setup_wizard_cancel_event_raises_in_progress_callback():
+    """_on_download_progress raises _DownloadCancelled when cancel event is set."""
+    from lilbee.cli.tui.screens.setup import SetupWizard, _DownloadCancelled
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            screen._cancel_event.set()
+            from lilbee.catalog import DownloadProgress
+
+            with pytest.raises(_DownloadCancelled):
+                screen._on_download_progress(
+                    lambda fn, *a: fn(*a),
+                    "test:ref",
+                    DownloadProgress(percent=50, detail="50%", is_cache_hit=False),
+                )
+
+
+async def test_setup_wizard_download_cancel_mid_download():
+    """Cancel event set during download triggers _DownloadCancelled in the loop."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+
+            def fake_download(model, on_progress=None):
+                # Set cancel during download; the progress callback will raise
+                screen._cancel_event.set()
+                if on_progress:
+                    on_progress(100, 1000)
+                return MagicMock(stem="model")
+
+            screen._download_models = [MagicMock(ref="chat:model", display_name="Test Model")]
+            with (
+                patch(
+                    "lilbee.cli.tui.screens.setup.download_model",
+                    side_effect=fake_download,
+                ),
+                patch("lilbee.settings.set_value"),
+                patch("lilbee.services.reset_services"),
+            ):
+                screen._download_loop(lambda fn, *a: fn(*a))
+                await pilot.pause()
+
+
+async def test_wizard_action_cancel_sets_event():
+    """action_cancel sets the cancel event so download threads abort."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            assert not screen._cancel_event.is_set()
+            screen.action_cancel()
+            assert screen._cancel_event.is_set()
+
+
 async def test_setup_wizard_single_model_download_error():
     from lilbee.cli.tui.screens.setup import SetupWizard
     from lilbee.cli.tui.widgets.grid_select import GridSelect
@@ -6393,6 +6499,25 @@ async def test_app_action_quit_when_streaming():
         with patch.object(screen, "action_cancel_stream") as mock_cancel:
             await app.action_quit()
             mock_cancel.assert_called_once()
+
+
+async def test_app_action_quit_routes_to_wizard_cancel():
+    """action_quit cancels the wizard instead of exiting when wizard is active."""
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        # Push a wizard on top
+        wizard = SetupWizard()
+        with _patch_setup_scan(), _patch_setup_ram(16.0):
+            app.push_screen(wizard)
+            await pilot.pause()
+            assert isinstance(app.screen, SetupWizard)
+            assert not wizard._cancel_event.is_set()
+            await app.action_quit()
+            assert wizard._cancel_event.is_set()
 
 
 async def test_app_action_quit_double_force_exits():

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2426,9 +2426,140 @@ class TestTaskBarAdditional:
             await pilot.pause()
 
 
-# ---------------------------------------------------------------------------
-# GridSelect additional coverage — highlight_first, highlight_last, cursor moves
-# ---------------------------------------------------------------------------
+class TestTaskBarIndeterminate:
+    """Tests for indeterminate progress bar rendering (BEE-65f) and
+    redundant ProgressBar update avoidance (BEE-jmj, BEE-73k).
+    """
+
+    async def test_add_task_indeterminate_creates_indeterminate_task(self) -> None:
+        """Tasks created with indeterminate=True start in indeterminate mode."""
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            task_id = bar.add_task("Sync", "sync", indeterminate=True)
+            task = bar.queue.get_task(task_id)
+            assert task is not None
+            assert task.indeterminate is True
+
+    async def test_enqueue_indeterminate_flag(self) -> None:
+        """TaskQueue.enqueue passes indeterminate to the Task."""
+        from lilbee.cli.tui.task_queue import TaskQueue
+
+        q = TaskQueue()
+        tid = q.enqueue(lambda: None, "Add", "add", indeterminate=True)
+        task = q.get_task(tid)
+        assert task is not None
+        assert task.indeterminate is True
+
+    async def test_indeterminate_renders_pulsing_bar(self) -> None:
+        """An indeterminate active task renders ProgressBar with total=None."""
+        from textual.widgets import ProgressBar as PB
+
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            task_id = bar.add_task("Sync", "sync", indeterminate=True)
+            bar.queue.advance()
+            bar._refresh_display()
+            # Wait for the panel to compose its children
+            await pilot.pause()
+            # Re-render now that children are mounted
+            bar._refresh_display()
+            await pilot.pause()
+            panel = bar._panels[task_id]
+            pb = panel.query_one(PB)
+            assert pb.total is None
+
+    async def test_progress_bar_not_updated_when_unchanged(self) -> None:
+        """Redundant ProgressBar.update calls are skipped when state matches."""
+        from textual.widgets import ProgressBar as PB
+
+        from lilbee.cli.tui.task_queue import Task, TaskStatus
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            task_id = bar.add_task("Download", "download")
+            bar.queue.advance()
+            bar._refresh_display()
+            await pilot.pause()
+            # Panel children are now composed. Re-render to populate tracking state.
+            bar._refresh_display()
+            await pilot.pause()
+
+            panel = bar._panels[task_id]
+            pb = panel.query_one(PB)
+            assert panel._last_progress == 0
+            assert panel._last_indeterminate is False
+
+            # Same state renders should not touch the progress bar
+            original_update = pb.update
+            call_count = 0
+
+            def counting_update(**kwargs: object) -> None:
+                nonlocal call_count
+                call_count += 1
+                original_update(**kwargs)
+
+            pb.update = counting_update  # type: ignore[assignment]
+
+            task = Task(
+                task_id=task_id,
+                fn=lambda: None,
+                name="Download",
+                task_type="download",
+                status=TaskStatus.ACTIVE,
+                progress=0,
+            )
+            bar._render_task_panel(task_id, task)
+            assert call_count == 0, "Should skip ProgressBar.update when state unchanged"
+
+    async def test_progress_bar_updated_when_progress_changes(self) -> None:
+        """ProgressBar.update is called when task progress changes."""
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            task_id = bar.add_task("Download", "download")
+            bar.queue.advance()
+            bar._refresh_display()
+            await pilot.pause()
+            # Panel children are now composed. Re-render to populate tracking state.
+            bar._refresh_display()
+            await pilot.pause()
+
+            panel = bar._panels[task_id]
+            assert panel._last_progress == 0
+
+            # Now change progress and verify the bar updates
+            bar.update_task(task_id, 50, "halfway")
+            bar._refresh_display()
+            await pilot.pause()
+            assert panel._last_progress == 50
+
+    async def test_controller_add_task_indeterminate(self) -> None:
+        """TaskBarController.add_task passes indeterminate through to queue."""
+        from lilbee.cli.tui.widgets.task_bar import TaskBarController
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            controller = app.task_bar
+            assert isinstance(controller, TaskBarController)
+            task_id = controller.add_task("Sync", "sync", indeterminate=True)
+            task = controller.queue.get_task(task_id)
+            assert task is not None
+            assert task.indeterminate is True
 
 
 class TestGridSelectExtra:

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2800,8 +2800,8 @@ class TestModelBarPopulateBranches:
             await pilot.pause()
             assert bar.display is True
 
-    async def test_after_model_change_with_streaming_chat(self) -> None:
-        """Cancel stream and defer reset when chat screen is streaming."""
+    async def test_after_model_change_with_chat_screen(self) -> None:
+        """Delegate to ChatScreen._apply_model_change when on a chat screen."""
         from lilbee.cli.tui.screens.chat import ChatScreen
         from lilbee.cli.tui.widgets.model_bar import ModelBar
 
@@ -2812,23 +2812,14 @@ class TestModelBarPopulateBranches:
             await pilot.pause()
             bar = app.query_one(ModelBar)
             mock_screen = mock.MagicMock(spec=ChatScreen)
-            mock_screen.streaming = True
-            mock_screen.workers = []
-            with (
-                mock.patch.object(
-                    type(app), "screen", new_callable=mock.PropertyMock, return_value=mock_screen
-                ),
-                mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services") as mock_reset,
+            with mock.patch.object(
+                type(app), "screen", new_callable=mock.PropertyMock, return_value=mock_screen
             ):
                 bar._after_model_change()
-                mock_screen.action_cancel_stream.assert_called_once()
-                mock_reset.assert_not_called()
-                await pilot.pause()
-                await pilot.pause()
-                mock_reset.assert_called_once()
+                mock_screen._apply_model_change.assert_called_once()
 
-    async def test_after_model_change_no_streaming(self) -> None:
-        """Reset services immediately when not streaming."""
+    async def test_after_model_change_no_chat_screen(self) -> None:
+        """Reset services directly when not on a chat screen."""
         from lilbee.cli.tui.widgets.model_bar import ModelBar
 
         cfg.chat_model = "test-model"
@@ -2840,32 +2831,6 @@ class TestModelBarPopulateBranches:
             with mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services") as mock_reset:
                 bar._after_model_change()
             mock_reset.assert_called_once()
-
-    async def test_deferred_reset_waits_for_workers(self) -> None:
-        """_deferred_reset retries when workers are still running."""
-        from lilbee.cli.tui.screens.chat import ChatScreen
-        from lilbee.cli.tui.widgets.model_bar import ModelBar
-
-        cfg.chat_model = "test-model"
-        cfg.embedding_model = "test-embed"
-        app = _ModelBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(ModelBar)
-            mock_screen = mock.MagicMock(spec=ChatScreen)
-            mock_screen.workers = [mock.MagicMock()]
-            with (
-                mock.patch.object(
-                    type(app), "screen", new_callable=mock.PropertyMock, return_value=mock_screen
-                ),
-                mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services") as mock_reset,
-            ):
-                bar._deferred_reset()
-                mock_reset.assert_not_called()
-                mock_screen.workers = []
-                await pilot.pause()
-                await pilot.pause()
-                mock_reset.assert_called_once()
 
 
 class TestModelBarCfgSourceOfTruth:


### PR DESCRIPTION
The /add and /sync progress bars showed a fake 0% bar before switching to indeterminate mode. They now start indeterminate from task creation, and redundant ProgressBar updates are skipped to reduce repaints during background operations.

The splash subprocess wrote a cursor-home escape during cleanup that landed on Textual's alt-screen, leaving a visible cursor artifact at (0,0). The subprocess now clears line-by-line, and the launcher stops the splash before Textual starts. dismiss() properly waits for the subprocess and clears the handle so the atexit handler cannot write stray escapes while the TUI is running.