### PR TITLE
Gate search and ingest on the embedding model that built the store

### DIFF
--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -36,7 +36,7 @@ from lilbee.cli.tui.widgets.grid_select import GridSelect
 from lilbee.cli.tui.widgets.model_card import ModelCard
 from lilbee.config import cfg
 from lilbee.models import ModelTask, get_system_ram_gb
-from lilbee.services import reset_services
+from lilbee.services import get_services, reset_services
 
 log = logging.getLogger(__name__)
 
@@ -247,6 +247,10 @@ class SetupWizard(Screen[str | None]):
             cfg.chat_model = ref
             settings.set_value(cfg.data_root, "chat_model", ref)
         elif task == ModelTask.EMBEDDING:
+            # Pin a legacy store's identity to the OLD model BEFORE the cfg
+            # mutation so the gate in store.search/add_chunks correctly detects
+            # drift on the next op. See bb-x1qa.
+            get_services().store.initialize_meta_if_legacy()
             cfg.embedding_model = ref
             settings.set_value(cfg.data_root, "embedding_model", ref)
 

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -25,7 +25,7 @@ from lilbee.providers.sdk_backend import (
     PROVIDER_KEYS,
     detect_backend_name,
 )
-from lilbee.services import reset_services
+from lilbee.services import get_services, reset_services
 from lilbee.store import SearchScope
 
 log = logging.getLogger(__name__)
@@ -387,6 +387,10 @@ class ModelBar(Widget, can_focus=False):
         value = self._extract_value(event, embed_sel)
         if value is None or value == cfg.embedding_model:
             return
+        # Pin a legacy store's identity to the OLD model BEFORE the cfg mutation
+        # so the gate in store.search/add_chunks correctly detects drift on the
+        # next op. See bb-x1qa.
+        get_services().store.initialize_meta_if_legacy()
         cfg.embedding_model = value
         settings.set_value(cfg.data_root, "embedding_model", value)
         self._after_model_change()

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -167,6 +167,7 @@ DEFAULT_HTTP_TIMEOUT = 30.0
 CHUNKS_TABLE = "chunks"
 SOURCES_TABLE = "_sources"
 CITATIONS_TABLE = "_citations"
+META_TABLE = "_meta"
 CONCEPT_NODES_TABLE = "concept_nodes"
 CONCEPT_EDGES_TABLE = "concept_edges"
 CHUNK_CONCEPTS_TABLE = "chunk_concepts"

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -406,14 +406,21 @@ def chat_stream(
     )
 
 
-async def _run_sync_with_sentinel(sse: SseStream, enable_ocr: bool | None) -> SyncResult:
+async def _run_sync_with_sentinel(
+    sse: SseStream, enable_ocr: bool | None, force_rebuild: bool = False
+) -> SyncResult:
     """Run ingest.sync() and guarantee the drain sentinel is enqueued."""
     from lilbee.cli.helpers import temporary_ocr_config
     from lilbee.ingest import sync
 
     try:
         with temporary_ocr_config(enable_ocr):
-            return await sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel)
+            return await sync(
+                quiet=True,
+                on_progress=sse.callback,
+                cancel=sse.cancel,
+                force_rebuild=force_rebuild,
+            )
     finally:
         sse.queue.put_nowait(None)
 
@@ -488,10 +495,16 @@ def _canonical_source_name(p_str: str) -> str:
     return Path(p_str).name
 
 
-async def sync_stream(*, enable_ocr: bool | None = None) -> AsyncGenerator[str, None]:
-    """Trigger sync, yield SSE progress events, then done event."""
+async def sync_stream(
+    *, enable_ocr: bool | None = None, force_rebuild: bool = False
+) -> AsyncGenerator[str, None]:
+    """Trigger sync, yield SSE progress events, then done event.
+
+    When ``force_rebuild`` is true, the underlying sync drops every table and
+    re-ingests from ``cfg.documents_dir`` (the REST equivalent of ``lilbee rebuild``).
+    """
     sse = SseStream()
-    task = asyncio.create_task(_run_sync_with_sentinel(sse, enable_ocr))
+    task = asyncio.create_task(_run_sync_with_sentinel(sse, enable_ocr, force_rebuild))
     async for event in sse.drain(task, "Sync stream"):
         yield event
     if not sse.cancel.is_set() and task.done() and not task.cancelled():
@@ -753,9 +766,19 @@ async def set_chat_model(model: str) -> SetModelResponse:
 
 
 async def set_embedding_model(model: str) -> SetModelResponse:
-    """Switch embedding model. Validates installation and catalog task."""
+    """Switch embedding model. Validates installation and catalog task.
+
+    Returns ``reindex_required=True`` when the new model differs from the
+    embedding model that built the persisted vector store. The caller is
+    expected to trigger a rebuild (``lilbee rebuild`` or ``POST /api/sync``
+    with ``force_rebuild=true``). Search and ingest will refuse to operate
+    until that happens.
+    """
     normalized = _require_model_for_task(model, ModelTask.EMBEDDING)
-    return await _set_model("embedding_model", normalized)
+    response = await _set_model("embedding_model", normalized)
+    meta = get_services().store.get_meta()
+    reindex_required = meta is not None and meta["embedding_model"] != normalized
+    return response.model_copy(update={"reindex_required": reindex_required})
 
 
 async def set_vision_model(model: str) -> SetModelResponse:

--- a/src/lilbee/server/handlers.py
+++ b/src/lilbee/server/handlers.py
@@ -773,12 +773,19 @@ async def set_embedding_model(model: str) -> SetModelResponse:
     expected to trigger a rebuild (``lilbee rebuild`` or ``POST /api/sync``
     with ``force_rebuild=true``). Search and ingest will refuse to operate
     until that happens.
