### PR TITLE
Catch ProviderError in ask command

### DIFF
--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -43,6 +43,7 @@ from lilbee.cli.helpers import (
 )
 from lilbee.config import cfg
 from lilbee.crawler import is_url
+from lilbee.providers.base import ProviderError
 from lilbee.services import get_services
 
 CHUNK_PREVIEW_LEN = 80  # characters shown in human-readable search output
@@ -442,7 +443,7 @@ def ask(
         for token in get_services().searcher.ask_stream(question):
             console.print(token.content, end="")
         console.print()
-    except RuntimeError as exc:
+    except (RuntimeError, ProviderError) as exc:
         if cfg.json_mode:
             json_output({"error": str(exc)})
             raise SystemExit(1) from None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1284,6 +1284,29 @@ class TestAskModelNotFound:
         assert "not found" in data["error"]
 
 
+class TestAskProviderError:
+    """ProviderError from the LLM backend must be caught, not dumped as a traceback."""
+
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_provider_error_human(self, mock_sync, mock_svc):
+        from lilbee.providers.base import ProviderError
+
+        mock_svc.searcher.ask_stream.side_effect = ProviderError("model 'ghost' not found")
+        result = runner.invoke(app, ["ask", "hello"])
+        assert result.exit_code == 1
+        assert "ghost" in result.output
+
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_provider_error_json(self, mock_sync, mock_svc):
+        from lilbee.providers.base import ProviderError
+
+        mock_svc.searcher.ask_raw.side_effect = ProviderError("model 'ghost' not found")
+        result = runner.invoke(app, ["--json", "ask", "hello"])
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert "ghost" in data["error"]
+
+
 class TestBackendUnavailable:
     """CLI commands should show friendly errors when the backend is unreachable."""
 


### PR DESCRIPTION
## Summary

- `ask` command now catches `ProviderError` alongside `RuntimeError` for clean error output
- Previously, a missing or unavailable model dumped a raw litellm/httpx traceback
- Both human and JSON modes now show a clean error message with exit code 1