### PR TITLE
Fix catalog navigation, model names, settings hover, task bar size

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -446,7 +446,7 @@ def _fetch_hf_models(
             CatalogModel(
                 name=slug,
                 tag=DEFAULT_TAG,
-                display_name=repo_name,
+                display_name=clean_display_name(repo_id),
                 hf_repo=repo_id,
                 gguf_filename="*.gguf",
                 size_gb=size_gb,

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -15,7 +15,7 @@ from textual.containers import VerticalScroll
 from textual.events import Click
 from textual.screen import Screen
 from textual.widgets import DataTable, Input, Static
-from textual.worker import Worker, WorkerState
+from textual.worker import Worker, WorkerState, get_current_worker
 
 from lilbee.catalog import (
     CatalogModel,
@@ -373,6 +373,16 @@ class CatalogScreen(Screen[None]):
             self._hf_fetched = True
             self._fetch_all_hf_models()
 
+    @on(GridSelect.LeaveDown)
+    def _on_grid_leave_down(self, event: GridSelect.LeaveDown) -> None:
+        """Move focus to the next GridSelect or focusable widget."""
+        self.focus_next()
+
+    @on(GridSelect.LeaveUp)
+    def _on_grid_leave_up(self, event: GridSelect.LeaveUp) -> None:
+        """Move focus to the previous GridSelect or focusable widget."""
+        self.focus_previous()
+
     @on(GridSelect.Selected)
     def _on_grid_selected(self, event: GridSelect.Selected) -> None:
         """Handle model selection from the grid view."""
@@ -501,8 +511,11 @@ class CatalogScreen(Screen[None]):
         """Download a model in a background thread, reporting to TaskBar."""
         from lilbee.catalog import download_model
 
+        worker = get_current_worker()
         try:
             download_model(model, on_progress=self._make_progress_callback(task_id, bar))
+            if worker.is_cancelled:
+                return
             self._safe_call(bar.complete_task, task_id)
             self._safe_call(self.notify, msg.CATALOG_INSTALLED_OK.format(name=model.display_name))
         except PermissionError:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -20,6 +20,10 @@ from textual.reactive import var
 from textual.screen import Screen
 from textual.widgets import Footer, Input, Label, Select, Static
 
+# Cancellation check for @work(thread=True) workers. Import at module level
+# since it's used in multiple methods.
+from textual.worker import get_current_worker as _get_worker
+
 from lilbee import settings
 from lilbee.cli.helpers import get_version
 from lilbee.cli.settings_map import SETTINGS_MAP
@@ -437,6 +441,7 @@ class ChatScreen(Screen[None]):
         """Run a crawl in a background thread, then trigger sync."""
         from lilbee.crawler import crawl_and_save
 
+        worker = _get_worker()
         task_bar = self._task_bar
         call_from_thread(self, task_bar.update_task, task_id, 0, f"Crawling {url}...")
 
@@ -460,13 +465,15 @@ class ChatScreen(Screen[None]):
                 self, self.notify, msg.CMD_CRAWL_SUCCESS.format(count=len(paths), url=url)
             )
         except Exception as exc:
-            call_from_thread(self, task_bar.fail_task, task_id, str(exc))
-            call_from_thread(
-                self, self.notify, msg.CMD_CRAWL_FAILED.format(error=exc), severity="error"
-            )
+            if not worker.is_cancelled:
+                call_from_thread(self, task_bar.fail_task, task_id, str(exc))
+                call_from_thread(
+                    self, self.notify, msg.CMD_CRAWL_FAILED.format(error=exc), severity="error"
+                )
             return
 
-        call_from_thread(self, self._run_sync)
+        if not worker.is_cancelled:
+            call_from_thread(self, self._run_sync)
 
     def _cmd_catalog(self, _args: str) -> None:
         from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -678,6 +685,7 @@ class ChatScreen(Screen[None]):
         """Generate wiki pages for each source in a background thread."""
         from lilbee.wiki.gen import generate_summary_page
 
+        worker = _get_worker()
         task_bar = self._task_bar
         svc = get_services()
         total = len(sources)
@@ -685,6 +693,8 @@ class ChatScreen(Screen[None]):
         last_error: str = ""
         try:
             for idx, source in enumerate(sources):
+                if worker.is_cancelled:
+                    break
                 base_pct = int(idx * 100 / total)
                 call_from_thread(
                     self,
@@ -771,6 +781,7 @@ class ChatScreen(Screen[None]):
     @work(thread=True)
     def _stream_response(self, question: str, widget: AssistantMessage) -> None:
         """Stream LLM response in a background thread."""
+        worker = _get_worker()
         response_parts: list[str] = []
         sources: list[str] = []
         last_scroll = 0.0
@@ -780,6 +791,8 @@ class ChatScreen(Screen[None]):
                 history_snapshot = self._history[:-1]
             stream = get_services().searcher.ask_stream(question, history=history_snapshot)
             for token in stream:
+                if worker.is_cancelled:
+                    break
                 try:
                     if token.is_reasoning:
                         call_from_thread(self, widget.append_reasoning, token.content)
@@ -886,13 +899,7 @@ class ChatScreen(Screen[None]):
 
     @work(thread=True)
     def _run_sync_worker(self, task_id: str) -> None:
-        """Run background document sync in a Textual worker thread.
-        Architecture: @work(thread=True) runs this method in a daemon thread,
-        keeping the Textual event loop free for UI updates. Progress is reported
-        back to the main thread via app.call_from_thread(). The asyncio.run()
-        call creates a fresh event loop because Textual workers are plain threads,
-        not coroutines on the app's async loop.
-        """
+        """Run background document sync in a Textual worker thread."""
         import asyncio
 
         self._sync_active = True

--- a/src/lilbee/cli/tui/screens/status.tcss
+++ b/src/lilbee/cli/tui/screens/status.tcss
@@ -6,11 +6,29 @@
 Collapsible {
     margin: 0 0 1 0;
     padding: 0 1;
+    background: $background;
+}
+
+Collapsible:hover {
+    background: $background;
 }
 
 Collapsible > CollapsibleTitle {
     color: $primary;
     text-style: bold;
+    background: $background;
+}
+
+Collapsible > CollapsibleTitle:hover {
+    background: $background;
+}
+
+Collapsible > Contents {
+    background: $background;
+}
+
+Collapsible > Contents *:hover {
+    background: $background;
 }
 
 #config-info, #arch-info, #storage-info {

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -247,6 +247,7 @@ class ModelBar(Widget, can_focus=False):
         screen = self.app.screen
         if isinstance(screen, ChatScreen):
             screen._apply_model_change()
+            screen._refresh_status_line()
         else:
             reset_services()
 

--- a/src/lilbee/cli/tui/widgets/model_card.tcss
+++ b/src/lilbee/cli/tui/widgets/model_card.tcss
@@ -8,16 +8,22 @@ ModelCard {
         background: $surface;
     }
 
+    &.-highlight {
+        border: tall $primary;
+    }
+
     #card-header {
         grid-size: 4 1;
         grid-columns: 1fr auto auto auto;
         height: auto;
+        overflow: hidden;
     }
 
     #card-name {
         text-style: bold;
         text-wrap: nowrap;
         text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     #card-pick {
@@ -37,6 +43,7 @@ ModelCard {
         color: $text-muted;
         text-wrap: nowrap;
         text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     #card-status {

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 _DONE_FLASH_SECONDS = 1.0
 _SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 _SPINNER_INTERVAL = 0.1
-_MAX_VISIBLE_PANELS = 5
+_MAX_VISIBLE_PANELS = 2
 
 
 class _TaskPanel(Static):
@@ -45,7 +45,7 @@ class _TaskPanel(Static):
     DEFAULT_CSS = """
     _TaskPanel {
         height: auto;
-        max-height: 3;
+        max-height: 2;
         padding: 0 1;
     }
     _TaskPanel .task-panel-label {
@@ -159,7 +159,7 @@ class TaskBar(Static):
     TaskBar {
         dock: bottom;
         height: auto;
-        max-height: 20;
+        max-height: 8;
         padding: 0;
     }
     TaskBar .task-queued-label {

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -214,6 +214,7 @@ class TestFetchHfModels:
         assert len(models) == 2
         assert models[0].name == "model-7b-gguf"
         assert models[0].hf_repo == "user/model-7b-gguf"
+        assert models[0].display_name == "model 7b"
         assert models[0].downloads == 5000
         assert models[0].featured is False
         assert models[0].task == "chat"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -365,6 +365,11 @@ class TestCorsOriginsConfig:
             c = Config()
             assert c.cors_origins == []
 
+    def test_cors_origins_list_passthrough(self) -> None:
+        """List values pass through the validator unchanged."""
+        cfg.cors_origins = ["https://a.com", "https://b.com"]
+        assert cfg.cors_origins == ["https://a.com", "https://b.com"]
+
 
 class TestCorsOriginRegexConfig:
     def test_cors_origin_regex_default_matches_obsidian_desktop(self, tmp_path) -> None:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -5909,6 +5909,46 @@ async def test_catalog_nav_actions_forward_to_grid_in_grid_view():
             screen.action_jump_bottom()
 
 
+async def test_catalog_grid_leave_down_focuses_next():
+    """GridSelect.LeaveDown moves focus to the next focusable widget."""
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+    from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+    app = CatalogTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        with _patch_catalog()[0], _patch_catalog()[1], _patch_catalog()[2]:
+            screen = CatalogScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            grids = list(screen.query(GridSelect))
+            if grids:
+                grids[0].focus()
+                await pilot.pause()
+                grids[0].post_message(GridSelect.LeaveDown(grids[0]))
+                await pilot.pause()
+                assert screen.focused is not grids[0]
+
+
+async def test_catalog_grid_leave_up_focuses_previous():
+    """GridSelect.LeaveUp moves focus to the previous focusable widget."""
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+    from lilbee.cli.tui.widgets.grid_select import GridSelect
+
+    app = CatalogTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        with _patch_catalog()[0], _patch_catalog()[1], _patch_catalog()[2]:
+            screen = CatalogScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            grids = list(screen.query(GridSelect))
+            assert grids, "Expected at least one GridSelect"
+            grids[0].focus()
+            await pilot.pause()
+            grids[0].post_message(GridSelect.LeaveUp(grids[0]))
+            await pilot.pause()
+            assert screen.focused is not grids[0]
+
+
 async def test_catalog_select_variant_row():
     """_select_row with a variant row triggers _install_variant."""
     from lilbee.catalog import ModelFamily, ModelVariant
@@ -6256,6 +6296,31 @@ async def test_catalog_run_download_generic_error():
                 while screen.workers:
                     await _pilot.pause()
                 mock_bar.fail_task.assert_called_once()
+
+
+async def test_catalog_run_download_cancelled():
+    """_run_download exits early when worker is cancelled."""
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+    app = CatalogTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with _patch_catalog()[0], _patch_catalog()[1], _patch_catalog()[2]:
+            screen = CatalogScreen()
+            app.push_screen(screen)
+            await _pilot.pause()
+            m = _make_catalog_model(name="cancel-model")
+            mock_bar = MagicMock()
+
+            def _dl_and_cancel(*a, **kw):
+                for w in screen.workers:
+                    w.cancel()
+
+            with patch("lilbee.catalog.download_model", side_effect=_dl_and_cancel):
+                screen._run_download(m, "task-1", mock_bar)
+                await _pilot.pause()
+                while screen.workers:
+                    await _pilot.pause()
+                mock_bar.complete_task.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -7156,6 +7221,40 @@ async def test_chat_cmd_wiki_generate_runs_background(tmp_path):
 
         add_task_spy.assert_called_once()
         assert generated_for == ["a.txt", "b.txt"]
+
+
+async def test_chat_cmd_wiki_generate_cancelled(tmp_path):
+    """/wiki generate stops early when worker is cancelled."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        await _pilot.pause()
+        fake_store = MagicMock()
+        fake_store.get_sources.return_value = [
+            {"filename": "a.txt"},
+            {"filename": "b.txt"},
+        ]
+        fake_store.get_chunks_by_source.return_value = [MagicMock()]
+        fake_svc = MagicMock(store=fake_store, provider=MagicMock())
+        generated_for: list[str] = []
+
+        def _fake_generate(source, chunks, provider, store, on_progress=None):
+            generated_for.append(source)
+            for w in app.screen.workers:
+                w.cancel()
+            return tmp_path / f"{source}.md"
+
+        with (
+            patch("lilbee.cli.tui.screens.chat.cfg") as mock_cfg,
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=fake_svc),
+            patch("lilbee.wiki.gen.generate_summary_page", side_effect=_fake_generate),
+        ):
+            mock_cfg.wiki = True
+            app.screen._cmd_wiki("generate")
+            await _pilot.pause()
+            while app.screen.workers:
+                await _pilot.pause()
+
+        assert len(generated_for) == 1
 
 
 async def test_chat_cmd_wiki_get_sources_raises_notifies_empty():

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2321,6 +2321,7 @@ class TestCollectNativeModelsError:
         assert buckets["chat"][0].ref == "gpt-4o"
 
     def test_collect_api_models_exception_suppressed(self) -> None:
+        import lilbee.model_manager as mm
         from lilbee.cli.tui.widgets.model_bar import _collect_api_models
 
         buckets: dict[str, list[ModelOption]] = {
@@ -2329,11 +2330,12 @@ class TestCollectNativeModelsError:
             "vision": [],
         }
         seen: set[str] = set()
-        with mock.patch(
-            "lilbee.model_manager.discover_api_models",
-            side_effect=RuntimeError("boom"),
-        ):
+        original = mm.discover_api_models
+        mm.discover_api_models = mock.Mock(side_effect=RuntimeError("boom"))
+        try:
             _collect_api_models(buckets, seen)
+        finally:
+            mm.discover_api_models = original
         assert buckets["chat"] == []
 
     def test_collect_api_models_skips_duplicates(self) -> None:
@@ -3097,6 +3099,7 @@ class TestModelBarPopulateBranches:
             ):
                 bar._after_model_change()
                 mock_screen._apply_model_change.assert_called_once()
+                mock_screen._refresh_status_line.assert_called_once()
 
     async def test_after_model_change_no_chat_screen(self) -> None:
         """Reset services directly when not on a chat screen."""


### PR DESCRIPTION
## Summary
- Tab navigates between grid sections in model catalog (was stuck)
- HF model names cleaned (no -GGUF/-Instruct suffixes in display)
- Model cards truncate long names with ellipsis, highlight on focus
- Settings rows have explicit hover background (no text overlap)
- Task bar reduced to 2 visible panels / 8 lines max (was 5/20)