### PR TITLE
Slim TaskBar to 1-line hint, move progress to Task Center

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -99,6 +99,7 @@ class LilbeeApp(App[None]):
         Binding("f1", "push_help", "Help", show=False),
         Binding("ctrl+h", "push_help", "Help", show=False),
         Binding("ctrl+t", "cycle_theme", "Theme", show=False),
+        Binding("t", "open_tasks", "Tasks", show=False),
         # priority=True is required: even though NavAwareInput lets [ and ]
         # bubble past Input.check_consume_key, Textual's focused Input still
         # handles printable keys in _on_key before a non-priority ancestor
@@ -220,6 +221,10 @@ class LilbeeApp(App[None]):
             self.action_hide_help_panel()
         else:
             self.action_show_help_panel()
+
+    def action_open_tasks(self) -> None:
+        """Jump to the Task Center screen (t key)."""
+        self.switch_view("Tasks")
 
     def action_nav_prev(self) -> None:
         """Navigate to previous view ([ key)."""

--- a/src/lilbee/cli/tui/screens/task_center.py
+++ b/src/lilbee/cli/tui/screens/task_center.py
@@ -90,11 +90,22 @@ class TaskCenter(Screen[None]):
         self.app.task_bar.queue.unsubscribe(self._on_queue_change)
 
     def _on_queue_change(self) -> None:
-        """Called when task queue changes - refresh the display."""
-        try:
-            self._refresh_tasks()
-        except Exception:
-            log.debug("Queue change refresh failed", exc_info=True)
+        """Called when task queue changes - refresh the display.
+
+        May fire from a worker thread (download callbacks), so marshal
+        back to the main thread via call_from_thread when needed.
+        """
+        import threading
+
+        from lilbee.cli.tui.thread_safe import call_from_thread
+
+        if threading.current_thread() is threading.main_thread():
+            try:
+                self._refresh_tasks()
+            except Exception:
+                log.debug("Queue change refresh failed", exc_info=True)
+        else:
+            call_from_thread(self, self._refresh_tasks)
 
     def action_refresh_tasks(self) -> None:
         """Refresh the task list."""

--- a/src/lilbee/cli/tui/task_queue.py
+++ b/src/lilbee/cli/tui/task_queue.py
@@ -103,25 +103,6 @@ class TaskQueue:
             return tasks
 
     @property
-    def displayable_tasks(self) -> list[Task]:
-        """Active tasks plus recently-finished (DONE/FAILED) tasks awaiting dismissal.
-        Widgets render this so completed tasks stay visible for their flash period.
-        """
-        with self._lock:
-            result: list[Task] = []
-            active_ids = set(self._active_ids.values())
-            for tid in self._active_ids.values():
-                task = self._tasks.get(tid)
-                if task:
-                    result.append(task)
-            for tid, task in self._tasks.items():
-                if tid in active_ids:
-                    continue
-                if task.status in (TaskStatus.DONE, TaskStatus.FAILED):
-                    result.append(task)
-            return result
-
-    @property
     def queued_tasks(self) -> list[Task]:
         with self._lock:
             result: list[Task] = []
@@ -278,7 +259,7 @@ class TaskQueue:
         # Snapshot under the lock so subscribe/unsubscribe from another thread
         # (or from inside a callback) cannot mutate the list mid-iteration.
         # Callbacks run outside the lock so synchronous subscribers that
-        # re-enter the queue (e.g. TaskBar refreshing from displayable_tasks)
+        # re-enter the queue (e.g. TaskBar refreshing from active_tasks)
         # do not deadlock on the non-reentrant lock.
         with self._lock:
             callbacks = list(self._on_change)

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -1,15 +1,16 @@
 """TaskBar widget and controller.
 
-The TaskBar is a browser-style docked panel that shows per-task progress bars.
+The TaskBar is a slim 1-line status indicator docked at the bottom of every
+screen. It shows a count of active/queued tasks and directs users to the
+Task Center (``t``) for detailed progress. Full progress panels with spinners
+and progress bars live only in the Task Center screen.
+
 State ownership is split so the bar can render on every screen:
 
-- `TaskBarController` lives on the app (`app.task_bar`) and owns the single
-  `TaskQueue`. Callers enqueue/update/complete/fail tasks through it.
-- `TaskBar` is a stateless view widget composed by each Screen. It subscribes
+- ``TaskBarController`` lives on the app (``app.task_bar``) and owns the
+  single ``TaskQueue``. Callers enqueue/update/complete/fail tasks through it.
+- ``TaskBar`` is a stateless view widget composed by each Screen. It subscribes
   to the shared queue and re-renders when the queue changes.
-
-This lets progress stay visible as the user navigates between screens,
-because each screen has its own `TaskBar` instance bound to the same queue.
 """
 
 from __future__ import annotations
@@ -21,11 +22,9 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
-from textual.css.query import NoMatches
-from textual.widgets import Label, ProgressBar, Static
+from textual.widgets import Label, Static
 
-from lilbee.cli.tui.task_queue import STATUS_ICONS, Task, TaskQueue, TaskStatus
+from lilbee.cli.tui.task_queue import TaskQueue
 from lilbee.cli.tui.thread_safe import call_from_thread
 
 if TYPE_CHECKING:
