### PR TITLE
Make the server play nicely with the Obsidian plugin's vault flow, plus crawler polish

### DIFF
--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -128,8 +128,41 @@ def json_output(data: dict) -> None:
 
 
 def clean_result(result: SearchChunk) -> dict:
-    """Convert SearchChunk to a JSON-friendly dict (no vector, no None scores)."""
-    return result.model_dump(exclude={"vector"}, exclude_none=True)
+    """Convert SearchChunk to a JSON-friendly dict (no vector, no None scores).
+
+    When ``cfg.vault_base`` is set, stamp ``vault_path`` — a vault-relative
+    path for the source file — so clients can deep-link into the native UI
+    instead of round-tripping through ``/api/source``. Best-effort: vault_path
+    is ``None`` when the source filename cannot be located under vault_base.
+    """
+    payload = result.model_dump(exclude={"vector"}, exclude_none=True)
+    vault_path = resolve_vault_path(result.source)
+    if vault_path is not None:
+        payload["vault_path"] = vault_path
+    return payload
+
+
+def resolve_vault_path(source_filename: str) -> str | None:
+    """Return ``source_filename`` as a vault-relative path, or ``None`` if unresolvable.
+
+    Returns a path when ``documents_dir`` is nested inside ``vault_base`` and
+    the source file actually exists on disk at the expected location. The
+    ``.is_file()`` check keeps clients from deep-linking into stale paths
+    left over from a deleted document or a mid-flight migration.
+
+    Sources ingested via ``/api/add`` that live outside ``documents_dir``
+    (e.g. a plugin pointing at a vault file in-place) still return ``None``
+    and fall back to the preview modal.
+    """
+    if cfg.vault_base is None:
+        return None
+    try:
+        relative_docs_dir = cfg.documents_dir.relative_to(cfg.vault_base)
+    except ValueError:
+        return None
+    if not (cfg.documents_dir / source_filename).is_file():
+        return None
+    return str(relative_docs_dir / source_filename)
 
 
 def gather_status() -> StatusResult:

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -109,7 +109,7 @@ class StatusResult(BaseModel):
 
 
 def _copytree_ignore(directory: str, contents: list[str]) -> set[str]:
