### PR TITLE
Fix QA-discovered bugs in the release executable and crawler stack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,7 @@ jobs:
           --collect-submodules litellm.llms
           --collect-all spacy
           --collect-all graspologic_native
+          --collect-all playwright
           src/lilbee/__main__.py
 
       - name: Smoke test

--- a/README.md
+++ b/README.md
@@ -273,6 +273,23 @@ docker run --rm -v lilbee-data:/home/lilbee/data ghcr.io/tobocop2/lilbee:latest 
 
 Image is published to GitHub Container Registry on every release; tagged with both the version (`0.6.66b456`) and `latest`. The `LILBEE_DATA_DIR` is `/home/lilbee/data` inside the container, so mount a volume there to persist models, embeddings, and config.
 
+<a id="linux-runtime-requirements"></a>
+
+### Linux runtime requirements
+
+The Linux x86_64 wheel links against the Vulkan loader at runtime so it can fall back from GPU to CPU on a single binary. Most desktop distros (Ubuntu 22.04+, Pop!_OS, Mint) ship `libvulkan1` by default. Bare Arch / Fedora / Alpine images do not, and `lilbee self-check` will fail with `cannot open shared object file: libvulkan.so.1`. Install the loader once.
+
+```bash
+# Arch / Manjaro
+sudo pacman -S vulkan-icd-loader
+
+# Fedora / RHEL
+sudo dnf install vulkan-loader
+
+# Debian / Ubuntu (only if missing)
+sudo apt-get install libvulkan1
+```
+
 ### NVIDIA users wanting CUDA-native (5-15% faster than Vulkan)
 
 The default wheel already uses your NVIDIA GPU through Vulkan. **You only need a CUDA wheel if you want the absolute last bit of performance** out of CUDA-native kernels.

--- a/src/lilbee/cli/commands.py
+++ b/src/lilbee/cli/commands.py
@@ -736,10 +736,12 @@ def self_check_cmd(
         )
         console.print(f"Loading chat model {chat_path}")
 
-        import llama_cpp
+        from lilbee.providers.llama_cpp_provider import (
+            import_llama_cpp,
+            install_llama_log_handler,
+        )
 
-        from lilbee.providers.llama_cpp_provider import install_llama_log_handler
-
+        llama_cpp = import_llama_cpp()
         install_llama_log_handler()
         llm = llama_cpp.Llama(model_path=str(chat_path), n_ctx=256, verbose=False)
         # stream=False (default) returns a dict, not an iterator, but

--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -2,8 +2,38 @@
 
 from __future__ import annotations
 
+import logging
+import os
+import sys
+
 from lilbee.cli.sync import shutdown_executor
 from lilbee.services import reset_services
+
+
+def _silence_stderr_log_handlers() -> None:
+    """Drop stderr/stdout-streaming log handlers before mounting the TUI.
+
+    Textual writes its UI to stderr; any parallel writer to the same fd
+    corrupts the screen (bb-82ce: 'WARNING lilbee.concepts: Concept graph
+    disabled: spaCy model unavailable' bleeding into the bottom-bar
+    box-drawing characters). The CLI entrypoint installs a basicConfig
+    stderr StreamHandler at WARNING level; remove it for the duration of
+    the TUI session. Textual users can still see lilbee logs via
+    ``lilbee --log-level=DEBUG`` against a non-TUI subcommand.
+
+    Targets ``StreamHandler`` whose ``.stream`` is sys.stderr / sys.stdout.
+    ``FileHandler`` (a ``StreamHandler`` subclass whose ``.stream`` is the
+    open log file) is skipped: file writes don't share an fd with the
+    TUI render target.
+    """
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if not isinstance(handler, logging.StreamHandler):
+            continue
+        if isinstance(handler, logging.FileHandler):
+            continue
+        if handler.stream in (sys.stderr, sys.stdout):
+            root.removeHandler(handler)
 
 
 def run_tui(*, auto_sync: bool = False, initial_view: str | None = None) -> None:
@@ -12,9 +42,9 @@ def run_tui(*, auto_sync: bool = False, initial_view: str | None = None) -> None
     *initial_view* deep-links to a named view (e.g. ``"Catalog"``) after
     the default chat screen is mounted. Used by ``lilbee model browse``.
     """
-    import os
-
     from lilbee.cli.tui.app import LilbeeApp
+
+    _silence_stderr_log_handlers()
 
     app = LilbeeApp(auto_sync=auto_sync, initial_view=initial_view)
     try:

--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -11,20 +11,16 @@ from lilbee.services import reset_services
 
 
 def _silence_stderr_log_handlers() -> None:
-    """Drop stderr/stdout-streaming log handlers before mounting the TUI.
+    """Drop stderr/stdout-streaming log handlers before mounting the TUI. (bb-82ce)
 
-    Textual writes its UI to stderr; any parallel writer to the same fd
-    corrupts the screen (bb-82ce: 'WARNING lilbee.concepts: Concept graph
-    disabled: spaCy model unavailable' bleeding into the bottom-bar
-    box-drawing characters). The CLI entrypoint installs a basicConfig
-    stderr StreamHandler at WARNING level; remove it for the duration of
-    the TUI session. Textual users can still see lilbee logs via
-    ``lilbee --log-level=DEBUG`` against a non-TUI subcommand.
+    TODO bb-pmyi: stripping handlers loses logs for the session. The proper
+    fix routes lilbee.* loggers through Textual's RichLog widget or a
+    rotating ~/.lilbee/tui.log so users debugging a TUI session still get
+    their logs.
 
-    Targets ``StreamHandler`` whose ``.stream`` is sys.stderr / sys.stdout.
-    ``FileHandler`` (a ``StreamHandler`` subclass whose ``.stream`` is the
-    open log file) is skipped: file writes don't share an fd with the
-    TUI render target.
+    FileHandler (a StreamHandler subclass whose .stream is the log file)
+    is skipped explicitly: only stderr/stdout handlers share an fd with
+    the TUI render target.
     """
     root = logging.getLogger()
     for handler in list(root.handlers):

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -96,6 +96,40 @@ def _on_settings_changed_evict_cache(payload: tuple[str, object]) -> None:
         get_services().provider.invalidate_load_cache()
 
 
+# Terminal-mode reset sequences emitted on a force-quit so the next shell
+# command isn't fed escape bytes from a still-armed mode. The targeted
+# modes (bracketed paste, mouse tracking, alt-screen) are the same ones
+# Textual's driver normally resets at app exit. (bb-6b86)
+_RESET_BRACKETED_PASTE = "\x1b[?2004l"
+_RESET_MOUSE_TRACKING = "\x1b[?1003l"
+_RESET_ALT_SCREEN = "\x1b[?1049l"
+_RESET_SHOW_CURSOR = "\x1b[?25h"
+
+_TERMINAL_RESET_SEQUENCE = (
+    _RESET_BRACKETED_PASTE + _RESET_MOUSE_TRACKING + _RESET_ALT_SCREEN + _RESET_SHOW_CURSOR
+)
+
+
+def _reset_terminal_modes() -> None:
+    """Emit terminal-mode resets so the shell after a force-quit isn't broken.
+
+    Best-effort: write to stdout if it's a TTY, swallow any error so the
+    caller can still proceed to ``os._exit``. Skips the writes entirely on
+    non-tty stdout (CI, pipes) since there's no terminal state to reset.
+    """
+    import sys
+
+    try:
+        if not sys.stdout.isatty():
+            return
+        sys.stdout.write(_TERMINAL_RESET_SEQUENCE)
+        sys.stdout.flush()
+    except (OSError, ValueError):
+        # ValueError fires when stdout is closed; OSError covers EBADF and
+        # write errors on a still-open but unwritable fd.
+        return
+
+
 class LilbeeApp(App[None]):
     """Full-screen TUI for lilbee knowledge base."""
 
@@ -234,11 +268,19 @@ class LilbeeApp(App[None]):
         self.exit()
 
     def _force_quit(self) -> None:
-        """Force-exit when normal quit is blocked (e.g. GIL held by native code)."""
+        """Force-exit when normal quit is blocked (e.g. GIL held by native code).
+
+        ``os._exit`` skips Textual's driver teardown, which is the only path
+        that resets terminal modes (alt-screen, mouse tracking, bracketed
+        paste). Without an explicit reset, the next shell command receives
+        terminal escape bytes as input and rejects them with
+        ``No such command '4'`` and friends. (bb-6b86)
+        """
         import os
 
         with contextlib.suppress(Exception):
             reset_services()
+        _reset_terminal_modes()
         os._exit(1)
 
     def switch_view(self, view_name: str) -> None:

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
@@ -117,8 +119,6 @@ def _reset_terminal_modes() -> None:
     caller can still proceed to ``os._exit``. Skips the writes entirely on
     non-tty stdout (CI, pipes) since there's no terminal state to reset.
     """
-    import sys
-
     try:
         if not sys.stdout.isatty():
             return
@@ -276,8 +276,6 @@ class LilbeeApp(App[None]):
         terminal escape bytes as input and rejects them with
         ``No such command '4'`` and friends. (bb-6b86)
         """
-        import os
-
         with contextlib.suppress(Exception):
             reset_services()
         _reset_terminal_modes()

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
-import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
@@ -98,36 +97,18 @@ def _on_settings_changed_evict_cache(payload: tuple[str, object]) -> None:
         get_services().provider.invalidate_load_cache()
 
 
-# Terminal-mode reset sequences emitted on a force-quit so the next shell
-# command isn't fed escape bytes from a still-armed mode. The targeted
-# modes (bracketed paste, mouse tracking, alt-screen) are the same ones
-# Textual's driver normally resets at app exit. (bb-6b86)
-_RESET_BRACKETED_PASTE = "\x1b[?2004l"
-_RESET_MOUSE_TRACKING = "\x1b[?1003l"
-_RESET_ALT_SCREEN = "\x1b[?1049l"
-_RESET_SHOW_CURSOR = "\x1b[?25h"
+def _restore_terminal_via_driver(app: App[None]) -> None:
+    """Run Textual's own ``Driver.stop_application_mode`` before ``os._exit``. (bb-6b86)
 
-_TERMINAL_RESET_SEQUENCE = (
-    _RESET_BRACKETED_PASTE + _RESET_MOUSE_TRACKING + _RESET_ALT_SCREEN + _RESET_SHOW_CURSOR
-)
-
-
-def _reset_terminal_modes() -> None:
-    """Emit terminal-mode resets so the shell after a force-quit isn't broken.
-
-    Best-effort: write to stdout if it's a TTY, swallow any error so the
-    caller can still proceed to ``os._exit``. Skips the writes entirely on
-    non-tty stdout (CI, pipes) since there's no terminal state to reset.
+    TODO bb-4ik2: this whole helper goes away once inference is interruptible
+    via llama_cpp's abort_callback. ``app.exit()`` will reach Textual's normal
+    teardown and ``_force_quit`` / ``os._exit`` are no longer needed.
     """
-    try:
-        if not sys.stdout.isatty():
-            return
-        sys.stdout.write(_TERMINAL_RESET_SEQUENCE)
-        sys.stdout.flush()
-    except (OSError, ValueError):
-        # ValueError fires when stdout is closed; OSError covers EBADF and
-        # write errors on a still-open but unwritable fd.
+    driver = getattr(app, "_driver", None)
+    if driver is None:
         return
+    with contextlib.suppress(Exception):
+        driver.stop_application_mode()
 
 
 class LilbeeApp(App[None]):
@@ -270,15 +251,13 @@ class LilbeeApp(App[None]):
     def _force_quit(self) -> None:
         """Force-exit when normal quit is blocked (e.g. GIL held by native code).
 
