### PR TITLE
Reset confirmation modal and model source labels

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog_utils.py
+++ b/src/lilbee/cli/tui/screens/catalog_utils.py
@@ -94,6 +94,7 @@ def variant_to_row(v: ModelVariant, f: ModelFamily, installed: bool) -> TableRow
         sort_downloads=0,
         sort_size=v.size_mb / 1024,
         ref=f"{f.slug}:{v.tag}",
+        backend="native",
         variant=v,
         family=f,
     )
@@ -114,6 +115,7 @@ def catalog_to_row(m: CatalogModel, installed: bool) -> TableRow:
         sort_downloads=m.downloads,
         sort_size=m.size_gb,
         ref=m.ref,
+        backend="native",
         catalog_model=m,
     )
 

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -581,7 +581,11 @@ class ChatScreen(Screen[None]):
             )
 
     def _cmd_reset(self, args: str) -> None:
-        if args == "confirm":
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+        def _on_confirm(confirmed: bool) -> None:
+            if not confirmed:
+                return
             from lilbee.cli.helpers import perform_reset
 
             try:
@@ -590,8 +594,11 @@ class ChatScreen(Screen[None]):
             except Exception as exc:
                 log.warning("Reset failed", exc_info=True)
                 self.notify(msg.CMD_RESET_FAILED.format(error=exc), severity="error")
-        else:
-            self.notify(msg.CMD_RESET_CONFIRM, severity="warning")
+
+        self.app.push_screen(
+            ConfirmDialog("Reset Knowledge Base", "This will permanently delete all data."),
+            _on_confirm,
+        )
 
     def _cmd_set(self, args: str) -> None:
         if not args:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -583,7 +583,7 @@ class ChatScreen(Screen[None]):
     def _cmd_reset(self, args: str) -> None:
         from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
 
-        def _on_confirm(confirmed: bool) -> None:
+        def _on_confirm(confirmed: bool | None) -> None:
             if not confirmed:
                 return
             from lilbee.cli.helpers import perform_reset

--- a/src/lilbee/cli/tui/widgets/confirm_dialog.py
+++ b/src/lilbee/cli/tui/widgets/confirm_dialog.py
@@ -1,0 +1,76 @@
+"""Reusable confirmation modal dialog."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Center, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
+
+
+class ConfirmDialog(ModalScreen[bool]):
+    """Modal yes/no dialog that returns True (confirmed) or False (cancelled)."""
+
+    DEFAULT_CSS = """
+    ConfirmDialog {
+        align: center middle;
+    }
+    ConfirmDialog > Vertical {
+        width: 50;
+        height: auto;
+        max-height: 12;
+        border: thick $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+    ConfirmDialog #confirm-title {
+        text-style: bold;
+        width: 100%;
+        content-align: center middle;
+        margin-bottom: 1;
+    }
+    ConfirmDialog #confirm-message {
+        width: 100%;
+        content-align: center middle;
+        margin-bottom: 1;
+    }
+    ConfirmDialog Center {
+        width: 100%;
+        height: auto;
+    }
+    ConfirmDialog Button {
+        margin: 0 1;
+    }
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("y", "confirm", "Yes", show=True),
+        Binding("enter", "confirm", "Confirm", show=False),
+        Binding("n", "cancel", "No", show=True),
+        Binding("escape", "cancel", "Cancel", show=False),
+    ]
+
+    def __init__(self, title: str, message: str) -> None:
+        super().__init__()
+        self._title = title
+        self._message = message
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static(self._title, id="confirm-title")
+            yield Label(self._message, id="confirm-message")
+            with Center():
+                yield Button("Yes (y)", variant="error", id="confirm-yes")
+                yield Button("No (n)", variant="default", id="confirm-no")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "confirm-yes")
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -372,11 +372,11 @@ class TestBackendField:
     a backend pill so users know lilbee cannot install/delete them.
     """
 
-    def test_catalog_to_row_backend_empty(self):
+    def test_catalog_to_row_backend_native(self):
         row = catalog_to_row(_make_catalog_model(), installed=False)
-        assert row.backend == ""
+        assert row.backend == "native"
 
-    def test_variant_to_row_backend_empty(self):
+    def test_variant_to_row_backend_native(self):
         from lilbee.catalog import ModelFamily, ModelVariant
 
         variant = ModelVariant(
@@ -392,7 +392,7 @@ class TestBackendField:
             slug="qwen3", name="Qwen3", task="chat", description="test", variants=(variant,)
         )
         row = variant_to_row(variant, family, installed=False)
-        assert row.backend == ""
+        assert row.backend == "native"
 
     def test_installed_name_to_row_backend_empty(self):
         from lilbee.cli.tui.screens.setup import _installed_name_to_row

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -1251,32 +1251,53 @@ async def test_chat_slash_delete_empty_sources(mock_svc):
             assert "No documents" in mock_notify.call_args[0][0]
 
 
-async def test_chat_slash_reset_confirm():
+async def test_chat_slash_reset_pushes_confirm_dialog():
+    """``/reset`` pushes a ConfirmDialog modal."""
+    from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        app.screen._handle_slash("/reset")
+        await _pilot.pause()
+        assert isinstance(app.screen_stack[-1], ConfirmDialog)
+
+
+async def test_chat_slash_reset_confirm_executes():
+    """Confirming the reset dialog calls perform_reset."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         with patch("lilbee.cli.helpers.perform_reset") as mock_reset:
             mock_reset.return_value = None
