### PR TITLE
Allow pulling any HuggingFace GGUF repo, not just featured ones

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -22,6 +22,7 @@ from typing import Any, NamedTuple
 import httpx
 from huggingface_hub import ModelInfo
 from huggingface_hub.hf_api import RepoSibling
+from huggingface_hub.utils import HFValidationError, validate_repo_id
 from pydantic import BaseModel
 from tqdm.auto import tqdm as _base_tqdm
 
@@ -681,20 +682,22 @@ def find_catalog_entry(query: str) -> CatalogModel | None:
     return idx.by_ref.get(q) or idx.by_name.get(q) or idx.by_display.get(q) or idx.by_hf_repo.get(q)
 
 
-def build_adhoc_entry(hf_repo: str, *, task: str = ModelTask.CHAT) -> CatalogModel:
-    """Build a minimal CatalogModel for any HuggingFace GGUF repo.
+def _is_hf_repo_id(value: str) -> bool:
+    """True if *value* is a well-formed ``owner/name`` HuggingFace repo id."""
+    if "/" not in value:
+        return False
+    try:
+        validate_repo_id(value)
+    except HFValidationError:
+        return False
+    return True
 
-    Fields mirror what ``_fetch_hf_models`` produces for non-featured HF
-    search hits (slug from repo name, ``DEFAULT_TAG``, wildcard
-    ``gguf_filename``). ``resolve_filename`` resolves the wildcard at
-    download time.
-    """
-    if "/" not in hf_repo:
-        raise ValueError(f"{hf_repo!r} is not a HuggingFace repo id (expected 'owner/name')")
+
+def build_adhoc_entry(hf_repo: str, *, task: str = ModelTask.CHAT) -> CatalogModel:
+    """Minimal CatalogModel for a non-featured HuggingFace GGUF repo."""
     repo_name = hf_repo.split("/")[-1]
