### PR TITLE
Poll for checkbox-toggle cfg update (Windows async)

### DIFF
--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -565,7 +565,10 @@ async def test_settings_checkbox_persist():
         cb = app.screen.query_one("#ed-show_reasoning", Checkbox)
         original = cfg.show_reasoning
         cb.toggle()
-        await pilot.pause()
+        for _ in range(10):
+            await pilot.pause()
+            if cfg.show_reasoning != original:
+                break
         assert cfg.show_reasoning != original
 
 
@@ -584,7 +587,10 @@ async def test_settings_tab_reaches_checkbox_and_space_toggles():
                 break
         assert app.focused is cb, "Tab failed to reach show_reasoning checkbox"
         await pilot.press("space")
-        await pilot.pause()
+        for _ in range(10):
+            await pilot.pause()
+            if cfg.show_reasoning != original:
+                break
         assert cfg.show_reasoning != original
 
 


### PR DESCRIPTION
Windows CI was failing on `test_settings_checkbox_persist` — the
`Checkbox.toggle()` call posts the Changed message asynchronously and
one `pilot.pause()` isn't always enough on Windows for the handler to
run and update `cfg`. Same pattern as the other "Windows async" polling
fixes that already landed on release/next; replace the single pause with
a bounded poll loop. Applied to the Tab+Space sibling test too since it
had the same single-trailing-pause fragility.