### PR TITLE
Fix model pagination

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -195,6 +195,15 @@ class CatalogResult:
     limit: int
     offset: int
     models: list[CatalogModel]
+    has_more: bool = False
+
+
+@dataclass(frozen=True)
+class _HfPage:
+    """Internal: one page of HuggingFace API results."""
+
+    models: list[CatalogModel]
+    has_more: bool
 
 
 @dataclass(frozen=True)
@@ -386,8 +395,10 @@ def _hf_headers() -> dict[str, str]:
 # ``RuntimeError: dictionary changed size during iteration``.
 _HF_CACHE_TTL = 300
 _HF_CACHE_MAX_ENTRIES = 50
-_hf_cache: dict[str, tuple[float, list["CatalogModel"]]] = {}
+_hf_cache: dict[str, tuple[float, _HfPage]] = {}
 _hf_cache_lock = threading.Lock()
+
+_EMPTY_HF_PAGE = _HfPage(models=[], has_more=False)
 
 
 def _fetch_hf_models(
@@ -396,12 +407,16 @@ def _fetch_hf_models(
     limit: int = 50,
     offset: int = 0,
     library: str | None = None,
-) -> list[CatalogModel]:
-    """Fetch GGUF models from HuggingFace API with 5-minute cache. Returns empty list on error."""
+) -> _HfPage:
+    """Fetch GGUF models from HuggingFace API with 5-minute cache.
+
+    Returns an ``_HfPage`` with a ``has_more`` flag derived from the
+    ``Link: <...>; rel="next"`` response header (RFC 5988), the same
+    mechanism the ``huggingface_hub`` library uses internally.
+    """
     cache_key = f"{pipeline_tag}:{sort}:{limit}:{offset}:{library}"
     now = time.monotonic()
     with _hf_cache_lock:
-        # Evict expired entries
         expired = [k for k, (ts, _) in _hf_cache.items() if now - ts >= _HF_CACHE_TTL]
         for k in expired:
             del _hf_cache[k]
