### PR TITLE
Catch garbage page titles before they ship, without another LLM call

### DIFF
--- a/src/lilbee/wiki/gen.py
+++ b/src/lilbee/wiki/gen.py
@@ -57,6 +57,7 @@ from lilbee.wiki.shared import (
     WIKI_LOG_ACTION_GENERATED,
     PageTarget,
     clean_label_for_display,
+    is_valid_label,
     make_slug,
     parse_frontmatter,
 )
@@ -416,6 +417,50 @@ def _verify_citations(
     return verified
 
 
+_FAITHFULNESS_TITLE_CAP = 0.5
+
+
+def _title_content_coherence(wiki_text: str, label: str) -> bool:
+    """Deterministic pre-check: title and body must reference the concept.
+
+    The LLM faithfulness score evaluates whether the prose reflects
+    the source chunks but does not penalize structural noise in the
+    title (bb-8b7s: ``| | designer`` passed at 0.90 because the body
+    was coherent). This pre-check asserts three invariants:
+
+    1. The first ``# `` heading must be a sanity-valid label per
+       :func:`is_valid_label`. A heading like ``| | designer`` fails
+       the structural-char gate even though it contains the cleaned
+       display name as a substring.
+    2. The cleaned display name must appear in the heading as a
+       case-insensitive substring. Covers LLM drift where the
+       heading names a different concept than requested.
+    3. The body must mention the display name at least once outside
+       the heading. Covers the "LLM talked about something adjacent
+       but never named the concept" regression.
+
+    Returns True when all three hold, False otherwise.
+    """
+    display = clean_label_for_display(label).lower()
+    if not display:
+        return False
+    heading: str | None = None
+    body_parts: list[str] = []
+    for line in wiki_text.splitlines():
+        if heading is None and line.startswith("# "):
+            heading = line[2:].strip()
+            continue
+        body_parts.append(line)
+    if heading is None:
+        return False
+    if not is_valid_label(heading):
+        return False
+    if display not in heading.lower():
+        return False
+    body = "\n".join(body_parts).lower()
+    return display in body
+
+
 def _check_faithfulness(
     chunks_text: str,
     wiki_text: str,
@@ -423,7 +468,14 @@ def _check_faithfulness(
     label: str,
     config: Config | None = None,
 ) -> float:
-    """Run the faithfulness check and return the score (0.0 on failure)."""
+    """Run the faithfulness check and return the score (0.0 on failure).
+
+    Caps the final score at :data:`_FAITHFULNESS_TITLE_CAP` (0.5) when
+    the deterministic title/body coherence pre-check fails, so pages
+    with garbage H1s or missing concept mentions drop below the
+    default faithfulness threshold (0.7) and route to drafts for
+    review even if the LLM self-scores the prose highly.
+    """
     if config is None:
         config = cfg
     template = config.wiki_faithfulness_prompt
@@ -435,10 +487,21 @@ def _check_faithfulness(
     )
     try:
         response = provider.chat(messages, stream=False, options=options)
-        return _parse_faithfulness_score(strip_reasoning(cast(str, response)))
+        llm_score = _parse_faithfulness_score(strip_reasoning(cast(str, response)))
     except Exception as exc:
         log.warning("Faithfulness check failed for %s: %s", label, exc)
         return 0.0
+
+    if _title_content_coherence(wiki_text, label):
+        return llm_score
+    log.info(
+        "Faithfulness title/body coherence failed for %r; capping score "
+        "at %.2f (LLM returned %.2f)",
+        label,
+        _FAITHFULNESS_TITLE_CAP,
+        llm_score,
+    )
+    return min(llm_score, _FAITHFULNESS_TITLE_CAP)
 
 
 def _build_frontmatter(
@@ -813,7 +876,7 @@ def _generate_synthesis_page(
         )
 
     return _generate_page(
-        label=repr(topic),
+        label=topic,
         prompt=prompt,
         chunks=all_chunks,
         chunks_text=chunks_text,

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -387,17 +387,20 @@ class TestBuildWikiMessages:
         assert messages == [{"role": "user", "content": "Summarize these chunks."}]
 
 
+_COHERENT_WIKI = "# Test\n\nThe test concept refers to the thing under test."
+
+
 class TestCheckFaithfulness:
     def test_returns_score(self):
         provider = MagicMock()
         provider.chat.return_value = "0.85"
-        score = _check_faithfulness("chunks", "wiki", provider, "test")
+        score = _check_faithfulness("chunks", _COHERENT_WIKI, provider, "test")
         assert score == 0.85
 
     def test_failure_returns_zero(self):
         provider = MagicMock()
         provider.chat.side_effect = ConnectionError("down")
-        score = _check_faithfulness("chunks", "wiki", provider, "test")
+        score = _check_faithfulness("chunks", _COHERENT_WIKI, provider, "test")
         assert score == 0.0
 
     def test_passes_faithfulness_max_tokens_cap(self):
@@ -409,7 +412,7 @@ class TestCheckFaithfulness:
         provider = MagicMock()
         provider.chat.return_value = "0.85"
         cfg.wiki_faithfulness_max_tokens = 42
-        _check_faithfulness("chunks", "wiki", provider, "test", cfg)
+        _check_faithfulness("chunks", _COHERENT_WIKI, provider, "test", cfg)
         _, kwargs = provider.chat.call_args
         assert kwargs["options"]["max_tokens"] == 42
 
@@ -418,9 +421,73 @@ class TestCheckFaithfulness:
         provider = MagicMock()
         provider.chat.return_value = "0.85"
         cfg.wiki_temperature = 0.05
-        _check_faithfulness("chunks", "wiki", provider, "test", cfg)
+        _check_faithfulness("chunks", _COHERENT_WIKI, provider, "test", cfg)
         _, kwargs = provider.chat.call_args
         assert kwargs["options"]["temperature"] == 0.05
+
+
+class TestTitleContentCoherence:
+    """B3: deterministic pre-check on title-and-body concept grounding."""
+
+    def test_garbage_title_caps_score(self):
+        """QA-driven (bb-8b7s): a garbage H1 with coherent body no
+        longer passes the faithfulness gate."""
+        provider = MagicMock()
+        provider.chat.return_value = "0.90"
+        wiki = "# | | designer\n\nThe designer refers to an individual."
+        score = _check_faithfulness("chunks", wiki, provider, "designer")
+        assert score == pytest.approx(0.5)
+
+    def test_missing_concept_mention_caps_score(self):
+        """Body must mention the concept; a page titled correctly but
+        whose body wanders off topic still fails."""
+        provider = MagicMock()
+        provider.chat.return_value = "0.95"
+        wiki = "# Brakes\n\nThis page talks about tires and wheels."
+        score = _check_faithfulness("chunks", wiki, provider, "brakes")
+        assert score == pytest.approx(0.5)
+
+    def test_missing_h1_caps_score(self):
+        provider = MagicMock()
+        provider.chat.return_value = "0.95"
+        wiki = "No heading here, just prose about brakes."
+        score = _check_faithfulness("chunks", wiki, provider, "brakes")
+        assert score == pytest.approx(0.5)
+
+    def test_llm_score_below_cap_is_not_raised(self):
+        """The pre-check caps at 0.5 but never LIFTS a lower LLM score."""
+        provider = MagicMock()
+        provider.chat.return_value = "0.2"
+        wiki = "# | | bad\n\nThe bad page."
+        score = _check_faithfulness("chunks", wiki, provider, "bad")
+        assert score == pytest.approx(0.2)
+
+    def test_coherent_page_preserves_llm_score(self):
+        provider = MagicMock()
+        provider.chat.return_value = "0.88"
+        score = _check_faithfulness(
+            "chunks",
+            "# Chevrolet\n\nChevrolet is a manufacturer of vehicles.",
+            provider,
+            "Chevrolet",
+        )
+        assert score == pytest.approx(0.88)
+
+    def test_display_name_cleanup_before_comparison(self):
+        """Structural chars in the label don't block coherence matching
+        because clean_label_for_display normalizes the comparison key."""
+        provider = MagicMock()
+        provider.chat.return_value = "0.8"
+        wiki = "# Designer\n\nThe designer of the Caprice was Irv Rybicki."
+        score = _check_faithfulness("chunks", wiki, provider, "| | designer")
+        assert score == pytest.approx(0.8)
+
+    def test_logs_info_on_coherence_failure(self, caplog: pytest.LogCaptureFixture):
+        provider = MagicMock()
+        provider.chat.return_value = "0.9"
+        caplog.set_level("INFO", logger="lilbee.wiki.gen")
+        _check_faithfulness("chunks", "# bad\n\nbody", provider, "brakes")
+        assert any("coherence failed" in r.message for r in caplog.records)
 
 
 class TestGroupChunksByPage:
@@ -609,9 +676,15 @@ class TestResolveMultiSourceCitations:
         assert records[0]["source_filename"] == "fallback.md"
 
 
-def _synthesis_wiki_text(sources: list[str]) -> str:
-    """Build a valid synthesis wiki text with citations to the given sources."""
-    lines = ["# Synthesis\n"]
+def _synthesis_wiki_text(sources: list[str], topic: str | None = None) -> str:
+    """Build a valid synthesis wiki text with citations to the given sources.
+
+    Heading defaults to ``# <topic>`` so the B3 title/body coherence
+    gate passes; override ``topic`` when a test wants to exercise a
+    mismatched-heading path.
+    """
+    heading = topic or "topic"
+    lines = [f"# {heading}\n", f"This page is about {heading}.\n"]
     cite_lines = [
         "---",
         "<!-- citations (auto-generated from _citations table -- do not edit) -->",
@@ -631,7 +704,7 @@ class TestGenerateSynthesisPage:
         chunks_by_source = {
             name: [_make_chunk(f"Fact from {name}.", source=name)] for name in sources
         }
-        wiki_text = _synthesis_wiki_text(sources)
+        wiki_text = _synthesis_wiki_text(sources, topic="gradual typing")
         provider = _mock_provider(wiki_text)
         store = _mock_store()
 
@@ -939,7 +1012,7 @@ class TestSynthesisDriftDetection:
         chunks_by_source = {
             name: [_make_chunk(f"Fact from {name}.", source=name)] for name in sources
         }
-        wiki_text = _synthesis_wiki_text(sources)
+        wiki_text = _synthesis_wiki_text(sources, topic="gradual typing")
         provider = _mock_provider(wiki_text)
         store = _mock_store()
 
@@ -1172,6 +1245,4 @@ class TestBuildFrontmatter:
         chunks = [_make_chunk("body", source=pathological, chunk_index=0)]
         fm = _build_frontmatter(cfg, ["benign.md"], 0.5, chunks=chunks)
         parsed = parse_frontmatter(fm + "body\n")
-        assert parsed["provenance"]["chunks"] == [
-            {"source": pathological, "chunk_index": 0}
-        ]
+        assert parsed["provenance"]["chunks"] == [{"source": pathological, "chunk_index": 0}]


### PR DESCRIPTION
## Problem

The faithfulness check grades each generated page on how well its prose reflects the source chunks. The problem is that a page with a nonsense title can still score high if the body text is internally coherent. A real example from the test corpus: a page titled `# | | designer` with perfectly readable prose about an automotive designer scored 0.90 and shipped as-is. The faithfulness check doesn't look at titles — only at whether the body is grounded in the sources.

## What changed

Before the language model scores faithfulness, a cheap deterministic check now runs over the generated page. Three invariants:

1. The H1 heading must itself pass the label-sanity gate — no pipes, hashes, angle brackets, or leading non-alphabetic characters.
2. The cleaned display name of the concept must appear in the heading.
3. The body must mention the concept at least once outside the heading.

If any of those fail, the faithfulness score is capped at 0.5 regardless of what the language model says. With the default threshold at 0.7, that cap automatically routes the page to drafts for human review instead of publishing it.

## Behavior

No extra LLM call. The coherence check is pure text comparison, runs in microseconds, and only affects pages that were going to land with nonsense titles anyway.