### PR TITLE
Gate file hashing on mtime vs ingested_at

### DIFF
--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -10,6 +10,7 @@ import os
 import threading
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
@@ -163,6 +164,25 @@ def file_hash(path: Path) -> str:
         for block in iter(lambda: f.read(8192), b""):
             h.update(block)
     return h.hexdigest()
+
+
+def _file_unchanged_since_ingest(path: Path, ingested_at: str) -> bool:
+    """Fast-path gate: True when mtime is strictly older than the stored ingest time.
+
+    Used to skip full SHA-256 hashing on unchanged files during sync. Any
+    failure (missing timestamp, unparseable ISO string, stat error) returns
+    False so the caller falls through to the authoritative hash compare.
+    """
+    if not ingested_at:
+        return False
+    try:
+        ingested_dt = datetime.fromisoformat(ingested_at)
+        mtime_dt = datetime.fromtimestamp(path.stat().st_mtime, UTC)
+    except (OSError, ValueError):
+        return False
+    if ingested_dt.tzinfo is None:
+        ingested_dt = ingested_dt.replace(tzinfo=UTC)
+    return mtime_dt < ingested_dt
 
 
 def _relative_name(path: Path) -> str:
@@ -616,7 +636,9 @@ async def sync(
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
 
     disk_files = discover_files()
-    existing_sources = {s["filename"]: s["file_hash"] for s in _store.get_sources()}
+    existing_sources = {
+        s["filename"]: (s["file_hash"], s.get("ingested_at", "")) for s in _store.get_sources()
+    }
 
     added: list[str] = []
     updated: list[str] = []
@@ -641,8 +663,14 @@ async def sync(
         if content_type is None:
             raise ValueError(f"Unsupported file slipped through discovery: {name}")
 
+        old = existing_sources.get(name)
+        old_hash = old[0] if old is not None else None
+
+        if old is not None and _file_unchanged_since_ingest(path, old[1]):
+            unchanged += 1
+            continue
+
         current_hash = file_hash(path)
-        old_hash = existing_sources.get(name)
 
         if old_hash == current_hash:
             unchanged += 1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,5 +1,6 @@
 """Tests for the document sync engine (mocked — no live server needed)."""
 
+import os
 import sys
 from pathlib import Path
 from unittest import mock
@@ -45,9 +46,18 @@ def mock_svc():
     store.bm25_probe.return_value = []
     store.get_sources.side_effect = lambda: list(_sources.values())
     store.add_chunks.side_effect = lambda records: len(records)
-    store.upsert_source.side_effect = lambda fn, fh, cc: _sources.update(
-        {fn: {"filename": fn, "file_hash": fh, "chunk_count": cc, "ingested_at": ""}}
-    )
+
+    def _upsert(fn, fh, cc):
+        from datetime import UTC, datetime
+
+        _sources[fn] = {
+            "filename": fn,
+            "file_hash": fh,
+            "chunk_count": cc,
+            "ingested_at": datetime.now(UTC).isoformat(),
+        }
+
+    store.upsert_source.side_effect = _upsert
     store.delete_source.side_effect = lambda fn: _sources.pop(fn, None)
     store.delete_by_source.return_value = None
     store.drop_all.side_effect = lambda: _sources.clear()
@@ -1634,3 +1644,105 @@ class TestUnsupportedFileInSync:
 
             with pytest.raises(ValueError, match="Unsupported file slipped through"):
                 await sync(quiet=True)
+
+
+class TestMtimeGate:
+    """Fast-path gate that skips SHA-256 when file mtime is older than ingested_at."""
+
+    def test_mtime_older_than_ingest_returns_true(self, tmp_path):
+        from datetime import UTC, datetime, timedelta
+
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "old.txt"
+        f.write_text("content")
+        # Backdate mtime to an hour before "now"
+        past = datetime.now(UTC) - timedelta(hours=1)
+        os.utime(f, (past.timestamp(), past.timestamp()))
+        ingested = datetime.now(UTC).isoformat()
+        assert _file_unchanged_since_ingest(f, ingested) is True
+
+    def test_mtime_after_ingest_returns_false(self, tmp_path):
+        from datetime import UTC, datetime, timedelta
+
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "new.txt"
+        f.write_text("content")
+        # Ingested in the past, file was modified "now"
+        ingested = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        assert _file_unchanged_since_ingest(f, ingested) is False
+
+    def test_empty_ingested_at_returns_false(self, tmp_path):
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "file.txt"
+        f.write_text("content")
+        assert _file_unchanged_since_ingest(f, "") is False
+
+    def test_malformed_ingested_at_returns_false(self, tmp_path):
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "file.txt"
+        f.write_text("content")
+        assert _file_unchanged_since_ingest(f, "not-a-timestamp") is False
+
+    def test_missing_file_returns_false(self, tmp_path):
+        from datetime import UTC, datetime
+
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        ghost = tmp_path / "does-not-exist.txt"
+        assert _file_unchanged_since_ingest(ghost, datetime.now(UTC).isoformat()) is False
+
+    def test_naive_ingested_at_treated_as_utc(self, tmp_path):
+        from datetime import UTC, datetime, timedelta
+
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "naive.txt"
+        f.write_text("content")
+        past = datetime.now(UTC) - timedelta(hours=1)
+        os.utime(f, (past.timestamp(), past.timestamp()))
+        # Stored without explicit tz (legacy record) — should be treated as
+        # UTC so aware/naive comparison doesn't raise TypeError.
+        naive_iso = (datetime.now(UTC) + timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+        assert _file_unchanged_since_ingest(f, naive_iso) is True
+
+    async def test_sync_skips_file_hash_on_fast_path(self, isolated_env, mock_svc):
+        """Second sync of an unchanged file must not re-hash it."""
+        from datetime import UTC, datetime, timedelta
+
+        f = isolated_env / "stable.txt"
+        f.write_text("content that does not change")
+        # Ensure mtime is older than the next ingested_at timestamp
+        past = datetime.now(UTC) - timedelta(seconds=5)
+        os.utime(f, (past.timestamp(), past.timestamp()))
+
+        from lilbee.ingest import sync
+
+        await sync(quiet=True)
+
+        with mock.patch("lilbee.ingest.file_hash") as hash_spy:
+            result = await sync(quiet=True)
+
+        assert result.unchanged == 1
+        assert hash_spy.call_count == 0
+
+    async def test_sync_hashes_when_file_modified_after_ingest(self, isolated_env, mock_svc):
+        """File touched after ingest must fall through to hashing."""
+        f = isolated_env / "modified.txt"
+        f.write_text("original content")
+
+        from lilbee.ingest import sync
+
+        await sync(quiet=True)
+
+        # Modify the file — mtime now postdates ingested_at
+        f.write_text("modified content — different hash")
+
+        with mock.patch("lilbee.ingest.file_hash", return_value="different-hash") as hash_spy:
+            result = await sync(quiet=True)
+
+        assert hash_spy.call_count >= 1
+        assert "modified.txt" in result.updated


### PR DESCRIPTION
Sync previously ran SHA-256 on every discovered file every cycle, even when nothing had changed. At 10k files / 1GB that's a ~1s floor per sync.

Adds `_file_unchanged_since_ingest`: if the file's mtime is strictly older than the stored `ingested_at`, content can't have changed and the hash is skipped. Any failure (missing timestamp, unparseable ISO, stat error, naive datetime) falls through to the existing authoritative hash compare, so correctness is unchanged.

No schema change — reuses the `ingested_at` field that `upsert_source` already writes.

Refs bb-7yyf.