@@ -423,11 +438,13 @@ def _fetch_hf_models(
         resp = httpx.get(HF_API_URL, params=params, timeout=_DEFAULT_TIMEOUT, headers=_hf_headers())
         if resp.status_code >= 400:
             log.warning("HuggingFace API returned HTTP %d", resp.status_code)
-            return []
+            return _EMPTY_HF_PAGE
         data = resp.json()
     except (httpx.HTTPError, ValueError) as exc:
         log.warning("Failed to fetch models from HuggingFace: %s", exc)
-        return []
+        return _EMPTY_HF_PAGE
+
+    has_more = "next" in resp.links
 
     models: list[CatalogModel] = []
     for item in data:
@@ -437,7 +454,6 @@ def _fetch_hf_models(
         downloads = item.get("downloads", 0)
         card_data = item.get("cardData", {}) or {}
         model_desc = item.get("description") or card_data.get("description") or ""
-        # Estimate size from siblings (empty on list API, populated on detail)
         size_gb = _estimate_size_from_siblings(item.get("siblings", []))
         task = _pipeline_to_task(item.get("pipeline_tag", ""))
         repo_name = repo_id.split("/")[-1]
@@ -457,13 +473,13 @@ def _fetch_hf_models(
                 task=task,
             )
         )
+    page = _HfPage(models=models, has_more=has_more)
     with _hf_cache_lock:
-        _hf_cache[cache_key] = (now, models)
-        # Cap cache size, evicting the oldest entry on overflow.
+        _hf_cache[cache_key] = (now, page)
         if len(_hf_cache) > _HF_CACHE_MAX_ENTRIES:
             oldest_key = min(_hf_cache, key=lambda k: _hf_cache[k][0])
             del _hf_cache[oldest_key]
-    return models
+    return page
 
 
 def _has_gguf_siblings(siblings: list[dict[str, Any]]) -> bool:
@@ -499,19 +515,21 @@ def get_catalog(
     """Get paginated, filtered catalog of models."""
     # Featured models only on the first page
     all_models = list(FEATURED_ALL) if offset == 0 else []
+    hf_has_more = False
 
     # Optionally fetch from HF API
     if not featured:
         hf_task, hf_library = _task_to_pipeline(task)
-        hf_models = _fetch_hf_models(
+        hf_page = _fetch_hf_models(
             pipeline_tag=hf_task,
             limit=limit,
             offset=offset,
             library=hf_library,
         )
+        hf_has_more = hf_page.has_more
         # Deduplicate: skip HF models whose repo matches a featured model
         featured_repos = {m.hf_repo for m in FEATURED_ALL}
-        hf_models = [m for m in hf_models if m.hf_repo not in featured_repos]
+        hf_models = [m for m in hf_page.models if m.hf_repo not in featured_repos]
         all_models.extend(hf_models)
 
     # Filter by task
@@ -556,7 +574,9 @@ def get_catalog(
     # to avoid double-applying the offset. Only slice for featured-only requests.
     paginated = all_models[offset : offset + limit] if featured else all_models[:limit]
 
-    return CatalogResult(total=total, limit=limit, offset=offset, models=paginated)
+    return CatalogResult(
+        total=total, limit=limit, offset=offset, models=paginated, has_more=hf_has_more
+    )
 
 
 def _task_to_pipeline(task: str | None) -> tuple[str, str | None]:

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -199,6 +199,7 @@ class CatalogScreen(Screen[None]):
         """Fetch one page of HF models for all task types (runs in worker thread)."""
         all_models: list[CatalogModel] = []
         seen_repos: set[str] = set()
+        any_has_more = False
         for task in _ALL_TASKS:
             result = get_catalog(
                 task=task,
@@ -206,11 +207,13 @@ class CatalogScreen(Screen[None]):
                 limit=_HF_PAGE_SIZE,
                 offset=self._hf_offset,
             )
+            if result.has_more:
+                any_has_more = True
             for m in result.models:
                 if not m.featured and m.hf_repo not in seen_repos:
                     seen_repos.add(m.hf_repo)
                     all_models.append(m)
-        self._hf_has_more = len(all_models) >= _HF_PAGE_SIZE
+        self._hf_has_more = any_has_more
         return all_models
 
     @work(thread=True, name=_WORKER_FETCH_HF)

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -643,6 +643,7 @@ async def models_catalog(
         total=result.total,
         limit=result.limit,
         offset=result.offset,
+        has_more=result.has_more,
         models=[
             CatalogEntryResponse(
                 name=e.name,

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -195,6 +195,7 @@ class ModelsCatalogResponse(BaseModel):
     limit: int
     offset: int
     models: list[CatalogEntryResponse]
+    has_more: bool = False
 
 
 class InstalledModelEntry(BaseModel):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -20,6 +20,7 @@ from lilbee.catalog import (
     ModelFamily,
     ModelVariant,
     _hf_token,
+    _HfPage,
     clean_display_name,
     download_model,
     enrich_catalog,
@@ -28,6 +29,8 @@ from lilbee.catalog import (
     get_families,
     quant_tier,
 )
+
+_EMPTY_HF_PAGE = _HfPage(models=[], has_more=False)
 
 
 @pytest.fixture(autouse=True)
@@ -210,7 +213,8 @@ class TestFetchHfModels:
             return mock_resp
 
         monkeypatch.setattr(httpx, "get", mock_get)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         assert len(models) == 2
         assert models[0].name == "model-7b-gguf"
         assert models[0].hf_repo == "user/model-7b-gguf"
@@ -222,14 +226,16 @@ class TestFetchHfModels:
     def test_estimates_size_from_largest_gguf(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_resp = httpx.Response(200, json=self._mock_hf_response())
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         # Largest GGUF file is 7GB -> ~6.5 GB estimate
         assert 6.0 < models[0].size_gb < 7.5
 
     def test_no_gguf_size_info_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_resp = httpx.Response(200, json=self._mock_hf_response())
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         # Second model has gguf sibling with size=0 -> fallback 0.0 (unknown)
         assert models[1].size_gb == 0.0
 
@@ -250,7 +256,8 @@ class TestFetchHfModels:
         data = [{"id": "", "downloads": 0}, {"downloads": 0}]
         mock_resp = httpx.Response(200, json=data)
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         assert len(models) == 0
 
     def test_http_error_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -258,7 +265,8 @@ class TestFetchHfModels:
             raise httpx.ConnectError("fail")
 
         monkeypatch.setattr(httpx, "get", mock_get)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         assert models == []
 
     def test_invalid_json_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -266,13 +274,15 @@ class TestFetchHfModels:
             raise ValueError("bad json")
 
         monkeypatch.setattr(httpx, "get", mock_get)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         assert models == []
 
     def test_http_status_error_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_resp = httpx.Response(500)
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         assert models == []
 
     def test_truncates_long_description(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -286,7 +296,8 @@ class TestFetchHfModels:
         ]
         mock_resp = httpx.Response(200, json=data)
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         assert len(models[0].description) <= 120
 
     def test_uses_pipeline_tag_for_task(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -306,7 +317,8 @@ class TestFetchHfModels:
         ]
         mock_resp = httpx.Response(200, json=data)
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         assert models[0].task == "embedding"
         assert models[1].task == "vision"
 
@@ -314,13 +326,42 @@ class TestFetchHfModels:
         data = [{"id": "user/model", "downloads": 100, "siblings": [{"rfilename": "m.gguf"}]}]
         mock_resp = httpx.Response(200, json=data)
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         assert models[0].task == "chat"
+
+    def test_has_more_true_when_link_header_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """has_more is True when the response contains a Link rel=next header."""
+        data = [{"id": "user/model", "downloads": 100, "siblings": []}]
+        mock_resp = httpx.Response(
+            200,
+            json=data,
+            headers={"Link": '<https://huggingface.co/api/models?limit=50&skip=50>; rel="next"'},
+        )
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
+        page = catalog._fetch_hf_models()
+        assert page.has_more is True
+        assert len(page.models) == 1
+
+    def test_has_more_false_when_no_link_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """has_more is False when no Link header in response (last page)."""
+        data = [{"id": "user/model", "downloads": 100, "siblings": []}]
+        mock_resp = httpx.Response(200, json=data)
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
+        page = catalog._fetch_hf_models()
+        assert page.has_more is False
+
+    def test_has_more_false_on_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Error responses return empty page with has_more=False."""
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(500))
+        page = catalog._fetch_hf_models()
+        assert page.has_more is False
+        assert page.models == []
 
 
 class TestGetCatalog:
     def test_returns_featured_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: [])
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog()
         assert result.total == len(FEATURED_ALL)
         assert all(m.featured for m in result.models)
@@ -343,13 +384,13 @@ class TestGetCatalog:
         assert all(m.task == "chat" for m in result.models)
 
     def test_filter_by_task_embedding(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: [])
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(task="embedding")
         assert all(m.task == "embedding" for m in result.models)
         assert result.total == len(FEATURED_EMBEDDING)
 
     def test_filter_by_task_vision(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: [])
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(task="vision")
         assert all(m.task == "vision" for m in result.models)
         assert result.total == len(FEATURED_VISION)
@@ -396,36 +437,36 @@ class TestGetCatalog:
         assert all(m.featured for m in result.models)
 
     def test_filter_featured_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: [])
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(featured=False)
         assert result.total == 0
 
     def test_sort_featured(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: [])
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(sort="featured")
         downloads = [m.downloads for m in result.models]
         assert downloads == sorted(downloads, reverse=True)
 
     def test_sort_downloads(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: [])
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(sort="downloads")
         downloads = [m.downloads for m in result.models]
         assert downloads == sorted(downloads, reverse=True)
 
     def test_sort_size_asc(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: [])
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(sort="size_asc")
         sizes = [m.size_gb for m in result.models]
         assert sizes == sorted(sizes)
 
     def test_sort_size_desc(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: [])
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(sort="size_desc")
         sizes = [m.size_gb for m in result.models]
         assert sizes == sorted(sizes, reverse=True)
 
     def test_sort_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: [])
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
         result = get_catalog(sort="name")
         names = [m.name.lower() for m in result.models]
         assert names == sorted(names)
@@ -470,7 +511,11 @@ class TestGetCatalog:
                 task="chat",
             )
         ]
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: hf_models)
+        monkeypatch.setattr(
+            catalog,
+            "_fetch_hf_models",
+            lambda **kw: _HfPage(models=hf_models, has_more=False),
+        )
         result = get_catalog()
         names = [m.name for m in result.models]
         assert "hf-model" in names
@@ -492,11 +537,35 @@ class TestGetCatalog:
                 task="chat",
             )
         ]
-        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: hf_models)
+        monkeypatch.setattr(
+            catalog,
+            "_fetch_hf_models",
+            lambda **kw: _HfPage(models=hf_models, has_more=False),
+        )
         result = get_catalog()
         qwen3_models = [m for m in result.models if m.hf_repo == "Qwen/Qwen3-8B-GGUF"]
         assert len(qwen3_models) == 1
         assert qwen3_models[0].featured is True
+
+    def test_has_more_propagated_from_hf(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CatalogResult.has_more reflects the HF API Link header."""
+        monkeypatch.setattr(
+            catalog,
+            "_fetch_hf_models",
+            lambda **kw: _HfPage(models=[], has_more=True),
+        )
+        result = get_catalog()
+        assert result.has_more is True
+
+    def test_has_more_false_when_featured_only(self) -> None:
+        """Featured-only requests have has_more=False (no HF fetch)."""
+        result = get_catalog(featured=True)
+        assert result.has_more is False
+
+    def test_has_more_false_when_no_more_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(catalog, "_fetch_hf_models", lambda **kw: _EMPTY_HF_PAGE)
+        result = get_catalog()
+        assert result.has_more is False
 
 
 class TestFindCatalogEntry:
@@ -877,7 +946,7 @@ class TestHfCacheEviction:
         from lilbee.catalog import _hf_cache
 
         # Seed an expired entry (timestamp 0, way older than TTL)
-        _hf_cache["old:key:sort:50"] = (0.0, [])
+        _hf_cache["old:key:sort:50"] = (0.0, _EMPTY_HF_PAGE)
         # Ensure monotonic returns a time that makes the entry expired
         monkeypatch.setattr(_time, "monotonic", lambda: 1000.0)
 
@@ -886,6 +955,7 @@ class TestHfCacheEviction:
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = []
+        mock_resp.links = {}
         monkeypatch.setattr("lilbee.catalog.httpx.get", lambda *a, **kw: mock_resp)
 
         catalog._fetch_hf_models(pipeline_tag="text-generation")
@@ -900,7 +970,7 @@ class TestHfCacheEviction:
         base_time = 1000.0
         # Fill cache with 50 entries (timestamps 1000..1049)
         for i in range(50):
-            _hf_cache[f"key:{i}"] = (base_time + i, [])
+            _hf_cache[f"key:{i}"] = (base_time + i, _EMPTY_HF_PAGE)
 
         # Next fetch will add entry #51, triggering eviction of oldest (key:0)
         monkeypatch.setattr(_time, "monotonic", lambda: base_time + 50)
@@ -910,6 +980,7 @@ class TestHfCacheEviction:
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = []
+        mock_resp.links = {}
         monkeypatch.setattr("lilbee.catalog.httpx.get", lambda *a, **kw: mock_resp)
 
         catalog._fetch_hf_models(pipeline_tag="unique")
@@ -1361,7 +1432,8 @@ class TestHfModelsSearchFilter:
         ]
         mock_resp = httpx.Response(200, json=data)
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
-        models = catalog._fetch_hf_models()
+        page = catalog._fetch_hf_models()
+        models = page.models
         assert len(models) == 2
 
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -559,6 +559,7 @@ class TestModelsCatalog:
         result = await handlers.models_catalog()
 
         assert result.total == 1
+        assert result.has_more is False
         assert len(result.models) == 1
         m = result.models[0]
         assert m.name == "qwen3"
@@ -625,6 +626,17 @@ class TestModelsCatalog:
         mock_svc.provider.list_models.return_value = ["qwen3:8b"]
         result = await handlers.models_catalog()
         assert result.models[0].installed is True
+
+    @patch("lilbee.catalog.get_catalog")
+    async def test_has_more_propagated(self, mock_get_catalog, mock_svc):
+        from lilbee.catalog import CatalogResult
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=0, limit=20, offset=0, models=[], has_more=True
+        )
+        mock_svc.provider.list_models.return_value = []
+        result = await handlers.models_catalog()
+        assert result.has_more is True
 
 
 class TestModelsInstalled:


### PR DESCRIPTION
## Summary

- Parse the HF API's `Link: rel=next` header to provide an authoritative `has_more` flag on catalog responses
- Replaces the TUI's `len >= page_size` heuristic which broke after deduplication
- Adds `has_more` to `CatalogResult`, `ModelsCatalogResponse`, and the REST API at `GET /api/models/catalog`