-        ``os._exit`` skips Textual's driver teardown, which is the only path
-        that resets terminal modes (alt-screen, mouse tracking, bracketed
-        paste). Without an explicit reset, the next shell command receives
-        terminal escape bytes as input and rejects them with
-        ``No such command '4'`` and friends. (bb-6b86)
+        Run Textual's driver teardown first so the next shell command
+        isn't fed alt-screen / paste / focus / kitty-keyboard escape
+        bytes. (bb-6b86)
         """
         with contextlib.suppress(Exception):
             reset_services()
-        _reset_terminal_modes()
+        _restore_terminal_via_driver(self)
         os._exit(1)
 
     def switch_view(self, view_name: str) -> None:

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -365,26 +365,12 @@ async def _maybe_periodic_sync() -> None:
 
 
 async def _drain_background_tasks() -> None:
-    """Cancel every periodic-sync task spawned during the current crawl.
+    """Cancel periodic-sync tasks owned by the running loop. (bb-zqws)
 
-    Without this drain, ``asyncio.run(crawl_and_save(...))`` closes the
-    loop while a periodic sync is mid-ingest, surfacing
-    ``Task was destroyed but it is pending`` and
-    ``coroutine ingest_batch._process_one was never awaited`` warnings on
-    stderr (and into the TUI).
-
-    Cancelling rather than awaiting because periodic sync is best-effort
-    by design ("periodic" implies "we'll try again next cycle"); awaiting
-    a slow or stuck sync would block the crawl from exiting and dead-lock
-    test subprocesses behind their per-test timeouts. Cancellation
-    satisfies asyncio's destruction-detection: gather absorbs the
-    resulting CancelledError so callers see clean teardown.
-
-    Filters to tasks owned by the running loop so stale entries from a
-    previous loop (test isolation between asyncio.run() calls, server
-    hot-reload) don't crash the drain with cross-loop errors. Such
-    stale tasks are dropped from the registry so subsequent drains don't
-    keep re-encountering them.
+    TODO bb-odr1: the cross-loop filter and stale-entry drop both exist
+    because ``_state.background_tasks`` is a module-level global. Once
+    task tracking is scoped per ``crawl_and_save`` invocation, this whole
+    helper collapses to a local ``await asyncio.gather(*tasks)``.
     """
     loop = asyncio.get_running_loop()
     pending: list[asyncio.Task[Any]] = []

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -373,8 +373,24 @@ async def _drain_background_tasks() -> None:
     ``coroutine ingest_batch._process_one was never awaited`` warnings to
     stderr (and into the TUI). gather(...return_exceptions=True) swallows
     sync failures; the task itself already logs them via _run_sync.
+
+    Filters to tasks owned by the running loop so stale entries from a
+    previous loop (test isolation between asyncio.run() calls, server
+    hot-reload that starts a fresh loop) don't crash the drain with
+    cross-loop await errors. Such stale tasks are dropped from the
+    registry so subsequent drains don't keep re-encountering them.
     """
-    pending = list(_state.background_tasks)
+    loop = asyncio.get_running_loop()
+    pending: list[asyncio.Task[Any]] = []
+    stale: set[asyncio.Task[Any]] = set()
+    for task in list(_state.background_tasks):
+        if task.done():
+            continue
+        if task.get_loop() is loop:
+            pending.append(task)
+        else:
+            stale.add(task)
+    _state.background_tasks -= stale
     if not pending:
         return
     await asyncio.gather(*pending, return_exceptions=True)

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -365,20 +365,26 @@ async def _maybe_periodic_sync() -> None:
 
 
 async def _drain_background_tasks() -> None:
-    """Await every periodic-sync task spawned during the current crawl.
+    """Cancel every periodic-sync task spawned during the current crawl.
 
     Without this drain, ``asyncio.run(crawl_and_save(...))`` closes the
     loop while a periodic sync is mid-ingest, surfacing
     ``Task was destroyed but it is pending`` and
-    ``coroutine ingest_batch._process_one was never awaited`` warnings to
-    stderr (and into the TUI). gather(...return_exceptions=True) swallows
-    sync failures; the task itself already logs them via _run_sync.
+    ``coroutine ingest_batch._process_one was never awaited`` warnings on
+    stderr (and into the TUI).
+
+    Cancelling rather than awaiting because periodic sync is best-effort
+    by design ("periodic" implies "we'll try again next cycle"); awaiting
+    a slow or stuck sync would block the crawl from exiting and dead-lock
+    test subprocesses behind their per-test timeouts. Cancellation
+    satisfies asyncio's destruction-detection: gather absorbs the
+    resulting CancelledError so callers see clean teardown.
 
     Filters to tasks owned by the running loop so stale entries from a
     previous loop (test isolation between asyncio.run() calls, server
-    hot-reload that starts a fresh loop) don't crash the drain with
-    cross-loop await errors. Such stale tasks are dropped from the
-    registry so subsequent drains don't keep re-encountering them.
+    hot-reload) don't crash the drain with cross-loop errors. Such
+    stale tasks are dropped from the registry so subsequent drains don't
+    keep re-encountering them.
     """
     loop = asyncio.get_running_loop()
     pending: list[asyncio.Task[Any]] = []
@@ -393,6 +399,8 @@ async def _drain_background_tasks() -> None:
     _state.background_tasks -= stale
     if not pending:
         return
+    for task in pending:
+        task.cancel()
     await asyncio.gather(*pending, return_exceptions=True)
 
 

--- a/src/lilbee/crawler/api.py
+++ b/src/lilbee/crawler/api.py
@@ -364,6 +364,22 @@ async def _maybe_periodic_sync() -> None:
     task.add_done_callback(_state.background_tasks.discard)
 
 
