### PR TITLE
Make wiki_prune_raw and wiki_faithfulness_threshold writable

### DIFF
--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -458,8 +458,8 @@ class Config(BaseSettings):
     # and disable wiki generation/sync.
     wiki: bool = True
     wiki_dir: str = "wiki"
-    wiki_prune_raw: bool = False
-    wiki_faithfulness_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
+    wiki_prune_raw: bool = ConfigField(default=False, writable=True)
+    wiki_faithfulness_threshold: float = ConfigField(default=0.7, ge=0.0, le=1.0, writable=True)
 
     # Fraction of citations that must be stale before a wiki page is flagged
     # for regeneration during pruning. 0.5 = flag when >50% are stale.

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -345,6 +345,9 @@ class TestConfigDefaultsRoute:
         assert data["crawl_exclude_patterns"] == list(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
         # Non-writable/non-public fields are not exposed.
         assert "chat_model" not in data
+        # Wiki cfg fields are writable and appear with their declared defaults.
+        assert data["wiki_prune_raw"] is False
+        assert data["wiki_faithfulness_threshold"] == 0.7
 
 
 class TestConfigUpdateRoute:


### PR DESCRIPTION
## What

`wiki_prune_raw` and `wiki_faithfulness_threshold` were declared as plain pydantic `Field`, so `WRITABLE_CONFIG_FIELDS` excluded them, `GET /api/config/defaults` omitted them, and `PATCH /api/config` 400'd with *"Unknown or read-only config field"*.

## Fix

Promote both to `ConfigField(writable=True)`. Same default values, same validator bounds.

## Why

The Obsidian plugin already wires onChange handlers for both fields through `api.updateConfig` and renders reset-to-default affordances on them (tobocop2/obsidian-lilbee#42). Every user toggle/slider change was silently rejected by the server, and the plugin's reset buttons for these rows silently no-op'd because the keys were missing from `GET /api/config/defaults`.


