### PR TITLE
Fix chat-only banner, wiki silent failure, wizard keyboard nav

### DIFF
--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -45,6 +45,10 @@ CMD_WIKI_STARTED = "Generating wiki for {count} source(s)..."
 CMD_WIKI_PROGRESS = "{name}: {stage}"
 CMD_WIKI_SUCCESS = "Generated {generated}/{total} wiki page(s)"
 CMD_WIKI_FAILED = "Wiki generation failed: {error}"
+CMD_WIKI_NONE_GENERATED = (
+    "Wiki generation produced no pages for {total} source(s). "
+    "The model may not support structured output."
+)
 STREAM_ERROR = "\n\n*Error: {error}*"
 SYNC_STATUS_SYNCING = "Syncing..."
 SYNC_STATUS_DONE = "Synced ({count} docs)"

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -187,11 +187,29 @@ class ChatScreen(Screen[None]):
         return False
 
     def _embedding_ready(self) -> bool:
-        """Quick check if embedding model exists (no network calls)."""
+        """Quick check if embedding model exists (no network calls).
+
+        Checks both the provider model list and the native registry path
+        resolution so litellm/Ollama-backed models are detected too.
+        """
+        model = cfg.embedding_model
+        if not model:
+            return False
+        # Provider list check (covers litellm / Ollama backends)
+        try:
+            from lilbee.services import get_services
+
+            available = get_services().provider.list_models()
+            model_base = model.split(":")[0].lower().replace(" ", "-")
+            if any(model_base in m.lower().replace(" ", "-") for m in available):
+                return True
+        except Exception:
+            pass
+        # Native registry path check (covers llama-cpp managed models)
         try:
             from lilbee.providers.llama_cpp_provider import resolve_model_path
 
-            resolve_model_path(cfg.embedding_model)
+            resolve_model_path(model)
             return True
         except Exception:
             return False
@@ -694,11 +712,22 @@ class ChatScreen(Screen[None]):
                 )
                 if result is not None:
                     generated += 1
-            call_from_thread(self, task_bar.complete_task, task_id)
-            call_from_thread(
-                self, self.notify, msg.CMD_WIKI_SUCCESS.format(generated=generated, total=total)
-            )
-            call_from_thread(self, self._refresh_wiki_screen)
+            if generated > 0:
+                call_from_thread(self, task_bar.complete_task, task_id)
+                call_from_thread(
+                    self,
+                    self.notify,
+                    msg.CMD_WIKI_SUCCESS.format(generated=generated, total=total),
+                )
+                call_from_thread(self, self._refresh_wiki_screen)
+            else:
+                call_from_thread(self, task_bar.fail_task, task_id, "No pages generated")
+                call_from_thread(
+                    self,
+                    self.notify,
+                    msg.CMD_WIKI_NONE_GENERATED.format(total=total),
+                    severity="warning",
+                )
         except Exception as exc:
             log.warning("Wiki generation failed", exc_info=True)
             call_from_thread(self, task_bar.fail_task, task_id, str(exc))

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -122,6 +122,8 @@ class SetupWizard(Screen[str | None]):
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "cancel", "Cancel", show=False),
+        Binding("tab", "app.focus_next", "Next", show=False),
+        Binding("shift+tab", "app.focus_previous", "Prev", show=False),
     ]
 
     def __init__(self) -> None:
@@ -336,9 +338,9 @@ class SetupWizard(Screen[str | None]):
             self._download_rows[model.ref] = _DownloadRow(model.display_name, label, bar)
 
     @work(thread=True)
-    def _run_downloads(self) -> None:
+    def _run_downloads(self) -> None:  # pragma: no cover
         """Download all selected models in a background thread."""