+
+    Pins a legacy store's identity to the OLD cfg before mutating it. Without
+    this step, a pre-upgrade store with chunks but no ``_meta`` row would have
+    its meta lazy-initialized from the NEW cfg on the next read, hiding the
+    drift the caller just introduced.
     """
     normalized = _require_model_for_task(model, ModelTask.EMBEDDING)
-    response = await _set_model("embedding_model", normalized)
-    meta = get_services().store.get_meta()
+    store = get_services().store
+    store.initialize_meta_if_legacy()
+    await _set_model("embedding_model", normalized)
+    meta = store.get_meta()
     reindex_required = meta is not None and meta["embedding_model"] != normalized
-    return response.model_copy(update={"reindex_required": reindex_required})
+    return SetModelResponse(model=normalized, reindex_required=reindex_required)
 
 
 async def set_vision_model(model: str) -> SetModelResponse:

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -60,9 +60,16 @@ class ChatRequest(BaseModel):
 
 
 class SyncRequest(BaseModel):
-    """Request body for /api/sync."""
+    """Request body for /api/sync.
+
+    ``force_rebuild`` triggers a full drop-and-reingest equivalent to ``lilbee rebuild``.
+    Use it to recover from an embedding-model switch (when the store refuses search
+    or ingest because ``cfg.embedding_model`` no longer matches the persisted vectors).
+    The default is incremental sync.
+    """
 
     enable_ocr: bool | None = None
+    force_rebuild: bool = False
 
 
 class AddRequest(BaseModel):
@@ -164,9 +171,16 @@ class AskResponse(BaseModel):
 
 
 class SetModelResponse(BaseModel):
-    """Response for PUT /api/models/{chat|embedding|vision|reranker}."""
+    """Response for PUT /api/models/{chat|embedding|vision|reranker}.
+
+    ``reindex_required`` is ``True`` only when the new embedding model differs from
+    the model that built the persisted vector store. The chat, vision, and reranker
+    handlers always return ``False`` because their changes do not invalidate stored
+    vectors. Mirrors the ``reindex_required`` flag on ``ConfigUpdateResponse``.
+    """
 
     model: str
+    reindex_required: bool = False
 
 
 class ConfigUpdateResponse(BaseModel):

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -27,10 +27,16 @@ class RemoveRequest(BaseModel):
 
 @post("/api/sync")
 async def sync_route(data: SyncRequest | None = None) -> Stream:
-    """Re-index changed documents with streaming SSE progress events."""
+    """Re-index changed documents with streaming SSE progress events.
+
+    Pass ``{"force_rebuild": true}`` to wipe the store and re-ingest every file
+    under the current ``cfg.embedding_model``. This is the recovery path after
+    a ``PUT /api/models/embedding`` that returned ``reindex_required=true``.
+    """
     enable_ocr = data.enable_ocr if data else None
+    force_rebuild = data.force_rebuild if data else False
     return Stream(
-        handlers.sync_stream(enable_ocr=enable_ocr),
+        handlers.sync_stream(enable_ocr=enable_ocr, force_rebuild=force_rebuild),
         media_type="text/event-stream",
     )
 

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 from lilbee.config import (
     CHUNKS_TABLE,
     CITATIONS_TABLE,
+    META_TABLE,
     SOURCES_TABLE,
     Config,
     cfg,
@@ -212,6 +213,61 @@ class CitationRecord(TypedDict):
     line_end: int
     excerpt: str
     created_at: str
+
+
+class StoreMeta(TypedDict):
+    """Single-row store metadata recording the embedding model used to build the store.
+
+    Compatibility is checked before every read and write. When ``cfg.embedding_model``
+    or ``cfg.embedding_dim`` drifts from the persisted row, the store refuses to serve
+    until ``lilbee rebuild`` (CLI) or ``POST /api/sync {"force_rebuild": true}`` (HTTP)
+    rewrites the chunks under the new model.
+    """
+
+    embedding_model: str
+    embedding_dim: int
+    schema_version: int
+    updated_at: str
+
+
+# ``schema_version`` is an integer for forward-compat. Bump only if we ever need to
+# add or rename a meta column without forcing every store to drop_all.
+META_SCHEMA_VERSION = 1
+
+
+class EmbeddingModelMismatchError(RuntimeError):
+    """Raised when stored vectors were built with a different embedding model than ``cfg``.
+
+    Carries a user-facing message naming both the persisted and the configured model and
+    pointing at the two recovery paths (``lilbee rebuild`` and ``POST /api/sync`` with
+    ``force_rebuild=true``).
+    """
+
+
+def _embedding_mismatch_message(
+    persisted_model: str,
+    persisted_dim: int,
+    current_model: str,
+    current_dim: int,
+) -> str:
+    return (
+        f"The vector store was built with embedding model '{persisted_model}' "
+        f"(dim {persisted_dim}), but lilbee is now configured to use "
+        f"'{current_model}' (dim {current_dim}). Search and ingest are disabled "
+        "until the store is rebuilt under the new model. "
+        'Run `lilbee rebuild` or POST /api/sync with `{"force_rebuild": true}`.'
+    )
+
+
+def _meta_schema() -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("embedding_model", pa.utf8()),
+            pa.field("embedding_dim", pa.int32()),
+            pa.field("schema_version", pa.int32()),
+            pa.field("updated_at", pa.utf8()),
+        ]
+    )
 
 
 def _sources_schema() -> pa.Schema:
@@ -412,6 +468,85 @@ class Store:
             ]
         )
 
+    def get_meta(self) -> StoreMeta | None:
+        """Return the persisted store metadata row, or ``None`` if unset."""
+        table = self.open_table(META_TABLE)
+        if table is None:
+            return None
+        rows = table.search().limit(1).to_list()
+        if not rows:
+            return None
+        row = rows[0]
+        return StoreMeta(
+            embedding_model=row["embedding_model"],
+            embedding_dim=int(row["embedding_dim"]),
+            schema_version=int(row["schema_version"]),
+            updated_at=row["updated_at"],
+        )
+
+    def _write_meta_unlocked(self) -> None:
+        """Overwrite the single ``_meta`` row with the current cfg snapshot.
+
+        Caller must hold ``write_lock()``. Maintains the single-row invariant via
+        delete-then-insert (mirrors ``upsert_source``).
+        """
+        db = self.get_db()
+        table = ensure_table(db, META_TABLE, _meta_schema())
+        _safe_delete_unlocked(table, "schema_version >= 0")
+        table.add(
+            [
+                {
+                    "embedding_model": self._config.embedding_model,
+                    "embedding_dim": self._config.embedding_dim,
+                    "schema_version": META_SCHEMA_VERSION,
+                    "updated_at": datetime.now(UTC).isoformat(),
+                }
+            ]
+        )
+
+    def _ensure_embedding_compat(self) -> None:
+        """Refuse to operate when the persisted embedding identity drifts from cfg.
+
+        Behavior matrix:
+        - ``_meta`` row matches cfg: no-op (the common case).
+        - ``_meta`` empty AND chunks table empty: no-op. Will be initialized on first
+          ``add_chunks``.
+        - ``_meta`` empty AND chunks present (legacy store from before this gate
+          existed): write ``_meta`` from current cfg with a one-time warning. This
+          trusts that current cfg matches the actual stored vectors. Pre-upgrade
+          silent corruption is not retroactively detectable, but the gate is active
+          from this point forward.
+        - ``_meta`` present and mismatches cfg: raise ``EmbeddingModelMismatchError``.
+        """
+        meta = self.get_meta()
+        if meta is not None:
+            if (
+                meta["embedding_model"] == self._config.embedding_model
+                and meta["embedding_dim"] == self._config.embedding_dim
+            ):
+                return
+            raise EmbeddingModelMismatchError(
+                _embedding_mismatch_message(
+                    persisted_model=meta["embedding_model"],
+                    persisted_dim=meta["embedding_dim"],
+                    current_model=self._config.embedding_model,
+                    current_dim=self._config.embedding_dim,
+                )
+            )
+        chunks = self.open_table(CHUNKS_TABLE)
+        if chunks is None or chunks.count_rows() == 0:
+            return
+        log.warning(
+            "Legacy store has chunks but no _meta row. Initializing _meta from "
+            "the current configuration (embedding_model=%s, embedding_dim=%d). "
+            "If you changed embedding_model before upgrading, run `lilbee rebuild` "
+            "to ensure the store is consistent.",
+            self._config.embedding_model,
+            self._config.embedding_dim,
+        )
+        with write_lock():
+            self._write_meta_unlocked()
+
     def get_db(self) -> lancedb.DBConnection:
         if self._db is None:
             import lancedb as _lancedb
@@ -455,7 +590,13 @@ class Store:
                 log.debug("FTS index ensure failed (empty table?)", exc_info=True)
 
     def add_chunks(self, records: list[dict]) -> int:
-        """Add chunk records to the store. Returns count added."""
+        """Add chunk records to the store. Returns count added.
+
+        Raises ``EmbeddingModelMismatchError`` if the persisted ``_meta`` row was
+        written under a different embedding model than the current ``cfg``. On the
+        first write to a fresh store, ``_meta`` is initialized from the current cfg.
+        """
+        self._ensure_embedding_compat()
         with write_lock():
             self._fts_ready = False
             if not records:
@@ -470,6 +611,8 @@ class Store:
             db = self.get_db()
             table = ensure_table(db, CHUNKS_TABLE, self._chunks_schema())
             table.add(records)
+            if self.get_meta() is None:
+                self._write_meta_unlocked()
             return len(records)
 
     def bm25_probe(self, query_text: str, top_k: int = 5) -> list[SearchChunk]:
@@ -496,10 +639,14 @@ class Store:
         query_text: str | None = None,
         chunk_type: str | None = None,
     ) -> list[SearchChunk]:
-        """Search for similar chunks — hybrid when FTS available, else vector-only.
+        """Search for similar chunks. Hybrid when FTS available, else vector-only.
+
         Results with distance > max_distance are filtered out (vector-only path).
         Pass max_distance=0 to disable filtering.
         When *chunk_type* is set, only chunks of that type ("raw" or "wiki") are returned.
+
+        Raises ``EmbeddingModelMismatchError`` if the persisted ``_meta`` row was
+        written under a different embedding model than the current ``cfg``.
         """
         if top_k is None:
             top_k = self._config.top_k
