### PR TITLE
fix: validate model exists before accepting PUT /api/models/chat

### DIFF
--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -469,20 +469,27 @@ async def _set_model(
     return SetModelResponse(model=model)
 
 
-async def set_chat_model(model: str) -> SetModelResponse:
-    """Switch active chat model. Validates the model exists before accepting."""
+def _require_model_available(model: str) -> str:
+    """Validate that *model* exists locally. Returns the normalized name or raises ValueError."""
     from lilbee.models import ensure_tag
 
     normalized = ensure_tag(model)
     available = get_services().provider.list_models()
     if normalized not in available:
         raise ValueError(f"Model '{normalized}' is not available. Pull it first or check the name.")
-    return await _set_model("chat_model", model, normalize=True)
+    return normalized
+
+
+async def set_chat_model(model: str) -> SetModelResponse:
+    """Switch active chat model. Validates the model exists before accepting."""
+    normalized = _require_model_available(model)
+    return await _set_model("chat_model", normalized, normalize=False)
 
 
 async def set_embedding_model(model: str) -> SetModelResponse:
-    """Switch embedding model."""
-    return await _set_model("embedding_model", model)
+    """Switch embedding model. Validates the model exists before accepting."""
+    normalized = _require_model_available(model)
+    return await _set_model("embedding_model", normalized, normalize=False)
 
 
 def _validate_config_updates(updates: dict[str, Any]) -> None:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -470,7 +470,13 @@ async def _set_model(
 
 
 async def set_chat_model(model: str) -> SetModelResponse:
-    """Switch active chat model."""
+    """Switch active chat model. Validates the model exists before accepting."""
+    from lilbee.models import ensure_tag
+
+    normalized = ensure_tag(model)
+    available = get_services().provider.list_models()
+    if normalized not in available:
+        raise ValueError(f"Model '{normalized}' is not available. Pull it first or check the name.")
     return await _set_model("chat_model", model, normalize=True)
 
 

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from litestar import delete, get, post, put
+from litestar.exceptions import HTTPException
 from litestar.params import Parameter
 from litestar.response import Stream
 from pydantic import BaseModel
@@ -45,7 +46,10 @@ async def models_external_route() -> ExternalModelsResponse:
 @put("/api/models/chat")
 async def models_set_chat_route(data: SetModelRequest) -> SetModelResponse:
     """Switch the active chat model used for RAG answers."""
-    return await handlers.set_chat_model(model=data.model)
+    try:
+        return await handlers.set_chat_model(model=data.model)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @put("/api/models/embedding")

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -55,7 +55,10 @@ async def models_set_chat_route(data: SetModelRequest) -> SetModelResponse:
 @put("/api/models/embedding")
 async def models_set_embedding_route(data: SetModelRequest) -> SetModelResponse:
     """Switch the active embedding model."""
-    return await handlers.set_embedding_model(model=data.model)
+    try:
+        return await handlers.set_embedding_model(model=data.model)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @get("/api/models/catalog")

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -496,15 +496,22 @@ class TestListModels:
 
 
 class TestSetChatModel:
-    async def test_updates_config_and_persists(self, tmp_path):
+    async def test_updates_config_and_persists(self, tmp_path, mock_svc):
+        mock_svc.provider.list_models.return_value = ["llama3:latest"]
         result = await handlers.set_chat_model("llama3")
         assert result.model == "llama3:latest"
         assert cfg.chat_model == "llama3:latest"
 
-    async def test_preserves_existing_tag(self, tmp_path):
+    async def test_preserves_existing_tag(self, tmp_path, mock_svc):
+        mock_svc.provider.list_models.return_value = ["llama3:7b"]
         result = await handlers.set_chat_model("llama3:7b")
         assert result.model == "llama3:7b"
         assert cfg.chat_model == "llama3:7b"
+
+    async def test_rejects_unavailable_model(self, tmp_path, mock_svc):
+        mock_svc.provider.list_models.return_value = ["llama3:latest"]
+        with pytest.raises(ValueError, match="not available"):
+            await handlers.set_chat_model("nonexistent:7b")
 
 
 class TestModelsCatalog:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -827,7 +827,9 @@ class TestUpdateConfig:
 
 
 class TestSetEmbeddingModel:
-    async def test_updates_config_and_persists(self, tmp_path):
+    @patch("lilbee.server.handlers.get_services")
+    async def test_updates_config_and_persists(self, mock_svc, tmp_path):
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:latest"]
         result = await handlers.set_embedding_model("nomic-embed-text:latest")
         assert result.model == "nomic-embed-text:latest"
         assert cfg.embedding_model == "nomic-embed-text:latest"
@@ -836,17 +838,25 @@ class TestSetEmbeddingModel:
         stored = s.load(cfg.data_root)
         assert stored["embedding_model"] == "nomic-embed-text:latest"
 
-    async def test_empty_string_rejected(self):
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
+    @patch("lilbee.server.handlers.get_services")
+    async def test_empty_string_rejected(self, mock_svc):
+        mock_svc.return_value.provider.list_models.return_value = []
+        with pytest.raises(ValueError, match="not available"):
             await handlers.set_embedding_model("")
 
-    async def test_embedding_model_without_tag(self, tmp_path):
-        """Setting embedding model without a tag stores it as-is (no :latest append)."""
+    @patch("lilbee.server.handlers.get_services")
+    async def test_embedding_model_without_tag_normalizes(self, mock_svc, tmp_path):
+        """Setting embedding model without a tag normalizes to :latest."""
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:latest"]
         result = await handlers.set_embedding_model("nomic-embed-text")
-        assert result.model == "nomic-embed-text"
-        assert cfg.embedding_model == "nomic-embed-text"
+        assert result.model == "nomic-embed-text:latest"
+        assert cfg.embedding_model == "nomic-embed-text:latest"
+
+    @patch("lilbee.server.handlers.get_services")
+    async def test_rejects_unavailable_embedding_model(self, mock_svc):
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:latest"]
+        with pytest.raises(ValueError, match="not available"):
+            await handlers.set_embedding_model("bogus-embed")
 
 
 class TestGetConfig:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -244,6 +244,19 @@ class TestModelsSetChatRoute:
     def test_returns_422_for_unavailable_model(self, mock_set, client):
         resp = client.put("/api/models/chat", json={"model": "bogus"})
         assert resp.status_code == 422
+        assert "not available" in resp.json()["detail"]
+
+
+class TestSetEmbeddingModelRoute:
+    @mock.patch(
+        "lilbee.server.handlers.set_embedding_model",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Model 'bogus:latest' is not available."),
+    )
+    def test_returns_422_for_unavailable_embedding(self, mock_set, client):
+        resp = client.put("/api/models/embedding", json={"model": "bogus"})
+        assert resp.status_code == 422
+        assert "not available" in resp.json()["detail"]
 
 
 class TestModelsCatalogRoute:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -236,6 +236,15 @@ class TestModelsSetChatRoute:
         assert resp.status_code == 200
         assert resp.json()["model"] == "llama3:8b"
 
+    @mock.patch(
+        "lilbee.server.handlers.set_chat_model",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Model 'bogus:latest' is not available."),
+    )
+    def test_returns_422_for_unavailable_model(self, mock_set, client):
+        resp = client.put("/api/models/chat", json={"model": "bogus"})
+        assert resp.status_code == 422
+
 
 class TestModelsCatalogRoute:
     @mock.patch(


### PR DESCRIPTION
The server accepted any model name on PUT /api/models/chat without verifying it was actually pulled. When the user then chatted, litellm raised 'model not found' which crashed the SSE stream mid-response. Now validates against the provider's model list and returns 422 if the model isn't available.