### PR TITLE
Clear LILBEE_DATA in test_cli_serve fixture

### DIFF
--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -18,7 +18,10 @@ def _close_coro(coro, *_args, **_kwargs):
 
 
 @pytest.fixture(autouse=True)
-def isolated_env(tmp_path):
+def isolated_env(tmp_path, monkeypatch):
+    # CI sets LILBEE_DATA at workflow level; clear it so the token command's
+    # apply_overrides() does not clobber cfg.data_dir during invocation.
+    monkeypatch.delenv("LILBEE_DATA", raising=False)
     snapshot = cfg.model_copy()
     cfg.documents_dir = tmp_path / "documents"
     cfg.documents_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
CI sets `LILBEE_DATA` at the workflow level. The `isolated_env` fixture set `cfg.data_dir` to `tmp_path` but left the env var alone, so the new `token` command's `apply_overrides` re-read it and clobbered `cfg.data_dir` back to the CI-wide path. Five `TestTokenCommand` tests then fell into the "no running server" branch and coverage dropped to 99.90%. Clearing `LILBEE_DATA` in the fixture mirrors the pattern already used in `test_cli.py`.