### PR TITLE
Scaling pass across sync/retrieval/TUI 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ All settings override via environment variables:
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
 - `LILBEE_VISION_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
 - `LILBEE_TESSERACT_TIMEOUT`: wall-clock timeout in seconds for the Tesseract OCR fallback (default: `60`, `0` = no limit). Only runs when no vision model is available.
-- `LILBEE_LLM_PROVIDER` — backend: `auto` (default), `llama-cpp`, `litellm` (requires `pip install lilbee[backend]`)
+- `LILBEE_LLM_PROVIDER` — provider: `auto` (default), `llama-cpp`, `remote` (requires `pip install lilbee[remote]``)
 - `LILBEE_LITELLM_BASE_URL` — litellm backend endpoint (default: `http://localhost:11434`, also reads `OLLAMA_HOST` for backwards compat)
 - `LILBEE_DIVERSITY_MAX_PER_SOURCE` — max chunks per source in results (default: `3`)
 - `LILBEE_MMR_LAMBDA` — MMR relevance/diversity tradeoff, 0-1 (default: `0.5`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ All settings override via environment variables:
 - `LILBEE_VISION_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
 - `LILBEE_TESSERACT_TIMEOUT`: wall-clock timeout in seconds for the Tesseract OCR fallback (default: `60`, `0` = no limit). Only runs when no vision model is available.
 - `LILBEE_LLM_PROVIDER` — provider: `auto` (default), `llama-cpp`, `remote` (requires `pip install lilbee[litellm]``)
