### PR TITLE
Stop writing garbage wiki filenames

### DIFF
--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -92,6 +92,11 @@ def _filter_noun_chunks(doc: Any, max_concepts: int) -> list[str]:
     delimiters, page-number-prefixed tokens, sub-three-char fragments)
     never enter the co-occurrence graph and therefore never become a
     synthesis-page cluster label.
+
+    The gate runs on the lowercased form here while the NER extractor
+    gates on the original-cased surface; the two decisions match
+    because ``is_valid_label`` is case-agnostic today. Any future
+    case-sensitive rule must land in both call sites together.
     """
     seen: set[str] = set()
     concepts: list[str] = []

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -27,10 +27,10 @@ from lilbee.config import (
     Config,
 )
 from lilbee.store import Store, escape_sql_string
+from lilbee.wiki.shared import is_valid_label
 
 log = logging.getLogger(__name__)
 
-_MIN_CONCEPT_LEN = 2
 _MIN_LEIDEN_WEIGHT = 0.01
 
 
@@ -85,12 +85,19 @@ def load_spacy_pipeline() -> Any:
 
 
 def _filter_noun_chunks(doc: Any, max_concepts: int) -> list[str]:
-    """Extract deduplicated, filtered noun chunks from a spaCy doc."""
+    """Extract deduplicated, filtered noun chunks from a spaCy doc.
+
+    Applies the same :func:`is_valid_label` gate the wiki entity
+    extractor uses, so structural-noise concepts (markdown table
+    delimiters, page-number-prefixed tokens, sub-three-char fragments)
+    never enter the co-occurrence graph and therefore never become a
+    synthesis-page cluster label.
+    """
     seen: set[str] = set()
     concepts: list[str] = []
     for chunk in doc.noun_chunks:
         concept = chunk.text.lower().strip()
-        if len(concept) < _MIN_CONCEPT_LEN:
+        if not is_valid_label(concept):
             continue
         if concept in seen:
             continue

--- a/src/lilbee/wiki/entity_extractor/ner_concepts.py
+++ b/src/lilbee/wiki/entity_extractor/ner_concepts.py
@@ -11,7 +11,7 @@ from lilbee.wiki.entity_extractor.base import (
     EntityKind,
     ExtractedEntity,
 )
-from lilbee.wiki.shared import make_slug
+from lilbee.wiki.shared import is_valid_label, make_slug
 
 if TYPE_CHECKING:
     from lilbee.config import Config
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 _ALLOWED_NER_LABELS: frozenset[str] = frozenset(
     {"PERSON", "ORG", "GPE", "LOC", "EVENT", "WORK_OF_ART", "PRODUCT"}
 )
-_MIN_CONCEPT_LEN = 2
 _WHITESPACE_RE = re.compile(r"\s+")
 
 
@@ -56,13 +55,16 @@ class NerConceptsExtractor:
         entity_records: dict[str, _Aggregate] = {}
         concept_records: dict[str, _Aggregate] = {}
 
+        debug_enabled = log.isEnabledFor(logging.DEBUG)
         for chunk, doc in zip(chunks, nlp.pipe(c.chunk for c in chunks), strict=True):
             ref = ChunkRef(source=chunk.source, chunk_index=chunk.chunk_index)
             for ent in doc.ents:
                 if ent.label_ not in _ALLOWED_NER_LABELS:
                     continue
                 surface = ent.text.strip()
-                if len(surface) < _MIN_CONCEPT_LEN:
+                if not is_valid_label(surface):
+                    if debug_enabled:
+                        log.debug("label-sanity: rejected entity %r", surface)
                     continue
                 key = _normalize(surface)
                 rec = entity_records.setdefault(
@@ -71,7 +73,9 @@ class NerConceptsExtractor:
                 rec.refs.add(ref)
             for noun_chunk in doc.noun_chunks:
                 surface = noun_chunk.text.strip()
-                if len(surface) < _MIN_CONCEPT_LEN:
+                if not is_valid_label(surface):
+                    if debug_enabled:
+                        log.debug("label-sanity: rejected noun-chunk %r", surface)
                     continue
                 key = _normalize(surface)
                 rec = concept_records.setdefault(

--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -54,6 +54,7 @@ from lilbee.wiki.shared import (
     WIKI_CONTENT_SUBDIRS,
     WIKI_LOG_ACTION_GENERATED,
     PageTarget,
+    clean_label_for_display,
     make_slug,
     parse_frontmatter,
 )
@@ -744,7 +745,8 @@ def _generate_synthesis_page(
     chunks_text = _chunks_to_text(all_chunks)
     source_list = "\n".join(f"- {name}" for name in sorted(source_names))
     template = config.wiki_synthesis_prompt
-    prompt = template.format(topic=topic, source_list=source_list, chunks_text=chunks_text)
+    display_topic = clean_label_for_display(topic)
+    prompt = template.format(topic=display_topic, source_list=source_list, chunks_text=chunks_text)
     slug = make_slug(topic)
 
     source_hashes: dict[str, str] = {}
@@ -915,7 +917,7 @@ def _generate_concept_like_page(
     source_list = "\n".join(f"- {name}" for name in source_names)
 
     prompt = config.wiki_concept_prompt.format(
-        topic=label,
+        topic=clean_label_for_display(label),
         kind=kind,
         source_list=source_list,
         chunks_text=chunks_text,

--- a/src/lilbee/wiki/shared.py
+++ b/src/lilbee/wiki/shared.py
@@ -68,12 +68,16 @@ WIKI_TYPE_HEADINGS: dict[WikiPageType, str] = {
 }
 
 _SLUG_CLEAN_RE = re.compile(r"[^a-z0-9-]")
-_DISPLAY_STRUCTURAL_RE = re.compile(r"[|#>]+")
+
+# Characters that signal markdown-structural noise in a concept label.
+# Single source of truth for both ``is_valid_label`` (membership check)
+# and ``clean_label_for_display`` (regex strip).
+_STRUCTURAL_CHARS = frozenset("|#>")
+_DISPLAY_STRUCTURAL_RE = re.compile(f"[{re.escape(''.join(_STRUCTURAL_CHARS))}]+")
 _DISPLAY_WHITESPACE_RE = re.compile(r"\s+")
 
 LABEL_SANITY_MIN_LEN = 3
 LABEL_SANITY_MIN_ALNUM_RATIO = 0.5
-_STRUCTURAL_CHARS = frozenset("|#>")
 
 
 @dataclass(frozen=True)

--- a/src/lilbee/wiki/shared.py
+++ b/src/lilbee/wiki/shared.py
@@ -131,18 +131,27 @@ def make_slug(label: str) -> str:
 def is_valid_label(label: str) -> bool:
     """Reject structural-noise labels before aggregation.
 
