### PR TITLE
Fix CLI --json error handling and search LLM regression

### DIFF
--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -154,6 +154,13 @@ def _default(
     install_lancedb_thread_error_suppressor()
 
     cfg.json_mode = json_output
+    if cfg.json_mode:
+        try:
+            import litellm
+
+            litellm.suppress_debug_info = True
+        except ImportError:
+            pass
     if ctx.invoked_subcommand is None:
         apply_overrides(data_dir=data_dir, model=model, use_global=use_global)
         if cfg.json_mode:

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -80,7 +80,21 @@ def search(
     """Search the knowledge base for relevant chunks."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
 
-    results = get_services().searcher.search(query, top_k=top_k or cfg.top_k)
+    if not query or not query.strip():
+        if cfg.json_mode:
+            json_output({"error": "query must not be empty"})
+            raise SystemExit(1)
+        console.print(f"[{theme.ERROR}]Error:[/{theme.ERROR}] query must not be empty")
+        raise SystemExit(1)
+
+    try:
+        results = get_services().searcher.search(query, top_k=top_k or cfg.top_k)
+    except Exception as exc:
+        if cfg.json_mode:
+            json_output({"error": str(exc)})
+            raise SystemExit(1) from None
+        console.print(f"[{theme.ERROR}]Error:[/{theme.ERROR}] {exc}")
+        raise SystemExit(1) from None
     cleaned = [clean_result(r) for r in results]
 
     if cfg.json_mode:
@@ -421,13 +435,18 @@ def ask(
         seed=seed,
     )
 
-    from lilbee.models import ensure_chat_model
-
-    ensure_chat_model()
-    get_services().embedder.validate_model()
-    auto_sync(console)
-
     try:
+        from lilbee.models import ensure_chat_model
+
+        ensure_chat_model()
+        get_services().embedder.validate_model()
+        if cfg.json_mode:
+            from rich.console import Console as _QuietConsole
+
+            auto_sync(_QuietConsole(quiet=True))
+        else:
+            auto_sync(console)
+
         if cfg.json_mode:
             result = get_services().searcher.ask_raw(question)
             json_output(
@@ -476,6 +495,9 @@ def chat(
         seed=seed,
     )
 
+    if cfg.json_mode:
+        json_output({"error": "Chat requires a terminal, not --json"})
+        raise SystemExit(1)
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         console.print(f"[{theme.ERROR}]Error:[/{theme.ERROR}] Chat requires a terminal.")
         raise SystemExit(1)

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -423,6 +423,9 @@ def _parse_source_or_bad_param(value: str | None) -> ModelSource | None:
     try:
         return ModelSource.parse(value)
     except ValueError as exc:
+        if cfg.json_mode:
+            json_output({"error": str(exc)})
+            raise SystemExit(1) from None
         raise typer.BadParameter(str(exc)) from exc
 
 

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -356,7 +356,7 @@ class Searcher:
             for concept in self._concept_query_expansion(question):
                 llm_variants.append((concept, self._embedder.embed(concept)))
             return llm_variants
-        except (ConnectionError, OSError, RuntimeError) as exc:
+        except Exception as exc:
             log.warning("Query expansion disabled for this call: %s", exc, exc_info=True)
             return []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,6 +356,15 @@ class TestChat:
         assert "error" in data
         assert "terminal" in data["error"].lower() or "json" in data["error"].lower()
 
+    def test_json_mode_suppresses_litellm_debug(self) -> None:
+        """--json sets litellm.suppress_debug_info when litellm is installed."""
+        fake_litellm = mock.MagicMock()
+        fake_litellm.suppress_debug_info = False
+        with mock.patch.dict("sys.modules", {"litellm": fake_litellm}):
+            result = runner.invoke(app, ["--json", "chat"])
+            assert result.exit_code == 1
+            assert fake_litellm.suppress_debug_info is True
+
     def test_json_mode_suppresses_litellm_without_litellm(self) -> None:
         """When litellm is not installed, the ImportError is silently caught."""
         with mock.patch.dict("sys.modules", {"litellm": None}):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,6 +356,12 @@ class TestChat:
         assert "error" in data
         assert "terminal" in data["error"].lower() or "json" in data["error"].lower()
 
+    def test_json_mode_suppresses_litellm_without_litellm(self) -> None:
+        """When litellm is not installed, the ImportError is silently caught."""
+        with mock.patch.dict("sys.modules", {"litellm": None}):
+            result = runner.invoke(app, ["--json", "chat"])
+            assert result.exit_code == 1
+
 
 class TestApplyOverrides:
     def test_data_dir_override(self, tmp_path):
@@ -757,6 +763,12 @@ class TestSearch:
         result = runner.invoke(app, ["search", ""])
         assert result.exit_code == 1
         assert "empty" in result.output.lower()
+
+    def test_search_human_provider_error(self, mock_svc):
+        mock_svc.searcher.search.side_effect = RuntimeError("connection refused")
+        result = runner.invoke(app, ["search", "test"])
+        assert result.exit_code == 1
+        assert "connection refused" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -345,10 +345,16 @@ class TestAddPathsBackground:
 
 class TestChat:
     def test_chat_non_tty_exits_with_error(self) -> None:
-        """CliRunner is non-TTY, so chat should exit with error."""
         result = runner.invoke(app, ["chat"])
         assert result.exit_code == 1
         assert "terminal" in result.output.lower()
+
+    def test_chat_json_returns_json_error(self) -> None:
+        result = runner.invoke(app, ["--json", "chat"])
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert "error" in data
+        assert "terminal" in data["error"].lower() or "json" in data["error"].lower()
 
 
 class TestApplyOverrides:
@@ -732,6 +738,25 @@ class TestSearch:
         data = json.loads(result.output.strip())
         assert "relevance_score" in data["results"][0]
         assert "distance" not in data["results"][0]
+
+    def test_search_json_empty_query_error(self, mock_svc):
+        result = runner.invoke(app, ["--json", "search", ""])
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert "error" in data
+        mock_svc.searcher.search.assert_not_called()
+
+    def test_search_json_provider_error(self, mock_svc):
+        mock_svc.searcher.search.side_effect = RuntimeError("provider down")
+        result = runner.invoke(app, ["--json", "search", "test"])
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert "provider down" in data["error"]
+
+    def test_search_human_empty_query_error(self, mock_svc):
+        result = runner.invoke(app, ["search", ""])
+        assert result.exit_code == 1
+        assert "empty" in result.output.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -240,6 +240,13 @@ class TestListCmd:
         assert result.exit_code != 0
         assert "bogus" in result.output
 
+    def test_invalid_source_json_returns_error(self, fake_manager):
+        result = runner.invoke(app, ["--json", "model", "list", "--source", "bogus"])
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert "error" in data
+        assert "bogus" in data["error"]
+
 
 class TestShowModelData:
     def test_catalog_and_installed_merged(self, fake_manager, native_manifests):


### PR DESCRIPTION
## Summary
- Empty query validation and provider error handling in search --json
- Ask --json no longer leaks Rich output on pre-flight errors
- Chat --json returns JSON error instead of plain text
- Model commands with invalid --source return JSON error instead of exit 2
- Query expansion catches all exceptions so search works without LLM (BEE-ibl)