### PR TITLE
Support model aliases to prevent duplicate manifests

### DIFF
--- a/src/lilbee/registry.py
+++ b/src/lilbee/registry.py
@@ -25,7 +25,7 @@ import logging
 import os
 import re
 import tempfile
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import NamedTuple
@@ -78,10 +78,17 @@ class ModelRef:
 
 @dataclass
 class ModelManifest:
-    """Manifest for an installed model version."""
+    """Manifest for an installed model version.
 
-    name: str  # family slug: "qwen3", "nomic-embed-text"
-    tag: str  # variant: "0.6b", "v1.5", "latest"
+    Each manifest has a canonical ``name:tag`` identity plus optional aliases.
+    Aliases let users refer to the same model by multiple names (e.g. a
+    repo-derived name and a short featured name). ``resolve()`` and
+    ``is_installed()`` check both canonical names and aliases.
+    ``list_installed()`` returns only canonical entries.
+    """
+
+    name: str  # canonical family slug: "qwen3", "nomic-embed-text"
+    tag: str  # canonical variant: "0.6b", "v1.5", "latest"
     size_bytes: int
     task: str  # "chat", "embedding", or "vision" — use TaskType constants
     source_repo: str  # HuggingFace repo
@@ -89,6 +96,7 @@ class ModelManifest:
     downloaded_at: str  # ISO 8601 timestamp
     blob: str = ""  # SHA-256 hash (filename in blobs/), set by install()
     display_name: str = ""  # human-readable label: "Qwen3 0.6B"
+    aliases: list[str] = field(default_factory=list)
 
 
 def _coerce_ref(ref: str | ModelRef) -> ModelRef:
@@ -121,10 +129,13 @@ class ModelRegistry:
 
     def resolve(self, ref: str | ModelRef) -> Path:
         """Resolve model name to file path in HF cache.
+        Checks canonical names first, then aliases.
         Raises ``KeyError`` if the model is not installed.
         """
         r = _coerce_ref(ref)
         manifest = self._read_manifest(r)
+        if manifest is None:
+            manifest = self._find_by_alias(str(r))
         if manifest is None:
             raise KeyError(f"Model {r} not installed")
 
@@ -171,7 +182,12 @@ class ModelRegistry:
             blobs_dir.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source_path, blob_path)
 
-        # Write manifest
+        # Absorb aliases from any conflicting manifest that references the same blob.
+        merged_aliases = list(manifest.aliases)
+        self._absorb_conflicting_aliases(
+            manifest.source_repo, manifest.source_filename, ref, merged_aliases
+        )
+
         updated = ModelManifest(
             name=manifest.name,
             tag=manifest.tag,
@@ -182,6 +198,7 @@ class ModelRegistry:
             downloaded_at=manifest.downloaded_at,
             blob=digest,
             display_name=manifest.display_name,
+            aliases=merged_aliases,
         )
         self._write_manifest(ref, updated)
         return blob_path
@@ -203,6 +220,7 @@ class ModelRegistry:
             downloaded_at=manifest.downloaded_at,
             blob=manifest.blob,
             display_name=manifest.display_name,
+            aliases=manifest.aliases,
         )
         self._write_manifest(ModelRef(name=ref.name, tag=DEFAULT_TAG), latest)
 
@@ -307,11 +325,60 @@ class ModelRegistry:
                 Path(tmp_path).unlink(missing_ok=True)
             raise
 
