### PR TITLE
Fit chat context, quiet runaway models, calm noisy log levels

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -351,7 +351,11 @@ LLM output shape. Unset values fall through to the model's own defaults.
 | `LILBEE_TOP_P` | *(model default)* | Nucleus sampling threshold |
 | `LILBEE_TOP_K_SAMPLING` | *(model default)* | Top-k sampling |
 | `LILBEE_REPEAT_PENALTY` | *(model default)* | Repetition penalty |
-| `LILBEE_NUM_CTX` | *(model default)* | Context window size |
+| `LILBEE_NUM_CTX` | *(auto)* | Context window size. Empty = sized automatically to the host's available memory, capped at `LILBEE_NUM_CTX_MAX`. Set explicitly to lock a specific value |
+| `LILBEE_NUM_CTX_MAX` | `16384` | Upper bound for the auto-sized context picker. Higher allows more retrieval context on hosts with spare memory |
+| `LILBEE_FLASH_ATTENTION` | *(auto)* | Flash attention. Empty/`auto` enables it with a TypeError fallback for older llama-cpp-python builds; `1`/`true`/`on` forces on; `0`/`false`/`off` disables. Resolves the `padding V cache to 1024` warning on models with uneven per-layer V dims |
+| `LILBEE_KV_CACHE_TYPE` | `f16` | KV cache element type: `f16`, `f32`, `q8_0`, `q4_0`. Quantized variants halve or quarter cache memory but require flash attention to be enabled |
+| `LILBEE_N_GPU_LAYERS` | *(auto)* | Layers to offload to GPU. Empty/`auto` = all (recommended), `cpu` = none, integer = partial offload for tight VRAM |
 | `LILBEE_SEED` | *(model default)* | Random seed for reproducibility |
 
 ### Server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,18 @@ select = [
     "SIM",   # flake8-simplify
     "RUF",   # ruff-specific
     "S",     # flake8-bandit: security antipatterns (eval, exec, pickle, unsafe subprocess, etc.)
+    "C90",   # mccabe complexity
+    "N",     # pep8-naming
+    "RET",   # flake8-return: consistent return semantics
+    "TID",   # flake8-tidy-imports: forbid relative imports
+    "PLR0911", # too many returns
+    "PLR0912", # too many branches
+    "PLR0915", # too many statements
+    "PLR2004", # magic value used in comparison
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 # Test-context S-rule noise. Each of these is either a test fixture
@@ -147,8 +158,45 @@ select = [
 # - S105/S106 hardcoded password string/arg (test fixtures)
 # - S108 /tmp paths (mocked, not actual temp-file usage)
 # - S603/S607 subprocess (e2e tests spawning sys.executable)
-"tests/**/*.py" = ["S101", "S104", "S105", "S106", "S108", "S603", "S607"]
+# Test files also ignore PLR2004 (test fixtures use literal expected
+# values inline; extracting them to constants hurts readability) and
+# the pep8-naming rules (test helpers frequently shadow PascalCase
+# class names from the system under test).
+"tests/**/*.py" = [
+    "S101", "S104", "S105", "S106", "S108", "S603", "S607",
+    "PLR2004",
+    "N802", "N806", "N818", "N817",
+]
 "conftest.py" = ["S101"]
+# Pre-existing complexity / magic-value / naming hits that predate the
+# tightened rule set. Each entry is grandfathered for cleanup later (the
+# tidy-module-organization branch refactors these); rules still apply to
+# new files.
+"src/lilbee/_splash_runner.py" = ["PLR0911", "PLR2004"]
+"src/lilbee/cancellation.py" = ["N818"]
+"src/lilbee/catalog.py" = ["C901", "PLR2004"]
+"src/lilbee/cli/app.py" = ["C901"]
+"src/lilbee/cli/commands.py" = ["C901", "PLR2004"]
+"src/lilbee/cli/tui/app.py" = ["PLR2004"]
+"src/lilbee/cli/tui/screens/catalog_utils.py" = ["PLR2004"]
+"src/lilbee/cli/tui/screens/chat.py" = ["PLR2004"]
+"src/lilbee/cli/tui/screens/wiki.py" = ["PLR2004"]
+"src/lilbee/cli/tui/widgets/autocomplete.py" = ["PLR2004"]
+"src/lilbee/config.py" = ["N802", "N806", "PLR2004"]
+"src/lilbee/crawler/api.py" = ["C901", "PLR0912"]
+"src/lilbee/crawler/bootstrap.py" = ["N818"]
+"src/lilbee/crawler/sitemap.py" = ["PLR2004"]
+"src/lilbee/ingest.py" = ["C901"]
+"src/lilbee/model_defaults.py" = ["PLR2004"]
+"src/lilbee/model_manager.py" = ["PLR2004"]
+"src/lilbee/providers/worker_process.py" = ["C901", "PLR0915"]
+"src/lilbee/query.py" = ["C901", "PLR2004"]
+"src/lilbee/reasoning.py" = ["C901", "N806"]
+"src/lilbee/store.py" = ["C901"]
+"src/lilbee/vision.py" = ["C901"]
+"src/lilbee/wiki/browse.py" = ["PLR2004"]
+"src/lilbee/wiki/entity_extractor/ner_concepts.py" = ["C901"]
+"src/lilbee/wiki/gen.py" = ["PLR2004"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 
 from pydantic_core import PydanticUndefined
 
-from lilbee.config import ClustererBackend, WikiEntityMode, cfg
+from lilbee.config import ClustererBackend, KvCacheType, WikiEntityMode, cfg
 
 
 class RenderStyle(StrEnum):
@@ -124,7 +124,45 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group="Generation",
         help_text=(
             "Context window size in tokens. Leave empty to size automatically "
-            "to the host's available memory (capped at LILBEE_NUM_CTX_MAX)."
+            "to the host's available memory (capped at num_ctx_max)."
+        ),
+    ),
+    "num_ctx_max": SettingDef(
+        int,
+        nullable=False,
+        group="Generation",
+        help_text=(
+            "Upper bound for the dynamic context picker when num_ctx is unset. "
+            "Higher allows more retrieval context on hosts with spare memory."
+        ),
+    ),
+    "flash_attention": SettingDef(
+        bool,
+        nullable=True,
+        group="Generation",
+        help_text=(
+            "Flash attention. Empty (auto) tries it on with a fallback for older "
+            "llama-cpp-python builds; resolves the V-cache padding warning on "
+            "models with uneven per-layer V dims."
+        ),
+    ),
+    "kv_cache_type": SettingDef(
+        str,
+        nullable=False,
+        group="Generation",
+        help_text=(
+            "KV cache element type. q8_0 / q4_0 halve or quarter cache memory "
+            "but require flash attention to be enabled."
+        ),
+        choices=tuple(t.value for t in KvCacheType),
+    ),
+    "n_gpu_layers": SettingDef(
+        int,
+        nullable=True,
+        group="Generation",
+        help_text=(
+            "Layers to offload to GPU. Empty = all (recommended), 0 = CPU only, "
+            "positive int = partial offload for tight VRAM."
         ),
     ),
     "seed": SettingDef(

--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -122,7 +122,10 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         int,
         nullable=True,
         group="Generation",
-        help_text="Context window size in tokens. Leave empty for the safe chat default (8192).",
+        help_text=(
+            "Context window size in tokens. Leave empty to size automatically "
+            "to the host's available memory (capped at LILBEE_NUM_CTX_MAX)."
+        ),
     ),
     "seed": SettingDef(
         int,

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -8,8 +8,9 @@ import logging
 import shutil
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual import on, work
 from textual.actions import SkipAction
@@ -54,6 +55,23 @@ log = logging.getLogger(__name__)
 _DISPATCH = build_dispatch_dict()
 
 _MAX_HISTORY_MESSAGES = 200
+
+# Coalesce per-token UI updates into ~50 ms windows. Tiny reasoning models
+# can emit 100+ tokens/sec; one call_from_thread per token saturates
+# Textual's message queue and makes key events visibly lag.
+_STREAM_FLUSH_INTERVAL = 0.05
+
+_STREAM_SCROLL_INTERVAL = 0.15
+
+
+def _close_stream(stream: Any) -> None:
+    """Best-effort close on a streaming iterator. Releases llama.cpp's chat lock."""
+    if stream is None:
+        return
+    close = getattr(stream, "close", None)
+    if callable(close):
+        with contextlib.suppress(Exception):
+            close()
 
 
 def _remove_copied_files(names: list[str]) -> None:
@@ -780,46 +798,95 @@ class ChatScreen(Screen[None]):
     def _stream_response(
         self, question: str, widget: AssistantMessage, chunk_type: str | None
     ) -> None:
-        """Stream LLM response in a background thread."""
-        worker = _get_worker()
+        """Stream LLM response in a background thread.
+
+        Tokens are coalesced into ``_STREAM_FLUSH_INTERVAL`` windows before
+        being shipped to the UI thread. At 100+ tok/s on small models, one
+        ``call_from_thread`` per token saturates the Textual message queue
+        and key events visibly lag.
+        """
         response_parts: list[str] = []
         sources: list[str] = []
-        last_scroll = 0.0
-
+        stream: Any = None
         try:
             with self._history_lock:
                 history_snapshot = self._history[:-1]
             stream = get_services().searcher.ask_stream(
                 question, history=history_snapshot, chunk_type=chunk_type
             )
-            for token in stream:
-                if worker.is_cancelled:
-                    break
-                try:
-                    if token.is_reasoning:
-                        call_from_thread(self, widget.append_reasoning, token.content)
-                    elif token.content:
-                        response_parts.append(token.content)
-                        call_from_thread(self, widget.append_content, token.content)
-                    now = time.monotonic()
-                    if now - last_scroll >= 0.15:
-                        call_from_thread(self, self._scroll_to_bottom)
-                        last_scroll = now
-                except Exception:
-                    break  # App shutting down (Ctrl-C) -- stop streaming
+            self._consume_stream(stream, widget, response_parts)
         except Exception as exc:
             log.debug("Stream error", exc_info=True)
             with contextlib.suppress(Exception):
                 call_from_thread(self, widget.append_content, msg.STREAM_ERROR.format(error=exc))
         finally:
-            self.streaming = False
-            full_response = "".join(response_parts)
-            if full_response:
-                with self._history_lock:
-                    self._history.append({"role": "assistant", "content": full_response})
-                    self._trim_history()
-            call_from_thread(self, widget.finish, sources)
+            _close_stream(stream)
+            self._finalize_stream(widget, sources, response_parts)
+
+    def _consume_stream(
+        self, stream: Any, widget: AssistantMessage, response_parts: list[str]
+    ) -> None:
+        """Pull tokens off *stream*, batching UI updates to ~50 ms windows."""
+        worker = _get_worker()
+        reason_buf: list[str] = []
+        content_buf: list[str] = []
+        timings = [time.monotonic(), 0.0]  # [last_flush, last_scroll]
+
+        def flush() -> None:
+            if reason_buf:
+                call_from_thread(self, widget.append_reasoning, "".join(reason_buf))
+                reason_buf.clear()
+            if content_buf:
+                call_from_thread(self, widget.append_content, "".join(content_buf))
+                content_buf.clear()
+
+        for token in stream:
+            if worker.is_cancelled:
+                break
+            try:
+                self._buffer_token(token, reason_buf, content_buf, response_parts)
+                self._maybe_flush_and_scroll(flush, timings)
+            except Exception:
+                break  # App shutting down (Ctrl-C) -- stop streaming
+        with contextlib.suppress(Exception):
+            flush()
+
+    @staticmethod
+    def _buffer_token(
+        token: Any,
+        reason_buf: list[str],
+        content_buf: list[str],
+        response_parts: list[str],
+    ) -> None:
+        """Append *token* to the right buffer; record response content for history."""
+        if token.is_reasoning:
+            reason_buf.append(token.content)
+        elif token.content:
+            response_parts.append(token.content)
+            content_buf.append(token.content)
+
+    def _maybe_flush_and_scroll(self, flush: Callable[[], None], timings: list[float]) -> None:
+        """Run *flush* and the auto-scroll on their respective intervals."""
+        now = time.monotonic()
+        if now - timings[0] >= _STREAM_FLUSH_INTERVAL:
+            flush()
+            timings[0] = now
+        if now - timings[1] >= _STREAM_SCROLL_INTERVAL:
             call_from_thread(self, self._scroll_to_bottom)
+            timings[1] = now
+
+    def _finalize_stream(
+        self, widget: AssistantMessage, sources: list[str], response_parts: list[str]
+    ) -> None:
+        """Persist the assistant turn and update the widget. Always runs."""
+        self.streaming = False
+        full_response = "".join(response_parts)
+        if full_response:
+            with self._history_lock:
+                self._history.append({"role": "assistant", "content": full_response})
+                self._trim_history()
+        call_from_thread(self, widget.finish, sources)
+        call_from_thread(self, self._scroll_to_bottom)
 
     def _trim_history(self) -> None:
         """Trim history to max size, dropping oldest messages. Caller must hold _history_lock."""

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -798,13 +798,7 @@ class ChatScreen(Screen[None]):
     def _stream_response(
         self, question: str, widget: AssistantMessage, chunk_type: str | None
     ) -> None:
-        """Stream LLM response in a background thread.
-
-        Tokens are coalesced into ``_STREAM_FLUSH_INTERVAL`` windows before
-        being shipped to the UI thread. At 100+ tok/s on small models, one
-        ``call_from_thread`` per token saturates the Textual message queue
-        and key events visibly lag.
-        """
+        """Stream LLM response in a background thread, coalescing UI updates."""
         response_parts: list[str] = []
         sources: list[str] = []
         stream: Any = None

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -42,6 +42,7 @@ from lilbee.config import cfg
 from lilbee.crawler import crawler_available, is_url, require_valid_crawl_url
 from lilbee.embedder import is_model_available
 from lilbee.progress import EventType, ProgressEvent
+from lilbee.providers.base import ClosableIterator
 from lilbee.providers.model_ref import parse_model_ref
 from lilbee.query import ChatMessage
 from lilbee.services import get_services, reset_services
@@ -65,13 +66,10 @@ _STREAM_SCROLL_INTERVAL = 0.15
 
 
 def _close_stream(stream: Any) -> None:
-    """Best-effort close on a streaming iterator. Releases llama.cpp's chat lock."""
-    if stream is None:
-        return
-    close = getattr(stream, "close", None)
-    if callable(close):
+    """Close a streaming iterator if it satisfies the ClosableIterator protocol."""
+    if isinstance(stream, ClosableIterator):
         with contextlib.suppress(Exception):
-            close()
+            stream.close()
 
 
 def _remove_copied_files(names: list[str]) -> None:

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -56,14 +56,7 @@ class Community:
 
 
 def _ensure_spacy_model() -> Any:
-    """Load the spaCy model. The user is expected to install it manually.
-
-    Auto-download via ``spacy.cli.download`` shells out to pip/uv and
-    fails noisily under ``uv tool install`` layouts (uv's stderr leaks
-    'No virtual environment found' into the chat panel). Users can run
-    ``python -m spacy download en_core_web_sm`` once at install time;
-    callers gate on :func:`concepts_available` for graceful degradation.
-    """
+    """Load the spaCy NER model; raise ImportError with an install hint if missing."""
     import spacy
 
     model_name = "en_core_web_sm"

--- a/src/lilbee/concepts.py
+++ b/src/lilbee/concepts.py
@@ -56,24 +56,23 @@ class Community:
 
 
 def _ensure_spacy_model() -> Any:
-    """Load the spaCy model, auto-downloading on first use."""
+    """Load the spaCy model. The user is expected to install it manually.
+
+    Auto-download via ``spacy.cli.download`` shells out to pip/uv and
+    fails noisily under ``uv tool install`` layouts (uv's stderr leaks
+    'No virtual environment found' into the chat panel). Users can run
+    ``python -m spacy download en_core_web_sm`` once at install time;
+    callers gate on :func:`concepts_available` for graceful degradation.
+    """
     import spacy
 
     model_name = "en_core_web_sm"
     try:
         return spacy.load(model_name)
-    except OSError:
-        log.info("Downloading spaCy model '%s'...", model_name)
-        try:
-            from spacy.cli import download
-
-            download(model_name)
-            return spacy.load(model_name)
-        except (SystemExit, OSError, Exception) as exc:
-            raise ImportError(
-                f"spaCy model '{model_name}' not available and auto-download failed. "
-                f"Install manually: python -m spacy download {model_name}"
-            ) from exc
+    except OSError as exc:
+        raise ImportError(
+            f"spaCy model '{model_name}' not installed. Run: python -m spacy download {model_name}"
+        ) from exc
 
 
 def load_spacy_pipeline() -> Any:

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -25,16 +25,22 @@ class ClustererBackend(StrEnum):
 
 
 class KvCacheType(StrEnum):
-    """KV cache element type for llama-cpp loads.
-
-    F16 is the upstream default; the q8_0 / q4_0 variants halve or quarter
-    cache memory but require flash attention to be enabled.
-    """
+    """KV cache element type. q8_0 / q4_0 require flash attention."""
 
     F16 = "f16"
     F32 = "f32"
     Q8_0 = "q8_0"
     Q4_0 = "q4_0"
+
+
+# Bytes per KV element for memory budgeting. q* shapes are 1 byte of data
+# plus shared scales, close enough for budgeting.
+KV_CACHE_TYPE_BYTES: dict[KvCacheType, int] = {
+    KvCacheType.F16: 2,
+    KvCacheType.F32: 4,
+    KvCacheType.Q8_0: 1,
+    KvCacheType.Q4_0: 1,
+}
 
 
 class WikiEntityMode(StrEnum):

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -549,6 +549,25 @@ class Config(BaseSettings):
     # Run embedding and vision inference in a subprocess (llama-cpp only).
     subprocess_embed: bool = ConfigField(default=False, writable=True)
 
+    # Upper bound for the dynamic n_ctx picker. The picker chooses the
+    # largest power-of-256 ctx that fits in available memory and the
+    # model's training window; this caps that at a sane ceiling.
+    num_ctx_max: int | None = ConfigField(default=16384, ge=512, writable=True)
+
+    # Flash attention: 'auto' (default, on with fallback), '1' (force on),
+    # '0' (off). Resolves the 'padding V cache to 1024' warning on models
+    # with uneven per-layer V dims (e.g. Gemma3) and saves ~25% KV memory.
+    flash_attention: str = ConfigField(default="auto", writable=True)
+
+    # KV cache element type: 'f16' (default), 'q8_0', 'q4_0', 'f32'. Quantized
+    # KV halves or quarters cache memory; needs flash attention to be on.
+    kv_cache_type: str = ConfigField(default="f16", writable=True)
+
+    # Number of model layers to offload to GPU: 'auto' (-1, all), 'cpu'
+    # (0, none), or an explicit integer. Useful when a discrete GPU has
+    # less VRAM than the model needs.
+    n_gpu_layers: str = ConfigField(default="auto", writable=True)
+
     # True = Markdown widget for chat; False = plain Static (faster).
     markdown_rendering: bool = True
 

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -24,6 +24,19 @@ class ClustererBackend(StrEnum):
     CONCEPTS = "concepts"
 
 
+class KvCacheType(StrEnum):
+    """KV cache element type for llama-cpp loads.
+
+    F16 is the upstream default; the q8_0 / q4_0 variants halve or quarter
+    cache memory but require flash attention to be enabled.
+    """
+
+    F16 = "f16"
+    F32 = "f32"
+    Q8_0 = "q8_0"
+    Q4_0 = "q4_0"
+
+
 class WikiEntityMode(StrEnum):
     """Strategy used to extract entities for the wiki.
 
@@ -550,23 +563,24 @@ class Config(BaseSettings):
     subprocess_embed: bool = ConfigField(default=False, writable=True)
 
     # Upper bound for the dynamic n_ctx picker. The picker chooses the
-    # largest power-of-256 ctx that fits in available memory and the
-    # model's training window; this caps that at a sane ceiling.
+    # largest 256-multiple ctx that fits in available memory and the
+    # model's training window; this caps it at a sane ceiling.
     num_ctx_max: int | None = ConfigField(default=16384, ge=512, writable=True)
 
-    # Flash attention: 'auto' (default, on with fallback), '1' (force on),
-    # '0' (off). Resolves the 'padding V cache to 1024' warning on models
-    # with uneven per-layer V dims (e.g. Gemma3) and saves ~25% KV memory.
-    flash_attention: str = ConfigField(default="auto", writable=True)
+    # Flash attention. None (default) = on with TypeError fallback for
+    # older llama-cpp-python builds, True = force on, False = off.
+    # Resolves the 'padding V cache to 1024' warning on models with
+    # uneven per-layer V dims (e.g. Gemma3) and saves ~25% KV memory.
+    flash_attention: bool | None = ConfigField(default=None, writable=True)
 
-    # KV cache element type: 'f16' (default), 'q8_0', 'q4_0', 'f32'. Quantized
-    # KV halves or quarters cache memory; needs flash attention to be on.
-    kv_cache_type: str = ConfigField(default="f16", writable=True)
+    # KV cache element type. q8_0 / q4_0 halve or quarter cache memory
+    # but require flash attention to be enabled.
+    kv_cache_type: KvCacheType = ConfigField(default=KvCacheType.F16, writable=True)
 
-    # Number of model layers to offload to GPU: 'auto' (-1, all), 'cpu'
-    # (0, none), or an explicit integer. Useful when a discrete GPU has
-    # less VRAM than the model needs.
-    n_gpu_layers: str = ConfigField(default="auto", writable=True)
+    # Number of model layers to offload to GPU. None (default) = all
+    # layers, 0 = CPU only, positive int = partial offload. Useful when a
+    # discrete GPU has less VRAM than the model needs.
+    n_gpu_layers: int | None = ConfigField(default=None, writable=True)
 
     # True = Markdown widget for chat; False = plain Static (faster).
     markdown_rendering: bool = True
@@ -803,6 +817,42 @@ class Config(BaseSettings):
             except ValueError:
                 pass
         return bool(v)
+
+    @field_validator("flash_attention", mode="before")
+    @classmethod
+    def _parse_flash_attention(cls, v: Any) -> bool | None:
+        """Auto/on/off tri-state: empty/auto/none -> None, else parse bool."""
+        if v is None:
+            return None
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            if v.strip().lower() in ("", "auto", "none"):
+                return None
+            try:
+                return _parse_bool(v)
+            except ValueError:
+                return None
+        return bool(v)
+
+    @field_validator("n_gpu_layers", mode="before")
+    @classmethod
+    def _parse_n_gpu_layers(cls, v: Any) -> int | None:
+        """Auto -> None, ``cpu`` alias -> 0, integers parsed verbatim."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            label = v.strip().lower()
+            if label in ("", "auto", "none"):
+                return None
+            if label == "cpu":
+                return 0
+            try:
+                return int(label)
+            except ValueError:
+                log.warning("Invalid LILBEE_N_GPU_LAYERS=%r, using auto", v)
+                return None
+        return int(v)
 
     @field_validator("semantic_chunking", mode="before")
     @classmethod

--- a/src/lilbee/config.py
+++ b/src/lilbee/config.py
@@ -571,7 +571,7 @@ class Config(BaseSettings):
     # Upper bound for the dynamic n_ctx picker. The picker chooses the
     # largest 256-multiple ctx that fits in available memory and the
     # model's training window; this caps it at a sane ceiling.
-    num_ctx_max: int | None = ConfigField(default=16384, ge=512, writable=True)
+    num_ctx_max: int = ConfigField(default=16384, ge=512, writable=True)
 
     # Flash attention. None (default) = on with TypeError fallback for
     # older llama-cpp-python builds, True = force on, False = off.

--- a/src/lilbee/mcp.py
+++ b/src/lilbee/mcp.py
@@ -65,6 +65,11 @@ def status() -> dict[str, Any]:
             "vision_model": cfg.vision_model,
             "reranker_model": cfg.reranker_model,
             "enable_ocr": cfg.enable_ocr,
+            "num_ctx": cfg.num_ctx,
+            "num_ctx_max": cfg.num_ctx_max,
+            "flash_attention": cfg.flash_attention,
+            "kv_cache_type": cfg.kv_cache_type.value,
+            "n_gpu_layers": cfg.n_gpu_layers,
         },
         "sources": [
             {"filename": s["filename"], "chunk_count": s["chunk_count"]}

--- a/src/lilbee/models.py
+++ b/src/lilbee/models.py
@@ -95,10 +95,9 @@ def get_system_ram_gb() -> float:
             stat.dwLength = ctypes.sizeof(stat)
             ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))  # type: ignore[attr-defined]
             return stat.ullTotalPhys / (1024**3)
