### PR TITLE
Crawler: flush pages to disk as they stream

### DIFF
--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -399,29 +399,6 @@ def _web_dir() -> Path:
     return cfg.documents_dir / "_web"
 
 
-def save_crawl_results(results: list[CrawlResult]) -> list[Path]:
-    """Write successful crawl results as .md files under documents/_web/.
-    Returns list of paths written.
-    """
-    written: list[Path] = []
-    web_dir = _web_dir()
-    resolved_web_dir = web_dir.resolve()
-    for result in results:
-        if not result.success or not result.markdown.strip():
-            continue
-        rel = url_to_filename(result.url)
-        dest = web_dir / rel
-        try:
-            validate_path_within(dest, resolved_web_dir)
-        except ValueError:
-            log.warning("Path traversal blocked: %s → %s", result.url, dest)
-            continue
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(result.markdown, encoding="utf-8")
-        written.append(dest)
-    return written
-
-
 def _crawl_meta_path() -> Path:
     """Path to the crawl metadata sidecar JSON."""
     return cfg.data_dir / "crawl_meta.json"
@@ -481,41 +458,26 @@ def content_hash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
-def update_metadata(results: list[CrawlResult]) -> None:
-    """Update crawl metadata with successful results."""
-    meta = load_crawl_metadata()
-    now = datetime.now(UTC).isoformat()
-    for r in results:
-        if r.success and r.markdown.strip():
-            meta[r.url] = CrawlMeta(
-                file=url_to_filename(r.url),
-                content_hash=content_hash(r.markdown),
-                crawled_at=now,
-            )
-    save_crawl_metadata(meta)
-
-
 def _save_single_result(result: CrawlResult, meta: dict[str, CrawlMeta]) -> Path | None:
     """Write one crawl result to disk if it's new or changed.
 
-    Per-page equivalent of _filter_changed + save_crawl_results for the streaming
-    flush path. Returns the written path, or None if skipped (failure, empty
-    markdown, unchanged hash with file on disk, or blocked by path traversal).
+    Returns the written path, or None if skipped (failure, empty markdown,
+    unchanged hash with file on disk, or blocked by path traversal).
     """
     if not result.success or not result.markdown.strip():
         return None
     web_dir = _web_dir()
     file_path = web_dir / url_to_filename(result.url)
-    new_hash = content_hash(result.markdown)
-    prev = meta.get(result.url)
-    if prev is not None and prev.content_hash == new_hash and file_path.exists():
-        log.info("Content unchanged, skipping save: %s", result.url)
-        return None
     resolved_web_dir = web_dir.resolve()
     try:
         validate_path_within(file_path, resolved_web_dir)
     except ValueError:
         log.warning("Path traversal blocked: %s -> %s", result.url, file_path)
+        return None
+    new_hash = content_hash(result.markdown)
+    prev = meta.get(result.url)
+    if prev is not None and prev.content_hash == new_hash and file_path.exists():
+        log.info("Content unchanged, skipping save: %s", result.url)
         return None
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text(result.markdown, encoding="utf-8")
@@ -765,7 +727,7 @@ async def crawl_recursive(
     *,
     quiet: bool = False,
     include_subdomains: bool = False,
-    on_result: Callable[[CrawlResult], Path | None] | None = None,
+    on_result: Callable[[CrawlResult], Any] | None = None,
 ) -> list[CrawlResult]:
     """Crawl a URL recursively using BFS, streaming per-page progress.
 
@@ -866,7 +828,13 @@ async def crawl_recursive(
                         )
                     results.append(new_result)
                     if on_result is not None:
-                        on_result(new_result)
+                        try:
+                            on_result(new_result)
+                        except OSError:
+                            # A disk-side flush failure must not masquerade as
+                            # a crawl failure. Log and keep streaming; the
+                            # caller still sees the result in its returned list.
+                            log.exception("Flush callback failed for %s", new_result.url)
                     # Hard cap on visible progress. crawl4ai's BFS uses
                     # max_pages to count successful pages, so failed /
                     # redirected pages can push our per-result counter past
@@ -1070,8 +1038,9 @@ async def crawl_and_save(
             pages_seen = len(results)
 
         # Final metadata flush covers both clean completion and cancel. Skip
-        # when nothing was written to avoid touching disk for no-op crawls.
-        if written_paths:
+        # when there are no in-memory entries still pending write (nothing
+        # written at all, or the stream ended exactly on an interval boundary).
+        if pages_since_metadata_flush > 0:
             _flush_metadata(meta)
 
         cancelled = cancel is not None and cancel.is_set()
@@ -1090,21 +1059,3 @@ async def crawl_and_save(
     finally:
         if sem is not None:
             sem.release()
-
-
-def _filter_changed(results: list[CrawlResult]) -> list[CrawlResult]:
-    """Return only results whose content differs from the last crawl."""
-    meta = load_crawl_metadata()
-    web_dir = _web_dir()
-    changed: list[CrawlResult] = []
-    for r in results:
-        if not r.success or not r.markdown.strip():
-            continue
-        prev = meta.get(r.url)
-        file_path = web_dir / url_to_filename(r.url)
-        new_hash = content_hash(r.markdown)
-        if prev is not None and prev.content_hash == new_hash and file_path.exists():
-            log.info("Content unchanged, skipping save: %s", r.url)
-            continue
-        changed.append(r)
-    return changed

--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -283,6 +283,13 @@ _MAX_FILENAME_LEN = 200
 # Sentinel for index pages (trailing slash or empty path)
 _INDEX_FILENAME = "index.md"
 
+# Batch window for the crawl metadata JSON rewrite. Markdown files are written
+# per page (durable immediately); metadata is flushed every N pages, plus
+# unconditionally at the end of the crawl, so we don't rewrite the full JSON
+# on every streamed result. At 10 pages the worst-case data-loss window on
+# crash is 9 metadata entries, all recoverable from the written markdown.
+METADATA_FLUSH_INTERVAL = 10
+
 
 _BLOCKED_NETWORKS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
     ipaddress.ip_network("127.0.0.0/8"),
@@ -1020,19 +1027,26 @@ async def crawl_and_save(
         meta = load_crawl_metadata()
         written_paths: list[Path] = []
         pages_seen = 0
+        pages_since_metadata_flush = 0
 
         def flush_page(result: CrawlResult) -> Path | None:
-            """Save one streamed result to disk and persist metadata.
+            """Save one streamed result and update metadata in memory.
 
-            Metadata is flushed after every successful save. Rewriting the JSON
-            per page is cheap for typical crawls (100s of pages) and makes the
-            cancel path trivially correct: whatever is on disk is consistent.
+            Markdown files are always flushed per page (durable immediately).
+            Metadata JSON rewrite is batched to reduce I/O on large crawls:
+            it flushes every METADATA_FLUSH_INTERVAL pages, and the post-loop
+            block flushes unconditionally so both the success and cancel
+            paths land in a consistent state.
             """
