### PR TITLE
Fix 4 TUI bugs from QA Run 4

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -223,8 +223,10 @@ class ChatScreen(Screen[None]):
         """Called when wizard completes or is skipped."""
         if result == "skipped":
             self._show_chat_only_banner()
-        elif self._auto_sync and self._embedding_ready():
-            self._run_sync()
+        elif self._embedding_ready():
+            self._hide_chat_only_banner()
+            if self._auto_sync:
+                self._run_sync()
         self._refresh_model_bar()
 
     def _show_chat_only_banner(self) -> None:

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -14,7 +14,7 @@ from textual.widgets import Label, Select
 from lilbee import settings
 from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.config import cfg
-from lilbee.models import ModelTask
+from lilbee.models import ModelTask, ensure_tag
 from lilbee.services import reset_services
 
 log = logging.getLogger(__name__)
@@ -113,8 +113,12 @@ def _collect_api_models(buckets: dict[str, list[ModelOption]], seen: set[str]) -
 def _sync_select(sel: Select, opts: list[ModelOption], default: str = "") -> None:
     """Populate a model Select and set it to *default* (from cfg).
 
+    Normalizes *default* with :latest when no tag is present so that a
+    bare name like ``qwen3`` matches the installed ``qwen3:latest`` option
+    instead of creating a broken fallback entry.
     Prepends *default* if it is not already in *opts*.
     """
+    default = ensure_tag(default)
     if default and not any(o.ref == default for o in opts):
         opts.insert(0, ModelOption(default, default))
     sel.set_options(opts)

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -65,7 +65,10 @@ def _ensure_spacy_model() -> Any:
         log.info("Downloading spaCy model '%s'...", model_name)
         from spacy.cli import download
 
-        download(model_name)
+        try:
+            download(model_name)
+        except SystemExit as exc:
+            raise RuntimeError(f"Failed to download spacy model {model_name}: {exc}") from exc
         return spacy.load(model_name)
 
 

--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -39,6 +39,50 @@ WikiProgressCallback = Callable[[str, dict[str, object]], None]
 
 _MAX_DIFF_PREVIEW_LINES = 20  # lines of unified diff shown in drift warnings
 
+# Conservative default context window when num_ctx is not configured.
+# Most modern models support at least 8192 tokens.
+_DEFAULT_CONTEXT_WINDOW = 8192
+
+# Fraction of context window reserved for chunks. The remainder leaves
+# room for the system/user prompt template and generation output.
+_CONTEXT_BUDGET_FRACTION = 0.75
+
+# Approximate characters per token for budget estimation. 4 chars/token
+# is a widely used heuristic for English text.
+_CHARS_PER_TOKEN = 4
+
+
+def _truncate_chunks_to_budget(
+    chunks: list[SearchChunk],
+    config: Config,
+) -> list[SearchChunk]:
+    """Drop trailing chunks so the total text fits within the model's context budget.
+
+    Uses a chars/4 heuristic for token estimation. Returns the original list
+    unchanged when all chunks fit.
+    """
+    context_window = config.num_ctx or _DEFAULT_CONTEXT_WINDOW
+    budget_tokens = int(context_window * _CONTEXT_BUDGET_FRACTION)
+    budget_chars = budget_tokens * _CHARS_PER_TOKEN
+
+    total_chars = 0
+    kept: list[SearchChunk] = []
+    for chunk in chunks:
+        chunk_chars = len(chunk.chunk)
+        if total_chars + chunk_chars > budget_chars and kept:
+            break
+        kept.append(chunk)
+        total_chars += chunk_chars
+
+    if len(kept) < len(chunks):
+        log.warning(
+            "Truncated chunks from %d to %d to fit context window (%d tokens)",
+            len(chunks),
+            len(kept),
+            context_window,
+        )
+    return kept
+
 
 def _chunks_to_text(chunks: list[SearchChunk]) -> str:
     """Format chunks as numbered text blocks for the LLM prompt."""