-    Catches the noise patterns observed in QA: empty/very-short
-    fragments (``cro``-class length gates), markdown table delimiters
-    (``| | designer``), page-number ordinals (``158 vehicle``), and
-    punctuation-heavy tokens that slipped past NER. Left intentionally
-    coarse: the alnum-ratio gate plus the structural-character gate
-    catch ~90% of the QA noise without rejecting legitimate labels
-    like ``E-mail`` or ``C++``.
+    Catches the noise patterns observed in QA (bb-8b7s):
+
+    - empty or sub-three-char fragments,
+    - markdown table delimiters (``| | designer``),
+    - page-number-prefixed tokens (``158 vehicle``),
+    - paren-prefixed numerics (``(7.0 l)`` — would otherwise slug to
+      ``70-l`` after punctuation cleanup),
+    - hyphen-prefixed fragments (``-answers`` — trailing text from
+      markdown bracket-link extraction).
+
+    Requires the first non-whitespace character to be a Unicode letter
+    so any non-alpha prefix (digit, bracket, hyphen, punctuation) is
+    rejected up front. Legitimate labels like ``E-mail`` or ``iPhone``
+    pass. Still permissive on three-char fragments like ``cro`` /
+    ``fus``; A3's entity-type filter and ``wiki_entity_min_mentions``
+    catch those downstream.
     """
     stripped = label.strip()
     if len(stripped) < LABEL_SANITY_MIN_LEN:
         return False
-    if stripped[0].isdigit():
+    if not stripped[0].isalpha():
         return False
     if any(ch in _STRUCTURAL_CHARS for ch in stripped):
         return False

--- a/src/lilbee/wiki/shared.py
+++ b/src/lilbee/wiki/shared.py
@@ -166,11 +166,18 @@ def is_valid_label(label: str) -> bool:
 def clean_label_for_display(label: str) -> str:
     """Return a prompt-safe version of *label* for the ``{topic}`` slot.
 
