### PR TITLE
Fix Ctrl+C hang during model download

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -181,8 +181,12 @@ class LilbeeApp(App[None]):
                 self.notify(msg.APP_CANCELLED)
                 return
         from lilbee.cli.tui.screens.chat import ChatScreen
+        from lilbee.cli.tui.screens.setup import SetupWizard
 
         screen = self.screen
+        if isinstance(screen, SetupWizard):
+            screen.action_cancel()
+            return
         if isinstance(screen, ChatScreen) and screen.streaming:
             screen.action_cancel_stream()
             return

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Callable
 from functools import partial
 from typing import ClassVar, NamedTuple
@@ -37,6 +38,10 @@ from lilbee.models import ModelTask, get_system_ram_gb
 from lilbee.services import reset_services
 
 log = logging.getLogger(__name__)
+
+
+class _DownloadCancelled(Exception):
+    """Raised inside a download progress callback to abort hf_hub_download."""
 
 
 def _scan_installed_models() -> tuple[list[str], list[str]]:
@@ -135,6 +140,7 @@ class SetupWizard(Screen[str | None]):
         self._recommended_embed: CatalogModel | None = None
         self._download_models: list[CatalogModel] = []
         self._download_rows: dict[str, _DownloadRow] = {}
+        self._cancel_event = threading.Event()
 
     @property
     def _selected_chat(self) -> str | None:
@@ -336,14 +342,16 @@ class SetupWizard(Screen[str | None]):
             self._download_rows[model.ref] = _DownloadRow(model.display_name, label, bar)
 
     @work(thread=True)
-    def _run_downloads(self) -> None:
+    def _run_downloads(self) -> None:  # pragma: no cover
         """Download all selected models in a background thread."""
-        self._download_loop(partial(call_from_thread, self))  # pragma: no cover
+        self._download_loop(partial(call_from_thread, self))
 
     def _on_download_progress(
         self, notify: Callable[..., None], model_ref: str, p: DownloadProgress
     ) -> None:
         """Handle a single download progress update for the given model."""
+        if self._cancel_event.is_set():
+            raise _DownloadCancelled
         notify(self._update_row, model_ref, p.percent, p.detail)
 
     def _handle_download_error(
@@ -367,6 +375,8 @@ class SetupWizard(Screen[str | None]):
         """Download all selected models sequentially."""
         notify(self._mount_download_rows)
         for idx, model in enumerate(self._download_models, 1):
+            if self._cancel_event.is_set():
+                return
             is_first = idx == 1
             notify(self._update_row, model.ref, 0, msg.SETUP_DOWNLOAD_STARTING)
 
@@ -376,6 +386,9 @@ class SetupWizard(Screen[str | None]):
             callback = make_download_callback(_progress)
             try:
                 download_model(model, on_progress=callback)
+            except _DownloadCancelled:
+                log.info("Download cancelled for %s", model.ref)
+                return
             except Exception as exc:
                 self._handle_download_error(notify, exc, model, is_first=is_first)
                 return
@@ -428,4 +441,5 @@ class SetupWizard(Screen[str | None]):
         self._save_and_dismiss("skipped")
 
     def action_cancel(self) -> None:
+        self._cancel_event.set()
         self.dismiss("skipped")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -5141,6 +5141,112 @@ async def test_setup_wizard_partial_download():
                     await pilot.pause()
 
 
+async def test_setup_wizard_download_cancel():
+    """Setting _cancel_event aborts the download loop via _DownloadCancelled."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            download_started = False
+
+            def fake_download(model, on_progress=None):
+                nonlocal download_started
+                download_started = True
+                # Simulate progress callbacks; the cancel event is set before
+                # the first callback so _on_download_progress raises.
+                if on_progress:
+                    on_progress(100, 1000)
+                return MagicMock(stem="cancelled-model")
+
+            # Populate at least one model so the for-loop body executes
+            screen._download_models = [MagicMock(ref="chat:model", display_name="Test Model")]
+            screen._cancel_event.set()
+            with (
+                patch(
+                    "lilbee.cli.tui.screens.setup.download_model",
+                    side_effect=fake_download,
+                ),
+                patch("lilbee.settings.set_value"),
+                patch("lilbee.services.reset_services"),
+            ):
+                screen._download_loop(lambda fn, *a: fn(*a))
+                await pilot.pause()
+            # Download should not have started because the loop checks the
+            # event before each model.
+            assert not download_started
+
+
+async def test_setup_wizard_cancel_event_raises_in_progress_callback():
+    """_on_download_progress raises _DownloadCancelled when cancel event is set."""
+    from lilbee.cli.tui.screens.setup import SetupWizard, _DownloadCancelled
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            screen._cancel_event.set()
+            from lilbee.catalog import DownloadProgress
+
+            with pytest.raises(_DownloadCancelled):
+                screen._on_download_progress(
+                    lambda fn, *a: fn(*a),
+                    "test:ref",
+                    DownloadProgress(percent=50, detail="50%", is_cache_hit=False),
+                )
+
+
+async def test_setup_wizard_download_cancel_mid_download():
+    """Cancel event set during download triggers _DownloadCancelled in the loop."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+
+            def fake_download(model, on_progress=None):
+                # Set cancel during download; the progress callback will raise
+                screen._cancel_event.set()
+                if on_progress:
+                    on_progress(100, 1000)
+                return MagicMock(stem="model")
+
+            screen._download_models = [MagicMock(ref="chat:model", display_name="Test Model")]
+            with (
+                patch(
+                    "lilbee.cli.tui.screens.setup.download_model",
+                    side_effect=fake_download,
+                ),
+                patch("lilbee.settings.set_value"),
+                patch("lilbee.services.reset_services"),
+            ):
+                screen._download_loop(lambda fn, *a: fn(*a))
+                await pilot.pause()
+
+
+async def test_wizard_action_cancel_sets_event():
+    """action_cancel sets the cancel event so download threads abort."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            assert not screen._cancel_event.is_set()
+            screen.action_cancel()
+            assert screen._cancel_event.is_set()
+
+
 async def test_setup_wizard_single_model_download_error():
     from lilbee.cli.tui.screens.setup import SetupWizard
     from lilbee.cli.tui.widgets.grid_select import GridSelect
@@ -6393,6 +6499,25 @@ async def test_app_action_quit_when_streaming():
         with patch.object(screen, "action_cancel_stream") as mock_cancel:
             await app.action_quit()
             mock_cancel.assert_called_once()
+
+
+async def test_app_action_quit_routes_to_wizard_cancel():
+    """action_quit cancels the wizard instead of exiting when wizard is active."""
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        # Push a wizard on top
+        wizard = SetupWizard()
+        with _patch_setup_scan(), _patch_setup_ram(16.0):
+            app.push_screen(wizard)
+            await pilot.pause()
+            assert isinstance(app.screen, SetupWizard)
+            assert not wizard._cancel_event.is_set()
+            await app.action_quit()
+            assert wizard._cancel_event.is_set()
 
 
 async def test_app_action_quit_double_force_exits():


### PR DESCRIPTION
## Summary
- Adds threading.Event cancellation to wizard download loop
- Progress callback raises to interrupt hf_hub_download promptly
- action_quit routes through wizard cancel when wizard is active