### PR TITLE
Vision OCR: mtmd backend, GGUF-templated handler, SSE heartbeat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,10 @@ All settings override via environment variables:
 - `LILBEE_MAX_DISTANCE` — cosine distance threshold, 0-1 (default: `0.9`). Higher = more results, lower = stricter filtering
 - `LILBEE_ADAPTIVE_THRESHOLD` — enable adaptive threshold widening (default: `false`). When true, widens distance threshold if too few results found
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
-- `LILBEE_VISION_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
+- `LILBEE_OCR_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
+- `LILBEE_VISION_MAX_TOKENS` — hard cap on tokens generated per vision OCR page (default: `2048`). Safety net against runaway generation on dense pages.
 - `LILBEE_TESSERACT_TIMEOUT`: wall-clock timeout in seconds for the Tesseract OCR fallback (default: `60`, `0` = no limit). Only runs when no vision model is available.
+- `LILBEE_SSE_HEARTBEAT_INTERVAL` — seconds between SSE heartbeat events when the producer queue is idle (default: `30`). Set to `0` to disable.
 - `LILBEE_LLM_PROVIDER` — provider: `auto` (default), `llama-cpp`, `remote` (requires `pip install lilbee[litellm]`)
 - `LILBEE_REMOTE_BASE_URL` — SDK backend endpoint (default: `http://localhost:11434`)
 - `LILBEE_DIVERSITY_MAX_PER_SOURCE` — max chunks per source in results (default: `3`)
@@ -64,7 +66,7 @@ All settings override via environment variables:
 - `LILBEE_LOG_LEVEL` — logging level: DEBUG, INFO, WARNING, ERROR (default: `WARNING`)
 - `LILBEE_NO_SPLASH` — set to any non-empty value to suppress the startup bee animation
 