-    Removes markdown-structural characters and collapses internal
-    whitespace so the LLM never sees ``| | designer`` and echoes it
-    into the generated H1. Preserves the original capitalization so
-    proper nouns (``Chevrolet Caprice``, ``iPhone``) survive intact;
-    the model title-cases lowercase common nouns on its own.
+    Defense-in-depth behind :func:`is_valid_label`: a concept or entity
+    label that reached this function already passed the sanity gate
+    and should not contain ``|#>`` in practice. The structural-char
+    strip here guards against a future code path that bypasses the
+    gate (synthesis cluster labels sourced from ``concept_nodes``,
+    user-supplied topics, tests). The always-useful work is whitespace
+    normalization: spaCy surface forms can carry internal runs of
+    whitespace that would reach the H1 verbatim.
+
+    Preserves the original capitalization so proper nouns
+    (``Chevrolet Caprice``, ``iPhone``) survive intact; the model
+    title-cases lowercase common nouns on its own.
     """
     clean = _DISPLAY_STRUCTURAL_RE.sub("", label)
     return _DISPLAY_WHITESPACE_RE.sub(" ", clean).strip()

--- a/src/lilbee/wiki/shared.py
+++ b/src/lilbee/wiki/shared.py
@@ -68,6 +68,12 @@ WIKI_TYPE_HEADINGS: dict[WikiPageType, str] = {
 }
 
 _SLUG_CLEAN_RE = re.compile(r"[^a-z0-9-]")
+_DISPLAY_STRUCTURAL_RE = re.compile(r"[|#>]+")
+_DISPLAY_WHITESPACE_RE = re.compile(r"\s+")
+
+LABEL_SANITY_MIN_LEN = 3
+LABEL_SANITY_MIN_ALNUM_RATIO = 0.5
+_STRUCTURAL_CHARS = frozenset("|#>")
 
 
 @dataclass(frozen=True)
@@ -106,8 +112,52 @@ def parse_frontmatter(text: str) -> dict[str, Any]:
 
 def make_slug(label: str) -> str:
     """Turn a concept label into a filesystem-safe slug.
