### PR TITLE
Guard prefer_wiki and thread chunk_type through search

### DIFF
--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -447,9 +447,15 @@ class Searcher:
         selected.sort()
         return [results[i] for i in selected]
 
-    def search(self, question: str, top_k: int = 0) -> list[SearchChunk]:
+    def search(
+        self,
+        question: str,
+        top_k: int = 0,
+        chunk_type: str | None = None,
+    ) -> list[SearchChunk]:
         """Embed question and search with expansion, HyDE, and concept boost.
         Returns up to top_k*2 candidates for downstream filtering.
+        When *chunk_type* is set, only chunks of that type are returned.
         """
         if top_k == 0:
             top_k = self._config.top_k
@@ -457,12 +463,22 @@ class Searcher:
         if mode is not None:
             return self._search_structured(mode, clean_query, top_k)
         query_vec = self._embedder.embed(question)
-        results = self._store.search(query_vec, top_k=top_k, query_text=question)
+        results = self._store.search(
+            query_vec,
+            top_k=top_k,
+            query_text=question,
+            chunk_type=chunk_type,
+        )
         if self._should_skip_expansion(question):
             return results[: top_k * 2]
         seen = {(r.source, r.chunk_index) for r in results}
         for variant, variant_vec in self._expand_query(question, query_vec):
-            variant_results = self._store.search(variant_vec, top_k=top_k, query_text=variant)
+            variant_results = self._store.search(
+                variant_vec,
+                top_k=top_k,
+                query_text=variant,
+                chunk_type=chunk_type,
+            )
             for r in variant_results:
                 key = (r.source, r.chunk_index)
                 if key not in seen:
@@ -489,7 +505,7 @@ class Searcher:
         """Build RAG context from search results."""
         results = self.search(question, top_k=top_k)
         mode, _ = self._parse_structured_query(question)
-        if mode is None:
+        if mode is None and self._config.wiki:
             results = prefer_wiki(results)
         if not results:
             return None

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -207,11 +207,11 @@ async def status() -> StatusResponse:
     return StatusResponse(**raw.model_dump(exclude_none=True))
 
 
-async def search(q: str, top_k: int = 5) -> list[DocumentResult]:
+async def search(q: str, top_k: int = 5, chunk_type: str | None = None) -> list[DocumentResult]:
     """Search and return grouped DocumentResults."""
     if not q or not q.strip():
         raise ValueError("query must not be empty")
