### PR TITLE
Fix Ollama model routing

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -38,8 +38,9 @@ from lilbee.cli.tui.widgets.model_list_item import ModelListItem
 from lilbee.cli.tui.widgets.nav_aware_input import NavAwareInput
 from lilbee.cli.tui.widgets.search_hf_cta_item import SearchHFCtaItem
 from lilbee.config import cfg
-from lilbee.model_manager import RemoteModel, get_model_manager
+from lilbee.model_manager import OLLAMA_PROVIDER_NAME, RemoteModel, get_model_manager
 from lilbee.models import ModelTask
+from lilbee.providers.model_ref import OLLAMA_PREFIX
 
 log = logging.getLogger(__name__)
 
@@ -577,8 +578,8 @@ class CatalogScreen(Screen[None]):
             self._install_model(row.catalog_model)
         elif row.remote_model:
             ref = (
-                f"ollama/{row.remote_model.name}"
-                if row.remote_model.provider == "Ollama"
+                f"{OLLAMA_PREFIX}{row.remote_model.name}"
+                if row.remote_model.provider == OLLAMA_PROVIDER_NAME
                 else row.remote_model.name
             )
             cfg.chat_model = ref

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -576,7 +576,12 @@ class CatalogScreen(Screen[None]):
         elif row.catalog_model:
             self._install_model(row.catalog_model)
         elif row.remote_model:
-            cfg.chat_model = row.remote_model.name
+            ref = (
+                f"ollama/{row.remote_model.name}"
+                if row.remote_model.provider == "Ollama"
+                else row.remote_model.name
+            )
+            cfg.chat_model = ref
             self.notify(msg.CATALOG_USING_REMOTE.format(name=row.remote_model.name))
 
     def _load_more(self) -> None:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -40,7 +40,9 @@ from lilbee.cli.tui.widgets.status_bar import ViewTabs
 from lilbee.cli.tui.widgets.task_bar import ProgressReporter, TaskBar
 from lilbee.config import cfg
 from lilbee.crawler import crawler_available, is_url, require_valid_crawl_url
+from lilbee.embedder import is_model_available
 from lilbee.progress import EventType, ProgressEvent
+from lilbee.providers.model_ref import parse_model_ref
 from lilbee.query import ChatMessage
 from lilbee.services import get_services, reset_services
 
@@ -192,15 +194,14 @@ class ChatScreen(Screen[None]):
     def _needs_setup(self) -> bool:
         """True when the setup wizard should run: fresh data dir or unresolved models.
 
-        Remote-prefixed refs (``ollama/`` and API providers) skip the native
-        registry probe since they resolve through litellm at call time.
+        Remote-prefixed refs skip the native probe since they resolve
+        through litellm at call time.
         """
         if not cfg.lancedb_dir.is_dir():
             log.debug("_needs_setup: lancedb_dir missing (%s)", cfg.lancedb_dir)
             return True
         from lilbee.providers.base import ProviderError
         from lilbee.providers.llama_cpp_provider import resolve_model_path
-        from lilbee.providers.model_ref import parse_model_ref
 
         for label, model in (("chat", cfg.chat_model), ("embedding", cfg.embedding_model)):
             if parse_model_ref(model).needs_litellm:
@@ -213,35 +214,8 @@ class ChatScreen(Screen[None]):
         return False
 
     def _embedding_ready(self) -> bool:
-        """Quick check if embedding model exists (no network calls).
-
-        Checks both the provider model list and the native registry path
-        resolution so litellm/Ollama-backed models are detected too.
-        """
-        model = cfg.embedding_model
-        if not model:
-            return False
-        from lilbee.providers.model_ref import parse_model_ref
-
-        ref = parse_model_ref(model)
-        name_base = ref.name.split(":")[0].lower().replace(" ", "-")
-        try:
-            from lilbee.services import get_services
-
-            available = get_services().provider.list_models()
-            if any(name_base in m.lower().replace(" ", "-") for m in available):
-                return True
-        except Exception:
-            pass
-        if ref.needs_litellm:
-            return False
-        try:
-            from lilbee.providers.llama_cpp_provider import resolve_model_path
-
-            resolve_model_path(model)
-            return True
-        except Exception:
-            return False
+        """Quick check if the embedding model resolves (no network calls)."""
+        return is_model_available(cfg.embedding_model, get_services().provider)
 
     def _on_setup_complete(self, result: str | None) -> None:
         """Called when wizard completes or is skipped."""

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -190,16 +190,21 @@ class ChatScreen(Screen[None]):
         self.refresh_model_bar()
 
     def _needs_setup(self) -> bool:
-        """True when the setup wizard should run: fresh data dir or unresolved models."""
-        # Fresh install: an uninitialized data dir still needs the wizard even
-        # if default models are already cached globally (Ollama, HF cache).
+        """True when the setup wizard should run: fresh data dir or unresolved models.
+
+        Remote-prefixed refs (``ollama/`` and API providers) skip the native
+        registry probe since they resolve through litellm at call time.
+        """
         if not cfg.lancedb_dir.is_dir():
             log.debug("_needs_setup: lancedb_dir missing (%s)", cfg.lancedb_dir)
             return True
         from lilbee.providers.base import ProviderError
         from lilbee.providers.llama_cpp_provider import resolve_model_path
+        from lilbee.providers.model_ref import parse_model_ref
 
         for label, model in (("chat", cfg.chat_model), ("embedding", cfg.embedding_model)):
+            if parse_model_ref(model).needs_litellm:
+                continue
             try:
                 resolve_model_path(model)
             except (ProviderError, KeyError, ValueError) as exc:
@@ -216,17 +221,20 @@ class ChatScreen(Screen[None]):
         model = cfg.embedding_model
         if not model:
             return False
-        # Provider list check (covers litellm / Ollama backends)
+        from lilbee.providers.model_ref import parse_model_ref
+
+        ref = parse_model_ref(model)
+        name_base = ref.name.split(":")[0].lower().replace(" ", "-")
         try:
             from lilbee.services import get_services
 
             available = get_services().provider.list_models()
-            model_base = model.split(":")[0].lower().replace(" ", "-")
-            if any(model_base in m.lower().replace(" ", "-") for m in available):
+            if any(name_base in m.lower().replace(" ", "-") for m in available):
                 return True
         except Exception:
             pass
