### PR TITLE
Fix circular import crash when setting model via env var

### DIFF
--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -402,9 +402,7 @@ class Config(BaseSettings):
         """Ensure model names always have an explicit tag (e.g. qwen3 -> qwen3:latest)."""
         if not v or ":" in v:
             return v
-        from lilbee.registry import DEFAULT_TAG
-
-        return f"{v}:{DEFAULT_TAG}"
+        return f"{v}:latest"
 
     @field_validator("cors_origins", mode="before")
     @classmethod


### PR DESCRIPTION
## Summary
- LILBEE_EMBEDDING_MODEL or LILBEE_CHAT_MODEL env vars caused ImportError on startup
- _normalize_model_tag validator imported from registry during Config init, triggering config -> registry -> models -> config circular import
- Inlined the DEFAULT_TAG constant ("latest") to break the cycle