-    Lowercases, replaces spaces with hyphens, slashes with double-hyphens,
-    and strips non-alphanumeric characters (except hyphens).
+
+    Lowercases, maps whitespace to single hyphens and slashes to double
+    hyphens (path encoding), strips anything outside ``[a-z0-9-]``, and
+    trims leading and trailing hyphens. Returns ``""`` when no sluggable
+    characters remain; callers must treat an empty slug as "skip this
+    entity" so the generator never writes a file called ``.md``.
+
+    Internal hyphen runs from the ``/`` path encoding are preserved;
+    only leading and trailing hyphens (e.g. ``--body`` from a stripped
+    ``| | Body``) are removed.
     """
     slug = label.lower().replace(" ", "-").replace("/", "--")
-    return _SLUG_CLEAN_RE.sub("", slug)
+    slug = _SLUG_CLEAN_RE.sub("", slug)
+    return slug.strip("-")
+
+
+def is_valid_label(label: str) -> bool:
+    """Reject structural-noise labels before aggregation.
+
+    Catches the noise patterns observed in QA: empty/very-short
+    fragments (``cro``-class length gates), markdown table delimiters
+    (``| | designer``), page-number ordinals (``158 vehicle``), and
+    punctuation-heavy tokens that slipped past NER. Left intentionally
+    coarse: the alnum-ratio gate plus the structural-character gate
+    catch ~90% of the QA noise without rejecting legitimate labels
+    like ``E-mail`` or ``C++``.
+    """
+    stripped = label.strip()
+    if len(stripped) < LABEL_SANITY_MIN_LEN:
+        return False
+    if stripped[0].isdigit():
+        return False
+    if any(ch in _STRUCTURAL_CHARS for ch in stripped):
+        return False
+    alnum = sum(1 for ch in stripped if ch.isalnum())
+    return alnum / len(stripped) >= LABEL_SANITY_MIN_ALNUM_RATIO
+
+
+def clean_label_for_display(label: str) -> str:
+    """Return a prompt-safe version of *label* for the ``{topic}`` slot.
+
+    Removes markdown-structural characters and collapses internal
+    whitespace so the LLM never sees ``| | designer`` and echoes it
+    into the generated H1. Preserves the original capitalization so
+    proper nouns (``Chevrolet Caprice``, ``iPhone``) survive intact;
+    the model title-cases lowercase common nouns on its own.
+    """
+    clean = _DISPLAY_STRUCTURAL_RE.sub("", label)
+    return _DISPLAY_WHITESPACE_RE.sub(" ", clean).strip()

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -159,11 +159,34 @@ class TestExtractConcepts:
 
     @patch("lilbee.concepts._ensure_spacy_model")
     def test_filters_short_concepts(self, mock_spacy, cg):
-        mock_spacy.return_value = _make_mock_nlp({"text": ["a", "ok", "good concept"]})
+        """Sub-three-char fragments are rejected by ``is_valid_label``.
+
+        Three-char and longer PDF-split noise (``cro``, ``fus``) is
+        intentionally NOT caught by the length gate; A3's entity-type
+        filter and the ``wiki_entity_min_mentions`` threshold catch it
+        downstream, and tightening the length gate further would reject
+        legitimate short labels like ``CPU`` or ``API``.
+        """
+        mock_spacy.return_value = _make_mock_nlp(
+            {"text": ["a", "ok", "good concept", "brake pads"]}
+        )
         result = cg.extract_concepts("text")
         assert "a" not in result
-        assert "ok" in result
+        assert "ok" not in result
         assert "good concept" in result
+        assert "brake pads" in result
+
+    @patch("lilbee.concepts._ensure_spacy_model")
+    def test_filters_structural_noise_concepts(self, mock_spacy, cg):
+        """QA-driven (bb-8b7s): markdown table, page-number, and
+        pipe-prefixed concepts never enter the graph."""
+        mock_spacy.return_value = _make_mock_nlp(
+            {"text": ["| | body", "158 vehicle", "chevrolet caprice"]}
+        )
+        result = cg.extract_concepts("text")
+        assert "| | body" not in result
+        assert "158 vehicle" not in result
+        assert "chevrolet caprice" in result
 
 
 class TestExtractConceptsBatch:
@@ -187,7 +210,7 @@ class TestExtractConceptsBatch:
     def test_batch_filters_short_concepts(self, mock_spacy, cg):
         mock_spacy.return_value = _make_mock_nlp({"text": ["a", "ok", "good"]})
         result = cg.extract_concepts_batch(["text"])
-        assert result == [["ok", "good"]]
+        assert result == [["good"]]
 
     @patch("lilbee.concepts._ensure_spacy_model")
     def test_batch_deduplicates(self, mock_spacy, cg):
@@ -198,7 +221,9 @@ class TestExtractConceptsBatch:
     @patch("lilbee.concepts._ensure_spacy_model")
     def test_batch_caps_at_max(self, mock_spacy, cg):
         cfg.concept_max_per_chunk = 2
-        mock_spacy.return_value = _make_mock_nlp({"text": ["aa", "bb", "cc", "dd"]})
+        mock_spacy.return_value = _make_mock_nlp(
+            {"text": ["alpha", "beta", "gamma", "delta"]}
+        )
         result = cg.extract_concepts_batch(["text"])
         assert len(result[0]) == 2
 
@@ -705,6 +730,6 @@ class TestFilterNounChunks:
     def test_filter_noun_chunks_max(self):
         from lilbee.concepts import _filter_noun_chunks
 
-        doc = _make_mock_doc(["aa", "bb", "cc"])
+        doc = _make_mock_doc(["alpha", "beta", "gamma"])
         result = _filter_noun_chunks(doc, max_concepts=2)
         assert len(result) == 2

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -731,3 +731,23 @@ class TestFilterNounChunks:
         doc = _make_mock_doc(["alpha", "beta", "gamma"])
         result = _filter_noun_chunks(doc, max_concepts=2)
         assert len(result) == 2
+
+    def test_filter_noun_chunks_rejects_structural_noise(self):
+        """Direct coverage of the structural-rejection branch inside
+        ``_filter_noun_chunks`` (bb-8b7s). Asserts that the module's
+        own filter drops the table, page-number, and paren-prefix
+        patterns even without going through ``extract_concepts``.
+        """
+        from lilbee.concepts import _filter_noun_chunks
+
+        doc = _make_mock_doc(
+            [
+                "| | body",
+                "158 vehicle",
+                "(7.0 l)",
+                "-answers",
+                "chevrolet caprice",
+            ]
+        )
+        result = _filter_noun_chunks(doc, max_concepts=10)
+        assert result == ["chevrolet caprice"]

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -221,9 +221,7 @@ class TestExtractConceptsBatch:
     @patch("lilbee.concepts._ensure_spacy_model")
     def test_batch_caps_at_max(self, mock_spacy, cg):
         cfg.concept_max_per_chunk = 2
-        mock_spacy.return_value = _make_mock_nlp(
-            {"text": ["alpha", "beta", "gamma", "delta"]}
-        )
+        mock_spacy.return_value = _make_mock_nlp({"text": ["alpha", "beta", "gamma", "delta"]})
         result = cg.extract_concepts_batch(["text"])
         assert len(result[0]) == 2
 

--- a/tests/test_ner_concepts_extractor.py
+++ b/tests/test_ner_concepts_extractor.py
@@ -282,16 +282,63 @@ class TestReturnRecordShape:
         assert rec.slug == "ford-motor-company"
 
     def test_empty_slug_record_is_dropped(self) -> None:
-        """Labels of only punctuation slug-clean to '' and must not
-        become ExtractedEntity records; otherwise the generator would
-        try to write a file called '.md'.
+        """Structural-noise labels never become ExtractedEntity records.
+
+        Belt-and-suspenders: ``is_valid_label`` rejects ``>>>>`` at the
+        extractor boundary (structural char), and ``make_slug`` would
+        also strip it to an empty slug downstream. Either path drops
+        the record before the generator writes ``/.md``.
         """