-    """Ignore callback for shutil.copytree , filters ignored directories."""
+    """Ignore callback for shutil.copytree that filters ignored directories."""
     return {
         name
         for name in contents
@@ -128,13 +128,7 @@ def json_output(data: dict) -> None:
 
 
 def clean_result(result: SearchChunk) -> dict:
-    """Convert SearchChunk to a JSON-friendly dict (no vector, no None scores).
-
-    When ``cfg.vault_base`` is set, stamp ``vault_path`` , a vault-relative
-    path for the source file , so clients can deep-link into the native UI
-    instead of round-tripping through ``/api/source``. Best-effort: vault_path
-    is ``None`` when the source filename cannot be located under vault_base.
-    """
+    """Return SearchChunk as a JSON dict, stamping vault_path when resolvable."""
     payload = result.model_dump(exclude={"vector"}, exclude_none=True)
     vault_path = resolve_vault_path(result.source)
     if vault_path is not None:
@@ -145,12 +139,8 @@ def clean_result(result: SearchChunk) -> dict:
 def resolve_vault_path(source_filename: str) -> str | None:
     """Return *source_filename* as a vault-relative path, or None if unresolvable.
 
-    Resolves symlinks on both ``vault_base`` and ``documents_dir`` so
-    macOS setups where ``~/Documents`` is a symlink target still produce
-    the same deep-link. Rejects paths that escape ``documents_dir`` via
-    ``..`` segments. Returns None when the resolved source file does not
-    exist on disk, when ``documents_dir`` is not nested under
-    ``vault_base``, or when ``vault_base`` is unset.
+    Resolves symlinks on both sides and rejects ``..`` escapes from
+    ``documents_dir``.
     """
     if cfg.vault_base is None:
         return None

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -109,7 +109,7 @@ class StatusResult(BaseModel):
 
 
 def _copytree_ignore(directory: str, contents: list[str]) -> set[str]:
-    """Ignore callback for shutil.copytree — filters ignored directories."""
+    """Ignore callback for shutil.copytree , filters ignored directories."""
     return {
         name
         for name in contents
@@ -130,8 +130,8 @@ def json_output(data: dict) -> None:
 def clean_result(result: SearchChunk) -> dict:
     """Convert SearchChunk to a JSON-friendly dict (no vector, no None scores).
 
-    When ``cfg.vault_base`` is set, stamp ``vault_path`` — a vault-relative
-    path for the source file — so clients can deep-link into the native UI
+    When ``cfg.vault_base`` is set, stamp ``vault_path`` , a vault-relative
+    path for the source file , so clients can deep-link into the native UI
     instead of round-tripping through ``/api/source``. Best-effort: vault_path
     is ``None`` when the source filename cannot be located under vault_base.
     """
@@ -143,26 +143,28 @@ def clean_result(result: SearchChunk) -> dict:
 
 
 def resolve_vault_path(source_filename: str) -> str | None:
-    """Return ``source_filename`` as a vault-relative path, or ``None`` if unresolvable.
+    """Return *source_filename* as a vault-relative path, or None if unresolvable.
 
-    Returns a path when ``documents_dir`` is nested inside ``vault_base`` and
-    the source file actually exists on disk at the expected location. The
-    ``.is_file()`` check keeps clients from deep-linking into stale paths
-    left over from a deleted document or a mid-flight migration.
-
-    Sources ingested via ``/api/add`` that live outside ``documents_dir``
-    (e.g. a plugin pointing at a vault file in-place) still return ``None``
-    and fall back to the preview modal.
+    Resolves symlinks on both ``vault_base`` and ``documents_dir`` so
+    macOS setups where ``~/Documents`` is a symlink target still produce
+    the same deep-link. Rejects paths that escape ``documents_dir`` via
+    ``..`` segments. Returns None when the resolved source file does not
+    exist on disk, when ``documents_dir`` is not nested under
+    ``vault_base``, or when ``vault_base`` is unset.
     """
     if cfg.vault_base is None:
         return None
     try:
-        relative_docs_dir = cfg.documents_dir.relative_to(cfg.vault_base)
-    except ValueError:
+        vault_base = cfg.vault_base.resolve()
+        documents_dir = cfg.documents_dir.resolve()
+        source_path = (cfg.documents_dir / source_filename).resolve()
+        source_path.relative_to(documents_dir)
+        relative_docs_dir = documents_dir.relative_to(vault_base)
+    except (OSError, ValueError):
         return None
-    if not (cfg.documents_dir / source_filename).is_file():
+    if not source_path.is_file():
         return None
-    return str(relative_docs_dir / source_filename)
+    return (relative_docs_dir / source_path.relative_to(documents_dir)).as_posix()
 
 
 def gather_status() -> StatusResult:

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -262,6 +262,27 @@ _META_EXCLUDE: tuple[str, ...] = (
     r"\.(jpe?g|png|gif|webp|avif|svg|ico|pdf|docx?|xlsx?|pptx?|zip|tar|gz|mp3|mp4|webm|ogg|ttf|woff2?|css|js|map|json|xml)(\?.*)?$",
 )
 
+# Mediawiki / Wikipedia chrome that sits in every article's DOM before the
+# body. Without these a BFS from ``/wiki/Chevrolet_Caprice`` spends its
+# first hop on ``Main_Page`` / ``Wikipedia:Contents`` / ``Portal:Current_events``
+# because those nav links appear ahead of the article prose in the HTML.
+_MEDIAWIKI_EXCLUDE: tuple[str, ...] = (
+    r"/wiki/Main_Page$",
+    r"/wiki/Wikipedia:",
+    r"/wiki/Portal:",
+    r"/wiki/Help:",
+    r"/wiki/Special:",
+    r"/wiki/Category:",
+    r"/wiki/Template:",
+    r"/wiki/Template_talk:",
+    r"/wiki/Talk:",
+    r"/wiki/File:",
+    r"/wiki/File_talk:",
+    r"/wiki/User:",
+    r"/wiki/User_talk:",
+    r"/w/index\.php",
+)
+
 DEFAULT_CRAWL_EXCLUDE_PATTERNS: tuple[str, ...] = (
     *_WP_EXCLUDE,
     *_ARCHIVE_EXCLUDE,
@@ -272,6 +293,7 @@ DEFAULT_CRAWL_EXCLUDE_PATTERNS: tuple[str, ...] = (
     *_ECOMMERCE_EXCLUDE,
     *_TRACKING_EXCLUDE,
     *_META_EXCLUDE,
+    *_MEDIAWIKI_EXCLUDE,
 )
 
 

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -307,10 +307,19 @@ class Config(BaseSettings):
 
     # Paths — resolved from env/defaults in model_validator(mode='before')
     data_root: Path = Field(default=Path())
-    documents_dir: Path = Field(default=Path())
+    # documents_dir is writable so plugin-managed servers can pivot storage
+    # to a vault-native path on first boot. Changing it on a server with
+    # indexed documents leaves old files in place but invisible to search;
+    # rebuild the index after migration.
+    documents_dir: Path = ConfigField(default=Path(), writable=True)
     data_dir: Path = Field(default=Path())
     lancedb_dir: Path = Field(default=Path())
     models_dir: Path = Field(default=Path())
+    # Filesystem root of the Obsidian vault (or equivalent). When set, the
+    # server stamps ``vault_path`` on search result chunks whose source file
+    # lives under this root, so clients can open sources in the native UI
+    # instead of fetching via ``/api/source``. Null = unset (server-local mode).
+    vault_base: Path | None = ConfigField(default=None, writable=True)
 
     chat_model: str = Field(default="qwen3:0.6b", min_length=1)
     embedding_model: str = Field(default="nomic-embed-text:v1.5", min_length=1)

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -262,10 +262,7 @@ _META_EXCLUDE: tuple[str, ...] = (
     r"\.(jpe?g|png|gif|webp|avif|svg|ico|pdf|docx?|xlsx?|pptx?|zip|tar|gz|mp3|mp4|webm|ogg|ttf|woff2?|css|js|map|json|xml)(\?.*)?$",
 )
 
-# Mediawiki / Wikipedia chrome that sits in every article's DOM before the
-# body. Without these a BFS from ``/wiki/Chevrolet_Caprice`` spends its
-# first hop on ``Main_Page`` / ``Wikipedia:Contents`` / ``Portal:Current_events``
-# because those nav links appear ahead of the article prose in the HTML.
+# Mediawiki/Wikipedia navlinks that dominate BFS before the article body.
 _MEDIAWIKI_EXCLUDE: tuple[str, ...] = (
     r"/wiki/Main_Page$",
     r"/wiki/Wikipedia:",
@@ -329,18 +326,14 @@ class Config(BaseSettings):
 
     # Paths — resolved from env/defaults in model_validator(mode='before')
     data_root: Path = Field(default=Path())
-    # documents_dir is writable so plugin-managed servers can pivot storage
-    # to a vault-native path on first boot. Changing it on a server with
-    # indexed documents leaves old files in place but invisible to search;
-    # rebuild the index after migration.
+    # Writable so plugin-managed servers can pivot storage to a vault path on
+    # first boot; rebuild the index after migrating.
     documents_dir: Path = ConfigField(default=Path(), writable=True)
     data_dir: Path = Field(default=Path())
     lancedb_dir: Path = Field(default=Path())
     models_dir: Path = Field(default=Path())
-    # Filesystem root of the Obsidian vault (or equivalent). When set, the
-    # server stamps ``vault_path`` on search result chunks whose source file
-    # lives under this root, so clients can open sources in the native UI
-    # instead of fetching via ``/api/source``. Null = unset (server-local mode).
+    # Obsidian vault root; when set, search results carry a vault-relative
+    # ``vault_path`` for native-UI deep-links.
     vault_base: Path | None = ConfigField(default=None, writable=True)
 
     chat_model: str = Field(default="qwen3:0.6b", min_length=1)

--- a/src/lilbee/crawler/__init__.py
+++ b/src/lilbee/crawler/__init__.py
@@ -28,6 +28,7 @@ from lilbee.crawler.api import (
     crawl_single,
 )
 from lilbee.crawler.bootstrap import (
+    CrawlerBackendMissing,
     CrawlerBrowserMissing,
     bootstrap_chromium,
     chromium_installed,
@@ -63,6 +64,7 @@ __all__ = [
     "ConcurrencySpec",
     "CrawlMeta",
     "CrawlResult",
+    "CrawlerBackendMissing",
     "CrawlerBrowserMissing",
     "FetchedPage",
     "FilterSpec",

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -131,16 +131,7 @@ def _fetched_to_result(page: FetchedPage) -> CrawlResult:
 
 
 async def crawl_single(url: str, *, quiet: bool = False) -> CrawlResult:
-    """Fetch a single URL and return its markdown content.
-
-    Fails fast with :class:`CrawlerBackendMissing` when the ``crawler``
-    extra isn't installed. Without this guard the lazy backend import
-    inside the fetcher would be swallowed by the broad ``except Exception``
-    below, turning a missing-extra install into a silent
-    ``CrawlResult(success=False)`` that the SSE layer renders as
-    ``crawl_done`` with ``files_written=0``. Matches the parity gate
-    :func:`crawl_recursive` already has.
-    """
+    """Fetch a single URL. Raises :class:`CrawlerBackendMissing` if crawl4ai isn't installed."""
     validate_crawl_url(url)
     from lilbee.crawler.crawl4ai_fetcher import crawler_available
 
@@ -275,12 +266,8 @@ async def crawl_recursive(
     depth = _resolve_limit(max_depth, cfg.crawl_max_depth)
     pages = _resolve_limit(max_pages, cfg.crawl_max_pages)
 
-    # Fail fast when the ``crawler`` extra wasn't installed. Without this
-    # the BFS silently drops out and the crawl returns ``files_written=0``
-    # because every lazy backend import inside the fetcher swallows the
-    # ImportError locally. Surfacing a clean ``CrawlerBackendMissing``
-    # here lets the server's SSE layer emit ``event: error`` with a
-    # fix-it message instead of a zero-results crawl_done.
+    # Fail fast when the ``crawler`` extra wasn't installed so SSE
+    # callers see ``event: error`` instead of a silent zero-results run.
     from lilbee.crawler.crawl4ai_fetcher import crawler_available
 
     if not crawler_available():

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -131,8 +131,24 @@ def _fetched_to_result(page: FetchedPage) -> CrawlResult:
 
 
 async def crawl_single(url: str, *, quiet: bool = False) -> CrawlResult:
-    """Fetch a single URL and return its markdown content."""
+    """Fetch a single URL and return its markdown content.
+
+    Fails fast with :class:`CrawlerBackendMissing` when the ``crawler``
+    extra isn't installed. Without this guard the lazy backend import
+    inside the fetcher would be swallowed by the broad ``except Exception``
+    below, turning a missing-extra install into a silent
+    ``CrawlResult(success=False)`` that the SSE layer renders as
+    ``crawl_done`` with ``files_written=0``. Matches the parity gate
+    :func:`crawl_recursive` already has.
+    """
     validate_crawl_url(url)
+    from lilbee.crawler.crawl4ai_fetcher import crawler_available
+
+    if not crawler_available():
+        raise bootstrap.CrawlerBackendMissing(
+            "crawl4ai is not installed. Run 'uv sync --extra crawler' "
+            "(or 'pip install crawl4ai') to enable web crawling."
+        )
     try:
         async with Crawl4aiFetcher(quiet=quiet) as fetcher:
             page = await fetcher.fetch_single(url, timeout=cfg.crawl_timeout)

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -259,6 +259,20 @@ async def crawl_recursive(
     depth = _resolve_limit(max_depth, cfg.crawl_max_depth)
     pages = _resolve_limit(max_pages, cfg.crawl_max_pages)
 
+    # Fail fast when the ``crawler`` extra wasn't installed. Without this
+    # the BFS silently drops out and the crawl returns ``files_written=0``
+    # because every lazy ``import crawl4ai`` inside the fetcher swallows
+    # the ImportError locally. Surfacing a clean ``CrawlerBackendMissing``
+    # here lets the server's SSE layer emit ``event: error`` with a
+    # fix-it message instead of a zero-results crawl_done.
+    from lilbee.crawler.crawl4ai_fetcher import crawler_available
+
+    if not crawler_available():
+        raise bootstrap.CrawlerBackendMissing(
+            "crawl4ai is not installed. Run 'uv sync --extra crawler' "
+            "(or 'pip install crawl4ai') to enable recursive web crawling."
+        )
+
     # Fail fast before pulling in crawl4ai submodules so callers get a clean
     # CrawlerBrowserMissing instead of a Playwright install banner.
     if not bootstrap.chromium_installed():

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -261,8 +261,8 @@ async def crawl_recursive(
 
     # Fail fast when the ``crawler`` extra wasn't installed. Without this
     # the BFS silently drops out and the crawl returns ``files_written=0``
-    # because every lazy ``import crawl4ai`` inside the fetcher swallows
-    # the ImportError locally. Surfacing a clean ``CrawlerBackendMissing``
+    # because every lazy backend import inside the fetcher swallows the
+    # ImportError locally. Surfacing a clean ``CrawlerBackendMissing``
     # here lets the server's SSE layer emit ``event: error`` with a
     # fix-it message instead of a zero-results crawl_done.
     from lilbee.crawler.crawl4ai_fetcher import crawler_available

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -24,22 +24,11 @@ from lilbee.progress import (
 
 
 class CrawlerBrowserMissing(RuntimeError):
-    """Playwright is installed but its Chromium browser binary is not.
-
-    Raised early by the crawl4ai adapter's ``_open_crawler`` so task
-    workers route to FAILED with an actionable message instead of
-    letting Playwright print its raw ASCII install banner into the TUI.
-    """
+    """Playwright is installed but its Chromium browser binary is not."""
 
 
 class CrawlerBackendMissing(RuntimeError):
-    """The ``crawler`` extra (crawl4ai) was never installed.
-
-    Raised by the crawl entry points before any work happens so callers
-    see an actionable error SSE event (``event: error``) instead of a
-    crawl that silently completes with ``files_written=0``. Message
-    names the fix so the user doesn't have to grep for it.
-    """
+    """The ``crawler`` extra (crawl4ai) was never installed."""
 
 
 _CHROMIUM_COMPONENT = "chromium"

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -32,6 +32,16 @@ class CrawlerBrowserMissing(RuntimeError):
     """
 
 
+class CrawlerBackendMissing(RuntimeError):
+    """The ``crawler`` extra (crawl4ai) was never installed.
+
+    Raised by the crawl entry points before any work happens so callers
+    see an actionable error SSE event (``event: error``) instead of a
+    crawl that silently completes with ``files_written=0``. Message
+    names the fix so the user doesn't have to grep for it.
+    """
+
+
 _CHROMIUM_COMPONENT = "chromium"
 # Rough size estimate for the Chromium download; Playwright bundles vary
 # slightly per platform but this gives the UI a decent denominator before

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -6,10 +6,11 @@ import asyncio
 import concurrent.futures
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
 
+from lilbee.cli.helpers import clean_result
 from lilbee.config import cfg
 from lilbee.crawl_task import get_task, start_crawl
 from lilbee.crawler import is_url, require_valid_crawl_url
@@ -22,9 +23,6 @@ from lilbee.wiki.shared import (
     WIKI_STATUS_FAILED,
     WIKI_STATUS_GENERATED,
 )
-
-if TYPE_CHECKING:
-    from lilbee.store import SearchChunk
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +39,7 @@ def search(query: str, top_k: int = 5) -> list[dict[str, Any]] | dict[str, Any]:
     try:
         results = get_services().searcher.search(query, top_k=top_k)
         results = [r for r in results if r.distance is None or r.distance <= cfg.max_distance]
-        return [clean(r) for r in results]
+        return [clean_result(r) for r in results]
     except Exception as exc:
         return {"error": str(exc)}
 
@@ -526,11 +524,6 @@ def model_rm(model: str, source: str = "") -> dict[str, Any]:
     except ValueError as exc:
         return {"error": str(exc)}
     return remove_model_data(model, source=src).model_dump()
-
-
-def clean(result: SearchChunk) -> dict[str, object]:
-    """Convert SearchChunk to a JSON-friendly dict."""
-    return result.model_dump(exclude={"vector"}, exclude_none=True)
 
 
 def main() -> None:

--- a/src/lilbee/results.py
+++ b/src/lilbee/results.py
@@ -19,6 +19,9 @@ class DocumentResult(BaseModel):
     content_type: str
     excerpts: list[Excerpt]
     best_relevance: float
+    # Vault-relative path for clients to deep-link into the native UI.
+    # ``None`` when the server can't resolve the source under ``cfg.vault_base``.
+    vault_path: str | None = None
 
 
 def _zero_to_none(val: int) -> int | None:
@@ -42,6 +45,8 @@ def _to_excerpt(chunk: SearchChunk) -> Excerpt:
 
 def group(chunks: list[SearchChunk]) -> list[DocumentResult]:
     """Group raw LanceDB chunks into document-centric results."""
+    from lilbee.cli.helpers import resolve_vault_path
+
     by_source: dict[str, list[SearchChunk]] = {}
     for chunk in chunks:
         source = chunk.source
@@ -60,6 +65,7 @@ def group(chunks: list[SearchChunk]) -> list[DocumentResult]:
                 content_type=source_chunks[0].content_type,
                 excerpts=excerpts,
                 best_relevance=excerpts[0].relevance,
+                vault_path=resolve_vault_path(source),
             )
         )
 

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -27,6 +27,7 @@ from lilbee.server.routes.general import (
     config_route,
     config_update_route,
     health_route,
+    source_content_route,
     status_route,
 )
 from lilbee.server.routes.models import (
@@ -107,6 +108,7 @@ def create_app() -> Litestar:
             config_route,
             config_defaults_route,
             config_update_route,
+            source_content_route,
             search_route,
             ask_route,
             ask_stream_route,

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -557,9 +557,17 @@ def _require_model_available(model: str) -> str:
     # ``available`` lists bare tags from /api/tags; stored refs may carry an
     # ``ollama/`` prefix. Match on either form so both client styles work.
     bare = parse_model_ref(normalized).name
-    if normalized not in available and bare not in available:
-        raise ValueError(f"Model '{normalized}' is not available. Pull it first or check the name.")
-    return normalized
+    if normalized in available or bare in available:
+        return normalized
+    # Providers may report the HuggingFace repo form instead of the catalog
+    # ``name:tag``. When the input resolved to a catalog entry, accept that
+    # entry's ``hf_repo`` (with or without ``:latest``) as an equivalent
+    # installed form so the canonical ref is still returned.
+    if entry is not None:
+        hf_candidates = {entry.hf_repo, ensure_tag(entry.hf_repo)}
+        if hf_candidates.intersection(available):
+            return normalized
+    raise ValueError(f"Model '{normalized}' is not available. Pull it first or check the name.")
 
 
 def _build_task_to_field() -> dict[ModelTask, str]:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -749,6 +749,13 @@ async def get_source_content(
 
     from lilbee.wiki.index import parse_title
 
+    # Windows ships ``mimetypes`` without a registered type for ``.md``
+    # unless a markdown-aware editor has written one into the registry,
+    # so CI runners on Windows see ``guess_type('doc.md')`` return
+    # ``(None, None)`` and fall through to ``application/octet-stream``.
+    # Pin the mapping explicitly; ``add_type`` is idempotent.
+    mimetypes.add_type("text/markdown", ".md")
+
     if not source or not source.strip():
         raise ValueError("source must not be empty")
     documents_dir = cfg.documents_dir

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -52,6 +52,7 @@ from lilbee.server.models import (
     ModelsInstalledResponse,
     ModelsShowResponse,
     SetModelResponse,
+    SourceContentResponse,
     StatusResponse,
     SyncSummary,
 )
@@ -539,10 +540,19 @@ async def _set_model(
 
 
 def _require_model_available(model: str) -> str:
-    """Validate that *model* exists locally. Returns the normalized name or raises ValueError."""
+    """Validate that *model* exists locally. Returns the normalized name or raises ValueError.
+
+    Callers may pass the catalog ``name:tag`` (``qwen3:4b``), the HuggingFace
+    repo id (``Qwen/Qwen3-4B-GGUF``, with or without ``:latest``), the
+    display name, or a provider-prefixed ref. Normalise via
+    ``find_catalog_entry`` first so a single installed variant resolves
+    regardless of which form the caller used.
+    """
+    from lilbee.catalog import find_catalog_entry
     from lilbee.models import ensure_tag
 
-    normalized = ensure_tag(model)
+    entry = find_catalog_entry(model)
+    normalized = entry.ref if entry is not None else ensure_tag(model)
     available = get_services().provider.list_models()
     # ``available`` lists bare tags from /api/tags; stored refs may carry an
     # ``ollama/`` prefix. Match on either form so both client styles work.
@@ -713,6 +723,44 @@ async def get_config() -> ConfigResponse:
     dumped = cfg.model_dump()
     result = {k: v for k, v in dumped.items() if k in _PUBLIC_CONFIG_FIELDS}
     return ConfigResponse(**result)
+
+
+async def get_source_content(
+    source: str, raw: bool = False
+) -> SourceContentResponse | tuple[bytes, str]:
+    """Read a stored source file and return its contents.
+
+    Resolves ``documents_dir / source`` and requires the result to stay
+    inside ``documents_dir``. With ``raw=True`` the caller gets
+    ``(bytes, content_type)`` to stream; otherwise the JSON shape is
+    populated with markdown text for textual formats and an empty
+    ``markdown`` field for binary ones (the caller should re-request
+    with ``raw=1`` in that case).
+    """
+    import mimetypes
+
+    from lilbee.wiki.index import parse_title
+
+    if not source or not source.strip():
+        raise ValueError("source must not be empty")
+    documents_dir = cfg.documents_dir
+    resolved = validate_path_within(documents_dir / source, documents_dir)
+    if not resolved.is_file():
+        raise FileNotFoundError(source)
+
+    content_type, _ = mimetypes.guess_type(resolved.name)
+    if content_type is None:
+        content_type = "application/octet-stream"
+
+    if raw:
+        return resolved.read_bytes(), content_type
+
+    if not content_type.startswith("text/"):
+        return SourceContentResponse(markdown="", content_type=content_type, title=None)
+
+    text = resolved.read_text(encoding="utf-8", errors="replace")
+    title = parse_title(text) or None
+    return SourceContentResponse(markdown=text, content_type=content_type, title=title)
 
 
 @functools.cache

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -12,6 +12,7 @@ import copy
 import functools
 import json
 import logging
+import mimetypes
 import threading
 import time
 import types
@@ -65,6 +66,11 @@ if TYPE_CHECKING:
     from lilbee.query import ChatMessage
 
 log = logging.getLogger(__name__)
+
+# Windows mimetypes reads from the registry, which may not define ``.md``
+# as ``text/markdown``. Pin the mapping at import time; ``add_type`` is
+# idempotent so repeated imports are safe.
+mimetypes.add_type("text/markdown", ".md")
 
 MAX_ADD_FILES = 100
 
@@ -745,16 +751,7 @@ async def get_source_content(
     ``markdown`` field for binary ones (the caller should re-request
     with ``raw=1`` in that case).
     """
-    import mimetypes
-
     from lilbee.wiki.index import parse_title
-
-    # Windows ships ``mimetypes`` without a registered type for ``.md``
-    # unless a markdown-aware editor has written one into the registry,
-    # so CI runners on Windows see ``guess_type('doc.md')`` return
-    # ``(None, None)`` and fall through to ``application/octet-stream``.
-    # Pin the mapping explicitly; ``add_type`` is idempotent.
-    mimetypes.add_type("text/markdown", ".md")
 
     if not source or not source.strip():
         raise ValueError("source must not be empty")

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -546,13 +546,10 @@ async def _set_model(
 
 
 def _require_model_available(model: str) -> str:
-    """Validate that *model* exists locally. Returns the normalized name or raises ValueError.
+    """Return the normalized installed model ref; raises ValueError when unavailable.
 
-    Callers may pass the catalog ``name:tag`` (``qwen3:4b``), the HuggingFace
-    repo id (``Qwen/Qwen3-4B-GGUF``, with or without ``:latest``), the
-    display name, or a provider-prefixed ref. Normalise via
-    ``find_catalog_entry`` first so a single installed variant resolves
-    regardless of which form the caller used.
+    Accepts catalog ``name:tag``, HuggingFace repo id, display name, or
+    provider-prefixed ref.
     """
     from lilbee.catalog import find_catalog_entry
     from lilbee.models import ensure_tag
@@ -742,14 +739,9 @@ async def get_config() -> ConfigResponse:
 async def get_source_content(
     source: str, raw: bool = False
 ) -> SourceContentResponse | tuple[bytes, str]:
-    """Read a stored source file and return its contents.
-
-    Resolves ``documents_dir / source`` and requires the result to stay
-    inside ``documents_dir``. With ``raw=True`` the caller gets
-    ``(bytes, content_type)`` to stream; otherwise the JSON shape is
-    populated with markdown text for textual formats and an empty
-    ``markdown`` field for binary ones (the caller should re-request
-    with ``raw=1`` in that case).
+    """Return a stored source file: JSON with markdown text for text types, or
+    ``(bytes, content_type)`` when *raw* is True. Binary types return empty
+    markdown so clients know to re-request with ``raw=1``.
     """
     from lilbee.wiki.index import parse_title
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -48,6 +48,19 @@ class SetModelRequest(BaseModel):
     model: str
 
 
+class SourceContentResponse(BaseModel):
+    """Response for GET /api/source?source=... (raw=0 JSON shape).
+
+    ``markdown`` holds UTF-8 text for markdown/html/plaintext sources.
+    For binary formats like PDFs, clients should request ``raw=1`` and
+    handle the bytes themselves; this JSON shape isn't populated for them.
+    """
+
+    markdown: str
+    content_type: str
+    title: str | None = None
+
+
 class ChatMessage(BaseModel):
     """A single message in a chat conversation."""
 
@@ -68,6 +81,11 @@ class CleanedChunk(BaseModel):
     line_start: int = 0
     line_end: int = 0
     chunk_index: int = 0
+    # Vault-relative path when ``cfg.vault_base`` is set and the source file
+    # lives inside the vault. Absent when the server is running headless or
+    # the source isn't resolvable as a vault file. Clients use this to open
+    # the source in a native editor instead of fetching ``/api/source``.
+    vault_path: str | None = None
 
 
 class StatusSourceInfo(BaseModel):

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -49,12 +49,7 @@ class SetModelRequest(BaseModel):
 
 
 class SourceContentResponse(BaseModel):
-    """Response for GET /api/source?source=... (raw=0 JSON shape).
-
-    ``markdown`` holds UTF-8 text for markdown/html/plaintext sources.
-    For binary formats like PDFs, clients should request ``raw=1`` and
-    handle the bytes themselves; this JSON shape isn't populated for them.
-    """
+    """JSON body for ``GET /api/source`` (``raw=0``); empty ``markdown`` for binary types."""
 
     markdown: str
     content_type: str

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -79,7 +79,9 @@ async def source_content_route(
 
         raise ValidationException(str(exc)) from exc
 
-    if raw:
-        body, content_type = result  # type: ignore[misc]
+    # ``raw=True`` returns ``(bytes, content_type)``; narrow via ``isinstance``
+    # so mypy sees the tuple branch without leaning on ``type: ignore``.
+    if isinstance(result, tuple):
+        body, content_type = result
         return Response(content=body, media_type=content_type, status_code=200)
-    return result  # type: ignore[return-value]
+    return result

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from litestar import get, patch
+from litestar import Response, get, patch
 from pydantic import ValidationError
 
 from lilbee.server import handlers
@@ -13,6 +13,7 @@ from lilbee.server.models import (
     ConfigResponse,
     ConfigUpdateResponse,
     HealthResponse,
+    SourceContentResponse,
     StatusResponse,
 )
 
@@ -54,3 +55,31 @@ async def config_update_route(data: dict[str, Any]) -> ConfigUpdateResponse:
         from litestar.exceptions import ValidationException
 
         raise ValidationException(str(exc)) from exc
+
+
+@get("/api/source")
+@read_only
+async def source_content_route(
+    source: str, raw: bool = False
+) -> SourceContentResponse | Response[bytes]:
+    """Return stored source file content.
+
+    ``raw=0`` (default) returns a JSON body with markdown text + content type.
+    ``raw=1`` streams the raw bytes with the guessed Content-Type header so
+    clients can render PDFs, images, or other binary formats directly.
+    """
+    from litestar.exceptions import NotFoundException
+
+    try:
+        result = await handlers.get_source_content(source, raw=raw)
+    except FileNotFoundError as exc:
+        raise NotFoundException(f"source not found: {source}") from exc
+    except ValueError as exc:
+        from litestar.exceptions import ValidationException
+
+        raise ValidationException(str(exc)) from exc
+
+    if raw:
+        body, content_type = result  # type: ignore[misc]
+        return Response(content=body, media_type=content_type, status_code=200)
+    return result  # type: ignore[return-value]

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -62,12 +62,7 @@ async def config_update_route(data: dict[str, Any]) -> ConfigUpdateResponse:
 async def source_content_route(
     source: str, raw: bool = False
 ) -> SourceContentResponse | Response[bytes]:
-    """Return stored source file content.
-
-    ``raw=0`` (default) returns a JSON body with markdown text + content type.
-    ``raw=1`` streams the raw bytes with the guessed Content-Type header so
-    clients can render PDFs, images, or other binary formats directly.
-    """
+    """Return stored source file as JSON (``raw=0``) or raw bytes (``raw=1``)."""
     from litestar.exceptions import NotFoundException
 
     try:

--- a/src/lilbee/wiki/index.py
+++ b/src/lilbee/wiki/index.py
@@ -25,8 +25,12 @@ def _wiki_root(config: Config) -> Path:
     return config.data_root / config.wiki_dir
 
 
-def _parse_title(text: str) -> str:
-    """Extract title from frontmatter or first heading."""
+def parse_title(text: str) -> str:
+    """Extract title from frontmatter ``title`` field or first H1 heading.
+
+    Returns the empty string when neither is present. Callers that want
+    an ``Optional[str]`` should check truthiness.
+    """
     fm = parse_frontmatter(text)
     if "title" in fm:
         return str(fm["title"])
@@ -35,6 +39,10 @@ def _parse_title(text: str) -> str:
         if stripped.startswith("# "):
             return stripped.removeprefix("# ").strip()
     return ""
+
+
+# Backwards-compat alias for the former private name.
+_parse_title = parse_title
 
 
 def parse_source_count(text: str) -> int:

--- a/src/lilbee/wiki/index.py
+++ b/src/lilbee/wiki/index.py
@@ -26,10 +26,10 @@ def _wiki_root(config: Config) -> Path:
 
 
 def parse_title(text: str) -> str:
-    """Extract title from frontmatter ``title`` field or first H1 heading.
+    """Extract title from YAML frontmatter ``title`` field or first H1 heading.
 
-    Returns the empty string when neither is present. Callers that want
-    an ``Optional[str]`` should check truthiness.
+    Assumes wiki/Obsidian markdown conventions. Returns the empty string
+    when neither is present.
     """
     fm = parse_frontmatter(text)
     if "title" in fm:

--- a/tests/crawler/test_api.py
+++ b/tests/crawler/test_api.py
@@ -47,6 +47,10 @@ def isolated_env(tmp_path, monkeypatch):
     cfg.data_dir.mkdir()
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
     monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: True)
+    # The ``crawl_recursive`` entry point now gates on ``crawler_available()``
+    # so a missing ``[crawler]`` extra produces ``CrawlerBackendMissing``.
+    # Stub it True here so orchestration tests don't require crawl4ai.
+    monkeypatch.setattr("lilbee.crawler.crawl4ai_fetcher.crawler_available", lambda: True)
     # Bypass SSRF DNS resolution by default so localhost-like test URLs
     # don't hit real DNS.
     monkeypatch.setattr(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -774,6 +774,75 @@ class TestCleanResult:
         assert "distance" not in result
 
 
+class TestResolveVaultPath:
+    """``resolve_vault_path`` returns a vault-relative string, or None.
+
+    Covers the four short-circuit conditions the Obsidian plugin relies
+    on for its deep-link vs preview-modal fallback.
+    """
+
+    def test_returns_none_when_vault_base_unset(self, tmp_path, monkeypatch):
+        from lilbee.cli.helpers import resolve_vault_path
+
+        monkeypatch.setattr(cfg, "vault_base", None)
+        monkeypatch.setattr(cfg, "documents_dir", tmp_path)
+        assert resolve_vault_path("anything.md") is None
+
+    def test_returns_none_when_documents_dir_outside_vault(self, tmp_path, monkeypatch):
+        """documents_dir not nested under vault_base → None, no stamping."""
+        from lilbee.cli.helpers import resolve_vault_path
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.setattr(cfg, "vault_base", vault)
+        monkeypatch.setattr(cfg, "documents_dir", elsewhere)
+        assert resolve_vault_path("doc.md") is None
+
+    def test_returns_none_when_file_does_not_exist(self, tmp_path, monkeypatch):
+        """Stale source name (file deleted after indexing) → None."""
+        from lilbee.cli.helpers import resolve_vault_path
+
+        vault = tmp_path / "vault"
+        docs = vault / "lilbee" / "documents"
+        docs.mkdir(parents=True)
+        monkeypatch.setattr(cfg, "vault_base", vault)
+        monkeypatch.setattr(cfg, "documents_dir", docs)
+        assert resolve_vault_path("missing.md") is None
+
+    def test_returns_vault_relative_path_when_file_exists(self, tmp_path, monkeypatch):
+        """documents_dir inside vault + file on disk → vault-relative posix path."""
+        from lilbee.cli.helpers import resolve_vault_path
+
+        vault = tmp_path / "vault"
+        docs = vault / "lilbee" / "documents"
+        docs.mkdir(parents=True)
+        (docs / "doc.md").write_text("hello")
+        monkeypatch.setattr(cfg, "vault_base", vault)
+        monkeypatch.setattr(cfg, "documents_dir", docs)
+        result = resolve_vault_path("doc.md")
+        assert result is not None
+        # Path separator is platform-native but both components must be present.
+        assert "doc.md" in result
+        assert "documents" in result
+
+
+class TestCleanResultVaultPath:
+    """clean_result stamps ``vault_path`` when resolve_vault_path returns a value."""
+
+    def test_stamps_vault_path_when_resolvable(self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        docs = vault / "lilbee" / "documents"
+        docs.mkdir(parents=True)
+        (docs / "a.pdf").write_text("stub")
+        monkeypatch.setattr(cfg, "vault_base", vault)
+        monkeypatch.setattr(cfg, "documents_dir", docs)
+        result = clean_result(_search_chunk(distance=0.5))
+        assert "vault_path" in result
+        assert "a.pdf" in result["vault_path"]
+
+
 class TestJsonFlag:
     def test_json_no_subcommand_returns_error(self):
         result = runner.invoke(app, ["--json"])

--- a/tests/test_crawl_task.py
+++ b/tests/test_crawl_task.py
@@ -128,6 +128,22 @@ class TestRunCrawl:
         assert "network error" in task.error
         assert task.finished_at != ""
 
+    @patch("lilbee.crawl_task.crawl_and_save", new_callable=AsyncMock)
+    async def test_crawler_backend_missing_surfaces_actionable_error(self, mock_crawl):
+        """When the crawler extra isn't installed, the task.error reaches the
+        client with the ``uv sync --extra crawler`` hint, not a raw stack trace."""
+        from lilbee.crawler import CrawlerBackendMissing
+
+        mock_crawl.side_effect = CrawlerBackendMissing(
+            "crawl4ai is not installed. Run `uv sync --extra crawler` to enable crawling."
+        )
+        task = CrawlTask(task_id="t1", url="https://example.com", depth=0, max_pages=10)
+
+        await run_crawl(task)
+        assert task.status == TaskStatus.FAILED
+        assert "uv sync --extra crawler" in task.error
+        assert task.finished_at != ""
+
     @patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=MagicMock())
     @patch("lilbee.crawl_task.crawl_and_save", new_callable=AsyncMock)
     async def test_sync_called_after_crawl(self, mock_crawl, mock_sync):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -408,6 +408,24 @@ class TestCrawlSingle:
         with pytest.raises(CrawlerBrowserMissing, match="Chromium"):
             await crawl_single("https://example.com")
 
+    async def test_missing_crawler_extra_raises_backend_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the ``crawler`` extra installed, crawl_single fails fast.
+
+        Without this guard the lazy ``import crawl4ai`` inside the fetcher
+        would be swallowed by the broad ``except Exception`` at the bottom
+        of crawl_single, turning a missing-extra install into a silent
+        ``CrawlResult(success=False)`` and a ``crawl_done`` with
+        ``files_written=0`` — same silent failure the recursive path
+        already guards against.
+        """
+        from lilbee.crawler import CrawlerBackendMissing
+
+        monkeypatch.setattr("lilbee.crawler.crawl4ai_fetcher.crawler_available", lambda: False)
+        with pytest.raises(CrawlerBackendMissing, match="crawl4ai is not installed"):
+            await crawl_single("https://example.com")
+
 
 class TestBootstrapChromium:
     """bb-wq8g: the subprocess wrapper that installs Playwright's Chromium."""
@@ -845,6 +863,23 @@ class TestCrawlRecursive:
         )
         monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: False)
         with pytest.raises(CrawlerBrowserMissing, match="Chromium"):
+            await crawl_recursive("https://example.com", max_depth=1)
+
+    async def test_missing_crawler_extra_raises_backend_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without the ``crawler`` extra, crawl_recursive fails fast.
+
+        Without this guard the BFS silently drops out and the crawl returns
+        ``files_written=0`` because every lazy backend import inside the
+        fetcher swallows the ImportError locally. The explicit raise lets
+        the server's SSE layer surface ``event: error`` with a fix-it
+        message instead of a zero-results ``crawl_done``.
+        """
+        from lilbee.crawler import CrawlerBackendMissing
+
+        monkeypatch.setattr("lilbee.crawler.crawl4ai_fetcher.crawler_available", lambda: False)
+        with pytest.raises(CrawlerBackendMissing, match="crawl4ai is not installed"):
             await crawl_recursive("https://example.com", max_depth=1)
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -11,7 +11,6 @@ from lilbee.crawl_task import clear_tasks
 from lilbee.ingest import SyncResult
 from lilbee.mcp import (
     add,
-    clean,
     crawl,
     crawl_status,
     init,
@@ -73,41 +72,6 @@ def _no_dns():
 
 
 _SYNC_NOOP = SyncResult()
-
-
-class TestClean:
-    def test_strips_vector(self):
-        chunk = SearchChunk(
-            source="a.pdf",
-            content_type="text",
-            page_start=0,
-            page_end=0,
-            line_start=0,
-            line_end=0,
-            chunk="hi",
-            chunk_index=0,
-            vector=[0.1],
-            distance=0.5,
-        )
-        result = clean(chunk)
-        assert "vector" not in result
-        assert result["source"] == "a.pdf"
-
-    def test_has_distance(self):
-        chunk = SearchChunk(
-            source="a.pdf",
-            content_type="text",
-            page_start=0,
-            page_end=0,
-            line_start=0,
-            line_end=0,
-            chunk="hi",
-            chunk_index=0,
-            vector=[0.1],
-            distance=0.42,
-        )
-        result = clean(chunk)
-        assert result["distance"] == 0.42
 
 
 class TestSearch:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1909,3 +1909,126 @@ class TestSearchRouteErrors:
                     "/api/ask", json={"question": "test"}, headers=self._auth_headers()
                 )
         assert resp.status_code == 503
+
+
+class TestSourceContentRoute:
+    """GET /api/source routing: JSON shape, raw streaming, and error paths.
+
+    ``get_source_content`` is covered through the route so we exercise the
+    ``isinstance(result, tuple)`` branch in ``source_content_route`` at the
+    same time; separate handler-level tests would double the surface
+    without adding signal.
+    """
+
+    @staticmethod
+    def _auth_headers() -> dict[str, str]:
+        from lilbee.server import auth as _auth_mod
+
+        return {"Authorization": f"Bearer {_auth_mod.session_manager.token}"}
+
+    async def test_empty_source_returns_400(self, isolated_env):
+        from litestar.testing import AsyncTestClient
+
+        from lilbee.server.app import create_app
+
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.get(
+                "/api/source", params={"source": "   "}, headers=self._auth_headers()
+            )
+        assert resp.status_code == 400
+
+    async def test_missing_file_returns_404(self, isolated_env):
+        from litestar.testing import AsyncTestClient
+
+        from lilbee.server.app import create_app
+
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.get(
+                "/api/source", params={"source": "nope.md"}, headers=self._auth_headers()
+            )
+        assert resp.status_code == 404
+
+    async def test_path_traversal_returns_400(self, isolated_env):
+        """``..`` traversal escapes ``documents_dir`` → ValueError → 400.
+
+        ``validate_path_within`` resolves the path and checks
+        ``is_relative_to``; the resulting ``ValueError`` is translated to
+        ValidationException by the route wrapper.
+        """
+        from litestar.testing import AsyncTestClient
+
+        from lilbee.server.app import create_app
+
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.get(
+                "/api/source",
+                params={"source": "../../etc/passwd"},
+                headers=self._auth_headers(),
+            )
+        assert resp.status_code == 400
+
+    async def test_text_file_returns_markdown_json(self, isolated_env):
+        """A markdown source returns JSON with markdown, title, content_type."""
+        from litestar.testing import AsyncTestClient
+
+        from lilbee.server.app import create_app
+
+        (cfg.documents_dir / "doc.md").write_text("# Hello\n\nbody\n", encoding="utf-8")
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.get(
+                "/api/source", params={"source": "doc.md"}, headers=self._auth_headers()
+            )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["markdown"].startswith("# Hello")
+        assert payload["title"] == "Hello"
+        assert payload["content_type"].startswith("text/")
+
+    async def test_binary_file_returns_empty_markdown(self, isolated_env):
+        """Non-text types return empty markdown; client should re-request raw=1."""
+        from litestar.testing import AsyncTestClient
+
+        from lilbee.server.app import create_app
+
+        (cfg.documents_dir / "doc.pdf").write_bytes(b"%PDF-1.4\nbinarydata")
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.get(
+                "/api/source", params={"source": "doc.pdf"}, headers=self._auth_headers()
+            )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["markdown"] == ""
+        assert payload["content_type"] == "application/pdf"
+        assert payload["title"] is None
+
+    async def test_unknown_extension_falls_back_to_octet_stream(self, isolated_env):
+        """A file without an extension maps to application/octet-stream."""
+        from litestar.testing import AsyncTestClient
+
+        from lilbee.server.app import create_app
+
+        (cfg.documents_dir / "mystery").write_bytes(b"\x00\x01\x02")
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.get(
+                "/api/source", params={"source": "mystery"}, headers=self._auth_headers()
+            )
+        assert resp.status_code == 200
+        assert resp.json()["content_type"] == "application/octet-stream"
+
+    async def test_raw_returns_bytes_with_content_type(self, isolated_env):
+        """raw=1 streams the file bytes with a real Content-Type header."""
+        from litestar.testing import AsyncTestClient
+
+        from lilbee.server.app import create_app
+
+        payload = b"%PDF-1.4\nbinarydata\n"
+        (cfg.documents_dir / "doc.pdf").write_bytes(payload)
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.get(
+                "/api/source",
+                params={"source": "doc.pdf", "raw": True},
+                headers=self._auth_headers(),
+            )
+        assert resp.status_code == 200
+        assert resp.content == payload
+        assert resp.headers["content-type"].startswith("application/pdf")


### PR DESCRIPTION
Qa with Obsidian plugin surfaced several adjacent rough edges in the server API. This PR takes them together because they share fixtures.

## Plugin setup wizard picks a model cleanly

Setting a role-bound model via the plugin used to return 422 for anyone who didn't already know the canonical `name:tag` form — the wizard sends HuggingFace repo ids, the catalog UI uses display names, and both were rejected. Those forms now resolve to the installed model, so the wizard's first chat-model pick works regardless of which form the catalog surfaced it as. Providers that report the HuggingFace repo form in their installed-models list are accepted as equivalent to the catalog `name:tag`, so the canonical ref is stored either way.

## Managed-mode storage sits inside the vault

The managed plugin can pivot its storage into the user's Obsidian vault on first boot and record the vault root. Ingested files end up where the user already looks for them, and downstream code knows where the vault is anchored.

## Clickable sources

Search and chat responses now carry a vault-relative path on every chunk whose source lives inside the vault. The plugin turns those into native vault links, so citation chips finally open the actual file in Obsidian. Sources that live outside the vault fall back to a new read-only endpoint that serves the stored content (JSON by default; `raw=1` streams bytes for PDFs and images).

## Clearer error when the crawler extra is missing

Before this, running a recursive crawl without `[crawler]` installed silently produced `crawl_done` with zero files and no hint at what went wrong. Users now see an actionable error naming the command that fixes it (`uv sync --extra crawler`).

## Mediawiki nav no longer hijacks recursive crawls

A recursive crawl starting at a Mediawiki article used to waste its first hop on the nav chrome — `Main_Page`, `Wikipedia:Contents`, `Portal:Current_events` — before reaching anything related to the starting article. Defaults now exclude the obvious non-article namespaces. Users who actually want those can override `crawl_exclude_patterns`.

## Verification

Full server test suite green: 4282 passed, 2 skipped, 2 xpassed, alongside 3 pre-existing failures in `tests/test_model_manager.py::TestDiscoverApiModels` that also fail on `release/next` and are unrelated to this branch. Lint, format-check, and mypy all clean.