### PR TITLE
TUI Settings: Collapsible list editor for crawl_exclude_patterns

### DIFF
--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -15,6 +15,7 @@ class RenderStyle(StrEnum):
 
     COMPACT = "compact"
     FULL = "full"
+    LIST_COLLAPSED = "list_collapsed"
 
 
 @dataclass(frozen=True)
@@ -266,6 +267,16 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         nullable=False,
         group="Crawling",
         help_text="Retry count per URL when a rate-limit code comes back",
+    ),
+    "crawl_exclude_patterns": SettingDef(
+        list,
+        nullable=False,
+        group="Crawling",
+        render=RenderStyle.LIST_COLLAPSED,
+        help_text=(
+            "Regex patterns that skip URLs at link-discovery time during "
+            "recursive crawls. One per line."
+        ),
     ),
     "openai_api_key": SettingDef(
         str,

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -130,6 +130,9 @@ SETTINGS_RESET_ALL_CONFIRM_MESSAGE = (
 )
 SETTINGS_RESET_ALL_SUCCESS = "All settings reset to defaults"
 SETTINGS_RESET_ALL_PARTIAL = "Settings reset with skips: {skipped}"
+SETTINGS_LIST_EDITOR_TITLE = "{key}  ({count} lines)"
+SETTINGS_LIST_EDITOR_INVALID_REGEX = "Invalid regex on line {n}: {error}"
+SETTINGS_LIST_EDITOR_RESTORE_DEFAULTS = "Restore defaults"
 WIKI_EMPTY_STATE = "No wiki pages found"
 WIKI_SEARCH_PLACEHOLDER = "Filter pages..."
 WIKI_NO_CONTENT = "Select a page to view"

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -43,26 +43,13 @@ _TYPE_COLORS: dict[str, tuple[str, str]] = {
 
 _DEFAULTS_REMAP: dict[str, str] = {"top_k_sampling": "top_k"}
 
-# DOM id prefix for the internal "Restore defaults" button inside a
-# Collapsible list editor. Kept distinct from any row-level reset affordance
-# so composition doesn't collide on the same id.
 _LIST_RESTORE_PREFIX = "list-restore-"
-
-# DOM id prefix for the inline regex-validation error Static inside a
-# Collapsible list editor.
 _LIST_ERROR_ID_PREFIX = "err-"
-
-# CSS class toggled on the inline validation error Static to show/hide it.
 _LIST_ERROR_VISIBLE_CLASS = "-visible"
 
 
 def _effective_value(key: str) -> str:
-    """Return the effective value for a setting, including model defaults.
-
-    For list-typed values the help-line would otherwise show Python repr like
-    ``['a', 'b']``; collapse to a count summary so the scroll line stays readable.
-    The full list is visible inside the Collapsible TextArea.
-    """
+    """Return the effective value for a setting, including model defaults."""
     user_value = getattr(cfg, key, None)
     if user_value is not None:
         if isinstance(user_value, list):
@@ -377,13 +364,7 @@ class SettingsScreen(Screen[None]):
 
     @staticmethod
     def _stringify_for_toml(parsed: object) -> str:
-        """Serialize a parsed value for the TOML settings store.
-
-        Lists become newline-joined so reload via `settings.load` + the
-        pydantic `splitlines()` validator returns the same list. Using
-        `str(parsed)` for a list would persist Python's repr such as
-        ``"['a', 'b']"`` and corrupt the config on next process start.
-        """
+        """Serialize a parsed value for the TOML settings store."""
         if parsed is None:
             return ""
         if isinstance(parsed, list):
@@ -412,9 +393,7 @@ class SettingsScreen(Screen[None]):
             return
         raw = ta.text
         parsed = self._parse_value(defn, raw)
-        # _parse_value returns object; mypy can't infer list[str] from the
-        # `defn.type is list` guard above, so this assert narrows the type.
-        assert isinstance(parsed, list)
+        assert isinstance(parsed, list)  # narrow for mypy; defn.type is list above
         err = self._validate_regex_list(parsed)
         error_widget = self.query_one(f"#{_LIST_ERROR_ID_PREFIX}{key}", Static)
         if err is not None:

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -412,8 +412,9 @@ class SettingsScreen(Screen[None]):
             return
         raw = ta.text
         parsed = self._parse_value(defn, raw)
-        # defn.type is list here, so _parse_value returned list[str].
-        assert isinstance(parsed, list)  # for type narrowing in save path
+        # _parse_value returns object; mypy can't infer list[str] from the
+        # `defn.type is list` guard above, so this assert narrows the type.
+        assert isinstance(parsed, list)
         err = self._validate_regex_list(parsed)
         error_widget = self.query_one(f"#{_LIST_ERROR_ID_PREFIX}{key}", Static)
         if err is not None:

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -57,9 +57,16 @@ _LIST_ERROR_VISIBLE_CLASS = "-visible"
 
 
 def _effective_value(key: str) -> str:
-    """Return the effective value for a setting, including model defaults."""
+    """Return the effective value for a setting, including model defaults.
+
+    For list-typed values the help-line would otherwise show Python repr like
+    ``['a', 'b']``; collapse to a count summary so the scroll line stays readable.
+    The full list is visible inside the Collapsible TextArea.
+    """
     user_value = getattr(cfg, key, None)
     if user_value is not None:
+        if isinstance(user_value, list):
+            return f"{len(user_value)} lines"
         return str(user_value)
     defaults = cfg.model_defaults
     if defaults is None:

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -43,6 +43,14 @@ _TYPE_COLORS: dict[str, tuple[str, str]] = {
 
 _DEFAULTS_REMAP: dict[str, str] = {"top_k_sampling": "top_k"}
 
+# DOM id prefix for the internal "Restore defaults" button inside a
+# Collapsible list editor. Kept distinct from any row-level reset affordance
+# so composition doesn't collide on the same id.
+_LIST_RESTORE_PREFIX = "list-restore-"
+
+# CSS class toggled on the inline validation error Static to show/hide it.
+_LIST_ERROR_VISIBLE_CLASS = "-visible"
+
 
 def _effective_value(key: str) -> str:
     """Return the effective value for a setting, including model defaults."""
@@ -129,7 +137,7 @@ def _group_settings() -> dict[str, list[tuple[str, SettingDef]]]:
 def _make_editor(key: str, defn: SettingDef) -> Widget:
     """Create the appropriate editor widget for a setting."""
     if defn.render is RenderStyle.LIST_COLLAPSED:
-        return _make_list_editor(key, defn)
+        return _make_list_editor(key)
     value = _effective_value(key)
     if defn.choices:
         return _make_select(key, defn, value)
@@ -138,7 +146,7 @@ def _make_editor(key: str, defn: SettingDef) -> Widget:
     return _make_input(key, value)
 
 
-def _make_list_editor(key: str, defn: SettingDef) -> Collapsible:
+def _make_list_editor(key: str) -> Collapsible:
     """Create a Collapsible with a line-numbered TextArea for list[str] settings."""
     current = getattr(cfg, key, None) or []
     title = msg.SETTINGS_LIST_EDITOR_TITLE.format(key=key, count=len(current))
@@ -150,14 +158,11 @@ def _make_list_editor(key: str, defn: SettingDef) -> Collapsible:
         classes="setting-list-editor",
     )
     error = Static("", id=f"err-{key}", classes="setting-list-error")
-    error.display = False
     reset = Button(
         msg.SETTINGS_LIST_EDITOR_RESTORE_DEFAULTS,
-        id=f"reset-{key}",
+        id=f"{_LIST_RESTORE_PREFIX}{key}",
         classes="setting-list-restore",
     )
-    # Silence unused defn in case future logic needs it; keep parameter for consistency.
-    _ = defn
     return Collapsible(
         editor,
         error,
@@ -337,7 +342,7 @@ class SettingsScreen(Screen[None]):
         try:
             parsed = self._parse_value(defn, raw)
             setattr(cfg, key, parsed)
-            persisted = str(parsed) if parsed is not None else ""
+            persisted = self._stringify_for_toml(parsed)
             settings.set_value(cfg.data_root, key, persisted)
             if not quiet:
                 self.notify(msg.CMD_SET_SUCCESS.format(key=key, value=parsed))
@@ -358,6 +363,21 @@ class SettingsScreen(Screen[None]):
         if defn.type is list:
             return [line.strip() for line in raw.split("\n") if line.strip()]
         return defn.type(raw)
+
+    @staticmethod
+    def _stringify_for_toml(parsed: object) -> str:
+        """Serialize a parsed value for the TOML settings store.
+
+        Lists become newline-joined so reload via `settings.load` + the
+        pydantic `splitlines()` validator returns the same list. Using
+        `str(parsed)` for a list would persist Python's repr such as
+        ``"['a', 'b']"`` and corrupt the config on next process start.
+        """
+        if parsed is None:
+            return ""
+        if isinstance(parsed, list):
+            return "\n".join(parsed)
+        return str(parsed)
 
     @staticmethod
     def _validate_regex_list(lines: list[str]) -> tuple[int, str] | None:
@@ -390,9 +410,9 @@ class SettingsScreen(Screen[None]):
             error_widget.update(
                 msg.SETTINGS_LIST_EDITOR_INVALID_REGEX.format(n=line_no, error=err_text)
             )
-            error_widget.display = True
+            error_widget.add_class(_LIST_ERROR_VISIBLE_CLASS)
             return
-        error_widget.display = False
+        error_widget.remove_class(_LIST_ERROR_VISIBLE_CLASS)
         self._persist_value(key, defn, raw)
         self._refresh_list_title(key, len(parsed))
 
@@ -400,9 +420,9 @@ class SettingsScreen(Screen[None]):
     def _on_list_restore(self, event: Button.Pressed) -> None:
         """Restore defaults for a LIST_COLLAPSED setting."""
         btn_id = event.button.id
-        if btn_id is None or not btn_id.startswith("reset-"):
+        if btn_id is None or not btn_id.startswith(_LIST_RESTORE_PREFIX):
             return
-        key = btn_id.removeprefix("reset-")
+        key = btn_id.removeprefix(_LIST_RESTORE_PREFIX)
         defn = SETTINGS_MAP.get(key)
         if defn is None:
             return
@@ -412,7 +432,7 @@ class SettingsScreen(Screen[None]):
         ta.load_text(text)
         self._persist_value(key, defn, text)
         error_widget = self.query_one(f"#err-{key}", Static)
-        error_widget.display = False
+        error_widget.remove_class(_LIST_ERROR_VISIBLE_CLASS)
         self._refresh_list_title(key, len(defaults))
 
     def _refresh_list_title(self, key: str, count: int) -> None:

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -48,6 +48,10 @@ _DEFAULTS_REMAP: dict[str, str] = {"top_k_sampling": "top_k"}
 # so composition doesn't collide on the same id.
 _LIST_RESTORE_PREFIX = "list-restore-"
 
+# DOM id prefix for the inline regex-validation error Static inside a
+# Collapsible list editor.
+_LIST_ERROR_ID_PREFIX = "err-"
+
 # CSS class toggled on the inline validation error Static to show/hide it.
 _LIST_ERROR_VISIBLE_CLASS = "-visible"
 
@@ -157,7 +161,7 @@ def _make_list_editor(key: str) -> Collapsible:
         id=f"ed-{key}",
         classes="setting-list-editor",
     )
-    error = Static("", id=f"err-{key}", classes="setting-list-error")
+    error = Static("", id=f"{_LIST_ERROR_ID_PREFIX}{key}", classes="setting-list-error")
     reset = Button(
         msg.SETTINGS_LIST_EDITOR_RESTORE_DEFAULTS,
         id=f"{_LIST_RESTORE_PREFIX}{key}",
@@ -404,7 +408,7 @@ class SettingsScreen(Screen[None]):
         # defn.type is list here, so _parse_value returned list[str].
         assert isinstance(parsed, list)  # for type narrowing in save path
         err = self._validate_regex_list(parsed)
-        error_widget = self.query_one(f"#err-{key}", Static)
+        error_widget = self.query_one(f"#{_LIST_ERROR_ID_PREFIX}{key}", Static)
         if err is not None:
             line_no, err_text = err
             error_widget.update(
@@ -431,7 +435,7 @@ class SettingsScreen(Screen[None]):
         ta = self.query_one(f"#ed-{key}", ListTextArea)
         ta.load_text(text)
         self._persist_value(key, defn, text)
-        error_widget = self.query_one(f"#err-{key}", Static)
+        error_widget = self.query_one(f"#{_LIST_ERROR_ID_PREFIX}{key}", Static)
         error_widget.remove_class(_LIST_ERROR_VISIBLE_CLASS)
         self._refresh_list_title(key, len(defaults))
 

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -1,9 +1,10 @@
-"""Settings screen — grouped, type-aware configuration editor."""
+"""Settings screen. Grouped, type-aware configuration editor."""
 
 from __future__ import annotations
 
 import logging
 import os
+import re
 from collections import defaultdict
 from typing import ClassVar
 
@@ -13,14 +14,16 @@ from textual.binding import Binding, BindingType
 from textual.containers import Horizontal, VerticalGroup, VerticalScroll
 from textual.content import Content
 from textual.screen import Screen
-from textual.widgets import Button, Checkbox, Input, Select, Static, TextArea
+from textual.widget import Widget
+from textual.widgets import Button, Checkbox, Collapsible, Input, Select, Static, TextArea
 
 from lilbee import settings
-from lilbee.cli.settings_map import SETTINGS_MAP, SettingDef, get_default
+from lilbee.cli.settings_map import SETTINGS_MAP, RenderStyle, SettingDef, get_default
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.pill import pill
+from lilbee.cli.tui.widgets.list_text_area import ListTextArea
 from lilbee.cli.tui.widgets.nav_aware_input import NavAwareInput
-from lilbee.config import cfg
+from lilbee.config import DEFAULT_CRAWL_EXCLUDE_PATTERNS, cfg
 
 _ROW_ID_PREFIX = "row-"
 _EDITOR_ID_PREFIX = "ed-"
@@ -123,14 +126,46 @@ def _group_settings() -> dict[str, list[tuple[str, SettingDef]]]:
     return dict(groups)
 
 
-def _make_editor(key: str, defn: SettingDef) -> Input | Checkbox | Select[str]:
+def _make_editor(key: str, defn: SettingDef) -> Widget:
     """Create the appropriate editor widget for a setting."""
+    if defn.render is RenderStyle.LIST_COLLAPSED:
+        return _make_list_editor(key, defn)
     value = _effective_value(key)
     if defn.choices:
         return _make_select(key, defn, value)
     if defn.type is bool:
         return _make_checkbox(key, value)
     return _make_input(key, value)
+
+
+def _make_list_editor(key: str, defn: SettingDef) -> Collapsible:
+    """Create a Collapsible with a line-numbered TextArea for list[str] settings."""
+    current = getattr(cfg, key, None) or []
+    title = msg.SETTINGS_LIST_EDITOR_TITLE.format(key=key, count=len(current))
+    editor = ListTextArea(
+        text="\n".join(current),
+        show_line_numbers=True,
+        name=key,
+        id=f"ed-{key}",
+        classes="setting-list-editor",
+    )
+    error = Static("", id=f"err-{key}", classes="setting-list-error")
+    error.display = False
+    reset = Button(
+        msg.SETTINGS_LIST_EDITOR_RESTORE_DEFAULTS,
+        id=f"reset-{key}",
+        classes="setting-list-restore",
+    )
+    # Silence unused defn in case future logic needs it; keep parameter for consistency.
+    _ = defn
+    return Collapsible(
+        editor,
+        error,
+        reset,
+        title=title,
+        collapsed=True,
+        id=f"collapsible-{key}",
+    )
 
 
 def _make_select(key: str, defn: SettingDef, value: str) -> Select[str]:
@@ -320,7 +355,73 @@ class SettingsScreen(Screen[None]):
             return None
         if defn.type is bool:
             return raw.lower() in ("true", "1", "yes", "on")
+        if defn.type is list:
+            return [line.strip() for line in raw.split("\n") if line.strip()]
         return defn.type(raw)
+
+    @staticmethod
+    def _validate_regex_list(lines: list[str]) -> tuple[int, str] | None:
+        """Return the 1-indexed line number and error for the first bad regex, or None."""
+        for i, line in enumerate(lines, 1):
+            try:
+                re.compile(line)
+            except re.error as exc:
+                return (i, str(exc))
+        return None
+
+    @on(ListTextArea.Blurred, ".setting-list-editor")
+    def _on_list_blur_save(self, event: ListTextArea.Blurred) -> None:
+        """Validate and save list values when a ListTextArea loses focus."""
+        ta = event.control
+        key = ta.name
+        if key is None:
+            return
+        defn = SETTINGS_MAP.get(key)
+        if defn is None:
+            return
+        raw = ta.text
+        parsed = self._parse_value(defn, raw)
+        # defn.type is list here, so _parse_value returned list[str].
+        assert isinstance(parsed, list)  # for type narrowing in save path
+        err = self._validate_regex_list(parsed)
+        error_widget = self.query_one(f"#err-{key}", Static)
+        if err is not None:
+            line_no, err_text = err
+            error_widget.update(
+                msg.SETTINGS_LIST_EDITOR_INVALID_REGEX.format(n=line_no, error=err_text)
+            )
+            error_widget.display = True
+            return
+        error_widget.display = False
+        self._persist_value(key, defn, raw)
+        self._refresh_list_title(key, len(parsed))
+
+    @on(Button.Pressed, ".setting-list-restore")
+    def _on_list_restore(self, event: Button.Pressed) -> None:
+        """Restore defaults for a LIST_COLLAPSED setting."""
+        btn_id = event.button.id
+        if btn_id is None or not btn_id.startswith("reset-"):
+            return
+        key = btn_id.removeprefix("reset-")
+        defn = SETTINGS_MAP.get(key)
+        if defn is None:
+            return
+        defaults = list(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
+        text = "\n".join(defaults)
+        ta = self.query_one(f"#ed-{key}", ListTextArea)
+        ta.load_text(text)
+        self._persist_value(key, defn, text)
+        error_widget = self.query_one(f"#err-{key}", Static)
+        error_widget.display = False
+        self._refresh_list_title(key, len(defaults))
+
+    def _refresh_list_title(self, key: str, count: int) -> None:
+        """Update the Collapsible title to reflect the current line count."""
+        try:
+            collapsible = self.query_one(f"#collapsible-{key}", Collapsible)
+            collapsible.title = msg.SETTINGS_LIST_EDITOR_TITLE.format(key=key, count=count)
+        except Exception:
+            log.debug("Failed to refresh collapsible title for %s", key, exc_info=True)
 
     def _refresh_help(self, key: str, defn: SettingDef) -> None:
         """Update the help text after a value change."""

--- a/src/lilbee/cli/tui/screens/settings.tcss
+++ b/src/lilbee/cli/tui/screens/settings.tcss
@@ -99,4 +99,23 @@ SettingsScreen {
     Input.-invalid {
         border: tall $error 60%;
     }
+
+    .setting-list-editor {
+        height: 16;
+        border: solid $surface;
+        margin-bottom: 1;
+    }
+
+    .setting-list-error {
+        color: $error;
+        display: none;
+    }
+
+    .setting-list-error.-visible {
+        display: block;
+    }
+
+    .setting-list-restore {
+        margin-top: 1;
+    }
 }

--- a/src/lilbee/cli/tui/widgets/list_text_area.py
+++ b/src/lilbee/cli/tui/widgets/list_text_area.py
@@ -1,0 +1,34 @@
+"""TextArea subclass that posts a ``Blurred`` message on focus loss.
+
+Textual's built-in :class:`TextArea` only emits ``Changed`` and
+``SelectionChanged`` messages. The settings screen needs to save list-typed
+values on focus loss (same save-on-blur UX as :class:`Input`), so this
+subclass posts a dedicated ``Blurred`` message after the default blur
+handling runs.
+"""
+
+from __future__ import annotations
+
+from textual.events import Blur
+from textual.message import Message
+from textual.widgets import TextArea
+
+
+class ListTextArea(TextArea):
+    """TextArea that posts a ``Blurred`` message when focus leaves it."""
+
+    class Blurred(Message):
+        """Posted after focus leaves the :class:`ListTextArea`."""
+
+        def __init__(self, control: ListTextArea) -> None:
+            super().__init__()
+            self._control = control
+
+        @property
+        def control(self) -> ListTextArea:
+            """The widget that lost focus. Enables ``@on`` selector matching."""
+            return self._control
+
+    def _on_blur(self, event: Blur) -> None:
+        super()._on_blur(event)
+        self.post_message(self.Blurred(self))

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -613,6 +613,153 @@ async def test_settings_pop_screen():
         assert not isinstance(app.screen, SettingsScreen)
 
 
+async def test_settings_crawl_exclude_patterns_renders_collapsible():
+    """crawl_exclude_patterns renders as a Collapsible with line count in title."""
+    from textual.widgets import Collapsible
+
+    from lilbee.config import DEFAULT_CRAWL_EXCLUDE_PATTERNS
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        collapsible = app.screen.query_one("#collapsible-crawl_exclude_patterns", Collapsible)
+        assert collapsible.collapsed is True
+        assert "crawl_exclude_patterns" in collapsible.title
+        assert str(len(DEFAULT_CRAWL_EXCLUDE_PATTERNS)) in collapsible.title
+
+
+async def test_settings_list_editor_expands_on_title_enter():
+    """Focusing the Collapsible title and pressing enter expands it."""
+    from textual.widgets import Collapsible
+    from textual.widgets._collapsible import CollapsibleTitle
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        collapsible = app.screen.query_one("#collapsible-crawl_exclude_patterns", Collapsible)
+        title = collapsible.query_one(CollapsibleTitle)
+        title.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert collapsible.collapsed is False
+
+
+async def test_settings_list_editor_saves_on_blur():
+    """Typing into the list TextArea and blurring persists the parsed list."""
+    from textual.widgets import Input
+
+    from lilbee.cli.tui.widgets.list_text_area import ListTextArea
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        ta = app.screen.query_one("#ed-crawl_exclude_patterns", ListTextArea)
+        ta.focus()
+        await pilot.pause()
+        ta.load_text("foo\nbar")
+        search = app.screen.query_one("#settings-search", Input)
+        search.focus()
+        await pilot.pause()
+        assert cfg.crawl_exclude_patterns == ["foo", "bar"]
+
+
+async def test_settings_list_editor_strips_blanks():
+    """Blank lines and surrounding whitespace are stripped during parsing."""
+    from textual.widgets import Input
+
+    from lilbee.cli.tui.widgets.list_text_area import ListTextArea
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        ta = app.screen.query_one("#ed-crawl_exclude_patterns", ListTextArea)
+        ta.focus()
+        await pilot.pause()
+        ta.load_text("a\n\nb\n")
+        search = app.screen.query_one("#settings-search", Input)
+        search.focus()
+        await pilot.pause()
+        assert cfg.crawl_exclude_patterns == ["a", "b"]
+
+
+async def test_settings_list_editor_invalid_regex_blocks_save():
+    """An invalid regex shows an error and does not mutate cfg."""
+    from textual.widgets import Input, Static
+
+    from lilbee.cli.tui.widgets.list_text_area import ListTextArea
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        cfg.crawl_exclude_patterns = ["keep"]
+        ta = app.screen.query_one("#ed-crawl_exclude_patterns", ListTextArea)
+        ta.focus()
+        await pilot.pause()
+        ta.load_text("[")
+        search = app.screen.query_one("#settings-search", Input)
+        search.focus()
+        await pilot.pause()
+        err = app.screen.query_one("#err-crawl_exclude_patterns", Static)
+        assert err.display is True
+        assert "line 1" in str(err.render())
+        assert cfg.crawl_exclude_patterns == ["keep"]
+
+
+async def test_settings_list_editor_restore_defaults():
+    """Pressing Restore resets both cfg and the TextArea to the defaults."""
+    from textual.widgets import Button
+
+    from lilbee.cli.tui.widgets.list_text_area import ListTextArea
+    from lilbee.config import DEFAULT_CRAWL_EXCLUDE_PATTERNS
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        cfg.crawl_exclude_patterns = ["old"]
+        btn = app.screen.query_one("#reset-crawl_exclude_patterns", Button)
+        btn.press()
+        await pilot.pause()
+        assert cfg.crawl_exclude_patterns == list(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
+        ta = app.screen.query_one("#ed-crawl_exclude_patterns", ListTextArea)
+        assert ta.text == "\n".join(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
+
+
+async def test_settings_parse_value_list_branch():
+    """_parse_value splits, strips, and drops blanks for list-typed settings."""
+    from lilbee.cli.settings_map import SettingDef
+    from lilbee.cli.tui.screens.settings import SettingsScreen
+
+    defn = SettingDef(list, nullable=False)
+    screen = SettingsScreen()
+    result = screen._parse_value(defn, "a\n\nb")
+    assert result == ["a", "b"]
+
+
+async def test_list_text_area_posts_blurred():
+    """ListTextArea posts its Blurred message when focus moves away."""
+    from textual.app import App
+    from textual.widgets import Input
+
+    from lilbee.cli.tui.widgets.list_text_area import ListTextArea
+
+    captured: list[ListTextArea.Blurred] = []
+
+    class _TestApp(App[None]):
+        CSS = ""
+
+        def compose(self) -> ComposeResult:
+            yield ListTextArea(id="ta")
+            yield Input(id="other")
+
+        def on_list_text_area_blurred(self, event: ListTextArea.Blurred) -> None:
+            captured.append(event)
+
+    app = _TestApp()
+    async with app.run_test(size=(80, 20)) as pilot:
+        ta = app.query_one("#ta", ListTextArea)
+        ta.focus()
+        await pilot.pause()
+        app.query_one("#other", Input).focus()
+        await pilot.pause()
+        assert captured, "Expected a Blurred message from ListTextArea"
+        assert captured[0].control is ta
+
+
 async def test_settings_effective_value_shows_model_default():
     """When user hasn't set a value, model default is shown with suffix."""
     from dataclasses import dataclass
@@ -6413,6 +6560,77 @@ async def test_settings_on_select_save_defn_none():
         with patch.object(screen, "_persist_value") as mock_pv:
             screen._on_select_save(event)
             mock_pv.assert_not_called()
+
+
+async def test_settings_on_list_blur_save_name_none():
+    """_on_list_blur_save returns early when the TextArea has no name."""
+    from lilbee.cli.tui.screens.settings import SettingsScreen
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)):
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        event = MagicMock()
+        event.control.name = None
+        with patch.object(screen, "_persist_value") as mock_pv:
+            screen._on_list_blur_save(event)
+            mock_pv.assert_not_called()
+
+
+async def test_settings_on_list_blur_save_defn_none():
+    """_on_list_blur_save returns early when SETTINGS_MAP has no entry."""
+    from lilbee.cli.tui.screens.settings import SettingsScreen
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)):
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        event = MagicMock()
+        event.control.name = "nonexistent_key_xyz"
+        with patch.object(screen, "_persist_value") as mock_pv:
+            screen._on_list_blur_save(event)
+            mock_pv.assert_not_called()
+
+
+async def test_settings_on_list_restore_bad_button_id():
+    """_on_list_restore ignores buttons whose id does not start with ``reset-``."""
+    from lilbee.cli.tui.screens.settings import SettingsScreen
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)):
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        event = MagicMock()
+        event.button.id = None
+        with patch.object(screen, "_persist_value") as mock_pv:
+            screen._on_list_restore(event)
+            mock_pv.assert_not_called()
+
+
+async def test_settings_on_list_restore_defn_none():
+    """_on_list_restore returns early when SETTINGS_MAP has no entry for the key."""
+    from lilbee.cli.tui.screens.settings import SettingsScreen
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)):
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        event = MagicMock()
+        event.button.id = "reset-nonexistent_key"
+        with patch.object(screen, "_persist_value") as mock_pv:
+            screen._on_list_restore(event)
+            mock_pv.assert_not_called()
+
+
+async def test_settings_refresh_list_title_missing_swallows():
+    """_refresh_list_title logs (does not raise) when the Collapsible is absent."""
+    from lilbee.cli.tui.screens.settings import SettingsScreen
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)):
+        screen = app.screen
+        assert isinstance(screen, SettingsScreen)
+        screen._refresh_list_title("nonexistent_key_xyz", 0)
 
 
 async def test_settings_parse_value_nullable_none():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -6643,7 +6643,7 @@ async def test_settings_on_list_restore_bad_button_id():
         with patch.object(screen, "_persist_value") as mock_pv:
             screen._on_list_restore(event)
             mock_pv.assert_not_called()