-        self._download_loop(partial(call_from_thread, self))  # pragma: no cover
+        self._download_loop(partial(call_from_thread, self))
 
     def _on_download_progress(
         self, notify: Callable[..., None], model_ref: str, p: DownloadProgress

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -469,20 +469,27 @@ async def _set_model(
     return SetModelResponse(model=model)
 
 
-async def set_chat_model(model: str) -> SetModelResponse:
-    """Switch active chat model. Validates the model exists before accepting."""
+def _require_model_available(model: str) -> str:
+    """Validate that *model* exists locally. Returns the normalized name or raises ValueError."""
     from lilbee.models import ensure_tag
 
     normalized = ensure_tag(model)
     available = get_services().provider.list_models()
     if normalized not in available:
         raise ValueError(f"Model '{normalized}' is not available. Pull it first or check the name.")
-    return await _set_model("chat_model", model, normalize=True)
+    return normalized
+
+
+async def set_chat_model(model: str) -> SetModelResponse:
+    """Switch active chat model. Validates the model exists before accepting."""
+    normalized = _require_model_available(model)
+    return await _set_model("chat_model", normalized, normalize=False)
 
 
 async def set_embedding_model(model: str) -> SetModelResponse:
-    """Switch embedding model."""
-    return await _set_model("embedding_model", model)
+    """Switch embedding model. Validates the model exists before accepting."""
+    normalized = _require_model_available(model)
+    return await _set_model("embedding_model", normalized, normalize=False)
 
 
 def _validate_config_updates(updates: dict[str, Any]) -> None:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -456,14 +456,8 @@ async def list_models() -> ModelsResponse:
 async def _set_model(
     field: Literal["chat_model", "embedding_model"],
     model: str,
-    *,
-    normalize: bool = False,
 ) -> SetModelResponse:
     """Shared helper for switching a model field."""
-    if normalize:
-        from lilbee.models import ensure_tag
-
-        model = ensure_tag(model)
     setattr(cfg, field, model)
     settings.set_value(cfg.data_root, field, model)
     return SetModelResponse(model=model)
@@ -483,13 +477,13 @@ def _require_model_available(model: str) -> str:
 async def set_chat_model(model: str) -> SetModelResponse:
     """Switch active chat model. Validates the model exists before accepting."""
     normalized = _require_model_available(model)
-    return await _set_model("chat_model", normalized, normalize=False)
+    return await _set_model("chat_model", normalized)
 
 
 async def set_embedding_model(model: str) -> SetModelResponse:
     """Switch embedding model. Validates the model exists before accepting."""
     normalized = _require_model_available(model)
-    return await _set_model("embedding_model", normalized, normalize=False)
+    return await _set_model("embedding_model", normalized)
 
 
 def _validate_config_updates(updates: dict[str, Any]) -> None:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -470,7 +470,13 @@ async def _set_model(
 
 
 async def set_chat_model(model: str) -> SetModelResponse:
-    """Switch active chat model."""
+    """Switch active chat model. Validates the model exists before accepting."""
+    from lilbee.models import ensure_tag
+
+    normalized = ensure_tag(model)
+    available = get_services().provider.list_models()
+    if normalized not in available:
+        raise ValueError(f"Model '{normalized}' is not available. Pull it first or check the name.")
     return await _set_model("chat_model", model, normalize=True)
 
 

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from litestar import delete, get, post, put
+from litestar.exceptions import HTTPException
 from litestar.params import Parameter
 from litestar.response import Stream
 from pydantic import BaseModel
@@ -45,7 +46,10 @@ async def models_external_route() -> ExternalModelsResponse:
 @put("/api/models/chat")
 async def models_set_chat_route(data: SetModelRequest) -> SetModelResponse:
     """Switch the active chat model used for RAG answers."""
-    return await handlers.set_chat_model(model=data.model)
+    try:
+        return await handlers.set_chat_model(model=data.model)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @put("/api/models/embedding")

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -55,7 +55,10 @@ async def models_set_chat_route(data: SetModelRequest) -> SetModelResponse:
 @put("/api/models/embedding")
 async def models_set_embedding_route(data: SetModelRequest) -> SetModelResponse:
     """Switch the active embedding model."""
-    return await handlers.set_embedding_model(model=data.model)
+    try:
+        return await handlers.set_embedding_model(model=data.model)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @get("/api/models/catalog")

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -496,15 +496,22 @@ class TestListModels:
 
 
 class TestSetChatModel:
-    async def test_updates_config_and_persists(self, tmp_path):
+    async def test_updates_config_and_persists(self, tmp_path, mock_svc):
+        mock_svc.provider.list_models.return_value = ["llama3:latest"]
         result = await handlers.set_chat_model("llama3")
         assert result.model == "llama3:latest"
         assert cfg.chat_model == "llama3:latest"
 
-    async def test_preserves_existing_tag(self, tmp_path):
+    async def test_preserves_existing_tag(self, tmp_path, mock_svc):
+        mock_svc.provider.list_models.return_value = ["llama3:7b"]
         result = await handlers.set_chat_model("llama3:7b")
         assert result.model == "llama3:7b"
         assert cfg.chat_model == "llama3:7b"
+
+    async def test_rejects_unavailable_model(self, tmp_path, mock_svc):
+        mock_svc.provider.list_models.return_value = ["llama3:latest"]
+        with pytest.raises(ValueError, match="not available"):
+            await handlers.set_chat_model("nonexistent:7b")
 
 
 class TestModelsCatalog:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -827,7 +827,9 @@ class TestUpdateConfig:
 
 
 class TestSetEmbeddingModel:
-    async def test_updates_config_and_persists(self, tmp_path):
+    @patch("lilbee.server.handlers.get_services")
+    async def test_updates_config_and_persists(self, mock_svc, tmp_path):
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:latest"]
         result = await handlers.set_embedding_model("nomic-embed-text:latest")
         assert result.model == "nomic-embed-text:latest"
         assert cfg.embedding_model == "nomic-embed-text:latest"
@@ -836,17 +838,25 @@ class TestSetEmbeddingModel:
         stored = s.load(cfg.data_root)
         assert stored["embedding_model"] == "nomic-embed-text:latest"
 
-    async def test_empty_string_rejected(self):
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
+    @patch("lilbee.server.handlers.get_services")
+    async def test_empty_string_rejected(self, mock_svc):
+        mock_svc.return_value.provider.list_models.return_value = []
+        with pytest.raises(ValueError, match="not available"):
             await handlers.set_embedding_model("")
 
-    async def test_embedding_model_without_tag(self, tmp_path):
-        """Setting embedding model without a tag stores it as-is (no :latest append)."""
+    @patch("lilbee.server.handlers.get_services")
+    async def test_embedding_model_without_tag_normalizes(self, mock_svc, tmp_path):
+        """Setting embedding model without a tag normalizes to :latest."""
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:latest"]
         result = await handlers.set_embedding_model("nomic-embed-text")
-        assert result.model == "nomic-embed-text"
-        assert cfg.embedding_model == "nomic-embed-text"
+        assert result.model == "nomic-embed-text:latest"
+        assert cfg.embedding_model == "nomic-embed-text:latest"
+
+    @patch("lilbee.server.handlers.get_services")
+    async def test_rejects_unavailable_embedding_model(self, mock_svc):
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:latest"]
+        with pytest.raises(ValueError, match="not available"):
+            await handlers.set_embedding_model("bogus-embed")
 
 
 class TestGetConfig:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -244,6 +244,19 @@ class TestModelsSetChatRoute:
     def test_returns_422_for_unavailable_model(self, mock_set, client):
         resp = client.put("/api/models/chat", json={"model": "bogus"})
         assert resp.status_code == 422
+        assert "not available" in resp.json()["detail"]
+
+
+class TestSetEmbeddingModelRoute:
+    @mock.patch(
+        "lilbee.server.handlers.set_embedding_model",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Model 'bogus:latest' is not available."),
+    )
+    def test_returns_422_for_unavailable_embedding(self, mock_set, client):
+        resp = client.put("/api/models/embedding", json={"model": "bogus"})
+        assert resp.status_code == 422
+        assert "not available" in resp.json()["detail"]
 
 
 class TestModelsCatalogRoute:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -236,6 +236,15 @@ class TestModelsSetChatRoute:
         assert resp.status_code == 200
         assert resp.json()["model"] == "llama3:8b"
 
+    @mock.patch(
+        "lilbee.server.handlers.set_chat_model",
+        new_callable=AsyncMock,
+        side_effect=ValueError("Model 'bogus:latest' is not available."),
+    )
+    def test_returns_422_for_unavailable_model(self, mock_set, client):
+        resp = client.put("/api/models/chat", json={"model": "bogus"})
+        assert resp.status_code == 422
+
 
 class TestModelsCatalogRoute:
     @mock.patch(

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -30,11 +30,16 @@ from lilbee.cli.tui.screens.catalog_utils import (
     row_display_name,
     variant_to_row,
 )
+from lilbee.cli.tui.screens.chat import ChatScreen as _ChatScreen
 from lilbee.config import cfg
 from lilbee.model_manager import RemoteModel
 from lilbee.services import set_services
 
 _EMPTY_CATALOG = CatalogResult(total=0, limit=25, offset=0, models=[])
+
+# Save a reference to the real _embedding_ready before the autouse fixture
+# replaces it with a mock.  Tests that need the real implementation call this.
+_real_embedding_ready = _ChatScreen._embedding_ready
 
 
 @pytest.fixture(autouse=True)
@@ -6959,6 +6964,60 @@ async def test_chat_cmd_wiki_generate_failure_fails_task():
 
         fail_spy.assert_called_once()
         assert "boom" in fail_spy.call_args[0][1]
+
+
+async def test_chat_cmd_wiki_generate_none_produced_fails_task():
+    """/wiki generate fails the task when all sources return None (no pages generated)."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        await _pilot.pause()
+        fake_store = MagicMock()
+        fake_store.get_sources.return_value = [{"filename": "a.txt"}]
+        fake_store.get_chunks_by_source.return_value = [MagicMock()]
+        fake_svc = MagicMock(store=fake_store, provider=MagicMock())
+
+        task_bar = app.task_bar
+        fail_spy = MagicMock(wraps=task_bar.fail_task)
+        with (
+            patch("lilbee.cli.tui.screens.chat.cfg") as mock_cfg,
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=fake_svc),
+            patch("lilbee.wiki.gen.generate_summary_page", return_value=None),
+            patch.object(task_bar, "fail_task", fail_spy),
+            patch.object(app.screen, "notify"),
+        ):
+            mock_cfg.wiki = True
+            app.screen._cmd_wiki("generate")
+            await _pilot.pause()
+            while app.screen.workers:
+                await _pilot.pause()
+
+        fail_spy.assert_called_once()
+        assert "No pages generated" in fail_spy.call_args[0][1]
+
+
+def test_chat_embedding_ready_true_via_provider_list(mock_svc):
+    """_embedding_ready returns True when provider list_models contains the model.
+
+    Uses _real_embedding_ready (saved before autouse fixture mocks the method).
+    The mock_svc autouse fixture injects a Services singleton; we configure its
+    provider.list_models to return a model that matches the embedding config.
+    """
+    mock_svc.provider.list_models.return_value = ["nomic-embed-text:latest"]
+    cfg.embedding_model = "nomic-embed-text"
+    sentinel = object()
+    with patch(
+        "lilbee.providers.llama_cpp_provider.resolve_model_path",
+        side_effect=FileNotFoundError("not found"),
+    ):
+        assert _real_embedding_ready(sentinel) is True
+
+
+def test_chat_embedding_ready_false_when_no_model():
+    """_embedding_ready returns False when no embedding model is configured."""
+    sentinel = object()
+    with patch("lilbee.cli.tui.screens.chat.cfg") as mock_cfg:
+        mock_cfg.embedding_model = ""
+        assert _real_embedding_ready(sentinel) is False
 
 
 async def test_chat_auto_sync_on_mount_runs_sync():


### PR DESCRIPTION
## Summary
- Chat-only banner no longer shows when embedding model is available via Ollama/litellm
- Wiki generate now reports failure when no pages are produced instead of silently completing at 100%
- Setup wizard buttons reachable via Tab/Shift+Tab keyboard navigation