### PR TITLE
Don't feed table markup and page numbers to the NER model

### DIFF
--- a/src/lilbee/wiki/entity_extractor/ner_concepts.py
+++ b/src/lilbee/wiki/entity_extractor/ner_concepts.py
@@ -25,10 +25,40 @@ _ALLOWED_NER_LABELS: frozenset[str] = frozenset(
 )
 _WHITESPACE_RE = re.compile(r"\s+")
 
+# Pre-spaCy markdown-noise strippers. Compiled once at module scope so
+# the extractor's hot path does not recompile them per chunk. Match on
+# line boundaries via re.MULTILINE; each sub() empties the matched
+# line so downstream line-joins collapse the hole to a single newline.
+_TABLE_ROW_RE = re.compile(r"^\|.*\|\s*$", re.MULTILINE)
+_PAGE_NUMBER_RE = re.compile(r"^\s*\d{1,4}\s*$", re.MULTILINE)
+_NAV_CHROME_RE = re.compile(
+    r"^\s*(?:Home|Menu|Navigation|Edit this page|Jump to navigation|Jump to search)\s*$",
+    re.MULTILINE,
+)
+
 
 def _normalize(text: str) -> str:
     """Lowercase, strip, and collapse internal whitespace for dedup keys."""
     return _WHITESPACE_RE.sub(" ", text.strip().lower())
+
+
+def pre_clean_for_ner(text: str) -> str:
+    """Strip markdown-structural noise before handing text to spaCy.
+
+    Removes whole-line markdown-table rows (``| Designer | Irv ... |``),
+    standalone page-number lines from PDF extraction (``42``), and
+    Wikipedia / CMS navigation chrome (``Edit this page``). Leaves
+    prose untouched: every regex anchors to a full line and emits an
+    empty line in place of the match, which spaCy treats as a sentence
+    break.
+
+    Only targets the noise patterns actually observed in the bb-8b7s
+    QA corpus. Fuller markdown parsing is deferred; a regex pre-clean
+    is sufficient for the current signal-to-noise ratio.
+    """
+    text = _TABLE_ROW_RE.sub("", text)
+    text = _PAGE_NUMBER_RE.sub("", text)
+    return _NAV_CHROME_RE.sub("", text)
 
 
 class NerConceptsExtractor:
@@ -56,7 +86,8 @@ class NerConceptsExtractor:
         concept_records: dict[str, _Aggregate] = {}
 
         debug_enabled = log.isEnabledFor(logging.DEBUG)
-        for chunk, doc in zip(chunks, nlp.pipe(c.chunk for c in chunks), strict=True):
+        cleaned_texts = (pre_clean_for_ner(c.chunk) for c in chunks)
+        for chunk, doc in zip(chunks, nlp.pipe(cleaned_texts), strict=True):
             ref = ChunkRef(source=chunk.source, chunk_index=chunk.chunk_index)
             for ent in doc.ents:
                 if ent.label_ not in _ALLOWED_NER_LABELS:

--- a/tests/test_ner_concepts_extractor.py
+++ b/tests/test_ner_concepts_extractor.py
@@ -18,7 +18,10 @@ import pytest
 from lilbee.config import cfg
 from lilbee.store import SearchChunk
 from lilbee.wiki.entity_extractor import EntityKind, ExtractedEntity
-from lilbee.wiki.entity_extractor.ner_concepts import NerConceptsExtractor
+from lilbee.wiki.entity_extractor.ner_concepts import (
+    NerConceptsExtractor,
+    pre_clean_for_ner,
+)
 
 
 @dataclass
@@ -360,3 +363,78 @@ class TestLabelSanityRejection:
             result = extractor.extract([_chunk("s.txt", 0, "t")])
         labels = {e.label for e in result}
         assert labels == {"Ford"}