-            app.screen._handle_slash("/reset confirm")
+            app.screen._handle_slash("/reset")
+            await _pilot.pause()
+            await _pilot.press("y")
+            await _pilot.pause()
             mock_reset.assert_called_once()
 
 
-async def test_chat_slash_reset_no_confirm():
+async def test_chat_slash_reset_cancel_does_nothing():
+    """Cancelling the reset dialog does not call perform_reset."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        with patch.object(app.screen, "notify") as mock_notify:
+        with patch("lilbee.cli.helpers.perform_reset") as mock_reset:
             app.screen._handle_slash("/reset")
-            mock_notify.assert_called_once()
-            assert "confirm" in mock_notify.call_args[0][0].lower()
+            await _pilot.pause()
+            await _pilot.press("n")
+            await _pilot.pause()
+            mock_reset.assert_not_called()
 
 
-async def test_chat_slash_reset_error():
+async def test_chat_slash_reset_error_notifies():
+    """Reset failure shows an error notification."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         with patch("lilbee.cli.helpers.perform_reset", side_effect=Exception("oops")):
             with patch.object(app.screen, "notify") as mock_notify:
-                app.screen._handle_slash("/reset confirm")
-                mock_notify.assert_called_once()
-                assert "oops" in mock_notify.call_args[0][0]
+                app.screen._handle_slash("/reset")
+                await _pilot.pause()
+                await _pilot.press("y")
+                await _pilot.pause()
+                assert any("oops" in str(c) for c in mock_notify.call_args_list)
 
 
 async def test_chat_slash_set_valid():

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -3292,3 +3292,113 @@ class TestModelBarCfgSourceOfTruth:
             )
             await pilot.pause()
             assert chat_sel.value == "smollm2:135m"
+
+
+class TestConfirmDialog:
+    async def test_confirm_with_y_key(self) -> None:
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+        results: list[bool] = []
+
+        class _App(App):
+            def on_mount(self):
+                self.push_screen(ConfirmDialog("Title", "Message"), results.append)
+
+        app = _App()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await pilot.press("y")
+            await pilot.pause()
+
+        assert results == [True]
+
+    async def test_cancel_with_n_key(self) -> None:
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+        results: list[bool] = []
+
+        class _App(App):
+            def on_mount(self):
+                self.push_screen(ConfirmDialog("Title", "Message"), results.append)
+
+        app = _App()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+
+        assert results == [False]
+
+    async def test_cancel_with_escape(self) -> None:
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+        results: list[bool] = []
+
+        class _App(App):
+            def on_mount(self):
+                self.push_screen(ConfirmDialog("Title", "Message"), results.append)
+
+        app = _App()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert results == [False]
+
+    async def test_confirm_with_yes_button(self) -> None:
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+        results: list[bool] = []
+
+        class _App(App):
+            def on_mount(self):
+                self.push_screen(ConfirmDialog("Title", "Message"), results.append)
+
+        app = _App()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+        assert results == [True]
+
+    async def test_yes_button_click(self) -> None:
+        from textual.widgets import Button
+
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+        results: list[bool] = []
+
+        class _App(App):
+            def on_mount(self):
+                self.push_screen(ConfirmDialog("Title", "Message"), results.append)
+
+        app = _App()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            btn = app.screen.query_one("#confirm-yes", Button)
+            btn.press()
+            await pilot.pause()
+
+        assert results == [True]
+
+    async def test_no_button_click(self) -> None:
+        from textual.widgets import Button
+
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+        results: list[bool] = []
+
+        class _App(App):
+            def on_mount(self):
+                self.push_screen(ConfirmDialog("Title", "Message"), results.append)
+
+        app = _App()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            btn = app.screen.query_one("#confirm-no", Button)
+            btn.press()
+            await pilot.pause()
+
+        assert results == [False]

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1308,7 +1308,7 @@ class TestSetupWizard:
         assert card.row is row
         assert card.row.featured is True
         assert card.row.task == "chat"
-        assert card.row.backend == ""
+        assert card.row.backend == "native"
 
     def test_pick_recommended_picks_largest_fitting_not_first(self) -> None:
         """Default pick is the biggest-size-gb model whose min_ram_gb fits."""


### PR DESCRIPTION
## Summary

- `/reset` now shows a modal dialog (y/n/Escape) instead of requiring `/reset confirm`
- Catalog grid cards show a "native" pill on GGUF models to distinguish them from Ollama-managed ones
- Reusable `ConfirmDialog` widget for other destructive operations

Fixes BEE-e2c, BEE-4m5.