### PR TITLE
Fix 8 CLI bugs from QA sweep

### DIFF
--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -191,8 +191,17 @@ def _crawl_urls_blocking(
     effective_depth = depth if depth is not None else (cfg.crawl_max_depth if crawl else 0)
     effective_pages = max_pages if max_pages is not None else cfg.crawl_max_pages
 
+    from rich.console import Console as RichConsole
+
+    err_console = RichConsole(stderr=True)
     all_paths: list[Path] = []
-    with Progress(SpinnerColumn(), TextColumn("{task.description}"), transient=True) as progress:
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("{task.description}"),
+        transient=True,
+        console=err_console,
+        disable=cfg.json_mode,
+    ) as progress:
         for url in urls:
             ptask = progress.add_task(f"Crawling {url}...", total=None)
 
@@ -213,6 +222,7 @@ def _crawl_urls_blocking(
                     depth=effective_depth,
                     max_pages=effective_pages,
                     on_progress=_make_callback(),
+                    quiet=cfg.json_mode,
                 )
             )
             all_paths.extend(paths)
@@ -562,7 +572,13 @@ def _port_file() -> Path:
 
 async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str) -> None:
     """Start uvicorn, write port file, and clean up on shutdown."""
+    import atexit
+
     port_path = _port_file()
+
+    def _cleanup_port_file() -> None:
+        port_path.unlink(missing_ok=True)
+
     if not config.loaded:
         config.load()
     server.lifespan = config.lifespan_class(config)
@@ -573,6 +589,7 @@ async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str)
             actual_port = sock.getsockname()[1]
             port_path.parent.mkdir(parents=True, exist_ok=True)
             port_path.write_text(str(actual_port))
