### PR TITLE
TUI startup crash: stop overwriting the configured model with the Select widget's default

### DIFF
--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -324,9 +324,18 @@ class ModelBar(Widget, can_focus=False):
 
     @on(Select.Changed, "#chat-model-select")
     def _on_chat_model_changed(self, event: Select.Changed) -> None:
-        """Handle chat model selection change."""
+        """Handle chat model selection change.
+
+        No-op when the incoming value matches the current config. Textual
+        posts ``Select.Changed`` asynchronously, so the ``_populating``
+        guard may already have cleared by the time the event is delivered
+        during startup. Without the equality short-circuit, Textual's
+        default-selection of the alphabetically-first option would
+        clobber a user's configured model (and trigger the
+        featured-catalog validator on a non-featured installed model).
+        """
         value = self._extract_value(event)
-        if value is None:
+        if value is None or value == cfg.chat_model:
             return
         cfg.chat_model = value
         settings.set_value(cfg.data_root, "chat_model", value)
@@ -334,9 +343,13 @@ class ModelBar(Widget, can_focus=False):
 
     @on(Select.Changed, "#embed-model-select")
     def _on_embed_model_changed(self, event: Select.Changed) -> None:
-        """Handle embedding model selection change."""
+        """Handle embedding model selection change.
+
+        Same equality guard as :meth:`_on_chat_model_changed` for the
+        same async-event-ordering reason.
+        """
         value = self._extract_value(event)
-        if value is None:
+        if value is None or value == cfg.embedding_model:
             return
         cfg.embedding_model = value
         settings.set_value(cfg.data_root, "embedding_model", value)

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -308,7 +308,18 @@ class ModelBar(Widget, can_focus=False):
         chat_models: list[ModelOption],
         embed_models: list[ModelOption],
     ) -> None:
-        """Populate Select widgets from scanned models (main thread)."""
+        """Populate Select widgets from scanned models (main thread).
+
+        ``_populating`` stays ``True`` until after the next refresh so
+        the async-delivered ``Select.Changed`` events queued by
+        ``set_options`` (Textual auto-selects the first option before
+        the caller reassigns the configured value) reach the handler
+        while the guard is still set. Clearing synchronously at the
+        end of this method leaves a window where an intermediate
+        event carrying the widget's auto-picked default would write
+        itself into cfg, bypassing the user's configured model and
+        tripping the featured-catalog validator.
+        """
         self._populating = True
 
         chat_sel = self.query_one("#chat-model-select", Select)
@@ -320,6 +331,10 @@ class ModelBar(Widget, can_focus=False):
         _sync_select(chat_sel, chat_opts, cfg.chat_model)
         _sync_select(embed_sel, embed_opts, cfg.embedding_model)
 
+        self.call_after_refresh(self._clear_populating_guard)
+
+    def _clear_populating_guard(self) -> None:
+        """Drop the ``_populating`` flag after queued Changed events drain."""
         self._populating = False
 
     @on(Select.Changed, "#chat-model-select")

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2457,9 +2457,7 @@ class TestModelBarAdditional:
             from textual.widgets import Select
 
             embed_sel = app.query_one("#embed-model-select", Select)
-            embed_sel.set_options(
-                [ModelOption("nomic-embed-text:v1.5", "nomic-embed-text:v1.5")]
-            )
+            embed_sel.set_options([ModelOption("nomic-embed-text:v1.5", "nomic-embed-text:v1.5")])
             write_tracker = mock.Mock()
             with (
                 mock.patch("lilbee.settings.set_value", write_tracker),

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2413,6 +2413,63 @@ class TestModelBarAdditional:
                 await pilot.pause()
             assert cfg.embedding_model == "new-embed:latest"
 
+    async def test_chat_model_change_noop_when_value_matches_config(self) -> None:
+        """bb-zvrv regression: an async Changed event whose value matches
+        cfg.chat_model already must NOT rewrite cfg. Textual posts
+        Select.Changed asynchronously, so the ``_populating`` guard can
+        clear before the event is delivered; this equality short-circuit
+        is the correct defense.
+        """
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+
+        cfg.chat_model = "qwen3:8b"
+        cfg.embedding_model = "test-embed"
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(ModelBar)
+            bar._populating = False
+            from textual.widgets import Select
+
+            chat_sel = app.query_one("#chat-model-select", Select)
+            chat_sel.set_options([ModelOption("qwen3:8b", "qwen3:8b")])
+            write_tracker = mock.Mock()
+            with (
+                mock.patch("lilbee.settings.set_value", write_tracker),
+                mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services"),
+            ):
+                chat_sel.value = "qwen3:8b"
+                await pilot.pause()
+            assert cfg.chat_model == "qwen3:8b"
+            write_tracker.assert_not_called()
+
+    async def test_embed_model_change_noop_when_value_matches_config(self) -> None:
+        """Same bb-zvrv guard for the embedding-model Select."""
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+
+        cfg.chat_model = "test-model"
+        cfg.embedding_model = "nomic-embed-text:v1.5"
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(ModelBar)
+            bar._populating = False
+            from textual.widgets import Select
+
+            embed_sel = app.query_one("#embed-model-select", Select)
+            embed_sel.set_options(
+                [ModelOption("nomic-embed-text:v1.5", "nomic-embed-text:v1.5")]
+            )
+            write_tracker = mock.Mock()
+            with (
+                mock.patch("lilbee.settings.set_value", write_tracker),
+                mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services"),
+            ):
+                embed_sel.value = "nomic-embed-text:v1.5"
+                await pilot.pause()
+            assert cfg.embedding_model == "nomic-embed-text:v1.5"
+            write_tracker.assert_not_called()
+
     async def test_populate_embed_model_in_scanned(self) -> None:
         from lilbee.cli.tui.widgets.model_bar import ModelBar
 


### PR DESCRIPTION
## Problem

Launching `lilbee chat` was crashing on startup on any data directory where the alphabetically-first installed model wasn't one of lilbee's featured models. Users got a validation error instead of the chat screen.

## What changed

The TUI starts cleanly again. The model-picker no longer overwrites the user's configured model with the Select widget's auto-picked default on startup, so a machine that has a non-featured model installed (even one that isn't the active one) doesn't block the user from using the TUI any more.

## Verification

Two regression tests cover the startup path that previously overwrote config.