### PR TITLE
Fix TUI freeze when changing model during active stream

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -510,6 +510,7 @@ class ChatScreen(Screen[None]):
             settings.set_value(cfg.data_root, "chat_model", tagged)
             self.app.title = f"lilbee -- {cfg.chat_model}"
             self.notify(msg.CMD_MODEL_SET.format(name=tagged))
+            self._apply_model_change()
             self._refresh_model_bar()
         else:
             from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -808,6 +809,21 @@ class ChatScreen(Screen[None]):
         inp = self.query_one("#chat-input", Input)
         if inp.has_focus:
             self.query_one("#chat-log", VerticalScroll).focus()
+
+    def _apply_model_change(self) -> None:
+        """Cancel active stream (if any) and reset services for the new model."""
+        if self.streaming:
+            self.action_cancel_stream()
+            self.call_later(self._deferred_service_reset)
+        else:
+            reset_services()
+
+    def _deferred_service_reset(self) -> None:
+        """Reset services once workers have drained."""
+        if self.workers:
+            self.call_later(self._deferred_service_reset)
+            return
+        reset_services()
 
     async def action_toggle_markdown(self) -> None:
         """Toggle between Markdown and plain-text rendering for chat responses."""

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -223,25 +223,10 @@ class ModelBar(Widget, can_focus=False):
         from lilbee.cli.tui.screens.chat import ChatScreen
 
         screen = self.app.screen
-        if isinstance(screen, ChatScreen) and screen.streaming:
-            screen.action_cancel_stream()
-            self.app.call_later(self._deferred_reset)
+        if isinstance(screen, ChatScreen):
+            screen._apply_model_change()
         else:
-            self._reset_services()
-
-    def _deferred_reset(self) -> None:
-        """Reset services after workers have finished (avoids freeing in-use models)."""
-        from lilbee.cli.tui.screens.chat import ChatScreen
-
-        screen = self.app.screen
-        if isinstance(screen, ChatScreen) and screen.workers:
-            self.app.call_later(self._deferred_reset)
-            return
-        self._reset_services()
-
-    @staticmethod
-    def _reset_services() -> None:
-        reset_services()
+            reset_services()
 
     def refresh_models(self) -> None:
         """Re-scan models (called after downloads complete)."""

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -191,7 +191,6 @@ class TestModelSwitchSafety:
             await pilot.pause()
             screen = app.screen
             screen.streaming = True
-            screen.action_cancel_stream = mock.MagicMock()
 
             bar = screen.query_one("#model-bar", ModelBar)
             bar._populating = False
@@ -202,13 +201,10 @@ class TestModelSwitchSafety:
             event.select = mock.MagicMock()
             event.select.id = "chat-model-select"
 
-            with (
-                mock.patch("lilbee.services.reset_services"),
-                mock.patch.object(bar, "_deferred_reset"),
-            ):
+            with mock.patch.object(screen, "_apply_model_change") as mock_apply:
                 bar._on_chat_model_changed(event)
 
-            screen.action_cancel_stream.assert_called_once()
+            mock_apply.assert_called_once()
 
 
 class TestViewTabsPresence:
@@ -2066,6 +2062,17 @@ class TestChatSlashCommands:
             app.screen._handle_slash("/model slash-test-model")
             await pilot.pause()
             assert "slash-test-model" in cfg.chat_model
+
+    async def test_cmd_model_cancels_stream_when_streaming(self, _mock_resolve):
+        """/model <name> cancels stream and resets services when streaming."""
+        app = ChatTestApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.screen.streaming = True
+            with mock.patch.object(app.screen, "_apply_model_change") as mock_apply:
+                app.screen._handle_slash("/model stream-switch-model")
+                await pilot.pause()
+                mock_apply.assert_called()
 
     async def test_cmd_model_without_name(self, _mock_resolve):
         """/model with no args pushes catalog."""

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -1411,6 +1411,63 @@ async def test_chat_cancel_stream_while_streaming():
         assert app.screen.streaming is False
 
 
