### PR TITLE
Fix irrelevant sources in search results and citation display

### DIFF
--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -148,12 +148,15 @@ def filter_results(
 
     Hybrid results (relevance_score set) are checked against min_relevance_score.
     Vector results (distance set) are checked against max_distance.
-    Results with neither score pass through.
+    Results with neither score pass through. When both scores are present,
+    relevance_score takes priority (hybrid results use RRF scoring, not
+    cosine distance). Pass max_distance=0 to disable distance filtering.
     """
     if max_distance <= 0 and min_relevance_score <= 0:
         return results
     filtered: list[SearchChunk] = []
     for r in results:
+        # Hybrid results: check relevance_score (takes priority over distance)
         if r.relevance_score is not None:
             if min_relevance_score > 0 and r.relevance_score < min_relevance_score:
                 continue
@@ -710,6 +713,9 @@ class Searcher:
         finally:
             if hasattr(raw_stream, "close"):
                 raw_stream.close()
+        # Note: LLM-generated citation blocks in streamed tokens cannot be
+        # retroactively stripped. The system prompt discourages them; this
+        # only filters the code-appended Sources block to cited chunks.
         full_answer = "".join(answer_parts)
         cited = _extract_cited_indices(full_answer)
         used = [results[i - 1] for i in sorted(cited) if 1 <= i <= len(results)]

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2146,13 +2146,19 @@ class TestChatSlashCommands:
             assert app.screen._history == []
 
     async def test_cmd_clear_cancels_stream(self, _mock_resolve):
-        """/clear cancels active stream before clearing."""
+        """/clear cancels active workers before clearing."""
         app = ChatTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
             app.screen.streaming = True
-            app.screen._handle_slash("/clear")
+            mock_worker = mock.MagicMock()
+            with mock.patch.object(
+                type(app.screen), "workers", new_callable=mock.PropertyMock
+            ) as mock_workers:
+                mock_workers.return_value = [mock_worker]
+                app.screen._handle_slash("/clear")
             await pilot.pause()
+            mock_worker.cancel.assert_called_once()
             assert app.screen.streaming is False
             assert app.screen._history == []
 


### PR DESCRIPTION
Irrelevant documents were appearing in search results for unrelated queries wasting LLM context. The code-generated Sources block also showed everything fed as context, even sources the LLM chose to ignore.

- Add distance/relevance filter after search expansion and concept boost
- Make IDF context selection distance-aware so far-away chunks lose to closer ones
- Cap concept boost with configurable floor to prevent artificial relevance inflation
- Only show sources the LLM actually cited (via [N] inline references)
- Strip redundant LLM-generated citation blocks before appending code-formatted sources