### PR TITLE
Fix bracket navigation getting stuck on Catalog screen

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -127,6 +127,7 @@ class LilbeeApp(App[None]):
         self._auto_sync = auto_sync
         self._initial_view = initial_view
         self.active_view = msg.DEFAULT_VIEW
+        self._switching = False
         self._theme_index = 0
         self.last_quit_time: float = 0.0
         self.settings_changed_signal: Signal[tuple[str, object]] = Signal(self, "settings_changed")
@@ -201,19 +202,36 @@ class LilbeeApp(App[None]):
         os._exit(1)
 
     def switch_view(self, view_name: str) -> None:
-        """Switch to a named view via lazy screen factories."""
+        """Switch to a named view via lazy screen factories.
+
+        Guards against concurrent switches: ``switch_screen`` is async
+        (processed on the next event-loop tick) but callers read
+        ``active_view`` synchronously. Without a guard, rapid keypresses
+        queue conflicting switches that corrupt the screen stack.
+        ``active_view`` is updated after the switch completes.
+        """
+        if self._switching:
+            return
+        self._switching = True
+
         if view_name == "Chat":
             from lilbee.cli.tui.screens.chat import ChatScreen
 
             if not isinstance(self.screen, ChatScreen):
                 self.switch_screen(_CHAT_SCREEN_NAME)
+            # Already on Chat, just update state below.
         else:
             factory = get_views().get(view_name)
             if factory is None:
+                self._switching = False
                 return
             self.switch_screen(factory())
 
-        self.active_view = view_name
+        def _finish() -> None:
+            self.active_view = view_name
+            self._switching = False
+
+        self.call_later(_finish)
 
     def action_push_help(self) -> None:
         if self.screen.query("HelpPanel"):

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -339,3 +339,68 @@ async def test_chat_m_key_skips_in_insert_mode():
         except SkipAction:
             raised = True
         assert raised
+
+
+async def test_backward_nav_from_catalog_after_visiting_tasks():
+    """Regression: [ from Catalog after visiting Task Center got stuck.
+
+    The bug was that switch_screen is async but active_view updated
+    synchronously. Rapid navigation queued conflicting screen switches
+    that corrupted the stack. Fixed by adding a _switching guard.
+    """
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+    from lilbee.cli.tui.screens.chat import ChatScreen
+    from lilbee.cli.tui.screens.task_center import TaskCenter
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, ChatScreen)
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # Forward to Catalog
+        await pilot.press("right_square_bracket")
+        await pilot.pause()
+        assert isinstance(app.screen, CatalogScreen)
+
+        # Forward past Catalog to Tasks (Catalog > Status > Settings > Tasks)
+        for _ in range(3):
+            await pilot.press("right_square_bracket")
+            await pilot.pause()
+        assert isinstance(app.screen, TaskCenter)
+
+        # Backward back to Catalog (Tasks > Settings > Status > Catalog)
+        for _ in range(3):
+            await pilot.press("left_square_bracket")
+            await pilot.pause()
+        assert isinstance(app.screen, CatalogScreen)
+
+        # The critical step: backward from Catalog to Chat
+        await pilot.press("left_square_bracket")
+        await pilot.pause()
+        assert isinstance(app.screen, ChatScreen), (
+            f"Expected ChatScreen after [ from Catalog, got {type(app.screen).__name__}"
+        )
+
+
+async def test_switching_guard_blocks_concurrent_switch():
+    """The _switching guard drops a second switch_view call while one is pending."""
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # Manually set the guard
+        app._switching = True
+        original_view = app.active_view
+
+        # This should be a no-op
+        app.switch_view("Status")
+
+        # active_view unchanged because guard blocked the call
+        assert app.active_view == original_view
+
+        # Clean up guard so teardown works
+        app._switching = False


### PR DESCRIPTION
## Summary

- Pressing `[` to navigate backward from the Catalog screen to Chat would silently fail after visiting the Task Center and returning to Catalog
- Root cause: `switch_screen()` is async but `active_view` was updated synchronously, allowing rapid keypresses to queue conflicting screen switches
- Added a `_switching` guard that blocks concurrent `switch_view` calls and defers `active_view` update to after the switch completes via `call_later`

Fixes BEE-heo.