### PR TITLE
Fix catalog returning size_gb=0 for HuggingFace models

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 import httpx
+from huggingface_hub import ModelInfo
+from huggingface_hub.hf_api import RepoSibling
 from pydantic import BaseModel
 from tqdm.auto import tqdm as _base_tqdm
 
@@ -147,38 +149,14 @@ class _ProgressTracker:
 
 
 class _HfGgufMeta(BaseModel):
-    """GGUF metadata returned by the HF API when expand=gguf is requested."""
+    """GGUF metadata returned by the HF API when expand=gguf is requested.
+
+    ModelInfo.gguf is typed as ``dict | None`` upstream, so we validate it ourselves.
+    """
 
     total: int = 0
     architecture: str = ""
     context_length: int = 0
-
-
-class _HfSibling(BaseModel):
-    """A single file entry in the HF API siblings array."""
-
-    rfilename: str = ""
-    size: int = 0
-
-
-class _HfCardData(BaseModel):
-    """Card metadata from the HF API cardData field."""
-
-    description: str = ""
-
-
-class _HfModelItem(BaseModel):
-    """A single model entry from the HF /api/models listing response."""
-
-    model_config = {"extra": "ignore"}
-
-    id: str = ""
-    downloads: int = 0
-    description: str = ""
-    pipeline_tag: str = ""
-    siblings: list[_HfSibling] = []
-    gguf: _HfGgufMeta | None = None
-    cardData: _HfCardData | None = None
 
 
 class DownloadConfig(BaseModel):
@@ -193,6 +171,10 @@ class DownloadConfig(BaseModel):
 
 
 _DEFAULT_TIMEOUT = 30.0
+
+# Fields to request from the HF listing API via ?expand=.
+# Without expand, the default response omits siblings, cardData, and gguf.
+_HF_EXPAND_FIELDS: list[str] = ["gguf", "siblings", "downloads", "pipeline_tag", "cardData"]
 
 
 @dataclass(frozen=True)