-        # Use a noun_chunk because make_slug() on punctuation strips
-        # everything. ">>>>" is >=2 chars (passes _MIN_CONCEPT_LEN),
-        # normalizes to ">>>>", but make_slug returns "".
         doc = _FakeDoc(noun_chunks=[_FakeSpan(">>>>"), _FakeSpan("tires")])
         extractor = NerConceptsExtractor(MagicMock(), cfg)
         with _patch_pipeline({"t": doc}):
             result = extractor.extract([_chunk("s.txt", 0, "t")])
         labels = {e.label for e in result}
         assert labels == {"tires"}
+
+
+class TestLabelSanityRejection:
+    """QA-driven (bb-8b7s) regressions on the noise patterns observed
+    in Wikipedia table markup and PDF chrome."""
+
+    def test_rejects_pipe_delimited_ner_entity(self) -> None:
+        doc = _FakeDoc(
+            ents=[
+                _FakeSpan("| | Designer", "PERSON"),
+                _FakeSpan("Chevrolet Caprice", "PRODUCT"),
+            ]
+        )
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            result = extractor.extract([_chunk("s.txt", 0, "t")])
+        labels = {e.label for e in result}
+        assert labels == {"Chevrolet Caprice"}
+
+    def test_rejects_page_number_prefixed_noun_chunk(self) -> None:
+        doc = _FakeDoc(
+            noun_chunks=[
+                _FakeSpan("158 vehicle"),
+                _FakeSpan("brake pads"),
+            ]
+        )
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            result = extractor.extract([_chunk("s.txt", 0, "t")])
+        labels = {e.label for e in result}
+        assert labels == {"brake pads"}
+
+    def test_rejects_short_fragment(self) -> None:
+        doc = _FakeDoc(noun_chunks=[_FakeSpan("ab"), _FakeSpan("tires")])
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            result = extractor.extract([_chunk("s.txt", 0, "t")])
+        labels = {e.label for e in result}
+        assert labels == {"tires"}
+
+    def test_logs_rejection_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level("DEBUG", logger="lilbee.wiki.entity_extractor.ner_concepts")
+        doc = _FakeDoc(noun_chunks=[_FakeSpan("| bad |"), _FakeSpan("tires")])
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            extractor.extract([_chunk("s.txt", 0, "t")])
+        assert any("label-sanity" in r.message for r in caplog.records)

