### PR TITLE
Fix Tab trapping in wizard GridSelect

### DIFF
--- a/src/lilbee/cli/tui/widgets/grid_select.py
+++ b/src/lilbee/cli/tui/widgets/grid_select.py
@@ -28,6 +28,8 @@ class GridSelect(containers.ItemGrid, can_focus=True):
         Binding("left", "cursor_left", "Left", show=False),
         Binding("right", "cursor_right", "Right", show=False),
         Binding("enter", "select", "Select", show=False),
+        Binding("tab", "tab_next", "Tab Next", show=False),
+        Binding("shift+tab", "tab_previous", "Tab Previous", show=False),
     ]
 
     highlighted: reactive[int | None] = reactive(None)
@@ -193,3 +195,27 @@ class GridSelect(containers.ItemGrid, can_focus=True):
                 pass
             else:
                 self.post_message(self.Selected(self, widget))
+
+    def action_tab_next(self) -> None:
+        """Advance highlight linearly; escape grid when past the last card."""
+        if not self.children:
+            self.post_message(self.LeaveDown(self))
+            return
+        if self.highlighted is None:
+            self.highlighted = 0
+        elif self.highlighted >= len(self.children) - 1:
+            self.post_message(self.LeaveDown(self))
+        else:
+            self.highlighted += 1
+
+    def action_tab_previous(self) -> None:
+        """Retreat highlight linearly; escape grid when before the first card."""
+        if not self.children:
+            self.post_message(self.LeaveUp(self))
+            return
+        if self.highlighted is None:
+            self.highlighted = len(self.children) - 1
+        elif self.highlighted <= 0:
+            self.post_message(self.LeaveUp(self))
+        else:
+            self.highlighted -= 1

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -5651,6 +5651,55 @@ async def test_setup_wizard_grid_leave_up_walks_focus_backward():
             assert app.focused is not None
 
 
+async def test_setup_wizard_tab_escapes_grid_to_install_button():
+    """Tab from the last card in the last grid reaches the Install & Go button."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+    from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            grids = list(screen.query(GridSelect))
+            assert grids, "expected at least one GridSelect in the wizard"
+            last_grid = grids[-1]
+            last_grid.focus()
+            last_grid.highlight_last()
+            await pilot.pause()
+            assert app.focused is last_grid
+            await pilot.press("tab")
+            await pilot.pause()
+            focused = app.focused
+            assert focused is not last_grid
+            assert focused is not None
+
+
+async def test_setup_wizard_shift_tab_escapes_grid_backward():
+    """Shift+Tab from the first card in a grid walks focus backward."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+    from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+            grids = list(screen.query(GridSelect))
+            assert len(grids) >= 2, "expected multiple GridSelects in the wizard"
+            second_grid = grids[1]
+            second_grid.focus()
+            second_grid.highlight_first()
+            await pilot.pause()
+            assert app.focused is second_grid
+            await pilot.press("shift+tab")
+            await pilot.pause()
+            assert app.focused is not second_grid
+            assert app.focused is not None
+
+
 async def test_setup_wizard_on_download_progress():
     """_on_download_progress updates progress bar and status."""
     from lilbee.cli.tui.screens.setup import SetupWizard

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2820,6 +2820,104 @@ class TestGridSelectExtra:
             await pilot.pause()
             assert grid.highlighted == 0
 
+    async def test_tab_next_advances_highlight(self) -> None:
+        """Tab advances the cursor within the grid."""
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            grid = app.query_one(GridSelect)
+            grid.highlighted = 0
+            grid.action_tab_next()
+            assert grid.highlighted == 1
+
+    async def test_tab_next_escapes_at_last_card(self) -> None:
+        """Tab on the last card posts LeaveDown to escape the grid."""
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            grid = app.query_one(GridSelect)
+            grid.highlighted = len(grid.children) - 1
+            messages: list[object] = []
+            orig_post = grid.post_message
+            grid.post_message = lambda m: messages.append(m) or orig_post(m)  # type: ignore[assignment]
+            grid.action_tab_next()
+            assert any(isinstance(m, GridSelect.LeaveDown) for m in messages)
+
+    async def test_tab_previous_retreats_highlight(self) -> None:
+        """Shift+Tab retreats the cursor within the grid."""
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            grid = app.query_one(GridSelect)
+            grid.highlighted = 2
+            grid.action_tab_previous()
+            assert grid.highlighted == 1
+
+    async def test_tab_previous_escapes_at_first_card(self) -> None:
+        """Shift+Tab on the first card posts LeaveUp to escape the grid."""
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            grid = app.query_one(GridSelect)
+            grid.highlighted = 0
+            messages: list[object] = []
+            orig_post = grid.post_message
+            grid.post_message = lambda m: messages.append(m) or orig_post(m)  # type: ignore[assignment]
+            grid.action_tab_previous()
+            assert any(isinstance(m, GridSelect.LeaveUp) for m in messages)
+
+    def test_tab_next_empty_grid_posts_leave_down(self) -> None:
+        """Tab on an empty grid posts LeaveDown."""
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        grid = GridSelect(min_column_width=20)
+        messages: list[object] = []
+        grid.post_message = lambda m: messages.append(m)  # type: ignore[assignment]
+        grid.action_tab_next()
+        assert any(isinstance(m, GridSelect.LeaveDown) for m in messages)
+
+    def test_tab_previous_empty_grid_posts_leave_up(self) -> None:
+        """Shift+Tab on an empty grid posts LeaveUp."""
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        grid = GridSelect(min_column_width=20)
+        messages: list[object] = []
+        grid.post_message = lambda m: messages.append(m)  # type: ignore[assignment]
+        grid.action_tab_previous()
+        assert any(isinstance(m, GridSelect.LeaveUp) for m in messages)
+
+    async def test_tab_next_initializes_highlight_when_none(self) -> None:
+        """Tab with no highlight initializes to 0."""
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            grid = app.query_one(GridSelect)
+            grid.highlighted = None
+            grid.action_tab_next()
+            assert grid.highlighted == 0
+
+    async def test_tab_previous_initializes_highlight_when_none(self) -> None:
+        """Shift+Tab with no highlight initializes to last card."""
+        from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+        app = _GridApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            grid = app.query_one(GridSelect)
+            grid.highlighted = None
+            grid.action_tab_previous()
+            assert grid.highlighted == len(grid.children) - 1
+
 
 # ---------------------------------------------------------------------------
 # ModelCard: _build_status with positive downloads


### PR DESCRIPTION
## Summary
- Tab/Shift+Tab in GridSelect now advances the cursor linearly through cards instead of cycling forever
- When Tab reaches the last card, focus escapes to the next widget (Install & Go button)
- Reuses existing LeaveDown/LeaveUp messages for consistent behavior with arrow keys