### PR TITLE
Suppress traceback on wizard download cancel

### DIFF
--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -365,7 +365,7 @@ class SetupWizard(Screen[str | None]):
         is_first: bool,
     ) -> None:
         """Mark the row as failed and, if the chat model succeeded first, save partial state."""
-        log.warning("Download failed for %s", model.ref, exc_info=True)
+        log.warning("Download failed for %s: %s", model.ref, exc)
         error_msg = str(exc)
         if "401" in error_msg or "PermissionError" in error_msg:
             error_msg = msg.SETUP_LOGIN_REQUIRED.format(name=model.display_name)
@@ -392,6 +392,9 @@ class SetupWizard(Screen[str | None]):
                 log.info("Download cancelled for %s", model.ref)
                 return
             except Exception as exc:
+                if self._cancel_event.is_set():
+                    log.info("Download cancelled for %s", model.ref)
+                    return
                 self._handle_download_error(notify, exc, model, is_first=is_first)
                 return
             notify(self._mark_row_done, model.ref)

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -14,7 +14,8 @@ from textual.widgets import Label, Select
 from lilbee import settings
 from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.config import cfg
-from lilbee.models import ModelTask, ensure_tag
+from lilbee.models import ModelTask
+from lilbee.providers.model_ref import parse_model_ref
 from lilbee.services import reset_services
 
 log = logging.getLogger(__name__)
@@ -99,13 +100,17 @@ def _collect_api_models(buckets: dict[str, list[ModelOption]], seen: set[str]) -
     try:
         from lilbee.model_manager import discover_api_models
 
-        for provider_name, models in discover_api_models().items():
+        for display_name, models in discover_api_models().items():
             for model in models:
-                if model.name in seen:
+                # model.provider is the display name ("Anthropic"), but the ref
+                # needs the litellm prefix ("anthropic/model-name") for routing.
+                prefix = display_name.lower()
+                qualified = f"{prefix}/{model.name}"
+                if qualified in seen:
                     continue
-                seen.add(model.name)
-                label = f"{model.name} ({provider_name})"
-                buckets[ModelTask.CHAT].append(ModelOption(label=label, ref=model.name))
+                seen.add(qualified)
+                label = f"{model.name} ({display_name})"
+                buckets[ModelTask.CHAT].append(ModelOption(label=label, ref=qualified))
     except Exception:
         log.debug("Could not discover API models", exc_info=True)
 
@@ -118,7 +123,8 @@ def _sync_select(sel: Select, opts: list[ModelOption], default: str = "") -> Non
     instead of creating a broken fallback entry.
     Prepends *default* if it is not already in *opts*.
     """
-    default = ensure_tag(default)
+    ref = parse_model_ref(default) if default else None
+    default = default if (ref and ref.is_api) else (ref.name if ref else default)
     if default and not any(o.ref == default for o in opts):
         opts.insert(0, ModelOption(default, default))
     sel.set_options(opts)

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -399,12 +399,22 @@ class Config(BaseSettings):
     @field_validator("chat_model", "embedding_model", mode="after")
     @classmethod
     def _normalize_model_tag(cls, v: str) -> str:
-        """Ensure model names always have an explicit tag (e.g. qwen3 -> qwen3:latest)."""
-        if not v or ":" in v:
-            return v
-        from lilbee.registry import DEFAULT_TAG
+        """Ensure model names always have an explicit tag (e.g. qwen3 -> qwen3:latest).
 
-        return f"{v}:{DEFAULT_TAG}"
+        API-prefixed models (openai/, anthropic/, gemini/) are left as-is
+        since they don't use tags. Ollama-prefixed models keep their prefix
+        for routing.
+        """
+        if not v:
+            return v
+        from lilbee.providers.model_ref import parse_model_ref
+
+        ref = parse_model_ref(v)
+        if ref.is_api:
+            return v
+        if ref.provider == "ollama":
+            return f"ollama/{ref.name}"
+        return ref.name
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -37,12 +37,21 @@ MODELS_BROWSE_URL = "https://huggingface.co/models?library=gguf&sort=trending"
 
 
 def ensure_tag(name: str) -> str:
-    """Ensure a model name has an explicit tag (e.g. ``llama3`` → ``llama3:latest``)."""
-    from lilbee.registry import DEFAULT_TAG
+    """Ensure a model name has an explicit tag (e.g. ``llama3`` → ``llama3:latest``).
 