--- a/tests/test_ner_concepts_extractor.py
+++ b/tests/test_ner_concepts_extractor.py
@@ -337,8 +337,26 @@ class TestLabelSanityRejection:
 
     def test_logs_rejection_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
         caplog.set_level("DEBUG", logger="lilbee.wiki.entity_extractor.ner_concepts")
-        doc = _FakeDoc(noun_chunks=[_FakeSpan("| bad |"), _FakeSpan("tires")])
+        doc = _FakeDoc(
+            ents=[_FakeSpan("| pipe-entity", "PERSON")],
+            noun_chunks=[_FakeSpan("| bad |"), _FakeSpan("tires")],
+        )
         extractor = NerConceptsExtractor(MagicMock(), cfg)
         with _patch_pipeline({"t": doc}):
             extractor.extract([_chunk("s.txt", 0, "t")])
-        assert any("label-sanity" in r.message for r in caplog.records)
+        messages = [r.message for r in caplog.records]
+        assert any("rejected entity" in m for m in messages)
+        assert any("rejected noun-chunk" in m for m in messages)
+
+    def test_unicode_label_passes_sanity_but_slugs_empty(self) -> None:
+        """Unicode letters satisfy ``is_valid_label`` (alnum + length) but
+        slug-clean to empty since ``make_slug`` restricts to ``[a-z0-9-]``.
+        The defensive ``if not slug`` check in ``_make_record`` drops the
+        aggregate rather than writing a file named ``.md``.
+        """
+        doc = _FakeDoc(ents=[_FakeSpan("αβγ", "PERSON"), _FakeSpan("Ford", "ORG")])
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            result = extractor.extract([_chunk("s.txt", 0, "t")])
+        labels = {e.label for e in result}
+        assert labels == {"Ford"}

--- a/tests/test_wiki_shared.py
+++ b/tests/test_wiki_shared.py
@@ -138,6 +138,16 @@ class TestIsValidLabel:
         # The bb-8b7s "158 vehicle" pattern: page numbers prepended to entities.
         assert is_valid_label("158 vehicle") is False
 
+    def test_rejects_paren_prefix(self):
+        # bb-8b7s: "(7.0 l)" slipped past the original digit-only first-char
+        # guard because "(" is not a digit; slug-cleanup then stripped the
+        # paren and wrote "70-l.md" on disk.
+        assert is_valid_label("(7.0 l)") is False
+
+    def test_rejects_hyphen_prefix(self):
+        # bb-8b7s: "-answers" from markdown bracket-link extraction residue.
+        assert is_valid_label("-answers") is False
+
     def test_rejects_low_alnum_ratio(self):
         assert is_valid_label("---!!") is False
 

--- a/tests/test_wiki_shared.py
+++ b/tests/test_wiki_shared.py
@@ -11,6 +11,8 @@ from lilbee.wiki.shared import (
     SUMMARIES_SUBDIR,
     SYNTHESIS_SUBDIR,
     WikiPageType,
+    clean_label_for_display,
+    is_valid_label,
     make_slug,
     parse_frontmatter,
 )
@@ -93,3 +95,72 @@ class TestMakeSlug:
 
     def test_empty_string(self):
         assert make_slug("") == ""