-CLI also accepts `--model` / `-m` for chat model, `--data-dir` / `-d`, `--vision-timeout`, and `--log-level`.
+CLI also accepts `--model` / `-m` for chat model, `--data-dir` / `-d`, `--ocr-timeout`, and `--log-level`.
 
 ## Code Quality Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,6 @@ All settings override via environment variables:
 - `LILBEE_ADAPTIVE_THRESHOLD` — enable adaptive threshold widening (default: `false`). When true, widens distance threshold if too few results found
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
 - `LILBEE_OCR_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
-- `LILBEE_VISION_MAX_TOKENS` — hard cap on tokens generated per vision OCR page (default: `2048`). Safety net against runaway generation on dense pages.
 - `LILBEE_TESSERACT_TIMEOUT`: wall-clock timeout in seconds for the Tesseract OCR fallback (default: `60`, `0` = no limit). Only runs when no vision model is available.
 - `LILBEE_SSE_HEARTBEAT_INTERVAL` — seconds between SSE heartbeat events when the producer queue is idle (default: `30`). Set to `0` to disable.
 - `LILBEE_LLM_PROVIDER` — provider: `auto` (default), `llama-cpp`, `remote` (requires `pip install lilbee[litellm]`)

--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -44,7 +44,31 @@ def _install_thread_only_tqdm_lock() -> None:
         _tqdm_base._lock = threading.RLock()
 
 
+def _prestart_mp_resource_tracker() -> None:
+    """Spawn multiprocessing's resource tracker now, while stderr is still real.
+
+    ``popen_spawn_posix._launch`` calls ``resource_tracker.getfd()`` every
+    time we start a worker subprocess, and the *first* call to ``getfd()``
+    fork_execs the tracker. Textual's App wrapper makes ``sys.stderr.fileno()
+    == -1``, which propagates into fork_exec's fds_to_keep tuple and raises
+    ``ValueError: bad value(s) in fds_to_keep`` before the tracker's own
+    pipe is even reached. Starting the tracker here, before Textual swaps
+    stderr, keeps the fd tracker alive for the rest of the process so every
+    later ``Process.start()`` in the TUI only sees a cached fd.
+    """
+    try:
+        from multiprocessing import resource_tracker
+
+        resource_tracker.ensure_running()
+    except Exception:
+        # Best-effort: if the tracker already crashed or cannot be started
+        # in the current env, leave the state alone. The worker's own
+        # spawn will surface a real error at call time.
+        pass
+
+
 _install_thread_only_tqdm_lock()
+_prestart_mp_resource_tracker()
 
 
 def _shrink_hf_download_chunk_size() -> None:

--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -49,7 +49,7 @@ def _prestart_mp_resource_tracker() -> None:
         from multiprocessing import resource_tracker
 
         resource_tracker.ensure_running()
-    except Exception:
+    except (OSError, RuntimeError, ValueError):
         # Best-effort: if the tracker already crashed or cannot be started
         # in the current env, leave the state alone. The worker's own
         # spawn will surface a real error at call time.

--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -23,18 +23,13 @@ os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 
 
 def _install_thread_only_tqdm_lock() -> None:
-    """Pin tqdm's class lock to a threading.RLock before anything touches tqdm.
+    """Pin ``tqdm.std.tqdm._lock`` to a threading RLock.
 
-    Textual's App swaps stdout/stderr for a wrapper whose ``fileno()`` returns
-    -1. The first call to ``tqdm.get_lock()`` lazily builds a
-    ``TqdmDefaultWriteLock``, which ends up spawning multiprocessing's
-    resource tracker via ``_posixsubprocess.fork_exec``. fork_exec rejects
-    fd -1 with ``ValueError: bad value(s) in fds_to_keep``, which in lilbee
-    surfaces as every vision OCR page failing the moment the TUI is the
-    frontmost process. Setting ``_lock`` on the base class short-circuits
-    the lazy path for every tqdm instance in the process, including the
-    ones HF hub, sentence-transformers, and llama-cpp create on their own.
-    Matches the approach taken upstream in huggingface_hub PR #4065.
+    Bypasses tqdm's lazy multiprocessing-lock init, which tries to
+    fork_exec the MP resource tracker with ``sys.stderr.fileno() == -1``
+    under Textual and crashes with ``bad value(s) in fds_to_keep``.
+    Matches huggingface_hub PR #4065 but applied at the base class so
+    every tqdm instance in the process inherits the lock via MRO.
     """
     try:
         from tqdm.std import tqdm as _tqdm_base
@@ -45,16 +40,10 @@ def _install_thread_only_tqdm_lock() -> None:
 
 
 def _prestart_mp_resource_tracker() -> None:
-    """Spawn multiprocessing's resource tracker now, while stderr is still real.
+    """Start the multiprocessing resource tracker before Textual swaps stderr.
 
-    ``popen_spawn_posix._launch`` calls ``resource_tracker.getfd()`` every
-    time we start a worker subprocess, and the *first* call to ``getfd()``
-    fork_execs the tracker. Textual's App wrapper makes ``sys.stderr.fileno()
-    == -1``, which propagates into fork_exec's fds_to_keep tuple and raises
-    ``ValueError: bad value(s) in fds_to_keep`` before the tracker's own
-    pipe is even reached. Starting the tracker here, before Textual swaps
-    stderr, keeps the fd tracker alive for the rest of the process so every
-    later ``Process.start()`` in the TUI only sees a cached fd.
+    Later ``Process.start()`` calls reuse the cached tracker fd and
+    never hit the fork_exec with a bad fd.
     """
     try:
         from multiprocessing import resource_tracker

--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -43,13 +43,18 @@ def _prestart_mp_resource_tracker() -> None:
     """Start the multiprocessing resource tracker before Textual swaps stderr.
 
     Later ``Process.start()`` calls reuse the cached tracker fd and
-    never hit the fork_exec with a bad fd.
+    never hit the fork_exec with a bad fd. No-op on Windows, which
+    doesn't use ``_posixsubprocess``.
     """
+    import sys as _sys
+
+    if _sys.platform == "win32":
+        return
     try:
         from multiprocessing import resource_tracker
 
         resource_tracker.ensure_running()
-    except (OSError, RuntimeError, ValueError):
+    except (OSError, RuntimeError, ValueError, ImportError):
         # Best-effort: if the tracker already crashed or cannot be started
         # in the current env, leave the state alone. The worker's own
         # spawn will surface a real error at call time.

--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import threading
 
 # Disable huggingface_hub's xet transfer layer before any HF submodule loads.
 # huggingface_hub.constants reads HF_HUB_DISABLE_XET at import time, so this
@@ -16,9 +17,34 @@ os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
 # Suppress HF-default tqdm bars (metadata probes, snapshot summaries) that
 # leak cursor escapes into the TUI. Our custom tqdm_class is NOT a subclass
 # of huggingface_hub.utils.tqdm, so huggingface_hub's `_create_progress_bar`
-# instantiates it directly without honoring this flag — download callbacks
+# instantiates it directly without honoring this flag. Download callbacks
 # continue to fire. See lilbee/catalog.py::_CallbackProgressBar.
 os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+
+
+def _install_thread_only_tqdm_lock() -> None:
+    """Pin tqdm's class lock to a threading.RLock before anything touches tqdm.
+
+    Textual's App swaps stdout/stderr for a wrapper whose ``fileno()`` returns
+    -1. The first call to ``tqdm.get_lock()`` lazily builds a
+    ``TqdmDefaultWriteLock``, which ends up spawning multiprocessing's
+    resource tracker via ``_posixsubprocess.fork_exec``. fork_exec rejects
+    fd -1 with ``ValueError: bad value(s) in fds_to_keep``, which in lilbee
+    surfaces as every vision OCR page failing the moment the TUI is the
+    frontmost process. Setting ``_lock`` on the base class short-circuits
+    the lazy path for every tqdm instance in the process, including the
+    ones HF hub, sentence-transformers, and llama-cpp create on their own.
+    Matches the approach taken upstream in huggingface_hub PR #4065.
+    """
+    try:
+        from tqdm.std import tqdm as _tqdm_base
+    except ImportError:
+        return
+    if getattr(_tqdm_base, "_lock", None) is None:
+        _tqdm_base._lock = threading.RLock()
+
+
+_install_thread_only_tqdm_lock()
 
 
 def _shrink_hf_download_chunk_size() -> None:

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -75,12 +75,7 @@ def _classify_installed_models() -> tuple[list[ModelOption], list[ModelOption]]:
     Uses registry manifests for native models and the SDK backend's
     backend metadata for remote models. Filters out mmproj files.
     """
-    buckets: dict[ModelTask, list[ModelOption]] = {
-        ModelTask.CHAT: [],
-        ModelTask.EMBEDDING: [],
-        ModelTask.VISION: [],
-        ModelTask.RERANK: [],
-    }
+    buckets: dict[ModelTask, list[ModelOption]] = {task: [] for task in ModelTask}
     seen: set[str] = set()
 
     _collect_native_models(buckets, seen)

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -397,6 +397,10 @@ class Config(BaseSettings):
     server_port: int = Field(default=0, ge=0, le=65535)
     cors_origins: list[str] = Field(default_factory=list)
     cors_origin_regex: str = Field(default=_DEFAULT_CORS_ORIGIN_REGEX)
+    # Seconds between SSE heartbeat events when the producer queue is idle.
+    # Must stay well below the plugin's STREAM_IDLE_TIMEOUT_MS (120s) so a
+    # single long-running vision OCR page can't starve the client into aborting.
+    sse_heartbeat_interval: float = ConfigField(default=30.0, ge=0.0, writable=True)
     json_mode: bool = False
     temperature: float | None = ConfigField(default=None, ge=0.0, writable=True)
     top_p: float | None = ConfigField(default=None, ge=0.0, le=1.0, writable=True)

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -388,6 +388,11 @@ class Config(BaseSettings):
     # (remote API, separate Ollama host). Local GPU models contend on a
     # single device and get slower with concurrency > 1.
     vision_concurrency: int = ConfigField(default=1, ge=1, writable=True)
+    # Hard cap on tokens generated per vision OCR page. Without a cap, some
+    # vision models hallucinate indefinitely on dense art pages and never
+    # emit an EOT, stalling the ingest. 2048 tokens (~8 KB of text) is well
+    # above any real scanned page.
+    vision_max_tokens: int = ConfigField(default=2048, ge=128, writable=True)
 
     # Tesseract fallback wall-clock timeout per file, seconds. 0 = no cap.
     tesseract_timeout: float = ConfigField(default=60.0, ge=0.0, writable=True)

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -388,11 +388,6 @@ class Config(BaseSettings):
     # (remote API, separate Ollama host). Local GPU models contend on a
     # single device and get slower with concurrency > 1.
     vision_concurrency: int = ConfigField(default=1, ge=1, writable=True)
-    # Hard cap on tokens generated per vision OCR page. Without a cap, some
-    # vision models hallucinate indefinitely on dense art pages and never
-    # emit an EOT, stalling the ingest. 2048 tokens (~8 KB of text) is well
-    # above any real scanned page.
-    vision_max_tokens: int = ConfigField(default=2048, ge=128, writable=True)
 
     # Tesseract fallback wall-clock timeout per file, seconds. 0 = no cap.
     tesseract_timeout: float = ConfigField(default=60.0, ge=0.0, writable=True)

--- a/src/lilbee/progress.py
+++ b/src/lilbee/progress.py
@@ -34,6 +34,7 @@ class SseEvent(StrEnum):
     ERROR = "error"
     DONE = "done"
     PROGRESS = "progress"
+    HEARTBEAT = "heartbeat"
 
 
 class FileStartEvent(BaseModel):

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -600,13 +600,7 @@ _CLIP_PROJECTOR_TYPE_KEY = "clip.projector_type"
 
 
 def read_mmproj_projector_type(mmproj_path: Path) -> str | None:
-    """Read ``clip.projector_type`` from a GGUF mmproj without loading the model.
-
-    Kept for diagnostic logging only. The mtmd backend in
-    :mod:`lilbee.providers.mtmd_backend` selects the image-tokenization
-    path from this metadata internally, so lilbee no longer needs a
-    projector-type-to-handler lookup table.
-    """
+    """Read ``clip.projector_type`` from a GGUF mmproj without loading the model."""
     try:
         reader = GGUFReader(str(mmproj_path))
         field = reader.get_field(_CLIP_PROJECTOR_TYPE_KEY)

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -363,7 +363,7 @@ class _LockedStreamIterator:
 _STDERR_LOCK = threading.Lock()
 
 
-def _suppress_stderr(fn: Any, *args: Any, **kwargs: Any) -> Any:
+def suppress_native_stderr(fn: Any, *args: Any, **kwargs: Any) -> Any:
     """Call *fn* with C-level stderr suppressed.
     llama.cpp prints noisy messages (e.g. 'init: embeddings required...')
     that bypass Python logging. This redirects fd 2 to /dev/null for the
@@ -384,7 +384,7 @@ def _suppress_stderr(fn: Any, *args: Any, **kwargs: Any) -> Any:
 
 def embed_one(llm: Any, text: str) -> list[float]:
     """Embed a single text with llama.cpp stderr noise suppressed."""
-    response = _suppress_stderr(llm.create_embedding, input=[text])
+    response = suppress_native_stderr(llm.create_embedding, input=[text])
     result: list[float] = response["data"][0]["embedding"]
     return result
 
@@ -396,7 +396,7 @@ def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
     """
     from llama_cpp import Llama
 
-    llm = _suppress_stderr(
+    llm = suppress_native_stderr(
         Llama, model_path=str(model_path), vocab_only=True, verbose=False, n_gpu_layers=0
     )
     try:
@@ -497,7 +497,7 @@ def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
 
         kwargs["pooling_type"] = LLAMA_POOLING_TYPE_RANK
 
-    return _suppress_stderr(Llama, **kwargs)
+    return suppress_native_stderr(Llama, **kwargs)
 
 
 def _is_rerank_model(model: str) -> bool:
@@ -520,7 +520,7 @@ def compute_rerank_scores(llm: Any, query: str, candidates: list[str]) -> list[f
     scores: list[float] = []
     for candidate in candidates:
         pair = f"{query}{_RERANK_PAIR_SEPARATOR}{candidate}"
-        response = _suppress_stderr(llm.create_embedding, input=pair)
+        response = suppress_native_stderr(llm.create_embedding, input=pair)
         score = _extract_rerank_score(response)
         scores.append(score)
     return scores

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -666,7 +666,12 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
         mmproj_path = find_mmproj_for_model(model_path)
 
     handler_cls = _resolve_vision_handler(mmproj_path)
-    log.info("Loading vision model %s with mmproj %s", model_path.name, mmproj_path.name)
+    log.info(
+        "Loading vision model %s (handler=%s, mmproj=%s, n_gpu_layers=-1)",
+        model_path.name,
+        handler_cls.__name__,
+        mmproj_path.name,
+    )
     chat_handler = _suppress_stderr(handler_cls, clip_model_path=str(mmproj_path))
 
     kwargs: dict[str, Any] = {
@@ -680,4 +685,11 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
     else:
         kwargs["n_ctx"] = 0
 
-    return _suppress_stderr(Llama, **kwargs)
+    llama = _suppress_stderr(Llama, **kwargs)
+    metadata = getattr(llama, "metadata", {}) or {}
+    log.info(
+        "Vision model loaded: n_ctx=%s arch=%s",
+        getattr(llama, "n_ctx", lambda: "?")() if callable(getattr(llama, "n_ctx", None)) else "?",
+        metadata.get("general.architecture", "?"),
+    )
+    return llama

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -70,8 +70,6 @@ class LlamaCppProvider(LLMProvider):
             keep_alive_seconds=cfg.model_keep_alive,
             loader=load_llama,
         )
-        self._vision_llm: Any | None = None
-        self._vision_model_path: str | None = None
         self._embed_queue: queue.Queue[_EmbedRequest | None] = queue.Queue()
         self._rerank_queue: queue.Queue[_RerankRequest | None] = queue.Queue()
         self._chat_lock = threading.Lock()
@@ -166,15 +164,6 @@ class LlamaCppProvider(LLMProvider):
         resolved_model = model or cfg.chat_model
         model_path = resolve_model_path(resolved_model)
         return self._cache.load_model(model_path, mode=MODE_CHAT)
-
-    def _get_vision_llm(self, model: str) -> Any:
-        """Lazy-load a Llama instance with a vision chat handler."""
-        model_path = resolve_model_path(model)
-
-        if self._vision_llm is None or self._vision_model_path != str(model_path):
-            self._vision_llm = load_vision_llama(model_path)
-            self._vision_model_path = str(model_path)
-        return self._vision_llm
 
     def _get_embed_llm(self) -> Any:
         """Load or return a cached Llama instance for embeddings."""
@@ -607,22 +596,17 @@ def find_mmproj_for_model(model_path: Path) -> Path:
     )
 
 
-_PROJECTOR_HANDLER_MAP: dict[str, str] = {
-    "ldp": "Llava15ChatHandler",
-    "ldpv2": "Llava16ChatHandler",
-    "lightonocr": "ObsidianChatHandler",
-    "minicpmv": "MiniCPMv26ChatHandler",
-    "moondream": "MoondreamChatHandler",
-    "qwen2vl": "Qwen25VLChatHandler",
-    "resampler": "Llava15ChatHandler",
-}
-
-
 _CLIP_PROJECTOR_TYPE_KEY = "clip.projector_type"
 
 
 def read_mmproj_projector_type(mmproj_path: Path) -> str | None:
-    """Read ``clip.projector_type`` from a GGUF mmproj without loading the model."""
+    """Read ``clip.projector_type`` from a GGUF mmproj without loading the model.
+
+    Kept for diagnostic logging only. The mtmd backend in
+    :mod:`lilbee.providers.mtmd_backend` selects the image-tokenization
+    path from this metadata internally, so lilbee no longer needs a
+    projector-type-to-handler lookup table.
+    """
     try:
         reader = GGUFReader(str(mmproj_path))
         field = reader.get_field(_CLIP_PROJECTOR_TYPE_KEY)
@@ -632,64 +616,3 @@ def read_mmproj_projector_type(mmproj_path: Path) -> str | None:
     if field is None or field.types[-1] != GGUFValueType.STRING:
         return None
     return bytes(field.parts[field.data[0]]).decode("utf-8", errors="replace")
-
-
-def _resolve_vision_handler(mmproj_path: Path) -> Any:
-    """Determine the correct chat handler class for a vision model's mmproj file."""
-    from llama_cpp import llama_chat_format
-
-    projector = read_mmproj_projector_type(mmproj_path)
-    if projector:
-        handler_name = _PROJECTOR_HANDLER_MAP.get(projector.lower())
-        if handler_name:
-            handler_cls = getattr(llama_chat_format, handler_name, None)
-            if handler_cls:
-                log.info("Using %s for projector type '%s'", handler_name, projector)
-                return handler_cls
-            log.warning("Handler %s not found in llama_chat_format", handler_name)
-        else:
-            log.warning("Unknown projector type '%s', falling back to Llava15", projector)
-
-    from llama_cpp.llama_chat_format import Llava15ChatHandler
-
-    return Llava15ChatHandler
-
-
-def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
-    """Load a Llama instance with the correct vision chat handler.
-    Reads the mmproj GGUF metadata to determine which chat handler to use,
-    rather than hardcoding Llava15ChatHandler for all models.
-    """
-    from llama_cpp import Llama
-
-    if mmproj_path is None:
-        mmproj_path = find_mmproj_for_model(model_path)
-
-    handler_cls = _resolve_vision_handler(mmproj_path)
-    log.info(
-        "Loading vision model %s (handler=%s, mmproj=%s, n_gpu_layers=-1)",
-        model_path.name,
-        handler_cls.__name__,
-        mmproj_path.name,
-    )
-    chat_handler = _suppress_stderr(handler_cls, clip_model_path=str(mmproj_path))
-
-    kwargs: dict[str, Any] = {
-        "model_path": str(model_path),
-        "chat_handler": chat_handler,
-        "verbose": False,
-        "n_gpu_layers": -1,
-    }
-    if cfg.num_ctx is not None:
-        kwargs["n_ctx"] = cfg.num_ctx
-    else:
-        kwargs["n_ctx"] = 0
-
-    llama = _suppress_stderr(Llama, **kwargs)
-    metadata = getattr(llama, "metadata", {}) or {}
-    log.info(
-        "Vision model loaded: n_ctx=%s arch=%s",
-        getattr(llama, "n_ctx", lambda: "?")() if callable(getattr(llama, "n_ctx", None)) else "?",
-        metadata.get("general.architecture", "?"),
-    )
-    return llama

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -61,9 +61,10 @@ def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
     """
     from llama_cpp.llama_chat_format import Llava15ChatHandler
 
-    # Defined per call so each loaded model binds its own CHAT_FORMAT to a
-    # fresh class; hoisting this to module scope would make the first
-    # loaded model's template leak into every subsequent one.
+    # Defined per call so each loaded model binds its own ``CHAT_FORMAT``
+    # (set below) to a fresh class; hoisting this to module scope would
+    # make the first loaded model's template leak into every subsequent
+    # one.
     class _GgufTemplateChatHandler(Llava15ChatHandler):
         DEFAULT_SYSTEM_MESSAGE = None
 
@@ -79,7 +80,8 @@ def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
         )
     else:
         log.info(
-            "Vision chat handler: no GGUF template in %s, falling back to Llava15 default",
+            "Vision chat handler: no GGUF-embedded chat template for %s; "
+            "using upstream default",
             model_path.name,
         )
 

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -14,9 +14,11 @@ log = logging.getLogger(__name__)
 
 
 # Image-placeholder tokens seen in GGUF chat templates. The upstream
-# Llava15ChatHandler pipeline substitutes image URLs with mtmd's media
-# marker, so these get rewritten to {{ content.image_url.url }} before
-# rendering.
+# mtmd pipeline substitutes image URLs with mtmd's media marker, so
+# these get rewritten to {{ content.image_url.url }} before rendering.
+# Case matters: GGUF templates are machine-emitted and stable, so a
+# case-insensitive replace would risk corrupting unrelated Jinja
+# identifiers.
 _GGUF_IMAGE_TOKENS: tuple[str, ...] = (
     "<|image_pad|>",
     "<image>",
@@ -34,7 +36,7 @@ def read_chat_template(model_path: Path) -> str | None:
     try:
         reader = GGUFReader(str(model_path))
         field = reader.get_field(_TOKENIZER_CHAT_TEMPLATE_KEY)
-    except Exception:
+    except (OSError, ValueError, IndexError, KeyError):
         log.debug("Failed to read chat template from %s", model_path, exc_info=True)
         return None
     if field is None:
@@ -51,14 +53,17 @@ def adapt_gguf_template_for_mtmd(template: str) -> str:
 
 
 def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
-    """Return a ``Llava15ChatHandler`` with the GGUF's own chat template.
+    """Return the mtmd chat handler configured with the GGUF's embedded template.
 
     ``DEFAULT_SYSTEM_MESSAGE`` is set to ``None`` so no stray system turn
-    is injected. Falls back to the upstream template when the GGUF has
-    no ``tokenizer.chat_template``.
+    is injected. Falls back to the upstream default template when the
+    GGUF has no ``tokenizer.chat_template``.
     """
     from llama_cpp.llama_chat_format import Llava15ChatHandler
 
+    # Defined per call so each loaded model binds its own CHAT_FORMAT to a
+    # fresh class; hoisting this to module scope would make the first
+    # loaded model's template leak into every subsequent one.
     class _GgufTemplateChatHandler(Llava15ChatHandler):
         DEFAULT_SYSTEM_MESSAGE = None
 
@@ -86,7 +91,7 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
     from llama_cpp import Llama
 
     from lilbee.config import cfg
-    from lilbee.providers.llama_cpp_provider import _suppress_stderr, find_mmproj_for_model
+    from lilbee.providers.llama_cpp_provider import find_mmproj_for_model, suppress_native_stderr
 
     if mmproj_path is None:
         mmproj_path = find_mmproj_for_model(model_path)
@@ -101,7 +106,7 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
         "n_ctx": cfg.num_ctx if cfg.num_ctx is not None else 0,
     }
 
-    llama = _suppress_stderr(Llama, **kwargs)
+    llama = suppress_native_stderr(Llama, **kwargs)
     metadata = getattr(llama, "metadata", {}) or {}
     n_ctx_fn = getattr(llama, "n_ctx", None)
     n_ctx = n_ctx_fn() if callable(n_ctx_fn) else "?"

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -1,24 +1,5 @@
-"""Vision OCR backend that drives llama.cpp's mtmd subsystem.
-
-``llama_cpp.llama_chat_format.Llava15ChatHandler`` already carries the full
-mtmd pipeline: it reads the mmproj, calls ``mtmd_tokenize`` + ``mtmd_helper_
-eval_chunk_single``, and then hands off to the standard completion sampler.
-The only reason earlier lilbee code picked a specific subclass
-(ObsidianChatHandler, Qwen25VLChatHandler, ...) was to get the right chat
-template. Those subclasses hardcode ``CHAT_FORMAT`` strings which drift
-from the GGUF's own embedded template and cause silent failures:
-
-- LightOnOCR-2-1B's GGUF ends turns on ``<|im_end|>`` but
-  ``ObsidianChatHandler`` emits ``###``. Sampling never sees the real EOT
-  and runs to the token cap.
-- ``Qwen25VLChatHandler`` injects a ``"You are a helpful assistant."``
-  system turn that pulls the model out of OCR mode and hallucinates.
-
-The fix is to load the chat template from the main GGUF itself (every
-recent vision GGUF ships one under ``tokenizer.chat_template``), rewrite
-the model's image-placeholder token into the URL-substitution pattern
-the upstream handler expects, and otherwise reuse the upstream mtmd
-pipeline unchanged.
+"""Vision OCR loader that drives llama.cpp's mtmd pipeline with the GGUF's
+own chat template, so there's no projector-type-to-handler lookup table.
 """
 
 from __future__ import annotations
@@ -32,10 +13,10 @@ from gguf import GGUFReader
 log = logging.getLogger(__name__)
 
 
-# Image-placeholder tokens we know ship inside GGUF chat templates.
-# ``Llava15ChatHandler.__call__`` replaces ``{{ content.image_url.url }}``
-# emissions with mtmd's default media marker; rewriting these tokens into
-# that Jinja expression makes the handler's pipeline work unchanged.
+# Image-placeholder tokens seen in GGUF chat templates. The upstream
+# Llava15ChatHandler pipeline substitutes image URLs with mtmd's media
+# marker, so these get rewritten to {{ content.image_url.url }} before
+# rendering.
 _GGUF_IMAGE_TOKENS: tuple[str, ...] = (
     "<|image_pad|>",
     "<image>",
@@ -62,17 +43,7 @@ def read_chat_template(model_path: Path) -> str | None:
 
 
 def adapt_gguf_template_for_mtmd(template: str) -> str:
-    """Rewrite image-placeholder tokens into the URL-substitution Jinja expression.
-
-    ``Llava15ChatHandler.__call__`` renders the template, then replaces
-    every image URL in the rendered text with ``mtmd_default_marker()``.
-    Many GGUF chat templates skip the URL and emit a fixed token instead
-    (``<|image_pad|>`` on Qwen-family vision models, ``<image>`` on
-    Llama/Llava, ``<__media__>`` on newer mtmd builds). Swapping those
-    for ``{{ content.image_url.url }}`` restores the URL contract so the
-    replacement loop finds a marker at the same position the template
-    meant to reserve for the image.
-    """
+    """Rewrite known image-placeholder tokens to ``{{ content.image_url.url }}``."""
     for token in _GGUF_IMAGE_TOKENS:
         if token in template:
             template = template.replace(token, _IMAGE_URL_JINJA)
@@ -80,14 +51,11 @@ def adapt_gguf_template_for_mtmd(template: str) -> str:
 
 
 def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
-    """Build a chat handler that uses the main GGUF's embedded chat template.
+    """Return a ``Llava15ChatHandler`` with the GGUF's own chat template.
 
-    Returns an instance of a ``Llava15ChatHandler`` subclass with
-    ``CHAT_FORMAT`` replaced by the GGUF template (image tokens rewritten)
-    and ``DEFAULT_SYSTEM_MESSAGE`` set to ``None`` so we never splice a
-    stray ``"You are a helpful assistant."`` into OCR prompts. If the
-    GGUF has no embedded template, falls back to the upstream
-    ``Llava15ChatHandler`` defaults.
+    ``DEFAULT_SYSTEM_MESSAGE`` is set to ``None`` so no stray system turn
+    is injected. Falls back to the upstream template when the GGUF has
+    no ``tokenizer.chat_template``.
     """
     from llama_cpp.llama_chat_format import Llava15ChatHandler
 
@@ -114,13 +82,7 @@ def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
 
 
 def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
-    """Load a vision-capable ``Llama`` tied to a GGUF-templated chat handler.
-
-    Replaces ``llama_cpp_provider.load_vision_llama``. Every vision model
-    goes through the same code path, driven by the main GGUF's chat
-    template and mmproj file. No per-model handler class, no projector
-    type lookup table.
-    """
+    """Load a vision-capable ``Llama`` using the GGUF-templated chat handler."""
     from llama_cpp import Llama
 
     from lilbee.config import cfg

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -80,8 +80,7 @@ def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
         )
     else:
         log.info(
-            "Vision chat handler: no GGUF-embedded chat template for %s; "
-            "using upstream default",
+            "Vision chat handler: no GGUF-embedded chat template for %s; using upstream default",
             model_path.name,
         )
 

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -1,0 +1,153 @@
+"""Vision OCR backend that drives llama.cpp's mtmd subsystem.
+
+``llama_cpp.llama_chat_format.Llava15ChatHandler`` already carries the full
+mtmd pipeline: it reads the mmproj, calls ``mtmd_tokenize`` + ``mtmd_helper_
+eval_chunk_single``, and then hands off to the standard completion sampler.
+The only reason earlier lilbee code picked a specific subclass
+(ObsidianChatHandler, Qwen25VLChatHandler, ...) was to get the right chat
+template. Those subclasses hardcode ``CHAT_FORMAT`` strings which drift
+from the GGUF's own embedded template and cause silent failures:
+
+- LightOnOCR-2-1B's GGUF ends turns on ``<|im_end|>`` but
+  ``ObsidianChatHandler`` emits ``###``. Sampling never sees the real EOT
+  and runs to the token cap.
+- ``Qwen25VLChatHandler`` injects a ``"You are a helpful assistant."``
+  system turn that pulls the model out of OCR mode and hallucinates.
+
+The fix is to load the chat template from the main GGUF itself (every
+recent vision GGUF ships one under ``tokenizer.chat_template``), rewrite
+the model's image-placeholder token into the URL-substitution pattern
+the upstream handler expects, and otherwise reuse the upstream mtmd
+pipeline unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from gguf import GGUFReader
+
+log = logging.getLogger(__name__)
+
+
+# Image-placeholder tokens we know ship inside GGUF chat templates.
+# ``Llava15ChatHandler.__call__`` replaces ``{{ content.image_url.url }}``
+# emissions with mtmd's default media marker; rewriting these tokens into
+# that Jinja expression makes the handler's pipeline work unchanged.
+_GGUF_IMAGE_TOKENS: tuple[str, ...] = (
+    "<|image_pad|>",
+    "<image>",
+    "<IMAGE>",
+    "<__media__>",
+    "<__image__>",
+)
+_IMAGE_URL_JINJA = "{{ content.image_url.url }}"
+
+_TOKENIZER_CHAT_TEMPLATE_KEY = "tokenizer.chat_template"
+
+
+def read_chat_template(model_path: Path) -> str | None:
+    """Return the Jinja chat template embedded in a GGUF model, or None."""
+    try:
+        reader = GGUFReader(str(model_path))
+        field = reader.get_field(_TOKENIZER_CHAT_TEMPLATE_KEY)
+    except Exception:
+        log.debug("Failed to read chat template from %s", model_path, exc_info=True)
+        return None
+    if field is None:
+        return None
+    return bytes(field.parts[field.data[0]]).decode("utf-8", errors="replace")
+
+
+def adapt_gguf_template_for_mtmd(template: str) -> str:
+    """Rewrite image-placeholder tokens into the URL-substitution Jinja expression.
+
+    ``Llava15ChatHandler.__call__`` renders the template, then replaces
+    every image URL in the rendered text with ``mtmd_default_marker()``.
+    Many GGUF chat templates skip the URL and emit a fixed token instead
+    (``<|image_pad|>`` on Qwen-family vision models, ``<image>`` on
+    Llama/Llava, ``<__media__>`` on newer mtmd builds). Swapping those
+    for ``{{ content.image_url.url }}`` restores the URL contract so the
+    replacement loop finds a marker at the same position the template
+    meant to reserve for the image.
+    """
+    for token in _GGUF_IMAGE_TOKENS:
+        if token in template:
+            template = template.replace(token, _IMAGE_URL_JINJA)
+    return template
+
+
+def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
+    """Build a chat handler that uses the main GGUF's embedded chat template.
+
+    Returns an instance of a ``Llava15ChatHandler`` subclass with
+    ``CHAT_FORMAT`` replaced by the GGUF template (image tokens rewritten)
+    and ``DEFAULT_SYSTEM_MESSAGE`` set to ``None`` so we never splice a
+    stray ``"You are a helpful assistant."`` into OCR prompts. If the
+    GGUF has no embedded template, falls back to the upstream
+    ``Llava15ChatHandler`` defaults.
+    """
+    from llama_cpp.llama_chat_format import Llava15ChatHandler
+
+    class _GgufTemplateChatHandler(Llava15ChatHandler):
+        DEFAULT_SYSTEM_MESSAGE = None
+
+    handler_cls: type[Llava15ChatHandler] = _GgufTemplateChatHandler
+
+    template = read_chat_template(model_path)
+    if template is not None:
+        handler_cls.CHAT_FORMAT = adapt_gguf_template_for_mtmd(template)
+        log.info(
+            "Vision chat handler: using GGUF-embedded template (%d bytes) from %s",
+            len(template),
+            model_path.name,
+        )
+    else:
+        log.info(
+            "Vision chat handler: no GGUF template in %s, falling back to Llava15 default",
+            model_path.name,
+        )
+
+    return handler_cls(str(mmproj_path), verbose=False)
+
+
+def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
+    """Load a vision-capable ``Llama`` tied to a GGUF-templated chat handler.
+
+    Replaces ``llama_cpp_provider.load_vision_llama``. Every vision model
+    goes through the same code path, driven by the main GGUF's chat
+    template and mmproj file. No per-model handler class, no projector
+    type lookup table.
+    """
+    from llama_cpp import Llama
+
+    from lilbee.config import cfg
+    from lilbee.providers.llama_cpp_provider import _suppress_stderr, find_mmproj_for_model
+
+    if mmproj_path is None:
+        mmproj_path = find_mmproj_for_model(model_path)
+
+    chat_handler = build_vision_chat_handler(model_path, mmproj_path)
+
+    kwargs: dict[str, Any] = {
+        "model_path": str(model_path),
+        "chat_handler": chat_handler,
+        "verbose": False,
+        "n_gpu_layers": -1,
+        "n_ctx": cfg.num_ctx if cfg.num_ctx is not None else 0,
+    }
+
+    llama = _suppress_stderr(Llama, **kwargs)
+    metadata = getattr(llama, "metadata", {}) or {}
+    n_ctx_fn = getattr(llama, "n_ctx", None)
+    n_ctx = n_ctx_fn() if callable(n_ctx_fn) else "?"
+    log.info(
+        "Vision model loaded: model=%s mmproj=%s n_ctx=%s arch=%s",
+        model_path.name,
+        mmproj_path.name,
+        n_ctx,
+        metadata.get("general.architecture", "?"),
+    )
+    return llama

--- a/src/lilbee/providers/worker_process.py
+++ b/src/lilbee/providers/worker_process.py
@@ -416,8 +416,9 @@ def _load_embed_model(model_name: str) -> Any:
 
 
 def _load_vision_model(model_name: str) -> Any:
-    """Load a vision model in the child process."""
-    from lilbee.providers.llama_cpp_provider import load_vision_llama, resolve_model_path
+    """Load a vision model in the child process via the mtmd backend."""
+    from lilbee.providers.llama_cpp_provider import resolve_model_path
+    from lilbee.providers.mtmd_backend import load_vision_llama
 
     return load_vision_llama(resolve_model_path(model_name))
 

--- a/src/lilbee/providers/worker_process.py
+++ b/src/lilbee/providers/worker_process.py
@@ -12,6 +12,7 @@ import contextlib
 import logging
 import multiprocessing
 import multiprocessing.queues
+import os
 import queue
 import time
 from dataclasses import dataclass, field
@@ -284,6 +285,29 @@ def _redirect_stdio() -> None:  # pragma: no cover
     sys.stderr = open(os.devnull, "w")  # noqa: SIM115
 
 
+def _configure_worker_logging() -> None:  # pragma: no cover
+    """Route the worker's Python logs to ``$LILBEE_DATA/worker.log``.
+
+    ``_redirect_stdio`` points stderr at /dev/null so the parent's Textual
+    render stays clean, but that also silences the subprocess's own
+    progress logs. Writing them to a file alongside the data directory
+    gives operators (and QA runs) a way to watch per-page timing, Metal
+    availability, and model load info without touching the TUI.
+    """
+    import logging as _logging
+    import os as _os
+
+    data_dir = _os.environ.get("LILBEE_DATA") or ""
+    if not data_dir:
+        return
+    log_path = _os.path.join(data_dir, "worker.log")
+    handler = _logging.FileHandler(log_path)
+    handler.setFormatter(_logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    root = _logging.getLogger()
+    root.addHandler(handler)
+    root.setLevel(_logging.INFO)
+
+
 def _worker_main(
     req_q: multiprocessing.Queue[_WorkerRequest],
     resp_q: multiprocessing.Queue[_WorkerResponse],
@@ -291,7 +315,9 @@ def _worker_main(
 ) -> None:
     """Child process entry point. Loads models lazily, processes requests."""
     _redirect_stdio()
+    _configure_worker_logging()
     _apply_config_snapshot(config)
+    log.info("Worker subprocess online (pid=%s)", os.getpid())
 
     embed_llm: Any = None
     vision_llm: Any = None
@@ -420,10 +446,20 @@ def _handle_vision(llm: Any, request: VisionRequest) -> VisionResponse:
 
         prompt = request.prompt or OCR_PROMPT
         messages = build_vision_messages(prompt, request.png_bytes)
+        start = time.monotonic()
         response = llm.create_chat_completion(
             messages=messages, stream=False, max_tokens=cfg.vision_max_tokens
         )
         text: str = response["choices"][0]["message"]["content"] or ""
+        usage = response.get("usage", {}) or {}
+        log.info(
+            "vision_ocr request_id=%s wall=%.1fs prompt_tokens=%s completion_tokens=%s chars=%d",
+            request.request_id,
+            time.monotonic() - start,
+            usage.get("prompt_tokens"),
+            usage.get("completion_tokens"),
+            len(text),
+        )
         return VisionResponse(text=text, request_id=request.request_id)
     except Exception as exc:
         return VisionResponse(error=str(exc), request_id=request.request_id)

--- a/src/lilbee/providers/worker_process.py
+++ b/src/lilbee/providers/worker_process.py
@@ -192,6 +192,8 @@ class WorkerProcess:
     def vision_ocr(self, png_bytes: bytes, model: str, prompt: str = "") -> str:
         """Send a vision OCR request and wait for the response.
         Auto-starts the worker if not running. Retries once on crash.
+        Honours ``cfg.ocr_timeout`` when set above zero so image-heavy pages
+        on slow vision models can complete instead of being skipped.
         """
         self._ensure_started()
         req = VisionRequest(
@@ -200,7 +202,13 @@ class WorkerProcess:
             prompt=prompt,
             request_id=self._next_request_id(),
         )
-        resp = self._round_trip(req, VisionResponse, _VISION_TIMEOUT_S, label="vision OCR")
+        from lilbee.config import cfg
+
+        # ``cfg.ocr_timeout == 0`` means the user asked for no limit. We
+        # still need a finite value for the internal deadline loop, so we
+        # substitute a day's worth of seconds.
+        timeout = cfg.ocr_timeout if cfg.ocr_timeout > 0 else 86_400.0
+        resp = self._round_trip(req, VisionResponse, timeout, label="vision OCR")
         return resp.text
 
     def _round_trip(

--- a/src/lilbee/providers/worker_process.py
+++ b/src/lilbee/providers/worker_process.py
@@ -191,10 +191,11 @@ class WorkerProcess:
         return resp.vectors
 
     def vision_ocr(self, png_bytes: bytes, model: str, prompt: str = "") -> str:
-        """Send a vision OCR request and wait for the response.
-        Auto-starts the worker if not running. Retries once on crash.
-        Honours ``cfg.ocr_timeout`` when set above zero so image-heavy pages
-        on slow vision models can complete instead of being skipped.
+        """Run vision OCR in the worker, honouring ``cfg.ocr_timeout``.
+
+        Auto-starts the worker and retries once on crash. ``cfg.ocr_timeout
+        == 0`` means no cap; substituted with a day-long finite deadline
+        for the internal wait loop.
         """
         self._ensure_started()
         req = VisionRequest(
@@ -205,9 +206,6 @@ class WorkerProcess:
         )
         from lilbee.config import cfg
 
-        # ``cfg.ocr_timeout == 0`` means the user asked for no limit. We
-        # still need a finite value for the internal deadline loop, so we
-        # substitute a day's worth of seconds.
         timeout = cfg.ocr_timeout if cfg.ocr_timeout > 0 else 86_400.0
         resp = self._round_trip(req, VisionResponse, timeout, label="vision OCR")
         return resp.text
@@ -286,14 +284,7 @@ def _redirect_stdio() -> None:  # pragma: no cover
 
 
 def _configure_worker_logging() -> None:  # pragma: no cover
-    """Route the worker's Python logs to ``$LILBEE_DATA/worker.log``.
-
-    ``_redirect_stdio`` points stderr at /dev/null so the parent's Textual
-    render stays clean, but that also silences the subprocess's own
-    progress logs. Writing them to a file alongside the data directory
-    gives operators (and QA runs) a way to watch per-page timing, Metal
-    availability, and model load info without touching the TUI.
-    """
+    """Route the worker's Python logs to ``$LILBEE_DATA/worker.log``."""
     import logging as _logging
     import os as _os
 
@@ -435,12 +426,7 @@ def _handle_embed(llm: Any, request: EmbedRequest) -> EmbedResponse:
 
 
 def _handle_vision(llm: Any, request: VisionRequest) -> VisionResponse:
-    """Process a single vision OCR request.
-
-    Caps generation at ``cfg.vision_max_tokens`` so a page that fails to
-    emit EOT (dense scanned art on some vision models) can't stall the
-    ingest. The cap is well above the token budget of any real page.
-    """
+    """Process a single vision OCR request, capped at ``cfg.vision_max_tokens``."""
     try:
         from lilbee.config import cfg
         from lilbee.vision import OCR_PROMPT, build_vision_messages

--- a/src/lilbee/providers/worker_process.py
+++ b/src/lilbee/providers/worker_process.py
@@ -423,33 +423,29 @@ def _handle_embed(llm: Any, request: EmbedRequest) -> EmbedResponse:
 
 
 def _handle_vision(llm: Any, request: VisionRequest) -> VisionResponse:
-    """Process a single vision OCR request, capped at ``cfg.vision_max_tokens``."""
+    """Process a single vision OCR request.
+
+    Generation is bounded by the model's ``n_ctx`` (llama.cpp stops when
+    the remaining context is exhausted) and by EOT, which the GGUF's own
+    chat template now fires correctly. No extra per-request cap.
+    """
     try:
         from lilbee.vision import OCR_PROMPT, build_vision_messages
 
         prompt = request.prompt or OCR_PROMPT
         messages = build_vision_messages(prompt, request.png_bytes)
         start = time.monotonic()
-        response = llm.create_chat_completion(
-            messages=messages, stream=False, max_tokens=cfg.vision_max_tokens
-        )
+        response = llm.create_chat_completion(messages=messages, stream=False)
         text: str = response["choices"][0]["message"]["content"] or ""
         usage = response.get("usage", {}) or {}
-        completion_tokens = usage.get("completion_tokens")
         log.info(
             "vision_ocr request_id=%s wall=%.1fs prompt_tokens=%s completion_tokens=%s chars=%d",
             request.request_id,
             time.monotonic() - start,
             usage.get("prompt_tokens"),
-            completion_tokens,
+            usage.get("completion_tokens"),
             len(text),
         )
-        if completion_tokens is not None and completion_tokens >= cfg.vision_max_tokens:
-            log.warning(
-                "vision_ocr request_id=%s hit vision_max_tokens cap (%d); output may be truncated",
-                request.request_id,
-                cfg.vision_max_tokens,
-            )
         return VisionResponse(text=text, request_id=request.request_id)
     except Exception as exc:
         return VisionResponse(error=str(exc), request_id=request.request_id)

--- a/src/lilbee/providers/worker_process.py
+++ b/src/lilbee/providers/worker_process.py
@@ -408,13 +408,21 @@ def _handle_embed(llm: Any, request: EmbedRequest) -> EmbedResponse:
 
 
 def _handle_vision(llm: Any, request: VisionRequest) -> VisionResponse:
-    """Process a single vision OCR request."""
+    """Process a single vision OCR request.
+
+    Caps generation at ``cfg.vision_max_tokens`` so a page that fails to
+    emit EOT (dense scanned art on some vision models) can't stall the
+    ingest. The cap is well above the token budget of any real page.
+    """
     try:
+        from lilbee.config import cfg
         from lilbee.vision import OCR_PROMPT, build_vision_messages
 
         prompt = request.prompt or OCR_PROMPT
         messages = build_vision_messages(prompt, request.png_bytes)
-        response = llm.create_chat_completion(messages=messages, stream=False)
+        response = llm.create_chat_completion(
+            messages=messages, stream=False, max_tokens=cfg.vision_max_tokens
+        )
         text: str = response["choices"][0]["message"]["content"] or ""
         return VisionResponse(text=text, request_id=request.request_id)
     except Exception as exc:

--- a/src/lilbee/providers/worker_process.py
+++ b/src/lilbee/providers/worker_process.py
@@ -26,9 +26,11 @@ log = logging.getLogger(__name__)
 _ResponseT = TypeVar("_ResponseT", "EmbedResponse", "VisionResponse")
 
 _EMBED_TIMEOUT_S = 30.0
-_VISION_TIMEOUT_S = 120.0
 _JOIN_TIMEOUT_S = 5.0
 _RESTART_DELAY_S = 0.1
+# Substituted when ``cfg.ocr_timeout == 0`` ("no limit"). The round-trip
+# wait loop needs a finite deadline; one day is effectively unlimited.
+_NO_CAP_TIMEOUT_S = 86_400.0
 
 
 @dataclass(frozen=True)
@@ -194,8 +196,8 @@ class WorkerProcess:
         """Run vision OCR in the worker, honouring ``cfg.ocr_timeout``.
 
         Auto-starts the worker and retries once on crash. ``cfg.ocr_timeout
-        == 0`` means no cap; substituted with a day-long finite deadline
-        for the internal wait loop.
+        == 0`` means no cap; substituted with ``_NO_CAP_TIMEOUT_S`` for
+        the round-trip wait loop.
         """
         self._ensure_started()
         req = VisionRequest(
@@ -204,9 +206,7 @@ class WorkerProcess:
             prompt=prompt,
             request_id=self._next_request_id(),
         )
-        from lilbee.config import cfg
-
-        timeout = cfg.ocr_timeout if cfg.ocr_timeout > 0 else 86_400.0
+        timeout = cfg.ocr_timeout if cfg.ocr_timeout > 0 else _NO_CAP_TIMEOUT_S
         resp = self._round_trip(req, VisionResponse, timeout, label="vision OCR")
         return resp.text
 
@@ -283,20 +283,17 @@ def _redirect_stdio() -> None:  # pragma: no cover
     sys.stderr = open(os.devnull, "w")  # noqa: SIM115
 
 
-def _configure_worker_logging() -> None:  # pragma: no cover
+def _configure_worker_logging() -> None:
     """Route the worker's Python logs to ``$LILBEE_DATA/worker.log``."""
-    import logging as _logging
-    import os as _os
-
-    data_dir = _os.environ.get("LILBEE_DATA") or ""
+    data_dir = os.environ.get("LILBEE_DATA") or ""
     if not data_dir:
         return
-    log_path = _os.path.join(data_dir, "worker.log")
-    handler = _logging.FileHandler(log_path)
-    handler.setFormatter(_logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
-    root = _logging.getLogger()
+    log_path = os.path.join(data_dir, "worker.log")
+    handler = logging.FileHandler(log_path)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    root = logging.getLogger()
     root.addHandler(handler)
-    root.setLevel(_logging.INFO)
+    root.setLevel(logging.INFO)
 
 
 def _worker_main(
@@ -428,7 +425,6 @@ def _handle_embed(llm: Any, request: EmbedRequest) -> EmbedResponse:
 def _handle_vision(llm: Any, request: VisionRequest) -> VisionResponse:
     """Process a single vision OCR request, capped at ``cfg.vision_max_tokens``."""
     try:
-        from lilbee.config import cfg
         from lilbee.vision import OCR_PROMPT, build_vision_messages
 
         prompt = request.prompt or OCR_PROMPT
@@ -439,14 +435,21 @@ def _handle_vision(llm: Any, request: VisionRequest) -> VisionResponse:
         )
         text: str = response["choices"][0]["message"]["content"] or ""
         usage = response.get("usage", {}) or {}
+        completion_tokens = usage.get("completion_tokens")
         log.info(
             "vision_ocr request_id=%s wall=%.1fs prompt_tokens=%s completion_tokens=%s chars=%d",
             request.request_id,
             time.monotonic() - start,
             usage.get("prompt_tokens"),
-            usage.get("completion_tokens"),
+            completion_tokens,
             len(text),
         )
+        if completion_tokens is not None and completion_tokens >= cfg.vision_max_tokens:
+            log.warning(
+                "vision_ocr request_id=%s hit vision_max_tokens cap (%d); output may be truncated",
+                request.request_id,
+                cfg.vision_max_tokens,
+            )
         return VisionResponse(text=text, request_id=request.request_id)
     except Exception as exc:
         return VisionResponse(error=str(exc), request_id=request.request_id)

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -234,9 +234,10 @@ class SseStream:
                     item = await asyncio.wait_for(self.queue.get(), timeout=0.1)
                 except TimeoutError:
                     now = time.monotonic()
-                    if now - last_yielded >= cfg.sse_heartbeat_interval:
+                    heartbeat_interval = cfg.sse_heartbeat_interval
+                    if heartbeat_interval > 0 and now - last_yielded >= heartbeat_interval:
                         last_yielded = now
-                        yield sse_event(SseEvent.HEARTBEAT, {"ts": now})
+                        yield sse_event(SseEvent.HEARTBEAT, {"ts": time.time()})
                     # Fallback for producers that die without a sentinel.
                     if task.done() and self.queue.empty():
                         break

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -221,18 +221,30 @@ class SseStream:
     async def drain(
         self, task: asyncio.Task[Any] | asyncio.Future[Any], label: str
     ) -> AsyncGenerator[str, None]:
-        """Yield SSE strings until a sentinel arrives. Cancels *task* on client disconnect."""
+        """Yield SSE strings until a sentinel arrives. Cancels *task* on client disconnect.
+
+        When the producer queue stays idle longer than ``cfg.sse_heartbeat_interval``
+        seconds, emit a ``heartbeat`` event so clients (Obsidian plugin, TUI) that
+        enforce a stream-idle timeout don't abort a long-running but still-healthy
+        producer (e.g. per-page vision OCR on an image-heavy PDF).
+        """
+        last_yielded = time.monotonic()
         try:
             while True:
                 try:
                     item = await asyncio.wait_for(self.queue.get(), timeout=0.1)
                 except TimeoutError:
+                    now = time.monotonic()
+                    if now - last_yielded >= cfg.sse_heartbeat_interval:
+                        last_yielded = now
+                        yield sse_event(SseEvent.HEARTBEAT, {"ts": now})
                     # Fallback for producers that die without a sentinel.
                     if task.done() and self.queue.empty():
                         break
                     continue
                 if item is None:
                     break
+                last_yielded = time.monotonic()
                 yield item
         except (asyncio.CancelledError, GeneratorExit):
             log.info("%s cancelled by client", label)

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -221,12 +221,11 @@ class SseStream:
     async def drain(
         self, task: asyncio.Task[Any] | asyncio.Future[Any], label: str
     ) -> AsyncGenerator[str, None]:
-        """Yield SSE strings until a sentinel arrives. Cancels *task* on client disconnect.
+        """Yield SSE strings until a sentinel arrives; cancel *task* on client disconnect.
 
-        When the producer queue stays idle longer than ``cfg.sse_heartbeat_interval``
-        seconds, emit a ``heartbeat`` event so clients (Obsidian plugin, TUI) that
-        enforce a stream-idle timeout don't abort a long-running but still-healthy
-        producer (e.g. per-page vision OCR on an image-heavy PDF).
+        Emits a ``heartbeat`` event whenever the producer queue stays
+        idle longer than ``cfg.sse_heartbeat_interval`` seconds so
+        clients that enforce a stream-idle timeout don't abort.
         """
         last_yielded = time.monotonic()
         try:

--- a/src/lilbee/vision.py
+++ b/src/lilbee/vision.py
@@ -183,6 +183,13 @@ def _record_page(
     """Drain one completed page future into ``extracted`` and fire progress."""
     i, text = fut.result()
     extracted[i] = text
+    log.info(
+        "Vision OCR completed page %d/%d of %s (%d chars)",
+        i + 1,
+        total,
+        path.name,
+        len(text) if text else 0,
+    )
     on_progress(
         EventType.EXTRACT,
         ExtractEvent(file=path.name, page=i + 1, total_pages=total),

--- a/src/lilbee/vision.py
+++ b/src/lilbee/vision.py
@@ -95,8 +95,8 @@ def _png_to_data_url(png_bytes: bytes) -> str:
 
 def build_vision_messages(prompt: str, png_bytes: bytes) -> list[dict]:
     """Build OpenAI-compatible messages with image content for vision models.
-    Uses the multipart content format expected by llama-cpp-python's
-    vision chat handlers (Llava15ChatHandler, etc.).
+    Uses the multipart content format expected by llama.cpp's mtmd
+    pipeline.
     """
     return [
         {

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -174,6 +174,43 @@ class TestAddEndpoint:
         # enable_ocr should be restored after the call
         assert cfg.enable_ocr == original_ocr
 
+    async def test_add_emits_heartbeat_during_slow_sync(
+        self, mock_extract_file, isolated_env, tmp_path
+    ):
+        """Root-cause fix for obsidian-lilbee-v8y.
+
+        A long-running vision OCR pass can go >120s without emitting a
+        progress event. The plugin's STREAM_IDLE_TIMEOUT_MS (120s) then
+        aborts the stream. The server must emit 'heartbeat' SSE events at
+        cfg.sse_heartbeat_interval whenever the producer queue is idle so
+        the plugin's withIdleTimeout keeps resetting. This test drives a
+        sync that sleeps longer than the heartbeat interval and asserts
+        at least one heartbeat event was delivered to the HTTP client.
+        """
+        from lilbee.server.app import create_app
+
+        src = tmp_path / "slow.txt"
+        src.write_text("Slow sync content for heartbeat test.")
+        cfg.sse_heartbeat_interval = 0.2
+
+        async def slow_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
+            from lilbee.ingest import SyncResult
+
+            await asyncio.sleep(0.6)
+            return SyncResult(added=["slow.txt"])
+
+        with mock.patch("lilbee.ingest.sync", side_effect=slow_sync):
+            async with AsyncTestClient(create_app()) as client:
+                resp = await client.post(
+                    "/api/add", json={"paths": [str(src)]}, headers=_auth_headers()
+                )
+
+        assert resp.status_code == 201
+        events = _parse_sse_events(resp.content)
+        heartbeats = [d for t, d in events if t == "heartbeat"]
+        assert heartbeats, f"expected heartbeat events during slow sync, got {events}"
+        assert "ts" in heartbeats[0]
+
 
 class TestAddValidation:
     async def test_empty_paths_returns_400(self, isolated_env):

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -282,9 +282,14 @@ class TestInitDefensiveBranches:
         monkeypatch.setattr(builtins, "__import__", fake_import)
         _install_thread_only_tqdm_lock()  # must not raise
 
-    def test_prestart_resource_tracker_swallows_runtime_error(self) -> None:
+    def test_prestart_resource_tracker_swallows_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
         from lilbee import _prestart_mp_resource_tracker
 
+        monkeypatch.setattr(sys, "platform", "linux")
         with mock.patch(
             "multiprocessing.resource_tracker.ensure_running",
             side_effect=RuntimeError("simulated crash"),

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -218,6 +218,47 @@ class TestCallbackProgressBarLockSafety:
         assert calls == [(250, 1000), (500, 1000), (1000, 1000)]
 
 
+class TestBaseTqdmLockInstalled:
+    """Pinning tqdm's class lock is the only way to keep vanilla tqdm (HF, llama-cpp,
+    sentence-transformers, anything that imports ``tqdm.auto``) from crashing when
+    Textual swaps stderr for a wrapper whose ``fileno()`` returns -1.
+    Mirrors huggingface_hub PR #4065 but applies at the base class so every tqdm
+    subclass in the process inherits the same lock via MRO.
+    """
+
+    def test_tqdm_std_lock_is_threading(self) -> None:
+        """Base ``tqdm.std.tqdm._lock`` was pinned to a threading RLock at package import."""
+        import threading
+
+        from tqdm.std import tqdm as _tqdm_base
+
+        assert isinstance(_tqdm_base._lock, type(threading.RLock()))
+
+    def test_vanilla_tqdm_get_lock_survives_bad_stderr_fileno(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Vanilla ``tqdm.auto.tqdm.get_lock()`` no longer triggers MP-lock lazy init."""
+
+        class _FakeStderr:
+            def write(self, _s: str) -> int:
+                return 0
+
+            def flush(self) -> None:
+                pass
+
+            def isatty(self) -> bool:
+                return True
+
+            def fileno(self) -> int:
+                return -1
+
+        monkeypatch.setattr("sys.stderr", _FakeStderr())
+        from tqdm.auto import tqdm as _vanilla
+
+        lock = _vanilla.get_lock()
+        assert lock is not None
+
+
 class TestDownloadModelProgressChain:
     """Verify download_model correctly chains progress through to the user callback."""
 

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -257,6 +258,56 @@ class TestBaseTqdmLockInstalled:
 
         lock = _vanilla.get_lock()
         assert lock is not None
+
+
+class TestInitDefensiveBranches:
+    """The package-init helpers each carry a swallow-and-continue branch.
+    Force each one so 100% coverage covers real behaviour, not pragmas.
+    """
+
+    def test_tqdm_lock_install_returns_on_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import builtins
+
+        from lilbee import _install_thread_only_tqdm_lock
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "tqdm.std" or name.startswith("tqdm."):
+                raise ImportError(name)
+            return real_import(name, *args, **kwargs)  # type: ignore[no-any-return]
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        _install_thread_only_tqdm_lock()  # must not raise
+
+    def test_prestart_resource_tracker_swallows_runtime_error(self) -> None:
+        from lilbee import _prestart_mp_resource_tracker
+
+        with mock.patch(
+            "multiprocessing.resource_tracker.ensure_running",
+            side_effect=RuntimeError("simulated crash"),
+        ):
+            _prestart_mp_resource_tracker()  # must not raise
+
+    def test_prestart_resource_tracker_noop_on_windows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows has no ``_posixsubprocess``; the prestart must short-circuit
+        so `import _posixsubprocess` inside multiprocessing is never reached.
+        """
+        import sys
+
+        from lilbee import _prestart_mp_resource_tracker
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        with mock.patch(
+            "multiprocessing.resource_tracker.ensure_running",
+            side_effect=AssertionError("must not be called on win32"),
+        ) as called:
+            _prestart_mp_resource_tracker()
+        called.assert_not_called()
 
 
 class TestDownloadModelProgressChain:

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -474,34 +474,25 @@ class TestLockedStreamIteratorExceptionRelease:
 
 
 class TestVisionModel:
-    def testload_vision_llama_creates_handler(
+    def test_load_vision_llama_creates_handler(
         self, models_dir: Path, mock_llama_cpp: mock.MagicMock
     ) -> None:
-        """load_vision_llama creates a Llama instance with a chat handler."""
-        from lilbee.providers.llama_cpp_provider import load_vision_llama
+        """``mtmd_backend.load_vision_llama`` wires a chat handler into Llama."""
+        from lilbee.providers.mtmd_backend import load_vision_llama
 
-        # Create mmproj file
         mmproj_path = models_dir / "test-mmproj-f16.gguf"
         mmproj_path.write_bytes(b"fake-mmproj")
-
         mock_handler = mock.MagicMock()
-        mock_handler_cls = mock.MagicMock(return_value=mock_handler)
 
-        # The mock_llama_cpp fixture puts a MagicMock in sys.modules["llama_cpp"],
-        # so submodule imports like llama_cpp.llama_chat_format need to work too.
-        mock_chat_format = mock.MagicMock()
-        mock_chat_format.Llava15ChatHandler = mock_handler_cls
-        sys.modules["llama_cpp.llama_chat_format"] = mock_chat_format
-
-        try:
+        with mock.patch(
+            "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+            return_value=mock_handler,
+        ) as build:
             load_vision_llama(models_dir / "test-model.gguf", mmproj_path)
 
-            mock_handler_cls.assert_called_once_with(clip_model_path=str(mmproj_path))
-            # Llama called with chat_handler
-            call_kwargs = mock_llama_cpp.Llama.call_args[1]
-            assert call_kwargs["chat_handler"] is mock_handler
-        finally:
-            sys.modules.pop("llama_cpp.llama_chat_format", None)
+        build.assert_called_once_with(models_dir / "test-model.gguf", mmproj_path)
+        call_kwargs = mock_llama_cpp.Llama.call_args[1]
+        assert call_kwargs["chat_handler"] is mock_handler
 
     def test_find_mmproj_raises_when_missing(self, models_dir: Path) -> None:
         """find_mmproj_for_model raises ProviderError when no mmproj found."""
@@ -519,33 +510,6 @@ class TestVisionModel:
         mmproj.write_bytes(b"fake")
         result = find_mmproj_for_model(models_dir / "test-model.gguf")
         assert result == mmproj
-
-    def test_get_vision_llm_caches(self, models_dir: Path, mock_llama_cpp: mock.MagicMock) -> None:
-        """_get_vision_llm caches the vision model instance."""
-        from lilbee.providers.llama_cpp_provider import LlamaCppProvider
-
-        mmproj = models_dir / "test-mmproj-f16.gguf"
-        mmproj.write_bytes(b"fake-mmproj")
-
-        mock_handler = mock.MagicMock()
-        mock_chat_format = mock.MagicMock()
-        mock_chat_format.Llava15ChatHandler = mock.MagicMock(return_value=mock_handler)
-        sys.modules["llama_cpp.llama_chat_format"] = mock_chat_format
-
-        instance = mock.MagicMock()
-        instance.create_chat_completion.return_value = {"choices": [{"message": {"content": "ok"}}]}
-        mock_llama_cpp.Llama.return_value = instance
-
-        try:
-            provider = LlamaCppProvider()
-            provider._get_vision_llm("test-model")
-            provider._get_vision_llm("test-model")
-
-            # Llama should only be called once (cached)
-            assert mock_llama_cpp.Llama.call_count == 1
-            provider.shutdown()
-        finally:
-            sys.modules.pop("llama_cpp.llama_chat_format", None)
 
 
 class TestLoadLlamaNCtx:

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -561,7 +561,7 @@ class TestLoadLlamaNCtx:
 
 
 class TestSuppressStderrThreadSafety:
-    def test_concurrentsuppress_native_stderr_no_corruption(self) -> None:
+    def test_concurrent_suppress_native_stderr_no_corruption(self) -> None:
         """B3: suppress_native_stderr serializes fd 2 manipulation via _STDERR_LOCK."""
         from lilbee.providers.llama_cpp_provider import suppress_native_stderr
 
@@ -586,7 +586,7 @@ class TestSuppressStderrThreadSafety:
         assert not errors, f"Errors during concurrent suppress_native_stderr: {errors}"
         assert sorted(results) == [0, 2, 4, 6]
 
-    def testsuppress_native_stderr_uses_lock(self) -> None:
+    def test_suppress_native_stderr_uses_lock(self) -> None:
         """B3: Verify suppress_native_stderr acquires _STDERR_LOCK."""
         from lilbee.providers.llama_cpp_provider import _STDERR_LOCK, suppress_native_stderr
 

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -561,9 +561,9 @@ class TestLoadLlamaNCtx:
 
 
 class TestSuppressStderrThreadSafety:
-    def test_concurrent_suppress_stderr_no_corruption(self) -> None:
-        """B3: _suppress_stderr serializes fd 2 manipulation via _STDERR_LOCK."""
-        from lilbee.providers.llama_cpp_provider import _suppress_stderr
+    def test_concurrentsuppress_native_stderr_no_corruption(self) -> None:
+        """B3: suppress_native_stderr serializes fd 2 manipulation via _STDERR_LOCK."""
+        from lilbee.providers.llama_cpp_provider import suppress_native_stderr
 
         results: list[int] = []
         errors: list[Exception] = []
@@ -572,7 +572,7 @@ class TestSuppressStderrThreadSafety:
         def worker(value: int) -> None:
             barrier.wait()
             try:
-                result = _suppress_stderr(lambda v: v * 2, value)
+                result = suppress_native_stderr(lambda v: v * 2, value)
                 results.append(result)
             except Exception as exc:
                 errors.append(exc)
@@ -583,12 +583,12 @@ class TestSuppressStderrThreadSafety:
         for t in threads:
             t.join(timeout=5)
 
-        assert not errors, f"Errors during concurrent _suppress_stderr: {errors}"
+        assert not errors, f"Errors during concurrent suppress_native_stderr: {errors}"
         assert sorted(results) == [0, 2, 4, 6]
 
-    def test_suppress_stderr_uses_lock(self) -> None:
-        """B3: Verify _suppress_stderr acquires _STDERR_LOCK."""
-        from lilbee.providers.llama_cpp_provider import _STDERR_LOCK, _suppress_stderr
+    def testsuppress_native_stderr_uses_lock(self) -> None:
+        """B3: Verify suppress_native_stderr acquires _STDERR_LOCK."""
+        from lilbee.providers.llama_cpp_provider import _STDERR_LOCK, suppress_native_stderr
 
         lock_was_held = []
 
@@ -600,6 +600,6 @@ class TestSuppressStderrThreadSafety:
             lock_was_held.append(locked)
             return 42
 
-        result = _suppress_stderr(check_lock)
+        result = suppress_native_stderr(check_lock)
         assert result == 42
         assert lock_was_held == [True]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1214,6 +1214,96 @@ class TestMtmdLoadVisionLlama:
         mock_handler.assert_called_once()
 
 
+class TestReadChatTemplate:
+    def test_reads_chat_template(self, tmp_path: Path) -> None:
+        import struct
+
+        from lilbee.providers.mtmd_backend import read_chat_template
+
+        template = "{% for message in messages %}{{ message.content }}{% endfor %}"
+        buf = bytearray()
+        buf += b"GGUF"
+        buf += struct.pack("<I", 3)
+        buf += struct.pack("<Q", 0)
+        buf += struct.pack("<Q", 1)
+        key = b"tokenizer.chat_template"
+        buf += struct.pack("<Q", len(key)) + key
+        buf += struct.pack("<I", 8)
+        value = template.encode("utf-8")
+        buf += struct.pack("<Q", len(value)) + value
+        f = tmp_path / "model.gguf"
+        f.write_bytes(bytes(buf))
+        assert read_chat_template(f) == template
+
+    def test_returns_none_on_missing_field(self, tmp_path: Path) -> None:
+        """A GGUF without tokenizer.chat_template returns None."""
+        import struct
+
+        from lilbee.providers.mtmd_backend import read_chat_template
+
+        buf = bytearray()
+        buf += b"GGUF"
+        buf += struct.pack("<I", 3)
+        buf += struct.pack("<Q", 0)
+        buf += struct.pack("<Q", 0)
+        f = tmp_path / "empty.gguf"
+        f.write_bytes(bytes(buf))
+        assert read_chat_template(f) is None
+
+    def test_returns_none_on_read_error(self) -> None:
+        from lilbee.providers.mtmd_backend import read_chat_template
+
+        assert read_chat_template(Path("/nonexistent/model.gguf")) is None
+
+
+class TestBuildVisionChatHandler:
+    """Use a stub Llava15ChatHandler so the test stays hermetic."""
+
+    def _patched(self, instances: list[object]):
+        class _StubHandler:
+            CHAT_FORMAT = "stub-default-format"
+            DEFAULT_SYSTEM_MESSAGE = "stub-default"
+
+            def __init__(self, clip_model_path: str, verbose: bool = True):
+                self.clip_model_path = clip_model_path
+                self.verbose = verbose
+                instances.append(self)
+
+        return mock.patch("llama_cpp.llama_chat_format.Llava15ChatHandler", _StubHandler)
+
+    def test_installs_gguf_template(self, tmp_path: Path) -> None:
+        from lilbee.providers.mtmd_backend import build_vision_chat_handler
+
+        template = "<|im_start|>user\n<|image_pad|>{{ content.text }}<|im_end|>"
+        instances: list[object] = []
+        with (
+            mock.patch(
+                "lilbee.providers.mtmd_backend.read_chat_template",
+                return_value=template,
+            ),
+            self._patched(instances),
+        ):
+            handler = build_vision_chat_handler(tmp_path / "model.gguf", tmp_path / "mmproj.gguf")
+        assert "<|image_pad|>" not in type(handler).CHAT_FORMAT
+        assert "{{ content.image_url.url }}" in type(handler).CHAT_FORMAT
+        assert type(handler).DEFAULT_SYSTEM_MESSAGE is None
+
+    def test_falls_back_when_no_template(self, tmp_path: Path) -> None:
+        from lilbee.providers.mtmd_backend import build_vision_chat_handler
+
+        instances: list[object] = []
+        with (
+            mock.patch(
+                "lilbee.providers.mtmd_backend.read_chat_template",
+                return_value=None,
+            ),
+            self._patched(instances),
+        ):
+            handler = build_vision_chat_handler(tmp_path / "model.gguf", tmp_path / "mmproj.gguf")
+        assert type(handler).CHAT_FORMAT == "stub-default-format"
+        assert type(handler).DEFAULT_SYSTEM_MESSAGE is None
+
+
 class TestAdaptGgufTemplate:
     """``adapt_gguf_template_for_mtmd`` rewrites GGUF image-placeholder tokens."""
 
@@ -1228,10 +1318,7 @@ class TestAdaptGgufTemplate:
     def test_replaces_image_tag(self) -> None:
         from lilbee.providers.mtmd_backend import adapt_gguf_template_for_mtmd
 
-        assert (
-            adapt_gguf_template_for_mtmd("A <image> B")
-            == "A {{ content.image_url.url }} B"
-        )
+        assert adapt_gguf_template_for_mtmd("A <image> B") == "A {{ content.image_url.url }} B"
 
     def test_noop_when_no_token(self) -> None:
         from lilbee.providers.mtmd_backend import adapt_gguf_template_for_mtmd

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1162,107 +1162,41 @@ class TestReadMmprojProjectorType:
         assert read_mmproj_projector_type(f) == "lightonocr"
 
 
-class TestResolveVisionHandler:
-    def test_known_projector(self, mock_llama_cpp: mock.MagicMock) -> None:
-        from lilbee.providers.llama_cpp_provider import _resolve_vision_handler
+class TestMtmdLoadVisionLlama:
+    """mtmd backend replaces the old projector-type → handler lookup."""
 
-        handler_cls = mock.MagicMock()
-        mock_llama_cpp.llama_chat_format.Llava15ChatHandler = handler_cls
-        mock_llama_cpp.llama_chat_format.MiniCPMv26ChatHandler = mock.MagicMock()
-
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider.read_mmproj_projector_type",
-            return_value="minicpmv",
-        ):
-            result = _resolve_vision_handler(Path("test.gguf"))
-        assert result is mock_llama_cpp.llama_chat_format.MiniCPMv26ChatHandler
-
-    def test_unknown_projector_falls_back(self, mock_llama_cpp: mock.MagicMock) -> None:
-        from lilbee.providers.llama_cpp_provider import _resolve_vision_handler
-
-        fallback = mock.MagicMock()
-        mock_llama_cpp.llama_chat_format.Llava15ChatHandler = fallback
-        # Register the submodule so `from llama_cpp.llama_chat_format import ...` works
-        sys.modules["llama_cpp.llama_chat_format"] = mock_llama_cpp.llama_chat_format
-
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider.read_mmproj_projector_type",
-            return_value="totally_unknown_projector",
-        ):
-            result = _resolve_vision_handler(Path("test.gguf"))
-        assert result is fallback
-        sys.modules.pop("llama_cpp.llama_chat_format", None)
-
-    def test_handler_not_found_falls_back(self, mock_llama_cpp: mock.MagicMock) -> None:
-        from lilbee.providers.llama_cpp_provider import _resolve_vision_handler
-
-        fallback = mock.MagicMock()
-        # Use a module mock where getattr returns None for the handler
-        fake_chat_format = mock.MagicMock(spec=[])
-        fake_chat_format.Llava15ChatHandler = fallback
-        mock_llama_cpp.llama_chat_format = fake_chat_format
-        sys.modules["llama_cpp.llama_chat_format"] = fake_chat_format
-
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider.read_mmproj_projector_type",
-            return_value="minicpmv",
-        ):
-            result = _resolve_vision_handler(Path("test.gguf"))
-        assert result is fallback
-        sys.modules.pop("llama_cpp.llama_chat_format", None)
-
-    def test_no_projector_falls_back(self, mock_llama_cpp: mock.MagicMock) -> None:
-        from lilbee.providers.llama_cpp_provider import _resolve_vision_handler
-
-        fallback = mock.MagicMock()
-        mock_llama_cpp.llama_chat_format.Llava15ChatHandler = fallback
-        sys.modules["llama_cpp.llama_chat_format"] = mock_llama_cpp.llama_chat_format
-
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider.read_mmproj_projector_type",
-            return_value=None,
-        ):
-            result = _resolve_vision_handler(Path("test.gguf"))
-        assert result is fallback
-        sys.modules.pop("llama_cpp.llama_chat_format", None)
-
-
-class TestLoadVisionLlama:
     def test_with_mmproj_and_num_ctx(self, mock_llama_cpp: mock.MagicMock) -> None:
-        from lilbee.providers.llama_cpp_provider import load_vision_llama
+        from lilbee.providers.mtmd_backend import load_vision_llama
 
-        handler_cls = mock.MagicMock()
-        mock_llama_cpp.llama_chat_format.Llava15ChatHandler = handler_cls
         cfg.num_ctx = 4096
 
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider._resolve_vision_handler",
-            return_value=handler_cls,
+        with (
+            mock.patch(
+                "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+                return_value=mock.MagicMock(),
+            ),
         ):
             load_vision_llama(Path("model.gguf"), mmproj_path=Path("mmproj.gguf"))
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         assert call_kwargs["n_ctx"] == 4096
+        assert call_kwargs["n_gpu_layers"] == -1
 
     def test_without_num_ctx(self, mock_llama_cpp: mock.MagicMock) -> None:
-        from lilbee.providers.llama_cpp_provider import load_vision_llama
+        from lilbee.providers.mtmd_backend import load_vision_llama
 
-        handler_cls = mock.MagicMock()
-        mock_llama_cpp.llama_chat_format.Llava15ChatHandler = handler_cls
         cfg.num_ctx = None
 
         with mock.patch(
-            "lilbee.providers.llama_cpp_provider._resolve_vision_handler",
-            return_value=handler_cls,
+            "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+            return_value=mock.MagicMock(),
         ):
             load_vision_llama(Path("model.gguf"), mmproj_path=Path("mmproj.gguf"))
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         assert call_kwargs["n_ctx"] == 0
 
     def test_without_mmproj_calls_find(self, mock_llama_cpp: mock.MagicMock) -> None:
-        from lilbee.providers.llama_cpp_provider import load_vision_llama
+        from lilbee.providers.mtmd_backend import load_vision_llama
 
-        handler_cls = mock.MagicMock()
-        mock_llama_cpp.llama_chat_format.Llava15ChatHandler = handler_cls
         cfg.num_ctx = None
 
         with (
@@ -1271,12 +1205,39 @@ class TestLoadVisionLlama:
                 return_value=Path("found_mmproj.gguf"),
             ),
             mock.patch(
-                "lilbee.providers.llama_cpp_provider._resolve_vision_handler",
-                return_value=handler_cls,
-            ),
+                "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+                return_value=mock.MagicMock(),
+            ) as mock_handler,
         ):
             load_vision_llama(Path("model.gguf"))
         assert mock_llama_cpp.Llama.called
+        mock_handler.assert_called_once()
+
+
+class TestAdaptGgufTemplate:
+    """``adapt_gguf_template_for_mtmd`` rewrites GGUF image-placeholder tokens."""
+
+    def test_replaces_image_pad(self) -> None:
+        from lilbee.providers.mtmd_backend import adapt_gguf_template_for_mtmd
+
+        template = "prefix <|image_pad|> suffix"
+        out = adapt_gguf_template_for_mtmd(template)
+        assert "<|image_pad|>" not in out
+        assert "{{ content.image_url.url }}" in out
+
+    def test_replaces_image_tag(self) -> None:
+        from lilbee.providers.mtmd_backend import adapt_gguf_template_for_mtmd
+
+        assert (
+            adapt_gguf_template_for_mtmd("A <image> B")
+            == "A {{ content.image_url.url }} B"
+        )
+
+    def test_noop_when_no_token(self) -> None:
+        from lilbee.providers.mtmd_backend import adapt_gguf_template_for_mtmd
+
+        template = "plain {{ content.image_url.url }} template"
+        assert adapt_gguf_template_for_mtmd(template) == template
 
 
 # ---------------------------------------------------------------------------
@@ -1470,16 +1431,12 @@ class TestLlamaCppProviderMethods:
         mock_cache_model = mock.MagicMock()
         provider._cache.load_model.return_value = mock_cache_model
 
-        with (
-            mock.patch(
-                "lilbee.providers.llama_cpp_provider.resolve_model_path",
-                return_value=Path("/models/vision.gguf"),
-            ),
-            mock.patch.object(provider, "_get_vision_llm") as mock_vis,
+        with mock.patch(
+            "lilbee.providers.llama_cpp_provider.resolve_model_path",
+            return_value=Path("/models/vision.gguf"),
         ):
             result = provider._get_chat_llm()
 
-        mock_vis.assert_not_called()
         assert result == mock_cache_model
         provider._cache.load_model.assert_called_once_with(Path("/models/vision.gguf"), mode="chat")
 
@@ -1497,44 +1454,6 @@ class TestLlamaCppProviderMethods:
         provider._cache.load_model.assert_called_once_with(
             Path("/models/override.gguf"), mode="chat"
         )
-
-    def test_get_vision_llm_caches(self, mock_llama_cpp: mock.MagicMock) -> None:
-        """_get_vision_llm caches the vision model."""
-        provider = _make_provider_no_thread()
-
-        mock_vis = mock.MagicMock()
-        with (
-            mock.patch(
-                "lilbee.providers.llama_cpp_provider.resolve_model_path",
-                return_value=Path("/models/vis.gguf"),
-            ),
-            mock.patch(
-                "lilbee.providers.llama_cpp_provider.load_vision_llama",
-                return_value=mock_vis,
-            ),
-        ):
-            result = provider._get_vision_llm("vis-model")
-
-        assert result == mock_vis
-        assert provider._vision_llm == mock_vis
-
-    def test_get_vision_llm_reuses_cache(
-        self, mock_llama_cpp: mock.MagicMock, tmp_path: Path
-    ) -> None:
-        """_get_vision_llm reuses cached model for same path."""
-        provider = _make_provider_no_thread()
-        vis_path = tmp_path / "models" / "vis.gguf"
-        existing_vis = mock.MagicMock()
-        provider._vision_llm = existing_vis
-        provider._vision_model_path = str(vis_path)
-
-        with mock.patch(
-            "lilbee.providers.llama_cpp_provider.resolve_model_path",
-            return_value=vis_path,
-        ):
-            result = provider._get_vision_llm("vis-model")
-
-        assert result is existing_vis
 
     def test_get_embed_llm(self, mock_llama_cpp: mock.MagicMock) -> None:
         """_get_embed_llm loads embedding model via cache."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -651,6 +651,57 @@ class TestDrainFallback:
         assert task.done()
 
 
+class TestDrainHeartbeat:
+    """Root cause for obsidian-lilbee-v8y: a long-running producer (vision OCR
+    on an image-heavy PDF) keeps the queue empty for longer than the plugin's
+    120s STREAM_IDLE_TIMEOUT_MS, so drain() must emit heartbeat events while
+    the producer is alive but silent."""
+
+    async def test_heartbeat_emitted_while_queue_idle(self):
+        """drain() emits heartbeat events while the producer is silent."""
+        from lilbee.server.handlers import SseStream
+
+        cfg.sse_heartbeat_interval = 0.05
+        sse = SseStream()
+
+        async def slow_producer():
+            await asyncio.sleep(0.25)
+            sse.queue.put_nowait("event: progress\ndata: {}\n\n")
+            sse.queue.put_nowait(None)
+
+        task = asyncio.create_task(slow_producer())
+        events = [e async for e in sse.drain(task, "slow")]
+
+        heartbeats = [e for e in events if e.startswith("event: heartbeat")]
+        progress = [e for e in events if e.startswith("event: progress")]
+        assert heartbeats, "expected at least one heartbeat while producer was idle"
+        assert progress == ["event: progress\ndata: {}\n\n"]
+        # Heartbeat payload must be JSON with a monotonic timestamp.
+        ts_payload = json.loads(heartbeats[0].split("data: ")[1].strip())
+        assert isinstance(ts_payload.get("ts"), int | float)
+
+    async def test_heartbeat_skipped_when_producer_emits_faster_than_interval(self):
+        """A chatty producer never triggers a heartbeat."""
+        from lilbee.server.handlers import SseStream
+
+        cfg.sse_heartbeat_interval = 5.0
+        sse = SseStream()
+
+        async def chatty_producer():
+            for i in range(3):
+                sse.queue.put_nowait(f'event: progress\ndata: {{"i": {i}}}\n\n')
+                await asyncio.sleep(0.01)
+            sse.queue.put_nowait(None)
+
+        task = asyncio.create_task(chatty_producer())
+        events = [e async for e in sse.drain(task, "chatty")]
+
+        heartbeats = [e for e in events if e.startswith("event: heartbeat")]
+        assert heartbeats == []
+        progress = [e for e in events if e.startswith("event: progress")]
+        assert len(progress) == 3
+
+
 class TestListModels:
     @patch("lilbee.server.handlers.get_model_manager")
     async def test_returns_catalogs(self, mock_get_mm):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -680,6 +680,21 @@ class TestDrainHeartbeat:
         ts_payload = json.loads(heartbeats[0].split("data: ")[1].strip())
         assert isinstance(ts_payload.get("ts"), int | float)
 
+    async def test_heartbeat_disabled_when_interval_is_zero(self):
+        """``cfg.sse_heartbeat_interval == 0`` opts out of heartbeats."""
+        from lilbee.server.handlers import SseStream
+
+        cfg.sse_heartbeat_interval = 0.0
+        sse = SseStream()
+
+        async def slow_producer():
+            await asyncio.sleep(0.25)
+            sse.queue.put_nowait(None)
+
+        task = asyncio.create_task(slow_producer())
+        events = [e async for e in sse.drain(task, "disabled")]
+        assert not any(e.startswith("event: heartbeat") for e in events)
+
     async def test_heartbeat_skipped_when_producer_emits_faster_than_interval(self):
         """A chatty producer never triggers a heartbeat."""
         from lilbee.server.handlers import SseStream

--- a/tests/test_worker_process.py
+++ b/tests/test_worker_process.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import logging
 import multiprocessing
 import sys
 from multiprocessing import get_context
@@ -191,6 +193,29 @@ class TestHandleVision:
         with mock.patch("lilbee.vision.build_vision_messages", return_value=[]):
             _handle_vision(llm, req)
         assert llm.create_chat_completion.call_args.kwargs["max_tokens"] == 1024
+
+    def test_warns_when_cap_hit(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Hitting the cap means output was truncated; surface it as a
+        WARNING so the symptom is visible in worker.log.
+        """
+        from lilbee.config import cfg
+
+        cfg.vision_max_tokens = 256
+        llm = mock.MagicMock()
+        llm.create_chat_completion.return_value = {
+            "choices": [{"message": {"content": "t"}}],
+            "usage": {"completion_tokens": 256, "prompt_tokens": 100},
+        }
+        req = VisionRequest(png_bytes=b"png", model="v", prompt="", request_id=7)
+        with (
+            mock.patch("lilbee.vision.build_vision_messages", return_value=[]),
+            caplog.at_level(logging.WARNING, "lilbee.providers.worker_process"),
+        ):
+            _handle_vision(llm, req)
+        assert any(
+            "hit vision_max_tokens cap" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
 
 
 class TestWorkerMain:
@@ -768,8 +793,10 @@ class TestWorkerProcessVision:
 
         assert seen == [600.0]
 
-    def test_vision_zero_timeout_means_no_limit(self, config_snap: ConfigSnapshot) -> None:
-        """cfg.ocr_timeout == 0 is translated to a day-long finite deadline."""
+    def test_zero_ocr_timeout_is_translated_to_day_cap(self, config_snap: ConfigSnapshot) -> None:
+        """cfg.ocr_timeout == 0 ("no limit") is translated to the day-long
+        ``_NO_CAP_TIMEOUT_S`` substitute for the round-trip deadline loop.
+        """
         from lilbee.config import cfg
 
         wp = WorkerProcess(config_snap)
@@ -1003,6 +1030,36 @@ class TestLoadVisionModel:
             result = _load_vision_model("test-vision")
         assert result is mock_llm
         mock_load.assert_called_once_with(vision_path)
+
+
+class TestConfigureWorkerLogging:
+    def test_no_data_dir_env_is_no_op(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.providers.worker_process import _configure_worker_logging
+
+        monkeypatch.delenv("LILBEE_DATA", raising=False)
+        root = logging.getLogger()
+        before = list(root.handlers)
+        _configure_worker_logging()
+        assert root.handlers == before
+
+    def test_attaches_file_handler_to_root_logger(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from lilbee.providers.worker_process import _configure_worker_logging
+
+        monkeypatch.setenv("LILBEE_DATA", str(tmp_path))
+        root = logging.getLogger()
+        before = len(root.handlers)
+        try:
+            _configure_worker_logging()
+            added = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+            assert any(h.baseFilename == str(tmp_path / "worker.log") for h in added)
+            assert root.level <= logging.INFO
+        finally:
+            for h in root.handlers[before:]:
+                root.removeHandler(h)
+                with contextlib.suppress(Exception):
+                    h.close()
 
 
 def test_redirect_stdio_points_stdout_stderr_to_devnull(tmp_path: Path) -> None:

--- a/tests/test_worker_process.py
+++ b/tests/test_worker_process.py
@@ -725,6 +725,57 @@ class TestWorkerProcessVision:
         ):
             wp.vision_ocr(b"png", "model")
 
+    def test_vision_uses_cfg_ocr_timeout(self, config_snap: ConfigSnapshot) -> None:
+        """vision_ocr passes cfg.ocr_timeout into the round-trip deadline.
+
+        Prevents an image-heavy page from being killed by the built-in 120s
+        cap when the user has explicitly raised LILBEE_VISION_TIMEOUT /
+        cfg.ocr_timeout for a slow vision model.
+        """
+        from lilbee.config import cfg
+
+        wp = WorkerProcess(config_snap)
+        wp._started = True
+        mock_proc = mock.MagicMock()
+        mock_proc.is_alive.return_value = True
+        wp._process = mock_proc
+        wp._request_queue = mock.MagicMock()
+
+        cfg.ocr_timeout = 600.0
+        seen: list[float] = []
+
+        def capture_round_trip(_req, _resp_type, timeout, *, label):
+            seen.append(timeout)
+            return VisionResponse(text="ok", request_id=1)
+
+        with mock.patch.object(wp, "_round_trip", side_effect=capture_round_trip):
+            wp.vision_ocr(b"png", "model")
+
+        assert seen == [600.0]
+
+    def test_vision_zero_timeout_means_no_limit(self, config_snap: ConfigSnapshot) -> None:
+        """cfg.ocr_timeout == 0 is translated to a day-long finite deadline."""
+        from lilbee.config import cfg
+
+        wp = WorkerProcess(config_snap)
+        wp._started = True
+        mock_proc = mock.MagicMock()
+        mock_proc.is_alive.return_value = True
+        wp._process = mock_proc
+        wp._request_queue = mock.MagicMock()
+
+        cfg.ocr_timeout = 0.0
+        seen: list[float] = []
+
+        def capture_round_trip(_req, _resp_type, timeout, *, label):
+            seen.append(timeout)
+            return VisionResponse(text="ok", request_id=1)
+
+        with mock.patch.object(wp, "_round_trip", side_effect=capture_round_trip):
+            wp.vision_ocr(b"png", "model")
+
+        assert seen == [86_400.0]
+
 
 class TestWorkerProcessLoadModel:
     def test_load_model_sends_request(self, config_snap: ConfigSnapshot) -> None:

--- a/tests/test_worker_process.py
+++ b/tests/test_worker_process.py
@@ -768,9 +768,9 @@ class TestWorkerProcessVision:
     def test_vision_uses_cfg_ocr_timeout(self, config_snap: ConfigSnapshot) -> None:
         """vision_ocr passes cfg.ocr_timeout into the round-trip deadline.
 
-        Prevents an image-heavy page from being killed by the built-in 120s
-        cap when the user has explicitly raised LILBEE_VISION_TIMEOUT /
-        cfg.ocr_timeout for a slow vision model.
+        Prevents an image-heavy page from being killed by the built-in
+        120s cap when the user has explicitly raised LILBEE_OCR_TIMEOUT
+        / cfg.ocr_timeout for a slow vision model.
         """
         from lilbee.config import cfg
 

--- a/tests/test_worker_process.py
+++ b/tests/test_worker_process.py
@@ -177,6 +177,21 @@ class TestHandleVision:
             _handle_vision(llm, req)
         assert mock_build.call_args[0][0] == "custom prompt"
 
+    def test_caps_generation_at_cfg_vision_max_tokens(self) -> None:
+        """Dense pages can push some vision models past EOT and into an
+        infinite emission loop. cfg.vision_max_tokens gives the worker a
+        hard stop so one page can't stall the whole ingest.
+        """
+        from lilbee.config import cfg
+
+        cfg.vision_max_tokens = 1024
+        llm = mock.MagicMock()
+        llm.create_chat_completion.return_value = {"choices": [{"message": {"content": "t"}}]}
+        req = VisionRequest(png_bytes=b"png", model="v", prompt="", request_id=1)
+        with mock.patch("lilbee.vision.build_vision_messages", return_value=[]):
+            _handle_vision(llm, req)
+        assert llm.create_chat_completion.call_args.kwargs["max_tokens"] == 1024
+
 
 class TestWorkerMain:
     """Test _worker_main loop handling of different request types."""

--- a/tests/test_worker_process.py
+++ b/tests/test_worker_process.py
@@ -996,7 +996,7 @@ class TestLoadVisionModel:
                 return_value=vision_path,
             ),
             mock.patch(
-                "lilbee.providers.llama_cpp_provider.load_vision_llama",
+                "lilbee.providers.mtmd_backend.load_vision_llama",
                 return_value=mock_llm,
             ) as mock_load,
         ):

--- a/tests/test_worker_process.py
+++ b/tests/test_worker_process.py
@@ -179,43 +179,16 @@ class TestHandleVision:
             _handle_vision(llm, req)
         assert mock_build.call_args[0][0] == "custom prompt"
 
-    def test_caps_generation_at_cfg_vision_max_tokens(self) -> None:
-        """Dense pages can push some vision models past EOT and into an
-        infinite emission loop. cfg.vision_max_tokens gives the worker a
-        hard stop so one page can't stall the whole ingest.
+    def test_does_not_impose_max_tokens_cap(self) -> None:
+        """Generation is bounded by the model's ``n_ctx`` and the GGUF's EOT,
+        so the worker intentionally does not pass ``max_tokens``.
         """
-        from lilbee.config import cfg
-
-        cfg.vision_max_tokens = 1024
         llm = mock.MagicMock()
         llm.create_chat_completion.return_value = {"choices": [{"message": {"content": "t"}}]}
         req = VisionRequest(png_bytes=b"png", model="v", prompt="", request_id=1)
         with mock.patch("lilbee.vision.build_vision_messages", return_value=[]):
             _handle_vision(llm, req)
-        assert llm.create_chat_completion.call_args.kwargs["max_tokens"] == 1024
-
-    def test_warns_when_cap_hit(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Hitting the cap means output was truncated; surface it as a
-        WARNING so the symptom is visible in worker.log.
-        """
-        from lilbee.config import cfg
-
-        cfg.vision_max_tokens = 256
-        llm = mock.MagicMock()
-        llm.create_chat_completion.return_value = {
-            "choices": [{"message": {"content": "t"}}],
-            "usage": {"completion_tokens": 256, "prompt_tokens": 100},
-        }
-        req = VisionRequest(png_bytes=b"png", model="v", prompt="", request_id=7)
-        with (
-            mock.patch("lilbee.vision.build_vision_messages", return_value=[]),
-            caplog.at_level(logging.WARNING, "lilbee.providers.worker_process"),
-        ):
-            _handle_vision(llm, req)
-        assert any(
-            "hit vision_max_tokens cap" in r.message and r.levelno == logging.WARNING
-            for r in caplog.records
-        )
+        assert "max_tokens" not in llm.create_chat_completion.call_args.kwargs
 
 
 class TestWorkerMain:


### PR DESCRIPTION
## The problem

Ingesting an image-heavy PDF through the Obsidian plugin silently stopped making progress. The task spinner would sit there, the plugin would eventually give up, and the user had no idea whether the server had crashed, was still working, or had finished and forgotten to say so.

Three unrelated bugs were all contributing to the same visible failure.

First, the server's SSE stream only emitted events when real progress happened. A single vision OCR page that took longer than the plugin's idle timeout looked to the plugin like the server had gone away, and it aborted the stream mid-ingest.

Second, running vision OCR from the TUI never actually started. The subprocess spawn path crashed before the model even got a request. Textual swaps stderr for a wrapper that has no real file descriptor, and every multiprocessing spawn inherits that bad fd, which Python's spawn helper rejects.

Third, and this is the one that had been there longest, the vision loader picked a chat template from a hardcoded per-model lookup table. Whenever the table's guess diverged from what the model was actually trained on, the model either ran away producing tokens until the context ran out or hallucinated unrelated content on dense pages. The symptom looked like a slow ingest; the cause was a template mismatch.

## How it's fixed

The stream now emits a periodic heartbeat any time the producer queue goes idle. The payload is a wall-clock timestamp so clients have something real to log. Idle clients keep their connection alive; clients that don't recognise the event ignore it.

The TUI-subprocess interaction is fixed by pinning a threading lock that tqdm would otherwise lazily build on top of a bad stderr, and by pre-starting the multiprocessing resource tracker while stderr is still real.

The vision loader no longer consults a per-model table. It reads the Jinja chat template out of the model's own GGUF metadata and hands it to a single generic handler. Every vision model, present or future, flows through the same code path and stays in sync with whatever template the model was trained on. The old handler-class dispatch, the projector-type lookup map, and the cached per-model handler instance are gone.

## What changed

- SSE `heartbeat` event, configurable via `LILBEE_SSE_HEARTBEAT_INTERVAL` (default 30s, set to 0 to disable).
- `LILBEE_OCR_TIMEOUT` actually honours its value now; the worker was hardcoded to 120s and ignored the env var.
- Vision OCR generation is bounded by the model's context window and its real EOT, nothing else. No per-request token cap.
- Vision worker logs land in `worker.log` next to the data directory with per-page timing, token counts, and output size.
- Public vision-loader code is `lilbee.providers.mtmd_backend`; the old `_PROJECTOR_HANDLER_MAP`, `_resolve_vision_handler`, and `load_vision_llama` on `llama_cpp_provider` are removed along with the dead `_get_vision_llm` cache on the provider.
- End-to-end verified with a 20-page excerpt of the Star Wars X-Wing Collector's Edition guide on `lightonocr:2-1b` + `nomic-embed-text:v1.5` + `qwen3:4b` through the TUI: all pages OCR'd in ~6 minutes, LanceDB populated, chat query returns sourced answers.