+    def _find_by_alias(self, alias: str) -> ModelManifest | None:
+        """Search all manifests for one that lists *alias* in its aliases."""
+        if not self._manifests_dir.exists():
+            return None
+        for name_dir in self._manifests_dir.iterdir():
+            if not name_dir.is_dir():
+                continue
+            for tag_file in name_dir.glob("*.json"):
+                manifest = self._load_manifest_file(tag_file)
+                if manifest is not None and alias in manifest.aliases:
+                    return manifest
+        return None
+
+    def _absorb_conflicting_aliases(
+        self,
+        source_repo: str,
+        source_filename: str,
+        keep: ModelRef,
+        aliases: list[str],
+    ) -> None:
+        """Find manifests with the same source and absorb them as aliases.
+
+        Deletes the conflicting manifest file and adds its ``name:tag`` to
+        the *aliases* list so the old name still resolves.
+        """
+        if not self._manifests_dir.exists():
+            return
+        keep_dir = self._manifests_dir / keep.name
+        for name_dir in list(self._manifests_dir.iterdir()):
+            if not name_dir.is_dir() or name_dir == keep_dir:
+                continue
+            for tag_file in list(name_dir.glob("*.json")):
+                manifest = self._load_manifest_file(tag_file)
+                if manifest is None:
+                    continue
+                if (
+                    manifest.source_repo != source_repo
+                    or manifest.source_filename != source_filename
+                ):
+                    continue
+                old_ref = f"{manifest.name}:{manifest.tag}"
+                if old_ref not in aliases:
+                    aliases.append(old_ref)
+                log.info("Absorbed %s as alias of %s", old_ref, keep)
+                tag_file.unlink()
+            if name_dir.exists() and not any(name_dir.iterdir()):
+                name_dir.rmdir()
+
     def _load_manifest_file(self, path: Path) -> ModelManifest | None:
         if not path.exists():
             return None
         try:
             data = json.loads(path.read_text())
+            data.setdefault("aliases", [])  # backwards compat with old manifests
             return ModelManifest(**data)
         except (json.JSONDecodeError, TypeError, KeyError):
             log.warning("Corrupt manifest: %s", path)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -310,7 +310,8 @@ class TestModelRegistry:
         assert blob_path.exists()
         assert registry.is_installed("removeme") is False
 
-    def test_remove_multiple_manifests_keeps_cache(self, tmp_path: Path) -> None:
+    def test_install_same_source_absorbs_alias(self, tmp_path: Path) -> None:
+        """Installing a model with same source as an existing one absorbs the old name as alias."""
         models_dir = tmp_path / "models"
         models_dir.mkdir()
         registry = ModelRegistry(models_dir)
@@ -325,9 +326,109 @@ class TestModelRegistry:
         registry.install(ref1, blob_path, m1)
         registry.install(ref2, blob_path, m2)
 
-        assert registry.remove("model-a") is True
-        assert blob_path.exists()  # still exists, still referenced by model-b
+        # model-a was absorbed as an alias of model-b
         assert registry.is_installed("model-b") is True
