### PR TITLE
Unify vision and chat model selection

### DIFF
--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
     import uvicorn
 from rich.table import Table
 
-from lilbee import settings
 from lilbee.cli import theme
 from lilbee.cli.app import (
     app,
@@ -47,130 +46,20 @@ from lilbee.services import get_services
 
 CHUNK_PREVIEW_LEN = 80  # characters shown in human-readable search output
 
-_vision_option = typer.Option(False, "--vision", help="Enable vision OCR for scanned PDFs.")
-_vision_timeout_option = typer.Option(
+_ocr_option = typer.Option(None, "--ocr/--no-ocr", help="Force vision OCR on/off for scanned PDFs.")
+_ocr_timeout_option = typer.Option(
     None,
-    "--vision-timeout",
+    "--ocr-timeout",
     help="Per-page timeout in seconds for vision OCR (default: 120, 0 = no limit).",
 )
 
 
-def _ensure_vision_model() -> None:
-    """Ensure a vision model is configured and available for this run."""
-    if cfg.vision_model:
-        _validate_configured_vision()
-        return
-
-    # Restore persisted model from TOML (--vision is explicit even if model was cleared)
-    saved = settings.get(cfg.data_root, "vision_model") or ""
-    if saved:
-        cfg.vision_model = saved
-        _validate_configured_vision()
-        return
-
-    from lilbee.models import list_installed_models
-
-    try:
-        installed = set(list_installed_models())
-    except Exception:
-        console.print(
-            f"[{theme.WARNING}]Warning: Cannot list models. Vision OCR disabled.[/{theme.WARNING}]"
-        )
-        return
-
-    if sys.stdin.isatty():
-        _pick_vision_interactive(installed)
-    else:
-        _pick_vision_auto(installed)
-
-
-def _validate_configured_vision() -> None:
-    """Check that a pre-configured vision model is available; pull if needed."""
-    from lilbee.models import ensure_tag, list_installed_models
-
-    tagged = ensure_tag(cfg.vision_model)
-    cfg.vision_model = tagged
-
-    try:
-        installed = set(list_installed_models())
-    except Exception:
-        # Can't reach model backend — keep the config and let downstream handle errors
-        return
-
-    if tagged in installed:
-        return
-
-    console.print(f"Vision model '{tagged}' not installed. Pulling...")
-    if not _try_pull(tagged):
-        cfg.vision_model = ""
-
-
-def _pick_vision_interactive(installed: set[str]) -> None:
-    """Interactive vision model picker for TTY sessions."""
-    from lilbee.models import (
-        VISION_CATALOG,
-        display_vision_picker,
-        get_free_disk_gb,
-        get_system_ram_gb,
-    )
-
-    ram_gb = get_system_ram_gb()
-    free_gb = get_free_disk_gb(cfg.data_dir)
-    recommended = display_vision_picker(ram_gb, free_gb)
-    default_idx = list(VISION_CATALOG).index(recommended) + 1
-
-    try:
-        raw = input(f"Choice [{default_idx}]: ").strip()
-    except (EOFError, KeyboardInterrupt):
-        return
-
-    if not raw:
-        model_info = recommended
-    else:
-        try:
-            choice = int(raw)
-        except ValueError:
-            console.print(f"[{theme.ERROR}]Enter a number 1-{len(VISION_CATALOG)}.[/{theme.ERROR}]")
-            return
-        if not (1 <= choice <= len(VISION_CATALOG)):
-            console.print(f"[{theme.ERROR}]Enter a number 1-{len(VISION_CATALOG)}.[/{theme.ERROR}]")
-            return
-        model_info = VISION_CATALOG[choice - 1]
-
-    _pull_and_save_vision(model_info.name, installed)
-
-
-def _pick_vision_auto(installed: set[str]) -> None:
-    """Non-interactive vision model auto-selection."""
-    from lilbee.models import pick_default_vision_model
-
-    model_info = pick_default_vision_model()
-    sys.stderr.write(f"No vision model configured. Auto-selecting '{model_info.name}'...\n")
-    _pull_and_save_vision(model_info.name, installed)
-
-
-def _try_pull(model_name: str) -> bool:
-    """Attempt to pull a model. Returns True on success, False on failure."""
-    from lilbee.models import pull_with_progress
-
-    try:
-        pull_with_progress(model_name)
-    except Exception as exc:
-        console.print(
-            f"[{theme.WARNING}]Warning: Failed to pull '{model_name}': {exc}[/{theme.WARNING}]"
-        )
-        console.print(f"[{theme.WARNING}]Continuing without vision OCR.[/{theme.WARNING}]")
-        return False
-    return True
-
-
-def _pull_and_save_vision(model_name: str, installed: set[str]) -> None:
-    """Pull if needed and persist vision model choice."""
-    if model_name not in installed and not _try_pull(model_name):
-        return
-
-    cfg.vision_model = model_name
-    settings.set_value(cfg.data_root, "vision_model", model_name)
+def _apply_ocr_overrides(ocr: bool | None, ocr_timeout: float | None) -> None:
+    """Apply --ocr/--no-ocr and --ocr-timeout CLI overrides to config."""
+    if ocr is not None:
+        cfg.enable_ocr = ocr
+    if ocr_timeout is not None:
+        cfg.ocr_timeout = ocr_timeout
 
 
 _paths_argument = typer.Argument(
@@ -221,19 +110,16 @@ def search(
 def sync_cmd(
     data_dir: Path | None = data_dir_option,
     use_global: bool = global_option,
-    vision: bool = _vision_option,
-    vision_timeout: float | None = _vision_timeout_option,
+    ocr: bool | None = _ocr_option,
+    ocr_timeout: float | None = _ocr_timeout_option,
 ) -> None:
     """Manually trigger document sync."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    if vision_timeout is not None:
-        cfg.vision_timeout = vision_timeout
-    if vision:
-        _ensure_vision_model()
+    _apply_ocr_overrides(ocr, ocr_timeout)
     from lilbee.ingest import sync
 
     try:
-        result = asyncio.run(sync(quiet=cfg.json_mode, force_vision=vision))
+        result = asyncio.run(sync(quiet=cfg.json_mode))
     except RuntimeError as exc:
         if cfg.json_mode:
             json_output({"error": str(exc)})
@@ -250,19 +136,16 @@ def sync_cmd(
 def rebuild(
     data_dir: Path | None = data_dir_option,
     use_global: bool = global_option,
-    vision: bool = _vision_option,
-    vision_timeout: float | None = _vision_timeout_option,
+    ocr: bool | None = _ocr_option,
+    ocr_timeout: float | None = _ocr_timeout_option,
 ) -> None:
     """Nuke the DB and re-ingest everything from documents/."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    if vision_timeout is not None:
-        cfg.vision_timeout = vision_timeout
-    if vision:
-        _ensure_vision_model()
+    _apply_ocr_overrides(ocr, ocr_timeout)
     from lilbee.ingest import sync
 
     try:
-        result = asyncio.run(sync(force_rebuild=True, quiet=cfg.json_mode, force_vision=vision))
+        result = asyncio.run(sync(force_rebuild=True, quiet=cfg.json_mode))
     except RuntimeError as exc:
         if cfg.json_mode:
             json_output({"error": str(exc)})
@@ -342,18 +225,15 @@ def add(
     data_dir: Path | None = data_dir_option,
     use_global: bool = global_option,
     force: bool = _force_option,
-    vision: bool = _vision_option,
-    vision_timeout: float | None = _vision_timeout_option,
+    ocr: bool | None = _ocr_option,
+    ocr_timeout: float | None = _ocr_timeout_option,
     crawl: bool = _crawl_option,
     depth: int | None = _depth_option,
     max_pages: int | None = _max_pages_option,
 ) -> None:
     """Copy files or crawl URLs into the knowledge base and ingest them."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    if vision_timeout is not None:
-        cfg.vision_timeout = vision_timeout
-    if vision:
-        _ensure_vision_model()
+    _apply_ocr_overrides(ocr, ocr_timeout)
 
     file_paths, urls = _partition_inputs(paths)
     # Validate file paths exist
@@ -392,7 +272,7 @@ def add(
             copied: list[str] = []
             if file_paths:
                 copied = copy_paths(file_paths, console, force=force)
-            result = asyncio.run(sync(quiet=True, force_vision=vision))
+            result = asyncio.run(sync(quiet=True))
             json_output(
                 {
                     "command": "add",
@@ -404,12 +284,12 @@ def add(
             return
 
         if file_paths:
-            add_paths(file_paths, console, force=force, force_vision=vision)
+            add_paths(file_paths, console, force=force)
         elif urls:
             # URLs already saved; just trigger sync
             from lilbee.ingest import sync
 
-            result = asyncio.run(sync(force_vision=vision))
+            result = asyncio.run(sync())
             console.print(result)
     except RuntimeError as exc:
         if cfg.json_mode:

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import shutil
 from collections.abc import Generator
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -44,7 +43,7 @@ class StatusConfig(BaseModel):
     data_dir: str
     chat_model: str
     embedding_model: str
-    vision_model: str | None = None
+    enable_ocr: bool | None = None
 
 
 class SourceInfo(BaseModel):
@@ -71,8 +70,9 @@ class StatusResult(BaseModel):
         yield f"[{theme.LABEL}]Database:[/{theme.LABEL}]   {self.config.data_dir}"
         yield f"[{theme.LABEL}]Chat model:[/{theme.LABEL}] {self.config.chat_model}"
         yield f"[{theme.LABEL}]Embeddings:[/{theme.LABEL}] {self.config.embedding_model}"
-        if self.config.vision_model:
-            yield f"[{theme.LABEL}]Vision OCR:[/{theme.LABEL}] {self.config.vision_model}"
+        if self.config.enable_ocr is not None:
+            ocr_label = "enabled" if self.config.enable_ocr else "disabled"
+            yield f"[{theme.LABEL}]Vision OCR:[/{theme.LABEL}] {ocr_label}"
         yield ""
 
         if not self.sources:
@@ -129,7 +129,7 @@ def gather_status() -> StatusResult:
             data_dir=str(cfg.data_dir),
             chat_model=cfg.chat_model,
             embedding_model=cfg.embedding_model,
-            vision_model=cfg.vision_model or None,
+            enable_ocr=cfg.enable_ocr,
         ),
         sources=[
             SourceInfo(
@@ -286,16 +286,3 @@ def auto_sync(con: Console, *, background: bool = False) -> None:
             f"{len(result.removed)} removed, "
             f"{len(result.failed)} failed[/{theme.MUTED}]"
         )
-
-
-@contextmanager
-def temporary_vision_model(model: str) -> Generator[None, None, None]:
-    """Temporarily override ``cfg.vision_model`` for the duration of the block."""
-    old = cfg.vision_model
-    if model:
-        cfg.vision_model = model
-    try:
-        yield
-    finally:
-        if model:
-            cfg.vision_model = old

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import shutil
 from collections.abc import Generator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -286,3 +287,25 @@ def auto_sync(con: Console, *, background: bool = False) -> None:
             f"{len(result.removed)} removed, "
             f"{len(result.failed)} failed[/{theme.MUTED}]"
         )
+
+
+@contextmanager
+def temporary_ocr_config(
+    enable_ocr: bool | None = None,
+    ocr_timeout: float | None = None,
+) -> Generator[None, None, None]:
+    """Temporarily override OCR config for the duration of the block.
+
+    Restores previous values on exit (even on exception). Pass None
+    to leave a field unchanged.
+    """
+    old_ocr, old_timeout = cfg.enable_ocr, cfg.ocr_timeout
+    try:
+        if enable_ocr is not None:
+            cfg.enable_ocr = enable_ocr
+        if ocr_timeout is not None:
+            cfg.ocr_timeout = ocr_timeout
+        yield
+    finally:
+        cfg.enable_ocr = old_ocr
+        cfg.ocr_timeout = old_timeout

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -191,7 +191,6 @@ def add_paths(
     con: Console,
     *,
     force: bool = False,
-    force_vision: bool = False,
     background: bool = False,
     chat_mode: bool = False,
     sync_status: SyncStatus | None = None,
@@ -213,12 +212,10 @@ def add_paths(
     if background:
         from lilbee.cli.sync import run_sync_background
 
-        run_sync_background(
-            con, force_vision=force_vision, chat_mode=chat_mode, sync_status=sync_status
-        )
+        run_sync_background(con, chat_mode=chat_mode, sync_status=sync_status)
         return
 
-    result = asyncio.run(sync(force_vision=force_vision))
+    result = asyncio.run(sync())
     con.print(result)
 
 

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -294,11 +294,7 @@ def temporary_ocr_config(
     enable_ocr: bool | None = None,
     ocr_timeout: float | None = None,
 ) -> Generator[None, None, None]:
-    """Temporarily override OCR config for the duration of the block.
-
-    Restores previous values on exit (even on exception). Pass None
-    to leave a field unchanged.
-    """
+    """Temporarily override OCR config for the duration of the block."""
     old_ocr, old_timeout = cfg.enable_ocr, cfg.ocr_timeout
     try:
         if enable_ocr is not None:

--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -43,6 +43,18 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group="Models",
         help_text="Vision model for OCR on images and PDFs",
     ),
+    "enable_ocr": SettingDef(
+        bool,
+        nullable=True,
+        group="Ingest",
+        help_text="Vision OCR for scanned PDFs (empty = auto-detect from chat model)",
+    ),
+    "ocr_timeout": SettingDef(
+        float,
+        nullable=False,
+        group="Ingest",
+        help_text="Per-page timeout in seconds for vision OCR (0 = no limit)",
+    ),
     "embedding_model": SettingDef(
         str,
         nullable=False,

--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -36,13 +36,6 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group="Models",
         help_text="LLM used for chat and generation",
     ),
-    "vision_model": SettingDef(
-        str,
-        nullable=True,
-        writable=False,
-        group="Models",
-        help_text="Vision model for OCR on images and PDFs",
-    ),
     "enable_ocr": SettingDef(
         bool,
         nullable=True,

--- a/src/lilbee/cli/sync.py
+++ b/src/lilbee/cli/sync.py
@@ -131,7 +131,6 @@ def _chat_sync_callback(status: SyncStatus) -> DetailedProgressCallback:
 def run_sync_background(
     con: Console,
     *,
-    force_vision: bool = False,
     chat_mode: bool = False,
     sync_status: SyncStatus | None = None,
 ) -> Future[object]:
@@ -143,7 +142,7 @@ def run_sync_background(
     def _run() -> object:
         if chat_mode:
             status.pending -= 1
-        return asyncio.run(sync(quiet=True, on_progress=callback, force_vision=force_vision))
+        return asyncio.run(sync(quiet=True, on_progress=callback))
 
     if chat_mode:
         status.pending += 1

--- a/src/lilbee/cli/tui/command_registry.py
+++ b/src/lilbee/cli/tui/command_registry.py
@@ -31,14 +31,6 @@ COMMANDS: tuple[SlashCommand, ...] = (
         has_arg_completion=True,
     ),
     SlashCommand(
-        "/vision",
-        "_cmd_vision",
-        aliases=(),
-        args_hint="[name]",
-        help_text="Set vision model (/vision off)",
-        has_arg_completion=True,
-    ),
-    SlashCommand(
         "/add",
         "_cmd_add",
         aliases=(),

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -86,27 +86,6 @@ class LilbeeCommandProvider(Provider):
         except Exception:
             log.debug("Failed to list installed models", exc_info=True)
 
-        try:
-            from lilbee.models import VISION_CATALOG
-
-            for m in VISION_CATALOG:
-                commands.append(
-                    (
-                        f"Set vision → {m.name}",
-                        m.description,
-                        lambda n=m.name: self._set_model("vision_model", n),
-                    )
-                )
-            commands.append(
-                (
-                    "Set vision → off",
-                    "Disable vision OCR",
-                    lambda: self._set_model("vision_model", ""),
-                )
-            )
-        except Exception:
-            log.debug("Failed to load vision catalog", exc_info=True)
-
         return commands
 
     def _document_commands(self) -> list[tuple[str, str, Any]]:

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -31,13 +31,6 @@ CMD_SET_UNKNOWN = "Unknown setting: {key}"
 CMD_SET_SUCCESS = "{key} = {value}"
 CMD_SET_INVALID = "Invalid value for {key}: {error}"
 CMD_MODEL_SET = "Model set to {name}"
-CMD_VISION_DISABLED = "Vision OCR disabled"
-CMD_VISION_SET = "Vision model: {name}"
-CMD_VISION_STATUS = (
-    "Vision: {current}\n"
-    "Recommended: maternion/LightOnOCR-2 (fastest, best quality)\n"
-    "Usage: /vision maternion/LightOnOCR-2:latest  or  /vision off"
-)
 CMD_REMOVE_USAGE = "Usage: /remove <model_name>"
 CMD_REMOVE_NOT_FOUND = "{name} is not installed"
 CMD_REMOVE_SUCCESS = "Removed {name}"

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -690,24 +690,6 @@ class ChatScreen(Screen[None]):
             if isinstance(screen, WikiScreen):
                 screen.reload()
 
-    def _cmd_vision(self, args: str) -> None:
-        if args == "off":
-            cfg.vision_model = ""
-            settings.set_value(cfg.data_root, "vision_model", "")
-            self.notify(msg.CMD_VISION_DISABLED)
-            self._refresh_model_bar()
-            return
-
-        if args:
-            cfg.vision_model = args
-            settings.set_value(cfg.data_root, "vision_model", args)
-            self.notify(msg.CMD_VISION_SET.format(name=args))
-            self._refresh_model_bar()
-            return
-
-        current = cfg.vision_model or "disabled"
-        self.notify(msg.CMD_VISION_STATUS.format(current=current))
-
     def _send_message(self, text: str) -> None:
         """Send a user message and stream the response."""
         log = self.query_one("#chat-log", VerticalScroll)

--- a/src/lilbee/cli/tui/screens/status.py
+++ b/src/lilbee/cli/tui/screens/status.py
@@ -39,6 +39,24 @@ def _config_line(label: str, value: str, status: Content) -> Content:
     )
 
 
+def _ocr_label() -> str:
+    """Return a human-readable OCR status string."""
+    if cfg.enable_ocr is True:
+        return "enabled"
+    if cfg.enable_ocr is False:
+        return "disabled"
+    return "auto"
+
+
+def _ocr_pill() -> Content:
+    """Return a pill reflecting OCR status."""
+    if cfg.enable_ocr is True:
+        return pill("on", "$success", "$text")
+    if cfg.enable_ocr is False:
+        return pill("off", "$warning", "$text")
+    return pill("auto", "$accent", "$text")
+
+
 def _data_dir_pill() -> Content:
     """Return a pill based on whether the data directory exists."""
     if Path(cfg.data_dir).exists():
@@ -52,7 +70,7 @@ def _build_config_content() -> Content:
         _config_line("Data dir", str(cfg.data_dir), _data_dir_pill()),
         _config_line("Chat model", cfg.chat_model, _model_pill(cfg.chat_model)),
         _config_line("Embed model", cfg.embedding_model, _model_pill(cfg.embedding_model)),
-        _config_line("Vision model", cfg.vision_model or "(none)", _model_pill(cfg.vision_model)),
+        _config_line("OCR", _ocr_label(), _ocr_pill()),
     ]
     return Content("\n").join(lines)
 
@@ -74,7 +92,7 @@ def _build_arch_content(info: ModelArchInfo) -> Content:
         Content.assemble(("Embed arch: ", "bold"), info.embed_arch),
         Content.assemble(("Handler: ", "bold"), info.active_handler),
     ]
-    if cfg.vision_model:
+    if info.vision_projector:
         lines.append(Content.assemble(("Vision proj: ", "bold"), info.vision_projector))
     return Content("\n").join(lines)
 

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -60,17 +60,6 @@ def _model_options() -> list[str]:
         return []
 
 
-def _vision_options() -> list[str]:
-    names = ["off"]
-    try:
-        from lilbee.models import VISION_CATALOG
-
-        names.extend(m.name for m in VISION_CATALOG)
-    except Exception:
-        log.debug("Failed to load vision catalog for autocomplete", exc_info=True)
-    return names
-
-
 def _setting_options() -> list[str]:
     return list(SETTINGS_MAP.keys())
 
@@ -124,7 +113,6 @@ def _path_options(partial: str = "") -> list[str]:
 
 _ARG_SOURCES: dict[str, Callable[[], list[str]]] = {
     "/model": _model_options,
-    "/vision": _vision_options,
     "/set": _setting_options,
     "/delete": _document_options,
     "/remove": _model_options,

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -1,4 +1,4 @@
-"""Model status bar — Select dropdowns for chat, embedding, and vision models."""
+"""Model status bar — Select dropdowns for chat and embedding models."""
 
 from __future__ import annotations
 
@@ -35,8 +35,8 @@ def _is_mmproj(name: str) -> bool:
     return _MMPROJ_MARKER in name.lower()
 
 
-def _classify_installed_models() -> tuple[list[ModelOption], list[ModelOption], list[ModelOption]]:
-    """Classify installed models into (chat, embedding, vision) lists.
+def _classify_installed_models() -> tuple[list[ModelOption], list[ModelOption]]:
+    """Classify installed models into (chat, embedding) lists.
     Uses registry manifests for native models and the litellm backend's
     backend metadata for remote models. Filters out mmproj files.
     """
@@ -53,7 +53,6 @@ def _classify_installed_models() -> tuple[list[ModelOption], list[ModelOption], 
     return (
         sorted(buckets[ModelTask.CHAT], key=lambda o: o.ref),
         sorted(buckets[ModelTask.EMBEDDING], key=lambda o: o.ref),
-        sorted(buckets[ModelTask.VISION], key=lambda o: o.ref),
     )
 
 
@@ -110,7 +109,7 @@ def _sync_select(sel: Select, opts: list[ModelOption], default: str = "") -> Non
         sel.value = target
 
 
-_SELECT_IDS = ("#chat-model-select", "#embed-model-select", "#vision-model-select")
+_SELECT_IDS = ("#chat-model-select", "#embed-model-select")
 
 
 class ModelBar(Widget, can_focus=False):
@@ -144,7 +143,6 @@ class ModelBar(Widget, can_focus=False):
     def compose(self) -> ComposeResult:
         chat_opts = [(cfg.chat_model, cfg.chat_model)] if cfg.chat_model else []
         embed_opts = [(cfg.embedding_model, cfg.embedding_model)] if cfg.embedding_model else []
-        vision_opts = [(cfg.vision_model, cfg.vision_model)] if cfg.vision_model else []
         with Horizontal():
             yield Label("Chat:")
             yield Select[str](
@@ -160,69 +158,42 @@ class ModelBar(Widget, can_focus=False):
                 id="embed-model-select",
                 allow_blank=False,
             )
-            yield Label("Vision:")
-            yield Select[str](
-                options=vision_opts,
-                prompt="Vision (optional)",
-                id="vision-model-select",
-                allow_blank=True,
-            )
 
     def on_mount(self) -> None:
         chat_sel = self.query_one("#chat-model-select", Select)
         embed_sel = self.query_one("#embed-model-select", Select)
-        vision_sel = self.query_one("#vision-model-select", Select)
 
         if cfg.chat_model:
             chat_sel.value = cfg.chat_model
         if cfg.embedding_model:
             embed_sel.value = cfg.embedding_model
-        if cfg.vision_model:
-            vision_sel.value = cfg.vision_model
 
         self._scan_models()
 
     @work(thread=True)
     def _scan_models(self) -> None:
         """Scan installed models in background, then populate dropdowns."""
-        chat, embed, vision = _classify_installed_models()
-        self.app.call_from_thread(self._populate, chat, embed, vision)
+        chat, embed = _classify_installed_models()
+        self.app.call_from_thread(self._populate, chat, embed)
 
     def _populate(
         self,
         chat_models: list[ModelOption],
         embed_models: list[ModelOption],
-        vision_models: list[ModelOption],
     ) -> None:
         """Populate Select widgets from scanned models (main thread)."""
         self._populating = True
 
         chat_sel = self.query_one("#chat-model-select", Select)
         embed_sel = self.query_one("#embed-model-select", Select)
-        vision_sel = self.query_one("#vision-model-select", Select)
 
         chat_opts = list(chat_models) if chat_models else [ModelOption("(none)", "")]
         embed_opts = list(embed_models) if embed_models else [ModelOption("(none)", "")]
 
         _sync_select(chat_sel, chat_opts, cfg.chat_model)
         _sync_select(embed_sel, embed_opts, cfg.embedding_model)
-        self._sync_vision_select(vision_sel, vision_models)
 
         self._populating = False
-
-    def _sync_vision_select(self, sel: Select, models: list[ModelOption]) -> None:
-        """Sync vision Select with extra fallback to cfg.vision_model."""
-        opts = list(models)
-        current = str(sel.value) if sel.value != _DISABLED else ""
-        target = current or cfg.vision_model
-        if target:
-            if not any(o.ref == target for o in opts):
-                opts.insert(0, ModelOption(target, target))
-            sel.set_options(opts)
-            sel.value = target
-        else:
-            sel.set_options(opts)
-            sel.value = _DISABLED
 
     @on(Select.Changed, "#chat-model-select")
     def _on_chat_model_changed(self, event: Select.Changed) -> None:
@@ -242,19 +213,6 @@ class ModelBar(Widget, can_focus=False):
             return
         cfg.embedding_model = value
         settings.set_value(cfg.data_root, "embedding_model", value)
-        self._after_model_change()
-
-    @on(Select.Changed, "#vision-model-select")
-    def _on_vision_model_changed(self, event: Select.Changed) -> None:
-        """Handle vision model selection change."""
-        if self._populating:
-            return
-        if event.value is _DISABLED or event.value is None or str(event.value) == "":
-            cfg.vision_model = ""
-            settings.set_value(cfg.data_root, "vision_model", "")
-            return
-        cfg.vision_model = str(event.value)
-        settings.set_value(cfg.data_root, "vision_model", cfg.vision_model)
         self._after_model_change()
 
     def _extract_value(self, event: Select.Changed) -> str | None:

--- a/src/lilbee/cli/tui/widgets/suggester.py
+++ b/src/lilbee/cli/tui/widgets/suggester.py
@@ -42,8 +42,6 @@ class SlashSuggester(Suggester):
 
         if cmd == "/model":
             return self._suggest_from_list(value, partial, self._get_model_names())
-        if cmd == "/vision":
-            return self._suggest_from_list(value, partial, self._get_vision_names())
         if cmd == "/set":
             return self._suggest_from_list(value, partial, self._get_setting_names())
         if cmd == "/delete":
@@ -65,16 +63,6 @@ class SlashSuggester(Suggester):
             return list_installed_models()
         except Exception:
             return []
-
-    def _get_vision_names(self) -> list[str]:
-        names = ["off"]
-        try:
-            from lilbee.models import VISION_CATALOG
-
-            names.extend(m.name for m in VISION_CATALOG)
-        except Exception:
-            pass
-        return names
 
     def _get_setting_names(self) -> list[str]:
         return list(SETTINGS_MAP.keys())

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -108,6 +108,15 @@ class Config(BaseSettings):
     ignore_dirs: frozenset[str] = Field(default=DEFAULT_IGNORE_DIRS)
     vision_model: str = ""
     vision_timeout: float = Field(default=120.0, ge=0.0)
+
+    # OCR for scanned PDFs via vision-capable chat model.
+    # None = auto-detect (use OCR if chat model is vision-capable).
+    # True = force OCR regardless of detection.
+    # False = disable OCR entirely.
+    enable_ocr: bool | None = ConfigField(default=None, writable=True)
+
+    # Per-page timeout in seconds for vision OCR (0 = no limit).
+    ocr_timeout: float = ConfigField(default=120.0, ge=0.0, writable=True)
     server_host: str = "127.0.0.1"
     server_port: int = Field(default=0, ge=0, le=65535)
     cors_origins: list[str] = Field(default_factory=list)
@@ -349,6 +358,28 @@ class Config(BaseSettings):
         if isinstance(v, str) and v.strip() == "":
             return None
         return v
+
+    @field_validator("enable_ocr", mode="before")
+    @classmethod
+    def _parse_enable_ocr(cls, v: Any) -> bool | None:
+        """Parse enable_ocr from env var string or direct value.
+
+        Accepts: true/false/1/0/yes/no (case-insensitive), empty string
+        or None for auto-detect.
+        """
+        if v is None:
+            return None
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            stripped = v.strip().lower()
+            if stripped in ("", "auto", "none"):
+                return None
+            if stripped in ("true", "1", "yes"):
+                return True
+            if stripped in ("false", "0", "no"):
+                return False
+        return bool(v)
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -106,9 +106,6 @@ class Config(BaseSettings):
     adaptive_threshold: bool = Field(default=False)
     system_prompt: str = ConfigField(default=_DEFAULT_SYSTEM_PROMPT, min_length=1, writable=True)
     ignore_dirs: frozenset[str] = Field(default=DEFAULT_IGNORE_DIRS)
-    vision_model: str = ""
-    vision_timeout: float = Field(default=120.0, ge=0.0)
-
     # OCR for scanned PDFs via vision-capable chat model.
     # None = auto-detect (use OCR if chat model is vision-capable).
     # True = force OCR regardless of detection.

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -255,6 +255,21 @@ async def _try_tesseract_ocr(
         return fallback
 
 
+def _should_run_ocr() -> bool:
+    """Decide whether to attempt vision-based OCR on scanned PDFs.
+
+    Uses ``cfg.enable_ocr``: True = force on, False = force off,
+    None = auto-detect from chat model capabilities.
+    """
+    if cfg.enable_ocr is True:
+        return True
+    if cfg.enable_ocr is False:
+        return False
+    from lilbee.model_manager import is_vision_capable
+
+    return is_vision_capable(cfg.chat_model)
+
+
 async def _vision_fallback(
     path: Path,
     source_name: str,
@@ -263,15 +278,29 @@ async def _vision_fallback(
     *,
     quiet: bool = False,
 ) -> list[ChunkRecord]:
-    """OCR a scanned PDF via vision model, chunk, and embed."""
-    page_texts = await asyncio.to_thread(
-        extract_pdf_vision,
-        path,
-        cfg.vision_model,
-        quiet=quiet,
-        timeout=cfg.vision_timeout,
-        on_progress=on_progress,
-    )
+    """OCR a scanned PDF via vision model, chunk, and embed.
+
+    Uses ``cfg.chat_model`` as the vision model. Wraps the OCR call in
+    a try/except so that forced OCR on an incompatible model degrades
+    gracefully (logs a warning and returns empty).
+    """
+    try:
+        page_texts = await asyncio.to_thread(
+            extract_pdf_vision,
+            path,
+            cfg.chat_model,
+            quiet=quiet,
+            timeout=cfg.ocr_timeout,
+            on_progress=on_progress,
+        )
+    except Exception:
+        log.warning(
+            "Vision OCR failed for %s. The chat model (%s) may not support vision input.",
+            source_name,
+            cfg.chat_model,
+            exc_info=True,
+        )
+        return []
     if not page_texts:
         return []
 
@@ -306,24 +335,29 @@ async def _handle_scanned_pdf_fallback(
     content_type: str,
     result: ExtractionResult,
     *,
-    use_vision: bool,
     quiet: bool,
     on_progress: DetailedProgressCallback,
 ) -> list[ChunkRecord] | ExtractionResult:
     """Handle scanned PDF fallback chain: Tesseract OCR then vision model.
+
     Returns chunk records if a fallback produced final results, or an
     updated ExtractionResult when Tesseract OCR succeeded (so the
     caller can proceed with normal chunking/embedding).
+
+    Vision OCR is attempted when ``_should_run_ocr()`` is True. When
+    force-OCR is on, Tesseract is skipped and we go straight to vision.
     """
-    if not use_vision:
+    use_ocr = _should_run_ocr()
+
+    if cfg.enable_ocr is not True:
         result = await _try_tesseract_ocr(path, source_name, result)
 
     if not _has_meaningful_text(result):
-        if not cfg.vision_model:
+        if not use_ocr:
             log.warning(
-                "Skipped %s: Tesseract OCR produced no usable text. "
-                "For better results on complex scans, set a vision model "
-                "with /vision or LILBEE_VISION_MODEL.",
+                "Skipped %s: text extraction produced no usable text. "
+                "For better results on scanned PDFs, switch to a vision-capable "
+                "chat model or set LILBEE_ENABLE_OCR=true.",
                 source_name,
             )
             return []
@@ -332,7 +366,7 @@ async def _handle_scanned_pdf_fallback(
 
     log.info(
         "Scanned PDF detected — extracted with Tesseract OCR: %s. "
-        "For structured markdown output (tables, headings), re-add with --vision.",
+        "For structured markdown output (tables, headings), use a vision-capable chat model.",
         source_name,
     )
     return result
@@ -343,18 +377,14 @@ async def ingest_document(
     source_name: str,
     content_type: str,
     *,
-    force_vision: bool = False,
     quiet: bool = False,
     on_progress: DetailedProgressCallback = noop_callback,
 ) -> list[ChunkRecord]:
     """Extract and chunk a document, embed, return records.
-    When *force_vision* is True (CLI ``--vision``) or a vision model is
-    configured, Tesseract OCR is skipped and we go straight to the vision
-    model for scanned PDFs.
+
+    Vision OCR is controlled by ``cfg.enable_ocr`` (see ``_should_run_ocr``).
     """
     from kreuzberg import extract_file
-
-    use_vision = force_vision or bool(cfg.vision_model)
 
     config = extraction_config(content_type)
     result = await extract_file(str(path), config=config)
@@ -365,7 +395,6 @@ async def ingest_document(
             source_name,
             content_type,
             result,
-            use_vision=use_vision,
             quiet=quiet,
             on_progress=on_progress,
         )
@@ -504,7 +533,6 @@ async def _ingest_file(
     source_name: str,
     content_type: str,
     *,
-    force_vision: bool = False,
     quiet: bool = False,
     on_progress: DetailedProgressCallback = noop_callback,
 ) -> int:
@@ -519,7 +547,6 @@ async def _ingest_file(
             path,
             source_name,
             content_type,
-            force_vision=force_vision,
             quiet=quiet,
             on_progress=on_progress,
         )
@@ -534,7 +561,6 @@ async def sync(
     force_rebuild: bool = False,
     quiet: bool = False,
     *,
-    force_vision: bool = False,
     on_progress: DetailedProgressCallback = noop_callback,
     cancel: threading.Event | None = None,
 ) -> SyncResult:
@@ -605,7 +631,6 @@ async def sync(
             updated,
             failed,
             quiet=quiet,
-            force_vision=force_vision,
             on_progress=on_progress,
             cancel=cancel,
         )
@@ -654,7 +679,6 @@ async def ingest_batch(
     failed: list[str],
     *,
     quiet: bool = False,
-    force_vision: bool = False,
     on_progress: DetailedProgressCallback = noop_callback,
     cancel: threading.Event | None = None,
 ) -> None:
@@ -689,7 +713,6 @@ async def ingest_batch(
                     path,
                     name,
                     content_type,
-                    force_vision=force_vision,
                     quiet=quiet,
                     on_progress=on_progress,
                 )

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -117,16 +117,10 @@ async def lilbee_add(
 
     copy_result = copy_files(valid, force=force)
 
-    old_ocr, old_timeout = cfg.enable_ocr, cfg.ocr_timeout
-    try:
-        if enable_ocr is not None:
-            cfg.enable_ocr = enable_ocr
-        if ocr_timeout is not None:
-            cfg.ocr_timeout = ocr_timeout
+    from lilbee.cli.helpers import temporary_ocr_config
+
+    with temporary_ocr_config(enable_ocr, ocr_timeout):
         sync_result = (await sync(quiet=True)).model_dump()
-    finally:
-        cfg.enable_ocr = old_ocr
-        cfg.ocr_timeout = old_timeout
 
     return {
         "command": "add",

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -43,7 +43,7 @@ def lilbee_status() -> dict[str, Any]:
             "data_dir": str(cfg.data_dir),
             "chat_model": cfg.chat_model,
             "embedding_model": cfg.embedding_model,
-            **({"vision_model": cfg.vision_model} if cfg.vision_model else {}),
+            "enable_ocr": cfg.enable_ocr,
         },
         "sources": [
             {"filename": s["filename"], "chunk_count": s["chunk_count"]}
@@ -65,7 +65,8 @@ async def lilbee_sync() -> dict[str, Any]:
 async def lilbee_add(
     paths: list[str],
     force: bool = False,
-    vision_model: str = "",
+    enable_ocr: bool | None = None,
+    ocr_timeout: float | None = None,
 ) -> dict[str, Any]:
     """Add files, directories, or URLs to the knowledge base and sync.
     Copies the given paths into the documents directory, then ingests them.
@@ -75,12 +76,12 @@ async def lilbee_add(
     Args:
         paths: Absolute file/directory paths or URLs to add.
         force: Overwrite files that already exist in the knowledge base.
-        vision_model: Vision model for scanned PDF OCR
-            (e.g. "maternion/LightOnOCR-2:latest"). If empty, uses
-            the configured default. If no model is configured,
-            scanned PDFs are skipped.
+        enable_ocr: Force vision OCR on (True), off (False), or auto-detect
+            from chat model capabilities (None/omit).
+        ocr_timeout: Per-page timeout in seconds for vision OCR. Overrides
+            the configured default for this invocation only.
     """
-    from lilbee.cli.helpers import copy_files, temporary_vision_model
+    from lilbee.cli.helpers import copy_files
     from lilbee.ingest import sync
 
     errors: list[str] = []
@@ -116,8 +117,16 @@ async def lilbee_add(
 
     copy_result = copy_files(valid, force=force)
 
-    with temporary_vision_model(vision_model):
-        sync_result = (await sync(quiet=True, force_vision=bool(vision_model))).model_dump()
+    old_ocr, old_timeout = cfg.enable_ocr, cfg.ocr_timeout
+    try:
+        if enable_ocr is not None:
+            cfg.enable_ocr = enable_ocr
+        if ocr_timeout is not None:
+            cfg.ocr_timeout = ocr_timeout
+        sync_result = (await sync(quiet=True)).model_dump()
+    finally:
+        cfg.enable_ocr = old_ocr
+        cfg.ocr_timeout = old_timeout
 
     return {
         "command": "add",

--- a/src/lilbee/model_info.py
+++ b/src/lilbee/model_info.py
@@ -68,8 +68,10 @@ def _read_embed_arch(info: ModelArchInfo) -> ModelArchInfo:
 
 
 def _read_vision_arch(info: ModelArchInfo) -> ModelArchInfo:
-    """Read vision projector type from GGUF metadata."""
-    if not cfg.vision_model:
+    """Read vision projector type from GGUF metadata for the chat model."""
+    from lilbee.model_manager import is_vision_capable
+
+    if not is_vision_capable(cfg.chat_model):
         return info
     try:
         from lilbee.providers.llama_cpp_provider import (
@@ -78,7 +80,7 @@ def _read_vision_arch(info: ModelArchInfo) -> ModelArchInfo:
             resolve_model_path,
         )
 
-        path = resolve_model_path(cfg.vision_model)
+        path = resolve_model_path(cfg.chat_model)
         mmproj = find_mmproj_for_model(path)
         proj_type = read_mmproj_projector_type(mmproj)
         info.vision_projector = proj_type or "unknown"

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -230,6 +230,58 @@ class ModelManager:
 _EMBEDDING_FAMILIES = frozenset({"bert", "nomic-bert", "e5", "bge"})
 _VISION_NAME_PATTERNS = frozenset({"llava", "vision", "moondream", "ocr", "minicpm-v"})
 
+_vision_cache: dict[str, bool] = {}
+
+
+def is_vision_capable(model: str) -> bool:
+    """Check whether *model* supports vision/image input.
+
+    Resolution order (first match wins):
+    1. Provider ``get_capabilities`` (mmproj for llama-cpp, /api/show for Ollama).
+    2. Featured catalog: model task is ``vision``.
+    3. Name-pattern fallback: model name contains a known vision keyword.
+
+    Results are cached per model name for the lifetime of the process.
+    """
+    if not model:
+        return False
+
+    if model in _vision_cache:
+        return _vision_cache[model]
+
+    result = _check_vision_capable(model)
+    _vision_cache[model] = result
+    return result
+
+
+def _check_vision_capable(model: str) -> bool:
+    """Uncached implementation of vision capability detection."""
+    from lilbee.services import get_services
+
+    try:
+        provider = get_services().provider
+        caps = provider.get_capabilities(model)
+        if "vision" in caps:
+            return True
+    except Exception:
+        log.debug("Provider capability check failed for %s", model, exc_info=True)
+
+    from lilbee.catalog import FEATURED_VISION
+
+    model_lower = model.lower()
+    if any(
+        model_lower in entry.name.lower() or model_lower in entry.hf_repo.lower()
+        for entry in FEATURED_VISION
+    ):
+        return True
+
+    return any(vp in model_lower for vp in _VISION_NAME_PATTERNS)
+
+
+def reset_vision_cache() -> None:
+    """Clear the vision capability cache (for testing)."""
+    _vision_cache.clear()
+
 
 @dataclass
 class RemoteModel:

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -79,18 +79,9 @@ def _get_model_catalog() -> tuple[ModelInfo, ...]:
     return _catalog_from_featured(FEATURED_CHAT)
 
 
-@functools.cache
-def _get_vision_catalog() -> tuple[ModelInfo, ...]:
-    from lilbee.catalog import FEATURED_VISION
-
-    return _catalog_from_featured(FEATURED_VISION)
-
-
 def __getattr__(name: str) -> tuple[ModelInfo, ...]:
     if name == "MODEL_CATALOG":
         return _get_model_catalog()
-    if name == "VISION_CATALOG":
-        return _get_vision_catalog()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -185,53 +176,6 @@ def display_model_picker(
 
     console.print()
     console.print("[bold]No chat model found.[/bold] Pick one to download:\n")
-    console.print(table)
-    console.print(f"\n  System: {ram_gb:.0f} GB RAM, {free_disk_gb:.1f} GB free disk")
-    console.print(f"  {FEATURED_STAR} = recommended for your system")
-    console.print(f"  Browse more models at {MODELS_BROWSE_URL}\n")
-
-    return recommended
-
-
-def pick_default_vision_model() -> ModelInfo:
-    """Return the recommended vision model (first catalog entry, best quality)."""
-    return _get_vision_catalog()[0]
-
-
-def display_vision_picker(
-    ram_gb: float, free_disk_gb: float, *, console: Console | None = None
-) -> ModelInfo:
-    """Show a Rich table of vision models and return the recommended model."""
-    console = console or Console(stderr=True)
-    recommended = pick_default_vision_model()
-
-    table = Table(title="Vision OCR Models", show_lines=False)
-    table.add_column("#", justify="right", style="bold")
-    table.add_column("Model", style="cyan")
-    table.add_column("Size", justify="right")
-    table.add_column("Description")
-
-    for idx, model in enumerate(_get_vision_catalog(), 1):
-        num_str = str(idx)
-        name = model.display_name
-        size_str = f"{model.size_gb:.1f} GB"
-        desc = model.description
-
-        is_recommended = model == recommended
-        disk_too_small = free_disk_gb < model.size_gb + _DISK_HEADROOM_GB
-
-        if is_recommended:
-            name = f"[bold]{name} {FEATURED_STAR}[/bold]"
-            desc = f"[bold]{desc}[/bold]"
-            num_str = f"[bold]{num_str}[/bold]"
-
-        if disk_too_small:
-            size_str = f"[red]{model.size_gb:.1f} GB[/red]"
-
-        table.add_row(num_str, name, size_str, desc)
-
-    console.print()
-    console.print("[bold]Select a vision OCR model for scanned PDF extraction:[/bold]\n")
     console.print(table)
     console.print(f"\n  System: {ram_gb:.0f} GB RAM, {free_disk_gb:.1f} GB free disk")
     console.print(f"  {FEATURED_STAR} = recommended for your system")
@@ -348,18 +292,12 @@ def ensure_chat_model() -> None:
     validate_disk_and_pull(model_info, free_gb)
 
 
-def list_installed_models(*, exclude_vision: bool = False) -> list[str]:
-    """Return installed model names, excluding embedding models.
-    When *exclude_vision* is True, also filters out known vision catalog models.
-    """
+def list_installed_models() -> list[str]:
+    """Return installed model names, excluding embedding models."""
     try:
         provider = get_services().provider
         embed_base = cfg.embedding_model.split(":")[0]
-        models = [m for m in provider.list_models() if m.split(":")[0] != embed_base]
-        if exclude_vision:
-            vision_refs = {m.ref for m in _get_vision_catalog()}
-            models = [m for m in models if m not in vision_refs]
-        return models
+        return [m for m in provider.list_models() if m.split(":")[0] != embed_base]
     except Exception:
         log.debug("Failed to list installed models", exc_info=True)
         return []

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -69,8 +69,16 @@ class LLMProvider(Protocol):
         """Download a model. Raises NotImplementedError if not supported."""
         ...
 
-    def show_model(self, model: str) -> dict[str, str] | None:
+    def show_model(self, model: str) -> dict[str, Any] | None:
         """Return model metadata, or None if backend doesn't expose it."""
+        ...
+
+    def get_capabilities(self, model: str) -> list[str]:
+        """Return capability tags (e.g. ``["completion", "vision"]``) for *model*.
+
+        Returns an empty list when the backend does not support capability
+        reporting or the model is not found.
+        """
         ...
 
     def shutdown(self) -> None:

--- a/src/lilbee/providers/litellm_provider.py
+++ b/src/lilbee/providers/litellm_provider.py
@@ -144,10 +144,15 @@ class LiteLLMProvider(LLMProvider):
         except httpx.HTTPError as exc:
             raise ProviderError(f"Cannot pull model {model!r}: {exc}", provider="litellm") from exc
 
-    def show_model(self, model: str) -> dict[str, str] | None:
+    def show_model(self, model: str) -> dict[str, Any] | None:
         """Get model info via the /api/show endpoint.
-        Also parses and caches per-model generation defaults from the
-        ``parameters`` field so they can be applied via config.
+
+        Parses and caches per-model generation defaults from the
+        ``parameters`` field. Also extracts the ``capabilities`` list
+        (newer Ollama versions) so callers can check for vision support.
+
+        Returns a dict with ``"parameters"`` and/or ``"capabilities"``
+        keys, or None on error.
         """
         try:
             resp = httpx.post(
@@ -157,16 +162,37 @@ class LiteLLMProvider(LLMProvider):
             )
             resp.raise_for_status()
             data = resp.json()
+
+            result: dict[str, Any] = {}
+
             params = data.get("parameters", "")
             if isinstance(params, str) and params:
                 _cache_ollama_defaults(model, params)
-                return {"parameters": params}
-            if params:
+                result["parameters"] = params
+            elif params:
                 _cache_ollama_defaults(model, str(params))
-                return {"parameters": str(params)}
-            return None
+                result["parameters"] = str(params)
+
+            capabilities = data.get("capabilities")
+            if isinstance(capabilities, list):
+                result["capabilities"] = capabilities
+
+            return result or None
         except httpx.HTTPError:
             return None
+
+    def get_capabilities(self, model: str) -> list[str]:
+        """Return capability tags for *model* from the backend.
+
+        Uses the Ollama ``/api/show`` ``capabilities`` array when
+        available; returns an empty list on error or if the backend
+        does not support capabilities.
+        """
+        info = self.show_model(model)
+        if info is None:
+            return []
+        caps = info.get("capabilities", [])
+        return caps if isinstance(caps, list) else []
 
     def shutdown(self) -> None:
         """No resources to release for litellm provider."""

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -199,13 +199,28 @@ class LlamaCppProvider(LLMProvider):
             "Download GGUF files manually or use the catalog."
         )
 
-    def show_model(self, model: str) -> dict[str, str] | None:
+    def show_model(self, model: str) -> dict[str, Any] | None:
         """Return model metadata from GGUF headers."""
         try:
             path = resolve_model_path(model)
         except ProviderError:
             return None
         return read_gguf_metadata(path)
+
+    def get_capabilities(self, model: str) -> list[str]:
+        """Detect capabilities from local GGUF files.
+
+        Vision is detected by the presence of an mmproj file alongside
+        the model.
+        """
+        caps: list[str] = ["completion"]
+        try:
+            path = resolve_model_path(model)
+            find_mmproj_for_model(path)
+            caps.append("vision")
+        except (ProviderError, Exception):
+            pass
+        return caps
 
     def shutdown(self) -> None:
         """Stop workers and unload all cached models."""

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -402,9 +402,6 @@ def load_llama(model_path: Path, *, embedding: bool) -> Any:
 
 def _is_vision_model(model: str) -> bool:
     """Check if a model name corresponds to a vision model in the catalog."""
-    if model == cfg.vision_model and cfg.vision_model:
-        return True
-
     from lilbee.catalog import FEATURED_VISION
 
     model_lower = model.lower()

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -100,9 +100,13 @@ class RoutingProvider(LLMProvider):
                 pass  # pragma: no cover
         raise ProviderError(f"Cannot pull model {model!r}: no pull-capable backend available")
 
-    def show_model(self, model: str) -> dict[str, str] | None:
+    def show_model(self, model: str) -> dict[str, Any] | None:
         """Show model info from the active provider."""
         return self._provider().show_model(model)
+
+    def get_capabilities(self, model: str) -> list[str]:
+        """Return capability tags from the active provider."""
+        return self._provider().get_capabilities(model)
 
     def invalidate_cache(self) -> None:
         """Clear cached litellm detection (after pull/delete)."""

--- a/src/lilbee/providers/worker_process.py
+++ b/src/lilbee/providers/worker_process.py
@@ -89,7 +89,7 @@ class ConfigSnapshot:
     embedding_dim: int
     num_ctx: int | None
     gpu_memory_fraction: float
-    vision_model: str
+    ocr_model: str
 
 
 _WorkerRequest = EmbedRequest | VisionRequest | LoadModelRequest | ShutdownRequest
@@ -104,7 +104,7 @@ def config_snapshot_from_cfg() -> ConfigSnapshot:
         embedding_dim=cfg.embedding_dim,
         num_ctx=cfg.num_ctx,
         gpu_memory_fraction=cfg.gpu_memory_fraction,
-        vision_model=cfg.chat_model,
+        ocr_model=cfg.chat_model,
     )
 
 
@@ -317,7 +317,7 @@ def _worker_main(
             continue
 
         if isinstance(request, VisionRequest):
-            model_name = request.model or config.vision_model
+            model_name = request.model or config.ocr_model
             if vision_llm is None or model_name != current_vision_model:
                 _close_model(vision_llm)
                 vision_llm = _load_vision_model(model_name)

--- a/src/lilbee/providers/worker_process.py
+++ b/src/lilbee/providers/worker_process.py
@@ -104,7 +104,7 @@ def config_snapshot_from_cfg() -> ConfigSnapshot:
         embedding_dim=cfg.embedding_dim,
         num_ctx=cfg.num_ctx,
         gpu_memory_fraction=cfg.gpu_memory_fraction,
-        vision_model=cfg.vision_model,
+        vision_model=cfg.chat_model,
     )
 
 
@@ -345,7 +345,6 @@ def _apply_config_snapshot(config: ConfigSnapshot) -> None:
 
     cfg.models_dir = Path(config.models_dir)
     cfg.embedding_model = config.embedding_model
-    cfg.vision_model = config.vision_model
     cfg.num_ctx = config.num_ctx
 
 

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -36,7 +36,6 @@ from lilbee.server.routes.models import (
     models_pull_route,
     models_set_chat_route,
     models_set_embedding_route,
-    models_set_vision_route,
     models_show_route,
 )
 from lilbee.server.routes.search import (
@@ -108,7 +107,6 @@ def create_app() -> Litestar:
             models_external_route,
             models_set_chat_route,
             models_set_embedding_route,
-            models_set_vision_route,
             models_catalog_route,
             models_installed_route,
             models_pull_route,

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -326,14 +326,16 @@ def chat_stream(
     return _stream_rag_response(question, history=history, top_k=top_k, options=options)
 
 
-async def sync_stream() -> AsyncGenerator[str, None]:
+async def sync_stream(*, enable_ocr: bool | None = None) -> AsyncGenerator[str, None]:
     """Trigger sync, yield SSE progress events, then done event."""
+    from lilbee.cli.helpers import temporary_ocr_config
     from lilbee.ingest import sync
 
     sse = SseStream()
-    task = asyncio.create_task(sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel))
-    async for event in sse.drain(task, "Sync stream"):
-        yield event
+    with temporary_ocr_config(enable_ocr):
+        task = asyncio.create_task(sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel))
+        async for event in sse.drain(task, "Sync stream"):
+            yield event
     if not sse.cancel.is_set() and task.done() and not task.cancelled():
         yield sse_done(task.result().model_dump())
 
@@ -365,16 +367,10 @@ async def _run_add(
         sse.queue.put_nowait(None)
         return AddSummary(copied=copy_result.copied, skipped=copy_result.skipped, errors=errors)
 
-    old_ocr, old_timeout = cfg.enable_ocr, cfg.ocr_timeout
-    try:
-        if enable_ocr is not None:
-            cfg.enable_ocr = enable_ocr
-        if ocr_timeout is not None:
-            cfg.ocr_timeout = ocr_timeout
+    from lilbee.cli.helpers import temporary_ocr_config
+
+    with temporary_ocr_config(enable_ocr, ocr_timeout):
         sync_result = await sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel)
-    finally:
-        cfg.enable_ocr = old_ocr
-        cfg.ocr_timeout = old_timeout
 
     sr = sync_result.model_dump()
     summary = AddSummary(
@@ -401,13 +397,19 @@ def validate_add_paths(
         validate_path_within(cfg.documents_dir / Path(p_str).name, cfg.documents_dir)
 
     force = bool(data.get("force", False))
+    enable_ocr, ocr_timeout = _parse_ocr_params(data)
+    return paths, force, enable_ocr, ocr_timeout
+
+
+def _parse_ocr_params(data: dict[str, Any]) -> tuple[bool | None, float | None]:
+    """Extract and coerce OCR parameters from a request dict."""
     enable_ocr = data.get("enable_ocr")
     ocr_timeout = data.get("ocr_timeout")
     if enable_ocr is not None:
         enable_ocr = bool(enable_ocr)
     if ocr_timeout is not None:
         ocr_timeout = float(ocr_timeout)
-    return paths, force, enable_ocr, ocr_timeout
+    return enable_ocr, ocr_timeout
 
 
 async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
@@ -416,12 +418,7 @@ async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
     """
     paths = data.get("paths", [])
     force = bool(data.get("force", False))
-    enable_ocr = data.get("enable_ocr")
-    ocr_timeout = data.get("ocr_timeout")
-    if enable_ocr is not None:
-        enable_ocr = bool(enable_ocr)
-    if ocr_timeout is not None:
-        ocr_timeout = float(ocr_timeout)
+    enable_ocr, ocr_timeout = _parse_ocr_params(data)
     sse = SseStream()
     task = asyncio.create_task(_run_add(paths, force, enable_ocr, ocr_timeout, sse))
     async for event in sse.drain(task, "Add files stream"):

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -118,7 +118,6 @@ class ModelsResponse(BaseModel):
     """Response for the list-models endpoint."""
 
     chat: ModelCatalogSection
-    vision: ModelCatalogSection | None = None
 
 
 def sse_event(event: str, data: Any) -> str:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -326,14 +326,12 @@ def chat_stream(
     return _stream_rag_response(question, history=history, top_k=top_k, options=options)
 
 
-async def sync_stream(*, force_vision: bool = False) -> AsyncGenerator[str, None]:
+async def sync_stream() -> AsyncGenerator[str, None]:
     """Trigger sync, yield SSE progress events, then done event."""
     from lilbee.ingest import sync
 
     sse = SseStream()
-    task = asyncio.create_task(
-        sync(quiet=True, on_progress=sse.callback, force_vision=force_vision, cancel=sse.cancel)
-    )
+    task = asyncio.create_task(sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel))
     async for event in sse.drain(task, "Sync stream"):
         yield event
     if not sse.cancel.is_set() and task.done() and not task.cancelled():
@@ -343,7 +341,8 @@ async def sync_stream(*, force_vision: bool = False) -> AsyncGenerator[str, None
 async def _run_add(
     paths: list[str],
     force: bool,
-    vision_model: str,
+    enable_ocr: bool | None,
+    ocr_timeout: float | None,
     sse: SseStream,
 ) -> AddSummary:
     """Copy files and sync, pushing SSE events to the queue.
@@ -366,12 +365,16 @@ async def _run_add(
         sse.queue.put_nowait(None)
         return AddSummary(copied=copy_result.copied, skipped=copy_result.skipped, errors=errors)
 
-    from lilbee.cli.helpers import temporary_vision_model
-
-    with temporary_vision_model(vision_model):
-        sync_result = await sync(
-            quiet=True, force_vision=bool(vision_model), on_progress=sse.callback, cancel=sse.cancel
-        )
+    old_ocr, old_timeout = cfg.enable_ocr, cfg.ocr_timeout
+    try:
+        if enable_ocr is not None:
+            cfg.enable_ocr = enable_ocr
+        if ocr_timeout is not None:
+            cfg.ocr_timeout = ocr_timeout
+        sync_result = await sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel)
+    finally:
+        cfg.enable_ocr = old_ocr
+        cfg.ocr_timeout = old_timeout
 
     sr = sync_result.model_dump()
     summary = AddSummary(
@@ -384,7 +387,9 @@ async def _run_add(
     return summary
 
 
-def validate_add_paths(data: dict[str, Any]) -> tuple[list[str], bool, str]:
+def validate_add_paths(
+    data: dict[str, Any],
+) -> tuple[list[str], bool, bool | None, float | None]:
     """Validate add-files input. Raises ValueError on bad input."""
     paths = data.get("paths")
     if not isinstance(paths, list) or not paths:
@@ -396,8 +401,13 @@ def validate_add_paths(data: dict[str, Any]) -> tuple[list[str], bool, str]:
         validate_path_within(cfg.documents_dir / Path(p_str).name, cfg.documents_dir)
 
     force = bool(data.get("force", False))
-    vision_model = str(data.get("vision_model", "") or "")
-    return paths, force, vision_model
+    enable_ocr = data.get("enable_ocr")
+    ocr_timeout = data.get("ocr_timeout")
+    if enable_ocr is not None:
+        enable_ocr = bool(enable_ocr)
+    if ocr_timeout is not None:
+        ocr_timeout = float(ocr_timeout)
+    return paths, force, enable_ocr, ocr_timeout
 
 
 async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
@@ -406,9 +416,14 @@ async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
     """
     paths = data.get("paths", [])
     force = bool(data.get("force", False))
-    vision_model = str(data.get("vision_model", "") or "")
+    enable_ocr = data.get("enable_ocr")
+    ocr_timeout = data.get("ocr_timeout")
+    if enable_ocr is not None:
+        enable_ocr = bool(enable_ocr)
+    if ocr_timeout is not None:
+        ocr_timeout = float(ocr_timeout)
     sse = SseStream()
-    task = asyncio.create_task(_run_add(paths, force, vision_model, sse))
+    task = asyncio.create_task(_run_add(paths, force, enable_ocr, ocr_timeout, sse))
     async for event in sse.drain(task, "Add files stream"):
         yield event
     if not sse.cancel.is_set() and task.done() and not task.cancelled():

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -88,7 +88,7 @@ def _derive_field_sets() -> tuple[
                 public.add(name)
             if _get_extra(info, "reindex"):
                 reindex.add(name)
-        elif name in {"chat_model", "embedding_model", "vision_model"}:
+        elif name in {"chat_model", "embedding_model"}:
             public.add(name)
     return types.MappingProxyType(writable), frozenset(reindex), frozenset(public)
 
@@ -118,7 +118,7 @@ class ModelsResponse(BaseModel):
     """Response for the list-models endpoint."""
 
     chat: ModelCatalogSection
-    vision: ModelCatalogSection
+    vision: ModelCatalogSection | None = None
 
 
 def sse_event(event: str, data: Any) -> str:
@@ -434,14 +434,12 @@ async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
 
 
 async def list_models() -> ModelsResponse:
-    """Return chat and vision model catalogs with installed status."""
-    from lilbee.models import MODEL_CATALOG, VISION_CATALOG, list_installed_models
+    """Return chat model catalog with installed status."""
+    from lilbee.models import MODEL_CATALOG, list_installed_models
 
     installed = set(list_installed_models())
-    chat_installed = set(list_installed_models(exclude_vision=True))
-    vision_refs = {v.ref for v in VISION_CATALOG}
 
-    response = ModelsResponse(
+    return ModelsResponse(
         chat=ModelCatalogSection(
             active=cfg.chat_model,
             catalog=[
@@ -454,28 +452,13 @@ async def list_models() -> ModelsResponse:
                 )
                 for m in MODEL_CATALOG
             ],
-            installed=sorted(chat_installed),
-        ),
-        vision=ModelCatalogSection(
-            active=cfg.vision_model,
-            catalog=[
-                ModelCatalogEntry(
-                    name=m.display_name,
-                    size_gb=m.size_gb,
-                    min_ram_gb=m.min_ram_gb,
-                    description=m.description,
-                    installed=m.ref in installed,
-                )
-                for m in VISION_CATALOG
-            ],
-            installed=sorted(m for m in installed if m in vision_refs),
+            installed=sorted(installed),
         ),
     )
-    return response
 
 
 async def _set_model(
-    field: Literal["chat_model", "vision_model", "embedding_model"],
+    field: Literal["chat_model", "embedding_model"],
     model: str,
     *,
     normalize: bool = False,
@@ -493,11 +476,6 @@ async def _set_model(
 async def set_chat_model(model: str) -> SetModelResponse:
     """Switch active chat model."""
     return await _set_model("chat_model", model, normalize=True)
-
-
-async def set_vision_model(model: str) -> SetModelResponse:
-    """Switch active vision model. Pass empty string to disable."""
-    return await _set_model("vision_model", model)
 
 
 async def set_embedding_model(model: str) -> SetModelResponse:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -334,8 +334,8 @@ async def sync_stream(*, enable_ocr: bool | None = None) -> AsyncGenerator[str, 
     sse = SseStream()
     with temporary_ocr_config(enable_ocr):
         task = asyncio.create_task(sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel))
-        async for event in sse.drain(task, "Sync stream"):
-            yield event
+    async for event in sse.drain(task, "Sync stream"):
+        yield event
     if not sse.cancel.is_set() and task.done() and not task.cancelled():
         yield sse_done(task.result().model_dump())
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -43,7 +43,7 @@ class AddRequest(BaseModel):
 
 
 class SetModelRequest(BaseModel):
-    """Request body for /api/models/chat and /api/models/vision."""
+    """Request body for /api/models/chat."""
 
     model: str
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -30,7 +30,7 @@ class ChatRequest(BaseModel):
 class SyncRequest(BaseModel):
     """Request body for /api/sync."""
 
-    force_vision: bool = False
+    enable_ocr: bool | None = None
 
 
 class AddRequest(BaseModel):
@@ -38,7 +38,8 @@ class AddRequest(BaseModel):
 
     paths: list[str]
     force: bool = False
-    vision_model: str = ""
+    enable_ocr: bool | None = None
+    ocr_timeout: float | None = None
 
 
 class SetModelRequest(BaseModel):
@@ -85,7 +86,7 @@ class StatusConfigInfo(BaseModel):
     data_dir: str
     chat_model: str
     embedding_model: str
-    vision_model: str | None = None
+    enable_ocr: bool | None = None
 
 
 class StatusResponse(BaseModel):

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -28,9 +28,12 @@ class RemoveRequest(BaseModel):
 @post("/api/sync")
 async def sync_route(data: SyncRequest | None = None) -> Stream:
     """Re-index changed documents with streaming SSE progress events."""
-    force_vision = data.force_vision if data else False
+    if data and data.enable_ocr is not None:
+        from lilbee.config import cfg
+
+        cfg.enable_ocr = data.enable_ocr
     return Stream(
-        handlers.sync_stream(force_vision=force_vision),
+        handlers.sync_stream(),
         media_type="text/event-stream",
     )
 

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -28,12 +28,9 @@ class RemoveRequest(BaseModel):
 @post("/api/sync")
 async def sync_route(data: SyncRequest | None = None) -> Stream:
     """Re-index changed documents with streaming SSE progress events."""
-    if data and data.enable_ocr is not None:
-        from lilbee.config import cfg
-
-        cfg.enable_ocr = data.enable_ocr
+    enable_ocr = data.enable_ocr if data else None
     return Stream(
-        handlers.sync_stream(),
+        handlers.sync_stream(enable_ocr=enable_ocr),
         media_type="text/event-stream",
     )
 

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -48,12 +48,6 @@ async def models_set_chat_route(data: SetModelRequest) -> SetModelResponse:
     return await handlers.set_chat_model(model=data.model)
 
 
-@put("/api/models/vision")
-async def models_set_vision_route(data: SetModelRequest) -> SetModelResponse:
-    """Switch the active vision model used for image and PDF OCR."""
-    return await handlers.set_vision_model(model=data.model)
-
-
 @put("/api/models/embedding")
 async def models_set_embedding_route(data: SetModelRequest) -> SetModelResponse:
     """Switch the active embedding model."""

--- a/tests/integration/test_pdf_integration.py
+++ b/tests/integration/test_pdf_integration.py
@@ -59,8 +59,6 @@ def pdf_pipeline(tmp_path_factory):
     cfg.query_expansion_count = 0
     cfg.concept_graph = False
     cfg.hyde = False
-    cfg.vision_model = ""
-
     reset_provider()
     reset_model_manager()
 
@@ -160,13 +158,14 @@ class TestTesseractOcrFallback:
 
 
 def _vision_model_available() -> bool:
-    """Check if a vision model is configured and actually exists locally."""
-    if not cfg.vision_model:
-        return False
+    """Check if the chat model is vision-capable and exists locally."""
     try:
+        from lilbee.model_manager import is_vision_capable
         from lilbee.providers.llama_cpp_provider import resolve_model_path
 
-        resolve_model_path(cfg.vision_model)
+        if not is_vision_capable(cfg.chat_model):
+            return False
+        resolve_model_path(cfg.chat_model)
         return True
     except Exception:
         return False
@@ -177,7 +176,7 @@ class TestVisionOcrFallback:
 
     @pytest.mark.skipif(
         not _vision_model_available(),
-        reason="No vision model available locally (set LILBEE_VISION_MODEL)",
+        reason="No vision-capable chat model available locally",
     )
     async def test_vision_extracts_text(self):
         """Vision model OCR produces non-empty text from the scanned PDF fixture."""
@@ -185,16 +184,16 @@ class TestVisionOcrFallback:
 
         page_texts = extract_pdf_vision(
             SCANNED_PDF,
-            cfg.vision_model,
+            cfg.chat_model,
             quiet=True,
-            timeout=cfg.vision_timeout,
+            timeout=cfg.ocr_timeout,
         )
         all_text = " ".join(page_texts)
         assert len(all_text.strip()) > 0, "Vision OCR produced empty text"
 
     @pytest.mark.skipif(
         not _vision_model_available(),
-        reason="No vision model available locally (set LILBEE_VISION_MODEL)",
+        reason="No vision-capable chat model available locally",
     )
     async def test_vision_extracts_known_phrases(self):
         """Vision model OCR captures key phrases from the scanned document."""
@@ -202,9 +201,9 @@ class TestVisionOcrFallback:
 
         page_texts = extract_pdf_vision(
             SCANNED_PDF,
-            cfg.vision_model,
+            cfg.chat_model,
             quiet=True,
-            timeout=cfg.vision_timeout,
+            timeout=cfg.ocr_timeout,
         )
         all_text = " ".join(page_texts).lower()
         recognized = any(

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -156,24 +156,24 @@ class TestAddEndpoint:
         assert file_start["total_files"] >= 1
         assert file_start["current_file"] >= 1
 
-    async def test_add_with_vision_model(self, mock_extract_file, isolated_env, tmp_path):
-        """Vision model parameter is temporarily set on cfg during sync."""
+    async def test_add_with_enable_ocr(self, mock_extract_file, isolated_env, tmp_path):
+        """enable_ocr parameter is temporarily set on cfg during sync."""
         from lilbee.server.app import create_app
 
         src = tmp_path / "doc.txt"
-        src.write_text("Content for vision model test.")
-        original_vision = cfg.vision_model
+        src.write_text("Content for enable_ocr test.")
+        original_ocr = cfg.enable_ocr
 
         async with AsyncTestClient(create_app()) as client:
             resp = await client.post(
                 "/api/add",
-                json={"paths": [str(src)], "vision_model": "test-vision"},
+                json={"paths": [str(src)], "enable_ocr": True},
                 headers=_auth_headers(),
             )
 
         assert resp.status_code == 201
-        # Vision model should be restored after the call
-        assert cfg.vision_model == original_vision
+        # enable_ocr should be restored after the call
+        assert cfg.enable_ocr == original_ocr
 
 
 class TestAddValidation:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1352,263 +1352,52 @@ class TestEnsureChatModelWiring:
 
 
 # ---------------------------------------------------------------------------
-# Vision model setup tests
+# --ocr flag tests
 # ---------------------------------------------------------------------------
 
 
-class TestEnsureVisionModel:
-    """Tests for _ensure_vision_model and helpers."""
-
-    def test_returns_early_if_vision_configured(self) -> None:
-        from lilbee.cli.commands import _ensure_vision_model
-
-        cfg.vision_model = "llava:7b"
-        with mock.patch("lilbee.cli.commands._validate_configured_vision") as mock_val:
-            _ensure_vision_model()
-            mock_val.assert_called_once()
-
-    def test_restores_saved_model_from_settings(self) -> None:
-        from lilbee.cli.commands import _ensure_vision_model
-
-        cfg.vision_model = ""
-        with (
-            mock.patch("lilbee.cli.commands.settings.get", return_value="saved-model"),
-            mock.patch("lilbee.cli.commands._validate_configured_vision") as mock_val,
-        ):
-            _ensure_vision_model()
-            assert cfg.vision_model == "saved-model"
-            mock_val.assert_called_once()
-
-    def test_backend_unreachable_disables_vision(self) -> None:
-        from lilbee.cli.commands import _ensure_vision_model
-
-        cfg.vision_model = ""
-        with (
-            mock.patch("lilbee.cli.commands.settings.get", return_value=""),
-            mock.patch("lilbee.models.list_installed_models", side_effect=RuntimeError("fail")),
-        ):
-            _ensure_vision_model()
-            assert cfg.vision_model == ""
-
-    def test_tty_calls_interactive_picker(self) -> None:
-        from lilbee.cli.commands import _ensure_vision_model
-
-        cfg.vision_model = ""
-        with (
-            mock.patch("lilbee.cli.commands.settings.get", return_value=""),
-            mock.patch("lilbee.models.list_installed_models", return_value=["m1"]),
-            mock.patch("sys.stdin") as mock_stdin,
-            mock.patch("lilbee.cli.commands._pick_vision_interactive") as mock_pick,
-        ):
-            mock_stdin.isatty.return_value = True
-            _ensure_vision_model()
-            mock_pick.assert_called_once()
-
-    def test_non_tty_calls_auto_picker(self) -> None:
-        from lilbee.cli.commands import _ensure_vision_model
-
-        cfg.vision_model = ""
-        with (
-            mock.patch("lilbee.cli.commands.settings.get", return_value=""),
-            mock.patch("lilbee.models.list_installed_models", return_value=["m1"]),
-            mock.patch("sys.stdin") as mock_stdin,
-            mock.patch("lilbee.cli.commands._pick_vision_auto") as mock_pick,
-        ):
-            mock_stdin.isatty.return_value = False
-            _ensure_vision_model()
-            mock_pick.assert_called_once()
-
-
-class TestValidateConfiguredVision:
-    def test_already_installed_noop(self) -> None:
-        from lilbee.cli.commands import _validate_configured_vision
-
-        cfg.vision_model = "llava:7b"
-        with mock.patch("lilbee.models.list_installed_models", return_value=["llava:7b"]):
-            _validate_configured_vision()
-            assert cfg.vision_model == "llava:7b"
-
-    def test_not_installed_pulls(self) -> None:
-        from lilbee.cli.commands import _validate_configured_vision
-
-        cfg.vision_model = "llava:7b"
-        with (
-            mock.patch("lilbee.models.list_installed_models", return_value=[]),
-            mock.patch("lilbee.cli.commands._try_pull", return_value=True) as mock_pull,
-        ):
-            _validate_configured_vision()
-            mock_pull.assert_called_once_with("llava:7b")
-
-    def test_pull_fails_clears_vision(self) -> None:
-        from lilbee.cli.commands import _validate_configured_vision
-
-        cfg.vision_model = "llava:7b"
-        with (
-            mock.patch("lilbee.models.list_installed_models", return_value=[]),
-            mock.patch("lilbee.cli.commands._try_pull", return_value=False),
-        ):
-            _validate_configured_vision()
-            assert cfg.vision_model == ""
-
-    def test_backend_unreachable_keeps_config(self) -> None:
-        from lilbee.cli.commands import _validate_configured_vision
-
-        cfg.vision_model = "llava:7b"
-        with mock.patch("lilbee.models.list_installed_models", side_effect=RuntimeError):
-            _validate_configured_vision()
-            assert cfg.vision_model == "llava:7b"
-
-
-class TestPickVisionInteractive:
-    @pytest.fixture(autouse=True)
-    def _patch_vision_deps(self):
-        from lilbee.models import VISION_CATALOG
-
-        with (
-            mock.patch("lilbee.models.get_system_ram_gb", return_value=16.0),
-            mock.patch("lilbee.models.get_free_disk_gb", return_value=50.0),
-            mock.patch("lilbee.models.display_vision_picker", return_value=VISION_CATALOG[0]),
-        ):
-            yield
-
-    def test_default_choice(self) -> None:
-        from lilbee.cli.commands import _pick_vision_interactive
-
-        with (
-            mock.patch("builtins.input", return_value=""),
-            mock.patch("lilbee.cli.commands._pull_and_save_vision") as mock_save,
-        ):
-            _pick_vision_interactive(set())
-            mock_save.assert_called_once()
-
-    @mock.patch("lilbee.cli.commands._pull_and_save_vision")
-    def test_eof_cancels(self, mock_save: mock.MagicMock) -> None:
-        from lilbee.cli.commands import _pick_vision_interactive
-
-        with mock.patch("builtins.input", side_effect=EOFError):
-            _pick_vision_interactive(set())
-        mock_save.assert_not_called()
-
-    @mock.patch("lilbee.cli.commands._pull_and_save_vision")
-    def test_invalid_input(self, mock_save: mock.MagicMock) -> None:
-        from lilbee.cli.commands import _pick_vision_interactive
-
-        with mock.patch("builtins.input", return_value="abc"):
-            _pick_vision_interactive(set())
-        mock_save.assert_not_called()
-
-    @mock.patch("lilbee.cli.commands._pull_and_save_vision")
-    def test_out_of_range(self, mock_save: mock.MagicMock) -> None:
-        from lilbee.cli.commands import _pick_vision_interactive
-
-        with mock.patch("builtins.input", return_value="999"):
-            _pick_vision_interactive(set())
-        mock_save.assert_not_called()
-
-    def test_valid_numeric_choice(self) -> None:
-        from lilbee.cli.commands import _pick_vision_interactive
-
-        with (
-            mock.patch("builtins.input", return_value="1"),
-            mock.patch("lilbee.cli.commands._pull_and_save_vision") as mock_save,
-        ):
-            _pick_vision_interactive(set())
-            mock_save.assert_called_once()
-
-
-class TestPickVisionAuto:
-    def test_auto_selects_and_pulls(self) -> None:
-        from lilbee.cli.commands import _pick_vision_auto
-
-        with (
-            mock.patch("lilbee.models.pick_default_vision_model") as mock_pick,
-            mock.patch("lilbee.cli.commands._pull_and_save_vision") as mock_save,
-        ):
-            mock_pick.return_value = mock.MagicMock(name="llava:7b")
-            _pick_vision_auto(set())
-            mock_save.assert_called_once()
-
-
-class TestTryPull:
-    def test_success(self) -> None:
-        from lilbee.cli.commands import _try_pull
-
-        with mock.patch("lilbee.models.pull_with_progress"):
-            assert _try_pull("model") is True
-
-    def test_failure(self) -> None:
-        from lilbee.cli.commands import _try_pull
-
-        with mock.patch("lilbee.models.pull_with_progress", side_effect=RuntimeError("fail")):
-            assert _try_pull("model") is False
-
-
-class TestPullAndSaveVision:
-    def test_already_installed(self) -> None:
-        from lilbee.cli.commands import _pull_and_save_vision
-
-        cfg.vision_model = ""
-        _pull_and_save_vision("llava:7b", {"llava:7b"})
-        assert cfg.vision_model == "llava:7b"
-
-    def test_pull_needed_succeeds(self) -> None:
-        from lilbee.cli.commands import _pull_and_save_vision
-
-        cfg.vision_model = ""
-        with mock.patch("lilbee.cli.commands._try_pull", return_value=True):
-            _pull_and_save_vision("llava:7b", set())
-        assert cfg.vision_model == "llava:7b"
-
-    def test_pull_fails(self) -> None:
-        from lilbee.cli.commands import _pull_and_save_vision
-
-        cfg.vision_model = ""
-        with mock.patch("lilbee.cli.commands._try_pull", return_value=False):
-            _pull_and_save_vision("llava:7b", set())
-        assert cfg.vision_model == ""
-
-
-# ---------------------------------------------------------------------------
-# --vision flag tests
-# ---------------------------------------------------------------------------
-
-
-class TestVisionTimeout:
-    """Tests for --vision-timeout flag on sync, add, rebuild."""
+class TestOcrFlags:
+    """Tests for --ocr/--no-ocr and --ocr-timeout flags on sync, add, rebuild."""
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
-    def test_vision_timeout_on_sync(self, mock_sync):
-        """--vision-timeout sets cfg.vision_timeout for sync."""
-        with mock.patch("lilbee.cli.commands._ensure_vision_model"):
-            result = runner.invoke(app, ["sync", "--vision", "--vision-timeout=60"])
+    def test_ocr_timeout_on_sync(self, mock_sync):
+        """--ocr-timeout sets cfg.ocr_timeout for sync."""
+        result = runner.invoke(app, ["sync", "--ocr", "--ocr-timeout=60"])
         assert result.exit_code == 0
-        assert cfg.vision_timeout == 60.0
+        assert cfg.enable_ocr is True
+        assert cfg.ocr_timeout == 60.0
 
-    def test_vision_timeout_on_add(self, isolated_env, tmp_path, mock_svc):
-        """--vision-timeout sets cfg.vision_timeout for add."""
+    def test_ocr_timeout_on_add(self, isolated_env, tmp_path, mock_svc):
+        """--ocr-timeout sets cfg.ocr_timeout for add."""
         src = tmp_path / "source" / "test.txt"
         src.parent.mkdir()
         src.write_text("content")
-        with mock.patch("lilbee.cli.commands._ensure_vision_model"):
-            result = runner.invoke(app, ["add", "--vision", "--vision-timeout=90", str(src)])
+        result = runner.invoke(app, ["add", "--ocr", "--ocr-timeout=90", str(src)])
         assert result.exit_code == 0
-        assert cfg.vision_timeout == 90.0
+        assert cfg.enable_ocr is True
+        assert cfg.ocr_timeout == 90.0
 
-    def test_vision_timeout_on_rebuild(self, mock_svc):
-        """--vision-timeout sets cfg.vision_timeout for rebuild."""
-        with mock.patch("lilbee.cli.commands._ensure_vision_model"):
-            result = runner.invoke(app, ["rebuild", "--vision", "--vision-timeout=120"])
+    def test_ocr_timeout_on_rebuild(self, mock_svc):
+        """--ocr-timeout sets cfg.ocr_timeout for rebuild."""
+        result = runner.invoke(app, ["rebuild", "--ocr", "--ocr-timeout=120"])
         assert result.exit_code == 0
-        assert cfg.vision_timeout == 120.0
+        assert cfg.enable_ocr is True
+        assert cfg.ocr_timeout == 120.0
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
-    def test_no_vision_timeout_leaves_default(self, mock_sync):
-        """Without --vision-timeout, cfg.vision_timeout stays at default."""
-        cfg.vision_timeout = 120.0
-        with mock.patch("lilbee.cli.commands._ensure_vision_model"):
-            result = runner.invoke(app, ["sync", "--vision"])
+    def test_no_ocr_timeout_leaves_default(self, mock_sync):
+        """Without --ocr-timeout, cfg.ocr_timeout stays at default."""
+        cfg.ocr_timeout = 120.0
+        result = runner.invoke(app, ["sync", "--ocr"])
         assert result.exit_code == 0
-        assert cfg.vision_timeout == 120.0
+        assert cfg.ocr_timeout == 120.0
+
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_no_ocr_flag_disables(self, mock_sync):
+        """--no-ocr sets cfg.enable_ocr to False."""
+        result = runner.invoke(app, ["sync", "--no-ocr"])
+        assert result.exit_code == 0
+        assert cfg.enable_ocr is False
 
 
 class TestLogLevel:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,14 +101,14 @@ class TestStatus:
         assert "Chat model:" in result.output
         assert "Embeddings:" in result.output
 
-    def test_status_shows_vision_model_when_set(self):
-        cfg.vision_model = "test-vision:latest"
+    def test_status_shows_ocr_when_enabled(self):
+        cfg.enable_ocr = True
         result = runner.invoke(app, ["status"])
         assert "Vision OCR:" in result.output
-        assert "test-vision:latest" in result.output
+        assert "enabled" in result.output
 
-    def test_status_hides_vision_model_when_empty(self):
-        cfg.vision_model = ""
+    def test_status_hides_ocr_when_none(self):
+        cfg.enable_ocr = None
         result = runner.invoke(app, ["status"])
         assert "Vision OCR:" not in result.output
 
@@ -602,15 +602,6 @@ class TestListInstalledModels:
         result = list_installed_models()
         assert result == ["llama3:latest"]
         assert "nomic-embed-text:latest" not in result
-
-    def test_exclude_vision_filters_vision_catalog(self, mock_svc):
-        mock_svc.provider.list_models.return_value = [
-            "llama3:latest",
-            "lightonocr:2-1b",
-        ]
-        result = list_installed_models(exclude_vision=True)
-        assert result == ["llama3:latest"]
-        assert "lightonocr:2-1b" not in result
 
 
 def _search_chunk(**overrides: object) -> SearchChunk:
@@ -1141,17 +1132,17 @@ class TestStatusJson:
         assert data["total_chunks"] == 10
         assert "documents_dir" in data["config"]
 
-    def test_status_json_includes_vision_model_when_set(self):
-        cfg.vision_model = "test-vision:latest"
+    def test_status_json_includes_enable_ocr_when_set(self):
+        cfg.enable_ocr = True
         result = runner.invoke(app, ["--json", "status"])
         data = json.loads(result.output.strip())
-        assert data["config"]["vision_model"] == "test-vision:latest"
+        assert data["config"]["enable_ocr"] is True
 
-    def test_status_json_excludes_vision_model_when_empty(self):
-        cfg.vision_model = ""
+    def test_status_json_excludes_enable_ocr_when_none(self):
+        cfg.enable_ocr = None
         result = runner.invoke(app, ["--json", "status"])
         data = json.loads(result.output.strip())
-        assert "vision_model" not in data["config"]
+        assert "enable_ocr" not in data["config"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2184,6 +2184,17 @@ class TestChatSyncCallback:
             cb(EventType.DONE, FileStartEvent(file="x", total_files=1, current_file=1))
 
 
+class TestTemporaryOcrConfig:
+    def test_ocr_timeout_override(self):
+        """temporary_ocr_config overrides ocr_timeout and restores it."""
+        from lilbee.cli.helpers import temporary_ocr_config
+
+        original = cfg.ocr_timeout
+        with temporary_ocr_config(ocr_timeout=99.0):
+            assert cfg.ocr_timeout == 99.0
+        assert cfg.ocr_timeout == original
+
+
 class TestSyncResultToJson:
     def test_non_sync_result_raises(self):
         """sync_result_to_json raises TypeError for non-SyncResult input."""

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -302,7 +302,7 @@ class TestRunSyncBackground:
         monkeypatch.setattr(sync_mod, "_bg_executor", mock_executor)
 
         con = MagicMock()
-        sync_mod.run_sync_background(con, force_vision=True)
+        sync_mod.run_sync_background(con)
 
         submitted_fn = mock_executor.submit.call_args[0][0]
         submitted_fn()
@@ -312,7 +312,6 @@ class TestRunSyncBackground:
         mock_sync.assert_called_once()
         call_kwargs = mock_sync.call_args[1]
         assert call_kwargs["quiet"] is True
-        assert call_kwargs["force_vision"] is True
         assert callable(call_kwargs["on_progress"])
 
     @patch("lilbee.cli.sync.asyncio.run", side_effect=lambda coro: coro.close())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -189,14 +189,14 @@ class TestTomlConfigFile:
             c = Config()
             assert c.system_prompt == "Be brief."
 
-    def test_vision_model_from_toml(self, tmp_path):
+    def test_enable_ocr_from_toml(self, tmp_path):
         toml_path = tmp_path / "config.toml"
-        toml_path.write_text('vision_model = "maternion/LightOnOCR-2"\n')
+        toml_path.write_text("enable_ocr = true\n")
         env = _clean_env()
         env["LILBEE_DATA"] = str(tmp_path)
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
-            assert c.vision_model == "maternion/LightOnOCR-2"
+            assert c.enable_ocr is True
 
     def test_top_p_from_toml(self, tmp_path):
         toml_path = tmp_path / "config.toml"
@@ -251,42 +251,6 @@ class TestTomlConfigFile:
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
             assert c.seed == 123
-
-
-class TestVisionModelConfig:
-    def test_default_vision_model_is_empty(self, tmp_path) -> None:
-        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
-            c = Config()
-            assert c.vision_model == ""
-
-    def test_vision_model_env_override(self) -> None:
-        with mock.patch.dict(os.environ, {"LILBEE_VISION_MODEL": "minicpm-v"}):
-            c = Config()
-            assert c.vision_model == "minicpm-v"
-
-
-class TestVisionTimeoutConfig:
-    def test_valid_timeout_from_env(self) -> None:
-        with mock.patch.dict(os.environ, {"LILBEE_VISION_TIMEOUT": "60.5"}):
-            c = Config()
-            assert c.vision_timeout == 60.5
-
-    def test_no_timeout_env_returns_default(self, tmp_path) -> None:
-        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
-            c = Config()
-            assert c.vision_timeout == 120.0
-
-    def test_zero_timeout_means_no_limit(self) -> None:
-        with mock.patch.dict(os.environ, {"LILBEE_VISION_TIMEOUT": "0"}):
-            c = Config()
-            assert c.vision_timeout == 0
-
-    def test_invalid_timeout_raises(self) -> None:
-        with (
-            mock.patch.dict(os.environ, {"LILBEE_VISION_TIMEOUT": "abc"}),
-            pytest.raises(ValueError),
-        ):
-            Config()
 
 
 class TestEnableOcrConfig:
@@ -586,8 +550,8 @@ class TestEmptyStringValidation:
                 ignore_dirs=frozenset(),
             )
 
-    def test_empty_vision_model_allowed(self, tmp_path):
-        """vision_model is nullable — empty string is valid."""
+    def test_enable_ocr_none_allowed(self, tmp_path):
+        """enable_ocr is nullable, None means auto."""
         c = Config(
             data_root=tmp_path,
             documents_dir=tmp_path / "docs",
@@ -604,9 +568,9 @@ class TestEmptyStringValidation:
             max_distance=0.7,
             system_prompt="You are helpful.",
             ignore_dirs=frozenset(),
-            vision_model="",
+            enable_ocr=None,
         )
-        assert c.vision_model == ""
+        assert c.enable_ocr is None
 
 
 class TestEmptyStringToNone:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -289,6 +289,91 @@ class TestVisionTimeoutConfig:
             Config()
 
 
+class TestEnableOcrConfig:
+    def test_default_is_none(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            assert c.enable_ocr is None
+
+    def test_true_from_env(self) -> None:
+        with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "true"}):
+            c = Config()
+            assert c.enable_ocr is True
+
+    def test_false_from_env(self) -> None:
+        with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "false"}):
+            c = Config()
+            assert c.enable_ocr is False
+
+    def test_empty_string_means_auto(self, tmp_path) -> None:
+        with mock.patch.dict(
+            os.environ, {**_clean_env(tmp_path), "LILBEE_ENABLE_OCR": ""}, clear=True
+        ):
+            c = Config()
+            assert c.enable_ocr is None
+
+    def test_auto_string_means_none(self) -> None:
+        with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "auto"}):
+            c = Config()
+            assert c.enable_ocr is None
+
+    def test_yes_no_variants(self) -> None:
+        with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "yes"}):
+            c = Config()
+            assert c.enable_ocr is True
+
+        with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "no"}):
+            c = Config()
+            assert c.enable_ocr is False
+
+    def test_numeric_variants(self) -> None:
+        with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "1"}):
+            c = Config()
+            assert c.enable_ocr is True
+
+        with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "0"}):
+            c = Config()
+            assert c.enable_ocr is False
+
+    def test_case_insensitive(self) -> None:
+        with mock.patch.dict(os.environ, {"LILBEE_ENABLE_OCR": "TRUE"}):
+            c = Config()
+            assert c.enable_ocr is True
+
+    def test_from_toml(self, tmp_path) -> None:
+        toml_path = tmp_path / "config.toml"
+        toml_path.write_text("enable_ocr = true\n")
+        env = _clean_env()
+        env["LILBEE_DATA"] = str(tmp_path)
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.enable_ocr is True
+
+
+class TestOcrTimeoutConfig:
+    def test_default_is_120(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            assert c.ocr_timeout == 120.0
+
+    def test_from_env(self) -> None:
+        with mock.patch.dict(os.environ, {"LILBEE_OCR_TIMEOUT": "60.5"}):
+            c = Config()
+            assert c.ocr_timeout == 60.5
+
+    def test_zero_means_no_limit(self) -> None:
+        with mock.patch.dict(os.environ, {"LILBEE_OCR_TIMEOUT": "0"}):
+            c = Config()
+            assert c.ocr_timeout == 0
+
+    def test_invalid_raises(self) -> None:
+        with (
+            mock.patch.dict(os.environ, {"LILBEE_OCR_TIMEOUT": "abc"}),
+            pytest.raises(ValueError),
+        ):
+            Config()
+
+
 class TestCorsOriginsConfig:
     def test_cors_origins_from_env(self) -> None:
         with mock.patch.dict(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -685,6 +685,15 @@ class TestOllamaHostFallback:
         assert c.litellm_base_url == "http://custom:11434"
 
 
+class TestParseEnableOcrFallback:
+    def test_non_string_non_bool_coerced_via_bool(self):
+        """An integer like 42 falls through to bool(v)."""
+        from lilbee.config import Config
+
+        assert Config._parse_enable_ocr(42) is True
+        assert Config._parse_enable_ocr(0) is False
+
+
 class TestPlainEnvSourceSkipsEmpty:
     def test_empty_chat_model_uses_default(self, tmp_path):
         env = _clean_env(tmp_path)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -842,12 +842,12 @@ class TestHasMeaningfulText:
 class TestVisionFallback:
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_vision_fallback_called_for_empty_pdf(self, mock_kf, isolated_env):
-        """When PDF extraction is empty and vision_model is set, fall back to vision."""
-        cfg.vision_model = "test-vision"
-        cfg.vision_timeout = 45.0
-        # Called twice: initial extraction + Tesseract OCR (both empty)
+        """When PDF extraction is empty and enable_ocr is True, fall back to vision."""
+        cfg.chat_model = "test-vision"
+        cfg.ocr_timeout = 45.0
+        cfg.enable_ocr = True
         empty = _make_empty_result()
-        mock_kf.side_effect = [empty, empty]
+        mock_kf.return_value = empty
 
         f = isolated_env / "scanned.pdf"
         f.write_bytes(b"fake pdf")
@@ -869,10 +869,11 @@ class TestVisionFallback:
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_vision_fallback_quiet_false_by_default(self, mock_kf, isolated_env):
         """Without quiet=True, vision fallback passes quiet=False."""
-        cfg.vision_model = "test-vision"
-        cfg.vision_timeout = 120.0
+        cfg.chat_model = "test-vision"
+        cfg.ocr_timeout = 120.0
+        cfg.enable_ocr = True
         empty = _make_empty_result()
-        mock_kf.side_effect = [empty, empty]
+        mock_kf.return_value = empty
 
         f = isolated_env / "scanned.pdf"
         f.write_bytes(b"fake pdf")
@@ -891,8 +892,9 @@ class TestVisionFallback:
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_ingest_file_threads_quiet_to_vision(self, mock_kf, isolated_env):
         """quiet=True flows from _ingest_file through ingest_document to vision."""
-        cfg.vision_model = "test-vision"
-        cfg.vision_timeout = 120.0
+        cfg.chat_model = "test-vision"
+        cfg.ocr_timeout = 120.0
+        cfg.enable_ocr = True
         empty = _make_empty_result()
         mock_kf.return_value = empty
 
@@ -911,10 +913,10 @@ class TestVisionFallback:
         )
 
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
-    async def test_vision_fallback_not_called_without_model(self, mock_kf, isolated_env):
-        """When vision_model is empty, no fallback occurs (Tesseract tried first)."""
+    async def test_vision_fallback_not_called_when_ocr_disabled(self, mock_kf, isolated_env):
+        """When enable_ocr is False, no vision fallback occurs."""
         mock_kf.return_value = _make_empty_result()
-        cfg.vision_model = ""
+        cfg.enable_ocr = False
         f = isolated_env / "scanned.pdf"
         f.write_bytes(b"fake pdf")
 
@@ -929,7 +931,7 @@ class TestVisionFallback:
     async def test_vision_fallback_not_called_for_non_pdf(self, mock_kf, isolated_env):
         """Vision fallback only triggers for PDF content type."""
         mock_kf.return_value = _make_empty_result()
-        cfg.vision_model = "test-vision"
+        cfg.enable_ocr = True
         f = isolated_env / "doc.txt"
         f.write_text("")
 
@@ -943,9 +945,9 @@ class TestVisionFallback:
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_vision_fallback_empty_vision_text_returns_empty(self, mock_kf, isolated_env):
         """When vision also returns empty text, return empty list."""
-        cfg.vision_model = "test-vision"
+        cfg.enable_ocr = True
         empty = _make_empty_result()
-        mock_kf.side_effect = [empty, empty]
+        mock_kf.return_value = empty
 
         f = isolated_env / "blank.pdf"
         f.write_bytes(b"fake pdf")
@@ -962,7 +964,7 @@ class TestVisionFallback:
         mock_kf.return_value = _make_kreuzberg_result(
             text="Meaningful PDF content. " * 20, num_chunks=1, has_pages=True
         )
-        cfg.vision_model = "test-vision"
+        cfg.enable_ocr = True
         f = isolated_env / "good.pdf"
         f.write_bytes(b"fake pdf")
 
@@ -976,9 +978,9 @@ class TestVisionFallback:
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_vision_fallback_no_chunks_returns_empty(self, mock_kf, isolated_env):
         """When vision text produces no chunks, return empty list."""
-        cfg.vision_model = "test-vision"
+        cfg.enable_ocr = True
         empty = _make_empty_result()
-        mock_kf.side_effect = [empty, empty]
+        mock_kf.return_value = empty
 
         f = isolated_env / "nochunks.pdf"
         f.write_bytes(b"fake pdf")
@@ -999,7 +1001,7 @@ class TestTesseractOcrMiddleTier:
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_tesseract_ocr_succeeds_skips_vision(self, mock_kf, isolated_env):
         """When Tesseract OCR produces meaningful text, vision is not called."""
-        cfg.vision_model = ""
+        cfg.enable_ocr = False
         empty = _make_empty_result()
         ocr_result = _make_kreuzberg_result(
             text="Tesseract extracted text. " * 20, num_chunks=1, has_pages=True
@@ -1020,11 +1022,12 @@ class TestTesseractOcrMiddleTier:
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_tesseract_ocr_fails_falls_through_to_vision(self, mock_kf, isolated_env):
         """When Tesseract OCR also yields < 50 chars, fall through to vision."""
-        cfg.vision_model = "test-vision"
-        cfg.vision_timeout = 120.0
+        cfg.chat_model = "test-vision"
+        cfg.ocr_timeout = 120.0
+        cfg.enable_ocr = True
         empty = _make_empty_result()
-        # Called twice: initial extraction + Tesseract OCR (both empty)
-        mock_kf.side_effect = [empty, empty]
+        # Called once: initial extraction (Tesseract skipped when enable_ocr=True)
+        mock_kf.return_value = empty
 
         f = isolated_env / "scanned.pdf"
         f.write_bytes(b"fake pdf")
@@ -1042,7 +1045,7 @@ class TestTesseractOcrMiddleTier:
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_tesseract_exception_falls_through(self, mock_kf, isolated_env):
         """When Tesseract is not installed (raises exception), fall through gracefully."""
-        cfg.vision_model = ""
+        cfg.enable_ocr = False
         empty = _make_empty_result()
         mock_kf.side_effect = [empty, RuntimeError("tesseract not found")]
 
@@ -1058,7 +1061,7 @@ class TestTesseractOcrMiddleTier:
     async def test_non_pdf_skips_tesseract_ocr(self, mock_kf, isolated_env):
         """Non-PDF files never attempt Tesseract OCR retry."""
         mock_kf.return_value = _make_empty_result()
-        cfg.vision_model = ""
+        cfg.enable_ocr = False
 
         f = isolated_env / "doc.txt"
         f.write_text("")
@@ -1071,9 +1074,10 @@ class TestTesseractOcrMiddleTier:
 
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_vision_explicit_skips_tesseract(self, mock_kf, isolated_env):
-        """When force_vision=True, Tesseract OCR tier is skipped entirely."""
-        cfg.vision_model = "test-vision"
-        cfg.vision_timeout = 120.0
+        """When enable_ocr=True, Tesseract OCR tier is skipped entirely."""
+        cfg.chat_model = "test-vision"
+        cfg.ocr_timeout = 120.0
+        cfg.enable_ocr = True
         empty = _make_empty_result()
         mock_kf.return_value = empty
 
@@ -1084,15 +1088,15 @@ class TestTesseractOcrMiddleTier:
         with mock.patch("lilbee.ingest.extract_pdf_vision", return_value=vision_pages):
             from lilbee.ingest import ingest_document
 
-            result = await ingest_document(f, "scanned.pdf", "pdf", force_vision=True)
+            result = await ingest_document(f, "scanned.pdf", "pdf")
         # extract_file called only once (initial extraction), not twice (no OCR retry)
         assert mock_kf.call_count == 1
         assert len(result) > 0
 
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
     async def test_tesseract_ocr_empty_no_vision_warns(self, mock_kf, isolated_env):
-        """When Tesseract fails and no vision model, warning mentions Tesseract."""
-        cfg.vision_model = ""
+        """When Tesseract fails and OCR disabled, warning is emitted."""
+        cfg.enable_ocr = False
         empty = _make_empty_result()
         mock_kf.side_effect = [empty, empty]
 
@@ -1105,10 +1109,11 @@ class TestTesseractOcrMiddleTier:
         assert result == []
 
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
-    async def test_configured_vision_model_skips_tesseract(self, mock_kf, isolated_env):
-        """With vision_model set, Tesseract is skipped — vision takes precedence."""
-        cfg.vision_model = "test-vision"
-        cfg.vision_timeout = 120.0
+    async def test_enable_ocr_skips_tesseract(self, mock_kf, isolated_env):
+        """With enable_ocr=True, Tesseract is skipped and vision takes precedence."""
+        cfg.chat_model = "test-vision"
+        cfg.ocr_timeout = 120.0
+        cfg.enable_ocr = True
         empty = _make_empty_result()
         mock_kf.return_value = empty
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -995,6 +995,45 @@ class TestVisionFallback:
         assert result == []
 
 
+class TestShouldRunOcrAutoDetect:
+    def test_auto_detect_vision_capable(self, isolated_env):
+        """When enable_ocr is None, _should_run_ocr defers to is_vision_capable."""
+        cfg.enable_ocr = None
+        cfg.chat_model = "some-model"
+        with mock.patch("lilbee.model_manager.is_vision_capable", return_value=True):
+            from lilbee.ingest import _should_run_ocr
+
+            assert _should_run_ocr() is True
+
+    def test_auto_detect_not_vision_capable(self, isolated_env):
+        """When enable_ocr is None and model lacks vision, returns False."""
+        cfg.enable_ocr = None
+        cfg.chat_model = "some-model"
+        with mock.patch("lilbee.model_manager.is_vision_capable", return_value=False):
+            from lilbee.ingest import _should_run_ocr
+
+            assert _should_run_ocr() is False
+
+
+class TestVisionFallbackException:
+    @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
+    async def test_exception_returns_empty(self, mock_kf, isolated_env):
+        """When extract_pdf_vision raises, _vision_fallback returns []."""
+        cfg.enable_ocr = True
+        cfg.chat_model = "test-vision"
+        empty = _make_empty_result()
+        mock_kf.return_value = empty
+
+        f = isolated_env / "broken.pdf"
+        f.write_bytes(b"fake pdf")
+
+        with mock.patch("lilbee.ingest.extract_pdf_vision", side_effect=RuntimeError("boom")):
+            from lilbee.ingest import ingest_document
+
+            result = await ingest_document(f, "broken.pdf", "pdf", quiet=True)
+        assert result == []
+
+
 class TestTesseractOcrMiddleTier:
     """Tests for the Tesseract OCR tier between text extraction and vision fallback."""
 

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -420,14 +420,11 @@ class TestVisionModel:
         result = find_mmproj_for_model(models_dir / "test-model.gguf")
         assert result == mmproj
 
-    def test_is_vision_model_matches_config(self, models_dir: Path) -> None:
-        """_is_vision_model returns True for cfg.vision_model."""
+    def test_is_vision_model_matches_catalog(self, models_dir: Path) -> None:
+        """_is_vision_model returns True for FEATURED_VISION entries."""
         from lilbee.providers.llama_cpp_provider import _is_vision_model
 
-        cfg.vision_model = "test-vision"
-        assert _is_vision_model("test-vision") is True
-        assert _is_vision_model("test-chat") is False
-        cfg.vision_model = ""
+        assert _is_vision_model("random-nonexistent-model") is False
 
     def test_get_vision_llm_caches(self, models_dir: Path, mock_llama_cpp: mock.MagicMock) -> None:
         """_get_vision_llm caches the vision model instance."""
@@ -435,7 +432,6 @@ class TestVisionModel:
 
         mmproj = models_dir / "test-mmproj-f16.gguf"
         mmproj.write_bytes(b"fake-mmproj")
-        cfg.vision_model = "test-model"
 
         mock_handler = mock.MagicMock()
         mock_chat_format = mock.MagicMock()
@@ -447,16 +443,18 @@ class TestVisionModel:
         mock_llama_cpp.Llama.return_value = instance
 
         try:
-            provider = LlamaCppProvider()
-            provider.chat([{"role": "user", "content": "hi"}], model="test-model")
-            provider.chat([{"role": "user", "content": "hi"}], model="test-model")
+            with mock.patch(
+                "lilbee.providers.llama_cpp_provider._is_vision_model", return_value=True
+            ):
+                provider = LlamaCppProvider()
+                provider.chat([{"role": "user", "content": "hi"}], model="test-model")
+                provider.chat([{"role": "user", "content": "hi"}], model="test-model")
 
-            # Llama should only be called once (cached)
-            assert mock_llama_cpp.Llama.call_count == 1
-            provider.shutdown()
+                # Llama should only be called once (cached)
+                assert mock_llama_cpp.Llama.call_count == 1
+                provider.shutdown()
         finally:
             sys.modules.pop("llama_cpp.llama_chat_format", None)
-            cfg.vision_model = ""
 
 
 class TestLoadLlamaNCtx:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -157,15 +157,15 @@ class TestLilbeeStatus:
         assert result["sources"][0]["filename"] == "test.pdf"
         assert result["total_chunks"] == 10
 
-    def test_status_includes_vision_model_when_set(self):
-        cfg.vision_model = "test-vision:latest"
+    def test_status_includes_enable_ocr_when_set(self):
+        cfg.enable_ocr = True
         result = lilbee_status()
-        assert result["config"]["vision_model"] == "test-vision:latest"
+        assert result["config"]["enable_ocr"] is True
 
-    def test_status_excludes_vision_model_when_empty(self):
-        cfg.vision_model = ""
+    def test_status_enable_ocr_none_by_default(self):
+        cfg.enable_ocr = None
         result = lilbee_status()
-        assert "vision_model" not in result["config"]
+        assert result["config"]["enable_ocr"] is None
 
 
 class TestLilbeeSync:
@@ -347,26 +347,26 @@ class TestLilbeeAdd:
         assert (cfg.documents_dir / "mydir" / "a.txt").read_text() == "a"
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
-    async def test_add_with_vision_model(self, mock_sync, tmp_path):
+    async def test_add_with_enable_ocr(self, mock_sync, tmp_path):
         src = tmp_path / "scan.pdf"
         src.write_bytes(b"%PDF-fake")
-        original_vision = cfg.vision_model
+        original_ocr = cfg.enable_ocr
 
-        await lilbee_add([str(src)], vision_model="test-vision:latest")
+        await lilbee_add([str(src)], enable_ocr=True)
 
-        # vision_model should be restored after the call
-        assert cfg.vision_model == original_vision
+        # enable_ocr should be restored after the call
+        assert cfg.enable_ocr == original_ocr
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, side_effect=RuntimeError("boom"))
-    async def test_add_vision_model_restored_on_error(self, mock_sync, tmp_path):
+    async def test_add_enable_ocr_restored_on_error(self, mock_sync, tmp_path):
         src = tmp_path / "file.txt"
         src.write_text("content")
-        original_vision = cfg.vision_model
+        original_ocr = cfg.enable_ocr
 
         with pytest.raises(RuntimeError, match="boom"):
-            await lilbee_add([str(src)], vision_model="test-vision:latest")
+            await lilbee_add([str(src)], enable_ocr=True)
 
-        assert cfg.vision_model == original_vision
+        assert cfg.enable_ocr == original_ocr
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     async def test_add_empty_paths(self, mock_sync):
@@ -416,13 +416,13 @@ class TestLilbeeAddWithUrls:
 
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     @mock.patch("lilbee.crawler.crawl_and_save", new_callable=AsyncMock)
-    async def test_add_url_with_vision(self, mock_crawl, mock_sync, isolated_env):
-        """Vision model is temporarily applied during sync."""
+    async def test_add_url_with_enable_ocr(self, mock_crawl, mock_sync, isolated_env):
+        """enable_ocr is temporarily applied during sync."""
         mock_crawl.return_value = []
-        old_vision = cfg.vision_model
+        old_ocr = cfg.enable_ocr
         with mock.patch("lilbee.crawler.crawler_available", return_value=True):
-            await lilbee_add(paths=["https://example.com"], vision_model="test-vision:latest")
-        assert cfg.vision_model == old_vision
+            await lilbee_add(paths=["https://example.com"], enable_ocr=True)
+        assert cfg.enable_ocr == old_ocr
 
     @mock.patch("lilbee.crawler.crawler_available", return_value=True)
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -666,3 +666,138 @@ class TestRemoteModelProvider:
     def test_remote_model_default_provider(self) -> None:
         model = RemoteModel(name="test", task="chat", family="llama", parameter_size="8B")
         assert model.provider == "Remote"
+
+
+class TestIsVisionCapable:
+    """Tests for is_vision_capable() — 4-tier detection."""
+
+    def setup_method(self) -> None:
+        from lilbee.model_manager import reset_vision_cache
+
+        reset_vision_cache()
+
+    def teardown_method(self) -> None:
+        from lilbee.model_manager import reset_vision_cache
+
+        reset_vision_cache()
+
+    def test_empty_model_returns_false(self) -> None:
+        from lilbee.model_manager import is_vision_capable
+
+        assert is_vision_capable("") is False
+
+    def test_provider_capabilities_vision(self) -> None:
+        """Tier 1: provider reports vision capability."""
+        from lilbee.model_manager import is_vision_capable
+
+        mock_provider = mock.MagicMock()
+        mock_provider.get_capabilities.return_value = ["completion", "vision"]
+        mock_services = mock.MagicMock()
+        mock_services.provider = mock_provider
+
+        with mock.patch("lilbee.services.get_services", return_value=mock_services):
+            assert is_vision_capable("llava:7b") is True
+
+    def test_provider_capabilities_no_vision(self) -> None:
+        """Tier 1: provider reports no vision, falls through to catalog/name."""
+        from lilbee.model_manager import is_vision_capable
+
+        mock_provider = mock.MagicMock()
+        mock_provider.get_capabilities.return_value = ["completion"]
+        mock_services = mock.MagicMock()
+        mock_services.provider = mock_provider
+
+        with mock.patch("lilbee.services.get_services", return_value=mock_services):
+            # "qwen3:8b" has no vision name pattern and isn't in catalog
+            assert is_vision_capable("qwen3:8b") is False
+
+    def test_provider_error_falls_through(self) -> None:
+        """Tier 1 failure falls through to tier 2 (catalog)."""
+        from lilbee.model_manager import is_vision_capable
+
+        mock_provider = mock.MagicMock()
+        mock_provider.get_capabilities.side_effect = RuntimeError("no backend")
+        mock_services = mock.MagicMock()
+        mock_services.provider = mock_provider
+
+        # "llava:7b" matches name pattern even without provider
+        with mock.patch("lilbee.services.get_services", return_value=mock_services):
+            assert is_vision_capable("llava:7b") is True
+
+    def test_catalog_match(self) -> None:
+        """Tier 2: model matches a FEATURED_VISION entry."""
+        from lilbee.model_manager import is_vision_capable
+
+        mock_entry = mock.MagicMock()
+        mock_entry.name = "lightonocr"
+        mock_entry.hf_repo = "noctrex/LightOnOCR-2-1B-GGUF"
+
+        mock_provider = mock.MagicMock()
+        mock_provider.get_capabilities.return_value = []
+        mock_services = mock.MagicMock()
+        mock_services.provider = mock_provider
+
+        with (
+            mock.patch("lilbee.services.get_services", return_value=mock_services),
+            mock.patch("lilbee.catalog.FEATURED_VISION", (mock_entry,)),
+        ):
+            assert is_vision_capable("lightonocr") is True
+
+    def test_name_pattern_fallback(self) -> None:
+        """Tier 3: model name contains a known vision keyword."""
+        from lilbee.model_manager import is_vision_capable
+
+        mock_provider = mock.MagicMock()
+        mock_provider.get_capabilities.return_value = []
+        mock_services = mock.MagicMock()
+        mock_services.provider = mock_provider
+
+        with mock.patch("lilbee.services.get_services", return_value=mock_services):
+            assert is_vision_capable("moondream:1.8b") is True
+            # Reset cache between checks
+            from lilbee.model_manager import reset_vision_cache
+
+            reset_vision_cache()
+            assert is_vision_capable("minicpm-v:8b") is True
+
+    def test_no_match_returns_false(self) -> None:
+        """Model matches no tier — returns False."""
+        from lilbee.model_manager import is_vision_capable
+
+        mock_provider = mock.MagicMock()
+        mock_provider.get_capabilities.return_value = []
+        mock_services = mock.MagicMock()
+        mock_services.provider = mock_provider
+
+        with mock.patch("lilbee.services.get_services", return_value=mock_services):
+            assert is_vision_capable("mistral:7b") is False
+
+    def test_result_is_cached(self) -> None:
+        """Second call uses cache, not provider."""
+        from lilbee.model_manager import is_vision_capable
+
+        mock_provider = mock.MagicMock()
+        mock_provider.get_capabilities.return_value = ["vision"]
+        mock_services = mock.MagicMock()
+        mock_services.provider = mock_provider
+
+        with mock.patch("lilbee.services.get_services", return_value=mock_services):
+            assert is_vision_capable("llava:7b") is True
+            assert is_vision_capable("llava:7b") is True
+            # Provider called only once due to cache
+            mock_provider.get_capabilities.assert_called_once()
+
+    def test_reset_clears_cache(self) -> None:
+        """reset_vision_cache allows re-detection."""
+        from lilbee.model_manager import is_vision_capable, reset_vision_cache
+
+        mock_provider = mock.MagicMock()
+        mock_provider.get_capabilities.return_value = ["vision"]
+        mock_services = mock.MagicMock()
+        mock_services.provider = mock_provider
+
+        with mock.patch("lilbee.services.get_services", return_value=mock_services):
+            is_vision_capable("llava:7b")
+            reset_vision_cache()
+            is_vision_capable("llava:7b")
+            assert mock_provider.get_capabilities.call_count == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ import pytest
 
 from lilbee import models
 from lilbee.config import cfg
-from lilbee.models import MODEL_CATALOG, VISION_CATALOG, ModelInfo
+from lilbee.models import MODEL_CATALOG, ModelInfo
 
 
 class TestModelCatalog:
@@ -371,64 +371,6 @@ class TestEnsureChatModel:
             mock.patch.object(models.sys.stdin, "isatty", return_value=False),
         ):
             models.ensure_chat_model()
-
-
-class TestVisionCatalog:
-    def test_catalog_not_empty(self) -> None:
-        assert len(VISION_CATALOG) > 0
-
-    def test_all_entries_are_model_info(self) -> None:
-        for m in VISION_CATALOG:
-            assert isinstance(m, ModelInfo)
-
-    def test_derived_from_catalog(self) -> None:
-        """VISION_CATALOG entries match catalog.py's FEATURED_VISION."""
-        from lilbee.catalog import FEATURED_VISION
-
-        assert len(VISION_CATALOG) == len(FEATURED_VISION)
-        for vc, fv in zip(VISION_CATALOG, FEATURED_VISION, strict=True):
-            assert vc.name == fv.name
-
-    def test_frozen(self) -> None:
-        with pytest.raises(AttributeError):
-            VISION_CATALOG[0].name = "nope"  # type: ignore[misc]
-
-
-class TestPickDefaultVisionModel:
-    def test_returns_first_catalog_entry(self) -> None:
-        """Always returns the best-quality model (first in catalog)."""
-        assert models.pick_default_vision_model() == VISION_CATALOG[0]
-
-
-class TestDisplayVisionPicker:
-    def test_renders_table(self, capsys: pytest.CaptureFixture[str]) -> None:
-        m = models.display_vision_picker(32, 50.0)
-        captured = capsys.readouterr()
-        assert "Vision OCR Models" in captured.err
-        assert isinstance(m, ModelInfo)
-
-    def test_recommended_highlighted(self, capsys: pytest.CaptureFixture[str]) -> None:
-        recommended = models.display_vision_picker(32.0, 100.0)
-        assert isinstance(recommended, ModelInfo)
-        captured = capsys.readouterr()
-        assert "\u2605" in captured.err
-
-    def test_disk_warning_with_low_space(self, capsys: pytest.CaptureFixture[str]) -> None:
-        models.display_vision_picker(32.0, 3.0)
-        captured = capsys.readouterr()
-        assert "3.0 GB free disk" in captured.err
-        assert "Vision OCR Models" in captured.err
-
-    def test_shows_system_stats(self, capsys: pytest.CaptureFixture[str]) -> None:
-        models.display_vision_picker(16.0, 42.5)
-        captured = capsys.readouterr()
-        assert "16 GB RAM" in captured.err
-        assert "42.5 GB free disk" in captured.err
-
-    def test_shows_browse_link(self, capsys: pytest.CaptureFixture[str]) -> None:
-        models.display_vision_picker(8.0, 50.0)
-        captured = capsys.readouterr()
-        assert models.MODELS_BROWSE_URL in captured.err
 
 
 class TestEnsureTag:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1917,28 +1917,15 @@ class TestLoadLlama:
 
 
 class TestIsVisionModel:
-    def test_matches_config_vision_model(self) -> None:
-        """_is_vision_model matches cfg.vision_model."""
+    def test_no_match_for_unknown_model(self) -> None:
+        """_is_vision_model returns False for models not in the catalog."""
         from lilbee.providers.llama_cpp_provider import _is_vision_model
 
-        cfg.vision_model = "my-vision"
-
-        assert _is_vision_model("my-vision") is True
-
-    def test_no_match_when_empty(self) -> None:
-        """_is_vision_model returns False for empty vision_model."""
-        from lilbee.providers.llama_cpp_provider import _is_vision_model
-
-        cfg.vision_model = ""
-
-        # Only matches featured catalog entries
         assert _is_vision_model("random-model") is False
 
     def test_matches_featured_vision(self) -> None:
         """_is_vision_model matches FEATURED_VISION entries."""
         from lilbee.providers.llama_cpp_provider import _is_vision_model
-
-        cfg.vision_model = ""
 
         mock_entry = mock.MagicMock()
         mock_entry.name = "LightOnOCR"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -8,11 +8,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest import mock
 
+import httpx
 import pytest
 
 from lilbee.config import cfg
 
 if TYPE_CHECKING:
+    from lilbee.providers.litellm_provider import LiteLLMProvider
     from lilbee.providers.routing_provider import RoutingProvider
 
 # ---------------------------------------------------------------------------
@@ -641,6 +643,17 @@ class TestRoutingProvider:
         with mock.patch("lilbee.providers.litellm_provider.litellm_available", return_value=False):
             assert rp._should_use_litellm() is False
 
+    def test_get_capabilities_delegates_to_active_provider(self) -> None:
+        rp = self._make_provider()
+        mock_litellm = mock.MagicMock()
+        mock_litellm.get_capabilities.return_value = ["completion", "vision"]
+        rp._litellm = mock_litellm
+        rp._use_litellm = True
+
+        caps = rp.get_capabilities("llava:7b")
+        assert caps == ["completion", "vision"]
+        mock_litellm.get_capabilities.assert_called_once_with("llava:7b")
+
 
 # ---------------------------------------------------------------------------
 # litellm_available guard
@@ -665,6 +678,103 @@ class TestLitellmAvailable:
             pytest.raises(ProviderError, match="litellm is not installed"),
         ):
             create_provider(cfg)
+
+
+class TestLiteLLMShowModelCapabilities:
+    """Tests for LiteLLMProvider.show_model capabilities parsing."""
+
+    def _make_provider(self) -> LiteLLMProvider:
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        return LiteLLMProvider(base_url="http://localhost:11434")
+
+    def test_show_model_returns_capabilities(self) -> None:
+        provider = self._make_provider()
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = {
+            "capabilities": ["completion", "vision"],
+            "parameters": "temperature 0.7",
+        }
+        mock_resp.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.post", return_value=mock_resp):
+            result = provider.show_model("llava:7b")
+
+        assert result is not None
+        assert result["capabilities"] == ["completion", "vision"]
+        assert result["parameters"] == "temperature 0.7"
+
+    def test_show_model_no_capabilities_field(self) -> None:
+        provider = self._make_provider()
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = {"parameters": "temperature 0.7"}
+        mock_resp.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.post", return_value=mock_resp):
+            result = provider.show_model("qwen3:8b")
+
+        assert result is not None
+        assert "capabilities" not in result
+        assert result["parameters"] == "temperature 0.7"
+
+    def test_show_model_only_capabilities_no_params(self) -> None:
+        provider = self._make_provider()
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = {"capabilities": ["completion"]}
+        mock_resp.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.post", return_value=mock_resp):
+            result = provider.show_model("some-model")
+
+        assert result is not None
+        assert result["capabilities"] == ["completion"]
+
+    def test_show_model_empty_returns_none(self) -> None:
+        provider = self._make_provider()
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = {}
+        mock_resp.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.post", return_value=mock_resp):
+            result = provider.show_model("empty-model")
+
+        assert result is None
+
+    def test_show_model_http_error(self) -> None:
+        provider = self._make_provider()
+        with mock.patch("httpx.post", side_effect=httpx.HTTPError("fail")):
+            result = provider.show_model("bad-model")
+
+        assert result is None
+
+    def test_get_capabilities_returns_list(self) -> None:
+        provider = self._make_provider()
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = {"capabilities": ["completion", "vision", "tools"]}
+        mock_resp.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.post", return_value=mock_resp):
+            caps = provider.get_capabilities("llava:7b")
+
+        assert caps == ["completion", "vision", "tools"]
+
+    def test_get_capabilities_returns_empty_on_error(self) -> None:
+        provider = self._make_provider()
+        with mock.patch("httpx.post", side_effect=httpx.HTTPError("fail")):
+            caps = provider.get_capabilities("bad-model")
+
+        assert caps == []
+
+    def test_get_capabilities_no_capabilities_field(self) -> None:
+        provider = self._make_provider()
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = {"parameters": "temp 0.7"}
+        mock_resp.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.post", return_value=mock_resp):
+            caps = provider.get_capabilities("qwen3:8b")
+
+        assert caps == []
 
 
 # ---------------------------------------------------------------------------
@@ -1398,6 +1508,59 @@ class TestLlamaCppProviderMethods:
             result = provider.show_model("missing-model")
 
         assert result is None
+
+    def test_get_capabilities_with_mmproj(self) -> None:
+        """get_capabilities returns ['completion', 'vision'] when mmproj found."""
+        provider = _make_provider_no_thread()
+
+        with (
+            mock.patch(
+                "lilbee.providers.llama_cpp_provider.resolve_model_path",
+                return_value=Path("/models/llava.gguf"),
+            ),
+            mock.patch(
+                "lilbee.providers.llama_cpp_provider.find_mmproj_for_model",
+                return_value=Path("/models/llava-mmproj.gguf"),
+            ),
+        ):
+            caps = provider.get_capabilities("llava:7b")
+
+        assert "completion" in caps
+        assert "vision" in caps
+
+    def test_get_capabilities_no_mmproj(self) -> None:
+        """get_capabilities returns ['completion'] when no mmproj found."""
+        from lilbee.providers.base import ProviderError
+
+        provider = _make_provider_no_thread()
+
+        with (
+            mock.patch(
+                "lilbee.providers.llama_cpp_provider.resolve_model_path",
+                return_value=Path("/models/qwen.gguf"),
+            ),
+            mock.patch(
+                "lilbee.providers.llama_cpp_provider.find_mmproj_for_model",
+                side_effect=ProviderError("no mmproj"),
+            ),
+        ):
+            caps = provider.get_capabilities("qwen:8b")
+
+        assert caps == ["completion"]
+
+    def test_get_capabilities_resolve_error(self) -> None:
+        """get_capabilities returns ['completion'] when model path not found."""
+        from lilbee.providers.base import ProviderError
+
+        provider = _make_provider_no_thread()
+
+        with mock.patch(
+            "lilbee.providers.llama_cpp_provider.resolve_model_path",
+            side_effect=ProviderError("not found"),
+        ):
+            caps = provider.get_capabilities("missing-model")
+
+        assert caps == ["completion"]
 
     def test_list_models(self) -> None:
         """list_models returns sorted registry models."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1093,6 +1093,15 @@ class TestRunLlmStreamCancel:
         assert items[-1] is None
 
 
+class TestParseOcrParams:
+    def test_ocr_timeout_coerced_to_float(self):
+        """_parse_ocr_params coerces ocr_timeout to float."""
+        enable_ocr, ocr_timeout = handlers._parse_ocr_params({"ocr_timeout": "60"})
+        assert ocr_timeout == 60.0
+        assert isinstance(ocr_timeout, float)
+        assert enable_ocr is None
+
+
 class TestAddHandlerCancel:
     async def test_cancel_returns_early(self):
         """When cancel is set before sync, add returns early with copy-only summary."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -364,9 +364,7 @@ class TestSyncStream:
     async def test_yields_progress_and_done(self):
         sync_result = SyncResult(added=["a.txt"], unchanged=0)
 
-        async def fake_sync(
-            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None, cancel=None
-        ):
+        async def fake_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
             if on_progress:
                 from lilbee.progress import FileDoneEvent, SyncDoneEvent
 
@@ -388,9 +386,7 @@ class TestSyncStream:
     async def test_yields_progress_events(self):
         sync_result = SyncResult(added=["b.txt"])
 
-        async def fake_sync(
-            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None, cancel=None
-        ):
+        async def fake_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
             if on_progress:
                 from lilbee.progress import FileDoneEvent, FileStartEvent, SyncDoneEvent
 
@@ -417,9 +413,7 @@ class TestSyncStream:
 
         sync_result = SyncResult()
 
-        async def slow_sync(
-            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None, cancel=None
-        ):
+        async def slow_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
             await asyncio.sleep(0.2)  # force at least one timeout iteration
             return sync_result
 
@@ -436,9 +430,7 @@ class TestSyncStream:
         barrier = threading.Event()
         captured_cancel: list[threading.Event] = []
 
-        async def blocking_sync(
-            force_rebuild=False, quiet=False, *, force_vision=False, on_progress=None, cancel=None
-        ):
+        async def blocking_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
             captured_cancel.append(cancel)
             if on_progress:
                 from lilbee.progress import FileStartEvent
@@ -1131,7 +1123,8 @@ class TestAddHandlerCancel:
             result = await handlers._run_add(
                 paths=[],
                 force=False,
-                vision_model="",
+                enable_ocr=None,
+                ocr_timeout=None,
                 sse=sse,
             )
         assert result is not None

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -482,8 +482,6 @@ class TestListModels:
         assert len(result.chat.catalog) > 0
         assert "qwen3:8b" in result.chat.installed
 
-        assert result.vision is None
-
     @patch("lilbee.models.list_installed_models")
     async def test_installed_flag_in_catalog(self, mock_list):
         mock_list.return_value = ["qwen3:0.6b"]

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -482,8 +482,7 @@ class TestListModels:
         assert len(result.chat.catalog) > 0
         assert "qwen3:8b" in result.chat.installed
 
-        assert isinstance(result.vision.catalog, list)
-        assert isinstance(result.vision.installed, list)
+        assert result.vision is None
 
     @patch("lilbee.models.list_installed_models")
     async def test_installed_flag_in_catalog(self, mock_list):
@@ -508,19 +507,6 @@ class TestSetChatModel:
         result = await handlers.set_chat_model("llama3:7b")
         assert result.model == "llama3:7b"
         assert cfg.chat_model == "llama3:7b"
-
-
-class TestSetVisionModel:
-    async def test_updates_config_and_persists(self, tmp_path):
-        result = await handlers.set_vision_model("minicpm-v:latest")
-        assert result.model == "minicpm-v:latest"
-        assert cfg.vision_model == "minicpm-v:latest"
-
-    async def test_empty_string_disables(self, tmp_path):
-        cfg.vision_model = "some-model:latest"
-        result = await handlers.set_vision_model("")
-        assert result.model == ""
-        assert cfg.vision_model == ""
 
 
 class TestModelsCatalog:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -192,14 +192,13 @@ class TestSyncRoute:
         resp = client.post("/api/sync")
         assert resp.status_code == 201
         assert b"event: done" in resp.content
-        mock_stream.assert_called_once_with()
+        mock_stream.assert_called_once_with(enable_ocr=None)
 
     @mock.patch("lilbee.server.handlers.sync_stream")
     def test_enable_ocr(self, mock_stream, client):
         mock_stream.return_value = mock_async_gen("event: done\ndata: {}\n\n")
         client.post("/api/sync", json={"enable_ocr": True})
-        mock_stream.assert_called_once_with()
-        assert cfg.enable_ocr is True
+        mock_stream.assert_called_once_with(enable_ocr=True)
 
 
 class TestModelsListRoute:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -238,18 +238,6 @@ class TestModelsSetChatRoute:
         assert resp.json()["model"] == "llama3:8b"
 
 
-class TestModelsSetVisionRoute:
-    @mock.patch(
-        "lilbee.server.handlers.set_vision_model",
-        new_callable=AsyncMock,
-        return_value={"model": "llava:13b"},
-    )
-    def test_returns_model(self, mock_set, client):
-        resp = client.put("/api/models/vision", json={"model": "llava:13b"})
-        assert resp.status_code == 200
-        assert resp.json()["model"] == "llava:13b"
-
-
 class TestModelsCatalogRoute:
     @mock.patch(
         "lilbee.server.handlers.models_catalog",

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -192,13 +192,14 @@ class TestSyncRoute:
         resp = client.post("/api/sync")
         assert resp.status_code == 201
         assert b"event: done" in resp.content
-        mock_stream.assert_called_once_with(force_vision=False)
+        mock_stream.assert_called_once_with()
 
     @mock.patch("lilbee.server.handlers.sync_stream")
-    def test_force_vision(self, mock_stream, client):
+    def test_enable_ocr(self, mock_stream, client):
         mock_stream.return_value = mock_async_gen("event: done\ndata: {}\n\n")
-        client.post("/api/sync", json={"force_vision": True})
-        mock_stream.assert_called_once_with(force_vision=True)
+        client.post("/api/sync", json={"enable_ocr": True})
+        mock_stream.assert_called_once_with()
+        assert cfg.enable_ocr is True
 
 
 class TestModelsListRoute:

--- a/tests/test_task_bar_per_screen.py
+++ b/tests/test_task_bar_per_screen.py
@@ -32,7 +32,6 @@ def _isolated_cfg(tmp_path):
     cfg.lancedb_dir = tmp_path / "lancedb"
     cfg.chat_model = "test-model:latest"
     cfg.embedding_model = "test-embed:latest"
-    cfg.vision_model = ""
     yield
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))
@@ -62,7 +61,7 @@ def _patch_chat_setup():
         ),
         patch(
             "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
-            return_value=([], [], []),
+            return_value=([], []),
         ),
         patch(
             "lilbee.cli.tui.screens.catalog.CatalogScreen._fetch_remote_models",

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -26,7 +26,6 @@ def _isolated_cfg(tmp_path):
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
     cfg.chat_model = "test-chat-model.gguf"
     cfg.embedding_model = "test-embed-model"
-    cfg.vision_model = ""
     cfg.subprocess_embed = False
     cfg.data_dir.mkdir(parents=True, exist_ok=True)
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
@@ -154,14 +153,12 @@ class TestModelClassification:
 
             mock_native.side_effect = fill_buckets
             with mock.patch("lilbee.cli.tui.widgets.model_bar._collect_remote_models"):
-                chat, embed, vision = _classify_installed_models()
+                chat, embed = _classify_installed_models()
 
         chat_refs = [o.ref for o in chat]
         embed_refs = [o.ref for o in embed]
-        vision_refs = [o.ref for o in vision]
         assert "Qwen3:latest" in chat_refs
         assert "Nomic Embed:latest" in embed_refs
-        assert "LightOnOCR:latest" in vision_refs
 
     def test_no_loose_gguf_scanning(self):
         """Legacy .gguf files NOT in registry must NOT appear in dropdowns."""
@@ -175,9 +172,9 @@ class TestModelClassification:
             mock.patch("lilbee.cli.tui.widgets.model_bar._collect_native_models"),
             mock.patch("lilbee.cli.tui.widgets.model_bar._collect_remote_models"),
         ):
-            chat, embed, vision = _classify_installed_models()
+            chat, embed = _classify_installed_models()
 
-        all_models = chat + embed + vision
+        all_models = chat + embed
         assert "loose-chat.gguf" not in all_models
         assert "loose-vision.gguf" not in all_models
 
@@ -2081,34 +2078,6 @@ class TestChatSlashCommands:
                 from lilbee.cli.tui.screens.catalog import CatalogScreen
 
                 assert isinstance(app.screen, CatalogScreen)
-
-    async def test_cmd_vision_set(self, _mock_resolve):
-        """/vision <model> sets the vision model."""
-        app = ChatTestApp()
-        async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
-            app.screen._handle_slash("/vision test-vision-model")
-            await pilot.pause()
-            assert cfg.vision_model == "test-vision-model"
-
-    async def test_cmd_vision_off(self, _mock_resolve):
-        """/vision off disables vision."""
-        app = ChatTestApp()
-        async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
-            cfg.vision_model = "some-model"
-            app.screen._handle_slash("/vision off")
-            await pilot.pause()
-            assert cfg.vision_model == ""
-
-    async def test_cmd_vision_status(self, _mock_resolve):
-        """/vision with no args shows current status."""
-        app = ChatTestApp()
-        async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
-            app.screen._handle_slash("/vision")
-            await pilot.pause()
-            assert app.screen.is_current
 
     async def test_cmd_reset_without_confirm(self, _mock_resolve):
         """/reset without confirm shows warning."""

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -31,7 +31,6 @@ def _isolated_cfg(tmp_path):
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
     cfg.chat_model = "test-chat-model.gguf"
     cfg.embedding_model = "test-embed-model"
-    cfg.vision_model = ""
     cfg.subprocess_embed = False
     cfg.wiki = False
     cfg.data_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -701,6 +701,36 @@ async def test_status_screen_escape_pops():
         assert not isinstance(app.screen, StatusScreen)
 
 
+def test_ocr_label_enabled():
+    from lilbee.cli.tui.screens.status import _ocr_label
+
+    cfg.enable_ocr = True
+    assert _ocr_label() == "enabled"
+
+
+def test_ocr_label_disabled():
+    from lilbee.cli.tui.screens.status import _ocr_label
+
+    cfg.enable_ocr = False
+    assert _ocr_label() == "disabled"
+
+
+def test_ocr_pill_enabled():
+    from lilbee.cli.tui.screens.status import _ocr_pill
+
+    cfg.enable_ocr = True
+    result = _ocr_pill()
+    assert "on" in str(result)
+
+
+def test_ocr_pill_disabled():
+    from lilbee.cli.tui.screens.status import _ocr_pill
+
+    cfg.enable_ocr = False
+    result = _ocr_pill()
+    assert "off" in str(result)
+
+
 def test_status_model_pill_truthy():
     from lilbee.cli.tui.screens.status import _model_pill
 

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -45,7 +45,6 @@ def _isolated_cfg(tmp_path):
     cfg.lancedb_dir = tmp_path / "lancedb"
     cfg.chat_model = "test-model:latest"
     cfg.embedding_model = "test-embed:latest"
-    cfg.vision_model = ""
     cfg.chunk_size = 512
     # Simulate "already-initialized" state so ChatScreen._needs_setup()
     # doesn't push the SetupWizard during tests that exercise chat.
@@ -84,7 +83,7 @@ def _patch_chat_setup():
         ),
         patch(
             "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
-            return_value=([], [], []),
+            return_value=([], []),
         ),
     ):
         yield
@@ -602,11 +601,10 @@ async def test_status_screen_config_shows_models(mock_svc):
         rendered = str(info.render())
         assert "Chat model" in rendered
         assert "Embed model" in rendered
-        assert "Vision model" in rendered
+        assert "OCR" in rendered
 
 
 async def test_status_screen_config_pills_render(mock_svc):
-    cfg.vision_model = ""
     app = StatusTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         info = app.screen.query_one("#config-info", Static)
@@ -657,7 +655,7 @@ async def test_status_screen_arch_section(mock_svc):
 
 
 async def test_status_screen_arch_with_vision(mock_svc):
-    cfg.vision_model = "test-vision:latest"
+    cfg.chat_model = "test-vision:latest"
     app = StatusTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         info = app.screen.query_one("#arch-info", Static)
@@ -757,9 +755,13 @@ def test_status_read_embed_arch_success():
 def test_status_read_vision_arch_success():
     from lilbee.model_info import ModelArchInfo, _read_vision_arch
 
-    cfg.vision_model = "test-vision:latest"
+    cfg.chat_model = "test-vision:latest"
     info = ModelArchInfo()
     with (
+        patch(
+            "lilbee.model_manager.is_vision_capable",
+            return_value=True,
+        ),
         patch(
             "lilbee.providers.llama_cpp_provider.resolve_model_path",
             return_value="/fake/path",
@@ -780,9 +782,10 @@ def test_status_read_vision_arch_success():
 def test_status_read_vision_arch_skips_when_no_model():
     from lilbee.model_info import ModelArchInfo, _read_vision_arch
 
-    cfg.vision_model = ""
+    cfg.chat_model = "test-chat:latest"
     info = ModelArchInfo()
-    result = _read_vision_arch(info)
+    with patch("lilbee.model_manager.is_vision_capable", return_value=False):
+        result = _read_vision_arch(info)
     assert result.vision_projector == "unknown"
 
 
@@ -999,32 +1002,6 @@ async def test_chat_slash_theme_non_lilbee_app():
             app.screen._handle_slash("/theme dracula")
             mock_notify.assert_called_once()
             assert "Themes:" in mock_notify.call_args[0][0]
-
-
-async def test_chat_slash_vision_set():
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        with patch("lilbee.settings.set_value"):
-            app.screen._cmd_vision("maternion/LightOnOCR-2:latest")
-            assert cfg.vision_model == "maternion/LightOnOCR-2:latest"
-
-
-async def test_chat_slash_vision_off():
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        cfg.vision_model = "some-model"
-        with patch("lilbee.settings.set_value"):
-            app.screen._cmd_vision("off")
-            assert cfg.vision_model == ""
-
-
-async def test_chat_slash_vision_no_arg():
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        with patch.object(app.screen, "notify") as mock_notify:
-            app.screen._cmd_vision("")
-            mock_notify.assert_called_once()
-            assert "Vision:" in mock_notify.call_args[0][0]
 
 
 async def test_chat_slash_delete_with_match(mock_svc):
@@ -1444,14 +1421,6 @@ async def test_chat_slash_add_dispatch():
             assert "Not found" in mock_notify.call_args[0][0]
 
 
-async def test_chat_slash_vision_dispatch():
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        with patch("lilbee.settings.set_value"):
-            app.screen._handle_slash("/vision off")
-            assert cfg.vision_model == ""
-
-
 async def test_chat_slash_delete_dispatch():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -1661,19 +1630,6 @@ async def test_command_provider_set_model():
             assert "new-model:latest" in app.title
 
 
-async def test_command_provider_set_model_vision():
-    from lilbee.cli.tui.app import LilbeeApp
-
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from lilbee.cli.tui.commands import LilbeeCommandProvider
-
-        provider = LilbeeCommandProvider(app.screen, match_style=None)
-        with patch("lilbee.settings.set_value"):
-            provider._set_model("vision_model", "")
-            assert cfg.vision_model == ""
-
-
 async def test_command_provider_wiki_generate_action():
     """Palette 'Generate wiki pages' action notifies the user to use /wiki generate."""
     from lilbee.cli.tui.app import LilbeeApp
@@ -1779,25 +1735,7 @@ async def test_command_provider_model_commands_error():
             side_effect=Exception("no provider"),
         ):
             cmds = provider._model_commands()
-            assert any("vision" in c[0].lower() for c in cmds)
-
-
-async def test_command_provider_model_commands_vision_error():
-    """When both list_installed_models and VISION_CATALOG fail."""
-    from lilbee.cli.tui.app import LilbeeApp
-
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from lilbee.cli.tui.commands import LilbeeCommandProvider
-
-        provider = LilbeeCommandProvider(app.screen, match_style=None)
-        with (
-            patch("lilbee.models.list_installed_models", side_effect=Exception("fail")),
-            patch("lilbee.models.VISION_CATALOG", side_effect=Exception("fail")),
-        ):
-            cmds = provider._model_commands()
-            # Both failed, should return empty or partial
-            assert isinstance(cmds, list)
+            assert cmds == []
 
 
 async def test_command_provider_document_commands(mock_svc):
@@ -2836,52 +2774,6 @@ def test_check_embedding_model_not_found():
         # Would call self.app.call_from_thread(self._show_setup_modal, remote_embeds)
 
 
-async def test_command_provider_vision_catalog_error():
-    """Cover the except block when VISION_CATALOG import fails (lines 91-92)."""
-    from lilbee.cli.tui.app import LilbeeApp
-
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from lilbee.cli.tui.commands import LilbeeCommandProvider
-
-        provider = LilbeeCommandProvider(app.screen, match_style=None)
-        with (
-            patch("lilbee.models.list_installed_models", return_value=[]),
-            patch.dict(
-                "sys.modules",
-                {
-                    "lilbee.models": MagicMock(
-                        list_installed_models=MagicMock(return_value=[]),
-                        VISION_CATALOG=property(lambda s: (_ for _ in ()).throw(Exception("fail"))),
-                    )
-                },
-            ),
-        ):
-            # VISION_CATALOG is accessed via import; take a different approach
-            pass
-
-    # Simpler approach: patch at the point of import inside _model_commands
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        from lilbee.cli.tui.commands import LilbeeCommandProvider
-
-        provider = LilbeeCommandProvider(app.screen, match_style=None)
-
-        # Make list_installed_models succeed but VISION_CATALOG raise
-        import lilbee.models as models_mod
-
-        original_vision = models_mod.VISION_CATALOG
-        try:
-            # Temporarily replace VISION_CATALOG with something that raises on iteration
-            models_mod.VISION_CATALOG = property(lambda s: 1 / 0)  # type: ignore[assignment]
-            with patch("lilbee.models.list_installed_models", return_value=["m1"]):
-                cmds = provider._model_commands()
-                # Should have model commands but no vision commands
-                assert any("m1" in c[0] for c in cmds)
-        finally:
-            models_mod.VISION_CATALOG = original_vision  # type: ignore[assignment]
-
-
 async def test_chat_slash_crawl_unavailable():
     """_cmd_crawl notifies when crawler is not installed."""
     app = ChatTestApp()
@@ -3451,7 +3343,6 @@ async def test_chat_escape_key_enters_normal_mode():
     """Escape key enters normal mode and focuses chat log."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         from textual.containers import VerticalScroll
@@ -3474,7 +3365,6 @@ async def test_chat_history_next_skips_in_normal_mode():
 
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         app.screen.action_enter_normal_mode()
@@ -3489,7 +3379,6 @@ async def test_chat_history_prev_skips_in_normal_mode():
 
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         app.screen.action_enter_normal_mode()
@@ -3502,7 +3391,6 @@ async def test_chat_enter_key_returns_to_insert_mode():
     """Enter key returns to insert mode from normal mode."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         from textual.widgets import Input
@@ -3522,7 +3410,6 @@ async def test_app_nav_prev_cycles_views():
     """App-level h/left binding cycles to previous view."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     from lilbee.cli.tui.app import LilbeeApp
 
     app = LilbeeApp()
@@ -3543,7 +3430,6 @@ async def test_app_nav_next_cycles_views():
     """App-level l/right binding cycles to next view."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     from lilbee.cli.tui.app import LilbeeApp
 
     app = LilbeeApp()
@@ -3564,7 +3450,6 @@ async def test_app_nav_switches_all_views():
     """Nav prev/next cycles through all 5 views including Tasks."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     from lilbee.cli.tui.app import LilbeeApp
 
     app = LilbeeApp()
@@ -3953,7 +3838,6 @@ async def test_chat_mode_indicator_shows_normal():
     """ViewTabs shows NORMAL when entering normal mode."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         from lilbee.cli.tui import messages as msg
@@ -3969,7 +3853,6 @@ async def test_chat_mode_indicator_shows_insert():
     """ViewTabs shows INSERT when returning to insert mode."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         from lilbee.cli.tui import messages as msg
@@ -3989,7 +3872,6 @@ async def test_chat_up_down_skip_in_normal_mode():
 
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         app.screen.action_enter_normal_mode()
@@ -4004,7 +3886,6 @@ async def test_chat_vim_scroll_in_normal_mode():
     """j/k scroll the chat log in normal mode."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         app.screen.action_enter_normal_mode()
@@ -4018,7 +3899,6 @@ async def test_chat_up_arrow_insert_mode_recalls_history():
     """Up arrow in insert mode still recalls input history."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         from textual.widgets import Input
@@ -4159,7 +4039,6 @@ async def test_chat_screen_has_status_line():
     """ChatScreen compose includes a ChatStatusLine widget."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
@@ -4173,7 +4052,6 @@ async def test_chat_screen_has_prompt_area():
     """ChatScreen compose wraps input in a PromptArea container."""
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
@@ -4187,7 +4065,6 @@ async def test_chat_refresh_status_line():
     """_refresh_status_line sets the model name on the status widget."""
     cfg.chat_model = "my-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2673,7 +2673,7 @@ class TestModelBarCfgSourceOfTruth:
     def mock_classify(self):
         with mock.patch(
             "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
-            return_value=([], [], []),
+            return_value=([], []),
         ):
             yield
 
@@ -2685,7 +2685,6 @@ class TestModelBarCfgSourceOfTruth:
 
         cfg.chat_model = "mistral:latest"
         cfg.embedding_model = "nomic:latest"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2698,7 +2697,6 @@ class TestModelBarCfgSourceOfTruth:
                     ModelOption("smollm2:135m", "smollm2:135m"),
                 ],
                 [ModelOption("nomic:latest", "nomic:latest")],
-                [],
             )
             await pilot.pause()
             assert chat_sel.value == "mistral:latest"
@@ -2711,7 +2709,6 @@ class TestModelBarCfgSourceOfTruth:
                     ModelOption("smollm2:135m", "smollm2:135m"),
                 ],
                 [ModelOption("nomic:latest", "nomic:latest")],
-                [],
             )
             await pilot.pause()
             assert chat_sel.value == "smollm2:135m"
@@ -2724,7 +2721,6 @@ class TestModelBarCfgSourceOfTruth:
 
         cfg.chat_model = "qwen3:8b"
         cfg.embedding_model = "nomic:latest"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2737,7 +2733,6 @@ class TestModelBarCfgSourceOfTruth:
                     ModelOption("nomic:latest", "nomic:latest"),
                     ModelOption("bge-small:latest", "bge-small:latest"),
                 ],
-                [],
             )
             await pilot.pause()
             assert embed_sel.value == "nomic:latest"
@@ -2749,48 +2744,9 @@ class TestModelBarCfgSourceOfTruth:
                     ModelOption("nomic:latest", "nomic:latest"),
                     ModelOption("bge-small:latest", "bge-small:latest"),
                 ],
-                [],
             )
             await pilot.pause()
             assert embed_sel.value == "bge-small:latest"
-
-    async def test_refresh_follows_cfg_vision_model_change(self) -> None:
-        """Vision dropdown also snaps to cfg on refresh."""
-        from textual.widgets import Select
-
-        from lilbee.cli.tui.widgets.model_bar import ModelBar
-
-        cfg.chat_model = "qwen3:8b"
-        cfg.embedding_model = "nomic:latest"
-        cfg.vision_model = "llava:7b"
-        app = _ModelBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(ModelBar)
-            vision_sel = app.query_one("#vision-model-select", Select)
-
-            bar._populate(
-                [ModelOption("qwen3:8b", "qwen3:8b")],
-                [ModelOption("nomic:latest", "nomic:latest")],
-                [
-                    ModelOption("llava:7b", "llava:7b"),
-                    ModelOption("moondream:latest", "moondream:latest"),
-                ],
-            )
-            await pilot.pause()
-            assert vision_sel.value == "llava:7b"
-
-            cfg.vision_model = "moondream:latest"
-            bar._populate(
-                [ModelOption("qwen3:8b", "qwen3:8b")],
-                [ModelOption("nomic:latest", "nomic:latest")],
-                [
-                    ModelOption("llava:7b", "llava:7b"),
-                    ModelOption("moondream:latest", "moondream:latest"),
-                ],
-            )
-            await pilot.pause()
-            assert vision_sel.value == "moondream:latest"
 
     async def test_manual_user_pick_writes_cfg_and_survives_refresh(self) -> None:
         """A real user pick flows through Select.Changed -> cfg, so refresh keeps it."""
@@ -2800,7 +2756,6 @@ class TestModelBarCfgSourceOfTruth:
 
         cfg.chat_model = "mistral:latest"
         cfg.embedding_model = "nomic:latest"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2813,7 +2768,6 @@ class TestModelBarCfgSourceOfTruth:
                     ModelOption("smollm2:135m", "smollm2:135m"),
                 ],
                 [ModelOption("nomic:latest", "nomic:latest")],
-                [],
             )
             await pilot.pause()
             assert chat_sel.value == "mistral:latest"
@@ -2833,7 +2787,6 @@ class TestModelBarCfgSourceOfTruth:
                     ModelOption("smollm2:135m", "smollm2:135m"),
                 ],
                 [ModelOption("nomic:latest", "nomic:latest")],