-    slug = repo_name.lower().replace(" ", "-")
     return CatalogModel(
-        name=slug,
+        name=repo_name.lower().replace(" ", "-"),
         tag=DEFAULT_TAG,
         display_name=clean_display_name(hf_repo),
         hf_repo=hf_repo,
@@ -709,22 +712,11 @@ def build_adhoc_entry(hf_repo: str, *, task: str = ModelTask.CHAT) -> CatalogMod
 
 
 def resolve_pull_target(model: str) -> CatalogModel | None:
-    """Resolve a pull request to a pullable ``CatalogModel``.
-
-    HuggingFace repo ids (containing ``/``) are always pullable. When the
-    repo matches a featured entry we return the featured entry so curated
-    metadata wins (explicit filename, vision mmproj wiring, recommended
-    variant tag). Otherwise we construct an ad-hoc entry from the repo id.
-
-    Short names (no ``/``) must resolve through the featured index; there
-    is no way to infer an HF repo from a bare slug. Returns ``None`` when
-    a short name is not featured so the caller can raise with its own
-    message.
-    """
-    if "/" in model:
-        featured = _build_catalog_index().by_hf_repo.get(model.lower())
-        return featured or build_adhoc_entry(model)
-    return find_catalog_entry(model)
+    """Resolve *model* to a pullable entry: featured first, then ad-hoc HF."""
+    featured = find_catalog_entry(model)
+    if featured is not None:
+        return featured
+    return build_adhoc_entry(model) if _is_hf_repo_id(model) else None
 
 
 def download_model(entry: CatalogModel, *, on_progress: ProgressCallback | None = None) -> Path:

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -681,6 +681,52 @@ def find_catalog_entry(query: str) -> CatalogModel | None:
     return idx.by_ref.get(q) or idx.by_name.get(q) or idx.by_display.get(q) or idx.by_hf_repo.get(q)
 
 
+def build_adhoc_entry(hf_repo: str, *, task: str = ModelTask.CHAT) -> CatalogModel:
+    """Build a minimal CatalogModel for any HuggingFace GGUF repo.
+
+    Fields mirror what ``_fetch_hf_models`` produces for non-featured HF
+    search hits (slug from repo name, ``DEFAULT_TAG``, wildcard
+    ``gguf_filename``). ``resolve_filename`` resolves the wildcard at
+    download time.
+    """
+    if "/" not in hf_repo:
+        raise ValueError(f"{hf_repo!r} is not a HuggingFace repo id (expected 'owner/name')")
+    repo_name = hf_repo.split("/")[-1]
+    slug = repo_name.lower().replace(" ", "-")
+    return CatalogModel(
+        name=slug,
+        tag=DEFAULT_TAG,
+        display_name=clean_display_name(hf_repo),
+        hf_repo=hf_repo,
+        gguf_filename="*.gguf",
+        size_gb=0.0,
+        min_ram_gb=2.0,
+        description="",
+        featured=False,
+        downloads=0,
+        task=task,
+    )
+
+
+def resolve_pull_target(model: str) -> CatalogModel | None:
+    """Resolve a pull request to a pullable ``CatalogModel``.
+
+    HuggingFace repo ids (containing ``/``) are always pullable. When the
+    repo matches a featured entry we return the featured entry so curated
+    metadata wins (explicit filename, vision mmproj wiring, recommended
+    variant tag). Otherwise we construct an ad-hoc entry from the repo id.
+
+    Short names (no ``/``) must resolve through the featured index; there
+    is no way to infer an HF repo from a bare slug. Returns ``None`` when
+    a short name is not featured so the caller can raise with its own
+    message.
+    """
+    if "/" in model:
+        featured = _build_catalog_index().by_hf_repo.get(model.lower())
+        return featured or build_adhoc_entry(model)
+    return find_catalog_entry(model)
+
+
 def download_model(entry: CatalogModel, *, on_progress: ProgressCallback | None = None) -> Path:
     """Download a GGUF model from HuggingFace to cfg.models_dir.
     Uses huggingface_hub for resumable downloads, caching, and auth.

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -145,12 +145,21 @@ class ModelManager:
         *,
         on_bytes: Callable[[int, int], None] | None = None,
     ) -> Path:
-        """Download model to the native GGUF directory via catalog."""
-        from lilbee.catalog import download_model, find_catalog_entry
+        """Download a model to the native GGUF directory.
 
-        entry = find_catalog_entry(model)
+        Accepts either a short featured name (``qwen3:0.6b``) or a
+        HuggingFace repo id (``owner/name``). Non-featured HF repos are
+        pulled via an ad-hoc catalog entry.
+        """
+        from lilbee.catalog import download_model, resolve_pull_target
+
+        entry = resolve_pull_target(model)
         if entry is None:
-            raise ModelNotFoundError(f"Model '{model}' not found in catalog")
+            raise ModelNotFoundError(
+                f"Model '{model}' not recognized. Pass a HuggingFace repo id "
+                "(e.g. 'bartowski/Meta-Llama-3.1-8B-Instruct-GGUF') or a "
+                "featured model name."
+            )
         path = download_model(entry, on_progress=on_bytes)
         log.info("Downloaded %s to %s", model, path)
         return path

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -145,20 +145,14 @@ class ModelManager:
         *,
         on_bytes: Callable[[int, int], None] | None = None,
     ) -> Path:
-        """Download a model to the native GGUF directory.
-
-        Accepts either a short featured name (``qwen3:0.6b``) or a
-        HuggingFace repo id (``owner/name``). Non-featured HF repos are
-        pulled via an ad-hoc catalog entry.
-        """
+        """Download a featured or ad-hoc HuggingFace model to the native GGUF directory."""
         from lilbee.catalog import download_model, resolve_pull_target
 
         entry = resolve_pull_target(model)
         if entry is None:
             raise ModelNotFoundError(
-                f"Model '{model}' not recognized. Pass a HuggingFace repo id "
-                "(e.g. 'bartowski/Meta-Llama-3.1-8B-Instruct-GGUF') or a "
-                "featured model name."
+                f"Model '{model}' not recognized. "
+                "Pass a HuggingFace repo id (owner/name) or a featured model name."
             )
         path = download_model(entry, on_progress=on_bytes)
         log.info("Downloaded %s to %s", model, path)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -690,15 +690,37 @@ class TestBuildAdhocEntry:
         assert entry.task == ModelTask.CHAT
         assert entry.display_name
 
-    def test_rejects_bare_name(self) -> None:
-        with pytest.raises(ValueError, match="owner/name"):
-            build_adhoc_entry("qwen3")
-
     def test_respects_task_override(self) -> None:
         from lilbee.models import ModelTask
 
         entry = build_adhoc_entry("foo/bar-GGUF", task=ModelTask.EMBEDDING)
         assert entry.task == ModelTask.EMBEDDING
+
+
+class TestIsHfRepoId:
+    @pytest.mark.parametrize(
+        "value",
+        ["bartowski/gemma-2-2b-it-GGUF", "Qwen/Qwen3-8B-GGUF", "foo/bar", "Foo-BAR_foo.bar123/x"],
+    )
+    def test_accepts_valid_repo_ids(self, value: str) -> None:
+        assert catalog._is_hf_repo_id(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "qwen3",
+            "qwen3:0.6b",
+            "https://huggingface.co/Qwen/Qwen3-8B-GGUF",
+            "datasets/foo/bar",
+            "foo--bar/baz",
+            "foo/bar..baz",
+            "/bar",
+            "foo/",
+            "",
+        ],
+    )
+    def test_rejects_non_repo_ids(self, value: str) -> None:
+        assert catalog._is_hf_repo_id(value) is False
 
 
 class TestResolvePullTarget:
@@ -729,6 +751,13 @@ class TestResolvePullTarget:
 
     def test_unknown_short_name_returns_none(self) -> None:
         assert catalog.resolve_pull_target("not-a-real-model") is None
+
+    @pytest.mark.parametrize(
+        "value",
+        ["https://huggingface.co/Qwen/Qwen3-8B-GGUF", "datasets/foo/bar", "foo--bar/baz"],
+    )
+    def test_malformed_hf_inputs_return_none(self, value: str) -> None:
+        assert catalog.resolve_pull_target(value) is None
 
 
 class TestDownloadModel:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -22,6 +22,7 @@ from lilbee.catalog import (
     ModelVariant,
     _hf_token,
     _HfPage,
+    build_adhoc_entry,
     clean_display_name,
     download_model,
     enrich_catalog,
@@ -673,6 +674,61 @@ class TestFindCatalogEntry:
     def test_empty_string(self) -> None:
         result = find_catalog_entry("")
         assert result is None
+
+
+class TestBuildAdhocEntry:
+    def test_valid_repo_derives_slug_and_defaults(self) -> None:
+        from lilbee.models import ModelTask
+        from lilbee.registry import DEFAULT_TAG
+
+        entry = build_adhoc_entry("bartowski/gemma-2-2b-it-GGUF")
+        assert entry.hf_repo == "bartowski/gemma-2-2b-it-GGUF"
+        assert entry.name == "gemma-2-2b-it-gguf"
+        assert entry.tag == DEFAULT_TAG
+        assert entry.gguf_filename == "*.gguf"
+        assert entry.featured is False
+        assert entry.task == ModelTask.CHAT
+        assert entry.display_name
+
+    def test_rejects_bare_name(self) -> None:
+        with pytest.raises(ValueError, match="owner/name"):
+            build_adhoc_entry("qwen3")
+
+    def test_respects_task_override(self) -> None:
+        from lilbee.models import ModelTask
+
+        entry = build_adhoc_entry("foo/bar-GGUF", task=ModelTask.EMBEDDING)
+        assert entry.task == ModelTask.EMBEDDING
+
+
+class TestResolvePullTarget:
+    def test_featured_short_name(self) -> None:
+        entry = catalog.resolve_pull_target("qwen3:0.6b")
+        assert entry is not None
+        assert entry.featured is True
+        assert entry.ref == "qwen3:0.6b"
+
+    def test_featured_hf_repo_returns_featured_entry(self) -> None:
+        entry = catalog.resolve_pull_target("Qwen/Qwen3-8B-GGUF")
+        assert entry is not None
+        assert entry.featured is True
+        assert entry.hf_repo == "Qwen/Qwen3-8B-GGUF"
+        assert entry.gguf_filename != "*.gguf"
+
+    def test_featured_hf_repo_case_insensitive(self) -> None:
+        entry = catalog.resolve_pull_target("qwen/qwen3-8b-gguf")
+        assert entry is not None
+        assert entry.featured is True
+
+    def test_unknown_hf_repo_builds_adhoc(self) -> None:
+        entry = catalog.resolve_pull_target("bartowski/gemma-2-2b-it-GGUF")
+        assert entry is not None
+        assert entry.featured is False
+        assert entry.hf_repo == "bartowski/gemma-2-2b-it-GGUF"
+        assert entry.gguf_filename == "*.gguf"
+
+    def test_unknown_short_name_returns_none(self) -> None:
+        assert catalog.resolve_pull_target("not-a-real-model") is None
 
 
 class TestDownloadModel:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -290,24 +290,49 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with (
-            mock.patch("lilbee.catalog.find_catalog_entry", return_value=fake_entry) as mock_find,
+            mock.patch(
+                "lilbee.catalog.resolve_pull_target", return_value=fake_entry
+            ) as mock_resolve,
             mock.patch("lilbee.catalog.download_model", side_effect=fake_download) as mock_dl,
         ):
             result = mgr.pull("test-model", ModelSource.NATIVE)
 
-        mock_find.assert_called_once_with("test-model")
+        mock_resolve.assert_called_once_with("test-model")
         mock_dl.assert_called_once_with(fake_entry, on_progress=None)
         assert result is not None
         assert result.name == "test-model.gguf"
 
-    def test_native_pull_not_in_catalog(self, tmp_path: Path) -> None:
+    def test_native_pull_succeeds_for_arbitrary_hf_repo(self, tmp_path: Path) -> None:
+        """Non-featured HF repos round-trip through an ad-hoc catalog entry."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+
+        captured: list[object] = []
+
+        def fake_download(entry: object, *, on_progress: object = None) -> Path:
+            captured.append(entry)
+            path = models_dir / "adhoc.gguf"
+            path.write_text("fake model")
+            return path
+
+        mgr = ModelManager(models_dir, "http://localhost:11434")
+        with mock.patch("lilbee.catalog.download_model", side_effect=fake_download):
+            mgr.pull("bartowski/gemma-2-2b-it-GGUF", ModelSource.NATIVE)
+
+        assert len(captured) == 1
+        entry = captured[0]
+        assert entry.hf_repo == "bartowski/gemma-2-2b-it-GGUF"
+        assert entry.gguf_filename == "*.gguf"
+        assert entry.featured is False
+
+    def test_native_pull_unknown_short_name_raises(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with (
-            mock.patch("lilbee.catalog.find_catalog_entry", return_value=None),
-            pytest.raises(RuntimeError, match="not found in catalog"),
+            mock.patch("lilbee.catalog.resolve_pull_target", return_value=None),
+            pytest.raises(RuntimeError, match="HuggingFace repo id"),
         ):
             mgr.pull("nonexistent-model", ModelSource.NATIVE)
 


### PR DESCRIPTION
The Obsidian plugin's catalog modal shows both featured entries and live HuggingFace search results. Pulls on the non-featured rows were failing because the server only accepted identifiers from the hardcoded featured list.

This change treats the HF repo id as the canonical pull identifier. Any public GGUF repo can be pulled directly. When the repo also matches a featured entry we keep the curated metadata (explicit filename, vision mmproj wiring). Short names keep working unchanged for CLI users.