@@ -508,6 +655,7 @@ class Store:
         table = self.open_table(CHUNKS_TABLE)
         if table is None:
             return []
+        self._ensure_embedding_compat()
 
         if query_text and not self._fts_ready:
             self.ensure_fts_index()

--- a/src/lilbee/store.py
+++ b/src/lilbee/store.py
@@ -234,6 +234,11 @@ class StoreMeta(TypedDict):
 # add or rename a meta column without forcing every store to drop_all.
 META_SCHEMA_VERSION = 1
 
+# Always-true predicate used to clear the single-row ``_meta`` table before re-insert.
+# Lance's ``Table.delete`` requires a SQL where clause; this matches every row without
+# coupling the deletion to any specific column's value domain.
+_META_DELETE_ALL_PREDICATE = "schema_version IS NOT NULL"
+
 
 class EmbeddingModelMismatchError(RuntimeError):
     """Raised when stored vectors were built with a different embedding model than ``cfg``.
@@ -484,68 +489,86 @@ class Store:
             updated_at=row["updated_at"],
         )
 
-    def _write_meta_unlocked(self) -> None:
-        """Overwrite the single ``_meta`` row with the current cfg snapshot.
+    def _write_meta_unlocked(self, *, embedding_model: str, embedding_dim: int) -> None:
+        """Overwrite the single ``_meta`` row with the supplied identity.
 
-        Caller must hold ``write_lock()``. Maintains the single-row invariant via
-        delete-then-insert (mirrors ``upsert_source``).
+        Caller must hold ``write_lock()``. Args are passed explicitly rather than
+        re-read from ``self._config`` so the caller can snapshot cfg at a coherent
+        instant and not race with a concurrent ``set_embedding_model``.
         """
         db = self.get_db()
         table = ensure_table(db, META_TABLE, _meta_schema())