-                [],
             )
             await pilot.pause()
             assert chat_sel.value == "smollm2:135m"
@@ -2846,7 +2799,6 @@ class TestModelBarCfgSourceOfTruth:
 
         cfg.chat_model = "qwen3:8b"
         cfg.embedding_model = "nomic:latest"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2870,7 +2822,6 @@ class TestModelBarCfgSourceOfTruth:
 
         cfg.chat_model = "smollm2:135m"
         cfg.embedding_model = "nomic:latest"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2884,7 +2835,6 @@ class TestModelBarCfgSourceOfTruth:
                     ModelOption("llama3:8b", "llama3:8b"),
                 ],
                 [ModelOption("nomic:latest", "nomic:latest")],
-                [],
             )
             await pilot.pause()
             assert chat_sel.value == "smollm2:135m"

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -24,7 +24,6 @@ def _isolated_cfg(tmp_path):
     cfg.documents_dir = tmp_path / "documents"
     cfg.chat_model = "test-model"
     cfg.embedding_model = "test-embed"
-    cfg.vision_model = ""
     yield
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))
@@ -329,7 +328,7 @@ class _ModelBarApp(App):
 class TestModelBar:
     @pytest.fixture(autouse=True)
     def mock_classify(self):
-        empty = ([], [], [])
+        empty = ([], [])
         with mock.patch(
             "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
             return_value=empty,
@@ -341,73 +340,36 @@ class TestModelBar:
 
         cfg.chat_model = "qwen3:8b"
         cfg.embedding_model = "nomic"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             selects = list(app.query(Select))
-            assert len(selects) == 3
+            assert len(selects) == 2
 
-    async def test_widget_exists_with_3_selects(self) -> None:
+    async def test_widget_exists_with_2_selects(self) -> None:
         from textual.widgets import Select
 
         cfg.chat_model = "qwen3:8b"
         cfg.embedding_model = "nomic"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             chat_sel = app.query_one("#chat-model-select", Select)
             embed_sel = app.query_one("#embed-model-select", Select)
-            vision_sel = app.query_one("#vision-model-select", Select)
             assert chat_sel is not None
             assert embed_sel is not None
-            assert vision_sel is not None
-
-    async def test_vision_set_when_configured(self) -> None:
-        from unittest.mock import patch
-
-        from textual.widgets import Select
-
-        cfg.vision_model = "llava"
-        app = _ModelBarApp()
-        with patch(
-            "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
-            return_value=(
-                [ModelOption("qwen3:8b", "qwen3:8b")],
-                [ModelOption("nomic", "nomic")],
-                [ModelOption("llava", "llava")],
-            ),
-        ):
-            async with app.run_test() as pilot:
-                await pilot.pause()
-                vision_sel = app.query_one("#vision-model-select", Select)
-                assert vision_sel.value == "llava"
-
-    async def test_vision_model_not_in_scan_still_selectable(self) -> None:
-        """Configured vision model is prepended even if not in scanned list."""
-        from textual.widgets import Select
-
-        cfg.vision_model = "nonexistent-model:latest"
-        app = _ModelBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            vision_sel = app.query_one("#vision-model-select", Select)
-            assert vision_sel.value == "nonexistent-model:latest"
 
     async def test_labels_rendered(self) -> None:
         from textual.widgets import Label
 
         cfg.chat_model = "qwen3:8b"
         cfg.embedding_model = "nomic"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             labels = [str(lbl.render()) for lbl in app.query(Label)]
             assert "Chat:" in labels
             assert "Embed:" in labels
-            assert "Vision:" in labels
 
 
 class TestIsMmproj:
@@ -474,14 +436,12 @@ class TestClassifyInstalledModels:
                 embed_manifest,
                 vision_manifest,
             ]