+            nonlocal pages_since_metadata_flush
             path = _save_single_result(result, meta)
             if path is None:
                 return None
             _update_single_metadata(meta, result, datetime.now(UTC).isoformat())
-            _flush_metadata(meta)
+            pages_since_metadata_flush += 1
+            if pages_since_metadata_flush >= METADATA_FLUSH_INTERVAL:
+                _flush_metadata(meta)
+                pages_since_metadata_flush = 0
             written_paths.append(path)
             return path
 
@@ -1054,6 +1068,11 @@ async def crawl_and_save(
                 on_result=flush_page,
             )
             pages_seen = len(results)
+
+        # Final metadata flush covers both clean completion and cancel. Skip
+        # when nothing was written to avoid touching disk for no-op crawls.
+        if written_paths:
+            _flush_metadata(meta)
 
         cancelled = cancel is not None and cancel.is_set()
         if not cancelled:

--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -283,11 +283,9 @@ _MAX_FILENAME_LEN = 200
 # Sentinel for index pages (trailing slash or empty path)
 _INDEX_FILENAME = "index.md"
 
-# Batch window for the crawl metadata JSON rewrite. Markdown files are written
-# per page (durable immediately); metadata is flushed every N pages, plus
-# unconditionally at the end of the crawl, so we don't rewrite the full JSON
-# on every streamed result. At 10 pages the worst-case data-loss window on
-# crash is 9 metadata entries, all recoverable from the written markdown.
+# How often the crawl metadata JSON is rewritten during a streaming crawl.
+# Markdown files are durable per-page; metadata batches to keep write volume
+# bounded. Worst-case loss on crash is N-1 entries, recoverable from the files.
 METADATA_FLUSH_INTERVAL = 10
 
 
