### PR TITLE
Serialize concurrent ingest of the same file

### DIFF
--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -740,13 +740,9 @@ async def sync(
             unchanged += 1
             continue
 
-        # Always set needs_cleanup=True so ingest_batch calls
-        # delete_by_source(name) before re-adding. delete_by_source is
-        # idempotent (no-op when no chunks exist), so this is cheap on the
-        # happy path. It closes a race where a previous ingest crashed after
-        # writing chunks but before upsert_source recorded the hash: the
-        # source row is missing from existing_sources, but the chunks are
-        # still in LanceDB, and a naive re-add would append duplicates.
+        # needs_cleanup=True unconditionally: delete_by_source is idempotent,
+        # and this closes the race where a prior ingest wrote chunks but died
+        # before upsert_source, leaving orphaned chunks that would duplicate.
         files_to_process.append(
             FileToProcess(name, path, content_type, current_hash, needs_cleanup=True)
         )

--- a/src/lilbee/ingest.py
+++ b/src/lilbee/ingest.py
@@ -740,17 +740,19 @@ async def sync(
             unchanged += 1
             continue
 
+        # Always set needs_cleanup=True so ingest_batch calls
+        # delete_by_source(name) before re-adding. delete_by_source is
+        # idempotent (no-op when no chunks exist), so this is cheap on the
+        # happy path. It closes a race where a previous ingest crashed after
+        # writing chunks but before upsert_source recorded the hash: the
+        # source row is missing from existing_sources, but the chunks are
+        # still in LanceDB, and a naive re-add would append duplicates.
+        files_to_process.append(
+            FileToProcess(name, path, content_type, current_hash, needs_cleanup=True)
+        )
         if old_hash is not None:
-            # Modified — defer old chunk deletion to ingest_batch so
-            # delete + re-ingest are atomic per file (no data loss on cancel).
-            files_to_process.append(
-                FileToProcess(name, path, content_type, current_hash, needs_cleanup=True)
-            )
             updated.append(name)
         else:
-            files_to_process.append(
-                FileToProcess(name, path, content_type, current_hash, needs_cleanup=False)
-            )
             added.append(name)
 
     # Ingest files (with optional progress bar)

--- a/src/lilbee/progress.py
+++ b/src/lilbee/progress.py
@@ -35,6 +35,7 @@ class SseEvent(StrEnum):
     DONE = "done"
     PROGRESS = "progress"
     HEARTBEAT = "heartbeat"
+    ALREADY_INGESTING = "already_ingesting"
 
 
 class FileStartEvent(BaseModel):

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -417,6 +417,68 @@ async def _run_sync_with_sentinel(sse: SseStream, enable_ocr: bool | None) -> Sy
         sse.queue.put_nowait(None)
 
 
+# Per-source ingest mutexes. Keyed on the canonical source name (the basename
+# used by ``copy_files`` when placing files under ``cfg.documents_dir``).
+# ``_INGEST_LOCK_REGISTRY`` serializes lock creation + the check-and-acquire
+# step so the TOCTOU between ``lock.locked()`` and ``lock.acquire()`` is not
+# racy under concurrent ``/api/add`` calls on the same event loop.
+_INGEST_LOCKS: dict[str, asyncio.Lock] = {}
+_INGEST_LOCK_REGISTRY: asyncio.Lock | None = None
+
+
+def _get_registry_lock() -> asyncio.Lock:
+    """Return the registry lock bound to the running event loop.
+
+    Created lazily so tests that spin up a fresh loop per case get a fresh
+    lock. Callers must be running inside an asyncio loop.
+    """
+    global _INGEST_LOCK_REGISTRY
+    if _INGEST_LOCK_REGISTRY is None:
+        _INGEST_LOCK_REGISTRY = asyncio.Lock()
+    return _INGEST_LOCK_REGISTRY
+
+
+def _reset_ingest_locks() -> None:
+    """Clear all per-source locks and the registry lock. Test-only hook.
+
+    Per-test teardown should call this so locks from a previous loop do not
+    leak into the next test's loop.
+    """
+    global _INGEST_LOCK_REGISTRY
+    _INGEST_LOCKS.clear()
+    _INGEST_LOCK_REGISTRY = None
+
+
+async def _try_acquire_source(name: str) -> asyncio.Lock | None:
+    """Atomically check + acquire the lock for ``name``.
+
+    Returns the acquired ``asyncio.Lock`` on success, or ``None`` when another
+    coroutine already holds it. Caller is responsible for releasing.
+    """
+    async with _get_registry_lock():
+        lock = _INGEST_LOCKS.get(name)
+        if lock is None:
+            lock = asyncio.Lock()
+            _INGEST_LOCKS[name] = lock
+        if lock.locked():
+            return None
+        # Safe: we hold the registry lock, no other coroutine can race us
+        # between the ``locked()`` check and ``acquire()``. Acquiring an
+        # unlocked ``asyncio.Lock`` completes without yielding.
+        await lock.acquire()
+        return lock
+
+
+def _canonical_source_name(p_str: str) -> str:
+    """Return the canonical source-name key used by the ingest mutex.
+
+    Matches the basename ``copy_files`` uses when placing the file under
+    ``cfg.documents_dir``. ``ingest.sync`` keys sources by relative path, and
+    for the add flow the relative path equals the basename.
+    """
+    return Path(p_str).name
+
+
 async def sync_stream(*, enable_ocr: bool | None = None) -> AsyncGenerator[str, None]:
     """Trigger sync, yield SSE progress events, then done event."""
     sse = SseStream()
@@ -470,6 +532,40 @@ async def _run_add(
         sse.queue.put_nowait(None)
 
 
+async def _acquire_add_locks(
+    paths: list[str],
+) -> tuple[list[tuple[str, asyncio.Lock]], list[str]]:
+    """Partition ``paths`` into acquired locks and 'already in flight' names.
+
+    Returns a pair ``(acquired, busy)`` where ``acquired`` is a list of
+    ``(name, lock)`` for the sources this request now owns, and ``busy`` is
+    the ordered list of canonical source names whose lock is already held by
+    another in-flight request.
+    """
+    acquired: list[tuple[str, asyncio.Lock]] = []
+    busy: list[str] = []
+    seen: set[str] = set()
+    for p_str in paths:
+        name = _canonical_source_name(p_str)
+        if name in seen:
+            continue
+        seen.add(name)
+        lock = await _try_acquire_source(name)
+        if lock is None:
+            busy.append(name)
+        else:
+            acquired.append((name, lock))
+    return acquired, busy
+
+
+def _release_add_locks(acquired: list[tuple[str, asyncio.Lock]]) -> None:
+    """Release every lock in ``acquired``. Safe to call multiple times."""
+    while acquired:
+        _, lock = acquired.pop()
+        if lock.locked():
+            lock.release()
+
+
 def validate_add_paths(
     data: dict[str, Any],
 ) -> tuple[list[str], bool, bool | None, float | None]:
@@ -501,22 +597,49 @@ def _parse_ocr_params(data: dict[str, Any]) -> tuple[bool | None, float | None]:
 
 async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
     """Copy files, sync, and yield SSE progress events.
+
     Validation is handled by the route layer before this is called.
+
+    Each incoming source name is guarded by a per-source mutex. If a second
+    ``/api/add`` arrives while the same source is still being ingested by an
+    earlier request, this handler emits one ``already_ingesting`` event per
+    contended source and closes the stream without a ``done`` event.
     """
     paths = data.get("paths", [])
     force = bool(data.get("force", False))
     enable_ocr, ocr_timeout = _parse_ocr_params(data)
-    sse = SseStream()
-    task = asyncio.create_task(_run_add(paths, force, enable_ocr, ocr_timeout, sse))
-    async for event in sse.drain(task, "Add files stream"):
-        yield event
-    if not sse.cancel.is_set() and task.done() and not task.cancelled():
-        exc = task.exception()
-        if exc is not None:
-            yield sse_error(str(exc))
+
+    acquired, busy = await _acquire_add_locks(paths)
+    try:
+        for name in busy:
+            log.info("Rejecting /api/add for %s: already ingesting", name)
+            yield sse_event(SseEvent.ALREADY_INGESTING, {"source": name})
+
+        if not acquired:
+            # Every requested source is already being ingested. Close the
+            # stream with no ``done`` event so the client recognises the
+            # neutral 'waiting on server' state and does not retry.
             return
-        summary = task.result()
-        yield sse_done(summary.model_dump())
+
+        sse = SseStream()
+        task = asyncio.create_task(_run_add(paths, force, enable_ocr, ocr_timeout, sse))
+        try:
+            async for event in sse.drain(task, "Add files stream"):
+                yield event
+            if not sse.cancel.is_set() and task.done() and not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    yield sse_error(str(exc))
+                    return
+                summary = task.result()
+                yield sse_done(summary.model_dump())
+        finally:
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
+    finally:
+        _release_add_locks(acquired)
 
 
 def _catalog_section(

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -7,6 +7,7 @@ Return types are dicts (JSON responses), lists, or async generators of SSE strin
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import copy
 import functools
 import json
@@ -417,21 +418,14 @@ async def _run_sync_with_sentinel(sse: SseStream, enable_ocr: bool | None) -> Sy
         sse.queue.put_nowait(None)
 
 
-# Per-source ingest mutexes. Keyed on the canonical source name (the basename
-# used by ``copy_files`` when placing files under ``cfg.documents_dir``).
-# ``_INGEST_LOCK_REGISTRY`` serializes lock creation + the check-and-acquire
-# step so the TOCTOU between ``lock.locked()`` and ``lock.acquire()`` is not
-# racy under concurrent ``/api/add`` calls on the same event loop.
+# Registry lock serializes lock creation and the check-and-acquire step to
+# avoid a TOCTOU between locked() and acquire() under concurrent /api/add.
 _INGEST_LOCKS: dict[str, asyncio.Lock] = {}
 _INGEST_LOCK_REGISTRY: asyncio.Lock | None = None
 
 
 def _get_registry_lock() -> asyncio.Lock:
-    """Return the registry lock bound to the running event loop.
-
-    Created lazily so tests that spin up a fresh loop per case get a fresh
-    lock. Callers must be running inside an asyncio loop.
-    """
+    """Return the registry lock, creating it on the running loop if needed."""
     global _INGEST_LOCK_REGISTRY
     if _INGEST_LOCK_REGISTRY is None:
         _INGEST_LOCK_REGISTRY = asyncio.Lock()
@@ -439,22 +433,14 @@ def _get_registry_lock() -> asyncio.Lock:
 
 
 def _reset_ingest_locks() -> None:
-    """Clear all per-source locks and the registry lock. Test-only hook.
-
-    Per-test teardown should call this so locks from a previous loop do not
-    leak into the next test's loop.
-    """
+    """Test hook: clear per-source locks and the registry lock."""
     global _INGEST_LOCK_REGISTRY
     _INGEST_LOCKS.clear()
     _INGEST_LOCK_REGISTRY = None
 
 
 async def _try_acquire_source(name: str) -> asyncio.Lock | None:
-    """Atomically check + acquire the lock for ``name``.
-
-    Returns the acquired ``asyncio.Lock`` on success, or ``None`` when another
-    coroutine already holds it. Caller is responsible for releasing.
-    """
+    """Acquire the lock for ``name`` or return ``None`` if already held."""
     async with _get_registry_lock():
         lock = _INGEST_LOCKS.get(name)
         if lock is None:
@@ -462,20 +448,12 @@ async def _try_acquire_source(name: str) -> asyncio.Lock | None:
             _INGEST_LOCKS[name] = lock
         if lock.locked():
             return None
-        # Safe: we hold the registry lock, no other coroutine can race us
-        # between the ``locked()`` check and ``acquire()``. Acquiring an
-        # unlocked ``asyncio.Lock`` completes without yielding.
         await lock.acquire()
         return lock
 
 
 def _canonical_source_name(p_str: str) -> str:
-    """Return the canonical source-name key used by the ingest mutex.
-
-    Matches the basename ``copy_files`` uses when placing the file under
-    ``cfg.documents_dir``. ``ingest.sync`` keys sources by relative path, and
-    for the add flow the relative path equals the basename.
-    """
+    """Match the basename ``copy_files`` writes under ``cfg.documents_dir``."""
     return Path(p_str).name
 
 
@@ -535,13 +513,7 @@ async def _run_add(
 async def _acquire_add_locks(
     paths: list[str],
 ) -> tuple[list[tuple[str, asyncio.Lock]], list[str]]:
-    """Partition ``paths`` into acquired locks and 'already in flight' names.
-
-    Returns a pair ``(acquired, busy)`` where ``acquired`` is a list of
-    ``(name, lock)`` for the sources this request now owns, and ``busy`` is
-    the ordered list of canonical source names whose lock is already held by
-    another in-flight request.
-    """
+    """Return ``(acquired, busy)`` partitioning of ``paths`` by lock state."""
     acquired: list[tuple[str, asyncio.Lock]] = []
     busy: list[str] = []
     seen: set[str] = set()
@@ -598,12 +570,8 @@ def _parse_ocr_params(data: dict[str, Any]) -> tuple[bool | None, float | None]:
 async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
     """Copy files, sync, and yield SSE progress events.
 
-    Validation is handled by the route layer before this is called.
-
-    Each incoming source name is guarded by a per-source mutex. If a second
-    ``/api/add`` arrives while the same source is still being ingested by an
-    earlier request, this handler emits one ``already_ingesting`` event per
-    contended source and closes the stream without a ``done`` event.
+    Contended sources emit ``already_ingesting`` and the stream closes
+    without a ``done`` event, signalling the client to wait rather than retry.
     """
     paths = data.get("paths", [])
     force = bool(data.get("force", False))
@@ -616,9 +584,6 @@ async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
             yield sse_event(SseEvent.ALREADY_INGESTING, {"source": name})
 
         if not acquired:
-            # Every requested source is already being ingested. Close the
-            # stream with no ``done`` event so the client recognises the
-            # neutral 'waiting on server' state and does not retry.
             return
 
         sse = SseStream()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -404,17 +404,24 @@ class TestAddIngestMutex:
         assert _canonical_source_name("/some/path/doc.txt") == "doc.txt"
         assert _canonical_source_name("doc.txt") == "doc.txt"
 
+    async def test_acquire_add_locks_dedups_repeated_paths(self, isolated_env):
+        """Duplicate paths in one request collapse to a single acquired lock."""
+        from lilbee.server.handlers import _acquire_add_locks, _release_add_locks
+
+        acquired, busy = await _acquire_add_locks(["/x/doc.txt", "/y/doc.txt"])
+        try:
+            assert busy == []
+            assert [name for name, _ in acquired] == ["doc.txt"]
+        finally:
+            _release_add_locks(acquired)
+
     async def test_second_concurrent_add_emits_already_ingesting(self, isolated_env, tmp_path):
-        """Concurrent ``/api/add`` for the same source yields one
-        ``already_ingesting`` event on the second request and closes the
-        stream without a ``done`` event.
-        """
+        """Second /api/add for a held source yields already_ingesting, no done."""
         from lilbee.server.handlers import _try_acquire_source, add_files_stream
 
         src = tmp_path / "holdme.txt"
         src.write_text("payload")
 
-        # Simulate the first request holding the mutex for this source.
         lock = await _try_acquire_source("holdme.txt")
         assert lock is not None
         try:
@@ -427,9 +434,7 @@ class TestAddIngestMutex:
         assert events[0][1] == {"source": "holdme.txt"}
 
     async def test_partial_contention_partitions_paths(self, isolated_env, tmp_path):
-        """When some paths are held and some are not, the handler emits
-        ``already_ingesting`` for the held ones and proceeds for the rest.
-        """
+        """Held paths emit already_ingesting; free paths still run to done."""
         from lilbee.server.handlers import _try_acquire_source, add_files_stream
 
         held = tmp_path / "held.txt"
@@ -455,9 +460,7 @@ class TestAddIngestMutex:
         assert "done" in event_types
 
     async def test_concurrent_different_sources_run_in_parallel(self, isolated_env, tmp_path):
-        """Two overlapping ``/api/add`` calls for disjoint sources both
-        complete with a ``done`` event.
-        """
+        """Disjoint sources do not contend — both requests complete with done."""
         from lilbee.server.handlers import add_files_stream
 
         a = tmp_path / "a.txt"
@@ -495,10 +498,8 @@ class TestAddIngestMutex:
         with mock.patch("lilbee.ingest.sync", new=_boom):
             events = await self._collect(add_files_stream({"paths": [str(src)]}))
 
-        # Error surfaces back to the client.
         assert any(t == "error" for t, _ in events)
 
-        # Lock must be free again: a follow-up try-acquire succeeds.
         retry = await _try_acquire_source("boom.txt")
         assert retry is not None
         retry.release()
@@ -520,7 +521,6 @@ class TestAddIngestMutex:
             outer.cancel()
             with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
                 await outer
-            # Close the generator to let the finally blocks run.
             await gen.aclose()
 
         retry = await _try_acquire_source("slow.txt")
@@ -532,11 +532,8 @@ class TestAddIngestHardening:
     """Option-A hardening: ``sync()`` always passes ``needs_cleanup=True``."""
 
     async def test_new_file_triggers_cleanup(self, isolated_env, tmp_path, mock_svc):
-        """Even when no prior source row exists, ingest now calls
-        ``delete_by_source`` before adding chunks. This closes the race where
-        a previous ingest crashed mid-flight, leaving orphaned chunks with no
-        matching source row.
-        """
+        """New files still call delete_by_source before adding — closes the
+        orphaned-chunks race when a prior ingest died before upsert_source."""
         from lilbee.ingest import sync
 
         src = isolated_env / "fresh.txt"

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -1,6 +1,7 @@
 """Tests for the /api/add endpoint and SSE progress streaming."""
 
 import asyncio
+import contextlib
 from pathlib import Path
 from unittest import mock
 from unittest.mock import AsyncMock
@@ -48,6 +49,20 @@ def mock_svc():
     set_services(services)
     yield services
     set_services(None)
+
+
+@pytest.fixture(autouse=True)
+def reset_ingest_locks():
+    """Clear per-source ingest locks so each test starts with a clean registry.
+
+    Locks are bound to the event loop; leaking them across tests produces
+    cryptic 'attached to a different loop' errors.
+    """
+    from lilbee.server.handlers import _reset_ingest_locks
+
+    _reset_ingest_locks()
+    yield
+    _reset_ingest_locks()
 
 
 def _make_kreuzberg_result(text: str = "Some extracted text. " * 20, num_chunks: int = 1):
@@ -336,3 +351,233 @@ class TestCreateApp:
         app = create_app()
         paths = [r.path for r in app.routes]
         assert "/api/add" in paths
+
+
+class TestAddIngestMutex:
+    """Tests for the per-source ingest mutex gating ``/api/add``."""
+
+    async def _collect(self, gen):
+        """Drain an async generator of SSE strings into (event, data) pairs."""
+        text = ""
+        async for frame in gen:
+            text += frame
+        return _parse_sse_events(text.encode())
+
+    async def test_try_acquire_rejects_while_held(self, isolated_env):
+        """A second ``_try_acquire_source`` for a held name returns ``None``."""
+        from lilbee.server.handlers import _try_acquire_source
+
+        first = await _try_acquire_source("doc.txt")
+        assert first is not None
+        try:
+            second = await _try_acquire_source("doc.txt")
+            assert second is None
+        finally:
+            first.release()
+
+    async def test_try_acquire_succeeds_after_release(self, isolated_env):
+        """Once released, the same name can be acquired again."""
+        from lilbee.server.handlers import _try_acquire_source
+
+        first = await _try_acquire_source("doc.txt")
+        assert first is not None
+        first.release()
+        second = await _try_acquire_source("doc.txt")
+        assert second is not None
+        second.release()
+
+    async def test_try_acquire_distinct_names_run_parallel(self, isolated_env):
+        """Locks for different source names are independent."""
+        from lilbee.server.handlers import _try_acquire_source
+
+        a = await _try_acquire_source("a.txt")
+        b = await _try_acquire_source("b.txt")
+        assert a is not None
+        assert b is not None
+        a.release()
+        b.release()
+
+    async def test_canonical_name_matches_basename(self, isolated_env):
+        """Canonical source names match what ``copy_files`` writes on disk."""
+        from lilbee.server.handlers import _canonical_source_name
+
+        assert _canonical_source_name("/some/path/doc.txt") == "doc.txt"
+        assert _canonical_source_name("doc.txt") == "doc.txt"
+
+    async def test_second_concurrent_add_emits_already_ingesting(self, isolated_env, tmp_path):
+        """Concurrent ``/api/add`` for the same source yields one
+        ``already_ingesting`` event on the second request and closes the
+        stream without a ``done`` event.
+        """
+        from lilbee.server.handlers import _try_acquire_source, add_files_stream
+
+        src = tmp_path / "holdme.txt"
+        src.write_text("payload")
+
+        # Simulate the first request holding the mutex for this source.
+        lock = await _try_acquire_source("holdme.txt")
+        assert lock is not None
+        try:
+            events = await self._collect(add_files_stream({"paths": [str(src)]}))
+        finally:
+            lock.release()
+
+        event_types = [e[0] for e in events]
+        assert event_types == ["already_ingesting"]
+        assert events[0][1] == {"source": "holdme.txt"}
+
+    async def test_partial_contention_partitions_paths(self, isolated_env, tmp_path):
+        """When some paths are held and some are not, the handler emits
+        ``already_ingesting`` for the held ones and proceeds for the rest.
+        """
+        from lilbee.server.handlers import _try_acquire_source, add_files_stream
+
+        held = tmp_path / "held.txt"
+        held.write_text("held payload")
+        free = tmp_path / "free.txt"
+        free.write_text("free payload")
+
+        lock = await _try_acquire_source("held.txt")
+        assert lock is not None
+        try:
+            with mock.patch(
+                "kreuzberg.extract_file",
+                new_callable=AsyncMock,
+                return_value=_make_kreuzberg_result(),
+            ):
+                events = await self._collect(add_files_stream({"paths": [str(held), str(free)]}))
+        finally:
+            lock.release()
+
+        event_types = [e[0] for e in events]
+        already = [d for t, d in events if t == "already_ingesting"]
+        assert {"source": "held.txt"} in already
+        assert "done" in event_types
+
+    async def test_concurrent_different_sources_run_in_parallel(self, isolated_env, tmp_path):
+        """Two overlapping ``/api/add`` calls for disjoint sources both
+        complete with a ``done`` event.
+        """
+        from lilbee.server.handlers import add_files_stream
+
+        a = tmp_path / "a.txt"
+        a.write_text("alpha")
+        b = tmp_path / "b.txt"
+        b.write_text("beta")
+
+        async def _run(path: Path):
+            text = ""
+            with mock.patch(
+                "kreuzberg.extract_file",
+                new_callable=AsyncMock,
+                return_value=_make_kreuzberg_result(),
+            ):
+                async for frame in add_files_stream({"paths": [str(path)]}):
+                    text += frame
+            return _parse_sse_events(text.encode())
+
+        events_a, events_b = await asyncio.gather(_run(a), _run(b))
+        assert "done" in [t for t, _ in events_a]
+        assert "done" in [t for t, _ in events_b]
+        assert "already_ingesting" not in [t for t, _ in events_a]
+        assert "already_ingesting" not in [t for t, _ in events_b]
+
+    async def test_mutex_released_on_exception(self, isolated_env, tmp_path):
+        """If ingest raises, the source mutex is released so retries succeed."""
+        from lilbee.server.handlers import _try_acquire_source, add_files_stream
+
+        src = tmp_path / "boom.txt"
+        src.write_text("contents")
+
+        async def _boom(*_args, **_kwargs):
+            raise RuntimeError("ingest exploded")
+
+        with mock.patch("lilbee.ingest.sync", new=_boom):
+            events = await self._collect(add_files_stream({"paths": [str(src)]}))
+
+        # Error surfaces back to the client.
+        assert any(t == "error" for t, _ in events)
+
+        # Lock must be free again: a follow-up try-acquire succeeds.
+        retry = await _try_acquire_source("boom.txt")
+        assert retry is not None
+        retry.release()
+
+    async def test_mutex_released_on_task_cancellation(self, isolated_env, tmp_path):
+        """Task cancellation during ingest still releases the source mutex."""
+        from lilbee.server.handlers import _try_acquire_source, add_files_stream
+
+        src = tmp_path / "slow.txt"
+        src.write_text("contents")
+
+        async def _hang(*_args, **_kwargs):
+            await asyncio.sleep(30)
+
+        gen = add_files_stream({"paths": [str(src)]})
+        with mock.patch("lilbee.ingest.sync", new=_hang):
+            outer = asyncio.create_task(gen.__anext__())
+            await asyncio.sleep(0.05)
+            outer.cancel()
+            with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
+                await outer
+            # Close the generator to let the finally blocks run.
+            await gen.aclose()
+
+        retry = await _try_acquire_source("slow.txt")
+        assert retry is not None
+        retry.release()
+
+
+class TestAddIngestHardening:
+    """Option-A hardening: ``sync()`` always passes ``needs_cleanup=True``."""
+
+    async def test_new_file_triggers_cleanup(self, isolated_env, tmp_path, mock_svc):
+        """Even when no prior source row exists, ingest now calls
+        ``delete_by_source`` before adding chunks. This closes the race where
+        a previous ingest crashed mid-flight, leaving orphaned chunks with no
+        matching source row.
+        """
+        from lilbee.ingest import sync
+
+        src = isolated_env / "fresh.txt"
+        src.write_text("Fresh content.")
+
+        store = mock_svc.store
+        # No prior sources: existing_sources lookup returns nothing.
+        store.get_sources.return_value = []
+
+        with mock.patch(
+            "kreuzberg.extract_file",
+            new_callable=AsyncMock,
+            return_value=_make_kreuzberg_result(),
+        ):
+            await sync(quiet=True)
+
+        # Option-A hardening: delete_by_source is called even for 'new' files.
+        store.delete_by_source.assert_any_call("fresh.txt")
+
+    async def test_retry_after_orphaned_chunks_cleans_up(self, isolated_env, tmp_path, mock_svc):
+        """If a prior run left chunks without an ``upsert_source`` record,
+        the retry path removes them before re-adding.
+        """
+        from lilbee.ingest import sync
+
+        src = isolated_env / "orphan.txt"
+        src.write_text("Recovered content.")
+
+        store = mock_svc.store
+        # No source row, yet chunks exist on disk (the crashed-previous-run
+        # scenario). ``delete_by_source`` is idempotent so it's safe to call.
+        store.get_sources.return_value = []
+
+        with mock.patch(
+            "kreuzberg.extract_file",
+            new_callable=AsyncMock,
+            return_value=_make_kreuzberg_result(),
+        ):
+            await sync(quiet=True)
+
+        # The stale chunks are removed before the new add.
+        call_args = [c.args for c in store.delete_by_source.call_args_list]
+        assert ("orphan.txt",) in call_args
+        store.add_chunks.assert_called()


### PR DESCRIPTION
## Problem

When a long-running ingest (typically an image-heavy PDF going through vision OCR) went silent for long enough, the plugin's idle timeout kicked in and the user hit Retry. The retry landed while the first ingest was still working the same file, and both runs ended up committing chunks for that source. LanceDB's `table.add` appends without dedup, so the knowledge base ended up with two full sets of chunks for one document. Wiki, search, and RAG then surfaced doubled content.

## What changed

`/api/add` now guards each source with a per-source mutex, keyed on the filename as it lives in the documents directory. If a second request arrives for a source that is still being ingested, the server replies on the SSE stream with a single `already_ingesting` event carrying the source name and closes the stream with no `done` event. That gives the client a distinct, non-error signal to render a neutral "waiting on server" state instead of treating the retry as another failure. Requests for disjoint files still run in parallel.

Alongside the mutex, the sync path now always cleans stale chunks before re-adding a file. On the happy path this is a cheap no-op, but it covers the subtler case where a previous ingest was killed after writing chunks but before recording the source hash: the orphaned chunks get removed instead of quietly piling up under a retry.

## Tests

Unit and handler tests exercise acquire / reject / release for the mutex, the single-`already_ingesting`-event-and-close response shape, parallel progress for disjoint sources, mutex release on exception and on task cancellation, and the cleanup hardening for the orphaned-chunks retry path. Full suite: 4306 passed (pre-existing `TestDiscoverApiModels` failures remain, same as `release/next`).