### PR TITLE
Add pytest-timeout guardrail for CI diagnosis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dev = [
     "types-pyyaml>=6.0.12.20250915",
     "pytest-xdist>=3.8.0",
     "pytest-forked>=1.6.0",
+    "pytest-timeout>=2.3",
 ]
 
 [tool.pytest.ini_options]
@@ -86,6 +87,7 @@ pythonpath = [".", "tests"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = "--ignore=tests/integration"
+timeout = 60
 markers = [
     "slow: integration tests that download models or take >10s",
     "real_model_classify: opt out of the global _classify_installed_models mock",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,6 +29,17 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 DOCS_DIR = FIXTURES_DIR / "docs"
 TEST_DOCS = {f.name: f.read_text() for f in sorted(DOCS_DIR.iterdir()) if f.is_file()}
 
+# Integration tests run real LLM inference; the global 60s unit-test cap is too
+# aggressive. 180s is ~4x the slowest observed test on Metal. Any test exceeding
+# it on CPU-only CI runners is a hang, not a slow pass. Tests can opt in to a
+# different cap with @pytest.mark.timeout(X).
+_INTEGRATION_TIMEOUT_SECONDS = 180
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        item.add_marker(pytest.mark.timeout(_INTEGRATION_TIMEOUT_SECONDS))
+
 
 @pytest.fixture(autouse=True)
 def _preserve_models_dir():

--- a/uv.lock
+++ b/uv.lock
@@ -1629,6 +1629,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-forked" },
     { name = "pytest-httpserver" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "reportlab" },
     { name = "ruff" },
@@ -1671,6 +1672,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-forked", specifier = ">=1.6.0" },
     { name = "pytest-httpserver" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "reportlab" },
     { name = "ruff", specifier = ">=0.15.4" },
@@ -3035,6 +3037,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/17/ad187f46998814014f7cda309de700b87c0eb4b2e111e18bc8c819be7116/pytest_httpserver-1.1.5.tar.gz", hash = "sha256:dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1", size = 70974 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/df/0bdf90b84c6a586a9fd2b509523a3ab26b1cc1b1dba2fb62a32e4411ea9e/pytest_httpserver-1.1.5-py3-none-any.whl", hash = "sha256:ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a", size = 23330 },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Integration CI silently wedges for the full 90-minute runner budget with no stack trace or failing test name. Without a per-test timeout a single hung test eats the whole job and leaves zero diagnostic signal.

## What

Wire `pytest-timeout` into the test harness:

- 60s default for unit tests (well above the slowest legitimate case).
- 180s for anything under `tests/integration/` since real inference wants real headroom.
- Thread-based timeout method so Windows CI also dumps per-thread stacks on fire.

Individual tests can still opt into a higher cap with `@pytest.mark.timeout(X)` when they genuinely need it.