-        _safe_delete_unlocked(table, "schema_version >= 0")
+        _safe_delete_unlocked(table, _META_DELETE_ALL_PREDICATE)
         table.add(
             [
                 {
-                    "embedding_model": self._config.embedding_model,
-                    "embedding_dim": self._config.embedding_dim,
+                    "embedding_model": embedding_model,
+                    "embedding_dim": embedding_dim,
                     "schema_version": META_SCHEMA_VERSION,
                     "updated_at": datetime.now(UTC).isoformat(),
                 }
             ]
         )
 
-    def _ensure_embedding_compat(self) -> None:
-        """Refuse to operate when the persisted embedding identity drifts from cfg.
-
-        Behavior matrix:
-        - ``_meta`` row matches cfg: no-op (the common case).
-        - ``_meta`` empty AND chunks table empty: no-op. Will be initialized on first
-          ``add_chunks``.
-        - ``_meta`` empty AND chunks present (legacy store from before this gate
-          existed): write ``_meta`` from current cfg with a one-time warning. This
-          trusts that current cfg matches the actual stored vectors. Pre-upgrade
-          silent corruption is not retroactively detectable, but the gate is active
-          from this point forward.
-        - ``_meta`` present and mismatches cfg: raise ``EmbeddingModelMismatchError``.
-        """
-        meta = self.get_meta()
-        if meta is not None:
-            if (
-                meta["embedding_model"] == self._config.embedding_model
-                and meta["embedding_dim"] == self._config.embedding_dim
-            ):
-                return
-            raise EmbeddingModelMismatchError(
-                _embedding_mismatch_message(
-                    persisted_model=meta["embedding_model"],
-                    persisted_dim=meta["embedding_dim"],
-                    current_model=self._config.embedding_model,
-                    current_dim=self._config.embedding_dim,
-                )
-            )
+    def _has_chunks(self) -> bool:
+        """Return True when the chunks table exists and has at least one row."""
         chunks = self.open_table(CHUNKS_TABLE)
-        if chunks is None or chunks.count_rows() == 0:
-            return
-        log.warning(
-            "Legacy store has chunks but no _meta row. Initializing _meta from "
-            "the current configuration (embedding_model=%s, embedding_dim=%d). "
-            "If you changed embedding_model before upgrading, run `lilbee rebuild` "
-            "to ensure the store is consistent.",
-            self._config.embedding_model,
-            self._config.embedding_dim,
-        )
+        return chunks is not None and chunks.count_rows() > 0
+
+    def initialize_meta_if_legacy(self) -> bool:
+        """Pin a legacy store's identity to the current cfg if not already set.
+
+        Returns ``True`` when a meta row was just written. No-op when meta already
+        exists or no chunks are present. This is the path that converts a
+        pre-upgrade store (chunks present, no ``_meta``) into a gated store. It
+        snapshots cfg under the write lock to keep the recorded identity coherent
+        with what the gate is comparing against.
+        """
+        if self.get_meta() is not None:
+            return False
+        if not self._has_chunks():
+            return False
+        embedding_model = self._config.embedding_model
+        embedding_dim = self._config.embedding_dim
         with write_lock():
-            self._write_meta_unlocked()
+            # Re-check under the lock so two callers do not both warn-and-write.
+            if self.get_meta() is not None:
+                return False
+            log.warning(
+                "Legacy store has chunks but no _meta row. Initializing _meta from "
+                "the current configuration (embedding_model=%s, embedding_dim=%d). "
+                "If you changed embedding_model before upgrading, run `lilbee rebuild` "
+                "to ensure the store is consistent.",
+                embedding_model,
+                embedding_dim,
+            )
+            self._write_meta_unlocked(embedding_model=embedding_model, embedding_dim=embedding_dim)
+            return True
+
+    def _ensure_embedding_compat(self) -> None:
+        """Raise when the persisted embedding identity drifts from cfg.
+
+        Pure check, no side effects. Migration of legacy stores (chunks present,
+        no ``_meta``) is the caller's responsibility via ``initialize_meta_if_legacy``
+        so this method is safe to call from inside an existing ``write_lock()``
+        (no recursive lock attempt). cfg fields are snapshotted at entry so the
+        comparison is coherent even if another thread mutates them mid-call.
+        """
+        current_model = self._config.embedding_model
+        current_dim = self._config.embedding_dim
+        meta = self.get_meta()
+        if meta is None:
+            return
+        if meta["embedding_model"] == current_model and meta["embedding_dim"] == current_dim:
+            return
+        raise EmbeddingModelMismatchError(
+            _embedding_mismatch_message(
+                persisted_model=meta["embedding_model"],
+                persisted_dim=meta["embedding_dim"],
+                current_model=current_model,
+                current_dim=current_dim,
+            )
+        )
 
     def get_db(self) -> lancedb.DBConnection:
         if self._db is None:
@@ -595,24 +618,32 @@ class Store:
         Raises ``EmbeddingModelMismatchError`` if the persisted ``_meta`` row was
         written under a different embedding model than the current ``cfg``. On the
         first write to a fresh store, ``_meta`` is initialized from the current cfg.
+
+        The gate runs inside the write lock and uses a single cfg snapshot so a
+        concurrent ``set_embedding_model`` cannot slip a write in past a stale
+        compatibility check.
         """
-        self._ensure_embedding_compat()
         with write_lock():
+            embedding_model = self._config.embedding_model
+            embedding_dim = self._config.embedding_dim
+            self._ensure_embedding_compat()
             self._fts_ready = False
             if not records:
                 return 0
             for rec in records:
                 vec = rec.get("vector", [])
-                if len(vec) != self._config.embedding_dim:
+                if len(vec) != embedding_dim:
                     raise ValueError(
-                        f"Vector dimension mismatch: expected {self._config.embedding_dim}, "
+                        f"Vector dimension mismatch: expected {embedding_dim}, "
                         f"got {len(vec)} (source={rec.get('source', '?')})"
                     )
             db = self.get_db()
             table = ensure_table(db, CHUNKS_TABLE, self._chunks_schema())
             table.add(records)
             if self.get_meta() is None:
-                self._write_meta_unlocked()
+                self._write_meta_unlocked(
+                    embedding_model=embedding_model, embedding_dim=embedding_dim
+                )
             return len(records)
 
     def bm25_probe(self, query_text: str, top_k: int = 5) -> list[SearchChunk]:
@@ -655,6 +686,7 @@ class Store:
         table = self.open_table(CHUNKS_TABLE)
         if table is None:
             return []
+        self.initialize_meta_if_legacy()
         self._ensure_embedding_compat()
 
         if query_text and not self._fts_ready:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1388,7 +1388,7 @@ class TestSetEmbeddingModel:
             await handlers.set_embedding_model("qwen3:0.6b")
 
     @patch("lilbee.server.handlers.get_services")
-    async def test_returns_reindex_required_when_persisted_meta_differs(self, mock_svc, tmp_path):
+    async def test_returns_reindex_required_when_persisted_meta_differs(self, mock_svc):
         """Switching to a model different from the one that built the store flags rebuild."""
         mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:v1.5"]
         mock_svc.return_value.store.get_meta.return_value = {
@@ -1402,7 +1402,7 @@ class TestSetEmbeddingModel:
         assert result.reindex_required is True
 
     @patch("lilbee.server.handlers.get_services")
-    async def test_returns_no_reindex_required_on_empty_store(self, mock_svc, tmp_path):
+    async def test_returns_no_reindex_required_on_empty_store(self, mock_svc):
         """A store with no _meta row (fresh install) does not need a rebuild."""
         mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:v1.5"]
         mock_svc.return_value.store.get_meta.return_value = None
@@ -1410,7 +1410,7 @@ class TestSetEmbeddingModel:
         assert result.reindex_required is False
 
     @patch("lilbee.server.handlers.get_services")
-    async def test_returns_no_reindex_required_when_same_model(self, mock_svc, tmp_path):
+    async def test_returns_no_reindex_required_when_same_model(self, mock_svc):
         """Re-setting the same model that already built the store does not need a rebuild."""
         mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:v1.5"]
         mock_svc.return_value.store.get_meta.return_value = {
@@ -1423,12 +1423,12 @@ class TestSetEmbeddingModel:
         assert result.reindex_required is False
 
     @patch("lilbee.server.handlers.get_services")
-    async def test_pins_legacy_meta_before_cfg_mutation(self, mock_svc, tmp_path):
+    async def test_pins_legacy_meta_before_cfg_mutation(self, mock_svc):
         """A pre-upgrade store with chunks but no _meta is pinned under the OLD cfg.
 
