### PR TITLE
Fix duplicate citation blocks in wiki pages

### DIFF
--- a/src/lilbee/wiki/__init__.py
+++ b/src/lilbee/wiki/__init__.py
@@ -16,6 +16,7 @@ from lilbee.wiki.citation import (
     find_unmarked_claims,
     parse_wiki_citations,
     render_citation_block,
+    strip_citation_block,
     verify_citation,
 )
 from lilbee.wiki.gen import WikiProgressCallback, generate_summary_page, generate_synthesis_pages
@@ -56,6 +57,7 @@ __all__ = [
     "prune_wiki",
     "read_page",
     "render_citation_block",
+    "strip_citation_block",
     "update_wiki_index",
     "verify_citation",
 ]

--- a/src/lilbee/wiki/citation.py
+++ b/src/lilbee/wiki/citation.py
@@ -110,6 +110,16 @@ def find_unmarked_claims(markdown: str) -> list[str]:
     return unmarked
 
 
+def strip_citation_block(markdown: str) -> str:
+    """Remove the auto-generated citation block (separator + comment + footnotes) from markdown."""
+    block_start = _find_citation_block_start(markdown)
+    if block_start is None:
+        return markdown
+    lines = markdown.splitlines()
+    body_end = _body_end_before_citations(lines, block_start)
+    return "\n".join(lines[:body_end]).rstrip() + "\n"
+
+
 def _find_citation_block_start(markdown: str) -> int | None:
     """Return the 0-based line index where the citation block begins, or None."""
     lines = markdown.splitlines()
@@ -119,6 +129,14 @@ def _find_citation_block_start(markdown: str) -> int | None:
     return None
 
 
+def _body_end_before_citations(lines: list[str], block_start: int) -> int:
+    """Return the line index to truncate at, stripping the --- separator if present."""
+    body_end = block_start
+    if body_end > 0 and lines[body_end - 1].strip() == _CITATION_BLOCK_SEP:
+        body_end -= 1
+    return body_end
+
+
 def _extract_body(markdown: str) -> str:
     """Return markdown body: strip YAML frontmatter and citation block."""
     text = _strip_frontmatter(markdown)
@@ -126,10 +144,7 @@ def _extract_body(markdown: str) -> str:
     if block_start is None:
         return text
     lines = text.splitlines()
-    # Also strip the --- separator line immediately before the comment
-    body_end = block_start
-    if body_end > 0 and lines[body_end - 1].strip() == _CITATION_BLOCK_SEP:
-        body_end -= 1
+    body_end = _body_end_before_citations(lines, block_start)
     return "\n".join(lines[:body_end])
 
 
@@ -167,6 +182,8 @@ def _format_source_ref(rec: CitationRecord) -> str:
             ref += f", pages {rec['page_start']}-{rec['page_end']}"
     elif has_line or has_line_end:
         ref += f", lines {rec['line_start']}-{rec['line_end']}"
+    if rec["excerpt"]:
+        ref += f', excerpt: "{rec["excerpt"]}"'
     return ref
 
 

--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -21,7 +21,12 @@ from lilbee.ingest import file_hash
 from lilbee.providers.base import LLMProvider
 from lilbee.reasoning import strip_reasoning
 from lilbee.store import CitationRecord, SearchChunk, Store
-from lilbee.wiki.citation import ParsedCitation, parse_wiki_citations, render_citation_block
+from lilbee.wiki.citation import (
+    ParsedCitation,
+    parse_wiki_citations,
+    render_citation_block,
+    strip_citation_block,
+)
 from lilbee.wiki.index import append_wiki_log, update_wiki_index
 from lilbee.wiki.shared import (
     DRAFTS_SUBDIR,
@@ -426,6 +431,7 @@ def _generate_page(
     if subdir == DRAFTS_SUBDIR:
         log.info("Wiki page %s scored %.2f (< %.2f), sending to drafts", label, score, threshold)
 
+    wiki_text = strip_citation_block(wiki_text)
     frontmatter = _build_frontmatter(config, source_names, score)
     citation_block = render_citation_block(verified)
     full_content = _assemble_content(frontmatter, wiki_text, citation_block)

--- a/tests/test_citation.py
+++ b/tests/test_citation.py
@@ -9,6 +9,7 @@ from lilbee.wiki.citation import (
     find_unmarked_claims,
     parse_wiki_citations,
     render_citation_block,
+    strip_citation_block,
     verify_citation,
 )
 from tests.conftest import make_citation as _citation_record
@@ -86,7 +87,7 @@ class TestRenderCitationBlock:
             ),
         ]
         result = render_citation_block(records)
