### PR TITLE
Filter numeric NER tags out of wiki candidates, make the pipeline debuggable

### DIFF
--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -879,12 +879,12 @@ class Config(BaseSettings):
     @field_validator("concept_allowed_ent_types", mode="before")
     @classmethod
     def _parse_ent_types(cls, v: Any) -> frozenset[str]:
-        """Replace-semantics override, unlike ``ignore_dirs``.
-
-        A user narrowing the NER type set (e.g. ``PERSON,ORG`` only)
-        wants exactly those kinds, not the project defaults unioned
-        with the override. Accepts comma-separated strings from env
-        and list / set / frozenset from code.
+        """Replace-semantics override: a narrowed set is used as-is,
+        not unioned with defaults. A user asking for ``PERSON,ORG``
+        wants exactly those kinds. Accepts comma-separated strings
+        from env and list / set / frozenset from code. Empty input
+        falls back to :data:`DEFAULT_ALLOWED_NER_LABELS` so an empty
+        env var does not silently disable the gate.
         """
         if isinstance(v, str):
             parts = frozenset(name.strip().upper() for name in v.split(",") if name.strip())

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -130,6 +130,16 @@ DEFAULT_IGNORE_DIRS = frozenset(
     }
 )
 
+# spaCy NER labels that map onto something wiki-shaped. Excludes
+# QUANTITY / ORDINAL / CARDINAL / DATE / TIME / MONEY / PERCENT /
+# LANGUAGE / LAW because pages for "42" or "2021" are never useful.
+# FAC (buildings / airports) and NORP (nationalities / political /
+# religious groups) are included because corpora routinely surface
+# them as wiki-worthy topics.
+DEFAULT_ALLOWED_NER_LABELS = frozenset(
+    {"PERSON", "ORG", "GPE", "LOC", "EVENT", "WORK_OF_ART", "PRODUCT", "FAC", "NORP"}
+)
+
 # Shared HTTP timeout (seconds) for backend catalog / management calls
 # (Ollama /api/tags, /api/show, /v1/models, OpenAI-compatible endpoints).
 # Not exposed as a user config field because changing it is a debugging
@@ -649,6 +659,12 @@ class Config(BaseSettings):
     # Caps extraction to avoid noise from very long chunks.
     concept_max_per_chunk: int = ConfigField(default=10, ge=1, writable=True)
 
+    # spaCy NER labels kept by the wiki entity extractor. Anything not
+    # in this set (QUANTITY, CARDINAL, DATE, TIME, MONEY, PERCENT,
+    # ORDINAL, ...) is dropped before aggregation. Override via
+    # LILBEE_CONCEPT_ALLOWED_ENT_TYPES as a comma-separated list.
+    concept_allowed_ent_types: frozenset[str] = Field(default=DEFAULT_ALLOWED_NER_LABELS)
+
     # Strategy used to extract concepts and entities for the concept/entity
     # wiki. NER_CONCEPTS (default) combines spaCy NER with noun-phrase
     # clusters. NER_CONCEPTS_PLUS_LLM_TYPES layers an LLM-proposed domain
@@ -859,6 +875,24 @@ class Config(BaseSettings):
         if isinstance(v, (set, frozenset, list)):
             return DEFAULT_IGNORE_DIRS | frozenset(v)
         return DEFAULT_IGNORE_DIRS
+
+    @field_validator("concept_allowed_ent_types", mode="before")
+    @classmethod
+    def _parse_ent_types(cls, v: Any) -> frozenset[str]:
+        """Replace-semantics override, unlike ``ignore_dirs``.
+
+        A user narrowing the NER type set (e.g. ``PERSON,ORG`` only)
+        wants exactly those kinds, not the project defaults unioned
+        with the override. Accepts comma-separated strings from env
+        and list / set / frozenset from code.
+        """
+        if isinstance(v, str):
+            parts = frozenset(name.strip().upper() for name in v.split(",") if name.strip())
+            return parts or DEFAULT_ALLOWED_NER_LABELS
+        if isinstance(v, (set, frozenset, list)):
+            parts = frozenset(str(x).upper() for x in v)
+            return parts or DEFAULT_ALLOWED_NER_LABELS
+        return DEFAULT_ALLOWED_NER_LABELS
 
     @model_validator(mode="before")
     @classmethod

--- a/src/lilbee/wiki/entity_extractor/ner_concepts.py
+++ b/src/lilbee/wiki/entity_extractor/ner_concepts.py
@@ -91,7 +91,8 @@ class NerConceptsExtractor:
             "raw_ents": 0,
             "raw_noun_chunks": 0,
             "type_filter_dropped": 0,
-            "label_sanity_dropped": 0,
+            "label_sanity_dropped_entities": 0,
+            "label_sanity_dropped_concepts": 0,
             "kept_entity_surfaces": 0,
             "kept_concept_surfaces": 0,
         }
@@ -105,7 +106,7 @@ class NerConceptsExtractor:
                     continue
                 surface = ent.text.strip()
                 if not is_valid_label(surface):
-                    funnel["label_sanity_dropped"] += 1
+                    funnel["label_sanity_dropped_entities"] += 1
                     if debug_enabled:
                         log.debug("label-sanity: rejected entity %r", surface)
                     continue
@@ -119,7 +120,7 @@ class NerConceptsExtractor:
                 funnel["raw_noun_chunks"] += 1
                 surface = noun_chunk.text.strip()
                 if not is_valid_label(surface):
-                    funnel["label_sanity_dropped"] += 1
+                    funnel["label_sanity_dropped_concepts"] += 1
                     if debug_enabled:
                         log.debug("label-sanity: rejected noun-chunk %r", surface)
                     continue
@@ -134,7 +135,8 @@ class NerConceptsExtractor:
             log.debug(
                 "ner funnel: raw_ents=%(raw_ents)d raw_noun_chunks=%(raw_noun_chunks)d "
                 "type_filter_dropped=%(type_filter_dropped)d "
-                "label_sanity_dropped=%(label_sanity_dropped)d "
+                "label_sanity_dropped_entities=%(label_sanity_dropped_entities)d "
+                "label_sanity_dropped_concepts=%(label_sanity_dropped_concepts)d "
                 "kept_entity_surfaces=%(kept_entity_surfaces)d "
                 "kept_concept_surfaces=%(kept_concept_surfaces)d",
                 funnel,

--- a/src/lilbee/wiki/entity_extractor/ner_concepts.py
+++ b/src/lilbee/wiki/entity_extractor/ner_concepts.py
@@ -20,9 +20,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_ALLOWED_NER_LABELS: frozenset[str] = frozenset(
-    {"PERSON", "ORG", "GPE", "LOC", "EVENT", "WORK_OF_ART", "PRODUCT"}
-)
 _WHITESPACE_RE = re.compile(r"\s+")
 
 # Pre-spaCy markdown-noise strippers. Compiled once at module scope so
@@ -84,16 +81,31 @@ class NerConceptsExtractor:
 
         entity_records: dict[str, _Aggregate] = {}
         concept_records: dict[str, _Aggregate] = {}
+        allowed_ent_types = self._config.concept_allowed_ent_types
 
         debug_enabled = log.isEnabledFor(logging.DEBUG)
+        # Per-pass funnel counters; emitted once after the loop so the
+        # DEBUG trace captures the whole corpus in one line instead of
+        # one per chunk.
+        funnel = {
+            "raw_ents": 0,
+            "raw_noun_chunks": 0,
+            "type_filter_dropped": 0,
+            "label_sanity_dropped": 0,
+            "kept_entity_surfaces": 0,
+            "kept_concept_surfaces": 0,
+        }
         cleaned_texts = (pre_clean_for_ner(c.chunk) for c in chunks)
         for chunk, doc in zip(chunks, nlp.pipe(cleaned_texts), strict=True):
             ref = ChunkRef(source=chunk.source, chunk_index=chunk.chunk_index)
             for ent in doc.ents:
-                if ent.label_ not in _ALLOWED_NER_LABELS:
+                funnel["raw_ents"] += 1
+                if ent.label_ not in allowed_ent_types:
+                    funnel["type_filter_dropped"] += 1
                     continue
                 surface = ent.text.strip()
                 if not is_valid_label(surface):
+                    funnel["label_sanity_dropped"] += 1
                     if debug_enabled:
                         log.debug("label-sanity: rejected entity %r", surface)
                     continue
@@ -102,9 +114,12 @@ class NerConceptsExtractor:
                     key, _Aggregate(label=surface, type_hint=ent.label_)
                 )
                 rec.refs.add(ref)
+                funnel["kept_entity_surfaces"] += 1
             for noun_chunk in doc.noun_chunks:
+                funnel["raw_noun_chunks"] += 1
                 surface = noun_chunk.text.strip()
                 if not is_valid_label(surface):
+                    funnel["label_sanity_dropped"] += 1
                     if debug_enabled:
                         log.debug("label-sanity: rejected noun-chunk %r", surface)
                     continue
@@ -113,6 +128,17 @@ class NerConceptsExtractor:
                     key, _Aggregate(label=key, type_hint="noun_phrase")
                 )
                 rec.refs.add(ref)
+                funnel["kept_concept_surfaces"] += 1
+
+        if debug_enabled:
+            log.debug(
+                "ner funnel: raw_ents=%(raw_ents)d raw_noun_chunks=%(raw_noun_chunks)d "
+                "type_filter_dropped=%(type_filter_dropped)d "
+                "label_sanity_dropped=%(label_sanity_dropped)d "
+                "kept_entity_surfaces=%(kept_entity_surfaces)d "
+                "kept_concept_surfaces=%(kept_concept_surfaces)d",
+                funnel,
+            )
 
         for key, entity_agg in entity_records.items():
             if key in concept_records:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -760,6 +760,40 @@ class TestIgnoreDirs:
             assert "bar" in c.ignore_dirs
 
 
+class TestConceptAllowedEntTypes:
+    """A3 entity-type filter: spaCy NER labels kept by the wiki extractor."""
+
+    def test_default_includes_core_wiki_types(self):
+        c = Config()
+        for label in ("PERSON", "ORG", "GPE", "PRODUCT", "FAC", "NORP"):
+            assert label in c.concept_allowed_ent_types
+
+    def test_default_excludes_quantitative_types(self):
+        c = Config()
+        for label in ("QUANTITY", "CARDINAL", "DATE", "TIME", "MONEY", "PERCENT"):
+            assert label not in c.concept_allowed_ent_types
+
+    def test_env_override_replaces_defaults(self):
+        # Replace-semantics: narrowing the set should NOT re-union with
+        # the defaults the way ``ignore_dirs`` does.
+        with mock.patch.dict(os.environ, {"LILBEE_CONCEPT_ALLOWED_ENT_TYPES": "PERSON,ORG"}):
+            c = Config()
+            assert c.concept_allowed_ent_types == frozenset({"PERSON", "ORG"})
+
+    def test_env_override_is_case_insensitive(self):
+        with mock.patch.dict(os.environ, {"LILBEE_CONCEPT_ALLOWED_ENT_TYPES": "person,Org"}):
+            c = Config()
+            assert c.concept_allowed_ent_types == frozenset({"PERSON", "ORG"})
+
+    def test_empty_env_falls_back_to_default(self):
+        # Empty override should not silently deactivate the gate.
+        env = _clean_env()
+        env["LILBEE_CONCEPT_ALLOWED_ENT_TYPES"] = ""
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert "PERSON" in c.concept_allowed_ent_types
+
+
 class TestEmptyStringValidation:
     def test_empty_chat_model_rejected(self, tmp_path):
         with pytest.raises(Exception, match="at least 1 character"):

--- a/tests/test_ner_concepts_extractor.py
+++ b/tests/test_ner_concepts_extractor.py
@@ -169,8 +169,12 @@ class TestNerExtraction:
         labels = {e.label for e in result}
         assert labels == {"Berlin"}
 
-    def test_all_seven_allowed_labels_accepted(self) -> None:
-        allowed = ["PERSON", "ORG", "GPE", "LOC", "EVENT", "WORK_OF_ART", "PRODUCT"]
+    def test_all_default_allowed_labels_accepted(self) -> None:
+        """All nine labels in ``DEFAULT_ALLOWED_NER_LABELS`` round-trip to
+        ``ExtractedEntity`` records. Uses the live default set from config
+        so the test doesn't drift when types are added or removed there.
+        """
+        allowed = sorted(cfg.concept_allowed_ent_types)
         doc = _FakeDoc(ents=[_FakeSpan(f"Thing{i}", lbl) for i, lbl in enumerate(allowed)])
         extractor = NerConceptsExtractor(MagicMock(), cfg)
         with _patch_pipeline({"text": doc}):
@@ -438,3 +442,94 @@ class TestExtractorAppliesPreClean:
             extractor.extract([_chunk("s.txt", 0, noisy)])
         assert seen_texts, "extractor should have called the pipeline"
         assert all("| Designer" not in t for t in seen_texts)
+
+
+class TestEntityTypeFilter:
+    """A3: spaCy NER labels outside ``concept_allowed_ent_types`` are dropped."""
+
+    def test_quantity_and_date_entities_are_dropped(self) -> None:
+        doc = _FakeDoc(
+            ents=[
+                _FakeSpan("42 miles", "QUANTITY"),
+                _FakeSpan("1965", "DATE"),
+                _FakeSpan("Chevrolet", "ORG"),
+            ]
+        )
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            result = extractor.extract([_chunk("s.txt", 0, "t")])
+        labels = {e.label for e in result}
+        assert labels == {"Chevrolet"}
+
+    def test_fac_and_norp_are_included_by_default(self) -> None:
+        """FAC (facilities) and NORP (nationalities/political/religious groups)
+        were missing from the pre-A3 hardcoded set but are useful wiki topics.
+        """
+        doc = _FakeDoc(
+            ents=[
+                _FakeSpan("Pentagon", "FAC"),
+                _FakeSpan("Americans", "NORP"),
+            ]
+        )
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            result = extractor.extract([_chunk("s.txt", 0, "t")])
+        labels = {e.label for e in result}
+        assert labels == {"Pentagon", "Americans"}
+
+    def test_config_override_narrows_allowed_types(self) -> None:
+        """Setting a narrower override via config keeps only those types."""
+        from dataclasses import replace  # noqa: F401  (pattern documentation)
+
+        doc = _FakeDoc(
+            ents=[
+                _FakeSpan("Chevrolet", "ORG"),
+                _FakeSpan("Irv Rybicki", "PERSON"),
+                _FakeSpan("Americans", "NORP"),
+            ]
+        )
+        prev = cfg.concept_allowed_ent_types
+        cfg.concept_allowed_ent_types = frozenset({"PERSON"})
+        try:
+            extractor = NerConceptsExtractor(MagicMock(), cfg)
+            with _patch_pipeline({"t": doc}):
+                result = extractor.extract([_chunk("s.txt", 0, "t")])
+        finally:
+            cfg.concept_allowed_ent_types = prev
+        labels = {e.label for e in result}
+        assert labels == {"Irv Rybicki"}
+
+
+class TestFunnelLogging:
+    """A3: per-extraction funnel counters emitted at DEBUG once per pass."""
+
+    def test_funnel_logged_once_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level("DEBUG", logger="lilbee.wiki.entity_extractor.ner_concepts")
+        doc = _FakeDoc(
+            ents=[
+                _FakeSpan("Chevrolet", "ORG"),
+                _FakeSpan("42", "QUANTITY"),
+                _FakeSpan("| bad", "PERSON"),
+            ],
+            noun_chunks=[_FakeSpan("the car"), _FakeSpan("ab")],
+        )
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            extractor.extract([_chunk("s.txt", 0, "t")])
+        funnel_messages = [r.message for r in caplog.records if "ner funnel" in r.message]
+        assert len(funnel_messages) == 1, "funnel should log exactly once per extraction"
+        message = funnel_messages[0]
+        assert "raw_ents=3" in message
+        assert "raw_noun_chunks=2" in message
+        assert "type_filter_dropped=1" in message  # the QUANTITY
+        assert "label_sanity_dropped=2" in message  # "| bad" and "ab"
+        assert "kept_entity_surfaces=1" in message  # Chevrolet
+        assert "kept_concept_surfaces=1" in message  # the car
+
+    def test_funnel_not_emitted_when_debug_off(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level("INFO", logger="lilbee.wiki.entity_extractor.ner_concepts")
+        doc = _FakeDoc(ents=[_FakeSpan("Chevrolet", "ORG")])
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with _patch_pipeline({"t": doc}):
+            extractor.extract([_chunk("s.txt", 0, "t")])
+        assert not any("ner funnel" in r.message for r in caplog.records)

--- a/tests/test_ner_concepts_extractor.py
+++ b/tests/test_ner_concepts_extractor.py
@@ -479,8 +479,6 @@ class TestEntityTypeFilter:
 
     def test_config_override_narrows_allowed_types(self) -> None:
         """Setting a narrower override via config keeps only those types."""
-        from dataclasses import replace  # noqa: F401  (pattern documentation)
-
         doc = _FakeDoc(
             ents=[
                 _FakeSpan("Chevrolet", "ORG"),
@@ -522,7 +520,8 @@ class TestFunnelLogging:
         assert "raw_ents=3" in message
         assert "raw_noun_chunks=2" in message
         assert "type_filter_dropped=1" in message  # the QUANTITY
-        assert "label_sanity_dropped=2" in message  # "| bad" and "ab"
+        assert "label_sanity_dropped_entities=1" in message  # "| bad"
+        assert "label_sanity_dropped_concepts=1" in message  # "ab"
         assert "kept_entity_surfaces=1" in message  # Chevrolet
         assert "kept_concept_surfaces=1" in message  # the car
 


### PR DESCRIPTION
## Problem

spaCy's named-entity recognizer tags chunks of text with dozens of categories, many of which aren't useful wiki topics: `QUANTITY`, `CARDINAL`, `DATE`, `TIME`, `MONEY`, `PERCENT`, `ORDINAL`. A number like `42 miles` or `$199` would sail through the previous filters and become a wiki page candidate. The hardcoded allowlist was also missing two categories that do belong (`FAC` for facilities and `NORP` for nationalities).

Separately, when the extractor ran there was no way to see where entities were being dropped. Silent filters make pipeline debugging painful.

## What changed

The allowlist moves onto the config dataclass with replace-semantics: narrowing to `PERSON,ORG` does exactly that, not "the defaults plus those two". `FAC` and `NORP` join the default set. The prior hardcoded list of seven categories is gone.

A single DEBUG line now fires once per extraction pass with the full funnel — raw entity count, raw noun-chunk count, drops by type filter, drops by label sanity (split by kind), surfaces kept on each side. Built only when DEBUG logging is active so there's no cost in production.

## Behavior

Running the extractor with `LILBEE_LOG_LEVEL=DEBUG` now shows the reduction stages. On the test corpora, roughly 40% of raw spaCy output gets filtered at the type stage — numbers and dates that used to slip through.