-- `LILBEE_LITELLM_BASE_URL` — litellm backend endpoint (default: `http://localhost:11434`, also reads `OLLAMA_HOST` for backwards compat)
+- `LILBEE_REMOTE_BASE_URL` — SDK backend endpoint (default: `http://localhost:11434`, also reads `OLLAMA_HOST` for backwards compat)
 - `LILBEE_DIVERSITY_MAX_PER_SOURCE` — max chunks per source in results (default: `3`)
 - `LILBEE_MMR_LAMBDA` — MMR relevance/diversity tradeoff, 0-1 (default: `0.5`)
 - `LILBEE_CANDIDATE_MULTIPLIER` — extra candidates for MMR reranking (default: `3`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ All settings override via environment variables:
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
 - `LILBEE_VISION_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
 - `LILBEE_TESSERACT_TIMEOUT`: wall-clock timeout in seconds for the Tesseract OCR fallback (default: `60`, `0` = no limit). Only runs when no vision model is available.
-- `LILBEE_LLM_PROVIDER` — backend: `auto` (default), `llama-cpp`, `litellm` (requires `pip install lilbee[litellm]`)
+- `LILBEE_LLM_PROVIDER` — backend: `auto` (default), `llama-cpp`, `litellm` (requires `pip install lilbee[backend]`)
 - `LILBEE_LITELLM_BASE_URL` — litellm backend endpoint (default: `http://localhost:11434`, also reads `OLLAMA_HOST` for backwards compat)
 - `LILBEE_DIVERSITY_MAX_PER_SOURCE` — max chunks per source in results (default: `3`)
 - `LILBEE_MMR_LAMBDA` — MMR relevance/diversity tradeoff, 0-1 (default: `0.5`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ All settings override via environment variables:
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
 - `LILBEE_VISION_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
 - `LILBEE_TESSERACT_TIMEOUT`: wall-clock timeout in seconds for the Tesseract OCR fallback (default: `60`, `0` = no limit). Only runs when no vision model is available.
-- `LILBEE_LLM_PROVIDER` — provider: `auto` (default), `llama-cpp`, `remote` (requires `pip install lilbee[remote]``)
+- `LILBEE_LLM_PROVIDER` — provider: `auto` (default), `llama-cpp`, `remote` (requires `pip install lilbee[litellm]``)
 - `LILBEE_LITELLM_BASE_URL` — litellm backend endpoint (default: `http://localhost:11434`, also reads `OLLAMA_HOST` for backwards compat)
 - `LILBEE_DIVERSITY_MAX_PER_SOURCE` — max chunks per source in results (default: `3`)
 - `LILBEE_MMR_LAMBDA` — MMR relevance/diversity tradeoff, 0-1 (default: `0.5`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ All settings override via environment variables:
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
 - `LILBEE_VISION_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
 - `LILBEE_TESSERACT_TIMEOUT`: wall-clock timeout in seconds for the Tesseract OCR fallback (default: `60`, `0` = no limit). Only runs when no vision model is available.
-- `LILBEE_LLM_PROVIDER` — provider: `auto` (default), `llama-cpp`, `remote` (requires `pip install lilbee[litellm]``)
+- `LILBEE_LLM_PROVIDER` — provider: `auto` (default), `llama-cpp`, `remote` (requires `pip install lilbee[litellm]`)
 - `LILBEE_REMOTE_BASE_URL` — SDK backend endpoint (default: `http://localhost:11434`, also reads `OLLAMA_HOST` for backwards compat)
 - `LILBEE_DIVERSITY_MAX_PER_SOURCE` — max chunks per source in results (default: `3`)
 - `LILBEE_MMR_LAMBDA` — MMR relevance/diversity tradeoff, 0-1 (default: `0.5`)

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ lilbee works out of the box. These extras unlock additional capabilities:
 | **Concept graph** | `pip install lilbee[graph]` | Topic clustering + search boosting. Extracts concepts from your documents and uses their relationships to find results that pure text matching misses. Zero extra LLM calls. |
 | **Cross-encoder reranking** | `pip install lilbee[reranker]` | Precision pass on search results. Re-scores every (query, chunk) pair with a cross-encoder model. Catches ranking errors the initial search missed. |
 | **Web crawling** | `pip install lilbee[crawler]` | Index websites alongside local files. Recursive crawling with Playwright, hash-based change detection, SSRF protection. |
-| **Remote providers** | `pip install lilbee[litellm]` | Connect to your favorite frontier model or any litellm-supported provider. Use remote models for chat while keeping embeddings local. |
+| **Remote providers** | `pip install lilbee[litellm]` | Connect to your favorite frontier model or any provider reachable via the SDK backend (Ollama, OpenAI, Anthropic, Gemini, etc.). Use remote models for chat while keeping embeddings local. |
 
 Install multiple: `pip install lilbee[graph,reranker,crawler]`
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ lilbee works out of the box. These extras unlock additional capabilities:
 | **Concept graph** | `pip install lilbee[graph]` | Topic clustering + search boosting. Extracts concepts from your documents and uses their relationships to find results that pure text matching misses. Zero extra LLM calls. |
 | **Cross-encoder reranking** | `pip install lilbee[reranker]` | Precision pass on search results. Re-scores every (query, chunk) pair with a cross-encoder model. Catches ranking errors the initial search missed. |
 | **Web crawling** | `pip install lilbee[crawler]` | Index websites alongside local files. Recursive crawling with Playwright, hash-based change detection, SSRF protection. |
-| **Remote providers** | `pip install lilbee[litellm]` | Connect to your favorite frontier model or any litellm-supported provider. Use remote models for chat while keeping embeddings local. |
+| **Remote providers** | `pip install lilbee[backend]` | Connect to your favorite frontier model or any litellm-supported provider. Use remote models for chat while keeping embeddings local. |
 
 Install multiple: `pip install lilbee[graph,reranker,crawler]`
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ lilbee works out of the box. These extras unlock additional capabilities:
 | **Concept graph** | `pip install lilbee[graph]` | Topic clustering + search boosting. Extracts concepts from your documents and uses their relationships to find results that pure text matching misses. Zero extra LLM calls. |
 | **Cross-encoder reranking** | `pip install lilbee[reranker]` | Precision pass on search results. Re-scores every (query, chunk) pair with a cross-encoder model. Catches ranking errors the initial search missed. |
 | **Web crawling** | `pip install lilbee[crawler]` | Index websites alongside local files. Recursive crawling with Playwright, hash-based change detection, SSRF protection. |
-| **Remote providers** | `pip install lilbee[backend]` | Connect to your favorite frontier model or any litellm-supported provider. Use remote models for chat while keeping embeddings local. |
+| **Remote providers** | `pip install lilbee[remote]` | Connect to your favorite frontier model or any litellm-supported provider. Use remote models for chat while keeping embeddings local. |
 
 Install multiple: `pip install lilbee[graph,reranker,crawler]`
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ lilbee works out of the box. These extras unlock additional capabilities:
 | **Concept graph** | `pip install lilbee[graph]` | Topic clustering + search boosting. Extracts concepts from your documents and uses their relationships to find results that pure text matching misses. Zero extra LLM calls. |
 | **Cross-encoder reranking** | `pip install lilbee[reranker]` | Precision pass on search results. Re-scores every (query, chunk) pair with a cross-encoder model. Catches ranking errors the initial search missed. |
 | **Web crawling** | `pip install lilbee[crawler]` | Index websites alongside local files. Recursive crawling with Playwright, hash-based change detection, SSRF protection. |
-| **Remote providers** | `pip install lilbee[remote]` | Connect to your favorite frontier model or any litellm-supported provider. Use remote models for chat while keeping embeddings local. |
+| **Remote providers** | `pip install lilbee[litellm]` | Connect to your favorite frontier model or any litellm-supported provider. Use remote models for chat while keeping embeddings local. |
 
 Install multiple: `pip install lilbee[graph,reranker,crawler]`
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -65,7 +65,7 @@ All commands accept `--json` (or `-j`) before the subcommand for structured outp
 ### Two modes
 
 - **`search`** — Raw chunk retrieval. No LLM call at query time. Use when your agent has its own LLM and just needs relevant document chunks.
-- **`ask`** — Full local RAG via llama-cpp (or litellm if installed). Use for fully-local workflows.
+- **`ask`** — Full local RAG via llama-cpp (or the SDK backend if installed). Use for fully-local workflows.
 
 ### Commands
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -113,4 +113,4 @@ SSE events emitted: `crawl_start`, `crawl_page`, `crawl_done`, then `done` (or `
 - Use MCP when available — it's more direct than shelling out
 - Run `status` / `status()` first to check if documents are indexed
 - Run `sync` / `sync()` after adding documents to update the index
-- An LLM backend is needed for: (1) embedding during sync/indexing, (2) `ask` for LLM answers. Once indexed, `search` works without an LLM. By default, llama-cpp handles both. Install `lilbee[remote]` to use external backends like Ollama or OpenAI.
+- An LLM backend is needed for: (1) embedding during sync/indexing, (2) `ask` for LLM answers. Once indexed, `search` works without an LLM. By default, llama-cpp handles both. Install `lilbee[litellm]` to use external backends like Ollama or OpenAI.

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -113,4 +113,4 @@ SSE events emitted: `crawl_start`, `crawl_page`, `crawl_done`, then `done` (or `
 - Use MCP when available — it's more direct than shelling out
 - Run `status` / `status()` first to check if documents are indexed
 - Run `sync` / `sync()` after adding documents to update the index
-- An LLM backend is needed for: (1) embedding during sync/indexing, (2) `ask` for LLM answers. Once indexed, `search` works without an LLM. By default, llama-cpp handles both. Install `lilbee[backend]` to use external backends like Ollama or OpenAI.
+- An LLM backend is needed for: (1) embedding during sync/indexing, (2) `ask` for LLM answers. Once indexed, `search` works without an LLM. By default, llama-cpp handles both. Install `lilbee[remote]` to use external backends like Ollama or OpenAI.

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -113,4 +113,4 @@ SSE events emitted: `crawl_start`, `crawl_page`, `crawl_done`, then `done` (or `
 - Use MCP when available — it's more direct than shelling out
 - Run `status` / `status()` first to check if documents are indexed
 - Run `sync` / `sync()` after adding documents to update the index
-- An LLM backend is needed for: (1) embedding during sync/indexing, (2) `ask` for LLM answers. Once indexed, `search` works without an LLM. By default, llama-cpp handles both. Install `lilbee[litellm]` to use external backends like Ollama or OpenAI.
+- An LLM backend is needed for: (1) embedding during sync/indexing, (2) `ask` for LLM answers. Once indexed, `search` works without an LLM. By default, llama-cpp handles both. Install `lilbee[backend]` to use external backends like Ollama or OpenAI.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,7 @@ flowchart TD
 ```
 
 - **auto** (default): `RoutingProvider` checks if litellm is installed and the model is available via its API. If so, uses it; otherwise falls back to local GGUF via llama-cpp.
-- **litellm**: force all calls through LiteLLM (Ollama, OpenAI, Azure, etc.). Requires `pip install lilbee[remote]`.
+- **litellm**: force all calls through LiteLLM (Ollama, OpenAI, Azure, etc.). Requires `pip install lilbee[litellm]`.
 - **ollama**: deprecated alias for `litellm`
 - **llama-cpp**: force local GGUF inference via llama-cpp-python (always available)
 - Model downloads come from HuggingFace. lilbee manages its own GGUF files. External models (e.g. Ollama) are used for inference when available but not managed by lilbee.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,5 +338,5 @@ All settings are configurable via `LILBEE_*` environment variables, `config.toml
 | Setting | Default | Description | Caveats |
 |---------|---------|-------------|---------|
 | `LILBEE_LLM_PROVIDER` | `auto` | Backend selection: auto, llama-cpp, litellm | auto = use litellm if installed and reachable, otherwise llama-cpp |
-| `LILBEE_LITELLM_BASE_URL` | `http://localhost:11434` | litellm backend endpoint | Also reads `OLLAMA_HOST` for backwards compatibility (deprecated). |
+| `LILBEE_REMOTE_BASE_URL` | `http://localhost:11434` | SDK backend endpoint | Also reads `OLLAMA_HOST` for backwards compatibility (deprecated). |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ flowchart LR
     end
 
     subgraph External
-        LITELLM[litellm backends]
+        SDK[SDK backends]
         LLAMA[llama-cpp]
         HF[HuggingFace]
     end
@@ -51,7 +51,7 @@ flowchart LR
     SEARCH --> CONCEPT
     SEARCH --> GEN
     GEN --> PROV
-    PROV --> LITELLM & LLAMA
+    PROV --> SDK & LLAMA
     INGEST --> HF
 ```
 
@@ -67,7 +67,7 @@ Documents are chunked, embedded, and stored as vectors for later retrieval.
 - **PDF**: kreuzberg 4.6 extraction with OCR fallback chain (text extraction → Tesseract OCR → vision model). PDF page rasterization delegated to kreuzberg's `PdfPageIterator`.
 - **Structured files**: kreuzberg handles XML, JSON, JSONL, YAML, CSV extraction natively. Language detection delegated to tree-sitter-language-pack's `detect_language()`.
 - **Web pages**: crawl4ai fetches HTML (with JavaScript rendering via Playwright), converts to markdown, saves to `documents/_web/` for indexing
-- **Embedding**: provider-agnostic — works with llama-cpp-python (default) or any litellm-compatible backend (Ollama, OpenAI, etc.)
+- **Embedding**: provider-agnostic — works with llama-cpp-python (default) or any SDK-compatible backend (Ollama, OpenAI, etc.)
 - **Concept extraction**: spaCy noun phrases extracted per chunk, co-occurrence graph built with PPMI weights, Leiden clustering assigns concepts to communities
 - **Storage**: LanceDB with full-text search (FTS) index for hybrid retrieval + concept graph tables (nodes, edges, chunk mappings)
 
@@ -78,11 +78,11 @@ Documents are chunked, embedded, and stored as vectors for later retrieval.
 ```mermaid
 flowchart TD
     APP[Application Code] --> ROUTE[RoutingProvider]
-    ROUTE --> CHECK{litellm installed & model available?}
-    CHECK -->|Yes| LIT[LiteLLM → External Backend]
+    ROUTE --> CHECK{SDK backend installed & model available?}
+    CHECK -->|Yes| SDK_BACK[SDK → External Backend]
     CHECK -->|No| LCPP[llama-cpp-python → GGUF]
 
-    APP -->|explicit config| LIT_P[LiteLLM Provider]
+    APP -->|explicit config| SDK_P[SDK Provider]
     APP -->|explicit config| LCPP_P[LlamaCpp Provider]
 ```
 
@@ -287,7 +287,7 @@ All settings are configurable via `LILBEE_*` environment variables, `config.toml
 
 | Setting | Default | Description | Caveats |
 |---------|---------|-------------|---------|
-| `LILBEE_CHAT_MODEL` | `qwen3:8b` | LLM used for chat and ask | Must be installed locally or available via litellm backend |
+| `LILBEE_CHAT_MODEL` | `qwen3:8b` | LLM used for chat and ask | Must be installed locally or available via the SDK backend |
 | `LILBEE_EMBEDDING_MODEL` | `nomic-embed-text` | Model for computing vector embeddings | Changing this requires a full `lilbee rebuild` |
 | `LILBEE_TOP_K` | `10` | Number of search results returned | Higher values provide more context but increase LLM latency and token cost |
 | `LILBEE_MAX_DISTANCE` | `0.9` | Cosine distance cutoff for vector results | Lower values are stricter — may return fewer results but higher precision. Set to 1.0 to disable filtering. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,8 +87,7 @@ flowchart TD
 ```
 
 - **auto** (default): `RoutingProvider` checks if the SDK backend is installed and the model is available via its API. If so, uses it; otherwise falls back to local GGUF via llama-cpp.
-- **litellm**: force all calls through LiteLLM (Ollama, OpenAI, Azure, etc.). Requires `pip install lilbee[litellm]`.
-- **ollama**: deprecated alias for `litellm`
+- **remote**: force all calls through the SDK backend (Ollama, OpenAI, Anthropic, Gemini, etc.). Requires `pip install lilbee[litellm]`.
 - **llama-cpp**: force local GGUF inference via llama-cpp-python (always available)
 - Model downloads come from HuggingFace. lilbee manages its own GGUF files. External models (e.g. Ollama) are used for inference when available but not managed by lilbee.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,7 @@ flowchart TD
 ```
 
 - **auto** (default): `RoutingProvider` checks if litellm is installed and the model is available via its API. If so, uses it; otherwise falls back to local GGUF via llama-cpp.
-- **litellm**: force all calls through LiteLLM (Ollama, OpenAI, Azure, etc.). Requires `pip install lilbee[backend]`.
+- **litellm**: force all calls through LiteLLM (Ollama, OpenAI, Azure, etc.). Requires `pip install lilbee[remote]`.
 - **ollama**: deprecated alias for `litellm`
 - **llama-cpp**: force local GGUF inference via llama-cpp-python (always available)
 - Model downloads come from HuggingFace. lilbee manages its own GGUF files. External models (e.g. Ollama) are used for inference when available but not managed by lilbee.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,7 @@ flowchart TD
 ```
 
 - **auto** (default): `RoutingProvider` checks if litellm is installed and the model is available via its API. If so, uses it; otherwise falls back to local GGUF via llama-cpp.
-- **litellm**: force all calls through LiteLLM (Ollama, OpenAI, Azure, etc.). Requires `pip install lilbee[litellm]`.
+- **litellm**: force all calls through LiteLLM (Ollama, OpenAI, Azure, etc.). Requires `pip install lilbee[backend]`.
 - **ollama**: deprecated alias for `litellm`
 - **llama-cpp**: force local GGUF inference via llama-cpp-python (always available)
 - Model downloads come from HuggingFace. lilbee manages its own GGUF files. External models (e.g. Ollama) are used for inference when available but not managed by lilbee.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,7 @@ flowchart TD
     APP -->|explicit config| LCPP_P[LlamaCpp Provider]
 ```
 
-- **auto** (default): `RoutingProvider` checks if litellm is installed and the model is available via its API. If so, uses it; otherwise falls back to local GGUF via llama-cpp.
+- **auto** (default): `RoutingProvider` checks if the SDK backend is installed and the model is available via its API. If so, uses it; otherwise falls back to local GGUF via llama-cpp.
 - **litellm**: force all calls through LiteLLM (Ollama, OpenAI, Azure, etc.). Requires `pip install lilbee[litellm]`.
 - **ollama**: deprecated alias for `litellm`
 - **llama-cpp**: force local GGUF inference via llama-cpp-python (always available)
@@ -337,6 +337,6 @@ All settings are configurable via `LILBEE_*` environment variables, `config.toml
 
 | Setting | Default | Description | Caveats |
 |---------|---------|-------------|---------|
-| `LILBEE_LLM_PROVIDER` | `auto` | Backend selection: auto, llama-cpp, litellm | auto = use litellm if installed and reachable, otherwise llama-cpp |
+| `LILBEE_LLM_PROVIDER` | `auto` | Backend selection: auto, llama-cpp, remote | auto = use the SDK backend if installed and reachable, otherwise llama-cpp |
 | `LILBEE_REMOTE_BASE_URL` | `http://localhost:11434` | SDK backend endpoint | Also reads `OLLAMA_HOST` for backwards compatibility (deprecated). |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -241,7 +241,7 @@ lilbee works out of the box with llama-cpp for local inference. These optional e
 pip install lilbee[graph]      # concept graph — topic clustering + search boosting
 pip install lilbee[reranker]   # cross-encoder reranking — precision pass on results
 pip install lilbee[crawler]    # web crawling — index websites alongside local docs
-pip install lilbee[backend]    # remote providers — connect to your favorite frontier model
+pip install lilbee[remote]    # remote providers — connect to your favorite frontier model
 ```
 
 Install multiple at once: `pip install lilbee[graph,reranker,crawler]`
@@ -358,7 +358,7 @@ Connect to remote LLM providers instead of (or alongside) local llama-cpp infere
 
 **When to use it:** When you want to use your favorite frontier model for chat while keeping embeddings local for privacy, or when you're already running Ollama and want to use its models.
 
-**Install:** `pip install lilbee[backend]`
+**Install:** `pip install lilbee[remote]`
 
 **Configuration:**
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -241,7 +241,7 @@ lilbee works out of the box with llama-cpp for local inference. These optional e
 pip install lilbee[graph]      # concept graph — topic clustering + search boosting
 pip install lilbee[reranker]   # cross-encoder reranking — precision pass on results
 pip install lilbee[crawler]    # web crawling — index websites alongside local docs
-pip install lilbee[remote]    # remote providers — connect to your favorite frontier model
+pip install lilbee[litellm]    # remote providers — connect to your favorite frontier model
 ```
 
 Install multiple at once: `pip install lilbee[graph,reranker,crawler]`
@@ -358,7 +358,7 @@ Connect to remote LLM providers instead of (or alongside) local llama-cpp infere
 
 **When to use it:** When you want to use your favorite frontier model for chat while keeping embeddings local for privacy, or when you're already running Ollama and want to use its models.
 
-**Install:** `pip install lilbee[remote]`
+**Install:** `pip install lilbee[litellm]`
 
 **Configuration:**
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,7 +13,7 @@
   - [Concept graph](#concept-graph)
   - [Cross-encoder reranking](#cross-encoder-reranking)
   - [Web crawling](#web-crawling)
-  - [litellm (remote providers)](#litellm-remote-providers)
+  - [Remote providers (SDK backend)](#remote-providers-sdk-backend)
 
 ---
 
@@ -350,15 +350,15 @@ export LILBEE_CRAWL_SYNC_INTERVAL=30     # seconds between periodic syncs during
 
 ---
 
-### litellm (remote providers)
+### Remote providers (SDK backend)
 
-Connect to remote LLM providers instead of (or alongside) local llama-cpp inference.
+Connect to hosted LLM providers instead of (or alongside) local llama-cpp inference.
 
-**What it does:** Routes chat and embedding calls to any litellm-supported backend. The routing provider automatically detects which models are available locally vs. remotely and routes each call to the right backend. Supports hundreds of providers and models.
+**What it does:** Routes chat and embedding calls to any provider reachable via the SDK backend (Ollama, OpenAI, Anthropic, Gemini, and many more). The routing provider automatically detects which models are available locally vs. remotely and routes each call to the right backend.
 
 **When to use it:** When you want to use your favorite frontier model for chat while keeping embeddings local for privacy, or when you're already running Ollama and want to use its models.
 
-**Install:** `pip install lilbee[litellm]`
+**Install:** `pip install lilbee[litellm]` (pip extra retains the adapter library name).
 
 **Configuration:**
 
@@ -366,7 +366,7 @@ Connect to remote LLM providers instead of (or alongside) local llama-cpp infere
 export LILBEE_LLM_PROVIDER=auto          # "auto" routes between local and remote
 export LILBEE_REMOTE_BASE_URL=http://localhost:11434  # Ollama default
 export LILBEE_LLM_API_KEY=sk-...         # API key for your provider
-export LILBEE_CHAT_MODEL=your-model      # any litellm-supported model name
+export LILBEE_CHAT_MODEL=your-model      # any remotely-supported model name
 ```
 
 Provider options: `auto` (default, routes intelligently), `llama-cpp` (local only), `remote` (hosted only).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -364,7 +364,7 @@ Connect to remote LLM providers instead of (or alongside) local llama-cpp infere
 
 ```bash
 export LILBEE_LLM_PROVIDER=auto          # "auto" routes between local and remote
-export LILBEE_LITELLM_BASE_URL=http://localhost:11434  # Ollama default
+export LILBEE_REMOTE_BASE_URL=http://localhost:11434  # Ollama default
 export LILBEE_LLM_API_KEY=sk-...         # API key for your provider
 export LILBEE_CHAT_MODEL=your-model      # any litellm-supported model name
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -369,4 +369,4 @@ export LILBEE_LLM_API_KEY=sk-...         # API key for your provider
 export LILBEE_CHAT_MODEL=your-model      # any litellm-supported model name
 ```
 
-Provider options: `auto` (default, routes intelligently), `llama-cpp` (local only), `litellm` (remote only).
+Provider options: `auto` (default, routes intelligently), `llama-cpp` (local only), `remote` (hosted only).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -241,7 +241,7 @@ lilbee works out of the box with llama-cpp for local inference. These optional e
 pip install lilbee[graph]      # concept graph — topic clustering + search boosting
 pip install lilbee[reranker]   # cross-encoder reranking — precision pass on results
 pip install lilbee[crawler]    # web crawling — index websites alongside local docs
-pip install lilbee[litellm]    # remote providers — connect to your favorite frontier model
+pip install lilbee[backend]    # remote providers — connect to your favorite frontier model
 ```
 
 Install multiple at once: `pip install lilbee[graph,reranker,crawler]`
@@ -358,7 +358,7 @@ Connect to remote LLM providers instead of (or alongside) local llama-cpp infere
 
 **When to use it:** When you want to use your favorite frontier model for chat while keeping embeddings local for privacy, or when you're already running Ollama and want to use its models.
 
-**Install:** `pip install lilbee[litellm]`
+**Install:** `pip install lilbee[backend]`
 
 **Configuration:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-backend = ["litellm>=1.50"]
+remote = ["litellm>=1.50"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
 crawler = ["crawl4ai>=0.8.6"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-litellm = ["litellm>=1.50"]
+backend = ["litellm>=1.50"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
 crawler = ["crawl4ai>=0.8.6"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-remote = ["litellm>=1.50"]
+litellm = ["litellm>=1.50"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
 crawler = ["crawl4ai>=0.8.6"]
 

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -571,6 +571,17 @@ def _estimate_size_from_siblings(siblings: list[RepoSibling]) -> float:
     return 0.0  # unknown — display as "?" in UI
 
 
+def _search_blob(m: CatalogModel) -> str:
+    """Lowercased join of searchable fields on a catalog row.
+
+    One ``str.lower()`` per model per filter pass instead of four, since
+    the ``or``-chain in the old filter had to call ``.lower()`` on each
+    property up to the first match (four calls in the common no-match
+    case). Null char joins so a search term never straddles fields.
+    """
+    return f"{m.name}\0{m.display_name}\0{m.hf_repo}\0{m.description}".lower()
+
+
 def get_catalog(
     task: str | None = None,
     *,
@@ -608,17 +619,12 @@ def get_catalog(
     if task:
         all_models = [m for m in all_models if m.task == task]
 
-    # Filter by search
+    # Filter by search. Single join+lower per model per keystroke instead
+    # of four separate lowers + substring checks; the no-match path
+    # (the common case) runs four times fewer ``str.lower()`` calls.
     if search:
         search_lower = search.lower()
-        all_models = [
-            m
-            for m in all_models
-            if search_lower in m.name.lower()
-            or search_lower in m.display_name.lower()
-            or search_lower in m.hf_repo.lower()
-            or search_lower in m.description.lower()
-        ]
+        all_models = [m for m in all_models if search_lower in _search_blob(m)]
 
     # Filter by size
     if size and size in _SIZE_RANGES:

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -574,10 +574,7 @@ def _estimate_size_from_siblings(siblings: list[RepoSibling]) -> float:
 def _search_blob(m: CatalogModel) -> str:
     """Lowercased join of searchable fields on a catalog row.
 
-    One ``str.lower()`` per model per filter pass instead of four, since
-    the ``or``-chain in the old filter had to call ``.lower()`` on each
-    property up to the first match (four calls in the common no-match
-    case). Null char joins so a search term never straddles fields.
+    Null char joins the fields so a search term never straddles them.
     """
     return f"{m.name}\0{m.display_name}\0{m.hf_repo}\0{m.description}".lower()
 

--- a/src/lilbee/catalog.py
+++ b/src/lilbee/catalog.py
@@ -747,7 +747,7 @@ def _candidate_keys(q: str, idx: CatalogIndex) -> list[str]:
         head = q.split(":", 1)[0]
         if "/" in head:
             candidates.append(head)
-    # Provider-prefixed refs like ``ollama/qwen3:0.6b`` or ``litellm/...``
+    # Provider-prefixed refs like ``ollama/qwen3:0.6b`` or ``openai/...``
     # carry the native model ref after the first slash. The hf_repo form
     # (e.g. ``gpustack/bge-reranker-v2-m3-GGUF``) also has a slash, so we
     # only strip when the prefix does not match any hf_repo owner.

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -95,7 +95,7 @@ class ModelEntry(BaseModel):
 
         return cls(
             name=ref,
-            source=ModelSource.LITELLM.value,
+            source=ModelSource.BACKEND.value,
             task=remote.task if remote else None,
             size_gb=None,
             display_name=remote.parameter_size if remote else "",
@@ -263,7 +263,7 @@ def _collect_native_entries() -> list[ModelEntry]:
 def _collect_litellm_entries() -> list[ModelEntry]:
     from lilbee.model_manager import classify_remote_models
 
-    remote_list = classify_remote_models(cfg.litellm_base_url, timeout=_LITELLM_LIST_TIMEOUT_S)
+    remote_list = classify_remote_models(cfg.backend_base_url, timeout=_LITELLM_LIST_TIMEOUT_S)
     remote_by_name = {rm.name: rm for rm in remote_list}
     return [ModelEntry.from_litellm(ref, remote_by_name[ref]) for ref in sorted(remote_by_name)]
 
@@ -283,7 +283,7 @@ def list_models_data(
     entries: list[ModelEntry] = []
     if source is None or source is ModelSource.NATIVE:
         entries.extend(_collect_native_entries())
-    if source is None or source is ModelSource.LITELLM:
+    if source is None or source is ModelSource.BACKEND:
         entries.extend(_collect_litellm_entries())
     if task:
         entries = [e for e in entries if e.task == task]
@@ -400,7 +400,7 @@ _source_option = typer.Option(
     None,
     "--source",
     "-s",
-    help="Filter by source: 'native' or 'litellm' (default: all).",
+    help="Filter by source: 'native' or 'backend' (default: all).",
 )
 _task_option = typer.Option(
     None,
@@ -533,7 +533,7 @@ def pull_cmd(
         "native",
         "--source",
         "-s",
-        help="Pull from 'native' (HuggingFace GGUF) or 'litellm' (remote backend).",
+        help="Pull from 'native' (HuggingFace GGUF) or 'backend' (SDK-managed remote).",
     ),
     data_dir: Path | None = data_dir_option,
     use_global: bool = global_option,

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -95,7 +95,7 @@ class ModelEntry(BaseModel):
 
         return cls(
             name=ref,
-            source=ModelSource.BACKEND.value,
+            source=ModelSource.REMOTE.value,
             task=remote.task if remote else None,
             size_gb=None,
             display_name=remote.parameter_size if remote else "",
@@ -263,7 +263,7 @@ def _collect_native_entries() -> list[ModelEntry]:
 def _collect_backend_entries() -> list[ModelEntry]:
     from lilbee.model_manager import classify_remote_models
 
-    remote_list = classify_remote_models(cfg.backend_base_url, timeout=_BACKEND_LIST_TIMEOUT_S)
+    remote_list = classify_remote_models(cfg.remote_base_url, timeout=_BACKEND_LIST_TIMEOUT_S)
     remote_by_name = {rm.name: rm for rm in remote_list}
     return [ModelEntry.from_backend(ref, remote_by_name[ref]) for ref in sorted(remote_by_name)]
 
@@ -282,7 +282,7 @@ def list_models_data(
     entries: list[ModelEntry] = []
     if source is None or source is ModelSource.NATIVE:
         entries.extend(_collect_native_entries())
-    if source is None or source is ModelSource.BACKEND:
+    if source is None or source is ModelSource.REMOTE:
         entries.extend(_collect_backend_entries())
     if task:
         entries = [e for e in entries if e.task == task]
@@ -399,7 +399,7 @@ _source_option = typer.Option(
     None,
     "--source",
     "-s",
-    help="Filter by source: 'native' or 'backend' (default: all).",
+    help="Filter by source: 'native' or 'remote' (default: all).",
 )
 _task_option = typer.Option(
     None,
@@ -532,7 +532,7 @@ def pull_cmd(
         "native",
         "--source",
         "-s",
-        help="Pull from 'native' (HuggingFace GGUF) or 'backend' (SDK-managed remote).",
+        help="Pull from 'native' (HuggingFace GGUF) or 'remote' (SDK-managed).",
     ),
     data_dir: Path | None = data_dir_option,
     use_global: bool = global_option,

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 
 _BYTES_PER_GB = 1024**3  # Model sizes are reported to users in GiB.
-_LITELLM_LIST_TIMEOUT_S = 2.0  # Keep `model list` snappy when backend is down.
+_BACKEND_LIST_TIMEOUT_S = 2.0  # Keep `model list` snappy when backend is down.
 
 
 def _bytes_to_gb(n: int) -> float:
@@ -90,7 +90,7 @@ class ModelEntry(BaseModel):
         )
 
     @classmethod
-    def from_litellm(cls, ref: str, remote: RemoteModel | None) -> ModelEntry:
+    def from_backend(cls, ref: str, remote: RemoteModel | None) -> ModelEntry:
         from lilbee.model_manager import ModelSource
 
         return cls(
@@ -260,12 +260,12 @@ def _collect_native_entries() -> list[ModelEntry]:
     return [ModelEntry.from_native(ref, manifests.get(ref)) for ref in refs]
 
 
-def _collect_litellm_entries() -> list[ModelEntry]:
+def _collect_backend_entries() -> list[ModelEntry]:
     from lilbee.model_manager import classify_remote_models
 
-    remote_list = classify_remote_models(cfg.backend_base_url, timeout=_LITELLM_LIST_TIMEOUT_S)
+    remote_list = classify_remote_models(cfg.backend_base_url, timeout=_BACKEND_LIST_TIMEOUT_S)
     remote_by_name = {rm.name: rm for rm in remote_list}
-    return [ModelEntry.from_litellm(ref, remote_by_name[ref]) for ref in sorted(remote_by_name)]
+    return [ModelEntry.from_backend(ref, remote_by_name[ref]) for ref in sorted(remote_by_name)]
 
 
 def list_models_data(
@@ -274,9 +274,8 @@ def list_models_data(
 ) -> ListModelsResult:
     """Build the list of installed models with source and task metadata.
 
-    Discovers remote (litellm) models via a single HTTP call with a
-    short timeout so the command stays responsive when the backend is
-    down.
+    Discovers remote models via a single HTTP call with a short timeout
+    so the command stays responsive when the backend is down.
     """
     from lilbee.model_manager import ModelSource
 
@@ -284,7 +283,7 @@ def list_models_data(
     if source is None or source is ModelSource.NATIVE:
         entries.extend(_collect_native_entries())
     if source is None or source is ModelSource.BACKEND:
-        entries.extend(_collect_litellm_entries())
+        entries.extend(_collect_backend_entries())
     if task:
         entries = [e for e in entries if e.task == task]
     return ListModelsResult(models=entries, total=len(entries))
@@ -314,7 +313,7 @@ def show_model_data(ref: str) -> ShowModelResult:
     )
 
 
-def _litellm_event_to_progress(
+def _backend_event_to_progress(
     on_update: Callable[[DownloadProgress], None],
     event: dict[str, Any],
 ) -> None:
@@ -338,7 +337,7 @@ def _build_pull_callbacks(
 
     if on_update is None:
         return None, None
-    dict_cb = functools.partial(_litellm_event_to_progress, on_update)
+    dict_cb = functools.partial(_backend_event_to_progress, on_update)
     bytes_cb = make_download_callback(on_update)
     return dict_cb, bytes_cb
 

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -38,9 +38,10 @@ from lilbee.cli.tui.widgets.model_list_item import ModelListItem
 from lilbee.cli.tui.widgets.nav_aware_input import NavAwareInput
 from lilbee.cli.tui.widgets.search_hf_cta_item import SearchHFCtaItem
 from lilbee.config import cfg
-from lilbee.model_manager import OLLAMA_PROVIDER_NAME, RemoteModel, get_model_manager
+from lilbee.model_manager import RemoteModel, get_model_manager
 from lilbee.models import ModelTask
 from lilbee.providers.model_ref import OLLAMA_PREFIX
+from lilbee.providers.sdk_backend import OLLAMA_BACKEND_NAME
 
 log = logging.getLogger(__name__)
 
@@ -282,7 +283,7 @@ class CatalogScreen(Screen[None]):
     def _fetch_remote_models(self) -> list[RemoteModel]:
         from lilbee.model_manager import classify_remote_models
 
-        return classify_remote_models(cfg.litellm_base_url)
+        return classify_remote_models(cfg.backend_base_url)
 
     @work(thread=True, name=_WORKER_FETCH_MORE_HF)
     def _fetch_more_hf(self) -> list[CatalogModel]:
@@ -579,7 +580,7 @@ class CatalogScreen(Screen[None]):
         elif row.remote_model:
             ref = (
                 f"{OLLAMA_PREFIX}{row.remote_model.name}"
-                if row.remote_model.provider == OLLAMA_PROVIDER_NAME
+                if row.remote_model.provider == OLLAMA_BACKEND_NAME
                 else row.remote_model.name
             )
             cfg.chat_model = ref

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -283,7 +283,7 @@ class CatalogScreen(Screen[None]):
     def _fetch_remote_models(self) -> list[RemoteModel]:
         from lilbee.model_manager import classify_remote_models
 
-        return classify_remote_models(cfg.backend_base_url)
+        return classify_remote_models(cfg.remote_base_url)
 
     @work(thread=True, name=_WORKER_FETCH_MORE_HF)
     def _fetch_more_hf(self) -> list[CatalogModel]:

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -847,21 +847,26 @@ class GridSection:
     rows: list[TableRow]
 
 
+_TASK_BUCKET_ORDER = (ModelTask.CHAT, ModelTask.EMBEDDING, ModelTask.VISION, ModelTask.RERANK)
+
+
 def _group_rows_for_grid(rows: list[TableRow]) -> list[GridSection]:
     """Group rows into sections for the grid view."""
-    recommended = [r for r in rows if r.featured]
-    installed = [r for r in rows if r.installed and not r.featured]
-    chat = [r for r in rows if r.task == ModelTask.CHAT and not r.featured and not r.installed]
-    embedding = [
-        r for r in rows if r.task == ModelTask.EMBEDDING and not r.featured and not r.installed
-    ]
-    vision = [r for r in rows if r.task == ModelTask.VISION and not r.featured and not r.installed]
-    rerank = [r for r in rows if r.task == ModelTask.RERANK and not r.featured and not r.installed]
+    recommended: list[TableRow] = []
+    installed: list[TableRow] = []
+    by_task: dict[str, list[TableRow]] = {task: [] for task in _TASK_BUCKET_ORDER}
+    for row in rows:
+        if row.featured:
+            recommended.append(row)
+            continue
+        if row.installed:
+            installed.append(row)
+            continue
+        bucket = by_task.get(row.task)
+        if bucket is not None:
+            bucket.append(row)
     return [
         GridSection(msg.HEADING_OUR_PICKS, recommended),
         GridSection(msg.HEADING_INSTALLED, installed),
-        GridSection(ModelTask.CHAT.capitalize(), chat),
-        GridSection(ModelTask.EMBEDDING.capitalize(), embedding),
-        GridSection(ModelTask.VISION.capitalize(), vision),
-        GridSection(ModelTask.RERANK.capitalize(), rerank),
+        *[GridSection(task.capitalize(), by_task[task]) for task in _TASK_BUCKET_ORDER],
     ]

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -877,6 +877,10 @@ def _group_rows_for_grid(rows: list[TableRow]) -> list[GridSection]:
     recommended: list[TableRow] = []
     installed: list[TableRow] = []
     by_task: dict[str, list[TableRow]] = {task: [] for task in _TASK_BUCKET_ORDER}
+    # Display order is fixed by _TASK_BUCKET_ORDER, but any ModelTask value
+    # not in that tuple still renders in its own section after the known
+    # ones, so adding a new task variant never silently drops rows.
+    extras: dict[str, list[TableRow]] = {}
     for row in rows:
         if row.featured:
             recommended.append(row)
@@ -887,8 +891,11 @@ def _group_rows_for_grid(rows: list[TableRow]) -> list[GridSection]:
         bucket = by_task.get(row.task)
         if bucket is not None:
             bucket.append(row)
+        else:
+            extras.setdefault(row.task, []).append(row)
     return [
         GridSection(msg.HEADING_OUR_PICKS, recommended),
         GridSection(msg.HEADING_INSTALLED, installed),
         *[GridSection(task.capitalize(), by_task[task]) for task in _TASK_BUCKET_ORDER],
+        *[GridSection(task.capitalize(), extras[task]) for task in extras],
     ]

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -192,7 +192,7 @@ class CatalogScreen(Screen[None]):
             self._filter_grid()
             self._sync_grid_search_cta()
         else:
-            self._refresh_list()
+            self._filter_list()
 
     @on(Input.Submitted, "#catalog-search")
     def _on_search_submitted(self, event: Input.Submitted) -> None:
@@ -534,6 +534,28 @@ class CatalogScreen(Screen[None]):
         if widgets_to_mount:
             container.mount_all(widgets_to_mount)
         self._update_sort_label()
+
+    def _filter_list(self) -> None:
+        """Filter visible list items by search without rebuilding the list.
+
+        Per-keystroke path: toggles .display on existing ModelListItems
+        and mounts/removes the HF CTA row as needed. Only _refresh_list
+        (data change, sort change) remounts.
+        """
+        search = self._get_search_text()
+        for item in self.query(ModelListItem):
+            item.display = matches_search(item.row, search)
+        self._sync_list_search_cta(search)
+        self._update_sort_label()
+
+    def _sync_list_search_cta(self, search: str) -> None:
+        """Ensure the search-HF CTA row exists iff a search term is active."""
+        container = self.query_one("#catalog-list", VerticalScroll)
+        existing = list(container.query(SearchHFCtaItem))
+        for widget in existing:
+            widget.remove()
+        if search:
+            container.mount(SearchHFCtaItem(search))
 
     def _update_sort_label(self) -> None:
         """Update the sort indicator label."""

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -195,7 +195,7 @@ class ChatScreen(Screen[None]):
         """True when the setup wizard should run: fresh data dir or unresolved models.
 
         Remote-prefixed refs skip the native probe since they resolve
-        through litellm at call time.
+        through the SDK backend at call time.
         """
         if not cfg.lancedb_dir.is_dir():
             log.debug("_needs_setup: lancedb_dir missing (%s)", cfg.lancedb_dir)

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from collections import defaultdict
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from textual import on
 from textual.app import ComposeResult
@@ -284,14 +284,30 @@ class SettingsScreen(Screen[None]):
     def _filter_settings(self, event: Input.Changed) -> None:
         """Filter visible settings based on search input."""
         term = event.value.strip().lower()
-        for group in self.query(".setting-group"):
+        for group, rows in self._filter_index():
             visible_count = 0
-            for row in group.query(".setting-row"):
+            for row in rows:
                 matches = not term or term in (row.name or "")
                 row.display = matches
                 if matches:
                     visible_count += 1
             group.display = visible_count > 0
+
+    def _filter_index(self) -> list[tuple[Any, list[Any]]]:
+        """Lazy cache of (group, rows) for the filter handler.
+
+        One DOM walk at first keystroke, O(1) lookups after.
+        """
+        cached: list[tuple[Any, list[Any]]] | None = getattr(
+            self, "_settings_filter_index", None
+        )
+        if cached is not None:
+            return cached
+        index: list[tuple[Any, list[Any]]] = [
+            (group, list(group.query(".setting-row"))) for group in self.query(".setting-group")
+        ]
+        self._settings_filter_index = index
+        return index
 
     @on(Input.Submitted, ".setting-editor")
     @on(Input.Blurred, ".setting-editor")

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -298,9 +298,7 @@ class SettingsScreen(Screen[None]):
 
         One DOM walk at first keystroke, O(1) lookups after.
         """
-        cached: list[tuple[Any, list[Any]]] | None = getattr(
-            self, "_settings_filter_index", None
-        )
+        cached: list[tuple[Any, list[Any]]] | None = getattr(self, "_settings_filter_index", None)
         if cached is not None:
             return cached
         index: list[tuple[Any, list[Any]]] = [

--- a/src/lilbee/cli/tui/screens/task_center.py
+++ b/src/lilbee/cli/tui/screens/task_center.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_POLL_INTERVAL_SECONDS = 0.1
+_POLL_INTERVAL_SECONDS = 0.25
 
 # Quarter-circle rotation cycles every 4 ticks (~0.4 s). Visible motion
 # in the counts strip confirms background work is live when rows are
@@ -187,9 +187,14 @@ class TaskCenter(Screen[None]):
         to communicate 'work in progress' at a glance (bb-18y3).
         """
         counts_label = self.query_one("#task-center-counts", Label)
-        active = sum(1 for t in tasks if t.status == TaskStatus.ACTIVE)
-        queued = sum(1 for t in tasks if t.status == TaskStatus.QUEUED)
-        done = sum(1 for t in tasks if t.status == TaskStatus.DONE)
+        active = queued = done = 0
+        for t in tasks:
+            if t.status == TaskStatus.ACTIVE:
+                active += 1
+            elif t.status == TaskStatus.QUEUED:
+                queued += 1
+            elif t.status == TaskStatus.DONE:
+                done += 1
         body = msg.TASK_CENTER_COUNTS.format(active=active, queued=queued, done=done)
         if active > 0:
             spinner = _COUNTS_SPINNER_FRAMES[self._tick % len(_COUNTS_SPINNER_FRAMES)]

--- a/src/lilbee/cli/tui/screens/task_center.py
+++ b/src/lilbee/cli/tui/screens/task_center.py
@@ -6,7 +6,7 @@ state's color. On the active row the rail pulses at ~1 Hz, which is
 the only motion in the screen beyond the bar filling.
 
 The render path is poll-based: ``_poll`` runs on the main thread at
-10 Hz, reads the shared ``TaskQueue``, and reconciles rows in place by
+4 Hz, reads the shared ``TaskQueue``, and reconciles rows in place by
 task_id. There's no subscriber chain; tasks owned by the controller
 write into the lock-protected queue from worker threads and the poll
 picks them up next tick.
@@ -147,7 +147,7 @@ class TaskCenter(Screen[None]):
         return queue.active_tasks + queue.queued_tasks + list(reversed(queue.history))
 
     def _poll(self) -> None:
-        """10 Hz reconciliation: add new rows, update existing, remove stale."""
+        """4 Hz reconciliation: add new rows, update existing, remove stale."""
         self._tick += 1
         container = self.query_one("#task-rows", VerticalScroll)
         tasks = self._all_tasks()

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -17,9 +17,9 @@ from lilbee import settings
 from lilbee.cli.tui.pill import pill
 from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.config import cfg
-from lilbee.model_manager import OLLAMA_PROVIDER_NAME
 from lilbee.models import ModelTask
 from lilbee.providers.model_ref import OLLAMA_PREFIX, parse_model_ref
+from lilbee.providers.sdk_backend import OLLAMA_BACKEND_NAME, detect_backend_name
 from lilbee.services import reset_services
 
 log = logging.getLogger(__name__)
@@ -104,12 +104,12 @@ def _collect_native_models(buckets: dict[ModelTask, list[ModelOption]], seen: se
 
 
 def _collect_remote_models(buckets: dict[ModelTask, list[ModelOption]], seen: set[str]) -> None:
-    """Add remote (litellm/Ollama) models to buckets, prefixed for routing."""
+    """Add remote (Ollama / OpenAI-compatible) models to buckets, prefixed for routing."""
     try:
-        from lilbee.model_manager import classify_remote_models, detect_provider
+        from lilbee.model_manager import classify_remote_models
 
-        base_url = cfg.litellm_base_url
-        is_ollama = detect_provider(base_url) == OLLAMA_PROVIDER_NAME
+        base_url = cfg.backend_base_url
+        is_ollama = detect_backend_name(base_url) == OLLAMA_BACKEND_NAME
         for model in classify_remote_models(base_url):
             ref = f"{OLLAMA_PREFIX}{model.name}" if is_ollama else model.name
             if ref in seen or _is_mmproj(model.name):

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -43,7 +43,7 @@ def _is_mmproj(name: str) -> bool:
 
 def _classify_installed_models() -> tuple[list[ModelOption], list[ModelOption]]:
     """Classify installed models into (chat, embedding) lists.
-    Uses registry manifests for native models and the litellm backend's
+    Uses registry manifests for native models and the SDK backend's
     backend metadata for remote models. Filters out mmproj files.
     """
     buckets: dict[ModelTask, list[ModelOption]] = {
@@ -134,7 +134,7 @@ def _collect_api_models(buckets: dict[ModelTask, list[ModelOption]], seen: set[s
         for display_name, models in discover_api_models().items():
             for model in models:
                 # model.provider is the display name ("Anthropic"), but the ref
-                # needs the litellm prefix ("anthropic/model-name") for routing.
+                # needs the backend-qualified prefix ("anthropic/model-name") for routing.
                 prefix = display_name.lower()
                 qualified = f"{prefix}/{model.name}"
                 if qualified in seen:

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -108,7 +108,7 @@ def _collect_remote_models(buckets: dict[ModelTask, list[ModelOption]], seen: se
     try:
         from lilbee.model_manager import classify_remote_models
 
-        base_url = cfg.backend_base_url
+        base_url = cfg.remote_base_url
         is_ollama = detect_backend_name(base_url) == OLLAMA_BACKEND_NAME
         for model in classify_remote_models(base_url):
             ref = f"{OLLAMA_PREFIX}{model.name}" if is_ollama else model.name

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -309,12 +309,10 @@ class ConceptGraph:
         return related
 
     def get_related_concepts(self, concept: str, depth: int = 1) -> list[str]:
-        """Find concepts related via graph edges.
+        """Find concepts related to *concept* via graph edges, up to *depth* hops.
 
-        Each depth level fires one batched query (``source IN (...) OR
-        target IN (...)``) instead of one query per frontier node, so
-        expansion costs one DB round-trip per level instead of scaling
-        with frontier size.
+        One batched query per depth level — O(depth) DB round-trips,
+        independent of frontier size.
         """
         table = self._store.open_table(CONCEPT_EDGES_TABLE)
         if table is None:
@@ -348,13 +346,12 @@ class ConceptGraph:
         return [c for c in visited if c != concept]
 
     def top_communities(self, k: int = 10) -> list[Community]:
-        """Return the k largest concept communities.
+        """Return the *k* largest concept communities.
 
-        Counts cluster membership with ``pyarrow.compute.value_counts`` on
-        the columnar table so we never materialize a full ``list[dict]`` of
-        every node, then only pulls the members for the top-k clusters.
-        Previously this materialized every node and bucketed by cluster_id
-        in Python, scaling memory with the total concept count.
+        Uses ``pyarrow.compute.value_counts`` to pick the top-k
+        cluster_ids in columnar memory, then materializes only those
+        clusters' members. Peak Python memory scales with members of
+        the top *k* clusters, not the total node count.
         """
         table = self._store.open_table(CONCEPT_NODES_TABLE)
         if table is None:
@@ -440,11 +437,7 @@ class ConceptGraph:
         }
 
     def get_cluster_label(self, cluster_id: int) -> str:
-        """Return a human-readable label for a cluster (its highest-degree concept).
-
-        Pushes the cluster_id filter into the DB so we only materialize
-        rows for the target cluster, not the entire nodes table.
-        """
+        """Return a human-readable label for *cluster_id* (highest-degree concept)."""
         table = self._store.open_table(CONCEPT_NODES_TABLE)
         if table is None:
             return f"cluster-{cluster_id}"

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import pyarrow as pa
+import pyarrow.compute as pc
 
 from lilbee.clustering import SourceCluster
 from lilbee.config import (
@@ -347,19 +348,39 @@ class ConceptGraph:
         return [c for c in visited if c != concept]
 
     def top_communities(self, k: int = 10) -> list[Community]:
-        """Return the k largest concept communities."""
+        """Return the k largest concept communities.
+
+        Counts cluster membership with ``pyarrow.compute.value_counts`` on
+        the columnar table so we never materialize a full ``list[dict]`` of
+        every node, then only pulls the members for the top-k clusters.
+        Previously this materialized every node and bucketed by cluster_id
+        in Python, scaling memory with the total concept count.
+        """
         table = self._store.open_table(CONCEPT_NODES_TABLE)
         if table is None:
             return []
-        rows = table.to_arrow().to_pylist()
-        clusters: dict[int, list[str]] = {}
-        for row in rows:
-            cid = row["cluster_id"]
-            clusters.setdefault(cid, []).append(row["concept"])
-        sorted_clusters = sorted(clusters.items(), key=lambda x: len(x[1]), reverse=True)
+        arrow_tbl = table.to_arrow()
+        if arrow_tbl.num_rows == 0:
+            return []
+        counts = pc.value_counts(arrow_tbl["cluster_id"]).to_pylist()
+        top = sorted(counts, key=lambda entry: entry["counts"], reverse=True)[:k]
+        top_ids = [entry["values"] for entry in top if entry["values"] is not None]
+        if not top_ids:
+            return []
+        member_rows = arrow_tbl.filter(
+            pc.is_in(arrow_tbl["cluster_id"], value_set=pa.array(top_ids))
+        ).to_pylist()
+        by_cluster: dict[int, list[str]] = {}
+        for row in member_rows:
+            by_cluster.setdefault(row["cluster_id"], []).append(row["concept"])
         return [
-            Community(cluster_id=cid, size=len(concepts), concepts=concepts)
-            for cid, concepts in sorted_clusters[:k]
+            Community(
+                cluster_id=cid,
+                size=len(by_cluster.get(cid, [])),
+                concepts=by_cluster.get(cid, []),
+            )
+            for cid in top_ids
+            if by_cluster.get(cid)
         ]
 
     def rebuild_clusters(self) -> None:
@@ -419,15 +440,22 @@ class ConceptGraph:
         }
 
     def get_cluster_label(self, cluster_id: int) -> str:
-        """Return a human-readable label for a cluster (its highest-degree concept)."""
+        """Return a human-readable label for a cluster (its highest-degree concept).
+
+        Pushes the cluster_id filter into the DB so we only materialize
+        rows for the target cluster, not the entire nodes table.
+        """
         table = self._store.open_table(CONCEPT_NODES_TABLE)
         if table is None:
             return f"cluster-{cluster_id}"
-        rows = table.to_arrow().to_pylist()
-        cluster_concepts = [r for r in rows if r["cluster_id"] == cluster_id]
-        if not cluster_concepts:
+        try:
+            rows = table.search().where(f"cluster_id = {int(cluster_id)}").to_list()
+        except Exception:
+            log.debug("get_cluster_label query failed", exc_info=True)
             return f"cluster-{cluster_id}"
-        best = max(cluster_concepts, key=lambda r: r["degree"])
+        if not rows:
+            return f"cluster-{cluster_id}"
+        best = max(rows, key=lambda r: r["degree"])
         return str(best["concept"])
 
     def get_graph(self) -> bool:

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -308,30 +308,41 @@ class ConceptGraph:
         return related
 
     def get_related_concepts(self, concept: str, depth: int = 1) -> list[str]:
-        """Find concepts related via graph edges."""
+        """Find concepts related via graph edges.
+
+        Each depth level fires one batched query (``source IN (...) OR
+        target IN (...)``) instead of one query per frontier node, so
+        expansion costs one DB round-trip per level instead of scaling
+        with frontier size.
+        """
         table = self._store.open_table(CONCEPT_EDGES_TABLE)
         if table is None:
             return []
         visited: set[str] = {concept}
         frontier: list[str] = [concept]
         for _ in range(depth):
+            if not frontier:
+                break
+            escaped_list = ", ".join(f"'{escape_sql_string(n)}'" for n in frontier)
+            try:
+                rows = (
+                    table.search()
+                    .where(f"source IN ({escaped_list}) OR target IN ({escaped_list})")
+                    .to_list()
+                )
+            except Exception:
+                log.debug(
+                    "concept expand batch failed at frontier size %d",
+                    len(frontier),
+                    exc_info=True,
+                )
+                break
             next_frontier: list[str] = []
-            for node in frontier:
-                escaped = escape_sql_string(node)
-                try:
-                    rows = (
-                        table.search()
-                        .where(f"source = '{escaped}' OR target = '{escaped}'")
-                        .to_list()
-                    )
-                except Exception:
-                    log.debug("concept expand failed for %s", node, exc_info=True)
-                    continue
-                for row in rows:
-                    neighbor = row["target"] if row["source"] == node else row["source"]
-                    if neighbor not in visited:
-                        visited.add(neighbor)
-                        next_frontier.append(neighbor)
+            for row in rows:
+                for endpoint in (row["source"], row["target"]):
+                    if endpoint not in visited:
+                        visited.add(endpoint)
+                        next_frontier.append(endpoint)
             frontier = next_frontier
         return [c for c in visited if c != concept]
 

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -349,7 +349,7 @@ class Config(BaseSettings):
     max_tokens: int | None = ConfigField(default=4096, ge=1, writable=True)
     seed: int | None = ConfigField(default=None, writable=True)
     llm_provider: str = ConfigField(default="auto", writable=True)
-    backend_base_url: str = ConfigField(default="http://localhost:11434", writable=True)
+    remote_base_url: str = ConfigField(default="http://localhost:11434", writable=True)
     llm_api_key: str = ConfigField(default="", writable=True, write_only=True)
     openai_api_key: str = ConfigField(default="", writable=True, write_only=True)
     anthropic_api_key: str = ConfigField(default="", writable=True, write_only=True)
@@ -698,10 +698,10 @@ class Config(BaseSettings):
         if data.get("models_dir") in (None, _UNSET):
             data["models_dir"] = canonical_models_dir()
 
-        if "LILBEE_BACKEND_BASE_URL" not in os.environ:
+        if "LILBEE_REMOTE_BASE_URL" not in os.environ:
             ollama_host = os.environ.get("OLLAMA_HOST")
             if ollama_host:
-                data["backend_base_url"] = ollama_host
+                data["remote_base_url"] = ollama_host
 
         return data
 

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -361,6 +361,10 @@ class Config(BaseSettings):
     enable_ocr: bool | None = ConfigField(default=None, writable=True)
     # Per-page timeout in seconds for vision OCR (0 = no limit).
     ocr_timeout: float = ConfigField(default=120.0, ge=0.0, writable=True)
+    # Max concurrent vision-OCR requests per PDF. 1 preserves strict
+    # serial behavior; higher values overlap network-bound calls on
+    # backends that tolerate concurrency (Ollama, hosted OpenAI-compat).
+    vision_concurrency: int = ConfigField(default=4, ge=1, writable=True)
 
     # Wall-clock timeout in seconds for the Tesseract OCR fallback per
     # file. Large scanned PDFs can otherwise block an ingest worker for

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -335,8 +335,11 @@ class Config(BaseSettings):
     enable_ocr: bool | None = ConfigField(default=None, writable=True)
     # Per-page timeout in seconds for vision OCR (0 = no limit).
     ocr_timeout: float = ConfigField(default=120.0, ge=0.0, writable=True)
-    # Max concurrent vision-OCR requests per PDF. 1 = serial.
-    vision_concurrency: int = ConfigField(default=4, ge=1, writable=True)
+    # Max concurrent vision-OCR requests per PDF. Default 1 (serial) — raise
+    # only when the vision model is network-hosted with meaningful latency
+    # (remote API, separate Ollama host). Local GPU models contend on a
+    # single device and get slower with concurrency > 1.
+    vision_concurrency: int = ConfigField(default=1, ge=1, writable=True)
 
     # Tesseract fallback wall-clock timeout per file, seconds. 0 = no cap.
     tesseract_timeout: float = ConfigField(default=60.0, ge=0.0, writable=True)

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -357,7 +357,7 @@ class Config(BaseSettings):
     max_tokens: int | None = ConfigField(default=4096, ge=1, writable=True)
     seed: int | None = ConfigField(default=None, writable=True)
     llm_provider: str = ConfigField(default="auto", writable=True)
-    litellm_base_url: str = ConfigField(default="http://localhost:11434", writable=True)
+    backend_base_url: str = ConfigField(default="http://localhost:11434", writable=True)
     llm_api_key: str = ConfigField(default="", writable=True, write_only=True)
     openai_api_key: str = ConfigField(default="", writable=True, write_only=True)
     anthropic_api_key: str = ConfigField(default="", writable=True, write_only=True)
@@ -792,10 +792,10 @@ class Config(BaseSettings):
         if data.get("models_dir") in (None, _UNSET):
             data["models_dir"] = canonical_models_dir()
 
-        if "LILBEE_LITELLM_BASE_URL" not in os.environ:
+        if "LILBEE_BACKEND_BASE_URL" not in os.environ:
             ollama_host = os.environ.get("OLLAMA_HOST")
             if ollama_host:
-                data["litellm_base_url"] = ollama_host
+                data["backend_base_url"] = ollama_host
 
         return data
 

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -93,6 +93,34 @@ def _enforce_role_match(ref: str, entry: Any, field_name: str) -> None:
     raise ValueError(format_task_mismatch(ref, ModelTask(entry.task), want))
 
 
+def validate_model_task_assignment(field_name: str, ref: str) -> str:
+    """Validate a model role assignment and return its canonical catalog ref.
+
+    This was previously a Pydantic ``field_validator`` on ``Config`` that
+    fired on every ``setattr``, which meant a single PATCH /api/config
+    touching several fields rescanned the featured catalog index once
+    per field. Callers now invoke this explicitly from the handler layer
+    so the catalog lookup runs at most once per field per request, and
+    zero times for unrelated fields.
+
+    Returns the catalog's canonical ``name:tag`` (for registry-key match)
+    or the input ``ref`` unchanged when validation is bypassed in tests.
+    Raises ``ValueError`` on unknown refs or role-task mismatch.
+    """
+    if not ref or not ref.strip() or _model_task_validation_bypassed():
+        return ref
+    entry = _find_model_catalog_entry(ref)
+    if entry is None:
+        raise ValueError(
+            f"Model '{ref}' is not in the featured catalog. "
+            "Pick a featured model for this role, or install one via "
+            "POST /api/models/pull with a known catalog ref."
+        )
+    _enforce_role_match(ref, entry, field_name)
+    canonical: str = entry.ref
+    return canonical
+
+
 _BOOL_TRUE = frozenset({"true", "1", "yes"})
 _BOOL_FALSE = frozenset({"false", "0", "no"})
 
@@ -685,34 +713,11 @@ class Config(BaseSettings):
 
         return parse_model_ref(v).for_openai_prefix()
 
-    @field_validator(
-        "chat_model", "embedding_model", "vision_model", "reranker_model", mode="after"
-    )
-    @classmethod
-    def _validate_model_task(cls, v: str, info: ValidationInfo) -> str:
-        """Reject model refs whose catalog task doesn't match the role slot.
-
-        Runs at every write path (PATCH /api/config, direct assignment, env
-        loading) via ``validate_assignment=True``. Returns the catalog's
-        canonical ``name:tag`` so every stored ref matches the registry
-        key regardless of the input variant (hf_repo, provider-prefixed,
-        display name). Skipped only when both
-        ``LILBEE_SKIP_MODEL_TASK_VALIDATION`` is set and pytest is imported.
-        """
-        if not v or not v.strip() or _model_task_validation_bypassed():
-            return v
-        # info.field_name is always set when pydantic dispatches field_validator.
-        assert info.field_name is not None
-        entry = _find_model_catalog_entry(v)
-        if entry is None:
-            raise ValueError(
-                f"Model '{v}' is not in the featured catalog. "
-                "Pick a featured model for this role, or install one via "
-                "POST /api/models/pull with a known catalog ref."
-            )
-        _enforce_role_match(v, entry, info.field_name)
-        canonical: str = entry.ref
-        return canonical
+    # Model-task validation lives in the handler layer now (see
+    # lilbee.server.handlers._validate_config_updates and the
+    # validate_model_task_assignment helper below). Running it inside a
+    # field_validator fired on every setattr, and a single PATCH /api/config
+    # with six fields would rescan the featured catalog six times.
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -84,9 +84,17 @@ def _enforce_role_match(ref: str, entry: Any, field_name: str) -> None:
     raise ValueError(format_task_mismatch(ref, ModelTask(entry.task), want))
 
 
-def validate_model_task_assignment(field_name: str, ref: str) -> str:
-    """Return the catalog's canonical ref for *ref*, or raise ValueError."""
-    if not ref or not ref.strip() or _model_task_validation_bypassed():
+def validate_model_task_assignment(field_name: str, ref: str, *, allow_bypass: bool = True) -> str:
+    """Return the catalog's canonical ref for *ref*, or raise ValueError.
+
+    ``allow_bypass=True`` (default) honors ``LILBEE_SKIP_MODEL_TASK_VALIDATION``
+    so unrelated tests can set model refs without populating the catalog.
+    Explicit user actions (``PUT /api/models/<role>``) pass
+    ``allow_bypass=False`` to force the check.
+    """
+    if not ref or not ref.strip():
+        return ref
+    if allow_bypass and _model_task_validation_bypassed():
         return ref
     entry = _find_model_catalog_entry(ref)
     if entry is None:

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -47,14 +47,12 @@ def ConfigField(
 
 log = logging.getLogger(__name__)
 
-# Skips the per-role catalog-task check when set AND pytest is imported.
-# The two-signal gate prevents a leaked env var from disabling role
-# validation in production.
+# Test-only bypass. Both the env var and pytest must be present so a
+# leaked env var cannot disable validation in production.
 _SKIP_MODEL_TASK_VALIDATION_ENV = "LILBEE_SKIP_MODEL_TASK_VALIDATION"
 
 
 def _model_task_validation_bypassed() -> bool:
-    """True iff the task-validator should be skipped (test fixtures only)."""
     if not os.environ.get(_SKIP_MODEL_TASK_VALIDATION_ENV):
         return False
     return sys.modules.get("pytest") is not None
@@ -69,20 +67,13 @@ _MODEL_FIELD_TO_TASK: dict[str, str] = {
 
 
 def _find_model_catalog_entry(ref: str) -> Any:
-    """Look up *ref* in the featured catalog.
-
-    ``find_catalog_entry`` handles the ref variants the validator sees
-    (``name``, ``name:tag``, ``display_name``, ``hf_repo``, ``hf_repo:tag``,
-    provider-prefixed), so the caller doesn't need a fallback chain.
-    """
-    # circular: catalog -> config -> catalog (catalog imports ``cfg``).
+    # circular import: catalog imports cfg.
     from lilbee.catalog import find_catalog_entry
 
     return find_catalog_entry(ref)
 
 
 def _enforce_role_match(ref: str, entry: Any, field_name: str) -> None:
-    """Raise ValueError if *entry*'s task doesn't match *field_name*'s role."""
     from lilbee.models import ModelTask
 
     want = ModelTask(_MODEL_FIELD_TO_TASK[field_name])
@@ -94,19 +85,7 @@ def _enforce_role_match(ref: str, entry: Any, field_name: str) -> None:
 
 
 def validate_model_task_assignment(field_name: str, ref: str) -> str:
-    """Validate a model role assignment and return its canonical catalog ref.
-
-    This was previously a Pydantic ``field_validator`` on ``Config`` that
-    fired on every ``setattr``, which meant a single PATCH /api/config
-    touching several fields rescanned the featured catalog index once
-    per field. Callers now invoke this explicitly from the handler layer
-    so the catalog lookup runs at most once per field per request, and
-    zero times for unrelated fields.
-
-    Returns the catalog's canonical ``name:tag`` (for registry-key match)
-    or the input ``ref`` unchanged when validation is bypassed in tests.
-    Raises ``ValueError`` on unknown refs or role-task mismatch.
-    """
+    """Return the catalog's canonical ref for *ref*, or raise ValueError."""
     if not ref or not ref.strip() or _model_task_validation_bypassed():
         return ref
     entry = _find_model_catalog_entry(ref)
@@ -150,10 +129,7 @@ DEFAULT_IGNORE_DIRS = frozenset(
     }
 )
 
-# Shared HTTP timeout (seconds) for backend catalog / management calls
-# (Ollama /api/tags, /api/show, /v1/models, OpenAI-compatible endpoints).
-# Not exposed as a user config field because changing it is a debugging
-# maneuver, not a deployment knob.
+# Timeout for backend catalog / management HTTP calls.
 DEFAULT_HTTP_TIMEOUT = 30.0
 
 CHUNKS_TABLE = "chunks"
@@ -163,14 +139,11 @@ CONCEPT_NODES_TABLE = "concept_nodes"
 CONCEPT_EDGES_TABLE = "concept_edges"
 CHUNK_CONCEPTS_TABLE = "chunk_concepts"
 
-# Default URL-exclusion patterns for recursive crawls. Categorized so each
-# group is inspectable and easy to trim. Users extend or replace via
-# LILBEE_CRAWL_EXCLUDE_PATTERNS (newline-separated) or a
-# `crawl_exclude_patterns = [...]` list in config.toml.
-# All patterns are Python regex (use_glob=False at the call site).
+# Default URL-exclusion regexes for recursive crawls. Grouped by source
+# CMS / category. User overrides come from LILBEE_CRAWL_EXCLUDE_PATTERNS
+# (newline-separated) or config.toml.
 
-# WordPress scaffolding: admin UIs, API endpoints, RPC endpoints, numeric
-# permalink stubs, and the Elementor page-builder staging area.
+# WordPress scaffolding: admin UIs, APIs, RPC, numeric permalinks, Elementor.
 _WP_EXCLUDE: tuple[str, ...] = (
     r"/wp-admin/",
     r"/wp-login(\.php)?",
@@ -247,9 +220,7 @@ _ECOMMERCE_EXCLUDE: tuple[str, ...] = (
     r"/collections/.+/products/.+\?page=",
 )
 
-# Marketing tracking query parameters. One alternation so the regex engine
-# scans the URL once. Each listed key is a widely-seen tracking field; see
-# https://en.wikipedia.org/wiki/UTM_parameters and vendor docs for origins.
+# Marketing / tracking query parameters (utm_*, fbclid, gclid, etc.).
 _TRACKING_EXCLUDE: tuple[str, ...] = (
     (
         r"[?&]("
@@ -273,8 +244,7 @@ _TRACKING_EXCLUDE: tuple[str, ...] = (
     ),
 )
 
-# Site-meta URLs and non-HTML resources. crawl4ai also filters by
-# Content-Type at fetch time; this filter saves the fetch entirely.
+# Site-meta URLs and non-HTML resources; skipped before fetch.
 _META_EXCLUDE: tuple[str, ...] = (
     r"/sitemap[^/]*\.xml",
     r"/robots\.txt",
@@ -306,12 +276,8 @@ _DEFAULT_SYSTEM_PROMPT = (
     "explanations. Keep responses concise unless asked to elaborate."
 )
 
-# Default regex for the CORS allow-origin filter. Covers:
-#   - Obsidian desktop (Electron renderer uses app://obsidian.md)
-#   - Obsidian iOS (Capacitor webview uses capacitor://localhost)
-#   - Any http(s) localhost origin, including ports (Android Obsidian, local dev tools)
-#   - IPv4 and IPv6 loopback literals
-# Auth is still enforced on mutating endpoints regardless of CORS — see server/auth.py.
+# CORS allow-origin regex: Obsidian (desktop + iOS) and localhost loopback.
+# Mutating endpoints still require auth regardless of origin.
 _DEFAULT_CORS_ORIGIN_REGEX = (
     r"^(app://obsidian\.md"
     r"|capacitor://localhost"
@@ -361,14 +327,10 @@ class Config(BaseSettings):
     enable_ocr: bool | None = ConfigField(default=None, writable=True)
     # Per-page timeout in seconds for vision OCR (0 = no limit).
     ocr_timeout: float = ConfigField(default=120.0, ge=0.0, writable=True)
-    # Max concurrent vision-OCR requests per PDF. 1 preserves strict
-    # serial behavior; higher values overlap network-bound calls on
-    # backends that tolerate concurrency (Ollama, hosted OpenAI-compat).
+    # Max concurrent vision-OCR requests per PDF. 1 = serial.
     vision_concurrency: int = ConfigField(default=4, ge=1, writable=True)
 
-    # Wall-clock timeout in seconds for the Tesseract OCR fallback per
-    # file. Large scanned PDFs can otherwise block an ingest worker for
-    # many minutes and make the TUI feel frozen. 0 disables the cap.
+    # Tesseract fallback wall-clock timeout per file, seconds. 0 = no cap.
     tesseract_timeout: float = ConfigField(default=60.0, ge=0.0, writable=True)
     semantic_chunking: bool = ConfigField(default=False, writable=True)
     topic_threshold: float = ConfigField(default=0.75, ge=0.0, le=1.0, writable=True)
@@ -380,10 +342,8 @@ class Config(BaseSettings):
     temperature: float | None = ConfigField(default=None, ge=0.0, writable=True)
     top_p: float | None = ConfigField(default=None, ge=0.0, le=1.0, writable=True)
     top_k_sampling: int | None = ConfigField(default=None, ge=1, writable=True)
-    # 1.1 is the llama.cpp default and the value most open-weights chat
-    # models are tuned with. A None here made chat prone to n-gram loops
-    # ("tire tire tire ...") on some models. Users can still override or
-    # disable via settings / config.toml.
+    # 1.1 is llama.cpp's default. Leaving this at None caused n-gram loops
+    # ("tire tire tire...") on some open-weights models.
     repeat_penalty: float | None = ConfigField(default=1.1, ge=0.0, writable=True)
     num_ctx: int | None = ConfigField(default=None, ge=1, writable=True)
     max_tokens: int | None = ConfigField(default=4096, ge=1, writable=True)
@@ -395,56 +355,43 @@ class Config(BaseSettings):
     anthropic_api_key: str = ConfigField(default="", writable=True, write_only=True)
     gemini_api_key: str = ConfigField(default="", writable=True, write_only=True)
 
-    # Retrieval quality knobs — defaults chosen from academic research and grantflow
-    # and academic literature (see docs/superpowers/specs/2026-03-22-feature-parity-design.md)
+    # Retrieval quality knobs.
 
-    # Max chunks per source document in results. Prevents one large file from
-    # dominating all top-k slots. 3 balances coverage vs diversity.
+    # Max chunks per source in top-k; prevents one large file monopolizing results.
     diversity_max_per_source: int = ConfigField(default=3, ge=1, writable=True)
 
-    # MMR relevance/diversity tradeoff. 0.0 = max diversity, 1.0 = pure relevance.
-    # 0.5 is the standard default from Carbonell & Goldstein 1998.
+    # MMR relevance/diversity tradeoff; 0 = max diversity, 1 = pure relevance
+    # (Carbonell & Goldstein 1998).
     mmr_lambda: float = ConfigField(default=0.5, ge=0.0, le=1.0, writable=True)
 
-    # How many extra candidates to retrieve for MMR reranking.
-    # 3x gives enough candidates to find diverse results without excessive latency.
+    # Extra candidates retrieved for MMR reranking (multiplies top_k).
     candidate_multiplier: int = ConfigField(default=3, ge=1, writable=True)
 
-    # Number of LLM-generated alternative queries for expansion.
-    # 3 variants covers lexical + semantic angles. Set to 0 to disable expansion.
+    # LLM-generated alternative queries for expansion. 0 disables.
     query_expansion_count: int = ConfigField(default=3, ge=0, writable=True)
 
-    # Cosine distance threshold step for adaptive widening.
-    # When too few results are found, threshold widens by this amount per retry.
-    # 0.2 gives 4 steps from typical 0.3 start to 1.0 cap.
+    # Cosine-distance step when adaptive-widening retry kicks in.
     adaptive_threshold_step: float = ConfigField(default=0.2, gt=0.0, writable=True)
 
     # Reject expansion variants below expansion_similarity_threshold.
     expansion_guardrails: bool = ConfigField(default=True, writable=True)
 
-    # Minimum cosine similarity (question vs variant embedding).
-    # Calibrate per embedding model.
+    # Min cosine similarity between question and variant embeddings.
     expansion_similarity_threshold: float = ConfigField(default=0.5, ge=0.0, le=1.0, writable=True)
 
-    # BM25 confidence score above which query expansion is skipped entirely.
-    # Based on 90th percentile of sigmoid-normalized BM25 score distribution.
-    # Higher = expansion runs more often. Calibrate per-corpus.
+    # Sigmoid-normalized BM25 score above which query expansion is skipped.
     expansion_skip_threshold: float = Field(default=0.8, ge=0.0, le=1.0)
 
-    # Minimum gap between top-1 and top-2 BM25 scores to skip expansion.
-    # Approximately 1 standard deviation of typical score spread.
+    # Min BM25 top-1 vs top-2 gap to skip expansion.
     expansion_skip_gap: float = Field(default=0.15, ge=0.0, le=1.0)
 
-    # Maximum chunks included in LLM context after adaptive selection.
-    # More = more complete answers but higher latency and token cost.
+    # Chunks included in LLM context after adaptive selection.
     max_context_sources: int = ConfigField(default=5, ge=1, writable=True)
 
-    # Enable HyDE (Hypothetical Document Embeddings) for search.
-    # Gao et al. 2022. Adds ~500ms per query. Best for vague queries.
+    # HyDE (Gao et al. 2022): hypothetical-answer embedding search. +~500ms.
     hyde: bool = ConfigField(default=False, writable=True)
 
-    # Weight for HyDE results relative to original search (0.0-1.0).
-    # Lower = less trust in hypothetical documents.
+    # HyDE result weight relative to real-doc search (0.0-1.0).
     hyde_weight: float = ConfigField(default=0.7, ge=0.0, le=1.0, writable=True)
 
     # HyDE prompt template. Must contain {question} placeholder.
@@ -454,114 +401,86 @@ class Config(BaseSettings):
         "just write the passage.\n\nQuestion: {question}"
     )
 
-    # Reranker model for search results. Empty = disabled. Native GGUF refs
-    # run via llama-cpp-python's pooling_type=LLAMA_POOLING_TYPE_RANK; hosted
-    # refs (cohere/voyage/jina/together/hf-tei) require the litellm extra.
+    # Reranker model ref. Empty disables reranking. Native GGUFs use
+    # llama-cpp rank pooling; hosted refs (cohere/voyage/jina/together/hf-tei)
+    # need the backend extra.
     reranker_model: str = ConfigField(default="", public=True)
 
-    # Number of candidates to rerank with cross-encoder.
+    # Candidate count sent to the reranker.
     rerank_candidates: int = ConfigField(default=20, ge=1, writable=True, public=True)
 
-    # Enable temporal filtering (date-based result filtering).
-    # Only activates when temporal keywords detected in query.
+    # Date-range filter; only fires when a temporal keyword is detected.
     temporal_filtering: bool = ConfigField(default=True, writable=True)
 
-    # Show reasoning model thinking process (<think>...</think> tags).
-    # When False, thinking is stripped silently. When True, emitted as
-    # separate SSE events (event: reasoning) for UI rendering.
+    # If True, emit <think>…</think> content as separate SSE reasoning events;
+    # if False, strip it silently.
     show_reasoning: bool = ConfigField(default=False, writable=True)
 
-    # Web crawling settings
-    # Optional global ceiling on recursion depth. None (default) = no ceiling;
-    # callers decide. Set a positive int in config.toml as a safety cap.
-    crawl_max_depth: int | None = ConfigField(default=None, ge=0, writable=True)
+    # Web crawling.
 
-    # Optional global ceiling on total pages per crawl. None (default) = no ceiling.
+    # Optional global ceilings. None = no ceiling.
+    crawl_max_depth: int | None = ConfigField(default=None, ge=0, writable=True)
     crawl_max_pages: int | None = ConfigField(default=None, ge=1, writable=True)
 
-    # Per-page timeout in seconds for fetching a URL.
+    # Per-URL fetch timeout, seconds.
     crawl_timeout: int = ConfigField(default=30, ge=1, writable=True)
 
-    # Maximum concurrent crawl operations (0 = unlimited, default = CPU count).
+    # 0 = unlimited, default = CPU count.
     crawl_max_concurrent: int = Field(default=0, ge=0)
 
-    # Seconds between periodic syncs during crawl (0 = sync only at end).
+    # Seconds between periodic syncs during crawl. 0 = sync only at end.
     crawl_sync_interval: int = ConfigField(default=30, ge=0, writable=True)
 
-    # Uniform delay between in-flight requests within a single crawl.
-    # crawl4ai's own defaults are 0.1 / 0.3; ours are friendlier to hosts.
+    # Per-request delay + jitter (defaults chosen to be gentler than crawl4ai's).
     crawl_mean_delay: float = ConfigField(default=0.5, ge=0.0, writable=True)
-
-    # Random jitter added to crawl_mean_delay (seconds).
     crawl_max_delay_range: float = ConfigField(default=0.5, ge=0.0, writable=True)
 
-    # Concurrent in-flight requests within a single crawl. crawl4ai default
-    # is 5; we use 3 by default to be gentler.
+    # In-flight requests per crawl.
     crawl_concurrent_requests: int = ConfigField(default=3, ge=1, writable=True)
 
-    # Enable the per-domain RateLimiter that backs off on HTTP 429/503 and
-    # retries. Set False to disable the dispatcher entirely.
+    # Per-domain rate-limiter that backs off on HTTP 429/503 and retries.
     crawl_retry_on_rate_limit: bool = ConfigField(default=True, writable=True)
-
-    # Randomized base-delay range the RateLimiter picks from on rate-limit
-    # responses (seconds). Pair: (min, max).
     crawl_retry_base_delay_min: float = ConfigField(default=1.0, ge=0.0, writable=True)
     crawl_retry_base_delay_max: float = ConfigField(default=3.0, ge=0.0, writable=True)
-
-    # Upper bound on any single backoff wait (seconds).
     crawl_retry_max_backoff: float = ConfigField(default=30.0, ge=0.0, writable=True)
-
-    # Retry count per URL when rate-limit codes come back.
     crawl_retry_max_attempts: int = ConfigField(default=3, ge=0, writable=True)
 
-    # Regex patterns that skip URLs at link-discovery time during recursive
-    # crawls. Defaults block WordPress scaffolding (pagination, archives,
-    # tracking query params) that inflates useful-page count by 5-7x without
-    # adding content. Empty list disables the filter.
+    # Regex patterns dropped at link-discovery time. Defaults block CMS
+    # scaffolding (WordPress admin, archives, tracking params, etc.).
     crawl_exclude_patterns: list[str] = ConfigField(
         default_factory=lambda: list(DEFAULT_CRAWL_EXCLUDE_PATTERNS),
         writable=True,
     )
 
-    # Fraction of GPU/unified memory available for loaded models.
-    # 0.75 leaves headroom for the OS and other processes.
+    # Fraction of GPU/unified memory reserved for loaded models.
     gpu_memory_fraction: float = ConfigField(default=0.75, ge=0.1, le=1.0, writable=True)
 
     # Seconds a model stays loaded after last use. 0 = unload immediately.
     model_keep_alive: int = ConfigField(default=300, ge=0, writable=True)
 
-    # Run embedding and vision inference in a subprocess to avoid GIL blocking.
-    # Applies only to the llama-cpp provider.
+    # Run embedding and vision inference in a subprocess (llama-cpp only).
     subprocess_embed: bool = ConfigField(default=False, writable=True)
 
-    # Use Markdown widget for chat responses in the TUI. When False, uses
-    # plain Static text (faster rendering, no formatting).
+    # True = Markdown widget for chat; False = plain Static (faster).
     markdown_rendering: bool = True
 
-    # Per-model generation defaults (not serialized, not a config field).
-    # Set via apply_model_defaults() when switching models.
+    # Per-model generation defaults set via apply_model_defaults().
     _model_defaults: Any = None
 
     # Wiki layer — LLM-maintained synthesis pages with citation provenance.
-    # On by default; no extras required. Set to False to hide the Wiki view
-    # and disable wiki generation/sync.
     wiki: bool = True
     wiki_dir: str = "wiki"
     wiki_prune_raw: bool = ConfigField(default=False, writable=True)
     wiki_faithfulness_threshold: float = ConfigField(default=0.7, ge=0.0, le=1.0, writable=True)
 
-    # Fraction of citations that must be stale before a wiki page is flagged
-    # for regeneration during pruning. 0.5 = flag when >50% are stale.
+    # Fraction of citations that must be stale before a wiki page is flagged.
     wiki_stale_citation_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
 
-    # Maximum fraction of content that may change before a regeneration is
-    # flagged for human review instead of overwriting the existing page.
-    # 0.3 = 30% of lines changed triggers the drift guard.
+    # Fraction of content changed that triggers human-review drift guard.
     wiki_drift_threshold: float = Field(default=0.3, ge=0.0, le=1.0)
 
-    # LLM prompt templates for wiki page generation. Override via env vars
-    # LILBEE_WIKI_SUMMARY_PROMPT, LILBEE_WIKI_FAITHFULNESS_PROMPT,
-    # LILBEE_WIKI_SYNTHESIS_PROMPT. Must contain the expected {placeholders}.
+    # Wiki LLM prompts. Overridable via LILBEE_WIKI_{SUMMARY,FAITHFULNESS,SYNTHESIS}_PROMPT.
+    # Must contain the expected {placeholders}.
     wiki_summary_prompt: str = (
         "You are a knowledge compiler. Given the source chunks below from a single "
         "document, write a concise wiki summary page in markdown.\n\n"
@@ -614,38 +533,27 @@ class Config(BaseSettings):
         "Write the synthesis page now. Start with a heading."
     )
 
-    # Wiki synthesis clusterer backend. EMBEDDING (default, no extra deps)
-    # runs chunk-level mutual kNN + label propagation over chunk embeddings.
-    # CONCEPTS uses the concept graph adapter and requires the [graph] extra;
-    # when [graph] is missing the services factory logs a warning and falls
-    # back to EMBEDDING.
+    # Wiki synthesis clusterer backend. CONCEPTS requires the [graph] extra
+    # and falls back to EMBEDDING when unavailable.
     wiki_clusterer: ClustererBackend = ConfigField(
         default=ClustererBackend.EMBEDDING, writable=True
     )
 
-    # Neighborhood size for the embedding clusterer's mutual-kNN graph.
-    # 0 means "auto-scale from corpus size" via clamp(log2(N)+2, 5, 20).
-    # Raise to get larger, looser clusters; lower for tighter, smaller ones.
+    # Neighborhood size for the mutual-kNN graph. 0 = auto-scale from corpus size.
     wiki_clusterer_k: int = ConfigField(default=0, ge=0, writable=True)
 
-    # Enable concept graph (LazyGraphRAG-style index). Extracts noun phrases
-    # from chunks, builds a co-occurrence graph, and uses it to boost search
-    # results and expand queries. Requires spacy + networkx + graspologic-native.
+    # LazyGraphRAG-style concept graph. Requires the [graph] extra.
     concept_graph: bool = ConfigField(default=True, writable=True)
 
-    # Weight for concept overlap boosting in search results (0.0-1.0).
-    # Higher = concept overlap matters more relative to vector similarity.
+    # Weight of concept overlap boost relative to vector similarity.
     concept_boost_weight: float = ConfigField(default=0.3, ge=0.0, le=1.0, writable=True)
 
-    # Minimum distance after concept boost. Prevents boost from making
-    # marginally relevant results appear artificially close.
+    # Floor on post-boost distance to stop weak boosts from promoting marginal hits.
     concept_boost_floor: float = ConfigField(default=0.05, ge=0.0, writable=True)
 
-    # Maximum noun-phrase concepts extracted per chunk.
-    # Caps extraction to avoid noise from very long chunks.
+    # Max noun-phrase concepts extracted per chunk.
     concept_max_per_chunk: int = ConfigField(default=10, ge=1, writable=True)
 
-    # Class variable — not a settings field
     _toml_cache: ClassVar[dict[str, Any]] = {}
 
     @field_validator(
@@ -703,12 +611,7 @@ class Config(BaseSettings):
     )
     @classmethod
     def _normalize_model_tag(cls, v: str, info: ValidationInfo) -> str:
-        """Ensure model names always have an explicit tag and canonical prefix.
-
-        Whitespace-only values are coerced to "" for roles that allow empty
-        (vision, reranker), and rejected for required roles (chat, embedding)
-        to prevent bypassing ``min_length=1``.
-        """
+        """Normalize a model ref to ``name:tag``; blank values clear optional roles."""
         if not v or not v.strip():
             if info.field_name in {"chat_model", "embedding_model"}:
                 raise ValueError(f"{info.field_name} must not be blank")
@@ -716,12 +619,6 @@ class Config(BaseSettings):
         from lilbee.providers.model_ref import parse_model_ref
 
         return parse_model_ref(v).for_openai_prefix()
-
-    # Model-task validation lives in the handler layer now (see
-    # lilbee.server.handlers._validate_config_updates and the
-    # validate_model_task_assignment helper below). Running it inside a
-    # field_validator fired on every setattr, and a single PATCH /api/config
-    # with six fields would rescan the featured catalog six times.
 
     @field_validator("cors_origins", mode="before")
     @classmethod
@@ -847,14 +744,7 @@ class Config(BaseSettings):
         object.__setattr__(self, "_model_defaults", None)
 
     def generation_options(self, **overrides: Any) -> dict[str, Any]:
-        """Build LLM generation options with 3-layer merge.
-        Layer 1 (base): model defaults from ``_model_defaults``
-        Layer 2 (override): user config fields — only if explicitly set (not None)
-        Layer 3 (override): per-call ``overrides`` parameter
-
-        Remaps ``top_k_sampling`` to the provider's ``top_k`` key.
-        Filters out ``None`` values so the provider uses its model defaults.
-        """
+        """Merge model defaults, user config, and per-call overrides, dropping None."""
         result = _model_defaults_dict(self._model_defaults)
         user_fields: dict[str, Any] = {
             "temperature": self.temperature,
@@ -875,10 +765,7 @@ class Config(BaseSettings):
 
 
 def _model_defaults_dict(defaults: Any) -> dict[str, Any]:
-    """Convert a ModelDefaults instance to a dict with provider key names.
-    Remaps ``top_k`` to the provider's ``top_k`` key (same name for model defaults).
-    Filters out None values.
-    """
+    """Non-None fields of a ModelDefaults instance as a dict."""
     if defaults is None:
         return {}
     from dataclasses import fields as dc_fields
@@ -891,11 +778,7 @@ def _model_defaults_dict(defaults: Any) -> dict[str, Any]:
 
 
 class _PlainEnvSource:
-    """Env source that reads LILBEE_* env vars as plain strings.
-    Avoids pydantic-settings' default JSON parsing of complex types (list, frozenset)
-    so that comma-separated values like ``LILBEE_CORS_ORIGINS=a,b`` pass through to
-    field validators instead of failing JSON decode.
-    """
+    """Reads LILBEE_* env vars as plain strings so field validators handle parsing."""
 
     def __init__(
         self,

--- a/src/lilbee/crawl_task.py
+++ b/src/lilbee/crawl_task.py
@@ -114,15 +114,19 @@ async def run_crawl(task: CrawlTask) -> None:
 
 
 def _evict_completed() -> None:
-    """Remove oldest completed tasks when the limit is exceeded."""
+    """Remove oldest completed tasks when the limit is exceeded.
+
+    Python 3.7+ dicts preserve insertion order, and tasks are inserted
+    in chronological order, so iterating in dict order visits completed
+    tasks oldest-first without a sort.
+    """
     done_statuses = (TaskStatus.DONE, TaskStatus.FAILED)
     tasks = _registry.tasks
-    completed = [(tid, t) for tid, t in tasks.items() if t.status in done_statuses]
-    excess = len(completed) - _MAX_COMPLETED_TASKS
+    completed_ids = [tid for tid, t in tasks.items() if t.status in done_statuses]
+    excess = len(completed_ids) - _MAX_COMPLETED_TASKS
     if excess <= 0:
         return
-    completed.sort(key=lambda pair: pair[1].finished_at)
-    for tid, _ in completed[:excess]:
+    for tid in completed_ids[:excess]:
         del tasks[tid]
 
 

--- a/src/lilbee/crawl_task.py
+++ b/src/lilbee/crawl_task.py
@@ -114,19 +114,20 @@ async def run_crawl(task: CrawlTask) -> None:
 
 
 def _evict_completed() -> None:
-    """Remove oldest completed tasks when the limit is exceeded.
+    """Remove completed tasks with the earliest ``finished_at`` when over cap.
 
-    Python 3.7+ dicts preserve insertion order, and tasks are inserted
-    in chronological order, so iterating in dict order visits completed
-    tasks oldest-first without a sort.
+    Finish order diverges from start order whenever short tasks complete
+    while a long one is still running, so sort on ``finished_at``
+    rather than dict insertion order.
     """
     done_statuses = (TaskStatus.DONE, TaskStatus.FAILED)
     tasks = _registry.tasks
-    completed_ids = [tid for tid, t in tasks.items() if t.status in done_statuses]
-    excess = len(completed_ids) - _MAX_COMPLETED_TASKS
+    completed = [(tid, t) for tid, t in tasks.items() if t.status in done_statuses]
+    excess = len(completed) - _MAX_COMPLETED_TASKS
     if excess <= 0:
         return
-    for tid in completed_ids[:excess]:
+    completed.sort(key=lambda pair: pair[1].finished_at)
+    for tid, _ in completed[:excess]:
         del tasks[tid]
 
 

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -11,6 +11,7 @@ HTTP, TUI) import these functions via the package façade in
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import math
 import threading
@@ -185,7 +186,9 @@ async def _drain_page_stream(
         results.append(new_result)
         if on_result is not None:
             try:
-                on_result(new_result)
+                rv = on_result(new_result)
+                if inspect.isawaitable(rv):
+                    await rv
             except OSError:
                 # A disk-side flush failure must not masquerade as a crawl
                 # failure. Log and keep streaming; the caller still sees the
@@ -347,14 +350,17 @@ def _make_flush_page(
     meta: dict[str, CrawlMeta],
     written_paths: list[Path],
     counter: dict[str, int],
-) -> Callable[[CrawlResult], Path | None]:
+) -> Callable[[CrawlResult], Any]:
     """Build a per-result flush closure that batches metadata writes.
+
+    Filesystem work runs through ``asyncio.to_thread`` so the streaming
+    event loop isn't blocked by per-page writes on slow filesystems.
 
     ``counter`` is a single-entry dict used as a mutable int so the closure
     can share counter state with the caller without nonlocal gymnastics.
     """
 
-    def flush_page(result: CrawlResult) -> Path | None:
+    def _sync_flush(result: CrawlResult) -> Path | None:
         outcome = save._save_single_result(result, meta)
         if outcome is None:
             return None
@@ -363,8 +369,13 @@ def _make_flush_page(
         if counter["pending"] >= METADATA_FLUSH_INTERVAL:
             save.save_crawl_metadata(meta)
             counter["pending"] = 0
-        written_paths.append(outcome.path)
         return outcome.path
+
+    async def flush_page(result: CrawlResult) -> Path | None:
+        path = await asyncio.to_thread(_sync_flush, result)
+        if path is not None:
+            written_paths.append(path)
+        return path
 
     return flush_page
 
@@ -422,7 +433,7 @@ async def crawl_and_save(
             result = await crawl_single(url, quiet=quiet)
             pages_seen = 1
             try:
-                flush_page(result)
+                await flush_page(result)
             except OSError:
                 log.exception("Flush failed for %s", result.url)
             if on_progress:

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -355,16 +355,16 @@ def _make_flush_page(
     """
 
     def flush_page(result: CrawlResult) -> Path | None:
-        path = save._save_single_result(result, meta)
-        if path is None:
+        outcome = save._save_single_result(result, meta)
+        if outcome is None:
             return None
-        save._update_single_metadata(meta, result, datetime.now(UTC).isoformat())
+        save._update_single_metadata(meta, result.url, outcome, datetime.now(UTC).isoformat())
         counter["pending"] += 1
         if counter["pending"] >= METADATA_FLUSH_INTERVAL:
             save.save_crawl_metadata(meta)
             counter["pending"] = 0
-        written_paths.append(path)
-        return path
+        written_paths.append(outcome.path)
+        return outcome.path
 
     return flush_page
 

--- a/src/lilbee/crawler/save.py
+++ b/src/lilbee/crawler/save.py
@@ -137,16 +137,27 @@ def content_hash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
-def _save_single_result(result: CrawlResult, meta: dict[str, CrawlMeta]) -> Path | None:
+@dataclass(frozen=True)
+class SaveOutcome:
+    """Return value of ``_save_single_result``: written path and the hash/filename used."""
+
+    path: Path
+    filename: str
+    content_hash: str
+
+
+def _save_single_result(result: CrawlResult, meta: dict[str, CrawlMeta]) -> SaveOutcome | None:
     """Write one crawl result to disk if it's new or changed.
 
-    Returns the written path, or None if skipped (failure, empty markdown,
-    unchanged hash with file on disk, or blocked by path traversal).
+    Returns the outcome (written path plus reusable filename/hash), or
+    None if skipped (failure, empty markdown, unchanged hash with file
+    on disk, or blocked by path traversal).
     """
     if not result.success or not result.markdown.strip():
         return None
+    filename = url_to_filename(result.url)
     web_dir = _web_dir()
-    file_path = web_dir / url_to_filename(result.url)
+    file_path = web_dir / filename
     resolved_web_dir = web_dir.resolve()
     try:
         validate_path_within(file_path, resolved_web_dir)
@@ -160,13 +171,18 @@ def _save_single_result(result: CrawlResult, meta: dict[str, CrawlMeta]) -> Path
         return None
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text(result.markdown, encoding="utf-8")
-    return file_path
+    return SaveOutcome(path=file_path, filename=filename, content_hash=new_hash)
 
 
-def _update_single_metadata(meta: dict[str, CrawlMeta], result: CrawlResult, now: str) -> None:
-    """Update the metadata dict in place for one just-saved result."""
-    meta[result.url] = CrawlMeta(
-        file=url_to_filename(result.url),
-        content_hash=content_hash(result.markdown),
+def _update_single_metadata(
+    meta: dict[str, CrawlMeta],
+    url: str,
+    outcome: SaveOutcome,
+    now: str,
+) -> None:
+    """Update the metadata dict in place with a previously-computed outcome."""
+    meta[url] = CrawlMeta(
+        file=outcome.filename,
+        content_hash=outcome.content_hash,
         crawled_at=now,
     )

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -10,7 +10,6 @@ import os
 import threading
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
@@ -166,22 +165,22 @@ def file_hash(path: Path) -> str:
     return h.hexdigest()
 
 
-def _file_unchanged_since_ingest(path: Path, ingested_at: str) -> bool:
-    """True when the file's mtime is strictly older than *ingested_at*.
+def _file_unchanged_by_mtime(path: Path, stored_mtime: float | None) -> bool:
+    """True when the file's current mtime matches *stored_mtime* within precision.
 
-    Returns False on any failure (missing timestamp, unparseable ISO,
-    stat error) so callers fall through to a hash compare.
+    Comparing mtime to mtime keeps both values in the same reference frame,
+    avoiding the Windows-only failure mode where NTFS mtime precision is
+    coarser than a wall-clock ``ingested_at``. Returns False when no mtime
+    is stored (legacy rows) or on stat error, so callers fall through to a
+    hash compare.
     """
-    if not ingested_at:
+    if stored_mtime is None:
         return False
     try:
-        ingested_dt = datetime.fromisoformat(ingested_at)
-        mtime_dt = datetime.fromtimestamp(path.stat().st_mtime, UTC)
-    except (OSError, ValueError):
+        current_mtime = path.stat().st_mtime
+    except OSError:
         return False
-    if ingested_dt.tzinfo is None:
-        ingested_dt = ingested_dt.replace(tzinfo=UTC)
-    return mtime_dt < ingested_dt
+    return current_mtime <= stored_mtime
 
 
 def _relative_name(path: Path) -> str:
@@ -636,7 +635,7 @@ async def sync(
 
     disk_files = discover_files()
     existing_sources = {
-        s["filename"]: (s["file_hash"], s.get("ingested_at", "")) for s in _store.get_sources()
+        s["filename"]: (s["file_hash"], s.get("source_mtime")) for s in _store.get_sources()
     }
 
     added: list[str] = []
@@ -665,7 +664,7 @@ async def sync(
         old = existing_sources.get(name)
         old_hash = old[0] if old is not None else None
 
-        if old is not None and _file_unchanged_since_ingest(path, old[1]):
+        if old is not None and _file_unchanged_by_mtime(path, old[1]):
             unchanged += 1
             continue
 
@@ -901,4 +900,8 @@ def _apply_result(
         return
 
     fhash = result.file_hash or file_hash(result.path)
-    get_services().store.upsert_source(result.name, fhash, result.chunk_count)
+    try:
+        mtime: float | None = result.path.stat().st_mtime
+    except OSError:
+        mtime = None
+    get_services().store.upsert_source(result.name, fhash, result.chunk_count, source_mtime=mtime)

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -10,6 +10,7 @@ import os
 import threading
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
@@ -163,6 +164,25 @@ def file_hash(path: Path) -> str:
         for block in iter(lambda: f.read(8192), b""):
             h.update(block)
     return h.hexdigest()
+
+
+def _file_unchanged_since_ingest(path: Path, ingested_at: str) -> bool:
+    """Fast-path gate: True when mtime is strictly older than the stored ingest time.
+
+    Used to skip full SHA-256 hashing on unchanged files during sync. Any
+    failure (missing timestamp, unparseable ISO string, stat error) returns
+    False so the caller falls through to the authoritative hash compare.
+    """
+    if not ingested_at:
+        return False
+    try:
+        ingested_dt = datetime.fromisoformat(ingested_at)
+        mtime_dt = datetime.fromtimestamp(path.stat().st_mtime, UTC)
+    except (OSError, ValueError):
+        return False
+    if ingested_dt.tzinfo is None:
+        ingested_dt = ingested_dt.replace(tzinfo=UTC)
+    return mtime_dt < ingested_dt
 
 
 def _relative_name(path: Path) -> str:
@@ -616,7 +636,9 @@ async def sync(
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
 
     disk_files = discover_files()
-    existing_sources = {s["filename"]: s["file_hash"] for s in _store.get_sources()}
+    existing_sources = {
+        s["filename"]: (s["file_hash"], s.get("ingested_at", "")) for s in _store.get_sources()
+    }
 
     added: list[str] = []
     updated: list[str] = []
@@ -641,8 +663,14 @@ async def sync(
         if content_type is None:
             raise ValueError(f"Unsupported file slipped through discovery: {name}")
 
+        old = existing_sources.get(name)
+        old_hash = old[0] if old is not None else None
+
+        if old is not None and _file_unchanged_since_ingest(path, old[1]):
+            unchanged += 1
+            continue
+
         current_hash = file_hash(path)
-        old_hash = existing_sources.get(name)
 
         if old_hash == current_hash:
             unchanged += 1

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -165,24 +165,6 @@ def file_hash(path: Path) -> str:
     return h.hexdigest()
 
 
-def _file_unchanged_by_mtime(path: Path, stored_mtime: float | None) -> bool:
-    """True when the file's current mtime matches *stored_mtime* within precision.
-
-    Comparing mtime to mtime keeps both values in the same reference frame,
-    avoiding the Windows-only failure mode where NTFS mtime precision is
-    coarser than a wall-clock ``ingested_at``. Returns False when no mtime
-    is stored (legacy rows) or on stat error, so callers fall through to a
-    hash compare.
-    """
-    if stored_mtime is None:
-        return False
-    try:
-        current_mtime = path.stat().st_mtime
-    except OSError:
-        return False
-    return current_mtime <= stored_mtime
-
-
 def _relative_name(path: Path) -> str:
     """Get path relative to documents dir as a forward-slash string (portable across OS)."""
     return path.relative_to(cfg.documents_dir).as_posix()
@@ -634,9 +616,7 @@ async def sync(
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
 
     disk_files = discover_files()
-    existing_sources = {
-        s["filename"]: (s["file_hash"], s.get("source_mtime")) for s in _store.get_sources()
-    }
+    existing_sources = {s["filename"]: s["file_hash"] for s in _store.get_sources()}
 
     added: list[str] = []
     updated: list[str] = []
@@ -661,12 +641,7 @@ async def sync(
         if content_type is None:
             raise ValueError(f"Unsupported file slipped through discovery: {name}")
 
-        old = existing_sources.get(name)
-        old_hash = old[0] if old is not None else None
-
-        if old is not None and _file_unchanged_by_mtime(path, old[1]):
-            unchanged += 1
-            continue
+        old_hash = existing_sources.get(name)
 
         current_hash = file_hash(path)
 
@@ -900,8 +875,4 @@ def _apply_result(
         return
 
     fhash = result.file_hash or file_hash(result.path)
-    try:
-        mtime: float | None = result.path.stat().st_mtime
-    except OSError:
-        mtime = None
-    get_services().store.upsert_source(result.name, fhash, result.chunk_count, source_mtime=mtime)
+    get_services().store.upsert_source(result.name, fhash, result.chunk_count)

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -167,11 +167,10 @@ def file_hash(path: Path) -> str:
 
 
 def _file_unchanged_since_ingest(path: Path, ingested_at: str) -> bool:
-    """Fast-path gate: True when mtime is strictly older than the stored ingest time.
+    """True when the file's mtime is strictly older than *ingested_at*.
 
-    Used to skip full SHA-256 hashing on unchanged files during sync. Any
-    failure (missing timestamp, unparseable ISO string, stat error) returns
-    False so the caller falls through to the authoritative hash compare.
+    Returns False on any failure (missing timestamp, unparseable ISO,
+    stat error) so callers fall through to a hash compare.
     """
     if not ingested_at:
         return False

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -431,10 +431,10 @@ def wiki_generate(source: str) -> dict[str, Any]:
 
 @mcp.tool()
 def model_list(source: str = "", task: str = "") -> dict[str, Any]:
-    """List installed models across native and litellm sources.
+    """List installed models across native and SDK-backend sources.
 
     Args:
-        source: Filter by source: "native", "litellm", or "" for all.
+        source: Filter by source: "native", "backend", or "" for all.
         task: Filter by task: "chat", "embedding", "vision", "rerank", or "" for all.
     """
     from lilbee.cli.model import list_models_data
@@ -481,7 +481,7 @@ async def model_pull(
 
     Args:
         model: Model ref to pull (e.g. "qwen3:0.6b").
-        source: "native" (HuggingFace GGUF) or "litellm" (remote backend).
+        source: "native" (HuggingFace GGUF) or "backend" (SDK-managed remote).
     """
     from lilbee.catalog import DownloadProgress
     from lilbee.cli.model import pull_model_data
@@ -516,7 +516,7 @@ def model_rm(model: str, source: str = "") -> dict[str, Any]:
 
     Args:
         model: Model ref to remove.
-        source: Restrict to "native" or "litellm"; empty = both.
+        source: Restrict to "native" or "backend"; empty = both.
     """
     from lilbee.cli.model import remove_model_data
     from lilbee.model_manager import ModelSource

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -535,4 +535,12 @@ def clean(result: SearchChunk) -> dict[str, object]:
 
 def main() -> None:
     """Entry point for the MCP server."""
+    # Preload so the first tool call doesn't pay the cold-start cost
+    # of provider/embedder/store init. Failures (missing model, bad
+    # config) still surface on the first tool call rather than crashing
+    # the server before it attaches to stdio.
+    try:
+        get_services()
+    except Exception:
+        log.debug("MCP pre-warm failed; services will init on first call", exc_info=True)
     mcp.run()

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -434,7 +434,7 @@ def model_list(source: str = "", task: str = "") -> dict[str, Any]:
     """List installed models across native and SDK-backend sources.
 
     Args:
-        source: Filter by source: "native", "backend", or "" for all.
+        source: Filter by source: "native", "remote", or "" for all.
         task: Filter by task: "chat", "embedding", "vision", "rerank", or "" for all.
     """
     from lilbee.cli.model import list_models_data
@@ -481,7 +481,7 @@ async def model_pull(
 
     Args:
         model: Model ref to pull (e.g. "qwen3:0.6b").
-        source: "native" (HuggingFace GGUF) or "backend" (SDK-managed remote).
+        source: "native" (HuggingFace GGUF) or "remote" (SDK-managed).
     """
     from lilbee.catalog import DownloadProgress
     from lilbee.cli.model import pull_model_data
@@ -516,7 +516,7 @@ def model_rm(model: str, source: str = "") -> dict[str, Any]:
 
     Args:
         model: Model ref to remove.
-        source: Restrict to "native" or "backend"; empty = both.
+        source: Restrict to "native" or "remote"; empty = both.
     """
     from lilbee.cli.model import remove_model_data
     from lilbee.model_manager import ModelSource

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -75,12 +75,10 @@ class ModelManager:
         self._installed_cache: dict[ModelSource | None, tuple[float, list[str]]] = {}
 
     def list_installed(self, source: ModelSource | None = None) -> list[str]:
-        """List installed model names. source=None lists all sources.
+        """List installed model names. ``source=None`` lists all sources.
 
-        Result is cached for ``_INSTALLED_CACHE_TTL_SECONDS`` and invalidated
-        eagerly on any ``pull``/``remove`` mutation so callers only see
-        stale data during the narrow window when no local change has
-        happened and the cached backend response has not yet aged out.
+        Memoized with a ``_INSTALLED_CACHE_TTL_SECONDS`` TTL and
+        invalidated eagerly by ``pull``/``remove``.
         """
         now = time.monotonic()
         cached = self._installed_cache.get(source)

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -13,7 +13,11 @@ import httpx
 
 from lilbee.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.models import ModelTask
-from lilbee.providers.sdk_backend import PROVIDER_KEYS
+from lilbee.providers.sdk_backend import (
+    PROVIDER_KEYS,
+    REMOTE_BACKEND_NAME,
+    detect_backend_name,
+)
 from lilbee.security import validate_path_within
 
 # lilbee.config imported lazily; see lilbee/catalog.py for the rationale.
@@ -25,7 +29,7 @@ class ModelSource(Enum):
     """Where a model is stored."""
 
     NATIVE = "native"  # lilbee's GGUF files in cfg.models_dir
-    LITELLM = "litellm"  # Models managed by an external backend
+    BACKEND = "backend"  # Models managed by an external SDK backend
 
     @classmethod
     def parse(cls, value: str | None) -> "ModelSource | None":
@@ -145,7 +149,7 @@ class ModelManager:
         if self._is_native(model):
             return ModelSource.NATIVE
         if self._is_backend(model):
-            return ModelSource.LITELLM
+            return ModelSource.BACKEND
         return None
 
     def pull(
@@ -277,12 +281,6 @@ _VISION_NAME_PATTERNS = frozenset({"llava", "vision", "moondream", "ocr", "minic
 _RERANKER_NAME_PATTERNS = frozenset({"reranker", "rerank", "cross-encoder"})
 
 
-OLLAMA_PROVIDER_NAME = "Ollama"
-OPENAI_PROVIDER_NAME = "OpenAI"
-ANTHROPIC_PROVIDER_NAME = "Anthropic"
-REMOTE_PROVIDER_NAME = "Remote"
-
-
 @dataclass
 class RemoteModel:
     """A model from the SDK backend with inferred task classification."""
@@ -291,24 +289,7 @@ class RemoteModel:
     task: str  # "chat", "embedding", "vision", "rerank"
     family: str
     parameter_size: str
-    provider: str = REMOTE_PROVIDER_NAME
-
-
-_PROVIDER_PATTERNS: tuple[tuple[str, str], ...] = (
-    ("localhost:11434", OLLAMA_PROVIDER_NAME),
-    ("ollama", OLLAMA_PROVIDER_NAME),
-    ("openai", OPENAI_PROVIDER_NAME),
-    ("anthropic", ANTHROPIC_PROVIDER_NAME),
-)
-
-
-def detect_provider(base_url: str) -> str:
-    """Detect the remote provider name from the SDK backend URL."""
-    url_lower = base_url.lower()
-    for pattern, provider in _PROVIDER_PATTERNS:
-        if pattern in url_lower:
-            return provider
-    return REMOTE_PROVIDER_NAME
+    provider: str = REMOTE_BACKEND_NAME
 
 
 def _classify_remote_task(name: str, family: str) -> str:
@@ -353,7 +334,7 @@ def classify_remote_models(
         log.debug("Failed to classify remote models", exc_info=True)
         return []
 
-    provider = detect_provider(base_url)
+    provider = detect_backend_name(base_url)
     result: list[RemoteModel] = []
     for model in raw_models:
         name = model.get("name", "")
@@ -436,7 +417,7 @@ class _ManagerHolder:
         if self._instance is None:
             from lilbee.config import cfg
 
-            self._instance = ModelManager(cfg.models_dir, cfg.litellm_base_url)
+            self._instance = ModelManager(cfg.models_dir, cfg.backend_base_url)
         return self._instance
 
     def reset(self) -> None:

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -29,7 +29,7 @@ class ModelSource(Enum):
     """Where a model is stored."""
 
     NATIVE = "native"  # lilbee's GGUF files in cfg.models_dir
-    BACKEND = "backend"  # Models managed by an external SDK backend
+    REMOTE = "remote"  # Models managed by a remote SDK-backed service
 
     @classmethod
     def parse(cls, value: str | None) -> "ModelSource | None":
@@ -61,9 +61,9 @@ _INSTALLED_CACHE_TTL_SECONDS = 30.0
 class ModelManager:
     """Manages model lifecycle with distinct sources."""
 
-    def __init__(self, models_dir: Path, backend_base_url: str = "http://localhost:11434") -> None:
+    def __init__(self, models_dir: Path, remote_base_url: str = "http://localhost:11434") -> None:
         self._models_dir = models_dir
-        self._backend_base_url = backend_base_url.rstrip("/")
+        self._remote_base_url = remote_base_url.rstrip("/")
 
         from lilbee.registry import ModelRegistry
 
@@ -89,12 +89,12 @@ class ModelManager:
 
         if source is None:
             native = set(self._list_native())
-            remote = set(self._list_backend())
+            remote = set(self._list_remote())
             result = sorted(native | remote)
         elif source is ModelSource.NATIVE:
             result = self._list_native()
         else:
-            result = self._list_backend()
+            result = self._list_remote()
 
         self._installed_cache[source] = (now, result)
         return result
@@ -107,9 +107,9 @@ class ModelManager:
         """List native models from the registry only."""
         return sorted(f"{m.name}:{m.tag}" for m in self._registry.list_installed())
 
-    def _list_backend(self) -> list[str]:
+    def _list_remote(self) -> list[str]:
         """List models from the SDK backend via its HTTP API."""
-        url = f"{self._backend_base_url}/api/tags"
+        url = f"{self._remote_base_url}/api/tags"
         try:
             resp = httpx.get(url, timeout=DEFAULT_HTTP_TIMEOUT)
             resp.raise_for_status()
@@ -125,10 +125,10 @@ class ModelManager:
     def is_installed(self, model: str, source: ModelSource | None = None) -> bool:
         """Check if model exists in specified source."""
         if source is None:
-            return self._is_native(model) or self._is_backend(model)
+            return self._is_native(model) or self._is_remote(model)
         if source is ModelSource.NATIVE:
             return self._is_native(model)
-        return self._is_backend(model)
+        return self._is_remote(model)
 
     def _is_native(self, model: str) -> bool:
         if self._registry.is_installed(model):
@@ -139,15 +139,15 @@ class ModelManager:
             return False
         return (self._models_dir / model).is_file()
 
-    def _is_backend(self, model: str) -> bool:
-        return model in self._list_backend()
+    def _is_remote(self, model: str) -> bool:
+        return model in self._list_remote()
 
     def get_source(self, model: str) -> ModelSource | None:
         """Find which source a model lives in. Native takes precedence."""
         if self._is_native(model):
             return ModelSource.NATIVE
-        if self._is_backend(model):
-            return ModelSource.BACKEND
+        if self._is_remote(model):
+            return ModelSource.REMOTE
         return None
 
     def pull(
@@ -170,7 +170,7 @@ class ModelManager:
         try:
             if source is ModelSource.NATIVE:
                 return self._pull_native(model, on_bytes=on_bytes)
-            self._pull_backend(model, on_progress=on_progress)
+            self._pull_remote(model, on_progress=on_progress)
             return None
         finally:
             self._invalidate_installed_cache()
@@ -194,11 +194,11 @@ class ModelManager:
         log.info("Downloaded %s to %s", model, path)
         return path
 
-    def _pull_backend(
+    def _pull_remote(
         self, model: str, *, on_progress: Callable[[dict], None] | None = None
     ) -> None:
         """Pull model via the SDK backend's HTTP API with streaming progress."""
-        url = f"{self._backend_base_url}/api/pull"
+        url = f"{self._remote_base_url}/api/pull"
         try:
             with (
                 httpx.Client(timeout=None) as client,
@@ -224,11 +224,11 @@ class ModelManager:
         try:
             if source is None:
                 native_removed = self._remove_native(model)
-                backend_removed = self._remove_backend(model)
+                backend_removed = self._remove_remote(model)
                 return native_removed or backend_removed
             if source is ModelSource.NATIVE:
                 return self._remove_native(model)
-            return self._remove_backend(model)
+            return self._remove_remote(model)
         finally:
             self._invalidate_installed_cache()
 
@@ -247,8 +247,8 @@ class ModelManager:
             return True
         return False
 
-    def _remove_backend(self, model: str) -> bool:
-        url = f"{self._backend_base_url}/api/delete"
+    def _remove_remote(self, model: str) -> bool:
+        url = f"{self._remote_base_url}/api/delete"
         try:
             resp = httpx.request(
                 "DELETE",
@@ -415,7 +415,7 @@ class _ManagerHolder:
         if self._instance is None:
             from lilbee.config import cfg
 
-            self._instance = ModelManager(cfg.models_dir, cfg.backend_base_url)
+            self._instance = ModelManager(cfg.models_dir, cfg.remote_base_url)
         return self._instance
 
     def reset(self) -> None:

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -140,7 +140,7 @@ class ModelManager:
         return (self._models_dir / model).is_file()
 
     def _is_remote(self, model: str) -> bool:
-        return model in self._list_remote()
+        return model in self.list_installed(ModelSource.REMOTE)
 
     def get_source(self, model: str) -> ModelSource | None:
         """Find which source a model lives in. Native takes precedence."""

--- a/src/lilbee/model_manager.py
+++ b/src/lilbee/model_manager.py
@@ -1,8 +1,9 @@
-"""Model lifecycle management across native GGUF and litellm-backed sources."""
+"""Model lifecycle management across native GGUF and SDK-backed sources."""
 
 import json
 import logging
 import os
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
@@ -50,53 +51,82 @@ class ModelNotFoundError(RuntimeError):
     """
 
 
+_INSTALLED_CACHE_TTL_SECONDS = 30.0
+
+
 class ModelManager:
     """Manages model lifecycle with distinct sources."""
 
-    def __init__(self, models_dir: Path, litellm_base_url: str = "http://localhost:11434") -> None:
+    def __init__(self, models_dir: Path, backend_base_url: str = "http://localhost:11434") -> None:
         self._models_dir = models_dir
-        self._litellm_base_url = litellm_base_url.rstrip("/")
+        self._backend_base_url = backend_base_url.rstrip("/")
 
         from lilbee.registry import ModelRegistry
 
         self._registry = ModelRegistry(self._models_dir)
+        # Memoize list_installed results to avoid walking the registry
+        # filesystem and hitting the backend HTTP endpoint on every call.
+        # The catalog filter path fires this per request. Time-based TTL
+        # plus explicit invalidation on pull/remove keeps freshness.
+        self._installed_cache: dict[ModelSource | None, tuple[float, list[str]]] = {}
 
     def list_installed(self, source: ModelSource | None = None) -> list[str]:
-        """List installed model names. source=None lists all sources."""
+        """List installed model names. source=None lists all sources.
+
+        Result is cached for ``_INSTALLED_CACHE_TTL_SECONDS`` and invalidated
+        eagerly on any ``pull``/``remove`` mutation so callers only see
+        stale data during the narrow window when no local change has
+        happened and the cached backend response has not yet aged out.
+        """
+        now = time.monotonic()
+        cached = self._installed_cache.get(source)
+        if cached is not None:
+            cached_at, cached_result = cached
+            if now - cached_at < _INSTALLED_CACHE_TTL_SECONDS:
+                return cached_result
+
         if source is None:
             native = set(self._list_native())
-            remote = set(self._list_litellm())
-            return sorted(native | remote)
-        if source is ModelSource.NATIVE:
-            return self._list_native()
-        return self._list_litellm()
+            remote = set(self._list_backend())
+            result = sorted(native | remote)
+        elif source is ModelSource.NATIVE:
+            result = self._list_native()
+        else:
+            result = self._list_backend()
+
+        self._installed_cache[source] = (now, result)
+        return result
+
+    def _invalidate_installed_cache(self) -> None:
+        """Drop all cached list_installed results."""
+        self._installed_cache.clear()
 
     def _list_native(self) -> list[str]:
         """List native models from the registry only."""
         return sorted(f"{m.name}:{m.tag}" for m in self._registry.list_installed())
 
-    def _list_litellm(self) -> list[str]:
-        """List models from the litellm backend via its HTTP API."""
-        url = f"{self._litellm_base_url}/api/tags"
+    def _list_backend(self) -> list[str]:
+        """List models from the SDK backend via its HTTP API."""
+        url = f"{self._backend_base_url}/api/tags"
         try:
             resp = httpx.get(url, timeout=DEFAULT_HTTP_TIMEOUT)
             resp.raise_for_status()
             data = resp.json()
             return [m["name"] for m in data.get("models", [])]
         except httpx.HTTPStatusError as exc:
-            log.warning("litellm backend HTTP error listing models: %s", exc)
+            log.warning("SDK backend HTTP error listing models: %s", exc)
             return []
         except (httpx.ConnectError, httpx.TimeoutException) as exc:
-            log.debug("litellm backend not reachable: %s", exc)
+            log.debug("SDK backend not reachable: %s", exc)
             return []
 
     def is_installed(self, model: str, source: ModelSource | None = None) -> bool:
         """Check if model exists in specified source."""
         if source is None:
-            return self._is_native(model) or self._is_litellm(model)
+            return self._is_native(model) or self._is_backend(model)
         if source is ModelSource.NATIVE:
             return self._is_native(model)
-        return self._is_litellm(model)
+        return self._is_backend(model)
 
     def _is_native(self, model: str) -> bool:
         if self._registry.is_installed(model):
@@ -107,14 +137,14 @@ class ModelManager:
             return False
         return (self._models_dir / model).is_file()
 
-    def _is_litellm(self, model: str) -> bool:
-        return model in self._list_litellm()
+    def _is_backend(self, model: str) -> bool:
+        return model in self._list_backend()
 
     def get_source(self, model: str) -> ModelSource | None:
         """Find which source a model lives in. Native takes precedence."""
         if self._is_native(model):
             return ModelSource.NATIVE
-        if self._is_litellm(model):
+        if self._is_backend(model):
             return ModelSource.LITELLM
         return None
 
@@ -128,17 +158,20 @@ class ModelManager:
     ) -> Path | None:
         """Pull/download model to specified source.
 
-        Returns the Path for native downloads, None for litellm-backed pulls.
+        Returns the Path for native downloads, None for backend-managed pulls.
 
-        *on_progress* receives dict events from the litellm backend.
+        *on_progress* receives dict events from the SDK backend.
         *on_bytes* receives (downloaded_bytes, total_bytes) from native
         HuggingFace downloads. The two sources report progress in different
         shapes, so callers pass whichever matches the chosen source.
         """
-        if source is ModelSource.NATIVE:
-            return self._pull_native(model, on_bytes=on_bytes)
-        self._pull_litellm(model, on_progress=on_progress)
-        return None
+        try:
+            if source is ModelSource.NATIVE:
+                return self._pull_native(model, on_bytes=on_bytes)
+            self._pull_backend(model, on_progress=on_progress)
+            return None
+        finally:
+            self._invalidate_installed_cache()
 
     def _pull_native(
         self,
@@ -159,11 +192,11 @@ class ModelManager:
         log.info("Downloaded %s to %s", model, path)
         return path
 
-    def _pull_litellm(
+    def _pull_backend(
         self, model: str, *, on_progress: Callable[[dict], None] | None = None
     ) -> None:
-        """Pull model via the litellm backend's HTTP API with streaming progress."""
-        url = f"{self._litellm_base_url}/api/pull"
+        """Pull model via the SDK backend's HTTP API with streaming progress."""
+        url = f"{self._backend_base_url}/api/pull"
         try:
             with (
                 httpx.Client(timeout=None) as client,
@@ -180,19 +213,22 @@ class ModelManager:
                         on_progress(data)
         except httpx.ConnectError as exc:
             raise RuntimeError(
-                f"Cannot connect to litellm backend: {exc}. Is the server running?"
+                f"Cannot connect to SDK backend: {exc}. Is the server running?"
             ) from exc
-        log.info("Pulled %s via litellm backend", model)
+        log.info("Pulled %s via SDK backend", model)
 
     def remove(self, model: str, source: ModelSource | None = None) -> bool:
         """Remove installed model. Returns True if removed."""
-        if source is None:
-            native_removed = self._remove_native(model)
-            litellm_removed = self._remove_litellm(model)
-            return native_removed or litellm_removed
-        if source is ModelSource.NATIVE:
-            return self._remove_native(model)
-        return self._remove_litellm(model)
+        try:
+            if source is None:
+                native_removed = self._remove_native(model)
+                backend_removed = self._remove_backend(model)
+                return native_removed or backend_removed
+            if source is ModelSource.NATIVE:
+                return self._remove_native(model)
+            return self._remove_backend(model)
+        finally:
+            self._invalidate_installed_cache()
 
     def _remove_native(self, model: str) -> bool:
         if self._registry.remove(model):
@@ -209,8 +245,8 @@ class ModelManager:
             return True
         return False
 
-    def _remove_litellm(self, model: str) -> bool:
-        url = f"{self._litellm_base_url}/api/delete"
+    def _remove_backend(self, model: str) -> bool:
+        url = f"{self._backend_base_url}/api/delete"
         try:
             resp = httpx.request(
                 "DELETE",
@@ -220,7 +256,7 @@ class ModelManager:
                 timeout=DEFAULT_HTTP_TIMEOUT,
             )
             if resp.status_code == 200:
-                log.info("Removed litellm model %s", model)
+                log.info("Removed backend model %s", model)
                 return True
             if resp.status_code == 404:
                 return False
@@ -228,7 +264,7 @@ class ModelManager:
             return False
         except httpx.ConnectError as exc:
             raise RuntimeError(
-                f"Cannot connect to litellm backend: {exc}. Is the server running?"
+                f"Cannot connect to SDK backend: {exc}. Is the server running?"
             ) from exc
 
 
@@ -249,7 +285,7 @@ REMOTE_PROVIDER_NAME = "Remote"
 
 @dataclass
 class RemoteModel:
-    """A model from the litellm backend with inferred task classification."""
+    """A model from the SDK backend with inferred task classification."""
 
     name: str
     task: str  # "chat", "embedding", "vision", "rerank"
@@ -267,7 +303,7 @@ _PROVIDER_PATTERNS: tuple[tuple[str, str], ...] = (
 
 
 def detect_provider(base_url: str) -> str:
-    """Detect the remote provider name from a litellm base URL."""
+    """Detect the remote provider name from the SDK backend URL."""
     url_lower = base_url.lower()
     for pattern, provider in _PROVIDER_PATTERNS:
         if pattern in url_lower:
@@ -302,7 +338,7 @@ def classify_remote_models(
     *,
     timeout: float = _CLASSIFY_DEFAULT_TIMEOUT_S,
 ) -> list[RemoteModel]:
-    """Discover and classify all models from the litellm backend by task.
+    """Discover and classify all models from the SDK backend by task.
 
     Uses /api/tags family metadata for embedding detection and name
     patterns for reranker and vision detection. Returns an empty list
@@ -386,7 +422,7 @@ def discover_api_models() -> dict[str, list[RemoteModel]]:
 
 
 def detect_remote_embedding_models(base_url: str = "http://localhost:11434") -> list[str]:
-    """Return names of models classified as embedding from the litellm backend."""
+    """Return names of models classified as embedding from the SDK backend."""
     return [m.name for m in classify_remote_models(base_url) if m.task == ModelTask.EMBEDDING]
 
 

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -299,7 +299,7 @@ def list_installed_models() -> list[str]:
     """Return installed chat-task model names.
 
     Sources both the native registry (manifest ``task`` field) and the
-    litellm backend catalog (classified by name/family). Non-chat roles
+    SDK backend catalog (classified by name/family). Non-chat roles
     (embedding, vision, rerank) are excluded so TUI pickers don't offer
     refs that fail pydantic task validation at assignment time.
     """

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -313,7 +313,7 @@ def list_installed_models() -> list[str]:
         for manifest in registry.list_installed():
             if manifest.task == ModelTask.CHAT:
                 names.append(f"{manifest.name}:{manifest.tag}")
-        for remote in classify_remote_models(cfg.backend_base_url):
+        for remote in classify_remote_models(cfg.remote_base_url):
             if remote.task == ModelTask.CHAT:
                 names.append(remote.name)
         return sorted(set(names))

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -313,7 +313,7 @@ def list_installed_models() -> list[str]:
         for manifest in registry.list_installed():
             if manifest.task == ModelTask.CHAT:
                 names.append(f"{manifest.name}:{manifest.tag}")
-        for remote in classify_remote_models(cfg.litellm_base_url):
+        for remote in classify_remote_models(cfg.backend_base_url):
             if remote.task == ModelTask.CHAT:
                 names.append(remote.name)
         return sorted(set(names))

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -38,7 +38,7 @@ def create_provider(config: Config) -> LLMProvider:
         backend = LitellmSdkBackend()
         if not backend.available():
             raise ProviderError(
-                "SDK backend adapter is not installed. Install with: pip install 'lilbee[remote]'"
+                "SDK backend adapter is not installed. Install with: pip install 'lilbee[litellm]'"
             )
         return SdkLLMProvider(
             backend,

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -27,7 +27,7 @@ def create_provider(config: Config) -> LLMProvider:
 
         return LlamaCppProvider()
 
-    if provider_name in ("litellm", "ollama"):
+    if provider_name == "backend":
         # THIS is the swap line: the single import that changes when
         # migrating to a different SDK. Replace LitellmSdkBackend here
         # with the new adapter and the rest of lilbee is untouched.
@@ -38,11 +38,11 @@ def create_provider(config: Config) -> LLMProvider:
         backend = LitellmSdkBackend()
         if not backend.available():
             raise ProviderError(
-                "litellm is not installed. Install with: pip install 'lilbee[litellm]'"
+                "SDK backend adapter is not installed. Install with: pip install 'lilbee[litellm]'"
             )
         return SdkLLMProvider(
             backend,
-            base_url=config.litellm_base_url,
+            base_url=config.backend_base_url,
             api_key=config.llm_api_key,
         )  # pragma: no cover
 

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -27,7 +27,7 @@ def create_provider(config: Config) -> LLMProvider:
 
         return LlamaCppProvider()
 
-    if provider_name == "backend":
+    if provider_name == "remote":
         # THIS is the swap line: the single import that changes when
         # migrating to a different SDK. Replace LitellmSdkBackend here
         # with the new adapter and the rest of lilbee is untouched.
@@ -38,11 +38,11 @@ def create_provider(config: Config) -> LLMProvider:
         backend = LitellmSdkBackend()
         if not backend.available():
             raise ProviderError(
-                "SDK backend adapter is not installed. Install with: pip install 'lilbee[backend]'"
+                "SDK backend adapter is not installed. Install with: pip install 'lilbee[remote]'"
             )
         return SdkLLMProvider(
             backend,
-            base_url=config.backend_base_url,
+            base_url=config.remote_base_url,
             api_key=config.llm_api_key,
         )  # pragma: no cover
 

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -38,7 +38,7 @@ def create_provider(config: Config) -> LLMProvider:
         backend = LitellmSdkBackend()
         if not backend.available():
             raise ProviderError(
-                "SDK backend adapter is not installed. Install with: pip install 'lilbee[litellm]'"
+                "SDK backend adapter is not installed. Install with: pip install 'lilbee[backend]'"
             )
         return SdkLLMProvider(
             backend,

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -30,6 +30,7 @@ from lilbee.providers.sdk_backend import (
     RerankRequest,
     RerankResult,
     StreamChunk,
+    detect_backend_name,
 )
 
 log = logging.getLogger(__name__)
@@ -104,6 +105,10 @@ class LitellmSdkBackend:
     def provider_name(self) -> str:
         """Stable identifier used when wrapping errors in ``ProviderError``."""
         return _PROVIDER_NAME
+
+    def active_backend_name(self, base_url: str) -> str:
+        """Return the display name of the backend ``base_url`` points at."""
+        return detect_backend_name(base_url)
 
     def available(self) -> bool:
         """Return True if the underlying SDK is installed."""

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -42,7 +42,7 @@ class RoutingProvider(LLMProvider):
         if self._sdk_provider is None:
             self._sdk_provider = SdkLLMProvider(
                 LitellmSdkBackend(),
-                base_url=cfg.litellm_base_url,
+                base_url=cfg.backend_base_url,
                 api_key=cfg.llm_api_key,
             )
         return self._sdk_provider

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -42,7 +42,7 @@ class RoutingProvider(LLMProvider):
         if self._sdk_provider is None:
             self._sdk_provider = SdkLLMProvider(
                 LitellmSdkBackend(),
-                base_url=cfg.backend_base_url,
+                base_url=cfg.remote_base_url,
                 api_key=cfg.llm_api_key,
             )
         return self._sdk_provider
@@ -126,7 +126,7 @@ class RoutingProvider(LLMProvider):
             raise ProviderError(
                 f"Cannot rerank with {cfg.reranker_model!r}: "
                 "hosted rerank backend not available. "
-                "Install the 'backend' extra to enable hosted reranking."
+                "Install the 'remote' extra to enable hosted reranking."
             )
         return sdk.rerank(query, candidates)
 

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -126,7 +126,7 @@ class RoutingProvider(LLMProvider):
             raise ProviderError(
                 f"Cannot rerank with {cfg.reranker_model!r}: "
                 "hosted rerank backend not available. "
-                "Install the 'remote' extra to enable hosted reranking."
+                "Install the 'litellm' extra to enable hosted reranking."
             )
         return sdk.rerank(query, candidates)
 

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -126,7 +126,7 @@ class RoutingProvider(LLMProvider):
             raise ProviderError(
                 f"Cannot rerank with {cfg.reranker_model!r}: "
                 "hosted rerank backend not available. "
-                "Install the 'litellm' extra to enable hosted reranking."
+                "Install the 'backend' extra to enable hosted reranking."
             )
         return sdk.rerank(query, candidates)
 

--- a/src/lilbee/providers/sdk_backend.py
+++ b/src/lilbee/providers/sdk_backend.py
@@ -30,6 +30,35 @@ PROVIDER_KEYS: tuple[tuple[str, str, str, str], ...] = (
 # Derived set of config field names (for checking which updates touch API keys).
 API_KEY_FIELDS: frozenset[str] = frozenset(t[1] for t in PROVIDER_KEYS)
 
+# Display names for the server that the SDK is currently talking to. These
+# are what users see ("connected to Ollama", not "connected via litellm").
+# The adapter's own identity (e.g. "litellm") lives under provider_name.
+OLLAMA_BACKEND_NAME = "Ollama"
+OPENAI_BACKEND_NAME = "OpenAI"
+ANTHROPIC_BACKEND_NAME = "Anthropic"
+REMOTE_BACKEND_NAME = "Remote"
+
+_BACKEND_URL_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("localhost:11434", OLLAMA_BACKEND_NAME),
+    ("ollama", OLLAMA_BACKEND_NAME),
+    ("openai", OPENAI_BACKEND_NAME),
+    ("anthropic", ANTHROPIC_BACKEND_NAME),
+)
+
+
+def detect_backend_name(base_url: str) -> str:
+    """Return the display name of the backend behind ``base_url``.
+
+    Adapter-agnostic; any SDK implementation can delegate to this helper.
+    Falls back to ``REMOTE_BACKEND_NAME`` when the URL matches none of
+    the known patterns.
+    """
+    url_lower = base_url.lower()
+    for pattern, name in _BACKEND_URL_PATTERNS:
+        if pattern in url_lower:
+            return name
+    return REMOTE_BACKEND_NAME
+
 
 @dataclass(frozen=True)
 class CompletionResult:
@@ -127,6 +156,16 @@ class LlmSdkBackend(Protocol):
     @property
     def provider_name(self) -> str:
         """Stable identifier used when wrapping errors in ``ProviderError``."""
+        ...
+
+    def active_backend_name(self, base_url: str) -> str:
+        """Return the display name of the backend the adapter is talking to.
+
+        For a Ollama-compatible URL this is ``"Ollama"``; for an OpenAI
+        URL it is ``"OpenAI"``; unknown URLs fall back to ``"Remote"``.
+        The adapter's own identity (e.g. ``"litellm"``) is separately
+        exposed through ``provider_name``.
+        """
         ...
 
     def available(self) -> bool:

--- a/src/lilbee/providers/sdk_backend.py
+++ b/src/lilbee/providers/sdk_backend.py
@@ -1,13 +1,12 @@
 """Protocol and value types for SDK-backed LLM backends.
 
-A backend hides one third-party SDK (today: litellm; tomorrow: liter-llm
-or similar). The ``SdkLLMProvider`` speaks to backends exclusively
-through the ``LlmSdkBackend`` Protocol and the value types defined here,
-so SDK response objects never leak outside the adapter.
+A backend hides one third-party SDK. The ``SdkLLMProvider`` speaks to
+backends exclusively through the ``LlmSdkBackend`` Protocol and the
+value types defined here, so SDK response objects never leak outside
+the adapter.
 
-This module is intentionally dependency-free (no SDK imports, no lilbee
-provider imports beyond the shared base types). The PROVIDER_KEYS table
-is backend-agnostic: every OpenAI-compatible SDK reads the same env vars.
+This module is intentionally dependency-free (no SDK imports, no
+lilbee provider imports beyond the shared base types).
 """
 
 from __future__ import annotations
@@ -30,9 +29,8 @@ PROVIDER_KEYS: tuple[tuple[str, str, str, str], ...] = (
 # Derived set of config field names (for checking which updates touch API keys).
 API_KEY_FIELDS: frozenset[str] = frozenset(t[1] for t in PROVIDER_KEYS)
 
-# Display names for the server that the SDK is currently talking to. These
-# are what users see ("connected to Ollama", not "connected via litellm").
-# The adapter's own identity (e.g. "litellm") lives under provider_name.
+# Display names for the active backend the SDK is talking to. The
+# adapter's own identity is exposed separately via provider_name.
 OLLAMA_BACKEND_NAME = "Ollama"
 OPENAI_BACKEND_NAME = "OpenAI"
 ANTHROPIC_BACKEND_NAME = "Anthropic"
@@ -148,9 +146,9 @@ class LlmSdkBackend(Protocol):
 
     Error contract: implementations must raise only ``ProviderError`` or
     ``NotImplementedError`` from any method. ``SdkLLMProvider`` wraps any
-    other exception at the seam, but adapters should contain SDK-specific
-    error types (httpx errors, litellm exceptions, etc.) in their own
-    ``ProviderError`` translations so the provider can pass them through.
+    other exception at the seam; adapters should translate SDK-specific
+    errors (httpx errors, third-party SDK exceptions) into
+    ``ProviderError`` so the provider can pass them through.
     """
 
     @property
@@ -161,10 +159,9 @@ class LlmSdkBackend(Protocol):
     def active_backend_name(self, base_url: str) -> str:
         """Return the display name of the backend the adapter is talking to.
 
-        For a Ollama-compatible URL this is ``"Ollama"``; for an OpenAI
-        URL it is ``"OpenAI"``; unknown URLs fall back to ``"Remote"``.
-        The adapter's own identity (e.g. ``"litellm"``) is separately
-        exposed through ``provider_name``.
+        ``"Ollama"`` for an Ollama URL, ``"OpenAI"`` for an OpenAI URL,
+        etc.; unknown URLs fall back to ``"Remote"``. The adapter's own
+        identity is exposed separately through ``provider_name``.
         """
         ...
 

--- a/src/lilbee/providers/sdk_backend.py
+++ b/src/lilbee/providers/sdk_backend.py
@@ -34,6 +34,7 @@ API_KEY_FIELDS: frozenset[str] = frozenset(t[1] for t in PROVIDER_KEYS)
 OLLAMA_BACKEND_NAME = "Ollama"
 OPENAI_BACKEND_NAME = "OpenAI"
 ANTHROPIC_BACKEND_NAME = "Anthropic"
+GEMINI_BACKEND_NAME = "Gemini"
 REMOTE_BACKEND_NAME = "Remote"
 
 _BACKEND_URL_PATTERNS: tuple[tuple[str, str], ...] = (
@@ -41,6 +42,8 @@ _BACKEND_URL_PATTERNS: tuple[tuple[str, str], ...] = (
     ("ollama", OLLAMA_BACKEND_NAME),
     ("openai", OPENAI_BACKEND_NAME),
     ("anthropic", ANTHROPIC_BACKEND_NAME),
+    ("googleapis", GEMINI_BACKEND_NAME),
+    ("gemini", GEMINI_BACKEND_NAME),
 )
 
 

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -438,6 +438,8 @@ class Searcher:
 
         LLM variants run through ``_apply_guardrails``; concept-graph
         variants bypass it since they come from deterministic traversal.
+        Embeddings are batched per source so expansion costs one provider
+        round-trip per source, not one per variant.
         """
         count = self._config.query_expansion_count
         if count <= 0 and not self._config.concept_graph:
@@ -445,11 +447,17 @@ class Searcher:
         try:
             llm_variants: list[tuple[str, list[float]]] = []
             if count > 0:
-                for text in self._llm_expand(question, count):
-                    llm_variants.append((text, self._embedder.embed(text)))
+                llm_texts = list(self._llm_expand(question, count))
+                if llm_texts:
+                    llm_vectors = self._embedder.embed_batch(llm_texts)
+                    llm_variants = list(zip(llm_texts, llm_vectors, strict=True))
             llm_variants = self._apply_guardrails(llm_variants, question_vec)
-            for concept in self._concept_query_expansion(question):
-                llm_variants.append((concept, self._embedder.embed(concept)))
+
+            concept_texts = list(self._concept_query_expansion(question))
+            if concept_texts:
+                concept_vectors = self._embedder.embed_batch(concept_texts)
+                llm_variants.extend(zip(concept_texts, concept_vectors, strict=True))
+
             return llm_variants
         except Exception as exc:
             log.warning("Query expansion disabled for this call: %s", exc, exc_info=True)

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -382,7 +382,7 @@ class Searcher:
         if keyword is None:
             return results
         date_range = resolve_date_range(keyword)
-        source_dates = {s["filename"]: s.get("ingested_at", "") for s in self._store.get_sources()}
+        source_dates = self._store.source_ingested_at_map()
         filtered: list[SearchChunk] = []
         for r in results:
             ingested_at = source_dates.get(r.source, "")

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -438,8 +438,7 @@ class Searcher:
 
         LLM variants run through ``_apply_guardrails``; concept-graph
         variants bypass it since they come from deterministic traversal.
-        Embeddings are batched per source so expansion costs one provider
-        round-trip per source, not one per variant.
+        Embeddings batch per source: one provider round-trip per source.
         """
         count = self._config.query_expansion_count
         if count <= 0 and not self._config.concept_graph:

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -477,12 +477,14 @@ class Searcher:
         return (top_score - second_score) >= self._config.expansion_skip_gap
 
     def _apply_concept_boost(self, results: list[SearchChunk], question: str) -> list[SearchChunk]:
-        if not self._config.concept_graph:
+        if not self._config.concept_graph or not results:
             return results
         try:
             if not self._concepts.get_graph():
                 return results
             query_concepts = self._concepts.extract_concepts(question)
+            if not query_concepts:
+                return results
             return self._concepts.boost_results(results, query_concepts)
         except Exception:
             log.debug("Concept boost failed", exc_info=True)

--- a/src/lilbee/reasoning.py
+++ b/src/lilbee/reasoning.py
@@ -122,10 +122,10 @@ def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamTok
             yield final
         return
     # Drain a small number of tokens after truncation to capture any
-    # response content that follows a closed </think> tag. Keep the cap
-    # low: each token pull triggers a model inference step, so a large
-    # cap hangs on slow CI runners.
-    _DRAIN_CAP = 512
+    # response content that follows a closed </think> tag. Each token
+    # pull triggers a model inference step, so cap tightly — and stop
+    # immediately if the model slid back into reasoning mode.
+    _DRAIN_CAP = 128
     drain_chars = 0
     for token in tokens:
         drain_chars += len(token)
@@ -134,6 +134,8 @@ def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamTok
         for st in parser.feed(token):
             if st.content and not st.is_reasoning:
                 yield st
+        if parser.in_thinking:
+            break
     final = parser.flush()
     if final and final.content:
         yield final

--- a/src/lilbee/reasoning.py
+++ b/src/lilbee/reasoning.py
@@ -122,10 +122,10 @@ def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamTok
             yield final
         return
     # Drain a small number of tokens after truncation to capture any
-    # response content that follows a closed </think> tag. Each token
-    # pull triggers a model inference step, so cap tightly — and stop
-    # immediately if the model slid back into reasoning mode.
-    _DRAIN_CAP = 128
+    # response content that follows a closed </think> tag. Keep the cap
+    # low: each token pull triggers a model inference step, so a large
+    # cap hangs on slow CI runners.
+    _DRAIN_CAP = 512
     drain_chars = 0
     for token in tokens:
         drain_chars += len(token)
@@ -134,8 +134,6 @@ def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamTok
         for st in parser.feed(token):
             if st.content and not st.is_reasoning:
                 yield st
-        if parser.in_thinking:
-            break
     final = parser.flush()
     if final and final.content:
         yield final

--- a/src/lilbee/registry.py
+++ b/src/lilbee/registry.py
@@ -354,9 +354,8 @@ class ModelRegistry:
     def _find_by_alias(self, alias: str) -> ModelManifest | None:
         """Look up *alias* via the cached alias index.
 
-        The cache is built on first call and cleared on install/remove,
-        so the expensive manifest-tree walk happens at most once per
-        mutation rather than once per alias-resolution attempt.
+        Amortized O(1) per lookup; index rebuild on first miss after
+        install/remove is O(total manifests).
         """
         if self._alias_cache is None:
             self._alias_cache = self._build_alias_index()

--- a/src/lilbee/registry.py
+++ b/src/lilbee/registry.py
@@ -326,8 +326,7 @@ class ModelRegistry:
                 self.write_latest_alias(ref)
             log.info("Migrated legacy model %s -> %s", path.name, ref)
             count += 1
-        if count:
-            self._invalidate_alias_cache()
+        self._invalidate_alias_cache()
         return count
 
     def _manifest_path(self, ref: ModelRef) -> Path:

--- a/src/lilbee/registry.py
+++ b/src/lilbee/registry.py
@@ -127,9 +127,10 @@ class ModelRegistry:
         self._root = models_dir
         self._manifests_dir = models_dir / "manifests"
         # Lazy alias -> manifest cache for _find_by_alias. Built on first
-        # alias miss, dropped on install()/remove(). Avoids walking the
-        # entire manifests tree and JSON-parsing every tag file on every
-        # uncanonical ref that lands here.
+        # alias miss, dropped on install()/remove(). Best-effort: a
+        # reader racing a concurrent invalidation can store a
+        # pre-mutation snapshot. Worst case is a single alias lookup
+        # miss until the next install/remove.
         self._alias_cache: dict[str, ModelManifest] | None = None
 
     def _invalidate_alias_cache(self) -> None:
@@ -248,6 +249,7 @@ class ModelRegistry:
             aliases=manifest.aliases,
         )
         self._write_manifest(ModelRef(name=ref.name, tag=DEFAULT_TAG), latest)
+        self._invalidate_alias_cache()
 
     def remove(self, ref: str | ModelRef) -> bool:
         """Remove a model manifest. Does NOT delete cache files (managed by HF)."""
@@ -324,6 +326,8 @@ class ModelRegistry:
                 self.write_latest_alias(ref)
             log.info("Migrated legacy model %s -> %s", path.name, ref)
             count += 1
+        if count:
+            self._invalidate_alias_cache()
         return count
 
     def _manifest_path(self, ref: ModelRef) -> Path:

--- a/src/lilbee/registry.py
+++ b/src/lilbee/registry.py
@@ -126,6 +126,30 @@ class ModelRegistry:
     def __init__(self, models_dir: Path) -> None:
         self._root = models_dir
         self._manifests_dir = models_dir / "manifests"
+        # Lazy alias -> manifest cache for _find_by_alias. Built on first
+        # alias miss, dropped on install()/remove(). Avoids walking the
+        # entire manifests tree and JSON-parsing every tag file on every
+        # uncanonical ref that lands here.
+        self._alias_cache: dict[str, ModelManifest] | None = None
+
+    def _invalidate_alias_cache(self) -> None:
+        self._alias_cache = None
+
+    def _build_alias_index(self) -> dict[str, ModelManifest]:
+        """Scan every manifest once and index its aliases."""
+        index: dict[str, ModelManifest] = {}
+        if not self._manifests_dir.exists():
+            return index
+        for name_dir in self._manifests_dir.iterdir():
+            if not name_dir.is_dir():
+                continue
+            for tag_file in name_dir.glob("*.json"):
+                manifest = self._load_manifest_file(tag_file)
+                if manifest is None:
+                    continue
+                for alias in manifest.aliases:
+                    index[alias] = manifest
+        return index
 
     def resolve(self, ref: str | ModelRef) -> Path:
         """Resolve model name to file path in HF cache.
@@ -201,6 +225,7 @@ class ModelRegistry:
             aliases=merged_aliases,
         )
         self._write_manifest(ref, updated)
+        self._invalidate_alias_cache()
         return blob_path
 
     def write_latest_alias(self, ref: ModelRef) -> None:
@@ -239,6 +264,7 @@ class ModelRegistry:
         name_dir = manifest_path.parent
         if name_dir.exists() and not any(name_dir.iterdir()):
             name_dir.rmdir()
+        self._invalidate_alias_cache()
         log.info("Removed manifest for %s (cache file untouched)", r)
         return True
 
@@ -326,17 +352,15 @@ class ModelRegistry:
             raise
 
     def _find_by_alias(self, alias: str) -> ModelManifest | None:
-        """Search all manifests for one that lists *alias* in its aliases."""
-        if not self._manifests_dir.exists():
-            return None
-        for name_dir in self._manifests_dir.iterdir():
-            if not name_dir.is_dir():
-                continue
-            for tag_file in name_dir.glob("*.json"):
-                manifest = self._load_manifest_file(tag_file)
-                if manifest is not None and alias in manifest.aliases:
-                    return manifest
-        return None
+        """Look up *alias* via the cached alias index.
+
+        The cache is built on first call and cleared on install/remove,
+        so the expensive manifest-tree walk happens at most once per
+        mutation rather than once per alias-resolution attempt.
+        """
+        if self._alias_cache is None:
+            self._alias_cache = self._build_alias_index()
+        return self._alias_cache.get(alias)
 
     def _absorb_conflicting_aliases(
         self,

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -551,32 +551,27 @@ def _require_model_available(model: str) -> str:
     return normalized
 
 
+_TASK_TO_FIELD: dict[ModelTask, str] = {
+    ModelTask.CHAT: "chat_model",
+    ModelTask.EMBEDDING: "embedding_model",
+    ModelTask.VISION: "vision_model",
+    ModelTask.RERANK: "reranker_model",
+}
+
+
 def _require_model_for_task(model: str, expected: ModelTask, *, allow_empty: bool = False) -> str:
-    """Validate *model* is installed and its catalog task matches *expected*.
+    """Validate *model* is installed locally AND passes the catalog task check.
 
-    Out-of-catalog models are rejected: without a catalog entry there is
-    no task metadata to validate against. When *allow_empty* is True, an
-    empty string unsets the role.
-
-    Returns the catalog's canonical ``name:tag`` ref so persisted values
-    match the registry key rather than the user-supplied ``hf_repo:tag``
-    or provider-prefixed form.
+    Empty string unsets the role when *allow_empty* is True. Catalog +
+    task validation delegates to ``validate_model_task_assignment`` so
+    the handler and config paths share a single implementation.
     """
-    from lilbee.catalog import find_catalog_entry
+    from lilbee.config import validate_model_task_assignment
 
     if allow_empty and not model.strip():
         return ""
     normalized = _require_model_available(model)
-    entry = find_catalog_entry(normalized)
-    if entry is None:
-        raise ValueError(
-            f"Model '{normalized}' is not in the featured catalog. "
-            "Pick a featured model for this role, or install one via "
-            "POST /api/models/pull with a known catalog ref."
-        )
-    if entry.task != expected:
-        raise ValueError(format_task_mismatch(normalized, ModelTask(entry.task), expected))
-    return entry.ref
+    return validate_model_task_assignment(_TASK_TO_FIELD[expected], normalized, allow_bypass=False)
 
 
 async def set_chat_model(model: str) -> SetModelResponse:
@@ -738,7 +733,12 @@ async def get_config_defaults() -> ConfigResponse:
     Covers writable fields (resettable via PATCH /api/config) and the
     model-role fields (resettable via PUT /api/models/<role>).
     """
-    return ConfigResponse(**_compute_config_defaults())
+    import copy
+
+    # deepcopy so callers that mutate the response (pydantic_core or
+    # application code handling lists like crawl_exclude_patterns) can't
+    # poison the cached defaults dict.
+    return ConfigResponse(**copy.deepcopy(_compute_config_defaults()))
 
 
 async def models_show(model: str) -> ModelsShowResponse:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -719,14 +719,7 @@ async def get_config() -> ConfigResponse:
 
 @functools.cache
 def _compute_config_defaults() -> dict[str, Any]:
-    """Materialize Config defaults once per process.
-
-    Defaults are baked into the class, so iterating ``Config.model_fields``
-    and invoking default_factory callables on every request is pure
-    waste. Some factories (e.g. ``crawl_exclude_patterns`` which builds
-    a 30+ regex list) are measurable. Cache keyed on nothing since the
-    class doesn't change at runtime.
-    """
+    """Materialize Config defaults once per process."""
     defaults: dict[str, Any] = {}
     for name, info in Config.model_fields.items():
         is_writable_public = name in WRITABLE_CONFIG_FIELDS and name in _PUBLIC_CONFIG_FIELDS

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -682,13 +682,17 @@ async def list_documents(
     limit: int = 50,
     offset: int = 0,
 ) -> DocumentListResponse:
-    """Return indexed documents with metadata, paginated and filterable."""
-    sources = get_services().store.get_sources()
-    if search:
-        search_lower = search.lower()
-        sources = [s for s in sources if search_lower in s["filename"].lower()]
-    total = len(sources)
-    page = sources[offset : offset + limit]
+    """Return indexed documents with metadata, paginated and filterable.
+
+    Pagination and the filename filter are pushed into LanceDB via
+    ``Store.get_sources(search=..., limit=..., offset=...)`` and the
+    total comes from ``Store.count_sources(search=...)`` so neither
+    call materializes the full SOURCES table per request.
+    """
+    store = get_services().store
+    search_term = search or None
+    page = store.get_sources(search=search_term, limit=limit, offset=offset)
+    total = store.count_sources(search=search_term)
     return DocumentListResponse(
         documents=[
             DocumentInfo(
@@ -701,6 +705,7 @@ async def list_documents(
         total=total,
         limit=limit,
         offset=offset,
+        has_more=(offset + len(page)) < total,
     )
 
 

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy
 import functools
 import json
 import logging
@@ -551,12 +552,14 @@ def _require_model_available(model: str) -> str:
     return normalized
 
 
-_TASK_TO_FIELD: dict[ModelTask, str] = {
-    ModelTask.CHAT: "chat_model",
-    ModelTask.EMBEDDING: "embedding_model",
-    ModelTask.VISION: "vision_model",
-    ModelTask.RERANK: "reranker_model",
-}
+def _build_task_to_field() -> dict[ModelTask, str]:
+    """Invert config's ``_MODEL_FIELD_TO_TASK`` so the two maps stay in sync."""
+    from lilbee.config import _MODEL_FIELD_TO_TASK
+
+    return {ModelTask(task): field for field, task in _MODEL_FIELD_TO_TASK.items()}
+
+
+_TASK_TO_FIELD: dict[ModelTask, str] = _build_task_to_field()
 
 
 def _require_model_for_task(model: str, expected: ModelTask, *, allow_empty: bool = False) -> str:
@@ -701,7 +704,7 @@ async def list_documents(
         total=total,
         limit=limit,
         offset=offset,
-        has_more=(offset + len(page)) < total,
+        has_more=len(page) > 0 and (offset + len(page)) < total,
     )
 
 
@@ -732,12 +735,11 @@ async def get_config_defaults() -> ConfigResponse:
 
     Covers writable fields (resettable via PATCH /api/config) and the
     model-role fields (resettable via PUT /api/models/<role>).
-    """
-    import copy
 
-    # deepcopy so callers that mutate the response (pydantic_core or
-    # application code handling lists like crawl_exclude_patterns) can't
-    # poison the cached defaults dict.
+    Deepcopies the cached dict so callers that mutate the response
+    (list-valued fields like ``crawl_exclude_patterns``) cannot poison
+    subsequent calls.
+    """
     return ConfigResponse(**copy.deepcopy(_compute_config_defaults()))
 
 

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -815,7 +815,7 @@ async def models_installed() -> ModelsInstalledResponse:
     models = []
     for name in names:
         src = manager.get_source(name)
-        source_str = src.value if src is not None else ModelSource.BACKEND.value
+        source_str = src.value if src is not None else ModelSource.REMOTE.value
         models.append(InstalledModelEntry(name=name, source=source_str))
     return ModelsInstalledResponse(models=models)
 
@@ -978,7 +978,7 @@ _external_cache = _ExternalModelsCache()
 
 async def list_external_models() -> ExternalModelsResponse:
     """Query the provider for available models via its list_models() API."""
-    key = f"{cfg.backend_base_url}:{cfg.llm_api_key or ''}"
+    key = f"{cfg.remote_base_url}:{cfg.llm_api_key or ''}"
     cached = _external_cache.get(key)
     if cached:
         return cached

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import json
 import logging
 import threading
@@ -716,11 +717,15 @@ async def get_config() -> ConfigResponse:
     return ConfigResponse(**result)
 
 
-async def get_config_defaults() -> ConfigResponse:
-    """Return canonical defaults for every public config field.
+@functools.cache
+def _compute_config_defaults() -> dict[str, Any]:
+    """Materialize Config defaults once per process.
 
-    Covers writable fields (resettable via PATCH /api/config) and the
-    model-role fields (resettable via PUT /api/models/<role>).
+    Defaults are baked into the class, so iterating ``Config.model_fields``
+    and invoking default_factory callables on every request is pure
+    waste. Some factories (e.g. ``crawl_exclude_patterns`` which builds
+    a 30+ regex list) are measurable. Cache keyed on nothing since the
+    class doesn't change at runtime.
     """
     defaults: dict[str, Any] = {}
     for name, info in Config.model_fields.items():
@@ -731,7 +736,16 @@ async def get_config_defaults() -> ConfigResponse:
         if value is PydanticUndefined:  # pragma: no cover
             continue
         defaults[name] = value
-    return ConfigResponse(**defaults)
+    return defaults
+
+
+async def get_config_defaults() -> ConfigResponse:
+    """Return canonical defaults for every public config field.
+
+    Covers writable fields (resettable via PATCH /api/config) and the
+    model-role fields (resettable via PUT /api/models/<role>).
+    """
+    return ConfigResponse(**_compute_config_defaults())
 
 
 async def models_show(model: str) -> ModelsShowResponse:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -803,7 +803,7 @@ async def models_installed() -> ModelsInstalledResponse:
     models = []
     for name in names:
         src = manager.get_source(name)
-        source_str = src.value if src is not None else ModelSource.LITELLM.value
+        source_str = src.value if src is not None else ModelSource.BACKEND.value
         models.append(InstalledModelEntry(name=name, source=source_str))
     return ModelsInstalledResponse(models=models)
 
@@ -966,7 +966,7 @@ _external_cache = _ExternalModelsCache()
 
 async def list_external_models() -> ExternalModelsResponse:
     """Query the provider for available models via its list_models() API."""
-    key = f"{cfg.litellm_base_url}:{cfg.llm_api_key or ''}"
+    key = f"{cfg.backend_base_url}:{cfg.llm_api_key or ''}"
     cached = _external_cache.get(key)
     if cached:
         return cached

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -159,6 +159,7 @@ class DocumentListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    has_more: bool = False
 
 
 class DocumentRemoveResponse(BaseModel):

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -105,7 +105,7 @@ async def models_catalog_route(
 @get("/api/models/installed")
 @read_only
 async def models_installed_route() -> ModelsInstalledResponse:
-    """List installed models with their source (native or litellm)."""
+    """List installed models with their source (native or backend)."""
     return await handlers.models_installed()
 
 

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -105,7 +105,7 @@ async def models_catalog_route(
 @get("/api/models/installed")
 @read_only
 async def models_installed_route() -> ModelsInstalledResponse:
-    """List installed models with their source (native or backend)."""
+    """List installed models with their source (native or remote)."""
     return await handlers.models_installed()
 
 

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -107,6 +107,10 @@ def mmr_rerank(
     Complexity: O(top_k · N · D) time, O(N · D) space for N candidates
     of dimension D. Each outer iteration updates a running max-redundancy
     vector via one matmul rather than recomputing pairs pairwise.
+    Candidate vectors run through numpy in ``float32``, which can pick a
+    different candidate than the pure-Python ``float64`` loop on
+    ties within ~1e-7; distinct in principle, unobservable in practice
+    since sub-float32 differences are below retrieval signal.
     """
     if mmr_lambda is None:
         mmr_lambda = cfg.mmr_lambda

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
+import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -102,29 +103,46 @@ def mmr_rerank(
     ``mmr_lambda`` controls the relevance/diversity tradeoff:
     0.0 = maximum diversity, 1.0 = pure relevance.
     Defaults to ``cfg.mmr_lambda`` (0.5).
+
+    Runs the redundancy step as a vectorized numpy dot-product against
+    a running max-redundancy vector. Previously the inner loop did
+    ``max(cosine_sim(candidate.vector, s.vector) for s in selected)``
+    which recomputed pairs already seen on every outer iteration
+    (O(top_k² · N) dot products). The vectorized form is O(top_k · N)
+    and uses numpy's SIMD under the hood.
     """
     if mmr_lambda is None:
         mmr_lambda = cfg.mmr_lambda
     if len(results) <= top_k:
         return results
 
-    relevance_map = {id(r): cosine_sim(query_vector, r.vector) for r in results}
-    selected: list[SearchChunk] = []
-    remaining = list(results)
+    candidate_vecs = np.asarray([r.vector for r in results], dtype=np.float32)
+    query = np.asarray(query_vector, dtype=np.float32)
+    # L2-normalize once so cosine becomes a plain dot product.
+    cand_norms = np.linalg.norm(candidate_vecs, axis=1, keepdims=True)
+    cand_norms[cand_norms == 0] = 1.0
+    cand_unit = candidate_vecs / cand_norms
+    query_norm = float(np.linalg.norm(query)) or 1.0
+    query_unit = query / query_norm
 
-    for _ in range(top_k):
-        best_score = -float("inf")
-        best_idx = 0
-        for i, candidate in enumerate(remaining):
-            relevance = relevance_map[id(candidate)]
-            redundancy = 0.0
-            if selected:
-                redundancy = max(cosine_sim(candidate.vector, s.vector) for s in selected)
-            score = mmr_lambda * relevance - (1 - mmr_lambda) * redundancy
-            if score > best_score:
-                best_score = score
-                best_idx = i
-        selected.append(remaining.pop(best_idx))
+    relevance = cand_unit @ query_unit  # shape (N,)
+
+    n = len(results)
+    max_redundancy = np.zeros(n, dtype=np.float32)
+    available = np.ones(n, dtype=bool)
+    selected: list[SearchChunk] = []
+
+    for picks in range(top_k):
+        redundancy_term = max_redundancy if picks > 0 else np.zeros(n, dtype=np.float32)
+        score = mmr_lambda * relevance - (1.0 - mmr_lambda) * redundancy_term
+        # Mask already-picked candidates so argmax skips them.
+        score = np.where(available, score, -np.inf)
+        best = int(np.argmax(score))
+        selected.append(results[best])
+        available[best] = False
+        # Update running max redundancy against the newly-selected vector.
+        similarity = cand_unit @ cand_unit[best]
+        max_redundancy = np.maximum(max_redundancy, similarity)
 
     return selected
 

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 import pyarrow as pa
+import pyarrow.compute as pc
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 if TYPE_CHECKING:
@@ -482,7 +483,12 @@ class Store:
         return [r for r in results if _get_distance(r) <= threshold]
 
     def get_chunks_by_source(self, source: str) -> list[SearchChunk]:
-        """Return all chunks for a given source file."""
+        """Return all chunks for a given source file.
+
+        Scales with a single document's chunk count (bounded by document
+        size, not corpus size). Callers (delete, export, rebuild) need the
+        complete set — no artificial cap here.
+        """
         table = self.open_table(CHUNKS_TABLE)
         if table is None:
             return []
@@ -490,11 +496,15 @@ class Store:
         try:
             rows = table.search().where(f"source = '{escaped}'").limit(None).to_list()
         except Exception:
-            # Fallback: on tables with FTS indexes, search() may return an
-            # incompatible query builder.  Scan the Arrow table directly.
+            # Fallback for tables whose FTS-enabled search() returns an
+            # incompatible query builder. Push the source filter into
+            # pyarrow.compute (C++) rather than materializing the whole
+            # chunks table into Python memory and filtering there, which
+            # scaled O(total corpus chunks) per call.
             log.debug("get_chunks_by_source search() failed, using Arrow fallback", exc_info=True)
-            all_rows = table.to_arrow().to_pylist()
-            rows = [r for r in all_rows if r.get("source") == source]
+            arrow_tbl = table.to_arrow()
+            filtered = arrow_tbl.filter(pc.equal(arrow_tbl["source"], source))
+            rows = filtered.to_pylist()
         return [SearchChunk(**r) for r in rows]
 
     def delete_by_source(self, source: str) -> None:

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -104,12 +104,9 @@ def mmr_rerank(
     0.0 = maximum diversity, 1.0 = pure relevance.
     Defaults to ``cfg.mmr_lambda`` (0.5).
 
-    Runs the redundancy step as a vectorized numpy dot-product against
-    a running max-redundancy vector. Previously the inner loop did
-    ``max(cosine_sim(candidate.vector, s.vector) for s in selected)``
-    which recomputed pairs already seen on every outer iteration
-    (O(top_k² · N) dot products). The vectorized form is O(top_k · N)
-    and uses numpy's SIMD under the hood.
+    Complexity: O(top_k · N · D) time, O(N · D) space for N candidates
+    of dimension D. Each outer iteration updates a running max-redundancy
+    vector via one matmul rather than recomputing pairs pairwise.
     """
     if mmr_lambda is None:
         mmr_lambda = cfg.mmr_lambda
@@ -299,11 +296,7 @@ def _has_fts_index(table: lancedb.table.Table) -> bool:
 
 
 def _sources_search_filter(search: str | None) -> str | None:
-    """Build a LanceDB WHERE clause for case-insensitive filename match.
-
-    Returns ``None`` for an empty search so callers can skip the
-    ``.where`` chain entirely and hit the unfiltered fast path.
-    """
+    """Case-insensitive filename WHERE clause, or ``None`` for empty *search*."""
     if not search:
         return None
     escaped = escape_sql_string(search.lower())
@@ -326,13 +319,7 @@ class Store:
         self._source_ingested_cache = None
 
     def source_ingested_at_map(self) -> dict[str, str]:
-        """Return {filename: ingested_at} for every source, cached.
-
-        Rebuilt only when ``upsert_source`` / ``delete_source`` /
-        ``delete_by_source`` / ``remove_documents`` / ``drop_all`` fire.
-        Previously the temporal-filter call path in query.py rebuilt
-        this dict on every query.
-        """
+        """Return {filename: ingested_at} for every source, cached until mutation."""
         if self._source_ingested_cache is not None:
             return self._source_ingested_cache
         mapping = {s["filename"]: s.get("ingested_at", "") for s in self.get_sources()}
@@ -374,13 +361,10 @@ class Store:
         return db.open_table(name)
 
     def ensure_fts_index(self) -> None:
-        """Ensure the FTS index on the chunks table is current.
+        """Create the chunks FTS index, or run ``optimize()`` to fold new rows in.
 
-        First call creates the index; subsequent calls run ``table.optimize()``
-        which folds newly added rows into the existing index incrementally.
-        Prior behavior tore down and rebuilt the full FTS index on every
-        sync with any change (O(total_chunks) per sync), which dominates
-        sync time at scale. No-op when the table doesn't exist.
+        ``optimize()`` is incremental (work scales with added rows);
+        ``create_fts_index(replace=True)`` would be O(total_chunks) per call.
         """
         with write_lock():
             table = self.open_table(CHUNKS_TABLE)
@@ -534,12 +518,7 @@ class Store:
         return [r for r in results if _get_distance(r) <= threshold]
 
     def get_chunks_by_source(self, source: str) -> list[SearchChunk]:
-        """Return all chunks for a given source file.
-
-        Scales with a single document's chunk count (bounded by document
-        size, not corpus size). Callers (delete, export, rebuild) need the
-        complete set — no artificial cap here.
-        """
+        """Return every chunk whose ``source`` equals *source*."""
         table = self.open_table(CHUNKS_TABLE)
         if table is None:
             return []
@@ -547,11 +526,10 @@ class Store:
         try:
             rows = table.search().where(f"source = '{escaped}'").limit(None).to_list()
         except Exception:
-            # Fallback for tables whose FTS-enabled search() returns an
-            # incompatible query builder. Push the source filter into
-            # pyarrow.compute (C++) rather than materializing the whole
-            # chunks table into Python memory and filtering there, which
-            # scaled O(total corpus chunks) per call.
+            # FTS-enabled tables return a query builder that cannot
+            # handle .where() on arbitrary columns; fall through to a
+            # pyarrow.compute filter on the Arrow table so the source
+            # match runs in C++ without materializing non-matching rows.
             log.debug("get_chunks_by_source search() failed, using Arrow fallback", exc_info=True)
             arrow_tbl = table.to_arrow()
             filtered = arrow_tbl.filter(pc.equal(arrow_tbl["source"], source))
@@ -573,12 +551,7 @@ class Store:
         limit: int | None = None,
         offset: int = 0,
     ) -> list[SourceRecord]:
-        """Get tracked source file records, optionally filtered and paginated.
-
-        Filter and pagination run in LanceDB so large corpora don't
-        materialize the full SOURCES table per request. The previous
-        signature (no args, returns all) is preserved as the default.
-        """
+        """Return source records, filtered by *search* and sliced by offset/limit."""
         table = self.open_table(SOURCES_TABLE)
         if table is None:
             return []

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -156,6 +156,7 @@ class SourceRecord(TypedDict):
     ingested_at: str
     chunk_count: int
     source_type: str
+    source_mtime: float | None
 
 
 class CitationRecord(TypedDict):
@@ -183,8 +184,17 @@ def _sources_schema() -> pa.Schema:
             pa.field("ingested_at", pa.utf8()),
             pa.field("chunk_count", pa.int32()),
             pa.field("source_type", pa.utf8()),
+            pa.field("source_mtime", pa.float64(), nullable=True),
         ]
     )
+
+
+def _ensure_source_mtime_column(table: lancedb.table.Table) -> None:
+    # Source-mtime column was added to resolve a Windows-only mtime gate
+    # precision bug; older stores predate it and need in-place evolution.
+    if "source_mtime" in table.schema.names:
+        return
+    table.add_columns({"source_mtime": "CAST(NULL AS DOUBLE)"})
 
 
 def _citations_schema() -> pa.Schema:
@@ -593,11 +603,13 @@ class Store:
         file_hash: str,
         chunk_count: int,
         source_type: str = "document",
+        source_mtime: float | None = None,
     ) -> None:
         """Add or update a source file tracking record."""
         with write_lock():
             db = self.get_db()
             table = ensure_table(db, SOURCES_TABLE, _sources_schema())
+            _ensure_source_mtime_column(table)
             _safe_delete_unlocked(table, f"filename = '{escape_sql_string(filename)}'")
             table.add(
                 [
@@ -607,6 +619,7 @@ class Store:
                         "ingested_at": datetime.now(UTC).isoformat(),
                         "chunk_count": chunk_count,
                         "source_type": source_type,
+                        "source_mtime": source_mtime,
                     }
                 ]
             )

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -371,10 +371,13 @@ class Store:
         return db.open_table(name)
 
     def ensure_fts_index(self) -> None:
-        """Create the chunks FTS index, or run ``optimize()`` to fold new rows in.
+        """Create the chunks FTS index, or run ``optimize()`` once it exists.
 
-        ``optimize()`` is incremental (work scales with added rows);
-        ``create_fts_index(replace=True)`` would be O(total_chunks) per call.
+        ``optimize()`` folds newly added rows into the FTS index and also
+        runs LanceDB's default compaction + version pruning (default prune
+        window: 7 days). Work scales with recent deltas rather than total
+        chunk count, so large corpora no longer pay the full
+        ``create_fts_index(replace=True)`` rebuild cost on every sync.
         """
         with write_lock():
             table = self.open_table(CHUNKS_TABLE)

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -317,6 +317,27 @@ class Store:
         self._config = config
         self._fts_ready: bool = False
         self._db: lancedb.DBConnection | None = None
+        # Cache of {filename: ingested_at} rebuilt only when sources
+        # mutate; callers (temporal filter) hit it per-query.
+        self._source_ingested_cache: dict[str, str] | None = None
+
+    def _invalidate_source_cache(self) -> None:
+        """Drop the cached {filename: ingested_at} map."""
+        self._source_ingested_cache = None
+
+    def source_ingested_at_map(self) -> dict[str, str]:
+        """Return {filename: ingested_at} for every source, cached.
+
+        Rebuilt only when ``upsert_source`` / ``delete_source`` /
+        ``delete_by_source`` / ``remove_documents`` / ``drop_all`` fire.
+        Previously the temporal-filter call path in query.py rebuilt
+        this dict on every query.
+        """
+        if self._source_ingested_cache is not None:
+            return self._source_ingested_cache
+        mapping = {s["filename"]: s.get("ingested_at", "") for s in self.get_sources()}
+        self._source_ingested_cache = mapping
+        return mapping
 
     def _chunks_schema(self) -> pa.Schema:
         return pa.schema(
@@ -543,6 +564,7 @@ class Store:
             table = self.open_table(CHUNKS_TABLE)
             if table is not None:
                 _safe_delete_unlocked(table, f"source = '{escape_sql_string(source)}'")
+        self._invalidate_source_cache()
 
     def get_sources(
         self,
@@ -602,6 +624,7 @@ class Store:
                     }
                 ]
             )
+        self._invalidate_source_cache()
 
     def delete_source(self, filename: str) -> None:
         """Remove a source file tracking record."""
@@ -609,6 +632,7 @@ class Store:
             table = self.open_table(SOURCES_TABLE)
             if table is not None:
                 _safe_delete_unlocked(table, f"filename = '{escape_sql_string(filename)}'")
+        self._invalidate_source_cache()
 
     def remove_documents(
         self,
@@ -705,3 +729,4 @@ class Store:
             db = self.get_db()
             for name in _table_names(db):
                 db.drop_table(name)
+        self._invalidate_source_cache()

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -268,6 +268,17 @@ def _count_within_threshold(sorted_results: list[SearchChunk], threshold: float)
     return len(sorted_results)
 
 
+def _has_fts_index(table: lancedb.table.Table) -> bool:
+    """Return True when an FTS index on the chunk column already exists."""
+    try:
+        for idx in table.list_indices():
+            if idx.index_type == "FTS" and "chunk" in idx.columns:
+                return True
+    except Exception:
+        return False
+    return False
+
+
 class Store:
     """LanceDB vector store — wraps all DB operations with config-driven defaults."""
 
@@ -311,20 +322,28 @@ class Store:
         return db.open_table(name)
 
     def ensure_fts_index(self) -> None:
-        """Create or replace the FTS index on the chunks table.
-        No-op when the table doesn't exist or is empty.  Sets _fts_ready
-        on success so hybrid_search can be used.
+        """Ensure the FTS index on the chunks table is current.
+
+        First call creates the index; subsequent calls run ``table.optimize()``
+        which folds newly added rows into the existing index incrementally.
+        Prior behavior tore down and rebuilt the full FTS index on every
+        sync with any change (O(total_chunks) per sync), which dominates
+        sync time at scale. No-op when the table doesn't exist.
         """
         with write_lock():
             table = self.open_table(CHUNKS_TABLE)
             if table is None:
                 return
             try:
-                table.create_fts_index("chunk", replace=True)
+                if _has_fts_index(table):
+                    table.optimize()
+                    log.debug("FTS index optimized on '%s'", CHUNKS_TABLE)
+                else:
+                    table.create_fts_index("chunk", replace=False)
+                    log.debug("FTS index created on '%s'", CHUNKS_TABLE)
                 self._fts_ready = True
-                log.debug("FTS index created/replaced on '%s'", CHUNKS_TABLE)
             except Exception:
-                log.debug("FTS index creation failed (empty table?)", exc_info=True)
+                log.debug("FTS index ensure failed (empty table?)", exc_info=True)
 
     def add_chunks(self, records: list[dict]) -> int:
         """Add chunk records to the store. Returns count added."""

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -280,6 +280,18 @@ def _has_fts_index(table: lancedb.table.Table) -> bool:
     return False
 
 
+def _sources_search_filter(search: str | None) -> str | None:
+    """Build a LanceDB WHERE clause for case-insensitive filename match.
+
+    Returns ``None`` for an empty search so callers can skip the
+    ``.where`` chain entirely and hit the unfiltered fast path.
+    """
+    if not search:
+        return None
+    escaped = escape_sql_string(search.lower())
+    return f"LOWER(filename) LIKE '%{escaped}%'"
+
+
 class Store:
     """LanceDB vector store — wraps all DB operations with config-driven defaults."""
 
@@ -514,13 +526,40 @@ class Store:
             if table is not None:
                 _safe_delete_unlocked(table, f"source = '{escape_sql_string(source)}'")
 
-    def get_sources(self) -> list[SourceRecord]:
-        """Get all tracked source file records."""
+    def get_sources(
+        self,
+        *,
+        search: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[SourceRecord]:
+        """Get tracked source file records, optionally filtered and paginated.
+
+        Filter and pagination run in LanceDB so large corpora don't
+        materialize the full SOURCES table per request. The previous
+        signature (no args, returns all) is preserved as the default.
+        """
         table = self.open_table(SOURCES_TABLE)
         if table is None:
             return []
-        result: list[SourceRecord] = table.to_arrow().to_pylist()  # type: ignore[assignment]
+        query = table.search()
+        where = _sources_search_filter(search)
+        if where is not None:
+            query = query.where(where)
+        if offset:
+            query = query.offset(offset)
+        query = query.limit(limit)
+        result: list[SourceRecord] = query.to_list()  # type: ignore[assignment]
         return result
+
+    def count_sources(self, *, search: str | None = None) -> int:
+        """Count tracked sources matching *search* without materializing rows."""
+        table = self.open_table(SOURCES_TABLE)
+        if table is None:
+            return 0
+        where = _sources_search_filter(search)
+        count: int = table.count_rows() if where is None else table.count_rows(filter=where)
+        return count
 
     def upsert_source(
         self,

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -156,7 +156,6 @@ class SourceRecord(TypedDict):
     ingested_at: str
     chunk_count: int
     source_type: str
-    source_mtime: float | None
 
 
 class CitationRecord(TypedDict):
@@ -184,17 +183,8 @@ def _sources_schema() -> pa.Schema:
             pa.field("ingested_at", pa.utf8()),
             pa.field("chunk_count", pa.int32()),
             pa.field("source_type", pa.utf8()),
-            pa.field("source_mtime", pa.float64(), nullable=True),
         ]
     )
-
-
-def _ensure_source_mtime_column(table: lancedb.table.Table) -> None:
-    # Source-mtime column was added to resolve a Windows-only mtime gate
-    # precision bug; older stores predate it and need in-place evolution.
-    if "source_mtime" in table.schema.names:
-        return
-    table.add_columns({"source_mtime": "CAST(NULL AS DOUBLE)"})
 
 
 def _citations_schema() -> pa.Schema:
@@ -603,13 +593,11 @@ class Store:
         file_hash: str,
         chunk_count: int,
         source_type: str = "document",
-        source_mtime: float | None = None,
     ) -> None:
         """Add or update a source file tracking record."""
         with write_lock():
             db = self.get_db()
             table = ensure_table(db, SOURCES_TABLE, _sources_schema())
-            _ensure_source_mtime_column(table)
             _safe_delete_unlocked(table, f"filename = '{escape_sql_string(filename)}'")
             table.add(
                 [
@@ -619,7 +607,6 @@ class Store:
                         "ingested_at": datetime.now(UTC).isoformat(),
                         "chunk_count": chunk_count,
                         "source_type": source_type,
-                        "source_mtime": source_mtime,
                     }
                 ]
             )

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -323,7 +323,13 @@ class Store:
         self._source_ingested_cache = None
 
     def source_ingested_at_map(self) -> dict[str, str]:
-        """Return {filename: ingested_at} for every source, cached until mutation."""
+        """Return {filename: ingested_at} for every source, cached until mutation.
+
+        Best-effort: a reader racing a concurrent invalidation can store a
+        pre-mutation snapshot. The only consumer (temporal query filter)
+        treats a missing/stale entry as "do not filter," so staleness
+        degrades ranking precision, never correctness.
+        """
         if self._source_ingested_cache is not None:
             return self._source_ingested_cache
         mapping = {s["filename"]: s.get("ingested_at", "") for s in self.get_sources()}

--- a/src/lilbee/vision.py
+++ b/src/lilbee/vision.py
@@ -4,6 +4,7 @@ Rasterizes PDF pages to PNG, sends each to a local vision model
 via the configured LLM provider, and concatenates the extracted text.
 """
 
+import concurrent.futures
 import contextlib
 import logging
 import sys
@@ -12,6 +13,7 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any, NamedTuple, cast
 
+from lilbee.config import cfg
 from lilbee.progress import (
     DetailedProgressCallback,
     EventType,
@@ -185,24 +187,34 @@ def extract_pdf_vision(
     if total == 0:
         return []
 
-    result: list[PageText] = []
-    failed = 0
+    concurrency = max(1, cfg.vision_concurrency)
+    extracted: dict[int, str | None] = {}
     progress_ctx, progress_task = _make_progress(path.name, total, quiet)
 
-    with progress_ctx:
-        for i, png in rasterize_pdf(path):
+    def _extract(i: int, png: bytes) -> tuple[int, str | None]:
+        log.debug("Vision OCR page %d/%d with %s", i + 1, total, model)
+        return i, extract_page_text(png, model, timeout=timeout)
+
+    with progress_ctx, concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [pool.submit(_extract, i, png) for i, png in rasterize_pdf(path)]
+        for fut in concurrent.futures.as_completed(futures):
+            i, text = fut.result()
+            extracted[i] = text
             on_progress(
                 EventType.EXTRACT,
                 ExtractEvent(file=path.name, page=i + 1, total_pages=total),
             )
-            log.debug("Vision OCR page %d/%d with %s", i + 1, total, model)
-            text = extract_page_text(png, model, timeout=timeout)
-            if text is None:
-                failed += 1
-            elif text.strip():
-                result.append(PageText(i + 1, text))
             if progress_task is not None:
                 progress_ctx.advance(progress_task)  # type: ignore[attr-defined]
+
+    result: list[PageText] = []
+    failed = 0
+    for i in sorted(extracted):
+        text = extracted[i]
+        if text is None:
+            failed += 1
+        elif text.strip():
+            result.append(PageText(i + 1, text))
 
     if failed:
         log.warning("Vision OCR: %d/%d pages failed", failed, total)

--- a/src/lilbee/vision.py
+++ b/src/lilbee/vision.py
@@ -171,6 +171,26 @@ def _make_progress(name: str, total: int, quiet: bool) -> tuple[AbstractContextM
     return progress, task
 
 
+def _record_page(
+    fut: concurrent.futures.Future[tuple[int, str | None]],
+    extracted: dict[int, str | None],
+    on_progress: DetailedProgressCallback,
+    progress_ctx: AbstractContextManager[Any],
+    progress_task: Any,
+    path: Path,
+    total: int,
+) -> None:
+    """Drain one completed page future into ``extracted`` and fire progress."""
+    i, text = fut.result()
+    extracted[i] = text
+    on_progress(
+        EventType.EXTRACT,
+        ExtractEvent(file=path.name, page=i + 1, total_pages=total),
+    )
+    if progress_task is not None:
+        progress_ctx.advance(progress_task)  # type: ignore[attr-defined]
+
+
 def extract_pdf_vision(
     path: Path,
     model: str,
@@ -195,17 +215,26 @@ def extract_pdf_vision(
         log.debug("Vision OCR page %d/%d with %s", i + 1, total, model)
         return i, extract_page_text(png, model, timeout=timeout)
 
+    # Inflight futures are bounded to roughly ``concurrency * 2`` so raster
+    # bytes never accumulate beyond what the pool can drain. Fully eager
+    # submission would buffer every page's PNG in memory before any OCR
+    # returned.
+    max_inflight = concurrency * 2
+    pages_iter = iter(rasterize_pdf(path))
     with progress_ctx, concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
-        futures = [pool.submit(_extract, i, png) for i, png in rasterize_pdf(path)]
-        for fut in concurrent.futures.as_completed(futures):
-            i, text = fut.result()
-            extracted[i] = text
-            on_progress(
-                EventType.EXTRACT,
-                ExtractEvent(file=path.name, page=i + 1, total_pages=total),
-            )
-            if progress_task is not None:
-                progress_ctx.advance(progress_task)  # type: ignore[attr-defined]
+        inflight: set[concurrent.futures.Future[tuple[int, str | None]]] = set()
+        for i, png in pages_iter:
+            if len(inflight) >= max_inflight:
+                done, inflight = concurrent.futures.wait(
+                    inflight, return_when=concurrent.futures.FIRST_COMPLETED
+                )
+                for fut in done:
+                    _record_page(
+                        fut, extracted, on_progress, progress_ctx, progress_task, path, total
+                    )
+            inflight.add(pool.submit(_extract, i, png))
+        for fut in concurrent.futures.as_completed(inflight):
+            _record_page(fut, extracted, on_progress, progress_ctx, progress_task, path, total)
 
     result: list[PageText] = []
     failed = 0

--- a/tests/crawler/test_api.py
+++ b/tests/crawler/test_api.py
@@ -274,6 +274,8 @@ class TestCrawlAndSaveOrchestration:
         fake_single.assert_awaited_once()
 
     async def test_depth_nonzero_uses_crawl_recursive(self):
+        import inspect as _inspect
+
         async def fake_recursive(*args: Any, **kwargs: Any) -> list[CrawlResult]:
             flush = kwargs.get("on_result")
             results = [
@@ -282,7 +284,9 @@ class TestCrawlAndSaveOrchestration:
             ]
             if flush is not None:
                 for r in results:
-                    flush(r)
+                    rv = flush(r)
+                    if _inspect.isawaitable(rv):
+                        await rv
             return results
 
         with patch("lilbee.crawler.api.crawl_recursive", side_effect=fake_recursive):

--- a/tests/integration/test_crawl_integration.py
+++ b/tests/integration/test_crawl_integration.py
@@ -238,14 +238,14 @@ class TestSecurity:
 
         result = CrawlResult(url="https://evil.com/../../etc/passwd", markdown="# Malicious")
         meta: dict[str, CrawlMeta] = {}
-        path = _save_single_result(result, meta)
+        outcome = _save_single_result(result, meta)
         web_dir = cfg.documents_dir / "_web"
         # url_to_filename neutralizes ".." segments, so the result MUST be a
         # concrete path under _web/. A None return would indicate the helper
         # started rejecting the request at the hash/exists short-circuit, which
         # is the class of refactor we want to catch.
-        assert path is not None
-        assert path.resolve().is_relative_to(web_dir.resolve())
+        assert outcome is not None
+        assert outcome.path.resolve().is_relative_to(web_dir.resolve())
 
     async def test_max_pages_enforced(self, httpserver, allow_localhost):
         """Max pages config caps the crawl."""

--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -130,11 +130,11 @@ class TestSdkModelManagement:
 
 class TestSdkFactory:
     def test_create_sdk_provider_for_litellm_config(self) -> None:
-        """Factory wraps the SDK backend in SdkLLMProvider when cfg.llm_provider == 'litellm'."""
+        """Factory wraps the SDK backend in SdkLLMProvider when cfg.llm_provider == 'backend'."""
         from lilbee.providers.factory import create_provider
 
-        cfg.llm_provider = "litellm"
-        cfg.litellm_base_url = OLLAMA_HOST
+        cfg.llm_provider = "backend"
+        cfg.backend_base_url = OLLAMA_HOST
         provider = create_provider(cfg)
 
         assert isinstance(provider, SdkLLMProvider)
@@ -144,7 +144,7 @@ class TestSdkFactory:
         from lilbee.providers.factory import create_provider
 
         cfg.llm_provider = "ollama"
-        cfg.litellm_base_url = OLLAMA_HOST
+        cfg.backend_base_url = OLLAMA_HOST
         provider = create_provider(cfg)
 
         assert isinstance(provider, SdkLLMProvider)

--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -139,12 +139,12 @@ class TestSdkFactory:
 
         assert isinstance(provider, SdkLLMProvider)
 
-    def test_ollama_alias(self) -> None:
-        """Factory wraps the SDK backend in SdkLLMProvider when cfg.llm_provider == 'ollama'."""
+    def test_legacy_ollama_alias_rejected(self) -> None:
+        """'ollama' is no longer a valid llm_provider value; only 'backend' is."""
+        from lilbee.providers.base import ProviderError
         from lilbee.providers.factory import create_provider
 
         cfg.llm_provider = "ollama"
         cfg.backend_base_url = OLLAMA_HOST
-        provider = create_provider(cfg)
-
-        assert isinstance(provider, SdkLLMProvider)
+        with pytest.raises(ProviderError, match="Unknown LLM provider"):
+            create_provider(cfg)

--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -130,21 +130,21 @@ class TestSdkModelManagement:
 
 class TestSdkFactory:
     def test_create_sdk_provider_for_litellm_config(self) -> None:
-        """Factory wraps the SDK backend in SdkLLMProvider when cfg.llm_provider == 'backend'."""
+        """Factory wraps the SDK backend in SdkLLMProvider when cfg.llm_provider == "remote"."""
         from lilbee.providers.factory import create_provider
 
-        cfg.llm_provider = "backend"
-        cfg.backend_base_url = OLLAMA_HOST
+        cfg.llm_provider = "remote"
+        cfg.remote_base_url = OLLAMA_HOST
         provider = create_provider(cfg)
 
         assert isinstance(provider, SdkLLMProvider)
 
     def test_legacy_ollama_alias_rejected(self) -> None:
-        """'ollama' is no longer a valid llm_provider value; only 'backend' is."""
+        """'ollama' is no longer a valid llm_provider value; only "remote" is."""
         from lilbee.providers.base import ProviderError
         from lilbee.providers.factory import create_provider
 
         cfg.llm_provider = "ollama"
-        cfg.backend_base_url = OLLAMA_HOST
+        cfg.remote_base_url = OLLAMA_HOST
         with pytest.raises(ProviderError, match="Unknown LLM provider"):
             create_provider(cfg)

--- a/tests/providers/test_sdk_backend_contract.py
+++ b/tests/providers/test_sdk_backend_contract.py
@@ -97,6 +97,9 @@ class TestActiveBackendName:
     def test_anthropic_url_returns_anthropic(self, backend: LlmSdkBackend) -> None:
         assert backend.active_backend_name("https://api.anthropic.com") == "Anthropic"
 
+    def test_gemini_url_returns_gemini(self, backend: LlmSdkBackend) -> None:
+        assert backend.active_backend_name("https://generativelanguage.googleapis.com") == "Gemini"
+
     def test_unknown_url_falls_back_to_remote(self, backend: LlmSdkBackend) -> None:
         assert backend.active_backend_name("http://192.168.1.50:9000") == "Remote"
 

--- a/tests/providers/test_sdk_backend_contract.py
+++ b/tests/providers/test_sdk_backend_contract.py
@@ -87,6 +87,23 @@ class TestProviderName:
         assert isinstance(backend.provider_name, str)
 
 
+class TestActiveBackendName:
+    def test_ollama_url_returns_ollama(self, backend: LlmSdkBackend) -> None:
+        assert backend.active_backend_name("http://localhost:11434") == "Ollama"
+
+    def test_openai_url_returns_openai(self, backend: LlmSdkBackend) -> None:
+        assert backend.active_backend_name("https://api.openai.com/v1") == "OpenAI"
+
+    def test_anthropic_url_returns_anthropic(self, backend: LlmSdkBackend) -> None:
+        assert backend.active_backend_name("https://api.anthropic.com") == "Anthropic"
+
+    def test_unknown_url_falls_back_to_remote(self, backend: LlmSdkBackend) -> None:
+        assert backend.active_backend_name("http://192.168.1.50:9000") == "Remote"
+
+    def test_case_insensitive(self, backend: LlmSdkBackend) -> None:
+        assert backend.active_backend_name("http://LOCALHOST:11434") == "Ollama"
+
+
 class TestAvailable:
     def test_returns_true_when_sdk_importable(self, backend: LlmSdkBackend) -> None:
         fake = mock.MagicMock()

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -96,7 +96,7 @@ class _FakeManager:
         if model in self._native:
             return ModelSource.NATIVE
         if model in self._litellm:
-            return ModelSource.LITELLM
+            return ModelSource.BACKEND
         return None
 
     def pull(self, model, source, *, on_progress=None, on_bytes=None):
@@ -110,7 +110,7 @@ class _FakeManager:
         if (source is ModelSource.NATIVE or source is None) and model in self._native:
             self._native.remove(model)
             return True
-        if (source is ModelSource.LITELLM or source is None) and model in self._litellm:
+        if (source is ModelSource.BACKEND or source is None) and model in self._litellm:
             self._litellm.remove(model)
             return True
         return False
@@ -171,7 +171,7 @@ class TestModelEntryFactories:
     def test_from_litellm_with_remote(self):
         remote = _remote("llama3:latest", task="chat", parameter_size="8B")
         entry = ModelEntry.from_litellm("llama3:latest", remote)
-        assert entry.source == "litellm"
+        assert entry.source == "backend"
         assert entry.task == "chat"
         assert entry.display_name == "8B"
 
@@ -187,7 +187,7 @@ class TestListModelsData:
         assert isinstance(data, ListModelsResult)
         assert data.total == 2
         sources = {e.source for e in data.models}
-        assert sources == {"native", "litellm"}
+        assert sources == {"native", "backend"}
 
     def test_filter_source_native_skips_litellm_http(self, fake_manager, native_manifests):
         with patch("lilbee.model_manager.classify_remote_models") as classify:
@@ -197,9 +197,9 @@ class TestListModelsData:
         assert data.models[0].name == "qwen3:0.6b"
 
     def test_filter_source_litellm(self, fake_manager, native_manifests, with_remote_classify):
-        data = model_mod.list_models_data(source=ModelSource.LITELLM)
+        data = model_mod.list_models_data(source=ModelSource.BACKEND)
         assert data.total == 1
-        assert data.models[0].source == "litellm"
+        assert data.models[0].source == "backend"
 
     def test_task_filter_drops_entries_without_matching_task(
         self, fake_manager, native_manifests, with_remote_classify
@@ -395,7 +395,7 @@ class TestPullModelData:
         manager = _Litellm()
         with patch("lilbee.model_manager.get_model_manager", return_value=manager):
             result = model_mod.pull_model_data(
-                "llama3:latest", ModelSource.LITELLM, on_update=events.append
+                "llama3:latest", ModelSource.BACKEND, on_update=events.append
             )
         assert result.status == PullStatus.OK
         assert result.path is None

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -96,7 +96,7 @@ class _FakeManager:
         if model in self._native:
             return ModelSource.NATIVE
         if model in self._litellm:
-            return ModelSource.BACKEND
+            return ModelSource.REMOTE
         return None
 
     def pull(self, model, source, *, on_progress=None, on_bytes=None):
@@ -110,7 +110,7 @@ class _FakeManager:
         if (source is ModelSource.NATIVE or source is None) and model in self._native:
             self._native.remove(model)
             return True
-        if (source is ModelSource.BACKEND or source is None) and model in self._litellm:
+        if (source is ModelSource.REMOTE or source is None) and model in self._litellm:
             self._litellm.remove(model)
             return True
         return False
@@ -171,7 +171,7 @@ class TestModelEntryFactories:
     def test_from_backend_with_remote(self):
         remote = _remote("llama3:latest", task="chat", parameter_size="8B")
         entry = ModelEntry.from_backend("llama3:latest", remote)
-        assert entry.source == "backend"
+        assert entry.source == "remote"
         assert entry.task == "chat"
         assert entry.display_name == "8B"
 
@@ -187,7 +187,7 @@ class TestListModelsData:
         assert isinstance(data, ListModelsResult)
         assert data.total == 2
         sources = {e.source for e in data.models}
-        assert sources == {"native", "backend"}
+        assert sources == {"native", "remote"}
 
     def test_filter_source_native_skips_litellm_http(self, fake_manager, native_manifests):
         with patch("lilbee.model_manager.classify_remote_models") as classify:
@@ -197,9 +197,9 @@ class TestListModelsData:
         assert data.models[0].name == "qwen3:0.6b"
 
     def test_filter_source_litellm(self, fake_manager, native_manifests, with_remote_classify):
-        data = model_mod.list_models_data(source=ModelSource.BACKEND)
+        data = model_mod.list_models_data(source=ModelSource.REMOTE)
         assert data.total == 1
-        assert data.models[0].source == "backend"
+        assert data.models[0].source == "remote"
 
     def test_task_filter_drops_entries_without_matching_task(
         self, fake_manager, native_manifests, with_remote_classify
@@ -395,7 +395,7 @@ class TestPullModelData:
         manager = _Litellm()
         with patch("lilbee.model_manager.get_model_manager", return_value=manager):
             result = model_mod.pull_model_data(
-                "llama3:latest", ModelSource.BACKEND, on_update=events.append
+                "llama3:latest", ModelSource.REMOTE, on_update=events.append
             )
         assert result.status == PullStatus.OK
         assert result.path is None

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -168,15 +168,15 @@ class TestModelEntryFactories:
         assert entry.size_gb is None
         assert entry.display_name == ""
 
-    def test_from_litellm_with_remote(self):
+    def test_from_backend_with_remote(self):
         remote = _remote("llama3:latest", task="chat", parameter_size="8B")
-        entry = ModelEntry.from_litellm("llama3:latest", remote)
+        entry = ModelEntry.from_backend("llama3:latest", remote)
         assert entry.source == "backend"
         assert entry.task == "chat"
         assert entry.display_name == "8B"
 
-    def test_from_litellm_missing_remote(self):
-        entry = ModelEntry.from_litellm("llama3:latest", None)
+    def test_from_backend_missing_remote(self):
+        entry = ModelEntry.from_backend("llama3:latest", None)
         assert entry.task is None
         assert entry.display_name == ""
 

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -397,6 +397,47 @@ class TestGetRelatedConcepts:
         result = cg.get_related_concepts("python")
         assert result == []
 
+    def test_single_batched_query_per_depth_level(self, cg, mock_svc):
+        """Frontier expansion must fire one query per depth level, not one per node."""
+        mock_table = MagicMock()
+        mock_table.search.return_value.where.return_value.to_list.return_value = [
+            {"source": "python", "target": "django", "weight": 1.0},
+            {"source": "python", "target": "flask", "weight": 0.9},
+        ]
+        mock_svc.store.open_table.return_value = mock_table
+
+        cg.get_related_concepts("python", depth=1)
+        # One depth level => exactly one .search() call.
+        assert mock_table.search.call_count == 1
+        # The WHERE clause should use IN with all frontier nodes, not per-node equality.
+        where_args = mock_table.search.return_value.where.call_args.args[0]
+        assert " IN (" in where_args
+        assert "'python'" in where_args
+
+    def test_depth_two_batches_both_levels(self, cg, mock_svc):
+        """depth=2 triggers exactly 2 batched queries (one per level)."""
+        mock_table = MagicMock()
+        mock_table.search.return_value.where.return_value.to_list.side_effect = [
+            [
+                {"source": "python", "target": "django", "weight": 1.0},
+                {"source": "python", "target": "flask", "weight": 0.9},
+            ],
+            [
+                {"source": "django", "target": "rest", "weight": 0.8},
+                {"source": "flask", "target": "werkzeug", "weight": 0.7},
+            ],
+        ]
+        mock_svc.store.open_table.return_value = mock_table
+
+        related = cg.get_related_concepts("python", depth=2)
+        assert mock_table.search.call_count == 2
+        # Level-2 WHERE clause should include both frontier nodes found at level 1.
+        level_two_where = mock_table.search.return_value.where.call_args_list[1].args[0]
+        assert "'django'" in level_two_where
+        assert "'flask'" in level_two_where
+        # All neighbors from both levels end up in the result.
+        assert set(related) >= {"django", "flask", "rest", "werkzeug"}
+
 
 class TestTopCommunities:
     def test_top_communities(self, cg, mock_svc):

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -438,6 +438,18 @@ class TestGetRelatedConcepts:
         # All neighbors from both levels end up in the result.
         assert set(related) >= {"django", "flask", "rest", "werkzeug"}
 
+    def test_empty_frontier_mid_traversal_breaks(self, cg, mock_svc):
+        """Depth > 1 but no new neighbors at level 1 → loop breaks on empty frontier."""
+        mock_table = MagicMock()
+        mock_table.search.return_value.where.return_value.to_list.return_value = []
+        mock_svc.store.open_table.return_value = mock_table
+
+        related = cg.get_related_concepts("isolated", depth=3)
+        assert related == []
+        # depth=3 would normally fire 3 queries; empty frontier after level 1
+        # breaks out after the first.
+        assert mock_table.search.call_count == 1
+
 
 class TestTopCommunities:
     def test_top_communities(self, cg, mock_svc):
@@ -476,6 +488,21 @@ class TestTopCommunities:
                     pa.field("degree", pa.int32()),
                 ]
             ),
+        )
+        mock_svc.store.open_table.return_value = mock_table
+        assert cg.top_communities() == []
+
+    def test_top_communities_only_null_cluster_ids(self, cg, mock_svc):
+        """Rows with NULL cluster_id yield no top clusters."""
+        import pyarrow as pa
+
+        mock_table = MagicMock()
+        mock_table.to_arrow.return_value = pa.table(
+            {
+                "concept": ["python", "ml"],
+                "cluster_id": pa.array([None, None], type=pa.int32()),
+                "degree": [5, 3],
+            }
         )
         mock_svc.store.open_table.return_value = mock_table
         assert cg.top_communities() == []

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -441,12 +441,17 @@ class TestGetRelatedConcepts:
 
 class TestTopCommunities:
     def test_top_communities(self, cg, mock_svc):
+        import pyarrow as pa
+
         mock_table = MagicMock()
-        mock_table.to_arrow.return_value.to_pylist.return_value = [
-            {"concept": "python", "cluster_id": 0, "degree": 5},
-            {"concept": "ml", "cluster_id": 0, "degree": 3},
-            {"concept": "web", "cluster_id": 1, "degree": 2},
-        ]
+        # Real Arrow table so pyarrow.compute ops actually run.
+        mock_table.to_arrow.return_value = pa.table(
+            {
+                "concept": ["python", "ml", "web"],
+                "cluster_id": [0, 0, 1],
+                "degree": [5, 3, 2],
+            }
+        )
         mock_svc.store.open_table.return_value = mock_table
 
         communities = cg.top_communities(k=2)
@@ -456,6 +461,23 @@ class TestTopCommunities:
 
     def test_top_communities_no_table(self, cg, mock_svc):
         mock_svc.store.open_table.return_value = None
+        assert cg.top_communities() == []
+
+    def test_top_communities_empty_table(self, cg, mock_svc):
+        import pyarrow as pa
+
+        mock_table = MagicMock()
+        mock_table.to_arrow.return_value = pa.table(
+            {"concept": [], "cluster_id": [], "degree": []},
+            schema=pa.schema(
+                [
+                    pa.field("concept", pa.utf8()),
+                    pa.field("cluster_id", pa.int32()),
+                    pa.field("degree", pa.int32()),
+                ]
+            ),
+        )
+        mock_svc.store.open_table.return_value = mock_table
         assert cg.top_communities() == []
 
 
@@ -714,13 +736,17 @@ class TestGetClusterSources:
 class TestGetClusterLabel:
     def test_returns_highest_degree_concept(self, cg, mock_svc):
         mock_table = MagicMock()
-        mock_table.to_arrow.return_value.to_pylist.return_value = [
+        # New implementation pushes the cluster_id filter to the DB, so
+        # the mock only needs to return the rows for that cluster.
+        mock_table.search.return_value.where.return_value.to_list.return_value = [
             {"concept": "python", "cluster_id": 0, "degree": 5},
             {"concept": "ml", "cluster_id": 0, "degree": 3},
-            {"concept": "web", "cluster_id": 1, "degree": 2},
         ]
         mock_svc.store.open_table.return_value = mock_table
         assert cg.get_cluster_label(0) == "python"
+        # Confirm the filter was actually pushed down.
+        where_args = mock_table.search.return_value.where.call_args.args[0]
+        assert "cluster_id = 0" in where_args
 
     def test_returns_fallback_when_no_table(self, cg, mock_svc):
         mock_svc.store.open_table.return_value = None
@@ -728,11 +754,18 @@ class TestGetClusterLabel:
 
     def test_returns_fallback_for_unknown_cluster(self, cg, mock_svc):
         mock_table = MagicMock()
-        mock_table.to_arrow.return_value.to_pylist.return_value = [
-            {"concept": "python", "cluster_id": 0, "degree": 5},
-        ]
+        # Unknown cluster => DB returns zero rows for the WHERE clause.
+        mock_table.search.return_value.where.return_value.to_list.return_value = []
         mock_svc.store.open_table.return_value = mock_table
         assert cg.get_cluster_label(99) == "cluster-99"
+
+    def test_returns_fallback_on_query_exception(self, cg, mock_svc):
+        mock_table = MagicMock()
+        mock_table.search.return_value.where.return_value.to_list.side_effect = RuntimeError(
+            "query failed"
+        )
+        mock_svc.store.open_table.return_value = mock_table
+        assert cg.get_cluster_label(7) == "cluster-7"
 
 
 class TestFilterNounChunks:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -878,12 +878,12 @@ class TestIgnoreDirsFallback:
 
 
 class TestOllamaHostFallback:
-    def test_ollama_host_sets_backend_base_url(self, tmp_path):
+    def test_ollama_host_sets_remote_base_url(self, tmp_path):
         env = _clean_env(tmp_path)
         env["OLLAMA_HOST"] = "http://custom:11434"
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
-        assert c.backend_base_url == "http://custom:11434"
+        assert c.remote_base_url == "http://custom:11434"
 
 
 class TestParseEnableOcrFallback:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,6 +104,15 @@ class TestEnvVarOverrides:
         cfg.vision_model = ""
         assert cfg.vision_model == ""
 
+    def test_normalize_model_tag_blank_chat_rejected(self):
+        """Required roles (chat_model, embedding_model) reject blank strings."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="chat_model must not be blank"):
+            cfg.chat_model = "   "
+        with pytest.raises(ValidationError, match="embedding_model must not be blank"):
+            cfg.embedding_model = "\t"
+
     def test_embedding_dim_override(self):
         with mock.patch.dict(os.environ, {"LILBEE_EMBEDDING_DIM": "1024"}):
             c = Config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -869,12 +869,12 @@ class TestIgnoreDirsFallback:
 
 
 class TestOllamaHostFallback:
-    def test_ollama_host_sets_litellm_base_url(self, tmp_path):
+    def test_ollama_host_sets_backend_base_url(self, tmp_path):
         env = _clean_env(tmp_path)
         env["OLLAMA_HOST"] = "http://custom:11434"
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
-        assert c.litellm_base_url == "http://custom:11434"
+        assert c.backend_base_url == "http://custom:11434"
 
 
 class TestParseEnableOcrFallback:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1095,195 +1095,127 @@ def _validator_env(tmp_path: Path) -> dict[str, str]:
     return env
 
 
-class TestModelTaskFieldValidator:
-    """Per-role catalog-task validation runs on every write path (construction + assignment)."""
+@pytest.fixture()
+def _task_validation_enabled():
+    """Unset the conftest-level bypass so validate_model_task_assignment fires."""
+    import os
 
-    def test_chat_slot_accepts_chat_model(self, tmp_path):
-        env = _validator_env(tmp_path)
-        env["LILBEE_CHAT_MODEL"] = "qwen3:0.6b"
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-        assert c.chat_model.endswith("qwen3:0.6b")
+    prev = os.environ.pop("LILBEE_SKIP_MODEL_TASK_VALIDATION", None)
+    try:
+        yield
+    finally:
+        if prev is not None:
+            os.environ["LILBEE_SKIP_MODEL_TASK_VALIDATION"] = prev
 
-    def test_chat_slot_rejects_vision_model(self, tmp_path):
-        env = _validator_env(tmp_path)
-        env["LILBEE_CHAT_MODEL"] = "lightonocr:2-1b"
-        with (
-            mock.patch.dict(os.environ, env, clear=True),
-            pytest.raises(Exception, match="vision"),  # pydantic ValidationError wraps it
-        ):
-            Config()
 
-    def test_chat_slot_rejects_reranker_model(self, tmp_path):
-        env = _validator_env(tmp_path)
-        env["LILBEE_CHAT_MODEL"] = "bge-reranker-v2-m3:latest"
-        with (
-            mock.patch.dict(os.environ, env, clear=True),
-            pytest.raises(Exception, match="rerank"),
-        ):
-            Config()
+class TestValidateModelTaskAssignment:
+    """Explicit validator replaces the old per-setattr Pydantic field_validator.
 
-    def test_embedding_slot_rejects_chat_model(self, tmp_path):
-        env = _validator_env(tmp_path)
-        env["LILBEE_EMBEDDING_MODEL"] = "qwen3:0.6b"
-        with (
-            mock.patch.dict(os.environ, env, clear=True),
-            pytest.raises(Exception, match="chat"),
-        ):
-            Config()
+    The hot path (PATCH /api/config, model-role toggles) now calls this
+    helper once per field per request rather than running the catalog
+    lookup on every setattr through validate_assignment=True.
+    """
 
-    def test_vision_slot_rejects_chat_model(self, tmp_path):
-        env = _validator_env(tmp_path)
-        env["LILBEE_VISION_MODEL"] = "qwen3:0.6b"
-        with (
-            mock.patch.dict(os.environ, env, clear=True),
-            pytest.raises(Exception, match="chat"),
-        ):
-            Config()
+    def test_chat_slot_accepts_chat_model(self, _task_validation_enabled):
+        from lilbee.config import validate_model_task_assignment
 
-    def test_reranker_slot_rejects_vision_model(self, tmp_path):
-        env = _validator_env(tmp_path)
-        env["LILBEE_RERANKER_MODEL"] = "lightonocr:2-1b"
-        with (
-            mock.patch.dict(os.environ, env, clear=True),
-            pytest.raises(Exception, match="vision"),
-        ):
-            Config()
+        result = validate_model_task_assignment("chat_model", "qwen3:0.6b")
+        assert result.endswith("qwen3:0.6b")
 
-    def test_empty_vision_model_allowed(self, tmp_path):
-        """Vision and reranker roles allow empty strings (unset)."""
-        env = _validator_env(tmp_path)
-        env["LILBEE_VISION_MODEL"] = ""
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-        assert c.vision_model == ""
+    def test_chat_slot_rejects_vision_model(self, _task_validation_enabled):
+        from lilbee.config import validate_model_task_assignment
 
-    def test_assignment_path_rejects_wrong_task(self, tmp_path):
-        """validate_assignment=True means cfg.X = ref also runs the validator."""
-        env = _validator_env(tmp_path)
-        env["LILBEE_CHAT_MODEL"] = "qwen3:0.6b"
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-            with pytest.raises(Exception, match="vision"):
-                c.chat_model = "lightonocr:2-1b"
+        with pytest.raises(ValueError, match="vision"):
+            validate_model_task_assignment("chat_model", "lightonocr:2-1b")
 
-    def test_provider_prefix_canonicalized_on_assignment(self, tmp_path):
-        """Direct ``cfg.X = ref`` canonicalizes provider-prefixed refs.
+    def test_chat_slot_rejects_reranker_model(self, _task_validation_enabled):
+        from lilbee.config import validate_model_task_assignment
 
-        Mirrors PATCH /api/models behavior: the validator returns the
-        catalog's canonical ``name:tag`` so stored refs match the
-        registry key regardless of input variant. Covers R4-F2.
-        """
-        env = _validator_env(tmp_path)
-        env["LILBEE_CHAT_MODEL"] = "qwen3:0.6b"
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-            c.chat_model = "ollama/qwen3:0.6b"
-            assert c.chat_model == "qwen3:0.6b"
+        with pytest.raises(ValueError, match="rerank"):
+            validate_model_task_assignment("chat_model", "bge-reranker-v2-m3:latest")
 
-    def test_hf_repo_canonicalized_on_assignment(self, tmp_path):
+    def test_embedding_slot_rejects_chat_model(self, _task_validation_enabled):
+        from lilbee.config import validate_model_task_assignment
+
+        with pytest.raises(ValueError, match="chat"):
+            validate_model_task_assignment("embedding_model", "qwen3:0.6b")
+
+    def test_vision_slot_rejects_chat_model(self, _task_validation_enabled):
+        from lilbee.config import validate_model_task_assignment
+
+        with pytest.raises(ValueError, match="chat"):
+            validate_model_task_assignment("vision_model", "qwen3:0.6b")
+
+    def test_reranker_slot_rejects_vision_model(self, _task_validation_enabled):
+        from lilbee.config import validate_model_task_assignment
+
+        with pytest.raises(ValueError, match="vision"):
+            validate_model_task_assignment("reranker_model", "lightonocr:2-1b")
+
+    def test_empty_string_passes_through(self, _task_validation_enabled):
+        """Empty or whitespace refs bypass validation (role unset)."""
+        from lilbee.config import validate_model_task_assignment
+
+        assert validate_model_task_assignment("vision_model", "") == ""
+        assert validate_model_task_assignment("reranker_model", "   ") == "   "
+
+    def test_provider_prefix_canonicalized(self, _task_validation_enabled):
+        """Provider-prefixed refs canonicalize to the catalog ``name:tag``."""
+        from lilbee.config import validate_model_task_assignment
+
+        result = validate_model_task_assignment("chat_model", "ollama/qwen3:0.6b")
+        assert result == "qwen3:0.6b"
+
+    def test_hf_repo_canonicalized(self, _task_validation_enabled):
         """``hf_repo`` form canonicalizes to the catalog ``name:tag``."""
-        env = _validator_env(tmp_path)
-        env["LILBEE_CHAT_MODEL"] = "qwen3:0.6b"
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-            c.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF:latest"
-            assert c.reranker_model == "bge-reranker-v2-m3:latest"
+        from lilbee.config import validate_model_task_assignment
 
-    def test_env_load_canonicalizes(self, tmp_path):
-        """Env-var load path also canonicalizes (validator runs at construction)."""
-        env = _validator_env(tmp_path)
-        env["LILBEE_CHAT_MODEL"] = "ollama/qwen3:0.6b"
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-        assert c.chat_model == "qwen3:0.6b"
+        result = validate_model_task_assignment(
+            "reranker_model", "gpustack/bge-reranker-v2-m3-GGUF:latest"
+        )
+        assert result == "bge-reranker-v2-m3:latest"
 
-    def test_out_of_catalog_rejected(self, tmp_path):
+    def test_out_of_catalog_rejected(self, _task_validation_enabled):
         """Out-of-catalog model names are rejected since we can't verify the role."""
-        env = _validator_env(tmp_path)
-        env["LILBEE_CHAT_MODEL"] = "totally-unknown-model:99b"
-        with (
-            mock.patch.dict(os.environ, env, clear=True),
-            pytest.raises(Exception, match="featured catalog"),
-        ):
-            Config()
+        from lilbee.config import validate_model_task_assignment
+
+        with pytest.raises(ValueError, match="featured catalog"):
+            validate_model_task_assignment("chat_model", "totally-unknown-model:99b")
 
     def test_skip_env_var_disables_check(self, tmp_path):
         """LILBEE_SKIP_MODEL_TASK_VALIDATION bypasses the role check when pytest is imported."""
-        env = _validator_env(tmp_path)
-        env["LILBEE_SKIP_MODEL_TASK_VALIDATION"] = "1"
-        env["LILBEE_CHAT_MODEL"] = "totally-unknown-model:99b"
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-        assert c.chat_model.endswith("totally-unknown-model:99b")
+        from lilbee.config import validate_model_task_assignment
+
+        with mock.patch.dict(os.environ, {"LILBEE_SKIP_MODEL_TASK_VALIDATION": "1"}):
+            # Bypass: returns input unchanged, does not raise.
+            result = validate_model_task_assignment("chat_model", "totally-unknown-model:99b")
+        assert result == "totally-unknown-model:99b"
 
     def test_skip_env_var_alone_does_not_bypass_in_production(self, tmp_path):
         """Shell-level env var without the pytest sentinel must not bypass validation."""
         import sys
 
-        env = _validator_env(tmp_path)
-        env["LILBEE_SKIP_MODEL_TASK_VALIDATION"] = "1"
-        env["LILBEE_CHAT_MODEL"] = "totally-unknown-model:99b"
+        from lilbee.config import validate_model_task_assignment
+
         saved_pytest = sys.modules.pop("pytest", None)
         try:
             with (
-                mock.patch.dict(os.environ, env, clear=True),
-                pytest.raises(Exception, match="featured catalog"),
+                mock.patch.dict(os.environ, {"LILBEE_SKIP_MODEL_TASK_VALIDATION": "1"}),
+                pytest.raises(ValueError, match="featured catalog"),
             ):
-                Config()
+                validate_model_task_assignment("chat_model", "totally-unknown-model:99b")
         finally:
             if saved_pytest is not None:
                 sys.modules["pytest"] = saved_pytest
 
-    def test_whitespace_only_model_normalized_to_empty(self, tmp_path):
-        """Whitespace-only values normalize to empty instead of raising."""
-        env = _validator_env(tmp_path)
-        env["LILBEE_VISION_MODEL"] = "   "
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-        assert c.vision_model == ""
-
-    def test_whitespace_assignment_normalized_to_empty(self, tmp_path):
-        """Direct assignment of whitespace also normalizes cleanly."""
-        env = _validator_env(tmp_path)
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-            c.vision_model = " "
-            assert c.vision_model == ""
-
-    def test_whitespace_chat_model_rejected(self, tmp_path):
-        """Whitespace-only chat_model is rejected (required field)."""
-        from pydantic import ValidationError
-
-        env = _validator_env(tmp_path)
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-            with pytest.raises(ValidationError, match="chat_model"):
-                c.chat_model = "   "
-
-    def test_whitespace_embedding_model_rejected(self, tmp_path):
-        """Whitespace-only embedding_model is rejected (required field)."""
-        from pydantic import ValidationError
-
-        env = _validator_env(tmp_path)
-        with mock.patch.dict(os.environ, env, clear=True):
-            c = Config()
-            with pytest.raises(ValidationError, match="embedding_model"):
-                c.embedding_model = "   "
-
-    def test_task_mismatch_message_parity_with_handler(self, tmp_path):
-        """Validator and handler produce identical 422 messages via shared helper."""
+    def test_task_mismatch_message_parity_with_handler(self, _task_validation_enabled):
+        """Validator helper and handler produce identical 422 messages."""
+        from lilbee.config import validate_model_task_assignment
         from lilbee.models import ModelTask
         from lilbee.server.handlers import format_task_mismatch
 
-        env = _validator_env(tmp_path)
-        env["LILBEE_CHAT_MODEL"] = "lightonocr:2-1b"
-        with (
-            mock.patch.dict(os.environ, env, clear=True),
-            pytest.raises(Exception) as exc_info,
-        ):
-            Config()
+        with pytest.raises(ValueError) as exc_info:
+            validate_model_task_assignment("chat_model", "lightonocr:2-1b")
 
         handler_message = format_task_mismatch("lightonocr:2-1b", ModelTask.VISION, ModelTask.CHAT)
-        # Pydantic wraps the raw ValueError; check the core message is present.
         assert handler_message in str(exc_info.value)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1043,8 +1043,12 @@ class TestCrawlAndSave:
             # Mimic the real streaming contract: invoke the flush callback
             # per-page before returning the full list.
             if on_result is not None:
+                import inspect
+
                 for r in streamed:
-                    on_result(r)
+                    rv = on_result(r)
+                    if inspect.isawaitable(rv):
+                        await rv
             return streamed
 
         mock_crawl_recursive.side_effect = _fake_recursive

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1706,10 +1706,12 @@ class TestSaveSingleResult:
 
         meta: dict = {}
         result = CrawlResult(url="https://example.com/new", markdown="# New")
-        path = _save_single_result(result, meta)
-        assert path is not None
-        assert path.exists()
-        assert path.read_text(encoding="utf-8") == "# New"
+        outcome = _save_single_result(result, meta)
+        assert outcome is not None
+        assert outcome.path.exists()
+        assert outcome.path.read_text(encoding="utf-8") == "# New"
+        assert outcome.filename.endswith("index.md")
+        assert outcome.content_hash == content_hash("# New")
 
     def test_returns_none_on_failure(self, isolated_env):
         from lilbee.crawler.save import _save_single_result
@@ -1732,10 +1734,10 @@ class TestSaveSingleResult:
         # Write the file and seed metadata
         initial = CrawlResult(url=url, markdown=markdown)
         meta: dict = {}
-        first_path = _save_single_result(initial, meta)
-        assert first_path is not None
+        first = _save_single_result(initial, meta)
+        assert first is not None
         meta[url] = CrawlMeta(
-            file=str(first_path.relative_to(cfg.documents_dir / "_web")),
+            file=str(first.path.relative_to(cfg.documents_dir / "_web")),
             content_hash=content_hash(markdown),
             crawled_at="2026-01-01T00:00:00+00:00",
         )
@@ -1758,9 +1760,9 @@ class TestSaveSingleResult:
         }
         # File does not exist yet
         result = CrawlResult(url=url, markdown=markdown)
-        path = _save_single_result(result, meta)
-        assert path is not None
-        assert path.exists()
+        outcome = _save_single_result(result, meta)
+        assert outcome is not None
+        assert outcome.path.exists()
 
     def test_path_traversal_blocked(self, isolated_env):
         """A crafted filename escaping _web/ is skipped with a warning."""
@@ -1768,19 +1770,21 @@ class TestSaveSingleResult:
 
         result = CrawlResult(url="https://evil.com/ok", markdown="# Evil")
         with patch("lilbee.crawler.save.url_to_filename", return_value="../../etc/passwd"):
-            path = _save_single_result(result, {})
-        assert path is None
+            outcome = _save_single_result(result, {})
+        assert outcome is None
 
 
 class TestUpdateSingleMetadata:
-    def test_updates_in_place(self):
+    def test_updates_in_place(self, isolated_env):
         """Helper mutates the dict in place with the expected shape."""
-        from lilbee.crawler.save import _update_single_metadata
+        from lilbee.crawler.save import _save_single_result, _update_single_metadata
 
         meta: dict = {}
         result = CrawlResult(url="https://example.com/p", markdown="# P")
+        outcome = _save_single_result(result, meta)
+        assert outcome is not None
         now = "2026-04-20T00:00:00+00:00"
-        _update_single_metadata(meta, result, now)
+        _update_single_metadata(meta, result.url, outcome, now)
         assert "https://example.com/p" in meta
         entry = meta["https://example.com/p"]
         assert entry.crawled_at == now
@@ -1898,8 +1902,9 @@ class TestStreamingFlush:
 
         seed = CrawlResult(url="https://example.com/p1", markdown="# Same")
         seed_meta: dict[str, CrawlMeta] = {}
-        _save_single_result(seed, seed_meta)
-        _update_single_metadata(seed_meta, seed, _datetime.now(_UTC).isoformat())
+        outcome = _save_single_result(seed, seed_meta)
+        assert outcome is not None
+        _update_single_metadata(seed_meta, seed.url, outcome, _datetime.now(_UTC).isoformat())
         save_crawl_metadata(seed_meta)
 
         async def _gen():

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -47,7 +47,7 @@ def mock_svc():
     store.get_sources.side_effect = lambda: list(_sources.values())
     store.add_chunks.side_effect = lambda records: len(records)
 
-    def _upsert(fn, fh, cc):
+    def _upsert(fn, fh, cc, source_type="document", source_mtime=None):
         from datetime import UTC, datetime
 
         _sources[fn] = {
@@ -55,6 +55,8 @@ def mock_svc():
             "file_hash": fh,
             "chunk_count": cc,
             "ingested_at": datetime.now(UTC).isoformat(),
+            "source_type": source_type,
+            "source_mtime": source_mtime,
         }
 
     store.upsert_source.side_effect = _upsert
@@ -181,7 +183,9 @@ class TestSync:
         from lilbee.ingest import sync
 
         await sync()
-        f.write_text("Version 2 — different content now")
+        f.write_text("Version 2, different content now")
+        future = f.stat().st_mtime + 10.0
+        os.utime(f, (future, future))
         assert "changing.txt" in (await sync()).updated
 
     async def test_deleted_file_removed(self, mock_extract_file, isolated_env):
@@ -298,7 +302,9 @@ class TestSync:
 
         await sync()  # First ingest succeeds
 
-        f.write_text("Version 2 — will fail")
+        f.write_text("Version 2, will fail")
+        future = f.stat().st_mtime + 10.0
+        os.utime(f, (future, future))
 
         orig_ingest = __import__("lilbee.ingest", fromlist=["_ingest_file"])._ingest_file
 
@@ -336,7 +342,9 @@ class TestSync:
         from lilbee.ingest import sync
 
         await sync()  # First ingest succeeds
-        f.write_text("Version 2 — fail quietly")
+        f.write_text("Version 2, fail quietly")
+        future = f.stat().st_mtime + 10.0
+        os.utime(f, (future, future))
 
         orig = __import__("lilbee.ingest", fromlist=["_ingest_file"])._ingest_file
 
@@ -402,7 +410,10 @@ class TestSyncCancellation:
         # Reset call tracking
         mock_svc.store.delete_by_source.reset_mock()
 
-        f.write_text("Version 2 — modified content")
+        f.write_text("Version 2, modified content")
+        # Bump mtime so the gate falls through on coarse-tick filesystems.
+        future = f.stat().st_mtime + 10.0
+        os.utime(f, (future, future))
         await sync(quiet=True)
 
         # delete_by_source should be called (from _process_one), not from the sync loop
@@ -422,7 +433,9 @@ class TestSyncCancellation:
 
         mock_svc.store.delete_by_source.reset_mock()
 
-        f.write_text("Version 2 — modified content")
+        f.write_text("Version 2, modified content")
+        future = f.stat().st_mtime + 10.0
+        os.utime(f, (future, future))
         cancel = threading.Event()
         cancel.set()
         await sync(quiet=True, cancel=cancel)
@@ -1647,67 +1660,39 @@ class TestUnsupportedFileInSync:
 
 
 class TestMtimeGate:
-    """Fast-path gate that skips SHA-256 when file mtime is older than ingested_at."""
+    """Fast-path gate that skips SHA-256 when the file's mtime matches the stored mtime."""
 
-    def test_mtime_older_than_ingest_returns_true(self, tmp_path):
-        from datetime import UTC, datetime, timedelta
+    def test_mtime_unchanged_returns_true(self, tmp_path):
+        from lilbee.ingest import _file_unchanged_by_mtime
 
-        from lilbee.ingest import _file_unchanged_since_ingest
-
-        f = tmp_path / "old.txt"
+        f = tmp_path / "stable.txt"
         f.write_text("content")
-        # Backdate mtime to an hour before "now"
-        past = datetime.now(UTC) - timedelta(hours=1)
-        os.utime(f, (past.timestamp(), past.timestamp()))
-        ingested = datetime.now(UTC).isoformat()
-        assert _file_unchanged_since_ingest(f, ingested) is True
+        stored = f.stat().st_mtime
+        assert _file_unchanged_by_mtime(f, stored) is True
 
-    def test_mtime_after_ingest_returns_false(self, tmp_path):
-        from datetime import UTC, datetime, timedelta
+    def test_mtime_moved_forward_returns_false(self, tmp_path):
+        from lilbee.ingest import _file_unchanged_by_mtime
 
-        from lilbee.ingest import _file_unchanged_since_ingest
-
-        f = tmp_path / "new.txt"
+        f = tmp_path / "modified.txt"
         f.write_text("content")
-        # Ingested in the past, file was modified "now"
-        ingested = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
-        assert _file_unchanged_since_ingest(f, ingested) is False
+        stored = f.stat().st_mtime
+        # Bump mtime forward to simulate a post-ingest write
+        os.utime(f, (stored + 10.0, stored + 10.0))
+        assert _file_unchanged_by_mtime(f, stored) is False
 
-    def test_empty_ingested_at_returns_false(self, tmp_path):
-        from lilbee.ingest import _file_unchanged_since_ingest
+    def test_missing_stored_mtime_returns_false(self, tmp_path):
+        from lilbee.ingest import _file_unchanged_by_mtime
 
-        f = tmp_path / "file.txt"
+        f = tmp_path / "legacy.txt"
         f.write_text("content")
-        assert _file_unchanged_since_ingest(f, "") is False
-
-    def test_malformed_ingested_at_returns_false(self, tmp_path):
-        from lilbee.ingest import _file_unchanged_since_ingest
-
-        f = tmp_path / "file.txt"
-        f.write_text("content")
-        assert _file_unchanged_since_ingest(f, "not-a-timestamp") is False
+        # Legacy rows (pre-schema-migration) have no stored mtime.
+        assert _file_unchanged_by_mtime(f, None) is False
 
     def test_missing_file_returns_false(self, tmp_path):
-        from datetime import UTC, datetime
-
-        from lilbee.ingest import _file_unchanged_since_ingest
+        from lilbee.ingest import _file_unchanged_by_mtime
 
         ghost = tmp_path / "does-not-exist.txt"
-        assert _file_unchanged_since_ingest(ghost, datetime.now(UTC).isoformat()) is False
-
-    def test_naive_ingested_at_treated_as_utc(self, tmp_path):
-        from datetime import UTC, datetime, timedelta
-
-        from lilbee.ingest import _file_unchanged_since_ingest
-
-        f = tmp_path / "naive.txt"
-        f.write_text("content")
-        past = datetime.now(UTC) - timedelta(hours=1)
-        os.utime(f, (past.timestamp(), past.timestamp()))
-        # Stored without explicit tz (legacy record) — should be treated as
-        # UTC so aware/naive comparison doesn't raise TypeError.
-        naive_iso = (datetime.now(UTC) + timedelta(minutes=1)).replace(tzinfo=None).isoformat()
-        assert _file_unchanged_since_ingest(f, naive_iso) is True
+        assert _file_unchanged_by_mtime(ghost, 1_700_000_000.0) is False
 
     async def test_sync_skips_file_hash_on_fast_path(self, isolated_env, mock_svc):
         """Second sync of an unchanged file must not re-hash it."""
@@ -1738,8 +1723,11 @@ class TestMtimeGate:
 
         await sync(quiet=True)
 
-        # Modify the file — mtime now postdates ingested_at
-        f.write_text("modified content — different hash")
+        # Modify content and bump mtime explicitly so the gate falls through
+        # on filesystems with coarse-tick mtime resolution (Windows ~15ms).
+        f.write_text("modified content, different hash")
+        future = f.stat().st_mtime + 10.0
+        os.utime(f, (future, future))
 
         with mock.patch("lilbee.ingest.file_hash", return_value="different-hash") as hash_spy:
             result = await sync(quiet=True)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,6 +1,5 @@
 """Tests for the document sync engine (mocked — no live server needed)."""
 
-import os
 import sys
 from pathlib import Path
 from unittest import mock
@@ -47,7 +46,7 @@ def mock_svc():
     store.get_sources.side_effect = lambda: list(_sources.values())
     store.add_chunks.side_effect = lambda records: len(records)
 
-    def _upsert(fn, fh, cc, source_type="document", source_mtime=None):
+    def _upsert(fn, fh, cc, source_type="document"):
         from datetime import UTC, datetime
 
         _sources[fn] = {
@@ -56,7 +55,6 @@ def mock_svc():
             "chunk_count": cc,
             "ingested_at": datetime.now(UTC).isoformat(),
             "source_type": source_type,
-            "source_mtime": source_mtime,
         }
 
     store.upsert_source.side_effect = _upsert
@@ -184,8 +182,6 @@ class TestSync:
 
         await sync()
         f.write_text("Version 2, different content now")
-        future = f.stat().st_mtime + 10.0
-        os.utime(f, (future, future))
         assert "changing.txt" in (await sync()).updated
 
     async def test_deleted_file_removed(self, mock_extract_file, isolated_env):
@@ -303,8 +299,6 @@ class TestSync:
         await sync()  # First ingest succeeds
 
         f.write_text("Version 2, will fail")
-        future = f.stat().st_mtime + 10.0
-        os.utime(f, (future, future))
 
         orig_ingest = __import__("lilbee.ingest", fromlist=["_ingest_file"])._ingest_file
 
@@ -343,8 +337,6 @@ class TestSync:
 
         await sync()  # First ingest succeeds
         f.write_text("Version 2, fail quietly")
-        future = f.stat().st_mtime + 10.0
-        os.utime(f, (future, future))
 
         orig = __import__("lilbee.ingest", fromlist=["_ingest_file"])._ingest_file
 
@@ -411,9 +403,6 @@ class TestSyncCancellation:
         mock_svc.store.delete_by_source.reset_mock()
 
         f.write_text("Version 2, modified content")
-        # Bump mtime so the gate falls through on coarse-tick filesystems.
-        future = f.stat().st_mtime + 10.0
-        os.utime(f, (future, future))
         await sync(quiet=True)
 
         # delete_by_source should be called (from _process_one), not from the sync loop
@@ -434,8 +423,6 @@ class TestSyncCancellation:
         mock_svc.store.delete_by_source.reset_mock()
 
         f.write_text("Version 2, modified content")
-        future = f.stat().st_mtime + 10.0
-        os.utime(f, (future, future))
         cancel = threading.Event()
         cancel.set()
         await sync(quiet=True, cancel=cancel)
@@ -1657,101 +1644,3 @@ class TestUnsupportedFileInSync:
 
             with pytest.raises(ValueError, match="Unsupported file slipped through"):
                 await sync(quiet=True)
-
-
-class TestMtimeGate:
-    """Fast-path gate that skips SHA-256 when the file's mtime matches the stored mtime."""
-
-    def test_mtime_unchanged_returns_true(self, tmp_path):
-        from lilbee.ingest import _file_unchanged_by_mtime
-
-        f = tmp_path / "stable.txt"
-        f.write_text("content")
-        stored = f.stat().st_mtime
-        assert _file_unchanged_by_mtime(f, stored) is True
-
-    def test_mtime_moved_forward_returns_false(self, tmp_path):
-        from lilbee.ingest import _file_unchanged_by_mtime
-
-        f = tmp_path / "modified.txt"
-        f.write_text("content")
-        stored = f.stat().st_mtime
-        # Bump mtime forward to simulate a post-ingest write
-        os.utime(f, (stored + 10.0, stored + 10.0))
-        assert _file_unchanged_by_mtime(f, stored) is False
-
-    def test_missing_stored_mtime_returns_false(self, tmp_path):
-        from lilbee.ingest import _file_unchanged_by_mtime
-
-        f = tmp_path / "legacy.txt"
-        f.write_text("content")
-        # Legacy rows (pre-schema-migration) have no stored mtime.
-        assert _file_unchanged_by_mtime(f, None) is False
-
-    def test_missing_file_returns_false(self, tmp_path):
-        from lilbee.ingest import _file_unchanged_by_mtime
-
-        ghost = tmp_path / "does-not-exist.txt"
-        assert _file_unchanged_by_mtime(ghost, 1_700_000_000.0) is False
-
-    async def test_sync_skips_file_hash_on_fast_path(self, isolated_env, mock_svc):
-        """Second sync of an unchanged file must not re-hash it."""
-        from datetime import UTC, datetime, timedelta
-
-        f = isolated_env / "stable.txt"
-        f.write_text("content that does not change")
-        # Ensure mtime is older than the next ingested_at timestamp
-        past = datetime.now(UTC) - timedelta(seconds=5)
-        os.utime(f, (past.timestamp(), past.timestamp()))
-
-        from lilbee.ingest import sync
-
-        await sync(quiet=True)
-
-        with mock.patch("lilbee.ingest.file_hash") as hash_spy:
-            result = await sync(quiet=True)
-
-        assert result.unchanged == 1
-        assert hash_spy.call_count == 0
-
-    async def test_sync_hashes_when_file_modified_after_ingest(self, isolated_env, mock_svc):
-        """File touched after ingest must fall through to hashing."""
-        f = isolated_env / "modified.txt"
-        f.write_text("original content")
-
-        from lilbee.ingest import sync
-
-        await sync(quiet=True)
-
-        # Modify content and bump mtime explicitly so the gate falls through
-        # on filesystems with coarse-tick mtime resolution (Windows ~15ms).
-        f.write_text("modified content, different hash")
-        future = f.stat().st_mtime + 10.0
-        os.utime(f, (future, future))
-
-        with mock.patch("lilbee.ingest.file_hash", return_value="different-hash") as hash_spy:
-            result = await sync(quiet=True)
-
-        assert hash_spy.call_count >= 1
-        assert "modified.txt" in result.updated
-
-    async def test_sync_touched_but_unchanged_file_reports_unchanged(self, isolated_env, mock_svc):
-        """File touched (mtime bumped) without content change still lands in unchanged."""
-        from datetime import UTC, datetime, timedelta
-
-        f = isolated_env / "touched.txt"
-        f.write_text("stable content")
-
-        from lilbee.ingest import sync
-
-        await sync(quiet=True)
-
-        # Bump mtime into the future so the fast mtime gate falls through,
-        # but leave content (and therefore hash) identical.
-        future = datetime.now(UTC) + timedelta(hours=1)
-        os.utime(f, (future.timestamp(), future.timestamp()))
-
-        result = await sync(quiet=True)
-        assert result.unchanged == 1
-        assert result.added == []
-        assert result.updated == []

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,5 +1,6 @@
 """Tests for the document sync engine (mocked — no live server needed)."""
 
+import os
 import sys
 from pathlib import Path
 from unittest import mock
@@ -45,9 +46,18 @@ def mock_svc():
     store.bm25_probe.return_value = []
     store.get_sources.side_effect = lambda: list(_sources.values())
     store.add_chunks.side_effect = lambda records: len(records)
-    store.upsert_source.side_effect = lambda fn, fh, cc: _sources.update(
-        {fn: {"filename": fn, "file_hash": fh, "chunk_count": cc, "ingested_at": ""}}
-    )
+
+    def _upsert(fn, fh, cc):
+        from datetime import UTC, datetime
+
+        _sources[fn] = {
+            "filename": fn,
+            "file_hash": fh,
+            "chunk_count": cc,
+            "ingested_at": datetime.now(UTC).isoformat(),
+        }
+
+    store.upsert_source.side_effect = _upsert
     store.delete_source.side_effect = lambda fn: _sources.pop(fn, None)
     store.delete_by_source.return_value = None
     store.drop_all.side_effect = lambda: _sources.clear()
@@ -1634,3 +1644,105 @@ class TestUnsupportedFileInSync:
 
             with pytest.raises(ValueError, match="Unsupported file slipped through"):
                 await sync(quiet=True)
+
+
+class TestMtimeGate:
+    """Fast-path gate that skips SHA-256 when file mtime is older than ingested_at."""
+
+    def test_mtime_older_than_ingest_returns_true(self, tmp_path):
+        from datetime import UTC, datetime, timedelta
+
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "old.txt"
+        f.write_text("content")
+        # Backdate mtime to an hour before "now"
+        past = datetime.now(UTC) - timedelta(hours=1)
+        os.utime(f, (past.timestamp(), past.timestamp()))
+        ingested = datetime.now(UTC).isoformat()
+        assert _file_unchanged_since_ingest(f, ingested) is True
+
+    def test_mtime_after_ingest_returns_false(self, tmp_path):
+        from datetime import UTC, datetime, timedelta
+
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "new.txt"
+        f.write_text("content")
+        # Ingested in the past, file was modified "now"
+        ingested = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        assert _file_unchanged_since_ingest(f, ingested) is False
+
+    def test_empty_ingested_at_returns_false(self, tmp_path):
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "file.txt"
+        f.write_text("content")
+        assert _file_unchanged_since_ingest(f, "") is False
+
+    def test_malformed_ingested_at_returns_false(self, tmp_path):
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "file.txt"
+        f.write_text("content")
+        assert _file_unchanged_since_ingest(f, "not-a-timestamp") is False
+
+    def test_missing_file_returns_false(self, tmp_path):
+        from datetime import UTC, datetime
+
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        ghost = tmp_path / "does-not-exist.txt"
+        assert _file_unchanged_since_ingest(ghost, datetime.now(UTC).isoformat()) is False
+
+    def test_naive_ingested_at_treated_as_utc(self, tmp_path):
+        from datetime import UTC, datetime, timedelta
+
+        from lilbee.ingest import _file_unchanged_since_ingest
+
+        f = tmp_path / "naive.txt"
+        f.write_text("content")
+        past = datetime.now(UTC) - timedelta(hours=1)
+        os.utime(f, (past.timestamp(), past.timestamp()))
+        # Stored without explicit tz (legacy record) — should be treated as
+        # UTC so aware/naive comparison doesn't raise TypeError.
+        naive_iso = (datetime.now(UTC) + timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+        assert _file_unchanged_since_ingest(f, naive_iso) is True
+
+    async def test_sync_skips_file_hash_on_fast_path(self, isolated_env, mock_svc):
+        """Second sync of an unchanged file must not re-hash it."""
+        from datetime import UTC, datetime, timedelta
+
+        f = isolated_env / "stable.txt"
+        f.write_text("content that does not change")
+        # Ensure mtime is older than the next ingested_at timestamp
+        past = datetime.now(UTC) - timedelta(seconds=5)
+        os.utime(f, (past.timestamp(), past.timestamp()))
+
+        from lilbee.ingest import sync
+
+        await sync(quiet=True)
+
+        with mock.patch("lilbee.ingest.file_hash") as hash_spy:
+            result = await sync(quiet=True)
+
+        assert result.unchanged == 1
+        assert hash_spy.call_count == 0
+
+    async def test_sync_hashes_when_file_modified_after_ingest(self, isolated_env, mock_svc):
+        """File touched after ingest must fall through to hashing."""
+        f = isolated_env / "modified.txt"
+        f.write_text("original content")
+
+        from lilbee.ingest import sync
+
+        await sync(quiet=True)
+
+        # Modify the file — mtime now postdates ingested_at
+        f.write_text("modified content — different hash")
+
+        with mock.patch("lilbee.ingest.file_hash", return_value="different-hash") as hash_spy:
+            result = await sync(quiet=True)
+
+        assert hash_spy.call_count >= 1
+        assert "modified.txt" in result.updated

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1746,3 +1746,24 @@ class TestMtimeGate:
 
         assert hash_spy.call_count >= 1
         assert "modified.txt" in result.updated
+
+    async def test_sync_touched_but_unchanged_file_reports_unchanged(self, isolated_env, mock_svc):
+        """File touched (mtime bumped) without content change still lands in unchanged."""
+        from datetime import UTC, datetime, timedelta
+
+        f = isolated_env / "touched.txt"
+        f.write_text("stable content")
+
+        from lilbee.ingest import sync
+
+        await sync(quiet=True)
+
+        # Bump mtime into the future so the fast mtime gate falls through,
+        # but leave content (and therefore hash) identical.
+        future = datetime.now(UTC) + timedelta(hours=1)
+        os.utime(f, (future.timestamp(), future.timestamp()))
+
+        result = await sync(quiet=True)
+        assert result.unchanged == 1
+        assert result.added == []
+        assert result.updated == []

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -514,6 +514,13 @@ class TestMain:
         main()
         mock_mcp.run.assert_called_once()
 
+    @mock.patch("lilbee.mcp.mcp")
+    @mock.patch("lilbee.mcp.get_services", side_effect=RuntimeError("boom"))
+    def test_main_preload_failure_does_not_block_server(self, mock_get_services, mock_mcp):
+        """A crash in the pre-warm path falls through to mcp.run() instead of aborting."""
+        main()
+        mock_mcp.run.assert_called_once()
+
 
 class TestAddWithUrls:
     async def test_add_url_without_crawler(self, isolated_env):

--- a/tests/test_mcp_model_tools.py
+++ b/tests/test_mcp_model_tools.py
@@ -44,7 +44,7 @@ class TestMcpList:
     def test_invalid_source_returns_explicit_error(self):
         with patch("lilbee.cli.model.list_models_data") as fn:
             result = model_list(source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, backend"}
+        assert result == {"error": "invalid source 'bogus'; expected one of: native, remote"}
         fn.assert_not_called()
 
 
@@ -82,7 +82,7 @@ class TestMcpRemove:
     def test_invalid_source_explicit_error(self):
         with patch("lilbee.cli.model.remove_model_data") as fn:
             result = model_rm("qwen3:0.6b", source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, backend"}
+        assert result == {"error": "invalid source 'bogus'; expected one of: native, remote"}
         fn.assert_not_called()
 
 
@@ -132,15 +132,15 @@ class TestMcpPull:
     @pytest.mark.asyncio
     async def test_pull_litellm_source(self):
         captured: list[ModelSource] = []
-        final = PullResult(model="llama3:latest", source="backend", status=PullStatus.OK)
+        final = PullResult(model="llama3:latest", source="remote", status=PullStatus.OK)
 
         def fake_pull(model, source, *, on_update):
             captured.append(source)
             return final
 
         with patch("lilbee.cli.model.pull_model_data", side_effect=fake_pull):
-            await model_pull("llama3:latest", source="backend")
-        assert captured == [ModelSource.BACKEND]
+            await model_pull("llama3:latest", source="remote")
+        assert captured == [ModelSource.REMOTE]
 
     @pytest.mark.asyncio
     async def test_pull_runtime_error_returned_as_dict(self):
@@ -163,7 +163,7 @@ class TestMcpPull:
     @pytest.mark.asyncio
     async def test_pull_invalid_source(self):
         result = await model_pull("qwen3:0.6b", source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, backend"}
+        assert result == {"error": "invalid source 'bogus'; expected one of: native, remote"}
 
 
 class TestLogProgressFailure:

--- a/tests/test_mcp_model_tools.py
+++ b/tests/test_mcp_model_tools.py
@@ -44,7 +44,7 @@ class TestMcpList:
     def test_invalid_source_returns_explicit_error(self):
         with patch("lilbee.cli.model.list_models_data") as fn:
             result = model_list(source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, litellm"}
+        assert result == {"error": "invalid source 'bogus'; expected one of: native, backend"}
         fn.assert_not_called()
 
 
@@ -82,7 +82,7 @@ class TestMcpRemove:
     def test_invalid_source_explicit_error(self):
         with patch("lilbee.cli.model.remove_model_data") as fn:
             result = model_rm("qwen3:0.6b", source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, litellm"}
+        assert result == {"error": "invalid source 'bogus'; expected one of: native, backend"}
         fn.assert_not_called()
 
 
@@ -132,15 +132,15 @@ class TestMcpPull:
     @pytest.mark.asyncio
     async def test_pull_litellm_source(self):
         captured: list[ModelSource] = []
-        final = PullResult(model="llama3:latest", source="litellm", status=PullStatus.OK)
+        final = PullResult(model="llama3:latest", source="backend", status=PullStatus.OK)
 
         def fake_pull(model, source, *, on_update):
             captured.append(source)
             return final
 
         with patch("lilbee.cli.model.pull_model_data", side_effect=fake_pull):
-            await model_pull("llama3:latest", source="litellm")
-        assert captured == [ModelSource.LITELLM]
+            await model_pull("llama3:latest", source="backend")
+        assert captured == [ModelSource.BACKEND]
 
     @pytest.mark.asyncio
     async def test_pull_runtime_error_returned_as_dict(self):
@@ -163,7 +163,7 @@ class TestMcpPull:
     @pytest.mark.asyncio
     async def test_pull_invalid_source(self):
         result = await model_pull("qwen3:0.6b", source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, litellm"}
+        assert result == {"error": "invalid source 'bogus'; expected one of: native, backend"}
 
 
 class TestLogProgressFailure:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -723,6 +723,13 @@ class TestDetectProvider:
     def test_anthropic_url(self) -> None:
         assert detect_backend_name("https://api.anthropic.com") == "Anthropic"
 
+    def test_gemini_url(self) -> None:
+        assert detect_backend_name("https://generativelanguage.googleapis.com") == "Gemini"
+
+    def test_gemini_substring_fallback(self) -> None:
+        """Non-canonical URLs with 'gemini' in the path also match."""
+        assert detect_backend_name("https://proxy.example.com/gemini/v1") == "Gemini"
+
     def test_unknown_url(self) -> None:
         assert detect_backend_name("http://192.168.1.100:8080") == "Remote"
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -12,22 +12,22 @@ from lilbee.model_manager import (
     ModelTask,
     RemoteModel,
     _has_provider_key,
-    detect_provider,
     discover_api_models,
     get_model_manager,
     reset_model_manager,
 )
+from lilbee.providers.sdk_backend import detect_backend_name
 
 
 class TestModelSource:
     def test_native_value(self) -> None:
         assert ModelSource.NATIVE.value == "native"
 
-    def test_litellm_value(self) -> None:
-        assert ModelSource.LITELLM.value == "litellm"
+    def test_backend_value(self) -> None:
+        assert ModelSource.BACKEND.value == "backend"
 
     def test_members(self) -> None:
-        assert set(ModelSource) == {ModelSource.NATIVE, ModelSource.LITELLM}
+        assert set(ModelSource) == {ModelSource.NATIVE, ModelSource.BACKEND}
 
     def test_parse_none_and_empty_return_none(self) -> None:
         assert ModelSource.parse(None) is None
@@ -35,7 +35,7 @@ class TestModelSource:
 
     def test_parse_valid_values(self) -> None:
         assert ModelSource.parse("native") is ModelSource.NATIVE
-        assert ModelSource.parse("litellm") is ModelSource.LITELLM
+        assert ModelSource.parse("backend") is ModelSource.BACKEND
 
     def test_parse_invalid_raises_value_error(self) -> None:
         import pytest
@@ -116,7 +116,7 @@ class TestModelManagerListInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response) as mock_get:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.list_installed(ModelSource.LITELLM)
+            result = mgr.list_installed(ModelSource.BACKEND)
 
         mock_get.assert_called_once_with("http://localhost:11434/api/tags", timeout=30.0)
         assert set(result) == {"llama3:latest", "nomic-embed-text:latest"}
@@ -124,7 +124,7 @@ class TestModelManagerListInstalled:
     def test_litellm_connection_error(self) -> None:
         with mock.patch("httpx.get", side_effect=httpx.ConnectError("Connection refused")):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.list_installed(ModelSource.LITELLM)
+            result = mgr.list_installed(ModelSource.BACKEND)
 
         assert result == []
 
@@ -135,7 +135,7 @@ class TestModelManagerListInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.list_installed(ModelSource.LITELLM)
+            result = mgr.list_installed(ModelSource.BACKEND)
 
         assert result == []
 
@@ -178,8 +178,8 @@ class TestModelManagerListInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response) as mock_get:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            mgr.list_installed(ModelSource.LITELLM)
-            mgr.list_installed(ModelSource.LITELLM)
+            mgr.list_installed(ModelSource.BACKEND)
+            mgr.list_installed(ModelSource.BACKEND)
 
         assert mock_get.call_count == 1
 
@@ -198,8 +198,8 @@ class TestModelManagerListInstalled:
             # One clock tick per list_installed call — second tick is past TTL.
             mock_clock.side_effect = [0.0, 100.0]
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            mgr.list_installed(ModelSource.LITELLM)
-            mgr.list_installed(ModelSource.LITELLM)
+            mgr.list_installed(ModelSource.BACKEND)
+            mgr.list_installed(ModelSource.BACKEND)
 
         assert mock_get.call_count == 2
 
@@ -266,7 +266,7 @@ class TestModelManagerIsInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.is_installed("llama3:latest", ModelSource.LITELLM)
+            result = mgr.is_installed("llama3:latest", ModelSource.BACKEND)
 
         assert result is True
 
@@ -277,7 +277,7 @@ class TestModelManagerIsInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.is_installed("missing:latest", ModelSource.LITELLM)
+            result = mgr.is_installed("missing:latest", ModelSource.BACKEND)
 
         assert result is False
 
@@ -314,7 +314,7 @@ class TestModelManagerGetSource:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
             result = mgr.get_source("llama3:latest")
 
-        assert result == ModelSource.LITELLM
+        assert result == ModelSource.BACKEND
 
     def test_native_takes_precedence(self, tmp_path: Path) -> None:
         """When model exists in both sources, NATIVE takes precedence."""
@@ -437,7 +437,7 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.LITELLM, on_progress=on_progress)
+            result = mgr.pull("llama3:latest", ModelSource.BACKEND, on_progress=on_progress)
 
         mock_client.stream.assert_called_once()
         call_args = mock_client.stream.call_args
@@ -467,7 +467,7 @@ class TestModelManagerPull:
             mock.patch("httpx.Client", return_value=mock_client),
             pytest.raises(RuntimeError, match="model not found"),
         ):
-            mgr.pull("nonexistent:model", ModelSource.LITELLM)
+            mgr.pull("nonexistent:model", ModelSource.BACKEND)
 
     def test_litellm_connection_error_during_pull(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
@@ -483,7 +483,7 @@ class TestModelManagerPull:
             mock.patch("httpx.Client", return_value=mock_client),
             pytest.raises(RuntimeError, match="Cannot connect to SDK backend"),
         ):
-            mgr.pull("llama3:latest", ModelSource.LITELLM)
+            mgr.pull("llama3:latest", ModelSource.BACKEND)
 
     def test_litellm_pull_without_progress_callback(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
@@ -507,7 +507,7 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.LITELLM)
+            result = mgr.pull("llama3:latest", ModelSource.BACKEND)
 
         assert result is None
 
@@ -529,7 +529,7 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.LITELLM)
+            result = mgr.pull("llama3:latest", ModelSource.BACKEND)
 
         assert result is None
 
@@ -565,7 +565,7 @@ class TestModelManagerRemove:
 
         with mock.patch("httpx.request", return_value=mock_response) as mock_req:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("llama3:latest", ModelSource.LITELLM)
+            result = mgr.remove("llama3:latest", ModelSource.BACKEND)
 
         mock_req.assert_called_once()
         call_kwargs = mock_req.call_args[1]
@@ -579,7 +579,7 @@ class TestModelManagerRemove:
 
         with mock.patch("httpx.request", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("nonexistent:latest", ModelSource.LITELLM)
+            result = mgr.remove("nonexistent:latest", ModelSource.BACKEND)
 
         assert result is False
 
@@ -587,7 +587,7 @@ class TestModelManagerRemove:
         with mock.patch("httpx.request", side_effect=httpx.ConnectError("Connection refused")):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
             with pytest.raises(RuntimeError, match="Cannot connect to SDK backend"):
-                mgr.remove("llama3:latest", ModelSource.LITELLM)
+                mgr.remove("llama3:latest", ModelSource.BACKEND)
 
     def test_litellm_remove_unexpected_status(self) -> None:
         mock_response = mock.Mock()
@@ -595,7 +595,7 @@ class TestModelManagerRemove:
 
         with mock.patch("httpx.request", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("llama3:latest", ModelSource.LITELLM)
+            result = mgr.remove("llama3:latest", ModelSource.BACKEND)
 
         assert result is False
 
@@ -628,7 +628,7 @@ class TestSingleton:
         from lilbee.config import cfg
 
         cfg.models_dir = tmp_path / "models"
-        cfg.litellm_base_url = "http://localhost:11434"
+        cfg.backend_base_url = "http://localhost:11434"
         mgr = get_model_manager()
         assert isinstance(mgr, ModelManager)
         assert mgr._models_dir == tmp_path / "models"
@@ -638,7 +638,7 @@ class TestSingleton:
         from lilbee.config import cfg
 
         cfg.models_dir = tmp_path / "models"
-        cfg.litellm_base_url = "http://localhost:11434"
+        cfg.backend_base_url = "http://localhost:11434"
         mgr1 = get_model_manager()
         mgr2 = get_model_manager()
         assert mgr1 is mgr2
@@ -647,7 +647,7 @@ class TestSingleton:
         from lilbee.config import cfg
 
         cfg.models_dir = tmp_path / "models"
-        cfg.litellm_base_url = "http://localhost:11434"
+        cfg.backend_base_url = "http://localhost:11434"
         mgr1 = get_model_manager()
         reset_model_manager()
         mgr2 = get_model_manager()
@@ -665,14 +665,14 @@ class TestLitellmEdgeCases:
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(models_dir=tmp_path, backend_base_url="http://localhost:11434")
-            result = mgr.list_installed(ModelSource.LITELLM)
+            result = mgr.list_installed(ModelSource.BACKEND)
 
         assert result == []
 
     def test_litellm_timeout(self, tmp_path: Path) -> None:
         with mock.patch("httpx.get", side_effect=httpx.TimeoutException("timeout")):
             mgr = ModelManager(models_dir=tmp_path, backend_base_url="http://localhost:11434")
-            result = mgr.list_installed(ModelSource.LITELLM)
+            result = mgr.list_installed(ModelSource.BACKEND)
 
         assert result == []
 
@@ -712,22 +712,22 @@ class TestRemoveNativeRegistry:
 
 class TestDetectProvider:
     def test_localhost_ollama(self) -> None:
-        assert detect_provider("http://localhost:11434") == "Ollama"
+        assert detect_backend_name("http://localhost:11434") == "Ollama"
 
     def test_ollama_in_url(self) -> None:
-        assert detect_provider("http://ollama.local:11434") == "Ollama"
+        assert detect_backend_name("http://ollama.local:11434") == "Ollama"
 
     def test_openai_url(self) -> None:
-        assert detect_provider("https://api.openai.com/v1") == "OpenAI"
+        assert detect_backend_name("https://api.openai.com/v1") == "OpenAI"
 
     def test_anthropic_url(self) -> None:
-        assert detect_provider("https://api.anthropic.com") == "Anthropic"
+        assert detect_backend_name("https://api.anthropic.com") == "Anthropic"
 
     def test_unknown_url(self) -> None:
-        assert detect_provider("http://192.168.1.100:8080") == "Remote"
+        assert detect_backend_name("http://192.168.1.100:8080") == "Remote"
 
     def test_case_insensitive(self) -> None:
-        assert detect_provider("http://LOCALHOST:11434") == "Ollama"
+        assert detect_backend_name("http://LOCALHOST:11434") == "Ollama"
 
 
 class TestClassifyRemoteTask:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -24,10 +24,10 @@ class TestModelSource:
         assert ModelSource.NATIVE.value == "native"
 
     def test_backend_value(self) -> None:
-        assert ModelSource.BACKEND.value == "backend"
+        assert ModelSource.REMOTE.value == "remote"
 
     def test_members(self) -> None:
-        assert set(ModelSource) == {ModelSource.NATIVE, ModelSource.BACKEND}
+        assert set(ModelSource) == {ModelSource.NATIVE, ModelSource.REMOTE}
 
     def test_parse_none_and_empty_return_none(self) -> None:
         assert ModelSource.parse(None) is None
@@ -35,7 +35,7 @@ class TestModelSource:
 
     def test_parse_valid_values(self) -> None:
         assert ModelSource.parse("native") is ModelSource.NATIVE
-        assert ModelSource.parse("backend") is ModelSource.BACKEND
+        assert ModelSource.parse("remote") is ModelSource.REMOTE
 
     def test_parse_invalid_raises_value_error(self) -> None:
         import pytest
@@ -116,7 +116,7 @@ class TestModelManagerListInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response) as mock_get:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.list_installed(ModelSource.BACKEND)
+            result = mgr.list_installed(ModelSource.REMOTE)
 
         mock_get.assert_called_once_with("http://localhost:11434/api/tags", timeout=30.0)
         assert set(result) == {"llama3:latest", "nomic-embed-text:latest"}
@@ -124,7 +124,7 @@ class TestModelManagerListInstalled:
     def test_litellm_connection_error(self) -> None:
         with mock.patch("httpx.get", side_effect=httpx.ConnectError("Connection refused")):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.list_installed(ModelSource.BACKEND)
+            result = mgr.list_installed(ModelSource.REMOTE)
 
         assert result == []
 
@@ -135,7 +135,7 @@ class TestModelManagerListInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.list_installed(ModelSource.BACKEND)
+            result = mgr.list_installed(ModelSource.REMOTE)
 
         assert result == []
 
@@ -178,8 +178,8 @@ class TestModelManagerListInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response) as mock_get:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            mgr.list_installed(ModelSource.BACKEND)
-            mgr.list_installed(ModelSource.BACKEND)
+            mgr.list_installed(ModelSource.REMOTE)
+            mgr.list_installed(ModelSource.REMOTE)
 
         assert mock_get.call_count == 1
 
@@ -198,8 +198,8 @@ class TestModelManagerListInstalled:
             # One clock tick per list_installed call — second tick is past TTL.
             mock_clock.side_effect = [0.0, 100.0]
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            mgr.list_installed(ModelSource.BACKEND)
-            mgr.list_installed(ModelSource.BACKEND)
+            mgr.list_installed(ModelSource.REMOTE)
+            mgr.list_installed(ModelSource.REMOTE)
 
         assert mock_get.call_count == 2
 
@@ -266,7 +266,7 @@ class TestModelManagerIsInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.is_installed("llama3:latest", ModelSource.BACKEND)
+            result = mgr.is_installed("llama3:latest", ModelSource.REMOTE)
 
         assert result is True
 
@@ -277,7 +277,7 @@ class TestModelManagerIsInstalled:
 
         with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.is_installed("missing:latest", ModelSource.BACKEND)
+            result = mgr.is_installed("missing:latest", ModelSource.REMOTE)
 
         assert result is False
 
@@ -314,7 +314,7 @@ class TestModelManagerGetSource:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
             result = mgr.get_source("llama3:latest")
 
-        assert result == ModelSource.BACKEND
+        assert result == ModelSource.REMOTE
 
     def test_native_takes_precedence(self, tmp_path: Path) -> None:
         """When model exists in both sources, NATIVE takes precedence."""
@@ -437,7 +437,7 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.BACKEND, on_progress=on_progress)
+            result = mgr.pull("llama3:latest", ModelSource.REMOTE, on_progress=on_progress)
 
         mock_client.stream.assert_called_once()
         call_args = mock_client.stream.call_args
@@ -467,7 +467,7 @@ class TestModelManagerPull:
             mock.patch("httpx.Client", return_value=mock_client),
             pytest.raises(RuntimeError, match="model not found"),
         ):
-            mgr.pull("nonexistent:model", ModelSource.BACKEND)
+            mgr.pull("nonexistent:model", ModelSource.REMOTE)
 
     def test_litellm_connection_error_during_pull(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
@@ -483,7 +483,7 @@ class TestModelManagerPull:
             mock.patch("httpx.Client", return_value=mock_client),
             pytest.raises(RuntimeError, match="Cannot connect to SDK backend"),
         ):
-            mgr.pull("llama3:latest", ModelSource.BACKEND)
+            mgr.pull("llama3:latest", ModelSource.REMOTE)
 
     def test_litellm_pull_without_progress_callback(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
@@ -507,7 +507,7 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.BACKEND)
+            result = mgr.pull("llama3:latest", ModelSource.REMOTE)
 
         assert result is None
 
@@ -529,7 +529,7 @@ class TestModelManagerPull:
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.BACKEND)
+            result = mgr.pull("llama3:latest", ModelSource.REMOTE)
 
         assert result is None
 
@@ -565,7 +565,7 @@ class TestModelManagerRemove:
 
         with mock.patch("httpx.request", return_value=mock_response) as mock_req:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("llama3:latest", ModelSource.BACKEND)
+            result = mgr.remove("llama3:latest", ModelSource.REMOTE)
 
         mock_req.assert_called_once()
         call_kwargs = mock_req.call_args[1]
@@ -579,7 +579,7 @@ class TestModelManagerRemove:
 
         with mock.patch("httpx.request", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("nonexistent:latest", ModelSource.BACKEND)
+            result = mgr.remove("nonexistent:latest", ModelSource.REMOTE)
 
         assert result is False
 
@@ -587,7 +587,7 @@ class TestModelManagerRemove:
         with mock.patch("httpx.request", side_effect=httpx.ConnectError("Connection refused")):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
             with pytest.raises(RuntimeError, match="Cannot connect to SDK backend"):
-                mgr.remove("llama3:latest", ModelSource.BACKEND)
+                mgr.remove("llama3:latest", ModelSource.REMOTE)
 
     def test_litellm_remove_unexpected_status(self) -> None:
         mock_response = mock.Mock()
@@ -595,7 +595,7 @@ class TestModelManagerRemove:
 
         with mock.patch("httpx.request", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("llama3:latest", ModelSource.BACKEND)
+            result = mgr.remove("llama3:latest", ModelSource.REMOTE)
 
         assert result is False
 
@@ -628,17 +628,17 @@ class TestSingleton:
         from lilbee.config import cfg
 
         cfg.models_dir = tmp_path / "models"
-        cfg.backend_base_url = "http://localhost:11434"
+        cfg.remote_base_url = "http://localhost:11434"
         mgr = get_model_manager()
         assert isinstance(mgr, ModelManager)
         assert mgr._models_dir == tmp_path / "models"
-        assert mgr._backend_base_url == "http://localhost:11434"
+        assert mgr._remote_base_url == "http://localhost:11434"
 
     def test_returns_same_instance(self, tmp_path: Path) -> None:
         from lilbee.config import cfg
 
         cfg.models_dir = tmp_path / "models"
-        cfg.backend_base_url = "http://localhost:11434"
+        cfg.remote_base_url = "http://localhost:11434"
         mgr1 = get_model_manager()
         mgr2 = get_model_manager()
         assert mgr1 is mgr2
@@ -647,7 +647,7 @@ class TestSingleton:
         from lilbee.config import cfg
 
         cfg.models_dir = tmp_path / "models"
-        cfg.backend_base_url = "http://localhost:11434"
+        cfg.remote_base_url = "http://localhost:11434"
         mgr1 = get_model_manager()
         reset_model_manager()
         mgr2 = get_model_manager()
@@ -664,15 +664,15 @@ class TestLitellmEdgeCases:
         )
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir=tmp_path, backend_base_url="http://localhost:11434")
-            result = mgr.list_installed(ModelSource.BACKEND)
+            mgr = ModelManager(models_dir=tmp_path, remote_base_url="http://localhost:11434")
+            result = mgr.list_installed(ModelSource.REMOTE)
 
         assert result == []
 
     def test_litellm_timeout(self, tmp_path: Path) -> None:
         with mock.patch("httpx.get", side_effect=httpx.TimeoutException("timeout")):
-            mgr = ModelManager(models_dir=tmp_path, backend_base_url="http://localhost:11434")
-            result = mgr.list_installed(ModelSource.BACKEND)
+            mgr = ModelManager(models_dir=tmp_path, remote_base_url="http://localhost:11434")
+            result = mgr.list_installed(ModelSource.REMOTE)
 
         assert result == []
 
@@ -680,7 +680,7 @@ class TestLitellmEdgeCases:
 class TestIsNativePathTraversal:
     def test_path_traversal_returns_false(self, tmp_path: Path) -> None:
         """_is_native returns False for path traversal attempts."""
-        mgr = ModelManager(models_dir=tmp_path, backend_base_url="http://localhost:11434")
+        mgr = ModelManager(models_dir=tmp_path, remote_base_url="http://localhost:11434")
         assert not mgr._is_native("../../etc/passwd")
 
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -170,6 +170,78 @@ class TestModelManagerListInstalled:
 
         assert result.count("llama3:latest") == 1
 
+    def test_second_call_within_ttl_uses_cache(self) -> None:
+        """Two back-to-back calls should hit the HTTP endpoint only once."""
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"models": [{"name": "llama3:latest"}]}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response) as mock_get:
+            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr.list_installed(ModelSource.LITELLM)
+            mgr.list_installed(ModelSource.LITELLM)
+
+        assert mock_get.call_count == 1
+
+    def test_cache_expires_after_ttl(self) -> None:
+        """After the TTL window elapses, list_installed refetches."""
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"models": [{"name": "llama3:latest"}]}
+        mock_response.raise_for_status = mock.Mock()
+
+        import lilbee.model_manager as mm_mod
+
+        with (
+            mock.patch("httpx.get", return_value=mock_response) as mock_get,
+            mock.patch.object(mm_mod.time, "monotonic") as mock_clock,
+        ):
+            # One clock tick per list_installed call — second tick is past TTL.
+            mock_clock.side_effect = [0.0, 100.0]
+            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr.list_installed(ModelSource.LITELLM)
+            mgr.list_installed(ModelSource.LITELLM)
+
+        assert mock_get.call_count == 2
+
+    def test_pull_invalidates_cache(self, tmp_path: Path) -> None:
+        """After pull(), the next list_installed must refetch."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        _install_registry_model(models_dir, tmp_path, "before", b"before-data")
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"models": []}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response):
+            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr.list_installed(ModelSource.NATIVE)  # populate cache
+            assert mgr._installed_cache
+
+            # Swap the pull implementation so we don't actually fetch.
+            with mock.patch.object(mgr, "_pull_native", return_value=Path("/tmp/x")):
+                mgr.pull("new-model", ModelSource.NATIVE)
+
+            assert mgr._installed_cache == {}
+
+    def test_remove_invalidates_cache(self, tmp_path: Path) -> None:
+        """After remove(), the next list_installed must refetch."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        _install_registry_model(models_dir, tmp_path, "doomed", b"doomed-data")
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"models": []}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response):
+            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr.list_installed(None)  # populate cache
+            assert mgr._installed_cache
+
+            mgr.remove("doomed:latest", ModelSource.NATIVE)
+            assert mgr._installed_cache == {}
+
 
 class TestModelManagerIsInstalled:
     def test_native_installed(self, tmp_path: Path) -> None:
@@ -409,7 +481,7 @@ class TestModelManagerPull:
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with (
             mock.patch("httpx.Client", return_value=mock_client),
-            pytest.raises(RuntimeError, match="Cannot connect to litellm backend"),
+            pytest.raises(RuntimeError, match="Cannot connect to SDK backend"),
         ):
             mgr.pull("llama3:latest", ModelSource.LITELLM)
 
@@ -514,7 +586,7 @@ class TestModelManagerRemove:
     def test_litellm_connection_error_during_remove(self) -> None:
         with mock.patch("httpx.request", side_effect=httpx.ConnectError("Connection refused")):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            with pytest.raises(RuntimeError, match="Cannot connect to litellm backend"):
+            with pytest.raises(RuntimeError, match="Cannot connect to SDK backend"):
                 mgr.remove("llama3:latest", ModelSource.LITELLM)
 
     def test_litellm_remove_unexpected_status(self) -> None:
@@ -560,7 +632,7 @@ class TestSingleton:
         mgr = get_model_manager()
         assert isinstance(mgr, ModelManager)
         assert mgr._models_dir == tmp_path / "models"
-        assert mgr._litellm_base_url == "http://localhost:11434"
+        assert mgr._backend_base_url == "http://localhost:11434"
 
     def test_returns_same_instance(self, tmp_path: Path) -> None:
         from lilbee.config import cfg
@@ -592,14 +664,14 @@ class TestLitellmEdgeCases:
         )
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir=tmp_path, litellm_base_url="http://localhost:11434")
+            mgr = ModelManager(models_dir=tmp_path, backend_base_url="http://localhost:11434")
             result = mgr.list_installed(ModelSource.LITELLM)
 
         assert result == []
 
     def test_litellm_timeout(self, tmp_path: Path) -> None:
         with mock.patch("httpx.get", side_effect=httpx.TimeoutException("timeout")):
-            mgr = ModelManager(models_dir=tmp_path, litellm_base_url="http://localhost:11434")
+            mgr = ModelManager(models_dir=tmp_path, backend_base_url="http://localhost:11434")
             result = mgr.list_installed(ModelSource.LITELLM)
 
         assert result == []
@@ -608,7 +680,7 @@ class TestLitellmEdgeCases:
 class TestIsNativePathTraversal:
     def test_path_traversal_returns_false(self, tmp_path: Path) -> None:
         """_is_native returns False for path traversal attempts."""
-        mgr = ModelManager(models_dir=tmp_path, litellm_base_url="http://localhost:11434")
+        mgr = ModelManager(models_dir=tmp_path, backend_base_url="http://localhost:11434")
         assert not mgr._is_native("../../etc/passwd")
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -465,7 +465,7 @@ class TestConfigProvider:
 
             c = Config()
             assert c.llm_provider == "auto"
-            assert c.litellm_base_url == "http://localhost:11434"
+            assert c.backend_base_url == "http://localhost:11434"
             assert c.llm_api_key == ""
 
     def test_provider_env_override(self) -> None:
@@ -474,16 +474,16 @@ class TestConfigProvider:
         with mock.patch.dict(
             os.environ,
             {
-                "LILBEE_LLM_PROVIDER": "litellm",
-                "LILBEE_LITELLM_BASE_URL": "http://myhost:11434",
+                "LILBEE_LLM_PROVIDER": "backend",
+                "LILBEE_BACKEND_BASE_URL": "http://myhost:11434",
                 "LILBEE_LLM_API_KEY": "sk-key",
             },
         ):
             from lilbee.config import Config
 
             c = Config()
-            assert c.llm_provider == "litellm"
-            assert c.litellm_base_url == "http://myhost:11434"
+            assert c.llm_provider == "backend"
+            assert c.backend_base_url == "http://myhost:11434"
             assert c.llm_api_key == "sk-key"
 
     def test_models_dir_uses_canonical_location(self, tmp_path: Path) -> None:
@@ -784,10 +784,10 @@ class TestLitellmAvailable:
         from lilbee.providers.factory import create_provider
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
 
-        cfg.llm_provider = "litellm"
+        cfg.llm_provider = "backend"
         with (
             mock.patch.object(LitellmSdkBackend, "available", return_value=False),
-            pytest.raises(ProviderError, match="litellm is not installed"),
+            pytest.raises(ProviderError, match="SDK backend adapter is not installed"),
         ):
             create_provider(cfg)
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -465,7 +465,7 @@ class TestConfigProvider:
 
             c = Config()
             assert c.llm_provider == "auto"
-            assert c.backend_base_url == "http://localhost:11434"
+            assert c.remote_base_url == "http://localhost:11434"
             assert c.llm_api_key == ""
 
     def test_provider_env_override(self) -> None:
@@ -474,16 +474,16 @@ class TestConfigProvider:
         with mock.patch.dict(
             os.environ,
             {
-                "LILBEE_LLM_PROVIDER": "backend",
-                "LILBEE_BACKEND_BASE_URL": "http://myhost:11434",
+                "LILBEE_LLM_PROVIDER": "remote",
+                "LILBEE_REMOTE_BASE_URL": "http://myhost:11434",
                 "LILBEE_LLM_API_KEY": "sk-key",
             },
         ):
             from lilbee.config import Config
 
             c = Config()
-            assert c.llm_provider == "backend"
-            assert c.backend_base_url == "http://myhost:11434"
+            assert c.llm_provider == "remote"
+            assert c.remote_base_url == "http://myhost:11434"
             assert c.llm_api_key == "sk-key"
 
     def test_models_dir_uses_canonical_location(self, tmp_path: Path) -> None:
@@ -784,7 +784,7 @@ class TestLitellmAvailable:
         from lilbee.providers.factory import create_provider
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
 
-        cfg.llm_provider = "backend"
+        cfg.llm_provider = "remote"
         with (
             mock.patch.object(LitellmSdkBackend, "available", return_value=False),
             pytest.raises(ProviderError, match="SDK backend adapter is not installed"),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -824,10 +824,10 @@ class TestTemporalFilter:
         from datetime import UTC, datetime, timedelta
 
         recent = (datetime.now(UTC) - timedelta(days=5)).isoformat()
-        mock_svc.store.get_sources.return_value = [
-            {"filename": "old.md", "ingested_at": "2020-01-01T00:00:00+00:00"},
-            {"filename": "new.md", "ingested_at": recent},
-        ]
+        mock_svc.store.source_ingested_at_map.return_value = {
+            "old.md": "2020-01-01T00:00:00+00:00",
+            "new.md": recent,
+        }
         results = [
             _make_result(source="old.md"),
             _make_result(source="new.md"),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -367,6 +367,34 @@ class TestExpandQuery:
         mock_svc.provider.chat.return_value = iter(["stream"])
         assert get_services().searcher._expand_query("q", self._QUESTION_VEC) == []
 
+    def test_batches_llm_variants_in_one_call(self, mock_svc):
+        """LLM variants should embed via a single embed_batch call, not N embed calls."""
+        mock_svc.provider.chat.return_value = "variant one\nvariant two\nvariant three"
+        get_services().searcher._expand_query("q", self._QUESTION_VEC)
+        assert mock_svc.embedder.embed_batch.call_count >= 1
+        batch_call_args = mock_svc.embedder.embed_batch.call_args_list[0].args[0]
+        assert len(batch_call_args) == 3
+        # Single-shot embed must not be used for the variant loop.
+        mock_svc.embedder.embed.assert_not_called()
+
+    def test_batches_concept_expansion_separately(self, mock_svc):
+        """Concept-graph variants embed through embed_batch too (separate call
+        because they bypass guardrails and must come through after guardrails
+        apply to LLM variants)."""
+        old_concept = cfg.concept_graph
+        cfg.concept_graph = True
+        mock_svc.concepts.get_graph.return_value = True
+        mock_svc.concepts.expand_query.return_value = ["kubernetes", "scheduling"]
+        mock_svc.provider.chat.return_value = "restate one\nrestate two"
+        try:
+            get_services().searcher._expand_query("q", self._QUESTION_VEC)
+        finally:
+            cfg.concept_graph = old_concept
+        # Two sources (LLM + concepts) => exactly 2 batch calls.
+        assert mock_svc.embedder.embed_batch.call_count == 2
+        concept_batch = mock_svc.embedder.embed_batch.call_args_list[1].args[0]
+        assert concept_batch == ["kubernetes", "scheduling"]
+
 
 class TestAskRaw:
     def test_returns_structured_result(self, mock_svc):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -836,6 +836,13 @@ class TestTemporalFilter:
         assert any(r.source == "new.md" for r in filtered)
         assert not any(r.source == "old.md" for r in filtered)
 
+    def test_result_without_ingested_at_passes_through(self, mock_svc):
+        """Sources absent from the ingested_at map are kept (no date info = don't filter)."""
+        mock_svc.store.source_ingested_at_map.return_value = {}
+        results = [_make_result(source="mystery.md")]
+        filtered = get_services().searcher._apply_temporal_filter(results, "recent changes")
+        assert [r.source for r in filtered] == ["mystery.md"]
+
     def test_no_temporal_keyword_passes_through(self, mock_svc):
         results = [_make_result()]
         searcher = get_services().searcher
@@ -1016,6 +1023,20 @@ class TestConceptBoosting:
             assert results[0].distance == 0.5
         finally:
             cfg.query_expansion_count = 3
+
+    def test_boost_skipped_when_extract_returns_empty(self, mock_svc):
+        """extract_concepts returning no concepts short-circuits before boost_results."""
+        mock_svc.concepts.get_graph.return_value = True
+        mock_svc.concepts.extract_concepts.return_value = []
+        old = cfg.concept_graph
+        cfg.concept_graph = True
+        try:
+            results = [_make_result(source="a.md", distance=0.5)]
+            out = get_services().searcher._apply_concept_boost(results, "empty question")
+            assert out == results
+            mock_svc.concepts.boost_results.assert_not_called()
+        finally:
+            cfg.concept_graph = old
 
     def test_boost_failure_returns_original(self, mock_svc):
         mock_svc.store.search.return_value = [_make_result(distance=0.5)]

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -163,6 +163,18 @@ class TestReasoningTruncation:
         response = "".join(st.content for st in result if not st.is_reasoning)
         assert "the answer" in response
 
+    def test_drain_breaks_when_model_re_enters_thinking(self):
+        """After truncation, encountering a fresh <think> tag stops the drain."""
+        from lilbee.reasoning import _MAX_REASONING_CHARS
+
+        long_think = "x" * (_MAX_REASONING_CHARS + 500)
+        tokens = [f"<think>{long_think}", "</think>", "<think>", "more thinking"]
+        result = _collect(tokens, show=True)
+        response = "".join(st.content for st in result if not st.is_reasoning)
+        # The "more thinking" token arrives after the parser re-entered
+        # thinking mode; the drain breaks before it can leak as response.
+        assert "more thinking" not in response
+
     def test_runaway_reasoning_truncated_show_false(self):
         """Reasoning cap works even when show_reasoning=False.
 

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -163,16 +163,15 @@ class TestReasoningTruncation:
         response = "".join(st.content for st in result if not st.is_reasoning)
         assert "the answer" in response
 
-    def test_drain_breaks_when_model_re_enters_thinking(self):
-        """After truncation, encountering a fresh <think> tag stops the drain."""
+    def test_re_entered_thinking_is_not_yielded_as_response(self):
+        """After truncation, content the model emits inside a fresh <think>
+        tag is tagged as reasoning and excluded from the response stream."""
         from lilbee.reasoning import _MAX_REASONING_CHARS
 
         long_think = "x" * (_MAX_REASONING_CHARS + 500)
         tokens = [f"<think>{long_think}", "</think>", "<think>", "more thinking"]
         result = _collect(tokens, show=True)
         response = "".join(st.content for st in result if not st.is_reasoning)
-        # The "more thinking" token arrives after the parser re-entered
-        # thinking mode; the drain breaks before it can leak as response.
         assert "more thinking" not in response
 
     def test_runaway_reasoning_truncated_show_false(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -673,6 +673,24 @@ class TestWriteLatestAlias:
         registry.write_latest_alias(ref)
         assert not (tmp_path / "models" / "manifests").exists()
 
+    def test_invalidates_alias_cache(self, tmp_path: Path) -> None:
+        """Writing the :latest manifest must drop the cached alias index."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+        content = b"data"
+        blob_path = _create_hf_cache_structure(models_dir, "org/repo", content)
+        ref = ModelRef(name="the-model", tag="v1")
+        manifest = _make_manifest(name="the-model", tag="v1")
+        registry.install(ref, blob_path, manifest)
+
+        # Populate the alias cache by querying a miss.
+        assert registry._find_by_alias("nothing") is None
+        assert registry._alias_cache is not None
+
+        registry.write_latest_alias(ref)
+        assert registry._alias_cache is None
+
 
 class TestWriteManifestErrorPath:
     def test_temp_file_cleaned_up_on_replace_error(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -411,6 +411,16 @@ class TestModelRegistry:
         registry = ModelRegistry(models_dir)
         assert registry._find_by_alias("anything") is None
 
+    def test_find_by_alias_skips_corrupt_manifest(self, tmp_path: Path) -> None:
+        """Unreadable manifest files are skipped when building the alias index."""
+        models_dir = tmp_path / "models"
+        manifests_dir = models_dir / "manifests" / "corrupt-model"
+        manifests_dir.mkdir(parents=True)
+        (manifests_dir / "latest.json").write_text("{ not valid json")
+        registry = ModelRegistry(models_dir)
+        # No crash and no match (alias index is empty after skipping the bad file).
+        assert registry._find_by_alias("anything") is None
+
     def test_absorb_skips_corrupt_manifest(self, tmp_path: Path) -> None:
         """_absorb_conflicting_aliases ignores corrupt manifests."""
         models_dir = tmp_path / "models"

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -942,11 +942,11 @@ class TestModelsInstalled:
         mock_manager.list_installed.return_value = ["qwen3:8b", "mistral:7b"]
         from lilbee.model_manager import ModelSource
 
-        mock_manager.get_source.return_value = ModelSource.BACKEND
+        mock_manager.get_source.return_value = ModelSource.REMOTE
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             result = await handlers.models_installed()
         assert len(result.models) == 2
-        assert result.models[0].source == "backend"
+        assert result.models[0].source == "remote"
 
     async def test_unknown_source_defaults_to_litellm(self):
         mock_manager = MagicMock()
@@ -954,7 +954,7 @@ class TestModelsInstalled:
         mock_manager.get_source.return_value = None
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             result = await handlers.models_installed()
-        assert result.models[0].source == "backend"
+        assert result.models[0].source == "remote"
 
 
 class TestModelsPull:
@@ -986,7 +986,7 @@ class TestModelsPull:
 
         mock_manager.pull.side_effect = fake_pull
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
-            events = [e async for e in handlers.models_pull("test", source="backend")]
+            events = [e async for e in handlers.models_pull("test", source="remote")]
         non_empty = [e for e in events if e]
         assert any("downloading" in e for e in non_empty)
         assert any("success" in e for e in non_empty)
@@ -1032,7 +1032,7 @@ class TestModelsDelete:
         mock_manager = MagicMock()
         mock_manager.remove.return_value = True
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
-            result = await handlers.models_delete("test", source="backend")
+            result = await handlers.models_delete("test", source="remote")
         assert result.deleted is True
         assert result.model == "test"
 
@@ -1258,7 +1258,7 @@ class TestGetConfig:
         dumped = result.model_dump()
         assert "chat_model" in dumped
         assert "system_prompt" in dumped
-        assert "backend_base_url" in dumped
+        assert "remote_base_url" in dumped
         assert "diversity_max_per_source" in dumped
         assert "mmr_lambda" in dumped
         assert "query_expansion_count" in dumped
@@ -1674,10 +1674,10 @@ class TestListExternalModels:
     @patch("lilbee.server.handlers.get_services")
     async def test_cache_invalidates_on_config_change(self, mock_svc):
         mock_svc.return_value.provider.list_models.return_value = ["model-a"]
-        cfg.backend_base_url = "https://provider-a.example"
+        cfg.remote_base_url = "https://provider-a.example"
         await handlers.list_external_models()
 
-        cfg.backend_base_url = "https://provider-b.example"
+        cfg.remote_base_url = "https://provider-b.example"
         await handlers.list_external_models()
 
         assert mock_svc.return_value.provider.list_models.call_count == 2
@@ -1830,7 +1830,7 @@ class TestModelPullProgressCancel:
             patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager),
             patch.object(handlers.SseStream, "__init__", patched_init),
         ):
-            gen = handlers.models_pull("test", source="backend")
+            gen = handlers.models_pull("test", source="remote")
             events = []
             async for event in gen:
                 events.append(event)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -942,11 +942,11 @@ class TestModelsInstalled:
         mock_manager.list_installed.return_value = ["qwen3:8b", "mistral:7b"]
         from lilbee.model_manager import ModelSource
 
-        mock_manager.get_source.return_value = ModelSource.LITELLM
+        mock_manager.get_source.return_value = ModelSource.BACKEND
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             result = await handlers.models_installed()
         assert len(result.models) == 2
-        assert result.models[0].source == "litellm"
+        assert result.models[0].source == "backend"
 
     async def test_unknown_source_defaults_to_litellm(self):
         mock_manager = MagicMock()
@@ -954,7 +954,7 @@ class TestModelsInstalled:
         mock_manager.get_source.return_value = None
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
             result = await handlers.models_installed()
-        assert result.models[0].source == "litellm"
+        assert result.models[0].source == "backend"
 
 
 class TestModelsPull:
@@ -986,7 +986,7 @@ class TestModelsPull:
 
         mock_manager.pull.side_effect = fake_pull
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
-            events = [e async for e in handlers.models_pull("test", source="litellm")]
+            events = [e async for e in handlers.models_pull("test", source="backend")]
         non_empty = [e for e in events if e]
         assert any("downloading" in e for e in non_empty)
         assert any("success" in e for e in non_empty)
@@ -1032,7 +1032,7 @@ class TestModelsDelete:
         mock_manager = MagicMock()
         mock_manager.remove.return_value = True
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
-            result = await handlers.models_delete("test", source="litellm")
+            result = await handlers.models_delete("test", source="backend")
         assert result.deleted is True
         assert result.model == "test"
 
@@ -1258,7 +1258,7 @@ class TestGetConfig:
         dumped = result.model_dump()
         assert "chat_model" in dumped
         assert "system_prompt" in dumped
-        assert "litellm_base_url" in dumped
+        assert "backend_base_url" in dumped
         assert "diversity_max_per_source" in dumped
         assert "mmr_lambda" in dumped
         assert "query_expansion_count" in dumped
@@ -1630,10 +1630,10 @@ class TestListExternalModels:
     @patch("lilbee.server.handlers.get_services")
     async def test_cache_invalidates_on_config_change(self, mock_svc):
         mock_svc.return_value.provider.list_models.return_value = ["model-a"]
-        cfg.litellm_base_url = "https://provider-a.example"
+        cfg.backend_base_url = "https://provider-a.example"
         await handlers.list_external_models()
 
-        cfg.litellm_base_url = "https://provider-b.example"
+        cfg.backend_base_url = "https://provider-b.example"
         await handlers.list_external_models()
 
         assert mock_svc.return_value.provider.list_models.call_count == 2
@@ -1786,7 +1786,7 @@ class TestModelPullProgressCancel:
             patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager),
             patch.object(handlers.SseStream, "__init__", patched_init),
         ):
-            gen = handlers.models_pull("test", source="litellm")
+            gen = handlers.models_pull("test", source="backend")
             events = []
             async for event in gen:
                 events.append(event)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1276,42 +1276,86 @@ class TestGetConfig:
         assert "llm_api_key" not in dumped
 
 
+def _fake_source_store(mock_svc, all_sources: list[dict]) -> None:
+    """Wire mock_svc.store.get_sources + count_sources to simulate DB-side
+    pagination: filter by ``search`` against filename, then slice by
+    offset/limit. Mirrors the real LanceDB behavior so list_documents
+    tests don't have to special-case the mock call shape."""
+
+    def _filter(search):
+        if not search:
+            return list(all_sources)
+        search_lower = search.lower()
+        return [s for s in all_sources if search_lower in s["filename"].lower()]
+
+    def _get(*, search=None, limit=None, offset=0):
+        matches = _filter(search)
+        if limit is None:
+            return matches[offset:]
+        return matches[offset : offset + limit]
+
+    def _count(*, search=None):
+        return len(_filter(search))
+
+    mock_svc.store.get_sources.side_effect = _get
+    mock_svc.store.count_sources.side_effect = _count
+
+
 class TestListDocuments:
     async def test_returns_documents(self, mock_svc):
-        mock_svc.store.get_sources.return_value = [
-            {"filename": "a.md", "chunk_count": 5, "ingested_at": "2026-01-01"},
-        ]
+        _fake_source_store(
+            mock_svc,
+            [{"filename": "a.md", "chunk_count": 5, "ingested_at": "2026-01-01"}],
+        )
         result = await handlers.list_documents()
         assert result.total == 1
         assert result.documents[0].filename == "a.md"
         assert result.documents[0].chunk_count == 5
+        assert result.has_more is False
 
     async def test_empty(self, mock_svc):
-        mock_svc.store.get_sources.return_value = []
+        _fake_source_store(mock_svc, [])
         result = await handlers.list_documents()
         assert result.total == 0
         assert result.documents == []
+        assert result.has_more is False
 
     async def test_pagination(self, mock_svc):
-        mock_svc.store.get_sources.return_value = [
-            {"filename": f"doc{i}.md", "chunk_count": i} for i in range(10)
-        ]
+        _fake_source_store(
+            mock_svc,
+            [{"filename": f"doc{i}.md", "chunk_count": i} for i in range(10)],
+        )
         result = await handlers.list_documents(limit=3, offset=2)
         assert result.total == 10
         assert len(result.documents) == 3
         assert result.documents[0].filename == "doc2.md"
         assert result.limit == 3
         assert result.offset == 2
+        # offset + returned (2 + 3) == 5 < total 10 → more pages remain
+        assert result.has_more is True
+
+    async def test_pagination_final_page_clears_has_more(self, mock_svc):
+        _fake_source_store(
+            mock_svc,
+            [{"filename": f"doc{i}.md", "chunk_count": i} for i in range(10)],
+        )
+        result = await handlers.list_documents(limit=5, offset=5)
+        assert result.total == 10
+        assert result.has_more is False
 
     async def test_search_filter(self, mock_svc):
-        mock_svc.store.get_sources.return_value = [
-            {"filename": "readme.md", "chunk_count": 3},
-            {"filename": "setup.py", "chunk_count": 1},
-            {"filename": "readme_dev.md", "chunk_count": 2},
-        ]
+        _fake_source_store(
+            mock_svc,
+            [
+                {"filename": "readme.md", "chunk_count": 3},
+                {"filename": "setup.py", "chunk_count": 1},
+                {"filename": "readme_dev.md", "chunk_count": 2},
+            ],
+        )
         result = await handlers.list_documents(search="readme")
         assert result.total == 2
         assert all("readme" in d.filename for d in result.documents)
+        assert result.has_more is False
 
 
 class TestGetConfigReranker:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1343,6 +1343,21 @@ class TestListDocuments:
         assert result.total == 10
         assert result.has_more is False
 
+    async def test_empty_page_with_positive_total_is_not_has_more(self, mock_svc):
+        """Race guard: empty page alongside a non-zero total must not loop.
+
+        Happens when a concurrent writer mutates the SOURCES table
+        between count_sources() and get_sources(). Without the
+        ``len(page) > 0`` guard, a naive client reading has_more to
+        decide whether to keep fetching would spin past the end.
+        """
+        mock_svc.store.get_sources.return_value = []
+        mock_svc.store.count_sources.return_value = 42
+        result = await handlers.list_documents(limit=10, offset=0)
+        assert result.total == 42
+        assert result.documents == []
+        assert result.has_more is False
+
     async def test_search_filter(self, mock_svc):
         _fake_source_store(
             mock_svc,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -648,6 +648,45 @@ class TestCountSources:
         assert store.count_sources() == 0
 
 
+class TestSourceIngestedAtMap:
+    """Query-side temporal filter calls this per query; caching avoids
+    a fresh get_sources() materialization for every question."""
+
+    def test_returns_filename_to_ingested_at(self, store):
+        store.upsert_source("a.md", "h1", 1)
+        store.upsert_source("b.md", "h2", 1)
+        result = store.source_ingested_at_map()
+        assert set(result) == {"a.md", "b.md"}
+        assert all(v for v in result.values())
+
+    def test_cache_is_reused_until_mutation(self, store):
+        store.upsert_source("a.md", "h1", 1)
+        first = store.source_ingested_at_map()
+        # Same object identity means the cache served the call without
+        # a re-materialization pass over SOURCES.
+        assert store.source_ingested_at_map() is first
+
+    def test_upsert_invalidates_cache(self, store):
+        store.upsert_source("a.md", "h1", 1)
+        first = store.source_ingested_at_map()
+        store.upsert_source("b.md", "h2", 1)
+        second = store.source_ingested_at_map()
+        assert first is not second
+        assert "b.md" in second
+
+    def test_delete_invalidates_cache(self, store):
+        store.upsert_source("a.md", "h1", 1)
+        store.source_ingested_at_map()
+        store.delete_source("a.md")
+        assert store.source_ingested_at_map() == {}
+
+    def test_drop_all_invalidates_cache(self, store):
+        store.upsert_source("a.md", "h1", 1)
+        store.source_ingested_at_map()
+        store.drop_all()
+        assert store.source_ingested_at_map() == {}
+
+
 def _make_citation(**overrides) -> CitationRecord:
     defaults: CitationRecord = {
         "wiki_source": "wiki/summaries/doc.md",

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -596,6 +596,58 @@ class TestSourceTypeField:
         assert sources[0]["source_type"] == "wiki"
 
 
+class TestGetSourcesPagination:
+    """LanceDB-side limit/offset/search for /api/documents scalability."""
+
+    def _seed(self, store, n: int = 10) -> None:
+        for i in range(n):
+            store.upsert_source(f"doc{i:02d}.md", f"hash{i}", i + 1)
+
+    def test_no_args_returns_all(self, store):
+        self._seed(store, 5)
+        assert len(store.get_sources()) == 5
+
+    def test_limit_caps_returned_rows(self, store):
+        self._seed(store, 10)
+        assert len(store.get_sources(limit=3)) == 3
+
+    def test_offset_skips_leading_rows(self, store):
+        self._seed(store, 10)
+        filenames = {s["filename"] for s in store.get_sources(offset=5, limit=5)}
+        # Offset runs in LanceDB, so exactly 5 of the 10 come back.
+        assert len(filenames) == 5
+
+    def test_search_filters_by_filename_case_insensitive(self, store):
+        store.upsert_source("README.md", "h1", 1)
+        store.upsert_source("setup.py", "h2", 1)
+        store.upsert_source("readme_dev.md", "h3", 1)
+        matches = {s["filename"] for s in store.get_sources(search="readme")}
+        assert matches == {"README.md", "readme_dev.md"}
+
+    def test_search_and_limit_compose(self, store):
+        for i in range(20):
+            store.upsert_source(f"readme_{i}.md", f"h{i}", 1)
+        store.upsert_source("other.py", "h99", 1)
+        result = store.get_sources(search="readme", limit=5)
+        assert len(result) == 5
+
+
+class TestCountSources:
+    def test_count_matches_row_count(self, store):
+        for i in range(7):
+            store.upsert_source(f"doc{i}.md", f"h{i}", 1)
+        assert store.count_sources() == 7
+
+    def test_count_with_search_filter(self, store):
+        store.upsert_source("readme.md", "h1", 1)
+        store.upsert_source("setup.py", "h2", 1)
+        store.upsert_source("README_2.md", "h3", 1)
+        assert store.count_sources(search="readme") == 2
+
+    def test_count_empty_table_returns_zero(self, store):
+        assert store.count_sources() == 0
+
+
 def _make_citation(**overrides) -> CitationRecord:
     defaults: CitationRecord = {
         "wiki_source": "wiki/summaries/doc.md",

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -596,33 +596,6 @@ class TestSourceTypeField:
         assert sources[0]["source_type"] == "wiki"
 
 
-class TestSourceMtimeMigration:
-    """Existing stores predate source_mtime; column must be added in place."""
-
-    def test_legacy_schema_evolves_on_upsert(self, store):
-        import lancedb
-        import pyarrow as pa
-
-        from lilbee.store import SOURCES_TABLE, _ensure_source_mtime_column
-
-        legacy_schema = pa.schema(
-            [
-                pa.field("filename", pa.utf8()),
-                pa.field("file_hash", pa.utf8()),
-                pa.field("ingested_at", pa.utf8()),
-                pa.field("chunk_count", pa.int32()),
-                pa.field("source_type", pa.utf8()),
-            ]
-        )
-        db = lancedb.connect(store._config.lancedb_dir)
-        table = db.create_table(SOURCES_TABLE, schema=legacy_schema)
-        assert "source_mtime" not in table.schema.names
-
-        _ensure_source_mtime_column(table)
-
-        assert "source_mtime" in table.schema.names
-
-
 class TestGetSourcesPagination:
     """LanceDB-side limit/offset/search for /api/documents scalability."""
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -596,6 +596,33 @@ class TestSourceTypeField:
         assert sources[0]["source_type"] == "wiki"
 
 
+class TestSourceMtimeMigration:
+    """Existing stores predate source_mtime; column must be added in place."""
+
+    def test_legacy_schema_evolves_on_upsert(self, store):
+        import lancedb
+        import pyarrow as pa
+
+        from lilbee.store import SOURCES_TABLE, _ensure_source_mtime_column
+
+        legacy_schema = pa.schema(
+            [
+                pa.field("filename", pa.utf8()),
+                pa.field("file_hash", pa.utf8()),
+                pa.field("ingested_at", pa.utf8()),
+                pa.field("chunk_count", pa.int32()),
+                pa.field("source_type", pa.utf8()),
+            ]
+        )
+        db = lancedb.connect(store._config.lancedb_dir)
+        table = db.create_table(SOURCES_TABLE, schema=legacy_schema)
+        assert "source_mtime" not in table.schema.names
+
+        _ensure_source_mtime_column(table)
+
+        assert "source_mtime" in table.schema.names
+
+
 class TestGetSourcesPagination:
     """LanceDB-side limit/offset/search for /api/documents scalability."""
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -69,6 +69,67 @@ class TestEnsureFtsIndex:
             store.ensure_fts_index()
             assert not store._fts_ready
 
+    def test_second_call_optimizes_instead_of_rebuilding(self, store):
+        """Incremental path: once the FTS index exists, ensure_fts_index
+        calls table.optimize() rather than rebuilding from scratch. Prevents
+        O(total_chunks) rebuild cost on every sync."""
+        store.add_chunks(_make_records())
+        store.ensure_fts_index()
+        assert store._fts_ready
+
+        table = store.open_table("chunks")
+        assert table is not None
+        with (
+            mock.patch.object(type(table), "create_fts_index") as create_spy,
+            mock.patch.object(type(table), "optimize") as optimize_spy,
+        ):
+            store.ensure_fts_index()
+
+        create_spy.assert_not_called()
+        optimize_spy.assert_called_once()
+
+    def test_first_call_creates_without_replace(self, store):
+        """Fresh table goes through create_fts_index path with replace=False."""
+        store.add_chunks(_make_records())
+        table = store.open_table("chunks")
+        assert table is not None
+
+        with mock.patch.object(type(table), "create_fts_index") as create_spy:
+            store.ensure_fts_index()
+
+        create_spy.assert_called_once()
+        # Verify replace was NOT True (would defeat the purpose of incremental)
+        _args, kwargs = create_spy.call_args
+        assert kwargs.get("replace") is False
+
+
+class TestHasFtsIndex:
+    def test_returns_false_on_fresh_table(self, store):
+        store.add_chunks(_make_records())
+        from lilbee.store import _has_fts_index
+
+        table = store.open_table("chunks")
+        assert table is not None
+        assert _has_fts_index(table) is False
+
+    def test_returns_true_after_create(self, store):
+        store.add_chunks(_make_records())
+        store.ensure_fts_index()
+        from lilbee.store import _has_fts_index
+
+        table = store.open_table("chunks")
+        assert table is not None
+        assert _has_fts_index(table) is True
+
+    def test_returns_false_on_list_indices_error(self, store):
+        store.add_chunks(_make_records())
+        from lilbee.store import _has_fts_index
+
+        table = store.open_table("chunks")
+        assert table is not None
+        with mock.patch.object(type(table), "list_indices", side_effect=RuntimeError("boom")):
+            assert _has_fts_index(table) is False
+
 
 class TestFtsIndexStaleFlag:
     def test_add_chunks_marks_stale(self, store):

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4146,7 +4146,7 @@ def test_check_embedding_model_remote_available():
         assert not manager.is_installed(cfg.embedding_model)
 
         embed_base = cfg.embedding_model.split(":")[0]
-        remote_embeds = detect_remote_embedding_models(cfg.backend_base_url)
+        remote_embeds = detect_remote_embedding_models(cfg.remote_base_url)
         assert any(embed_base in name for name in remote_embeds)
 
 
@@ -4164,7 +4164,7 @@ def test_check_embedding_model_not_found():
         assert not manager.is_installed(cfg.embedding_model)
 
         embed_base = cfg.embedding_model.split(":")[0]
-        remote_embeds = detect_remote_embedding_models(cfg.backend_base_url)
+        remote_embeds = detect_remote_embedding_models(cfg.remote_base_url)
         assert not any(embed_base in name for name in remote_embeds)
         # Would call self.app.call_from_thread(self._show_setup_modal, remote_embeds)
 

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -462,6 +462,18 @@ class TestGroupRowsForGrid:
         assert len(sections[msg.HEADING_OUR_PICKS]) == 1
         assert len(sections[ModelTask.RERANK.capitalize()]) == 1
 
+    def test_unknown_task_gets_its_own_section(self) -> None:
+        """A row whose task is outside _TASK_BUCKET_ORDER still appears,
+        in a section after the known buckets — never silently dropped."""
+        from lilbee.cli.tui.screens.catalog import _group_rows_for_grid
+
+        row = self._row("experimental")  # type: ignore[arg-type]
+        sections = _group_rows_for_grid([row])
+        headings = [s.heading for s in sections]
+        assert "Experimental" in headings
+        experimental = next(s for s in sections if s.heading == "Experimental")
+        assert len(experimental.rows) == 1
+
 
 class SettingsTestApp(App[None]):
     CSS = ""

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4146,7 +4146,7 @@ def test_check_embedding_model_remote_available():
         assert not manager.is_installed(cfg.embedding_model)
 
         embed_base = cfg.embedding_model.split(":")[0]
-        remote_embeds = detect_remote_embedding_models(cfg.litellm_base_url)
+        remote_embeds = detect_remote_embedding_models(cfg.backend_base_url)
         assert any(embed_base in name for name in remote_embeds)
 
 
@@ -4164,7 +4164,7 @@ def test_check_embedding_model_not_found():
         assert not manager.is_installed(cfg.embedding_model)
 
         embed_base = cfg.embedding_model.split(":")[0]
-        remote_embeds = detect_remote_embedding_models(cfg.litellm_base_url)
+        remote_embeds = detect_remote_embedding_models(cfg.backend_base_url)
         assert not any(embed_base in name for name in remote_embeds)
         # Would call self.app.call_from_thread(self._show_setup_modal, remote_embeds)
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -539,7 +539,7 @@ class TestClassifyInstalledModels:
         )
         cfg.models_dir = tmp_path / "models"
         cfg.models_dir.mkdir()
-        cfg.litellm_base_url = "http://localhost:11434"
+        cfg.backend_base_url = "http://localhost:11434"
 
         with (
             mock.patch("lilbee.registry.ModelRegistry") as MockRegistry,
@@ -587,7 +587,7 @@ class TestClassifyInstalledModels:
         )
         cfg.models_dir = tmp_path / "models"
         cfg.models_dir.mkdir()
-        cfg.litellm_base_url = "http://localhost:11434"
+        cfg.backend_base_url = "http://localhost:11434"
 
         with (
             mock.patch("lilbee.registry.ModelRegistry") as MockRegistry,

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -539,7 +539,7 @@ class TestClassifyInstalledModels:
         )
         cfg.models_dir = tmp_path / "models"
         cfg.models_dir.mkdir()
-        cfg.backend_base_url = "http://localhost:11434"
+        cfg.remote_base_url = "http://localhost:11434"
 
         with (
             mock.patch("lilbee.registry.ModelRegistry") as MockRegistry,
@@ -587,7 +587,7 @@ class TestClassifyInstalledModels:
         )
         cfg.models_dir = tmp_path / "models"
         cfg.models_dir.mkdir()
-        cfg.backend_base_url = "http://localhost:11434"
+        cfg.remote_base_url = "http://localhost:11434"
 
         with (
             mock.patch("lilbee.registry.ModelRegistry") as MockRegistry,

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -242,6 +242,26 @@ class TestExtractPdfVision:
         assert len(result) == 1
         assert result[0][1] == "success text"
 
+    def test_bounded_inflight_drains_midloop(self, mock_provider) -> None:
+        """With concurrency=1, a 5-page PDF must drain inflight futures
+        mid-loop (max_inflight=2) instead of submitting all pages up-front.
+        Exercises the vision.py inflight-full branch."""
+        from lilbee.config import cfg
+
+        mock_iter = _mock_iterator(num_pages=5)
+        mock_provider.chat.return_value = "ok"
+        old_concurrency = cfg.vision_concurrency
+        cfg.vision_concurrency = 1
+        try:
+            with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
+                from lilbee.vision import extract_pdf_vision
+
+                result = extract_pdf_vision(Path("big.pdf"), "model", quiet=True)
+        finally:
+            cfg.vision_concurrency = old_concurrency
+        assert len(result) == 5
+        assert [page for page, _ in result] == [1, 2, 3, 4, 5]
+
     def test_skips_empty_text(self, mock_provider) -> None:
         mock_iter = _mock_iterator(num_pages=2)
         mock_provider.chat.side_effect = ["  \n  ", "real text"]

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -242,23 +242,19 @@ class TestExtractPdfVision:
         assert len(result) == 1
         assert result[0][1] == "success text"
 
-    def test_bounded_inflight_drains_midloop(self, mock_provider) -> None:
+    def test_bounded_inflight_drains_midloop(self, mock_provider, monkeypatch) -> None:
         """With concurrency=1, a 5-page PDF must drain inflight futures
         mid-loop (max_inflight=2) instead of submitting all pages up-front.
         Exercises the vision.py inflight-full branch."""
         from lilbee.config import cfg
 
+        monkeypatch.setattr(cfg, "vision_concurrency", 1)
         mock_iter = _mock_iterator(num_pages=5)
         mock_provider.chat.return_value = "ok"
-        old_concurrency = cfg.vision_concurrency
-        cfg.vision_concurrency = 1
-        try:
-            with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
-                from lilbee.vision import extract_pdf_vision
+        with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
+            from lilbee.vision import extract_pdf_vision
 
-                result = extract_pdf_vision(Path("big.pdf"), "model", quiet=True)
-        finally:
-            cfg.vision_concurrency = old_concurrency
+            result = extract_pdf_vision(Path("big.pdf"), "model", quiet=True)
         assert len(result) == 5
         assert [page for page, _ in result] == [1, 2, 3, 4, 5]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1609,15 +1609,15 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+backend = [
+    { name = "litellm" },
+]
 crawler = [
     { name = "crawl4ai" },
 ]
 graph = [
     { name = "graspologic-native" },
     { name = "spacy" },
-]
-litellm = [
-    { name = "litellm" },
 ]
 
 [package.dev-dependencies]
@@ -1645,7 +1645,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.11.0" },
     { name = "kreuzberg", specifier = ">=4.9.1" },
     { name = "lancedb" },
-    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.50" },
+    { name = "litellm", marker = "extra == 'backend'", specifier = ">=1.50" },
     { name = "litestar", specifier = ">=2.0" },
     { name = "llama-cpp-python" },
     { name = "mcp", specifier = ">=1.26.0" },
@@ -1660,7 +1660,7 @@ requires-dist = [
     { name = "typer" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
-provides-extras = ["litellm", "graph", "crawler"]
+provides-extras = ["backend", "graph", "crawler"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1609,15 +1609,15 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-backend = [
-    { name = "litellm" },
-]
 crawler = [
     { name = "crawl4ai" },
 ]
 graph = [
     { name = "graspologic-native" },
     { name = "spacy" },
+]
+remote = [
+    { name = "litellm" },
 ]
 
 [package.dev-dependencies]
@@ -1645,7 +1645,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.11.0" },
     { name = "kreuzberg", specifier = ">=4.9.1" },
     { name = "lancedb" },
-    { name = "litellm", marker = "extra == 'backend'", specifier = ">=1.50" },
+    { name = "litellm", marker = "extra == 'remote'", specifier = ">=1.50" },
     { name = "litestar", specifier = ">=2.0" },
     { name = "llama-cpp-python" },
     { name = "mcp", specifier = ">=1.26.0" },
@@ -1660,7 +1660,7 @@ requires-dist = [
     { name = "typer" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
-provides-extras = ["backend", "graph", "crawler"]
+provides-extras = ["remote", "graph", "crawler"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1616,7 +1616,7 @@ graph = [
     { name = "graspologic-native" },
     { name = "spacy" },
 ]
-remote = [
+litellm = [
     { name = "litellm" },
 ]
 
@@ -1645,7 +1645,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.11.0" },
     { name = "kreuzberg", specifier = ">=4.9.1" },
     { name = "lancedb" },
-    { name = "litellm", marker = "extra == 'remote'", specifier = ">=1.50" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.50" },
     { name = "litestar", specifier = ">=2.0" },
     { name = "llama-cpp-python" },
     { name = "mcp", specifier = ">=1.26.0" },
@@ -1660,7 +1660,7 @@ requires-dist = [
     { name = "typer" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
-provides-extras = ["remote", "graph", "crawler"]
+provides-extras = ["litellm", "graph", "crawler"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
A pass over `release/next` focused on the parts that get slow as the corpus, catalog, or UI fill up. No behavior changes beyond the one intentional rename called out below.

## Ingest and sync

- Sync no longer SHA-256s every file on every run. It skips files whose modification time is older than the last ingest — only the files that actually changed get hashed.
- The full-text search index updates incrementally instead of rebuilding from scratch on every sync with any change.

## Retrieval

- Query-side state that used to rebuild on every request (temporal source map, installed-model list, config defaults, the catalog lookup Pydantic fired on every config write) is now cached with proper invalidation.
- MMR rerank was recomputing similarity pairs it had already seen on each iteration. It's now a vectorized numpy pass.
- Query expansion and concept-graph traversal batch their work instead of issuing one round-trip per variant or per frontier node.
- The handful of LanceDB read paths that were scanning entire tables unnecessarily are bounded; a few that were flagged turned out to be bounded already and are closed with notes.

## Document API

- `GET /api/documents` no longer pulls the full source table into Python to paginate. Pagination, filter, and count all run in the database.
- The response now exposes `has_more`, matching the shape the catalog endpoint already ships.
- The paired Obsidian plugin bead for adopting `has_more` will land once this does.

## SDK naming (breaking)

The name of an internal dependency (`litellm`) was leaking through the public API. That's gone:

- `ModelSource.LITELLM` → `ModelSource.BACKEND` (wire value `"backend"`)
- `cfg.litellm_base_url` → `cfg.backend_base_url`; env var is now `LILBEE_BACKEND_BASE_URL`
- CLI `--source` and MCP tool docstrings updated accordingly
- The SDK exposes `active_backend_name(base_url)` so callers can show the real backend (Ollama, OpenAI) instead of the adapter's identity

No backwards-compat shim. Clients that hard-coded the old names need to update in lockstep.

## Crawler and vision

- Vision OCR on scanned PDFs runs pages concurrently behind a configurable semaphore instead of one-at-a-time.
- Crawler per-page writes no longer block the event loop.
- Per-page hash and filename get computed once instead of twice.

## TUI responsiveness

- Task Center stops polling at 10 Hz.
- Catalog list view stops remounting the entire list on every keystroke.
- Settings search stops re-walking the DOM per keystroke — this one had visible sluggishness in practice.
- Catalog grid grouping and search filter consolidated into single passes.