-        This is the bb-x1qa upgrade-window protection: without the pin, lazy-init
-        on the next op would adopt the NEW cfg as the legacy identity, hiding the
-        drift the caller just introduced.
+        Asserts call ordering: initialize_meta_if_legacy must run BEFORE cfg is
+        mutated. A regression that swaps the two would let lazy-init adopt the
+        NEW cfg as the legacy identity, hiding the drift the caller just introduced.
         """
         mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:v1.5"]
         store_mock = mock_svc.return_value.store
@@ -1438,8 +1438,16 @@ class TestSetEmbeddingModel:
             "schema_version": 1,
             "updated_at": "2026-04-25T00:00:00+00:00",
         }
+        cfg_at_pin: dict[str, str] = {}
+
+        def record_cfg() -> None:
+            cfg_at_pin["embedding_model"] = cfg.embedding_model
+
+        store_mock.initialize_meta_if_legacy.side_effect = record_cfg
+        original_model = cfg.embedding_model
         await handlers.set_embedding_model("nomic-embed-text:v1.5")
         store_mock.initialize_meta_if_legacy.assert_called_once()
+        assert cfg_at_pin["embedding_model"] == original_model
 
 
 class TestGetConfig:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1422,6 +1422,25 @@ class TestSetEmbeddingModel:
         result = await handlers.set_embedding_model("nomic-embed-text:v1.5")
         assert result.reindex_required is False
 
+    @patch("lilbee.server.handlers.get_services")
+    async def test_pins_legacy_meta_before_cfg_mutation(self, mock_svc, tmp_path):
+        """A pre-upgrade store with chunks but no _meta is pinned under the OLD cfg.
+
+        This is the bb-x1qa upgrade-window protection: without the pin, lazy-init
+        on the next op would adopt the NEW cfg as the legacy identity, hiding the
+        drift the caller just introduced.
+        """
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:v1.5"]
+        store_mock = mock_svc.return_value.store
+        store_mock.get_meta.return_value = {
+            "embedding_model": "previous-model:v1",
+            "embedding_dim": 768,
+            "schema_version": 1,
+            "updated_at": "2026-04-25T00:00:00+00:00",
+        }
+        await handlers.set_embedding_model("nomic-embed-text:v1.5")
+        store_mock.initialize_meta_if_legacy.assert_called_once()
+
 
 class TestGetConfig:
     async def test_returns_all_config_keys(self):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -633,6 +633,34 @@ class TestSyncStreamDoneDelivery:
         # No done frame should be emitted when sync failed.
         assert done_events == []
 
+    async def test_force_rebuild_flag_reaches_sync(self):
+        """sync_stream(force_rebuild=True) plumbs the flag through to ingest.sync."""
+        sync_result = SyncResult(added=[])
+        observed: dict[str, bool] = {}
+
+        async def fake_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
+            observed["force_rebuild"] = force_rebuild
+            return sync_result
+
+        with patch("lilbee.ingest.sync", side_effect=fake_sync):
+            _ = [e async for e in handlers.sync_stream(force_rebuild=True)]
+
+        assert observed["force_rebuild"] is True
+
+    async def test_force_rebuild_defaults_to_false(self):
+        """sync_stream() with no arguments leaves the existing incremental sync semantics."""
+        sync_result = SyncResult(added=[])
+        observed: dict[str, bool] = {}
+
+        async def fake_sync(force_rebuild=False, quiet=False, *, on_progress=None, cancel=None):
+            observed["force_rebuild"] = force_rebuild
+            return sync_result
+
+        with patch("lilbee.ingest.sync", side_effect=fake_sync):
+            _ = [e async for e in handlers.sync_stream()]
+
+        assert observed["force_rebuild"] is False
+
 
 class TestDrainFallback:
     async def test_drain_exits_when_task_done_without_sentinel(self):
@@ -1358,6 +1386,41 @@ class TestSetEmbeddingModel:
         mock_svc.return_value.provider.list_models.return_value = ["qwen3:0.6b"]
         with pytest.raises(ValueError, match="not embedding"):
             await handlers.set_embedding_model("qwen3:0.6b")
+
+    @patch("lilbee.server.handlers.get_services")
+    async def test_returns_reindex_required_when_persisted_meta_differs(self, mock_svc, tmp_path):
+        """Switching to a model different from the one that built the store flags rebuild."""
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:v1.5"]
+        mock_svc.return_value.store.get_meta.return_value = {
+            "embedding_model": "previous-model:v1",
+            "embedding_dim": 768,
+            "schema_version": 1,
+            "updated_at": "2026-04-25T00:00:00+00:00",
+        }
+        result = await handlers.set_embedding_model("nomic-embed-text:v1.5")
+        assert result.model == "nomic-embed-text:v1.5"
+        assert result.reindex_required is True
+
+    @patch("lilbee.server.handlers.get_services")
+    async def test_returns_no_reindex_required_on_empty_store(self, mock_svc, tmp_path):
+        """A store with no _meta row (fresh install) does not need a rebuild."""
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:v1.5"]
+        mock_svc.return_value.store.get_meta.return_value = None
+        result = await handlers.set_embedding_model("nomic-embed-text:v1.5")
+        assert result.reindex_required is False
+
+    @patch("lilbee.server.handlers.get_services")
+    async def test_returns_no_reindex_required_when_same_model(self, mock_svc, tmp_path):
+        """Re-setting the same model that already built the store does not need a rebuild."""
+        mock_svc.return_value.provider.list_models.return_value = ["nomic-embed-text:v1.5"]
+        mock_svc.return_value.store.get_meta.return_value = {
+            "embedding_model": "nomic-embed-text:v1.5",
+            "embedding_dim": 768,
+            "schema_version": 1,
+            "updated_at": "2026-04-25T00:00:00+00:00",
+        }
+        result = await handlers.set_embedding_model("nomic-embed-text:v1.5")
+        assert result.reindex_required is False
 
 
 class TestGetConfig:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -245,13 +245,21 @@ class TestSyncRoute:
         resp = client.post("/api/sync")
         assert resp.status_code == 201
         assert b"event: done" in resp.content
-        mock_stream.assert_called_once_with(enable_ocr=None)
+        mock_stream.assert_called_once_with(enable_ocr=None, force_rebuild=False)
 
     @mock.patch("lilbee.server.handlers.sync_stream")
     def test_enable_ocr(self, mock_stream, client):
         mock_stream.return_value = mock_async_gen("event: done\ndata: {}\n\n")
         client.post("/api/sync", json={"enable_ocr": True})
-        mock_stream.assert_called_once_with(enable_ocr=True)
+        mock_stream.assert_called_once_with(enable_ocr=True, force_rebuild=False)
+
+    @mock.patch("lilbee.server.handlers.sync_stream")
+    def test_force_rebuild_plumbs_through(self, mock_stream, client):
+        """REST callers can request a full rebuild via {"force_rebuild": true}."""
+        mock_stream.return_value = mock_async_gen("event: done\ndata: {}\n\n")
+        resp = client.post("/api/sync", json={"force_rebuild": True})
+        assert resp.status_code == 201
+        mock_stream.assert_called_once_with(enable_ocr=None, force_rebuild=True)
 
 
 class TestModelsListRoute:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from lilbee.config import cfg
+from lilbee.config import META_TABLE, cfg
 from lilbee.store import (
     CitationRecord,
     SearchChunk,
@@ -1035,20 +1035,20 @@ class TestEmbeddingModelGate:
         with pytest.raises(EmbeddingModelMismatchError):
             store.search([0.1] * test_config.embedding_dim)
 
-    def test_search_returns_empty_on_fresh_store_no_gate_trip(self, store, test_config):
-        """An empty store (no chunks table) returns [] without consulting _meta."""
+    def test_search_short_circuits_on_missing_chunks_table(self, store, test_config):
+        """Empty stores (no chunks table) return [] before the gate runs."""
         assert store.search([0.1] * test_config.embedding_dim) == []
 
-    def test_legacy_store_with_chunks_but_no_meta_lazy_inits(self, store, test_config, caplog):
-        """Pre-upgrade stores have chunks but no _meta row; first op writes it with a warning."""
+    def test_legacy_store_search_writes_meta_with_warning(self, store, test_config, caplog):
+        """First search on a pre-upgrade store (chunks present, no _meta) lazy-inits meta."""
         import logging
 
         store.add_chunks(_make_records())
-        meta_table = store.open_table("_meta")
+        meta_table = store.open_table(META_TABLE)
         assert meta_table is not None
-        from lilbee.store import _safe_delete_unlocked
+        from lilbee.store import _META_DELETE_ALL_PREDICATE, _safe_delete_unlocked
 
-        _safe_delete_unlocked(meta_table, "schema_version >= 0")
+        _safe_delete_unlocked(meta_table, _META_DELETE_ALL_PREDICATE)
         assert store.get_meta() is None
 
         with caplog.at_level(logging.WARNING, logger="lilbee.store"):
@@ -1072,6 +1072,57 @@ class TestEmbeddingModelGate:
         store.add_chunks(_make_records())
         store.drop_all()
         store.add_chunks(_make_records())
-        meta_table = store.open_table("_meta")
+        meta_table = store.open_table(META_TABLE)
         assert meta_table is not None
         assert meta_table.count_rows() == 1
+
+    def test_initialize_meta_if_legacy_pins_old_identity(self, store, test_config):
+        """Pinning legacy meta uses the cfg present at the time of the call.
+
+        This is the bb-x1qa upgrade-window protection: ``set_embedding_model``
+        calls this BEFORE mutating cfg, so the recorded model identity is the
+        OLD model. The next search/ingest then detects drift instead of silently
+        adopting the new model as if it had built the store.
+        """
+        store.add_chunks(_make_records())
+        meta_table = store.open_table(META_TABLE)
+        assert meta_table is not None
+        from lilbee.store import _META_DELETE_ALL_PREDICATE, _safe_delete_unlocked
+
+        _safe_delete_unlocked(meta_table, _META_DELETE_ALL_PREDICATE)
+        original_model = test_config.embedding_model
+
+        wrote = store.initialize_meta_if_legacy()
+        assert wrote is True
+        meta = store.get_meta()
+        assert meta is not None
+        assert meta["embedding_model"] == original_model
+
+        # Second call is a no-op — meta already pinned.
+        assert store.initialize_meta_if_legacy() is False
+
+    def test_initialize_meta_if_legacy_noop_on_empty_store(self, store):
+        """No chunks, no meta = nothing to pin."""
+        assert store.initialize_meta_if_legacy() is False
+        assert store.get_meta() is None
+
+    def test_initialize_meta_if_legacy_skips_when_another_caller_won_the_race(
+        self, store, test_config
+    ):
+        """Defensive re-check inside the lock: if a concurrent caller already wrote
+        meta between the unlocked pre-check and acquiring the lock, do not double-write."""
+        store.add_chunks(_make_records())
+        meta_table = store.open_table(META_TABLE)
+        assert meta_table is not None
+        from lilbee.store import _META_DELETE_ALL_PREDICATE, _safe_delete_unlocked
+
+        _safe_delete_unlocked(meta_table, _META_DELETE_ALL_PREDICATE)
+
+        winning_meta = {
+            "embedding_model": "winner-model:v1",
+            "embedding_dim": test_config.embedding_dim,
+            "schema_version": 1,
+            "updated_at": "2026-04-26T00:00:00+00:00",
+        }
+        with mock.patch.object(store, "get_meta", side_effect=[None, winning_meta]):
+            assert store.initialize_meta_if_legacy() is False

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -983,3 +983,95 @@ class TestChunkTypePredicate:
         pred = _chunk_type_predicate("wiki")
         assert "IS NULL" not in pred
         assert pred == "chunk_type = 'wiki'"
+
+
+class TestEmbeddingModelGate:
+    """Refuse search/ingest when cfg.embedding_model drifts from the persisted _meta row."""
+
+    def test_first_add_chunks_initializes_meta_from_cfg(self, store, test_config):
+        """A fresh store has no _meta row; first ingest writes one from current cfg."""
+        assert store.get_meta() is None
+        store.add_chunks(_make_records())
+        meta = store.get_meta()
+        assert meta is not None
+        assert meta["embedding_model"] == test_config.embedding_model
+        assert meta["embedding_dim"] == test_config.embedding_dim
+        assert meta["schema_version"] == 1
+        assert meta["updated_at"]
+
+    def test_add_chunks_raises_when_model_drifts_same_dim(self, store, test_config):
+        """Same dim, different model = silent corruption today; the gate refuses now."""
+        from lilbee.store import EmbeddingModelMismatchError
+
+        store.add_chunks(_make_records())
+        original_model = test_config.embedding_model
+        test_config.embedding_model = "different-model:v1"
+
+        with pytest.raises(EmbeddingModelMismatchError) as exc_info:
+            store.add_chunks(_make_records())
+        assert original_model in str(exc_info.value)
+        assert "different-model:v1" in str(exc_info.value)
+        assert "lilbee rebuild" in str(exc_info.value)
+        assert "force_rebuild" in str(exc_info.value)
+
+    def test_search_raises_when_model_drifts(self, store, test_config):
+        """Search refuses to serve under a different embedding model than the persisted one."""
+        from lilbee.store import EmbeddingModelMismatchError
+
+        store.add_chunks(_make_records())
+        test_config.embedding_model = "switched-model:latest"
+
+        with pytest.raises(EmbeddingModelMismatchError):
+            store.search([0.1] * test_config.embedding_dim)
+
+    def test_search_raises_when_dim_drifts(self, store, test_config):
+        """Switching to a different-dim model is rejected by the meta gate."""
+        from lilbee.store import EmbeddingModelMismatchError
+
+        store.add_chunks(_make_records())
+        test_config.embedding_dim = test_config.embedding_dim + 16
+        test_config.embedding_model = "wider-model:v1"
+
+        with pytest.raises(EmbeddingModelMismatchError):
+            store.search([0.1] * test_config.embedding_dim)
+
+    def test_search_returns_empty_on_fresh_store_no_gate_trip(self, store, test_config):
+        """An empty store (no chunks table) returns [] without consulting _meta."""
+        assert store.search([0.1] * test_config.embedding_dim) == []
+
+    def test_legacy_store_with_chunks_but_no_meta_lazy_inits(self, store, test_config, caplog):
+        """Pre-upgrade stores have chunks but no _meta row; first op writes it with a warning."""
+        import logging
+
+        store.add_chunks(_make_records())
+        meta_table = store.open_table("_meta")
+        assert meta_table is not None
+        from lilbee.store import _safe_delete_unlocked
+
+        _safe_delete_unlocked(meta_table, "schema_version >= 0")
+        assert store.get_meta() is None
+
+        with caplog.at_level(logging.WARNING, logger="lilbee.store"):
+            results = store.search([0.1] * test_config.embedding_dim)
+
+        assert isinstance(results, list)
+        meta = store.get_meta()
+        assert meta is not None
+        assert meta["embedding_model"] == test_config.embedding_model
+        assert any("Legacy store" in r.message for r in caplog.records)
+
+    def test_drop_all_includes_meta(self, store):
+        """drop_all wipes _meta along with the other tables."""
+        store.add_chunks(_make_records())
+        assert store.get_meta() is not None
+        store.drop_all()
+        assert store.get_meta() is None
+
+    def test_meta_row_is_overwritten_not_appended(self, store, test_config):
+        """Re-ingesting after drop_all writes a single fresh _meta row, not a second one."""
+        store.add_chunks(_make_records())
+        store.drop_all()
+        store.add_chunks(_make_records())
+        meta_table = store.open_table("_meta")
+        assert meta_table is not None
+        assert meta_table.count_rows() == 1

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1098,7 +1098,7 @@ class TestEmbeddingModelGate:
         assert meta is not None
         assert meta["embedding_model"] == original_model
 
-        # Second call is a no-op — meta already pinned.
+        # Second call is a no-op: meta already pinned.
         assert store.initialize_meta_if_legacy() is False
 
     def test_initialize_meta_if_legacy_noop_on_empty_store(self, store):


### PR DESCRIPTION
## The bug

Switching the embedding model in lilbee silently corrupts search. The change takes effect immediately whether you go through the REST endpoint, the TUI, an environment variable, or hand-edit `config.toml`, but the chunks already in LanceDB stay in the old model's embedding space while every new query is encoded in the new space. Cosine distance across two different spaces is meaningless, so the search returns plausible-looking results that are wrong, with no error.

If the new model has a different output dimension, the next ingest fails noisily with a dimension-mismatch error, but the existing chunks remain queryable under the old vectors until someone manually rebuilds. Either way, the user has no signal that the store is broken.

## Why it happens

Nothing on disk records which embedding model produced the persisted vectors. There is no ground truth for the gate to compare against, so no code path can detect the mismatch.

## The fix

A new single-row `_meta` table in LanceDB now records the embedding model and embedding dimension at first chunk write. `Store.search` and `Store.add_chunks` read that row and compare it against the current configuration. When they drift, both raise a clear error that names the persisted model, the configured model, and the two recovery paths. The gate runs inside the existing write lock and snapshots the configuration at entry so a concurrent model swap cannot slip a write past a stale check.

## Telling the user before they hit the gate

The model-switch endpoint now returns a `reindex_required` flag on its response. It is `true` only when the new model differs from the model that built the persisted store. The flag mirrors the existing `reindex_required` on `PATCH /api/config` and lets the caller prompt the user before the next search fails. The hard refusal still lives at search and ingest, so a UI that ignores the flag cannot silently corrupt the store.

## Recovery

CLI users have always had `lilbee rebuild`, which drops every table and re-ingests every file from `documents/` under the current model. REST and Obsidian users had no equivalent because `POST /api/sync` only does incremental re-ingest, which would skip every file whose hash had not changed. `POST /api/sync` now accepts `{\"force_rebuild\": true}` and routes to the same drop-and-reingest path. After a rebuild the `_meta` row is rewritten from the current configuration and the gate clears.

## The upgrade window

Stores built with an older lilbee have chunks but no `_meta` row. The naive lazy-init writes `_meta` from whatever the configuration says at the time of the first read, which would re-introduce the original bug if the user had already changed the model. Every code path that mutates `cfg.embedding_model` (the REST handler, the TUI setup screen, the chat model bar dropdown) now pins the legacy `_meta` row to the OLD model identity before the mutation, so the gate detects drift on the next operation. Direct configuration writes through environment variables or `config.toml` are not retroactively detectable, but every interactive path is covered.