-        assert "[^src1]: python-docs/typing.md, lines 12-45" in result
+        assert '[^src1]: python-docs/typing.md, lines 12-45, excerpt: "some text"' in result
         assert "<!-- citations" in result
         assert result.startswith("---\n")
 
@@ -102,7 +103,7 @@ class TestRenderCitationBlock:
             ),
         ]
         result = render_citation_block(records)
-        assert "[^src1]: mypy-manual.pdf, page 3" in result
+        assert '[^src1]: mypy-manual.pdf, page 3, excerpt: "some text"' in result
 
     def test_renders_page_range(self):
         records = [
@@ -115,7 +116,7 @@ class TestRenderCitationBlock:
             ),
         ]
         result = render_citation_block(records)
-        assert "[^src1]: manual.pdf, pages 2-5" in result
+        assert '[^src1]: manual.pdf, pages 2-5, excerpt: "text"' in result
 
     def test_renders_filename_only_when_no_location(self):
         records = [
@@ -126,7 +127,7 @@ class TestRenderCitationBlock:
             ),
         ]
         result = render_citation_block(records)
-        assert "[^src1]: notes.txt\n" in result
+        assert '[^src1]: notes.txt, excerpt: "text"' in result
 
     def test_renders_multiple_citations(self):
         records = [
@@ -147,11 +148,22 @@ class TestRenderCitationBlock:
             ),
         ]
         result = render_citation_block(records)
-        assert "[^src1]: a.md, lines 1-10" in result
-        assert "[^src2]: b.pdf, page 5" in result
+        assert '[^src1]: a.md, lines 1-10, excerpt: "t1"' in result
+        assert '[^src2]: b.pdf, page 5, excerpt: "t2"' in result
 
     def test_renders_empty_list(self):
         assert render_citation_block([]) == ""
+
+    def test_renders_no_excerpt_when_empty(self):
+        records = [
+            _citation_record(
+                source_filename="notes.txt",
+                excerpt="",
+            ),
+        ]
+        result = render_citation_block(records)
+        assert "[^src1]: notes.txt\n" in result
+        assert "excerpt" not in result
 
     def test_page_zero_treated_as_no_location(self):
         """page_start=0 should not produce a 'page 0' reference."""
@@ -166,7 +178,7 @@ class TestRenderCitationBlock:
             ),
         ]
         result = render_citation_block(records)
-        assert "[^src1]: doc.txt\n" in result
+        assert '[^src1]: doc.txt, excerpt: "text"' in result
         assert "page" not in result
         assert "lines" not in result
 
@@ -273,6 +285,46 @@ class TestFindUnmarkedClaims:
             "[^src1]: doc.md, lines 1-5\n"
         )
         assert find_unmarked_claims(md) == []
+
+
+class TestStripCitationBlock:
+    def test_strips_citation_block(self):
+        md = (
+            "# Heading\n\n"
+            "> Cited fact.[^src1]\n\n"
+            "---\n"
+            "<!-- citations (auto-generated from _citations table -- do not edit) -->\n"
+            "[^src1]: doc.md, lines 1-5\n"
+        )
+        result = strip_citation_block(md)
+        assert "# Heading" in result
+        assert "> Cited fact.[^src1]" in result
+        assert "<!-- citations" not in result
+        assert "[^src1]: doc.md" not in result
+
+    def test_no_citation_block_returns_unchanged(self):
+        md = "# Heading\n\nSome text.\n"
+        assert strip_citation_block(md) == md
+
+    def test_empty_string(self):
+        assert strip_citation_block("") == ""
+
+    def test_strips_block_without_separator(self):
+        md = (
+            "# Heading\n\n"
+            "<!-- citations (auto-generated from _citations table -- do not edit) -->\n"
+            "[^src1]: doc.md, lines 1-5\n"
+        )
+        result = strip_citation_block(md)
+        assert "# Heading" in result
+        assert "<!-- citations" not in result
+
+    def test_strips_from_full_wiki_page(self):
+        result = strip_citation_block(SAMPLE_WIKI_PAGE)
+        assert "<!-- citations" not in result
+        assert "[^src1]: python-docs/typing.md" not in result
+        assert "Python Type System" in result
+        assert "[^src1]" in result  # inline anchors preserved
 
 
 class TestCitationStatusEnum:


### PR DESCRIPTION
## Summary

- Wiki pages were getting two citation blocks: one from the LLM with excerpts, and a second bare one from the code. Now only one block is produced, with excerpts included.