@@ -36,54 +35,18 @@ log = logging.getLogger(__name__)
 _DONE_FLASH_SECONDS = 1.0
 _SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 _SPINNER_INTERVAL = 0.1
-_MAX_VISIBLE_PANELS = 2
-
-
-class _TaskPanel(Static):
-    """A single task's label + progress bar row."""
-
-    DEFAULT_CSS = """
-    _TaskPanel {
-        height: auto;
-        max-height: 2;
-        padding: 0 1;
-    }
-    _TaskPanel .task-panel-label {
-        height: 1;
-    }
-    _TaskPanel ProgressBar {
-        height: 1;
-    }
-    _TaskPanel.task-done .task-panel-label {
-        color: $success;
-    }
-    _TaskPanel.task-failed .task-panel-label {
-        color: $error;
-    }
-    """
-
-    def __init__(self, task_id: str, **kwargs: object) -> None:
-        super().__init__(id=f"task-panel-{task_id}", **kwargs)  # type: ignore[arg-type]
-        self.task_id = task_id
-        self._last_progress: int = -1
-        # None means "never rendered yet", distinct from False (rendered as determinate).
-        self._last_indeterminate: bool | None = None
-
-    def compose(self) -> ComposeResult:
-        yield Label("", classes="task-panel-label")
-        yield ProgressBar(total=100, show_eta=False)
 
 
 class TaskBarController:
-    """App-level coordinator for background tasks.
+    """App-level owner of the shared TaskQueue.
 
-    Owns the shared `TaskQueue` and schedules the brief post-completion flash
-    period before finished tasks are removed. `TaskBar` view widgets subscribe
-    to `queue.on_change` and re-render whenever this controller mutates state.
+    The controller is attached as ``app.task_bar`` during ``LilbeeApp.__init__``.
+    All task lifecycle methods (add/update/complete/fail/cancel) go through here
+    so every ``TaskBar`` widget sees the same state.
     """
 
-    def __init__(self, app: App[None]) -> None:
-        self._app = app
+    def __init__(self, app: App[object]) -> None:
+        self.app = app
         self.queue = TaskQueue()
 
     def add_task(
@@ -107,33 +70,24 @@ class TaskBarController:
         *,
         indeterminate: bool | None = None,
     ) -> None:
-        """Update progress and detail text for a task.
-        When *indeterminate* is True the panel renders a pulsing bar instead
-        of a percentage, so long-running phases without a reliable percent
-        don't falsely claim to be finished.
-        """
+        """Update progress and detail text for a task."""
         self.queue.update_task(task_id, progress, detail, indeterminate=indeterminate)
 
     def complete_task(self, task_id: str) -> None:
         """Mark a task done; keep it visible for a brief flash, then remove."""
         self.queue.complete_task(task_id)
-        self._app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id))
+        self.app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id, "complete"))
 
     def fail_task(self, task_id: str, detail: str = "") -> None:
-        """Mark a task failed; keep it visible for a brief flash, then remove."""
+        """Mark a task as failed; flash, then remove."""
         self.queue.fail_task(task_id, detail)
-        self._app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id))
+        self.app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id, "fail"))
 
     def cancel_task(self, task_id: str) -> None:
-        """Cancel and immediately remove a task."""
-        task = self.queue.get_task(task_id)
-        task_type = task.task_type if task else None
         self.queue.cancel(task_id)
-        self.queue.remove_task(task_id)
-        self._advance_all(task_type)
+        self._dismiss(task_id, "cancel")
 
-    def _dismiss(self, task_id: str) -> None:
-        """Final cleanup after the flash period: remove and advance the queue."""
+    def _dismiss(self, task_id: str, reason: str) -> None:
         task = self.queue.get_task(task_id)
         task_type = task.task_type if task else None
         self.queue.remove_task(task_id)
@@ -148,35 +102,29 @@ class TaskBarController:
 
 
 class TaskBar(Static):
-    """Docked view of the app's TaskBarController.
+    """Slim 1-line status indicator for background tasks.
 
-    Each Screen composes its own `TaskBar` instance. All instances subscribe
-    to the app-level `TaskBarController.queue` and render its displayable
-    tasks, so progress is visible regardless of which screen is on top.
+    Shows a compact summary when tasks are active and hides when idle.
+    Detailed progress (spinners, progress bars, task panels) lives in
+    the Task Center screen, accessible via ``t``.
     """
 
     DEFAULT_CSS = """
     TaskBar {
         dock: bottom;
-        height: auto;
-        max-height: 8;
-        padding: 0;
-    }
-    TaskBar .task-queued-label {
         height: 1;
-        color: $text-muted;
+        max-height: 1;
         padding: 0 1;
+        color: $text-muted;
     }
     """
 
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)  # type: ignore[arg-type]
         self._spinner_index = 0
-        self._panels: dict[str, _TaskPanel] = {}
 
     def compose(self) -> ComposeResult:
