### PR TITLE
Index wiki pages + explicit wiki/raw scope on every surface

### DIFF
--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -48,6 +48,7 @@ from lilbee.crawler import CrawlerBrowserMissing, bootstrap_chromium, chromium_i
 from lilbee.progress import EventType, SetupProgressEvent
 from lilbee.providers.base import ProviderError
 from lilbee.services import get_services
+from lilbee.store import SearchScope, scope_to_chunk_type
 from lilbee.wiki.shared import (
     DRAFTS_SUBDIR,
     SUMMARIES_SUBDIR,
@@ -60,6 +61,13 @@ _ocr_timeout_option = typer.Option(
     None,
     "--ocr-timeout",
     help="Per-page timeout in seconds for vision OCR (default: 120, 0 = no limit).",
+)
+_scope_option = typer.Option(
+    SearchScope.BOTH,
+    "--scope",
+    "-s",
+    help="Restrict the pool to raw chunks, wiki pages, or both (default).",
+    case_sensitive=False,
 )
 
 
@@ -81,6 +89,7 @@ _paths_argument = typer.Argument(
 def search(
     query: str = typer.Argument(..., help="Search query"),
     top_k: int = typer.Option(None, "--top-k", "-k", help="Number of results"),
+    scope: SearchScope = _scope_option,
     data_dir: Path | None = data_dir_option,
     use_global: bool = global_option,
 ) -> None:
@@ -95,7 +104,11 @@ def search(
         raise SystemExit(1)
 
     try:
-        results = get_services().searcher.search(query, top_k=top_k or cfg.top_k)
+        results = get_services().searcher.search(
+            query,
+            top_k=top_k or cfg.top_k,
+            chunk_type=scope_to_chunk_type(scope),
+        )
     except Exception as exc:
         if cfg.json_mode:
             json_output({"error": str(exc)})
@@ -525,6 +538,7 @@ def remove(
 @app.command()
 def ask(
     question: str = typer.Argument(..., help="Question to ask"),
+    scope: SearchScope = _scope_option,
     data_dir: Path | None = data_dir_option,
     model: str | None = model_option,
     use_global: bool = global_option,
@@ -560,8 +574,10 @@ def ask(
         else:
             auto_sync(console)
 
+        chunk_type = scope_to_chunk_type(scope)
+
         if cfg.json_mode:
-            result = get_services().searcher.ask_raw(question)
+            result = get_services().searcher.ask_raw(question, chunk_type=chunk_type)
             json_output(
                 {
                     "command": "ask",
@@ -572,7 +588,7 @@ def ask(
             )
             return
 
-        for token in get_services().searcher.ask_stream(question):
+        for token in get_services().searcher.ask_stream(question, chunk_type=chunk_type):
             console.print(token.content, end="")
         console.print()
     except (RuntimeError, ProviderError) as exc:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -45,6 +45,7 @@ from lilbee.progress import EventType, ProgressEvent
 from lilbee.providers.model_ref import parse_model_ref
 from lilbee.query import ChatMessage
 from lilbee.services import get_services, reset_services
+from lilbee.store import scope_to_chunk_type
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.widgets.task_bar import TaskBarController
@@ -766,8 +767,6 @@ class ChatScreen(Screen[None]):
         (e.g. test apps).
         """
         from textual.css.query import NoMatches
-
-        from lilbee.store import scope_to_chunk_type
 
         try:
             bar = self.query_one("#model-bar", ModelBar)

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -756,10 +756,29 @@ class ChatScreen(Screen[None]):
         with self._history_lock:
             self._history.append({"role": "user", "content": text})
         self.streaming = True
-        self._stream_response(text, assistant_msg)
+        self._stream_response(text, assistant_msg, self._current_chunk_type())
+
+    def _current_chunk_type(self) -> str | None:
+        """Translate the ModelBar scope selection into a ``chunk_type`` arg.
+
+        Returns ``None`` for "both" (no filter) and the raw/wiki string
+        otherwise. Defaults to ``None`` when the ModelBar isn't mounted
+        (e.g. test apps).
+        """
+        from textual.css.query import NoMatches
+
+        from lilbee.store import scope_to_chunk_type
+
+        try:
+            bar = self.query_one("#model-bar", ModelBar)
+        except NoMatches:
+            return None
+        return scope_to_chunk_type(bar.scope)
 
     @work(thread=True)
-    def _stream_response(self, question: str, widget: AssistantMessage) -> None:
+    def _stream_response(
+        self, question: str, widget: AssistantMessage, chunk_type: str | None
+    ) -> None:
         """Stream LLM response in a background thread."""
         worker = _get_worker()
         response_parts: list[str] = []
@@ -769,7 +788,9 @@ class ChatScreen(Screen[None]):
         try:
             with self._history_lock:
                 history_snapshot = self._history[:-1]
-            stream = get_services().searcher.ask_stream(question, history=history_snapshot)
+            stream = get_services().searcher.ask_stream(
+                question, history=history_snapshot, chunk_type=chunk_type
+            )
             for token in stream:
                 if worker.is_cancelled:
                     break

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -21,6 +21,7 @@ from lilbee.model_manager import OLLAMA_PROVIDER_NAME
 from lilbee.models import ModelTask
 from lilbee.providers.model_ref import OLLAMA_PREFIX, parse_model_ref
 from lilbee.services import reset_services
+from lilbee.store import SearchScope
 
 log = logging.getLogger(__name__)
 
@@ -190,6 +191,14 @@ def _refresh_select_label(sel: Select, opts: list[ModelOption], value: str) -> N
 
 _SELECT_IDS = ("#chat-model-select", "#embed-model-select")
 
+# Presentation labels for the scope toggle. Values match ``SearchScope``
+# so the widget's ``.value`` feeds directly into ``scope_to_chunk_type``.
+_SCOPE_OPTIONS: tuple[tuple[str, str], ...] = (
+    ("Both", SearchScope.BOTH.value),
+    ("Wiki", SearchScope.WIKI.value),
+    ("Raw", SearchScope.RAW.value),
+)
+
 
 class ModelBar(Widget, can_focus=False):
     """Compact bar with Select dropdowns for active model assignments."""
@@ -226,6 +235,12 @@ class ModelBar(Widget, can_focus=False):
     def __init__(self, id: str | None = None) -> None:
         super().__init__(id=id)
         self._populating = True  # Guard against change events during init
+        self._scope: SearchScope = SearchScope.BOTH
+
+    @property
+    def scope(self) -> SearchScope:
+        """Current scope selection; consumed by ChatScreen when building RAG context."""
+        return self._scope
 
     def compose(self) -> ComposeResult:
         chat_opts = [(cfg.chat_model, cfg.chat_model)] if cfg.chat_model else []
@@ -245,6 +260,18 @@ class ModelBar(Widget, can_focus=False):
                 id="embed-model-select",
                 allow_blank=False,
             )
+            # Scope picker only appears when the wiki layer is on. With wiki
+            # off, ``CHUNKS_TABLE`` contains only raw rows so a wiki/raw/both
+            # toggle has nothing to pick between; hiding it keeps the choice
+            # from implying a capability the user hasn't opted into.
+            if cfg.wiki:
+                yield Static(pill("Scope", "$accent", "$text"), classes="model-bar-pill")
+                yield Select[str](
+                    options=list(_SCOPE_OPTIONS),
+                    value=SearchScope.BOTH.value,
+                    id="scope-select",
+                    allow_blank=False,
+                )
 
     def on_mount(self) -> None:
         chat_sel = self.query_one("#chat-model-select", Select)
@@ -314,6 +341,19 @@ class ModelBar(Widget, can_focus=False):
         cfg.embedding_model = value
         settings.set_value(cfg.data_root, "embedding_model", value)
         self._after_model_change()
+
+    @on(Select.Changed, "#scope-select")
+    def _on_scope_changed(self, event: Select.Changed) -> None:
+        """Track scope selection for the next ask_stream call.
+
+        Session-scoped on purpose; not written to settings so each new
+        session starts at "both" and the user opts into a narrower pool
+        explicitly each time.
+        """
+        value = self._extract_value(event)
+        if value is None:
+            return
+        self._scope = SearchScope(value)
 
     def _extract_value(self, event: Select.Changed) -> str | None:
         """Extract a non-empty value from a Select.Changed event, or None to skip."""

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -43,6 +43,7 @@ from lilbee.progress import (
 )
 from lilbee.security import validate_path_within
 from lilbee.services import get_services
+from lilbee.store import CHUNK_TYPE_RAW
 from lilbee.vision import extract_pdf_vision
 
 log = logging.getLogger(__name__)
@@ -91,6 +92,7 @@ class ChunkRecord(TypedDict):
 
     source: str
     content_type: str
+    chunk_type: str
     page_start: int
     page_end: int
     line_start: int
@@ -353,6 +355,7 @@ async def _vision_fallback(
         ChunkRecord(
             source=source_name,
             content_type=content_type,
+            chunk_type=CHUNK_TYPE_RAW,
             page_start=page_num,
             page_end=page_num,
             line_start=0,
@@ -460,6 +463,7 @@ async def ingest_document(
         ChunkRecord(
             source=source_name,
             content_type=content_type,
+            chunk_type=CHUNK_TYPE_RAW,
             page_start=chunk.metadata.get("first_page") or 0,
             page_end=chunk.metadata.get("last_page") or 0,
             line_start=0,
@@ -490,6 +494,7 @@ def ingest_code_sync(
         ChunkRecord(
             source=source_name,
             content_type="code",
+            chunk_type=CHUNK_TYPE_RAW,
             page_start=0,
             page_end=0,
             line_start=cc.line_start,
@@ -526,6 +531,7 @@ async def ingest_markdown(
         ChunkRecord(
             source=source_name,
             content_type="text",
+            chunk_type=CHUNK_TYPE_RAW,
             page_start=0,
             page_end=0,
             line_start=0,

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -29,14 +29,25 @@ mcp = FastMCP("lilbee", instructions="Local RAG knowledge base. Search indexed d
 
 
 @mcp.tool()
-def search(query: str, top_k: int = 5) -> list[dict[str, Any]] | dict[str, Any]:
+def search(
+    query: str, top_k: int = 5, scope: str = "both"
+) -> list[dict[str, Any]] | dict[str, Any]:
     """Search the knowledge base for relevant document chunks.
-    Returns chunks sorted by relevance. No LLM call -- uses pre-computed embeddings.
+
+    ``scope`` picks the pool: ``"raw"`` (source chunks), ``"wiki"`` (wiki
+    page bodies), or ``"both"`` (default, unfiltered). Returns chunks
+    sorted by relevance. No LLM call -- uses pre-computed embeddings.
     """
     if not query or not query.strip():
         return {"error": "query must not be empty"}
+    from lilbee.store import scope_to_chunk_type
+
     try:
-        results = get_services().searcher.search(query, top_k=top_k)
+        chunk_type = scope_to_chunk_type(scope)
+    except ValueError as exc:
+        return {"error": str(exc)}
+    try:
+        results = get_services().searcher.search(query, top_k=top_k, chunk_type=chunk_type)
         results = [r for r in results if r.distance is None or r.distance <= cfg.max_distance]
         return [clean(r) for r in results]
     except Exception as exc:

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -14,6 +14,7 @@ from lilbee.config import cfg
 from lilbee.crawl_task import get_task, start_crawl
 from lilbee.crawler import is_url, require_valid_crawl_url
 from lilbee.services import get_services, reset_services
+from lilbee.store import SearchScope, scope_to_chunk_type
 from lilbee.wiki.shared import (
     DRAFTS_SUBDIR,
     SUMMARIES_SUBDIR,
@@ -30,7 +31,7 @@ mcp = FastMCP("lilbee", instructions="Local RAG knowledge base. Search indexed d
 
 @mcp.tool()
 def search(
-    query: str, top_k: int = 5, scope: str = "both"
+    query: str, top_k: int = 5, scope: str = SearchScope.BOTH.value
 ) -> list[dict[str, Any]] | dict[str, Any]:
     """Search the knowledge base for relevant document chunks.
 
@@ -40,8 +41,6 @@ def search(
     """
     if not query or not query.strip():
         return {"error": "query must not be empty"}
-    from lilbee.store import scope_to_chunk_type
-
     try:
         chunk_type = scope_to_chunk_type(scope)
     except ValueError as exc:

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -234,42 +234,6 @@ def format_source(result: SearchChunk, citations: list[CitationRecord] | None = 
     return f"  → {source_display}"
 
 
-def _source_slug(source_name: str) -> str:
-    """Derive the wiki filename stem from a raw source name.
-    Mirrors the slug logic in gen.py: "subdir/doc.md" -> "subdir--doc".
-    """
-    return source_name.replace("/", "--").rsplit(".", 1)[0]
-
-
-def _wiki_covered_raw_sources(results: list[SearchChunk]) -> set[str]:
-    """Build a set of raw source names that have wiki coverage.
-    Wiki chunks have sources like "wiki/summaries/subdir--doc.md" while raw
-    chunks have sources like "subdir/doc.md". Match by comparing the wiki
-    file stem against the slug derived from the raw source name.
-    """
-    wiki_stems: set[str] = set()
-    for r in results:
-        if r.chunk_type == "wiki":
-            # "wiki/summaries/subdir--doc.md" -> "subdir--doc"
-            filename = r.source.rsplit("/", 1)[-1]
-            wiki_stems.add(filename.rsplit(".", 1)[0])
-    if not wiki_stems:
-        return set()
-    raw_covered: set[str] = set()
-    for r in results:
-        if r.chunk_type != "wiki" and _source_slug(r.source) in wiki_stems:
-            raw_covered.add(r.source)
-    return raw_covered
-
-
-def prefer_wiki(results: list[SearchChunk]) -> list[SearchChunk]:
-    """When both wiki and raw chunks exist for the same source, prefer wiki."""
-    covered = _wiki_covered_raw_sources(results)
-    if not covered:
-        return results
-    return [r for r in results if r.chunk_type == "wiki" or r.source not in covered]
-
-
 def deduplicate_sources(
     results: list[SearchChunk],
     max_citations: int = 5,
@@ -597,12 +561,14 @@ class Searcher:
         question: str,
         top_k: int = 0,
         history: list[ChatMessage] | None = None,
+        chunk_type: str | None = None,
     ) -> tuple[list[SearchChunk], list[ChatMessage]] | None:
-        """Build RAG context from search results."""
-        results = self.search(question, top_k=top_k)
-        mode, _ = self._parse_structured_query(question)
-        if mode is None and self._config.wiki:
-            results = prefer_wiki(results)
+        """Build RAG context from search results.
+
+        ``chunk_type`` restricts the pool to ``"raw"`` or ``"wiki"`` rows;
+        ``None`` (default) searches the mixed pool.
+        """
+        results = self.search(question, top_k=top_k, chunk_type=chunk_type)
         results = filter_results(
             results, self._config.max_distance, self._config.min_relevance_score
         )
@@ -647,6 +613,7 @@ class Searcher:
         top_k: int = 0,
         history: list[ChatMessage] | None = None,
         options: dict[str, Any] | None = None,
+        chunk_type: str | None = None,
     ) -> AskResult:
         """Ask a question and get a structured result."""
         if not self._embedder.embedding_available():
@@ -656,7 +623,7 @@ class Searcher:
             raw = str(self._provider.chat(provider_messages, options=opts or None) or "")
             clean = raw if self._config.show_reasoning else strip_reasoning(raw)
             return AskResult(answer=self._NO_EMBED_WARNING + clean, sources=[])
-        rag = self.build_rag_context(question, top_k=top_k, history=history)
+        rag = self.build_rag_context(question, top_k=top_k, history=history, chunk_type=chunk_type)
         if rag is None:
             return AskResult(
                 answer=self._NO_RESULTS_MESSAGE,
@@ -675,9 +642,12 @@ class Searcher:
         top_k: int = 0,
         history: list[ChatMessage] | None = None,
         options: dict[str, Any] | None = None,
+        chunk_type: str | None = None,
     ) -> str:
         """Ask a question and get a formatted answer with citations."""
-        result = self.ask_raw(question, top_k=top_k, history=history, options=options)
+        result = self.ask_raw(
+            question, top_k=top_k, history=history, options=options, chunk_type=chunk_type
+        )
         if not result.sources:
             return result.answer
         cited = _extract_cited_indices(result.answer)
@@ -693,6 +663,7 @@ class Searcher:
         top_k: int = 0,
         history: list[ChatMessage] | None = None,
         options: dict[str, Any] | None = None,
+        chunk_type: str | None = None,
     ) -> Generator[StreamToken, None, None]:
         """Stream answer tokens with citations appended at the end."""
         from lilbee.reasoning import StreamToken, filter_reasoning
@@ -716,7 +687,7 @@ class Searcher:
                     raw.close()
             return
 
-        rag = self.build_rag_context(question, top_k=top_k, history=history)
+        rag = self.build_rag_context(question, top_k=top_k, history=history, chunk_type=chunk_type)
         if rag is None:
             yield StreamToken(
                 content=self._NO_RESULTS_MESSAGE,

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -22,7 +22,14 @@ from lilbee.config import Config, cfg
 from lilbee.embedder import Embedder
 from lilbee.providers.base import LLMProvider
 from lilbee.reasoning import strip_reasoning
-from lilbee.store import CitationRecord, SearchChunk, Store, cosine_sim
+from lilbee.store import (
+    CHUNK_TYPE_RAW,
+    CHUNK_TYPE_WIKI,
+    CitationRecord,
+    SearchChunk,
+    Store,
+    cosine_sim,
+)
 
 log = logging.getLogger(__name__)
 
@@ -215,7 +222,7 @@ def format_source(result: SearchChunk, citations: list[CitationRecord] | None = 
     For wiki chunks, shows the wiki page path followed by indented transitive citations.
     """
     source_display = display_source_path(result.source)
-    if result.chunk_type == "wiki" and citations:
+    if result.chunk_type == CHUNK_TYPE_WIKI and citations:
         parts = [f"  → {source_display}"]
         for cit in citations:
             parts.append(_format_citation(cit))
@@ -465,13 +472,33 @@ class Searcher:
             log.debug("HyDE search failed", exc_info=True)
             return []
 
+    def _normalize_chunk_type(self, chunk_type: str | None) -> str | None:
+        """Drop ``chunk_type="wiki"`` when wiki generation is disabled.
+
+        With wiki off the chunks table contains only raw rows, so the
+        filter would return empty. Logging once keeps the surprise out
+        of the user's way while surfacing the misuse in logs.
+        """
+        if chunk_type == CHUNK_TYPE_WIKI and not self._config.wiki:
+            log.warning(
+                "wiki scope requested but wiki is disabled; searching the full pool instead"
+            )
+            return None
+        return chunk_type
+
     def _parse_structured_query(self, question: str) -> tuple[str | None, str]:
         for prefix in ("term:", "vec:", "hyde:", "wiki:", "raw:"):
             if question.strip().lower().startswith(prefix):
                 return prefix[:-1], question.strip()[len(prefix) :].strip()
         return None, question
 
-    def _search_structured(self, mode: str, query: str, top_k: int) -> list[SearchChunk]:
+    def _search_structured(
+        self,
+        mode: str,
+        query: str,
+        top_k: int,
+        chunk_type: str | None = None,
+    ) -> list[SearchChunk]:
         if mode == "term":
             return self._store.bm25_probe(query, top_k=top_k)
         if mode == "vec":
@@ -479,9 +506,13 @@ class Searcher:
             return self._store.search(query_vec, top_k=top_k, query_text=None)
         if mode == "hyde":
             return self._hyde_search(query, top_k)
-        if mode in ("wiki", "raw"):
+        if mode in (CHUNK_TYPE_WIKI, CHUNK_TYPE_RAW):
+            # Explicit ``chunk_type`` arg beats the prefix shortcut.
+            effective = chunk_type if chunk_type is not None else mode
             query_vec = self._embedder.embed(query)
-            return self._store.search(query_vec, top_k=top_k, query_text=query, chunk_type=mode)
+            return self._store.search(
+                query_vec, top_k=top_k, query_text=query, chunk_type=effective
+            )
         return []
 
     def select_context(
@@ -511,17 +542,28 @@ class Searcher:
         self,
         question: str,
         top_k: int = 0,
+        *,
         chunk_type: str | None = None,
     ) -> list[SearchChunk]:
         """Embed question and search with expansion, HyDE, and concept boost.
         Returns up to top_k*2 candidates for downstream filtering.
-        When *chunk_type* is set, only chunks of that type are returned.
+
+        When *chunk_type* is set (``"raw"`` or ``"wiki"``), only chunks of
+        that type are returned. An explicit ``chunk_type`` always wins
+        over the ``wiki:``/``raw:`` prefix shortcut in *question* so the
+        user-facing scope choice has the final say.
+
+        When ``chunk_type="wiki"`` but wiki generation is disabled on the
+        config, the filter is normalized to ``None`` (mixed pool) and a
+        warning is logged — with wiki off the chunks table has no wiki
+        rows, so honouring the filter would silently return zero results.
         """
         if top_k == 0:
             top_k = self._config.top_k
+        chunk_type = self._normalize_chunk_type(chunk_type)
         mode, clean_query = self._parse_structured_query(question)
         if mode is not None:
-            return self._search_structured(mode, clean_query, top_k)
+            return self._search_structured(mode, clean_query, top_k, chunk_type=chunk_type)
         query_vec = self._embedder.embed(question)
         results = self._store.search(
             query_vec,
@@ -561,6 +603,7 @@ class Searcher:
         question: str,
         top_k: int = 0,
         history: list[ChatMessage] | None = None,
+        *,
         chunk_type: str | None = None,
     ) -> tuple[list[SearchChunk], list[ChatMessage]] | None:
         """Build RAG context from search results.
@@ -613,6 +656,7 @@ class Searcher:
         top_k: int = 0,
         history: list[ChatMessage] | None = None,
         options: dict[str, Any] | None = None,
+        *,
         chunk_type: str | None = None,
     ) -> AskResult:
         """Ask a question and get a structured result."""
@@ -642,6 +686,7 @@ class Searcher:
         top_k: int = 0,
         history: list[ChatMessage] | None = None,
         options: dict[str, Any] | None = None,
+        *,
         chunk_type: str | None = None,
     ) -> str:
         """Ask a question and get a formatted answer with citations."""
@@ -663,6 +708,7 @@ class Searcher:
         top_k: int = 0,
         history: list[ChatMessage] | None = None,
         options: dict[str, Any] | None = None,
+        *,
         chunk_type: str | None = None,
     ) -> Generator[StreamToken, None, None]:
         """Stream answer tokens with citations appended at the end."""

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -358,10 +358,13 @@ async def chat(
     history: list[ChatMessage],
     top_k: int = 0,
     options: dict[str, Any] | None = None,
+    chunk_type: str | None = None,
 ) -> AskResponse:
     """Chat with history. Returns answer and sources."""
     opts = _resolve_generation_options(options)
-    result = get_services().searcher.ask_raw(question, top_k=top_k, history=history, options=opts)
+    result = get_services().searcher.ask_raw(
+        question, top_k=top_k, history=history, options=opts, chunk_type=chunk_type
+    )
     return AskResponse(
         answer=result.answer,
         sources=[CleanedChunk(**clean_result(s)) for s in result.sources],
@@ -373,9 +376,12 @@ def chat_stream(
     history: list[ChatMessage],
     top_k: int = 0,
     options: dict[str, Any] | None = None,
+    chunk_type: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """Yield SSE events with chat history support."""
-    return _stream_rag_response(question, history=history, top_k=top_k, options=options)
+    return _stream_rag_response(
+        question, history=history, top_k=top_k, options=options, chunk_type=chunk_type
+    )
 
 
 async def _run_sync_with_sentinel(sse: SseStream, enable_ocr: bool | None) -> SyncResult:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -251,12 +251,19 @@ async def search(q: str, top_k: int = 5, chunk_type: str | None = None) -> list[
     return group(results)
 
 
-async def ask(question: str, top_k: int = 0, options: dict[str, Any] | None = None) -> AskResponse:
+async def ask(
+    question: str,
+    top_k: int = 0,
+    options: dict[str, Any] | None = None,
+    chunk_type: str | None = None,
+) -> AskResponse:
     """One-shot RAG answer. Returns answer and sources."""
     if not question or not question.strip():
         raise ValueError("question must not be empty")
     opts = _resolve_generation_options(options)
-    result = get_services().searcher.ask_raw(question, top_k=top_k, options=opts)
+    result = get_services().searcher.ask_raw(
+        question, top_k=top_k, options=opts, chunk_type=chunk_type
+    )
     return AskResponse(
         answer=result.answer,
         sources=[CleanedChunk(**clean_result(s)) for s in result.sources],
@@ -298,11 +305,14 @@ async def _stream_rag_response(
     history: list[ChatMessage] | None = None,
     top_k: int = 0,
     options: dict[str, Any] | None = None,
+    chunk_type: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """Shared SSE streaming for ask_stream and chat_stream."""
     yield ""  # force generator
 
-    rag = get_services().searcher.build_rag_context(question, top_k=top_k, history=history)
+    rag = get_services().searcher.build_rag_context(
+        question, top_k=top_k, history=history, chunk_type=chunk_type
+    )
     if rag is None:
         yield sse_error("No relevant documents found.")
         return
@@ -334,10 +344,13 @@ async def _stream_rag_response(
 
 
 def ask_stream(
-    question: str, top_k: int = 0, options: dict[str, Any] | None = None
+    question: str,
+    top_k: int = 0,
+    options: dict[str, Any] | None = None,
+    chunk_type: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """Yield SSE events: token, sources, done."""
-    return _stream_rag_response(question, top_k=top_k, options=options)
+    return _stream_rag_response(question, top_k=top_k, options=options, chunk_type=chunk_type)
 
 
 async def chat(

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -16,6 +16,7 @@ class AskRequest(BaseModel):
     question: str
     top_k: int = Field(default=0, le=100)
     options: dict[str, Any] | None = None
+    chunk_type: str | None = None
 
 
 class ChatRequest(BaseModel):

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -26,6 +26,7 @@ class ChatRequest(BaseModel):
     history: list[ChatMessage] = []
     top_k: int = Field(default=0, le=100)
     options: dict[str, Any] | None = None
+    chunk_type: str | None = None
 
 
 class SyncRequest(BaseModel):

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -7,7 +7,27 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from lilbee.store import SearchScope
+
+_VALID_CHUNK_TYPES = frozenset({SearchScope.RAW.value, SearchScope.WIKI.value})
+
+
+def _validate_chunk_type(value: str | None) -> str | None:
+    """Reject unknown ``chunk_type`` values at the HTTP boundary.
+
+    Matches the CLI/MCP behaviour: only ``"raw"`` or ``"wiki"`` filter the
+    pool; everything else (including ``None`` and the UI-side ``"both"``)
+    means no filter.
+    """
+    if value is None or value == SearchScope.BOTH.value:
+        return None
+    if value not in _VALID_CHUNK_TYPES:
+        raise ValueError(
+            f"chunk_type must be one of 'raw', 'wiki', 'both', or omitted; got {value!r}"
+        )
+    return value
 
 
 class AskRequest(BaseModel):
@@ -18,6 +38,11 @@ class AskRequest(BaseModel):
     options: dict[str, Any] | None = None
     chunk_type: str | None = None
 
+    @field_validator("chunk_type")
+    @classmethod
+    def _check_chunk_type(cls, v: str | None) -> str | None:
+        return _validate_chunk_type(v)
+
 
 class ChatRequest(BaseModel):
     """Request body for /api/chat."""
@@ -27,6 +52,11 @@ class ChatRequest(BaseModel):
     top_k: int = Field(default=0, le=100)
     options: dict[str, Any] | None = None
     chunk_type: str | None = None
+
+    @field_validator("chunk_type")
+    @classmethod
+    def _check_chunk_type(cls, v: str | None) -> str | None:
+        return _validate_chunk_type(v)
 
 
 class SyncRequest(BaseModel):

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -16,6 +16,7 @@ from lilbee.server.models import (
     AskResponse,
     ChatRequest,
 )
+from lilbee.store import scope_to_chunk_type
 
 
 @get("/api/search")
@@ -26,6 +27,10 @@ async def search_route(
     chunk_type: str | None = Parameter(query="chunk_type", default=None),
 ) -> list[DocumentResult]:
     """Search indexed documents by semantic similarity. No LLM call required."""
+    try:
+        chunk_type = scope_to_chunk_type(chunk_type)
+    except ValueError as exc:
+        raise ValidationException(str(exc)) from exc
     try:
         return await handlers.search(q, top_k=top_k, chunk_type=chunk_type)
     except ValueError as exc:

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -42,6 +42,7 @@ async def ask_route(data: AskRequest) -> AskResponse:
             question=data.question,
             top_k=data.top_k,
             options=data.options,
+            chunk_type=data.chunk_type,
         )
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
@@ -57,6 +58,7 @@ async def ask_stream_route(data: AskRequest) -> Stream:
             question=data.question,
             top_k=data.top_k,
             options=data.options,
+            chunk_type=data.chunk_type,
         ),
         media_type="text/event-stream",
     )

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -75,6 +75,7 @@ async def chat_route(data: ChatRequest) -> AskResponse:
         history=history,
         top_k=data.top_k,
         options=data.options,
+        chunk_type=data.chunk_type,
     )
 
 
@@ -90,6 +91,7 @@ async def chat_stream_route(data: ChatRequest) -> Stream:
             history=history,
             top_k=data.top_k,
             options=data.options,
+            chunk_type=data.chunk_type,
         ),
         media_type="text/event-stream",
     )

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -262,23 +262,44 @@ def escape_sql_string(value: str) -> str:
     return value.replace("\\", "\\\\").replace("'", "''")
 
 
+def _chunk_type_predicate(chunk_type: str) -> str:
+    """SQL predicate that matches ``chunk_type`` while tolerating NULL rows.
+
+    Rows written before ``chunk_type`` was populated land as NULL. They
+    are semantically raw, so a ``'raw'`` filter still includes them; a
+    ``'wiki'`` filter excludes them.
+    """
+    escaped = escape_sql_string(chunk_type)
+    if chunk_type == CHUNK_TYPE_RAW:
+        return f"(chunk_type = '{escaped}' OR chunk_type IS NULL)"
+    return f"chunk_type = '{escaped}'"
+
+
 def _hybrid_search(
     table: lancedb.table.Table,
     query_text: str,
     query_vector: list[float],
     top_k: int,
+    chunk_type: str | None = None,
 ) -> list[SearchChunk]:
-    """Run hybrid (vector + FTS) search with RRF reranking."""
+    """Run hybrid (vector + FTS) search with RRF reranking.
+
+    When ``chunk_type`` is set, the predicate is pushed into the query so
+    the limit applies *after* the type filter. Post-filtering would
+    silently starve wiki-only queries whose matches live past the top-K
+    hybrid window.
+    """
     from lancedb.rerankers import RRFReranker
 
-    rows = (
+    query = (
         table.search(query_type="hybrid")
         .vector(query_vector)
         .text(query_text)
         .rerank(RRFReranker())
-        .limit(top_k)
-        .to_list()
     )
+    if chunk_type:
+        query = query.where(_chunk_type_predicate(chunk_type))
+    rows = query.limit(top_k).to_list()
     return [SearchChunk(**r) for r in rows]
 
 
@@ -425,17 +446,14 @@ class Store:
 
         if query_text and self._fts_ready:
             try:
-                results = _hybrid_search(table, query_text, query_vector, top_k)
-                if chunk_type:
-                    results = [r for r in results if r.chunk_type == chunk_type]
-                return results
+                return _hybrid_search(table, query_text, query_vector, top_k, chunk_type)
             except Exception:
                 log.debug("Hybrid search failed, falling back to vector-only", exc_info=True)
 
         candidate_k = top_k * self._config.candidate_multiplier
         query = table.search(query_vector).metric("cosine").limit(candidate_k)
         if chunk_type:
-            query = query.where(f"chunk_type = '{escape_sql_string(chunk_type)}'")
+            query = query.where(_chunk_type_predicate(chunk_type))
         rows = query.to_list()
         log.debug(
             "Vector search: query=%r, candidates=%d, max_distance=%.2f",

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -7,6 +7,7 @@ import math
 import threading
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
@@ -57,6 +58,33 @@ READ_CONSISTENCY_INTERVAL = timedelta(seconds=5)
 # pages written by the wiki producer; callers filter with ``Store.search(chunk_type=...)``.
 CHUNK_TYPE_RAW = "raw"
 CHUNK_TYPE_WIKI = "wiki"
+
+
+class SearchScope(StrEnum):
+    """What the user wants to search over.
+
+    Values are used as-is on CLI flags, MCP params, and HTTP query strings.
+    ``BOTH`` resolves to a ``None`` ``chunk_type`` (no filter); the two
+    others map 1:1 to the chunks-table values.
+    """
+
+    RAW = CHUNK_TYPE_RAW
+    WIKI = CHUNK_TYPE_WIKI
+    BOTH = "both"
+
+
+def scope_to_chunk_type(scope: SearchScope | str | None) -> str | None:
+    """Translate a user-facing scope into a ``Store.search`` ``chunk_type`` arg.
+
+    ``None``/``"both"`` → no filter. ``"raw"`` / ``"wiki"`` → the matching
+    chunks-table value. Raises ``ValueError`` on any other string.
+    """
+    if scope is None:
+        return None
+    normalized = SearchScope(scope)
+    if normalized is SearchScope.BOTH:
+        return None
+    return normalized.value
 
 
 class SearchChunk(BaseModel):

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -53,6 +53,11 @@ def install_lancedb_thread_error_suppressor() -> None:
 # on slow media (HDD) at the cost of serving slightly stale data.
 READ_CONSISTENCY_INTERVAL = timedelta(seconds=5)
 
+# Values for the ``chunk_type`` column. Everything goes in as raw except wiki
+# pages written by the wiki producer; callers filter with ``Store.search(chunk_type=...)``.
+CHUNK_TYPE_RAW = "raw"
+CHUNK_TYPE_WIKI = "wiki"
+
 
 class SearchChunk(BaseModel):
     """A search result from LanceDB.
@@ -64,13 +69,13 @@ class SearchChunk(BaseModel):
 
     source: str
     content_type: str
-    chunk_type: str = "raw"
+    chunk_type: str = CHUNK_TYPE_RAW
 
     @field_validator("chunk_type", mode="before")
     @classmethod
     def _coerce_none_chunk_type(cls, v: str | None) -> str:
         """LanceDB rows from before the chunk_type column was added return None."""
-        return v if v is not None else "raw"
+        return v if v is not None else CHUNK_TYPE_RAW
 
     page_start: int
     page_end: int

--- a/src/lilbee/wiki/citation.py
+++ b/src/lilbee/wiki/citation.py
@@ -92,7 +92,7 @@ def find_unmarked_claims(markdown: str) -> list[str]:
     Scans non-empty, non-metadata lines in the body (before the citation block).
     Returns the text of each unmarked line.
     """
-    body = _extract_body(markdown)
+    body = extract_body(markdown)
     lines = body.splitlines()
     unmarked: list[str] = []
     for line in lines:
@@ -132,7 +132,7 @@ def _body_end_before_citations(lines: list[str], block_start: int) -> int:
     return body_end
 
 
-def _extract_body(markdown: str) -> str:
+def extract_body(markdown: str) -> str:
     """Return markdown body: strip YAML frontmatter and citation block."""
     text = _strip_frontmatter(markdown)
     block_start = _find_citation_block_start(text)

--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -19,14 +19,24 @@ from operator import itemgetter
 from pathlib import Path
 from typing import cast
 
+from lilbee.chunk import chunk_text
 from lilbee.clustering import SourceClusterer
-from lilbee.config import Config, cfg
+from lilbee.config import CHUNKS_TABLE, Config, cfg
 from lilbee.ingest import file_hash
 from lilbee.providers.base import LLMProvider
 from lilbee.reasoning import strip_reasoning
-from lilbee.store import CitationRecord, SearchChunk, Store
+from lilbee.services import get_services
+from lilbee.store import (
+    CHUNK_TYPE_RAW,
+    CHUNK_TYPE_WIKI,
+    CitationRecord,
+    SearchChunk,
+    Store,
+    escape_sql_string,
+)
 from lilbee.wiki.citation import (
     ParsedCitation,
+    extract_body,
     parse_wiki_citations,
     render_citation_block,
     strip_citation_block,
@@ -491,6 +501,52 @@ def _assemble_content(
     return full
 
 
+def _index_wiki_page(
+    content: str,
+    target: PageTarget,
+    store: Store,
+    config: Config,
+) -> None:
+    """Chunk a wiki page body, embed it, and write rows with ``chunk_type="wiki"``.
+
+    Drafts and archive pages never enter the search pool. Stale rows for
+    the same ``wiki_source`` are cleared first so regeneration replaces
+    instead of accumulating.
+    """
+    if target.subdir not in WIKI_CONTENT_SUBDIRS:
+        return
+
+    body = extract_body(content).strip()
+    store.clear_table(
+        CHUNKS_TABLE,
+        f"source = '{escape_sql_string(target.wiki_source)}' AND chunk_type = '{CHUNK_TYPE_WIKI}'",
+    )
+    if not body:
+        return
+
+    chunks = chunk_text(body, mime_type="text/markdown", use_semantic=True)
+    if not chunks:
+        return
+
+    vectors = get_services().embedder.embed_batch(chunks)
+    records = [
+        {
+            "source": target.wiki_source,
+            "content_type": "text/markdown",
+            "chunk_type": CHUNK_TYPE_WIKI,
+            "page_start": 1,
+            "page_end": 1,
+            "line_start": 1,
+            "line_end": 1,
+            "chunk": text,
+            "chunk_index": idx,
+            "vector": vector,
+        }
+        for idx, (text, vector) in enumerate(zip(chunks, vectors, strict=True))
+    ]
+    store.add_chunks(records)
+
+
 def _persist_and_finalize(
     content: str,
     target: PageTarget,
@@ -499,7 +555,7 @@ def _persist_and_finalize(
     store: Store,
     config: Config,
 ) -> Path:
-    """Write page to disk, persist citations, update index and log."""
+    """Write page to disk, persist citations, index body chunks, update index and log."""
     page_path = _write_page(
         target.wiki_root, target.subdir, target.slug, content, config.wiki_drift_threshold
     )
@@ -507,6 +563,8 @@ def _persist_and_finalize(
         rec["wiki_source"] = target.wiki_source
     store.delete_citations_for_wiki(target.wiki_source)
     store.add_citations(verified)
+
+    _index_wiki_page(content, target, store, config)
 
     if config.wiki_prune_raw:
         for name in source_names:
@@ -812,7 +870,7 @@ def _gather_chunks_for_label(
         query_vector=vectors[0],
         top_k=pool_size,
         query_text=label,
-        chunk_type="raw",
+        chunk_type=CHUNK_TYPE_RAW,
     )
     if not candidates:
         return []

--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -501,17 +501,14 @@ def _assemble_content(
     return full
 
 
-def _index_wiki_page(
-    content: str,
-    target: PageTarget,
-    store: Store,
-    config: Config,
-) -> None:
+def _index_wiki_page(content: str, target: PageTarget, store: Store) -> None:
     """Chunk a wiki page body, embed it, and write rows with ``chunk_type="wiki"``.
 
     Drafts and archive pages never enter the search pool. Stale rows for
     the same ``wiki_source`` are cleared first so regeneration replaces
-    instead of accumulating.
+    instead of accumulating. Record shape matches the markdown-ingest
+    convention in ``ingest.py``: ``content_type="text"``, all four
+    page/line positions ``0`` (wiki pages are not paginated).
     """
     if target.subdir not in WIKI_CONTENT_SUBDIRS:
         return
@@ -532,12 +529,12 @@ def _index_wiki_page(
     records = [
         {
             "source": target.wiki_source,
-            "content_type": "text/markdown",
+            "content_type": "text",
             "chunk_type": CHUNK_TYPE_WIKI,
-            "page_start": 1,
-            "page_end": 1,
-            "line_start": 1,
-            "line_end": 1,
+            "page_start": 0,
+            "page_end": 0,
+            "line_start": 0,
+            "line_end": 0,
             "chunk": text,
             "chunk_index": idx,
             "vector": vector,
@@ -564,7 +561,7 @@ def _persist_and_finalize(
     store.delete_citations_for_wiki(target.wiki_source)
     store.add_citations(verified)
 
-    _index_wiki_page(content, target, store, config)
+    _index_wiki_page(content, target, store)
 
     if config.wiki_prune_raw:
         for name in source_names:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -809,6 +809,30 @@ class TestSearch:
         assert "error" in data
         mock_svc.searcher.search.assert_not_called()
 
+    def test_search_scope_wiki_passes_wiki_chunk_type(self, mock_svc):
+        mock_svc.searcher.search.return_value = []
+        result = runner.invoke(app, ["search", "--scope", "wiki", "q"])
+        assert result.exit_code == 0
+        assert mock_svc.searcher.search.call_args.kwargs.get("chunk_type") == "wiki"
+
+    def test_search_scope_raw_passes_raw_chunk_type(self, mock_svc):
+        mock_svc.searcher.search.return_value = []
+        result = runner.invoke(app, ["search", "--scope", "raw", "q"])
+        assert result.exit_code == 0
+        assert mock_svc.searcher.search.call_args.kwargs.get("chunk_type") == "raw"
+
+    def test_search_default_scope_is_mixed_pool(self, mock_svc):
+        """Omitting --scope means chunk_type=None (both)."""
+        mock_svc.searcher.search.return_value = []
+        result = runner.invoke(app, ["search", "q"])
+        assert result.exit_code == 0
+        assert mock_svc.searcher.search.call_args.kwargs.get("chunk_type") is None
+
+    def test_search_invalid_scope_exits_nonzero(self, mock_svc):
+        result = runner.invoke(app, ["search", "--scope", "bogus", "q"])
+        assert result.exit_code != 0
+        mock_svc.searcher.search.assert_not_called()
+
     def test_search_json_provider_error(self, mock_svc):
         mock_svc.searcher.search.side_effect = RuntimeError("provider down")
         result = runner.invoke(app, ["--json", "search", "test"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -271,6 +271,42 @@ class TestAsk:
         result = runner.invoke(app, ["ask", "question", "--model", "llama3"])
         assert result.exit_code == 0
 
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_scope_wiki_reaches_ask_stream(self, mock_sync, mock_svc):
+        mock_svc.searcher.ask_stream.return_value = _mock_stream("a")
+        result = runner.invoke(app, ["ask", "--scope", "wiki", "q"])
+        assert result.exit_code == 0
+        assert mock_svc.searcher.ask_stream.call_args.kwargs.get("chunk_type") == "wiki"
+
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_scope_raw_reaches_ask_stream(self, mock_sync, mock_svc):
+        mock_svc.searcher.ask_stream.return_value = _mock_stream("a")
+        result = runner.invoke(app, ["ask", "--scope", "raw", "q"])
+        assert result.exit_code == 0
+        assert mock_svc.searcher.ask_stream.call_args.kwargs.get("chunk_type") == "raw"
+
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_default_scope_is_mixed_pool(self, mock_sync, mock_svc):
+        mock_svc.searcher.ask_stream.return_value = _mock_stream("a")
+        result = runner.invoke(app, ["ask", "q"])
+        assert result.exit_code == 0
+        assert mock_svc.searcher.ask_stream.call_args.kwargs.get("chunk_type") is None
+
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_invalid_scope_exits_nonzero(self, mock_sync, mock_svc):
+        result = runner.invoke(app, ["ask", "--scope", "bogus", "q"])
+        assert result.exit_code != 0
+        mock_svc.searcher.ask_stream.assert_not_called()
+
+    @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_json_scope_reaches_ask_raw(self, mock_sync, mock_svc):
+        from lilbee.query import AskResult
+
+        mock_svc.searcher.ask_raw.return_value = AskResult(answer="a", sources=[])
+        result = runner.invoke(app, ["--json", "ask", "--scope", "wiki", "q"])
+        assert result.exit_code == 0
+        assert mock_svc.searcher.ask_raw.call_args.kwargs.get("chunk_type") == "wiki"
+
 
 class TestDataDirFlag:
     def test_status_with_data_dir(self, tmp_path):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -130,7 +130,7 @@ class TestSearch:
         assert len(results) == 1
         assert "vector" not in results[0]
         assert results[0]["distance"] == 0.3
-        mock_svc.searcher.search.assert_called_once_with("test query", top_k=3)
+        mock_svc.searcher.search.assert_called_once_with("test query", top_k=3, chunk_type=None)
 
     def test_empty_results(self, mock_svc):
         mock_svc.searcher.search.return_value = []
@@ -151,6 +151,26 @@ class TestSearch:
         result = search("test", top_k=3)
         assert "error" in result
         assert "embed failed" in result["error"]
+
+    def test_scope_wiki_filters_to_wiki_chunks(self, mock_svc):
+        mock_svc.searcher.search.return_value = []
+        search("q", top_k=3, scope="wiki")
+        mock_svc.searcher.search.assert_called_once_with("q", top_k=3, chunk_type="wiki")
+
+    def test_scope_raw_filters_to_raw_chunks(self, mock_svc):
+        mock_svc.searcher.search.return_value = []
+        search("q", top_k=3, scope="raw")
+        mock_svc.searcher.search.assert_called_once_with("q", top_k=3, chunk_type="raw")
+
+    def test_scope_both_means_no_filter(self, mock_svc):
+        mock_svc.searcher.search.return_value = []
+        search("q", top_k=3, scope="both")
+        mock_svc.searcher.search.assert_called_once_with("q", top_k=3, chunk_type=None)
+
+    def test_invalid_scope_returns_error(self, mock_svc):
+        result = search("q", top_k=3, scope="bogus")
+        assert "error" in result
+        mock_svc.searcher.search.assert_not_called()
 
     def test_filters_irrelevant_results(self, mock_svc):
         """Results with distance > max_distance are excluded."""

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -253,7 +253,7 @@ class TestDiversifySources:
 
         Per-source cap keys on the exact ``source`` string. A wiki page
         paraphrasing ``doc.md`` becomes ``wiki/summaries/doc.md`` in the
-        store, which is a distinct source — so the cap applies to each
+        store, which is a distinct source. So the cap applies to each
         side independently. With ``max_per_source=1`` both sides still
         surface together.
         """
@@ -1184,13 +1184,13 @@ class TestFormatSourceWiki:
 class TestChunkTypeScope:
     """build_rag_context and ask_stream forward ``chunk_type`` to the store search.
 
-    This replaced the former implicit ``prefer_wiki`` pass: callers (CLI
-    --scope, MCP scope, HTTP chunk_type, TUI toggle, Obsidian toggle)
-    always choose raw/wiki/both explicitly.
+    Replaced the former implicit pool preference. Callers (CLI --scope,
+    MCP scope, HTTP chunk_type, TUI toggle) always choose raw/wiki/both
+    explicitly.
     """
 
     def test_build_rag_context_default_is_mixed_pool(self, mock_svc):
-        """No ``chunk_type`` arg means no filter — both sides survive."""
+        """No ``chunk_type`` arg means no filter. Both sides survive."""
         wiki_chunk = _make_result(source="wiki/summaries/doc.md", chunk_type="wiki")
         raw_chunk = _make_result(source="doc.md", chunk_type="raw")
         mock_svc.store.search.return_value = [wiki_chunk, raw_chunk]
@@ -1227,6 +1227,51 @@ class TestChunkTypeScope:
         mock_svc.provider.chat.return_value = iter(["answer"])
         tokens = list(get_services().searcher.ask_stream("question", chunk_type="wiki"))
         assert tokens  # stream produced something
+        kwargs = mock_svc.store.search.call_args.kwargs
+        assert kwargs.get("chunk_type") == "wiki"
+
+
+class TestNormalizeChunkType:
+    """Wiki-scope requests normalize to no-filter when wiki generation is off.
+
+    Keeps the CLI/MCP/HTTP experience honest (no silent empty results)
+    and mirrors the TUI hiding the toggle altogether.
+    """
+
+    def test_wiki_scope_with_wiki_disabled_normalizes_to_none(self, mock_svc, caplog):
+        cfg.wiki = False
+        try:
+            mock_svc.store.search.return_value = []
+            get_services().searcher.search("q", chunk_type="wiki")
+            kwargs = mock_svc.store.search.call_args.kwargs
+            assert kwargs.get("chunk_type") is None
+            assert any("wiki is disabled" in r.message for r in caplog.records)
+        finally:
+            cfg.wiki = True
+
+    def test_raw_scope_with_wiki_disabled_unchanged(self, mock_svc):
+        cfg.wiki = False
+        try:
+            mock_svc.store.search.return_value = []
+            get_services().searcher.search("q", chunk_type="raw")
+            kwargs = mock_svc.store.search.call_args.kwargs
+            assert kwargs.get("chunk_type") == "raw"
+        finally:
+            cfg.wiki = True
+
+
+class TestStructuredQueryScopeInteraction:
+    """Explicit ``chunk_type`` beats the ``wiki:``/``raw:`` prefix shortcut."""
+
+    def test_explicit_chunk_type_overrides_wiki_prefix(self, mock_svc):
+        mock_svc.store.search.return_value = []
+        get_services().searcher.search("wiki: energy", chunk_type="raw")
+        kwargs = mock_svc.store.search.call_args.kwargs
+        assert kwargs.get("chunk_type") == "raw"
+
+    def test_wiki_prefix_alone_still_filters_to_wiki(self, mock_svc):
+        mock_svc.store.search.return_value = []
+        get_services().searcher.search("wiki: energy")
         kwargs = mock_svc.store.search.call_args.kwargs
         assert kwargs.get("chunk_type") == "wiki"
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -13,7 +13,6 @@ from lilbee.query import (
     deduplicate_sources,
     filter_results,
     format_source,
-    prefer_wiki,
     sort_by_relevance,
     strip_llm_citations,
 )
@@ -1162,88 +1161,54 @@ class TestFormatSourceWiki:
         assert "wiki/summaries/doc.md" in result.replace("\\", "/")
 
 
-class TestPreferWiki:
-    def test_prefers_wiki_over_raw(self):
-        results = [
-            _make_result(source="wiki/summaries/doc.md", chunk_type="wiki"),
-            _make_result(source="doc.md", chunk_type="raw"),
-        ]
-        filtered = prefer_wiki(results)
-        assert len(filtered) == 1
-        assert filtered[0].chunk_type == "wiki"
+class TestChunkTypeScope:
+    """build_rag_context and ask_stream forward ``chunk_type`` to the store search.
 
-    def test_keeps_raw_when_no_wiki(self):
-        results = [
-            _make_result(source="doc.md", chunk_type="raw"),
-            _make_result(source="other.md", chunk_type="raw"),
-        ]
-        assert prefer_wiki(results) == results
+    This replaced the former implicit ``prefer_wiki`` pass: callers (CLI
+    --scope, MCP scope, HTTP chunk_type, TUI toggle, Obsidian toggle)
+    always choose raw/wiki/both explicitly.
+    """
 
-    def test_keeps_raw_without_wiki_coverage(self):
-        results = [
-            _make_result(source="wiki/summaries/doc.md", chunk_type="wiki"),
-            _make_result(source="other.md", chunk_type="raw"),
-        ]
-        filtered = prefer_wiki(results)
-        assert len(filtered) == 2
-
-    def test_empty_input(self):
-        assert prefer_wiki([]) == []
-
-    def test_nested_path_matching(self):
-        """Raw source "subdir/doc.md" maps to wiki slug "subdir--doc"."""
-        results = [
-            _make_result(source="wiki/summaries/subdir--doc.md", chunk_type="wiki"),
-            _make_result(source="subdir/doc.md", chunk_type="raw"),
-        ]
-        filtered = prefer_wiki(results)
-        assert len(filtered) == 1
-        assert filtered[0].chunk_type == "wiki"
-
-    def test_deeply_nested_path_matching(self):
-        """Raw source "a/b/c.md" maps to wiki slug "a--b--c"."""
-        results = [
-            _make_result(source="wiki/summaries/a--b--c.md", chunk_type="wiki"),
-            _make_result(source="a/b/c.md", chunk_type="raw"),
-        ]
-        filtered = prefer_wiki(results)
-        assert len(filtered) == 1
-        assert filtered[0].chunk_type == "wiki"
-
-
-class TestPreferWikiGuard:
-    """prefer_wiki should only run in build_rag_context when wiki is enabled."""
-
-    def test_prefer_wiki_skipped_when_wiki_disabled(self, mock_svc):
+    def test_build_rag_context_default_is_mixed_pool(self, mock_svc):
+        """No ``chunk_type`` arg means no filter — both sides survive."""
         wiki_chunk = _make_result(source="wiki/summaries/doc.md", chunk_type="wiki")
         raw_chunk = _make_result(source="doc.md", chunk_type="raw")
         mock_svc.store.search.return_value = [wiki_chunk, raw_chunk]
-        old_wiki = cfg.wiki
-        cfg.wiki = False
-        try:
-            result = get_services().searcher.build_rag_context("question")
-            assert result is not None
-            chunks, _ = result
-            # Both chunks survive — prefer_wiki was NOT applied
-            assert len(chunks) == 2
-        finally:
-            cfg.wiki = old_wiki
+        result = get_services().searcher.build_rag_context("question")
+        assert result is not None
+        chunks, _ = result
+        assert len(chunks) == 2
 
-    def test_prefer_wiki_applied_when_wiki_enabled(self, mock_svc):
-        wiki_chunk = _make_result(source="wiki/summaries/doc.md", chunk_type="wiki")
-        raw_chunk = _make_result(source="doc.md", chunk_type="raw")
-        mock_svc.store.search.return_value = [wiki_chunk, raw_chunk]
-        old_wiki = cfg.wiki
-        cfg.wiki = True
-        try:
-            result = get_services().searcher.build_rag_context("question")
-            assert result is not None
-            chunks, _ = result
-            # Only wiki chunk survives — prefer_wiki removed the raw duplicate
-            assert len(chunks) == 1
-            assert chunks[0].chunk_type == "wiki"
-        finally:
-            cfg.wiki = old_wiki
+    def test_build_rag_context_forwards_chunk_type_to_store(self, mock_svc):
+        mock_svc.store.search.return_value = []
+        get_services().searcher.build_rag_context("question", chunk_type="wiki")
+        assert mock_svc.store.search.called
+        kwargs = mock_svc.store.search.call_args.kwargs
+        assert kwargs.get("chunk_type") == "wiki"
+
+    def test_ask_raw_forwards_chunk_type(self, mock_svc):
+        mock_svc.store.search.return_value = [_make_result(source="doc.md", chunk_type="raw")]
+        mock_svc.provider.chat.return_value = "answer"
+        get_services().searcher.ask_raw("question", chunk_type="raw")
+        kwargs = mock_svc.store.search.call_args.kwargs
+        assert kwargs.get("chunk_type") == "raw"
+
+    def test_ask_forwards_chunk_type(self, mock_svc):
+        mock_svc.store.search.return_value = [_make_result(source="doc.md", chunk_type="raw")]
+        mock_svc.provider.chat.return_value = "answer"
+        get_services().searcher.ask("question", chunk_type="raw")
+        kwargs = mock_svc.store.search.call_args.kwargs
+        assert kwargs.get("chunk_type") == "raw"
+
+    def test_ask_stream_forwards_chunk_type(self, mock_svc):
+        mock_svc.store.search.return_value = [
+            _make_result(source="wiki/summaries/doc.md", chunk_type="wiki")
+        ]
+        mock_svc.provider.chat.return_value = iter(["answer"])
+        tokens = list(get_services().searcher.ask_stream("question", chunk_type="wiki"))
+        assert tokens  # stream produced something
+        kwargs = mock_svc.store.search.call_args.kwargs
+        assert kwargs.get("chunk_type") == "wiki"
 
 
 class TestStructuredQueryWikiRaw:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -248,6 +248,26 @@ class TestDiversifySources:
         diverse = diversify_sources(results)
         assert len(diverse) == 3
 
+    def test_wiki_and_raw_with_same_stem_are_independent_sources(self):
+        """``wiki/summaries/doc.md`` and ``doc.md`` keep separate caps.
+
+        Per-source cap keys on the exact ``source`` string. A wiki page
+        paraphrasing ``doc.md`` becomes ``wiki/summaries/doc.md`` in the
+        store, which is a distinct source — so the cap applies to each
+        side independently. With ``max_per_source=1`` both sides still
+        surface together.
+        """
+        from lilbee.query import diversify_sources
+
+        results = [
+            _make_result(source="wiki/summaries/doc.md", chunk_type="wiki", distance=0.1),
+            _make_result(source="doc.md", chunk_type="raw", distance=0.2),
+            _make_result(source="doc.md", chunk_type="raw", distance=0.3),
+        ]
+        diverse = diversify_sources(results, max_per_source=1)
+        assert len(diverse) == 2
+        assert {r.chunk_type for r in diverse} == {"wiki", "raw"}
+
 
 class TestBuildContext:
     def test_numbers_chunks(self):

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -164,3 +164,42 @@ class TestRerankerBlendPositions:
         with _patch_provider(lambda query, cands: [0.1, 0.9]):
             reranked = r.rerank("test", results)
         assert reranked[0].chunk == "high rerank"
+
+
+class TestMixedPoolBias:
+    """A mixed wiki+raw pool shouldn't drop one side entirely when the
+    reranker returns ambiguous scores. Regression guard against a future
+    reranker model that happened to score markdown differently from
+    plain text.
+    """
+
+    def _wiki_chunk(self, source: str, text: str, relevance: float) -> SearchChunk:
+        return SearchChunk(
+            source=source,
+            content_type="text/markdown",
+            chunk_type="wiki",
+            page_start=1,
+            page_end=1,
+            line_start=1,
+            line_end=1,
+            chunk=text,
+            chunk_index=0,
+            vector=[0.1],
+            relevance_score=relevance,
+        )
+
+    def test_ambiguous_scores_keep_both_sides(self, reranker):
+        cfg.reranker_model = "test"
+        results = [
+            self._wiki_chunk("wiki/summaries/a.md", "wiki a", relevance=0.5),
+            _chunk("a.md", "raw a", relevance=0.5),
+            self._wiki_chunk("wiki/summaries/b.md", "wiki b", relevance=0.5),
+            _chunk("b.md", "raw b", relevance=0.5),
+        ]
+        # Identical provider scores — tie-break falls to blended fusion
+        # weighting; no systematic wiki or raw bias should drop either.
+        with _patch_provider(lambda query, cands: [0.5] * len(cands)):
+            reranked = reranker.rerank("query", results)
+        assert len(reranked) == 4
+        chunk_types = {r.chunk_type for r in reranked}
+        assert chunk_types == {"wiki", "raw"}

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -196,7 +196,7 @@ class TestMixedPoolBias:
             self._wiki_chunk("wiki/summaries/b.md", "wiki b", relevance=0.5),
             _chunk("b.md", "raw b", relevance=0.5),
         ]
-        # Identical provider scores — tie-break falls to blended fusion
+        # Identical provider scores. Tie-break falls to blended fusion
         # weighting; no systematic wiki or raw bias should drop either.
         with _patch_provider(lambda query, cands: [0.5] * len(cands)):
             reranked = reranker.rerank("query", results)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -303,7 +303,7 @@ class TestChat:
         result = await handlers.chat("follow up", history)
         assert result.answer == "ok"
         mock_svc.searcher.ask_raw.assert_called_once_with(
-            "follow up", top_k=0, history=history, options=None
+            "follow up", top_k=0, history=history, options=None, chunk_type=None
         )
 
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -201,6 +201,13 @@ class TestAsk:
         with pytest.raises(ValueError, match="question must not be empty"):
             await handlers.ask("   ")
 
+    async def test_forwards_chunk_type_to_searcher(self, mock_svc):
+        from lilbee.query import AskResult
+
+        mock_svc.searcher.ask_raw.return_value = AskResult(answer="a", sources=[])
+        await handlers.ask("q", chunk_type="wiki")
+        assert mock_svc.searcher.ask_raw.call_args.kwargs.get("chunk_type") == "wiki"
+
 
 class TestAskStream:
     async def test_no_results_yields_error(self, mock_svc):
@@ -221,6 +228,12 @@ class TestAskStream:
         assert "token" in event_types
         assert "sources" in event_types
         assert "done" in event_types
+
+    async def test_forwards_chunk_type_to_build_rag_context(self, mock_svc):
+        mock_svc.searcher.build_rag_context.return_value = None
+        async for _ in handlers.ask_stream("q", chunk_type="wiki"):
+            pass
+        assert mock_svc.searcher.build_rag_context.call_args.kwargs.get("chunk_type") == "wiki"
 
     async def test_provider_error_yields_error_event(self, mock_svc):
         mock_svc.searcher.build_rag_context.return_value = _rag_return()
@@ -306,6 +319,13 @@ class TestChat:
             "follow up", top_k=0, history=history, options=None, chunk_type=None
         )
 
+    async def test_forwards_chunk_type(self, mock_svc):
+        from lilbee.query import AskResult
+
+        mock_svc.searcher.ask_raw.return_value = AskResult(answer="ok", sources=[])
+        await handlers.chat("q", [], chunk_type="raw")
+        assert mock_svc.searcher.ask_raw.call_args.kwargs.get("chunk_type") == "raw"
+
 
 class TestChatStream:
     async def test_no_results_yields_error(self, mock_svc):
@@ -324,6 +344,12 @@ class TestChatStream:
         event_types = [e.split("\n")[0].replace("event: ", "") for e in non_empty]
         assert "token" in event_types
         assert "done" in event_types
+
+    async def test_forwards_chunk_type_to_build_rag_context(self, mock_svc):
+        mock_svc.searcher.build_rag_context.return_value = None
+        async for _ in handlers.chat_stream("q", [], chunk_type="raw"):
+            pass
+        assert mock_svc.searcher.build_rag_context.call_args.kwargs.get("chunk_type") == "raw"
 
     async def test_provider_error_yields_error_event(self, mock_svc):
         mock_svc.searcher.build_rag_context.return_value = _rag_return()

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -91,6 +91,10 @@ class TestSearchRoute:
         client.get("/api/search", params={"q": "x"})
         mock_search.assert_awaited_once_with("x", top_k=5, chunk_type=None)
 
+    def test_invalid_chunk_type_rejected_with_400(self, client):
+        resp = client.get("/api/search", params={"q": "x", "chunk_type": "bogus"})
+        assert resp.status_code == 400
+
 
 class TestAskRoute:
     @mock.patch(

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -102,7 +102,9 @@ class TestAskRoute:
         resp = client.post("/api/ask", json={"question": "meaning?"})
         assert resp.status_code == 201
         assert resp.json()["answer"] == "42"
-        mock_ask.assert_awaited_once_with(question="meaning?", top_k=0, options=None)
+        mock_ask.assert_awaited_once_with(
+            question="meaning?", top_k=0, options=None, chunk_type=None
+        )
 
     @mock.patch(
         "lilbee.server.handlers.ask",
@@ -112,7 +114,7 @@ class TestAskRoute:
     def test_forwards_top_k(self, mock_ask, client):
         resp = client.post("/api/ask", json={"question": "q", "top_k": 10})
         assert resp.status_code == 201
-        mock_ask.assert_awaited_once_with(question="q", top_k=10, options=None)
+        mock_ask.assert_awaited_once_with(question="q", top_k=10, options=None, chunk_type=None)
 
     @mock.patch(
         "lilbee.server.handlers.ask",
@@ -142,6 +144,16 @@ class TestAskRoute:
         assert sources[0]["source"] == "doc.pdf"
         assert sources[0]["distance"] == 0.1
 
+    @mock.patch(
+        "lilbee.server.handlers.ask",
+        new_callable=AsyncMock,
+        return_value={"answer": "yes", "sources": []},
+    )
+    def test_forwards_chunk_type_raw(self, mock_ask, client):
+        resp = client.post("/api/ask", json={"question": "q", "chunk_type": "raw"})
+        assert resp.status_code == 201
+        assert mock_ask.call_args.kwargs.get("chunk_type") == "raw"
+
 
 class TestAskStreamRoute:
     @mock.patch("lilbee.server.handlers.ask_stream")
@@ -151,6 +163,13 @@ class TestAskStreamRoute:
         assert resp.status_code == 201
         assert "text/event-stream" in resp.headers["content-type"]
         assert b"event: token" in resp.content
+
+    @mock.patch("lilbee.server.handlers.ask_stream")
+    def test_forwards_chunk_type(self, mock_stream, client):
+        mock_stream.return_value = mock_async_gen("")
+        resp = client.post("/api/ask/stream", json={"question": "hi", "chunk_type": "wiki"})
+        assert resp.status_code == 201
+        assert mock_stream.call_args.kwargs.get("chunk_type") == "wiki"
 
 
 class TestChatRoute:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -154,6 +154,20 @@ class TestAskRoute:
         assert resp.status_code == 201
         assert mock_ask.call_args.kwargs.get("chunk_type") == "raw"
 
+    @mock.patch(
+        "lilbee.server.handlers.ask",
+        new_callable=AsyncMock,
+        return_value={"answer": "yes", "sources": []},
+    )
+    def test_chunk_type_both_normalizes_to_none(self, mock_ask, client):
+        resp = client.post("/api/ask", json={"question": "q", "chunk_type": "both"})
+        assert resp.status_code == 201
+        assert mock_ask.call_args.kwargs.get("chunk_type") is None
+
+    def test_invalid_chunk_type_rejected_with_400(self, client):
+        resp = client.post("/api/ask", json={"question": "q", "chunk_type": "bogus"})
+        assert resp.status_code == 400
+
 
 class TestAskStreamRoute:
     @mock.patch("lilbee.server.handlers.ask_stream")

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -182,7 +182,9 @@ class TestChatRoute:
         history = [{"role": "user", "content": "hi"}]
         resp = client.post("/api/chat", json={"question": "q", "history": history})
         assert resp.status_code == 201
-        mock_chat.assert_awaited_once_with(question="q", history=history, top_k=0, options=None)
+        mock_chat.assert_awaited_once_with(
+            question="q", history=history, top_k=0, options=None, chunk_type=None
+        )
 
     @mock.patch(
         "lilbee.server.handlers.chat",
@@ -191,7 +193,9 @@ class TestChatRoute:
     )
     def test_default_empty_history(self, mock_chat, client):
         client.post("/api/chat", json={"question": "q"})
-        mock_chat.assert_awaited_once_with(question="q", history=[], top_k=0, options=None)
+        mock_chat.assert_awaited_once_with(
+            question="q", history=[], top_k=0, options=None, chunk_type=None
+        )
 
 
 class TestChatStreamRoute:
@@ -204,6 +208,16 @@ class TestChatStreamRoute:
         )
         assert resp.status_code == 201
         assert b"event: done" in resp.content
+
+    @mock.patch("lilbee.server.handlers.chat_stream")
+    def test_forwards_chunk_type(self, mock_stream, client):
+        mock_stream.return_value = mock_async_gen("")
+        resp = client.post(
+            "/api/chat/stream",
+            json={"question": "hi", "history": [], "chunk_type": "raw"},
+        )
+        assert resp.status_code == 201
+        assert mock_stream.call_args.kwargs.get("chunk_type") == "raw"
 
 
 class TestSyncRoute:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -263,8 +263,8 @@ class TestMMRRerank:
     def test_wiki_paraphrase_near_duplicate_diversified_out(self):
         """Wiki paraphrase lands near its raw source in vector space; MMR
         drops one of them at ``top_k=2`` in favour of a clearly different
-        candidate. Whichever side wins is acceptable — "always a choice"
-        means neither is preferred by default; diversity should simply
+        candidate. Whichever side wins is acceptable (always a choice:
+        neither is preferred by default) so diversity should simply
         do its job on near-duplicates regardless of ``chunk_type``.
 
         The query is at ``[1, 1]/√2`` so both the near-dup cluster on
@@ -314,7 +314,7 @@ class TestMMRRerank:
         )
         selected = mmr_rerank(query, [wiki_chunk, raw_duplicate, distinct], top_k=2, mmr_lambda=0.5)
         sources = {r.source for r in selected}
-        # The orthogonal chunk must appear — it's the diversity win.
+        # The orthogonal chunk must appear. That's the diversity win.
         assert "other.md" in sources
         # Only one of the two near-duplicates survives.
         dup_count = sum(1 for r in selected if r.source in ("wiki/summaries/doc.md", "doc.md"))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -813,3 +813,21 @@ class TestScopeResolution:
     def test_invalid_scope_raises(self):
         with pytest.raises(ValueError):
             scope_to_chunk_type("bogus")
+
+
+class TestChunkTypePredicate:
+    """The SQL predicate for scope filtering tolerates NULL for raw."""
+
+    def test_raw_matches_null_for_legacy_rows(self):
+        from lilbee.store import _chunk_type_predicate
+
+        pred = _chunk_type_predicate("raw")
+        assert "IS NULL" in pred
+        assert "'raw'" in pred
+
+    def test_wiki_does_not_match_null(self):
+        from lilbee.store import _chunk_type_predicate
+
+        pred = _chunk_type_predicate("wiki")
+        assert "IS NULL" not in pred
+        assert pred == "chunk_type = 'wiki'"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -260,6 +260,66 @@ class TestMMRRerank:
         selected = mmr_rerank(query, results, top_k=5)
         assert len(selected) == 1
 
+    def test_wiki_paraphrase_near_duplicate_diversified_out(self):
+        """Wiki paraphrase lands near its raw source in vector space; MMR
+        drops one of them at ``top_k=2`` in favour of a clearly different
+        candidate. Whichever side wins is acceptable — "always a choice"
+        means neither is preferred by default; diversity should simply
+        do its job on near-duplicates regardless of ``chunk_type``.
+
+        The query is at ``[1, 1]/√2`` so both the near-dup cluster on
+        the x-axis and the orthogonal y-axis chunk are equally relevant;
+        the diversity penalty is the only tiebreaker, which is what
+        MMR is supposed to give.
+        """
+        query = [0.707, 0.707]
+        wiki_chunk = SearchChunk(
+            source="wiki/summaries/doc.md",
+            content_type="text/markdown",
+            chunk_type="wiki",
+            page_start=1,
+            page_end=1,
+            line_start=1,
+            line_end=1,
+            chunk="Wiki paraphrase of doc content.",
+            chunk_index=0,
+            vector=[1.0, 0.0],
+            distance=0.30,
+        )
+        raw_duplicate = SearchChunk(
+            source="doc.md",
+            content_type="text",
+            chunk_type="raw",
+            page_start=0,
+            page_end=0,
+            line_start=0,
+            line_end=0,
+            chunk="Raw doc content the wiki paraphrased.",
+            chunk_index=0,
+            vector=[1.0, 0.01],
+            distance=0.30,
+        )
+        distinct = SearchChunk(
+            source="other.md",
+            content_type="text",
+            chunk_type="raw",
+            page_start=0,
+            page_end=0,
+            line_start=0,
+            line_end=0,
+            chunk="Orthogonal topic.",
+            chunk_index=0,
+            vector=[0.0, 1.0],
+            distance=0.30,
+        )
+        selected = mmr_rerank(query, [wiki_chunk, raw_duplicate, distinct], top_k=2, mmr_lambda=0.5)
+        sources = {r.source for r in selected}
+        # The orthogonal chunk must appear — it's the diversity win.
+        assert "other.md" in sources
+        # Only one of the two near-duplicates survives.
+        dup_count = sum(1 for r in selected if r.source in ("wiki/summaries/doc.md", "doc.md"))
+        assert dup_count == 1
+
     def testcosine_sim_zero_vectors(self):
         assert cosine_sim([0.0, 0.0], [1.0, 0.0]) == 0.0
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -8,10 +8,12 @@ from lilbee.config import cfg
 from lilbee.store import (
     CitationRecord,
     SearchChunk,
+    SearchScope,
     Store,
     cosine_sim,
     escape_sql_string,
     mmr_rerank,
+    scope_to_chunk_type,
 )
 
 
@@ -728,3 +730,26 @@ class TestSuppressLancedbThreadError:
 
         assert len(calls) == 1
         assert calls[0] is args
+
+
+class TestScopeResolution:
+    """scope_to_chunk_type maps user-facing scope strings to store filter values."""
+
+    def test_none_is_passthrough(self):
+        assert scope_to_chunk_type(None) is None
+
+    def test_both_disables_filter(self):
+        assert scope_to_chunk_type("both") is None
+        assert scope_to_chunk_type(SearchScope.BOTH) is None
+
+    def test_raw_maps_to_raw(self):
+        assert scope_to_chunk_type("raw") == "raw"
+        assert scope_to_chunk_type(SearchScope.RAW) == "raw"
+
+    def test_wiki_maps_to_wiki(self):
+        assert scope_to_chunk_type("wiki") == "wiki"
+        assert scope_to_chunk_type(SearchScope.WIKI) == "wiki"
+
+    def test_invalid_scope_raises(self):
+        with pytest.raises(ValueError):
+            scope_to_chunk_type("bogus")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -1990,6 +1990,47 @@ async def test_chat_slash_unknown_command():
             assert "Unknown command" in mock_notify.call_args[0][0]
 
 
+async def test_chat_current_chunk_type_reflects_model_bar():
+    """The helper reads the scope Select via query_one; test the happy path."""
+    from lilbee.cli.tui.widgets.model_bar import ModelBar
+    from lilbee.store import SearchScope
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        # Default scope is "both" -> chunk_type None
+        assert app.screen._current_chunk_type() is None
+
+        # Flip the ModelBar scope state directly; the change-handler path is
+        # exercised by test_tui_widgets.TestModelBar.test_scope_change_updates_bar_state.
+        bar = app.screen.query_one("#model-bar", ModelBar)
+        bar._scope = SearchScope.WIKI
+        assert app.screen._current_chunk_type() == "wiki"
+
+
+async def test_chat_current_chunk_type_without_model_bar_returns_none():
+    """Test apps without a ModelBar (e.g. mounting ChatScreen in isolation)
+    must get ``None`` from the helper, not a ``NoMatches`` crash.
+    """
+    from textual.app import App
+
+    from lilbee.cli.tui.screens.chat import ChatScreen
+
+    class _BareChatApp(App):
+        def on_mount(self) -> None:
+            # Push ChatScreen but manually remove the ModelBar after mount
+            self.push_screen(ChatScreen())
+
+    app = _BareChatApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        # Uninstall the ModelBar so the NoMatches branch fires
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+
+        bar = app.screen.query_one("#model-bar", ModelBar)
+        await bar.remove()
+        await pilot.pause()
+        assert app.screen._current_chunk_type() is None
+
+
 async def test_chat_slash_version():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -369,9 +369,10 @@ class TestModelBar:
         async with app.run_test() as pilot:
             await pilot.pause()
             selects = list(app.query(Select))
-            assert len(selects) == 2
+            # Chat + Embed + Scope
+            assert len(selects) == 3
 
-    async def test_widget_exists_with_2_selects(self) -> None:
+    async def test_widget_exists_with_3_selects(self) -> None:
         from textual.widgets import Select
 
         cfg.chat_model = "qwen3:8b"
@@ -381,11 +382,13 @@ class TestModelBar:
             await pilot.pause()
             chat_sel = app.query_one("#chat-model-select", Select)
             embed_sel = app.query_one("#embed-model-select", Select)
+            scope_sel = app.query_one("#scope-select", Select)
             assert chat_sel is not None
             assert embed_sel is not None
+            assert scope_sel is not None
 
     async def test_labels_rendered(self) -> None:
-        """bb-ec3q: Chat/Embed labels render as pills, not plain text.
+        """Chat/Embed/Scope labels render as pills, not plain text.
 
         Each pill is a Static carrying a pill() Content with half-block
         ends around the label text. Assert the text survives, wrapped
@@ -401,6 +404,57 @@ class TestModelBar:
             pills = [str(s.render()) for s in app.query(Static) if "model-bar-pill" in s.classes]
             assert any("Chat" in p and "▌" in p and "▐" in p for p in pills)
             assert any("Embed" in p and "▌" in p and "▐" in p for p in pills)
+            assert any("Scope" in p and "▌" in p and "▐" in p for p in pills)
+
+    async def test_scope_defaults_to_both(self) -> None:
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+        from lilbee.store import SearchScope
+
+        cfg.chat_model = "qwen3:8b"
+        cfg.embedding_model = "nomic"
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(ModelBar)
+            assert bar.scope is SearchScope.BOTH
+
+    async def test_scope_change_updates_bar_state(self) -> None:
+        from textual.widgets import Select
+
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+        from lilbee.store import SearchScope
+
+        cfg.chat_model = "qwen3:8b"
+        cfg.embedding_model = "nomic"
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            scope_sel = app.query_one("#scope-select", Select)
+            scope_sel.value = SearchScope.WIKI.value
+            await pilot.pause()
+            assert app.query_one(ModelBar).scope is SearchScope.WIKI
+
+    async def test_scope_hidden_when_wiki_disabled(self) -> None:
+        """With ``cfg.wiki=False`` the scope pill+select are omitted entirely.
+
+        With wiki off the chunks table has only raw rows, so the choice
+        would imply a capability the user hasn't opted into.
+        """
+        from textual.css.query import NoMatches
+        from textual.widgets import Select
+
+        cfg.chat_model = "qwen3:8b"
+        cfg.embedding_model = "nomic"
+        cfg.wiki = False
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Still shows chat + embed selects
+            assert app.query_one("#chat-model-select", Select) is not None
+            assert app.query_one("#embed-model-select", Select) is not None
+            # But no scope select
+            with pytest.raises(NoMatches):
+                app.query_one("#scope-select", Select)
 
 
 class TestIsMmproj:

--- a/tests/test_wiki_concept_pages.py
+++ b/tests/test_wiki_concept_pages.py
@@ -33,6 +33,20 @@ from lilbee.wiki.gen import (
 from lilbee.wiki.shared import CONCEPTS_SUBDIR, ENTITIES_SUBDIR
 
 
+@pytest.fixture(autouse=True)
+def _stub_wiki_index_services(monkeypatch):
+    """Stub ``get_services`` inside ``wiki.gen`` so tests that drive
+    ``_persist_and_finalize`` don't hit the real provider when the new
+    wiki-body indexer runs.
+    """
+    svc = MagicMock()
+    svc.embedder.embed_batch.side_effect = lambda texts, **kw: [
+        [0.1] * cfg.embedding_dim for _ in texts
+    ]
+    monkeypatch.setattr("lilbee.wiki.gen.get_services", lambda: svc)
+    return svc
+
+
 def _chunk(source: str, idx: int, text: str = "t") -> SearchChunk:
     return SearchChunk(
         source=source,

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -996,7 +996,7 @@ class TestWikiIndexing:
                 return_value=["Brakes convert kinetic energy to heat through friction pads."],
             ),
         ):
-            _index_wiki_page(content, target, store, cfg)
+            _index_wiki_page(content, target, store)
 
         store.clear_table.assert_called_once()
         call_args = store.clear_table.call_args
@@ -1011,14 +1011,17 @@ class TestWikiIndexing:
         rec = records[0]
         assert rec["chunk_type"] == CHUNK_TYPE_WIKI
         assert rec["source"] == target.wiki_source
-        assert rec["content_type"] == "text/markdown"
+        assert rec["content_type"] == "text"
+        # page/line positions follow the markdown ingest convention: all zero
+        assert rec["page_start"] == 0
+        assert rec["line_start"] == 0
         assert "friction pads" in rec["chunk"]
         # Frontmatter and citation block are stripped from what gets chunked
         assert "title: Brakes" not in rec["chunk"]
         assert "src1" not in rec["chunk"]
 
     def test_drafts_subdir_is_not_indexed(self):
-        """Drafts never enter the search pool — no clear, no add."""
+        """Drafts never enter the search pool. No clear, no add."""
         store = MagicMock(spec=Store)
         target = self._target(subdir=DRAFTS_SUBDIR)
 
@@ -1026,7 +1029,7 @@ class TestWikiIndexing:
             patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
             patch("lilbee.wiki.gen.chunk_text", return_value=["body"]),
         ):
-            _index_wiki_page(self._content("body"), target, store, cfg)
+            _index_wiki_page(self._content("body"), target, store)
 
         store.clear_table.assert_not_called()
         store.add_chunks.assert_not_called()
@@ -1037,7 +1040,7 @@ class TestWikiIndexing:
         """
         store = MagicMock(spec=Store)
         target = self._target()
-        # Body is pure whitespace — after extract_body + strip, nothing remains
+        # Body is pure whitespace. After extract_body + strip, nothing remains
         content = (
             "---\ntitle: Empty\n---\n\n   \n\n"
             "---\n"
@@ -1049,7 +1052,7 @@ class TestWikiIndexing:
             patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
             patch("lilbee.wiki.gen.chunk_text") as chunker,
         ):
-            _index_wiki_page(content, target, store, cfg)
+            _index_wiki_page(content, target, store)
 
         store.clear_table.assert_called_once()
         chunker.assert_not_called()
@@ -1064,13 +1067,13 @@ class TestWikiIndexing:
             patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
             patch("lilbee.wiki.gen.chunk_text", return_value=[]),
         ):
-            _index_wiki_page(self._content("some body"), target, store, cfg)
+            _index_wiki_page(self._content("some body"), target, store)
 
         store.clear_table.assert_called_once()
         store.add_chunks.assert_not_called()
 
     def test_regen_invalidates_before_writing(self):
-        """Second call still clears first, then adds — no accumulation."""
+        """Second call still clears first, then adds. No accumulation."""
         store = MagicMock(spec=Store)
         target = self._target()
 
@@ -1082,7 +1085,7 @@ class TestWikiIndexing:
             patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
             patch("lilbee.wiki.gen.chunk_text", return_value=["one chunk"]),
         ):
-            _index_wiki_page(self._content("first body"), target, store, cfg)
-            _index_wiki_page(self._content("second body"), target, store, cfg)
+            _index_wiki_page(self._content("first body"), target, store)
+            _index_wiki_page(self._content("second body"), target, store)
 
         assert call_order == ["clear", "add", "clear", "add"]

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from lilbee.config import cfg
-from lilbee.store import SearchChunk, Store
+from lilbee.config import CHUNKS_TABLE, cfg
+from lilbee.store import CHUNK_TYPE_WIKI, SearchChunk, Store
 from lilbee.wiki.citation import ParsedCitation
 from lilbee.wiki.gen import (
     _check_faithfulness,
@@ -21,6 +21,7 @@ from lilbee.wiki.gen import (
     _find_excerpt_source,
     _generate_synthesis_page,
     _group_chunks_by_page,
+    _index_wiki_page,
     _leaf_hash,
     _match_citation_source,
     _parse_faithfulness_score,
@@ -30,12 +31,32 @@ from lilbee.wiki.gen import (
     _verify_citations,
     generate_synthesis_pages,
 )
-from lilbee.wiki.shared import make_slug
+from lilbee.wiki.shared import (
+    CONCEPTS_SUBDIR,
+    DRAFTS_SUBDIR,
+    PageTarget,
+    make_slug,
+)
 
 
 @pytest.fixture(autouse=True)
 def isolated_env(wiki_isolated_env: Path):
     yield wiki_isolated_env
+
+
+@pytest.fixture(autouse=True)
+def _stub_wiki_index_services(monkeypatch):
+    """Stub ``get_services`` inside ``wiki.gen`` so tests that drive
+    ``_persist_and_finalize`` don't hit the real provider when the new
+    wiki-body indexer runs. ``TestWikiIndexing`` re-patches explicitly
+    to exercise the indexer's own assertions.
+    """
+    svc = MagicMock()
+    svc.embedder.embed_batch.side_effect = lambda texts, **kw: [
+        [0.1] * cfg.embedding_dim for _ in texts
+    ]
+    monkeypatch.setattr("lilbee.wiki.gen.get_services", lambda: svc)
+    return svc
 
 
 def _make_chunk(text: str, source: str = "doc.md", **kwargs) -> SearchChunk:
@@ -929,3 +950,139 @@ class TestSynthesisDriftDetection:
         assert "drafts" in str(result)
         # Original should be unchanged
         assert "Totally different synthesis" in existing.read_text()
+
+
+class TestWikiIndexing:
+    """``_index_wiki_page`` chunks, embeds and writes wiki page bodies."""
+
+    @staticmethod
+    def _target(subdir: str = CONCEPTS_SUBDIR, slug: str = "brakes") -> PageTarget:
+        wiki_root = cfg.data_root / cfg.wiki_dir
+        return PageTarget(
+            wiki_root=wiki_root,
+            subdir=subdir,
+            slug=slug,
+            wiki_source=f"{cfg.wiki_dir}/{subdir}/{slug}.md",
+            page_type=subdir.rstrip("s"),  # summaries -> summary, concepts -> concept
+            label=slug,
+        )
+
+    @staticmethod
+    def _services_mock(vector_dim: int | None = None) -> MagicMock:
+        dim = vector_dim if vector_dim is not None else cfg.embedding_dim
+        svc = MagicMock()
+        svc.embedder.embed_batch.side_effect = lambda texts, **kw: [[0.1] * dim for _ in texts]
+        return svc
+
+    @staticmethod
+    def _content(body: str) -> str:
+        return (
+            "---\ntitle: Brakes\ntype: concept\n---\n\n"
+            f"{body}\n\n"
+            "---\n"
+            "<!-- citations (auto-generated from _citations table -- do not edit) -->\n"
+            '[^src1]: doc.md, excerpt: "brake fluid"\n'
+        )
+
+    def test_concept_page_writes_wiki_chunks(self):
+        store = MagicMock(spec=Store)
+        target = self._target()
+        content = self._content("Brakes convert kinetic energy to heat through friction pads.")
+
+        with (
+            patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
+            patch(
+                "lilbee.wiki.gen.chunk_text",
+                return_value=["Brakes convert kinetic energy to heat through friction pads."],
+            ),
+        ):
+            _index_wiki_page(content, target, store, cfg)
+
+        store.clear_table.assert_called_once()
+        call_args = store.clear_table.call_args
+        assert call_args.args[0] == CHUNKS_TABLE
+        predicate = call_args.args[1]
+        assert target.wiki_source in predicate
+        assert CHUNK_TYPE_WIKI in predicate
+
+        store.add_chunks.assert_called_once()
+        records = store.add_chunks.call_args.args[0]
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["chunk_type"] == CHUNK_TYPE_WIKI
+        assert rec["source"] == target.wiki_source
+        assert rec["content_type"] == "text/markdown"
+        assert "friction pads" in rec["chunk"]
+        # Frontmatter and citation block are stripped from what gets chunked
+        assert "title: Brakes" not in rec["chunk"]
+        assert "src1" not in rec["chunk"]
+
+    def test_drafts_subdir_is_not_indexed(self):
+        """Drafts never enter the search pool — no clear, no add."""
+        store = MagicMock(spec=Store)
+        target = self._target(subdir=DRAFTS_SUBDIR)
+
+        with (
+            patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
+            patch("lilbee.wiki.gen.chunk_text", return_value=["body"]),
+        ):
+            _index_wiki_page(self._content("body"), target, store, cfg)
+
+        store.clear_table.assert_not_called()
+        store.add_chunks.assert_not_called()
+
+    def test_empty_body_clears_stale_but_adds_nothing(self):
+        """A page whose body is empty after frontmatter+citation stripping invalidates
+        old rows but writes none, so stale wiki rows from a prior generation are removed.
+        """
+        store = MagicMock(spec=Store)
+        target = self._target()
+        # Body is pure whitespace — after extract_body + strip, nothing remains
+        content = (
+            "---\ntitle: Empty\n---\n\n   \n\n"
+            "---\n"
+            "<!-- citations (auto-generated from _citations table -- do not edit) -->\n"
+            '[^src1]: doc.md, excerpt: "x"\n'
+        )
+
+        with (
+            patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
+            patch("lilbee.wiki.gen.chunk_text") as chunker,
+        ):
+            _index_wiki_page(content, target, store, cfg)
+
+        store.clear_table.assert_called_once()
+        chunker.assert_not_called()
+        store.add_chunks.assert_not_called()
+
+    def test_chunker_returns_empty_skips_add(self):
+        """If chunk_text returns no chunks, invalidate stale rows and return."""
+        store = MagicMock(spec=Store)
+        target = self._target()
+
+        with (
+            patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
+            patch("lilbee.wiki.gen.chunk_text", return_value=[]),
+        ):
+            _index_wiki_page(self._content("some body"), target, store, cfg)
+
+        store.clear_table.assert_called_once()
+        store.add_chunks.assert_not_called()
+
+    def test_regen_invalidates_before_writing(self):
+        """Second call still clears first, then adds — no accumulation."""
+        store = MagicMock(spec=Store)
+        target = self._target()
+
+        call_order: list[str] = []
+        store.clear_table.side_effect = lambda *a, **kw: call_order.append("clear")
+        store.add_chunks.side_effect = lambda records: call_order.append("add") or len(records)
+
+        with (
+            patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
+            patch("lilbee.wiki.gen.chunk_text", return_value=["one chunk"]),
+        ):
+            _index_wiki_page(self._content("first body"), target, store, cfg)
+            _index_wiki_page(self._content("second body"), target, store, cfg)
+
+        assert call_order == ["clear", "add", "clear", "add"]


### PR DESCRIPTION
## What this fixes

Wiki pages never showed up in search. The generator wrote them to disk and the UI already had a "wiki vs raw" toggle, but the underlying index had no wiki content — so every wiki-scoped query came back empty. The toggle was cosmetic.

Scope choice was also inconsistent. Some paths silently preferred wiki pages over their source documents; others didn't expose the choice at all; the defaults disagreed.

## What changes

### Wiki pages are searchable

Every time a wiki page is saved, it joins the main search index alongside your raw documents. Regenerating a page cleanly replaces its old version so repeated syncs don't pile up duplicates, and drafts or archived pages stay out of the index.

### Scope is always an explicit choice

You can narrow any search or ask to raw documents, wiki pages, or both, from:

- the `lilbee search` and `lilbee ask` commands
- the `search` tool over MCP
- the ask and chat HTTP endpoints
- the chat model bar in the TUI

There are no silent preferences anywhere. "Both" is the default on every surface.

### The choice disappears when it's meaningless

When wiki generation is off, the scope toggle is hidden in the TUI entirely. With no wiki pages in the index, offering the choice would imply a capability that isn't turned on.

## Confidence

The new mixed pool of wiki and raw results is covered by small regression tests that pin diversity and reranker behaviour, so a future model swap can't silently start favouring one side over the other.