### PR TITLE
fix: model pull pipeline — SSE stream, data dir, catalog lookup

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -17,7 +17,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import httpx
 from pydantic import BaseModel
@@ -605,13 +605,17 @@ def _sort_models(models: list[CatalogModel], sort: str) -> list[CatalogModel]:
     return sorted(models, key=key_fn, reverse=reverse)
 
 
+class CatalogIndex(NamedTuple):
+    """Case-insensitive lookup indexes for find_catalog_entry."""
+
+    by_ref: dict[str, CatalogModel]
+    by_name: dict[str, CatalogModel]
+    by_display: dict[str, CatalogModel]
+    by_hf_repo: dict[str, CatalogModel]
+
+
 @functools.cache
-def _build_catalog_index() -> tuple[
-    dict[str, CatalogModel],
-    dict[str, CatalogModel],
-    dict[str, CatalogModel],
-    dict[str, CatalogModel],
-]:
+def _build_catalog_index() -> CatalogIndex:
     """Build case-insensitive lookup indexes for find_catalog_entry."""
     by_ref: dict[str, CatalogModel] = {}
     by_name: dict[str, CatalogModel] = {}
@@ -625,7 +629,7 @@ def _build_catalog_index() -> tuple[
             by_name[name_key] = m
         by_display.setdefault(m.display_name.lower(), m)
         by_hf_repo.setdefault(m.hf_repo.lower(), m)
-    return by_ref, by_name, by_display, by_hf_repo
+    return CatalogIndex(by_ref, by_name, by_display, by_hf_repo)
 
 
 def find_catalog_entry(query: str) -> CatalogModel | None:
@@ -633,9 +637,9 @@ def find_catalog_entry(query: str) -> CatalogModel | None:
     Resolution order: exact ``name:tag`` → bare ``name`` (recommended variant)
     → ``display_name`` → ``hf_repo``.
     """
-    by_ref, by_name, by_display, by_hf_repo = _build_catalog_index()
+    idx = _build_catalog_index()
     q = query.lower()
-    return by_ref.get(q) or by_name.get(q) or by_display.get(q) or by_hf_repo.get(q)
+    return idx.by_ref.get(q) or idx.by_name.get(q) or idx.by_display.get(q) or idx.by_hf_repo.get(q)
 
 
 def download_model(entry: CatalogModel, *, on_progress: ProgressCallback | None = None) -> Path:

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -607,12 +607,16 @@ def _sort_models(models: list[CatalogModel], sort: str) -> list[CatalogModel]:
 
 @functools.cache
 def _build_catalog_index() -> tuple[
-    dict[str, CatalogModel], dict[str, CatalogModel], dict[str, CatalogModel]
+    dict[str, CatalogModel],
+    dict[str, CatalogModel],
+    dict[str, CatalogModel],
+    dict[str, CatalogModel],
 ]:
     """Build case-insensitive lookup indexes for find_catalog_entry."""
     by_ref: dict[str, CatalogModel] = {}
     by_name: dict[str, CatalogModel] = {}
     by_display: dict[str, CatalogModel] = {}
+    by_hf_repo: dict[str, CatalogModel] = {}
     for m in FEATURED_ALL:
         ref_key = m.ref.lower()
         name_key = m.name.lower()
@@ -620,17 +624,18 @@ def _build_catalog_index() -> tuple[
         if name_key not in by_name or m.recommended:
             by_name[name_key] = m
         by_display.setdefault(m.display_name.lower(), m)
-    return by_ref, by_name, by_display
+        by_hf_repo.setdefault(m.hf_repo.lower(), m)
+    return by_ref, by_name, by_display, by_hf_repo
 
 
 def find_catalog_entry(query: str) -> CatalogModel | None:
-    """Find a featured model by ref, name, or display name (case-insensitive).
+    """Find a featured model by ref, name, display name, or hf_repo (case-insensitive).
     Resolution order: exact ``name:tag`` → bare ``name`` (recommended variant)
-    → ``display_name``.
+    → ``display_name`` → ``hf_repo``.
     """
-    by_ref, by_name, by_display = _build_catalog_index()
+    by_ref, by_name, by_display, by_hf_repo = _build_catalog_index()
     q = query.lower()
-    return by_ref.get(q) or by_name.get(q) or by_display.get(q)
+    return by_ref.get(q) or by_name.get(q) or by_display.get(q) or by_hf_repo.get(q)
 
 
 def download_model(entry: CatalogModel, *, on_progress: ProgressCallback | None = None) -> Path:

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -413,7 +413,7 @@ class Config(BaseSettings):
     @model_validator(mode="before")
     @classmethod
     def _resolve_defaults(cls, data: Any) -> Any:
-        from lilbee.platform import canonical_models_dir, default_data_dir, find_local_root
+        from lilbee.platform import default_data_dir, find_local_root
 
         if not isinstance(data, dict):  # pragma: no cover
             return data
@@ -435,7 +435,7 @@ class Config(BaseSettings):
         if data.get("lancedb_dir") in (None, _UNSET):
             data["lancedb_dir"] = root / "data" / "lancedb"
         if data.get("models_dir") in (None, _UNSET):
-            data["models_dir"] = canonical_models_dir()
+            data["models_dir"] = root / "models"
 
         if "LILBEE_LITELLM_BASE_URL" not in os.environ:
             ollama_host = os.environ.get("OLLAMA_HOST")

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -247,13 +247,11 @@ def pull_with_progress(model: str, *, console: Console | None = None) -> None:
         desc = f"Downloading model '{model}'..."
         ptask = progress.add_task(desc, total=None)
 
-        def _on_progress(data: dict) -> None:
-            total = data.get("total", 0) or 0
-            completed = data.get("completed", 0) or 0
+        def _on_bytes(downloaded: int, total: int) -> None:
             if total > 0:
-                progress.update(ptask, total=total, completed=completed)
+                progress.update(ptask, total=total, completed=downloaded)
 
-        manager.pull(model, ModelSource.NATIVE, on_progress=_on_progress)
+        manager.pull(model, ModelSource.NATIVE, on_bytes=_on_bytes)
     console.print(f"Model '{model}' ready.")
 
 

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -685,8 +685,14 @@ async def models_pull(model: str, *, source: str = "native") -> AsyncGenerator[s
             payload = sse_event(SseEvent.PROGRESS, data)
             sse.loop.call_soon_threadsafe(sse.queue.put_nowait, payload)
 
+        def _on_bytes(downloaded: int, total: int) -> None:
+            if sse.cancel.is_set():
+                return
+            payload = sse_event(SseEvent.PROGRESS, {"current": downloaded, "total": total})
+            sse.loop.call_soon_threadsafe(sse.queue.put_nowait, payload)
+
         try:
-            manager.pull(model, src, on_progress=_on_progress)
+            manager.pull(model, src, on_progress=_on_progress, on_bytes=_on_bytes)
         except Exception as exc:
             sse.loop.call_soon_threadsafe(sse.queue.put_nowait, sse_error(str(exc)))
         finally:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -551,6 +551,16 @@ class TestFindCatalogEntry:
             assert result.recommended is False
         catalog._build_catalog_index.cache_clear()  # restore for other tests
 
+    def test_match_by_hf_repo(self) -> None:
+        result = find_catalog_entry("Qwen/Qwen3-8B-GGUF")
+        assert result is not None
+        assert result.hf_repo == "Qwen/Qwen3-8B-GGUF"
+
+    def test_match_by_hf_repo_case_insensitive(self) -> None:
+        result = find_catalog_entry("qwen/qwen3-8b-gguf")
+        assert result is not None
+        assert result.hf_repo == "Qwen/Qwen3-8B-GGUF"
+
     def test_not_found(self) -> None:
         result = find_catalog_entry("Nonexistent Model")
         assert result is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -232,9 +232,9 @@ class TestPullWithProgress:
     def test_calls_manager_pull(self, mock_get_manager):
         mock_manager = mock.MagicMock()
 
-        def fake_pull(model, source, *, on_progress=None):
-            if on_progress:
-                on_progress({"total": 100, "completed": 100})
+        def fake_pull(model, source, *, on_bytes=None):
+            if on_bytes:
+                on_bytes(100, 100)
             return None
 
         mock_manager.pull.side_effect = fake_pull
@@ -246,9 +246,9 @@ class TestPullWithProgress:
     def test_handles_zero_total(self, mock_get_manager):
         mock_manager = mock.MagicMock()
 
-        def fake_pull(model, source, *, on_progress=None):
-            if on_progress:
-                on_progress({"total": 0, "completed": 0})
+        def fake_pull(model, source, *, on_bytes=None):
+            if on_bytes:
+                on_bytes(0, 0)
             return None
 
         mock_manager.pull.side_effect = fake_pull

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -476,17 +476,15 @@ class TestConfigProvider:
             assert c.litellm_base_url == "http://myhost:11434"
             assert c.llm_api_key == "sk-key"
 
-    def test_models_dir_is_canonical(self, tmp_path: Path) -> None:
-        """models_dir uses canonical system path, not per-project data_root."""
+    def test_models_dir_derives_from_data_root(self, tmp_path: Path) -> None:
+        """models_dir derives from data_root so LILBEE_DATA controls it."""
         import os
-
-        from lilbee.platform import canonical_models_dir
 
         with mock.patch.dict(os.environ, {"LILBEE_DATA": str(tmp_path / "test-lilbee")}):
             from lilbee.config import Config
 
             c = Config()
-            assert c.models_dir == canonical_models_dir()
+            assert c.models_dir == tmp_path / "test-lilbee" / "models"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -633,10 +633,26 @@ class TestModelsInstalled:
 
 
 class TestModelsPull:
-    async def test_yields_progress_events(self):
+    async def test_yields_progress_events_native(self):
         mock_manager = MagicMock()
 
-        def fake_pull(model, source, *, on_progress=None):
+        def fake_pull(model, source, *, on_progress=None, on_bytes=None):
+            if on_bytes:
+                on_bytes(500, 1000)
+                on_bytes(1000, 1000)
+            return None
+
+        mock_manager.pull.side_effect = fake_pull
+        with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
+            events = [e async for e in handlers.models_pull("test", source="native")]
+        non_empty = [e for e in events if e]
+        assert any('"current": 500' in e for e in non_empty)
+        assert any('"total": 1000' in e for e in non_empty)
+
+    async def test_yields_progress_events_litellm(self):
+        mock_manager = MagicMock()
+
+        def fake_pull(model, source, *, on_progress=None, on_bytes=None):
             if on_progress:
                 on_progress({"status": "downloading"})
                 on_progress({"status": "success"})
@@ -644,7 +660,7 @@ class TestModelsPull:
 
         mock_manager.pull.side_effect = fake_pull
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
-            events = [e async for e in handlers.models_pull("test", source="native")]
+            events = [e async for e in handlers.models_pull("test", source="litellm")]
         non_empty = [e for e in events if e]
         assert any("downloading" in e for e in non_empty)
         assert any("success" in e for e in non_empty)
@@ -664,19 +680,19 @@ class TestModelsPull:
         barrier = threading.Event()
         mock_manager = MagicMock()
 
-        def blocking_pull(model, source, *, on_progress=None):
-            if on_progress:
-                on_progress({"status": "downloading"})
+        def blocking_pull(model, source, *, on_progress=None, on_bytes=None):
+            if on_bytes:
+                on_bytes(100, 1000)
             barrier.wait(timeout=2)
-            if on_progress:
-                on_progress({"status": "done"})
+            if on_bytes:
+                on_bytes(1000, 1000)
 
         mock_manager.pull.side_effect = blocking_pull
         caplog.set_level(logging.INFO, logger="lilbee.server.handlers")
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             gen = handlers.models_pull("test", source="native")
             async for event in gen:
-                if event and "downloading" in event:
+                if event and "current" in event:
                     await gen.aclose()
                     barrier.set()
                     break
@@ -1165,10 +1181,10 @@ class TestModelPullProgressCancel:
         mock_manager = MagicMock()
         progress_called = threading.Event()
 
-        def fake_pull(model, source, *, on_progress=None):
-            if on_progress:
+        def fake_pull(model, source, *, on_progress=None, on_bytes=None):
+            if on_bytes:
                 # All progress calls should see cancel already set
-                on_progress({"status": "should_be_suppressed"})
+                on_bytes(500, 1000)
                 progress_called.set()
 
         mock_manager.pull.side_effect = fake_pull
@@ -1191,5 +1207,38 @@ class TestModelPullProgressCancel:
             # Wait for the pull thread to complete
             await asyncio.sleep(0.2)
 
-        assert progress_called.is_set()  # Pull did call on_progress
+        assert progress_called.is_set()  # Pull did call on_bytes
+        assert not any("current" in e for e in events if e)
+
+    async def test_cancel_during_litellm_pull_skips_progress(self):
+        """When cancel is set before litellm pull starts, on_progress returns early."""
+        import threading
+
+        mock_manager = MagicMock()
+        progress_called = threading.Event()
+
+        def fake_pull(model, source, *, on_progress=None, on_bytes=None):
+            if on_progress:
+                on_progress({"status": "should_be_suppressed"})
+                progress_called.set()
+
+        mock_manager.pull.side_effect = fake_pull
+
+        original_init = handlers.SseStream.__init__
+
+        def patched_init(self):
+            original_init(self)
+            self.cancel.set()
+
+        with (
+            patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager),
+            patch.object(handlers.SseStream, "__init__", patched_init),
+        ):
+            gen = handlers.models_pull("test", source="litellm")
+            events = []
+            async for event in gen:
+                events.append(event)
+            await asyncio.sleep(0.2)
+
+        assert progress_called.is_set()
         assert not any("should_be_suppressed" in e for e in events if e)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -650,6 +650,7 @@ class TestModelsPull:
         assert any('"total": 1000' in e for e in non_empty)
 
     async def test_yields_progress_events_litellm(self):
+        """Litellm pulls use on_progress (dict), not on_bytes (int, int)."""
         mock_manager = MagicMock()
 
         def fake_pull(model, source, *, on_progress=None, on_bytes=None):


### PR DESCRIPTION
POST /api/models/pull was completely broken for native model pulls. Three root causes fixed:

**SSE stream empty** — the handler passed `on_progress` (dict callback) to `manager.pull()`, but native pulls use `on_bytes` (int, int). Added `_on_bytes` callback that emits `{current, total}` SSE events matching what the plugin expects. Also fixed the same bug in `pull_with_progress()` (CLI/TUI progress bar).

**Wrong data directory** — `models_dir` defaulted to `canonical_models_dir()` (platform-specific path like `~/.local/share/lilbee/models`) instead of deriving from `data_root / "models"`. Now respects LILBEE_DATA like every other directory.

**Catalog lookup by hf_repo** — `find_catalog_entry()` only searched by ref, name, and display_name. The plugin sends `hf_repo` (e.g. `Qwen/Qwen3-4B-GGUF`) from the catalog modal, which was never matched. Added hf_repo as a fourth lookup index.