-        yield Vertical(id="task-bar-panels")
-        yield Label("", id="task-queued-label", classes="task-queued-label")
+        yield Label("", id="task-status-label")
 
     def on_mount(self) -> None:
         self.queue.subscribe(self._on_queue_change)
@@ -188,13 +136,6 @@ class TaskBar(Static):
 
     @property
     def _controller(self) -> TaskBarController:
-        """Return the app's TaskBarController, creating one if missing.
-        LilbeeApp wires up a controller in its `__init__`. Bare test harnesses
-        that instantiate a TaskBar on a plain `App` (without a controller) get
-        one lazily attached so every screen in the app still shares state. In
-        production this branch is a bug indicator: log a warning so accidental
-        misuse surfaces instead of silently regressing the per-screen fix.
-        """
         controller = getattr(self.app, "task_bar", None)
         if not isinstance(controller, TaskBarController):
             log.warning(
@@ -240,10 +181,6 @@ class TaskBar(Static):
     def cancel_task(self, task_id: str) -> None:
         self._controller.cancel_task(task_id)
 
-    @staticmethod
-    def _status_icon(status: TaskStatus) -> str:
-        return STATUS_ICONS.get(status, "▸")
-
     def _on_queue_change(self) -> None:
         """Queue callback. May fire on either the main or a worker thread."""
         if threading.current_thread() is threading.main_thread():
@@ -258,81 +195,37 @@ class TaskBar(Static):
             self._refresh_display()
 
     def _refresh_display(self) -> None:
-        """Rebuild panels from the shared queue's displayable tasks."""
+        """Rebuild the 1-line status label from the shared queue."""
         queue = self.queue
-        displayable = queue.displayable_tasks[:_MAX_VISIBLE_PANELS]
+        active = queue.active_tasks
         queued = queue.queued_tasks
 
-        if not displayable and not queued:
+        if not active and not queued:
             self.display = False
-            self._clear_panels()
             return
 
         self.display = True
+        spinner = _SPINNER_FRAMES[self._spinner_index]
+        parts: list[str] = []
 
-        visible_ids = {task.task_id for task in displayable}
-        for tid in list(self._panels.keys()):
-            if tid not in visible_ids:
-                panel = self._panels.pop(tid)
-                panel.remove()
+        if active:
+            count = len(active)
+            task = active[0]
+            pct = f" {task.progress}%" if task.progress > 0 else ""
+            if count == 1:
+                parts.append(f"{spinner} {task.name}{pct}")
+            else:
+                parts.append(f"{spinner} {count} tasks running")
 
-        for task in displayable:
-            self._ensure_panel(task.task_id)
-            self._render_task_panel(task.task_id, task)
-
-        queued_label = self.query_one("#task-queued-label", Label)
         if queued:
-            names = ", ".join(t.name for t in queued[:3])
-            suffix = f" +{len(queued) - 3} more" if len(queued) > 3 else ""
-            queued_label.update(f"   Queued: {names}{suffix}")
-            queued_label.display = True
-        else:
-            queued_label.display = False
+            parts.append(f"{len(queued)} queued")
 
-        self.refresh()
+        summary = " | ".join(parts)
+        label_text = f" {summary}  press t for Task Center"
 
-    def _clear_panels(self) -> None:
-        for panel in self._panels.values():
-            panel.remove()
-        self._panels.clear()
-
-    def _ensure_panel(self, task_id: str) -> _TaskPanel:
-        if task_id not in self._panels:
-            panel = _TaskPanel(task_id)
-            self._panels[task_id] = panel
-            container = self.query_one("#task-bar-panels", Vertical)
-            container.mount(panel)
-        return self._panels[task_id]
-
-    def _render_task_panel(self, task_id: str, task: Task | None) -> None:
-        panel = self._panels.get(task_id)
-        if not panel or task is None:
-            return
-
-        panel.set_class(task.status == TaskStatus.DONE, "task-done")
-        panel.set_class(task.status == TaskStatus.FAILED, "task-failed")
-
-        if task.status == TaskStatus.ACTIVE:
-            icon = _SPINNER_FRAMES[self._spinner_index]
-        else:
-            icon = self._status_icon(task.status)
-
-        detail = f"  {task.detail}" if task.detail else ""
         try:
-            label = panel.query_one(".task-panel-label", Label)
-            label.update(f" {icon} {task.name}{detail}")
-            is_indeterminate = task.indeterminate and task.status == TaskStatus.ACTIVE
-            progress_changed = (
-                is_indeterminate != panel._last_indeterminate
-                or task.progress != panel._last_progress
-            )
-            if progress_changed:
-                progress_bar = panel.query_one(ProgressBar)
-                if is_indeterminate:
-                    progress_bar.update(total=None, progress=0)
-                else:
-                    progress_bar.update(total=100, progress=task.progress)
-                panel._last_progress = task.progress
-                panel._last_indeterminate = is_indeterminate
-        except NoMatches:
-            pass  # panel children not yet composed, next refresh will catch up
+            label = self.query_one("#task-status-label", Label)
+            label.update(label_text)
+        except Exception:
+            pass
+

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -76,18 +76,18 @@ class TaskBarController:
     def complete_task(self, task_id: str) -> None:
         """Mark a task done; keep it visible for a brief flash, then remove."""
         self.queue.complete_task(task_id)
-        self.app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id, "complete"))
+        self.app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id))
 
     def fail_task(self, task_id: str, detail: str = "") -> None:
         """Mark a task as failed; flash, then remove."""
         self.queue.fail_task(task_id, detail)