@@ -460,16 +442,16 @@ def _fetch_hf_models(
         if cached and now - cached[0] < _HF_CACHE_TTL:
             return cached[1]
 
-    params: dict[str, str | int | list[str]] = {
-        "pipeline_tag": pipeline_tag,
-        "search": "GGUF",
-        "sort": sort,
-        "limit": limit,
-        "skip": offset,
-        "expand": ["gguf", "siblings", "downloads", "pipeline_tag", "cardData"],
-    }
+    params = httpx.QueryParams(
+        pipeline_tag=pipeline_tag,
+        search="GGUF",
+        sort=sort,
+        limit=limit,
+        skip=offset,
+        expand=_HF_EXPAND_FIELDS,
+    )
     if library:
-        params["library"] = library
+        params = params.add("library", library)
     try:
         resp = httpx.get(HF_API_URL, params=params, timeout=_DEFAULT_TIMEOUT, headers=_hf_headers())
         if resp.status_code >= 400:
@@ -484,17 +466,17 @@ def _fetch_hf_models(
 
     models: list[CatalogModel] = []
     for raw in data:
-        item = _HfModelItem.model_validate(raw)
-        if not item.id:
+        if not raw.get("id"):
             continue
-        card_desc = item.cardData.description if item.cardData else ""
-        model_desc = item.description or card_desc
-        gguf_total = item.gguf.total if item.gguf else 0
-        if gguf_total > 0:
-            size_gb = round(gguf_total / (1024**3), 1)
+        item = ModelInfo(**raw)
+        card_desc = item.card_data.get("description", "") if item.card_data else ""
+        model_desc = card_desc
+        gguf_meta = _HfGgufMeta(**(item.gguf or {}))
+        if gguf_meta.total > 0:
+            size_gb = round(gguf_meta.total / (1024**3), 1)
         else:
-            size_gb = _estimate_size_from_siblings(item.siblings)
-        task = _pipeline_to_task(item.pipeline_tag)
+            size_gb = _estimate_size_from_siblings(item.siblings or [])
+        task = _pipeline_to_task(item.pipeline_tag or "")
         repo_name = item.id.split("/")[-1]
         slug = repo_name.lower().replace(" ", "-")
         models.append(
@@ -508,7 +490,7 @@ def _fetch_hf_models(
                 min_ram_gb=max(2.0, size_gb * 1.5),
                 description=model_desc[:120] if model_desc else "",
                 featured=False,
-                downloads=item.downloads,
+                downloads=item.downloads or 0,
                 task=task,
             )
         )
@@ -521,17 +503,17 @@ def _fetch_hf_models(
     return page
 
 
-def _has_gguf_siblings(siblings: list[_HfSibling]) -> bool:
+def _has_gguf_siblings(siblings: list[RepoSibling]) -> bool:
     """Return True if the sibling list contains at least one .gguf file."""
     return any(s.rfilename.endswith(".gguf") for s in siblings)
 
 
-def _estimate_size_from_siblings(siblings: list[_HfSibling]) -> float:
+def _estimate_size_from_siblings(siblings: list[RepoSibling]) -> float:
     """Estimate model size in GB from the largest GGUF file in siblings."""
     max_bytes = 0
     for sib in siblings:
         if sib.rfilename.endswith(".gguf"):
-            max_bytes = max(max_bytes, sib.size)
+            max_bytes = max(max_bytes, sib.size or 0)
     if max_bytes > 0:
         return round(max_bytes / (1024**3), 1)
     return 0.0  # unknown — display as "?" in UI

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -146,6 +146,41 @@ class _ProgressTracker:
         return _Cls
 
 
+class _HfGgufMeta(BaseModel):
+    """GGUF metadata returned by the HF API when expand=gguf is requested."""
+
+    total: int = 0
+    architecture: str = ""
+    context_length: int = 0
+
+
+class _HfSibling(BaseModel):
+    """A single file entry in the HF API siblings array."""
+
+    rfilename: str = ""
+    size: int = 0
+
+
+class _HfCardData(BaseModel):
+    """Card metadata from the HF API cardData field."""
+
+    description: str = ""
+
+
+class _HfModelItem(BaseModel):
+    """A single model entry from the HF /api/models listing response."""
+
+    model_config = {"extra": "ignore"}
+
+    id: str = ""
+    downloads: int = 0
+    description: str = ""
+    pipeline_tag: str = ""
+    siblings: list[_HfSibling] = []
+    gguf: _HfGgufMeta | None = None
+    cardData: _HfCardData | None = None
+
+
 class DownloadConfig(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
@@ -448,34 +483,32 @@ def _fetch_hf_models(
     has_more = "next" in resp.links
 
     models: list[CatalogModel] = []
-    for item in data:
-        repo_id = item.get("id", "")
-        if not repo_id:
+    for raw in data:
+        item = _HfModelItem.model_validate(raw)
+        if not item.id:
             continue
-        downloads = item.get("downloads", 0)
-        card_data = item.get("cardData", {}) or {}
-        model_desc = item.get("description") or card_data.get("description") or ""
-        gguf_meta = item.get("gguf") or {}
-        gguf_total = gguf_meta.get("total", 0)
+        card_desc = item.cardData.description if item.cardData else ""
+        model_desc = item.description or card_desc
+        gguf_total = item.gguf.total if item.gguf else 0
         if gguf_total > 0:
             size_gb = round(gguf_total / (1024**3), 1)
         else:
-            size_gb = _estimate_size_from_siblings(item.get("siblings", []))
-        task = _pipeline_to_task(item.get("pipeline_tag", ""))
-        repo_name = repo_id.split("/")[-1]
+            size_gb = _estimate_size_from_siblings(item.siblings)
+        task = _pipeline_to_task(item.pipeline_tag)
+        repo_name = item.id.split("/")[-1]
         slug = repo_name.lower().replace(" ", "-")
         models.append(
             CatalogModel(
                 name=slug,
                 tag=DEFAULT_TAG,
-                display_name=clean_display_name(repo_id),
-                hf_repo=repo_id,
+                display_name=clean_display_name(item.id),
+                hf_repo=item.id,
                 gguf_filename="*.gguf",
                 size_gb=size_gb,
                 min_ram_gb=max(2.0, size_gb * 1.5),
                 description=model_desc[:120] if model_desc else "",
                 featured=False,
-                downloads=downloads,
+                downloads=item.downloads,
                 task=task,
             )
         )
@@ -488,19 +521,17 @@ def _fetch_hf_models(
     return page
 
 
-def _has_gguf_siblings(siblings: list[dict[str, Any]]) -> bool:
+def _has_gguf_siblings(siblings: list[_HfSibling]) -> bool:
     """Return True if the sibling list contains at least one .gguf file."""
-    return any(s.get("rfilename", "").endswith(".gguf") for s in siblings)
+    return any(s.rfilename.endswith(".gguf") for s in siblings)
 
 
-def _estimate_size_from_siblings(siblings: list[dict[str, Any]]) -> float:
+def _estimate_size_from_siblings(siblings: list[_HfSibling]) -> float:
     """Estimate model size in GB from the largest GGUF file in siblings."""
     max_bytes = 0
     for sib in siblings:
-        filename = sib.get("rfilename", "")
-        if filename.endswith(".gguf"):
-            size = sib.get("size", 0) or 0
-            max_bytes = max(max_bytes, size)
+        if sib.rfilename.endswith(".gguf"):
+            max_bytes = max(max_bytes, sib.size)
     if max_bytes > 0:
         return round(max_bytes / (1024**3), 1)
     return 0.0  # unknown — display as "?" in UI

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -425,12 +425,13 @@ def _fetch_hf_models(
         if cached and now - cached[0] < _HF_CACHE_TTL:
             return cached[1]
 
-    params: dict[str, str | int] = {
+    params: dict[str, str | int | list[str]] = {
         "pipeline_tag": pipeline_tag,
         "search": "GGUF",
         "sort": sort,
         "limit": limit,
         "skip": offset,
+        "expand": ["gguf", "siblings", "downloads", "pipeline_tag", "cardData"],
     }
     if library:
         params["library"] = library
@@ -454,7 +455,12 @@ def _fetch_hf_models(
         downloads = item.get("downloads", 0)
         card_data = item.get("cardData", {}) or {}
         model_desc = item.get("description") or card_data.get("description") or ""
-        size_gb = _estimate_size_from_siblings(item.get("siblings", []))
+        gguf_meta = item.get("gguf") or {}
+        gguf_total = gguf_meta.get("total", 0)
+        if gguf_total > 0:
+            size_gb = round(gguf_total / (1024**3), 1)
+        else:
+            size_gb = _estimate_size_from_siblings(item.get("siblings", []))
         task = _pipeline_to_task(item.get("pipeline_tag", ""))
         repo_name = repo_id.split("/")[-1]
         slug = repo_name.lower().replace(" ", "-")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -21,6 +21,7 @@ from lilbee.catalog import (
     ModelVariant,
     _hf_token,
     _HfPage,
+    _HfSibling,
     clean_display_name,
     download_model,
     enrich_catalog,
@@ -173,11 +174,11 @@ class TestFeaturedModels:
 
 class TestHasGgufSiblings:
     def test_returns_true_when_gguf_present(self) -> None:
-        siblings = [{"rfilename": "model-Q4_K_M.gguf"}, {"rfilename": "README.md"}]
+        siblings = [_HfSibling(rfilename="model-Q4_K_M.gguf"), _HfSibling(rfilename="README.md")]
         assert catalog._has_gguf_siblings(siblings) is True
 
     def test_returns_false_when_no_gguf(self) -> None:
-        siblings = [{"rfilename": "model.bin"}, {"rfilename": "config.json"}]
+        siblings = [_HfSibling(rfilename="model.bin"), _HfSibling(rfilename="config.json")]
         assert catalog._has_gguf_siblings(siblings) is False
 
     def test_returns_false_for_empty_list(self) -> None:
@@ -187,14 +188,14 @@ class TestHasGgufSiblings:
 class TestEstimateSizeFromSiblings:
     def test_returns_size_from_largest_gguf(self) -> None:
         siblings = [
-            {"rfilename": "model-Q4_K_M.gguf", "size": 4_000_000_000},
-            {"rfilename": "model-Q8_0.gguf", "size": 7_000_000_000},
+            _HfSibling(rfilename="model-Q4_K_M.gguf", size=4_000_000_000),
+            _HfSibling(rfilename="model-Q8_0.gguf", size=7_000_000_000),
         ]
         result = catalog._estimate_size_from_siblings(siblings)
         assert result == round(7_000_000_000 / (1024**3), 1)
 
     def test_returns_zero_when_no_size(self) -> None:
-        siblings = [{"rfilename": "model.gguf", "size": 0}]
+        siblings = [_HfSibling(rfilename="model.gguf", size=0)]
         assert catalog._estimate_size_from_siblings(siblings) == 0.0
 
     def test_returns_zero_for_empty_list(self) -> None:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -184,25 +184,45 @@ class TestHasGgufSiblings:
         assert catalog._has_gguf_siblings([]) is False
 
 
+class TestEstimateSizeFromSiblings:
+    def test_returns_size_from_largest_gguf(self) -> None:
+        siblings = [
+            {"rfilename": "model-Q4_K_M.gguf", "size": 4_000_000_000},
+            {"rfilename": "model-Q8_0.gguf", "size": 7_000_000_000},
+        ]
+        result = catalog._estimate_size_from_siblings(siblings)
+        assert result == round(7_000_000_000 / (1024**3), 1)
+
+    def test_returns_zero_when_no_size(self) -> None:
+        siblings = [{"rfilename": "model.gguf", "size": 0}]
+        assert catalog._estimate_size_from_siblings(siblings) == 0.0
+
+    def test_returns_zero_for_empty_list(self) -> None:
+        assert catalog._estimate_size_from_siblings([]) == 0.0
+
+
 class TestFetchHfModels:
     def _mock_hf_response(self) -> list[dict]:
         return [
             {
                 "id": "user/model-7b-gguf",
                 "downloads": 5000,
-                "description": "A test model",
+                "cardData": {"description": "A test model"},
+                "pipeline_tag": "text-generation",
                 "siblings": [
-                    {"rfilename": "model-7b-Q4_K_M.gguf", "size": 4_000_000_000},
-                    {"rfilename": "model-7b-Q8_0.gguf", "size": 7_000_000_000},
+                    {"rfilename": "model-7b-Q4_K_M.gguf"},
+                    {"rfilename": "model-7b-Q8_0.gguf"},
                 ],
+                "gguf": {"total": 7_000_000_000, "architecture": "llama"},
             },
             {
                 "id": "user/model-13b-gguf",
                 "downloads": 1000,
-                "description": "",
+                "pipeline_tag": "text-generation",
                 "siblings": [
-                    {"rfilename": "model-13b-Q4_K_M.gguf", "size": 0},
+                    {"rfilename": "model-13b-Q4_K_M.gguf"},
                 ],
+                "gguf": {},
             },
         ]
 
@@ -223,21 +243,35 @@ class TestFetchHfModels:
         assert models[0].featured is False
         assert models[0].task == "chat"
 
-    def test_estimates_size_from_largest_gguf(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_estimates_size_from_gguf_total(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_resp = httpx.Response(200, json=self._mock_hf_response())
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
         page = catalog._fetch_hf_models()
         models = page.models
-        # Largest GGUF file is 7GB -> ~6.5 GB estimate
-        assert 6.0 < models[0].size_gb < 7.5
+        # gguf.total = 7_000_000_000 bytes -> ~6.5 GB
+        assert models[0].size_gb == round(7_000_000_000 / (1024**3), 1)
+        assert models[0].min_ram_gb == max(2.0, models[0].size_gb * 1.5)
 
-    def test_no_gguf_size_info_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_empty_gguf_meta_falls_back_to_siblings(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_resp = httpx.Response(200, json=self._mock_hf_response())
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
         page = catalog._fetch_hf_models()
         models = page.models
-        # Second model has gguf sibling with size=0 -> fallback 0.0 (unknown)
+        # Second model has empty gguf metadata and siblings without size -> 0.0
         assert models[1].size_gb == 0.0
+
+    def test_gguf_expand_param_sent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify expand=gguf is included in API request params."""
+        mock_resp = httpx.Response(200, json=[])
+        captured_params: dict = {}
+
+        def capture_get(url: str, params: dict | None = None, **kwargs: Any) -> httpx.Response:
+            captured_params.update(params or {})
+            return mock_resp
+
+        monkeypatch.setattr(httpx, "get", capture_get)
+        catalog._fetch_hf_models()
+        assert "gguf" in captured_params.get("expand", [])
 
     def test_library_param_passed_to_api(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Verify library parameter is included in API request."""

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from huggingface_hub.hf_api import RepoSibling
 
 from lilbee import catalog
 from lilbee.catalog import (
@@ -21,7 +22,6 @@ from lilbee.catalog import (
     ModelVariant,
     _hf_token,
     _HfPage,
-    _HfSibling,
     clean_display_name,
     download_model,
     enrich_catalog,
@@ -174,11 +174,11 @@ class TestFeaturedModels:
 
 class TestHasGgufSiblings:
     def test_returns_true_when_gguf_present(self) -> None:
-        siblings = [_HfSibling(rfilename="model-Q4_K_M.gguf"), _HfSibling(rfilename="README.md")]
+        siblings = [RepoSibling(rfilename="model-Q4_K_M.gguf"), RepoSibling(rfilename="README.md")]
         assert catalog._has_gguf_siblings(siblings) is True
 
     def test_returns_false_when_no_gguf(self) -> None:
-        siblings = [_HfSibling(rfilename="model.bin"), _HfSibling(rfilename="config.json")]
+        siblings = [RepoSibling(rfilename="model.bin"), RepoSibling(rfilename="config.json")]
         assert catalog._has_gguf_siblings(siblings) is False
 
     def test_returns_false_for_empty_list(self) -> None:
@@ -188,14 +188,14 @@ class TestHasGgufSiblings:
 class TestEstimateSizeFromSiblings:
     def test_returns_size_from_largest_gguf(self) -> None:
         siblings = [
-            _HfSibling(rfilename="model-Q4_K_M.gguf", size=4_000_000_000),
-            _HfSibling(rfilename="model-Q8_0.gguf", size=7_000_000_000),
+            RepoSibling(rfilename="model-Q4_K_M.gguf", size=4_000_000_000),
+            RepoSibling(rfilename="model-Q8_0.gguf", size=7_000_000_000),
         ]
         result = catalog._estimate_size_from_siblings(siblings)
         assert result == round(7_000_000_000 / (1024**3), 1)
 
     def test_returns_zero_when_no_size(self) -> None:
-        siblings = [_HfSibling(rfilename="model.gguf", size=0)]
+        siblings = [RepoSibling(rfilename="model.gguf", size=0)]
         assert catalog._estimate_size_from_siblings(siblings) == 0.0
 
     def test_returns_zero_for_empty_list(self) -> None:
@@ -325,7 +325,7 @@ class TestFetchHfModels:
             {
                 "id": "user/test",
                 "downloads": 0,
-                "description": "A" * 200,
+                "cardData": {"description": "A" * 200},
                 "siblings": [{"rfilename": "model.gguf"}],
             }
         ]
@@ -333,7 +333,7 @@ class TestFetchHfModels:
         monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
         page = catalog._fetch_hf_models()
         models = page.models
-        assert len(models[0].description) <= 120
+        assert len(models[0].description) == 120
 
     def test_uses_pipeline_tag_for_task(self, monkeypatch: pytest.MonkeyPatch) -> None:
         data = [


### PR DESCRIPTION
## Summary

- HF listing API wasn't returning file sizes because the `expand` param was missing
- Added `expand=gguf` which returns `gguf.total` (tensor size in bytes) per model
- Also requests siblings, downloads, pipeline_tag, cardData so all read fields are present
- Falls back to sibling-based estimation when gguf metadata is absent

Fixes BEE-enn.