@@ -998,14 +996,7 @@ async def crawl_and_save(
         pages_since_metadata_flush = 0
 
         def flush_page(result: CrawlResult) -> Path | None:
-            """Save one streamed result and update metadata in memory.
-
-            Markdown files are always flushed per page (durable immediately).
-            Metadata JSON rewrite is batched to reduce I/O on large crawls:
-            it flushes every METADATA_FLUSH_INTERVAL pages, and the post-loop
-            block flushes unconditionally so both the success and cancel
-            paths land in a consistent state.
-            """
+            """Save one streamed result and update metadata in memory."""
             nonlocal pages_since_metadata_flush
             path = _save_single_result(result, meta)
             if path is None:
@@ -1024,9 +1015,6 @@ async def crawl_and_save(
             try:
                 flush_page(result)
             except OSError:
-                # Mirror the recursive path: a disk-side flush failure must not
-                # masquerade as a crawl failure. Log and return the (empty)
-                # written_paths list.
                 log.exception("Flush failed for %s", result.url)
             if on_progress:
                 on_progress(EventType.CRAWL_PAGE, CrawlPageEvent(url=url, current=1, total=1))
@@ -1043,23 +1031,14 @@ async def crawl_and_save(
             )
             pages_seen = len(results)
 
-        # Final metadata flush covers both clean completion and cancel. Skip
-        # when there are no in-memory entries still pending write (nothing
-        # written at all, or the stream ended exactly on an interval boundary).
         if pages_since_metadata_flush > 0:
             try:
                 _flush_metadata(meta)
             except OSError:
-                # Markdown files were already written durably per page; a
-                # failed final metadata flush is observable at next startup
-                # when load_crawl_metadata() loses the last batch of entries,
-                # but it should not fail a crawl that otherwise succeeded.
                 log.exception("Final metadata flush failed")
 
         cancelled = cancel is not None and cancel.is_set()
         if not cancelled:
-            # Partial crawls skip auto-sync: the client (plugin/TUI) decides
-            # whether to ingest a partial result set.
             await _maybe_periodic_sync()
 
         if on_progress:

--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -14,7 +14,7 @@ import socket
 import sys
 import threading
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -488,6 +488,47 @@ def update_metadata(results: list[CrawlResult]) -> None:
     save_crawl_metadata(meta)
 
 
+def _save_single_result(result: CrawlResult, meta: dict[str, CrawlMeta]) -> Path | None:
+    """Write one crawl result to disk if it's new or changed.
+
+    Per-page equivalent of _filter_changed + save_crawl_results for the streaming
+    flush path. Returns the written path, or None if skipped (failure, empty
+    markdown, unchanged hash with file on disk, or blocked by path traversal).
+    """
+    if not result.success or not result.markdown.strip():
+        return None
+    web_dir = _web_dir()
+    file_path = web_dir / url_to_filename(result.url)
+    new_hash = content_hash(result.markdown)
+    prev = meta.get(result.url)
+    if prev is not None and prev.content_hash == new_hash and file_path.exists():
+        log.info("Content unchanged, skipping save: %s", result.url)
+        return None
+    resolved_web_dir = web_dir.resolve()
+    try:
+        validate_path_within(file_path, resolved_web_dir)
+    except ValueError:
+        log.warning("Path traversal blocked: %s -> %s", result.url, file_path)
+        return None
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(result.markdown, encoding="utf-8")
+    return file_path
+
+
+def _update_single_metadata(meta: dict[str, CrawlMeta], result: CrawlResult, now: str) -> None:
+    """Update the metadata dict in place for one just-saved result."""
+    meta[result.url] = CrawlMeta(
+        file=url_to_filename(result.url),
+        content_hash=content_hash(result.markdown),
+        crawled_at=now,
+    )
+
+
+def _flush_metadata(meta: dict[str, CrawlMeta]) -> None:
+    """Persist the metadata dict atomically. Thin wrapper over save_crawl_metadata."""
+    save_crawl_metadata(meta)
+
+
 def _build_rate_limited_dispatcher() -> Any:
     """Build a SemaphoreDispatcher + RateLimiter from cfg, or None when disabled.
 
@@ -717,6 +758,7 @@ async def crawl_recursive(
     *,
     quiet: bool = False,
     include_subdomains: bool = False,
+    on_result: Callable[[CrawlResult], Path | None] | None = None,
 ) -> list[CrawlResult]:
     """Crawl a URL recursively using BFS, streaming per-page progress.
 
@@ -730,6 +772,10 @@ async def crawl_recursive(
     article doesn't wander into other language editions. Pass
     ``include_subdomains=True`` to broaden scope to the starting host plus any
     subdomains (e.g. ``en.wikipedia.org`` plus ``af.wikipedia.org``).
+
+    If *on_result* is provided, it's called for each streamed CrawlResult the
+    moment it arrives (before the next page yields). Callers use this to flush
+    pages to disk incrementally so a cancelled crawl keeps its partial output.
     """
     validate_crawl_url(url)
     depth = _resolve_limit(max_depth, cfg.crawl_max_depth)
@@ -804,15 +850,16 @@ async def crawl_recursive(
                             CrawlPageEvent(url=cr.url, current=counter, total=sitemap_total),
                         )
                     if cr.success:
-                        results.append(CrawlResult(url=cr.url, markdown=cr.markdown or ""))
+                        new_result = CrawlResult(url=cr.url, markdown=cr.markdown or "")
                     else:
-                        results.append(
-                            CrawlResult(
-                                url=cr.url,
-                                success=False,
-                                error=cr.error_message or "Unknown error",
-                            )
+                        new_result = CrawlResult(
+                            url=cr.url,
+                            success=False,
+                            error=cr.error_message or "Unknown error",
                         )
+                    results.append(new_result)
+                    if on_result is not None:
+                        on_result(new_result)
                     # Hard cap on visible progress. crawl4ai's BFS uses
                     # max_pages to count successful pages, so failed /
                     # redirected pages can push our per-result counter past
@@ -950,8 +997,9 @@ async def crawl_and_save(
     subdomains of the starting host.
 
     Uses hash-based change detection: always fetches, but only saves files
-    whose content has changed (or is new). When *cancel* is set, returns
-    early with an empty list.
+    whose content has changed (or is new). Pages are flushed to disk as they
+    stream so a cancelled crawl preserves the pages already fetched instead
+    of discarding them.
     """
     # Auto-bootstrap Chromium on first use so every crawl entry point works
     # on a fresh install without a separate setup step. bootstrap_chromium
@@ -969,9 +1017,29 @@ async def crawl_and_save(
             start_depth = depth if depth is not None else 0
             on_progress(EventType.CRAWL_START, CrawlStartEvent(url=url, depth=start_depth))
 
+        meta = load_crawl_metadata()
+        written_paths: list[Path] = []
+        pages_seen = 0
+
+        def flush_page(result: CrawlResult) -> Path | None:
+            """Save one streamed result to disk and persist metadata.
+
+            Metadata is flushed after every successful save. Rewriting the JSON
+            per page is cheap for typical crawls (100s of pages) and makes the
+            cancel path trivially correct: whatever is on disk is consistent.
+            """
+            path = _save_single_result(result, meta)
+            if path is None:
+                return None
+            _update_single_metadata(meta, result, datetime.now(UTC).isoformat())
+            _flush_metadata(meta)
+            written_paths.append(path)
+            return path
+
         if depth == 0:
             result = await crawl_single(url, quiet=quiet)
-            results = [result]
+            pages_seen = 1
+            flush_page(result)
             if on_progress:
                 on_progress(EventType.CRAWL_PAGE, CrawlPageEvent(url=url, current=1, total=1))
         else:
@@ -983,23 +1051,23 @@ async def crawl_and_save(
                 cancel=cancel,
                 quiet=quiet,
                 include_subdomains=include_subdomains,
+                on_result=flush_page,
             )
+            pages_seen = len(results)
 
-        if cancel and cancel.is_set():
-            return []
-
-        changed = _filter_changed(results)
-        paths = save_crawl_results(changed)
-        update_metadata(changed)
-        await _maybe_periodic_sync()
+        cancelled = cancel is not None and cancel.is_set()
+        if not cancelled:
+            # Partial crawls skip auto-sync: the client (plugin/TUI) decides
+            # whether to ingest a partial result set.
+            await _maybe_periodic_sync()
 
         if on_progress:
             on_progress(
                 EventType.CRAWL_DONE,
-                CrawlDoneEvent(pages_crawled=len(results), files_written=len(paths)),
+                CrawlDoneEvent(pages_crawled=pages_seen, files_written=len(written_paths)),
             )
 
-        return paths
+        return written_paths
     finally:
         if sem is not None:
             sem.release()

--- a/src/lilbee/crawler.py
+++ b/src/lilbee/crawler.py
@@ -1021,7 +1021,13 @@ async def crawl_and_save(
         if depth == 0:
             result = await crawl_single(url, quiet=quiet)
             pages_seen = 1
-            flush_page(result)
+            try:
+                flush_page(result)
+            except OSError:
+                # Mirror the recursive path: a disk-side flush failure must not
+                # masquerade as a crawl failure. Log and return the (empty)
+                # written_paths list.
+                log.exception("Flush failed for %s", result.url)
             if on_progress:
                 on_progress(EventType.CRAWL_PAGE, CrawlPageEvent(url=url, current=1, total=1))
         else:
@@ -1041,7 +1047,14 @@ async def crawl_and_save(
         # when there are no in-memory entries still pending write (nothing
         # written at all, or the stream ended exactly on an interval boundary).
         if pages_since_metadata_flush > 0:
-            _flush_metadata(meta)
+            try:
+                _flush_metadata(meta)
+            except OSError:
+                # Markdown files were already written durably per page; a
+                # failed final metadata flush is observable at next startup
+                # when load_crawl_metadata() loses the last batch of entries,
+                # but it should not fail a crawl that otherwise succeeded.
+                log.exception("Final metadata flush failed")
 
         cancelled = cancel is not None and cancel.is_set()
         if not cancelled:

--- a/tests/integration/test_crawl_integration.py
+++ b/tests/integration/test_crawl_integration.py
@@ -18,12 +18,7 @@ crawl4ai = pytest.importorskip("crawl4ai")
 from lilbee import crawler as crawler_mod  # noqa: E402
 from lilbee.config import cfg  # noqa: E402
 from lilbee.crawler import (  # noqa: E402
-    # `_save_single_result` is underscore-prefixed but used here deliberately:
-    # the path-traversal test below pins the helper's hash-check short-circuit
-    # behavior, which is NOT observable through the public crawl_and_save
-    # wrapper once upstream filtering runs. If this helper ever becomes a
-    # stable public API, drop the underscore; until then, accept the coupling.
-    _save_single_result,
+    _save_single_result,  # pins the helper directly; public wrapper hides it
     crawl_and_save,
     load_crawl_metadata,
     validate_crawl_url,

--- a/tests/integration/test_crawl_integration.py
+++ b/tests/integration/test_crawl_integration.py
@@ -18,9 +18,9 @@ crawl4ai = pytest.importorskip("crawl4ai")
 from lilbee import crawler as crawler_mod  # noqa: E402
 from lilbee.config import cfg  # noqa: E402
 from lilbee.crawler import (  # noqa: E402
+    _save_single_result,
     crawl_and_save,
     load_crawl_metadata,
-    save_crawl_results,
     validate_crawl_url,
 )
 from lilbee.progress import EventType  # noqa: E402
@@ -230,13 +230,14 @@ class TestSecurity:
 
     def test_path_traversal_contained(self, isolated_env):
         """Path traversal in URL stays contained within _web/."""
-        from lilbee.crawler import CrawlResult
+        from lilbee.crawler import CrawlMeta, CrawlResult
 
         result = CrawlResult(url="https://evil.com/../../etc/passwd", markdown="# Malicious")
-        paths = save_crawl_results([result])
+        meta: dict[str, CrawlMeta] = {}
+        path = _save_single_result(result, meta)
         web_dir = cfg.documents_dir / "_web"
-        for p in paths:
-            assert p.resolve().is_relative_to(web_dir.resolve())
+        if path is not None:
+            assert path.resolve().is_relative_to(web_dir.resolve())
 
     async def test_max_pages_enforced(self, httpserver, allow_localhost):
         """Max pages config caps the crawl."""

--- a/tests/integration/test_crawl_integration.py
+++ b/tests/integration/test_crawl_integration.py
@@ -236,8 +236,12 @@ class TestSecurity:
         meta: dict[str, CrawlMeta] = {}
         path = _save_single_result(result, meta)
         web_dir = cfg.documents_dir / "_web"
-        if path is not None:
-            assert path.resolve().is_relative_to(web_dir.resolve())
+        # url_to_filename neutralizes ".." segments, so the result MUST be a
+        # concrete path under _web/. A None return would indicate the helper
+        # started rejecting the request at the hash/exists short-circuit, which
+        # is the class of refactor we want to catch.
+        assert path is not None
+        assert path.resolve().is_relative_to(web_dir.resolve())
 
     async def test_max_pages_enforced(self, httpserver, allow_localhost):
         """Max pages config caps the crawl."""

--- a/tests/integration/test_crawl_integration.py
+++ b/tests/integration/test_crawl_integration.py
@@ -18,6 +18,11 @@ crawl4ai = pytest.importorskip("crawl4ai")
 from lilbee import crawler as crawler_mod  # noqa: E402
 from lilbee.config import cfg  # noqa: E402
 from lilbee.crawler import (  # noqa: E402
+    # `_save_single_result` is underscore-prefixed but used here deliberately:
+    # the path-traversal test below pins the helper's hash-check short-circuit
+    # behavior, which is NOT observable through the public crawl_and_save
+    # wrapper once upstream filtering runs. If this helper ever becomes a
+    # stable public API, drop the underscore; until then, accept the coupling.
     _save_single_result,
     crawl_and_save,
     load_crawl_metadata,

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2123,7 +2123,14 @@ class TestStreamingFlush:
     async def test_depth_zero_flush_failure_does_not_fail_the_crawl(
         self, mock_crawl_single, isolated_env
     ):
-        """OSError from flush on the single-URL path is logged, not reraised."""
+        """OSError from flush on the single-URL path is logged, not reraised.
+
+        At depth=0 only `_save_single_result` can raise OSError in flush_page
+        (the interval-based metadata flush is unreachable with just one page),
+        so `paths == []` reliably means "the page was never written". If a
+        future change moves `written_paths.append` before the write, update
+        this test to explicitly mock the failing helper.
+        """
         mock_crawl_single.return_value = CrawlResult(
             url="https://example.com/only", markdown="# Only"
         )

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import lilbee.crawler as lilbee_crawler
 from lilbee.config import cfg
 from lilbee.crawler import (
     CrawlMeta,
@@ -1140,10 +1141,20 @@ class TestCrawlAndSave:
 
     @patch("lilbee.crawler.crawl_recursive")
     async def test_recursive(self, mock_crawl_recursive, isolated_env):
-        mock_crawl_recursive.return_value = [
+        streamed = [
             CrawlResult(url="https://example.com", markdown="# Home"),
             CrawlResult(url="https://example.com/about", markdown="# About"),
         ]
+
+        async def _fake_recursive(*args, on_result=None, **kwargs):
+            # Mimic the real streaming contract: invoke the flush callback
+            # per-page before returning the full list.
+            if on_result is not None:
+                for r in streamed:
+                    on_result(r)
+            return streamed
+
+        mock_crawl_recursive.side_effect = _fake_recursive
         paths = await crawl_and_save("https://example.com", depth=2, max_pages=10)
         assert len(paths) == 2
 
@@ -1289,15 +1300,21 @@ class TestCrawlAndSave:
         crawler_mod._state.semaphore = None
 
     @patch("lilbee.crawler.crawl_single")
-    async def test_cancel_returns_empty(self, mock_crawl_single, isolated_env):
-        """Setting cancel event causes crawl_and_save to return empty list."""
+    async def test_cancel_keeps_fetched_page(self, mock_crawl_single, isolated_env):
+        """A single-URL crawl that gets cancelled still keeps the page it fetched.
+
+        The new streaming-flush contract: anything already on disk stays on
+        disk. For depth=0, crawl_single has already run by the time cancel is
+        observed, so the page is flushed and returned.
+        """
         import threading
 
         mock_crawl_single.return_value = CrawlResult(url="https://example.com", markdown="# Hello")
         cancel = threading.Event()
         cancel.set()
         paths = await crawl_and_save("https://example.com", depth=0, cancel=cancel)
-        assert paths == []
+        assert len(paths) == 1
+        assert paths[0].exists()
 
 
 class TestPeriodicSync:
@@ -1768,3 +1785,391 @@ class TestCrawlDispatcher:
             crawler = _LilbeeAsyncCrawler(verbose=False, dispatcher="DEFAULT")
             await crawler.arun_many(["u"], dispatcher="EXPLICIT")
         inner.arun_many.assert_awaited_once_with(["u"], config=None, dispatcher="EXPLICIT")
+
+
+class TestSaveSingleResult:
+    """Unit tests for _save_single_result (per-page flush helper)."""
+
+    def test_writes_new_content(self, isolated_env):
+        from lilbee.crawler import _save_single_result
+
+        meta: dict = {}
+        result = CrawlResult(url="https://example.com/new", markdown="# New")
+        path = _save_single_result(result, meta)
+        assert path is not None
+        assert path.exists()
+        assert path.read_text(encoding="utf-8") == "# New"
+
+    def test_returns_none_on_failure(self, isolated_env):
+        from lilbee.crawler import _save_single_result
+
+        result = CrawlResult(url="https://example.com/fail", success=False, error="oops")
+        assert _save_single_result(result, {}) is None
+
+    def test_returns_none_on_empty_markdown(self, isolated_env):
+        from lilbee.crawler import _save_single_result
+
+        result = CrawlResult(url="https://example.com/empty", markdown="   ")
+        assert _save_single_result(result, {}) is None
+
+    def test_hash_match_with_file_present_skips(self, isolated_env):
+        """Prev metadata hash matches AND file exists -> skip."""
+        from lilbee.crawler import _save_single_result
+
+        url = "https://example.com/dup"
+        markdown = "# Dup"
+        # Write the file and seed metadata
+        initial = CrawlResult(url=url, markdown=markdown)
+        meta: dict = {}
+        first_path = _save_single_result(initial, meta)
+        assert first_path is not None
+        meta[url] = CrawlMeta(
+            file=str(first_path.relative_to(cfg.documents_dir / "_web")),
+            content_hash=content_hash(markdown),
+            crawled_at="2026-01-01T00:00:00+00:00",
+        )
+        # Identical content on re-save returns None
+        again = CrawlResult(url=url, markdown=markdown)
+        assert _save_single_result(again, meta) is None
+
+    def test_hash_match_with_missing_file_rewrites(self, isolated_env):
+        """Prev metadata hash matches but file was deleted -> re-write."""
+        from lilbee.crawler import _save_single_result
+
+        url = "https://example.com/gone"
+        markdown = "# Gone"
+        meta: dict = {
+            url: CrawlMeta(
+                file="example.com/gone/index.md",
+                content_hash=content_hash(markdown),
+                crawled_at="2026-01-01T00:00:00+00:00",
+            )
+        }
+        # File does not exist yet
+        result = CrawlResult(url=url, markdown=markdown)
+        path = _save_single_result(result, meta)
+        assert path is not None
+        assert path.exists()
+
+    def test_path_traversal_blocked(self, isolated_env):
+        """A crafted filename escaping _web/ is skipped with a warning."""
+        from lilbee.crawler import _save_single_result
+
+        result = CrawlResult(url="https://evil.com/ok", markdown="# Evil")
+        with patch("lilbee.crawler.url_to_filename", return_value="../../etc/passwd"):
+            path = _save_single_result(result, {})
+        assert path is None
+
+
+class TestUpdateSingleMetadata:
+    def test_updates_in_place(self):
+        """Helper mutates the dict in place with the expected shape."""
+        from lilbee.crawler import _update_single_metadata
+
+        meta: dict = {}
+        result = CrawlResult(url="https://example.com/p", markdown="# P")
+        now = "2026-04-20T00:00:00+00:00"
+        _update_single_metadata(meta, result, now)
+        assert "https://example.com/p" in meta
+        entry = meta["https://example.com/p"]
+        assert entry.crawled_at == now
+        assert entry.content_hash == content_hash("# P")
+        assert entry.file == "example.com/p/index.md"
+
+
+class TestFlushMetadata:
+    def test_atomic_write_leaves_no_tmp(self, isolated_env):
+        """_flush_metadata writes the file and cleans up the temp file."""
+        from lilbee.crawler import _flush_metadata
+
+        meta = {
+            "https://example.com": CrawlMeta(
+                file="example.com/index.md",
+                content_hash="abc",
+                crawled_at="2026-04-20T00:00:00+00:00",
+            )
+        }
+        _flush_metadata(meta)
+        assert (cfg.data_dir / "crawl_meta.json").exists()
+        # No tmp files remain in data_dir
+        leftover = list(cfg.data_dir.glob("*.tmp"))
+        assert leftover == []
+
+    def test_failed_rename_cleans_up_tmp(self, isolated_env):
+        """If rename fails mid-write, the tmp file is removed and the error bubbles up."""
+        from lilbee.crawler import _flush_metadata
+
+        meta = {
+            "https://example.com": CrawlMeta(
+                file="example.com/index.md",
+                content_hash="abc",
+                crawled_at="2026-04-20T00:00:00+00:00",
+            )
+        }
+        with (
+            patch("lilbee.crawler.Path.replace", side_effect=OSError("boom")),
+            pytest.raises(OSError, match="boom"),
+        ):
+            _flush_metadata(meta)
+        # No half-written tmp files
+        leftover = list(cfg.data_dir.glob("*.tmp"))
+        assert leftover == []
+
+
+class TestStreamingFlush:
+    """End-to-end tests for the per-page flush contract in crawl_and_save."""
+
+    def _setup_crawl4ai(self, mock_instance):
+        mock_crawler_cls = MagicMock(return_value=mock_instance)
+        mock_mod = _mock_crawl4ai(mock_crawler_cls)
+        mock_deep = MagicMock()
+        mock_deep.BFSDeepCrawlStrategy = MagicMock()
+        mock_dispatcher_mod = MagicMock()
+        mock_dispatcher_mod.RateLimiter = MagicMock()
+        mock_dispatcher_mod.SemaphoreDispatcher = MagicMock()
+        mock_filters_mod = MagicMock()
+        mock_filters_mod.FilterChain = MagicMock()
+        mock_filters_mod.URLPatternFilter = MagicMock()
+        return {
+            "crawl4ai": mock_mod,
+            "crawl4ai.deep_crawling": mock_deep,
+            "crawl4ai.deep_crawling.filters": mock_filters_mod,
+            "crawl4ai.async_dispatcher": mock_dispatcher_mod,
+        }
+
+    async def test_cancel_preserves_written_pages(self, isolated_env):
+        """A cancelled recursive crawl keeps the pages it already streamed."""
+        import asyncio as _asyncio
+        import threading
+
+        cancel = threading.Event()
+
+        async def _gen():
+            yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# P1")
+            await _asyncio.sleep(0)
+            yield _make_crawl4ai_result(url="https://example.com/p2", markdown="# P2")
+            cancel.set()
+            await _asyncio.sleep(0)
+            yield _make_crawl4ai_result(url="https://example.com/p3", markdown="# P3")
+            yield _make_crawl4ai_result(url="https://example.com/p4", markdown="# P4")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)):
+            paths = await crawl_and_save(
+                "https://example.com", depth=2, max_pages=10, cancel=cancel
+            )
+
+        # At least p1 and p2 were flushed before cancel stopped the stream.
+        assert len(paths) >= 2
+        for p in paths:
+            assert p.exists()
+        # Metadata reflects what's on disk.
+        meta = load_crawl_metadata()
+        written_urls = {
+            f"https://example.com/p{i}"
+            for i in range(1, 5)
+            if (cfg.documents_dir / "_web" / f"example.com/p{i}/index.md").exists()
+        }
+        for url in written_urls:
+            assert url in meta
+
+    async def test_flushes_per_page_not_batched(self, isolated_env):
+        """_save_single_result is invoked once per streamed page inside the loop."""
+        import asyncio as _asyncio
+
+        call_order: list[str] = []
+
+        async def _gen():
+            for i in range(1, 4):
+                call_order.append(f"yield-{i}")
+                await _asyncio.sleep(0)
+                yield _make_crawl4ai_result(url=f"https://example.com/p{i}", markdown=f"# P{i}")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        real_save = lilbee_crawler._save_single_result
+
+        def _wrapped(result, meta):
+            call_order.append(f"flush-{result.url.rsplit('/', 1)[-1]}")
+            return real_save(result, meta)
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch("lilbee.crawler._save_single_result", side_effect=_wrapped),
+        ):
+            await crawl_and_save("https://example.com", depth=2, max_pages=10)
+
+        # Each yield is followed by its own flush before the next yield starts.
+        assert call_order == [
+            "yield-1",
+            "flush-p1",
+            "yield-2",
+            "flush-p2",
+            "yield-3",
+            "flush-p3",
+        ]
+
+    async def test_skips_unchanged_per_page(self, isolated_env):
+        """Per-page flush skips URLs whose hash matches prior metadata."""
+        import asyncio as _asyncio
+
+        # Pre-seed: p1 was crawled last time with this exact content.
+        seed = CrawlResult(url="https://example.com/p1", markdown="# Same")
+        save_crawl_results([seed])
+        update_metadata([seed])
+
+        async def _gen():
+            yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# Same")
+            await _asyncio.sleep(0)
+            yield _make_crawl4ai_result(url="https://example.com/p2", markdown="# NewPage")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)):
+            paths = await crawl_and_save("https://example.com", depth=2, max_pages=10)
+
+        # p1 is skipped (unchanged), p2 is written.
+        assert len(paths) == 1
+        assert paths[0].name == "index.md"
+        assert paths[0].read_text(encoding="utf-8") == "# NewPage"
+
+    @patch("lilbee.crawler.crawl_single")
+    async def test_single_url_flushes_via_per_page_path(self, mock_crawl_single, isolated_env):
+        """depth=0 uses the same flush_page callback, not the old batch helpers."""
+        mock_crawl_single.return_value = CrawlResult(
+            url="https://example.com/only", markdown="# Only"
+        )
+        with patch(
+            "lilbee.crawler._save_single_result", wraps=lilbee_crawler._save_single_result
+        ) as spy:
+            paths = await crawl_and_save("https://example.com/only", depth=0)
+        assert len(paths) == 1
+        spy.assert_called_once()
+        # Metadata written by the per-page path
+        meta = load_crawl_metadata()
+        assert "https://example.com/only" in meta
+
+    async def test_full_success_matches_prior_behavior(self, isolated_env):
+        """With no cancel, a full successful crawl produces the same on-disk result."""
+        import asyncio as _asyncio
+
+        urls_and_content = [
+            ("https://example.com/a", "# A"),
+            ("https://example.com/b", "# B"),
+            ("https://example.com/c", "# C"),
+        ]
+
+        async def _gen():
+            for url, md in urls_and_content:
+                await _asyncio.sleep(0)
+                yield _make_crawl4ai_result(url=url, markdown=md)
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)):
+            paths = await crawl_and_save("https://example.com", depth=2, max_pages=10)
+
+        assert len(paths) == 3
+        contents = {p.read_text(encoding="utf-8") for p in paths}
+        assert contents == {"# A", "# B", "# C"}
+
+        meta = load_crawl_metadata()
+        for url, md in urls_and_content:
+            assert url in meta
+            assert meta[url].content_hash == content_hash(md)
+
+    async def test_cancel_does_not_trigger_auto_sync(self, isolated_env):
+        """On cancel, _maybe_periodic_sync is NOT awaited."""
+        import asyncio as _asyncio
+        import threading
+
+        cancel = threading.Event()
+
+        async def _gen():
+            yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# P1")
+            cancel.set()
+            await _asyncio.sleep(0)
+            yield _make_crawl4ai_result(url="https://example.com/p2", markdown="# P2")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch("lilbee.crawler._maybe_periodic_sync", new_callable=AsyncMock) as mock_sync,
+        ):
+            await crawl_and_save("https://example.com", depth=2, max_pages=10, cancel=cancel)
+        mock_sync.assert_not_awaited()
+
+    async def test_success_triggers_auto_sync(self, isolated_env):
+        """On a clean (non-cancelled) crawl, _maybe_periodic_sync IS awaited."""
+        import asyncio as _asyncio
+
+        async def _gen():
+            await _asyncio.sleep(0)
+            yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# P1")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch("lilbee.crawler._maybe_periodic_sync", new_callable=AsyncMock) as mock_sync,
+        ):
+            await crawl_and_save("https://example.com", depth=2, max_pages=10)
+        mock_sync.assert_awaited_once()
+
+    async def test_done_event_reports_partial_counts_on_cancel(self, isolated_env):
+        """CRAWL_DONE fires even on cancel and reports what was actually flushed."""
+        import asyncio as _asyncio
+        import threading
+
+        cancel = threading.Event()
+
+        async def _gen():
+            yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# P1")
+            cancel.set()
+            await _asyncio.sleep(0)
+            yield _make_crawl4ai_result(url="https://example.com/p2", markdown="# P2")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        done_events: list = []
+
+        def on_progress(event_type, data):
+            if event_type == EventType.CRAWL_DONE:
+                done_events.append(data)
+
+        with patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)):
+            paths = await crawl_and_save(
+                "https://example.com",
+                depth=2,
+                max_pages=10,
+                cancel=cancel,
+                on_progress=on_progress,
+            )
+
+        assert len(done_events) == 1
+        evt = done_events[0]
+        assert evt.files_written == len(paths)
+        assert evt.files_written >= 1

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -12,9 +12,10 @@ from lilbee.config import cfg
 from lilbee.crawler import (
     CrawlMeta,
     CrawlResult,
-    _filter_changed,
     _get_crawl_semaphore,
     _maybe_periodic_sync,
+    _save_single_result,
+    _update_single_metadata,
     content_hash,
     crawl_and_save,
     crawl_recursive,
@@ -23,8 +24,6 @@ from lilbee.crawler import (
     load_crawl_metadata,
     require_valid_crawl_url,
     save_crawl_metadata,
-    save_crawl_results,
-    update_metadata,
     url_to_filename,
     validate_crawl_url,
 )
@@ -114,60 +113,6 @@ class TestUrlToFilename:
         assert ".." not in result
 
 
-class TestSaveCrawlResults:
-    def test_saves_successful_results(self, isolated_env):
-        results = [
-            CrawlResult(url="https://example.com/page1", markdown="# Page 1\nContent"),
-            CrawlResult(url="https://example.com/page2", markdown="# Page 2\nMore content"),
-        ]
-        paths = save_crawl_results(results)
-        assert len(paths) == 2
-        for p in paths:
-            assert p.exists()
-            assert p.suffix == ".md"
-
-    def test_skips_failed_results(self, isolated_env):
-        results = [
-            CrawlResult(url="https://example.com/ok", markdown="# OK"),
-            CrawlResult(url="https://example.com/fail", success=False, error="404"),
-        ]
-        paths = save_crawl_results(results)
-        assert len(paths) == 1
-
-    def test_skips_empty_markdown(self, isolated_env):
-        results = [
-            CrawlResult(url="https://example.com/empty", markdown="   "),
-        ]
-        paths = save_crawl_results(results)
-        assert len(paths) == 0
-
-    def test_creates_nested_dirs(self, isolated_env):
-        results = [
-            CrawlResult(url="https://docs.example.com/a/b/c/page.html", markdown="# Deep"),
-        ]
-        paths = save_crawl_results(results)
-        assert len(paths) == 1
-        assert "docs.example.com" in str(paths[0])
-
-    def test_content_written_correctly(self, isolated_env):
-        content = "# Hello\n\nThis is a test page."
-        results = [CrawlResult(url="https://example.com/test", markdown=content)]
-        paths = save_crawl_results(results)
-        assert paths[0].read_text(encoding="utf-8") == content
-
-    def test_path_traversal_blocked(self, isolated_env):
-        """Symlinks or crafted filenames that escape _web/ are skipped."""
-        results = [
-            CrawlResult(url="https://evil.com/../../etc/passwd", markdown="# Malicious"),
-        ]
-        paths = save_crawl_results(results)
-        # File is saved because url_to_filename neutralizes .., but let's verify
-        # the containment check itself by mocking url_to_filename
-        with patch("lilbee.crawler.url_to_filename", return_value="../../etc/passwd"):
-            paths = save_crawl_results(results)
-        assert paths == []
-
-
 class TestCrawlMetadata:
     def test_load_empty(self, isolated_env):
         meta = load_crawl_metadata()
@@ -218,16 +163,6 @@ class TestCrawlMetadata:
         tmp_path = cfg.data_dir / "crawl_meta.tmp"
         assert not tmp_path.exists()
 
-    def test_update_metadata(self, isolated_env):
-        results = [
-            CrawlResult(url="https://example.com/p1", markdown="Content 1"),
-            CrawlResult(url="https://example.com/p2", success=False, error="oops"),
-        ]
-        update_metadata(results)
-        meta = load_crawl_metadata()
-        assert "https://example.com/p1" in meta
-        assert "https://example.com/p2" not in meta
-
 
 class TestContentHash:
     def test_consistent(self):
@@ -235,48 +170,6 @@ class TestContentHash:
 
     def test_different_for_different_content(self):
         assert content_hash("hello") != content_hash("world")
-
-
-class TestFilterChanged:
-    def test_new_url_passes_through(self, isolated_env):
-        results = [CrawlResult(url="https://example.com/new", markdown="# New")]
-        changed = _filter_changed(results)
-        assert len(changed) == 1
-
-    def test_unchanged_content_filtered(self, isolated_env):
-        """When metadata hash matches and file exists, result is filtered out."""
-        result = CrawlResult(url="https://example.com/same", markdown="# Same")
-        # Save first, then update metadata
-        save_crawl_results([result])
-        update_metadata([result])
-        changed = _filter_changed([result])
-        assert changed == []
-
-    def test_changed_content_passes_through(self, isolated_env):
-        """When content hash differs, result passes through."""
-        original = CrawlResult(url="https://example.com/page", markdown="# Original")
-        save_crawl_results([original])
-        update_metadata([original])
-        updated = CrawlResult(url="https://example.com/page", markdown="# Updated")
-        changed = _filter_changed([updated])
-        assert len(changed) == 1
-
-    def test_missing_file_passes_through(self, isolated_env):
-        """If metadata exists but file was deleted, re-save."""
-        result = CrawlResult(url="https://example.com/gone", markdown="# Gone")
-        update_metadata([result])  # metadata exists but file does not
-        changed = _filter_changed([result])
-        assert len(changed) == 1
-
-    def test_failed_results_filtered(self, isolated_env):
-        results = [CrawlResult(url="https://example.com/fail", success=False, error="404")]
-        changed = _filter_changed(results)
-        assert changed == []
-
-    def test_empty_markdown_filtered(self, isolated_env):
-        results = [CrawlResult(url="https://example.com/empty", markdown="   ")]
-        changed = _filter_changed(results)
-        assert changed == []
 
 
 def _make_crawl4ai_result(url="https://example.com", markdown="# Test", success=True, error=None):
@@ -2021,9 +1914,16 @@ class TestStreamingFlush:
         import asyncio as _asyncio
 
         # Pre-seed: p1 was crawled last time with this exact content.
+        from datetime import UTC as _UTC
+        from datetime import datetime as _datetime
+
+        from lilbee.crawler import _flush_metadata
+
         seed = CrawlResult(url="https://example.com/p1", markdown="# Same")
-        save_crawl_results([seed])
-        update_metadata([seed])
+        seed_meta: dict[str, CrawlMeta] = {}
+        _save_single_result(seed, seed_meta)
+        _update_single_metadata(seed_meta, seed, _datetime.now(_UTC).isoformat())
+        _flush_metadata(seed_meta)
 
         async def _gen():
             yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# Same")
@@ -2162,6 +2062,62 @@ class TestStreamingFlush:
 
         # One flush at the interval boundary + one final flush after the loop.
         assert mock_flush.call_count == 2
+
+    async def test_exact_interval_boundary_does_not_double_flush(self, isolated_env):
+        """Ending on an exact METADATA_FLUSH_INTERVAL boundary runs one flush, not two."""
+        import asyncio as _asyncio
+
+        from lilbee.crawler import METADATA_FLUSH_INTERVAL
+
+        async def _gen():
+            for i in range(1, METADATA_FLUSH_INTERVAL + 1):
+                await _asyncio.sleep(0)
+                yield _make_crawl4ai_result(url=f"https://example.com/p{i}", markdown=f"# P{i}")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch("lilbee.crawler._flush_metadata") as mock_flush,
+        ):
+            await crawl_and_save("https://example.com", depth=2, max_pages=METADATA_FLUSH_INTERVAL)
+
+        # Interval boundary triggers the only flush; post-loop skipped because
+        # no entries remain pending after the counter reset.
+        assert mock_flush.call_count == 1
+
+    async def test_flush_callback_failure_does_not_fail_the_crawl(self, isolated_env):
+        """An OSError from the flush callback is logged, not reraised as a crawl error."""
+        import asyncio as _asyncio
+
+        async def _gen():
+            for i in range(1, 3):
+                await _asyncio.sleep(0)
+                yield _make_crawl4ai_result(url=f"https://example.com/p{i}", markdown=f"# P{i}")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        call_count = {"n": 0}
+
+        def failing_save(result, meta):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise OSError("disk full")
+            return None  # second page falls through unchanged
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch("lilbee.crawler._save_single_result", side_effect=failing_save),
+        ):
+            # Must not raise even though the first page write fails.
+            paths = await crawl_and_save("https://example.com", depth=2, max_pages=10)
+        assert paths == []
 
     async def test_final_metadata_flush_fires_on_cancel(self, isolated_env):
         """Cancel still produces a final metadata flush so on-disk state stays consistent."""

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2123,14 +2123,7 @@ class TestStreamingFlush:
     async def test_depth_zero_flush_failure_does_not_fail_the_crawl(
         self, mock_crawl_single, isolated_env
     ):