-        self.app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id, "fail"))
+        self.app.set_timer(_DONE_FLASH_SECONDS, lambda: self._dismiss(task_id))
 
     def cancel_task(self, task_id: str) -> None:
         self.queue.cancel(task_id)
-        self._dismiss(task_id, "cancel")
+        self._dismiss(task_id)
 
-    def _dismiss(self, task_id: str, reason: str) -> None:
+    def _dismiss(self, task_id: str) -> None:
         task = self.queue.get_task(task_id)
         task_type = task.task_type if task else None
         self.queue.remove_task(task_id)
@@ -223,8 +223,6 @@ class TaskBar(Static):
         summary = " | ".join(parts)
         label_text = f" {summary}  press t for Task Center"
 
-        try:
+        with contextlib.suppress(Exception):
             label = self.query_one("#task-status-label", Label)
             label.update(label_text)
-        except Exception:
-            pass

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -19,7 +19,7 @@ import contextlib
 import logging
 import threading
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from textual.app import ComposeResult
 from textual.widgets import Label, Static
@@ -45,7 +45,7 @@ class TaskBarController:
     so every ``TaskBar`` widget sees the same state.
     """
 
-    def __init__(self, app: App[object]) -> None:
+    def __init__(self, app: App[Any]) -> None:
         self.app = app
         self.queue = TaskQueue()
 
@@ -228,4 +228,3 @@ class TaskBar(Static):
             label.update(label_text)
         except Exception:
             pass
-

--- a/tests/test_task_bar_per_screen.py
+++ b/tests/test_task_bar_per_screen.py
@@ -208,6 +208,42 @@ async def test_task_bar_state_shared_across_screens() -> None:
         assert catalog_bar.queue.active_task.name == "Background sync"
 
 
+async def test_action_open_tasks_switches_to_task_center() -> None:
+    """Pressing 't' (action_open_tasks) should navigate to the Task Center."""
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.task_center import TaskCenter
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.action_open_tasks()
+        await pilot.pause()
+        assert isinstance(app.screen, TaskCenter)
+
+
+async def test_task_center_queue_change_from_worker_thread() -> None:
+    """Queue changes from a worker thread should call_from_thread safely."""
+    import threading
+
+    app = _ControllerApp(_task_center_screen)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.task_bar.add_task("Background work", "sync")
+        app.task_bar.queue.advance()
+        # Simulate a queue change from a worker thread
+        done = threading.Event()
+
+        def worker():
+            app.task_bar.queue.update_task(app.task_bar.queue.active_task.task_id, 50, "halfway")
+            done.set()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        done.wait(timeout=5)
+        t.join(timeout=5)
+        await pilot.pause()
+
+
 async def test_task_bar_auto_hides_when_queue_drains() -> None:
     """When all tasks finish, every screen's TaskBar should hide again."""
     app = _ControllerApp(_chat_screen)

--- a/tests/test_task_bar_per_screen.py
+++ b/tests/test_task_bar_per_screen.py
@@ -176,11 +176,10 @@ async def test_task_bar_shows_active_task_on_catalog_screen() -> None:
         await pilot.pause()
         bar = app.screen.query_one(TaskBar)
         assert bar.display is False  # idle: hidden
-        task_id = app.task_bar.add_task("Download test-model", "download")
+        app.task_bar.add_task("Download test-model", "download")
         app.task_bar.queue.advance()
         await pilot.pause()
         assert bar.display is True
-        assert task_id in bar._panels
 
 
 async def test_task_bar_state_shared_across_screens() -> None:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8130,13 +8130,13 @@ async def test_cmd_add_uses_indeterminate_progress_during_ingest(tmp_path):
         )
 
 
-async def test_task_bar_indeterminate_renders_total_none():
-    """BEE-65f: indeterminate tasks render the Textual ProgressBar with total=None.
-    Setting total=None is how Textual draws an indeterminate pulsing bar.
-    A task flagged indeterminate=True must not leak a total=100 update.
-    """
-    from textual.widgets import ProgressBar
+async def test_task_bar_indeterminate_flag_propagated():
+    """BEE-65f: indeterminate flag is stored on the task in the queue.
 
+    The TaskBar no longer renders ProgressBar widgets (those live in the
+    Task Center), but the indeterminate flag must still propagate through
+    the controller into the queue so the Task Center can render correctly.
+    """
     from lilbee.cli.tui.task_queue import TaskStatus
     from lilbee.cli.tui.widgets.task_bar import TaskBar
 
@@ -8155,28 +8155,12 @@ async def test_task_bar_indeterminate_renders_total_none():
         task_id = app.task_bar.add_task("indet", "add")
         app.task_bar.queue.advance("add")
         app.task_bar.update_task(task_id, 0, "working", indeterminate=True)
