### PR TITLE
Hide chat-only banner on wizard skip when embedding is ready

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -221,7 +221,7 @@ class ChatScreen(Screen[None]):
 
     def _on_setup_complete(self, result: str | None) -> None:
         """Called when wizard completes or is skipped."""
-        if result == "skipped":
+        if result == "skipped" and not self._embedding_ready():
             self._show_chat_only_banner()
         elif self._embedding_ready():
             self._hide_chat_only_banner()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2824,6 +2824,17 @@ async def test_chat_on_setup_complete_skipped_shows_banner():
         assert banner.display is True
 
 
+async def test_chat_on_setup_complete_skipped_no_banner_when_embedding_ready():
+    """Skipping wizard does not show banner when embedding model is already configured."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with patch.object(app.screen, "_embedding_ready", return_value=True):
+            app.screen._on_setup_complete("skipped")
+            await _pilot.pause()
+            banner = app.screen.query_one("#chat-only-banner")
+            assert banner.display is False
+
+
 async def test_chat_on_setup_complete_success():
     """Cover _on_setup_complete with successful setup."""
     app = ChatTestApp()


### PR DESCRIPTION
## Summary
- Don't show "Chat only" banner when wizard is skipped via Escape if embedding model is already configured (e.g. via LILBEE_EMBEDDING_MODEL env var)