### PR TITLE
Fix search after init and crawl_status race condition

### DIFF
--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -11,7 +11,6 @@ from rich.console import Console
 from lilbee.cli.helpers import get_version
 from lilbee.cli.helpers import json_output as json_out
 from lilbee.config import cfg
-from lilbee.models import ensure_tag
 
 app = typer.Typer(help="lilbee — Local RAG knowledge base", invoke_without_command=True)
 console = Console()
@@ -96,7 +95,7 @@ def apply_overrides(
             _apply_data_root(Path(data_env))
 
     if model is not None:
-        cfg.chat_model = ensure_tag(model)
+        cfg.chat_model = model
     if temperature is not None:
         cfg.temperature = temperature
     if top_p is not None:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -528,13 +528,10 @@ class ChatScreen(Screen[None]):
 
     def _cmd_model(self, args: str) -> None:
         if args:
-            from lilbee.models import ensure_tag
-
-            tagged = ensure_tag(args)
-            cfg.chat_model = tagged
-            settings.set_value(cfg.data_root, "chat_model", tagged)
+            cfg.chat_model = args
+            settings.set_value(cfg.data_root, "chat_model", cfg.chat_model)
             self.app.title = f"lilbee -- {cfg.chat_model}"
-            self.notify(msg.CMD_MODEL_SET.format(name=tagged))
+            self.notify(msg.CMD_MODEL_SET.format(name=cfg.chat_model))
             self._apply_model_change()
             self._refresh_model_bar()
         else:

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -109,8 +109,8 @@ class Config(BaseSettings):
     lancedb_dir: Path = Field(default=Path())
     models_dir: Path = Field(default=Path())
 
-    chat_model: str = Field(default="qwen3", min_length=1)
-    embedding_model: str = Field(default="nomic-embed-text", min_length=1)
+    chat_model: str = Field(default="qwen3:latest", min_length=1)
+    embedding_model: str = Field(default="nomic-embed-text:latest", min_length=1)
     embedding_dim: int = Field(default=768, ge=1)
     chunk_size: int = ConfigField(default=512, ge=1, writable=True, reindex=True)
     chunk_overlap: int = ConfigField(default=100, ge=0, writable=True, reindex=True)
@@ -395,6 +395,16 @@ class Config(BaseSettings):
             if stripped in ("false", "0", "no"):
                 return False
         return bool(v)
+
+    @field_validator("chat_model", "embedding_model", mode="after")
+    @classmethod
+    def _normalize_model_tag(cls, v: str) -> str:
+        """Ensure model names always have an explicit tag (e.g. qwen3 -> qwen3:latest)."""
+        if not v or ":" in v:
+            return v
+        from lilbee.registry import DEFAULT_TAG
+
+        return f"{v}:{DEFAULT_TAG}"
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/src/lilbee/crawl_task.py
+++ b/src/lilbee/crawl_task.py
@@ -92,6 +92,7 @@ async def run_crawl(task: CrawlTask) -> None:
         )
         task.status = TaskStatus.DONE
         task.pages_crawled = task.pages_crawled or len(paths)
+        task.finished_at = now_iso()
         log.info("Crawl complete: %s → %d files", task.url, len(paths))
         try:
             from lilbee.ingest import sync
@@ -102,9 +103,9 @@ async def run_crawl(task: CrawlTask) -> None:
     except Exception as exc:
         task.status = TaskStatus.FAILED
         task.error = str(exc)
+        task.finished_at = now_iso()
         log.warning("Crawl failed: %s — %s", task.url, exc)
     finally:
-        task.finished_at = now_iso()
         task._async_task = None
 
 

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -217,12 +217,6 @@ def init(path: str = "") -> dict[str, Any]:
     cfg.lancedb_dir = root / "data" / "lancedb"
     reset_services()
 