-        event.button.id = "not-a-list-restore-foo"
+        event.button.id = "wrong-prefix-foo"
         with patch.object(screen, "_persist_value") as mock_pv:
             screen._on_list_restore(event)
             mock_pv.assert_not_called()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -833,6 +833,18 @@ async def test_settings_effective_value_shows_model_default():
         object.__setattr__(cfg, "_model_defaults", old_defaults)
 
 
+def test_settings_effective_value_summarizes_list():
+    """List values are shown as a line count, not Python repr, on the help line."""
+    from lilbee.cli.tui.screens.settings import _effective_value
+
+    cfg.crawl_exclude_patterns = ["a", "b", "c"]
+    result = _effective_value("crawl_exclude_patterns")
+    assert result == "3 lines"
+    # Specifically guards against the "current: ['a', 'b', 'c']" regression.
+    assert "[" not in result
+    assert "'" not in result
+
+
 async def test_settings_effective_value_user_overrides_default():
     """When user has set a value, it takes precedence over model default."""
     from dataclasses import dataclass

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -844,6 +844,11 @@ def test_settings_effective_value_summarizes_list():
     assert "[" not in result
     assert "'" not in result
 
+    # Empty list must still be rendered as a count, not fall through to
+    # "None" or model defaults. Guards off-by-one refactors of len().
+    cfg.crawl_exclude_patterns = []
+    assert _effective_value("crawl_exclude_patterns") == "0 lines"
+
 
 async def test_settings_effective_value_user_overrides_default():
     """When user has set a value, it takes precedence over model default."""

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -617,14 +617,15 @@ async def test_settings_crawl_exclude_patterns_renders_collapsible():
     """crawl_exclude_patterns renders as a Collapsible with line count in title."""
     from textual.widgets import Collapsible
 