-    results = get_services().searcher.search(q, top_k=top_k)
+    results = get_services().searcher.search(q, top_k=top_k, chunk_type=chunk_type)
     results = [r for r in results if r.distance is None or r.distance <= cfg.max_distance]
     return group(results)
 

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -23,10 +23,11 @@ from lilbee.server.models import (
 async def search_route(
     q: str = Parameter(query="q"),
     top_k: int = Parameter(query="top_k", default=5, le=100),
+    chunk_type: str | None = Parameter(query="chunk_type", default=None),
 ) -> list[DocumentResult]:
     """Search indexed documents by semantic similarity. No LLM call required."""
     try:
-        return await handlers.search(q, top_k=top_k)
+        return await handlers.search(q, top_k=top_k, chunk_type=chunk_type)
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
     except Exception as exc:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -212,6 +212,18 @@ class TestSearchContext:
         mock_svc.store.search.assert_called_once()
         assert mock_svc.store.search.call_args[1]["query_text"] == "my question"
 
+    def test_passes_chunk_type(self, mock_svc):
+        mock_svc.store.search.return_value = [_make_result()]
+        get_services().searcher.search("my question", chunk_type="wiki")
+        mock_svc.store.search.assert_called_once()
+        assert mock_svc.store.search.call_args[1]["chunk_type"] == "wiki"
+
+    def test_chunk_type_defaults_to_none(self, mock_svc):
+        mock_svc.store.search.return_value = [_make_result()]
+        get_services().searcher.search("my question")
+        mock_svc.store.search.assert_called_once()
+        assert mock_svc.store.search.call_args[1]["chunk_type"] is None
+
     def test_expansion_merges_results(self, mock_svc):
         original = _make_result(source="a.md", chunk_index=0)
         expanded = _make_result(source="b.md", chunk_index=0)
@@ -1119,6 +1131,41 @@ class TestPreferWiki:
         filtered = prefer_wiki(results)
         assert len(filtered) == 1
         assert filtered[0].chunk_type == "wiki"
+
+
+class TestPreferWikiGuard:
+    """prefer_wiki should only run in build_rag_context when wiki is enabled."""
+
+    def test_prefer_wiki_skipped_when_wiki_disabled(self, mock_svc):
+        wiki_chunk = _make_result(source="wiki/summaries/doc.md", chunk_type="wiki")
+        raw_chunk = _make_result(source="doc.md", chunk_type="raw")
+        mock_svc.store.search.return_value = [wiki_chunk, raw_chunk]
+        old_wiki = cfg.wiki
+        cfg.wiki = False
+        try:
+            result = get_services().searcher.build_rag_context("question")
+            assert result is not None
+            chunks, _ = result
+            # Both chunks survive — prefer_wiki was NOT applied
+            assert len(chunks) == 2
+        finally:
+            cfg.wiki = old_wiki
+
+    def test_prefer_wiki_applied_when_wiki_enabled(self, mock_svc):
+        wiki_chunk = _make_result(source="wiki/summaries/doc.md", chunk_type="wiki")
+        raw_chunk = _make_result(source="doc.md", chunk_type="raw")
+        mock_svc.store.search.return_value = [wiki_chunk, raw_chunk]
+        old_wiki = cfg.wiki
+        cfg.wiki = True
+        try:
+            result = get_services().searcher.build_rag_context("question")
+            assert result is not None
+            chunks, _ = result
+            # Only wiki chunk survives — prefer_wiki removed the raw duplicate
+            assert len(chunks) == 1
+            assert chunks[0].chunk_type == "wiki"
+        finally:
+            cfg.wiki = old_wiki
 
 
 class TestStructuredQueryWikiRaw:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -123,7 +123,7 @@ class TestSearch:
         result = await handlers.search("test", top_k=3)
         assert len(result) == 1
         assert result[0].source == "doc.pdf"
-        mock_svc.searcher.search.assert_called_once_with("test", top_k=3)
+        mock_svc.searcher.search.assert_called_once_with("test", top_k=3, chunk_type=None)
 
     async def test_empty_results(self, mock_svc):
         mock_svc.searcher.search.return_value = []
@@ -137,6 +137,16 @@ class TestSearch:
     async def test_whitespace_query_raises(self):
         with pytest.raises(ValueError, match="query must not be empty"):
             await handlers.search("   ")
+
+    async def test_chunk_type_passed_to_searcher(self, mock_svc):
+        mock_svc.searcher.search.return_value = []
+        await handlers.search("test", chunk_type="wiki")
+        mock_svc.searcher.search.assert_called_once_with("test", top_k=5, chunk_type="wiki")
+
+    async def test_chunk_type_defaults_to_none(self, mock_svc):
+        mock_svc.searcher.search.return_value = []
+        await handlers.search("test")
+        mock_svc.searcher.search.assert_called_once_with("test", top_k=5, chunk_type=None)
 
 
 class TestAsk:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -72,7 +72,7 @@ class TestSearchRoute:
         resp = client.get("/api/search", params={"q": "hello", "top_k": "3"})
         assert resp.status_code == 200
         assert resp.json() == []
-        mock_search.assert_awaited_once_with("hello", top_k=3)
+        mock_search.assert_awaited_once_with("hello", top_k=3, chunk_type=None)
 
     @mock.patch(
         "lilbee.server.handlers.search",
@@ -87,7 +87,7 @@ class TestSearchRoute:
     @mock.patch("lilbee.server.handlers.search", new_callable=AsyncMock, return_value=[])
     def test_default_top_k(self, mock_search, client):
         client.get("/api/search", params={"q": "x"})
-        mock_search.assert_awaited_once_with("x", top_k=5)
+        mock_search.assert_awaited_once_with("x", top_k=5, chunk_type=None)
 
 
 class TestAskRoute:


### PR DESCRIPTION
When wiki is disabled in config, prefer_wiki() in build_rag_context() was still running and filtering results. This guards it behind cfg.wiki.

Also threads the chunk_type parameter from the search route through the handler into Searcher.search(), so the client's chunk_type filter (all/raw/wiki) is respected at the store level rather than just via structured query prefixes.

Pairs with tobocop2/obsidian-lilbee#26 which adds the UI toggle.