-    # Normalize bare model names (e.g. "qwen3" -> "qwen3:latest")
-    from lilbee.models import ensure_tag
-
-    cfg.chat_model = ensure_tag(cfg.chat_model)
-    cfg.embedding_model = ensure_tag(cfg.embedding_model)
-
     return {"command": "init", "path": str(root), "created": created}
 
 

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -217,6 +217,12 @@ def init(path: str = "") -> dict[str, Any]:
     cfg.lancedb_dir = root / "data" / "lancedb"
     reset_services()
 
+    # Normalize bare model names (e.g. "qwen3" -> "qwen3:latest")
+    from lilbee.models import ensure_tag
+
+    cfg.chat_model = ensure_tag(cfg.chat_model)
+    cfg.embedding_model = ensure_tag(cfg.embedding_model)
+
     return {"command": "init", "path": str(root), "created": created}
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from lilbee.config import (
     DEFAULT_IGNORE_DIRS,
     SOURCES_TABLE,
     Config,
+    cfg,
 )
 
 
@@ -33,8 +34,8 @@ class TestFromEnvDefaults:
     def test_default_values(self, tmp_path):
         with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
             c = Config()
-            assert c.chat_model == "qwen3"
-            assert c.embedding_model == "nomic-embed-text"
+            assert c.chat_model == "qwen3:latest"
+            assert c.embedding_model == "nomic-embed-text:latest"
             assert c.embedding_dim == 768
             assert c.chunk_size == 512
             assert c.chunk_overlap == 100
@@ -67,12 +68,23 @@ class TestEnvVarOverrides:
     def test_chat_model_override(self):
         with mock.patch.dict(os.environ, {"LILBEE_CHAT_MODEL": "llama3"}):
             c = Config()
-            assert c.chat_model == "llama3"
+            assert c.chat_model == "llama3:latest"
+
+    def test_chat_model_override_tagged(self):
+        with mock.patch.dict(os.environ, {"LILBEE_CHAT_MODEL": "llama3:8b"}):
+            c = Config()
+            assert c.chat_model == "llama3:8b"
 
     def test_embedding_model_override(self):
         with mock.patch.dict(os.environ, {"LILBEE_EMBEDDING_MODEL": "mxbai-embed-large"}):
             c = Config()
-            assert c.embedding_model == "mxbai-embed-large"
+            assert c.embedding_model == "mxbai-embed-large:latest"
+
+    def test_model_tag_normalized_on_assignment(self):
+        cfg.chat_model = "qwen3"
+        assert cfg.chat_model == "qwen3:latest"
+        cfg.chat_model = "qwen3:0.6b"
+        assert cfg.chat_model == "qwen3:0.6b"
 
     def test_embedding_dim_override(self):
         with mock.patch.dict(os.environ, {"LILBEE_EMBEDDING_DIM": "1024"}):
@@ -118,7 +130,7 @@ class TestTomlConfigFile:
         env["LILBEE_DATA"] = str(tmp_path)
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
-            assert c.chat_model == "my-saved-model"
+            assert c.chat_model == "my-saved-model:latest"
 
     def test_env_var_overrides_toml(self, tmp_path):
         toml_path = tmp_path / "config.toml"
@@ -128,12 +140,12 @@ class TestTomlConfigFile:
         env["LILBEE_CHAT_MODEL"] = "env-model"
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
-            assert c.chat_model == "env-model"
+            assert c.chat_model == "env-model:latest"
 
     def test_no_toml_uses_defaults(self, tmp_path):
         with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
             c = Config()
-            assert c.chat_model == "qwen3"
+            assert c.chat_model == "qwen3:latest"
 
     def test_corrupt_toml_uses_defaults(self, tmp_path):
         toml_path = tmp_path / "config.toml"
@@ -142,7 +154,7 @@ class TestTomlConfigFile:
         env["LILBEE_DATA"] = str(tmp_path)
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
-            assert c.chat_model == "qwen3"
+            assert c.chat_model == "qwen3:latest"
 
     def test_embedding_model_from_toml(self, tmp_path):
         toml_path = tmp_path / "config.toml"
@@ -151,7 +163,7 @@ class TestTomlConfigFile:
         env["LILBEE_DATA"] = str(tmp_path)
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
-            assert c.embedding_model == "my-embed"
+            assert c.embedding_model == "my-embed:latest"
 
     def test_temperature_from_toml(self, tmp_path):
         toml_path = tmp_path / "config.toml"