+            atexit.register(_cleanup_port_file)
             console.print(f"Listening on http://{host}:{actual_port}")
         await server.main_loop()
     finally:

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -29,10 +29,11 @@ from lilbee.cli.app import (
     top_p_option,
 )
 from lilbee.cli.helpers import (
+    CopyResult,
     add_paths,
     auto_sync,
     clean_result,
-    copy_paths,
+    copy_files,
     gather_status,
     get_version,
     json_output,
@@ -269,14 +270,15 @@ def add(
         if cfg.json_mode:
             from lilbee.ingest import sync
 
-            copied: list[str] = []
+            copy_result = CopyResult()
             if file_paths:
-                copied = copy_paths(file_paths, console, force=force)
+                copy_result = copy_files(file_paths, force=force)
             result = asyncio.run(sync(quiet=True))
             json_output(
                 {
                     "command": "add",
-                    "copied": copied,
+                    "copied": copy_result.copied,
+                    "skipped": copy_result.skipped,
                     "crawled": len(crawled_paths),
                     "sync": sync_result_to_json(result),
                 }
@@ -370,6 +372,8 @@ def remove(
         if result.not_found:
             payload["not_found"] = result.not_found
         json_output(payload)
+        if not result.removed and result.not_found:
+            raise SystemExit(1)
         return
 
     for name in result.removed:

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -569,6 +569,8 @@ def rm_cmd(
     data = remove_model_data(ref, source=src)
     if cfg.json_mode:
         json_output(data.model_dump())
+        if not data.deleted:
+            raise typer.Exit(1)
         return
     if not data.deleted:
         console.print(f"[{theme.WARNING}]Not found: {ref}[/{theme.WARNING}]")

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -63,18 +63,36 @@ def _ensure_spacy_model() -> Any:
         return spacy.load(model_name)
     except OSError:
         log.info("Downloading spaCy model '%s'...", model_name)
-        from spacy.cli import download
-
         try:
+            from spacy.cli import download
+
             download(model_name)
-        except SystemExit as exc:
-            raise RuntimeError(f"Failed to download spacy model {model_name}: {exc}") from exc
-        return spacy.load(model_name)
+            return spacy.load(model_name)
+        except (SystemExit, OSError, Exception) as exc:
+            raise ImportError(
+                f"spaCy model '{model_name}' not available and auto-download failed. "
+                f"Install manually: python -m spacy download {model_name}"
+            ) from exc
 
 
-def _get_nlp() -> Any:
+_nlp_cache: Any = None
+_nlp_failed: bool = False
+
+
+def _get_nlp() -> Any | None:
     """Lazy-load and cache the spaCy model (used only by ConceptGraph)."""
-    return _ensure_spacy_model()
+    global _nlp_cache, _nlp_failed
+    if _nlp_failed:
+        return None
+    if _nlp_cache is not None:
+        return _nlp_cache
+    try:
+        _nlp_cache = _ensure_spacy_model()
+        return _nlp_cache
+    except ImportError:
+        log.warning("Concept graph disabled: spaCy model unavailable")
+        _nlp_failed = True
+        return None
 
 
 def _filter_noun_chunks(doc: Any, max_concepts: int) -> list[str]:
@@ -175,8 +193,8 @@ class ConceptGraph:
         self._store = store
         self._nlp: Any = None
 
-    def _ensure_nlp(self) -> Any:
-        """Lazy-load and cache the spaCy model."""
+    def _ensure_nlp(self) -> Any | None:
+        """Lazy-load and cache the spaCy model. Returns None if unavailable."""
         if self._nlp is None:
             self._nlp = _get_nlp()
         return self._nlp
@@ -187,15 +205,20 @@ class ConceptGraph:
             max_concepts = self._config.concept_max_per_chunk
         if not text.strip():
             return []
-        doc = self._ensure_nlp()(text)
+        nlp = self._ensure_nlp()
+        if nlp is None:
+            return []
+        doc = nlp(text)
         return _filter_noun_chunks(doc, max_concepts)
 
     def extract_concepts_batch(self, texts: list[str]) -> list[list[str]]:
         """Batch-extract concepts from multiple texts."""
         if not texts:
             return []
-        max_concepts = self._config.concept_max_per_chunk
         nlp = self._ensure_nlp()
+        if nlp is None:
+            return [[] for _ in texts]
+        max_concepts = self._config.concept_max_per_chunk
         return [_filter_noun_chunks(doc, max_concepts) for doc in nlp.pipe(texts)]
 
     def build_from_chunks(

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -75,25 +75,6 @@ def _ensure_spacy_model() -> Any:
             ) from exc
 
 
-_nlp_cache: Any = None
-_nlp_failed: bool = False
-
-
-def _get_nlp() -> Any | None:
-    """Lazy-load and cache the spaCy model (used only by ConceptGraph)."""
-    global _nlp_cache, _nlp_failed
-    if _nlp_failed:
-        return None
-    if _nlp_cache is not None:
-        return _nlp_cache
-    try:
-        _nlp_cache = _ensure_spacy_model()
-        return _nlp_cache
-    except ImportError:
-        log.warning("Concept graph disabled: spaCy model unavailable")
-        _nlp_failed = True
-        return None
-
 
 def _filter_noun_chunks(doc: Any, max_concepts: int) -> list[str]:
     """Extract deduplicated, filtered noun chunks from a spaCy doc."""
@@ -192,11 +173,19 @@ class ConceptGraph:
         self._config = config
         self._store = store
         self._nlp: Any = None
+        self._nlp_unavailable: bool = False
 
     def _ensure_nlp(self) -> Any | None:
         """Lazy-load and cache the spaCy model. Returns None if unavailable."""
+        if self._nlp_unavailable:
+            return None
         if self._nlp is None:
-            self._nlp = _get_nlp()
+            try:
+                self._nlp = _ensure_spacy_model()
+            except ImportError:
+                log.warning("Concept graph disabled: spaCy model unavailable")
+                self._nlp_unavailable = True
+                return None
         return self._nlp
 
     def extract_concepts(self, text: str, max_concepts: int | None = None) -> list[str]:
@@ -440,6 +429,7 @@ class ConceptGraph:
     def reset_nlp_cache(self) -> None:
         """Clear the spaCy model cache. For testing only."""
         self._nlp = None
+        self._nlp_unavailable = False
 
 
 class ConceptGraphClusterer:

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -75,7 +75,6 @@ def _ensure_spacy_model() -> Any:
             ) from exc
 
 
-
 def _filter_noun_chunks(doc: Any, max_concepts: int) -> list[str]:
     """Extract deduplicated, filtered noun chunks from a spaCy doc."""
     seen: set[str] = set()

--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -11,9 +11,11 @@ import re
 import socket
 import threading
 import time
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from lilbee.config import cfg
@@ -287,23 +289,28 @@ def update_metadata(results: list[CrawlResult]) -> None:
     save_crawl_metadata(meta)
 
 
+@contextlib.asynccontextmanager
+async def _open_crawler(*, quiet: bool = False) -> AsyncIterator[Any]:
+    """Open an AsyncWebCrawler, suppressing stdout when quiet."""
+    from crawl4ai import AsyncWebCrawler
+
+    stdout_ctx = contextlib.redirect_stdout(io.StringIO()) if quiet else contextlib.nullcontext()
+    with stdout_ctx:
+        async with AsyncWebCrawler(verbose=not quiet) as crawler:
+            yield crawler
+
+
 async def crawl_single(url: str, *, quiet: bool = False) -> CrawlResult:
     """Fetch a single URL and return its markdown content."""
     validate_crawl_url(url)
-    from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
+    from crawl4ai import CrawlerRunConfig
 
     config = CrawlerRunConfig(
         page_timeout=cfg.crawl_timeout * 1000,  # ms
     )
-    # crawl4ai writes progress to stdout regardless of verbose flag;
-    # suppress it by redirecting stdout to devnull when quiet.
-    stdout_ctx = contextlib.redirect_stdout(io.StringIO()) if quiet else contextlib.nullcontext()
     try:
-        with stdout_ctx:
-            async with AsyncWebCrawler(verbose=not quiet) as crawler:
-                result = await crawler.arun(url=url, config=config)
-        # crawl4ai may set success=False for sub-resource failures (e.g. favicon 404)
-        # even when the main page has valid markdown. Trust the content, not the flag.
+        async with _open_crawler(quiet=quiet) as crawler:
+            result = await crawler.arun(url=url, config=config)
         markdown = (result.markdown or "").strip()
         if markdown:
             return CrawlResult(url=url, markdown=markdown, success=True)
@@ -330,7 +337,7 @@ async def crawl_recursive(
     Falls back to cfg defaults when max_depth/max_pages are 0.
     """
     validate_crawl_url(url)
-    from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
+    from crawl4ai import CrawlerRunConfig
     from crawl4ai.deep_crawling import BFSDeepCrawlStrategy
 
     depth = max_depth if max_depth > 0 else cfg.crawl_max_depth
@@ -346,30 +353,27 @@ async def crawl_recursive(
     )
 
     results: list[CrawlResult] = []
-    stdout_ctx = contextlib.redirect_stdout(io.StringIO()) if quiet else contextlib.nullcontext()
     try:
-        with stdout_ctx:
-            async with AsyncWebCrawler(verbose=not quiet) as crawler:
-                crawl_results = await crawler.arun(url=url, config=config)
-        # arun with deep crawl returns a list
+        async with _open_crawler(quiet=quiet) as crawler:
+            crawl_results = await crawler.arun(url=url, config=config)
         if not isinstance(crawl_results, list):
             crawl_results = [crawl_results]
         for i, cr in enumerate(crawl_results):
-                if on_progress:
-                    on_progress(
-                        EventType.CRAWL_PAGE,
-                        CrawlPageEvent(url=cr.url, current=i + 1, total=len(crawl_results)),
+            if on_progress:
+                on_progress(
+                    EventType.CRAWL_PAGE,
+                    CrawlPageEvent(url=cr.url, current=i + 1, total=len(crawl_results)),
+                )
+            if cr.success:
+                results.append(CrawlResult(url=cr.url, markdown=cr.markdown or ""))
+            else:
+                results.append(
+                    CrawlResult(
+                        url=cr.url,
+                        success=False,
+                        error=cr.error_message or "Unknown error",
                     )
-                if cr.success:
-                    results.append(CrawlResult(url=cr.url, markdown=cr.markdown or ""))
-                else:
-                    results.append(
-                        CrawlResult(
-                            url=cr.url,
-                            success=False,
-                            error=cr.error_message or "Unknown error",
-                        )
-                    )
+                )
     except Exception as exc:
         log.warning("Recursive crawl of %s failed: %s", url, exc)
         if not results:

--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -285,7 +285,7 @@ def update_metadata(results: list[CrawlResult]) -> None:
     save_crawl_metadata(meta)
 
 
-async def crawl_single(url: str) -> CrawlResult:
+async def crawl_single(url: str, *, quiet: bool = False) -> CrawlResult:
     """Fetch a single URL and return its markdown content."""
     validate_crawl_url(url)
     from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
@@ -294,7 +294,7 @@ async def crawl_single(url: str) -> CrawlResult:
         page_timeout=cfg.crawl_timeout * 1000,  # ms
     )
     try:
-        async with AsyncWebCrawler() as crawler:
+        async with AsyncWebCrawler(verbose=not quiet) as crawler:
             result = await crawler.arun(url=url, config=config)
             # crawl4ai may set success=False for sub-resource failures (e.g. favicon 404)
             # even when the main page has valid markdown. Trust the content, not the flag.
@@ -316,6 +316,8 @@ async def crawl_recursive(
     max_depth: int = 0,
     max_pages: int = 0,
     on_progress: DetailedProgressCallback | None = None,
+    *,
+    quiet: bool = False,
 ) -> list[CrawlResult]:
     """Crawl a URL recursively using BFS, returning results for all pages.
     Uses crawl4ai's deep crawl strategy for link discovery.
@@ -339,7 +341,7 @@ async def crawl_recursive(
 
     results: list[CrawlResult] = []
     try:
-        async with AsyncWebCrawler() as crawler:
+        async with AsyncWebCrawler(verbose=not quiet) as crawler:
             crawl_results = await crawler.arun(url=url, config=config)
             # arun with deep crawl returns a list
             if not isinstance(crawl_results, list):
@@ -407,6 +409,7 @@ async def crawl_and_save(
     max_pages: int = 0,
     on_progress: DetailedProgressCallback | None = None,
     cancel: threading.Event | None = None,
+    quiet: bool = False,
 ) -> list[Path]:
     """Crawl URL(s), save as markdown, update metadata. Returns paths written.
     Uses hash-based change detection: always fetches, but only saves files
@@ -424,10 +427,10 @@ async def crawl_and_save(
 
         if depth > 0:
             results = await crawl_recursive(
-                url, max_depth=depth, max_pages=max_pages, on_progress=on_progress
+                url, max_depth=depth, max_pages=max_pages, on_progress=on_progress, quiet=quiet
             )
         else:
-            result = await crawl_single(url)
+            result = await crawl_single(url, quiet=quiet)
             results = [result]
             if on_progress:
                 on_progress(EventType.CRAWL_PAGE, CrawlPageEvent(url=url, current=1, total=1))

--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -1,7 +1,9 @@
 """Web crawling — fetch pages as markdown and save to the documents directory."""
 
 import asyncio
+import contextlib
 import hashlib
+import io
 import ipaddress
 import json
 import logging
@@ -293,19 +295,23 @@ async def crawl_single(url: str, *, quiet: bool = False) -> CrawlResult:
     config = CrawlerRunConfig(
         page_timeout=cfg.crawl_timeout * 1000,  # ms
     )
+    # crawl4ai writes progress to stdout regardless of verbose flag;
+    # suppress it by redirecting stdout to devnull when quiet.
+    stdout_ctx = contextlib.redirect_stdout(io.StringIO()) if quiet else contextlib.nullcontext()
     try:
-        async with AsyncWebCrawler(verbose=not quiet) as crawler:
-            result = await crawler.arun(url=url, config=config)
-            # crawl4ai may set success=False for sub-resource failures (e.g. favicon 404)
-            # even when the main page has valid markdown. Trust the content, not the flag.
-            markdown = (result.markdown or "").strip()
-            if markdown:
-                return CrawlResult(url=url, markdown=markdown, success=True)
-            return CrawlResult(
-                url=url,
-                success=False,
-                error=result.error_message or "No content extracted",
-            )
+        with stdout_ctx:
+            async with AsyncWebCrawler(verbose=not quiet) as crawler:
+                result = await crawler.arun(url=url, config=config)
+        # crawl4ai may set success=False for sub-resource failures (e.g. favicon 404)
+        # even when the main page has valid markdown. Trust the content, not the flag.
+        markdown = (result.markdown or "").strip()
+        if markdown:
+            return CrawlResult(url=url, markdown=markdown, success=True)
+        return CrawlResult(
+            url=url,
+            success=False,
+            error=result.error_message or "No content extracted",
+        )
     except Exception as exc:
         log.warning("Failed to crawl %s: %s", url, exc)
         return CrawlResult(url=url, success=False, error=str(exc))
@@ -340,9 +346,11 @@ async def crawl_recursive(
     )
 
     results: list[CrawlResult] = []
+    stdout_ctx = contextlib.redirect_stdout(io.StringIO()) if quiet else contextlib.nullcontext()
     try:
-        async with AsyncWebCrawler(verbose=not quiet) as crawler:
-            crawl_results = await crawler.arun(url=url, config=config)
+        with stdout_ctx:
+            async with AsyncWebCrawler(verbose=not quiet) as crawler:
+                crawl_results = await crawler.arun(url=url, config=config)
             # arun with deep crawl returns a list
             if not isinstance(crawl_results, list):
                 crawl_results = [crawl_results]

--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -351,10 +351,10 @@ async def crawl_recursive(
         with stdout_ctx:
             async with AsyncWebCrawler(verbose=not quiet) as crawler:
                 crawl_results = await crawler.arun(url=url, config=config)
-            # arun with deep crawl returns a list
-            if not isinstance(crawl_results, list):
-                crawl_results = [crawl_results]
-            for i, cr in enumerate(crawl_results):
+        # arun with deep crawl returns a list
+        if not isinstance(crawl_results, list):
+            crawl_results = [crawl_results]
+        for i, cr in enumerate(crawl_results):
                 if on_progress:
                     on_progress(
                         EventType.CRAWL_PAGE,

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -177,6 +177,7 @@ class LlamaCppProvider(LLMProvider):
                 filtered = filter_options(options)
                 if "num_predict" in filtered:
                     filtered["max_tokens"] = filtered.pop("num_predict")
+                filtered.pop("num_ctx", None)  # model-load param, not per-call
                 kwargs.update(filtered)
             response = llm.create_chat_completion(messages=messages, stream=stream, **kwargs)
             if stream:

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -20,6 +20,7 @@ from typing_extensions import TypedDict
 from lilbee.config import Config, cfg
 from lilbee.embedder import Embedder
 from lilbee.providers.base import LLMProvider
+from lilbee.reasoning import strip_reasoning
 from lilbee.store import CitationRecord, SearchChunk, Store, cosine_sim
 
 log = logging.getLogger(__name__)
@@ -536,8 +537,9 @@ class Searcher:
             messages = self._direct_messages(question, history)
             provider_messages = self._messages_for_provider(messages)
             opts = options if options is not None else self._config.generation_options()
-            answer = self._provider.chat(provider_messages, options=opts or None)
-            return AskResult(answer=self._NO_EMBED_WARNING + str(answer or ""), sources=[])
+            raw = str(self._provider.chat(provider_messages, options=opts or None) or "")
+            clean = raw if self._config.show_reasoning else strip_reasoning(raw)
+            return AskResult(answer=self._NO_EMBED_WARNING + clean, sources=[])
         rag = self.build_rag_context(question, top_k=top_k, history=history)
         if rag is None:
             return AskResult(
@@ -547,8 +549,9 @@ class Searcher:
         results, messages = rag
         provider_messages = self._messages_for_provider(messages)
         opts = options if options is not None else self._config.generation_options()
-        answer = self._provider.chat(provider_messages, options=opts or None)
-        return AskResult(answer=str(answer) or "", sources=results)
+        raw = str(self._provider.chat(provider_messages, options=opts or None) or "")
+        clean = raw if self._config.show_reasoning else strip_reasoning(raw)
+        return AskResult(answer=clean, sources=results)
 
     def ask(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,15 +46,14 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> None:
 
 @pytest.fixture(autouse=True)
 def _suppress_model_scan(request, monkeypatch):
-    """Prevent ModelBar._scan_models from spawning background threads.
+    """Prevent ModelBar._scan_models from doing real work in tests.
 
     ModelBar.on_mount calls _scan_models which is @work(thread=True).
-    The spawned thread can outlive the Textual app's run_test() context,
-    accumulating across 3400+ tests and blocking xdist process teardown.
+    The real function does registry scans, HTTP calls, and litellm imports.
+    Mocking it to return empty results makes the worker thread complete
+    instantly, avoiding both thread accumulation and per-test join overhead.
 
-    We mock _classify_installed_models (the heavy function inside the
-    worker) rather than _scan_models itself, so the method body stays
-    covered but no real I/O or litellm imports happen.
+    Tests that need real classification use @pytest.mark.real_model_classify.
     """
     if "real_model_classify" not in {m.name for m in request.node.iter_markers()}:
         monkeypatch.setattr(
@@ -65,10 +64,7 @@ def _suppress_model_scan(request, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _drain_textual_threads():
-    """Wait for Textual worker threads to finish after each test.
-
-    Safety net for any remaining threads not prevented by _suppress_model_scan.
-    """
+    """Safety net: join any Textual worker threads that outlive the test."""
     before = set(threading.enumerate())
     yield
     for thread in threading.enumerate():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1528,6 +1528,22 @@ class TestAddWithUrls:
         assert data["crawled"] == 1
 
     @mock.patch("lilbee.crawler.crawler_available", return_value=True)
+    @mock.patch("lilbee.cli.commands._crawl_urls_blocking")
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_add_url_json_output_is_clean(self, mock_sync, mock_crawl, mock_avail, isolated_env):
+        """--json add with a URL produces clean JSON with no crawl4ai prefix text."""
+        from pathlib import Path
+
+        mock_crawl.return_value = [Path("a.md")]
+        result = runner.invoke(app, ["--json", "add", "https://example.com"])
+        assert result.exit_code == 0
+        raw = result.output.strip()
+        # Must start with '{' — no [INIT]/[FETCH]/spinner text leaked to stdout
+        assert raw.startswith("{"), f"stdout has non-JSON prefix: {raw[:80]}"
+        data = json.loads(raw)
+        assert data["command"] == "add"
+
+    @mock.patch("lilbee.crawler.crawler_available", return_value=True)
     @mock.patch("lilbee.cli.commands._crawl_urls_blocking", return_value=[])
     def test_add_mixed_urls_and_files(
         self, mock_crawl, mock_avail, isolated_env, tmp_path, mock_svc
@@ -1646,6 +1662,17 @@ class TestCrawlUrlsBlocking:
         call_kwargs = mock_crawl.call_args[1]
         assert call_kwargs["depth"] == 5
         assert call_kwargs["max_pages"] == 20
+
+    @mock.patch("lilbee.crawler.crawl_and_save", new_callable=AsyncMock)
+    def test_json_mode_passes_quiet(self, mock_crawl, isolated_env):
+        """In JSON mode, quiet=True is passed to crawl_and_save."""
+        from lilbee.cli.commands import _crawl_urls_blocking
+
+        mock_crawl.return_value = []
+        cfg.json_mode = True
+        _crawl_urls_blocking(["https://example.com"], crawl=False, depth=None, max_pages=None)
+        call_kwargs = mock_crawl.call_args[1]
+        assert call_kwargs["quiet"] is True
 
 
 class TestTopicsCommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -829,14 +829,14 @@ class TestRemove:
         assert data["command"] == "remove"
         assert "test.pdf" in data["removed"]
 
-    def test_remove_json_not_found(self, mock_svc):
+    def test_remove_json_not_found_exits_1(self, mock_svc):
         from lilbee.store import RemoveResult
 
         mock_svc.store.remove_documents.return_value = RemoveResult(
             removed=[], not_found=["nope.pdf"]
         )
         result = runner.invoke(app, ["--json", "remove", "nope.pdf"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         data = json.loads(result.output.strip())
         assert data["removed"] == []
         assert "nope.pdf" in data["not_found"]
@@ -1196,6 +1196,22 @@ class TestAddJson:
         assert data["command"] == "add"
         assert "manual.txt" in data["copied"]
         assert "sync" in data
+
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_add_json_skipped_no_stdout_pollution(self, mock_sync, isolated_env, tmp_path):
+        """JSON add with existing file returns skipped list, no console warnings."""
+        src = tmp_path / "source" / "notes.txt"
+        src.parent.mkdir()
+        src.write_text("some content")
+        # Pre-populate documents dir so file is skipped
+        cfg.documents_dir.mkdir(parents=True, exist_ok=True)
+        (cfg.documents_dir / "notes.txt").write_text("old content")
+        result = runner.invoke(app, ["--json", "add", str(src)])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert data["copied"] == []
+        assert "notes.txt" in data["skipped"]
+        assert "Warning" not in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -484,6 +484,12 @@ class TestRmCmd:
         assert parsed.deleted is True
         assert parsed.freed_gb == 5.0
 
+    def test_json_not_found_exits_1(self, fake_manager, native_manifests):
+        result = runner.invoke(app, ["--json", "model", "rm", "ghost:1.0"])
+        assert result.exit_code == 1
+        parsed = RemoveResult.model_validate_json(result.output)
+        assert parsed.deleted is False
+
     def test_invalid_source(self, fake_manager):
         result = runner.invoke(app, ["model", "rm", "--yes", "qwen3:0.6b", "--source", "bad"])
         assert result.exit_code != 0

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -183,3 +183,29 @@ class TestRunServer:
         # Dir was created, port file cleaned up after shutdown
         assert cfg.data_dir.exists()
         assert not (cfg.data_dir / "server.port").exists()
+
+    @mock.patch("atexit.register")
+    def test_registers_atexit_cleanup(self, mock_atexit):
+        """Port file cleanup is registered via atexit for SIGTERM resilience."""
+        from lilbee.cli.commands import _run_server
+
+        sock = mock.MagicMock()
+        sock.getsockname.return_value = ("127.0.0.1", 11111)
+
+        fake_server_obj = mock.MagicMock()
+        fake_server_obj.servers = [mock.MagicMock(sockets=[sock])]
+        fake_server_obj.startup = mock.AsyncMock()
+        fake_server_obj.main_loop = mock.AsyncMock()
+        fake_server_obj.shutdown = mock.AsyncMock()
+
+        fake_config = mock.MagicMock()
+
+        asyncio.run(_run_server(fake_server_obj, fake_config, "127.0.0.1"))
+
+        mock_atexit.assert_called_once()
+        cleanup_fn = mock_atexit.call_args[0][0]
+        # Write a port file and verify the cleanup function removes it
+        port_path = cfg.data_dir / "server.port"
+        port_path.write_text("11111")
+        cleanup_fn()
+        assert not port_path.exists()

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import lilbee.concepts as concepts_mod
 import lilbee.services as svc_mod
 from lilbee.concepts import ConceptGraph
 from lilbee.config import cfg
@@ -51,14 +50,10 @@ def mock_svc():
 
 @pytest.fixture(autouse=True)
 def reset_singletons(mock_svc):
-    """Reset ConceptGraph nlp cache and module-level globals between tests."""
+    """Reset ConceptGraph nlp cache between tests."""
     mock_svc.concepts.reset_nlp_cache()
-    concepts_mod._nlp_cache = None
-    concepts_mod._nlp_failed = False
     yield
     mock_svc.concepts.reset_nlp_cache()
-    concepts_mod._nlp_cache = None
-    concepts_mod._nlp_failed = False
 
 
 @pytest.fixture()
@@ -136,35 +131,35 @@ class TestConceptsAvailable:
 
 
 class TestExtractConcepts:
-    @patch("lilbee.concepts._get_nlp")
-    def test_basic_extraction(self, mock_get_nlp, cg):
-        mock_get_nlp.return_value = _make_mock_nlp(
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_basic_extraction(self, mock_spacy, cg):
+        mock_spacy.return_value = _make_mock_nlp(
             {"hello world": ["machine learning", "neural networks"]}
         )
         result = cg.extract_concepts("hello world")
         assert result == ["machine learning", "neural networks"]
 
-    @patch("lilbee.concepts._get_nlp")
-    def test_deduplication(self, mock_get_nlp, cg):
-        mock_get_nlp.return_value = _make_mock_nlp({"text": ["Concept", "concept", "Other"]})
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_deduplication(self, mock_spacy, cg):
+        mock_spacy.return_value = _make_mock_nlp({"text": ["Concept", "concept", "Other"]})
         result = cg.extract_concepts("text")
         assert result == ["concept", "other"]
 
-    @patch("lilbee.concepts._get_nlp")
-    def test_max_cap(self, mock_get_nlp, cg):
-        mock_get_nlp.return_value = _make_mock_nlp({"text": ["alpha", "beta", "gamma", "delta"]})
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_max_cap(self, mock_spacy, cg):
+        mock_spacy.return_value = _make_mock_nlp({"text": ["alpha", "beta", "gamma", "delta"]})
         result = cg.extract_concepts("text", max_concepts=2)
         assert len(result) == 2
 
-    @patch("lilbee.concepts._get_nlp")
-    def test_empty_input(self, mock_get_nlp, cg):
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_empty_input(self, mock_spacy, cg):
         result = cg.extract_concepts("")
         assert result == []
-        mock_get_nlp.assert_not_called()
+        mock_spacy.assert_not_called()
 
-    @patch("lilbee.concepts._get_nlp")
-    def test_filters_short_concepts(self, mock_get_nlp, cg):
-        mock_get_nlp.return_value = _make_mock_nlp({"text": ["a", "ok", "good concept"]})
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_filters_short_concepts(self, mock_spacy, cg):
+        mock_spacy.return_value = _make_mock_nlp({"text": ["a", "ok", "good concept"]})
         result = cg.extract_concepts("text")
         assert "a" not in result
         assert "ok" in result
@@ -172,9 +167,9 @@ class TestExtractConcepts:
 
 
 class TestExtractConceptsBatch:
-    @patch("lilbee.concepts._get_nlp")
-    def test_batch_extraction(self, mock_get_nlp, cg):
-        mock_get_nlp.return_value = _make_mock_nlp(
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_batch_extraction(self, mock_spacy, cg):
+        mock_spacy.return_value = _make_mock_nlp(
             {"doc1": ["concept a"], "doc2": ["concept b", "concept c"]}
         )
         result = cg.extract_concepts_batch(["doc1", "doc2"])
@@ -182,28 +177,28 @@ class TestExtractConceptsBatch:
         assert result[0] == ["concept a"]
         assert result[1] == ["concept b", "concept c"]
 
-    @patch("lilbee.concepts._get_nlp")
-    def test_empty_input(self, mock_get_nlp, cg):
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_empty_input(self, mock_spacy, cg):
         result = cg.extract_concepts_batch([])
         assert result == []
-        mock_get_nlp.assert_not_called()
+        mock_spacy.assert_not_called()
 
-    @patch("lilbee.concepts._get_nlp")
-    def test_batch_filters_short_concepts(self, mock_get_nlp, cg):
-        mock_get_nlp.return_value = _make_mock_nlp({"text": ["a", "ok", "good"]})
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_batch_filters_short_concepts(self, mock_spacy, cg):
+        mock_spacy.return_value = _make_mock_nlp({"text": ["a", "ok", "good"]})
         result = cg.extract_concepts_batch(["text"])
         assert result == [["ok", "good"]]
 
-    @patch("lilbee.concepts._get_nlp")
-    def test_batch_deduplicates(self, mock_get_nlp, cg):
-        mock_get_nlp.return_value = _make_mock_nlp({"text": ["Alpha", "alpha", "Beta"]})
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_batch_deduplicates(self, mock_spacy, cg):
+        mock_spacy.return_value = _make_mock_nlp({"text": ["Alpha", "alpha", "Beta"]})
         result = cg.extract_concepts_batch(["text"])
         assert result == [["alpha", "beta"]]
 
-    @patch("lilbee.concepts._get_nlp")
-    def test_batch_caps_at_max(self, mock_get_nlp, cg):
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_batch_caps_at_max(self, mock_spacy, cg):
         cfg.concept_max_per_chunk = 2
-        mock_get_nlp.return_value = _make_mock_nlp({"text": ["aa", "bb", "cc", "dd"]})
+        mock_spacy.return_value = _make_mock_nlp({"text": ["aa", "bb", "cc", "dd"]})
         result = cg.extract_concepts_batch(["text"])
         assert len(result[0]) == 2
 
@@ -256,52 +251,38 @@ class TestEnsureSpacyModel:
                 _ensure_spacy_model()
 
 
-class TestGetNlpFallback:
-    def test_returns_none_when_model_unavailable(self):
-        with patch("lilbee.concepts._ensure_spacy_model", side_effect=ImportError("no model")):
-            from lilbee.concepts import _get_nlp
-
-            result = _get_nlp()
-            assert result is None
-            assert concepts_mod._nlp_failed is True
-
-    def test_caches_failure_state(self):
-        with patch("lilbee.concepts._ensure_spacy_model", side_effect=ImportError("no model")) as m:
-            from lilbee.concepts import _get_nlp
-
-            _get_nlp()
-            _get_nlp()
-            # Only called once; second call uses cached failure
-            m.assert_called_once()
-
-    def test_caches_successful_load(self):
-        mock_nlp = MagicMock()
-        with patch("lilbee.concepts._ensure_spacy_model", return_value=mock_nlp) as m:
-            from lilbee.concepts import _get_nlp
-
-            result1 = _get_nlp()
-            result2 = _get_nlp()
-            m.assert_called_once()
-            assert result1 is mock_nlp
-            assert result2 is mock_nlp
-
-
 class TestGracefulDegradation:
-    def test_extract_concepts_returns_empty_when_nlp_unavailable(self, cg):
-        concepts_mod._nlp_failed = True
-        cg.reset_nlp_cache()
+    @patch("lilbee.concepts._ensure_spacy_model", side_effect=ImportError("no model"))
+    def test_ensure_nlp_returns_none_on_failure(self, mock_spacy, cg):
+        assert cg._ensure_nlp() is None
+
+    @patch("lilbee.concepts._ensure_spacy_model", side_effect=ImportError("no model"))
+    def test_caches_failure_state(self, mock_spacy, cg):
+        cg._ensure_nlp()
+        cg._ensure_nlp()
+        mock_spacy.assert_called_once()
+
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_caches_successful_load(self, mock_spacy, cg):
+        mock_nlp = MagicMock()
+        mock_spacy.return_value = mock_nlp
+        assert cg._ensure_nlp() is mock_nlp
+        assert cg._ensure_nlp() is mock_nlp
+        mock_spacy.assert_called_once()
+
+    @patch("lilbee.concepts._ensure_spacy_model", side_effect=ImportError("no model"))
+    def test_extract_concepts_returns_empty(self, mock_spacy, cg):
         assert cg.extract_concepts("some text about python") == []
 
-    def test_extract_concepts_batch_returns_empty_lists_when_nlp_unavailable(self, cg):
-        concepts_mod._nlp_failed = True
-        cg.reset_nlp_cache()
+    @patch("lilbee.concepts._ensure_spacy_model", side_effect=ImportError("no model"))
+    def test_extract_concepts_batch_returns_empty_lists(self, mock_spacy, cg):
         result = cg.extract_concepts_batch(["text one", "text two"])
         assert result == [[], []]
 
-    def test_expand_query_returns_empty_when_nlp_unavailable(self, cg):
-        concepts_mod._nlp_failed = True
-        cg.reset_nlp_cache()
+    @patch("lilbee.concepts._ensure_spacy_model", side_effect=ImportError("no model"))
+    def test_expand_query_returns_empty(self, mock_spacy, cg):
         assert cg.expand_query("python frameworks") == []
+
 
 class TestBuildFromChunks:
     @patch("lilbee.lock.write_lock")
@@ -360,9 +341,9 @@ class TestBoostResults:
 
 
 class TestExpandQuery:
-    @patch("lilbee.concepts._get_nlp")
-    def test_expand_query(self, mock_get_nlp, cg, mock_svc):
-        mock_get_nlp.return_value = _make_mock_nlp({"python frameworks": ["python"]})
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_expand_query(self, mock_spacy, cg, mock_svc):
+        mock_spacy.return_value = _make_mock_nlp({"python frameworks": ["python"]})
         mock_table = MagicMock()
         mock_table.search.return_value.where.return_value.to_list.return_value = [
             {"source": "python", "target": "django", "weight": 1.0},
@@ -373,9 +354,9 @@ class TestExpandQuery:
         assert "django" in related
         assert "flask" in related
 
-    @patch("lilbee.concepts._get_nlp")
-    def test_expand_query_no_concepts(self, mock_get_nlp, cg):
-        mock_get_nlp.return_value = _make_mock_nlp({"???": []})
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_expand_query_no_concepts(self, mock_spacy, cg):
+        mock_spacy.return_value = _make_mock_nlp({"???": []})
         assert cg.expand_query("???") == []
 
 

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import lilbee.concepts as concepts_mod
 import lilbee.services as svc_mod
 from lilbee.concepts import ConceptGraph
 from lilbee.config import cfg
@@ -50,10 +51,14 @@ def mock_svc():
 
 @pytest.fixture(autouse=True)
 def reset_singletons(mock_svc):
-    """Reset ConceptGraph nlp cache between tests."""
+    """Reset ConceptGraph nlp cache and module-level globals between tests."""
     mock_svc.concepts.reset_nlp_cache()
+    concepts_mod._nlp_cache = None
+    concepts_mod._nlp_failed = False
     yield
     mock_svc.concepts.reset_nlp_cache()
+    concepts_mod._nlp_cache = None
+    concepts_mod._nlp_failed = False
 
 
 @pytest.fixture()
@@ -238,7 +243,7 @@ class TestEnsureSpacyModel:
             mock_cli.download.assert_called_once_with("en_core_web_sm")
             assert result is not None
 
-    def test_download_sysexit_raises_runtime_error(self):
+    def test_raises_import_error_when_download_fails(self):
         mock_spacy = MagicMock()
         mock_spacy.load.side_effect = OSError("not found")
         mock_cli = MagicMock()
@@ -247,9 +252,56 @@ class TestEnsureSpacyModel:
         with patch.dict("sys.modules", {"spacy": mock_spacy, "spacy.cli": mock_cli}):
             from lilbee.concepts import _ensure_spacy_model
 
-            with pytest.raises(RuntimeError, match="Failed to download spacy model"):
+            with pytest.raises(ImportError, match="auto-download failed"):
                 _ensure_spacy_model()
 
+
+class TestGetNlpFallback:
+    def test_returns_none_when_model_unavailable(self):
+        with patch("lilbee.concepts._ensure_spacy_model", side_effect=ImportError("no model")):
+            from lilbee.concepts import _get_nlp
+
+            result = _get_nlp()
+            assert result is None
+            assert concepts_mod._nlp_failed is True
+
+    def test_caches_failure_state(self):
+        with patch("lilbee.concepts._ensure_spacy_model", side_effect=ImportError("no model")) as m:
+            from lilbee.concepts import _get_nlp
+
+            _get_nlp()
+            _get_nlp()
+            # Only called once; second call uses cached failure
+            m.assert_called_once()
+
+    def test_caches_successful_load(self):
+        mock_nlp = MagicMock()
+        with patch("lilbee.concepts._ensure_spacy_model", return_value=mock_nlp) as m:
+            from lilbee.concepts import _get_nlp
+
+            result1 = _get_nlp()
+            result2 = _get_nlp()
+            m.assert_called_once()
+            assert result1 is mock_nlp
+            assert result2 is mock_nlp
+
+
+class TestGracefulDegradation:
+    def test_extract_concepts_returns_empty_when_nlp_unavailable(self, cg):
+        concepts_mod._nlp_failed = True
+        cg.reset_nlp_cache()
+        assert cg.extract_concepts("some text about python") == []
+
+    def test_extract_concepts_batch_returns_empty_lists_when_nlp_unavailable(self, cg):
+        concepts_mod._nlp_failed = True
+        cg.reset_nlp_cache()
+        result = cg.extract_concepts_batch(["text one", "text two"])
+        assert result == [[], []]
+
+    def test_expand_query_returns_empty_when_nlp_unavailable(self, cg):
+        concepts_mod._nlp_failed = True
+        cg.reset_nlp_cache()
+        assert cg.expand_query("python frameworks") == []
 
 class TestBuildFromChunks:
     @patch("lilbee.lock.write_lock")

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -463,6 +463,20 @@ class TestCrawlSingle:
         assert not result.success
         assert "timeout" in result.error
 
+    async def test_quiet_passes_verbose_false(self):
+        """quiet=True passes verbose=False to AsyncWebCrawler."""
+        mock_result = _make_crawl4ai_result()
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=mock_result)
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_crawler_cls = MagicMock(return_value=mock_instance)
+        mock_mod = _mock_crawl4ai(mock_crawler_cls)
+
+        with patch.dict("sys.modules", {"crawl4ai": mock_mod}):
+            await crawl_single("https://example.com", quiet=True)
+        mock_crawler_cls.assert_called_once_with(verbose=False)
+
 
 class TestCrawlRecursive:
     def _setup_crawl4ai(self, mock_instance):
@@ -561,6 +575,20 @@ class TestCrawlRecursive:
         with patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)):
             await crawl_recursive("https://example.com", max_depth=1, max_pages=999)
 
+    async def test_quiet_passes_verbose_false(self):
+        """quiet=True passes verbose=False to AsyncWebCrawler."""
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=[])
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_crawler_cls = MagicMock(return_value=mock_instance)
+        modules = self._setup_crawl4ai(mock_instance)
+        modules["crawl4ai"].AsyncWebCrawler = mock_crawler_cls
+
+        with patch.dict("sys.modules", modules):
+            await crawl_recursive("https://example.com", max_depth=1, quiet=True)
+        mock_crawler_cls.assert_called_once_with(verbose=False)
+
 
 class TestCrawlAndSave:
     @patch("lilbee.crawler.crawl_single")
@@ -578,6 +606,21 @@ class TestCrawlAndSave:
         ]
         paths = await crawl_and_save("https://example.com", depth=2, max_pages=10)
         assert len(paths) == 2
+
+    @patch("lilbee.crawler.crawl_single")
+    async def test_quiet_forwarded_to_crawl_single(self, mock_crawl_single, isolated_env):
+        """quiet=True is forwarded to crawl_single."""
+        mock_crawl_single.return_value = CrawlResult(url="https://example.com", markdown="# Hi")
+        await crawl_and_save("https://example.com", quiet=True)
+        mock_crawl_single.assert_awaited_once_with("https://example.com", quiet=True)
+
+    @patch("lilbee.crawler.crawl_recursive")
+    async def test_quiet_forwarded_to_crawl_recursive(self, mock_crawl_recursive, isolated_env):
+        """quiet=True is forwarded to crawl_recursive."""
+        mock_crawl_recursive.return_value = []
+        await crawl_and_save("https://example.com", depth=2, quiet=True)
+        call_kwargs = mock_crawl_recursive.call_args[1]
+        assert call_kwargs["quiet"] is True
 
     @patch("lilbee.crawler.crawl_single")
     async def test_single_page_with_progress(self, mock_crawl_single, isolated_env):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1434,6 +1434,25 @@ class TestLlamaCppProviderMethods:
         assert call_kwargs["max_tokens"] == 100
         assert "num_predict" not in call_kwargs
 
+    def test_chat_strips_num_ctx(self, mock_llama_cpp: mock.MagicMock) -> None:
+        """chat() strips num_ctx since it is a model-load param, not per-call."""
+        provider = _make_provider_no_thread()
+
+        mock_llm = mock.MagicMock()
+        mock_llm.create_chat_completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+        with mock.patch.object(provider, "_get_chat_llm", return_value=mock_llm):
+            result = provider.chat(
+                [{"role": "user", "content": "hi"}],
+                stream=False,
+                options={"temperature": 0.7, "num_ctx": 2048},
+            )
+
+        assert result == "ok"
+        call_kwargs = mock_llm.create_chat_completion.call_args[1]
+        assert call_kwargs["temperature"] == 0.7
+        assert "num_ctx" not in call_kwargs
+
     def test_chat_non_stream_no_options(self, mock_llama_cpp: mock.MagicMock) -> None:
         """chat() without options passes no extra kwargs."""
         provider = _make_provider_no_thread()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -319,6 +319,24 @@ class TestAskRaw:
         messages = mock_svc.provider.chat.call_args[0][0]
         assert len(messages) == 3  # system + history + user
 
+    def test_ask_raw_strips_think_tags(self, mock_svc):
+        mock_svc.store.search.return_value = [_make_result()]
+        mock_svc.provider.chat.return_value = "<think>reasoning</think>The answer is 42."
+        result = get_services().searcher.ask_raw("question")
+        assert "<think>" not in result.answer
+        assert result.answer == "The answer is 42."
+
+    def test_ask_raw_preserves_think_tags_when_show_reasoning(self, mock_svc):
+        mock_svc.store.search.return_value = [_make_result()]
+        mock_svc.provider.chat.return_value = "<think>reasoning</think>The answer is 42."
+        old = cfg.show_reasoning
+        cfg.show_reasoning = True
+        try:
+            result = get_services().searcher.ask_raw("question")
+            assert "<think>reasoning</think>" in result.answer
+        finally:
+            cfg.show_reasoning = old
+
 
 class TestAsk:
     def test_returns_answer_with_citations(self, mock_svc):
@@ -1166,6 +1184,23 @@ class TestAskRawNoEmbed:
         assert "Chat only" in result.answer
         assert "direct answer" in result.answer
         assert result.sources == []
+
+    def test_no_embed_strips_think_tags(self, mock_svc):
+        """ask_raw no-embed path strips <think> tags."""
+        mock_svc.embedder.embedding_available.return_value = False
+        mock_svc.provider.chat.return_value = "<think>inner thought</think>direct answer"
+
+        searcher = Searcher(
+            cfg,
+            mock_svc.provider,
+            mock_svc.store,
+            mock_svc.embedder,
+            mock_svc.reranker,
+            mock_svc.concepts,
+        )
+        result = searcher.ask_raw("hello")
+        assert "<think>" not in result.answer
+        assert "direct answer" in result.answer
 
 
 class TestAskStreamNoEmbed:


### PR DESCRIPTION
## Summary

- `--json model rm` and `--json remove` now exit 1 when target not found, matching human mode
- `--json add` uses `copy_files` instead of `copy_paths` to avoid leaking Rich warnings to stdout
- `--num-ctx` filtered from llama-cpp per-call options (model-load param, not per-call)
- `--json ask` strips `<think>` reasoning tags via `strip_reasoning`
- Concept graph degrades gracefully when spaCy model can't load (caching on ConceptGraph instance, no module globals)
- crawl4ai stdout suppressed in JSON mode via `_open_crawler` context manager
- Server port file cleaned up via atexit handler