### PR TITLE
Review, accept, or reject wiki drafts from the command line

### DIFF
--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -1260,3 +1260,134 @@ def wiki_update(
     lands in the ingest-hook task and will re-route this command then.
     """
     wiki_build(data_dir=data_dir, use_global=use_global)
+
+
+drafts_app = typer.Typer(help="Review wiki drafts: list, diff, accept, reject.")
+wiki_app.add_typer(drafts_app, name="drafts")
+
+
+@drafts_app.command(name="list")
+def wiki_drafts_list(
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """List pending wiki drafts with drift, faithfulness, and pairing info."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    from lilbee.wiki.drafts import list_drafts
+
+    wiki_root = cfg.data_root / cfg.wiki_dir
+    drafts = list_drafts(wiki_root)
+
+    if cfg.json_mode:
+        json_output(
+            {
+                "command": "wiki_drafts_list",
+                "drafts": [d.to_dict() for d in drafts],
+                "total": len(drafts),
+            }
+        )
+        return
+
+    if not drafts:
+        console.print("No drafts pending review.")
+        return
+
+    table = Table(title="Wiki Drafts")
+    table.add_column("Slug", style=theme.ACCENT)
+    table.add_column("Drift")
+    table.add_column("Faithfulness")
+    table.add_column("Published?", style=theme.MUTED)
+    for d in drafts:
+        drift = f"{d.drift_ratio:.0%}" if d.drift_ratio is not None else "-"
+        faith = f"{d.faithfulness_score:.2f}" if d.faithfulness_score is not None else "-"
+        published = "yes" if d.published_exists else "no"
+        table.add_row(d.slug, drift, faith, published)
+    console.print(table)
+
+
+@drafts_app.command(name="diff")
+def wiki_drafts_diff(
+    slug: str = typer.Argument(..., help="Draft slug (e.g. chevrolet)."),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Show a unified diff of the draft against its published counterpart."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    from lilbee.wiki.drafts import diff_draft
+
+    wiki_root = cfg.data_root / cfg.wiki_dir
+    try:
+        diff = diff_draft(slug, wiki_root)
+    except FileNotFoundError as exc:
+        if cfg.json_mode:
+            json_output({"error": str(exc)})
+        else:
+            console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(1) from None
+
+    if cfg.json_mode:
+        json_output({"command": "wiki_drafts_diff", "slug": slug, "diff": diff})
+        return
+    console.print(diff or "(no differences)")
+
+
+@drafts_app.command(name="accept")
+def wiki_drafts_accept(
+    slug: str = typer.Argument(..., help="Draft slug to accept."),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Overwrite the published page with the draft and re-index its chunks."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    from lilbee.wiki.drafts import accept_draft
+
+    wiki_root = cfg.data_root / cfg.wiki_dir
+    try:
+        result = accept_draft(slug, wiki_root, get_services().store)
+    except FileNotFoundError as exc:
+        if cfg.json_mode:
+            json_output({"error": str(exc)})
+        else:
+            console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(1) from None
+
+    if cfg.json_mode:
+        json_output(
+            {
+                "command": "wiki_drafts_accept",
+                "slug": result.slug,
+                "moved_to": str(result.moved_to),
+                "reindexed_chunks": result.reindexed_chunks,
+            }
+        )
+        return
+    console.print(
+        f"Accepted [{theme.ACCENT}]{slug}[/{theme.ACCENT}] -> "
+        f"{result.moved_to} ({result.reindexed_chunks} chunks re-indexed)"
+    )
+
+
+@drafts_app.command(name="reject")
+def wiki_drafts_reject(
+    slug: str = typer.Argument(..., help="Draft slug to reject."),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Delete the draft file. Does not touch the published page or index."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    from lilbee.wiki.drafts import reject_draft
+
+    wiki_root = cfg.data_root / cfg.wiki_dir
+    try:
+        reject_draft(slug, wiki_root)
+    except FileNotFoundError as exc:
+        if cfg.json_mode:
+            json_output({"error": str(exc)})
+        else:
+            console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(1) from None
+
+    if cfg.json_mode:
+        json_output({"command": "wiki_drafts_reject", "slug": slug})
+        return
+    console.print(f"Rejected [{theme.ACCENT}]{slug}[/{theme.ACCENT}]")

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -518,6 +518,40 @@ def model_rm(model: str, source: str = "") -> dict[str, Any]:
     return remove_model_data(model, source=src).model_dump()
 
 
+@mcp.tool()
+def wiki_drafts_list() -> dict[str, Any]:
+    """List pending wiki drafts with drift, faithfulness, and pairing info.
+
+    Read-only. Accept and reject are CLI-only (destructive, explicit).
+    """
+    from lilbee.wiki.drafts import list_drafts
+
+    wiki_root = cfg.data_root / cfg.wiki_dir
+    drafts = list_drafts(wiki_root)
+    return {
+        "command": "wiki_drafts_list",
+        "drafts": [d.to_dict() for d in drafts],
+        "total": len(drafts),
+    }
+
+
+@mcp.tool()
+def wiki_drafts_diff(slug: str) -> dict[str, Any]:
+    """Return a unified diff of the draft against its published counterpart.
+
+    Args:
+        slug: Draft slug (e.g. ``"chevrolet"``).
+    """
+    from lilbee.wiki.drafts import diff_draft
+
+    wiki_root = cfg.data_root / cfg.wiki_dir
+    try:
+        diff = diff_draft(slug, wiki_root)
+    except FileNotFoundError as exc:
+        return {"error": str(exc)}
+    return {"command": "wiki_drafts_diff", "slug": slug, "diff": diff}
+
+
 def clean(result: SearchChunk) -> dict[str, object]:
     """Convert SearchChunk to a JSON-friendly dict."""
     return result.model_dump(exclude={"vector"}, exclude_none=True)

--- a/src/lilbee/wiki/drafts.py
+++ b/src/lilbee/wiki/drafts.py
@@ -1,4 +1,4 @@
-"""Draft review surface — list, diff, accept, reject wiki drafts.
+"""Draft review surface. List, diff, accept, reject wiki drafts.
 
 Wiki generation routes pages to ``wiki/drafts/`` when the content
 drift against an existing page exceeds the configured threshold or
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from lilbee.store import Store
+from lilbee.wiki.gen import index_wiki_page
 from lilbee.wiki.shared import (
     CONCEPTS_SUBDIR,
     DRAFTS_SUBDIR,
@@ -188,6 +189,12 @@ def accept_draft(slug: str, wiki_root: Path, store: Store) -> AcceptResult:
     ``wiki_source`` are cleared, then the accepted body is chunked,
     embedded, and re-written.
 
+    Sequence is deliberate: write the published file first, re-index
+    next, delete the draft last. If the re-index raises (chunker,
+    embedder, LanceDB contention), the draft file stays on disk so
+    the user can retry ``accept`` — ``index_wiki_page`` is idempotent
+    on the same ``wiki_source`` (``clear_table`` + re-write).
+
     Raises :class:`FileNotFoundError` when the draft does not exist.
     """
     draft = _draft_path(wiki_root, slug)
@@ -208,9 +215,9 @@ def accept_draft(slug: str, wiki_root: Path, store: Store) -> AcceptResult:
         )
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(clean, encoding="utf-8")
-    draft.unlink()
 
     reindexed = _reindex_accepted_page(target, wiki_root, store)
+    draft.unlink()
     log.info("Accepted draft %s -> %s (%d chunks indexed)", slug, target, reindexed)
     return AcceptResult(slug=slug, moved_to=target, reindexed_chunks=reindexed)
 
@@ -232,8 +239,6 @@ def _reindex_accepted_page(target: Path, wiki_root: Path, store: Store) -> int:
     page generation, so an accepted draft is indexed identically to a
     fresh page and no bespoke accept-time code path exists.
     """
-    from lilbee.wiki.gen import index_wiki_page
-
     wiki_source = _wiki_source_for(target, wiki_root)
     content = target.read_text(encoding="utf-8")
     return index_wiki_page(content, wiki_source, store)

--- a/src/lilbee/wiki/drafts.py
+++ b/src/lilbee/wiki/drafts.py
@@ -1,0 +1,260 @@
+"""Draft review surface — list, diff, accept, reject wiki drafts.
+
+Wiki generation routes pages to ``wiki/drafts/`` when the content
+drift against an existing page exceeds the configured threshold or
+when the faithfulness score falls below it. Without a review
+surface drafts accumulate with no exit ramp, so this module exposes
+the four operations a reviewer needs: see what is pending, diff
+against the published version, accept (overwrite the published
+page and re-index its chunks), or reject (delete the draft file).
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lilbee.store import Store
+from lilbee.wiki.shared import (
+    CONCEPTS_SUBDIR,
+    DRAFTS_SUBDIR,
+    ENTITIES_SUBDIR,
+    SUMMARIES_SUBDIR,
+    SYNTHESIS_SUBDIR,
+    parse_frontmatter,
+)
+
+log = logging.getLogger(__name__)
+
+_DRIFT_MARKER_RE = re.compile(
+    r"<!--\s*DRIFT:\s*(?P<pct>\d+)%\s*content changed[^>]*-->",
+    re.IGNORECASE,
+)
+
+# Published wiki subdirs searched in priority order when pairing a
+# draft slug with its counterpart. Summaries and synthesis come first
+# because they are the subdirs most drafts originate from (drift
+# detection runs on regen of an existing source or cluster page).
+_PUBLISHED_SUBDIRS: tuple[str, ...] = (
+    SUMMARIES_SUBDIR,
+    SYNTHESIS_SUBDIR,
+    CONCEPTS_SUBDIR,
+    ENTITIES_SUBDIR,
+)
+
+
+@dataclass
+class DraftInfo:
+    """Metadata about a single draft, surfaced in ``wiki drafts list``."""
+
+    slug: str
+    path: Path
+    drift_ratio: float | None
+    faithfulness_score: float | None
+    bad_title: bool
+    published_path: Path | None
+    mtime: float
+
+    @property
+    def published_exists(self) -> bool:
+        """True when a matching published page exists for this draft."""
+        return self.published_path is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly dict."""
+        return {
+            "slug": self.slug,
+            "path": str(self.path),
+            "drift_ratio": self.drift_ratio,
+            "faithfulness_score": self.faithfulness_score,
+            "bad_title": self.bad_title,
+            "published_path": str(self.published_path) if self.published_path else None,
+            "published_exists": self.published_exists,
+            "mtime": self.mtime,
+        }
+
+
+@dataclass
+class AcceptResult:
+    """Outcome of accepting a draft. Returned so callers can confirm."""
+
+    slug: str
+    moved_to: Path
+    reindexed_chunks: int
+
+
+def _draft_path(wiki_root: Path, slug: str) -> Path:
+    return wiki_root / DRAFTS_SUBDIR / f"{slug}.md"
+
+
+def _find_published(wiki_root: Path, slug: str) -> Path | None:
+    """Return the first published page matching *slug*, or None.
+
+    Checks summaries, synthesis, concepts, and entities subdirs in
+    priority order so a draft regenerated from an existing summary
+    page pairs with its original rather than the same slug under a
+    different page type.
+    """
+    for subdir in _PUBLISHED_SUBDIRS:
+        candidate = wiki_root / subdir / f"{slug}.md"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _parse_drift_ratio(text: str) -> float | None:
+    """Extract the drift percentage from a draft's leading marker."""
+    match = _DRIFT_MARKER_RE.search(text)
+    if match is None:
+        return None
+    return int(match.group("pct")) / 100.0
+
+
+def _strip_drift_marker(text: str) -> str:
+    """Remove the drift-review marker so accepted content lands clean."""
+    return _DRIFT_MARKER_RE.sub("", text, count=1).lstrip()
+
+
+def list_drafts(wiki_root: Path) -> list[DraftInfo]:
+    """Return one ``DraftInfo`` per draft markdown file under ``drafts/``.
+
+    Recurses so per-source draft nesting (``drafts/<source>/page.md``)
+    is covered. Reads only frontmatter plus the first ~200 bytes for
+    the drift marker; full body stays on disk.
+    """
+    drafts_dir = wiki_root / DRAFTS_SUBDIR
+    if not drafts_dir.is_dir():
+        return []
+    infos: list[DraftInfo] = []
+    for path in sorted(drafts_dir.rglob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        drift = _parse_drift_ratio(text)
+        # ``parse_frontmatter`` anchors on line 0. The drift marker
+        # that ``_divert_to_drafts`` prepends shifts the frontmatter
+        # one block down, so we read it from the drift-stripped body.
+        fm = parse_frontmatter(_strip_drift_marker(text))
+        slug = str(path.relative_to(drafts_dir).with_suffix("")).replace("\\", "/")
+        infos.append(
+            DraftInfo(
+                slug=slug,
+                path=path,
+                drift_ratio=drift,
+                faithfulness_score=_coerce_float(fm.get("faithfulness_score")),
+                bad_title=bool(fm.get("bad_title", False)),
+                published_path=_find_published(wiki_root, slug),
+                mtime=path.stat().st_mtime,
+            )
+        )
+    return infos
+
+
+def diff_draft(slug: str, wiki_root: Path) -> str:
+    """Return a unified diff of the draft against its published counterpart.
+
+    Raises :class:`FileNotFoundError` when the draft does not exist.
+    When no published counterpart exists the diff shows the draft as
+    all-new (baseline empty), which is useful for reviewing drafts
+    that originated from a fresh low-faithfulness generation.
+    """
+    draft = _draft_path(wiki_root, slug)
+    if not draft.is_file():
+        raise FileNotFoundError(f"draft not found: {slug}")
+    draft_text = draft.read_text(encoding="utf-8")
+    published = _find_published(wiki_root, slug)
+    baseline = published.read_text(encoding="utf-8") if published else ""
+    diff = difflib.unified_diff(
+        baseline.splitlines(),
+        draft_text.splitlines(),
+        fromfile=str(published) if published else "(new draft)",
+        tofile=str(draft),
+        lineterm="",
+    )
+    return "\n".join(diff)
+
+
+def accept_draft(slug: str, wiki_root: Path, store: Store) -> AcceptResult:
+    """Move the draft into its published subdir and re-index its chunks.
+
+    When a matching published page exists the draft takes its place
+    (same subdir, same filename). Otherwise the draft lands in
+    ``summaries/`` as the safe default; the caller can move it later
+    if the page type was different. The drift marker is stripped on
+    the way in so accepted content looks exactly like a native
+    regeneration. Existing ``chunk_type="wiki"`` rows for the target
+    ``wiki_source`` are cleared, then the accepted body is chunked,
+    embedded, and re-written.
+
+    Raises :class:`FileNotFoundError` when the draft does not exist.
+    """
+    draft = _draft_path(wiki_root, slug)
+    if not draft.is_file():
+        raise FileNotFoundError(f"draft not found: {slug}")
+    raw = draft.read_text(encoding="utf-8")
+    clean = _strip_drift_marker(raw)
+
+    published = _find_published(wiki_root, slug)
+    if published is not None:
+        target = published
+    else:
+        target = wiki_root / SUMMARIES_SUBDIR / f"{slug}.md"
+        log.info(
+            "Draft %s has no published counterpart; accepting into %s",
+            slug,
+            SUMMARIES_SUBDIR,
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(clean, encoding="utf-8")
+    draft.unlink()
+
+    reindexed = _reindex_accepted_page(target, wiki_root, store)
+    log.info("Accepted draft %s -> %s (%d chunks indexed)", slug, target, reindexed)
+    return AcceptResult(slug=slug, moved_to=target, reindexed_chunks=reindexed)
+
+
+def reject_draft(slug: str, wiki_root: Path) -> None:
+    """Delete the draft file without touching the published page or the index."""
+    draft = _draft_path(wiki_root, slug)
+    if not draft.is_file():
+        raise FileNotFoundError(f"draft not found: {slug}")
+    draft.unlink()
+    log.info("Rejected draft %s", slug)
+
+
+def _reindex_accepted_page(target: Path, wiki_root: Path, store: Store) -> int:
+    """Re-index *target* via :func:`lilbee.wiki.gen.index_wiki_page`.
+
+    Returns the number of ``chunk_type="wiki"`` rows written. Routes
+    through the same chunk / embed / clear-and-rewrite path as initial
+    page generation, so an accepted draft is indexed identically to a
+    fresh page and no bespoke accept-time code path exists.
+    """
+    from lilbee.wiki.gen import index_wiki_page
+
+    wiki_source = _wiki_source_for(target, wiki_root)
+    content = target.read_text(encoding="utf-8")
+    return index_wiki_page(content, wiki_source, store)
+
+
+def _wiki_source_for(target: Path, wiki_root: Path) -> str:
+    """Build the ``wiki_source`` identifier used in the chunks table.
+
+    Shape matches :attr:`PageTarget.wiki_source`:
+    ``<wiki_dir>/<subdir>/<slug>.md``.
+    """
+    wiki_dir_name = wiki_root.name
+    relative = target.relative_to(wiki_root)
+    return f"{wiki_dir_name}/{relative.as_posix()}"
+
+
+def _coerce_float(value: Any) -> float | None:
+    """Return *value* as a float, or None when conversion is not sensible."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -505,18 +505,27 @@ def _assemble_content(
 def index_wiki_page(content: str, wiki_source: str, store: Store) -> int:
     """Chunk a wiki page body, embed it, and write rows with ``chunk_type="wiki"``.
 
-    Drafts and archive pages never enter the search pool: a
-    ``wiki_source`` whose first path component is not a content
-    subdir returns 0 without touching the store. Stale rows for the
-    same ``wiki_source`` are cleared first so regeneration replaces
-    instead of accumulating. Record shape matches the markdown-ingest
-    convention in ``ingest.py``: ``content_type="text"``, all four
-    page/line positions ``0`` (wiki pages are not paginated).
+    ``wiki_source`` must follow the ``<wiki_dir>/<subdir>/<slug>.md``
+    shape (see :attr:`PageTarget.wiki_source`). Three branches:
 
-    Returns the number of chunk rows written.
+    - subdir in :data:`WIKI_CONTENT_SUBDIRS`: clear stale rows, chunk,
+      embed, write. Returns the row count.
+    - subdir is ``drafts/`` or ``archive/``: skip without touching the
+      store. Returns 0.
+    - malformed ``wiki_source`` (no subdir component): log.warning and
+      return 0. Does not raise because the caller set is narrow (only
+      internal wiki paths reach here) and surfacing the bad input in
+      the log is sufficient triage.
+
+    Record shape matches the markdown-ingest convention in
+    ``ingest.py``: ``content_type="text"``, all four page/line
+    positions ``0`` (wiki pages are not paginated).
     """
     subdir = _subdir_from_wiki_source(wiki_source)
-    if subdir is None or subdir not in WIKI_CONTENT_SUBDIRS:
+    if subdir is None:
+        log.warning("index_wiki_page: malformed wiki_source %r (no subdir)", wiki_source)
+        return 0
+    if subdir not in WIKI_CONTENT_SUBDIRS:
         return 0
 
     body = extract_body(content).strip()

--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -502,34 +502,39 @@ def _assemble_content(
     return full
 
 
-def _index_wiki_page(content: str, target: PageTarget, store: Store) -> None:
+def index_wiki_page(content: str, wiki_source: str, store: Store) -> int:
     """Chunk a wiki page body, embed it, and write rows with ``chunk_type="wiki"``.
 
-    Drafts and archive pages never enter the search pool. Stale rows for
-    the same ``wiki_source`` are cleared first so regeneration replaces
+    Drafts and archive pages never enter the search pool: a
+    ``wiki_source`` whose first path component is not a content
+    subdir returns 0 without touching the store. Stale rows for the
+    same ``wiki_source`` are cleared first so regeneration replaces
     instead of accumulating. Record shape matches the markdown-ingest
     convention in ``ingest.py``: ``content_type="text"``, all four
     page/line positions ``0`` (wiki pages are not paginated).
+
+    Returns the number of chunk rows written.
     """
-    if target.subdir not in WIKI_CONTENT_SUBDIRS:
-        return
+    subdir = _subdir_from_wiki_source(wiki_source)
+    if subdir is None or subdir not in WIKI_CONTENT_SUBDIRS:
+        return 0
 
     body = extract_body(content).strip()
     store.clear_table(
         CHUNKS_TABLE,
-        f"source = '{escape_sql_string(target.wiki_source)}' AND chunk_type = '{CHUNK_TYPE_WIKI}'",
+        f"source = '{escape_sql_string(wiki_source)}' AND chunk_type = '{CHUNK_TYPE_WIKI}'",
     )
     if not body:
-        return
+        return 0
 
     chunks = chunk_text(body, mime_type="text/markdown", use_semantic=True)
     if not chunks:
-        return
+        return 0
 
     vectors = get_services().embedder.embed_batch(chunks)
     records = [
         {
-            "source": target.wiki_source,
+            "source": wiki_source,
             "content_type": "text",
             "chunk_type": CHUNK_TYPE_WIKI,
             "page_start": 0,
@@ -543,6 +548,18 @@ def _index_wiki_page(content: str, target: PageTarget, store: Store) -> None:
         for idx, (text, vector) in enumerate(zip(chunks, vectors, strict=True))
     ]
     store.add_chunks(records)
+    return len(records)
+
+
+def _subdir_from_wiki_source(wiki_source: str) -> str | None:
+    """Return the subdir component (``summaries``, ``concepts``, ...) of *wiki_source*.
+
+    ``wiki_source`` is the ``<wiki_dir>/<subdir>/<slug>.md`` path
+    stored in citations and chunks. Returns None when the path has
+    fewer than two components.
+    """
+    parts = wiki_source.split("/")
+    return parts[1] if len(parts) >= 2 else None
 
 
 def _persist_and_finalize(
@@ -562,7 +579,7 @@ def _persist_and_finalize(
     store.delete_citations_for_wiki(target.wiki_source)
     store.add_citations(verified)
 
-    _index_wiki_page(content, target, store)
+    index_wiki_page(content, target.wiki_source, store)
 
     if config.wiki_prune_raw:
         for name in source_names:

--- a/tests/test_wiki_drafts.py
+++ b/tests/test_wiki_drafts.py
@@ -1,0 +1,244 @@
+"""Tests for the wiki drafts review surface (B1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lilbee.config import cfg
+from lilbee.wiki.drafts import (
+    AcceptResult,
+    DraftInfo,
+    accept_draft,
+    diff_draft,
+    list_drafts,
+    reject_draft,
+)
+from lilbee.wiki.shared import (
+    CONCEPTS_SUBDIR,
+    DRAFTS_SUBDIR,
+    SUMMARIES_SUBDIR,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _draft_content(
+    body: str = "body",
+    *,
+    faithfulness: float | None = 0.85,
+    drift_pct: int | None = None,
+    bad_title: bool = False,
+) -> str:
+    drift_marker = ""
+    if drift_pct is not None:
+        drift_marker = (
+            f"<!-- DRIFT: {drift_pct}% content changed - flagged for human review -->\n\n"
+        )
+    fm_lines = ["---"]
+    if faithfulness is not None:
+        fm_lines.append(f"faithfulness_score: {faithfulness}")
+    if bad_title:
+        fm_lines.append("bad_title: true")
+    fm_lines.append("---")
+    frontmatter = "\n".join(fm_lines) + "\n"
+    return f"{drift_marker}{frontmatter}\n{body}\n"
+
+
+class TestListDrafts:
+    def test_returns_empty_when_no_drafts_dir(self, tmp_path: Path) -> None:
+        assert list_drafts(tmp_path / "wiki") == []
+
+    def test_returns_empty_when_drafts_dir_is_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "wiki" / DRAFTS_SUBDIR).mkdir(parents=True)
+        assert list_drafts(tmp_path / "wiki") == []
+
+    def test_lists_drafts_with_frontmatter_fields(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(
+            wiki_root / DRAFTS_SUBDIR / "chevrolet.md",
+            _draft_content("Chevrolet body", faithfulness=0.85, drift_pct=32),
+        )
+        drafts = list_drafts(wiki_root)
+        assert len(drafts) == 1
+        d = drafts[0]
+        assert d.slug == "chevrolet"
+        assert d.faithfulness_score == pytest.approx(0.85)
+        assert d.drift_ratio == pytest.approx(0.32)
+        assert d.bad_title is False
+        assert d.published_exists is False
+
+    def test_pairs_draft_with_existing_published_page(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / DRAFTS_SUBDIR / "chevrolet.md", _draft_content())
+        _write(
+            wiki_root / SUMMARIES_SUBDIR / "chevrolet.md",
+            "---\n---\n\nPublished chevrolet summary\n",
+        )
+        drafts = list_drafts(wiki_root)
+        assert drafts[0].published_exists is True
+        assert drafts[0].published_path is not None
+        assert drafts[0].published_path.name == "chevrolet.md"
+        assert SUMMARIES_SUBDIR in drafts[0].published_path.parts
+
+    def test_recurses_into_per_source_draft_nesting(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / DRAFTS_SUBDIR / "cars" / "caprice.md", _draft_content())
+        drafts = list_drafts(wiki_root)
+        assert len(drafts) == 1
+        assert drafts[0].slug == "cars/caprice"
+
+    def test_bad_title_flag_surfaces_from_frontmatter(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(
+            wiki_root / DRAFTS_SUBDIR / "garbage.md",
+            _draft_content(bad_title=True),
+        )
+        [d] = list_drafts(wiki_root)
+        assert d.bad_title is True
+
+    def test_non_numeric_faithfulness_coerces_to_none(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(
+            wiki_root / DRAFTS_SUBDIR / "weird.md",
+            "---\nfaithfulness_score: not-a-number\n---\n\nbody\n",
+        )
+        [d] = list_drafts(wiki_root)
+        assert d.faithfulness_score is None
+
+    def test_draft_info_to_dict_shape(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / DRAFTS_SUBDIR / "x.md", _draft_content(drift_pct=20))
+        d = list_drafts(wiki_root)[0]
+        payload = d.to_dict()
+        assert payload["slug"] == "x"
+        assert payload["drift_ratio"] == pytest.approx(0.20)
+        assert payload["bad_title"] is False
+        assert payload["published_exists"] is False
+
+
+class TestDiffDraft:
+    def test_raises_when_draft_missing(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            diff_draft("absent", tmp_path / "wiki")
+
+    def test_diff_against_published_shows_delta(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / SUMMARIES_SUBDIR / "x.md", "old line\n")
+        _write(wiki_root / DRAFTS_SUBDIR / "x.md", "new line\n")
+        diff = diff_draft("x", wiki_root)
+        assert "-old line" in diff
+        assert "+new line" in diff
+
+    def test_diff_against_no_published_shows_all_new(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / DRAFTS_SUBDIR / "x.md", "new body\n")
+        diff = diff_draft("x", wiki_root)
+        assert "+new body" in diff
+        assert "(new draft)" in diff
+
+
+class TestAcceptDraft:
+    def test_accepts_into_published_subdir_when_match_exists(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / CONCEPTS_SUBDIR / "brakes.md", "old\n")
+        _write(wiki_root / DRAFTS_SUBDIR / "brakes.md", _draft_content("new brakes body"))
+        store = MagicMock()
+        with patch("lilbee.wiki.gen.index_wiki_page", return_value=3) as idx:
+            result = accept_draft("brakes", wiki_root, store)
+        assert isinstance(result, AcceptResult)
+        assert result.slug == "brakes"
+        assert CONCEPTS_SUBDIR in result.moved_to.parts
+        assert result.reindexed_chunks == 3
+        idx.assert_called_once()
+        # Draft file gone, published content replaced.
+        assert not (wiki_root / DRAFTS_SUBDIR / "brakes.md").exists()
+        assert "new brakes body" in (wiki_root / CONCEPTS_SUBDIR / "brakes.md").read_text()
+
+    def test_accepts_into_summaries_when_no_published_counterpart(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / DRAFTS_SUBDIR / "fresh.md", _draft_content("fresh body"))
+        store = MagicMock()
+        with patch("lilbee.wiki.gen.index_wiki_page", return_value=1):
+            result = accept_draft("fresh", wiki_root, store)
+        assert SUMMARIES_SUBDIR in result.moved_to.parts
+        assert (wiki_root / SUMMARIES_SUBDIR / "fresh.md").is_file()
+
+    def test_strips_drift_marker_from_accepted_content(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / SUMMARIES_SUBDIR / "x.md", "old\n")
+        _write(wiki_root / DRAFTS_SUBDIR / "x.md", _draft_content(drift_pct=40))
+        store = MagicMock()
+        with patch("lilbee.wiki.gen.index_wiki_page", return_value=1):
+            accept_draft("x", wiki_root, store)
+        accepted = (wiki_root / SUMMARIES_SUBDIR / "x.md").read_text()
+        assert "DRIFT" not in accepted
+
+    def test_raises_when_draft_missing(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            accept_draft("missing", tmp_path / "wiki", MagicMock())
+
+
+class TestRejectDraft:
+    def test_deletes_draft_file(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        draft_path = wiki_root / DRAFTS_SUBDIR / "x.md"
+        _write(draft_path, _draft_content())
+        reject_draft("x", wiki_root)
+        assert not draft_path.exists()
+
+    def test_does_not_touch_published_or_store(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / SUMMARIES_SUBDIR / "x.md", "published\n")
+        _write(wiki_root / DRAFTS_SUBDIR / "x.md", _draft_content())
+        reject_draft("x", wiki_root)
+        assert (wiki_root / SUMMARIES_SUBDIR / "x.md").read_text() == "published\n"
+
+    def test_raises_when_draft_missing(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            reject_draft("missing", tmp_path / "wiki")
+
+
+class TestDraftInfoDefaults:
+    """Edge cases on :class:`DraftInfo` surfaced via direct construction."""
+
+    def test_published_exists_is_false_for_none_path(self) -> None:
+        d = DraftInfo(
+            slug="x",
+            path=Path("/tmp/x.md"),
+            drift_ratio=None,
+            faithfulness_score=None,
+            bad_title=False,
+            published_path=None,
+            mtime=0.0,
+        )
+        assert d.published_exists is False
+
+    def test_serialized_published_path_is_string_when_set(self, tmp_path: Path) -> None:
+        published = tmp_path / "x.md"
+        d = DraftInfo(
+            slug="x",
+            path=tmp_path / "d.md",
+            drift_ratio=0.1,
+            faithfulness_score=0.9,
+            bad_title=True,
+            published_path=published,
+            mtime=0.0,
+        )
+        payload = d.to_dict()
+        assert payload["published_path"] == str(published)
+        assert payload["published_exists"] is True
+        assert payload["bad_title"] is True
+
+
+class TestCfgUnused:
+    """Placeholder so the test module still passes when run in isolation
+    against a real cfg. Exercises that the module imports cleanly."""
+
+    def test_cfg_has_wiki_dir(self) -> None:
+        assert isinstance(cfg.wiki_dir, str)

--- a/tests/test_wiki_drafts.py
+++ b/tests/test_wiki_drafts.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from lilbee.config import cfg
 from lilbee.wiki.drafts import (
     AcceptResult,
     DraftInfo,
@@ -149,7 +148,7 @@ class TestAcceptDraft:
         _write(wiki_root / CONCEPTS_SUBDIR / "brakes.md", "old\n")
         _write(wiki_root / DRAFTS_SUBDIR / "brakes.md", _draft_content("new brakes body"))
         store = MagicMock()
-        with patch("lilbee.wiki.gen.index_wiki_page", return_value=3) as idx:
+        with patch("lilbee.wiki.drafts.index_wiki_page", return_value=3) as idx:
             result = accept_draft("brakes", wiki_root, store)
         assert isinstance(result, AcceptResult)
         assert result.slug == "brakes"
@@ -164,7 +163,7 @@ class TestAcceptDraft:
         wiki_root = tmp_path / "wiki"
         _write(wiki_root / DRAFTS_SUBDIR / "fresh.md", _draft_content("fresh body"))
         store = MagicMock()
-        with patch("lilbee.wiki.gen.index_wiki_page", return_value=1):
+        with patch("lilbee.wiki.drafts.index_wiki_page", return_value=1):
             result = accept_draft("fresh", wiki_root, store)
         assert SUMMARIES_SUBDIR in result.moved_to.parts
         assert (wiki_root / SUMMARIES_SUBDIR / "fresh.md").is_file()
@@ -174,7 +173,7 @@ class TestAcceptDraft:
         _write(wiki_root / SUMMARIES_SUBDIR / "x.md", "old\n")
         _write(wiki_root / DRAFTS_SUBDIR / "x.md", _draft_content(drift_pct=40))
         store = MagicMock()
-        with patch("lilbee.wiki.gen.index_wiki_page", return_value=1):
+        with patch("lilbee.wiki.drafts.index_wiki_page", return_value=1):
             accept_draft("x", wiki_root, store)
         accepted = (wiki_root / SUMMARIES_SUBDIR / "x.md").read_text()
         assert "DRIFT" not in accepted
@@ -219,26 +218,35 @@ class TestDraftInfoDefaults:
         )
         assert d.published_exists is False
 
-    def test_serialized_published_path_is_string_when_set(self, tmp_path: Path) -> None:
-        published = tmp_path / "x.md"
-        d = DraftInfo(
-            slug="x",
-            path=tmp_path / "d.md",
-            drift_ratio=0.1,
-            faithfulness_score=0.9,
-            bad_title=True,
-            published_path=published,
-            mtime=0.0,
+
+class TestAcceptCrashSafety:
+    """Review-driven: the draft file survives a re-index failure so
+    accept is idempotent and no content is lost."""
+
+    def test_reindex_failure_keeps_draft_on_disk(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(wiki_root / SUMMARIES_SUBDIR / "x.md", "old\n")
+        _write(wiki_root / DRAFTS_SUBDIR / "x.md", _draft_content("new"))
+
+        boom = MagicMock(side_effect=RuntimeError("indexer down"))
+        with patch("lilbee.wiki.drafts.index_wiki_page", boom), pytest.raises(RuntimeError):
+            accept_draft("x", wiki_root, MagicMock())
+
+        # Published page was updated (first write), but the draft
+        # survives so the user can re-run accept once the indexer is back.
+        assert (wiki_root / DRAFTS_SUBDIR / "x.md").is_file()
+
+
+class TestListDraftsWithOnlyDriftMarker:
+    """Drift marker parses even when frontmatter is missing."""
+
+    def test_drift_marker_without_frontmatter(self, tmp_path: Path) -> None:
+        wiki_root = tmp_path / "wiki"
+        _write(
+            wiki_root / DRAFTS_SUBDIR / "x.md",
+            "<!-- DRIFT: 15% content changed - flagged for human review -->\n\nbody\n",
         )
-        payload = d.to_dict()
-        assert payload["published_path"] == str(published)
-        assert payload["published_exists"] is True
-        assert payload["bad_title"] is True
-
-
-class TestCfgUnused:
-    """Placeholder so the test module still passes when run in isolation
-    against a real cfg. Exercises that the module imports cleanly."""
-
-    def test_cfg_has_wiki_dir(self) -> None:
-        assert isinstance(cfg.wiki_dir, str)
+        [d] = list_drafts(wiki_root)
+        assert d.drift_ratio == pytest.approx(0.15)
+        assert d.faithfulness_score is None
+        assert d.bad_title is False

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -21,7 +21,6 @@ from lilbee.wiki.gen import (
     _find_excerpt_source,
     _generate_synthesis_page,
     _group_chunks_by_page,
-    _index_wiki_page,
     _leaf_hash,
     _match_citation_source,
     _parse_faithfulness_score,
@@ -30,6 +29,7 @@ from lilbee.wiki.gen import (
     _truncate_chunks_to_budget,
     _verify_citations,
     generate_synthesis_pages,
+    index_wiki_page,
 )
 from lilbee.wiki.shared import (
     CONCEPTS_SUBDIR,
@@ -953,7 +953,7 @@ class TestSynthesisDriftDetection:
 
 
 class TestWikiIndexing:
-    """``_index_wiki_page`` chunks, embeds and writes wiki page bodies."""
+    """``index_wiki_page`` chunks, embeds and writes wiki page bodies."""
 
     @staticmethod
     def _target(subdir: str = CONCEPTS_SUBDIR, slug: str = "brakes") -> PageTarget:
@@ -996,7 +996,7 @@ class TestWikiIndexing:
                 return_value=["Brakes convert kinetic energy to heat through friction pads."],
             ),
         ):
-            _index_wiki_page(content, target, store)
+            index_wiki_page(content, target.wiki_source, store)
 
         store.clear_table.assert_called_once()
         call_args = store.clear_table.call_args
@@ -1029,7 +1029,7 @@ class TestWikiIndexing:
             patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
             patch("lilbee.wiki.gen.chunk_text", return_value=["body"]),
         ):
-            _index_wiki_page(self._content("body"), target, store)
+            index_wiki_page(self._content("body"), target.wiki_source, store)
 
         store.clear_table.assert_not_called()
         store.add_chunks.assert_not_called()
@@ -1052,7 +1052,7 @@ class TestWikiIndexing:
             patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
             patch("lilbee.wiki.gen.chunk_text") as chunker,
         ):
-            _index_wiki_page(content, target, store)
+            index_wiki_page(content, target.wiki_source, store)
 
         store.clear_table.assert_called_once()
         chunker.assert_not_called()
@@ -1067,7 +1067,7 @@ class TestWikiIndexing:
             patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
             patch("lilbee.wiki.gen.chunk_text", return_value=[]),
         ):
-            _index_wiki_page(self._content("some body"), target, store)
+            index_wiki_page(self._content("some body"), target.wiki_source, store)
 
         store.clear_table.assert_called_once()
         store.add_chunks.assert_not_called()
@@ -1085,7 +1085,7 @@ class TestWikiIndexing:
             patch("lilbee.wiki.gen.get_services", return_value=self._services_mock()),
             patch("lilbee.wiki.gen.chunk_text", return_value=["one chunk"]),
         ):
-            _index_wiki_page(self._content("first body"), target, store)
-            _index_wiki_page(self._content("second body"), target, store)
+            index_wiki_page(self._content("first body"), target.wiki_source, store)
+            index_wiki_page(self._content("second body"), target.wiki_source, store)
 
         assert call_order == ["clear", "add", "clear", "add"]

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -1034,6 +1034,19 @@ class TestWikiIndexing:
         store.clear_table.assert_not_called()
         store.add_chunks.assert_not_called()
 
+    def test_malformed_wiki_source_logs_warning_and_skips(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """A ``wiki_source`` without a subdir component is logged and
+        skipped rather than silently writing to the store or crashing.
+        """
+        store = MagicMock(spec=Store)
+        caplog.set_level("WARNING", logger="lilbee.wiki.gen")
+        result = index_wiki_page(self._content("body"), "malformed", store)
+        assert result == 0
+        store.clear_table.assert_not_called()
+        assert any("malformed wiki_source" in r.message for r in caplog.records)
+
     def test_empty_body_clears_stale_but_adds_nothing(self):
         """A page whose body is empty after frontmatter+citation stripping invalidates
         old rows but writes none, so stale wiki rows from a prior generation are removed.


### PR DESCRIPTION
## Problem

The wiki builder already knew how to send a generated page to `drafts/` when it drifted too far from the prior version or scored below the faithfulness threshold. It just never gave the user a way to look at those drafts afterward. They piled up invisibly, there was no diff against the current published page, no way to accept a draft as the new published version, and no way to reject and delete one. "Drafts" was a dead-end directory.

## What changed

Four new commands under `lilbee wiki drafts`:

- **`list`** shows every pending draft with its drift percent, faithfulness score, and whether a published counterpart exists.
- **`diff <slug>`** prints a unified diff against the published page (or shows the draft as all-new when there's nothing published yet).
- **`accept <slug>`** replaces the published page with the draft and re-indexes its chunks so it shows up in search. The sequence is deliberately write-then-reindex-then-unlink: if re-indexing fails, the draft stays on disk and the user can retry.
- **`reject <slug>`** deletes the draft without touching the published page or the index.

The first two operations are also exposed through MCP; accept and reject stay CLI-only so destructive actions need explicit intent.

## Behavior

After a drift or a low-faithfulness event, `wiki drafts list` shows the pending pages. The user diffs, decides, and moves on. Nothing accumulates silently anymore.