-    from lilbee.config import DEFAULT_CRAWL_EXCLUDE_PATTERNS
+    from lilbee.config import cfg
 
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         collapsible = app.screen.query_one("#collapsible-crawl_exclude_patterns", Collapsible)
         assert collapsible.collapsed is True
         assert "crawl_exclude_patterns" in collapsible.title
-        assert str(len(DEFAULT_CRAWL_EXCLUDE_PATTERNS)) in collapsible.title
+        current = cfg.crawl_exclude_patterns or []
+        assert f"({len(current)} lines)" in collapsible.title
 
 
 async def test_settings_list_editor_can_be_expanded():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -627,20 +627,21 @@ async def test_settings_crawl_exclude_patterns_renders_collapsible():
         assert str(len(DEFAULT_CRAWL_EXCLUDE_PATTERNS)) in collapsible.title
 
 
-async def test_settings_list_editor_expands_on_title_enter():
-    """Focusing the Collapsible title and pressing enter expands it."""
+async def test_settings_list_editor_can_be_expanded():
+    """Setting `collapsed = False` on the public Collapsible API reveals the editor."""
     from textual.widgets import Collapsible
-    from textual.widgets._collapsible import CollapsibleTitle
+
+    from lilbee.cli.tui.widgets.list_text_area import ListTextArea
 
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         collapsible = app.screen.query_one("#collapsible-crawl_exclude_patterns", Collapsible)
-        title = collapsible.query_one(CollapsibleTitle)
-        title.focus()
+        assert collapsible.collapsed is True
+        collapsible.collapsed = False
         await pilot.pause()