@@ -700,4 +712,4 @@ class TestPlainEnvSourceSkipsEmpty:
         env["LILBEE_CHAT_MODEL"] = ""
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
-        assert c.chat_model == "qwen3"  # default, not empty
+        assert c.chat_model == "qwen3:latest"  # default, not empty

--- a/tests/test_crawl_task.py
+++ b/tests/test_crawl_task.py
@@ -152,6 +152,23 @@ class TestRunCrawl:
         assert task.status == TaskStatus.DONE
         assert task.error is None
 
+    @patch("lilbee.crawl_task.crawl_and_save", new_callable=AsyncMock)
+    async def test_finished_at_set_before_sync(self, mock_crawl):
+        """finished_at is set before sync runs, not after (BEE-ays)."""
+        from pathlib import Path
+
+        captured_finished_at: list[str] = []
+
+        async def spy_sync(*, quiet: bool = False) -> MagicMock:
+            captured_finished_at.append(task.finished_at)
+            return MagicMock()
+
+        mock_crawl.return_value = [Path("a.md")]
+        task = CrawlTask(task_id="t1", url="https://example.com", depth=0, max_pages=10)
+        with patch("lilbee.ingest.sync", new_callable=AsyncMock, side_effect=spy_sync):
+            await run_crawl(task)
+        assert captured_finished_at[0] != "", "finished_at must be set before sync starts"
+
 
 class TestTaskRegistry:
     @patch("lilbee.crawl_task.run_crawl", new_callable=AsyncMock)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -860,7 +860,7 @@ class TestVisionFallback:
 
             result = await ingest_document(f, "scanned.pdf", "pdf", quiet=True)
         mock_vision.assert_called_once_with(
-            f, "test-vision", quiet=True, timeout=45.0, on_progress=mock.ANY
+            f, "test-vision:latest", quiet=True, timeout=45.0, on_progress=mock.ANY
         )
         assert len(result) > 0
         assert result[0]["content_type"] == "pdf"
@@ -886,7 +886,7 @@ class TestVisionFallback:
 
             await ingest_document(f, "scanned.pdf", "pdf")
         mock_vision.assert_called_once_with(
-            f, "test-vision", quiet=False, timeout=120.0, on_progress=mock.ANY
+            f, "test-vision:latest", quiet=False, timeout=120.0, on_progress=mock.ANY
         )
 
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)
@@ -909,7 +909,7 @@ class TestVisionFallback:
 
             await _ingest_file(f, "scanned.pdf", "pdf", quiet=True)
         mock_vision.assert_called_once_with(
-            f, "test-vision", quiet=True, timeout=120.0, on_progress=mock.ANY
+            f, "test-vision:latest", quiet=True, timeout=120.0, on_progress=mock.ANY
         )
 
     @mock.patch("kreuzberg.extract_file", new_callable=AsyncMock)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -385,6 +385,26 @@ class TestInit:
         assert cfg.documents_dir == root / "documents"
         assert cfg.data_root == tmp_path
 
+    def test_init_normalizes_model_tags(self, tmp_path):
+        """Init adds :latest to bare model names (BEE-bhe)."""
+        cfg.chat_model = "qwen3"
+        cfg.embedding_model = "nomic-embed-text"
+        target = tmp_path / "proj"
+        target.mkdir()
+        init(str(target))
+        assert cfg.chat_model == "qwen3:latest"
+        assert cfg.embedding_model == "nomic-embed-text:latest"
+
+    def test_init_preserves_tagged_models(self, tmp_path):
+        """Init does not alter models that already have a tag."""
+        cfg.chat_model = "qwen3:0.6b"
+        cfg.embedding_model = "nomic-embed-text:v1.5"
+        target = tmp_path / "proj"
+        target.mkdir()
+        init(str(target))
+        assert cfg.chat_model == "qwen3:0.6b"
+        assert cfg.embedding_model == "nomic-embed-text:v1.5"
+
 
 class TestAdd:
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -385,25 +385,12 @@ class TestInit:
         assert cfg.documents_dir == root / "documents"
         assert cfg.data_root == tmp_path
 