-            chat, embed, vision = _classify_installed_models()
+            chat, embed = _classify_installed_models()
 
         chat_refs = [ref for _, ref in chat]
         embed_refs = [ref for _, ref in embed]
-        vision_refs = [ref for _, ref in vision]
         assert "qwen3:8b" in chat_refs
         assert "nomic-embed-text:latest" in embed_refs
-        assert "llava:latest" in vision_refs
 
     def test_mmproj_filtered_from_all_sources(self, tmp_path) -> None:
         from lilbee.cli.tui.widgets.model_bar import _classify_installed_models
@@ -516,9 +476,9 @@ class TestClassifyInstalledModels:
             ),
         ):
             MockRegistry.return_value.list_installed.return_value = [mmproj_manifest]
-            chat, embed, vision = _classify_installed_models()
+            chat, embed = _classify_installed_models()
 
-        all_refs = [ref for _, ref in chat + embed + vision]
+        all_refs = [ref for _, ref in chat + embed]
         assert not any("mmproj" in r.lower() for r in all_refs)
 
     def test_remote_models_classified(self, tmp_path) -> None:
@@ -548,7 +508,7 @@ class TestClassifyInstalledModels:
             ),
         ):
             MockRegistry.return_value.list_installed.return_value = []
-            chat, embed, _vision = _classify_installed_models()
+            chat, embed = _classify_installed_models()
 
         chat_refs = [ref for _, ref in chat]
         embed_refs = [ref for _, ref in embed]