+async def test_apply_model_change_cancels_stream_when_streaming():
+    """_apply_model_change cancels stream and defers service reset."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = True
+        with (
+            patch.object(screen, "action_cancel_stream") as mock_cancel,
+            patch.object(screen, "call_later") as mock_later,
+        ):
+            screen._apply_model_change()
+            mock_cancel.assert_called_once()
+            mock_later.assert_called_once_with(screen._deferred_service_reset)
+
+
+async def test_apply_model_change_resets_immediately_when_not_streaming():
+    """_apply_model_change resets services immediately when not streaming."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = False
+        with patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset:
+            screen._apply_model_change()
+            mock_reset.assert_called_once()
+
+
+async def test_deferred_service_reset_retries_while_workers_active():
+    """_deferred_service_reset retries via call_later when workers exist."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        with (
+            patch.object(
+                type(screen), "workers", new_callable=MagicMock, return_value=[MagicMock()]
+            ),
+            patch.object(screen, "call_later") as mock_later,
+            patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset,
+        ):
+            screen._deferred_service_reset()
+            mock_later.assert_called_once_with(screen._deferred_service_reset)
+            mock_reset.assert_not_called()
+
+
+async def test_deferred_service_reset_resets_when_no_workers():
+    """_deferred_service_reset calls reset_services when workers drained."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        # Cancel background workers so the screen's worker manager is empty
+        for w in list(screen.workers):
+            w.cancel()
+        await pilot.pause()
+        with patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset:
+            screen._deferred_service_reset()
+            mock_reset.assert_called_once()
+
+
 async def test_chat_vim_j_k_scrolls_in_normal_mode():
     """j/k scroll the chat log in normal mode."""
     app = ChatTestApp()

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2800,8 +2800,8 @@ class TestModelBarPopulateBranches:
             await pilot.pause()
             assert bar.display is True
 
-    async def test_after_model_change_with_streaming_chat(self) -> None:
-        """Cancel stream and defer reset when chat screen is streaming."""
+    async def test_after_model_change_with_chat_screen(self) -> None:
+        """Delegate to ChatScreen._apply_model_change when on a chat screen."""
         from lilbee.cli.tui.screens.chat import ChatScreen
         from lilbee.cli.tui.widgets.model_bar import ModelBar
 
@@ -2812,23 +2812,14 @@ class TestModelBarPopulateBranches:
             await pilot.pause()
             bar = app.query_one(ModelBar)
             mock_screen = mock.MagicMock(spec=ChatScreen)
-            mock_screen.streaming = True
-            mock_screen.workers = []
-            with (
-                mock.patch.object(
-                    type(app), "screen", new_callable=mock.PropertyMock, return_value=mock_screen
-                ),
-                mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services") as mock_reset,
+            with mock.patch.object(
+                type(app), "screen", new_callable=mock.PropertyMock, return_value=mock_screen
             ):
                 bar._after_model_change()
-                mock_screen.action_cancel_stream.assert_called_once()
-                mock_reset.assert_not_called()
-                await pilot.pause()
-                await pilot.pause()
-                mock_reset.assert_called_once()
+                mock_screen._apply_model_change.assert_called_once()
 
-    async def test_after_model_change_no_streaming(self) -> None:
-        """Reset services immediately when not streaming."""
+    async def test_after_model_change_no_chat_screen(self) -> None:
+        """Reset services directly when not on a chat screen."""
         from lilbee.cli.tui.widgets.model_bar import ModelBar
 
         cfg.chat_model = "test-model"
@@ -2840,32 +2831,6 @@ class TestModelBarPopulateBranches:
             with mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services") as mock_reset:
                 bar._after_model_change()
             mock_reset.assert_called_once()
-
-    async def test_deferred_reset_waits_for_workers(self) -> None:
-        """_deferred_reset retries when workers are still running."""
-        from lilbee.cli.tui.screens.chat import ChatScreen
-        from lilbee.cli.tui.widgets.model_bar import ModelBar
-
-        cfg.chat_model = "test-model"
-        cfg.embedding_model = "test-embed"
-        app = _ModelBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(ModelBar)
-            mock_screen = mock.MagicMock(spec=ChatScreen)
-            mock_screen.workers = [mock.MagicMock()]
-            with (
-                mock.patch.object(
-                    type(app), "screen", new_callable=mock.PropertyMock, return_value=mock_screen
-                ),
-                mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services") as mock_reset,
-            ):
-                bar._deferred_reset()
-                mock_reset.assert_not_called()
-                mock_screen.workers = []
-                await pilot.pause()
-                await pilot.pause()
-                mock_reset.assert_called_once()
 
 
 class TestModelBarCfgSourceOfTruth:


### PR DESCRIPTION
## Summary

- Changing the chat model (via /model command or ModelBar dropdown) while the LLM was streaming caused the TUI to freeze because reset_services() invalidated the provider mid-stream
- Both model-change paths now cancel the active stream first, then defer the service reset until workers drain
- Consolidates the cancel-then-reset logic into ChatScreen so ModelBar delegates instead of duplicating it