@@ -422,6 +466,7 @@ def generate_summary_page(
         log.warning("No chunks for source %s, skipping wiki generation", source_name)
         return None
 
+    chunks = _truncate_chunks_to_budget(chunks, config)
     chunks_text = _chunks_to_text(chunks)
     template = config.wiki_summary_prompt
     prompt = template.format(source_name=source_name, chunks_text=chunks_text)
@@ -531,6 +576,7 @@ def _generate_synthesis_page(
         log.warning("No chunks for synthesis topic %r, skipping", topic)
         return None
 
+    all_chunks = _truncate_chunks_to_budget(all_chunks, config)
     chunks_text = _chunks_to_text(all_chunks)
     source_list = "\n".join(f"- {name}" for name in sorted(source_names))
     template = config.wiki_synthesis_prompt

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -238,6 +238,18 @@ class TestEnsureSpacyModel:
             mock_cli.download.assert_called_once_with("en_core_web_sm")
             assert result is not None
 
+    def test_download_sysexit_raises_runtime_error(self):
+        mock_spacy = MagicMock()
+        mock_spacy.load.side_effect = OSError("not found")
+        mock_cli = MagicMock()
+        mock_cli.download.side_effect = SystemExit(1)
+        mock_spacy.cli = mock_cli
+        with patch.dict("sys.modules", {"spacy": mock_spacy, "spacy.cli": mock_cli}):
+            from lilbee.concepts import _ensure_spacy_model
+
+            with pytest.raises(RuntimeError, match="Failed to download spacy model"):
+                _ensure_spacy_model()
+
 
 class TestBuildFromChunks:
     @patch("lilbee.lock.write_lock")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -6226,6 +6226,19 @@ async def test_chat_on_setup_complete_completed_with_auto_sync():
             mock_sync.assert_called_once()
 
 
+async def test_chat_on_setup_complete_hides_banner_when_embedding_ready():
+    """_on_setup_complete hides chat-only banner after wizard configures embedding."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        # Simulate banner being visible (e.g. from /setup command while in chat-only mode)
+        app.screen._show_chat_only_banner()
+        assert app.screen.query_one("#chat-only-banner").display is True
+        with patch.object(app.screen, "_embedding_ready", return_value=True):
+            app.screen._on_setup_complete("done")
+            await _pilot.pause()
+            assert app.screen.query_one("#chat-only-banner").display is False
+
+
 async def test_chat_on_key_insert_mode_unfocused_input():
     """on_key in insert mode with unfocused input redirects printable chars."""
     app = ChatTestApp()

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2099,7 +2099,8 @@ class TestModelBarAdditional:
             from textual.widgets import Select
 
             chat_sel = app.query_one("#chat-model-select", Select)
-            assert chat_sel.value == "test-model"
+            # Bare name normalizes to name:latest via ensure_tag
+            assert chat_sel.value == "test-model:latest"
 
     async def test_on_embed_model_changed(self) -> None:
         from lilbee.cli.tui.widgets.model_bar import ModelBar
@@ -2183,6 +2184,36 @@ class TestSyncSelectPrepend:
         passed = sel.set_options.call_args_list[0][0][0]
         assert passed[0] == ModelOption("llama3:8b", "llama3:8b")
         assert sel.value == "llama3:8b"
+
+    def test_bare_name_matches_latest_alias(self) -> None:
+        """A bare name like 'qwen3' normalizes to 'qwen3:latest' and matches the option."""
+        from lilbee.cli.tui.widgets.model_bar import ModelOption, _sync_select
+
+        sel = mock.MagicMock()
+        sel.value = "qwen3"
+        opts = [
+            ModelOption("Qwen3 0.6B", "qwen3:0.6b"),
+            ModelOption("Qwen3", "qwen3:latest"),
+        ]
+        _sync_select(sel, opts, default="qwen3")
+        # Should resolve to qwen3:latest, not create a broken fallback
+        assert sel.value == "qwen3:latest"
+        passed = sel.set_options.call_args_list[0][0][0]
+        # No fallback prepended since qwen3:latest is already in opts
+        assert len(passed) == 2
+        assert all(o.ref != "qwen3" for o in passed)
+
+    def test_bare_name_prepended_when_no_latest_alias(self) -> None:
+        """A bare name with no :latest match still prepends as fallback with the tag."""
+        from lilbee.cli.tui.widgets.model_bar import ModelOption, _sync_select
+
+        sel = mock.MagicMock()
+        opts = [ModelOption("Qwen3 0.6B", "qwen3:0.6b")]
+        _sync_select(sel, opts, default="llama3")
+        # Should normalize to llama3:latest and prepend that
+        assert sel.value == "llama3:latest"
+        passed = sel.set_options.call_args_list[0][0][0]
+        assert passed[0] == ModelOption("llama3:latest", "llama3:latest")
 
     def test_no_default_leaves_value_untouched(self) -> None:
         """When there's no default, don't assign a value."""
@@ -2831,23 +2862,23 @@ class TestModelBarPopulateBranches:
         """When scanned models match config, values are preserved."""
         from lilbee.cli.tui.widgets.model_bar import ModelBar
 
-        cfg.chat_model = "test-model"
-        cfg.embedding_model = "test-embed"
+        cfg.chat_model = "test-model:7b"
+        cfg.embedding_model = "test-embed:v1"
         app = _ModelBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             bar = app.query_one(ModelBar)
             bar._populate(
-                [ModelOption("test-model", "test-model"), ModelOption("other", "other")],
-                [ModelOption("test-embed", "test-embed"), ModelOption("nomic", "nomic")],
+                [ModelOption("test-model:7b", "test-model:7b"), ModelOption("other", "other")],
+                [ModelOption("test-embed:v1", "test-embed:v1"), ModelOption("nomic", "nomic")],
             )
             await pilot.pause()
             from textual.widgets import Select
 
             chat_sel = app.query_one("#chat-model-select", Select)
             embed_sel = app.query_one("#embed-model-select", Select)
-            assert chat_sel.value == "test-model"
-            assert embed_sel.value == "test-embed"
+            assert chat_sel.value == "test-model:7b"
+            assert embed_sel.value == "test-embed:v1"
 
     async def test_populate_empty_lists_uses_config_default(self) -> None:
         """When no models found, configured default from cfg is used."""
@@ -2864,7 +2895,8 @@ class TestModelBarPopulateBranches:
             from textual.widgets import Select
 
             chat_sel = app.query_one("#chat-model-select", Select)
-            assert chat_sel.value == "test-model"
+            # Bare name normalizes to name:latest via ensure_tag
+            assert chat_sel.value == "test-model:latest"
 
     async def test_populate_retains_matching_value(self) -> None:
         """When current value matches a scanned model, it's preserved."""
@@ -2931,9 +2963,9 @@ class TestModelBarPopulateBranches:
                 [ModelOption("Nomic Embed Text", "nomic:latest")],
             )
             await pilot.pause()
-            # Falls back to cfg.chat_model / cfg.embedding_model, not models[0]
-            assert chat_sel.value == "test-model"
-            assert embed_sel.value == "test-embed"
+            # Falls back to cfg values, normalized with :latest via ensure_tag
+            assert chat_sel.value == "test-model:latest"
+            assert embed_sel.value == "test-embed:latest"
 
     async def test_refresh_models(self) -> None:
         """Cover line 267: refresh_models calls _scan_models."""

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -23,6 +23,7 @@ from lilbee.wiki.gen import (
     _parse_faithfulness_score,
     _resolve_citations,
     _resolve_multi_source_citations,
+    _truncate_chunks_to_budget,
     _verify_citations,
     generate_summary_page,
     generate_synthesis_pages,
@@ -81,6 +82,45 @@ class TestChunksToText:
         chunks = [_make_chunk("Code", line_start=10, line_end=20)]
         result = _chunks_to_text(chunks)
         assert "(lines 10-20)" in result
+
+
+class TestTruncateChunksToBudget:
+    def test_small_chunks_unchanged(self):
+        """Chunks that fit within budget are returned as-is."""
+        chunks = [_make_chunk("short text")]
+        result = _truncate_chunks_to_budget(chunks, cfg)
+        assert result == chunks
+
+    def test_truncates_when_exceeding_budget(self):
+        """Large chunk sets are truncated to fit the context window."""
+        cfg.num_ctx = 100  # 100 tokens * 0.75 * 4 chars = 300 chars budget
+        big_text = "x" * 200  # 200 chars each, only one fits in 300
+        chunks = [_make_chunk(big_text, chunk_index=i) for i in range(5)]
+        result = _truncate_chunks_to_budget(chunks, cfg)
+        assert len(result) == 1
+
+    def test_always_keeps_at_least_one_chunk(self):
+        """Even if the first chunk exceeds the budget, it is kept."""
+        cfg.num_ctx = 10  # tiny budget: 10 * 0.75 * 4 = 30 chars
+        huge_chunk = _make_chunk("x" * 10000)
+        result = _truncate_chunks_to_budget([huge_chunk], cfg)
+        assert len(result) == 1
+
+    def test_uses_default_context_when_num_ctx_none(self):
+        """Falls back to default context window when num_ctx is not set."""
+        cfg.num_ctx = None
+        # Default 8192 * 0.75 * 4 = 24576 chars budget
+        small_chunks = [_make_chunk("hello", chunk_index=i) for i in range(10)]
+        result = _truncate_chunks_to_budget(small_chunks, cfg)
+        assert len(result) == 10  # all fit easily
+
+    def test_logs_warning_on_truncation(self, caplog: pytest.LogCaptureFixture):
+        """A warning is logged when chunks are truncated."""
+        cfg.num_ctx = 100
+        chunks = [_make_chunk("x" * 200, chunk_index=i) for i in range(5)]
+        with caplog.at_level("WARNING", logger="lilbee.wiki.gen"):
+            _truncate_chunks_to_budget(chunks, cfg)
+        assert "Truncated chunks from 5 to 1" in caplog.text
 
 
 class TestParseFaithfulnessScore:


### PR DESCRIPTION
## Summary
- Catch SystemExit from spacy model download to prevent TUI crash on /add
- Hide chat-only banner after wizard configures embedding model
- Truncate wiki chunks to fit model context window on large documents
- Normalize bare model names with :latest tag in model bar dropdown