@@ -569,11 +529,10 @@ class TestClassifyInstalledModels:
             ),
         ):
             MockRegistry.return_value.list_installed.return_value = []
-            chat, embed, vision = _classify_installed_models()
+            chat, embed = _classify_installed_models()
 
         assert chat == []
         assert embed == []
-        assert vision == []
 
 
 class TestSlashSuggester:
@@ -625,16 +584,6 @@ class TestSlashSuggester:
         r = await s.get_suggestion("/model qw")
         assert r is not None
         assert "qwen3:8b" in r
-
-    @mock.patch("lilbee.cli.tui.widgets.suggester.SlashSuggester._get_vision_names")
-    async def test_suggest_vision_arg(self, mock_names: mock.MagicMock) -> None:
-        from lilbee.cli.tui.widgets.suggester import SlashSuggester
-
-        mock_names.return_value = ["off", "llava:latest"]
-        s = SlashSuggester(use_cache=False)
-        r = await s.get_suggestion("/vision ll")
-        assert r is not None
-        assert "llava:latest" in r
 
     async def test_suggest_set_arg(self) -> None:
         from lilbee.cli.tui.widgets.suggester import SlashSuggester
@@ -695,30 +644,6 @@ class TestSlashSuggester:
         # Direct call with mock
         with mock.patch("lilbee.models.list_installed_models", side_effect=Exception("err")):
             assert s._get_model_names() == []
