### PR TITLE
Fix 4 server bugs from REST API QA

### DIFF
--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -209,12 +209,17 @@ async def status() -> StatusResponse:
 
 async def search(q: str, top_k: int = 5) -> list[DocumentResult]:
     """Search and return grouped DocumentResults."""
+    if not q or not q.strip():
+        raise ValueError("query must not be empty")
     results = get_services().searcher.search(q, top_k=top_k)
+    results = [r for r in results if r.distance is None or r.distance <= cfg.max_distance]
     return group(results)
 
 
 async def ask(question: str, top_k: int = 0, options: dict[str, Any] | None = None) -> AskResponse:
     """One-shot RAG answer. Returns answer and sources."""
+    if not question or not question.strip():
+        raise ValueError("question must not be empty")
     opts = _resolve_generation_options(options)
     result = get_services().searcher.ask_raw(question, top_k=top_k, options=opts)
     return AskResponse(
@@ -424,9 +429,7 @@ async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
         yield event
     if not sse.cancel.is_set() and task.done() and not task.cancelled():
         summary = task.result()
-        dumped = summary.model_dump()
-        yield sse_event("summary", dumped)
-        yield sse_done(dumped)
+        yield sse_done(summary.model_dump())
 
 
 async def list_models() -> ModelsResponse:

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from litestar import get, post
+from litestar.exceptions import HTTPException, ValidationException
 from litestar.params import Parameter
 from litestar.response import Stream
 
@@ -24,17 +25,27 @@ async def search_route(
     top_k: int = Parameter(query="top_k", default=5, le=100),
 ) -> list[DocumentResult]:
     """Search indexed documents by semantic similarity. No LLM call required."""
-    return await handlers.search(q, top_k=top_k)
+    try:
+        return await handlers.search(q, top_k=top_k)
+    except ValueError as exc:
+        raise ValidationException(str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @post("/api/ask")
 async def ask_route(data: AskRequest) -> AskResponse:
     """One-shot RAG question returning an answer with source chunks."""
-    return await handlers.ask(
-        question=data.question,
-        top_k=data.top_k,
-        options=data.options,
-    )
+    try:
+        return await handlers.ask(
+            question=data.question,
+            top_k=data.top_k,
+            options=data.options,
+        )
+    except ValueError as exc:
+        raise ValidationException(str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @post("/api/ask/stream")

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -84,7 +84,6 @@ class TestAddEndpoint:
         assert "file_start" in event_types
         assert "file_done" in event_types
         assert "done" in event_types
-        assert "summary" in event_types
 
     async def test_add_nonexistent_file_in_errors(self, mock_extract_file, isolated_env, tmp_path):
         """Nonexistent paths appear in the summary errors list."""
@@ -97,7 +96,7 @@ class TestAddEndpoint:
 
         assert resp.status_code == 201
         events = _parse_sse_events(resp.content)
-        summary = next(d for t, d in events if t == "summary")
+        summary = [d for t, d in events if t == "done" and "copied" in d][-1]
         assert "/no/such/file.txt" in summary["errors"]
 
     async def test_add_with_force_flag(self, mock_extract_file, isolated_env, tmp_path):
@@ -115,7 +114,7 @@ class TestAddEndpoint:
 
         assert resp.status_code == 201
         events = _parse_sse_events(resp.content)
-        summary = next(d for t, d in events if t == "summary")
+        summary = [d for t, d in events if t == "done" and "copied" in d][-1]
         assert "dup.txt" in summary["copied"]
 
     async def test_done_event_has_correct_fields(self, mock_extract_file, isolated_env, tmp_path):


### PR DESCRIPTION
## Summary
- Empty query validation on search/ask (returns 400 instead of results)
- Provider errors caught in search/ask routes (returns 503 instead of raw 500)
- max_distance filtering applied to search results (matches MCP behavior)
- Single done SSE event from add endpoint (was emitting done + summary)