### PR TITLE
fix: mark ask endpoints as read-only to fix 401 auth error

### DIFF
--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -35,6 +35,7 @@ async def search_route(
 
 
 @post("/api/ask")
+@read_only
 async def ask_route(data: AskRequest) -> AskResponse:
     """One-shot RAG question returning an answer with source chunks."""
     try:
@@ -50,6 +51,7 @@ async def ask_route(data: AskRequest) -> AskResponse:
 
 
 @post("/api/ask/stream")
+@read_only
 async def ask_stream_route(data: AskRequest) -> Stream:
     """Streaming SSE version of ask, emitting token-by-token answer chunks."""
     return Stream(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,6 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     """
     import asyncio
     import concurrent.futures
-
     import warnings
 
     try:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -748,3 +748,20 @@ class TestAuthRequiredRoutes:
     def test_put_models_embedding_requires_auth(self, auth_client):
         resp = auth_client.put("/api/models/embedding", json={"model": "nomic-embed-text:latest"})
         assert resp.status_code == 401
+
+    @mock.patch(
+        "lilbee.server.handlers.ask",
+        new_callable=AsyncMock,
+        return_value={"answer": "42", "sources": []},
+    )
+    def test_ask_is_read_only(self, _mock_ask, auth_client):
+        """POST /api/ask should not require a bearer token."""
+        resp = auth_client.post("/api/ask", json={"question": "test"})
+        assert resp.status_code == 201
+
+    @mock.patch("lilbee.server.handlers.ask_stream")
+    def test_ask_stream_is_read_only(self, mock_stream, auth_client):
+        """POST /api/ask/stream should not require a bearer token."""
+        mock_stream.return_value = mock_async_gen("event: done\ndata: {}\n\n")
+        resp = auth_client.post("/api/ask/stream", json={"question": "test"})
+        assert resp.status_code == 201


### PR DESCRIPTION
POST /api/ask and POST /api/ask/stream returned 401 even with a valid session token. Both endpoints are semantically read-only (they query the knowledge base and generate answers, with no side effects), but they were missing the @read_only decorator that search already had. Without it, the auth middleware required a bearer token that the plugin doesn't send for query endpoints.

Added @read_only to ask_route and ask_stream_route, matching the pattern already used by search_route. Added two tests in TestAuthRequiredRoutes verifying both ask endpoints accept unauthenticated requests when auth is enabled. Also fixed a pre-existing import sort issue in tests/conftest.py.