-    if not name or ":" in name:
+    API-prefixed models (openai/, anthropic/, gemini/) are returned as-is
+    since they don't use tags.
+    """
+    if not name:
         return name
-    return f"{name}:{DEFAULT_TAG}"
+    from lilbee.providers.model_ref import parse_model_ref
+
+    ref = parse_model_ref(name)
+    if ref.is_api:
+        return name
+    if ref.provider == "ollama":
+        return f"ollama/{ref.name}"
+    return ref.name
 
 
 @dataclass(frozen=True)

--- a/src/lilbee/providers/litellm_provider.py
+++ b/src/lilbee/providers/litellm_provider.py
@@ -16,29 +16,15 @@ from typing import Any
 import httpx
 
 from lilbee.config import cfg
-from lilbee.providers.base import LLMProvider, ProviderError, filter_options
+from lilbee.providers.base import LLMProvider, ProviderError
+from lilbee.providers.model_ref import parse_model_ref, translate_options
 
 log = logging.getLogger(__name__)
 
 # HTTP timeout for litellm API calls (seconds)
 _HTTP_TIMEOUT = 30
 
-_OLLAMA_PREFIX = "ollama/"
-
 _OLLAMA_URL_PATTERNS = ("localhost:11434", "127.0.0.1:11434", "ollama")
-
-
-def _needs_api_base(routed_model: str) -> bool:
-    """Return True if litellm needs an explicit ``api_base`` for this model.
-
-    Models with a non-Ollama provider prefix (e.g. ``openai/gpt-4o``,
-    ``anthropic/claude-3``) should NOT get ``api_base`` because litellm
-    auto-routes them to the correct provider endpoint. Passing ``api_base``
-    would override that routing and send the request to the wrong backend.
-    """
-    if "/" not in routed_model:
-        return True
-    return routed_model.startswith(_OLLAMA_PREFIX)
 
 
 # Single source of truth for per-provider API key configuration.
@@ -58,19 +44,6 @@ def _is_ollama(base_url: str) -> bool:
     """Return True if *base_url* points to an Ollama instance."""
     url_lower = base_url.lower()
     return any(p in url_lower for p in _OLLAMA_URL_PATTERNS)
-
-
-def _route_model(name: str, base_url: str) -> str:
-    """Add the ``ollama/`` prefix only when targeting an Ollama backend.
-
-    Models that already carry a provider prefix (e.g. ``openai/gpt-4o``)
-    are returned as-is regardless of the backend.
-    """
-    if "/" in name:
-        return name
-    if _is_ollama(base_url):
-        return f"{_OLLAMA_PREFIX}{name}"
-    return name
 
 
 def inject_provider_keys() -> None:
@@ -110,24 +83,35 @@ class LiteLLMProvider(LLMProvider):
         self._api_key = api_key
 
     def _model_name(self, model: str | None = None) -> str:
-        """Route model name for litellm, adding ollama/ prefix only when needed."""
-        return _route_model(model or cfg.chat_model, self._base_url)
+        """Route model name for litellm via parse_model_ref."""
+        ref = parse_model_ref(model or cfg.chat_model)
+        if ref.is_api:
+            return ref.for_litellm()
+        if _is_ollama(self._base_url):
+            return f"ollama/{ref.name}"
+        return ref.name
 
     def _embed_model_name(self) -> str:
         """Route embedding model name for litellm."""
-        return _route_model(cfg.embedding_model, self._base_url)
+        ref = parse_model_ref(cfg.embedding_model)
+        if ref.is_api:
+            return ref.for_litellm()
+        if _is_ollama(self._base_url):
+            return f"ollama/{ref.name}"
+        return ref.name
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed texts via litellm."""
         import litellm
 
         try:
+            ref = parse_model_ref(cfg.embedding_model)
             routed = self._embed_model_name()
             embed_kwargs: dict[str, Any] = {
                 "model": routed,
                 "input": texts,
             }
-            if _needs_api_base(routed):
+            if ref.needs_api_base:
                 embed_kwargs["api_base"] = self._base_url
             if self._api_key:
                 embed_kwargs["api_key"] = self._api_key
@@ -148,6 +132,7 @@ class LiteLLMProvider(LLMProvider):
         import litellm
 
         inject_provider_keys()
