### PR TITLE
Fix wiki generation failure with small models

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -699,12 +699,18 @@ class ChatScreen(Screen[None]):
                 if not chunks:
                     continue
 
+                last_error: str = ""
+
                 def _on_progress(
                     stage: str,
                     _data: dict[str, object],
                     source_name: str = source,
                     source_idx: int = idx,
                 ) -> None:
+                    nonlocal last_error
+                    if stage == "failed":
+                        last_error = str(_data.get("error", "Unknown error"))
+                        return
                     fraction = _WIKI_STAGE_FRACTIONS.get(stage, 0.0)
                     pct = int((source_idx + fraction) * 100 / total)
                     call_from_thread(
@@ -729,7 +735,8 @@ class ChatScreen(Screen[None]):
                 )
                 call_from_thread(self, self._refresh_wiki_screen)
             else:
-                call_from_thread(self, task_bar.fail_task, task_id, "No pages generated")
+                fail_reason = last_error or "No pages generated"
+                call_from_thread(self, task_bar.fail_task, task_id, fail_reason)
                 call_from_thread(
                     self,
                     self.notify,

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -685,6 +685,7 @@ class ChatScreen(Screen[None]):
         svc = get_services()
         total = len(sources)
         generated = 0
+        last_error: str = ""
         try:
             for idx, source in enumerate(sources):
                 base_pct = int(idx * 100 / total)
@@ -698,8 +699,6 @@ class ChatScreen(Screen[None]):
                 chunks = svc.store.get_chunks_by_source(source)
                 if not chunks:
                     continue
-
-                last_error: str = ""
 
                 def _on_progress(
                     stage: str,

--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -287,7 +287,7 @@ def _check_faithfulness(
     try:
         response = provider.chat(messages, stream=False)
         return _parse_faithfulness_score(strip_reasoning(cast(str, response)))
-    except (ConnectionError, OSError, RuntimeError) as exc:
+    except Exception as exc:
         log.warning("Faithfulness check failed for %s: %s", label, exc)
         return 0.0
 
@@ -402,11 +402,14 @@ def _generate_page(
     try:
         response = provider.chat(messages, stream=False)
         wiki_text = strip_reasoning(cast(str, response)).strip()
-    except (ConnectionError, OSError, RuntimeError) as exc:
+    except Exception as exc:
         log.warning("LLM failed to generate wiki page for %s: %s", label, exc)
+        _emit("failed", error=str(exc))
         return None
 
     if not wiki_text:
+        log.warning("LLM returned empty response for wiki page %s", label)
+        _emit("failed", error="Model returned empty response")
         return None
 
     parsed_citations = parse_wiki_citations(wiki_text)

--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -416,6 +416,7 @@ def _generate_page(
     verified = _verify_citations(citation_resolver(parsed_citations), chunks, label, config)
     if not verified:
         log.warning("No valid citations for %s, skipping", label)
+        _emit("failed", error="No valid citations found")
         return None
 
     _emit("faithfulness_check")

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -397,6 +397,93 @@ class TestGenerateSummaryPage:
         result = generate_summary_page("doc.md", chunks, provider, store)
         assert result is None
 
+    def test_provider_error_returns_none(self, tmp_path: Path):
+        """ProviderError from chat() is caught and returns None."""
+        from lilbee.providers.base import ProviderError
+
+        source = tmp_path / "documents" / "doc.md"
+        source.write_text("Content")
+        chunks = [_make_chunk("Content")]
+        provider = MagicMock()
+        provider.chat.side_effect = ProviderError("model not found", provider="litellm")
+        store = _mock_store()
+
+        result = generate_summary_page("doc.md", chunks, provider, store)
+        assert result is None
+
+    def test_unexpected_exception_returns_none(self, tmp_path: Path):
+        """Unexpected exceptions (ValueError, KeyError, etc.) are caught."""
+        source = tmp_path / "documents" / "doc.md"
+        source.write_text("Content")
+        chunks = [_make_chunk("Content")]
+        provider = MagicMock()
+        provider.chat.side_effect = ValueError("context window exceeded")
+        store = _mock_store()
+
+        result = generate_summary_page("doc.md", chunks, provider, store)
+        assert result is None
+
+    def test_llm_failure_emits_failed_progress(self, tmp_path: Path):
+        """Progress callback receives 'failed' stage with error on LLM failure."""
+        source = tmp_path / "documents" / "doc.md"
+        source.write_text("Content")
+        chunks = [_make_chunk("Content")]
+        provider = MagicMock()
+        provider.chat.side_effect = RuntimeError("GPU OOM")
+        store = _mock_store()
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def on_progress(stage: str, data: dict[str, object]) -> None:
+            events.append((stage, data))
+
+        generate_summary_page("doc.md", chunks, provider, store, on_progress=on_progress)
+        failed_events = [(s, d) for s, d in events if s == "failed"]
+        assert len(failed_events) == 1
+        assert "GPU OOM" in str(failed_events[0][1]["error"])
+
+    def test_empty_response_emits_failed_progress(self, tmp_path: Path):
+        """Progress callback receives 'failed' stage when model returns empty."""
+        source = tmp_path / "documents" / "doc.md"
+        source.write_text("Content")
+        chunks = [_make_chunk("Content")]
+        provider = _mock_provider("   ")
+        store = _mock_store()
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def on_progress(stage: str, data: dict[str, object]) -> None:
+            events.append((stage, data))
+
+        generate_summary_page("doc.md", chunks, provider, store, on_progress=on_progress)
+        failed_events = [(s, d) for s, d in events if s == "failed"]
+        assert len(failed_events) == 1
+        assert "empty" in str(failed_events[0][1]["error"]).lower()
+
+    def test_faithfulness_provider_error_uses_zero(self, tmp_path: Path):
+        """ProviderError during faithfulness check returns score 0.0."""
+        from lilbee.providers.base import ProviderError
+
+        source = tmp_path / "documents" / "doc.md"
+        source.write_text("Content")
+        chunks = [_make_chunk("Content")]
+
+        wiki_text = (
+            "# Test\n\n"
+            "> Content.[^src1]\n\n"
+            "---\n"
+            "<!-- citations (auto-generated from _citations table -- do not edit) -->\n"
+            '[^src1]: doc.md, excerpt: "Content"'
+        )
+        provider = MagicMock()
+        provider.chat.side_effect = [
+            wiki_text,
+            ProviderError("timeout", provider="litellm"),
+        ]
+        store = _mock_store()
+
+        result = generate_summary_page("doc.md", chunks, provider, store)
+        assert result is not None
+        assert "drafts" in str(result)  # score=0.0 < threshold=0.7
+
     def test_inference_citations_pass_verification(self, tmp_path: Path):
         source = tmp_path / "documents" / "doc.md"
         source.write_text("Content here.")

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -367,6 +367,31 @@ class TestGenerateSummaryPage:
         result = generate_summary_page("doc.md", chunks, provider, store)
         assert result is None
 
+    def test_no_valid_citations_emits_failed_progress(self, tmp_path: Path):
+        """Progress callback receives 'failed' stage when no citations verify."""
+        source = tmp_path / "documents" / "doc.md"
+        source.write_text("Content")
+        chunks = [_make_chunk("Content")]
+
+        wiki_text = (
+            "# Bad\n\n"
+            "> Fabricated claim.[^src1]\n\n"
+            "---\n"
+            "<!-- citations (auto-generated from _citations table -- do not edit) -->\n"
+            '[^src1]: doc.md, excerpt: "This text is not in any chunk at all"'
+        )
+        provider = _mock_provider(wiki_text)
+        store = _mock_store()
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def on_progress(stage: str, data: dict[str, object]) -> None:
+            events.append((stage, data))
+
+        generate_summary_page("doc.md", chunks, provider, store, on_progress=on_progress)
+        failed_events = [(s, d) for s, d in events if s == "failed"]
+        assert len(failed_events) == 1
+        assert "citation" in str(failed_events[0][1]["error"]).lower()
+
     def test_faithfulness_check_failure_uses_zero(self, tmp_path: Path):
         source = tmp_path / "documents" / "doc.md"
         source.write_text("Content")


### PR DESCRIPTION
## Summary
- Wiki generation crashed at 33% with small models (qwen3:0.6b) because the exception handler only caught ConnectionError/OSError/RuntimeError, missing ProviderError and other exception types
- Broadened exception handling and added "failed" progress events so the TUI task center shows the actual error reason instead of generic "No pages generated"
- Fixed potential UnboundLocalError when all sources have no chunks

Fixes BEE-ae7.