### PR TITLE
Guarantee SSE sync/add streams deliver the final progress event

### DIFF
--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -51,6 +51,7 @@ from lilbee.server.models import (
 from lilbee.services import get_services
 
 if TYPE_CHECKING:
+    from lilbee.ingest import SyncResult
     from lilbee.query import ChatMessage
 
 log = logging.getLogger(__name__)
@@ -177,15 +178,25 @@ class SseStream:
     async def drain(
         self, task: asyncio.Task[Any] | asyncio.Future[Any], label: str
     ) -> AsyncGenerator[str, None]:
-        """Yield SSE strings from the queue until *task* completes.
+        """Yield SSE strings from the queue until a sentinel arrives or the task fails.
+
+        Producers are expected to enqueue ``None`` as a sentinel when they
+        finish (successfully or via cancel). ``drain()`` exits when it sees
+        the sentinel. If the task raises before producing a sentinel,
+        ``drain()`` exits via the fallback so the stream does not hang.
+
         On ``CancelledError`` / ``GeneratorExit`` (client disconnect),
         sets :attr:`cancel` and cancels *task*.
         """
         try:
-            while not task.done() or not self.queue.empty():
+            while True:
                 try:
                     item = await asyncio.wait_for(self.queue.get(), timeout=0.1)
                 except TimeoutError:
+                    # Fallback: if the task crashed or finished without a
+                    # sentinel, stop waiting rather than hanging forever.
+                    if task.done() and self.queue.empty():
+                        break
                     continue
                 if item is None:
                     break
@@ -330,17 +341,35 @@ def chat_stream(
     return _stream_rag_response(question, history=history, top_k=top_k, options=options)
 
 
-async def sync_stream(*, enable_ocr: bool | None = None) -> AsyncGenerator[str, None]:
-    """Trigger sync, yield SSE progress events, then done event."""
+async def _run_sync_with_sentinel(sse: SseStream, enable_ocr: bool | None) -> SyncResult:
+    """Run ingest.sync() and always enqueue the sentinel in a finally block.
+
+    The sentinel guarantees ``drain()`` exits only after every progress event
+    (including the final ``EventType.DONE``) has been consumed, even when the
+    task resolves before the event loop dispatches pending threadsafe
+    callbacks.
+    """
     from lilbee.cli.helpers import temporary_ocr_config
     from lilbee.ingest import sync
 
+    try:
+        with temporary_ocr_config(enable_ocr):
+            return await sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel)
+    finally:
+        sse.queue.put_nowait(None)
+
+
+async def sync_stream(*, enable_ocr: bool | None = None) -> AsyncGenerator[str, None]:
+    """Trigger sync, yield SSE progress events, then done event."""
     sse = SseStream()
-    with temporary_ocr_config(enable_ocr):
-        task = asyncio.create_task(sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel))
+    task = asyncio.create_task(_run_sync_with_sentinel(sse, enable_ocr))
     async for event in sse.drain(task, "Sync stream"):
         yield event
     if not sse.cancel.is_set() and task.done() and not task.cancelled():
+        exc = task.exception()
+        if exc is not None:
+            yield sse_error(str(exc))
+            return
         yield sse_done(task.result().model_dump())
 
 
@@ -352,39 +381,40 @@ async def _run_add(
     sse: SseStream,
 ) -> AddSummary:
     """Copy files and sync, pushing SSE events to the queue.
-    Returns the summary so the caller can emit the final done event.
+
+    Returns the summary so the caller can emit the final done event. The
+    sentinel is always enqueued in a finally block so ``drain()`` exits
+    cleanly even when sync raises.
     """
+    from lilbee.cli.helpers import temporary_ocr_config
     from lilbee.ingest import sync
 
-    errors: list[str] = []
-    valid: list[Path] = []
-    for p_str in paths:
-        p = Path(p_str)
-        if not p.exists():
-            errors.append(p_str)
-        else:
-            valid.append(p)
+    try:
+        errors: list[str] = []
+        valid: list[Path] = []
+        for p_str in paths:
+            p = Path(p_str)
+            if not p.exists():
+                errors.append(p_str)
+            else:
+                valid.append(p)
 
-    copy_result = copy_files(valid, force=force)
+        copy_result = copy_files(valid, force=force)
 
-    if sse.cancel.is_set():
+        if sse.cancel.is_set():
+            return AddSummary(copied=copy_result.copied, skipped=copy_result.skipped, errors=errors)
+
+        with temporary_ocr_config(enable_ocr, ocr_timeout):
+            sync_result = await sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel)
+
+        return AddSummary(
+            copied=copy_result.copied,
+            skipped=copy_result.skipped,
+            errors=errors,
+            sync=SyncSummary(**sync_result.model_dump()),
+        )
+    finally:
         sse.queue.put_nowait(None)
-        return AddSummary(copied=copy_result.copied, skipped=copy_result.skipped, errors=errors)
-
-    from lilbee.cli.helpers import temporary_ocr_config
-
-    with temporary_ocr_config(enable_ocr, ocr_timeout):
-        sync_result = await sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel)
-
-    sr = sync_result.model_dump()
-    summary = AddSummary(
-        copied=copy_result.copied,
-        skipped=copy_result.skipped,
-        errors=errors,
-        sync=SyncSummary(**sr),
-    )
-    sse.queue.put_nowait(None)  # sentinel
-    return summary
 
 
 def validate_add_paths(
@@ -428,6 +458,10 @@ async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
     async for event in sse.drain(task, "Add files stream"):
         yield event
     if not sse.cancel.is_set() and task.done() and not task.cancelled():
+        exc = task.exception()
+        if exc is not None:
+            yield sse_error(str(exc))
+            return
         summary = task.result()
         yield sse_done(summary.model_dump())
 

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -178,23 +178,13 @@ class SseStream:
     async def drain(
         self, task: asyncio.Task[Any] | asyncio.Future[Any], label: str
     ) -> AsyncGenerator[str, None]:
-        """Yield SSE strings from the queue until a sentinel arrives or the task fails.
-
-        Producers are expected to enqueue ``None`` as a sentinel when they
-        finish (successfully or via cancel). ``drain()`` exits when it sees
-        the sentinel. If the task raises before producing a sentinel,
-        ``drain()`` exits via the fallback so the stream does not hang.
-
-        On ``CancelledError`` / ``GeneratorExit`` (client disconnect),
-        sets :attr:`cancel` and cancels *task*.
-        """
+        """Yield SSE strings until a sentinel arrives. Cancels *task* on client disconnect."""
         try:
             while True:
                 try:
                     item = await asyncio.wait_for(self.queue.get(), timeout=0.1)
                 except TimeoutError:
-                    # Fallback: if the task crashed or finished without a
-                    # sentinel, stop waiting rather than hanging forever.
+                    # Fallback for producers that die without a sentinel.
                     if task.done() and self.queue.empty():
                         break
                     continue
@@ -342,13 +332,7 @@ def chat_stream(
 
 
 async def _run_sync_with_sentinel(sse: SseStream, enable_ocr: bool | None) -> SyncResult:
-    """Run ingest.sync() and always enqueue the sentinel in a finally block.
-
-    The sentinel guarantees ``drain()`` exits only after every progress event
-    (including the final ``EventType.DONE``) has been consumed, even when the
-    task resolves before the event loop dispatches pending threadsafe
-    callbacks.
-    """
+    """Run ingest.sync() and guarantee the drain sentinel is enqueued."""
     from lilbee.cli.helpers import temporary_ocr_config
     from lilbee.ingest import sync
 
@@ -380,12 +364,7 @@ async def _run_add(
     ocr_timeout: float | None,
     sse: SseStream,
 ) -> AddSummary:
-    """Copy files and sync, pushing SSE events to the queue.
-
-    Returns the summary so the caller can emit the final done event. The
-    sentinel is always enqueued in a finally block so ``drain()`` exits
-    cleanly even when sync raises.
-    """
+    """Copy files and sync, returning the summary for the final done event."""
     from lilbee.cli.helpers import temporary_ocr_config
     from lilbee.ingest import sync
 
@@ -770,9 +749,12 @@ async def crawl_stream(url: str, depth: int = 0, max_pages: int = 50) -> AsyncGe
     async def _run_crawl() -> list[Path]:
         from lilbee.crawler import crawl_and_save
 
-        return await crawl_and_save(
-            url, depth=depth, max_pages=max_pages, on_progress=sse.callback, cancel=sse.cancel
-        )
+        try:
+            return await crawl_and_save(
+                url, depth=depth, max_pages=max_pages, on_progress=sse.callback, cancel=sse.cancel
+            )
+        finally:
+            sse.queue.put_nowait(None)
 
     task = asyncio.create_task(_run_crawl())
     async for event in sse.drain(task, "Crawl stream"):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -563,21 +563,23 @@ class TestSyncStreamDoneDelivery:
         counts = json.loads(done_events[0].split("data: ")[1].strip())
         assert counts == {"added": 0, "updated": 0, "removed": 0, "failed": 0}
 
-    async def test_drain_yields_queued_events_before_sentinel(self):
-        """drain() yields every queued event before the sentinel closes the stream."""
+    async def test_drain_exits_cleanly_when_producer_raises(self):
+        """A raising producer still enqueues the sentinel via finally so drain closes."""
         from lilbee.server.handlers import SseStream
 
         sse = SseStream()
 
-        async def producer():
+        async def raising_producer():
             try:
-                sse.queue.put_nowait("event: embed\ndata: {}\n\n")
+                raise RuntimeError("boom")
             finally:
                 sse.queue.put_nowait(None)
 
-        task = asyncio.create_task(producer())
-        events = [e async for e in sse.drain(task, "queued-before-sentinel")]
-        assert any(e.startswith("event: embed") for e in events), events
+        task = asyncio.create_task(raising_producer())
+        events = [e async for e in sse.drain(task, "raising")]
+        assert events == []
+        assert task.done()
+        assert isinstance(task.exception(), RuntimeError)
 
     async def test_stream_reports_error_when_sync_raises(self):
         """If the sync coroutine raises, sync_stream emits an error SSE frame."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -497,12 +497,7 @@ class TestAddFiles:
             assert any("done" in e for e in events)
 
     async def test_stream_emits_sentinel_on_sync_failure(self, isolated_env):
-        """If sync raises, _run_add still emits the sentinel via its finally block.
-
-        Without the finally-based sentinel, drain() would only exit via the
-        task.done() fallback path. Verifies the stream closes cleanly and the
-        caller gets an error frame rather than a hung connection.
-        """
+        """Sync failure emits one error frame and closes the stream without a done frame."""
         test_file = isolated_env / "documents" / "test.txt"
         test_file.write_text("test content")
 
@@ -526,12 +521,7 @@ class TestSyncStreamDoneDelivery:
     """Regression tests for the SSE drain race (bb-7enj)."""
 
     async def test_done_event_delivered_on_fast_completion(self):
-        """When sync completes almost instantly, the final SSE done event is still delivered.
-
-        Previously, drain() exited on task.done() without waiting for a
-        sentinel, which could drop the last event if the task resolved
-        before the event loop dispatched pending queue puts.
-        """
+        """A fast-completing sync still delivers both done frames in order."""
         sync_result = SyncResult(added=["fast.txt"])
 
         async def instant_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
@@ -555,12 +545,7 @@ class TestSyncStreamDoneDelivery:
         assert lists_done["added"] == ["fast.txt"]
 
     async def test_done_event_delivered_on_noop_sync(self):
-        """A sync with zero file changes must still emit a done event.
-
-        The task description flagged this as a potential no-op code path
-        that could skip EventType.DONE emission. Confirms every return path
-        in sync() emits it (which it does) and the stream delivers it.
-        """
+        """A sync with zero file changes still emits the done frame."""
         sync_result = SyncResult()  # empty: no added/updated/removed
 
         async def noop_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
@@ -579,12 +564,7 @@ class TestSyncStreamDoneDelivery:
         assert counts == {"added": 0, "updated": 0, "removed": 0, "failed": 0}
 
     async def test_drain_delivers_late_threadsafe_event_before_exit(self):
-        """Events enqueued via call_soon_threadsafe at task end must be delivered.
-
-        Simulates the race where a worker thread calls call_soon_threadsafe
-        immediately before the sync task resolves. drain() must deliver
-        the late event rather than exiting on task.done().
-        """
+        """A threadsafe-enqueued event lands before the sentinel closes drain."""
         import threading
 
         from lilbee.server.handlers import SseStream
@@ -632,10 +612,8 @@ class TestSyncStreamDoneDelivery:
 
 
 class TestDrainFallback:
-    """The drain() fallback covers tasks that finish without a sentinel."""
-
     async def test_drain_exits_when_task_done_without_sentinel(self):
-        """drain() exits via the timeout fallback if a task finishes with no sentinel."""
+        """drain() exits cleanly when a task finishes with no sentinel."""
         from lilbee.server.handlers import SseStream
 
         sse = SseStream()

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -563,35 +563,20 @@ class TestSyncStreamDoneDelivery:
         counts = json.loads(done_events[0].split("data: ")[1].strip())
         assert counts == {"added": 0, "updated": 0, "removed": 0, "failed": 0}
 
-    async def test_drain_delivers_late_threadsafe_event_before_exit(self):
-        """A threadsafe-enqueued event lands before the sentinel closes drain."""
-        import threading
-
+    async def test_drain_yields_queued_events_before_sentinel(self):
+        """drain() yields every queued event before the sentinel closes the stream."""
         from lilbee.server.handlers import SseStream
 
         sse = SseStream()
-        barrier = threading.Event()
-
-        def worker():
-            # Emit a progress payload via threadsafe; mirrors how
-            # embed_batch callbacks cross thread boundaries.
-            sse.loop.call_soon_threadsafe(sse.queue.put_nowait, "event: embed\ndata: {}\n\n")
-            barrier.set()
 
         async def producer():
             try:
-                # Kick off the worker, then yield just long enough for the
-                # threadsafe put to land before we emit the sentinel.
-                import concurrent.futures
-
-                with concurrent.futures.ThreadPoolExecutor() as pool:
-                    await asyncio.get_running_loop().run_in_executor(pool, worker)
+                sse.queue.put_nowait("event: embed\ndata: {}\n\n")
             finally:
                 sse.queue.put_nowait(None)
 
         task = asyncio.create_task(producer())
-        events = [e async for e in sse.drain(task, "race test")]
-        assert barrier.is_set()
+        events = [e async for e in sse.drain(task, "queued-before-sentinel")]
         assert any(e.startswith("event: embed") for e in events), events
 
     async def test_stream_reports_error_when_sync_raises(self):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -496,6 +496,159 @@ class TestAddFiles:
                 events.append(event)
             assert any("done" in e for e in events)
 
+    async def test_stream_emits_sentinel_on_sync_failure(self, isolated_env):
+        """If sync raises, _run_add still emits the sentinel via its finally block.
+
+        Without the finally-based sentinel, drain() would only exit via the
+        task.done() fallback path. Verifies the stream closes cleanly and the
+        caller gets an error frame rather than a hung connection.
+        """
+        test_file = isolated_env / "documents" / "test.txt"
+        test_file.write_text("test content")
+
+        async def failing_sync(**kwargs):
+            raise RuntimeError("sync blew up")
+
+        with patch("lilbee.ingest.sync", side_effect=failing_sync):
+            events = []
+            async for event in handlers.add_files_stream({"paths": [str(test_file)]}):
+                events.append(event)
+
+        error_events = [e for e in events if e.startswith("event: error")]
+        done_events = [e for e in events if e.startswith("event: done")]
+        assert len(error_events) == 1
+        assert "sync blew up" in error_events[0]
+        # No done event when the task failed.
+        assert done_events == []
+
+
+class TestSyncStreamDoneDelivery:
+    """Regression tests for the SSE drain race (bb-7enj)."""
+
+    async def test_done_event_delivered_on_fast_completion(self):
+        """When sync completes almost instantly, the final SSE done event is still delivered.
+
+        Previously, drain() exited on task.done() without waiting for a
+        sentinel, which could drop the last event if the task resolved
+        before the event loop dispatched pending queue puts.
+        """
+        sync_result = SyncResult(added=["fast.txt"])
+
+        async def instant_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
+            if on_progress:
+                from lilbee.progress import SyncDoneEvent
+
+                on_progress("done", SyncDoneEvent(added=1, updated=0, removed=0, failed=0))
+            return sync_result
+
+        with patch("lilbee.ingest.sync", side_effect=instant_sync):
+            events = [e async for e in handlers.sync_stream()]
+
+        # The sync-emitted done (SyncDoneEvent counts) must be delivered, and
+        # the handler-emitted done (SyncResult lists) must follow it.
+        done_events = [e for e in events if e.startswith("event: done")]
+        assert len(done_events) == 2, f"expected 2 done events, got {done_events}"
+
+        counts_done = json.loads(done_events[0].split("data: ")[1].strip())
+        lists_done = json.loads(done_events[1].split("data: ")[1].strip())
+        assert counts_done == {"added": 1, "updated": 0, "removed": 0, "failed": 0}
+        assert lists_done["added"] == ["fast.txt"]
+
+    async def test_done_event_delivered_on_noop_sync(self):
+        """A sync with zero file changes must still emit a done event.
+
+        The task description flagged this as a potential no-op code path
+        that could skip EventType.DONE emission. Confirms every return path
+        in sync() emits it (which it does) and the stream delivers it.
+        """
+        sync_result = SyncResult()  # empty: no added/updated/removed
+
+        async def noop_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
+            if on_progress:
+                from lilbee.progress import SyncDoneEvent
+
+                on_progress("done", SyncDoneEvent(added=0, updated=0, removed=0, failed=0))
+            return sync_result
+
+        with patch("lilbee.ingest.sync", side_effect=noop_sync):
+            events = [e async for e in handlers.sync_stream()]
+
+        done_events = [e for e in events if e.startswith("event: done")]
+        assert len(done_events) == 2
+        counts = json.loads(done_events[0].split("data: ")[1].strip())
+        assert counts == {"added": 0, "updated": 0, "removed": 0, "failed": 0}
+
+    async def test_drain_delivers_late_threadsafe_event_before_exit(self):
+        """Events enqueued via call_soon_threadsafe at task end must be delivered.
+
+        Simulates the race where a worker thread calls call_soon_threadsafe
+        immediately before the sync task resolves. drain() must deliver
+        the late event rather than exiting on task.done().
+        """
+        import threading
+
+        from lilbee.server.handlers import SseStream
+
+        sse = SseStream()
+        barrier = threading.Event()
+
+        def worker():
+            # Emit a progress payload via threadsafe; mirrors how
+            # embed_batch callbacks cross thread boundaries.
+            sse.loop.call_soon_threadsafe(sse.queue.put_nowait, "event: embed\ndata: {}\n\n")
+            barrier.set()
+
+        async def producer():
+            try:
+                # Kick off the worker, then yield just long enough for the
+                # threadsafe put to land before we emit the sentinel.
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    await asyncio.get_running_loop().run_in_executor(pool, worker)
+            finally:
+                sse.queue.put_nowait(None)
+
+        task = asyncio.create_task(producer())
+        events = [e async for e in sse.drain(task, "race test")]
+        assert barrier.is_set()
+        assert any(e.startswith("event: embed") for e in events), events
+
+    async def test_stream_reports_error_when_sync_raises(self):
+        """If the sync coroutine raises, sync_stream emits an error SSE frame."""
+
+        async def failing_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
+            raise RuntimeError("boom")
+
+        with patch("lilbee.ingest.sync", side_effect=failing_sync):
+            events = [e async for e in handlers.sync_stream()]
+
+        error_events = [e for e in events if e.startswith("event: error")]
+        done_events = [e for e in events if e.startswith("event: done")]
+        assert len(error_events) == 1
+        assert "boom" in error_events[0]
+        # No done frame should be emitted when sync failed.
+        assert done_events == []
+
+
+class TestDrainFallback:
+    """The drain() fallback covers tasks that finish without a sentinel."""
+
+    async def test_drain_exits_when_task_done_without_sentinel(self):
+        """drain() exits via the timeout fallback if a task finishes with no sentinel."""
+        from lilbee.server.handlers import SseStream
+
+        sse = SseStream()
+
+        async def quiet_producer():
+            # Never emits anything; simulates a crashed or misbehaving producer.
+            return None
+
+        task = asyncio.create_task(quiet_producer())
+        events = [e async for e in sse.drain(task, "no-sentinel test")]
+        assert events == []
+        assert task.done()
+
 
 class TestListModels:
     @patch("lilbee.models.list_installed_models")


### PR DESCRIPTION
## Problem

Background sync and add operations exposed over SSE could close the stream before the final progress event reached the client. The Obsidian plugin (and anything else consuming the stream) would see the task disappear without a clean completion signal, which is the server-side half of bb-7enj.

## Fix

Streams now close on an explicit sentinel rather than by polling whether the background task finished. The ingest flow only sends that sentinel once all its progress events have been queued, so the consumer always gets every frame — including the final one — before the stream ends.

If the producer crashes, the stream still exits cleanly: it emits an `error` frame instead of re-raising, and the fallback path prevents the stream from hanging when the producer dies without emitting anything.