-        # Wait until the ProgressBar exists and reflects indeterminate mode.
-        # The render loop may need several frames on slow CI runners.
-        bar = app.screen.query_one("#tbar", TaskBar)
-        pb = None
-        for _ in range(30):
-            await _pilot.pause()
-            pbs = bar.query(ProgressBar)
-            if pbs:
-                pb = pbs.first()
-                if pb.total is None:
-                    break
+        await _pilot.pause()
 
         task = app.task_bar.queue.get_task(task_id)
         assert task is not None
         assert task.indeterminate is True
         assert task.status == TaskStatus.ACTIVE
-        assert pb is not None, "ProgressBar never appeared"
-        assert pb.total is None
 
-        # Completing flips indeterminate off and drives the bar to 100
-        app.task_bar.complete_task(task_id)
-        await _pilot.pause()
-        task = app.task_bar.queue.get_task(task_id)
-        if task is not None:
-            assert task.indeterminate is False
+        bar = app.screen.query_one("#tbar", TaskBar)
+        assert bar.display is True

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1211,51 +1211,6 @@ class TestTaskQueue:
         assert len(q.active_tasks) == 1
         assert q.active_tasks[0].task_id == t2
 
-    def test_displayable_tasks_includes_active(self) -> None:
-        from lilbee.cli.tui.task_queue import TaskQueue
-
-        q = TaskQueue()
-        q.enqueue(lambda: None, "DL", "download")
-        q.advance("download")
-        assert len(q.displayable_tasks) == 1
-        assert q.displayable_tasks[0].name == "DL"
-
-    def test_displayable_tasks_includes_done_before_removal(self) -> None:
-        from lilbee.cli.tui.task_queue import TaskQueue, TaskStatus
-
-        q = TaskQueue()
-        tid = q.enqueue(lambda: None, "Sync", "sync")
-        q.advance()
-        q.complete_task(tid)
-        displayable = q.displayable_tasks
-        assert any(t.status == TaskStatus.DONE for t in displayable)
-
-    def test_displayable_tasks_includes_failed_before_removal(self) -> None:
-        from lilbee.cli.tui.task_queue import TaskQueue, TaskStatus
-
-        q = TaskQueue()
-        tid = q.enqueue(lambda: None, "Sync", "sync")
-        q.advance()
-        q.fail_task(tid, "oops")
-        displayable = q.displayable_tasks
-        assert any(t.status == TaskStatus.FAILED for t in displayable)
-
-    def test_displayable_tasks_empty_when_idle(self) -> None:
-        from lilbee.cli.tui.task_queue import TaskQueue
-
-        q = TaskQueue()
-        assert q.displayable_tasks == []
-
-    def test_displayable_tasks_multiple_active_types(self) -> None:
-        from lilbee.cli.tui.task_queue import TaskQueue
-
-        q = TaskQueue()
-        q.enqueue(lambda: None, "DL", "download")
-        q.enqueue(lambda: None, "Sync", "sync")
-        q.advance("download")
-        q.advance("sync")
-        assert len(q.displayable_tasks) == 2
-
 
 class TestCompletionOverlayCyclePrev:
     async def test_cycle_prev_wraps(self) -> None:

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1211,6 +1211,51 @@ class TestTaskQueue:
         assert len(q.active_tasks) == 1
         assert q.active_tasks[0].task_id == t2
 
+    def test_displayable_tasks_includes_active(self) -> None:
+        from lilbee.cli.tui.task_queue import TaskQueue
+
+        q = TaskQueue()
+        q.enqueue(lambda: None, "DL", "download")
+        q.advance("download")
+        assert len(q.displayable_tasks) == 1
+        assert q.displayable_tasks[0].name == "DL"
+
+    def test_displayable_tasks_includes_done_before_removal(self) -> None:
+        from lilbee.cli.tui.task_queue import TaskQueue, TaskStatus
+
+        q = TaskQueue()
+        tid = q.enqueue(lambda: None, "Sync", "sync")
+        q.advance()
+        q.complete_task(tid)
+        displayable = q.displayable_tasks
+        assert any(t.status == TaskStatus.DONE for t in displayable)
+
+    def test_displayable_tasks_includes_failed_before_removal(self) -> None:
+        from lilbee.cli.tui.task_queue import TaskQueue, TaskStatus
+
+        q = TaskQueue()
+        tid = q.enqueue(lambda: None, "Sync", "sync")
+        q.advance()
+        q.fail_task(tid, "oops")
+        displayable = q.displayable_tasks
+        assert any(t.status == TaskStatus.FAILED for t in displayable)
+
+    def test_displayable_tasks_empty_when_idle(self) -> None:
+        from lilbee.cli.tui.task_queue import TaskQueue
+
+        q = TaskQueue()
+        assert q.displayable_tasks == []
+
+    def test_displayable_tasks_multiple_active_types(self) -> None:
+        from lilbee.cli.tui.task_queue import TaskQueue
+
+        q = TaskQueue()
+        q.enqueue(lambda: None, "DL", "download")
+        q.enqueue(lambda: None, "Sync", "sync")
+        q.advance("download")
+        q.advance("sync")
+        assert len(q.displayable_tasks) == 2
+
 
 class TestCompletionOverlayCyclePrev:
     async def test_cycle_prev_wraps(self) -> None:

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -7,7 +7,6 @@ from unittest import mock
 
 import pytest
 from textual.app import App, ComposeResult
