### PR TITLE
Route RoutingProvider through SDK protocol and narrow rerank score shape

### DIFF
--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -540,11 +540,8 @@ def compute_rerank_scores(llm: Any, query: str, candidates: list[str]) -> list[f
 def _extract_rerank_score(response: dict[str, Any]) -> float:
     """Extract a single relevance score from a pooling_type=RANK response.
 
-    llama-cpp-python's ``create_embedding`` with ``LLAMA_POOLING_TYPE_RANK``
-    returns ``data[i]["embedding"]`` as a ``list[float]`` of length
-    ``n_embd`` (1 for rerank models). Any other shape indicates an
-    upstream format change and raises ``ProviderError`` with the observed
-    shape in the message so the drift is visible.
+    Raises ``ProviderError`` with the observed shape for anything other
+    than a non-empty ``list[float]`` so upstream format changes surface.
     """
     data = response.get("data") or []
     if not data:

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -538,20 +538,26 @@ def compute_rerank_scores(llm: Any, query: str, candidates: list[str]) -> list[f
 
 
 def _extract_rerank_score(response: dict[str, Any]) -> float:
-    """Extract a single relevance score from a pooling_type=RANK response."""
+    """Extract a single relevance score from a pooling_type=RANK response.
+
+    llama-cpp-python's ``create_embedding`` with ``LLAMA_POOLING_TYPE_RANK``
+    returns ``data[i]["embedding"]`` as a ``list[float]`` of length
+    ``n_embd`` (1 for rerank models). Any other shape indicates an
+    upstream format change and raises ``ProviderError`` with the observed
+    shape in the message so the drift is visible.
+    """
     data = response.get("data") or []
     if not data:
         raise ProviderError("Reranker returned no data", provider="llama-cpp")
     embedding = data[-1].get("embedding")
-    if isinstance(embedding, (int, float)):
-        return float(embedding)
-    if isinstance(embedding, list) and embedding:
-        first = embedding[0]
-        if isinstance(first, (int, float)):
-            return float(first)
-        if isinstance(first, list) and first:
-            return float(first[0])
-    raise ProviderError("Reranker returned unrecognized score shape", provider="llama-cpp")
+    if isinstance(embedding, list) and embedding and isinstance(embedding[0], (int, float)):
+        return float(embedding[0])
+    raise ProviderError(
+        "Reranker returned unexpected score shape "
+        f"(got {type(embedding).__name__}: {embedding!r}); "
+        "llama-cpp-python may have changed its response format",
+        provider="llama-cpp",
+    )
 
 
 _HF_BLOBS_DIR_NAME = "blobs"

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -113,12 +113,9 @@ class RoutingProvider(LLMProvider):
     def rerank(self, query: str, candidates: list[str]) -> list[float]:
         """Dispatch rerank to the backend that owns ``cfg.reranker_model``.
 
-        Native GGUF refs go to llama-cpp; hosted refs (Cohere, Voyage,
-        Jina, Together AI, HF TEI) go through the SDK provider.
-
-        Raises ``ProviderError`` when ``cfg.reranker_model`` is empty or
-        the configured backend for the chosen model does not support
-        reranking.
+        Native GGUF refs go to llama-cpp; hosted refs go through the SDK
+        provider. Raises ``ProviderError`` when ``cfg.reranker_model`` is
+        empty or the selected backend does not support reranking.
         """
         if not cfg.reranker_model:
             raise ProviderError("No reranker configured. Set cfg.reranker_model first.")

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -10,7 +10,7 @@ from typing import Any
 from lilbee.catalog import is_rerank_ref
 from lilbee.config import cfg
 from lilbee.providers.base import LLMProvider, ProviderError
-from lilbee.providers.litellm_sdk import LitellmSdkBackend, litellm_available
+from lilbee.providers.litellm_sdk import LitellmSdkBackend
 from lilbee.providers.model_ref import ProviderModelRef, parse_model_ref
 from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
@@ -29,7 +29,7 @@ class RoutingProvider(LLMProvider):
 
     def __init__(self) -> None:
         self._llama_cpp: LLMProvider | None = None
-        self._sdk_provider: LLMProvider | None = None
+        self._sdk_provider: SdkLLMProvider | None = None
 
     def _get_llama_cpp(self) -> LLMProvider:
         if self._llama_cpp is None:
@@ -38,7 +38,7 @@ class RoutingProvider(LLMProvider):
             self._llama_cpp = LlamaCppProvider()
         return self._llama_cpp
 
-    def _get_sdk_provider(self) -> LLMProvider:
+    def _get_sdk_provider(self) -> SdkLLMProvider:
         if self._sdk_provider is None:
             self._sdk_provider = SdkLLMProvider(
                 LitellmSdkBackend(),
@@ -77,25 +77,28 @@ class RoutingProvider(LLMProvider):
         native: set[str] = set()
         with contextlib.suppress(Exception):
             native = set(self._get_llama_cpp().list_models())
-        if not litellm_available():
+        sdk = self._get_sdk_provider()
+        if not sdk.available():
             return sorted(native)
         try:
-            remote = set(self._get_sdk_provider().list_models())
+            remote = set(sdk.list_models())
         except Exception:
             return sorted(native)
         return sorted(native | remote)
 
     def list_chat_models(self, provider: str) -> list[str]:
         """Delegate to the SDK backend; native llama-cpp has no catalog."""
-        if not litellm_available():
+        sdk = self._get_sdk_provider()
+        if not sdk.available():
             return []
-        return self._get_sdk_provider().list_chat_models(provider)
+        return sdk.list_chat_models(provider)
 
     def pull_model(self, model: str, *, on_progress: Callable[..., Any] | None = None) -> None:
         """Pull via the SDK backend if installed, otherwise raise."""
-        if not litellm_available():
+        sdk = self._get_sdk_provider()
+        if not sdk.available():
             raise ProviderError(f"Cannot pull model {model!r}: no pull-capable backend available")
-        self._get_sdk_provider().pull_model(model, on_progress=on_progress)
+        sdk.pull_model(model, on_progress=on_progress)
 
     def show_model(self, model: str) -> dict[str, Any] | None:
         """Show model info from the backend selected by the ref prefix."""
@@ -111,21 +114,24 @@ class RoutingProvider(LLMProvider):
         """Dispatch rerank to the backend that owns ``cfg.reranker_model``.
 
         Native GGUF refs go to llama-cpp; hosted refs (Cohere, Voyage,
-        Jina, Together AI, HF TEI) go through the SDK provider, which
-        requires the ``litellm`` extra.
+        Jina, Together AI, HF TEI) go through the SDK provider.
 
         Raises ``ProviderError`` when ``cfg.reranker_model`` is empty or
-        hosted dispatch is requested without the ``litellm`` extra.
+        the configured backend for the chosen model does not support
+        reranking.
         """
         if not cfg.reranker_model:
             raise ProviderError("No reranker configured. Set cfg.reranker_model first.")
         if _is_native_rerank_ref(cfg.reranker_model):
             return self._get_llama_cpp().rerank(query, candidates)
-        if not litellm_available():
+        sdk = self._get_sdk_provider()
+        if not sdk.supports_rerank():
             raise ProviderError(
-                f"Cannot rerank with {cfg.reranker_model!r}: litellm extra not installed"
+                f"Cannot rerank with {cfg.reranker_model!r}: "
+                "hosted rerank backend not available. "
+                "Install the 'litellm' extra to enable hosted reranking."
             )
-        return self._get_sdk_provider().rerank(query, candidates)
+        return sdk.rerank(query, candidates)
 
     def supports_rerank(self) -> bool:
         """Capability probe: can the routed backend rerank if configured?
@@ -142,7 +148,7 @@ class RoutingProvider(LLMProvider):
             return True
         if _is_native_rerank_ref(model):
             return self._get_llama_cpp().supports_rerank()
-        return litellm_available()
+        return self._get_sdk_provider().supports_rerank()
 
     def shutdown(self) -> None:
         """Shut down sub-providers to release resources."""

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -246,5 +246,9 @@ class SdkLLMProvider(LLMProvider):
         """SDK-backed rerank is available when the underlying SDK is importable."""
         return self._backend.available()
 
+    def available(self) -> bool:
+        """Return True when the configured SDK backend can service catalog calls."""
+        return self._backend.available()
+
     def shutdown(self) -> None:
         """SDK-backed providers hold no lilbee-side resources."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -603,22 +603,7 @@ class TestRoutingProvider:
         mock_llama.embed.assert_called_once()
         mock_litellm.embed.assert_not_called()
 
-    def test_list_models_native_only_when_litellm_unavailable(self) -> None:
-        rp = self._make_provider()
-
-        mock_llama = mock.MagicMock()
-        mock_llama.list_models.return_value = ["local.gguf"]
-        rp._llama_cpp = mock_llama
-
-        with mock.patch(
-            "lilbee.providers.routing_provider.litellm_available",
-            return_value=False,
-        ):
-            result = rp.list_models()
-        assert result == ["local.gguf"]
-
-    def test_list_models_union_when_both_available(self) -> None:
-        """Native and remote listings are merged when litellm is installed."""
+    def test_list_models_native_only_when_sdk_unavailable(self) -> None:
         rp = self._make_provider()
 
         mock_llama = mock.MagicMock()
@@ -626,14 +611,27 @@ class TestRoutingProvider:
         rp._llama_cpp = mock_llama
 
         mock_sdk = mock.MagicMock()
+        mock_sdk.available.return_value = False
+        rp._sdk_provider = mock_sdk
+
+        result = rp.list_models()
+        assert result == ["local.gguf"]
+        mock_sdk.list_models.assert_not_called()
+
+    def test_list_models_union_when_both_available(self) -> None:
+        """Native and remote listings are merged when the SDK backend is installed."""
+        rp = self._make_provider()
+
+        mock_llama = mock.MagicMock()
+        mock_llama.list_models.return_value = ["local.gguf"]
+        rp._llama_cpp = mock_llama
+
+        mock_sdk = mock.MagicMock()
+        mock_sdk.available.return_value = True
         mock_sdk.list_models.return_value = ["ollama/qwen3:8b"]
         rp._sdk_provider = mock_sdk
 
-        with mock.patch(
-            "lilbee.providers.routing_provider.litellm_available",
-            return_value=True,
-        ):
-            result = rp.list_models()
+        result = rp.list_models()
         assert result == ["local.gguf", "ollama/qwen3:8b"]
 
     def test_list_models_remote_error_returns_native_only(self) -> None:
@@ -645,14 +643,11 @@ class TestRoutingProvider:
         rp._llama_cpp = mock_llama
 
         mock_sdk = mock.MagicMock()
+        mock_sdk.available.return_value = True
         mock_sdk.list_models.side_effect = RuntimeError("remote down")
         rp._sdk_provider = mock_sdk
 
-        with mock.patch(
-            "lilbee.providers.routing_provider.litellm_available",
-            return_value=True,
-        ):
-            result = rp.list_models()
+        result = rp.list_models()
         assert result == ["local.gguf"]
 
     def test_get_llama_cpp_caches_instance(self) -> None:
@@ -673,15 +668,16 @@ class TestRoutingProvider:
         second = rp._get_sdk_provider()
         assert first is second
 
-    def test_list_chat_models_empty_when_litellm_unavailable(self) -> None:
-        # list_chat_models must skip the SDK backend entirely when litellm
+    def test_list_chat_models_empty_when_sdk_unavailable(self) -> None:
+        # list_chat_models must skip the SDK backend entirely when the SDK
         # is not installed; native llama-cpp never has a frontier catalog.
         rp = self._make_provider()
-        with mock.patch(
-            "lilbee.providers.routing_provider.litellm_available",
-            return_value=False,
-        ):
-            assert rp.list_chat_models("openai") == []
+        mock_sdk = mock.MagicMock()
+        mock_sdk.available.return_value = False
+        rp._sdk_provider = mock_sdk
+
+        assert rp.list_chat_models("openai") == []
+        mock_sdk.list_chat_models.assert_not_called()
 
     def test_list_chat_models_delegates_through_sdk_provider(self) -> None:
         # Pins the suppression chain: list_chat_models must reach the SDK
@@ -689,14 +685,11 @@ class TestRoutingProvider:
         # can apply cfg.json_mode before any SDK import inside the backend.
         rp = self._make_provider()
         mock_sdk = mock.MagicMock()
+        mock_sdk.available.return_value = True
         mock_sdk.list_chat_models.return_value = ["openai/gpt-4o", "openai/gpt-4o-mini"]
         rp._sdk_provider = mock_sdk
 
-        with mock.patch(
-            "lilbee.providers.routing_provider.litellm_available",
-            return_value=True,
-        ):
-            result = rp.list_chat_models("openai")
+        result = rp.list_chat_models("openai")
 
         assert result == ["openai/gpt-4o", "openai/gpt-4o-mini"]
         mock_sdk.list_chat_models.assert_called_once_with("openai")
@@ -722,35 +715,30 @@ class TestRoutingProvider:
         assert result is None
         mock_llama.show_model.assert_called_once_with("local.gguf")
 
-    def test_pull_model_raises_when_litellm_unavailable(self) -> None:
+    def test_pull_model_raises_when_sdk_unavailable(self) -> None:
         from lilbee.providers.base import ProviderError
 
         rp = self._make_provider()
+        mock_sdk = mock.MagicMock()
+        mock_sdk.available.return_value = False
+        rp._sdk_provider = mock_sdk
 
-        with (
-            mock.patch(
-                "lilbee.providers.routing_provider.litellm_available",
-                return_value=False,
-            ),
-            pytest.raises(ProviderError, match="no pull-capable backend"),
-        ):
+        with pytest.raises(ProviderError, match="no pull-capable backend"):
             rp.pull_model("bad-model")
+        mock_sdk.pull_model.assert_not_called()
 
     def test_pull_model_delegates_to_sdk_when_available(self) -> None:
-        """With litellm available, pull_model forwards to the SDK provider."""
+        """With the SDK backend available, pull_model forwards to the SDK provider."""
         rp = self._make_provider()
         mock_sdk = mock.MagicMock()
+        mock_sdk.available.return_value = True
         rp._sdk_provider = mock_sdk
         captured: dict[str, object] = {}
 
         def _on_progress(evt: dict[str, object]) -> None:
             captured["saw"] = evt
 
-        with mock.patch(
-            "lilbee.providers.routing_provider.litellm_available",
-            return_value=True,
-        ):
-            rp.pull_model("ollama/llama3:8b", on_progress=_on_progress)
+        rp.pull_model("ollama/llama3:8b", on_progress=_on_progress)
 
         mock_sdk.pull_model.assert_called_once_with("ollama/llama3:8b", on_progress=_on_progress)
 
@@ -2729,21 +2717,38 @@ class TestExtractRerankScore:
         with pytest.raises(ProviderError, match="no data"):
             _extract_rerank_score({"data": []})
 
-    def test_scalar_embedding_returned_as_float(self) -> None:
+    def test_flat_list_embedding_returns_first_element(self) -> None:
+        """llama-cpp-python 0.3.x returns ``list[float]`` with length n_embd=1."""
         from lilbee.providers.llama_cpp_provider import _extract_rerank_score
 
-        assert _extract_rerank_score({"data": [{"embedding": 0.73}]}) == 0.73
+        assert _extract_rerank_score({"data": [{"embedding": [0.73]}]}) == 0.73
 
-    def test_nested_list_embedding_returns_inner_scalar(self) -> None:
-        from lilbee.providers.llama_cpp_provider import _extract_rerank_score
-
-        assert _extract_rerank_score({"data": [{"embedding": [[0.42]]}]}) == 0.42
-
-    def test_unrecognized_shape_raises(self) -> None:
+    def test_scalar_embedding_is_unexpected(self) -> None:
         from lilbee.providers.base import ProviderError
         from lilbee.providers.llama_cpp_provider import _extract_rerank_score
 
-        with pytest.raises(ProviderError, match="unrecognized"):
+        with pytest.raises(ProviderError, match=r"unexpected score shape.*float"):
+            _extract_rerank_score({"data": [{"embedding": 0.73}]})
+
+    def test_nested_list_embedding_is_unexpected(self) -> None:
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.llama_cpp_provider import _extract_rerank_score
+
+        with pytest.raises(ProviderError, match=r"unexpected score shape.*list"):
+            _extract_rerank_score({"data": [{"embedding": [[0.42]]}]})
+
+    def test_empty_embedding_list_is_unexpected(self) -> None:
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.llama_cpp_provider import _extract_rerank_score
+
+        with pytest.raises(ProviderError, match=r"unexpected score shape.*list: \[\]"):
+            _extract_rerank_score({"data": [{"embedding": []}]})
+
+    def test_non_numeric_embedding_is_unexpected(self) -> None:
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.llama_cpp_provider import _extract_rerank_score
+
+        with pytest.raises(ProviderError, match="unexpected score shape"):
             _extract_rerank_score({"data": [{"embedding": "not-a-number"}]})
 
 
@@ -2759,38 +2764,31 @@ class TestRoutingProviderRerank:
         rp = self._make_provider()
         mock_llama = mock.MagicMock()
         mock_sdk = mock.MagicMock()
+        mock_sdk.supports_rerank.return_value = True
         mock_sdk.rerank.return_value = [0.9, 0.1]
         rp._llama_cpp = mock_llama
         rp._sdk_provider = mock_sdk
 
         cfg.reranker_model = "cohere/rerank-english-v3.0"
-        with mock.patch(
-            "lilbee.providers.routing_provider.litellm_available",
-            return_value=True,
-        ):
-            scores = rp.rerank("q", ["a", "b"])
+        scores = rp.rerank("q", ["a", "b"])
         assert scores == [0.9, 0.1]
         mock_sdk.rerank.assert_called_once_with("q", ["a", "b"])
         mock_llama.rerank.assert_not_called()
 
-    def test_rerank_raises_when_hosted_ref_and_litellm_missing(self) -> None:
+    def test_rerank_raises_when_hosted_ref_and_sdk_backend_missing(self) -> None:
         from lilbee.providers.base import ProviderError
 
         rp = self._make_provider()
         mock_llama = mock.MagicMock()
         mock_sdk = mock.MagicMock()
+        mock_sdk.supports_rerank.return_value = False
         rp._llama_cpp = mock_llama
         rp._sdk_provider = mock_sdk
 
         cfg.reranker_model = "cohere/rerank-english-v3.0"
-        with (
-            mock.patch(
-                "lilbee.providers.routing_provider.litellm_available",
-                return_value=False,
-            ),
-            pytest.raises(ProviderError, match="litellm extra not installed"),
-        ):
+        with pytest.raises(ProviderError, match="hosted rerank backend not available"):
             rp.rerank("q", ["a", "b"])
+        mock_sdk.rerank.assert_not_called()
 
     def test_supports_rerank_disabled_model_always_true(self) -> None:
         rp = self._make_provider()
@@ -2807,19 +2805,16 @@ class TestRoutingProviderRerank:
         assert rp.supports_rerank() is True
         mock_llama.supports_rerank.assert_called_once()
 
-    def test_supports_rerank_hosted_requires_litellm(self) -> None:
+    def test_supports_rerank_hosted_delegates_to_sdk(self) -> None:
         rp = self._make_provider()
+        mock_sdk = mock.MagicMock()
+        rp._sdk_provider = mock_sdk
         cfg.reranker_model = "cohere/rerank-english-v3.0"
-        with mock.patch(
-            "lilbee.providers.routing_provider.litellm_available",
-            return_value=False,
-        ):
-            assert rp.supports_rerank() is False
-        with mock.patch(
-            "lilbee.providers.routing_provider.litellm_available",
-            return_value=True,
-        ):
-            assert rp.supports_rerank() is True
+
+        mock_sdk.supports_rerank.return_value = False
+        assert rp.supports_rerank() is False
+        mock_sdk.supports_rerank.return_value = True
+        assert rp.supports_rerank() is True
 
     def test_rerank_routes_bare_gguf_to_llama_cpp(self) -> None:
         rp = self._make_provider()


### PR DESCRIPTION
## Summary

Two small provider-layer cleanups that fell out of the PR #156 review. Both are about honoring the `LlmSdkBackend` seam we introduced in #153 instead of reaching around it.

## Stop leaking litellm through the routing layer

`RoutingProvider` was calling `litellm_available()` directly in five places. That defeats the abstraction — swapping the concrete SDK would leave the router still asking the wrong question.

Catalog paths (`list_models`, `list_chat_models`, `pull_model`) now go through a new `SdkLLMProvider.available()`. The rerank path uses the existing `SdkLLMProvider.supports_rerank()`. `RoutingProvider` no longer imports anything litellm-specific.

## Stop silently coercing rerank response shapes

`_extract_rerank_score` was accepting three different embedding shapes, which meant a future llama-cpp-python format change would quietly fall through one of the unused fallbacks instead of failing loudly.

It now accepts exactly the one shape the pinned 0.3.x wrapper emits under `LLAMA_POOLING_TYPE_RANK` — a non-empty `list[float]`. Anything else raises `ProviderError` with the observed type and value so drift is visible.