### PR TITLE
Bump kreuzberg to 4.8.5, remove heading dedup bandaid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 dependencies = [
     "lancedb",
-    "kreuzberg>=4.6.3",
+    "kreuzberg>=4.8.5",
     "filelock",
     "tree-sitter-language-pack>=1.4.0",
     "typer",

--- a/src/lilbee/chunk.py
+++ b/src/lilbee/chunk.py
@@ -41,25 +41,5 @@ def chunk_text(
     )
     result = extract_bytes_sync(text.encode("utf-8"), mime_type, config=config)
     if result.chunks:
-        if heading_context:
-            return [_dedup_heading(c.content) for c in result.chunks]
         return [c.content for c in result.chunks]
     return []
-
-
-def _dedup_heading(text: str) -> str:
-    """Remove duplicate heading caused by kreuzberg's prepend_heading_context.
-
-    kreuzberg prepends a heading breadcrumb (e.g. ``# Top > ## Sub``) followed
-    by a blank line. When the chunk body starts with the same heading that ends
-    the breadcrumb, the heading appears twice. This strips the duplicate.
-    """
-    parts = text.split("\n\n", 2)
-    if len(parts) < 2:
-        return text
-    ctx = parts[0]
-    last_seg = ctx.rsplit(" > ", 1)[-1]
-    if parts[1].strip() == last_seg.strip():
-        rest = parts[2] if len(parts) > 2 else ""
-        return ctx + ("\n\n" + rest if rest else "")
-    return text

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -234,38 +234,9 @@ class Greeter:
             path.unlink()
 
 
-class TestDedupHeading:
-    def test_dedup_single_heading(self):
-        from lilbee.chunk import _dedup_heading
-
-        text = "# Heading\n\n# Heading"
-        assert _dedup_heading(text) == "# Heading"
-
-    def test_dedup_breadcrumb(self):
-        from lilbee.chunk import _dedup_heading
-
-        text = "# Top > ## Sub\n\n## Sub"
-        assert _dedup_heading(text) == "# Top > ## Sub"
-
-    def test_dedup_with_body(self):
-        from lilbee.chunk import _dedup_heading
-
-        text = "# Heading\n\n# Heading\n\nBody content here."
-        assert _dedup_heading(text) == "# Heading\n\nBody content here."
-
-    def test_no_dedup_when_different(self):
-        from lilbee.chunk import _dedup_heading
-
-        text = "# Heading\n\nSome body text."
-        assert _dedup_heading(text) == text
-
-    def test_no_dedup_single_part(self):
-        from lilbee.chunk import _dedup_heading
-
-        assert _dedup_heading("no heading here") == "no heading here"
-
-    def test_heading_context_chunks_no_duplicate(self):
-        """Integration: chunk_text with heading_context strips duplicates."""
+class TestHeadingContextNoDuplicate:
+    def test_heading_context_no_duplicate(self):
+        """kreuzberg >= 4.8.5 should not duplicate headings with prepend_heading_context."""
         md = "# Title\n\n" + "Word " * 500 + "\n\n## Section\n\n" + "More " * 500
         chunks = chunk_text(md, mime_type="text/markdown", heading_context=True)
         for c in chunks:


### PR DESCRIPTION
## Summary
- Bump kreuzberg from >=4.6.3 to >=4.8.5 (PR 85 fixes duplicate heading in prepend_heading_context)
- Remove _dedup_heading workaround from chunk.py
- Remove unit tests for the removed bandaid, keep integration test