### PR TITLE
Curate more featured embeddings: EmbeddingGemma + MiniLM

### DIFF
--- a/src/lilbee/featured_models.toml
+++ b/src/lilbee/featured_models.toml
@@ -92,6 +92,26 @@ size_gb = 0.3
 min_ram_gb = 2.0
 description = "Fast, high quality — default for lilbee"
 
+[[embedding]]
+name = "embeddinggemma-300m"
+tag = "qat-q8_0"
+display_name = "EmbeddingGemma 300M"
+hf_repo = "ggml-org/embeddinggemma-300m-qat-q8_0-GGUF"
+gguf_filename = "*q8_0.gguf"
+size_gb = 0.3
+min_ram_gb = 2.0
+description = "Google Gemma embedder — strong multilingual + retrieval"
+
+[[embedding]]
+name = "all-minilm-l6-v2"
+tag = "latest"
+display_name = "all-MiniLM-L6-v2"
+hf_repo = "second-state/All-MiniLM-L6-v2-Embedding-GGUF"
+gguf_filename = "*.gguf"
+size_gb = 0.025
+min_ram_gb = 1.0
+description = "Tiny classic embedder — fits anywhere, 384 dims"
+
 [[vision]]
 name = "lightonocr"
 tag = "2-1b"


### PR DESCRIPTION
## Problem

The featured catalog had a single embedding entry (`nomic-embed-text:v1.5`), which left the plugin's settings and chat-toolbar embedding pickers with no alternative to switch to — the "change embedding model + reindex" flow was effectively a no-op.

## What changed

Two more featured embedding entries land so the picker is actually useful:

- **EmbeddingGemma-300m** (`ggml-org/embeddinggemma-300m-qat-q8_0-GGUF`). Google's Gemma-trained embedder, ~300 MB. Similar footprint to nomic but a different training recipe and stronger multilingual retrieval.
- **all-MiniLM-L6-v2** (`second-state/All-MiniLM-L6-v2-Embedding-GGUF`). The classic 22 MB 384-dim embedder. Fits anywhere, good for low-RAM setups or short-text retrieval where nomic's 768 dims are overkill.

## Verification

Catalog tests + server tests pass (308 tests green).