-
-    def test_get_vision_names_error(self) -> None:
-        from lilbee.cli.tui.widgets.suggester import SlashSuggester
-
-        s = SlashSuggester(use_cache=False)
-        with mock.patch("lilbee.cli.tui.widgets.suggester.SlashSuggester._get_vision_names") as m:
-            m.return_value = ["off"]
-            r = s._get_vision_names()
-            assert "off" in r
-
-    def test_get_vision_names_iteration_error(self) -> None:
-        """Cover the except branch in _get_vision_names (lines 87-88)."""
-        from lilbee.cli.tui.widgets.suggester import SlashSuggester
-
-        s = SlashSuggester(use_cache=False)
-
-        # Make VISION_CATALOG iteration explode
-        class BrokenIter:
-            def __iter__(self):
-                raise RuntimeError("boom")
-
-        with mock.patch("lilbee.models.VISION_CATALOG", BrokenIter()):
-            r = s._get_vision_names()
-        assert r == ["off"]
 
     def test_get_document_names_error(self) -> None:
         from lilbee.cli.tui.widgets.suggester import SlashSuggester
@@ -798,42 +723,6 @@ class TestModelOptions:
 
         with mock.patch("lilbee.models.list_installed_models", side_effect=Exception("err")):
             assert _model_options() == []