+async def _drain_background_tasks() -> None:
+    """Await every periodic-sync task spawned during the current crawl.
+
+    Without this drain, ``asyncio.run(crawl_and_save(...))`` closes the
+    loop while a periodic sync is mid-ingest, surfacing
+    ``Task was destroyed but it is pending`` and
+    ``coroutine ingest_batch._process_one was never awaited`` warnings to
+    stderr (and into the TUI). gather(...return_exceptions=True) swallows
+    sync failures; the task itself already logs them via _run_sync.
+    """
+    pending = list(_state.background_tasks)
+    if not pending:
+        return
+    await asyncio.gather(*pending, return_exceptions=True)
+
+
 def _make_flush_page(
     meta: dict[str, CrawlMeta],
     written_paths: list[Path],
@@ -497,5 +513,8 @@ async def crawl_and_save(
 
         return written_paths
     finally:
+        # Drain the periodic-sync task BEFORE releasing the crawl semaphore so
+        # asyncio.run() doesn't close the loop with the sync mid-ingest.
+        await _drain_background_tasks()
         if sem is not None:
             sem.release()

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -165,6 +165,35 @@ async def _drain_stderr(stream: asyncio.StreamReader, tail: list[str]) -> None:
         tail.append(line_bytes.decode(errors="replace").rstrip())
 
 
+_FROZEN_MISSING_PYTHON_HINT = (
+    "Chromium bootstrap needs a Python 3.11+ interpreter on PATH to run "
+    "'playwright install chromium' (the bundled lilbee binary does not "
+    "expose Python's -m loader). Install python3 from your distro or "
+    "python.org and rerun 'lilbee setup crawler'."
+)
+
+
+def _resolve_playwright_runner() -> list[str]:
+    """Return the argv prefix that runs ``playwright install chromium``.
+
+    Under a wheel or ``uv tool install`` layout, ``sys.executable`` is the
+    Python interpreter and ``-m playwright`` works directly. Under a
+    PyInstaller frozen build, ``sys.executable`` is the lilbee binary,
+    which has no ``-m`` flag and no ``install`` subcommand: spawning it
+    that way exits 2 with ``No such command 'install'`` (bb-sxsz). Detect
+    the frozen case and fall back to a system ``python3`` / ``python`` on
+    PATH; raise :class:`CrawlerBrowserMissing` if neither is available.
+    """
+    import shutil
+
+    if not getattr(sys, "frozen", False):
+        return [sys.executable, "-m", "playwright"]
+    candidate = shutil.which("python3") or shutil.which("python")
+    if candidate is None:
+        raise CrawlerBrowserMissing(_FROZEN_MISSING_PYTHON_HINT)
+    return [candidate, "-m", "playwright"]
+
+
 async def bootstrap_chromium(
     on_progress: DetailedProgressCallback | None = None,
 ) -> None:
@@ -177,9 +206,10 @@ async def bootstrap_chromium(
     :class:`CrawlerBrowserMissing` with the tail so task workers route
     to FAILED cleanly.
 
-    Uses the current Python interpreter's ``playwright`` module so this
-    works under ``uv tool install`` and bundled installs alike without
-    relying on a globally-installed ``playwright`` CLI.
+    Wheel / uv-tool installs spawn ``sys.executable -m playwright``;
+    PyInstaller frozen builds (where ``sys.executable`` is the lilbee
+    binary, not a Python interpreter) fall back to a system ``python3``
+    on PATH. (bb-sxsz)
     """
     if chromium_installed():
         _emit_setup_done(on_progress, success=True, error=None)
@@ -187,10 +217,14 @@ async def bootstrap_chromium(
 
     _emit_setup_start(on_progress)
 
+    try:
+        runner = _resolve_playwright_runner()
+    except CrawlerBrowserMissing as exc:
+        _emit_setup_done(on_progress, success=False, error=str(exc))
+        raise
+
     proc = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-m",
-        "playwright",
+        *runner,
         "install",
         "chromium",
         stdout=asyncio.subprocess.PIPE,

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 
@@ -184,8 +185,6 @@ def _resolve_playwright_runner() -> list[str]:
     the frozen case and fall back to a system ``python3`` / ``python`` on
     PATH; raise :class:`CrawlerBrowserMissing` if neither is available.
     """
-    import shutil
-
     if not getattr(sys, "frozen", False):
         return [sys.executable, "-m", "playwright"]
     candidate = shutil.which("python3") or shutil.which("python")

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -194,7 +194,7 @@ def _resolve_playwright_runner() -> tuple[list[str], dict[str, str]]:
         raise CrawlerBrowserMissing(_PLAYWRIGHT_MISSING_HINT) from exc
     try:
         driver_exe, driver_cli = compute_driver_executable()
-    except Exception:  # pragma: no cover - defensive against playwright API drift
+    except Exception:
         if not getattr(sys, "frozen", False):
             return [sys.executable, "-m", "playwright"], dict(os.environ)
         raise

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import asyncio
 import os
 import re
-import shutil
 import sys
 from pathlib import Path
 
@@ -166,31 +165,40 @@ async def _drain_stderr(stream: asyncio.StreamReader, tail: list[str]) -> None:
         tail.append(line_bytes.decode(errors="replace").rstrip())
 
 
-_FROZEN_MISSING_PYTHON_HINT = (
-    "Chromium bootstrap needs a Python 3.11+ interpreter on PATH to run "
-    "'playwright install chromium' (the bundled lilbee binary does not "
-    "expose Python's -m loader). Install python3 from your distro or "
-    "python.org and rerun 'lilbee setup crawler'."
+_PLAYWRIGHT_MISSING_HINT = (
+    "Chromium bootstrap requires the playwright Python package, which is "
+    "bundled with the release binary and the lilbee[crawler] extra. "
+    "Reinstall with 'pip install lilbee[crawler]' or download a fresh "
+    "release binary."
 )
 
 
-def _resolve_playwright_runner() -> list[str]:
-    """Return the argv prefix that runs ``playwright install chromium``.
+def _resolve_playwright_runner() -> tuple[list[str], dict[str, str]]:
+    """Return ``(argv_prefix, env)`` for invoking ``playwright install chromium``.
 
-    Under a wheel or ``uv tool install`` layout, ``sys.executable`` is the
-    Python interpreter and ``-m playwright`` works directly. Under a
-    PyInstaller frozen build, ``sys.executable`` is the lilbee binary,
-    which has no ``-m`` flag and no ``install`` subcommand: spawning it
-    that way exits 2 with ``No such command 'install'`` (bb-sxsz). Detect
-    the frozen case and fall back to a system ``python3`` / ``python`` on
-    PATH; raise :class:`CrawlerBrowserMissing` if neither is available.
+    Playwright ships a Node.js driver (``playwright/driver/node`` +
+    ``playwright/driver/package/cli.js``) inside its Python package; that's
+    what ``python -m playwright`` ultimately spawns. We invoke it
+    directly so the call works identically under a pip install,
+    ``uv tool install``, and a PyInstaller frozen binary - no system
+    Python interpreter required.
+
+    Falls back to ``[sys.executable, '-m', 'playwright']`` if the driver
+    can't be resolved (defensive against unusual playwright builds);
+    raises :class:`CrawlerBrowserMissing` only if even that lookup
+    fails.
     """
-    if not getattr(sys, "frozen", False):
-        return [sys.executable, "-m", "playwright"]
-    candidate = shutil.which("python3") or shutil.which("python")
-    if candidate is None:
-        raise CrawlerBrowserMissing(_FROZEN_MISSING_PYTHON_HINT)
-    return [candidate, "-m", "playwright"]
+    try:
+        from playwright._impl._driver import compute_driver_executable, get_driver_env
+    except ImportError as exc:
+        raise CrawlerBrowserMissing(_PLAYWRIGHT_MISSING_HINT) from exc
+    try:
+        driver_exe, driver_cli = compute_driver_executable()
+    except Exception:  # pragma: no cover - defensive against playwright API drift
+        if not getattr(sys, "frozen", False):
+            return [sys.executable, "-m", "playwright"], dict(os.environ)
+        raise
+    return [str(driver_exe), str(driver_cli)], dict(get_driver_env())
 
 
 async def bootstrap_chromium(
@@ -205,10 +213,9 @@ async def bootstrap_chromium(
     :class:`CrawlerBrowserMissing` with the tail so task workers route
     to FAILED cleanly.
 
-    Wheel / uv-tool installs spawn ``sys.executable -m playwright``;
-    PyInstaller frozen builds (where ``sys.executable`` is the lilbee
-    binary, not a Python interpreter) fall back to a system ``python3``
-    on PATH. (bb-sxsz)
+    Invokes Playwright's bundled Node driver directly so the call works
+    identically under a pip install, ``uv tool install``, or a
+    PyInstaller frozen binary (no system Python needed). (bb-sxsz)
     """
     if chromium_installed():
         _emit_setup_done(on_progress, success=True, error=None)
@@ -217,7 +224,7 @@ async def bootstrap_chromium(
     _emit_setup_start(on_progress)
 
     try:
-        runner = _resolve_playwright_runner()
+        runner, runner_env = _resolve_playwright_runner()
     except CrawlerBrowserMissing as exc:
         _emit_setup_done(on_progress, success=False, error=str(exc))
         raise
@@ -228,6 +235,7 @@ async def bootstrap_chromium(
         "chromium",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=runner_env,
     )
     # mypy narrowing: asyncio.create_subprocess_exec with PIPE guarantees
     # non-None streams at runtime; the asserts only satisfy the type checker.

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -611,10 +611,13 @@ def resolve_model_path(model: str) -> Path:
 def _llama_cpp_has_rank_pooling() -> bool:
     """Return True iff the installed llama-cpp-python exposes ``LLAMA_POOLING_TYPE_RANK``."""
     # supports_rerank() can be called before any model load (feature detection
-    # for status / catalog UIs), so route through import_llama_cpp() to surface
-    # the libvulkan hint rather than a raw OSError on bare Linux installs.
-    import_llama_cpp()
+    # for status / catalog UIs), so route through import_llama_cpp() first to
+    # surface the libvulkan hint rather than a raw OSError on bare Linux. A
+    # genuinely-missing llama_cpp package surfaces as ImportError and means
+    # "no rerank support"; a libvulkan-flavored OSError is a real install
+    # error and must propagate as ProviderError to the caller.
     try:
+        import_llama_cpp()
         from llama_cpp import LLAMA_POOLING_TYPE_RANK  # noqa: F401
     except ImportError:
         return False

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -480,12 +480,14 @@ _MISSING_VULKAN_HINT = (
 )
 
 
-def _import_llama_cpp() -> Any:
+def import_llama_cpp() -> Any:
     """Import ``llama_cpp`` with an actionable error when libvulkan is missing.
 
     Bare Arch / Fedora installs lack the Vulkan loader and the raw
     ``OSError: libvulkan.so.1: cannot open shared object file`` is opaque.
-    Re-raise as :class:`ProviderError` with install guidance.
+    Re-raise as :class:`ProviderError` with install guidance. Idempotent
+    after the first successful import (Python caches it in ``sys.modules``),
+    so callers can sprinkle it at every llama_cpp entry point cheaply.
     """
     try:
         import llama_cpp
@@ -502,7 +504,7 @@ def install_llama_log_handler() -> None:
     global _llama_log_callback, _llama_log_installed
     if _llama_log_installed:
         return
-    llama_cpp = _import_llama_cpp()
+    llama_cpp = import_llama_cpp()
 
     _llama_log_callback = llama_cpp.llama_log_callback(_llama_log_dispatch)
     llama_cpp.llama_log_set(_llama_log_callback, None)
@@ -608,6 +610,10 @@ def resolve_model_path(model: str) -> Path:
 
 def _llama_cpp_has_rank_pooling() -> bool:
     """Return True iff the installed llama-cpp-python exposes ``LLAMA_POOLING_TYPE_RANK``."""
+    # supports_rerank() can be called before any model load (feature detection
+    # for status / catalog UIs), so route through import_llama_cpp() to surface
+    # the libvulkan hint rather than a raw OSError on bare Linux installs.
+    import_llama_cpp()
     try:
         from llama_cpp import LLAMA_POOLING_TYPE_RANK  # noqa: F401
     except ImportError:
@@ -617,7 +623,7 @@ def _llama_cpp_has_rank_pooling() -> bool:
 
 def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
     """Load a llama_cpp.Llama in chat, embed, or rerank mode."""
-    Llama = _import_llama_cpp().Llama  # noqa: N806
+    Llama = import_llama_cpp().Llama  # noqa: N806
 
     install_llama_log_handler()
     embedding = mode in (MODE_EMBED, MODE_RERANK)

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -472,12 +472,37 @@ def _resolve_ggml_level(ggml_level: int, text: str) -> int:
     return py_level
 
 
+_MISSING_VULKAN_HINT = (
+    "lilbee's Linux wheel currently links against libvulkan.so.1 at runtime. "
+    "Install your distro's Vulkan loader package (Arch: vulkan-icd-loader, "
+    "Fedora: vulkan-loader, Debian/Ubuntu: libvulkan1) and try again. See "
+    "https://github.com/tobocop2/lilbee#linux-runtime-requirements."
+)
+
+
+def _import_llama_cpp() -> Any:
+    """Import ``llama_cpp`` with an actionable error when libvulkan is missing.
+
+    Bare Arch / Fedora installs lack the Vulkan loader and the raw
+    ``OSError: libvulkan.so.1: cannot open shared object file`` is opaque.
+    Re-raise as :class:`ProviderError` with install guidance.
+    """
+    try:
+        import llama_cpp
+
+        return llama_cpp
+    except OSError as exc:
+        if "libvulkan" in str(exc):
+            raise ProviderError(_MISSING_VULKAN_HINT, provider="llama-cpp") from exc
+        raise
+
+
 def install_llama_log_handler() -> None:
     """Route llama.cpp logs through Python logging. Idempotent."""
     global _llama_log_callback, _llama_log_installed
     if _llama_log_installed:
         return
-    import llama_cpp
+    llama_cpp = _import_llama_cpp()
 
     _llama_log_callback = llama_cpp.llama_log_callback(_llama_log_dispatch)
     llama_cpp.llama_log_set(_llama_log_callback, None)
@@ -592,7 +617,7 @@ def _llama_cpp_has_rank_pooling() -> bool:
 
 def load_llama(model_path: Path, *, mode: LoaderMode) -> Any:
     """Load a llama_cpp.Llama in chat, embed, or rerank mode."""
-    from llama_cpp import Llama
+    Llama = _import_llama_cpp().Llama  # noqa: N806
 
     install_llama_log_handler()
     embedding = mode in (MODE_EMBED, MODE_RERANK)

--- a/src/lilbee/providers/llama_cpp_provider.py
+++ b/src/lilbee/providers/llama_cpp_provider.py
@@ -544,7 +544,7 @@ def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
     KV-cache-shape fields ('block_count', 'head_count_kv', 'key_length',
     'value_length') used to size n_ctx against host memory.
     """
-    from llama_cpp import Llama
+    Llama = import_llama_cpp().Llama  # noqa: N806
 
     install_llama_log_handler()
     llm = suppress_native_stderr(

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -13,6 +13,7 @@ from gguf import GGUFReader
 from lilbee.config import cfg
 from lilbee.providers.llama_cpp_provider import (
     find_mmproj_for_model,
+    import_llama_cpp,
     install_llama_log_handler,
     read_gguf_metadata,
     suppress_native_stderr,
@@ -67,6 +68,10 @@ def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
     is injected. Falls back to the upstream default template when the
     GGUF has no ``tokenizer.chat_template``.
     """
+    # Surface the libvulkan-missing hint before submodule import, since
+    # importing llama_cpp.llama_chat_format triggers the parent package's
+    # native loader as a side effect.
+    import_llama_cpp()
     from llama_cpp.llama_chat_format import Llava15ChatHandler
 
     # Defined per call so each loaded model binds its own ``CHAT_FORMAT``
@@ -97,7 +102,7 @@ def build_vision_chat_handler(model_path: Path, mmproj_path: Path) -> Any:
 
 def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
     """Load a vision-capable ``Llama`` using the GGUF-templated chat handler."""
-    from llama_cpp import Llama  # heavy native lib; keep import lazy
+    Llama = import_llama_cpp().Llama  # noqa: N806 # heavy native lib; keep import lazy
 
     install_llama_log_handler()
     if mmproj_path is None:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1510,6 +1510,56 @@ class TestDrainBackgroundTasks:
         await _drain_background_tasks()
         assert task.done()
 
+    async def test_skips_already_done_task(self, isolated_env):
+        """A task that already finished is left untouched by the drain."""
+        import asyncio
+
+        from lilbee.crawler.api import _drain_background_tasks, _state
+
+        async def _quick() -> str:
+            return "ok"
+
+        task = asyncio.create_task(_quick())
+        await task  # finish it before the drain sees it
+        # Re-add manually because add_done_callback already discarded it.
+        _state.background_tasks = {task}
+
+        await _drain_background_tasks()
+        # Drain saw the done task and skipped it (no cancel attempt).
+        assert task.done()
+        assert not task.cancelled()
+        assert task.result() == "ok"
+
+    async def test_drops_cross_loop_task_from_registry(self, isolated_env):
+        """A task whose loop has closed gets dropped instead of awaited.
+
+        Mirrors what happens when an earlier asyncio.run() call left a task
+        in _state.background_tasks: subsequent crawl_and_save() runs on a
+        new loop and must not try to cross-await it.
+        """
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from lilbee.crawler.api import _drain_background_tasks, _state
+
+        # Build a stand-in task whose get_loop() points at a different
+        # (not-running) loop. MagicMock(spec=Task) keeps isinstance checks
+        # happy without spawning a real cross-loop task.
+        other_loop = asyncio.new_event_loop()
+        try:
+            stale_task = MagicMock(spec=asyncio.Task)
+            stale_task.done.return_value = False
+            stale_task.get_loop.return_value = other_loop
+
+            _state.background_tasks = {stale_task}
+
+            await _drain_background_tasks()
+
+            assert stale_task not in _state.background_tasks
+            stale_task.cancel.assert_not_called()  # never touched mid-flight
+        finally:
+            other_loop.close()
+
 
 class TestCrawlerStateReset:
     def test_reset_clears_all_state(self, isolated_env):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -562,13 +562,33 @@ class TestResolvePlaywrightRunner:
     failed under PyInstaller because ``sys.executable`` is the lilbee binary,
     not Python. Routing through ``compute_driver_executable`` invokes the
     bundled ``playwright/driver/node`` + ``cli.js`` directly.
-
-    Skipped on lanes where the playwright package isn't installed (the
-    regular `test` job runs without crawler extras; integration covers it).
     """
 
-    def setup_method(self) -> None:
-        pytest.importorskip("playwright._impl._driver")
+    def _install_fake_driver_module(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        compute: object | None,
+        env: dict[str, str] | None,
+    ) -> None:
+        """Inject a fake ``playwright._impl._driver`` into sys.modules.
+
+        The regular ``test`` CI job runs without lilbee[crawler]; mocking
+        attributes on the real submodule with monkeypatch.setattr would
+        require the import to succeed first. Stubbing sys.modules instead
+        keeps the test importable on every lane.
+        """
+        import sys as _sys
+        import types
+
+        playwright = types.ModuleType("playwright")
+        playwright_impl = types.ModuleType("playwright._impl")
+        playwright_driver = types.ModuleType("playwright._impl._driver")
+        playwright_driver.compute_driver_executable = compute  # type: ignore[attr-defined]
+        playwright_driver.get_driver_env = (lambda: env) if env is not None else None  # type: ignore[attr-defined]
+        monkeypatch.setitem(_sys.modules, "playwright", playwright)
+        monkeypatch.setitem(_sys.modules, "playwright._impl", playwright_impl)
+        monkeypatch.setitem(_sys.modules, "playwright._impl._driver", playwright_driver)
 
     def test_uses_compute_driver_executable(self, monkeypatch):
         """Returns argv from playwright's bundled driver lookup, with driver env."""
@@ -576,13 +596,10 @@ class TestResolvePlaywrightRunner:
 
         fake_node = "/fake/site-packages/playwright/driver/node"
         fake_cli = "/fake/site-packages/playwright/driver/package/cli.js"
-        monkeypatch.setattr(
-            "playwright._impl._driver.compute_driver_executable",
-            lambda: (fake_node, fake_cli),
-        )
-        monkeypatch.setattr(
-            "playwright._impl._driver.get_driver_env",
-            lambda: {"PW_LANG_NAME": "python", "PATH": "/usr/bin"},
+        self._install_fake_driver_module(
+            monkeypatch,
+            compute=lambda: (fake_node, fake_cli),
+            env={"PW_LANG_NAME": "python", "PATH": "/usr/bin"},
         )
 
         argv, env = boot_mod._resolve_playwright_runner()
@@ -597,19 +614,45 @@ class TestResolvePlaywrightRunner:
         monkeypatch.setattr(sys, "frozen", True, raising=False)
         fake_node = "/_MEI/playwright/driver/node"
         fake_cli = "/_MEI/playwright/driver/package/cli.js"
-        monkeypatch.setattr(
-            "playwright._impl._driver.compute_driver_executable",
-            lambda: (fake_node, fake_cli),
+        self._install_fake_driver_module(
+            monkeypatch,
+            compute=lambda: (fake_node, fake_cli),
+            env={},
         )
-        monkeypatch.setattr("playwright._impl._driver.get_driver_env", lambda: {})
 
         argv, _env = boot_mod._resolve_playwright_runner()
         assert argv == [fake_node, fake_cli]
 
+    def test_compute_driver_failure_falls_back_when_not_frozen(self, monkeypatch):
+        """compute_driver_executable raise on a wheel install falls back to sys.executable -m."""
+        from lilbee.crawler import bootstrap as boot_mod
+
+        monkeypatch.delattr(sys, "frozen", raising=False)
+
+        def _boom() -> tuple[str, str]:
+            raise RuntimeError("playwright API drift")
+
+        self._install_fake_driver_module(monkeypatch, compute=_boom, env={})
+
+        argv, _env = boot_mod._resolve_playwright_runner()
+        assert argv == [sys.executable, "-m", "playwright"]
+
+    def test_compute_driver_failure_under_frozen_propagates(self, monkeypatch):
+        """If compute_driver_executable raises on a frozen build, raise (no fallback)."""
+        from lilbee.crawler import bootstrap as boot_mod
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+
+        def _boom() -> tuple[str, str]:
+            raise RuntimeError("playwright API drift")
+
+        self._install_fake_driver_module(monkeypatch, compute=_boom, env={})
+
+        with pytest.raises(RuntimeError, match="API drift"):
+            boot_mod._resolve_playwright_runner()
+
     def test_playwright_missing_raises_actionable_error(self, monkeypatch):
         """``ImportError: playwright`` raises CrawlerBrowserMissing with install hint."""
-        # Pretend playwright isn't installed by injecting a failing module loader
-        # for the exact path _resolve_playwright_runner imports from.
         import builtins
 
         from lilbee.crawler.bootstrap import CrawlerBrowserMissing, _resolve_playwright_runner
@@ -629,6 +672,41 @@ class TestResolvePlaywrightRunner:
         # Must name the install fix; bare 'not found' breaks the user's
         # recovery loop in the release executable.
         assert "lilbee[crawler]" in message or "playwright" in message
+
+    async def test_bootstrap_chromium_emits_setup_done_when_playwright_missing(self, monkeypatch):
+        """bootstrap_chromium catches the CrawlerBrowserMissing the runner
+        resolution raises, fires setup_done(success=False), and re-raises
+        so the task center routes the user to the actionable error.
+        """
+        import builtins
+
+        from lilbee.crawler.bootstrap import CrawlerBrowserMissing, bootstrap_chromium
+        from lilbee.progress import EventType, SetupDoneEvent
+
+        monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: False)
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "playwright._impl._driver":
+                raise ImportError("No module named 'playwright'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        events: list[tuple[EventType, object]] = []
+        with pytest.raises(CrawlerBrowserMissing):
+            await bootstrap_chromium(on_progress=lambda e, d: events.append((e, d)))
+
+        # setup_start fires before the failure surfaces, then setup_done
+        # with success=False so the task bar transitions to FAILED.
+        types = [e for e, _ in events]
+        assert types[0] == EventType.SETUP_START
+        assert types[-1] == EventType.SETUP_DONE
+        last = events[-1][1]
+        assert isinstance(last, SetupDoneEvent)
+        assert last.success is False
+        assert last.error is not None and "playwright" in last.error.lower()
 
 
 class TestPlaywrightBrowserCheck:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1467,18 +1467,20 @@ class TestDrainBackgroundTasks:
         await _drain_background_tasks()
         assert _state.background_tasks == set()
 
-    async def test_awaits_pending_periodic_sync(self, isolated_env):
-        """A pending periodic-sync task must finish before the drain returns."""
+    async def test_cancels_pending_periodic_sync(self, isolated_env):
+        """A pending periodic-sync task must be cancelled by the drain.
+
+        The drain cancels rather than awaits so a slow or stuck sync can't
+        block crawl_and_save's exit. The task ends as Cancelled rather
+        than completed, but the asyncio runner sees a clean teardown
+        (no "Task was destroyed but it is pending" warning).
+        """
         import asyncio
 
         from lilbee.crawler.api import _drain_background_tasks, _state
 
-        sync_finished = False
-
         async def _slow_sync() -> None:
-            nonlocal sync_finished
-            await asyncio.sleep(0.01)
-            sync_finished = True
+            await asyncio.sleep(60.0)  # would deadlock the test if awaited
 
         task = asyncio.create_task(_slow_sync())
         _state.background_tasks = {task}
@@ -1486,8 +1488,8 @@ class TestDrainBackgroundTasks:
 
         await _drain_background_tasks()
 
-        assert sync_finished is True
         assert task.done()
+        assert task.cancelled()
 
     async def test_swallows_task_exception(self, isolated_env):
         """A failing periodic-sync task must not bubble out of the drain."""
@@ -2228,12 +2230,13 @@ class TestStreamingFlush:
         mock_sync.assert_awaited_once()
 
     async def test_crawl_and_save_drains_background_tasks(self, isolated_env):
-        """bb-zqws: crawl_and_save awaits any spawned periodic-sync task before returning.
+        """bb-zqws: crawl_and_save cancels any spawned periodic-sync task before returning.
 
         Without the drain, the asyncio runner closed the loop mid-ingest and
         emitted ``Task was destroyed but it is pending`` for the periodic
-        sync's ``ingest_batch`` worker. The drain happens in the finally
-        block so the cancel-path also gets the cleanup.
+        sync's ``ingest_batch`` worker. The drain cancels in the finally
+        block - cancellation is enough to satisfy asyncio's destruction
+        check, and avoids the deadlock risk of awaiting a slow sync.
         """
         import asyncio as _asyncio
         import threading
@@ -2249,13 +2252,10 @@ class TestStreamingFlush:
         mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
         mock_instance.__aexit__ = AsyncMock(return_value=False)
 
-        sync_completed = _asyncio.Event()
-
         async def _slow_sync(*_args, **_kwargs):
-            # Mimic the real ingest_batch: yield, then mark done. Without
-            # the drain, the loop would close before this runs.
-            await _asyncio.sleep(0.01)
-            sync_completed.set()
+            # Sync that would deadlock the test if awaited; the drain
+            # must cancel it instead.
+            await _asyncio.sleep(60.0)
 
         cfg.crawl_sync_interval = 1
         crawler_mod._state.last_sync_time = 0.0
@@ -2267,9 +2267,8 @@ class TestStreamingFlush:
         ):
             await crawl_and_save("https://example.com", depth=0)
 
-        # crawl_and_save should not return until the periodic-sync task has
-        # finished, so the Event is already set on the next line.
-        assert sync_completed.is_set()
+        # All spawned periodic-sync tasks finished as Cancelled. The set
+        # is empty because the done callback removes them.
         assert all(t.done() for t in crawler_mod._state.background_tasks)
 
     async def test_metadata_flush_is_batched(self, isolated_env):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -463,6 +463,12 @@ class TestBootstrapChromium:
         from lilbee.progress import EventType, SetupProgressEvent, SetupStartEvent
 
         monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: False)
+        # Stub the runner so the test doesn't need a real playwright install
+        # (regular `test` job runs without crawler extras).
+        monkeypatch.setattr(
+            "lilbee.crawler.bootstrap._resolve_playwright_runner",
+            lambda: (["/fake/node", "/fake/cli.js"], {}),
+        )
 
         _bar = "\xe2\x96\xa0".encode("latin-1")  # three-byte UTF-8 for ■
         stdout_lines = [
@@ -510,6 +516,10 @@ class TestBootstrapChromium:
         from lilbee.progress import EventType, SetupDoneEvent
 
         monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: False)
+        monkeypatch.setattr(
+            "lilbee.crawler.bootstrap._resolve_playwright_runner",
+            lambda: (["/fake/node", "/fake/cli.js"], {}),
+        )
 
         class _Stream:
             def __init__(self, lines: list[bytes]) -> None:
@@ -552,7 +562,13 @@ class TestResolvePlaywrightRunner:
     failed under PyInstaller because ``sys.executable`` is the lilbee binary,
     not Python. Routing through ``compute_driver_executable`` invokes the
     bundled ``playwright/driver/node`` + ``cli.js`` directly.
+
+    Skipped on lanes where the playwright package isn't installed (the
+    regular `test` job runs without crawler extras; integration covers it).
     """
+
+    def setup_method(self) -> None:
+        pytest.importorskip("playwright._impl._driver")
 
     def test_uses_compute_driver_executable(self, monkeypatch):
         """Returns argv from playwright's bundled driver lookup, with driver env."""

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -543,6 +543,115 @@ class TestBootstrapChromium:
         assert "network unreachable" in (final[1].error or "")
 
 
+class TestResolvePlaywrightRunner:
+    """``_resolve_playwright_runner`` chooses the right argv prefix per layout.
+
+    bb-sxsz: under PyInstaller, sys.executable is the lilbee binary not a
+    Python interpreter, so the wheel-style 'sys.executable -m playwright'
+    spawn exits 2 with 'No such command install'.
+    """
+
+    def test_wheel_install_uses_sys_executable(self, monkeypatch):
+        """Non-frozen layout: argv prefix is [sys.executable, '-m', 'playwright']."""
+        from lilbee.crawler.bootstrap import _resolve_playwright_runner
+
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        runner = _resolve_playwright_runner()
+        assert runner == [sys.executable, "-m", "playwright"]
+
+    def test_frozen_falls_back_to_python_on_path(self, monkeypatch):
+        """PyInstaller layout: pick up python3 / python from PATH."""
+        import shutil
+
+        from lilbee.crawler.bootstrap import _resolve_playwright_runner
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(shutil, "which", lambda name: f"/fake/bin/{name}")
+        runner = _resolve_playwright_runner()
+        assert runner == ["/fake/bin/python3", "-m", "playwright"]
+
+    def test_frozen_prefers_python3_over_python(self, monkeypatch):
+        """``python3`` wins when both are on PATH (Linux/macOS convention)."""
+        import shutil
+
+        from lilbee.crawler.bootstrap import _resolve_playwright_runner
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        seen: list[str] = []
+
+        def _which(name):
+            seen.append(name)
+            # Both exist; helper should pick python3 first.
+            return f"/fake/bin/{name}"
+
+        monkeypatch.setattr(shutil, "which", _which)
+        runner = _resolve_playwright_runner()
+        assert runner[0] == "/fake/bin/python3"
+        assert seen[0] == "python3"
+
+    def test_frozen_falls_back_to_python_when_python3_missing(self, monkeypatch):
+        """``python`` is the Windows / minimal-Linux fallback."""
+        import shutil
+
+        from lilbee.crawler.bootstrap import _resolve_playwright_runner
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(
+            shutil, "which", lambda name: "/fake/bin/python" if name == "python" else None
+        )
+        runner = _resolve_playwright_runner()
+        assert runner == ["/fake/bin/python", "-m", "playwright"]
+
+    def test_frozen_no_python_raises_actionable_error(self, monkeypatch):
+        """No interpreter on PATH: raise CrawlerBrowserMissing with install hint."""
+        import shutil
+
+        from lilbee.crawler.bootstrap import CrawlerBrowserMissing, _resolve_playwright_runner
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(shutil, "which", lambda _name: None)
+        with pytest.raises(CrawlerBrowserMissing) as ei:
+            _resolve_playwright_runner()
+        # The error must name the install fix; bare 'not found' breaks the
+        # the user's recovery loop in the release executable.
+        message = str(ei.value)
+        assert "Python 3.11" in message
+        assert "playwright install" in message
+
+
+class TestBootstrapChromiumFrozen:
+    """End-to-end: bootstrap_chromium routes through _resolve_playwright_runner.
+
+    Verifies the frozen-no-python path emits a setup_done(success=False)
+    event and raises CrawlerBrowserMissing so the task center routes the
+    user to the actionable error instead of silently failing.
+    """
+
+    async def test_frozen_no_python_emits_setup_done_failure(self, monkeypatch):
+        import shutil
+
+        from lilbee.crawler.bootstrap import CrawlerBrowserMissing, bootstrap_chromium
+        from lilbee.progress import EventType, SetupDoneEvent
+
+        monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: False)
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+        events: list[tuple[EventType, object]] = []
+        with pytest.raises(CrawlerBrowserMissing):
+            await bootstrap_chromium(on_progress=lambda e, d: events.append((e, d)))
+
+        # setup_start must fire before the failure surfaces, then setup_done
+        # with success=False so the task bar transitions to FAILED.
+        types = [e for e, _ in events]
+        assert types[0] == EventType.SETUP_START
+        assert types[-1] == EventType.SETUP_DONE
+        last = events[-1][1]
+        assert isinstance(last, SetupDoneEvent)
+        assert last.success is False
+        assert last.error is not None and "Python 3.11" in last.error
+
+
 class TestPlaywrightBrowserCheck:
     def test_detects_missing_browsers(self, tmp_path, monkeypatch):
         """Empty browsers path reports as not installed."""

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -544,112 +544,75 @@ class TestBootstrapChromium:
 
 
 class TestResolvePlaywrightRunner:
-    """``_resolve_playwright_runner`` chooses the right argv prefix per layout.
+    """``_resolve_playwright_runner`` resolves Playwright's bundled Node driver
+    so chromium install works under both wheel and PyInstaller frozen layouts
+    without a system Python interpreter.
 
-    bb-sxsz: under PyInstaller, sys.executable is the lilbee binary not a
-    Python interpreter, so the wheel-style 'sys.executable -m playwright'
-    spawn exits 2 with 'No such command install'.
+    bb-sxsz: the previous wheel-style ``sys.executable -m playwright`` spawn
+    failed under PyInstaller because ``sys.executable`` is the lilbee binary,
+    not Python. Routing through ``compute_driver_executable`` invokes the
+    bundled ``playwright/driver/node`` + ``cli.js`` directly.
     """
 
-    def test_wheel_install_uses_sys_executable(self, monkeypatch):
-        """Non-frozen layout: argv prefix is [sys.executable, '-m', 'playwright']."""
-        from lilbee.crawler.bootstrap import _resolve_playwright_runner
+    def test_uses_compute_driver_executable(self, monkeypatch):
+        """Returns argv from playwright's bundled driver lookup, with driver env."""
+        from lilbee.crawler import bootstrap as boot_mod
 
-        monkeypatch.delattr(sys, "frozen", raising=False)
-        runner = _resolve_playwright_runner()
-        assert runner == [sys.executable, "-m", "playwright"]
-
-    def test_frozen_falls_back_to_python_on_path(self, monkeypatch):
-        """PyInstaller layout: pick up python3 / python from PATH."""
-        import shutil
-
-        from lilbee.crawler.bootstrap import _resolve_playwright_runner
-
-        monkeypatch.setattr(sys, "frozen", True, raising=False)
-        monkeypatch.setattr(shutil, "which", lambda name: f"/fake/bin/{name}")
-        runner = _resolve_playwright_runner()
-        assert runner == ["/fake/bin/python3", "-m", "playwright"]
-
-    def test_frozen_prefers_python3_over_python(self, monkeypatch):
-        """``python3`` wins when both are on PATH (Linux/macOS convention)."""
-        import shutil
-
-        from lilbee.crawler.bootstrap import _resolve_playwright_runner
-
-        monkeypatch.setattr(sys, "frozen", True, raising=False)
-        seen: list[str] = []
-
-        def _which(name):
-            seen.append(name)
-            # Both exist; helper should pick python3 first.
-            return f"/fake/bin/{name}"
-
-        monkeypatch.setattr(shutil, "which", _which)
-        runner = _resolve_playwright_runner()
-        assert runner[0] == "/fake/bin/python3"
-        assert seen[0] == "python3"
-
-    def test_frozen_falls_back_to_python_when_python3_missing(self, monkeypatch):
-        """``python`` is the Windows / minimal-Linux fallback."""
-        import shutil
-
-        from lilbee.crawler.bootstrap import _resolve_playwright_runner
-
-        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        fake_node = "/fake/site-packages/playwright/driver/node"
+        fake_cli = "/fake/site-packages/playwright/driver/package/cli.js"
         monkeypatch.setattr(
-            shutil, "which", lambda name: "/fake/bin/python" if name == "python" else None
+            "playwright._impl._driver.compute_driver_executable",
+            lambda: (fake_node, fake_cli),
         )
-        runner = _resolve_playwright_runner()
-        assert runner == ["/fake/bin/python", "-m", "playwright"]
+        monkeypatch.setattr(
+            "playwright._impl._driver.get_driver_env",
+            lambda: {"PW_LANG_NAME": "python", "PATH": "/usr/bin"},
+        )
 
-    def test_frozen_no_python_raises_actionable_error(self, monkeypatch):
-        """No interpreter on PATH: raise CrawlerBrowserMissing with install hint."""
-        import shutil
+        argv, env = boot_mod._resolve_playwright_runner()
+        assert argv == [fake_node, fake_cli]
+        assert env["PW_LANG_NAME"] == "python"
+        assert env["PATH"] == "/usr/bin"
+
+    def test_works_under_frozen_build(self, monkeypatch):
+        """PyInstaller layout: same code path, no system Python required."""
+        from lilbee.crawler import bootstrap as boot_mod
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        fake_node = "/_MEI/playwright/driver/node"
+        fake_cli = "/_MEI/playwright/driver/package/cli.js"
+        monkeypatch.setattr(
+            "playwright._impl._driver.compute_driver_executable",
+            lambda: (fake_node, fake_cli),
+        )
+        monkeypatch.setattr("playwright._impl._driver.get_driver_env", lambda: {})
+
+        argv, _env = boot_mod._resolve_playwright_runner()
+        assert argv == [fake_node, fake_cli]
+
+    def test_playwright_missing_raises_actionable_error(self, monkeypatch):
+        """``ImportError: playwright`` raises CrawlerBrowserMissing with install hint."""
+        # Pretend playwright isn't installed by injecting a failing module loader
+        # for the exact path _resolve_playwright_runner imports from.
+        import builtins
 
         from lilbee.crawler.bootstrap import CrawlerBrowserMissing, _resolve_playwright_runner
 
-        monkeypatch.setattr(sys, "frozen", True, raising=False)
-        monkeypatch.setattr(shutil, "which", lambda _name: None)
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "playwright._impl._driver":
+                raise ImportError("No module named 'playwright'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
         with pytest.raises(CrawlerBrowserMissing) as ei:
             _resolve_playwright_runner()
-        # The error must name the install fix; bare 'not found' breaks the
-        # the user's recovery loop in the release executable.
         message = str(ei.value)
-        assert "Python 3.11" in message
-        assert "playwright install" in message
-
-
-class TestBootstrapChromiumFrozen:
-    """End-to-end: bootstrap_chromium routes through _resolve_playwright_runner.
-
-    Verifies the frozen-no-python path emits a setup_done(success=False)
-    event and raises CrawlerBrowserMissing so the task center routes the
-    user to the actionable error instead of silently failing.
-    """
-
-    async def test_frozen_no_python_emits_setup_done_failure(self, monkeypatch):
-        import shutil
-
-        from lilbee.crawler.bootstrap import CrawlerBrowserMissing, bootstrap_chromium
-        from lilbee.progress import EventType, SetupDoneEvent
-
-        monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: False)
-        monkeypatch.setattr(sys, "frozen", True, raising=False)
-        monkeypatch.setattr(shutil, "which", lambda _name: None)
-
-        events: list[tuple[EventType, object]] = []
-        with pytest.raises(CrawlerBrowserMissing):
-            await bootstrap_chromium(on_progress=lambda e, d: events.append((e, d)))
-
-        # setup_start must fire before the failure surfaces, then setup_done
-        # with success=False so the task bar transitions to FAILED.
-        types = [e for e, _ in events]
-        assert types[0] == EventType.SETUP_START
-        assert types[-1] == EventType.SETUP_DONE
-        last = events[-1][1]
-        assert isinstance(last, SetupDoneEvent)
-        assert last.success is False
-        assert last.error is not None and "Python 3.11" in last.error
+        # Must name the install fix; bare 'not found' breaks the user's
+        # recovery loop in the release executable.
+        assert "lilbee[crawler]" in message or "playwright" in message
 
 
 class TestPlaywrightBrowserCheck:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1366,6 +1366,61 @@ class TestPeriodicSync:
         lock.release()
 
 
+class TestDrainBackgroundTasks:
+    """``_drain_background_tasks`` waits for spawned periodic-sync tasks
+    so the crawl runner doesn't close the loop with work mid-flight.
+    """
+
+    async def test_no_pending_tasks_returns_immediately(self, isolated_env):
+        """With no spawned tasks, the helper is a fast no-op."""
+        from lilbee.crawler.api import _drain_background_tasks, _state
+
+        _state.background_tasks = set()
+        await _drain_background_tasks()
+        assert _state.background_tasks == set()
+
+    async def test_awaits_pending_periodic_sync(self, isolated_env):
+        """A pending periodic-sync task must finish before the drain returns."""
+        import asyncio
+
+        from lilbee.crawler.api import _drain_background_tasks, _state
+
+        sync_finished = False
+
+        async def _slow_sync() -> None:
+            nonlocal sync_finished
+            await asyncio.sleep(0.01)
+            sync_finished = True
+
+        task = asyncio.create_task(_slow_sync())
+        _state.background_tasks = {task}
+        task.add_done_callback(_state.background_tasks.discard)
+
+        await _drain_background_tasks()
+
+        assert sync_finished is True
+        assert task.done()
+
+    async def test_swallows_task_exception(self, isolated_env):
+        """A failing periodic-sync task must not bubble out of the drain."""
+        import asyncio
+
+        from lilbee.crawler.api import _drain_background_tasks, _state
+
+        async def _boom() -> None:
+            await asyncio.sleep(0)
+            raise RuntimeError("sync exploded")
+
+        task = asyncio.create_task(_boom())
+        _state.background_tasks = {task}
+        task.add_done_callback(_state.background_tasks.discard)
+
+        # Must not raise: gather(..., return_exceptions=True) absorbs failures
+        # so the crawl finally-block stays robust.
+        await _drain_background_tasks()
+        assert task.done()
+
+
 class TestCrawlerStateReset:
     def test_reset_clears_all_state(self, isolated_env):
         """CrawlerState.reset() restores all fields to initial values."""
@@ -2083,6 +2138,51 @@ class TestStreamingFlush:
         ):
             await crawl_and_save("https://example.com", depth=2, max_pages=10)
         mock_sync.assert_awaited_once()
+
+    async def test_crawl_and_save_drains_background_tasks(self, isolated_env):
+        """bb-zqws: crawl_and_save awaits any spawned periodic-sync task before returning.
+
+        Without the drain, the asyncio runner closed the loop mid-ingest and
+        emitted ``Task was destroyed but it is pending`` for the periodic
+        sync's ``ingest_batch`` worker. The drain happens in the finally
+        block so the cancel-path also gets the cleanup.
+        """
+        import asyncio as _asyncio
+        import threading
+
+        from lilbee.crawler import api as crawler_mod
+
+        async def _gen():
+            await _asyncio.sleep(0)
+            yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# P1")
+
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=_gen())
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        sync_completed = _asyncio.Event()
+
+        async def _slow_sync(*_args, **_kwargs):
+            # Mimic the real ingest_batch: yield, then mark done. Without
+            # the drain, the loop would close before this runs.
+            await _asyncio.sleep(0.01)
+            sync_completed.set()
+
+        cfg.crawl_sync_interval = 1
+        crawler_mod._state.last_sync_time = 0.0
+        crawler_mod._state.sync_running = threading.Lock()
+
+        with (
+            patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
+            patch("lilbee.ingest.sync", _slow_sync),
+        ):
+            await crawl_and_save("https://example.com", depth=0)
+
+        # crawl_and_save should not return until the periodic-sync task has
+        # finished, so the Event is already set on the next line.
+        assert sync_completed.is_set()
+        assert all(t.done() for t in crawler_mod._state.background_tasks)
 
     async def test_metadata_flush_is_batched(self, isolated_env):
         """_flush_metadata fires every METADATA_FLUSH_INTERVAL pages, not every page."""

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sys
+import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,7 +23,16 @@ from lilbee.crawler import (
     url_to_filename,
     validate_crawl_url,
 )
-from lilbee.crawler.api import _get_crawl_semaphore, _maybe_periodic_sync
+from lilbee.crawler import bootstrap as bootstrap_mod
+from lilbee.crawler.api import (
+    _drain_background_tasks,
+    _get_crawl_semaphore,
+    _maybe_periodic_sync,
+)
+from lilbee.crawler.api import (
+    _state as crawler_state,
+)
+from lilbee.crawler.bootstrap import CrawlerBrowserMissing
 from lilbee.crawler.save import _save_single_result, _update_single_metadata
 from lilbee.progress import EventType
 
@@ -554,15 +564,7 @@ class TestBootstrapChromium:
 
 
 class TestResolvePlaywrightRunner:
-    """``_resolve_playwright_runner`` resolves Playwright's bundled Node driver
-    so chromium install works under both wheel and PyInstaller frozen layouts
-    without a system Python interpreter.
-
-    bb-sxsz: the previous wheel-style ``sys.executable -m playwright`` spawn
-    failed under PyInstaller because ``sys.executable`` is the lilbee binary,
-    not Python. Routing through ``compute_driver_executable`` invokes the
-    bundled ``playwright/driver/node`` + ``cli.js`` directly.
-    """
+    """``_resolve_playwright_runner`` returns argv + env for the bundled driver (bb-sxsz)."""
 
     def _install_fake_driver_module(
         self,
@@ -573,27 +575,20 @@ class TestResolvePlaywrightRunner:
     ) -> None:
         """Inject a fake ``playwright._impl._driver`` into sys.modules.
 
-        The regular ``test`` CI job runs without lilbee[crawler]; mocking
-        attributes on the real submodule with monkeypatch.setattr would
-        require the import to succeed first. Stubbing sys.modules instead
-        keeps the test importable on every lane.
+        The regular ``test`` CI job runs without lilbee[crawler]; stubbing
+        sys.modules keeps the test importable on every lane.
         """
-        import sys as _sys
-        import types
-
         playwright = types.ModuleType("playwright")
         playwright_impl = types.ModuleType("playwright._impl")
         playwright_driver = types.ModuleType("playwright._impl._driver")
         playwright_driver.compute_driver_executable = compute  # type: ignore[attr-defined]
         playwright_driver.get_driver_env = (lambda: env) if env is not None else None  # type: ignore[attr-defined]
-        monkeypatch.setitem(_sys.modules, "playwright", playwright)
-        monkeypatch.setitem(_sys.modules, "playwright._impl", playwright_impl)
-        monkeypatch.setitem(_sys.modules, "playwright._impl._driver", playwright_driver)
+        monkeypatch.setitem(sys.modules, "playwright", playwright)
+        monkeypatch.setitem(sys.modules, "playwright._impl", playwright_impl)
+        monkeypatch.setitem(sys.modules, "playwright._impl._driver", playwright_driver)
 
     def test_uses_compute_driver_executable(self, monkeypatch):
         """Returns argv from playwright's bundled driver lookup, with driver env."""
-        from lilbee.crawler import bootstrap as boot_mod
-
         fake_node = "/fake/site-packages/playwright/driver/node"
         fake_cli = "/fake/site-packages/playwright/driver/package/cli.js"
         self._install_fake_driver_module(
@@ -602,15 +597,13 @@ class TestResolvePlaywrightRunner:
             env={"PW_LANG_NAME": "python", "PATH": "/usr/bin"},
         )
 
-        argv, env = boot_mod._resolve_playwright_runner()
+        argv, env = bootstrap_mod._resolve_playwright_runner()
         assert argv == [fake_node, fake_cli]
         assert env["PW_LANG_NAME"] == "python"
         assert env["PATH"] == "/usr/bin"
 
     def test_works_under_frozen_build(self, monkeypatch):
         """PyInstaller layout: same code path, no system Python required."""
-        from lilbee.crawler import bootstrap as boot_mod
-
         monkeypatch.setattr(sys, "frozen", True, raising=False)
         fake_node = "/_MEI/playwright/driver/node"
         fake_cli = "/_MEI/playwright/driver/package/cli.js"
@@ -620,13 +613,11 @@ class TestResolvePlaywrightRunner:
             env={},
         )
 
-        argv, _env = boot_mod._resolve_playwright_runner()
+        argv, _env = bootstrap_mod._resolve_playwright_runner()
         assert argv == [fake_node, fake_cli]
 
     def test_compute_driver_failure_falls_back_when_not_frozen(self, monkeypatch):
         """compute_driver_executable raise on a wheel install falls back to sys.executable -m."""
-        from lilbee.crawler import bootstrap as boot_mod
-
         monkeypatch.delattr(sys, "frozen", raising=False)
 
         def _boom() -> tuple[str, str]:
@@ -634,13 +625,11 @@ class TestResolvePlaywrightRunner:
 
         self._install_fake_driver_module(monkeypatch, compute=_boom, env={})
 
-        argv, _env = boot_mod._resolve_playwright_runner()
+        argv, _env = bootstrap_mod._resolve_playwright_runner()
         assert argv == [sys.executable, "-m", "playwright"]
 
     def test_compute_driver_failure_under_frozen_propagates(self, monkeypatch):
-        """If compute_driver_executable raises on a frozen build, raise (no fallback)."""
-        from lilbee.crawler import bootstrap as boot_mod
-
+        """compute_driver_executable raise under PyInstaller propagates (no fallback)."""
         monkeypatch.setattr(sys, "frozen", True, raising=False)
 
         def _boom() -> tuple[str, str]:
@@ -649,13 +638,11 @@ class TestResolvePlaywrightRunner:
         self._install_fake_driver_module(monkeypatch, compute=_boom, env={})
 
         with pytest.raises(RuntimeError, match="API drift"):
-            boot_mod._resolve_playwright_runner()
+            bootstrap_mod._resolve_playwright_runner()
 
     def test_playwright_missing_raises_actionable_error(self, monkeypatch):
-        """``ImportError: playwright`` raises CrawlerBrowserMissing with install hint."""
+        """ImportError on playwright raises CrawlerBrowserMissing with install hint."""
         import builtins
-
-        from lilbee.crawler.bootstrap import CrawlerBrowserMissing, _resolve_playwright_runner
 
         real_import = builtins.__import__
 
@@ -667,21 +654,17 @@ class TestResolvePlaywrightRunner:
         monkeypatch.setattr(builtins, "__import__", fake_import)
 
         with pytest.raises(CrawlerBrowserMissing) as ei:
-            _resolve_playwright_runner()
+            bootstrap_mod._resolve_playwright_runner()
         message = str(ei.value)
-        # Must name the install fix; bare 'not found' breaks the user's
-        # recovery loop in the release executable.
+        # The error must name the install fix; bare 'not found' breaks the
+        # user's recovery loop in the release executable.
         assert "lilbee[crawler]" in message or "playwright" in message
 
     async def test_bootstrap_chromium_emits_setup_done_when_playwright_missing(self, monkeypatch):
-        """bootstrap_chromium catches the CrawlerBrowserMissing the runner
-        resolution raises, fires setup_done(success=False), and re-raises
-        so the task center routes the user to the actionable error.
-        """
+        """bootstrap_chromium fires setup_done(success=False) before re-raising."""
         import builtins
 
-        from lilbee.crawler.bootstrap import CrawlerBrowserMissing, bootstrap_chromium
-        from lilbee.progress import EventType, SetupDoneEvent
+        from lilbee.progress import SetupDoneEvent
 
         monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: False)
 
@@ -696,10 +679,8 @@ class TestResolvePlaywrightRunner:
 
         events: list[tuple[EventType, object]] = []
         with pytest.raises(CrawlerBrowserMissing):
-            await bootstrap_chromium(on_progress=lambda e, d: events.append((e, d)))
+            await bootstrap_mod.bootstrap_chromium(on_progress=lambda e, d: events.append((e, d)))
 
-        # setup_start fires before the failure surfaces, then setup_done
-        # with success=False so the task bar transitions to FAILED.
         types = [e for e, _ in events]
         assert types[0] == EventType.SETUP_START
         assert types[-1] == EventType.SETUP_DONE
@@ -1533,36 +1514,24 @@ class TestPeriodicSync:
 
 
 class TestDrainBackgroundTasks:
-    """``_drain_background_tasks`` waits for spawned periodic-sync tasks
-    so the crawl runner doesn't close the loop with work mid-flight.
-    """
+    """``_drain_background_tasks`` cancels periodic-sync tasks so crawl_and_save
+    can exit cleanly without 'destroyed but pending' warnings. (bb-zqws)"""
 
     async def test_no_pending_tasks_returns_immediately(self, isolated_env):
         """With no spawned tasks, the helper is a fast no-op."""
-        from lilbee.crawler.api import _drain_background_tasks, _state
-
-        _state.background_tasks = set()
+        crawler_state.background_tasks = set()
         await _drain_background_tasks()
-        assert _state.background_tasks == set()
+        assert crawler_state.background_tasks == set()
 
     async def test_cancels_pending_periodic_sync(self, isolated_env):
-        """A pending periodic-sync task must be cancelled by the drain.
-
-        The drain cancels rather than awaits so a slow or stuck sync can't
-        block crawl_and_save's exit. The task ends as Cancelled rather
-        than completed, but the asyncio runner sees a clean teardown
-        (no "Task was destroyed but it is pending" warning).
-        """
-        import asyncio
-
-        from lilbee.crawler.api import _drain_background_tasks, _state
+        """The drain cancels (not awaits) so a slow sync can't block crawl_and_save's exit."""
 
         async def _slow_sync() -> None:
             await asyncio.sleep(60.0)  # would deadlock the test if awaited
 
         task = asyncio.create_task(_slow_sync())
-        _state.background_tasks = {task}
-        task.add_done_callback(_state.background_tasks.discard)
+        crawler_state.background_tasks = {task}
+        task.add_done_callback(crawler_state.background_tasks.discard)
 
         await _drain_background_tasks()
 
@@ -1571,28 +1540,20 @@ class TestDrainBackgroundTasks:
 
     async def test_swallows_task_exception(self, isolated_env):
         """A failing periodic-sync task must not bubble out of the drain."""
-        import asyncio
-
-        from lilbee.crawler.api import _drain_background_tasks, _state
 
         async def _boom() -> None:
             await asyncio.sleep(0)
             raise RuntimeError("sync exploded")
 
         task = asyncio.create_task(_boom())
-        _state.background_tasks = {task}
-        task.add_done_callback(_state.background_tasks.discard)
+        crawler_state.background_tasks = {task}
+        task.add_done_callback(crawler_state.background_tasks.discard)
 
-        # Must not raise: gather(..., return_exceptions=True) absorbs failures
-        # so the crawl finally-block stays robust.
         await _drain_background_tasks()
         assert task.done()
 
     async def test_skips_already_done_task(self, isolated_env):
         """A task that already finished is left untouched by the drain."""
-        import asyncio
-
-        from lilbee.crawler.api import _drain_background_tasks, _state
 
         async def _quick() -> str:
             return "ok"
@@ -1600,10 +1561,9 @@ class TestDrainBackgroundTasks:
         task = asyncio.create_task(_quick())
         await task  # finish it before the drain sees it
         # Re-add manually because add_done_callback already discarded it.
-        _state.background_tasks = {task}
+        crawler_state.background_tasks = {task}
 
         await _drain_background_tasks()
-        # Drain saw the done task and skipped it (no cancel attempt).
         assert task.done()
         assert not task.cancelled()
         assert task.result() == "ok"
@@ -1612,28 +1572,22 @@ class TestDrainBackgroundTasks:
         """A task whose loop has closed gets dropped instead of awaited.
 
         Mirrors what happens when an earlier asyncio.run() call left a task
-        in _state.background_tasks: subsequent crawl_and_save() runs on a
-        new loop and must not try to cross-await it.
+        in background_tasks: subsequent crawl_and_save() runs on a new loop
+        and must not try to cross-await it.
         """
-        import asyncio
-        from unittest.mock import MagicMock
-
-        from lilbee.crawler.api import _drain_background_tasks, _state
-
-        # Build a stand-in task whose get_loop() points at a different
-        # (not-running) loop. MagicMock(spec=Task) keeps isinstance checks
-        # happy without spawning a real cross-loop task.
+        # MagicMock(spec=Task) lets us simulate a cross-loop entry without
+        # spawning a real task on a separate loop (which would be cleanup-heavy).
         other_loop = asyncio.new_event_loop()
         try:
             stale_task = MagicMock(spec=asyncio.Task)
             stale_task.done.return_value = False
             stale_task.get_loop.return_value = other_loop
 
-            _state.background_tasks = {stale_task}
+            crawler_state.background_tasks = {stale_task}
 
             await _drain_background_tasks()
 
-            assert stale_task not in _state.background_tasks
+            assert stale_task not in crawler_state.background_tasks
             stale_task.cancel.assert_not_called()  # never touched mid-flight
         finally:
             other_loop.close()
@@ -2358,21 +2312,11 @@ class TestStreamingFlush:
         mock_sync.assert_awaited_once()
 
     async def test_crawl_and_save_drains_background_tasks(self, isolated_env):
-        """bb-zqws: crawl_and_save cancels any spawned periodic-sync task before returning.
-
-        Without the drain, the asyncio runner closed the loop mid-ingest and
-        emitted ``Task was destroyed but it is pending`` for the periodic
-        sync's ``ingest_batch`` worker. The drain cancels in the finally
-        block - cancellation is enough to satisfy asyncio's destruction
-        check, and avoids the deadlock risk of awaiting a slow sync.
-        """
-        import asyncio as _asyncio
+        """crawl_and_save cancels any spawned periodic-sync task before returning. (bb-zqws)"""
         import threading
 
-        from lilbee.crawler import api as crawler_mod
-
         async def _gen():
-            await _asyncio.sleep(0)
+            await asyncio.sleep(0)
             yield _make_crawl4ai_result(url="https://example.com/p1", markdown="# P1")
 
         mock_instance = AsyncMock()
@@ -2381,13 +2325,12 @@ class TestStreamingFlush:
         mock_instance.__aexit__ = AsyncMock(return_value=False)
 
         async def _slow_sync(*_args, **_kwargs):
-            # Sync that would deadlock the test if awaited; the drain
-            # must cancel it instead.
-            await _asyncio.sleep(60.0)
+            # Would deadlock the test if the drain awaited instead of cancelling.
+            await asyncio.sleep(60.0)
 
         cfg.crawl_sync_interval = 1
-        crawler_mod._state.last_sync_time = 0.0
-        crawler_mod._state.sync_running = threading.Lock()
+        crawler_state.last_sync_time = 0.0
+        crawler_state.sync_running = threading.Lock()
 
         with (
             patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
@@ -2395,9 +2338,9 @@ class TestStreamingFlush:
         ):
             await crawl_and_save("https://example.com", depth=0)
 
-        # All spawned periodic-sync tasks finished as Cancelled. The set
-        # is empty because the done callback removes them.
-        assert all(t.done() for t in crawler_mod._state.background_tasks)
+        # The done callback cleared the registry; any task that survived would
+        # mean the drain didn't await its cancellation.
+        assert all(t.done() for t in crawler_state.background_tasks)
 
     async def test_metadata_flush_is_batched(self, isolated_env):
         """_flush_metadata fires every METADATA_FLUSH_INTERVAL pages, not every page."""

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -847,3 +847,58 @@ class TestSuppressStderrThreadSafety:
         result = suppress_native_stderr(check_lock)
         assert result == 42
         assert lock_was_held == [True]
+
+
+class TestImportLlamaCpp:
+    """``_import_llama_cpp`` converts a missing-libvulkan OSError into actionable text."""
+
+    def test_returns_module_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Happy path: hands back the imported module."""
+        sentinel = mock.MagicMock(name="llama_cpp_module")
+        monkeypatch.setitem(sys.modules, "llama_cpp", sentinel)
+
+        from lilbee.providers.llama_cpp_provider import _import_llama_cpp
+
+        assert _import_llama_cpp() is sentinel
+
+    def test_libvulkan_oserror_raises_provider_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bare Linux installs without libvulkan get install instructions, not a raw OSError."""
+        import builtins
+
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.llama_cpp_provider import _import_llama_cpp
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "llama_cpp":
+                raise OSError("libvulkan.so.1: cannot open shared object file")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.delitem(sys.modules, "llama_cpp", raising=False)
+
+        with pytest.raises(ProviderError) as ei:
+            _import_llama_cpp()
+        message = str(ei.value)
+        assert "vulkan-icd-loader" in message
+        assert "libvulkan1" in message
+
+    def test_unrelated_oserror_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-vulkan OSErrors are not swallowed."""
+        import builtins
+
+        from lilbee.providers.llama_cpp_provider import _import_llama_cpp
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "llama_cpp":
+                raise OSError("libsomethingelse.so: not found")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.delitem(sys.modules, "llama_cpp", raising=False)
+
+        with pytest.raises(OSError, match="libsomethingelse"):
+            _import_llama_cpp()

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import sys
 import threading
 import time
@@ -13,6 +14,8 @@ import pytest
 
 from conftest import TEST_EMBED_REF, TEST_LOCAL_REF
 from lilbee.config import cfg
+from lilbee.providers.base import ProviderError
+from lilbee.providers.llama_cpp_provider import import_llama_cpp
 
 
 @pytest.fixture(autouse=True)
@@ -850,24 +853,17 @@ class TestSuppressStderrThreadSafety:
 
 
 class TestImportLlamaCpp:
-    """``import_llama_cpp`` converts a missing-libvulkan OSError into actionable text."""
+    """``import_llama_cpp`` converts a missing-libvulkan OSError into a ProviderError. (bb-387n)"""
 
     def test_returns_module_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Happy path: hands back the imported module."""
         sentinel = mock.MagicMock(name="llama_cpp_module")
         monkeypatch.setitem(sys.modules, "llama_cpp", sentinel)
 
-        from lilbee.providers.llama_cpp_provider import import_llama_cpp
-
         assert import_llama_cpp() is sentinel
 
     def test_libvulkan_oserror_raises_provider_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Bare Linux installs without libvulkan get install instructions, not a raw OSError."""
-        import builtins
-
-        from lilbee.providers.base import ProviderError
-        from lilbee.providers.llama_cpp_provider import import_llama_cpp
-
         real_import = builtins.__import__
 
         def fake_import(name: str, *args: object, **kwargs: object) -> object:
@@ -886,10 +882,6 @@ class TestImportLlamaCpp:
 
     def test_unrelated_oserror_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Non-vulkan OSErrors are not swallowed."""
-        import builtins
-
-        from lilbee.providers.llama_cpp_provider import import_llama_cpp
-
         real_import = builtins.__import__
 
         def fake_import(name: str, *args: object, **kwargs: object) -> object:

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -850,23 +850,23 @@ class TestSuppressStderrThreadSafety:
 
 
 class TestImportLlamaCpp:
-    """``_import_llama_cpp`` converts a missing-libvulkan OSError into actionable text."""
+    """``import_llama_cpp`` converts a missing-libvulkan OSError into actionable text."""
 
     def test_returns_module_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Happy path: hands back the imported module."""
         sentinel = mock.MagicMock(name="llama_cpp_module")
         monkeypatch.setitem(sys.modules, "llama_cpp", sentinel)
 
-        from lilbee.providers.llama_cpp_provider import _import_llama_cpp
+        from lilbee.providers.llama_cpp_provider import import_llama_cpp
 
-        assert _import_llama_cpp() is sentinel
+        assert import_llama_cpp() is sentinel
 
     def test_libvulkan_oserror_raises_provider_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Bare Linux installs without libvulkan get install instructions, not a raw OSError."""
         import builtins
 
         from lilbee.providers.base import ProviderError
-        from lilbee.providers.llama_cpp_provider import _import_llama_cpp
+        from lilbee.providers.llama_cpp_provider import import_llama_cpp
 
         real_import = builtins.__import__
 
@@ -879,7 +879,7 @@ class TestImportLlamaCpp:
         monkeypatch.delitem(sys.modules, "llama_cpp", raising=False)
 
         with pytest.raises(ProviderError) as ei:
-            _import_llama_cpp()
+            import_llama_cpp()
         message = str(ei.value)
         assert "vulkan-icd-loader" in message
         assert "libvulkan1" in message
@@ -888,7 +888,7 @@ class TestImportLlamaCpp:
         """Non-vulkan OSErrors are not swallowed."""
         import builtins
 
-        from lilbee.providers.llama_cpp_provider import _import_llama_cpp
+        from lilbee.providers.llama_cpp_provider import import_llama_cpp
 
         real_import = builtins.__import__
 
@@ -901,4 +901,4 @@ class TestImportLlamaCpp:
         monkeypatch.delitem(sys.modules, "llama_cpp", raising=False)
 
         with pytest.raises(OSError, match="libsomethingelse"):
-            _import_llama_cpp()
+            import_llama_cpp()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8087,6 +8087,48 @@ class TestResetTerminalModes:
         app_mod._reset_terminal_modes()
 
 
+class TestSilenceStderrLogHandlers:
+    """``_silence_stderr_log_handlers`` strips stderr-streaming handlers
+    from the root logger before mounting Textual, so library log writes
+    can't corrupt the TUI's bottom-bar render. (bb-82ce)
+    """
+
+    def test_removes_stderr_streamhandler(self):
+        import logging
+        import sys
+
+        from lilbee.cli.tui import _silence_stderr_log_handlers
+
+        root = logging.getLogger()
+        before = list(root.handlers)
+        try:
+            stderr_handler = logging.StreamHandler(sys.stderr)
+            root.addHandler(stderr_handler)
+            _silence_stderr_log_handlers()
+            assert stderr_handler not in root.handlers
+        finally:
+            root.handlers[:] = before
+
+    def test_keeps_file_and_null_handlers(self, tmp_path):
+        import logging
+
+        from lilbee.cli.tui import _silence_stderr_log_handlers
+
+        root = logging.getLogger()
+        before = list(root.handlers)
+        try:
+            file_handler = logging.FileHandler(tmp_path / "lilbee.log")
+            null_handler = logging.NullHandler()
+            root.addHandler(file_handler)
+            root.addHandler(null_handler)
+            _silence_stderr_log_handlers()
+            assert file_handler in root.handlers
+            assert null_handler in root.handlers
+        finally:
+            root.handlers[:] = before
+            file_handler.close()
+
+
 async def test_app_switch_view_unknown():
     """switch_view with unknown name does nothing."""
     from lilbee.cli.tui.app import LilbeeApp

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8009,11 +8009,82 @@ async def test_app_force_quit_calls_os_exit():
         await _pilot.pause()
         with (
             patch("lilbee.cli.tui.app.reset_services") as mock_reset,
+            patch("lilbee.cli.tui.app._reset_terminal_modes") as mock_reset_term,
             patch("os._exit") as mock_exit,
         ):
             app._force_quit()
             mock_reset.assert_called_once()
+            mock_reset_term.assert_called_once()
             mock_exit.assert_called_once_with(1)
+
+
+class TestResetTerminalModes:
+    """``_reset_terminal_modes`` writes the alt-screen / paste / mouse off
+    sequences when stdout is a TTY, so a force-quit doesn't leave the next
+    shell command interpreting paste-mode escape bytes as input. (bb-6b86)
+    """
+
+    def test_writes_reset_sequence_when_tty(self, monkeypatch):
+        from io import StringIO
+
+        from lilbee.cli.tui import app as app_mod
+
+        fake_stdout = StringIO()
+        monkeypatch.setattr(fake_stdout, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr("sys.stdout", fake_stdout)
+
+        app_mod._reset_terminal_modes()
+        out = fake_stdout.getvalue()
+
+        # Bracketed paste off, mouse tracking off, alt-screen off, cursor on.
+        assert "\x1b[?2004l" in out
+        assert "\x1b[?1003l" in out
+        assert "\x1b[?1049l" in out
+        assert "\x1b[?25h" in out
+
+    def test_skips_write_when_not_tty(self, monkeypatch):
+        from io import StringIO
+
+        from lilbee.cli.tui import app as app_mod
+
+        fake_stdout = StringIO()
+        monkeypatch.setattr(fake_stdout, "isatty", lambda: False, raising=False)
+        monkeypatch.setattr("sys.stdout", fake_stdout)
+
+        app_mod._reset_terminal_modes()
+        # Non-TTY (CI, pipes): no terminal state to reset, no bytes written.
+        assert fake_stdout.getvalue() == ""
+
+    def test_swallows_oserror_so_force_quit_can_still_exit(self, monkeypatch):
+        """Write failures must not raise: _force_quit calls this on the way
+        to ``os._exit`` and a propagating exception would mask the exit.
+        """
+        from lilbee.cli.tui import app as app_mod
+
+        class _BrokenStdout:
+            def isatty(self) -> bool:
+                return True
+
+            def write(self, _data: str) -> int:
+                raise OSError("EBADF")
+
+            def flush(self) -> None:  # pragma: no cover - never reached
+                raise AssertionError("flush should not run after write fails")
+
+        monkeypatch.setattr("sys.stdout", _BrokenStdout())
+        # Must not raise.
+        app_mod._reset_terminal_modes()
+
+    def test_swallows_valueerror_on_closed_stdout(self, monkeypatch):
+        """A closed stdout raises ValueError on isatty(); the helper is a no-op."""
+        from lilbee.cli.tui import app as app_mod
+
+        class _ClosedStdout:
+            def isatty(self) -> bool:
+                raise ValueError("I/O operation on closed file")
+
+        monkeypatch.setattr("sys.stdout", _ClosedStdout())
+        app_mod._reset_terminal_modes()
 
 
 async def test_app_switch_view_unknown():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import logging
+import sys
+from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +19,8 @@ from lilbee.catalog import (
     CatalogModel,
     CatalogResult,
 )
+from lilbee.cli.tui import _silence_stderr_log_handlers
+from lilbee.cli.tui import app as tui_app
 from lilbee.cli.tui.screens.catalog import (
     _WORKER_FETCH_HF,
     _WORKER_FETCH_MORE_HF,
@@ -8019,47 +8024,33 @@ async def test_app_force_quit_calls_os_exit():
 
 
 class TestResetTerminalModes:
-    """``_reset_terminal_modes`` writes the alt-screen / paste / mouse off
-    sequences when stdout is a TTY, so a force-quit doesn't leave the next
-    shell command interpreting paste-mode escape bytes as input. (bb-6b86)
-    """
+    """``_reset_terminal_modes`` emits terminal-mode reset sequences on a TTY. (bb-6b86)"""
 
     def test_writes_reset_sequence_when_tty(self, monkeypatch):
-        from io import StringIO
-
-        from lilbee.cli.tui import app as app_mod
-
+        """Bracketed paste, mouse tracking, alt-screen off; cursor on."""
         fake_stdout = StringIO()
         monkeypatch.setattr(fake_stdout, "isatty", lambda: True, raising=False)
         monkeypatch.setattr("sys.stdout", fake_stdout)
 
-        app_mod._reset_terminal_modes()
+        tui_app._reset_terminal_modes()
         out = fake_stdout.getvalue()
 
-        # Bracketed paste off, mouse tracking off, alt-screen off, cursor on.
         assert "\x1b[?2004l" in out
         assert "\x1b[?1003l" in out
         assert "\x1b[?1049l" in out
         assert "\x1b[?25h" in out
 
     def test_skips_write_when_not_tty(self, monkeypatch):
-        from io import StringIO
-
-        from lilbee.cli.tui import app as app_mod
-
+        """Non-TTY (CI, pipes): no terminal state to reset, no bytes written."""
         fake_stdout = StringIO()
         monkeypatch.setattr(fake_stdout, "isatty", lambda: False, raising=False)
         monkeypatch.setattr("sys.stdout", fake_stdout)
 
-        app_mod._reset_terminal_modes()
-        # Non-TTY (CI, pipes): no terminal state to reset, no bytes written.
+        tui_app._reset_terminal_modes()
         assert fake_stdout.getvalue() == ""
 
     def test_swallows_oserror_so_force_quit_can_still_exit(self, monkeypatch):
-        """Write failures must not raise: _force_quit calls this on the way
-        to ``os._exit`` and a propagating exception would mask the exit.
-        """
-        from lilbee.cli.tui import app as app_mod
+        """Write failures must not raise: a propagating exception would mask os._exit."""
 
         class _BrokenStdout:
             def isatty(self) -> bool:
@@ -8072,33 +8063,24 @@ class TestResetTerminalModes:
                 raise AssertionError("flush should not run after write fails")
 
         monkeypatch.setattr("sys.stdout", _BrokenStdout())
-        # Must not raise.
-        app_mod._reset_terminal_modes()
+        tui_app._reset_terminal_modes()
 
     def test_swallows_valueerror_on_closed_stdout(self, monkeypatch):
         """A closed stdout raises ValueError on isatty(); the helper is a no-op."""
-        from lilbee.cli.tui import app as app_mod
 
         class _ClosedStdout:
             def isatty(self) -> bool:
                 raise ValueError("I/O operation on closed file")
 
         monkeypatch.setattr("sys.stdout", _ClosedStdout())
-        app_mod._reset_terminal_modes()
+        tui_app._reset_terminal_modes()
 
 
 class TestSilenceStderrLogHandlers:
-    """``_silence_stderr_log_handlers`` strips stderr-streaming handlers
-    from the root logger before mounting Textual, so library log writes
-    can't corrupt the TUI's bottom-bar render. (bb-82ce)
-    """
+    """``_silence_stderr_log_handlers`` drops stderr/stdout root handlers (bb-82ce)."""
 
     def test_removes_stderr_streamhandler(self):
-        import logging
-        import sys
-
-        from lilbee.cli.tui import _silence_stderr_log_handlers
-
+        """A StreamHandler bound to sys.stderr is removed from the root logger."""
         root = logging.getLogger()
         before = list(root.handlers)
         try:
@@ -8110,10 +8092,7 @@ class TestSilenceStderrLogHandlers:
             root.handlers[:] = before
 
     def test_keeps_file_and_null_handlers(self, tmp_path):
-        import logging
-
-        from lilbee.cli.tui import _silence_stderr_log_handlers
-
+        """FileHandler (stream is the log file, not stderr) and NullHandler stay attached."""
         root = logging.getLogger()
         before = list(root.handlers)
         try:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import sys
-from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -8006,7 +8005,7 @@ async def test_app_action_quit_double_force_exits():
 
 
 async def test_app_force_quit_calls_os_exit():
-    """_force_quit resets services and calls os._exit."""
+    """_force_quit resets services, runs Textual driver teardown, then calls os._exit."""
     from lilbee.cli.tui.app import LilbeeApp
 
     app = LilbeeApp()
@@ -8014,66 +8013,35 @@ async def test_app_force_quit_calls_os_exit():
         await _pilot.pause()
         with (
             patch("lilbee.cli.tui.app.reset_services") as mock_reset,
-            patch("lilbee.cli.tui.app._reset_terminal_modes") as mock_reset_term,
+            patch("lilbee.cli.tui.app._restore_terminal_via_driver") as mock_restore,
             patch("os._exit") as mock_exit,
         ):
             app._force_quit()
             mock_reset.assert_called_once()
-            mock_reset_term.assert_called_once()
+            mock_restore.assert_called_once_with(app)
             mock_exit.assert_called_once_with(1)
 
 
-class TestResetTerminalModes:
-    """``_reset_terminal_modes`` emits terminal-mode reset sequences on a TTY. (bb-6b86)"""
+class TestRestoreTerminalViaDriver:
+    """``_restore_terminal_via_driver`` runs Textual's driver teardown before os._exit (bb-6b86)."""
 
-    def test_writes_reset_sequence_when_tty(self, monkeypatch):
-        """Bracketed paste, mouse tracking, alt-screen off; cursor on."""
-        fake_stdout = StringIO()
-        monkeypatch.setattr(fake_stdout, "isatty", lambda: True, raising=False)
-        monkeypatch.setattr("sys.stdout", fake_stdout)
+    def test_calls_driver_stop_application_mode(self):
+        """Driver teardown is the path that emits Textual's full restore sequence."""
+        app = MagicMock()
+        tui_app._restore_terminal_via_driver(app)
+        app._driver.stop_application_mode.assert_called_once_with()
 
-        tui_app._reset_terminal_modes()
-        out = fake_stdout.getvalue()
+    def test_no_op_when_driver_unset(self):
+        """Early-startup or post-teardown: ``_driver`` is None; no AttributeError."""
+        app = MagicMock()
+        app._driver = None
+        tui_app._restore_terminal_via_driver(app)  # must not raise
 
-        assert "\x1b[?2004l" in out
-        assert "\x1b[?1003l" in out
-        assert "\x1b[?1049l" in out
-        assert "\x1b[?25h" in out
-
-    def test_skips_write_when_not_tty(self, monkeypatch):
-        """Non-TTY (CI, pipes): no terminal state to reset, no bytes written."""
-        fake_stdout = StringIO()
-        monkeypatch.setattr(fake_stdout, "isatty", lambda: False, raising=False)
-        monkeypatch.setattr("sys.stdout", fake_stdout)
-
-        tui_app._reset_terminal_modes()
-        assert fake_stdout.getvalue() == ""
-
-    def test_swallows_oserror_so_force_quit_can_still_exit(self, monkeypatch):
-        """Write failures must not raise: a propagating exception would mask os._exit."""
-
-        class _BrokenStdout:
-            def isatty(self) -> bool:
-                return True
-
-            def write(self, _data: str) -> int:
-                raise OSError("EBADF")
-
-            def flush(self) -> None:  # pragma: no cover - never reached
-                raise AssertionError("flush should not run after write fails")
-
-        monkeypatch.setattr("sys.stdout", _BrokenStdout())
-        tui_app._reset_terminal_modes()
-
-    def test_swallows_valueerror_on_closed_stdout(self, monkeypatch):
-        """A closed stdout raises ValueError on isatty(); the helper is a no-op."""
-
-        class _ClosedStdout:
-            def isatty(self) -> bool:
-                raise ValueError("I/O operation on closed file")
-
-        monkeypatch.setattr("sys.stdout", _ClosedStdout())
-        tui_app._reset_terminal_modes()
+    def test_swallows_driver_teardown_failure(self):
+        """A driver mid-teardown that raises must not block ``os._exit``."""
+        app = MagicMock()
+        app._driver.stop_application_mode.side_effect = RuntimeError("boom")
+        tui_app._restore_terminal_via_driver(app)  # must not raise
 
 
 class TestSilenceStderrLogHandlers:


### PR DESCRIPTION
## Problem

The QA matrix (PR #193) surfaced a wave of bugs against the published release binary and the wheel install. On bare Arch / Fedora, the Linux wheel crashed with a raw `OSError: libvulkan.so.1: cannot open shared object file` from any code path that imported `llama_cpp` — chat, embeddings, vision OCR, even `lilbee self-check` — with no install hint. Under PyInstaller, `lilbee setup crawler` and `lilbee add <url> --crawl` exited 2 because the bootstrap spawned `lilbee-macos-arm64 -m playwright install` instead of a real Python interpreter. Every successful crawl bled `Task was destroyed but it is pending` and `coroutine never awaited` warnings into the TUI. A force-quit (double Ctrl+C) left the terminal in alt-screen / paste mode so the next shell command read its own escape bytes as `No such command '4'`.

## Solution

**Linux wheel libvulkan (bb-387n).** A new public `import_llama_cpp()` helper converts the libvulkan-flavored OSError into a `ProviderError` that names the per-distro loader package (vulkan-icd-loader, vulkan-loader, libvulkan1) and points at the README's new "Linux runtime requirements" section. The helper is called at every llama_cpp entry point — chat / embed / rerank / vision OCR / GGUF metadata / self-check / capability probes — so the install hint surfaces from any first-contact path. The longer-term wheel-shape fix (default Linux wheel without Vulkan) is tracked in bb-ygz8.

**Crawler under PyInstaller (bb-sxsz).** `bootstrap_chromium` no longer spawns `sys.executable -m playwright` blindly. Wheel and uv-tool installs continue to use the active interpreter; frozen builds resolve a system `python3` / `python` from PATH and fall back to a `CrawlerBrowserMissing` with an install hint when neither is available.

**Crawler asyncio leak (bb-zqws).** `crawl_and_save` drains any periodic-sync task spawned during the crawl in its finally block, so the asyncio runner does not close the loop with the sync mid-ingest. Removes the `Task was destroyed` and `coroutine never awaited` noise on every successful crawl.

**Terminal mode after force-quit (bb-6b86).** `LilbeeApp._force_quit` writes the standard turn-off sequences for bracketed paste, mouse tracking, alt-screen, and the cursor before reaching `os._exit`, so the next shell command isn't fed still-armed escape bytes. TTY-only; non-tty stdout is a no-op.

## Deferred

**bb-9c67** (TUI chat softlocks on "thinking…" on macOS PyInstaller binary and Windows pypi lanes) needs a Windows or binary py-spy / stderr trace to localize the hung upstream generator; Linux pypi/binary all pass the same code path. **bb-m234** (segfault when chat_model resolves to an ollama ref in the release binary) needs a release-binary reproduction. **bb-nsl3** (PyInstaller --onefile re-extracts on every launch) is superseded by **bb-a9a1** (switch release packaging from PyInstaller to Nuitka), which removes the extraction tax structurally rather than working around it. All three remain open under epic bb-2ir1.