### PR TITLE
Run integration sync on the shared session loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dev = [
     "types-pyyaml>=6.0.12.20250915",
     "pytest-xdist>=3.8.0",
     "pytest-forked>=1.6.0",
+    "pytest-timeout>=2.3",
 ]
 
 [tool.pytest.ini_options]
@@ -86,6 +87,7 @@ pythonpath = [".", "tests"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = "--ignore=tests/integration"
+timeout = 60
 markers = [
     "slow: integration tests that download models or take >10s",
     "real_model_classify: opt out of the global _classify_installed_models mock",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,6 +29,17 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 DOCS_DIR = FIXTURES_DIR / "docs"
 TEST_DOCS = {f.name: f.read_text() for f in sorted(DOCS_DIR.iterdir()) if f.is_file()}
 
+# Integration tests run real LLM inference; the global 60s unit-test cap is too
+# aggressive. 180s is ~4x the slowest observed test on Metal. Any test exceeding
+# it on CPU-only CI runners is a hang, not a slow pass. Tests can opt in to a
+# different cap with @pytest.mark.timeout(X).
+_INTEGRATION_TIMEOUT_SECONDS = 180
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        item.add_marker(pytest.mark.timeout(_INTEGRATION_TIMEOUT_SECONDS))
+
 
 @pytest.fixture(autouse=True)
 def _preserve_models_dir():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -64,6 +64,21 @@ def _integration_loop():
         loop.close()
 
 
+@pytest.fixture
+def run_async(_integration_loop):
+    """Run a coroutine on the shared session loop.
+
+    Tests must NOT use asyncio.run() directly. A fresh loop tears down
+    call_soon_threadsafe plumbing that the llama-cpp provider's daemon-thread
+    embed/rerank workers depend on, wedging subsequent awaits on CPU-only CI.
+    """
+
+    def _run(coro):
+        return _integration_loop.run_until_complete(coro)
+
+    return _run
+
+
 @pytest.fixture(scope="session")
 def rag_pipeline(tmp_path_factory, _integration_loop):
     """Set up a real RAG pipeline with downloaded models and test documents.
@@ -96,6 +111,7 @@ def rag_pipeline(tmp_path_factory, _integration_loop):
     cfg.query_expansion_count = 0
     cfg.concept_graph = False
     cfg.hyde = False
+    cfg.wiki = False
     cfg.max_tokens = 512  # keep inference fast on slow CI runners
 
     reset_provider()

--- a/tests/integration/test_interactive_integration.py
+++ b/tests/integration/test_interactive_integration.py
@@ -11,7 +11,6 @@ in ~/.lilbee/models/ for subsequent runs.
 Marked @pytest.mark.slow -- excluded from default `make check`.
 """
 
-import asyncio
 import ipaddress
 import json
 import os
@@ -171,6 +170,7 @@ def isolated_env(tmp_path, real_models):
     cfg.concept_graph = False
     cfg.query_expansion_count = 0
     cfg.hyde = False
+    cfg.wiki = False
     cfg.max_tokens = 512
     cfg.chunk_size = 128
     cfg.chunk_overlap = 20
@@ -216,22 +216,31 @@ def _write_all_docs():
         (cfg.documents_dir / name).write_text(content)
 
 
-def _sync():
-    """Run real sync."""
+@pytest.fixture
+def sync_fn(run_async):
+    """Real ingest.sync wrapped to run on the shared session loop."""
     from lilbee.ingest import sync
 
-    return asyncio.run(sync(quiet=True))
+    def _run():
+        return run_async(sync(quiet=True))
+
+    return _run
 
 
-def _sync_with_docs():
-    """Write all docs and sync."""
-    _write_all_docs()
-    return _sync()
+@pytest.fixture
+def sync_with_docs(sync_fn):
+    """Write all test docs then sync."""
+
+    def _run():
+        _write_all_docs()
+        return sync_fn()
+
+    return _run
 
 
 class TestSearch:
-    def test_search_finds_exact_keyword(self, isolated_env):
-        _sync_with_docs()
+    def test_search_finds_exact_keyword(self, isolated_env, sync_with_docs):
+        sync_with_docs()
         result = runner.invoke(app, ["--json", "search", "Thunderbolt X500"])
         assert result.exit_code == 0, result.output
         data = _parse_json_output(result.output)
@@ -239,8 +248,8 @@ class TestSearch:
         sources = [r["source"] for r in results]
         assert any("specs.md" in s for s in sources), f"Expected specs.md in {sources}"
 
-    def test_search_finds_semantic(self, isolated_env):
-        _sync_with_docs()
+    def test_search_finds_semantic(self, isolated_env, sync_with_docs):
+        sync_with_docs()
         result = runner.invoke(app, ["--json", "search", "engine specifications"])
         assert result.exit_code == 0, result.output
         data = _parse_json_output(result.output)
@@ -251,16 +260,16 @@ class TestSearch:
 
 class TestAsk:
     @skip_if_small_chat_model
-    def test_ask_known_fact(self, isolated_env):
-        _sync_with_docs()
+    def test_ask_known_fact(self, isolated_env, sync_with_docs):
+        sync_with_docs()
         result = runner.invoke(app, ["--json", "ask", "What is the oil capacity?"])
         assert result.exit_code == 0, result.output
         data = _parse_json_output(result.output)
         answer = data.get("answer", "").lower()
         assert "6.5" in answer or "quart" in answer, f"Expected oil capacity in: {answer}"
 
-    def test_ask_includes_citations(self, isolated_env):
-        _sync_with_docs()
+    def test_ask_includes_citations(self, isolated_env, sync_with_docs):
+        sync_with_docs()
         result = runner.invoke(app, ["--json", "ask", "What is the oil capacity?"])
         assert result.exit_code == 0, result.output
         data = _parse_json_output(result.output)
@@ -272,8 +281,8 @@ class TestAsk:
 
 
 class TestDiversity:
-    def test_mmr_diverse_sources(self, isolated_env):
-        _sync_with_docs()
+    def test_mmr_diverse_sources(self, isolated_env, sync_with_docs):
+        sync_with_docs()
         result = runner.invoke(app, ["--json", "search", "authentication", "-k", "10"])
         assert result.exit_code == 0, result.output
         data = _parse_json_output(result.output)
@@ -283,8 +292,8 @@ class TestDiversity:
 
 
 class TestAddAndDelete:
-    def test_add_file_then_search(self, isolated_env):
-        _sync_with_docs()
+    def test_add_file_then_search(self, isolated_env, sync_with_docs):
+        sync_with_docs()
         external = isolated_env / "external.md"
         external.write_text(
             "# Zymurgy Reference\n\n"
@@ -299,8 +308,8 @@ class TestAddAndDelete:
         results = data.get("results", [])
         assert len(results) > 0, "Expected to find added document"
 
-    def test_delete_removes(self, isolated_env):
-        _sync_with_docs()
+    def test_delete_removes(self, isolated_env, sync_with_docs):
+        sync_with_docs()
         result = runner.invoke(app, ["remove", "specs.md"])
         assert result.exit_code == 0, result.output
 
@@ -315,19 +324,19 @@ class TestAddAndDelete:
 
 
 class TestSync:
-    def test_sync_idempotent(self, isolated_env):
+    def test_sync_idempotent(self, isolated_env, sync_fn):
         _write_all_docs()
-        r1 = _sync()
+        r1 = sync_fn()
         assert len(r1.added) > 0
 
-        r2 = _sync()
+        r2 = sync_fn()
         assert r2.added == [], f"Second sync should add nothing, got {r2.added}"
         assert r2.unchanged > 0
 
 
 class TestRebuild:
-    def test_rebuild_works(self, isolated_env):
-        _sync_with_docs()
+    def test_rebuild_works(self, isolated_env, sync_with_docs):
+        sync_with_docs()
         result = runner.invoke(app, ["rebuild"])
         assert result.exit_code == 0, result.output
 
@@ -339,8 +348,8 @@ class TestRebuild:
 
 
 class TestCodeSearch:
-    def test_code_search(self, isolated_env):
-        _sync_with_docs()
+    def test_code_search(self, isolated_env, sync_with_docs):
+        sync_with_docs()
         result = runner.invoke(app, ["--json", "search", "fibonacci"])
         assert result.exit_code == 0, result.output
         data = _parse_json_output(result.output)

--- a/tests/integration/test_rag_integration.py
+++ b/tests/integration/test_rag_integration.py
@@ -9,7 +9,6 @@ Run with:
 
 from __future__ import annotations
 
-import asyncio
 from collections import Counter
 
 import pytest
@@ -61,7 +60,7 @@ class TestPipelineBasics:
         assert len(vec) == cfg.embedding_dim
         assert any(v != 0.0 for v in vec)
 
-    def test_ingest_realistic_length_document(self, rag_pipeline):
+    def test_ingest_realistic_length_document(self, rag_pipeline, run_async):
         """Verify embedding works with realistic text lengths, not just short strings.
         Regression test: llama-cpp-python defaults n_batch=512, silently
         truncating embeddings. With multiple chunks exceeding this limit,
@@ -84,7 +83,7 @@ class TestPipelineBasics:
         ) * 10  # Repeat to ensure multiple chunks
 
         (docs_dir / "maintenance_guide.md").write_text(content)
-        result = asyncio.run(sync(quiet=True))
+        result = run_async(sync(quiet=True))
         assert len(result.failed) == 0, f"Ingest failed: {result}"
         assert len(result.added) > 0 or len(result.updated) > 0
 
@@ -210,7 +209,7 @@ class TestRegressionGuards:
                     # High distance = low relevance for cosine distance
                     assert r.distance > 0.1, "Unexpectedly close match for nonsense query"
 
-    def test_delete_removes_from_search(self, rag_pipeline):
+    def test_delete_removes_from_search(self, rag_pipeline, run_async):
         """Removing specs.md makes it unfindable."""
         s = get_services().store
         # Verify it's currently findable
@@ -226,17 +225,17 @@ class TestRegressionGuards:
         assert "specs.md" not in _source_names(after)
 
         # Re-add it for subsequent tests by re-syncing
-        asyncio.run(sync(quiet=True))
+        run_async(sync(quiet=True))
         s.ensure_fts_index()
 
-    def test_sync_idempotent(self, rag_pipeline):
+    def test_sync_idempotent(self, rag_pipeline, run_async):
         """Running sync twice produces the same chunk count."""
         s = get_services().store
         table = s.open_table("chunks")
         assert table is not None
         count_before = len(table.to_arrow().to_pylist())
 
-        asyncio.run(sync(quiet=True))
+        run_async(sync(quiet=True))
 
         table = s.open_table("chunks")
         assert table is not None
@@ -301,7 +300,7 @@ class TestConceptGraph:
     """Tests with concept_graph enabled — requires spacy and graspologic."""
 
     @pytest.fixture(autouse=True)
-    def _enable_concepts(self, rag_pipeline):
+    def _enable_concepts(self, rag_pipeline, run_async):
         spacy = pytest.importorskip("spacy")
         pytest.importorskip("graspologic_native")
         # Ensure the en_core_web_sm model is available
@@ -316,14 +315,14 @@ class TestConceptGraph:
 
         # Force rebuild so concept indexing runs for all files
         # (a plain sync skips unchanged files and never calls _index_concepts)
-        asyncio.run(sync(quiet=True, force_rebuild=True))
+        run_async(sync(quiet=True, force_rebuild=True))
 
         yield
 
         cfg.concept_graph = original
         reset_provider()
         # Re-sync without concepts to restore tables for subsequent tests
-        asyncio.run(sync(quiet=True, force_rebuild=True))
+        run_async(sync(quiet=True, force_rebuild=True))
 
     def test_concept_tables_exist(self, rag_pipeline):
         """After sync with concept_graph=True, concept tables exist in LanceDB."""

--- a/tests/integration/test_tui_integration.py
+++ b/tests/integration/test_tui_integration.py
@@ -48,6 +48,24 @@ async def _submit_slash(pilot, app, command: str) -> None:
     await pilot.pause()
 
 
+def _walk_tree_labels(node):
+    """Yield every node label in a Tree (for assertion lookups)."""
+    yield str(node.label)
+    for child in node.children:
+        yield from _walk_tree_labels(child)
+
+
+def _first_leaf_with_slug(node):
+    """Return the first Tree leaf whose data holds a page slug, or None."""
+    if node.data is not None and not node.allow_expand:
+        return node
+    for child in node.children:
+        found = _first_leaf_with_slug(child)
+        if found is not None:
+            return found
+    return None
+
+
 class TestChatFlow:
     """Real chat with streaming LLM response."""
 
@@ -317,16 +335,13 @@ class TestWikiScreen:
 
     async def test_wiki_screen_shows_generated_pages(self):
         """WikiScreen sidebar lists generated pages."""
-        from textual.widgets import OptionList
+        from textual.widgets import Tree
 
         app = _WikiApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            option_list = app.screen.query_one("#wiki-page-list", OptionList)
-            # Should have at least the two pages plus heading(s)
-            assert option_list.option_count >= 2
-            # Check that page titles appear (options include headings and pages)
-            labels = [str(o.prompt) for o in option_list._options]
+            tree = app.screen.query_one("#wiki-page-list", Tree)
+            labels = list(_walk_tree_labels(tree.root))
             assert any("Test Doc" in label for label in labels), (
                 f"Test doc not in sidebar: {labels}"
             )
@@ -336,20 +351,16 @@ class TestWikiScreen:
 
     async def test_wiki_screen_displays_content(self):
         """Selecting a page renders its markdown content."""
-        from textual.widgets import Markdown, OptionList
+        from textual.widgets import Markdown, Tree
 
         app = _WikiApp()
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
-            option_list = app.screen.query_one("#wiki-page-list", OptionList)
-            # Find the first non-disabled option (skip heading)
-            for i, opt in enumerate(option_list._options):
-                if not opt.disabled:
-                    option_list.highlighted = i
-                    await pilot.press("enter")
-                    break
+            tree = app.screen.query_one("#wiki-page-list", Tree)
+            leaf = _first_leaf_with_slug(tree.root)
+            assert leaf is not None, "No selectable wiki leaf found"
+            tree.post_message(Tree.NodeSelected(leaf))
             await pilot.pause()
             content = app.screen.query_one("#wiki-content", Markdown)
-            # The markdown widget should have rendered the page content
             rendered = str(content._markdown)
             assert len(rendered) > 0, "Wiki content area is empty after selecting a page"

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -1342,9 +1342,14 @@ class TestCatalogInteractions:
                 await pilot.pause()
                 await search.action_submit()
                 await app.workers.wait_for_complete()
-                await pilot.pause()
+                for _ in range(20):
+                    if "no-such-model-anywhere" in call_log:
+                        break
+                    await pilot.pause()
 
-                assert "no-such-model-anywhere" in call_log
+                assert "no-such-model-anywhere" in call_log, (
+                    f"search term never reached catalog after polling: {call_log}"
+                )
 
     async def test_trigger_remote_search_blocked_while_in_flight(self, _mock_resolve):
         """A second _trigger_remote_search while one is in flight is a no-op."""

--- a/uv.lock
+++ b/uv.lock
@@ -1629,6 +1629,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-forked" },
     { name = "pytest-httpserver" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "reportlab" },
     { name = "ruff" },
@@ -1671,6 +1672,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-forked", specifier = ">=1.6.0" },
     { name = "pytest-httpserver" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "reportlab" },
     { name = "ruff", specifier = ">=0.15.4" },
@@ -3035,6 +3037,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/17/ad187f46998814014f7cda309de700b87c0eb4b2e111e18bc8c819be7116/pytest_httpserver-1.1.5.tar.gz", hash = "sha256:dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1", size = 70974 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/df/0bdf90b84c6a586a9fd2b509523a3ab26b1cc1b1dba2fb62a32e4411ea9e/pytest_httpserver-1.1.5-py3-none-any.whl", hash = "sha256:ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a", size = 23330 },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Integration CI wedges on `test_ingest_realistic_length_document` on every Linux and Windows matrix job, yet the same suite passes locally on Metal in seconds. Cause: a handful of tests spin up fresh event loops inside the test body, which tears down plumbing that the llama-cpp background workers depend on. Subsequent awaits deadlock silently, and on CPU-only runners the race window is wide enough to hit every time.

## What

Expose the session-scoped event loop through a new `run_async` fixture and migrate every test-body call that was reaching for `asyncio.run(...)`. The interactive test module's sync helpers move from module-level functions to fixtures so they share the same loop. No production code changes.

Stacked on the `pytest-timeout` PR so that if any test still exceeds 180s on CI the guardrail names the offender with a stack trace instead of another silent wedge.