### PR TITLE
fix(catalog): drop install-state coupling from source field

### DIFF
--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -1084,14 +1084,7 @@ class EnrichedModel:
 
 
 def enrich_catalog(result: CatalogResult, installed_names: set[str]) -> list[EnrichedModel]:
-    """Enrich catalog models with display names, quality tiers, and install status.
-
-    ``source`` describes the model's origin, not its install state. Every
-    catalog entry (featured TOML or HF-search result) is a native HuggingFace
-    GGUF, so it always reports ``source="native"``. ``installed`` is populated
-    separately from ``installed_names`` and may be true for either a native
-    entry that exists on disk or a name that a litellm backend claims to route.
-    """
+    """Enrich catalog models with display names, quality tiers, and install status."""
     enriched: list[EnrichedModel] = []
     for m in result.models:
         is_installed = m.ref in installed_names

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -29,6 +29,7 @@ from tqdm.auto import tqdm as _base_tqdm
 
 from lilbee.cancellation import TaskCancelled
 from lilbee.config import cfg
+from lilbee.model_manager import ModelSource
 from lilbee.models import ModelTask
 from lilbee.registry import DEFAULT_TAG, ModelManifest, ModelRef, ModelRegistry
 
@@ -1083,7 +1084,14 @@ class EnrichedModel:
 
 
 def enrich_catalog(result: CatalogResult, installed_names: set[str]) -> list[EnrichedModel]:
-    """Enrich catalog models with display names, quality tiers, and install status."""
+    """Enrich catalog models with display names, quality tiers, and install status.
+
+    ``source`` describes the model's origin, not its install state. Every
+    catalog entry (featured TOML or HF-search result) is a native HuggingFace
+    GGUF, so it always reports ``source="native"``. ``installed`` is populated
+    separately from ``installed_names`` and may be true for either a native
+    entry that exists on disk or a name that a litellm backend claims to route.
+    """
     enriched: list[EnrichedModel] = []
     for m in result.models:
         is_installed = m.ref in installed_names
@@ -1103,7 +1111,7 @@ def enrich_catalog(result: CatalogResult, installed_names: set[str]) -> list[Enr
                 param_count=_derive_param_count(m),
                 quality_tier=quant_tier(_extract_quant(m.gguf_filename)),
                 installed=is_installed,
-                source="litellm" if is_installed else "native",
+                source=ModelSource.NATIVE.value,
             )
         )
     return enriched

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1790,7 +1790,22 @@ class TestEnrichCatalog:
         assert enriched[0].installed is False
         assert enriched[0].source == "native"
         assert enriched[1].installed is True
-        assert enriched[1].source == "litellm"
+        # source describes origin (HF GGUF), not install-state. Every catalog
+        # entry is a native HF GGUF regardless of whether it happens to appear
+        # in a provider's list_models() snapshot.
+        assert enriched[1].source == "native"
+
+    def test_source_is_native_regardless_of_installed_names(self) -> None:
+        """Regression: featured catalog entries are native GGUFs. Provider
+        list_models() overlap (e.g. litellm reporting it can route a name)
+        must not flip source to 'litellm'.
+        """
+        result = self._make_result()
+        # Simulate a litellm provider that claims to route both entries.
+        enriched = enrich_catalog(result, {"model-7b-gguf:latest", "qwen3:8b"})
+        assert all(e.source == "native" for e in enriched)
+        assert enriched[0].installed is True
+        assert enriched[1].installed is True
 
     def test_preserves_original_fields(self) -> None:
         result = self._make_result()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1790,18 +1790,10 @@ class TestEnrichCatalog:
         assert enriched[0].installed is False
         assert enriched[0].source == "native"
         assert enriched[1].installed is True
-        # source describes origin (HF GGUF), not install-state. Every catalog
-        # entry is a native HF GGUF regardless of whether it happens to appear
-        # in a provider's list_models() snapshot.
         assert enriched[1].source == "native"
 
     def test_source_is_native_regardless_of_installed_names(self) -> None:
-        """Regression: featured catalog entries are native GGUFs. Provider
-        list_models() overlap (e.g. litellm reporting it can route a name)
-        must not flip source to 'litellm'.
-        """
         result = self._make_result()
-        # Simulate a litellm provider that claims to route both entries.
         enriched = enrich_catalog(result, {"model-7b-gguf:latest", "qwen3:8b"})
         assert all(e.source == "native" for e in enriched)
         assert enriched[0].installed is True

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -722,8 +722,6 @@ class TestModelsCatalog:
         assert m.downloads == 1000
         assert m.param_count == "8B"
         assert m.installed is True
-        # Catalog entries are always native HF GGUFs. Source must not flip to
-        # 'litellm' just because the provider's list_models() overlaps.
         assert m.source == "native"
 
     @patch("lilbee.catalog.get_catalog")

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -722,7 +722,9 @@ class TestModelsCatalog:
         assert m.downloads == 1000
         assert m.param_count == "8B"
         assert m.installed is True
-        assert m.source == "litellm"
+        # Catalog entries are always native HF GGUFs. Source must not flip to
+        # 'litellm' just because the provider's list_models() overlaps.
+        assert m.source == "native"
 
     @patch("lilbee.catalog.get_catalog")
     async def test_filters_passed_to_catalog(self, mock_get_catalog, mock_svc):


### PR DESCRIPTION
The catalog was labeling every featured GGUF as `source=litellm` on servers that use the LiteLLM provider, because `enrich_catalog` was deriving `source` from install state instead of origin. All featured entries are native HuggingFace GGUFs, so `source` should always be `native`.

The Obsidian wizard uses `source` to pick what to render and to route pull/delete — with the bad label, users saw an empty picks grid. Fix is one line: `source` is now unconditionally `native` for catalog entries. `installed` stays as a separate concern.

Follow-up filed: `installed` still leaks LiteLLM's routing claims for GGUFs not on disk. Separate PR.