### PR TITLE
Use canonical models dir regardless of LILBEE_DATA

### DIFF
--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -436,7 +436,7 @@ class Config(BaseSettings):
     @model_validator(mode="before")
     @classmethod
     def _resolve_defaults(cls, data: Any) -> Any:
-        from lilbee.platform import default_data_dir, find_local_root
+        from lilbee.platform import canonical_models_dir, default_data_dir, find_local_root
 
         if not isinstance(data, dict):  # pragma: no cover
             return data
@@ -458,7 +458,7 @@ class Config(BaseSettings):
         if data.get("lancedb_dir") in (None, _UNSET):
             data["lancedb_dir"] = root / "data" / "lancedb"
         if data.get("models_dir") in (None, _UNSET):
-            data["models_dir"] = root / "models"
+            data["models_dir"] = canonical_models_dir()
 
         if "LILBEE_LITELLM_BASE_URL" not in os.environ:
             ollama_host = os.environ.get("OLLAMA_HOST")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -476,15 +476,17 @@ class TestConfigProvider:
             assert c.litellm_base_url == "http://myhost:11434"
             assert c.llm_api_key == "sk-key"
 
-    def test_models_dir_derives_from_data_root(self, tmp_path: Path) -> None:
-        """models_dir derives from data_root so LILBEE_DATA controls it."""
+    def test_models_dir_uses_canonical_location(self, tmp_path: Path) -> None:
+        """models_dir always uses the canonical shared location, not data_root."""
         import os
+
+        from lilbee.platform import canonical_models_dir
 
         with mock.patch.dict(os.environ, {"LILBEE_DATA": str(tmp_path / "test-lilbee")}):
             from lilbee.config import Config
 
             c = Config()
-            assert c.models_dir == tmp_path / "test-lilbee" / "models"
+            assert c.models_dir == canonical_models_dir()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- models_dir now always uses the canonical shared location instead of
  deriving from data_root, so models installed globally are visible
  when using custom LILBEE_DATA paths