-from textual.css.query import NoMatches
 from textual.widgets import Static
 
 from conftest import make_test_catalog_model as _make_model
@@ -2405,26 +2404,116 @@ class TestModelCardBuildHelpers:
 
 
 class TestTaskBarAdditional:
-    async def test_refresh_display_no_active_but_queued(self) -> None:
+    async def test_single_active_task_shows_name_in_label(self) -> None:
+        """One active task displays its name in the status label."""
+        from textual.widgets import Label
+
         from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         app = _TaskBarApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             bar = app.query_one(TaskBar)
-            # Add tasks but don't advance (so no active, but queued)
+            bar.add_task("Sync docs", "sync")
+            bar.queue.advance()
+            bar._refresh_display()
+            await pilot.pause()
+            label = bar.query_one("#task-status-label", Label)
+            assert "Sync docs" in str(label._Static__content)  # type: ignore[attr-defined]
+
+    async def test_multiple_active_tasks_shows_count(self) -> None:
+        """Two or more active tasks show a running count instead of a name."""
+        from textual.widgets import Label
+
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            bar.add_task("Download A", "download")
+            bar.add_task("Sync B", "sync")
+            bar.queue.advance("download")
+            bar.queue.advance("sync")
+            bar._refresh_display()
+            await pilot.pause()
+            label = bar.query_one("#task-status-label", Label)
+            text = str(label._Static__content)  # type: ignore[attr-defined]
+            assert "2 tasks running" in text
+
+    async def test_queued_tasks_shown_in_label(self) -> None:
+        """Queued tasks appear as 'N queued' in the status label."""
+        from textual.widgets import Label
+
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            bar.add_task("Download A", "download")
+            bar.queue.advance()
+            bar.add_task("Sync B", "sync")
+            bar.add_task("Crawl C", "crawl")
+            bar._refresh_display()
+            await pilot.pause()
+            label = bar.query_one("#task-status-label", Label)
+            text = str(label._Static__content)  # type: ignore[attr-defined]
+            assert "2 queued" in text
+
+    async def test_no_tasks_hides_bar(self) -> None:
+        """When no tasks exist, the bar is hidden."""
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            assert bar.display is False
+
+    async def test_only_queued_no_active_shows_bar(self) -> None:
+        """Queued-only tasks (no active) still show the bar."""
+        from textual.widgets import Label
+
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
             bar.add_task("Sync", "sync")
             bar._refresh_display()
             await pilot.pause()
             assert bar.display is True
-            # No panels created since no task is active
-            assert len(bar._panels) == 0
+            label = bar.query_one("#task-status-label", Label)
+            text = str(label._Static__content)  # type: ignore[attr-defined]
+            assert "queued" in text
 
-    async def test_status_icon_unknown_status(self) -> None:
+    async def test_spinner_index_advances(self) -> None:
+        """The spinner frame index increments when active tasks exist."""
         from lilbee.cli.tui.widgets.task_bar import TaskBar
 
-        icon = TaskBar._status_icon("unknown_status")  # type: ignore[arg-type]
-        assert icon == "▸"
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            bar.add_task("Sync", "sync")
+            bar.queue.advance()
+            initial = bar._spinner_index
+            bar._tick_spinner()
+            assert bar._spinner_index == initial + 1
+
+    async def test_spinner_does_not_advance_when_idle(self) -> None:
+        """The spinner stays put when there are no active tasks."""
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            initial = bar._spinner_index
+            bar._tick_spinner()
+            assert bar._spinner_index == initial
 
     async def test_on_queue_change_exception_suppressed(self) -> None:
         from lilbee.cli.tui.widgets.task_bar import TaskBar
@@ -2433,133 +2522,8 @@ class TestTaskBarAdditional:
         async with app.run_test() as pilot:
             await pilot.pause()
             bar = app.query_one(TaskBar)
-            # call_from_thread might raise if not on worker thread, but suppress
             bar._on_queue_change()  # should not raise
             assert bar.display is False