+
+
+class TestPreCleanForNer:
+    """Pure-function unit tests for the A2 markdown-noise stripper."""
+
+    def test_strips_markdown_table_row(self) -> None:
+        noisy = "intro\n| Designer | Irv Rybicki |\noutro"
+        cleaned = pre_clean_for_ner(noisy)
+        assert "| Designer" not in cleaned
+        assert "intro" in cleaned
+        assert "outro" in cleaned
+
+    def test_strips_page_number_only_line(self) -> None:
+        noisy = "paragraph text\n  42  \nmore text"
+        cleaned = pre_clean_for_ner(noisy)
+        assert " 42 " not in cleaned
+        assert "paragraph text" in cleaned
+        assert "more text" in cleaned
+
+    def test_preserves_inline_numbers(self) -> None:
+        # "42" inside prose must NOT be stripped; only standalone
+        # page-number-only lines get removed.
+        noisy = "Chapter 42 introduces the concept."
+        assert pre_clean_for_ner(noisy) == noisy
+
+    def test_strips_nav_chrome(self) -> None:
+        noisy = "lede\nEdit this page\nJump to search\nbody"
+        cleaned = pre_clean_for_ner(noisy)
+        assert "Edit this page" not in cleaned
+        assert "Jump to search" not in cleaned
+        assert "lede" in cleaned
+        assert "body" in cleaned
+
+    def test_normal_prose_round_trips_unchanged(self) -> None:
+        prose = "The Chevrolet Caprice is a full-size car.\nIt was produced from 1965."
+        assert pre_clean_for_ner(prose) == prose
+
+    def test_mixed_noise_and_prose(self) -> None:
+        noisy = (
+            "The Caprice was designed by\n"
+            "| Designer | Irv Rybicki |\n"
+            "| --- | --- |\n"
+            "Irv Rybicki, a GM designer."
+        )
+        cleaned = pre_clean_for_ner(noisy)
+        assert "|" not in cleaned
+        assert "The Caprice was designed by" in cleaned
+        assert "Irv Rybicki, a GM designer." in cleaned
+
+    def test_empty_input(self) -> None:
+        assert pre_clean_for_ner("") == ""
+
+
+class TestExtractorAppliesPreClean:
+    """Integration: the extractor hands pre-cleaned text to spaCy."""
+
+    def test_table_row_never_reaches_pipeline(self) -> None:
+        """Captured pipeline input must not contain the table markup."""
+        seen_texts: list[str] = []
+
+        class _CapturingPipeline:
+            def pipe(self, texts: Any) -> Any:
+                for text in texts:
+                    seen_texts.append(text)
+                    yield _FakeDoc()
+
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        noisy = "Chevrolet Caprice.\n| Designer | Irv Rybicki |\n"
+        with patch(
+            "lilbee.wiki.entity_extractor.ner_concepts._load_spacy",
+            return_value=_CapturingPipeline(),
+        ):
+            extractor.extract([_chunk("s.txt", 0, noisy)])
+        assert seen_texts, "extractor should have called the pipeline"
+        assert all("| Designer" not in t for t in seen_texts)


### PR DESCRIPTION
## Problem

The wiki entity extractor was handing kreuzberg's raw markdown output directly to spaCy. That included Wikipedia table rows (`| Designer | Irv Rybicki |`), standalone page numbers from PDF extraction (`42`), and CMS navigation chrome (`Edit this page`, `Jump to search`). spaCy dutifully ran named-entity recognition over all of it, turning markup scaffolding into candidate entities. The previous PR caught the resulting garbage at the slug stage, but the upstream noise still consumed extraction budget and cluttered the debug traces.

## What changed

Adds a small pre-clean pass that strips whole-line table rows, page-number-only lines, and a short list of common nav chrome strings before the text reaches spaCy. Normal prose is unchanged byte-for-byte; `Chapter 42 introduces` stays intact because only bare page-number lines are stripped.

## Behavior

On the same Wikipedia and PDF test corpora, the candidate-entity count per chunk drops substantially and the debug trace stops showing phantom entities derived from markup. The final page output is unchanged — the previous PR already blocked those labels from becoming pages. This one reduces wasted work upstream.