-        """OSError from flush on the single-URL path is logged, not reraised.
-
-        At depth=0 only `_save_single_result` can raise OSError in flush_page
-        (the interval-based metadata flush is unreachable with just one page),
-        so `paths == []` reliably means "the page was never written". If a
-        future change moves `written_paths.append` before the write, update
-        this test to explicitly mock the failing helper.
-        """
+        """OSError from flush on the single-URL path is logged, not reraised."""
         mock_crawl_single.return_value = CrawlResult(
             url="https://example.com/only", markdown="# Only"
         )

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2119,6 +2119,52 @@ class TestStreamingFlush:
             paths = await crawl_and_save("https://example.com", depth=2, max_pages=10)
         assert paths == []
 
+    @patch("lilbee.crawler.crawl_single")
+    async def test_depth_zero_flush_failure_does_not_fail_the_crawl(
+        self, mock_crawl_single, isolated_env
+    ):
+        """OSError from flush on the single-URL path is logged, not reraised."""
+        mock_crawl_single.return_value = CrawlResult(
+            url="https://example.com/only", markdown="# Only"
+        )
+        with patch("lilbee.crawler._save_single_result", side_effect=OSError("disk full")):
+            # Must not raise even though the depth=0 flush fails.
+            paths = await crawl_and_save("https://example.com/only", depth=0)
+        assert paths == []
+
+    async def test_final_flush_failure_does_not_fail_the_crawl(self, isolated_env):
+        """OSError from the post-loop metadata flush is logged, not reraised."""
+        import asyncio as _asyncio
+
+        async def _gen():
+            yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# P1")
+            await _asyncio.sleep(0)
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        real_flush = lilbee_crawler._flush_metadata
+        call_count = {"n": 0}
+
+        def flush_or_fail(meta):
+            call_count["n"] += 1
+            # Let interval-boundary flushes succeed; fail only the post-loop flush.
+            if call_count["n"] == 1 and len(meta) >= 1:
+                raise OSError("disk full")
+            real_flush(meta)
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch("lilbee.crawler._flush_metadata", side_effect=flush_or_fail),
+        ):
+            # Markdown was already written durably; the final flush must not
+            # reraise since the caller has already consumed the stream.
+            paths = await crawl_and_save("https://example.com", depth=2, max_pages=10)
+        assert len(paths) == 1
+        assert paths[0].exists()
+
     async def test_final_metadata_flush_fires_on_cancel(self, isolated_env):
         """Cancel still produces a final metadata flush so on-disk state stays consistent."""
         import asyncio as _asyncio

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2136,6 +2136,86 @@ class TestStreamingFlush:
             await crawl_and_save("https://example.com", depth=2, max_pages=10)
         mock_sync.assert_awaited_once()
 
