### PR TITLE
Enforce minimum chunk_size of 64 tokens

### DIFF
--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -112,7 +112,7 @@ class Config(BaseSettings):
     chat_model: str = Field(default="qwen3:latest", min_length=1)
     embedding_model: str = Field(default="nomic-embed-text:latest", min_length=1)
     embedding_dim: int = Field(default=768, ge=1)
-    chunk_size: int = ConfigField(default=512, ge=1, writable=True, reindex=True)
+    chunk_size: int = ConfigField(default=512, ge=64, writable=True, reindex=True)
     chunk_overlap: int = ConfigField(default=100, ge=0, writable=True, reindex=True)
     max_embed_chars: int = Field(default=2000, ge=1)
     top_k: int = ConfigField(default=10, ge=1, writable=True)

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -489,13 +489,19 @@ async def set_embedding_model(model: str) -> SetModelResponse:
     return await _set_model("embedding_model", normalized)
 
 
+_MIN_CHUNK_SIZE = 64
+
+
 def _validate_config_updates(updates: dict[str, Any]) -> None:
-    """Reject unknown fields and null values on non-nullable fields."""
+    """Reject unknown fields, null values on non-nullable fields, and invalid ranges."""
     for key, value in updates.items():
         if key not in WRITABLE_CONFIG_FIELDS:
             raise ValueError(f"Unknown or read-only config field: {key}")
         if value is None and not WRITABLE_CONFIG_FIELDS[key]:
             raise ValueError(f"Field '{key}' does not accept null")
+    chunk_val = updates.get("chunk_size")
+    if isinstance(chunk_val, int) and chunk_val < _MIN_CHUNK_SIZE:
+        raise ValueError(f"chunk_size must be >= {_MIN_CHUNK_SIZE}")
 
 
 def _apply_config_updates(updates: dict[str, Any]) -> tuple[dict[str, str], list[str]]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,6 +101,12 @@ class TestEnvVarOverrides:
             c = Config()
             assert c.chunk_size == 256
 
+    def test_chunk_size_below_minimum_rejected(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            cfg.chunk_size = 5
+
     def test_chunk_overlap_override(self):
         with mock.patch.dict(os.environ, {"LILBEE_CHUNK_OVERLAP": "50"}):
             c = Config()

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -839,6 +839,15 @@ class TestUpdateConfig:
         with pytest.raises(ValidationError):
             await handlers.update_config({"chunk_size": "not_a_number"})
 
+    async def test_chunk_size_below_minimum_rejected(self):
+        with pytest.raises(ValueError, match="chunk_size must be >= 64"):
+            await handlers.update_config({"chunk_size": 5})
+
+    async def test_chunk_size_at_minimum_accepted(self, tmp_path):
+        result = await handlers.update_config({"chunk_size": 64})
+        assert result.updated == ["chunk_size"]
+        assert cfg.chunk_size == 64
+
     async def test_llm_api_key_write_only(self, tmp_path):
         """llm_api_key can be written via PATCH but is excluded from GET."""
         result = await handlers.update_config({"llm_api_key": "sk-test123"})


### PR DESCRIPTION
## Summary

A consumer set chunk_size to 5 via the API, producing 1-2 word chunks that broke search quality. Adds validation at both the config field level and the API handler level to enforce a minimum of 64 tokens (~256 chars, enough for meaningful embeddings).

Fixes BEE-cj8.