### PR TITLE
Add `lilbee token` command

### DIFF
--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -658,18 +659,27 @@ def token(
     use_global: bool = global_option,
 ) -> None:
     """Print the auth token for a running server."""
-    import json
+    from lilbee.server.auth import server_json_path
 
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    path = cfg.data_dir / "server.json"
+    path = server_json_path()
     if not path.exists():
         if cfg.json_mode:
             json_output({"error": "No running server found"})
         else:
             console.print("No running server found (server.json missing).")
-        raise typer.Exit(1)
-    data = json.loads(path.read_text())
-    tok = data.get("token", "")
+        raise SystemExit(1)
+    try:
+        data = json.loads(path.read_text())
+        tok = data.get("token", "")
+    except (json.JSONDecodeError, OSError) as exc:
+        if cfg.json_mode:
+            json_output({"error": f"Could not read server.json: {exc}"})
+        else:
+            console.print(
+                f"[{theme.ERROR}]Error:[/{theme.ERROR}] Could not read server.json: {exc}"
+            )
+        raise SystemExit(1) from None
     if cfg.json_mode:
         json_output({"token": tok})
         return

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -653,6 +653,30 @@ def serve(
 
 
 @app.command()
+def token(
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Print the auth token for a running server."""
+    import json
+
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    path = cfg.data_dir / "server.json"
+    if not path.exists():
+        if cfg.json_mode:
+            json_output({"error": "No running server found"})
+        else:
+            console.print("No running server found (server.json missing).")
+        raise typer.Exit(1)
+    data = json.loads(path.read_text())
+    tok = data.get("token", "")
+    if cfg.json_mode:
+        json_output({"token": tok})
+        return
+    console.print(tok)
+
+
+@app.command()
 def topics(
     query: str = typer.Argument(None, help="Optional query to find related concepts."),
     top_k: int = typer.Option(10, "--top-k", "-k", help="Number of results."),

--- a/src/lilbee/server/auth.py
+++ b/src/lilbee/server/auth.py
@@ -27,7 +27,8 @@ def read_only(fn: F) -> F:
     return fn
 
 
-def _server_json_path() -> Path:
+def server_json_path() -> Path:
+    """Return the path to the server session file."""
     return cfg.data_dir / "server.json"
 
 
@@ -43,7 +44,7 @@ class SessionManager:
     def generate(self) -> str:
         """Generate a random session token and persist to server.json."""
         self.token = secrets.token_urlsafe(32)
-        path = _server_json_path()
+        path = server_json_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps({"token": self.token}))
         if sys.platform != "win32":
@@ -53,7 +54,7 @@ class SessionManager:
     def cleanup(self) -> None:
         """Remove server.json on shutdown and clear the in-memory token."""
         self.token = None
-        path = _server_json_path()
+        path = server_json_path()
         path.unlink(missing_ok=True)
 
     def validate(self, auth_header: str) -> bool:

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from unittest import mock
 
 import pytest
@@ -27,6 +28,36 @@ def isolated_env(tmp_path):
     yield tmp_path
     for name in type(cfg).model_fields:
         setattr(cfg, name, getattr(snapshot, name))
+
+
+class TestTokenCommand:
+    def test_prints_token_when_server_running(self, tmp_path):
+        server_json = cfg.data_dir / "server.json"
+        server_json.write_text(json.dumps({"token": "test-secret-token"}))
+
+        result = runner.invoke(app, ["token"])
+        assert result.exit_code == 0
+        assert "test-secret-token" in result.output
+
+    def test_exits_1_when_no_server(self):
+        result = runner.invoke(app, ["token"])
+        assert result.exit_code == 1
+        assert "No running server found" in result.output
+
+    def test_json_mode_prints_token(self, tmp_path):
+        server_json = cfg.data_dir / "server.json"
+        server_json.write_text(json.dumps({"token": "json-token-val"}))
+
+        result = runner.invoke(app, ["--json", "token"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["token"] == "json-token-val"
+
+    def test_json_mode_exits_1_when_no_server(self):
+        result = runner.invoke(app, ["--json", "token"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert "error" in data
 
 
 class TestServeCommand:

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 
 from lilbee.cli import app
 from lilbee.config import cfg
+from lilbee.server.auth import server_json_path
 
 runner = CliRunner()
 
@@ -31,9 +32,9 @@ def isolated_env(tmp_path):
 
 
 class TestTokenCommand:
-    def test_prints_token_when_server_running(self, tmp_path):
-        server_json = cfg.data_dir / "server.json"
-        server_json.write_text(json.dumps({"token": "test-secret-token"}))
+    def test_prints_token_when_server_running(self):
+        path = server_json_path()
+        path.write_text(json.dumps({"token": "test-secret-token"}))
 
         result = runner.invoke(app, ["token"])
         assert result.exit_code == 0
@@ -44,9 +45,9 @@ class TestTokenCommand:
         assert result.exit_code == 1
         assert "No running server found" in result.output
 
-    def test_json_mode_prints_token(self, tmp_path):
-        server_json = cfg.data_dir / "server.json"
-        server_json.write_text(json.dumps({"token": "json-token-val"}))
+    def test_json_mode_prints_token(self):
+        path = server_json_path()
+        path.write_text(json.dumps({"token": "json-token-val"}))
 
         result = runner.invoke(app, ["--json", "token"])
         assert result.exit_code == 0
@@ -58,6 +59,31 @@ class TestTokenCommand:
         assert result.exit_code == 1
         data = json.loads(result.output)
         assert "error" in data
+
+    def test_corrupted_server_json_exits_1(self):
+        path = server_json_path()
+        path.write_text("not valid json{{{")
+
+        result = runner.invoke(app, ["token"])
+        assert result.exit_code == 1
+        assert "Could not read server.json" in result.output
+
+    def test_corrupted_server_json_json_mode(self):
+        path = server_json_path()
+        path.write_text("not valid json{{{")
+
+        result = runner.invoke(app, ["--json", "token"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert "error" in data
+        assert "Could not read server.json" in data["error"]
+
+    def test_missing_token_key_returns_empty(self):
+        path = server_json_path()
+        path.write_text(json.dumps({"other": "field"}))
+
+        result = runner.invoke(app, ["token"])
+        assert result.exit_code == 0
 
 
 class TestServeCommand:


### PR DESCRIPTION
## Summary

- Adds a `lilbee token` command that prints the auth token for a running server, so clients (like the Obsidian plugin) can connect without manually reading `server.json`
- Supports `--json`, `--data-dir`, and `--global` flags consistent with other CLI commands
- Exits with code 1 and a clear message when no server is running