+        ref = parse_model_ref(model or cfg.chat_model)
         formatted = _format_messages(messages)
         routed = self._model_name(model)
         kwargs: dict[str, Any] = {
@@ -155,12 +140,12 @@ class LiteLLMProvider(LLMProvider):
             "messages": formatted,
             "stream": stream,
         }
-        if _needs_api_base(routed):
+        if ref.needs_api_base:
             kwargs["api_base"] = self._base_url
         if self._api_key:
             kwargs["api_key"] = self._api_key
         if options:
-            kwargs.update(filter_options(options))
+            kwargs.update(translate_options(options, ref))
 
         try:
             response = litellm.completion(**kwargs)

--- a/src/lilbee/providers/model_ref.py
+++ b/src/lilbee/providers/model_ref.py
@@ -1,0 +1,94 @@
+"""Model reference parsing and option translation.
+
+Single source of truth for classifying model strings and translating
+generation options per provider type. This module must NOT import from
+lilbee.config or lilbee.models to avoid circular imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from lilbee.providers.base import filter_options
+
+_API_PROVIDERS = {"openai", "anthropic", "gemini"}
+
+
+@dataclass(frozen=True)
+class ProviderModelRef:
+    """Parsed model reference with provider routing information."""
+
+    raw: str
+    provider: str  # "local", "ollama", "openai", "anthropic", "gemini"
+    name: str  # provider-specific name with tag normalization applied
+
+    @property
+    def is_api(self) -> bool:
+        return self.provider in _API_PROVIDERS
+
+    @property
+    def is_local(self) -> bool:
+        return self.provider == "local"
+
+    @property
+    def needs_litellm(self) -> bool:
+        """True if this model must route through litellm (API or Ollama)."""
+        return self.provider != "local"
+
+    def for_litellm(self) -> str:
+        """Name formatted for litellm dispatch."""
+        if self.provider == "ollama":
+            return f"ollama/{self.name}"
+        if self.is_api:
+            return f"{self.provider}/{self.name}"
+        return self.name
+
+    def for_display(self) -> str:
+        """Human-readable name for UI."""
+        return self.raw
+
+    @property
+    def needs_api_base(self) -> bool:
+        """True if litellm needs an explicit api_base (Ollama/local)."""
+        return not self.is_api
+
+
+def parse_model_ref(raw: str) -> ProviderModelRef:
+    """Parse a model string into a ProviderModelRef.
+
+    Classifies model strings by prefix:
+    - ``openai/gpt-4o`` -> API provider, no tag normalization
+    - ``anthropic/claude-sonnet-4-20250514`` -> API provider
+    - ``ollama/qwen3:8b`` -> Ollama provider
+    - ``org/model-name`` -> local (HuggingFace-style), tag normalization applied
+    - ``qwen3:8b`` -> local, already has tag
+    - ``qwen3`` -> local, ``:latest`` appended
+    """
+    if "/" in raw:
+        prefix, rest = raw.split("/", 1)
+        if prefix in _API_PROVIDERS:
+            return ProviderModelRef(raw=raw, provider=prefix, name=rest)
+        if prefix == "ollama":
+            name = rest if ":" in rest else f"{rest}:latest"
+            return ProviderModelRef(raw=raw, provider="ollama", name=name)
+        # Unknown prefix (HuggingFace org/model). Treat as local.
+        name = raw if ":" in raw else f"{raw}:latest"
+        return ProviderModelRef(raw=raw, provider="local", name=name)
+    # No prefix = local model. Add :latest if no tag.
+    name = raw if ":" in raw else f"{raw}:latest"
+    return ProviderModelRef(raw=raw, provider="local", name=name)
+
+
+def translate_options(options: dict[str, Any], ref: ProviderModelRef) -> dict[str, Any]:
+    """Translate generation options for the target provider."""
+    filtered = filter_options(options)
+    if ref.is_api:
+        # API providers use max_tokens, not num_predict
+        if "num_predict" in filtered:
+            filtered["max_tokens"] = filtered.pop("num_predict")
+        # num_ctx is a model-load param, not per-call
+        filtered.pop("num_ctx", None)
+        # top_k not supported by most API providers
+        filtered.pop("top_k", None)
+    return filtered

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from lilbee.config import cfg
 from lilbee.providers.base import LLMProvider, ProviderError
+from lilbee.providers.model_ref import parse_model_ref
 
 log = logging.getLogger(__name__)
 
@@ -62,7 +63,10 @@ class RoutingProvider(LLMProvider):
         return self._get_llama_cpp()
 
     def embed(self, texts: list[str]) -> list[list[float]]:
-        return self._provider().embed(texts)
+        ref = parse_model_ref(cfg.embedding_model)
+        if ref.is_api or ref.provider == "ollama":
+            return self._get_litellm().embed(texts)
+        return self._get_llama_cpp().embed(texts)
 
     def chat(
         self,
@@ -72,7 +76,10 @@ class RoutingProvider(LLMProvider):
         options: dict[str, Any] | None = None,
         model: str | None = None,
     ) -> str | Iterator[str]:
-        return self._provider().chat(messages, stream=stream, options=options, model=model)
+        ref = parse_model_ref(model or cfg.chat_model)
+        if ref.is_api or ref.provider == "ollama":
+            return self._get_litellm().chat(messages, stream=stream, options=options, model=model)
+        return self._get_llama_cpp().chat(messages, stream=stream, options=options, model=model)
 
     def list_models(self) -> list[str]:
         """Return models from the active provider."""

--- a/tests/test_model_ref.py
+++ b/tests/test_model_ref.py
@@ -1,0 +1,142 @@
+"""Tests for providers.model_ref — model reference parsing and option translation."""
+
+from __future__ import annotations
+
+from lilbee.providers.model_ref import parse_model_ref, translate_options
+
+
+class TestParseModelRef:
+    def test_local_bare_name(self) -> None:
+        ref = parse_model_ref("qwen3")
+        assert ref.provider == "local"
+        assert ref.name == "qwen3:latest"
+        assert ref.raw == "qwen3"
+
+    def test_local_with_tag(self) -> None:
+        ref = parse_model_ref("qwen3:0.6b")
+        assert ref.provider == "local"
+        assert ref.name == "qwen3:0.6b"
+
+    def test_ollama_prefix(self) -> None:
+        ref = parse_model_ref("ollama/qwen3:8b")
+        assert ref.provider == "ollama"
+        assert ref.name == "qwen3:8b"
+
+    def test_ollama_prefix_bare_name(self) -> None:
+        ref = parse_model_ref("ollama/qwen3")
+        assert ref.provider == "ollama"
+        assert ref.name == "qwen3:latest"
+
+    def test_openai_prefix(self) -> None:
+        ref = parse_model_ref("openai/gpt-4o")
+        assert ref.provider == "openai"
+        assert ref.name == "gpt-4o"
+
+    def test_anthropic_prefix(self) -> None:
+        ref = parse_model_ref("anthropic/claude-sonnet-4-20250514")
+        assert ref.provider == "anthropic"
+        assert ref.name == "claude-sonnet-4-20250514"
+
+    def test_gemini_prefix(self) -> None:
+        ref = parse_model_ref("gemini/gemini-2.5-pro")
+        assert ref.provider == "gemini"
+        assert ref.name == "gemini-2.5-pro"
+
+    def test_unknown_prefix_treated_as_local(self) -> None:
+        ref = parse_model_ref("maternion/LightOnOCR-2")
+        assert ref.provider == "local"
+        assert ref.name == "maternion/LightOnOCR-2:latest"
+
+    def test_unknown_prefix_with_tag(self) -> None:
+        ref = parse_model_ref("maternion/LightOnOCR-2:v1")
+        assert ref.provider == "local"
+        assert ref.name == "maternion/LightOnOCR-2:v1"
+
+    def test_empty_string(self) -> None:
+        ref = parse_model_ref("")
+        assert ref.provider == "local"
+        assert ref.name == ":latest"
+
+
+class TestProviderModelRefProperties:
+    def test_api_model_is_api(self) -> None:
+        ref = parse_model_ref("openai/gpt-4o")
+        assert ref.is_api is True
+        assert ref.is_local is False
+        assert ref.needs_litellm is True
+
+    def test_local_model_is_local(self) -> None:
+        ref = parse_model_ref("qwen3:8b")
+        assert ref.is_local is True
+        assert ref.is_api is False
+        assert ref.needs_litellm is False
+
+    def test_ollama_model_needs_litellm(self) -> None:
+        ref = parse_model_ref("ollama/qwen3:8b")
+        assert ref.needs_litellm is True
+        assert ref.is_api is False
+        assert ref.is_local is False
+
+    def test_api_model_does_not_need_api_base(self) -> None:
+        ref = parse_model_ref("openai/gpt-4o")
+        assert ref.needs_api_base is False
+
+    def test_local_model_needs_api_base(self) -> None:
+        ref = parse_model_ref("qwen3:8b")
+        assert ref.needs_api_base is True
+
+    def test_ollama_model_needs_api_base(self) -> None:
+        ref = parse_model_ref("ollama/qwen3:8b")
+        assert ref.needs_api_base is True
+
+
+class TestForLitellm:
+    def test_ollama_model(self) -> None:
+        ref = parse_model_ref("ollama/qwen3:8b")
+        assert ref.for_litellm() == "ollama/qwen3:8b"
+
+    def test_openai_model(self) -> None:
+        ref = parse_model_ref("openai/gpt-4o")
+        assert ref.for_litellm() == "openai/gpt-4o"
+
+    def test_anthropic_model(self) -> None:
+        ref = parse_model_ref("anthropic/claude-sonnet-4-20250514")
+        assert ref.for_litellm() == "anthropic/claude-sonnet-4-20250514"
+
+    def test_local_model(self) -> None:
+        ref = parse_model_ref("qwen3:8b")
+        assert ref.for_litellm() == "qwen3:8b"
+
+
+class TestForDisplay:
+    def test_preserves_raw(self) -> None:
+        ref = parse_model_ref("openai/gpt-4o")
+        assert ref.for_display() == "openai/gpt-4o"
+
+
+class TestTranslateOptions:
+    def test_api_model_strips_local_options(self) -> None:
+        ref = parse_model_ref("openai/gpt-4o")
+        opts = {"temperature": 0.7, "num_predict": 1024, "num_ctx": 4096, "top_k": 40}
+        result = translate_options(opts, ref)
+        assert result == {"temperature": 0.7, "max_tokens": 1024}
+        assert "num_predict" not in result
+        assert "num_ctx" not in result
+        assert "top_k" not in result
+
+    def test_local_model_keeps_options(self) -> None:
+        ref = parse_model_ref("qwen3:8b")
+        opts = {"temperature": 0.7, "num_predict": 1024, "num_ctx": 4096}
+        result = translate_options(opts, ref)
+        assert result == {"temperature": 0.7, "num_predict": 1024, "num_ctx": 4096}
+
+    def test_api_model_without_num_predict(self) -> None:
+        ref = parse_model_ref("anthropic/claude-sonnet-4-20250514")
+        opts = {"temperature": 0.5}
+        result = translate_options(opts, ref)
+        assert result == {"temperature": 0.5}
+
+    def test_empty_options(self) -> None:
+        ref = parse_model_ref("openai/gpt-4o")
+        result = translate_options({}, ref)
+        assert result == {}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -391,3 +391,12 @@ class TestEnsureTag:
 
     def test_namespaced_model_with_tag(self) -> None:
         assert models.ensure_tag("maternion/LightOnOCR-2:latest") == "maternion/LightOnOCR-2:latest"
+
+    def test_api_model_returned_as_is(self) -> None:
+        assert models.ensure_tag("openai/gpt-4o") == "openai/gpt-4o"
+
+    def test_ollama_model_preserves_prefix(self) -> None:
+        assert models.ensure_tag("ollama/qwen3") == "ollama/qwen3:latest"
+
+    def test_ollama_model_with_tag(self) -> None:
+        assert models.ensure_tag("ollama/qwen3:8b") == "ollama/qwen3:8b"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -511,50 +511,57 @@ class TestRoutingProvider:
         self._to_shutdown.append(rp)
         return rp
 
-    def test_routes_chat_to_litellm_when_available(self) -> None:
+    def test_routes_chat_to_litellm_for_api_model(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.chat.return_value = "hello"
         rp._litellm = mock_litellm
-        rp._use_litellm = True
 
-        cfg.chat_model = "qwen3:8b"
-        result = rp.chat([{"role": "user", "content": "hi"}])
+        result = rp.chat([{"role": "user", "content": "hi"}], model="openai/gpt-4o")
         assert result == "hello"
         mock_litellm.chat.assert_called_once()
 
-    def test_routes_chat_to_llama_cpp_when_litellm_unavailable(self) -> None:
+    def test_routes_chat_to_litellm_for_ollama_model(self) -> None:
         rp = self._make_provider()
-        rp._use_litellm = False
+        mock_litellm = mock.MagicMock()
+        mock_litellm.chat.return_value = "hello"
+        rp._litellm = mock_litellm
+
+        result = rp.chat([{"role": "user", "content": "hi"}], model="ollama/qwen3:8b")
+        assert result == "hello"
+        mock_litellm.chat.assert_called_once()
+
+    def test_routes_chat_to_llama_cpp_for_local_model(self) -> None:
+        rp = self._make_provider()
 
         mock_llama = mock.MagicMock()
         mock_llama.chat.return_value = "local"
         rp._llama_cpp = mock_llama
 
-        cfg.chat_model = "local-model.gguf"
+        cfg.chat_model = "local-model:latest"
         result = rp.chat([{"role": "user", "content": "hi"}])
         assert result == "local"
         mock_llama.chat.assert_called_once()
 
-    def test_routes_embed_to_litellm_when_available(self) -> None:
+    def test_routes_embed_to_litellm_for_ollama_model(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.embed.return_value = [[0.1, 0.2]]
         rp._litellm = mock_litellm
-        rp._use_litellm = True
 
+        cfg.embedding_model = "ollama/nomic-embed-text:latest"
         result = rp.embed(["test"])
         assert result == [[0.1, 0.2]]
         mock_litellm.embed.assert_called_once()
 
-    def test_routes_embed_to_llama_cpp_when_litellm_unavailable(self) -> None:
+    def test_routes_embed_to_llama_cpp_for_local_model(self) -> None:
         rp = self._make_provider()
-        rp._use_litellm = False
 
         mock_llama = mock.MagicMock()
         mock_llama.embed.return_value = [[0.3, 0.4]]
         rp._llama_cpp = mock_llama
 
+        cfg.embedding_model = "nomic-embed-text:latest"
         result = rp.embed(["test"])
         assert result == [[0.3, 0.4]]
 
@@ -569,15 +576,14 @@ class TestRoutingProvider:
         result = rp.list_models()
         assert result == ["local.gguf"]
 
-    def test_litellm_unreachable_falls_back_to_llama_cpp(self) -> None:
+    def test_local_model_uses_llama_cpp_directly(self) -> None:
         rp = self._make_provider()
-        rp._use_litellm = False
 
         mock_llama = mock.MagicMock()
         mock_llama.chat.return_value = "fallback"
         rp._llama_cpp = mock_llama
 
-        cfg.chat_model = "local.gguf"
+        cfg.chat_model = "local-model:latest"
         result = rp.chat([{"role": "user", "content": "hi"}])
         assert result == "fallback"
 
@@ -619,17 +625,16 @@ class TestRoutingProvider:
         with pytest.raises(ProviderError, match="no pull-capable backend"):
             rp.pull_model("bad-model")
 
-    def test_chat_with_explicit_model_override(self) -> None:
+    def test_chat_with_explicit_api_model_override(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.chat.return_value = "saw it"
         rp._litellm = mock_litellm
-        rp._use_litellm = True
 
-        cfg.chat_model = "local.gguf"
+        cfg.chat_model = "local-model:latest"
         result = rp.chat(
             [{"role": "user", "content": "describe"}],
-            model="vision:7b",
+            model="openai/gpt-4o",
         )
         assert result == "saw it"
         mock_litellm.chat.assert_called_once()
@@ -2090,25 +2095,31 @@ class TestIsOllama:
 
 
 class TestRouteModel:
-    def test_ollama_url_adds_prefix(self) -> None:
-        from lilbee.providers.litellm_provider import _route_model
+    """Tests for LiteLLMProvider._model_name which routes via parse_model_ref."""
 
-        assert _route_model("qwen3:8b", "http://localhost:11434") == "ollama/qwen3:8b"
+    def test_ollama_url_adds_prefix(self) -> None:
+        from lilbee.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider(base_url="http://localhost:11434")
+        assert provider._model_name("qwen3:8b") == "ollama/qwen3:8b"
 
     def test_non_ollama_url_no_prefix(self) -> None:
-        from lilbee.providers.litellm_provider import _route_model
+        from lilbee.providers.litellm_provider import LiteLLMProvider
 
-        assert _route_model("gpt-4o", "https://api.openai.com") == "gpt-4o"
+        provider = LiteLLMProvider(base_url="https://api.openai.com")
+        assert provider._model_name("gpt-4o") == "gpt-4o:latest"
 
     def test_already_prefixed_passes_through(self) -> None:
-        from lilbee.providers.litellm_provider import _route_model
+        from lilbee.providers.litellm_provider import LiteLLMProvider
 
-        assert _route_model("openai/gpt-4o", "http://localhost:11434") == "openai/gpt-4o"
+        provider = LiteLLMProvider(base_url="http://localhost:11434")
+        assert provider._model_name("openai/gpt-4o") == "openai/gpt-4o"
 
     def test_provider_prefixed_on_non_ollama(self) -> None:
-        from lilbee.providers.litellm_provider import _route_model
+        from lilbee.providers.litellm_provider import LiteLLMProvider
 
-        assert _route_model("anthropic/claude-sonnet-4-6", "https://api.anthropic.com") == (
+        provider = LiteLLMProvider(base_url="https://api.anthropic.com")
+        assert provider._model_name("anthropic/claude-sonnet-4-6") == (
             "anthropic/claude-sonnet-4-6"
         )
 
@@ -2203,29 +2214,29 @@ class TestLiteLLMListModelsRouting:
 
 class TestNeedsApiBase:
     def test_ollama_prefixed_model_needs_api_base(self) -> None:
-        from lilbee.providers.litellm_provider import _needs_api_base
+        from lilbee.providers.model_ref import parse_model_ref
 
-        assert _needs_api_base("ollama/qwen3:8b") is True
+        assert parse_model_ref("ollama/qwen3:8b").needs_api_base is True
 
     def test_bare_model_needs_api_base(self) -> None:
-        from lilbee.providers.litellm_provider import _needs_api_base
+        from lilbee.providers.model_ref import parse_model_ref
 
-        assert _needs_api_base("qwen3:8b") is True
+        assert parse_model_ref("qwen3:8b").needs_api_base is True
 
     def test_openai_prefixed_model_skips_api_base(self) -> None:
-        from lilbee.providers.litellm_provider import _needs_api_base
+        from lilbee.providers.model_ref import parse_model_ref
 
-        assert _needs_api_base("openai/gpt-4o") is False
+        assert parse_model_ref("openai/gpt-4o").needs_api_base is False
 
     def test_anthropic_prefixed_model_skips_api_base(self) -> None:
-        from lilbee.providers.litellm_provider import _needs_api_base
+        from lilbee.providers.model_ref import parse_model_ref
 
-        assert _needs_api_base("anthropic/claude-sonnet-4-6") is False
+        assert parse_model_ref("anthropic/claude-sonnet-4-6").needs_api_base is False
 
     def test_gemini_prefixed_model_skips_api_base(self) -> None:
-        from lilbee.providers.litellm_provider import _needs_api_base
+        from lilbee.providers.model_ref import parse_model_ref
 
-        assert _needs_api_base("gemini/gemini-pro") is False
+        assert parse_model_ref("gemini/gemini-pro").needs_api_base is False
 
 
 class TestChatApiBaseRouting:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -5369,6 +5369,37 @@ async def test_setup_wizard_download_cancel_mid_download():
                 await pilot.pause()
 
 
+async def test_setup_wizard_download_cancel_wrapped_exception():
+    """Cancel during download where catalog wraps _DownloadCancelled in RuntimeError."""
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    app = SetupTestApp()
+    with _patch_setup_scan(), _patch_setup_ram(16.0):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, SetupWizard)
+
+            def fake_download(model, on_progress=None):
+                # Simulate catalog.download_model wrapping _DownloadCancelled
+                screen._cancel_event.set()
+                raise RuntimeError("Failed to download Test: _DownloadCancelled:")
+
+            screen._download_models = [MagicMock(ref="chat:model", display_name="Test Model")]
+            with (
+                patch(
+                    "lilbee.cli.tui.screens.setup.download_model",
+                    side_effect=fake_download,
+                ),
+                patch("lilbee.settings.set_value"),
+                patch("lilbee.services.reset_services"),
+            ):
+                screen._download_loop(lambda fn, *a: fn(*a))
+                await pilot.pause()
+                # Should NOT call _handle_download_error since cancel_event is set
+                # The screen should not be corrupted with traceback text
+
+
 async def test_wizard_action_cancel_sets_event():
     """action_cancel sets the cancel event so download threads abort."""
     from lilbee.cli.tui.screens.setup import SetupWizard


### PR DESCRIPTION
## Summary
- Canceling a model download in the wizard no longer corrupts the screen with a Python traceback
- Error logging no longer writes stack traces to stderr while the TUI is running