-    def test_init_normalizes_model_tags(self, tmp_path):
-        """Init adds :latest to bare model names (BEE-bhe)."""
+    def test_bare_model_normalized_after_init(self, tmp_path):
+        """Config validator normalizes bare model names (BEE-bhe)."""
         cfg.chat_model = "qwen3"
-        cfg.embedding_model = "nomic-embed-text"
-        target = tmp_path / "proj"
-        target.mkdir()
-        init(str(target))
         assert cfg.chat_model == "qwen3:latest"
+        cfg.embedding_model = "nomic-embed-text"
         assert cfg.embedding_model == "nomic-embed-text:latest"
-
-    def test_init_preserves_tagged_models(self, tmp_path):
-        """Init does not alter models that already have a tag."""
-        cfg.chat_model = "qwen3:0.6b"
-        cfg.embedding_model = "nomic-embed-text:v1.5"
-        target = tmp_path / "proj"
-        target.mkdir()
-        init(str(target))
-        assert cfg.chat_model == "qwen3:0.6b"
-        assert cfg.embedding_model == "nomic-embed-text:v1.5"
 
 
 class TestAdd:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1325,7 +1325,7 @@ class TestLlamaCppProviderMethods:
         ):
             result = provider._get_chat_llm()
 
-        mock_vis.assert_called_once_with("vision-model")
+        mock_vis.assert_called_once_with("vision-model:latest")
         assert result == mock_vis.return_value
 
     def test_get_chat_llm_with_override_model(self, mock_llama_cpp: mock.MagicMock) -> None:

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -886,7 +886,7 @@ class TestChatInteractions:
             await pilot.pause()
             app.screen._handle_slash("/set chat_model new-test-model")
             await pilot.pause()
-            assert cfg.chat_model == "new-test-model"
+            assert cfg.chat_model == "new-test-model:latest"
 
     async def test_slash_command_set_unknown_key(self, _mock_resolve):
         """/set nonexistent_key warns."""

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4345,7 +4345,7 @@ async def test_chat_refresh_status_line():
         from lilbee.cli.tui.screens.chat import ChatStatusLine
 
         status = app.screen.query_one("#chat-status-line", ChatStatusLine)
-        assert status.model_name == "my-model"
+        assert status.model_name == "my-model:latest"
 
 
 async def test_settings_group_titles_present():

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2123,7 +2123,7 @@ class TestModelBarAdditional:
             ):
                 embed_sel.value = "new-embed"
                 await pilot.pause()
-            assert cfg.embedding_model == "new-embed"
+            assert cfg.embedding_model == "new-embed:latest"
 
     async def test_populate_embed_model_in_scanned(self) -> None:
         from lilbee.cli.tui.widgets.model_bar import ModelBar

--- a/tests/test_wiki_lint.py
+++ b/tests/test_wiki_lint.py
@@ -248,12 +248,12 @@ class TestParseFrontmatter:
 
 class TestLintModelChanged:
     def test_same_model_no_issue(self):
-        text = "---\ngenerated_by: test-model\n---\n\n# Doc\n"
+        text = f"---\ngenerated_by: {cfg.chat_model}\n---\n\n# Doc\n"
         result = _lint_model_changed("wiki/summaries/doc.md", text, cfg)
         assert result is None
 
     def test_different_model_flags_issue(self):
-        text = "---\ngenerated_by: old-model\n---\n\n# Doc\n"
+        text = "---\ngenerated_by: old-model:latest\n---\n\n# Doc\n"
         result = _lint_model_changed("wiki/summaries/doc.md", text, cfg)
         assert result is not None
         assert result.severity == IssueSeverity.WARNING


### PR DESCRIPTION
## Summary
- Normalize bare model names after init so search doesn't fail with 'model not found'
- Set finished_at timestamp before post-crawl sync to prevent inconsistent crawl_status