### PR TITLE
Install crawl4ai via the [crawler] extra in make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-integration:
 check: lint format-check typecheck test  ## Run all checks (same as CI)
 
 install:
-	uv tool install . --force --reinstall --compile-bytecode
+	uv tool install ".[crawler]" --force --reinstall --compile-bytecode
 
 crawl-setup:  ## Download Playwright Chromium for /crawl
 	uv run playwright install chromium


### PR DESCRIPTION
## What

`make install` now pulls `crawl4ai` via the `[crawler]` extra instead of silently omitting it.

## Why

`pyproject.toml` declares `crawl4ai` in `[project.optional-dependencies].crawler`. `uv tool install . --force --reinstall` without `--extra` (or the `[crawler]` specifier) does not install optional deps, so the installed venv at `~/.local/share/uv/tools/lilbee/...` shipped without `crawl4ai`. Any call to `/api/crawl` crashed with `ModuleNotFoundError: No module named 'crawl4ai'`, surfacing to the plugin Task Center as a failed crawl task.

## Fix

One-line Makefile change: `uv tool install ".[crawler]"` instead of `uv tool install .`.
