### PR TITLE
Validate crawl_exclude_patterns regex at PATCH time

### DIFF
--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -649,6 +649,27 @@ class Config(BaseSettings):
             return [p.strip() for p in v.splitlines() if p.strip()]
         return v
 
+    @field_validator("crawl_exclude_patterns", mode="after")
+    @classmethod
+    def _validate_crawl_exclude_patterns(cls, v: list[str]) -> list[str]:
+        """Reject any entry that isn't a valid Python regex.
+
+        These patterns are compiled at crawl time. An invalid pattern there
+        surfaces as an opaque mid-crawl error; catching it at PATCH time gives
+        the user a 400 with a pointer to the bad entry.
+        """
+        import re
+
+        bad: list[str] = []
+        for i, pattern in enumerate(v):
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                bad.append(f"[{i}] {pattern!r}: {exc}")
+        if bad:
+            raise ValueError("invalid regex in crawl_exclude_patterns:\n  " + "\n  ".join(bad))
+        return v
+
     @field_validator("ignore_dirs", mode="before")
     @classmethod
     def _merge_ignore_dirs(cls, v: Any) -> frozenset[str]:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -391,6 +391,21 @@ class TestConfigUpdateRoute:
 
         _inner()
 
+    def test_crawl_exclude_patterns_rejects_invalid_regex(self, client):
+        # Invalid character class — `p-a` is a backwards range; should be rejected
+        # at PATCH time rather than crashing the next crawl with an opaque error.
+        resp = client.patch("/api/config", json={"crawl_exclude_patterns": ["[wp-a]"]})
+        assert resp.status_code == 400
+        body = resp.text
+        assert "crawl_exclude_patterns" in body or "regex" in body or "[0]" in body
+
+    def test_crawl_exclude_patterns_accepts_valid_regex(self, client):
+        resp = client.patch(
+            "/api/config", json={"crawl_exclude_patterns": [r"/page/\d+/?$", r"/tag/"]}
+        )
+        assert resp.status_code == 200
+        assert "crawl_exclude_patterns" in resp.json()["updated"]
+
 
 class TestModelsSetEmbeddingRoute:
     @mock.patch(


### PR DESCRIPTION
## Problem

`PATCH /api/config` accepted any list of strings for `crawl_exclude_patterns` without validating each entry was a valid Python regex. Invalid patterns crashed the next crawl with opaque messages like `bad character range p-a at position 4`, with no hint that the root cause was a malformed pattern stored earlier.

## Fix

New `@field_validator("crawl_exclude_patterns", mode="after")` in `src/lilbee/config.py` runs `re.compile()` on each entry. Bad entries are reported with their index in the error, e.g.:

```
invalid regex in crawl_exclude_patterns:
  [3] '[wp-a]': bad character range p-a at position 1
```

Pydantic's `validate_assignment=True` (already enabled on `Config`) makes this surface as a 400 on PATCH.

## Tests

`tests/test_server_litestar.py::TestConfigUpdateRoute`:
- `test_crawl_exclude_patterns_rejects_invalid_regex` — PATCH with `["[wp-a]"]` → 400.
- `test_crawl_exclude_patterns_accepts_valid_regex` — PATCH with two valid patterns → 200.

## Discovered during

PR tobocop2/obsidian-lilbee#42 QA. After a round-trip through the plugin's textarea path, the on-disk `crawl_exclude_patterns` was left as a single-element list whose element was the repr of the full default list. The opaque crawl error masked the actual problem; the user had no idea what to fix.