-
-    async def test_render_task_panel_done_status(self) -> None:
-        """Cover _render_task_panel when status is DONE (shows checkmark icon)."""
-        from lilbee.cli.tui.task_queue import Task, TaskStatus
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        app = _TaskBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(TaskBar)
-            task_id = bar.add_task("Sync", "sync")
-            bar.queue.advance()
-            bar._refresh_display()
-            await pilot.pause()
-            # Manually set the task to DONE and re-render its panel
-            done_task = Task(
-                task_id=task_id,
-                fn=lambda: None,
-                name="Sync",
-                task_type="sync",
-                status=TaskStatus.DONE,
-                progress=100,
-                detail="",
-            )
-            bar._render_task_panel(task_id, done_task)
-            await pilot.pause()
-
-    async def test_multiple_panels_for_concurrent_downloads(self) -> None:
-        """Each active task gets its own panel with progress bar."""
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        app = _TaskBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(TaskBar)
-            t1 = bar.add_task("Download A", "download")
-            t2 = bar.add_task("Sync B", "sync")
-            bar.queue.advance("download")
-            bar.queue.advance("sync")
-            bar._refresh_display()
-            await pilot.pause()
-            assert len(bar._panels) == 2
-            assert t1 in bar._panels
-            assert t2 in bar._panels
-
-    async def test_panel_removed_when_task_removed_from_queue(self) -> None:
-        """Removing a task from the shared queue drops its panel on next refresh."""
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        app = _TaskBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(TaskBar)
-            task_id = bar.add_task("Download", "download")
-            bar.queue.advance()
-            await pilot.pause()
-            bar.query_one(f"#task-panel-{task_id}")  # raises NoMatches if absent
-            bar.queue.remove_task(task_id)
-            await pilot.pause()
-            with pytest.raises(NoMatches):
-                bar.query_one(f"#task-panel-{task_id}")
-
-    async def test_fail_task_adds_failed_class_to_panel(self) -> None:
-        """fail_task marks the panel with task-failed CSS class."""
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        app = _TaskBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(TaskBar)
-            task_id = bar.add_task("Download", "download")
-            bar.queue.advance()
-            bar._refresh_display()
-            await pilot.pause()
-            bar.fail_task(task_id, "Network error")
-            await pilot.pause()
-            panel = bar._panels.get(task_id)
-            assert panel is not None
-            assert panel.has_class("task-failed")
-
-    async def test_render_task_panel_with_failed_status(self) -> None:
-        """_render_task_panel renders FAILED status icon."""
-        from lilbee.cli.tui.task_queue import Task, TaskStatus
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        app = _TaskBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(TaskBar)
-            task_id = bar.add_task("Download", "download")
-            bar.queue.advance()
-            bar._refresh_display()
-            await pilot.pause()
-            failed_task = Task(
-                task_id=task_id,
-                fn=lambda: None,
-                name="Download",
-                task_type="download",
-                status=TaskStatus.FAILED,
-                progress=0,
-                detail="timeout",
-            )
-            bar._render_task_panel(task_id, failed_task)
-            await pilot.pause()
-
-    async def test_render_task_panel_no_panel_is_noop(self) -> None:
-        """_render_task_panel with unknown task_id does nothing."""
-        from lilbee.cli.tui.task_queue import Task, TaskStatus
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        app = _TaskBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(TaskBar)
-            task = Task(
-                task_id="nonexistent",
-                fn=lambda: None,
-                name="X",
-                task_type="x",
-                status=TaskStatus.ACTIVE,
-                progress=0,
-            )
-            bar._render_task_panel("nonexistent", task)  # should not raise
-            bar._render_task_panel("nonexistent", None)  # should not raise
 
     async def test_on_queue_change_from_worker_thread(self) -> None:
         """Queue notifications fired from a background thread must marshal back."""
@@ -2580,7 +2544,6 @@ class TestTaskBarAdditional:
 
             thread = threading.Thread(target=worker)
             thread.start()
-            # Poll instead of fixed timeout to handle slow CI runners.
             for _ in range(20):
                 await pilot.pause()
                 if called.is_set():
@@ -2588,9 +2551,27 @@ class TestTaskBarAdditional:
             thread.join(timeout=5)
             assert called.is_set()
 
-    async def test_render_task_panel_queued_status(self) -> None:
-        """_render_task_panel with QUEUED status uses fallback icon."""
-        from lilbee.cli.tui.task_queue import Task, TaskStatus
+    async def test_label_contains_task_center_hint(self) -> None:
+        """The status label includes the 'press t for Task Center' hint."""
+        from textual.widgets import Label
+
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            bar.add_task("Sync", "sync")
+            bar.queue.advance()
+            bar._refresh_display()
+            await pilot.pause()
+            label = bar.query_one("#task-status-label", Label)
+            assert "press t for Task Center" in str(label._Static__content)  # type: ignore[attr-defined]
+
+    async def test_active_task_with_progress_shows_percentage(self) -> None:
+        """An active task with nonzero progress shows its percentage."""
+        from textual.widgets import Label
+
         from lilbee.cli.tui.widgets.task_bar import TaskBar
 
         app = _TaskBarApp()
@@ -2599,24 +2580,34 @@ class TestTaskBarAdditional:
             bar = app.query_one(TaskBar)
             task_id = bar.add_task("Download", "download")
             bar.queue.advance()
+            bar.update_task(task_id, 45)
             bar._refresh_display()
             await pilot.pause()
-            queued_task = Task(
-                task_id=task_id,
-                fn=lambda: None,
-                name="Download",
-                task_type="download",
-                status=TaskStatus.QUEUED,
-                progress=0,
-            )
-            bar._render_task_panel(task_id, queued_task)
+            label = bar.query_one("#task-status-label", Label)
+            assert "45%" in str(label._Static__content)  # type: ignore[attr-defined]
+
+    async def test_refresh_display_exception_suppressed(self) -> None:
+        """_refresh_display handles missing label gracefully."""
+        from textual.widgets import Label
+
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
             await pilot.pause()