-        # Native registry path check (covers llama-cpp managed models)
+        if ref.needs_litellm:
+            return False
         try:
             from lilbee.providers.llama_cpp_provider import resolve_model_path
 

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -82,17 +82,26 @@ def _collect_native_models(buckets: dict[str, list[ModelOption]], seen: set[str]
 
 
 def _collect_remote_models(buckets: dict[str, list[ModelOption]], seen: set[str]) -> None:
-    """Add remote (litellm/Ollama) models to buckets."""
-    try:
-        from lilbee.model_manager import classify_remote_models
+    """Add remote (litellm/Ollama) models to buckets.
 
+    Ollama-backed refs are stored prefixed (``ollama/<name>``) so routing
+    can dispatch on the prefix instead of probing the native registry.
+    The prefixed form is also the dedup key, so an Ollama entry whose
+    tag collides with a native manifest stays visible in the dropdown
+    as a distinct option.
+    """
+    try:
+        from lilbee.model_manager import classify_remote_models, detect_provider
+
+        is_ollama = detect_provider(cfg.litellm_base_url) == "Ollama"
         for model in classify_remote_models(cfg.litellm_base_url):
-            if model.name in seen or _is_mmproj(model.name):
+            ref = f"ollama/{model.name}" if is_ollama else model.name
+            if ref in seen or _is_mmproj(model.name):
                 continue
-            seen.add(model.name)
+            seen.add(ref)
             label = f"{model.name} ({model.provider})"
             buckets.get(model.task, buckets[ModelTask.CHAT]).append(
-                ModelOption(label=label, ref=model.name)
+                ModelOption(label=label, ref=ref)
             )
     except Exception:
         log.debug("Could not classify remote models", exc_info=True)
@@ -131,7 +140,7 @@ def _sync_select(sel: Select, opts: list[ModelOption], default: str = "") -> Non
     backward compatibility, but the UI makes the real state obvious.
     """
     ref = parse_model_ref(default) if default else None
-    default = default if (ref and ref.is_api) else (ref.name if ref else default)
+    default = ref.for_litellm() if ref else default
     if default and not any(o.ref == default for o in opts):
         opts.insert(0, ModelOption(f"{default} (not installed)", default))
     sel.set_options(opts)

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -17,8 +17,9 @@ from lilbee import settings
 from lilbee.cli.tui.pill import pill
 from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.config import cfg
+from lilbee.model_manager import OLLAMA_PROVIDER_NAME
 from lilbee.models import ModelTask
-from lilbee.providers.model_ref import parse_model_ref
+from lilbee.providers.model_ref import OLLAMA_PREFIX, parse_model_ref
 from lilbee.services import reset_services
 
 log = logging.getLogger(__name__)
@@ -82,20 +83,14 @@ def _collect_native_models(buckets: dict[str, list[ModelOption]], seen: set[str]
 
 
 def _collect_remote_models(buckets: dict[str, list[ModelOption]], seen: set[str]) -> None:
-    """Add remote (litellm/Ollama) models to buckets.
-
-    Ollama-backed refs are stored prefixed (``ollama/<name>``) so routing
-    can dispatch on the prefix instead of probing the native registry.
-    The prefixed form is also the dedup key, so an Ollama entry whose
-    tag collides with a native manifest stays visible in the dropdown
-    as a distinct option.
-    """
+    """Add remote (litellm/Ollama) models to buckets, prefixed for routing."""
     try:
         from lilbee.model_manager import classify_remote_models, detect_provider
 
-        is_ollama = detect_provider(cfg.litellm_base_url) == "Ollama"
-        for model in classify_remote_models(cfg.litellm_base_url):
-            ref = f"ollama/{model.name}" if is_ollama else model.name
+        base_url = cfg.litellm_base_url
+        is_ollama = detect_provider(base_url) == OLLAMA_PROVIDER_NAME
+        for model in classify_remote_models(base_url):
+            ref = f"{OLLAMA_PREFIX}{model.name}" if is_ollama else model.name
             if ref in seen or _is_mmproj(model.name):
                 continue
             seen.add(ref)

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -612,22 +612,12 @@ class Config(BaseSettings):
     @field_validator("chat_model", "embedding_model", mode="after")
     @classmethod
     def _normalize_model_tag(cls, v: str) -> str:
-        """Ensure model names always have an explicit tag (e.g. qwen3 -> qwen3:latest).
-
-        API-prefixed models (openai/, anthropic/, gemini/) are left as-is
-        since they don't use tags. Ollama-prefixed models keep their prefix
-        for routing.
-        """
+        """Ensure model names always have an explicit tag and canonical prefix."""
         if not v:
             return v
         from lilbee.providers.model_ref import parse_model_ref
 
-        ref = parse_model_ref(v)
-        if ref.is_api:
-            return v
-        if ref.provider == "ollama":
-            return f"ollama/{ref.name}"
-        return ref.name
+        return parse_model_ref(v).for_litellm()
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/src/lilbee/embedder.py
+++ b/src/lilbee/embedder.py
@@ -53,13 +53,18 @@ class Embedder:
         model = self._config.embedding_model
         if not model:
             return False
+        from lilbee.providers.model_ref import parse_model_ref
+
+        ref = parse_model_ref(model)
+        name_base = ref.name.split(":")[0].lower().replace(" ", "-")
         try:
             available = self._provider.list_models()
-            model_base = model.split(":")[0].lower().replace(" ", "-")
-            if any(model_base in m.lower().replace(" ", "-") for m in available):
+            if any(name_base in m.lower().replace(" ", "-") for m in available):
                 return True
         except Exception:
             log.debug("embedding_available provider check failed", exc_info=True)
+        if ref.needs_litellm:
+            return False
         try:
             from lilbee.providers.llama_cpp_provider import resolve_model_path
 

--- a/src/lilbee/embedder.py
+++ b/src/lilbee/embedder.py
@@ -6,10 +6,51 @@ import math
 from lilbee.config import Config
 from lilbee.progress import DetailedProgressCallback, EmbedEvent, EventType, noop_callback
 from lilbee.providers.base import LLMProvider
+from lilbee.providers.model_ref import ProviderModelRef, parse_model_ref
 
 log = logging.getLogger(__name__)
 
 MAX_BATCH_CHARS = 6000
+
+
+def _name_base(ref: ProviderModelRef) -> str:
+    return ref.name.split(":")[0].lower().replace(" ", "-")
+
+
+def _remote_sees_model(ref: ProviderModelRef, provider: LLMProvider) -> bool:
+    try:
+        available = provider.list_models()
+    except Exception:
+        log.debug("provider list_models failed during availability check", exc_info=True)
+        return False
+    base = _name_base(ref)
+    return any(base in m.lower().replace(" ", "-") for m in available)
+
+
+def _native_has_model(model: str) -> bool:
+    from lilbee.providers.llama_cpp_provider import resolve_model_path
+
+    try:
+        resolve_model_path(model)
+    except Exception:
+        return False
+    return True
+
+
+def is_model_available(model: str, provider: LLMProvider) -> bool:
+    """Return True if *model* resolves via *provider* or the native registry.
+
+    Remote-prefixed refs (``ollama/`` and API providers) skip the native
+    probe since they resolve through litellm at call time.
+    """
+    if not model:
+        return False
+    ref = parse_model_ref(model)
+    if _remote_sees_model(ref, provider):
+        return True
+    if ref.needs_litellm:
+        return False
+    return _native_has_model(model)
 
 
 class Embedder:
@@ -47,31 +88,11 @@ class Embedder:
 
     def embedding_available(self) -> bool:
         """Return True if the embedding model can be resolved.
+
         Checks the provider model list and the native registry path
-        resolution.  Returns True if either finds the model.
+        resolution. Returns True if either finds the model.
         """
-        model = self._config.embedding_model
-        if not model:
-            return False
-        from lilbee.providers.model_ref import parse_model_ref
-
-        ref = parse_model_ref(model)
-        name_base = ref.name.split(":")[0].lower().replace(" ", "-")
-        try:
-            available = self._provider.list_models()
-            if any(name_base in m.lower().replace(" ", "-") for m in available):
-                return True
-        except Exception:
-            log.debug("embedding_available provider check failed", exc_info=True)
-        if ref.needs_litellm:
-            return False
-        try:
-            from lilbee.providers.llama_cpp_provider import resolve_model_path
-
-            resolve_model_path(model)
-            return True
-        except Exception:
-            return False
+        return is_model_available(self._config.embedding_model, self._provider)
 
     def embed(self, text: str) -> list[float]:
         """Embed a single text string, return vector."""

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -287,6 +287,12 @@ def reset_vision_cache() -> None:
     _vision_cache.clear()
 
 
+OLLAMA_PROVIDER_NAME = "Ollama"
+OPENAI_PROVIDER_NAME = "OpenAI"
+ANTHROPIC_PROVIDER_NAME = "Anthropic"
+REMOTE_PROVIDER_NAME = "Remote"
+
+
 @dataclass
 class RemoteModel:
     """A model from the litellm backend with inferred task classification."""
@@ -295,14 +301,14 @@ class RemoteModel:
     task: str  # "chat", "embedding", "vision"
     family: str
     parameter_size: str
-    provider: str = "Remote"  # "Ollama", "OpenAI", "Anthropic", or "Remote"
+    provider: str = REMOTE_PROVIDER_NAME
 
 
 _PROVIDER_PATTERNS: tuple[tuple[str, str], ...] = (
-    ("localhost:11434", "Ollama"),
-    ("ollama", "Ollama"),
-    ("openai", "OpenAI"),
-    ("anthropic", "Anthropic"),
+    ("localhost:11434", OLLAMA_PROVIDER_NAME),
+    ("ollama", OLLAMA_PROVIDER_NAME),
+    ("openai", OPENAI_PROVIDER_NAME),
+    ("anthropic", ANTHROPIC_PROVIDER_NAME),
 )
 
 
@@ -312,7 +318,7 @@ def detect_provider(base_url: str) -> str:
     for pattern, provider in _PROVIDER_PATTERNS:
         if pattern in url_lower:
             return provider
-    return "Remote"
+    return REMOTE_PROVIDER_NAME
 
 
 def _classify_remote_task(name: str, family: str) -> str:

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -15,6 +15,7 @@ from rich.table import Table
 
 from lilbee import settings
 from lilbee.config import cfg
+from lilbee.providers.model_ref import parse_model_ref
 from lilbee.services import get_services
 
 
@@ -37,21 +38,10 @@ MODELS_BROWSE_URL = "https://huggingface.co/models?library=gguf&sort=trending"
 
 
 def ensure_tag(name: str) -> str:
-    """Ensure a model name has an explicit tag (e.g. ``llama3`` → ``llama3:latest``).
-
-    API-prefixed models (openai/, anthropic/, gemini/) are returned as-is
-    since they don't use tags.
-    """
+    """Ensure a model name has an explicit tag and canonical prefix."""
     if not name:
         return name
-    from lilbee.providers.model_ref import parse_model_ref
-
-    ref = parse_model_ref(name)
-    if ref.is_api:
-        return name
-    if ref.provider == "ollama":
-        return f"ollama/{ref.name}"
-    return ref.name
+    return parse_model_ref(name).for_litellm()
 
 
 @dataclass(frozen=True)
@@ -279,8 +269,6 @@ def ensure_chat_model() -> None:
         raise RuntimeError(f"Cannot list models: {exc}") from exc
 
     # Filter out embedding model — only check for chat models
-    from lilbee.providers.model_ref import parse_model_ref
-
     embed_base = parse_model_ref(cfg.embedding_model).name.split(":")[0]
     chat_models = [m for m in installed if m.split(":")[0] != embed_base]
     if chat_models:
@@ -304,8 +292,6 @@ def ensure_chat_model() -> None:
 def list_installed_models() -> list[str]:
     """Return installed model names, excluding embedding models."""
     try:
-        from lilbee.providers.model_ref import parse_model_ref
-
         provider = get_services().provider
         embed_base = parse_model_ref(cfg.embedding_model).name.split(":")[0]
         return [m for m in provider.list_models() if m.split(":")[0] != embed_base]

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -279,7 +279,9 @@ def ensure_chat_model() -> None:
         raise RuntimeError(f"Cannot list models: {exc}") from exc
 
     # Filter out embedding model — only check for chat models
-    embed_base = cfg.embedding_model.split(":")[0]
+    from lilbee.providers.model_ref import parse_model_ref
+
+    embed_base = parse_model_ref(cfg.embedding_model).name.split(":")[0]
     chat_models = [m for m in installed if m.split(":")[0] != embed_base]
     if chat_models:
         return
@@ -302,8 +304,10 @@ def ensure_chat_model() -> None:
 def list_installed_models() -> list[str]:
     """Return installed model names, excluding embedding models."""
     try:
+        from lilbee.providers.model_ref import parse_model_ref
+
         provider = get_services().provider
-        embed_base = cfg.embedding_model.split(":")[0]
+        embed_base = parse_model_ref(cfg.embedding_model).name.split(":")[0]
         return [m for m in provider.list_models() if m.split(":")[0] != embed_base]
     except Exception:
         log.debug("Failed to list installed models", exc_info=True)

--- a/src/lilbee/providers/litellm_provider.py
+++ b/src/lilbee/providers/litellm_provider.py
@@ -17,7 +17,7 @@ import httpx
 
 from lilbee.config import cfg
 from lilbee.providers.base import LLMProvider, ProviderError
-from lilbee.providers.model_ref import parse_model_ref, translate_options
+from lilbee.providers.model_ref import OLLAMA_PREFIX, parse_model_ref, translate_options
 
 log = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ class LiteLLMProvider(LLMProvider):
         if ref.is_api:
             return ref.for_litellm()
         if _is_ollama(self._base_url):
-            return f"ollama/{ref.name}"
+            return f"{OLLAMA_PREFIX}{ref.name}"
         return ref.name
 
     def _embed_model_name(self) -> str:
@@ -97,7 +97,7 @@ class LiteLLMProvider(LLMProvider):
         if ref.is_api:
             return ref.for_litellm()
         if _is_ollama(self._base_url):
-            return f"ollama/{ref.name}"
+            return f"{OLLAMA_PREFIX}{ref.name}"
         return ref.name
 
     def embed(self, texts: list[str]) -> list[list[float]]:

--- a/src/lilbee/providers/model_ref.py
+++ b/src/lilbee/providers/model_ref.py
@@ -14,6 +14,8 @@ from lilbee.providers.base import filter_options
 
 _API_PROVIDERS = {"openai", "anthropic", "gemini"}
 
+OLLAMA_PREFIX = "ollama/"
+
 
 @dataclass(frozen=True)
 class ProviderModelRef:
@@ -39,7 +41,7 @@ class ProviderModelRef:
     def for_litellm(self) -> str:
         """Name formatted for litellm dispatch."""
         if self.provider == "ollama":
-            return f"ollama/{self.name}"
+            return f"{OLLAMA_PREFIX}{self.name}"
         if self.is_api:
             return f"{self.provider}/{self.name}"
         return self.name

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -1,28 +1,32 @@
-"""Routing provider — auto-selects backend based on litellm availability."""
+"""Routing provider: prefix-based dispatch between litellm and llama-cpp."""
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Callable, Iterator
 from typing import Any
 
 from lilbee.config import cfg
 from lilbee.providers.base import LLMProvider, ProviderError
-from lilbee.providers.model_ref import parse_model_ref
+from lilbee.providers.model_ref import ProviderModelRef, parse_model_ref
 
 log = logging.getLogger(__name__)
 
 
 class RoutingProvider(LLMProvider):
-    """Routes all calls to litellm if available, otherwise llama-cpp.
-    When litellm is installed and the backend is reachable, all operations
-    go through litellm. Otherwise, falls back to llama-cpp for local GGUF files.
+    """Dispatches calls based on the model ref prefix.
+
+    ``ollama/``, ``openai/``, ``anthropic/``, ``gemini/`` go to litellm.
+    Unprefixed refs (``qwen3:8b``) go to llama-cpp, which resolves them
+    against the native registry. A registry miss surfaces the native
+    ProviderError unchanged, rather than silently falling through to a
+    remote backend.
     """
 
     def __init__(self) -> None:
         self._llama_cpp: LLMProvider | None = None
         self._litellm: LLMProvider | None = None
-        self._use_litellm: bool | None = None
 
     def _get_llama_cpp(self) -> LLMProvider:  # pragma: no cover
         if self._llama_cpp is None:
@@ -38,66 +42,9 @@ class RoutingProvider(LLMProvider):
             self._litellm = LiteLLMProvider(base_url=cfg.litellm_base_url, api_key=cfg.llm_api_key)
         return self._litellm
 
-    def _should_use_litellm(self) -> bool:
-        """Check once whether litellm is installed and reachable, then cache."""
-        if self._use_litellm is not None:
-            return self._use_litellm
-
-        from lilbee.providers.litellm_provider import litellm_available
-
-        if not litellm_available():
-            self._use_litellm = False
-            return False
-        try:  # pragma: no cover
-            self._get_litellm().list_models()  # pragma: no cover
-            self._use_litellm = True  # pragma: no cover
-        except Exception:  # pragma: no cover
-            log.debug("litellm backend not reachable, using llama-cpp")  # pragma: no cover
-            self._use_litellm = False  # pragma: no cover
-        return self._use_litellm  # pragma: no cover
-
-    def _provider(self) -> LLMProvider:
-        """Return the active provider."""
-        if self._should_use_litellm():
-            return self._get_litellm()
-        return self._get_llama_cpp()
-
-    def _native_has(self, name: str) -> bool:
-        """Return True if the model resolves natively via the local registry.
-
-        Treats registry / path lookup failures as 'not native' so routing
-        falls through to litellm when the ref isn't a local GGUF. This
-        keeps Ollama-backed refs like ``nomic-embed-text:v1.5`` from
-        crashing in llama-cpp when no native copy is installed (bb-0ud4).
-        Any other exception (services-container bootstrap errors, etc.)
-        gets logged at debug level so it doesn't silently mask real
-        routing regressions.
-        """
-        from lilbee.providers.llama_cpp_provider import resolve_model_path
-
-        try:
-            resolve_model_path(name)
-        except ProviderError:
-            return False
-        except Exception:
-            log.debug("Native registry probe for %r raised unexpectedly", name, exc_info=True)
-            return False
-        return True
-
-    def _pick_backend(self, ref: Any) -> LLMProvider:
-        """Choose litellm vs llama-cpp for a parsed ref.
-
-        Remote (API or Ollama-prefixed) refs always go to litellm. Bare
-        refs prefer llama-cpp when a native copy exists, and fall through
-        to litellm otherwise so litellm can try to reach them via Ollama
-        (it auto-prefixes bare refs with ``ollama/`` when configured
-        against an Ollama base URL).
-        """
-        if ref.is_api or ref.provider == "ollama":
-            return self._get_litellm()
-        if self._native_has(ref.name):
-            return self._get_llama_cpp()
-        if self._should_use_litellm():
+    def _pick_backend(self, ref: ProviderModelRef) -> LLMProvider:
+        """Pick the backend for *ref* purely by prefix."""
+        if ref.needs_litellm:
             return self._get_litellm()
         return self._get_llama_cpp()
 
@@ -117,42 +64,41 @@ class RoutingProvider(LLMProvider):
         return self._pick_backend(ref).chat(messages, stream=stream, options=options, model=model)
 
     def list_models(self) -> list[str]:
-        """Return models from the active provider."""
-        import contextlib
+        """Return the union of native and litellm-visible models.
+
+        Both halves are wrapped so an unreachable remote backend or a
+        missing native registry does not mask the other.
+        """
+        from lilbee.providers.litellm_provider import litellm_available
 
         native: set[str] = set()
         with contextlib.suppress(Exception):
             native = set(self._get_llama_cpp().list_models())
-        if self._should_use_litellm():
-            try:  # pragma: no cover
-                remote = set(self._get_litellm().list_models())  # pragma: no cover
-                return sorted(native | remote)  # pragma: no cover
-            except Exception:  # pragma: no cover
-                pass  # pragma: no cover
-        return sorted(native)
+        if not litellm_available():
+            return sorted(native)
+        try:  # pragma: no cover
+            remote = set(self._get_litellm().list_models())  # pragma: no cover
+        except Exception:  # pragma: no cover
+            return sorted(native)  # pragma: no cover
+        return sorted(native | remote)  # pragma: no cover
 
     def pull_model(self, model: str, *, on_progress: Callable[..., Any] | None = None) -> None:
-        """Pull via litellm if available, otherwise raise."""
-        if self._should_use_litellm():
-            try:  # pragma: no cover
-                self._get_litellm().pull_model(model, on_progress=on_progress)  # pragma: no cover
-                self.invalidate_cache()  # pragma: no cover
-                return  # pragma: no cover
-            except Exception:  # pragma: no cover
-                pass  # pragma: no cover
-        raise ProviderError(f"Cannot pull model {model!r}: no pull-capable backend available")
+        """Pull via litellm if installed, otherwise raise."""
+        from lilbee.providers.litellm_provider import litellm_available
+
+        if not litellm_available():
+            raise ProviderError(f"Cannot pull model {model!r}: no pull-capable backend available")
+        self._get_litellm().pull_model(model, on_progress=on_progress)  # pragma: no cover
 
     def show_model(self, model: str) -> dict[str, Any] | None:
-        """Show model info from the active provider."""
-        return self._provider().show_model(model)
+        """Show model info from the backend selected by the ref prefix."""
+        ref = parse_model_ref(model)
+        return self._pick_backend(ref).show_model(model)
 
     def get_capabilities(self, model: str) -> list[str]:
-        """Return capability tags from the active provider."""
-        return self._provider().get_capabilities(model)
-
-    def invalidate_cache(self) -> None:
-        """Clear cached litellm detection (after pull/delete)."""
-        self._use_litellm = None
+        """Return capability tags from the backend selected by the ref prefix."""
+        ref = parse_model_ref(model)
+        return self._pick_backend(ref).get_capabilities(model)
 
     def shutdown(self) -> None:
         """Shut down sub-providers to release resources."""

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -26,6 +26,7 @@ from lilbee.cli.helpers import clean_result, copy_files, gather_status, get_vers
 from lilbee.config import Config, cfg
 from lilbee.model_manager import ModelSource, get_model_manager
 from lilbee.progress import DetailedProgressCallback, EventType, ProgressEvent, SseEvent
+from lilbee.providers.model_ref import parse_model_ref
 from lilbee.results import DocumentResult, group
 from lilbee.security import validate_path_within
 from lilbee.server.models import (
@@ -484,13 +485,11 @@ async def _set_model(
 def _require_model_available(model: str) -> str:
     """Validate that *model* exists locally. Returns the normalized name or raises ValueError."""
     from lilbee.models import ensure_tag
-    from lilbee.providers.model_ref import parse_model_ref
 
     normalized = ensure_tag(model)
     available = get_services().provider.list_models()
-    # ``available`` contains bare tags for remote models (from /api/tags)
-    # but we store and return prefixed refs. Compare on the parsed name so
-    # ``ollama/qwen3:8b`` matches a remote ``qwen3:8b`` entry.
+    # ``available`` lists bare tags from /api/tags; stored refs may carry an
+    # ``ollama/`` prefix. Match on either form so both client styles work.
     bare = parse_model_ref(normalized).name
     if normalized not in available and bare not in available:
         raise ValueError(f"Model '{normalized}' is not available. Pull it first or check the name.")

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -484,10 +484,15 @@ async def _set_model(
 def _require_model_available(model: str) -> str:
     """Validate that *model* exists locally. Returns the normalized name or raises ValueError."""
     from lilbee.models import ensure_tag
+    from lilbee.providers.model_ref import parse_model_ref
 
     normalized = ensure_tag(model)
     available = get_services().provider.list_models()
-    if normalized not in available:
+    # ``available`` contains bare tags for remote models (from /api/tags)
+    # but we store and return prefixed refs. Compare on the parsed name so
+    # ``ollama/qwen3:8b`` matches a remote ``qwen3:8b`` entry.
+    bare = parse_model_ref(normalized).name
+    if normalized not in available and bare not in available:
         raise ValueError(f"Model '{normalized}' is not available. Pull it first or check the name.")
     return normalized
 

--- a/tests/test_chat_setup_detection.py
+++ b/tests/test_chat_setup_detection.py
@@ -62,6 +62,23 @@ def test_needs_setup_true_when_initialized_but_model_missing(isolated_data_dir):
         assert _make_screen()._needs_setup() is True
 
 
+def test_needs_setup_skips_native_probe_for_remote_prefixed_models(isolated_data_dir):
+    """ollama/ and API-prefixed models bypass the llama-cpp registry check.
+
+    The native resolver only knows about GGUFs. A remote ref resolves at
+    call time via litellm, so asking resolve_model_path about it would
+    always raise and wrongly trigger the setup wizard.
+    """
+    cfg.lancedb_dir.mkdir(parents=True)
+    cfg.chat_model = "ollama/qwen3:0.6b"
+    cfg.embedding_model = "ollama/nomic-embed-text:v1.5"
+    with mock.patch(
+        "lilbee.providers.llama_cpp_provider.resolve_model_path",
+    ) as resolve:
+        assert _make_screen()._needs_setup() is False
+        resolve.assert_not_called()
+
+
 def test_needs_setup_true_when_lancedb_path_is_a_file(isolated_data_dir):
     """A stray file at the lancedb path is not a real data directory."""
     cfg.lancedb_dir.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -626,6 +626,16 @@ class TestListInstalledModels:
         assert result == ["llama3:latest"]
         assert "nomic-embed-text:latest" not in result
 
+    def test_excludes_embedding_model_with_ollama_prefix(self, mock_svc):
+        """ollama/<name> embedding refs still filter out the bare /api/tags entry."""
+        cfg.embedding_model = "ollama/nomic-embed-text:v1.5"
+        mock_svc.provider.list_models.return_value = [
+            "llama3:latest",
+            "nomic-embed-text:v1.5",
+        ]
+        result = list_installed_models()
+        assert result == ["llama3:latest"]
+
 
 def _search_chunk(**overrides: object) -> SearchChunk:
     defaults: dict[str, object] = {

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,5 +1,6 @@
 """Tests for the embedding wrapper (mocked -- no live server needed)."""
 
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -141,5 +142,38 @@ class TestValidateModel:
         try:
             embedder = Embedder(cfg, mock_provider)
             assert embedder.embedding_available() is False
+        finally:
+            cfg.embedding_model = old
+
+    def test_embedding_available_true_for_prefixed_model_matching_bare_list(self, mock_provider):
+        """ollama/ ref matches against bare tags returned by list_models.
+
+        provider.list_models returns raw /api/tags entries without the
+        ollama/ prefix, so the availability check must compare on the
+        stripped name.
+        """
+        from lilbee.config import cfg
+
+        old = cfg.embedding_model
+        cfg.embedding_model = "ollama/nomic-embed-text:v1.5"
+        try:
+            mock_provider.list_models.return_value = ["nomic-embed-text:v1.5"]
+            embedder = Embedder(cfg, mock_provider)
+            assert embedder.embedding_available() is True
+        finally:
+            cfg.embedding_model = old
+
+    def test_embedding_available_false_for_prefixed_model_skips_native_probe(self, mock_provider):
+        """ollama/ ref not in list_models returns False without resolve_model_path."""
+        from lilbee.config import cfg
+
+        old = cfg.embedding_model
+        cfg.embedding_model = "ollama/nomic-embed-text:v1.5"
+        try:
+            mock_provider.list_models.return_value = []
+            embedder = Embedder(cfg, mock_provider)
+            with mock.patch("lilbee.providers.llama_cpp_provider.resolve_model_path") as resolve:
+                assert embedder.embedding_available() is False
+                resolve.assert_not_called()
         finally:
             cfg.embedding_model = old

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -533,14 +533,18 @@ class TestRoutingProvider:
         assert result == "hello"
         mock_litellm.chat.assert_called_once()
 
-    def test_routes_chat_to_llama_cpp_for_local_model(self) -> None:
+    def test_routes_chat_to_llama_cpp_for_bare_ref(self) -> None:
+        """Bare refs dispatch to llama-cpp regardless of registry contents.
+
+        The new routing is strict: no prefix means native. If the native
+        registry doesn't have the model, llama-cpp raises its own
+        'not installed' error; routing never falls through to litellm.
+        """
         rp = self._make_provider()
 
         mock_llama = mock.MagicMock()
         mock_llama.chat.return_value = "local"
         rp._llama_cpp = mock_llama
-        # Native registry has the model → keep routing to llama-cpp.
-        rp._native_has = lambda _name: True  # type: ignore[method-assign]
 
         cfg.chat_model = "local-model:latest"
         result = rp.chat([{"role": "user", "content": "hi"}])
@@ -558,142 +562,63 @@ class TestRoutingProvider:
         assert result == [[0.1, 0.2]]
         mock_litellm.embed.assert_called_once()
 
-    def test_routes_embed_to_llama_cpp_for_local_model(self) -> None:
+    def test_routes_embed_to_llama_cpp_for_bare_ref(self) -> None:
         rp = self._make_provider()
 
         mock_llama = mock.MagicMock()
         mock_llama.embed.return_value = [[0.3, 0.4]]
         rp._llama_cpp = mock_llama
-        # Native registry has the model → keep routing to llama-cpp.
-        rp._native_has = lambda _name: True  # type: ignore[method-assign]
 
         cfg.embedding_model = "nomic-embed-text:latest"
         result = rp.embed(["test"])
         assert result == [[0.3, 0.4]]
 
-    def test_routes_bare_embed_to_litellm_when_not_installed_natively(self) -> None:
-        """bb-0ud4: bare embedding ref falls through to litellm if not native.
+    def test_bare_ref_never_falls_through_to_litellm(self) -> None:
+        """Bare refs stay on llama-cpp even when litellm is installed.
 
-        When cfg.embedding_model = 'nomic-embed-text:latest' and no native
-        GGUF is installed, the routing provider used to crash in
-        llama_cpp_provider.resolve_model_path. It now defers to litellm,
-        which auto-prefixes the ref with 'ollama/' when configured against
-        an Ollama base URL.
+        This is the behaviour change from bb-0ud4's probe-based routing:
+        prefix is the single source of truth, so users who want Ollama
+        must say so explicitly with 'ollama/<name>'.
         """
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
-        mock_litellm.embed.return_value = [[0.5, 0.6]]
-        rp._litellm = mock_litellm
-        rp._use_litellm = True
-        rp._native_has = lambda _name: False  # type: ignore[method-assign]
-
-        cfg.embedding_model = "nomic-embed-text:latest"
-        result = rp.embed(["test"])
-        assert result == [[0.5, 0.6]]
-        mock_litellm.embed.assert_called_once()
-
-    def test_routes_bare_chat_to_litellm_when_not_installed_natively(self) -> None:
-        """bb-0ud4 parallel: bare chat ref also falls through to litellm."""
-        rp = self._make_provider()
-        mock_litellm = mock.MagicMock()
-        mock_litellm.chat.return_value = "remote"
-        rp._litellm = mock_litellm
-        rp._use_litellm = True
-        rp._native_has = lambda _name: False  # type: ignore[method-assign]
-
-        cfg.chat_model = "mistral:latest"
-        result = rp.chat([{"role": "user", "content": "hi"}])
-        assert result == "remote"
-        mock_litellm.chat.assert_called_once()
-
-    def test_routes_bare_ref_to_llama_cpp_when_litellm_unavailable(self) -> None:
-        """Fallback: with no native install and no litellm, still try llama-cpp.
-
-        The llama-cpp call will then raise its own ProviderError if the
-        ref can't be resolved — but that preserves existing behaviour for
-        environments with neither backend configured.
-        """
-        rp = self._make_provider()
         mock_llama = mock.MagicMock()
         mock_llama.embed.return_value = [[0.9, 1.0]]
+        rp._litellm = mock_litellm
         rp._llama_cpp = mock_llama
-        rp._use_litellm = False
-        rp._native_has = lambda _name: False  # type: ignore[method-assign]
 
-        cfg.embedding_model = "unknown-model:latest"
+        cfg.embedding_model = "mistral:latest"
         result = rp.embed(["test"])
         assert result == [[0.9, 1.0]]
         mock_llama.embed.assert_called_once()
-
-    def test_native_has_true_when_resolve_succeeds(self) -> None:
-        """_native_has returns True when resolve_model_path does not raise."""
-        rp = self._make_provider()
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider.resolve_model_path",
-            return_value="/fake/path.gguf",
-        ):
-            assert rp._native_has("any-model") is True
-
-    def test_native_has_false_when_resolve_raises(self) -> None:
-        """_native_has swallows the registry error and returns False."""
-        from lilbee.providers.base import ProviderError
-
-        rp = self._make_provider()
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider.resolve_model_path",
-            side_effect=ProviderError("not installed", provider="llama-cpp"),
-        ):
-            assert rp._native_has("missing-model") is False
-
-    def test_native_has_false_on_unexpected_exception(self) -> None:
-        """bb-0ud4: unexpected errors during the probe fall through to False
-        with a debug log, not an uncaught exception.
-        """
-        rp = self._make_provider()
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider.resolve_model_path",
-            side_effect=RuntimeError("services bootstrap blew up"),
-        ):
-            assert rp._native_has("any-model") is False
+        mock_litellm.embed.assert_not_called()
 
     def test_list_models_native_only_when_litellm_unavailable(self) -> None:
         rp = self._make_provider()
-        rp._use_litellm = False
 
         mock_llama = mock.MagicMock()
         mock_llama.list_models.return_value = ["local.gguf"]
         rp._llama_cpp = mock_llama
 
-        result = rp.list_models()
+        with mock.patch(
+            "lilbee.providers.litellm_provider.litellm_available",
+            return_value=False,
+        ):
+            result = rp.list_models()
         assert result == ["local.gguf"]
 
-    def test_local_model_uses_llama_cpp_directly(self) -> None:
-        rp = self._make_provider()
-
-        mock_llama = mock.MagicMock()
-        mock_llama.chat.return_value = "fallback"
-        rp._llama_cpp = mock_llama
-        # Native registry has the model → skip litellm fall-through (bb-0ud4).
-        rp._native_has = lambda _name: True  # type: ignore[method-assign]
-
-        cfg.chat_model = "local-model:latest"
-        result = rp.chat([{"role": "user", "content": "hi"}])
-        assert result == "fallback"
-
-    def test_show_model_delegates_to_litellm_when_available(self) -> None:
+    def test_show_model_delegates_by_prefix(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.show_model.return_value = {"parameters": "temp 0.7"}
         rp._litellm = mock_litellm
-        rp._use_litellm = True
 
-        result = rp.show_model("qwen3:8b")
+        result = rp.show_model("ollama/qwen3:8b")
         assert result == {"parameters": "temp 0.7"}
-        mock_litellm.show_model.assert_called_once_with("qwen3:8b")
+        mock_litellm.show_model.assert_called_once_with("ollama/qwen3:8b")
 
-    def test_show_model_uses_llama_cpp_when_litellm_unavailable(self) -> None:
+    def test_show_model_bare_ref_uses_llama_cpp(self) -> None:
         rp = self._make_provider()
-        rp._use_litellm = False
 
         mock_llama = mock.MagicMock()
         mock_llama.show_model.return_value = None
@@ -701,21 +626,20 @@ class TestRoutingProvider:
 
         result = rp.show_model("local.gguf")
         assert result is None
-
-    def test_invalidate_cache_clears_detection(self) -> None:
-        rp = self._make_provider()
-        rp._use_litellm = True
-
-        rp.invalidate_cache()
-        assert rp._use_litellm is None
+        mock_llama.show_model.assert_called_once_with("local.gguf")
 
     def test_pull_model_raises_when_litellm_unavailable(self) -> None:
         from lilbee.providers.base import ProviderError
 
         rp = self._make_provider()
-        rp._use_litellm = False
 
-        with pytest.raises(ProviderError, match="no pull-capable backend"):
+        with (
+            mock.patch(
+                "lilbee.providers.litellm_provider.litellm_available",
+                return_value=False,
+            ),
+            pytest.raises(ProviderError, match="no pull-capable backend"),
+        ):
             rp.pull_model("bad-model")
 
     def test_chat_with_explicit_api_model_override(self) -> None:
@@ -732,23 +656,15 @@ class TestRoutingProvider:
         assert result == "saw it"
         mock_litellm.chat.assert_called_once()
 
-    def test_litellm_not_installed_skips_remote(self) -> None:
-        """When litellm is not installed, routing provider uses llama-cpp."""
-        rp = self._make_provider()
-
-        with mock.patch("lilbee.providers.litellm_provider.litellm_available", return_value=False):
-            assert rp._should_use_litellm() is False
-
-    def test_get_capabilities_delegates_to_active_provider(self) -> None:
+    def test_get_capabilities_delegates_by_prefix(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()
         mock_litellm.get_capabilities.return_value = ["completion", "vision"]
         rp._litellm = mock_litellm
-        rp._use_litellm = True
 
-        caps = rp.get_capabilities("llava:7b")
+        caps = rp.get_capabilities("ollama/llava:7b")
         assert caps == ["completion", "vision"]
-        mock_litellm.get_capabilities.assert_called_once_with("llava:7b")
+        mock_litellm.get_capabilities.assert_called_once_with("ollama/llava:7b")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -657,6 +657,30 @@ class TestSetChatModel:
         with pytest.raises(ValueError, match="not available"):
             await handlers.set_chat_model("nonexistent:7b")
 
+    async def test_accepts_ollama_prefixed_ref_matching_bare_list(self, tmp_path, mock_svc):
+        """ollama/ refs match against bare /api/tags entries returned by list_models.
+
+        Without this path, every Ollama pick via the server API would be
+        rejected as unavailable even when the backend reports the tag.
+        """
+        mock_svc.provider.list_models.return_value = ["qwen3:0.6b"]
+        result = await handlers.set_chat_model("ollama/qwen3:0.6b")
+        assert result.model == "ollama/qwen3:0.6b"
+        assert cfg.chat_model == "ollama/qwen3:0.6b"
+
+    async def test_accepts_bare_ref_matching_remote_only_list(self, tmp_path, mock_svc):
+        """Bare refs still validate against the remote list for legacy callers.
+
+        The server API takes verbatim user input. A user who posts a bare
+        tag that happens to match only a remote entry must still be
+        accepted so clients that never learned the ollama/ prefix keep
+        working.
+        """
+        mock_svc.provider.list_models.return_value = ["qwen3:0.6b"]
+        result = await handlers.set_chat_model("qwen3:0.6b")
+        assert result.model == "qwen3:0.6b"
+        assert cfg.chat_model == "qwen3:0.6b"
+
 
 class TestModelsCatalog:
     @patch("lilbee.catalog.get_catalog")

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2733,3 +2733,56 @@ class TestChatEmbeddingReadyCoverage:
                 side_effect=FileNotFoundError("not found"),
             ):
                 assert screen._embedding_ready() is False
+
+    async def test_embedding_ready_true_for_prefixed_model_in_provider_list(self):
+        """ollama/ refs match against bare names returned by provider.list_models.
+
+        provider.list_models returns tags without the ollama/ prefix
+        (from /api/tags), so _embedding_ready must strip the prefix
+        before substring-matching.
+        """
+        from lilbee.cli.tui.screens.chat import ChatScreen
+        from lilbee.services import set_services
+
+        snapshot_embed = cfg.embedding_model
+        cfg.embedding_model = "ollama/nomic-embed-text:v1.5"
+        mock_svc = mock.MagicMock()
+        mock_svc.provider.list_models.return_value = ["nomic-embed-text:v1.5"]
+        set_services(mock_svc)
+        try:
+            app = ChatTestApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                screen = app.screen
+                assert isinstance(screen, ChatScreen)
+                assert screen._embedding_ready() is True
+        finally:
+            set_services(None)
+            cfg.embedding_model = snapshot_embed
+
+    async def test_embedding_ready_false_for_prefixed_model_not_in_list(self):
+        """ollama/ refs that don't appear in provider.list_models return False
+        without falling through to the native registry probe.
+        """
+        from lilbee.cli.tui.screens.chat import ChatScreen
+        from lilbee.services import set_services
+
+        snapshot_embed = cfg.embedding_model
+        cfg.embedding_model = "ollama/nomic-embed-text:v1.5"
+        mock_svc = mock.MagicMock()
+        mock_svc.provider.list_models.return_value = []
+        set_services(mock_svc)
+        try:
+            app = ChatTestApp()
+            async with app.run_test(size=(120, 40)) as pilot:
+                await pilot.pause()
+                screen = app.screen
+                assert isinstance(screen, ChatScreen)
+                with mock.patch(
+                    "lilbee.providers.llama_cpp_provider.resolve_model_path"
+                ) as resolve:
+                    assert screen._embedding_ready() is False
+                    resolve.assert_not_called()
+        finally:
+            set_services(None)
+            cfg.embedding_model = snapshot_embed

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3076,6 +3076,27 @@ async def test_catalog_select_remote_row():
             assert cfg.chat_model == "remote-chat:latest"
 
 
+async def test_catalog_select_ollama_remote_row_stores_prefix():
+    """Picking an Ollama-backed catalog row stores the ollama/ prefix.
+
+    Without the prefix, routing would classify it as local and dispatch
+    to llama-cpp, silently bypassing the user's Ollama choice.
+    """
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+    from lilbee.cli.tui.screens.catalog_utils import remote_to_row
+
+    app = CatalogTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with _patch_catalog()[0], _patch_catalog()[1], _patch_catalog()[2]:
+            screen = CatalogScreen()
+            app.push_screen(screen)
+            await _pilot.pause()
+            om = _make_remote_model(name="qwen3:0.6b", provider="Ollama")
+            row = remote_to_row(om)
+            screen._select_row(row)
+            assert cfg.chat_model == "ollama/qwen3:0.6b"
+
+
 async def test_catalog_load_more():
     from lilbee.cli.tui.screens.catalog import _HF_PAGE_SIZE, CatalogScreen
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -513,7 +513,13 @@ class TestClassifyInstalledModels:
         all_refs = [ref for _, ref in chat + embed]
         assert not any("mmproj" in r.lower() for r in all_refs)
 
-    def test_remote_models_classified(self, tmp_path) -> None:
+    def test_remote_ollama_models_stored_with_prefix(self, tmp_path) -> None:
+        """Ollama-backed options carry the ollama/ prefix in their ref.
+
+        Routing uses the prefix as the single source of truth, so the
+        origin must survive in config. The human label still shows the
+        tag without the prefix so the dropdown stays readable.
+        """
         from lilbee.cli.tui.widgets.model_bar import _classify_installed_models
         from lilbee.model_manager import RemoteModel
 
@@ -522,15 +528,18 @@ class TestClassifyInstalledModels:
             task="chat",
             family="llama",
             parameter_size="8B",
+            provider="Ollama",
         )
         remote_embed = RemoteModel(
             name="nomic-embed-text:latest",
             task="embedding",
             family="nomic-bert",
             parameter_size="137M",
+            provider="Ollama",
         )
         cfg.models_dir = tmp_path / "models"
         cfg.models_dir.mkdir()
+        cfg.litellm_base_url = "http://localhost:11434"
 
         with (
             mock.patch("lilbee.registry.ModelRegistry") as MockRegistry,
@@ -544,8 +553,55 @@ class TestClassifyInstalledModels:
 
         chat_refs = [ref for _, ref in chat]
         embed_refs = [ref for _, ref in embed]
-        assert "llama3:8b" in chat_refs
-        assert "nomic-embed-text:latest" in embed_refs
+        chat_labels = [label for label, _ in chat]
+        assert "ollama/llama3:8b" in chat_refs
+        assert "ollama/nomic-embed-text:latest" in embed_refs
+        assert any("llama3:8b" in lbl and "Ollama" in lbl for lbl in chat_labels)
+
+    def test_remote_ollama_coexists_with_native_tag_collision(self, tmp_path) -> None:
+        """When a tag collides with a native manifest, both stay visible.
+
+        Regression coverage for the dedup bug: _collect_native_models added
+        the bare tag to seen first, which silently dropped the Ollama
+        duplicate. Prefixing the ref makes the two entries distinct.
+        """
+        from lilbee.cli.tui.widgets.model_bar import _classify_installed_models
+        from lilbee.model_manager import RemoteModel
+        from lilbee.registry import ModelManifest
+
+        native = ModelManifest(
+            name="mistral",
+            tag="latest",
+            size_bytes=100,
+            task="chat",
+            source_repo="",
+            source_filename="",
+            downloaded_at="",
+        )
+        remote = RemoteModel(
+            name="mistral:latest",
+            task="chat",
+            family="mistral",
+            parameter_size="7B",
+            provider="Ollama",
+        )
+        cfg.models_dir = tmp_path / "models"
+        cfg.models_dir.mkdir()
+        cfg.litellm_base_url = "http://localhost:11434"
+
+        with (
+            mock.patch("lilbee.registry.ModelRegistry") as MockRegistry,
+            mock.patch(
+                "lilbee.model_manager.classify_remote_models",
+                return_value=[remote],
+            ),
+        ):
+            MockRegistry.return_value.list_installed.return_value = [native]
+            chat, _ = _classify_installed_models()
+
+        chat_refs = {ref for _, ref in chat}
+        assert "mistral:latest" in chat_refs
+        assert "ollama/mistral:latest" in chat_refs
 
     def test_no_models_returns_empty(self, tmp_path) -> None:
         from lilbee.cli.tui.widgets.model_bar import _classify_installed_models
@@ -2465,7 +2521,7 @@ class TestCollectNativeModelsError:
             _collect_remote_models(buckets, seen)
         assert len(buckets["chat"]) == 1
         assert buckets["chat"][0].label == "llama3:8b (Ollama)"
-        assert buckets["chat"][0].ref == "llama3:8b"
+        assert buckets["chat"][0].ref == "ollama/llama3:8b"
 
     def test_collect_api_models_adds_frontier_models(self) -> None:
         from lilbee.cli.tui.widgets.model_bar import _collect_api_models


### PR DESCRIPTION
## What was broken

Picking an Ollama model in the TUI or catalog silently ran chat against the native llama-cpp backend instead of Ollama. You'd select `qwen3:0.6b (Ollama)`, click it, and responses would come from the local GGUF of the same name, never touching Ollama. Even worse, the Ollama option often didn't show up at all when its tag collided with a native manifest.

## Why

The routing layer classified model refs by prefix, but the picker wrote Ollama choices into config without one. Once stored as a bare `qwen3:0.6b`, every downstream check treated it as native. A fallback probe tried to recover by calling litellm when the native registry missed, but the native registry had manifests for every common Ollama tag, so the probe never fired. The dropdown's dedup logic then dropped the Ollama entry outright whenever a native tag matched.

## The fix

Routing is now a pure prefix dispatch:

- `ollama/<name>` goes to litellm.
- `<name>` with no prefix goes to llama-cpp.

No fallback between them. A misrouted request raises a clear "not installed" error instead of silently running the wrong model.

The model-bar and catalog now write the `ollama/` prefix into config when you pick a remote model, so the origin survives a restart. When an Ollama tag collides with a native manifest, both options show up in the dropdown with distinct refs.

Setup detection, availability checks, and the server-side model validator were also updated to understand the prefix, so a stored `ollama/...` ref no longer looks "missing" to them.

## Cleanup that came along for the ride

Two duplicated availability checks collapsed into a single helper, three copies of the tag-normalization logic collapsed into one call to `ProviderModelRef.for_litellm`, and the raw `"ollama/"` / `"Ollama"` literals scattered across modules are now named constants.

## Verified

Full end-to-end run against a local Ollama: sync, ask, and TUI chat with retrieval all route through Ollama for both chat and embeddings, and through llama-cpp for bare-name native refs.