### PR TITLE
Fix glob patterns on the new featured embedding entries

### DIFF
--- a/src/lilbee/featured_models.toml
+++ b/src/lilbee/featured_models.toml
@@ -97,20 +97,20 @@ name = "embeddinggemma-300m"
 tag = "qat-q8_0"
 display_name = "EmbeddingGemma 300M"
 hf_repo = "ggml-org/embeddinggemma-300m-qat-q8_0-GGUF"
-gguf_filename = "*q8_0.gguf"
+gguf_filename = "*Q8_0.gguf"
 size_gb = 0.3
 min_ram_gb = 2.0
-description = "Google Gemma embedder — strong multilingual + retrieval"
+description = "Google Gemma embedder, strong multilingual + retrieval"
 
 [[embedding]]
 name = "all-minilm-l6-v2"
 tag = "latest"
 display_name = "all-MiniLM-L6-v2"
 hf_repo = "second-state/All-MiniLM-L6-v2-Embedding-GGUF"
-gguf_filename = "*.gguf"
+gguf_filename = "*Q4_K_M.gguf"
 size_gb = 0.025
 min_ram_gb = 1.0
-description = "Tiny classic embedder — fits anywhere, 384 dims"
+description = "Tiny classic embedder, fits anywhere, 384 dims"
 
 [[vision]]
 name = "lightonocr"


### PR DESCRIPTION
Follow-up to #175.

EmbeddingGemma's HF repo ships the single GGUF with an uppercase \`Q8_0\` suffix. The lowercase \`*q8_0.gguf\` pattern in the featured catalog matches zero files under POSIX \`fnmatch\`, so downloading the model via the catalog surface fails with "No GGUF files found".

all-MiniLM-L6-v2's repo ships 13 quantization variants. \`*.gguf\` resolves to whichever filename sorts first (Q2_K), not the balanced Q4_K_M the rest of the catalog uses. Tighten to \`*Q4_K_M.gguf\` for consistency.

Also drop em-dashes from the new descriptions to match the project style rule.