+        assert registry.is_installed("model-a") is True  # resolves via alias
+        # Only model-b appears in list (canonical)
+        names = [f"{m.name}:{m.tag}" for m in registry.list_installed()]
+        assert "model-b:latest" in names
+        assert "model-a:latest" not in names
+
+    def test_resolve_by_alias(self, tmp_path: Path) -> None:
+        """A model can be resolved by its alias name."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+        content = b"alias test"
+        blob_path = _create_hf_cache_structure(models_dir, "org/repo", content)
+        ref_old = ModelRef(name="old-name")
+        ref_new = ModelRef(name="new-name")
+        m_old = _make_manifest(name="old-name", source_repo="org/repo")
+        m_new = _make_manifest(name="new-name", source_repo="org/repo")
+        registry.install(ref_old, blob_path, m_old)
+        registry.install(ref_new, blob_path, m_new)
+        # old-name resolves via alias
+        path = registry.resolve("old-name")
+        assert path == blob_path
+
+    def test_alias_stored_in_manifest(self, tmp_path: Path) -> None:
+        """Absorbed aliases appear in the manifest's aliases field."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+        content = b"alias data"
+        blob_path = _create_hf_cache_structure(models_dir, "org/repo", content)
+        ref1 = ModelRef(name="first")
+        ref2 = ModelRef(name="second")
+        m1 = _make_manifest(name="first", source_repo="org/repo")
+        m2 = _make_manifest(name="second", source_repo="org/repo")
+        registry.install(ref1, blob_path, m1)
+        registry.install(ref2, blob_path, m2)
+        manifest = registry.list_installed()[0]
+        assert "first:latest" in manifest.aliases
+
+    def test_old_manifest_file_deleted_on_absorb(self, tmp_path: Path) -> None:
+        """The old manifest file is deleted when absorbed as an alias."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+        content = b"absorb data"
+        blob_path = _create_hf_cache_structure(models_dir, "org/repo", content)
+        ref1 = ModelRef(name="stale")
+        ref2 = ModelRef(name="canonical")
+        m1 = _make_manifest(name="stale", source_repo="org/repo")
+        m2 = _make_manifest(name="canonical", source_repo="org/repo")
+        registry.install(ref1, blob_path, m1)
+        old_manifest = models_dir / "manifests" / "stale" / "latest.json"
+        assert old_manifest.exists()
+        registry.install(ref2, blob_path, m2)
+        assert not old_manifest.exists()  # deleted
+        assert not old_manifest.parent.exists()  # empty dir cleaned up
+
+    def test_install_different_source_no_alias(self, tmp_path: Path) -> None:
+        """Models from different sources don't create aliases."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+        blob1 = _create_hf_cache_structure(models_dir, "org/repo-a", b"data-a")
+        blob2 = _create_hf_cache_structure(models_dir, "org/repo-b", b"data-b")
+        ref1 = ModelRef(name="model-a")
+        ref2 = ModelRef(name="model-b")
+        m1 = _make_manifest(name="model-a", source_repo="org/repo-a")
+        m2 = _make_manifest(name="model-b", source_repo="org/repo-b")
+        registry.install(ref1, blob1, m1)
+        registry.install(ref2, blob2, m2)
+        assert len(registry.list_installed()) == 2
+        for m in registry.list_installed():
+            assert m.aliases == []
+
+    def test_find_by_alias_skips_non_dirs(self, tmp_path: Path) -> None:
+        """_find_by_alias ignores non-directory entries in manifests dir."""
+        models_dir = tmp_path / "models"
+        manifests_dir = models_dir / "manifests"
+        manifests_dir.mkdir(parents=True)
+        (manifests_dir / "stray_file.txt").write_text("not a dir")
+        registry = ModelRegistry(models_dir)
+        assert registry._find_by_alias("anything") is None
+
+    def test_absorb_skips_corrupt_manifest(self, tmp_path: Path) -> None:
+        """_absorb_conflicting_aliases ignores corrupt manifests."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+        content = b"data"
+        blob_path = _create_hf_cache_structure(models_dir, "org/repo", content)
+
+        # Create a corrupt manifest
+        corrupt_dir = models_dir / "manifests" / "corrupt-model"
+        corrupt_dir.mkdir(parents=True)
+        (corrupt_dir / "latest.json").write_text("not valid json")
+
+        # Install should succeed despite the corrupt manifest
+        ref = ModelRef(name="good-model")
+        m = _make_manifest(name="good-model", source_repo="org/repo")
+        registry.install(ref, blob_path, m)
+        assert registry.is_installed("good-model") is True
 
     def test_remove_nonexistent(self, tmp_path: Path) -> None:
         registry = ModelRegistry(tmp_path)


### PR DESCRIPTION
## Summary

When the same GGUF file gets downloaded through different paths (e.g. featured catalog vs HuggingFace browser), the registry previously created duplicate manifests under different names. This adds alias support so both names resolve to the same model.

- On install, if a manifest with the same source already exists under a different name, the old name becomes an alias
- `resolve()` and `is_installed()` check both canonical names and aliases
- `list_installed()` returns only canonical entries
- Old manifest files are cleaned up automatically
- Backwards-compatible: existing manifests without aliases work unchanged

Fixes BEE-bph.