+
+    def test_strips_leading_and_trailing_hyphens(self):
+        assert make_slug("-well-known-") == "well-known"
+
+    def test_table_delimited_label_reduces_to_body(self):
+        # Even if the sanity gate let this through, the slug should not
+        # contain the leading double hyphen that bit bb-8b7s.
+        assert make_slug("| | Body") == "body"
+
+    def test_preserves_internal_double_hyphen_path_encoding(self):
+        # ``/`` encodes as ``--`` so path-like labels round-trip.
+        # Trimming only targets leading/trailing runs.
+        assert make_slug("path/to/concept") == "path--to--concept"
+
+    def test_punctuation_only_returns_empty(self):
+        assert make_slug("!!!") == ""
+
+
+class TestIsValidLabel:
+    def test_accepts_ordinary_label(self):
+        assert is_valid_label("Chevrolet Caprice") is True
+
+    def test_accepts_short_but_nonempty_acronym_boundary(self):
+        # "C++" length 3, alnum ratio 1/3 < 0.5 -> reject.
+        # Document the boundary so future edits know this is intentional.
+        assert is_valid_label("C++") is False
+
+    def test_rejects_under_min_length(self):
+        assert is_valid_label("ab") is False
+
+    def test_rejects_structural_pipe(self):
+        assert is_valid_label("| | Body") is False
+
+    def test_rejects_structural_hash(self):
+        assert is_valid_label("#heading") is False
+
+    def test_rejects_structural_angle(self):
+        assert is_valid_label(">>>>") is False
+
+    def test_rejects_leading_digit(self):
+        # The bb-8b7s "158 vehicle" pattern: page numbers prepended to entities.
+        assert is_valid_label("158 vehicle") is False
+
+    def test_rejects_low_alnum_ratio(self):
+        assert is_valid_label("---!!") is False
+
+    def test_accepts_hyphenated_label(self):
+        assert is_valid_label("E-mail") is True
+
+    def test_strips_whitespace_before_checking(self):
+        assert is_valid_label("  ab  ") is False
+        assert is_valid_label("  Chevrolet  ") is True
+
+
+class TestCleanLabelForDisplay:
+    def test_strips_pipes(self):
+        assert clean_label_for_display("| | designer") == "designer"
+
+    def test_collapses_whitespace(self):
+        assert clean_label_for_display("Chevrolet   Caprice") == "Chevrolet Caprice"
+
+    def test_preserves_proper_noun_case(self):
+        assert clean_label_for_display("iPhone") == "iPhone"
+
+    def test_returns_empty_for_all_structural(self):
+        assert clean_label_for_display("|#>") == ""
+
+    def test_leaves_ordinary_label_unchanged(self):
+        assert clean_label_for_display("brake pads") == "brake pads"

--- a/tests/test_wiki_shared.py
+++ b/tests/test_wiki_shared.py
@@ -112,6 +112,13 @@ class TestMakeSlug:
     def test_punctuation_only_returns_empty(self):
         assert make_slug("!!!") == ""
 
+    def test_hyphens_only_returns_empty(self):
+        # Separate branch from general punctuation: hyphens survive the
+        # slug-clean regex and are removed only by the leading/trailing
+        # strip. ``"---"`` must still collapse to ``""`` so the
+        # ``if not slug: return None`` guard in the extractor fires.
+        assert make_slug("---") == ""
+
 
 class TestIsValidLabel:
     def test_accepts_ordinary_label(self):


### PR DESCRIPTION
## Problem

Running the wiki builder on real documents produced pages with names like `| | designer.md`, `158 vehicle.md`, `-answers.md`, `70-l.md`. These are not useful topics — they're table-markup fragments, PDF page numbers, and link-text residue that survived extraction. Worse, the generated H1 inside each page echoed the same garbage, so a reader saw `# | | designer` at the top of what was supposed to be a biographical article about a GM designer named Irv Rybicki.

## What changed

A sanity gate now rejects a label before it can become a slug or reach the language model as a topic. Labels need a real leading letter, at least three characters, mostly alphanumeric content, and no markdown-structural characters. The slug generator stops producing filenames that start with a stray hyphen. The prompt template receives a cleaned display name so the model never sees raw noise in the first place.

## Behavior

On the vehicle-manual and Chevrolet Caprice Wikipedia test corpora, the pages that previously landed as noise are no longer produced. The legitimate pages (`chevrolet.md`, `caprice.md`) are unaffected.

## Stack

First of seven PRs in a wiki-quality pass. Subsequent PRs continue to tighten upstream stages.