-        else:
-            pages = os.sysconf("SC_PHYS_PAGES")
-            page_size = os.sysconf("SC_PAGE_SIZE")
-            return (pages * page_size) / (1024**3)
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        return (pages * page_size) / (1024**3)
     except (OSError, AttributeError, ValueError):
         log.debug("RAM detection failed, falling back to 8.0 GB")
         return 8.0

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -4,9 +4,24 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from pydantic import BaseModel
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+@runtime_checkable
+class ClosableIterator(Iterator[T_co], Protocol[T_co]):
+    """An iterator that releases resources when ``close()`` is called.
+
+    Streaming chat responses use this to guarantee the upstream model lock
+    is released even when callers truncate the stream before exhaustion.
+    Generators satisfy this implicitly; explicit wrappers (e.g. the llama-cpp
+    chat-lock iterator) implement it directly.
+    """
+
+    def close(self) -> None: ...
 
 
 class LLMOptions(BaseModel):
@@ -58,8 +73,8 @@ class LLMProvider(Protocol):
         stream: bool = False,
         options: dict[str, Any] | None = None,
         model: str | None = None,
-    ) -> str | Iterator[str]:
-        """Chat completion. Returns str for non-stream, Iterator[str] for stream."""
+    ) -> str | ClosableIterator[str]:
+        """Chat completion. Returns str for non-stream, ClosableIterator[str] for stream."""
         ...
 
     def list_models(self) -> list[str]:

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -69,6 +69,11 @@ _GGML_ERROR_SOFT_DEMOTE = (
 )
 
 _BATCH_WINDOW_S = 0.01  # 10ms — collect concurrent requests before dispatching
+
+# Cap on tokens consumed during _LockedStreamIterator.close()'s drain.
+# A runaway model (e.g. Qwen3-0.6B in a never-closing <think> loop)
+# would otherwise block close() indefinitely.
+_LOCKED_STREAM_DRAIN_CAP = 1024
 _EMBED_FUTURE_TIMEOUT_S = 300.0  # Safety net: max wait for embed result
 _RERANK_FUTURE_TIMEOUT_S = 300.0  # Safety net: max wait for rerank result
 
@@ -396,17 +401,20 @@ class _LockedStreamIterator:
             self._lock.release()
 
     def close(self) -> None:
-        """Exhaust the underlying C iterator, then release the lock.
+        """Drain (capped) the underlying C iterator, then release the lock.
 
         Simply releasing the lock without finishing inference leaves the
-        llama-cpp model in an inconsistent state. The next streaming call
-        would hang because the C runtime is still processing the previous
-        request. Draining the iterator ensures inference completes cleanly.
+        llama-cpp model in an inconsistent state. Draining lets inference
+        complete cleanly. The cap (``_LOCKED_STREAM_DRAIN_CAP``) keeps a
+        runaway think loop from blocking close() indefinitely; once the
+        cap fires we accept the inconsistent state in exchange for not
+        hanging the UI.
         """
         if not self._released:
             try:
-                for _ in self._response:
-                    pass
+                for i, _ in enumerate(self._response):
+                    if i >= _LOCKED_STREAM_DRAIN_CAP:
+                        break
             except Exception:  # noqa: S110 -- best-effort drain during release; ignore partial-read errors
                 pass
             self._release()

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -58,6 +58,16 @@ _GGML_TO_PY_LEVEL = {
     _GGML_LOG_LEVEL_DEBUG: logging.DEBUG,
 }
 
+# Substrings llama.cpp emits at GGML_LOG_LEVEL_ERROR but which are
+# advisory: the model still loads correctly. Demoted to WARNING so users
+# don't think their setup is broken.
+_GGML_ERROR_SOFT_DEMOTE = (
+    "special_eos_id is not in special_eog_ids",
+    "embeddings required but some input tokens were not marked as outputs",
+    "n_ctx_seq",  # 'n_ctx_seq (X) > n_ctx_train (Y)' -- our embed clamp prevents this
+    "tokenizer config may be incorrect",
+)
+
 _BATCH_WINDOW_S = 0.01  # 10ms — collect concurrent requests before dispatching
 _EMBED_FUTURE_TIMEOUT_S = 300.0  # Safety net: max wait for embed result
 _RERANK_FUTURE_TIMEOUT_S = 300.0  # Safety net: max wait for rerank result
@@ -429,16 +439,22 @@ def _llama_log_dispatch(level: int, text_bytes: bytes, _user_data: Any) -> None:
         if 0 in _llama_log_pending:
             buffered = _llama_log_pending.pop(0).rstrip()
             if buffered:
-                _llama_log.log(
-                    _GGML_TO_PY_LEVEL.get(_llama_log_pending_level, logging.DEBUG), buffered
-                )
+                _llama_log.log(_resolve_ggml_level(_llama_log_pending_level, buffered), buffered)
         _llama_log_pending_level = level
         _llama_log_pending[0] = text
 
     if "\n" in _llama_log_pending.get(0, ""):
         full = _llama_log_pending.pop(0).rstrip()
         if full:
-            _llama_log.log(_GGML_TO_PY_LEVEL.get(_llama_log_pending_level, logging.DEBUG), full)
+            _llama_log.log(_resolve_ggml_level(_llama_log_pending_level, full), full)
+
+
+def _resolve_ggml_level(ggml_level: int, text: str) -> int:
+    """Translate ggml log level to Python, demoting known-advisory ERRORs to WARNING."""
+    py_level = _GGML_TO_PY_LEVEL.get(ggml_level, logging.DEBUG)
+    if py_level == logging.ERROR and any(s in text for s in _GGML_ERROR_SOFT_DEMOTE):
+        return logging.WARNING
+    return py_level
 
 
 def install_llama_log_handler() -> None:
@@ -578,11 +594,18 @@ def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
         "n_gpu_layers": _resolve_n_gpu_layers(embedding=embedding),
     }
 
-    if cfg.num_ctx is not None:
+    if embedding:
+        # Embedding/rerank: clamp n_ctx to the model's training context.
+        # Passing a chat-sized cfg.num_ctx through here triggers
+        # ``n_ctx_seq > n_ctx_train`` warnings and wastes KV memory.
+        embed_meta = _safe_read_gguf_metadata(model_path)
+        embed_train_ctx = int((embed_meta or {}).get("context_length", "2048"))
+        if cfg.num_ctx is not None:
+            kwargs["n_ctx"] = min(cfg.num_ctx, embed_train_ctx)
+        else:
+            kwargs["n_ctx"] = 0  # 0 -> llama.cpp uses the model's training context
+    elif cfg.num_ctx is not None:
         kwargs["n_ctx"] = cfg.num_ctx
-    elif embedding:
-        # n_ctx=0 -> llama.cpp uses the model's training context (else 512).
-        kwargs["n_ctx"] = 0
     else:
         meta = _safe_read_gguf_metadata(model_path)
         kwargs["n_ctx"] = _resolve_chat_ctx(model_path, meta)
@@ -597,11 +620,7 @@ def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
         # llama-cpp-python defaults n_batch = min(n_ctx, 512), silently
         # truncating embeddings to 512 tokens. Set n_batch = n_ctx so each
         # text can use the model's full context window.
-        if kwargs["n_ctx"] == 0:
-            meta = _safe_read_gguf_metadata(model_path)
-            ctx_len = int((meta or {}).get("context_length", "2048"))
-        else:
-            ctx_len = kwargs["n_ctx"]
+        ctx_len = embed_train_ctx if kwargs["n_ctx"] == 0 else kwargs["n_ctx"]
         kwargs["n_batch"] = ctx_len
         kwargs["n_ubatch"] = ctx_len
 
@@ -697,17 +716,10 @@ def _apply_kv_cache_type(kwargs: dict[str, Any]) -> None:
     label = (cfg.kv_cache_type or "f16").lower()
     if label == "f16":
         return
-    try:
-        from llama_cpp import llama_cpp as _llc
-    except Exception:
+    type_map = _ggml_type_map()
+    if type_map is None:
         log.debug("llama_cpp internal types unavailable; skipping KV quant")
         return
-    type_map = {
-        "f32": getattr(_llc, "GGML_TYPE_F32", None),
-        "f16": getattr(_llc, "GGML_TYPE_F16", None),
-        "q8_0": getattr(_llc, "GGML_TYPE_Q8_0", None),
-        "q4_0": getattr(_llc, "GGML_TYPE_Q4_0", None),
-    }
     ggml_type = type_map.get(label)
     if ggml_type is None:
         log.warning("Unknown LILBEE_KV_CACHE_TYPE=%r, falling back to f16", label)
@@ -716,9 +728,27 @@ def _apply_kv_cache_type(kwargs: dict[str, Any]) -> None:
     kwargs["type_v"] = ggml_type
 
 
+def _ggml_type_map() -> dict[str, Any] | None:
+    """Resolve llama-cpp-python's GGML_TYPE_* constants, or None on older builds."""
+    try:
+        from llama_cpp import llama_cpp as _llc
+    except Exception:  # pragma: no cover -- only fires on llama-cpp-python without _llc
+        return None
+    return {
+        "f32": getattr(_llc, "GGML_TYPE_F32", None),
+        "f16": getattr(_llc, "GGML_TYPE_F16", None),
+        "q8_0": getattr(_llc, "GGML_TYPE_Q8_0", None),
+        "q4_0": getattr(_llc, "GGML_TYPE_Q4_0", None),
+    }
+
+
 def _construct_llama(llama_cls: Any, model_path: Path, kwargs: dict[str, Any]) -> Any:
-    """Call ``llama_cls(**kwargs)`` with FA fallback and OOM-retry-with-halved-ctx."""
-    last_exc: BaseException | None = None
+    """Call ``llama_cls(**kwargs)`` with FA fallback and OOM-retry-with-halved-ctx.
+
+    Each loop iteration either returns the loaded model, raises (failure
+    or unrelated TypeError), or continues with halved n_ctx; the loop is
+    therefore structurally exhaustive and never falls through.
+    """
     fa_dropped = False
     for attempt in range(_MAX_OOM_RETRIES + 1):
         try:
@@ -729,13 +759,11 @@ def _construct_llama(llama_cls: Any, model_path: Path, kwargs: dict[str, Any]) -
             fa_dropped = True
             continue
         except ValueError as exc:
-            last_exc = exc
             if attempt == _MAX_OOM_RETRIES or not _is_load_oom(exc):
                 _raise_load_error(model_path, kwargs, exc)
             if not _halve_ctx_for_retry(kwargs, exc):
                 _raise_load_error(model_path, kwargs, exc)
-    assert last_exc is not None  # noqa: S101 -- loop exits via raise or return
-    raise last_exc
+    raise RuntimeError("unreachable: _construct_llama loop fell through")  # pragma: no cover
 
 
 def _drop_flash_attn_if_unsupported(

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from gguf import GGUFReader, GGUFValueType
 
 from lilbee.catalog import is_rerank_ref
-from lilbee.config import DEFAULT_NUM_CTX, cfg
+from lilbee.config import DEFAULT_NUM_CTX, KvCacheType, cfg
 from lilbee.providers.base import LLMProvider, ProviderError, filter_options
 from lilbee.providers.model_cache import (
     KV_CACHE_TYPE_BYTES,
@@ -691,62 +691,58 @@ def _resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
 
 def _kv_elem_bytes_for_cfg() -> int:
     """Bytes per KV element implied by the configured cache type."""
-    return KV_CACHE_TYPE_BYTES.get(cfg.kv_cache_type, 2)
+    return KV_CACHE_TYPE_BYTES.get(cfg.kv_cache_type.value, 2)
+
+
+_N_GPU_LAYERS_AUTO = -1
 
 
 def _resolve_n_gpu_layers(*, embedding: bool) -> int:
-    """Pick n_gpu_layers from cfg, honoring 'auto' / 'cpu' / explicit int."""
-    if embedding:
-        return -1
-    raw = cfg.n_gpu_layers or "auto"
-    if raw == "cpu":
-        return 0
-    if raw == "auto":
-        return -1
-    try:
-        return int(raw)
-    except (TypeError, ValueError):
-        log.warning("Invalid LILBEE_N_GPU_LAYERS=%r, falling back to auto", raw)
-        return -1
+    """Resolve ``cfg.n_gpu_layers`` to llama-cpp-python's offload integer.
+
+    Embedding loads always use all layers; chat honors ``cfg.n_gpu_layers``
+    (None -> all, 0 -> CPU only, positive int -> partial offload).
+    """
+    if embedding or cfg.n_gpu_layers is None:
+        return _N_GPU_LAYERS_AUTO
+    return cfg.n_gpu_layers
 
 
 def _apply_flash_attention(kwargs: dict[str, Any]) -> None:
-    """Set ``flash_attn`` kwarg per ``cfg.flash_attention`` (auto/1/0)."""
-    setting = (cfg.flash_attention or "auto").lower()
-    if setting in ("0", "false", "off", "no"):
+    """Set ``flash_attn`` per ``cfg.flash_attention`` (None=auto, True/False=force)."""
+    if cfg.flash_attention is False:
         return
-    if setting in ("1", "true", "on", "yes", "auto"):
-        kwargs["flash_attn"] = True
+    # None (auto) and True both pass flash_attn=True; the construct loop
+    # drops it on TypeError if llama-cpp-python doesn't support it.
+    kwargs["flash_attn"] = True
 
 
 def _apply_kv_cache_type(kwargs: dict[str, Any]) -> None:
     """Map ``cfg.kv_cache_type`` to llama-cpp-python ``type_k`` / ``type_v``."""
-    label = (cfg.kv_cache_type or "f16").lower()
-    if label == "f16":
+    if cfg.kv_cache_type is KvCacheType.F16:
         return
     type_map = _ggml_type_map()
     if type_map is None:
         log.debug("llama_cpp internal types unavailable; skipping KV quant")
         return
-    ggml_type = type_map.get(label)
-    if ggml_type is None:
-        log.warning("Unknown LILBEE_KV_CACHE_TYPE=%r, falling back to f16", label)
+    ggml_type = type_map.get(cfg.kv_cache_type)
+    if ggml_type is None:  # pragma: no cover -- defensive against new enum values
         return
     kwargs["type_k"] = ggml_type
     kwargs["type_v"] = ggml_type
 
 
-def _ggml_type_map() -> dict[str, Any] | None:
+def _ggml_type_map() -> dict[KvCacheType, Any] | None:
     """Resolve llama-cpp-python's GGML_TYPE_* constants, or None on older builds."""
     try:
         from llama_cpp import llama_cpp as _llc
     except Exception:  # pragma: no cover -- only fires on llama-cpp-python without _llc
         return None
     return {
-        "f32": getattr(_llc, "GGML_TYPE_F32", None),
-        "f16": getattr(_llc, "GGML_TYPE_F16", None),
-        "q8_0": getattr(_llc, "GGML_TYPE_Q8_0", None),
-        "q4_0": getattr(_llc, "GGML_TYPE_Q4_0", None),
+        KvCacheType.F32: getattr(_llc, "GGML_TYPE_F32", None),
+        KvCacheType.F16: getattr(_llc, "GGML_TYPE_F16", None),
+        KvCacheType.Q8_0: getattr(_llc, "GGML_TYPE_Q8_0", None),
+        KvCacheType.Q4_0: getattr(_llc, "GGML_TYPE_Q4_0", None),
     }
 
 

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -24,7 +24,16 @@ from gguf import GGUFReader, GGUFValueType
 from lilbee.catalog import is_rerank_ref
 from lilbee.config import DEFAULT_NUM_CTX, cfg
 from lilbee.providers.base import LLMProvider, ProviderError, filter_options
-from lilbee.providers.model_cache import MODE_CHAT, MODE_EMBED, MODE_RERANK, LoaderMode
+from lilbee.providers.model_cache import (
+    KV_CACHE_TYPE_BYTES,
+    MODE_CHAT,
+    MODE_EMBED,
+    MODE_RERANK,
+    LoaderMode,
+    compute_dynamic_ctx,
+    get_available_memory,
+    kv_bytes_per_token,
+)
 from lilbee.services import get_services
 
 if TYPE_CHECKING:
@@ -213,7 +222,7 @@ class LlamaCppProvider(LLMProvider):
     def _get_subprocess_worker(self) -> WorkerProcess:
         """Lazy-create and return the subprocess worker."""
         if self._subprocess_worker is None:
-            from lilbee.providers.worker_process import WorkerProcess as WP
+            from lilbee.providers.worker_process import WorkerProcess as WP  # noqa: N817
 
             self._subprocess_worker = WP()
         return self._subprocess_worker
@@ -473,7 +482,9 @@ def embed_one(llm: Any, text: str) -> list[float]:
 def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
     """Read metadata from a GGUF file's headers via llama-cpp-python.
     Returns a dict with keys like 'architecture', 'context_length',
-    'embedding_length', 'chat_template', 'file_type'.
+    'embedding_length', 'chat_template', 'file_type', plus the
+    KV-cache-shape fields ('block_count', 'head_count_kv', 'key_length',
+    'value_length') used to size n_ctx against host memory.
     """
     from llama_cpp import Llama
 
@@ -493,6 +504,15 @@ def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
         emb_key = f"{arch}.embedding_length"
         if emb_key in raw:
             result["embedding_length"] = str(raw[emb_key])
+        for arch_key, out_key in (
+            (f"{arch}.block_count", "block_count"),
+            (f"{arch}.attention.head_count_kv", "head_count_kv"),
+            (f"{arch}.attention.head_count", "head_count"),
+            (f"{arch}.attention.key_length", "key_length"),
+            (f"{arch}.attention.value_length", "value_length"),
+        ):
+            if arch_key in raw:
+                result[out_key] = str(raw[arch_key])
         if "tokenizer.chat_template" in raw:
             result["chat_template"] = str(raw["tokenizer.chat_template"])
         if "general.file_type" in raw:
@@ -542,8 +562,10 @@ def _llama_cpp_has_rank_pooling() -> bool:
 def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
     """Load a llama_cpp.Llama instance in chat, embed, or rerank mode.
 
-    Rerank mode sets ``embedding=True`` and ``pooling_type=LLAMA_POOLING_TYPE_RANK``
-    so llama.cpp emits cross-encoder scores instead of token embeddings.
+    Chat picks ``n_ctx`` dynamically against host memory (unless
+    ``cfg.num_ctx`` is set) and enables flash attention with a fallback for
+    older llama-cpp-python builds. Rerank uses ``pooling_type=RANK`` so
+    llama.cpp emits cross-encoder scores instead of token embeddings.
     """
     from llama_cpp import Llama
 
@@ -553,32 +575,31 @@ def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
         "model_path": str(model_path),
         "embedding": embedding,
         "verbose": False,
-        "n_gpu_layers": -1,  # Offload all layers to GPU (Metal/CUDA)
+        "n_gpu_layers": _resolve_n_gpu_layers(embedding=embedding),
     }
+
     if cfg.num_ctx is not None:
         kwargs["n_ctx"] = cfg.num_ctx
     elif embedding:
         # n_ctx=0 -> llama.cpp uses the model's training context (else 512).
         kwargs["n_ctx"] = 0
     else:
-        # Cap chat at DEFAULT_NUM_CTX so 128K+ training contexts don't OOM.
-        training_ctx = DEFAULT_NUM_CTX
-        try:
-            meta = read_gguf_metadata(model_path)
-        except Exception:
-            log.debug("read_gguf_metadata failed for %s", model_path, exc_info=True)
-            meta = None
-        if meta:
-            training_ctx = int(meta.get("context_length", DEFAULT_NUM_CTX))
-        kwargs["n_ctx"] = min(training_ctx, DEFAULT_NUM_CTX)
+        meta = _safe_read_gguf_metadata(model_path)
+        kwargs["n_ctx"] = _resolve_chat_ctx(model_path, meta)
+        log.info(
+            "Chat n_ctx=%d for %s (dynamic, training_ctx=%s)",
+            kwargs["n_ctx"],
+            model_path.name,
+            (meta or {}).get("context_length", "unknown"),
+        )
 
     if embedding:
         # llama-cpp-python defaults n_batch = min(n_ctx, 512), silently
         # truncating embeddings to 512 tokens. Set n_batch = n_ctx so each
         # text can use the model's full context window.
         if kwargs["n_ctx"] == 0:
-            meta = read_gguf_metadata(model_path)
-            ctx_len = int(meta.get("context_length", 2048)) if meta else 2048
+            meta = _safe_read_gguf_metadata(model_path)
+            ctx_len = int((meta or {}).get("context_length", "2048"))
         else:
             ctx_len = kwargs["n_ctx"]
         kwargs["n_batch"] = ctx_len
@@ -589,13 +610,178 @@ def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
 
         kwargs["pooling_type"] = LLAMA_POOLING_TYPE_RANK
 
+    if not embedding:
+        _apply_flash_attention(kwargs)
+        _apply_kv_cache_type(kwargs)
+
+    return _construct_llama(Llama, model_path, kwargs)
+
+
+_MAX_OOM_RETRIES = 2
+_CTX_QUANTUM = 256
+_CTX_FLOOR = 512
+
+
+def _safe_read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
+    """Best-effort GGUF metadata read, returning None on any failure."""
     try:
-        return suppress_native_stderr(Llama, **kwargs)
-    except ValueError as exc:
-        wrapped = _wrap_llama_load_error(model_path, kwargs, exc)
-        if wrapped is None:
-            raise
-        raise wrapped from exc
+        return read_gguf_metadata(model_path)
+    except Exception:
+        log.debug("read_gguf_metadata failed for %s", model_path, exc_info=True)
+        return None
+
+
+def _resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
+    """Pick a chat n_ctx that fits available memory.
+
+    Honors ``LILBEE_NUM_CTX_MAX`` as the upper bound. Falls back to the
+    static ``min(training_ctx, DEFAULT_NUM_CTX)`` cap if memory accounting
+    goes wrong (e.g., psutil missing).
+    """
+    training_ctx = DEFAULT_NUM_CTX
+    if meta:
+        try:
+            training_ctx = int(meta.get("context_length", DEFAULT_NUM_CTX))
+        except (TypeError, ValueError):
+            training_ctx = DEFAULT_NUM_CTX
+    ceiling = cfg.num_ctx_max or 16384
+
+    try:
+        model_bytes = model_path.stat().st_size
+        available = get_available_memory(cfg.gpu_memory_fraction)
+        kv_per_tok = kv_bytes_per_token(meta, _kv_elem_bytes_for_cfg())
+        return compute_dynamic_ctx(
+            model_bytes=model_bytes,
+            available_bytes=available,
+            training_ctx=training_ctx,
+            kv_bytes_per_tok=kv_per_tok,
+            ceiling=ceiling,
+        )
+    except (OSError, ValueError):
+        log.debug("dynamic ctx sizing failed for %s, using static cap", model_path, exc_info=True)
+        return min(training_ctx, DEFAULT_NUM_CTX)
+
+
+def _kv_elem_bytes_for_cfg() -> int:
+    """Bytes per KV element implied by the configured cache type."""
+    return KV_CACHE_TYPE_BYTES.get(cfg.kv_cache_type, 2)
+
+
+def _resolve_n_gpu_layers(*, embedding: bool) -> int:
+    """Pick n_gpu_layers from cfg, honoring 'auto' / 'cpu' / explicit int."""
+    if embedding:
+        return -1
+    raw = cfg.n_gpu_layers or "auto"
+    if raw == "cpu":
+        return 0
+    if raw == "auto":
+        return -1
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        log.warning("Invalid LILBEE_N_GPU_LAYERS=%r, falling back to auto", raw)
+        return -1
+
+
+def _apply_flash_attention(kwargs: dict[str, Any]) -> None:
+    """Set ``flash_attn`` kwarg per ``cfg.flash_attention`` (auto/1/0)."""
+    setting = (cfg.flash_attention or "auto").lower()
+    if setting in ("0", "false", "off", "no"):
+        return
+    if setting in ("1", "true", "on", "yes", "auto"):
+        kwargs["flash_attn"] = True
+
+
+def _apply_kv_cache_type(kwargs: dict[str, Any]) -> None:
+    """Map ``cfg.kv_cache_type`` to llama-cpp-python ``type_k`` / ``type_v``."""
+    label = (cfg.kv_cache_type or "f16").lower()
+    if label == "f16":
+        return
+    try:
+        from llama_cpp import llama_cpp as _llc
+    except Exception:
+        log.debug("llama_cpp internal types unavailable; skipping KV quant")
+        return
+    type_map = {
+        "f32": getattr(_llc, "GGML_TYPE_F32", None),
+        "f16": getattr(_llc, "GGML_TYPE_F16", None),
+        "q8_0": getattr(_llc, "GGML_TYPE_Q8_0", None),
+        "q4_0": getattr(_llc, "GGML_TYPE_Q4_0", None),
+    }
+    ggml_type = type_map.get(label)
+    if ggml_type is None:
+        log.warning("Unknown LILBEE_KV_CACHE_TYPE=%r, falling back to f16", label)
+        return
+    kwargs["type_k"] = ggml_type
+    kwargs["type_v"] = ggml_type
+
+
+def _construct_llama(llama_cls: Any, model_path: Path, kwargs: dict[str, Any]) -> Any:
+    """Call ``llama_cls(**kwargs)`` with FA fallback and OOM-retry-with-halved-ctx."""
+    last_exc: BaseException | None = None
+    fa_dropped = False
+    for attempt in range(_MAX_OOM_RETRIES + 1):
+        try:
+            return suppress_native_stderr(llama_cls, **kwargs)
+        except TypeError as exc:
+            if not _drop_flash_attn_if_unsupported(exc, kwargs, fa_dropped):
+                raise
+            fa_dropped = True
+            continue
+        except ValueError as exc:
+            last_exc = exc
+            if attempt == _MAX_OOM_RETRIES or not _is_load_oom(exc):
+                _raise_load_error(model_path, kwargs, exc)
+            if not _halve_ctx_for_retry(kwargs, exc):
+                _raise_load_error(model_path, kwargs, exc)
+    assert last_exc is not None  # noqa: S101 -- loop exits via raise or return
+    raise last_exc
+
+
+def _drop_flash_attn_if_unsupported(
+    exc: TypeError, kwargs: dict[str, Any], already_dropped: bool
+) -> bool:
+    """If the TypeError is about an unsupported ``flash_attn`` kwarg, drop it."""
+    if already_dropped or "flash_attn" not in kwargs or "flash_attn" not in str(exc):
+        return False
+    log.info("llama-cpp-python rejected flash_attn=True; retrying without it")
+    kwargs.pop("flash_attn", None)
+    return True
+
+
+def _halve_ctx_for_retry(kwargs: dict[str, Any], exc: ValueError) -> bool:
+    """Halve n_ctx (and matching batch sizes) for an OOM retry. Returns False if no progress."""
+    current_ctx = int(kwargs.get("n_ctx", 0) or 0)
+    if current_ctx <= 0:
+        return False
+    new_ctx = max(_CTX_FLOOR, (current_ctx // 2 // _CTX_QUANTUM) * _CTX_QUANTUM)
+    if new_ctx >= current_ctx:
+        return False
+    log.warning(
+        "llama.cpp load failed at n_ctx=%d (%s); retrying at n_ctx=%d",
+        current_ctx,
+        str(exc).splitlines()[0],
+        new_ctx,
+    )
+    kwargs["n_ctx"] = new_ctx
+    for key in ("n_batch", "n_ubatch"):
+        if key in kwargs:
+            kwargs[key] = new_ctx
+    return True
+
+
+def _raise_load_error(model_path: Path, kwargs: dict[str, Any], exc: ValueError) -> None:
+    """Raise the wrapped diagnostic for a llama.cpp load failure, or re-raise as-is."""
+    wrapped = _wrap_llama_load_error(model_path, kwargs, exc)
+    if wrapped is None:
+        raise exc
+    raise wrapped from exc
+
+
+def _is_load_oom(exc: ValueError) -> bool:
+    """Does this ValueError look like a llama.cpp memory failure?"""
+    err = str(exc)
+    return "llama_context" in err or "load model from file" in err
 
 
 def _wrap_llama_load_error(
@@ -622,7 +808,8 @@ def _wrap_llama_load_error(
     except Exception as psu_exc:  # pragma: no cover
         log.debug("psutil unavailable: %s", psu_exc)
     parts.append(
-        "Try a smaller model, lower LILBEE_NUM_CTX, or close other processes to free RAM. "
+        "Try a smaller model, lower LILBEE_NUM_CTX, set LILBEE_KV_CACHE_TYPE=q8_0, "
+        "or close other processes to free RAM. "
         f"(llama.cpp: {err})"
     )
     return ValueError(" ".join(parts))

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -13,7 +13,7 @@ import os
 import queue
 import threading
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,7 +23,7 @@ from gguf import GGUFReader, GGUFValueType
 
 from lilbee.catalog import is_rerank_ref
 from lilbee.config import DEFAULT_NUM_CTX, KV_CACHE_TYPE_BYTES, KvCacheType, cfg
-from lilbee.providers.base import LLMProvider, ProviderError, filter_options
+from lilbee.providers.base import ClosableIterator, LLMProvider, ProviderError, filter_options
 from lilbee.providers.model_cache import (
     MODE_CHAT,
     MODE_EMBED,
@@ -67,7 +67,7 @@ _GGML_ERROR_SOFT_DEMOTE = (
     "tokenizer config may be incorrect",
 )
 
-_BATCH_WINDOW_S = 0.01  # 10ms — collect concurrent requests before dispatching
+_BATCH_WINDOW_S = 0.01  # 10ms, collect concurrent requests before dispatching
 
 # Cap on tokens consumed during _LockedStreamIterator.close()'s drain.
 # A runaway model (e.g. Qwen3-0.6B in a never-closing <think> loop)
@@ -75,6 +75,14 @@ _BATCH_WINDOW_S = 0.01  # 10ms — collect concurrent requests before dispatchin
 _LOCKED_STREAM_DRAIN_CAP = 1024
 _EMBED_FUTURE_TIMEOUT_S = 300.0  # Safety net: max wait for embed result
 _RERANK_FUTURE_TIMEOUT_S = 300.0  # Safety net: max wait for rerank result
+
+# Chat-load OOM retry knobs.
+_MAX_OOM_RETRIES = 2
+_CTX_QUANTUM = 256
+_CTX_FLOOR = 512
+
+# Sentinel passed to llama-cpp-python for "offload all layers".
+_N_GPU_LAYERS_AUTO = -1
 
 # Settings baked into Llama() at load time, or whose change picks a
 # different model file. Sampling params are read per-call and excluded.
@@ -276,7 +284,7 @@ class LlamaCppProvider(LLMProvider):
         stream: bool = False,
         options: dict[str, Any] | None = None,
         model: str | None = None,
-    ) -> str | Iterator[str]:
+    ) -> str | ClosableIterator[str]:
         """Chat completion — serialized via lock (Llama is not thread-safe)."""
         self._chat_lock.acquire()
         try:
@@ -637,11 +645,6 @@ def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
     return _construct_llama(Llama, model_path, kwargs)
 
 
-_MAX_OOM_RETRIES = 2
-_CTX_QUANTUM = 256
-_CTX_FLOOR = 512
-
-
 def _safe_read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
     """Best-effort GGUF metadata read, returning None on any failure."""
     try:
@@ -659,7 +662,7 @@ def _resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
             training_ctx = int(meta.get("context_length", DEFAULT_NUM_CTX))
         except (TypeError, ValueError):
             training_ctx = DEFAULT_NUM_CTX
-    ceiling = cfg.num_ctx_max or 16384
+    ceiling = cfg.num_ctx_max
 
     try:
         model_bytes = model_path.stat().st_size
@@ -680,9 +683,6 @@ def _resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
 def _kv_elem_bytes_for_cfg() -> int:
     """Bytes per KV element implied by the configured cache type."""
     return KV_CACHE_TYPE_BYTES[cfg.kv_cache_type]
-
-
-_N_GPU_LAYERS_AUTO = -1
 
 
 def _resolve_n_gpu_layers(*, embedding: bool) -> int:

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -22,10 +22,9 @@ from typing import TYPE_CHECKING, Any
 from gguf import GGUFReader, GGUFValueType
 
 from lilbee.catalog import is_rerank_ref
-from lilbee.config import DEFAULT_NUM_CTX, KvCacheType, cfg
+from lilbee.config import DEFAULT_NUM_CTX, KV_CACHE_TYPE_BYTES, KvCacheType, cfg
 from lilbee.providers.base import LLMProvider, ProviderError, filter_options
 from lilbee.providers.model_cache import (
-    KV_CACHE_TYPE_BYTES,
     MODE_CHAT,
     MODE_EMBED,
     MODE_RERANK,
@@ -584,13 +583,7 @@ def _llama_cpp_has_rank_pooling() -> bool:
 
 
 def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
-    """Load a llama_cpp.Llama instance in chat, embed, or rerank mode.
-
-    Chat picks ``n_ctx`` dynamically against host memory (unless
-    ``cfg.num_ctx`` is set) and enables flash attention with a fallback for
-    older llama-cpp-python builds. Rerank uses ``pooling_type=RANK`` so
-    llama.cpp emits cross-encoder scores instead of token embeddings.
-    """
+    """Load a llama_cpp.Llama in chat, embed, or rerank mode."""
     from llama_cpp import Llama
 
     install_llama_log_handler()
@@ -659,12 +652,7 @@ def _safe_read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
 
 
 def _resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
-    """Pick a chat n_ctx that fits available memory.
-
-    Honors ``LILBEE_NUM_CTX_MAX`` as the upper bound. Falls back to the
-    static ``min(training_ctx, DEFAULT_NUM_CTX)`` cap if memory accounting
-    goes wrong (e.g., psutil missing).
-    """
+    """Pick the largest 256-multiple n_ctx that fits in available memory."""
     training_ctx = DEFAULT_NUM_CTX
     if meta:
         try:
@@ -691,18 +679,14 @@ def _resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
 
 def _kv_elem_bytes_for_cfg() -> int:
     """Bytes per KV element implied by the configured cache type."""
-    return KV_CACHE_TYPE_BYTES.get(cfg.kv_cache_type.value, 2)
+    return KV_CACHE_TYPE_BYTES[cfg.kv_cache_type]
 
 
 _N_GPU_LAYERS_AUTO = -1
 
 
 def _resolve_n_gpu_layers(*, embedding: bool) -> int:
-    """Resolve ``cfg.n_gpu_layers`` to llama-cpp-python's offload integer.
-
-    Embedding loads always use all layers; chat honors ``cfg.n_gpu_layers``
-    (None -> all, 0 -> CPU only, positive int -> partial offload).
-    """
+    """Resolve ``cfg.n_gpu_layers`` (None=all) to llama-cpp's offload integer."""
     if embedding or cfg.n_gpu_layers is None:
         return _N_GPU_LAYERS_AUTO
     return cfg.n_gpu_layers

--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -36,9 +36,6 @@ _DEFAULT_CTX_LEN = 2048
 # Floor for the dynamic n_ctx computation (smaller is unusable for chat)
 _DYNAMIC_CTX_FLOOR = 512
 
-# Default ceiling for dynamic n_ctx (overridable via cfg.num_ctx_max)
-_DYNAMIC_CTX_DEFAULT_CEILING = 16384
-
 # Round dynamic n_ctx down to a multiple of this (clean batch sizes)
 _DYNAMIC_CTX_QUANTUM = 256
 
@@ -110,7 +107,7 @@ def compute_dynamic_ctx(
     available_bytes: int,
     training_ctx: int,
     kv_bytes_per_tok: int,
-    ceiling: int = _DYNAMIC_CTX_DEFAULT_CEILING,
+    ceiling: int,
     floor: int = _DYNAMIC_CTX_FLOOR,
     quantum: int = _DYNAMIC_CTX_QUANTUM,
 ) -> int:

--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -45,15 +45,6 @@ _DYNAMIC_CTX_QUANTUM = 256
 # KV cache element size for f16 (bytes). Quantized KV reduces this.
 _KV_ELEM_BYTES_F16 = 2
 
-# Map cache-type label -> bytes per KV element (rough; q* shapes are 1 byte
-# of data plus shared scales, close enough for budgeting).
-KV_CACHE_TYPE_BYTES = {
-    "f16": 2,
-    "f32": 4,
-    "q8_0": 1,
-    "q4_0": 1,
-}
-
 
 @dataclass
 class _CacheEntry:

--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -22,7 +22,9 @@ MODE_CHAT: LoaderMode = "chat"
 MODE_EMBED: LoaderMode = "embed"
 MODE_RERANK: LoaderMode = "rerank"
 
-# KV cache memory estimate: 2048 bytes per context token (conservative)
+# Fallback KV cache estimate when GGUF metadata can't be read.
+# 2048 bytes/token undershoots real KV size for modern models (Gemma3-4B is
+# ~640 KB/token f16) but is fine as a coarse pre-load eviction signal.
 _KV_BYTES_PER_CTX_TOKEN = 2048
 
 # Metal/CUDA buffer overhead as fraction of model weight memory
@@ -30,6 +32,27 @@ _BUFFER_OVERHEAD_FRACTION = 0.10
 
 # Default context length for estimation when metadata unavailable
 _DEFAULT_CTX_LEN = 2048
+
+# Floor for the dynamic n_ctx computation (smaller is unusable for chat)
+_DYNAMIC_CTX_FLOOR = 512
+
+# Default ceiling for dynamic n_ctx (overridable via cfg.num_ctx_max)
+_DYNAMIC_CTX_DEFAULT_CEILING = 16384
+
+# Round dynamic n_ctx down to a multiple of this (clean batch sizes)
+_DYNAMIC_CTX_QUANTUM = 256
+
+# KV cache element size for f16 (bytes). Quantized KV reduces this.
+_KV_ELEM_BYTES_F16 = 2
+
+# Map cache-type label -> bytes per KV element (rough; q* shapes are 1 byte
+# of data plus shared scales — close enough for budgeting).
+KV_CACHE_TYPE_BYTES = {
+    "f16": 2,
+    "f32": 4,
+    "q8_0": 1,
+    "q4_0": 1,
+}
 
 
 @dataclass
@@ -53,14 +76,70 @@ class _CacheEntry:
         return self.mode in (MODE_EMBED, MODE_RERANK)
 
 
-def estimate_model_memory(model_path: Path, n_ctx: int = _DEFAULT_CTX_LEN) -> int:
+def kv_bytes_per_token(meta: dict[str, str] | None, kv_elem_bytes: int = _KV_ELEM_BYTES_F16) -> int:
+    """Estimate per-token KV cache size in bytes from GGUF metadata.
+
+    Formula: 2 (K + V) * n_layers * n_kv_heads * head_dim * elem_bytes.
+    Falls back to ``_KV_BYTES_PER_CTX_TOKEN`` when metadata is missing.
+    """
+    if not meta:
+        return _KV_BYTES_PER_CTX_TOKEN
+    try:
+        n_layers = int(meta["block_count"])
+        head_count_kv = int(meta.get("head_count_kv") or meta["head_count"])
+        if "key_length" in meta and "value_length" in meta:
+            kv_dim = int(meta["key_length"]) + int(meta["value_length"])
+        else:
+            embed = int(meta["embedding_length"])
+            head_count = int(meta.get("head_count") or head_count_kv)
+            head_dim = embed // head_count
+            kv_dim = 2 * head_dim
+    except (KeyError, ValueError, ZeroDivisionError):
+        return _KV_BYTES_PER_CTX_TOKEN
+    return n_layers * head_count_kv * kv_dim * kv_elem_bytes
+
+
+def estimate_model_memory(
+    model_path: Path,
+    n_ctx: int = _DEFAULT_CTX_LEN,
+    kv_bytes_per_tok: int = _KV_BYTES_PER_CTX_TOKEN,
+) -> int:
     """Estimate memory consumption for a GGUF model.
     Approximation: file_size (weights) + KV cache + 10% buffer overhead.
     """
     file_bytes = model_path.stat().st_size if model_path.exists() else 0
-    kv_bytes = n_ctx * _KV_BYTES_PER_CTX_TOKEN
+    kv_bytes = n_ctx * kv_bytes_per_tok
     overhead = int(file_bytes * _BUFFER_OVERHEAD_FRACTION)
     return file_bytes + kv_bytes + overhead
+
+
+def compute_dynamic_ctx(
+    *,
+    model_bytes: int,
+    available_bytes: int,
+    training_ctx: int,
+    kv_bytes_per_tok: int,
+    ceiling: int = _DYNAMIC_CTX_DEFAULT_CEILING,
+    floor: int = _DYNAMIC_CTX_FLOOR,
+    quantum: int = _DYNAMIC_CTX_QUANTUM,
+) -> int:
+    """Pick the largest n_ctx that fits in available memory.
+
+    Subtracts model weights and a 10% buffer overhead from ``available_bytes``,
+    then divides the remainder by ``kv_bytes_per_tok``. Clamps to
+    ``[floor, min(training_ctx, ceiling)]`` and rounds down to ``quantum``.
+    """
+    if kv_bytes_per_tok <= 0:
+        return min(training_ctx, ceiling)
+    overhead = int(model_bytes * _BUFFER_OVERHEAD_FRACTION)
+    budget = available_bytes - model_bytes - overhead
+    if budget <= 0:
+        return floor
+    raw_ctx = budget // kv_bytes_per_tok
+    upper = min(training_ctx, ceiling)
+    bounded = max(floor, min(raw_ctx, upper))
+    quantized = (bounded // quantum) * quantum
+    return max(floor, quantized)
 
 
 def get_available_memory(fraction: float) -> int:
@@ -77,7 +156,7 @@ def get_available_memory(fraction: float) -> int:
         total = psutil.virtual_memory().total
         return int(total * fraction)
 
-    if system == "Linux":
+    if system in ("Linux", "Windows"):
         nvidia_mem = _try_nvidia_memory()
         if nvidia_mem is not None:
             return int(nvidia_mem * fraction)

--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -46,7 +46,7 @@ _DYNAMIC_CTX_QUANTUM = 256
 _KV_ELEM_BYTES_F16 = 2
 
 # Map cache-type label -> bytes per KV element (rough; q* shapes are 1 byte
-# of data plus shared scales — close enough for budgeting).
+# of data plus shared scales, close enough for budgeting).
 KV_CACHE_TYPE_BYTES = {
     "f16": 2,
     "f32": 4,

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -10,6 +10,14 @@ from typing import Any
 
 from gguf import GGUFReader
 
+from lilbee.config import cfg
+from lilbee.providers.llama_cpp_provider import (
+    find_mmproj_for_model,
+    install_llama_log_handler,
+    read_gguf_metadata,
+    suppress_native_stderr,
+)
+
 log = logging.getLogger(__name__)
 
 
@@ -89,13 +97,7 @@ def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
 
 def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
     """Load a vision-capable ``Llama`` using the GGUF-templated chat handler."""
-    from llama_cpp import Llama
-
-    from lilbee.providers.llama_cpp_provider import (
-        find_mmproj_for_model,
-        install_llama_log_handler,
-        suppress_native_stderr,
-    )
+    from llama_cpp import Llama  # heavy native lib; keep import lazy
 
     install_llama_log_handler()
     if mmproj_path is None:
@@ -126,15 +128,7 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
 
 
 def _resolve_vision_n_ctx(model_path: Path) -> int:
-    """Pick n_ctx for a vision load, clamped to the model's training context.
-
-    Mirrors the embedding clamp in :func:`lilbee.providers.llama_cpp_provider.load_llama`.
-    Without this, ``LILBEE_NUM_CTX`` set for chat is passed through to a
-    smaller-trained vision model and llama.cpp logs ``n_ctx_seq > n_ctx_train``.
-    """
-    from lilbee.config import cfg
-    from lilbee.providers.llama_cpp_provider import read_gguf_metadata
-
+    """Pick n_ctx for a vision load, clamped to the model's training context."""
     try:
         meta = read_gguf_metadata(model_path)
     except Exception:

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -91,7 +91,6 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
     """Load a vision-capable ``Llama`` using the GGUF-templated chat handler."""
     from llama_cpp import Llama
 
-    from lilbee.config import cfg
     from lilbee.providers.llama_cpp_provider import (
         find_mmproj_for_model,
         install_llama_log_handler,
@@ -109,7 +108,7 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
         "chat_handler": chat_handler,
         "verbose": False,
         "n_gpu_layers": -1,
-        "n_ctx": cfg.num_ctx if cfg.num_ctx is not None else 0,
+        "n_ctx": _resolve_vision_n_ctx(model_path),
     }
 
     llama = suppress_native_stderr(Llama, **kwargs)
@@ -124,3 +123,26 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
         metadata.get("general.architecture", "?"),
     )
     return llama
+
+
+def _resolve_vision_n_ctx(model_path: Path) -> int:
+    """Pick n_ctx for a vision load, clamped to the model's training context.
+
+    Mirrors the embedding clamp in :func:`lilbee.providers.llama_cpp_provider.load_llama`.
+    Without this, ``LILBEE_NUM_CTX`` set for chat is passed through to a
+    smaller-trained vision model and llama.cpp logs ``n_ctx_seq > n_ctx_train``.
+    """
+    from lilbee.config import cfg
+    from lilbee.providers.llama_cpp_provider import read_gguf_metadata
+
+    try:
+        meta = read_gguf_metadata(model_path)
+    except Exception:
+        log.debug("read_gguf_metadata failed for vision %s", model_path, exc_info=True)
+        meta = None
+    train_ctx = int((meta or {}).get("context_length", "0"))
+    if cfg.num_ctx is None:
+        return 0  # 0 -> llama.cpp uses the model's training context
+    if train_ctx <= 0:
+        return cfg.num_ctx
+    return min(cfg.num_ctx, train_ctx)

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from lilbee.catalog import is_rerank_ref
 from lilbee.config import cfg
-from lilbee.providers.base import LLMProvider, ProviderError
+from lilbee.providers.base import ClosableIterator, LLMProvider, ProviderError
 from lilbee.providers.litellm_sdk import LitellmSdkBackend
 from lilbee.providers.model_ref import ProviderModelRef, parse_model_ref
 from lilbee.providers.sdk_llm_provider import SdkLLMProvider
@@ -65,7 +65,7 @@ class RoutingProvider(LLMProvider):
         stream: bool = False,
         options: dict[str, Any] | None = None,
         model: str | None = None,
-    ) -> str | Iterator[str]:
+    ) -> str | ClosableIterator[str]:
         ref = parse_model_ref(model or cfg.chat_model)
         return self._pick_backend(ref).chat(messages, stream=stream, options=options, model=model)
 

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from lilbee.config import cfg
-from lilbee.providers.base import LLMProvider, ProviderError
+from lilbee.providers.base import ClosableIterator, LLMProvider, ProviderError
 from lilbee.providers.model_ref import parse_model_ref, translate_options
 from lilbee.providers.sdk_backend import (
     PROVIDER_KEYS,
@@ -109,7 +109,7 @@ class SdkLLMProvider(LLMProvider):
         stream: bool = False,
         options: dict[str, Any] | None = None,
         model: str | None = None,
-    ) -> str | Iterator[str]:
+    ) -> str | ClosableIterator[str]:
         """Chat completion via the configured backend."""
         self._ensure_initialized()
         ref = parse_model_ref(model or cfg.chat_model)
@@ -133,7 +133,7 @@ class SdkLLMProvider(LLMProvider):
             ) from exc
         return result.content
 
-    def _chat_stream(self, request: CompletionRequest) -> Iterator[str]:
+    def _chat_stream(self, request: CompletionRequest) -> ClosableIterator[str]:
         """Yield content tokens from a streaming completion.
 
         Exceptions surfaced by the backend at either call time or during

--- a/src/lilbee/query.py
+++ b/src/lilbee/query.py
@@ -20,7 +20,7 @@ from typing_extensions import TypedDict
 
 from lilbee.config import Config, cfg
 from lilbee.embedder import Embedder
-from lilbee.providers.base import LLMProvider
+from lilbee.providers.base import ClosableIterator, LLMProvider
 from lilbee.reasoning import strip_reasoning
 from lilbee.store import (
     CHUNK_TYPE_RAW,
@@ -744,7 +744,7 @@ class Searcher:
             except (ConnectionError, OSError) as exc:
                 yield StreamToken(content=f"\n\n[Connection lost: {exc}]", is_reasoning=False)
             finally:
-                if hasattr(raw, "close"):
+                if isinstance(raw, ClosableIterator):
                     raw.close()
             return
 
@@ -770,7 +770,7 @@ class Searcher:
         except (ConnectionError, OSError) as exc:
             yield StreamToken(content=f"\n\n[Connection lost: {exc}]", is_reasoning=False)
         finally:
-            if hasattr(raw_stream, "close"):
+            if isinstance(raw_stream, ClosableIterator):
                 raw_stream.close()
         # Note: LLM-generated citation blocks in streamed tokens cannot be
         # retroactively stripped. The system prompt discourages them; this

--- a/src/lilbee/reasoning.py
+++ b/src/lilbee/reasoning.py
@@ -7,9 +7,11 @@ classifies tokens as reasoning or response content.
 
 from __future__ import annotations
 
+import contextlib
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass
+from typing import Any
 
 _OPEN_TAG = "<think>"
 _CLOSE_TAG = "</think>"
@@ -94,6 +96,10 @@ class _TagParser:
 
 _MAX_REASONING_CHARS = 16_000  # ~4K tokens — safety limit for runaway reasoning
 
+# Drain at most this many chars of post-truncation response content
+# before giving up; each token pull triggers another inference step.
+_DRAIN_CAP = 512
+
 
 def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamToken]:
     """Filter ``<think>...</think>`` tags from a token stream.
@@ -102,10 +108,24 @@ def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamTok
     Tokens outside thinking blocks are always yielded as ``is_reasoning=False``.
 
     Reasoning is capped at ``_MAX_REASONING_CHARS`` to prevent runaway
-    thinking loops (common with Qwen3 and similar models).
+    thinking loops (common with Qwen3 and similar models). On truncation
+    or normal completion we close the upstream generator so llama.cpp
+    doesn't sit suspended holding the chat lock.
     """
     parser = _TagParser(show=show)
-    truncated = False
+    try:
+        truncated = yield from _stream_until_cap(parser, tokens)
+        if truncated:
+            yield from _drain_after_truncation(parser, tokens)
+        final = parser.flush()
+        if final and final.content:
+            yield final
+    finally:
+        _close_iterator(tokens)
+
+
+def _stream_until_cap(parser: _TagParser, tokens: Iterator[str]) -> Iterator[StreamToken]:
+    """Yield from *tokens* until the reasoning cap fires. Returns True if truncated."""
     for token in tokens:
         for st in parser.feed(token):
             if st.content:
@@ -114,29 +134,28 @@ def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamTok
             parser.in_thinking = False
             parser.buf = ""
             yield StreamToken(content="\n[reasoning truncated]", is_reasoning=True)
-            truncated = True
-            break
-    if not truncated:
-        final = parser.flush()
-        if final and final.content:
-            yield final
-        return
-    # Drain a small number of tokens after truncation to capture any
-    # response content that follows a closed </think> tag. Keep the cap
-    # low: each token pull triggers a model inference step, so a large
-    # cap hangs on slow CI runners.
-    _DRAIN_CAP = 512
+            return True
+    return False
+
+
+def _drain_after_truncation(parser: _TagParser, tokens: Iterator[str]) -> Iterator[StreamToken]:
+    """After truncation, yield up to ``_DRAIN_CAP`` chars of response content."""
     drain_chars = 0
     for token in tokens:
         drain_chars += len(token)
         if drain_chars > _DRAIN_CAP:
-            break
+            return
         for st in parser.feed(token):
             if st.content and not st.is_reasoning:
                 yield st
-    final = parser.flush()
-    if final and final.content:
-        yield final
+
+
+def _close_iterator(tokens: Any) -> None:
+    """Close *tokens* if it exposes a close method (generator or stream wrapper)."""
+    close = getattr(tokens, "close", None)
+    if callable(close):
+        with contextlib.suppress(Exception):
+            close()
 
 
 def strip_reasoning(text: str) -> str:

--- a/src/lilbee/reasoning.py
+++ b/src/lilbee/reasoning.py
@@ -102,15 +102,11 @@ _DRAIN_CAP = 512
 
 
 def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamToken]:
-    """Filter ``<think>...</think>`` tags from a token stream.
-    When *show* is True, yields thinking content as ``StreamToken(is_reasoning=True)``.
-    When *show* is False, strips thinking content entirely.
-    Tokens outside thinking blocks are always yielded as ``is_reasoning=False``.
+    """Filter ``<think>...</think>`` tags from a token stream; cap runaway reasoning.
 
-    Reasoning is capped at ``_MAX_REASONING_CHARS`` to prevent runaway
-    thinking loops (common with Qwen3 and similar models). On truncation
-    or normal completion we close the upstream generator so llama.cpp
-    doesn't sit suspended holding the chat lock.
+    When *show* is True, yields thinking content as ``StreamToken(is_reasoning=True)``;
+    when False, strips it. Always closes the upstream iterator on exit so a
+    runaway think loop doesn't leave llama.cpp holding the chat lock.
     """
     parser = _TagParser(show=show)
     try:

--- a/src/lilbee/reasoning.py
+++ b/src/lilbee/reasoning.py
@@ -11,7 +11,8 @@ import contextlib
 import re
 from collections.abc import Generator, Iterator
 from dataclasses import dataclass
-from typing import Any
+
+from lilbee.providers.base import ClosableIterator
 
 _OPEN_TAG = "<think>"
 _CLOSE_TAG = "</think>"
@@ -148,12 +149,11 @@ def _drain_after_truncation(parser: _TagParser, tokens: Iterator[str]) -> Iterat
                 yield st
 
 
-def _close_iterator(tokens: Any) -> None:
-    """Close *tokens* if it exposes a close method (generator or stream wrapper)."""
-    close = getattr(tokens, "close", None)
-    if callable(close):
+def _close_iterator(tokens: Iterator[str]) -> None:
+    """Close *tokens* if it satisfies the ClosableIterator protocol."""
+    if isinstance(tokens, ClosableIterator):
         with contextlib.suppress(Exception):
-            close()
+            tokens.close()
 
 
 def strip_reasoning(text: str) -> str:

--- a/src/lilbee/reasoning.py
+++ b/src/lilbee/reasoning.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import re
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -124,7 +124,9 @@ def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamTok
         _close_iterator(tokens)
 
 
-def _stream_until_cap(parser: _TagParser, tokens: Iterator[str]) -> Iterator[StreamToken]:
+def _stream_until_cap(
+    parser: _TagParser, tokens: Iterator[str]
+) -> Generator[StreamToken, None, bool]:
     """Yield from *tokens* until the reasoning cap fires. Returns True if truncated."""
     for token in tokens:
         for st in parser.feed(token):

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -395,7 +395,7 @@ class TestPullModelData:
                 self.pull_calls.append((model, source))
                 if on_progress is not None:
                     on_progress({"status": "pulling", "completed": 25, "total": 100})
-                return None
+                return
 
         manager = _Litellm()
         with patch("lilbee.model_manager.get_model_manager", return_value=manager):

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -249,28 +249,18 @@ class TestEnsureSpacyModel:
             mock_spacy.load.assert_called_once_with("en_core_web_sm")
             assert result is not None
 
-    def test_downloads_on_oserror(self):
-        mock_spacy = MagicMock()
-        mock_spacy.load.side_effect = [OSError("not found"), MagicMock()]
-        mock_cli = MagicMock()
-        mock_spacy.cli = mock_cli
-        with patch.dict("sys.modules", {"spacy": mock_spacy, "spacy.cli": mock_cli}):
-            from lilbee.concepts import _ensure_spacy_model
+    def test_raises_import_error_with_install_hint_when_model_missing(self):
+        """Missing spaCy model emits a manual-install hint rather than shelling out.
 
-            result = _ensure_spacy_model()
-            mock_cli.download.assert_called_once_with("en_core_web_sm")
-            assert result is not None
-
-    def test_raises_import_error_when_download_fails(self):
+        Auto-download via spacy.cli.download surfaced uv stderr in the chat
+        panel under uv tool install layouts; we now degrade gracefully.
+        """
         mock_spacy = MagicMock()
         mock_spacy.load.side_effect = OSError("not found")
-        mock_cli = MagicMock()
-        mock_cli.download.side_effect = SystemExit(1)
-        mock_spacy.cli = mock_cli
-        with patch.dict("sys.modules", {"spacy": mock_spacy, "spacy.cli": mock_cli}):
+        with patch.dict("sys.modules", {"spacy": mock_spacy}):
             from lilbee.concepts import _ensure_spacy_model
 
-            with pytest.raises(ImportError, match="auto-download failed"):
+            with pytest.raises(ImportError, match="python -m spacy download en_core_web_sm"):
                 _ensure_spacy_model()
 
     def test_load_spacy_pipeline_delegates_to_ensure(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -395,6 +395,78 @@ class TestEnableOcrConfig:
             assert c.enable_ocr is None
 
 
+class TestFlashAttentionConfig:
+    def test_default_is_none(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            assert c.flash_attention is None
+
+    def test_bool_true_passes_through(self) -> None:
+        """A bool already in the right type bypasses string parsing."""
+        with mock.patch.dict(os.environ, {"LILBEE_FLASH_ATTENTION": "true"}):
+            c = Config()
+            assert c.flash_attention is True
+
+    def test_invalid_string_falls_back_to_none(self, tmp_path) -> None:
+        """Garbage values fall back to auto rather than crashing the load."""
+        env = {**_clean_env(tmp_path), "LILBEE_FLASH_ATTENTION": "maybe?"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.flash_attention is None
+
+    def test_assignment_with_bool(self, tmp_path) -> None:
+        """Validator on assignment accepts bool inputs verbatim."""
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            c.flash_attention = True
+            assert c.flash_attention is True
+
+    def test_assignment_with_int_coerces_to_bool(self, tmp_path) -> None:
+        """Non-string non-bool values fall through to bool(v)."""
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            c.flash_attention = 1  # type: ignore[assignment]
+            assert c.flash_attention is True
+
+
+class TestNGpuLayersConfig:
+    def test_default_is_none(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            assert c.n_gpu_layers is None
+
+    def test_cpu_alias_means_zero(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_N_GPU_LAYERS": "cpu"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.n_gpu_layers == 0
+
+    def test_explicit_int_string(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_N_GPU_LAYERS": "12"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.n_gpu_layers == 12
+
+    def test_invalid_string_falls_back_to_none(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_N_GPU_LAYERS": "not-a-number"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.n_gpu_layers is None
+
+    def test_assignment_with_int(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            c.n_gpu_layers = 4
+            assert c.n_gpu_layers == 4
+
+    def test_assignment_with_float_coerces(self, tmp_path) -> None:
+        """Non-string non-None values fall through to int(v)."""
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            c.n_gpu_layers = 3.0  # type: ignore[assignment]
+            assert c.n_gpu_layers == 3
+
+
 class TestSemanticChunkingConfig:
     def test_default_is_false(self, tmp_path) -> None:
         """Semantic chunking is opt-in: default False, enabled via env/config."""

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2157,7 +2157,7 @@ class TestStreamingFlush:
             call_count["n"] += 1
             if call_count["n"] == 1:
                 raise OSError("disk full")
-            return None  # second page falls through unchanged
+            return  # second page falls through unchanged
 
         with (
             patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -561,11 +561,11 @@ class TestLoadLlamaNCtx:
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         assert call_kwargs["embedding"] is False
 
-    def test_chat_default_caps_at_safe_value_when_num_ctx_unset(
+    def test_chat_default_stays_below_safe_ceiling_when_num_ctx_unset(
         self, models_dir: Path, mock_llama_cpp: mock.MagicMock
     ) -> None:
-        """num_ctx=None on chat mode caps at 8192 even when the model trains at 128K."""
-        from lilbee.providers.llama_cpp_provider import DEFAULT_NUM_CTX, load_llama
+        """num_ctx=None on chat mode never lets a 128K training window dictate KV size."""
+        from lilbee.providers.llama_cpp_provider import load_llama
         from lilbee.providers.model_cache import MODE_CHAT
 
         cfg.num_ctx = None
@@ -578,7 +578,10 @@ class TestLoadLlamaNCtx:
         load_llama(models_dir / "test-model.gguf", mode=MODE_CHAT)
 
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
-        assert call_kwargs["n_ctx"] == DEFAULT_NUM_CTX  # 8192
+        # Dynamic picker stays at or below the configured ceiling.
+        assert call_kwargs["n_ctx"] <= (cfg.num_ctx_max or 16384)
+        assert call_kwargs["n_ctx"] < 131072
+        assert call_kwargs["n_ctx"] % 256 == 0
 
     def test_chat_default_uses_training_ctx_when_smaller(
         self, models_dir: Path, mock_llama_cpp: mock.MagicMock

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -673,7 +673,7 @@ class TestLoadLlamaNCtx:
 
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         # Dynamic picker stays at or below the configured ceiling.
-        assert call_kwargs["n_ctx"] <= (cfg.num_ctx_max or 16384)
+        assert call_kwargs["n_ctx"] <= cfg.num_ctx_max
         assert call_kwargs["n_ctx"] < 131072
         assert call_kwargs["n_ctx"] % 256 == 0
 

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -551,7 +551,7 @@ class TestVisionModel:
                 return_value=mock.MagicMock(),
             ),
             mock.patch(
-                "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                "lilbee.providers.mtmd_backend.read_gguf_metadata",
                 return_value={"context_length": "2048"},
             ),
         ):
@@ -574,7 +574,7 @@ class TestVisionModel:
                 return_value=mock.MagicMock(),
             ),
             mock.patch(
-                "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                "lilbee.providers.mtmd_backend.read_gguf_metadata",
                 return_value={"context_length": "2048"},
             ),
         ):
@@ -596,7 +596,7 @@ class TestVisionModel:
                 return_value=mock.MagicMock(),
             ),
             mock.patch(
-                "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                "lilbee.providers.mtmd_backend.read_gguf_metadata",
                 side_effect=RuntimeError("metadata read broken"),
             ),
         ):

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -536,6 +536,73 @@ class TestVisionModel:
         result = find_mmproj_for_model(models_dir / "test-model.gguf")
         assert result == mmproj
 
+    def test_load_vision_llama_clamps_n_ctx_to_training_window(
+        self, models_dir: Path, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """LILBEE_NUM_CTX > vision training_ctx clamps to avoid n_ctx_seq overflow."""
+        from lilbee.providers.mtmd_backend import load_vision_llama
+
+        mmproj_path = models_dir / "test-mmproj-f16.gguf"
+        mmproj_path.write_bytes(b"fake-mmproj")
+        cfg.num_ctx = 8192
+        with (
+            mock.patch(
+                "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+                return_value=mock.MagicMock(),
+            ),
+            mock.patch(
+                "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                return_value={"context_length": "2048"},
+            ),
+        ):
+            load_vision_llama(models_dir / "test-model.gguf", mmproj_path)
+        call_kwargs = mock_llama_cpp.Llama.call_args[1]
+        assert call_kwargs["n_ctx"] == 2048
+
+    def test_load_vision_llama_unset_num_ctx_uses_model_default(
+        self, models_dir: Path, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """When LILBEE_NUM_CTX is unset, vision passes n_ctx=0 (model picks)."""
+        from lilbee.providers.mtmd_backend import load_vision_llama
+
+        mmproj_path = models_dir / "test-mmproj-f16.gguf"
+        mmproj_path.write_bytes(b"fake-mmproj")
+        cfg.num_ctx = None
+        with (
+            mock.patch(
+                "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+                return_value=mock.MagicMock(),
+            ),
+            mock.patch(
+                "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                return_value={"context_length": "2048"},
+            ),
+        ):
+            load_vision_llama(models_dir / "test-model.gguf", mmproj_path)
+        assert mock_llama_cpp.Llama.call_args[1]["n_ctx"] == 0
+
+    def test_load_vision_llama_handles_missing_metadata(
+        self, models_dir: Path, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """If GGUF metadata read fails, vision honors LILBEE_NUM_CTX verbatim."""
+        from lilbee.providers.mtmd_backend import load_vision_llama
+
+        mmproj_path = models_dir / "test-mmproj-f16.gguf"
+        mmproj_path.write_bytes(b"fake-mmproj")
+        cfg.num_ctx = 4096
+        with (
+            mock.patch(
+                "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+                return_value=mock.MagicMock(),
+            ),
+            mock.patch(
+                "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                side_effect=RuntimeError("metadata read broken"),
+            ),
+        ):
+            load_vision_llama(models_dir / "test-model.gguf", mmproj_path)
+        assert mock_llama_cpp.Llama.call_args[1]["n_ctx"] == 4096
+
 
 class TestLoadLlamaNCtx:
     def test_default_n_ctx(self, models_dir: Path, mock_llama_cpp: mock.MagicMock) -> None:

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -451,6 +451,30 @@ class TestLockedStreamIteratorClose:
         assert lock.acquire(blocking=False)
         lock.release()
 
+    def test_close_drain_cap_does_not_hang_on_runaway_model(self):
+        """A runaway model (never-closing <think>) must not block close() forever."""
+        from lilbee.providers.llama_cpp_provider import (
+            _LOCKED_STREAM_DRAIN_CAP,
+            _LockedStreamIterator,
+        )
+
+        consumed = [0]
+
+        def runaway() -> object:
+            while True:
+                consumed[0] += 1
+                yield {"choices": [{"delta": {"content": "x"}}]}
+
+        lock = threading.Lock()
+        lock.acquire()
+        stream = _LockedStreamIterator(runaway(), lock)
+        stream.close()
+        # Lock is released even though the iterator never naturally ends.
+        assert lock.acquire(blocking=False)
+        lock.release()
+        # Drain stopped near the configured cap; no infinite consumption.
+        assert consumed[0] <= _LOCKED_STREAM_DRAIN_CAP + 2
+
 
 class TestLockedStreamIteratorExceptionRelease:
     def test_non_stop_iteration_exception_releases_lock(self):

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -533,14 +533,17 @@ class TestLoadLlamaNCtx:
         assert call_kwargs["n_batch"] == 2048
 
     def test_custom_n_ctx(self, models_dir: Path, mock_llama_cpp: mock.MagicMock) -> None:
-        """When num_ctx is set, load_llama uses it for n_ctx and n_batch."""
+        """When num_ctx is set, embedding load clamps to the model's training context."""
         from lilbee.providers.llama_cpp_provider import load_llama
         from lilbee.providers.model_cache import MODE_EMBED
 
         cfg.num_ctx = 8192
+        # Embedding model trains at 8192; cfg.num_ctx fits, no clamp.
+        mock_llama_cpp.Llama.return_value.metadata = {
+            "general.architecture": "nomic-bert",
+            "nomic-bert.context_length": "8192",
+        }
         load_llama(models_dir / "test-model.gguf", mode=MODE_EMBED)
-
-        # No metadata read needed when n_ctx is explicit
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         assert call_kwargs["n_ctx"] == 8192
         assert call_kwargs["n_batch"] == 8192

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -233,6 +233,14 @@ class TestStatus:
         assert "vision_model" in result["config"]
         assert "reranker_model" in result["config"]
 
+    def test_status_exposes_memory_tuning_settings(self):
+        """MCP status reports the dynamic-ctx tuning knobs so clients can read them."""
+        result = status()
+        for key in ("num_ctx", "num_ctx_max", "flash_attention", "kv_cache_type", "n_gpu_layers"):
+            assert key in result["config"], f"missing {key} in MCP status"
+        # Enum value is stringified (kv_cache_type is a StrEnum, not raw text)
+        assert isinstance(result["config"]["kv_cache_type"], str)
+
 
 class TestSync:
     @mock.patch("lilbee.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -485,3 +485,15 @@ def test_compute_dynamic_ctx_honors_ceiling() -> None:
         ceiling=8192,
     )
     assert ctx == 8192
+
+
+def test_compute_dynamic_ctx_zero_kv_falls_back_to_training_or_ceiling() -> None:
+    """Zero/negative kv_bytes_per_tok (degenerate metadata) returns min(training, ceiling)."""
+    ctx = compute_dynamic_ctx(
+        model_bytes=1_000_000,
+        available_bytes=10**12,
+        training_ctx=4096,
+        kv_bytes_per_tok=0,
+        ceiling=8192,
+    )
+    assert ctx == 4096

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -13,8 +13,10 @@ from lilbee.providers.model_cache import (
     MemoryAwareModelCache,
     _CacheEntry,
     _try_nvidia_memory,
+    compute_dynamic_ctx,
     estimate_model_memory,
     get_available_memory,
+    kv_bytes_per_token,
 )
 
 
@@ -356,3 +358,130 @@ def test_try_nvidia_memory_nvidia_smi_nonzero_exit() -> None:
         result = _try_nvidia_memory()
 
     assert result is None
+
+
+@mock.patch("psutil.virtual_memory")
+def test_get_available_memory_windows_nvidia(mock_vm: mock.MagicMock) -> None:
+    """Windows + NVIDIA picks pynvml VRAM, not system RAM."""
+    mock_vm.return_value = mock.MagicMock(total=16 * 1024**3)
+    gpu_total = 8 * 1024**3
+    with (
+        mock.patch("lilbee.providers.model_cache.platform.system", return_value="Windows"),
+        mock.patch("lilbee.providers.model_cache._try_nvidia_memory", return_value=gpu_total),
+    ):
+        result = get_available_memory(0.75)
+    assert result == int(gpu_total * 0.75)
+
+
+@mock.patch("psutil.virtual_memory")
+def test_get_available_memory_windows_no_nvidia(mock_vm: mock.MagicMock) -> None:
+    """Windows without NVIDIA falls back to system RAM."""
+    mock_vm.return_value = mock.MagicMock(total=16 * 1024**3)
+    with (
+        mock.patch("lilbee.providers.model_cache.platform.system", return_value="Windows"),
+        mock.patch("lilbee.providers.model_cache._try_nvidia_memory", return_value=None),
+    ):
+        result = get_available_memory(0.5)
+    assert result == int(16 * 1024**3 * 0.5)
+
+
+def test_kv_bytes_per_token_uses_metadata() -> None:
+    """KV bytes/token = 2 * n_layers * n_kv_heads * (key_length + value_length) * elem_bytes."""
+    meta = {
+        "block_count": "32",
+        "head_count_kv": "8",
+        "key_length": "128",
+        "value_length": "128",
+    }
+    # f16: 2 bytes/elem, no leading factor of 2 here because key+value already sum
+    expected = 32 * 8 * (128 + 128) * 2
+    assert kv_bytes_per_token(meta, kv_elem_bytes=2) == expected
+
+
+def test_kv_bytes_per_token_quantized_kv() -> None:
+    """q8_0 cuts per-token bytes in half vs f16."""
+    meta = {
+        "block_count": "32",
+        "head_count_kv": "8",
+        "key_length": "128",
+        "value_length": "128",
+    }
+    f16 = kv_bytes_per_token(meta, kv_elem_bytes=2)
+    q8 = kv_bytes_per_token(meta, kv_elem_bytes=1)
+    assert q8 == f16 // 2
+
+
+def test_kv_bytes_per_token_fallback_when_meta_missing() -> None:
+    """Missing metadata returns the conservative flat constant."""
+    assert kv_bytes_per_token(None) == 2048
+    assert kv_bytes_per_token({}) == 2048
+
+
+def test_kv_bytes_per_token_derives_head_dim_from_embedding() -> None:
+    """Without explicit key_length, fall back to embedding_length / head_count."""
+    meta = {
+        "block_count": "16",
+        "head_count_kv": "4",
+        "head_count": "8",
+        "embedding_length": "1024",
+    }
+    head_dim = 1024 // 8
+    expected = 16 * 4 * (2 * head_dim) * 2
+    assert kv_bytes_per_token(meta, kv_elem_bytes=2) == expected
+
+
+def test_compute_dynamic_ctx_typical_case() -> None:
+    """Picks the largest 256-multiple ctx that fits the budget."""
+    # 4 GB model, 8 GB available, 256 KB/token KV.
+    model_bytes = 4 * 1024**3
+    available = 8 * 1024**3
+    kv_per_tok = 256 * 1024
+    ctx = compute_dynamic_ctx(
+        model_bytes=model_bytes,
+        available_bytes=available,
+        training_ctx=131072,
+        kv_bytes_per_tok=kv_per_tok,
+        ceiling=16384,
+    )
+    overhead = int(model_bytes * 0.10)
+    budget = available - model_bytes - overhead
+    raw = budget // kv_per_tok
+    expected = (min(raw, 16384) // 256) * 256
+    assert ctx == expected
+    assert ctx % 256 == 0
+
+
+def test_compute_dynamic_ctx_returns_floor_when_oversubscribed() -> None:
+    """When the model alone exceeds available memory, return the floor."""
+    ctx = compute_dynamic_ctx(
+        model_bytes=10 * 1024**3,
+        available_bytes=2 * 1024**3,
+        training_ctx=8192,
+        kv_bytes_per_tok=128 * 1024,
+        ceiling=16384,
+    )
+    assert ctx == 512
+
+
+def test_compute_dynamic_ctx_honors_training_ctx_upper_bound() -> None:
+    """Even with infinite memory, never exceed the model's training window."""
+    ctx = compute_dynamic_ctx(
+        model_bytes=100,
+        available_bytes=10**12,
+        training_ctx=4096,
+        kv_bytes_per_tok=1,
+        ceiling=131072,
+    )
+    assert ctx == 4096
+
+
+def test_compute_dynamic_ctx_honors_ceiling() -> None:
+    """The ceiling caps a generous training window on a generous host."""
+    ctx = compute_dynamic_ctx(
+        model_bytes=100,
+        available_bytes=10**12,
+        training_ctx=131072,
+        kv_bytes_per_tok=1,
+        ceiling=8192,
+    )
+    assert ctx == 8192

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -236,7 +236,7 @@ class TestPullWithProgress:
         def fake_pull(model, source, *, on_bytes=None):
             if on_bytes:
                 on_bytes(100, 100)
-            return None
+            return
 
         mock_manager.pull.side_effect = fake_pull
         mock_get_manager.return_value = mock_manager
@@ -250,7 +250,7 @@ class TestPullWithProgress:
         def fake_pull(model, source, *, on_bytes=None):
             if on_bytes:
                 on_bytes(0, 0)
-            return None
+            return
 
         mock_manager.pull.side_effect = fake_pull
         mock_get_manager.return_value = mock_manager

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -355,6 +355,125 @@ class TestLlamaCppProvider:
         # bare re-raise preserves the original chain; the exception isn't its own cause
         assert exc_info.value.__cause__ is None
 
+    def testload_llama_chat_passes_flash_attn_by_default(self, models_dir: Path) -> None:
+        """Chat mode enables flash attention to halve the KV cache padding waste."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 4096
+        cfg.flash_attention = "auto"
+        with patch("llama_cpp.Llama") as mock_llama_cls:
+            load_llama(models_dir / "test-model.gguf", mode="chat")
+            assert mock_llama_cls.call_args[1].get("flash_attn") is True
+
+    def testload_llama_chat_skips_flash_attn_when_disabled(self, models_dir: Path) -> None:
+        """LILBEE_FLASH_ATTENTION=0 leaves the kwarg unset (llama-cpp default)."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 4096
+        cfg.flash_attention = "0"
+        try:
+            with patch("llama_cpp.Llama") as mock_llama_cls:
+                load_llama(models_dir / "test-model.gguf", mode="chat")
+                assert "flash_attn" not in mock_llama_cls.call_args[1]
+        finally:
+            cfg.flash_attention = "auto"
+
+    def testload_llama_falls_back_when_flash_attn_unsupported(self, models_dir: Path) -> None:
+        """Older llama-cpp-python builds reject flash_attn=True; we drop it and retry."""
+        from unittest.mock import MagicMock, patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 4096
+        cfg.flash_attention = "auto"
+        instance = MagicMock()
+        call_log: list[dict[str, object]] = []
+
+        def fake_llama(**kwargs: object) -> object:
+            call_log.append(kwargs)
+            if kwargs.get("flash_attn"):
+                raise TypeError("Llama.__init__() got an unexpected keyword argument 'flash_attn'")
+            return instance
+
+        with patch("llama_cpp.Llama", side_effect=fake_llama):
+            result = load_llama(models_dir / "test-model.gguf", mode="chat")
+        assert result is instance
+        assert len(call_log) == 2
+        assert call_log[0].get("flash_attn") is True
+        assert "flash_attn" not in call_log[1]
+
+    def testload_llama_retries_with_halved_ctx_on_oom(self, models_dir: Path) -> None:
+        """A llama_context load failure halves n_ctx and retries before wrapping the error."""
+        from unittest.mock import MagicMock, patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 4096
+        cfg.flash_attention = "0"  # keep the call shape simple
+        instance = MagicMock()
+        ctx_seen: list[int] = []
+
+        def fake_llama(**kwargs: object) -> object:
+            ctx_seen.append(int(kwargs["n_ctx"]))
+            if int(kwargs["n_ctx"]) > 1024:
+                raise ValueError("Failed to create llama_context")
+            return instance
+
+        try:
+            with patch("llama_cpp.Llama", side_effect=fake_llama):
+                result = load_llama(models_dir / "test-model.gguf", mode="chat")
+            assert result is instance
+            assert ctx_seen[0] == 4096
+            assert ctx_seen[-1] <= 1024
+            assert len(ctx_seen) >= 2
+        finally:
+            cfg.flash_attention = "auto"
+
+    def testload_llama_dynamic_ctx_picks_smaller_for_tight_memory(self, models_dir: Path) -> None:
+        """When LILBEE_NUM_CTX is unset, n_ctx is sized to the host's free memory."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = None
+        cfg.flash_attention = "0"
+        meta = {
+            "context_length": "131072",
+            "block_count": "32",
+            "head_count_kv": "8",
+            "key_length": "128",
+            "value_length": "128",
+        }
+        try:
+            with (
+                patch("llama_cpp.Llama") as mock_llama_cls,
+                patch(
+                    "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                    return_value=meta,
+                ),
+                patch(
+                    "lilbee.providers.llama_cpp_provider.cfg.gpu_memory_fraction",
+                    0.75,
+                ),
+                patch(
+                    "lilbee.providers.model_cache.get_available_memory",
+                    return_value=(8 * 1024**3),
+                ),
+            ):
+                load_llama(models_dir / "test-model.gguf", mode="chat")
+                ctx_used = mock_llama_cls.call_args[1]["n_ctx"]
+            assert 512 <= ctx_used <= 16384
+            assert ctx_used % 256 == 0
+            # Should be much smaller than the 131072 training window on a tight host.
+            assert ctx_used < 131072
+        finally:
+            cfg.num_ctx = None
+            cfg.flash_attention = "auto"
+
     def testload_llama_routes_llama_logs_through_python_logger(
         self, models_dir: Path, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1739,7 +1739,7 @@ class TestMtmdLoadVisionLlama:
 
         with (
             mock.patch(
-                "lilbee.providers.llama_cpp_provider.find_mmproj_for_model",
+                "lilbee.providers.mtmd_backend.find_mmproj_for_model",
                 return_value=Path("found_mmproj.gguf"),
             ),
             mock.patch(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -266,6 +266,11 @@ class TestLlamaCppProvider:
             "general.file_type": "15",
             "qwen3.context_length": "32768",
             "qwen3.embedding_length": "4096",
+            "qwen3.block_count": "32",
+            "qwen3.attention.head_count_kv": "8",
+            "qwen3.attention.head_count": "32",
+            "qwen3.attention.key_length": "128",
+            "qwen3.attention.value_length": "128",
             "tokenizer.chat_template": "{% if messages %}...",
         }
         with patch("llama_cpp.Llama", return_value=mock_llm):
@@ -275,6 +280,12 @@ class TestLlamaCppProvider:
         assert result["embedding_length"] == "4096"
         assert result["chat_template"] == "{% if messages %}..."
         assert result["name"] == "Qwen3 8B"
+        # KV-shape fields surfaced for the dynamic n_ctx picker.
+        assert result["block_count"] == "32"
+        assert result["head_count_kv"] == "8"
+        assert result["head_count"] == "32"
+        assert result["key_length"] == "128"
+        assert result["value_length"] == "128"
         mock_llm.close.assert_called_once()
 
     def testread_gguf_metadata_empty(self, models_dir: Path) -> None:
@@ -433,6 +444,225 @@ class TestLlamaCppProvider:
         finally:
             cfg.flash_attention = "auto"
 
+    def testload_llama_resolves_n_gpu_layers_modes(self, models_dir: Path) -> None:
+        """LILBEE_N_GPU_LAYERS supports 'auto', 'cpu', explicit int, and falls back on garbage."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 4096
+        cfg.flash_attention = "0"
+        try:
+            cases = [
+                ("cpu", 0),
+                ("auto", -1),
+                ("12", 12),
+                ("not-an-int", -1),
+            ]
+            for raw, expected in cases:
+                cfg.n_gpu_layers = raw
+                with patch("llama_cpp.Llama") as mock_llama_cls:
+                    load_llama(models_dir / "test-model.gguf", mode="chat")
+                    assert mock_llama_cls.call_args[1]["n_gpu_layers"] == expected
+        finally:
+            cfg.n_gpu_layers = "auto"
+            cfg.flash_attention = "auto"
+
+    def testapply_kv_cache_type_skips_when_internal_module_missing(self) -> None:
+        """Older llama-cpp-python without ``llama_cpp.llama_cpp`` skips the KV-quant kwargs."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import _apply_kv_cache_type
+
+        kwargs: dict[str, object] = {}
+        with (
+            patch.object(cfg, "kv_cache_type", "q8_0"),
+            patch("lilbee.providers.llama_cpp_provider._ggml_type_map", return_value=None),
+        ):
+            _apply_kv_cache_type(kwargs)
+        assert "type_k" not in kwargs
+        assert "type_v" not in kwargs
+
+    def testload_llama_oom_retry_halves_embed_batch_sizes(self, models_dir: Path) -> None:
+        """OOM retry on embed loads halves n_batch and n_ubatch alongside n_ctx."""
+        from unittest.mock import MagicMock, patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 4096
+        cfg.flash_attention = "0"
+        instance = MagicMock()
+        seen: list[dict[str, int]] = []
+
+        def fake_llama(**kwargs: object) -> object:
+            seen.append({k: int(kwargs[k]) for k in ("n_ctx", "n_batch", "n_ubatch")})
+            if int(kwargs["n_ctx"]) > 1024:
+                raise ValueError("Failed to create llama_context")
+            return instance
+
+        try:
+            mock_llama_cpp = MagicMock()
+            mock_llama_cpp.metadata = {
+                "general.architecture": "nomic-bert",
+                "nomic-bert.context_length": "8192",
+            }
+            with (
+                patch("llama_cpp.Llama", side_effect=fake_llama),
+                patch(
+                    "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                    return_value={"context_length": "8192"},
+                ),
+            ):
+                load_llama(models_dir / "test-model.gguf", mode="embed")
+            # First attempt at 4096 fails; retry halves all three.
+            assert seen[0]["n_ctx"] == 4096
+            assert seen[0]["n_batch"] == 4096
+            assert seen[0]["n_ubatch"] == 4096
+            assert seen[-1]["n_ctx"] <= 1024
+            assert seen[-1]["n_batch"] == seen[-1]["n_ctx"]
+            assert seen[-1]["n_ubatch"] == seen[-1]["n_ctx"]
+        finally:
+            cfg.flash_attention = "auto"
+
+    def testhalve_ctx_for_retry_returns_false_with_no_n_ctx(self) -> None:
+        """``_halve_ctx_for_retry`` is a no-op when n_ctx is missing or zero."""
+        from lilbee.providers.llama_cpp_provider import _halve_ctx_for_retry
+
+        kwargs: dict[str, object] = {}
+        assert _halve_ctx_for_retry(kwargs, ValueError("oom")) is False
+
+    def testload_llama_kv_cache_type_drops_to_f16_on_unknown_label(self, models_dir: Path) -> None:
+        """Unknown LILBEE_KV_CACHE_TYPE values warn and fall back to default f16."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 4096
+        cfg.flash_attention = "0"
+        cfg.kv_cache_type = "totally-not-a-real-type"
+        try:
+            with patch("llama_cpp.Llama") as mock_llama_cls:
+                load_llama(models_dir / "test-model.gguf", mode="chat")
+                kwargs = mock_llama_cls.call_args[1]
+                assert "type_k" not in kwargs
+                assert "type_v" not in kwargs
+        finally:
+            cfg.kv_cache_type = "f16"
+            cfg.flash_attention = "auto"
+
+    def testload_llama_kv_cache_type_q8_0_passes_ggml_type_to_llama(self, models_dir: Path) -> None:
+        """LILBEE_KV_CACHE_TYPE=q8_0 maps to llama-cpp-python's GGML_TYPE_Q8_0 constant."""
+        from unittest.mock import patch
+
+        import llama_cpp.llama_cpp as _llc
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 4096
+        cfg.flash_attention = "0"
+        cfg.kv_cache_type = "q8_0"
+        try:
+            with patch("llama_cpp.Llama") as mock_llama_cls:
+                load_llama(models_dir / "test-model.gguf", mode="chat")
+                kwargs = mock_llama_cls.call_args[1]
+                assert kwargs["type_k"] == _llc.GGML_TYPE_Q8_0
+                assert kwargs["type_v"] == _llc.GGML_TYPE_Q8_0
+        finally:
+            cfg.kv_cache_type = "f16"
+            cfg.flash_attention = "auto"
+
+    def testload_llama_unrelated_typeerror_propagates(self, models_dir: Path) -> None:
+        """A TypeError that isn't about flash_attn passes through unchanged."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 4096
+        with (
+            patch("llama_cpp.Llama", side_effect=TypeError("totally unrelated")),
+            pytest.raises(TypeError, match="totally unrelated"),
+        ):
+            load_llama(models_dir / "test-model.gguf", mode="chat")
+
+    def testload_llama_oom_at_min_ctx_raises_diagnostic(self, models_dir: Path) -> None:
+        """When n_ctx is already at the floor, OOM retry gives up and wraps the error."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 512  # Already at the floor; halving can't progress.
+        cfg.flash_attention = "0"
+        try:
+            model = models_dir / "tiny.gguf"
+            model.write_bytes(b"x" * 1024)
+            with (
+                patch("llama_cpp.Llama", side_effect=ValueError("Failed to create llama_context")),
+                pytest.raises(ValueError, match=r"Failed to load tiny\.gguf"),
+            ):
+                load_llama(model, mode="chat")
+        finally:
+            cfg.flash_attention = "auto"
+
+    def testload_llama_dynamic_ctx_falls_back_to_static_cap_on_psutil_failure(
+        self, models_dir: Path
+    ) -> None:
+        """If memory accounting raises (psutil missing/broken), use min(training, default)."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = None
+        cfg.flash_attention = "0"
+        try:
+            with (
+                patch("llama_cpp.Llama") as mock_llama_cls,
+                patch(
+                    "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                    return_value={"context_length": "4096"},
+                ),
+                patch(
+                    "lilbee.providers.model_cache.get_available_memory",
+                    side_effect=OSError("psutil broken"),
+                ),
+            ):
+                load_llama(models_dir / "test-model.gguf", mode="chat")
+                # Falls back to min(4096, DEFAULT_NUM_CTX=8192) -> 4096
+                assert mock_llama_cls.call_args[1]["n_ctx"] == 4096
+        finally:
+            cfg.flash_attention = "auto"
+
+    def testload_llama_dynamic_ctx_handles_bad_training_ctx_metadata(
+        self, models_dir: Path
+    ) -> None:
+        """A non-numeric context_length in metadata falls back to DEFAULT_NUM_CTX."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp_provider import (
+            DEFAULT_NUM_CTX,
+            load_llama,
+        )
+
+        cfg.num_ctx = None
+        cfg.flash_attention = "0"
+        try:
+            with (
+                patch("llama_cpp.Llama") as mock_llama_cls,
+                patch(
+                    "lilbee.providers.llama_cpp_provider.read_gguf_metadata",
+                    return_value={"context_length": "not-a-number"},
+                ),
+                patch(
+                    "lilbee.providers.model_cache.get_available_memory",
+                    return_value=64 * 1024**3,
+                ),
+            ):
+                load_llama(models_dir / "test-model.gguf", mode="chat")
+                # With DEFAULT_NUM_CTX as the training fallback and 64 GB
+                # available memory, the picker is bounded by that fallback.
+                assert mock_llama_cls.call_args[1]["n_ctx"] <= DEFAULT_NUM_CTX
+        finally:
+            cfg.flash_attention = "auto"
+
     def testload_llama_dynamic_ctx_picks_smaller_for_tight_memory(self, models_dir: Path) -> None:
         """When LILBEE_NUM_CTX is unset, n_ctx is sized to the host's free memory."""
         from unittest.mock import patch
@@ -575,6 +805,36 @@ class TestLlamaCppProvider:
             prov._llama_log_pending.update(prior_pending)
             prov._llama_log_pending_level = prior_pending_level
 
+    def testllama_log_demotes_known_advisory_errors_to_warning(self) -> None:
+        """Tokenizer / KV-cache advisories emit at GGML ERROR but aren't load failures."""
+        import logging
+
+        from lilbee.providers import llama_cpp_provider as prov
+
+        prior_pending = dict(prov._llama_log_pending)
+        prior_pending_level = prov._llama_log_pending_level
+        prov._llama_log_pending.clear()
+        logger = logging.getLogger("lilbee.llama_cpp")
+        records: list[logging.LogRecord] = []
+        handler = logging.Handler()
+        handler.emit = records.append  # type: ignore[method-assign]
+        logger.addHandler(handler)
+        try:
+            advisories = (
+                b"load: special_eos_id is not in special_eog_ids\n",
+                b"init: embeddings required but some input tokens were not marked as outputs\n",
+                b"llama_context: n_ctx_seq (3072) > n_ctx_train (2048)\n",
+            )
+            for line in advisories:
+                prov._llama_log_dispatch(3, line, None)
+            for r in records:
+                assert r.levelno == logging.WARNING, f"advisory '{r.message}' kept at ERROR"
+        finally:
+            logger.removeHandler(handler)
+            prov._llama_log_pending.clear()
+            prov._llama_log_pending.update(prior_pending)
+            prov._llama_log_pending_level = prior_pending_level
+
     def testresolve_model_path_direct(self, models_dir: Path, tmp_path: Path) -> None:
         self._resolve_patcher.stop()
         try:
@@ -641,16 +901,20 @@ class TestLlamaCppProvider:
     def test_embed_caches_llm(self, mock_llama_cpp: mock.MagicMock) -> None:
         mock_llama_instance = mock.MagicMock()
         mock_llama_instance.create_embedding.return_value = {"data": [{"embedding": [0.1] * 3}]}
+        mock_llama_instance.metadata = {
+            "general.architecture": "nomic-bert",
+            "nomic-bert.context_length": "8192",
+        }
         mock_llama_cpp.Llama.return_value = mock_llama_instance
 
-        cfg.num_ctx = 4096  # Explicit ctx skips metadata read
+        cfg.num_ctx = 4096
         provider = self._make_provider()
         provider.embed(["a"])
         provider.embed(["b"])
 
-        # With explicit num_ctx, no metadata read needed — only 1 Llama call.
-        # Second embed reuses the cached instance.
-        assert mock_llama_cpp.Llama.call_count == 1
+        # Embedding load reads metadata once (vocab_only) plus the actual
+        # load. Second embed reuses the cached instance, so we expect 2.
+        assert mock_llama_cpp.Llama.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -2362,16 +2626,40 @@ class TestLoadLlama:
         assert call_kwargs["n_batch"] == 2048
 
     def test_embedding_with_explicit_ctx(self, mock_llama_cpp: mock.MagicMock) -> None:
-        """load_llama with explicit num_ctx uses it for n_batch."""
+        """Explicit num_ctx <= training_ctx is honored verbatim for embeddings."""
         from lilbee.providers.llama_cpp_provider import load_llama
 
         cfg.num_ctx = 4096
+        mock_llama_cpp.Llama.return_value.metadata = {
+            "general.architecture": "nomic-bert",
+            "nomic-bert.context_length": "8192",
+        }
 
         load_llama(Path("/test.gguf"), mode="embed")
 
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         assert call_kwargs["n_ctx"] == 4096
         assert call_kwargs["n_batch"] == 4096
+
+    def test_embedding_clamps_explicit_ctx_to_training_ctx(
+        self, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """num_ctx > training_ctx clamps to the model's training window for embeddings."""
+        from lilbee.providers.llama_cpp_provider import load_llama
+
+        cfg.num_ctx = 3072
+        # Embedding model trains at 2048: clamp 3072 -> 2048 to avoid the
+        # 'n_ctx_seq (3072) > n_ctx_train (2048)' warning users see in the chat.
+        mock_llama_cpp.Llama.return_value.metadata = {
+            "general.architecture": "nomic-bert",
+            "nomic-bert.context_length": "2048",
+        }
+
+        load_llama(Path("/test.gguf"), mode="embed")
+
+        call_kwargs = mock_llama_cpp.Llama.call_args[1]
+        assert call_kwargs["n_ctx"] == 2048
+        assert call_kwargs["n_batch"] == 2048
 
     def test_chat_mode(self, mock_llama_cpp: mock.MagicMock) -> None:
         """load_llama for chat does not set n_batch."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -531,24 +531,12 @@ class TestLlamaCppProvider:
         kwargs: dict[str, object] = {}
         assert _halve_ctx_for_retry(kwargs, ValueError("oom")) is False
 
-    def testload_llama_kv_cache_type_drops_to_f16_on_unknown_label(self, models_dir: Path) -> None:
-        """Unknown LILBEE_KV_CACHE_TYPE values warn and fall back to default f16."""
-        from unittest.mock import patch
+    def testkv_cache_type_rejects_unknown_values_at_assignment(self) -> None:
+        """Pydantic enforces the KvCacheType enum; unknown labels raise at assignment."""
+        from pydantic import ValidationError
 
-        from lilbee.providers.llama_cpp_provider import load_llama
-
-        cfg.num_ctx = 4096
-        cfg.flash_attention = "0"
-        cfg.kv_cache_type = "totally-not-a-real-type"
-        try:
-            with patch("llama_cpp.Llama") as mock_llama_cls:
-                load_llama(models_dir / "test-model.gguf", mode="chat")
-                kwargs = mock_llama_cls.call_args[1]
-                assert "type_k" not in kwargs
-                assert "type_v" not in kwargs
-        finally:
-            cfg.kv_cache_type = "f16"
-            cfg.flash_attention = "auto"
+        with pytest.raises(ValidationError, match="Input should be"):
+            cfg.kv_cache_type = "totally-not-a-real-type"  # type: ignore[assignment]
 
     def testload_llama_kv_cache_type_q8_0_passes_ggml_type_to_llama(self, models_dir: Path) -> None:
         """LILBEE_KV_CACHE_TYPE=q8_0 maps to llama-cpp-python's GGML_TYPE_Q8_0 constant."""

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -224,6 +224,54 @@ class TestReasoningTruncation:
         result = _collect(tokens, show=True)
         assert any("truncated" in st.content for st in result)
 
+    def test_upstream_generator_closed_on_truncation(self):
+        """Truncation closes the upstream iterator so llama.cpp doesn't hang.
+
+        Without this, a runaway think loop leaves llama.cpp suspended at
+        its yield point and the chat lock isn't released until garbage
+        collection eventually fires __del__.
+        """
+        from lilbee.reasoning import filter_reasoning
+
+        closed = {"value": False}
+
+        def runaway_tokens():
+            """Yields forever; never emits </think>. Simulates a stuck model."""
+            try:
+                yield "<think>"
+                while True:
+                    yield "x"
+            except GeneratorExit:
+                closed["value"] = True
+                raise
+
+        # Drive the filter to completion. Truncation should fire and the
+        # generator must be left in a suspended state for close() to act on.
+        list(filter_reasoning(runaway_tokens(), show=True))
+        assert closed["value"], "filter_reasoning must close upstream iterator"
+
+    def test_close_called_on_stream_wrapper_early_exit(self):
+        """A stream-wrapper iterator (e.g. _LockedStreamIterator) gets close()."""
+        from lilbee.reasoning import _MAX_REASONING_CHARS, filter_reasoning
+
+        class FakeStream:
+            def __init__(self) -> None:
+                self.tokens = iter(["<think>"] + ["x"] * (_MAX_REASONING_CHARS + 100))
+                self.closed = False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                return next(self.tokens)
+
+            def close(self) -> None:
+                self.closed = True
+
+        stream = FakeStream()
+        list(filter_reasoning(stream, show=True))
+        assert stream.closed, "filter_reasoning must call close() on stream wrapper"
+
 
 class TestStripReasoning:
     def test_strips_think_block(self):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1072,7 +1072,7 @@ class TestModelsPull:
             if on_bytes:
                 on_bytes(500, 1000)
                 on_bytes(1000, 1000)
-            return None
+            return
 
         mock_manager.pull.side_effect = fake_pull
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):
@@ -1089,7 +1089,7 @@ class TestModelsPull:
             if on_progress:
                 on_progress({"status": "downloading"})
                 on_progress({"status": "success"})
-            return None
+            return
 
         mock_manager.pull.side_effect = fake_pull
         with patch("lilbee.server.handlers.get_model_manager", return_value=mock_manager):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -120,3 +120,41 @@ class TestTomlEscaping:
         assert _escape_toml_string("a\tb") == r"a\tb"
         assert _escape_toml_string("normal") == "normal"
         assert _escape_toml_string("") == ""
+
+
+class TestMemoryTuningSettingsMap:
+    """The dynamic-ctx tuning knobs are surfaced in the TUI settings map."""
+
+    def test_num_ctx_max_in_settings_map(self):
+        from lilbee.cli.settings_map import SETTINGS_MAP, get_default
+
+        defn = SETTINGS_MAP["num_ctx_max"]
+        assert defn.writable is True
+        assert defn.nullable is False
+        assert defn.group == "Generation"
+        assert get_default("num_ctx_max") == 16384
+
+    def test_flash_attention_in_settings_map(self):
+        from lilbee.cli.settings_map import SETTINGS_MAP, get_default
+
+        defn = SETTINGS_MAP["flash_attention"]
+        assert defn.writable is True
+        assert defn.nullable is True  # tri-state: None=auto
+        assert defn.type is bool
+        assert get_default("flash_attention") is None
+
+    def test_kv_cache_type_in_settings_map(self):
+        from lilbee.cli.settings_map import SETTINGS_MAP
+        from lilbee.config import KvCacheType
+
+        defn = SETTINGS_MAP["kv_cache_type"]
+        assert defn.writable is True
+        assert defn.choices == tuple(t.value for t in KvCacheType)
+
+    def test_n_gpu_layers_in_settings_map(self):
+        from lilbee.cli.settings_map import SETTINGS_MAP, get_default
+
+        defn = SETTINGS_MAP["n_gpu_layers"]
+        assert defn.writable is True
+        assert defn.nullable is True  # None = auto/all
+        assert get_default("n_gpu_layers") is None

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -579,9 +579,9 @@ class TestThemes:
         app = LilbeeApp()
         async with app.run_test() as pilot:
             await pilot.pause()
+            original = app.theme
             app.set_theme("nonexistent_theme_xyz")
-            # Should still be on default theme (monokai)
-            assert app.theme == "gruvbox"
+            assert app.theme == original
 
 
 class TestDetectRemoteEmbeddings:

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2803,3 +2803,47 @@ class TestChatEmbeddingReadyCoverage:
         finally:
             set_services(None)
             cfg.embedding_model = snapshot_embed
+
+
+class TestStreamFlushCoalescing:
+    """Token coalescing in _consume_stream prevents per-token call_from_thread floods."""
+
+    def test_maybe_flush_calls_flush_when_interval_elapses(self):
+        """When the elapsed time crosses the threshold, flush() runs and timing advances."""
+        from unittest.mock import MagicMock
+
+        from lilbee.cli.tui.screens.chat import ChatScreen
+
+        screen = MagicMock(spec=ChatScreen)
+        flush_calls: list[None] = []
+
+        def fake_flush() -> None:
+            flush_calls.append(None)
+
+        # Past timings: long enough ago that both the flush and the scroll fire.
+        timings = [0.0, 0.0]
+        with mock.patch("lilbee.cli.tui.screens.chat.call_from_thread"):
+            ChatScreen._maybe_flush_and_scroll(screen, fake_flush, timings)
+        assert len(flush_calls) == 1
+        assert timings[0] > 0  # last_flush bumped
+
+    def test_maybe_flush_skips_flush_within_interval(self):
+        """Inside the flush window, flush() is not called and timings stay unchanged."""
+        import time
+        from unittest.mock import MagicMock
+
+        from lilbee.cli.tui.screens.chat import ChatScreen
+
+        screen = MagicMock(spec=ChatScreen)
+        flush_calls: list[None] = []
+
+        def fake_flush() -> None:
+            flush_calls.append(None)
+
+        # Set timings to 'right now' so the interval check fails.
+        now = time.monotonic()
+        timings = [now, now]
+        with mock.patch("lilbee.cli.tui.screens.chat.call_from_thread"):
+            ChatScreen._maybe_flush_and_scroll(screen, fake_flush, timings)
+        assert flush_calls == []
+        assert timings == [now, now]

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -1468,8 +1468,7 @@ class TestRunFullSynthesize:
         captured: dict[str, object] = {}
 
         def fake_get_services():
-            svc = MagicMock()
-            return svc
+            return MagicMock()
 
         def fake_generate(provider, store, clusterer, config):
             captured["config"] = config


### PR DESCRIPTION
## The bug

Massive thanks to my friend @ELbioinfogene for surfacing these and helping me test

Two QA reports on Windows. Both log captures are part of the test matrix:

* **Memory log** - A 16 GB Windows laptop fails to load Gemma3 with our `Host has 4.8 GB free RAM. Try a smaller model, lower LILBEE_NUM_CTX, or close other processes to free RAM` diagnostic, plus the smoking-gun llama.cpp warning `V embeddings have different sizes across layers and FA is not enabled - padding V cache to 1024`. ollama runs the same model fine on the same machine, so the hardware fits; lilbee was wasting memory ollama wasn't.
* **Streaming log** - Asking `do yang and reinhardt ever meet?` with Qwen3-0.6B leaves the chat stuck at `thinking...` with no way to switch tabs. Above the prompt are three llama.cpp lines logged at ERROR (`special_eos_id is not in special_eog_ids`, `n_ctx_seq (3072) > n_ctx_train (2048)`, `init: embeddings required but some input tokens were not marked as outputs`) and a stray `error: No virtual environment found; run 'uv venv'` leaking from spaCy's auto-download.

## What changed

### Chat context size now fits the host

The chat path used to cap n_ctx at `min(training_ctx, 8192)` regardless of host memory, and the eviction-time KV-cache estimate was a flat 2 KB/token. Modern architectures' real KV is hundreds of KB/token, so our accounting passed and llama.cpp's actual allocation failed. The chat loader now reads the GGUF architecture (block count, KV head count, key/value lengths), computes accurate KV bytes/token, and picks the largest 256-multiple n_ctx that fits in available memory minus the model weights and a 10% buffer. Ceiling is configurable via `LILBEE_NUM_CTX_MAX`.

### Embedding and vision loads clamp n_ctx to the training window

When users set a chat-sized `LILBEE_NUM_CTX`, the embedding model would receive the same value and trigger `n_ctx_seq (X) > n_ctx_train (Y)`. The same shape was hiding in the vision/MTMD load path. Both now clamp to the model's training context.

### Flash attention on by default

Without flash attention, llama.cpp pads the V cache to the worst-case per-layer size, exactly the warning surfaced on Gemma3. Chat loads now pass `flash_attn=True`. If the installed llama-cpp-python predates that kwarg, we drop it and retry once. `LILBEE_FLASH_ATTENTION=0` keeps the old behavior.

### Defense-in-depth on memory

If a load still fails with a llama.cpp memory error, we halve n_ctx (and matching n_batch / n_ubatch on embed loads) and retry up to twice before raising the diagnostic. The diagnostic now points users at `LILBEE_KV_CACHE_TYPE=q8_0` as a quick win for tight hosts. New env vars `LILBEE_KV_CACHE_TYPE`, `LILBEE_N_GPU_LAYERS`, and `LILBEE_NUM_CTX_MAX` let power users tune further. Each follows the project's existing config conventions: bool tri-state with a validator (matching `enable_ocr`), a `StrEnum` for the closed set of cache types, and an `int | None` with `auto` / `cpu` aliases for layer counts.

### Windows VRAM detection

`get_available_memory` now consults pynvml on Windows in addition to Linux, so a Windows host with a discrete NVIDIA GPU sees real VRAM rather than a 75% slice of system RAM.

### Qwen3-0.6B thinking softlock

Two changes together:

* `_stream_response` saturated Textual's message queue at 100+ tok/s with one `call_from_thread` per token. UI updates now coalesce into ~50 ms windows, and the worker explicitly closes the upstream stream wrapper on exit so the chat lock isn't held until garbage collection.
* `filter_reasoning` now closes its upstream iterator on truncation, normal completion, or generator exit. That surfaced a latent infinite-drain in `_LockedStreamIterator.close()`, which is now capped at 1024 tokens; once the cap fires we accept an inconsistent llama.cpp state in exchange for not hanging the UI.

### Quieter llama.cpp logs

Three substrings llama.cpp emits at GGML ERROR are advisory (the model still loads correctly): `special_eos_id is not in special_eog_ids`, `embeddings required but some input tokens were not marked as outputs`, and `n_ctx_seq` overflow warnings. They're now demoted to WARNING so users don't think their setup is broken. The embed-clamp above means the n_ctx_seq line shouldn't fire any more.

### spaCy model auto-download removed

`spacy.cli.download` shells out to pip/uv. Under `uv tool install` layouts, uv complains `No virtual environment found` and the stderr leaked into the chat panel as visible noise. Auto-download is gone; users install the model once with `python -m spacy download en_core_web_sm`. `concepts_available()` and `ConceptGraph._ensure_nlp()` already handled the missing-model case gracefully (the concept graph just stays disabled), so removing the auto-download path is a strict improvement.

### Adopted ruff rules from the upcoming refactor branch

Pulls in the `C90 / N / RET / TID / PLR091x / PLR2004` selects from `tidy-module-organization` so new code is held to the same standard. Pre-existing offenders are grandfathered via narrow per-file ignores; the parallel branch handles those upstream.

### Theme test fix

Cherry-picked one small fix: `test_set_invalid_theme_noop` captures the current theme rather than asserting a hardcoded `gruvbox`, so it stops failing when a developer's persisted theme differs from the original test author's.
