### PR TITLE
Add GET /api/config/defaults endpoint

### DIFF
--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -22,6 +22,7 @@ from lilbee.server.routes.documents import (
     sync_route,
 )
 from lilbee.server.routes.general import (
+    config_defaults_route,
     config_route,
     config_update_route,
     health_route,
@@ -104,6 +105,7 @@ def create_app() -> Litestar:
             health_route,
             status_route,
             config_route,
+            config_defaults_route,
             config_update_route,
             search_route,
             ask_route,

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Literal, Union, cast, get_args, get_origi
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 
 from lilbee import settings
 from lilbee.cli.helpers import clean_result, copy_files, gather_status, get_version
@@ -616,6 +617,25 @@ async def get_config() -> ConfigResponse:
         result["reranker_model"] = dumped["reranker_model"]
         result["rerank_candidates"] = dumped["rerank_candidates"]
     return ConfigResponse(**result)
+
+
+async def get_config_defaults() -> ConfigResponse:
+    """Return canonical defaults for every writable, public config field.
+
+    Used by plugin/TUI reset-to-default affordances so clients never need to
+    hardcode defaults locally.
+    """
+    defaults: dict[str, Any] = {}
+    for name, info in Config.model_fields.items():
+        if name not in WRITABLE_CONFIG_FIELDS or name not in _PUBLIC_CONFIG_FIELDS:
+            continue
+        if info.default_factory is not None:
+            defaults[name] = info.default_factory()
+            continue
+        if info.default is PydanticUndefined:
+            continue
+        defaults[name] = info.default
+    return ConfigResponse(**defaults)
 
 
 async def models_show(model: str) -> ModelsShowResponse:

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -38,6 +38,13 @@ async def config_route() -> ConfigResponse:
     return await handlers.get_config()
 
 
+@get("/api/config/defaults")
+@read_only
+async def config_defaults_route() -> ConfigResponse:
+    """Return canonical defaults for every writable, public configuration field."""
+    return await handlers.get_config_defaults()
+
+
 @patch("/api/config")
 async def config_update_route(data: dict[str, Any]) -> ConfigUpdateResponse:
     """Partial update of writable configuration fields."""

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -328,6 +328,25 @@ class TestConfigRoute:
         assert "system_prompt" in resp.json()
 
 
+class TestConfigDefaultsRoute:
+    def test_returns_writable_defaults(self, client):
+        from lilbee.config import DEFAULT_CRAWL_EXCLUDE_PATTERNS
+
+        resp = client.get("/api/config/defaults")
+        assert resp.status_code == 200
+        data = resp.json()
+        # Scalar defaults present.
+        assert data["chunk_size"] == 512
+        assert data["top_k"] == 10
+        # Nullable defaults come through as null.
+        assert data["crawl_max_depth"] is None
+        assert data["crawl_max_pages"] is None
+        # default_factory fields come through as their evaluated list.
+        assert data["crawl_exclude_patterns"] == list(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
+        # Non-writable/non-public fields are not exposed.
+        assert "chat_model" not in data
+
+
 class TestConfigUpdateRoute:
     @mock.patch(
         "lilbee.server.handlers.update_config",


### PR DESCRIPTION
## New endpoint

Adds `GET /api/config/defaults`: same shape as `/api/config`, but populated with canonical field defaults rather than current values. Sized to unblock tobocop2/obsidian-lilbee#42, which surfaces per-setting reset-to-default affordances in the Obsidian plugin.

## Response shape

Nullable fields come through as `null`; list-factory fields (`crawl_exclude_patterns`) as their full default list. Non-writable and credential-like fields are excluded.