+            bar = app.query_one(TaskBar)
+            bar.add_task("test", "download")
+            bar.queue.advance()
+            # Remove the label to trigger the except path
+            label = bar.query_one("#task-status-label", Label)
+            label.remove()
+            await pilot.pause()
+            # Should not raise
+            bar._refresh_display()
 
 
 class TestTaskBarIndeterminate:
-    """Tests for indeterminate progress bar rendering (BEE-65f) and
-    redundant ProgressBar update avoidance (BEE-jmj, BEE-73k).
-    """
+    """Tests for indeterminate task flag propagation."""
 
     async def test_add_task_indeterminate_creates_indeterminate_task(self) -> None:
         """Tasks created with indeterminate=True start in indeterminate mode."""
@@ -2641,99 +2632,6 @@ class TestTaskBarIndeterminate:
         assert task is not None
         assert task.indeterminate is True
 
-    async def test_indeterminate_renders_pulsing_bar(self) -> None:
-        """An indeterminate active task renders ProgressBar with total=None."""
-        from textual.widgets import ProgressBar as PB
-
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        app = _TaskBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(TaskBar)
-            task_id = bar.add_task("Sync", "sync", indeterminate=True)
-            bar.queue.advance()
-            bar._refresh_display()
-            # Wait for the panel to compose its children
-            await pilot.pause()
-            # Re-render now that children are mounted
-            bar._refresh_display()
-            await pilot.pause()
-            panel = bar._panels[task_id]
-            pb = panel.query_one(PB)
-            assert pb.total is None
-
-    async def test_progress_bar_not_updated_when_unchanged(self) -> None:
-        """Redundant ProgressBar.update calls are skipped when state matches."""
-        from textual.widgets import ProgressBar as PB
-
-        from lilbee.cli.tui.task_queue import Task, TaskStatus
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        app = _TaskBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(TaskBar)
-            task_id = bar.add_task("Download", "download")
-            bar.queue.advance()
-            bar._refresh_display()
-            await pilot.pause()
-            # Panel children are now composed. Re-render to populate tracking state.
-            bar._refresh_display()
-            await pilot.pause()
-
-            panel = bar._panels[task_id]
-            pb = panel.query_one(PB)
-            assert panel._last_progress == 0
-            assert panel._last_indeterminate is False
-
-            # Same state renders should not touch the progress bar
-            original_update = pb.update
-            call_count = 0
-
-            def counting_update(**kwargs: object) -> None:
-                nonlocal call_count
-                call_count += 1
-                original_update(**kwargs)
-
-            pb.update = counting_update  # type: ignore[assignment]
-
-            task = Task(
-                task_id=task_id,
-                fn=lambda: None,
-                name="Download",
-                task_type="download",
-                status=TaskStatus.ACTIVE,
-                progress=0,
-            )
-            bar._render_task_panel(task_id, task)
-            assert call_count == 0, "Should skip ProgressBar.update when state unchanged"
-
-    async def test_progress_bar_updated_when_progress_changes(self) -> None:
-        """ProgressBar.update is called when task progress changes."""
-        from lilbee.cli.tui.widgets.task_bar import TaskBar
-
-        app = _TaskBarApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            bar = app.query_one(TaskBar)
-            task_id = bar.add_task("Download", "download")
-            bar.queue.advance()
-            bar._refresh_display()
-            await pilot.pause()
-            # Panel children are now composed. Re-render to populate tracking state.
-            bar._refresh_display()
-            await pilot.pause()
-
-            panel = bar._panels[task_id]
-            assert panel._last_progress == 0
-
-            # Now change progress and verify the bar updates
-            bar.update_task(task_id, 50, "halfway")
-            bar._refresh_display()
-            await pilot.pause()
-            assert panel._last_progress == 50
-
     async def test_controller_add_task_indeterminate(self) -> None:
         """TaskBarController.add_task passes indeterminate through to queue."""
         from lilbee.cli.tui.widgets.task_bar import TaskBarController
@@ -2747,6 +2645,24 @@ class TestTaskBarIndeterminate:
             task = controller.queue.get_task(task_id)
             assert task is not None
             assert task.indeterminate is True
+
+    async def test_indeterminate_task_shows_in_label(self) -> None:
+        """An indeterminate active task still renders its name in the label."""
+        from textual.widgets import Label
+
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            bar.add_task("Sync", "sync", indeterminate=True)
+            bar.queue.advance()
+            bar._refresh_display()
+            await pilot.pause()
+            label = bar.query_one("#task-status-label", Label)
+            assert "Sync" in str(label._Static__content)  # type: ignore[attr-defined]
+            assert bar.display is True
 
 
 class TestGridSelectExtra:


### PR DESCRIPTION
## Summary

- Replace expanding inline TaskBar (up to 8 lines) with a 1-line status label
- Shows task name + progress + "press t for Task Center" hint
- Hidden when no tasks active (same as before)
- Full progress panels (spinners, progress bars) now live only in Task Center
- Chat input area stays usable during downloads

Fixes BEE-n83.