### PR TITLE
Fix frontier API models routing to Ollama instead of native endpoints

### DIFF
--- a/src/lilbee/providers/litellm_provider.py
+++ b/src/lilbee/providers/litellm_provider.py
@@ -27,6 +27,20 @@ _OLLAMA_PREFIX = "ollama/"
 
 _OLLAMA_URL_PATTERNS = ("localhost:11434", "127.0.0.1:11434", "ollama")
 
+
+def _needs_api_base(routed_model: str) -> bool:
+    """Return True if litellm needs an explicit ``api_base`` for this model.
+
+    Models with a non-Ollama provider prefix (e.g. ``openai/gpt-4o``,
+    ``anthropic/claude-3``) should NOT get ``api_base`` because litellm
+    auto-routes them to the correct provider endpoint. Passing ``api_base``
+    would override that routing and send the request to the wrong backend.
+    """
+    if "/" not in routed_model:
+        return True
+    return routed_model.startswith(_OLLAMA_PREFIX)
+
+
 # Single source of truth for per-provider API key configuration.
 # Maps (litellm_provider_name, config_field, env_var, display_label).
 # Used by inject_provider_keys(), discover_api_models(), and config update handler.
@@ -108,12 +122,16 @@ class LiteLLMProvider(LLMProvider):
         import litellm
 
         try:
-            response = litellm.embedding(
-                model=self._embed_model_name(),
-                input=texts,
-                api_base=self._base_url,
-                api_key=self._api_key or None,
-            )
+            routed = self._embed_model_name()
+            embed_kwargs: dict[str, Any] = {
+                "model": routed,
+                "input": texts,
+            }
+            if _needs_api_base(routed):
+                embed_kwargs["api_base"] = self._base_url
+            if self._api_key:
+                embed_kwargs["api_key"] = self._api_key
+            response = litellm.embedding(**embed_kwargs)
             return [item["embedding"] for item in response["data"]]
         except Exception as exc:
             raise ProviderError(f"Embedding failed: {exc}", provider="litellm") from exc
@@ -129,13 +147,16 @@ class LiteLLMProvider(LLMProvider):
         """Chat completion via litellm."""
         import litellm
 
+        inject_provider_keys()
         formatted = _format_messages(messages)
+        routed = self._model_name(model)
         kwargs: dict[str, Any] = {
-            "model": self._model_name(model),
+            "model": routed,
             "messages": formatted,
             "stream": stream,
-            "api_base": self._base_url,
         }
+        if _needs_api_base(routed):
+            kwargs["api_base"] = self._base_url
         if self._api_key:
             kwargs["api_key"] = self._api_key
         if options:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2199,3 +2199,126 @@ class TestLiteLLMListModelsRouting:
 
         headers = mock_get.call_args[1].get("headers", {})
         assert headers.get("Authorization") == "Bearer sk-secret"
+
+
+class TestNeedsApiBase:
+    def test_ollama_prefixed_model_needs_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import _needs_api_base
+
+        assert _needs_api_base("ollama/qwen3:8b") is True
+
+    def test_bare_model_needs_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import _needs_api_base
+
+        assert _needs_api_base("qwen3:8b") is True
+
+    def test_openai_prefixed_model_skips_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import _needs_api_base
+
+        assert _needs_api_base("openai/gpt-4o") is False
+
+    def test_anthropic_prefixed_model_skips_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import _needs_api_base
+
+        assert _needs_api_base("anthropic/claude-sonnet-4-6") is False
+
+    def test_gemini_prefixed_model_skips_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import _needs_api_base
+
+        assert _needs_api_base("gemini/gemini-pro") is False
+
+
+class TestChatApiBaseRouting:
+    """Verify that chat() omits api_base for non-Ollama provider-prefixed models."""
+
+    def _make_fake_litellm(self) -> mock.MagicMock:
+        fake = mock.MagicMock()
+        resp = mock.MagicMock()
+        resp.choices = [mock.MagicMock()]
+        resp.choices[0].message.content = "hello"
+        fake.completion.return_value = resp
+        return fake
+
+    def test_ollama_model_passes_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(base_url="http://localhost:11434")
+        fake = self._make_fake_litellm()
+
+        with mock.patch.dict("sys.modules", {"litellm": fake}):
+            provider.chat([{"role": "user", "content": "hi"}], model="qwen3:0.6b")
+
+        call_kwargs = fake.completion.call_args[1]
+        assert call_kwargs["api_base"] == "http://localhost:11434"
+        assert call_kwargs["model"] == "ollama/qwen3:0.6b"
+
+    def test_frontier_model_omits_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(base_url="http://localhost:11434")
+        fake = self._make_fake_litellm()
+
+        with mock.patch.dict("sys.modules", {"litellm": fake}):
+            provider.chat([{"role": "user", "content": "hi"}], model="openai/gpt-4o")
+
+        call_kwargs = fake.completion.call_args[1]
+        assert "api_base" not in call_kwargs
+        assert call_kwargs["model"] == "openai/gpt-4o"
+
+    def test_anthropic_model_omits_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(base_url="http://localhost:11434")
+        fake = self._make_fake_litellm()
+
+        with mock.patch.dict("sys.modules", {"litellm": fake}):
+            provider.chat([{"role": "user", "content": "hi"}], model="anthropic/claude-sonnet-4-6")
+
+        call_kwargs = fake.completion.call_args[1]
+        assert "api_base" not in call_kwargs
+
+    def test_chat_calls_inject_provider_keys(self) -> None:
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(base_url="http://localhost:11434")
+        fake = self._make_fake_litellm()
+
+        with (
+            mock.patch.dict("sys.modules", {"litellm": fake}),
+            mock.patch("lilbee.providers.litellm_provider.inject_provider_keys") as mock_inject,
+        ):
+            provider.chat([{"role": "user", "content": "hi"}], model="openai/gpt-4o")
+
+        mock_inject.assert_called_once()
+
+
+class TestEmbedApiBaseRouting:
+    """Verify that embed() omits api_base for non-Ollama provider-prefixed models."""
+
+    def test_ollama_embed_passes_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(base_url="http://localhost:11434")
+        cfg.embedding_model = "nomic-embed-text"
+        fake = mock.MagicMock()
+        fake.embedding.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
+
+        with mock.patch.dict("sys.modules", {"litellm": fake}):
+            provider.embed(["hello"])
+
+        call_kwargs = fake.embedding.call_args[1]
+        assert call_kwargs["api_base"] == "http://localhost:11434"
+
+    def test_prefixed_embed_omits_api_base(self) -> None:
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(base_url="http://localhost:11434")
+        cfg.embedding_model = "openai/text-embedding-3-small"
+        fake = mock.MagicMock()
+        fake.embedding.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
+
+        with mock.patch.dict("sys.modules", {"litellm": fake}):
+            provider.embed(["hello"])
+
+        call_kwargs = fake.embedding.call_args[1]
+        assert "api_base" not in call_kwargs


### PR DESCRIPTION
## Summary
- Frontier models were discoverable in the model dropdown when API keys were set, but selecting one failed because litellm always received `api_base` pointing to Ollama