-        await pilot.press("enter")
-        await pilot.pause()
-        assert collapsible.collapsed is False
+        # The TextArea is inside the body once the Collapsible is open.
+        ta = collapsible.query_one(ListTextArea)
+        assert ta is not None
 
 
 async def test_settings_list_editor_saves_on_blur():
@@ -696,7 +697,7 @@ async def test_settings_list_editor_invalid_regex_blocks_save():
         search.focus()
         await pilot.pause()
         err = app.screen.query_one("#err-crawl_exclude_patterns", Static)
-        assert err.display is True
+        assert err.has_class("-visible")
         assert "line 1" in str(err.render())
         assert cfg.crawl_exclude_patterns == ["keep"]
 
@@ -711,7 +712,7 @@ async def test_settings_list_editor_restore_defaults():
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         cfg.crawl_exclude_patterns = ["old"]
-        btn = app.screen.query_one("#reset-crawl_exclude_patterns", Button)
+        btn = app.screen.query_one("#list-restore-crawl_exclude_patterns", Button)
         btn.press()
         await pilot.pause()
         assert cfg.crawl_exclude_patterns == list(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
@@ -728,6 +729,43 @@ async def test_settings_parse_value_list_branch():
     screen = SettingsScreen()
     result = screen._parse_value(defn, "a\n\nb")
     assert result == ["a", "b"]
+
+
+async def test_settings_list_editor_persists_through_toml_round_trip(tmp_path):
+    """Editing a list-typed setting survives a full settings.save + pydantic reload.
+
+    Guards against the bug where `_persist_value` used `str(parsed)` for lists,
+    which wrote Python repr such as "['foo', 'bar']" into the TOML store.
+    After reload, the pydantic `splitlines()` validator then produced a
+    one-element list with corrupt contents.
+    """
+    from textual.widgets import Input
+
+    from lilbee import settings
+    from lilbee.cli.settings_map import SETTINGS_MAP
+    from lilbee.cli.tui.screens.settings import SettingsScreen
+    from lilbee.cli.tui.widgets.list_text_area import ListTextArea
+
+    cfg.data_root = tmp_path
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        ta = app.screen.query_one("#ed-crawl_exclude_patterns", ListTextArea)
+        ta.focus()
+        await pilot.pause()
+        ta.load_text("pat-a\npat-b")
+        app.screen.query_one("#settings-search", Input).focus()
+        await pilot.pause()
+
+    # Raw TOML value is a newline-joined string (not Python repr of the list).
+    reloaded = settings.load(tmp_path)
+    raw = reloaded["crawl_exclude_patterns"]
+    assert raw == "pat-a\npat-b"
+    assert "[" not in raw  # would indicate list repr leaked into TOML
+
+    # Pydantic's `splitlines()` validator then reconstructs the list cleanly.
+    screen = SettingsScreen()
+    parsed = screen._parse_value(SETTINGS_MAP["crawl_exclude_patterns"], raw)
+    assert parsed == ["pat-a", "pat-b"]
 
 
 async def test_list_text_area_posts_blurred():
@@ -6593,7 +6631,7 @@ async def test_settings_on_list_blur_save_defn_none():
 
 
 async def test_settings_on_list_restore_bad_button_id():
-    """_on_list_restore ignores buttons whose id does not start with ``reset-``."""
+    """_on_list_restore ignores buttons whose id does not start with the list-restore prefix."""
     from lilbee.cli.tui.screens.settings import SettingsScreen
 
     app = SettingsTestApp()
@@ -6602,6 +6640,10 @@ async def test_settings_on_list_restore_bad_button_id():
         assert isinstance(screen, SettingsScreen)
         event = MagicMock()
         event.button.id = None
+        with patch.object(screen, "_persist_value") as mock_pv:
+            screen._on_list_restore(event)
+            mock_pv.assert_not_called()
+        event.button.id = "not-a-list-restore-foo"
         with patch.object(screen, "_persist_value") as mock_pv:
             screen._on_list_restore(event)
             mock_pv.assert_not_called()
@@ -6616,7 +6658,7 @@ async def test_settings_on_list_restore_defn_none():
         screen = app.screen
         assert isinstance(screen, SettingsScreen)
         event = MagicMock()
-        event.button.id = "reset-nonexistent_key"
+        event.button.id = "list-restore-nonexistent_key"
         with patch.object(screen, "_persist_value") as mock_pv:
             screen._on_list_restore(event)
             mock_pv.assert_not_called()


### PR DESCRIPTION
## What changed

- The `crawl_exclude_patterns` setting is now editable from the Settings screen.
- It renders as a collapsed section titled `crawl_exclude_patterns (N lines)`. Expanding it reveals a line-numbered text editor containing the current patterns.
- Editing a line and moving focus away saves the updated list. If any line fails to compile as a regex, an inline error highlights the offending line number and the save is blocked until it is fixed.
- A "Restore defaults" button inside the section puts the built-in default list back.

## Why

The field existed server-side but was invisible in the Settings screen because there was no renderer for list-of-strings values. Users who wanted to customize which URLs are skipped during recursive crawls had to edit `config.toml` by hand. Now the full list is visible, editable, and recoverable from the TUI.