-
-
-class TestVisionOptions:
-    def test_returns_off_plus_catalog(self) -> None:
-        from lilbee.cli.tui.widgets.autocomplete import _vision_options
-        from lilbee.models import ModelInfo
-
-        fake_catalog = (
-            ModelInfo(
-                ref="llava:latest",
-                display_name="LLaVA",
-                size_gb=5.5,
-                min_ram_gb=8,
-                description="test",
-            ),
-        )
-        with mock.patch("lilbee.models.VISION_CATALOG", fake_catalog):
-            r = _vision_options()
-            assert r[0] == "off"
-            assert "llava" in r
-
-    def test_returns_off_on_error(self) -> None:
-        import builtins
-
-        from lilbee.cli.tui.widgets.autocomplete import _vision_options
-
-        real_import = builtins.__import__
-
-        def bad_import(name, *args, **kwargs):
-            if name == "lilbee.models":
-                raise ImportError("mocked")
-            return real_import(name, *args, **kwargs)
-
-        with mock.patch("builtins.__import__", side_effect=bad_import):
-            r = _vision_options()
-        assert r == ["off"]
 
 
 class TestSettingOptions:
@@ -1552,7 +1441,6 @@ class TestLilbeeAppViewTabs:
     async def test_screen_composes_status_bar(self) -> None:
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.screens.chat import ChatScreen
         from lilbee.cli.tui.widgets.status_bar import ViewTabs