+    async def test_metadata_flush_is_batched(self, isolated_env):
+        """_flush_metadata fires every METADATA_FLUSH_INTERVAL pages, not every page."""
+        import asyncio as _asyncio
+
+        from lilbee.crawler import METADATA_FLUSH_INTERVAL
+
+        total_pages = METADATA_FLUSH_INTERVAL + 3
+
+        async def _gen():
+            for i in range(1, total_pages + 1):
+                await _asyncio.sleep(0)
+                yield _make_crawl4ai_result(url=f"https://example.com/p{i}", markdown=f"# P{i}")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch("lilbee.crawler._flush_metadata") as mock_flush,
+        ):
+            await crawl_and_save("https://example.com", depth=2, max_pages=total_pages)
+
+        # One flush at the interval boundary + one final flush after the loop.
+        assert mock_flush.call_count == 2
+
+    async def test_final_metadata_flush_fires_on_cancel(self, isolated_env):
+        """Cancel still produces a final metadata flush so on-disk state stays consistent."""
+        import asyncio as _asyncio
+        import threading
+
+        cancel = threading.Event()
+
+        async def _gen():
+            yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# P1")
+            cancel.set()
+            await _asyncio.sleep(0)
+            yield _make_crawl4ai_result(url="https://example.com/p2", markdown="# P2")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch(
+                "lilbee.crawler._flush_metadata", wraps=lilbee_crawler._flush_metadata
+            ) as spy_flush,
+        ):
+            await crawl_and_save("https://example.com", depth=2, max_pages=10, cancel=cancel)
+
+        # One page written, below the interval, so the only flush is the final one.
+        assert spy_flush.call_count == 1
+        meta = load_crawl_metadata()
+        assert "https://example.com/p1" in meta
+
+    async def test_no_final_flush_when_nothing_written(self, isolated_env):
+        """If zero pages were flushed, the post-loop metadata write is skipped."""
+        import asyncio as _asyncio
+
+        async def _gen():
+            await _asyncio.sleep(0)
+            # Empty markdown is skipped by _save_single_result
+            yield _make_crawl4ai_result(url="https://example.com/empty", markdown="")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch("lilbee.crawler._flush_metadata") as mock_flush,
+        ):
+            paths = await crawl_and_save("https://example.com", depth=2, max_pages=10)
+        assert paths == []
+        mock_flush.assert_not_called()
+
     async def test_done_event_reports_partial_counts_on_cancel(self, isolated_env):
         """CRAWL_DONE fires even on cancel and reports what was actually flushed."""
         import asyncio as _asyncio


### PR DESCRIPTION
## What changed

- Pages land on disk as they stream instead of being buffered in memory until the whole crawl finishes.
- Cancelling a crawl mid-way keeps whatever was already downloaded, so the partial set can be ingested instead of thrown away.

## Why

Recursive crawls routinely pull hundreds of pages. Previously, cancelling a crawl discarded everything fetched so far, and any hash-based change detection was also lost. With streaming flush, a partial crawl is immediately useful: files are on disk, metadata is recorded, and auto-sync still knows which pages it already has.