@@ -1569,7 +1457,6 @@ class TestLilbeeAppViewTabs:
     async def test_status_bar_default_is_chat(self) -> None:
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.screens.chat import ChatScreen
         from lilbee.cli.tui.widgets.status_bar import ViewTabs
@@ -2049,7 +1936,7 @@ class TestModelCardSelected:
 class TestModelBarAdditional:
     @pytest.fixture(autouse=True)
     def mock_classify(self):
-        empty = ([], [], [])
+        empty = ([], [])
         with mock.patch(
             "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
             return_value=empty,
@@ -2062,7 +1949,6 @@ class TestModelBarAdditional:
 
         cfg.chat_model = "qwen3:8b"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2070,7 +1956,6 @@ class TestModelBarAdditional:
             bar._populate(
                 [ModelOption("Qwen3 8B", "qwen3:8b"), ModelOption("Llama 7B", "llama:7b")],
                 [ModelOption("test-embed", "test-embed")],
-                [],
             )
             await pilot.pause()
             from textual.widgets import Select
@@ -2083,69 +1968,23 @@ class TestModelBarAdditional:
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             bar = app.query_one(ModelBar)
             # Populate with empty lists — falls back to configured default
-            bar._populate([], [], [])
+            bar._populate([], [])
             await pilot.pause()
             from textual.widgets import Select
 
             chat_sel = app.query_one("#chat-model-select", Select)
             assert chat_sel.value == "test-model"
 
-    async def test_populate_vision_model_fallback(self) -> None:
-        """Vision model in config but not in scan results → prepended and selected."""
-        from lilbee.cli.tui.widgets.model_bar import ModelBar
-
-        cfg.chat_model = "test-model"
-        cfg.embedding_model = "test-embed"
-        cfg.vision_model = "llava:custom"
-        app = _ModelBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(ModelBar)
-            # vision model configured but not in scanned list
-            bar._populate(
-                [ModelOption("test-model", "test-model")],
-                [ModelOption("test-embed", "test-embed")],
-                [ModelOption("Llava 7B", "llava:7b")],
-            )
-            await pilot.pause()
-            from textual.widgets import Select
-
-            vision_sel = app.query_one("#vision-model-select", Select)
-            assert vision_sel.value == "llava:custom"
-
-    async def test_populate_vision_model_not_in_list_or_config(self) -> None:
-        from lilbee.cli.tui.widgets.model_bar import _DISABLED, ModelBar
-
-        cfg.chat_model = "test-model"
-        cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
-        app = _ModelBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(ModelBar)
-            bar._populate(
-                [ModelOption("test-model", "test-model")],
-                [ModelOption("test-embed", "test-embed")],
-                [],
-            )
-            await pilot.pause()
-            from textual.widgets import Select
-
-            vision_sel = app.query_one("#vision-model-select", Select)
-            assert vision_sel.value is _DISABLED
-
     async def test_on_embed_model_changed(self) -> None:
         from lilbee.cli.tui.widgets.model_bar import ModelBar
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2168,7 +2007,6 @@ class TestModelBarAdditional:
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "nomic:latest"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2176,7 +2014,6 @@ class TestModelBarAdditional:
             bar._populate(
                 [ModelOption("test-model", "test-model")],
                 [ModelOption("Nomic Embed Text", "nomic:latest")],
-                [],
             )
             await pilot.pause()
             from textual.widgets import Select
@@ -2632,7 +2469,7 @@ class TestModelCardBuildStatusDownloads:
 class TestModelBarPopulateBranches:
     @pytest.fixture(autouse=True)
     def mock_classify(self):
-        empty = ([], [], [])
+        empty = ([], [])
         with mock.patch(
             "lilbee.cli.tui.widgets.model_bar._classify_installed_models",
             return_value=empty,
@@ -2645,7 +2482,6 @@ class TestModelBarPopulateBranches:
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2653,7 +2489,6 @@ class TestModelBarPopulateBranches:
             bar._populate(
                 [ModelOption("test-model", "test-model"), ModelOption("other", "other")],
                 [ModelOption("test-embed", "test-embed"), ModelOption("nomic", "nomic")],
-                [ModelOption("Llava 7B", "llava:7b")],
             )
             await pilot.pause()
             from textual.widgets import Select
@@ -2669,61 +2504,16 @@ class TestModelBarPopulateBranches:
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             bar = app.query_one(ModelBar)
-            bar._populate([], [], [])
+            bar._populate([], [])
             await pilot.pause()
             from textual.widgets import Select
 
             chat_sel = app.query_one("#chat-model-select", Select)
             assert chat_sel.value == "test-model"
-
-    async def test_populate_vision_from_cfg_fallback(self) -> None:
-        """Vision from cfg when not in scan → prepended and selected."""
-        from lilbee.cli.tui.widgets.model_bar import ModelBar
-
-        cfg.chat_model = "test-model"
-        cfg.embedding_model = "test-embed"
-        cfg.vision_model = "llava:custom"
-        app = _ModelBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(ModelBar)
-            bar._populate(
-                [ModelOption("test-model", "test-model")],
-                [ModelOption("test-embed", "test-embed")],
-                [],
-            )
-            await pilot.pause()
-            from textual.widgets import Select
-
-            vision_sel = app.query_one("#vision-model-select", Select)
-            assert vision_sel.value == "llava:custom"
-
-    async def test_populate_vision_in_scanned_list(self) -> None:
-        """Vision model in scanned list gets selected."""
-        from lilbee.cli.tui.widgets.model_bar import ModelBar
-
-        cfg.chat_model = "test-model"
-        cfg.embedding_model = "test-embed"
-        cfg.vision_model = "llava:7b"
-        app = _ModelBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(ModelBar)
-            bar._populate(
-                [ModelOption("test-model", "test-model")],
-                [ModelOption("test-embed", "test-embed")],
-                [ModelOption("Llava 7B", "llava:7b"), ModelOption("Moondream", "moondream:latest")],
-            )
-            await pilot.pause()
-            from textual.widgets import Select
-
-            vision_sel = app.query_one("#vision-model-select", Select)
-            assert vision_sel.value == "llava:7b"
 
     async def test_populate_retains_matching_value(self) -> None:
         """When current value matches a scanned model, it's preserved."""
@@ -2731,7 +2521,6 @@ class TestModelBarPopulateBranches:
 
         cfg.chat_model = "qwen3:8b"
         cfg.embedding_model = "nomic:latest"
-        cfg.vision_model = "llava:7b"
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2740,17 +2529,14 @@ class TestModelBarPopulateBranches:
 
             chat_sel = app.query_one("#chat-model-select", Select)
             embed_sel = app.query_one("#embed-model-select", Select)
-            vision_sel = app.query_one("#vision-model-select", Select)
 
             bar._populate(
                 [ModelOption("Qwen3 8B", "qwen3:8b"), ModelOption("Llama 7B", "llama:7b")],
                 [ModelOption("Nomic Embed Text", "nomic:latest")],
-                [ModelOption("Llava 7B", "llava:7b")],
             )
             await pilot.pause()
             assert chat_sel.value == "qwen3:8b"
             assert embed_sel.value == "nomic:latest"
-            assert vision_sel.value == "llava:7b"
 
     async def test_populate_blank_value_uses_config_default(self) -> None:
         """When Select has no value, falls back to configured default from cfg.
@@ -2761,7 +2547,6 @@ class TestModelBarPopulateBranches:
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2793,7 +2578,6 @@ class TestModelBarPopulateBranches:
             bar._populate(
                 [ModelOption("Qwen3 8B", "qwen3:8b")],
                 [ModelOption("Nomic Embed Text", "nomic:latest")],
-                [],
             )
             await pilot.pause()
             # Falls back to cfg.chat_model / cfg.embedding_model, not models[0]
@@ -2806,7 +2590,6 @@ class TestModelBarPopulateBranches:
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2822,7 +2605,6 @@ class TestModelBarPopulateBranches:
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2849,7 +2631,6 @@ class TestModelBarPopulateBranches:
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2865,7 +2646,6 @@ class TestModelBarPopulateBranches:
 
         cfg.chat_model = "test-model"
         cfg.embedding_model = "test-embed"
-        cfg.vision_model = ""
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()

--- a/tests/test_worker_process.py
+++ b/tests/test_worker_process.py
@@ -47,7 +47,7 @@ def config_snap(tmp_path: Path) -> ConfigSnapshot:
         embedding_dim=768,
         num_ctx=None,
         gpu_memory_fraction=0.75,
-        vision_model="test-vision",
+        ocr_model="test-vision",
     )
 
 


### PR DESCRIPTION
Vision models and chat models are no longer separate concepts. Pick a chat model; if it supports vision, OCR just works.

New `enable_ocr` setting (auto/on/off) replaces the old vision model selector everywhere: config, CLI, TUI, MCP, REST API. Graceful fallback when OCR is forced on a model that can't handle it.