### PR TITLE
Cleanup follow-ups: TUI log routing, crawler scoped state, cooperative shutdown

### DIFF
--- a/src/lilbee/cli/commands/ingest_sync.py
+++ b/src/lilbee/cli/commands/ingest_sync.py
@@ -218,13 +218,6 @@ def _run_crawl_with_signal_cancel(
             include_subdomains=include_subdomains,
         )
         result: list[Path] = loop.run_until_complete(coro)
-        # Wait for the periodic-sync fire-and-forget task before tearing the
-        # loop down, otherwise we get 'Task was destroyed but it is pending!'
-        # warnings on CLI exit. Long-lived callers (HTTP server, MCP) don't
-        # need this, their loops stay open.
-        from lilbee.crawler.runner import drain_background_tasks
-
-        loop.run_until_complete(drain_background_tasks())
         return result
     finally:
         loop.close()

--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -7,20 +7,16 @@ import os
 import sys
 
 from lilbee.cli.sync import shutdown_executor
+from lilbee.cli.tui.log_routing import setup_tui_log_file
 from lilbee.core.services import reset_services
 
 
 def _silence_stderr_log_handlers() -> None:
     """Drop stderr/stdout-streaming log handlers before mounting the TUI. (bb-82ce)
 
-    TODO bb-pmyi: stripping handlers loses logs for the session. The proper
-    fix routes lilbee.* loggers through Textual's RichLog widget or a
-    rotating ~/.lilbee/tui.log so users debugging a TUI session still get
-    their logs.
-
-    FileHandler (a StreamHandler subclass whose .stream is the log file)
-    is skipped explicitly: only stderr/stdout handlers share an fd with
-    the TUI render target.
+    lilbee logs route to ``cfg.data_root/logs/tui.log`` for the duration of
+    the TUI session via :func:`setup_tui_log_file`. FileHandler instances
+    are skipped explicitly here so that file route survives.
     """
     root = logging.getLogger()
     for handler in list(root.handlers):
@@ -40,6 +36,7 @@ def run_tui(*, auto_sync: bool = False, initial_view: str | None = None) -> None
     """
     from lilbee.cli.tui.app import LilbeeApp
 
+    setup_tui_log_file()
     _silence_stderr_log_handlers()
 
     app = LilbeeApp(auto_sync=auto_sync, initial_view=initial_view)

--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
 
 from lilbee.cli.sync import shutdown_executor
@@ -48,9 +47,5 @@ def run_tui(*, auto_sync: bool = False, initial_view: str | None = None) -> None
     except KeyboardInterrupt:
         pass
     finally:
-        try:
-            shutdown_executor()
-            reset_services()
-        except (KeyboardInterrupt, Exception):
-            # Rapid Ctrl+C during shutdown: force exit immediately
-            os._exit(1)
+        shutdown_executor()
+        reset_services()

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
@@ -20,14 +19,13 @@ from lilbee.cli.tui.commands import LilbeeCommandProvider
 from lilbee.cli.tui.widgets.status_bar import ViewTabs
 from lilbee.core import settings
 from lilbee.core.config import cfg
-from lilbee.core.services import get_services, reset_services
+from lilbee.core.services import get_services
+from lilbee.providers.llama_cpp.abort_signal import request_abort
 
 log = logging.getLogger(__name__)
 
 _DEFAULT_THEME = "gruvbox"  # warm retro CRT aesthetic
 _CHAT_SCREEN_NAME = "chat"
-# Two-press Ctrl+C window: a second press inside this many seconds force-quits.
-_FORCE_QUIT_WINDOW_SECONDS = 2.0
 DARK_THEMES = (
     "monokai",
     "dracula",
@@ -99,20 +97,6 @@ def _on_settings_changed_evict_cache(payload: tuple[str, object]) -> None:
         get_services().provider.invalidate_load_cache()
 
 
-def _restore_terminal_via_driver(app: App[None]) -> None:
-    """Run Textual's own ``Driver.stop_application_mode`` before ``os._exit``. (bb-6b86)
-
-    TODO bb-4ik2: this whole helper goes away once inference is interruptible
-    via llama_cpp's abort_callback. ``app.exit()`` will reach Textual's normal
-    teardown and ``_force_quit`` / ``os._exit`` are no longer needed.
-    """
-    driver = getattr(app, "_driver", None)
-    if driver is None:
-        return
-    with contextlib.suppress(Exception):
-        driver.stop_application_mode()
-
-
 class LilbeeApp(App[None]):
     """Full-screen TUI for lilbee knowledge base."""
 
@@ -159,7 +143,6 @@ class LilbeeApp(App[None]):
         self.active_view = msg.DEFAULT_VIEW
         self._switching = False
         self._theme_index = 0
-        self.last_quit_time: float = 0.0
         self.settings_changed_signal: Signal[tuple[str, object]] = Signal(self, "settings_changed")
         from lilbee.cli.tui.widgets.task_bar import TaskBarController
 
@@ -219,17 +202,8 @@ class LilbeeApp(App[None]):
             self._theme_index = 0
 
     async def action_quit(self) -> None:
-        """Context-aware Ctrl+C: cancel active task > cancel stream > quit.
-        On second Ctrl+C (within 2s), force-exits via os._exit to handle
-        cases where the GIL is held by native code.
-        """
-        import time
-
-        now = time.monotonic()
-        if now - self.last_quit_time < _FORCE_QUIT_WINDOW_SECONDS:
-            self._force_quit()
-            return
-        self.last_quit_time = now
+        """Context-aware Ctrl+C: cancel active task > cancel stream > quit."""
+        request_abort()
 
         if not self.task_bar.queue.is_empty:
             active = self.task_bar.queue.active_task
@@ -248,18 +222,6 @@ class LilbeeApp(App[None]):
             screen.action_cancel_stream()
             return
         self.exit()
-
-    def _force_quit(self) -> None:
-        """Force-exit when normal quit is blocked (e.g. GIL held by native code).
-
-        Run Textual's driver teardown first so the next shell command
-        isn't fed alt-screen / paste / focus / kitty-keyboard escape
-        bytes. (bb-6b86)
-        """
-        with contextlib.suppress(Exception):
-            reset_services()
-        _restore_terminal_via_driver(self)
-        os._exit(1)
 
     def switch_view(self, view_name: str) -> None:
         """Switch to a named view via lazy screen factories.

--- a/src/lilbee/cli/tui/log_routing.py
+++ b/src/lilbee/cli/tui/log_routing.py
@@ -1,0 +1,33 @@
+"""TUI log file routing: rotating file handler that survives the stderr strip."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from lilbee.core.config import cfg
+
+_TUI_LOG_DIR_NAME = "logs"
+_TUI_LOG_FILE_NAME = "tui.log"
+_MAX_BYTES = 1_048_576  # 1 MiB
+_BACKUP_COUNT = 5
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+
+def setup_tui_log_file() -> Path:
+    """Install a RotatingFileHandler at ``cfg.data_root/logs/tui.log``. Idempotent."""
+    log_dir = cfg.data_root / _TUI_LOG_DIR_NAME
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / _TUI_LOG_FILE_NAME
+
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if isinstance(handler, RotatingFileHandler) and Path(handler.baseFilename) == log_path:
+            return log_path
+
+    handler = RotatingFileHandler(log_path, maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT)
+    handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+    handler.setLevel(logging.WARNING)
+    root.addHandler(handler)
+    return log_path

--- a/src/lilbee/core/services.py
+++ b/src/lilbee/core/services.py
@@ -8,8 +8,10 @@ between runs.
 
 from __future__ import annotations
 
+import asyncio
 import atexit
-from dataclasses import dataclass
+import threading
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -24,6 +26,14 @@ if TYPE_CHECKING:
     from lilbee.retrieval.query import Searcher
     from lilbee.retrieval.reranker import Reranker
     from lilbee.runtime.ingest_lock import IngestLockRegistry
+
+
+@dataclass
+class CrawlerSyncState:
+    """Process-wide sync coordination state (lock + last-run timestamp)."""
+
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    last_run: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -41,6 +51,8 @@ class Services:
     hf_client: HfClient
     ingest_lock_registry: IngestLockRegistry
     model_manager: ModelManager
+    crawler_semaphore: asyncio.Semaphore | None
+    crawler_sync_state: CrawlerSyncState
 
 
 _svc: Services | None = None
@@ -84,6 +96,10 @@ def get_services() -> Services:
     hf_client = HfClient()
     ingest_lock_registry = IngestLockRegistry()
     model_manager = ModelManager(cfg.models_dir, cfg.remote_base_url)
+    crawler_semaphore = (
+        asyncio.Semaphore(cfg.crawl_max_concurrent) if cfg.crawl_max_concurrent > 0 else None
+    )
+    crawler_sync_state = CrawlerSyncState()
     _svc = Services(
         provider=provider,
         store=store,
@@ -96,6 +112,8 @@ def get_services() -> Services:
         hf_client=hf_client,
         ingest_lock_registry=ingest_lock_registry,
         model_manager=model_manager,
+        crawler_semaphore=crawler_semaphore,
+        crawler_sync_state=crawler_sync_state,
     )
     return _svc
 

--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from lilbee.core.config import cfg
+from lilbee.core.services import get_services
 from lilbee.crawler import bootstrap, save, sitemap
 from lilbee.crawler.bootstrap import CrawlerBrowserError
 from lilbee.crawler.crawl4ai_fetcher import Crawl4aiFetcher
@@ -56,8 +57,6 @@ async def drain_background_tasks() -> None:
 
 def _get_crawl_semaphore() -> asyncio.Semaphore | None:
     """Return the process-wide crawl semaphore, or None when unlimited."""
-    from lilbee.core.services import get_services
-
     return get_services().crawler_semaphore
 
 
@@ -202,8 +201,6 @@ async def _maybe_periodic_sync(tasks: set[asyncio.Task[None]]) -> None:
     is already running. The spawned task is added to ``tasks`` so the
     caller can drain it before returning.
     """
-    from lilbee.core.services import get_services
-
     interval = cfg.crawl_sync_interval
     sync_state = get_services().crawler_sync_state
     if interval <= 0 or not sync_state.lock.acquire(blocking=False):

--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -44,57 +44,21 @@ from lilbee.runtime.progress import (
 log = logging.getLogger(__name__)
 
 
-class CrawlerState:
-    """Per-process mutable state for the crawler (semaphore, periodic sync tracking).
-
-    Encapsulates state that would otherwise live as bare module-level globals.
-    Held as a module-level singleton (``_state``) rather than under
-    :class:`lilbee.core.services.Services`: the asyncio.Semaphore is bound to
-    whichever event loop happens to be running, and Services may be rebuilt
-    across event-loop boundaries via ``reset_services``. Test isolation is via
-    :meth:`reset`.
-    """
-
-    def __init__(self) -> None:
-        self.semaphore: asyncio.Semaphore | None = None
-        self.semaphore_limit: int = 0
-        self.last_sync_time: float = 0.0
-        self.sync_running: threading.Lock = threading.Lock()
-        self.background_tasks: set[asyncio.Task[None]] = set()
-
-    def reset(self) -> None:
-        """Reset all state (useful for testing)."""
-        self.semaphore = None
-        self.semaphore_limit = 0
-        self.last_sync_time = 0.0
-        self.sync_running = threading.Lock()
-        self.background_tasks = set()
-
-
-_state = CrawlerState()
-
-
 async def drain_background_tasks() -> None:
-    """Await any in-flight ``_maybe_periodic_sync`` tasks.
+    """Deprecated: no-op kept for one release while CLI callers migrate.
 
-    Short-lived callers (CLI) should call this right before closing their
-    event loop. Long-lived callers (HTTP server, MCP) skip it; their loops
-    stay open long enough for the fire-and-forget syncs to finish naturally.
+    ``crawl_and_save`` now drains its own periodic-sync tasks before
+    returning, so external callers no longer need to invoke this. Will
+    be removed once :mod:`lilbee.cli.commands.ingest_sync` drops its call.
     """
-    if not _state.background_tasks:
-        return
-    await asyncio.gather(*_state.background_tasks, return_exceptions=True)
+    return
 
 
 def _get_crawl_semaphore() -> asyncio.Semaphore | None:
-    """Return an asyncio semaphore for crawl concurrency, or None if unlimited (0)."""
-    limit = cfg.crawl_max_concurrent
-    if limit <= 0:
-        return None
-    if _state.semaphore is None or _state.semaphore_limit != limit:
-        _state.semaphore = asyncio.Semaphore(limit)
-        _state.semaphore_limit = limit
-    return _state.semaphore
+    """Return the process-wide crawl semaphore, or None when unlimited."""
+    from lilbee.core.services import get_services
+
+    return get_services().crawler_semaphore
 
 
 def _resolve_limit(value: int | None, cfg_ceiling: int | None) -> int | None:
@@ -231,23 +195,26 @@ async def crawl_recursive(
     return results
 
 
-async def _maybe_periodic_sync() -> None:
+async def _maybe_periodic_sync(tasks: set[asyncio.Task[None]]) -> None:
     """Fire off a background sync if the ``crawl_sync_interval`` has elapsed.
 
-    Skips if a sync is already running or periodic sync is disabled
-    (``interval=0``). Uses a ``threading.Lock`` to avoid asyncio
-    event-loop binding issues when called from different loops.
+    Skips when periodic sync is disabled (``interval=0``) or another sync
+    is already running. The spawned task is added to ``tasks`` so the
+    caller can drain it before returning.
     """
+    from lilbee.core.services import get_services
+
     interval = cfg.crawl_sync_interval
-    if interval <= 0 or not _state.sync_running.acquire(blocking=False):
+    sync_state = get_services().crawler_sync_state
+    if interval <= 0 or not sync_state.lock.acquire(blocking=False):
         return
 
     now = time.monotonic()
-    if now - _state.last_sync_time < interval:
-        _state.sync_running.release()
+    if now - sync_state.last_run < interval:
+        sync_state.lock.release()
         return
 
-    _state.last_sync_time = now
+    sync_state.last_run = now
 
     async def _run_sync() -> None:
         try:
@@ -257,37 +224,11 @@ async def _maybe_periodic_sync() -> None:
         except Exception as exc:
             log.warning("Periodic sync during crawl failed: %s", exc)
         finally:
-            _state.sync_running.release()
+            sync_state.lock.release()
 
     task = asyncio.create_task(_run_sync())
-    _state.background_tasks.add(task)
-    task.add_done_callback(_state.background_tasks.discard)
-
-
-async def _drain_background_tasks() -> None:
-    """Cancel periodic-sync tasks owned by the running loop. (bb-zqws)
-
-    TODO bb-odr1: the cross-loop filter and stale-entry drop both exist
-    because ``_state.background_tasks`` is a module-level global. Once
-    task tracking is scoped per ``crawl_and_save`` invocation, this whole
-    helper collapses to a local ``await asyncio.gather(*tasks)``.
-    """
-    loop = asyncio.get_running_loop()
-    pending: list[asyncio.Task[Any]] = []
-    stale: set[asyncio.Task[Any]] = set()
-    for task in list(_state.background_tasks):
-        if task.done():
-            continue
-        if task.get_loop() is loop:
-            pending.append(task)
-        else:
-            stale.add(task)
-    _state.background_tasks -= stale
-    if not pending:
-        return
-    for task in pending:
-        task.cancel()
-    await asyncio.gather(*pending, return_exceptions=True)
+    tasks.add(task)
+    task.add_done_callback(tasks.discard)
 
 
 def _make_flush_page(
@@ -411,6 +352,7 @@ async def crawl_and_save(
     sem = _get_crawl_semaphore()
     if sem is not None:
         await sem.acquire()
+    tasks: set[asyncio.Task[None]] = set()
     try:
         if on_progress:
             start_depth = depth if depth is not None else 0
@@ -440,7 +382,7 @@ async def crawl_and_save(
 
         cancelled = cancel is not None and cancel.is_set()
         if not cancelled:
-            await _maybe_periodic_sync()
+            await _maybe_periodic_sync(tasks)
 
         if on_progress:
             on_progress(
@@ -450,8 +392,9 @@ async def crawl_and_save(
 
         return written_paths
     finally:
-        # Drain the periodic-sync task BEFORE releasing the crawl semaphore so
-        # asyncio.run() doesn't close the loop with the sync mid-ingest.
-        await _drain_background_tasks()
+        # Drain this call's periodic-sync tasks BEFORE releasing the crawl
+        # semaphore so asyncio.run() doesn't close the loop mid-ingest.
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
         if sem is not None:
             sem.release()

--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -45,16 +45,6 @@ from lilbee.runtime.progress import (
 log = logging.getLogger(__name__)
 
 
-async def drain_background_tasks() -> None:
-    """Deprecated: no-op kept for one release while CLI callers migrate.
-
-    ``crawl_and_save`` now drains its own periodic-sync tasks before
-    returning, so external callers no longer need to invoke this. Will
-    be removed once :mod:`lilbee.cli.commands.ingest_sync` drops its call.
-    """
-    return
-
-
 def _get_crawl_semaphore() -> asyncio.Semaphore | None:
     """Return the process-wide crawl semaphore, or None when unlimited."""
     return get_services().crawler_semaphore
@@ -389,8 +379,8 @@ async def crawl_and_save(
 
         return written_paths
     finally:
-        # Drain this call's periodic-sync tasks BEFORE releasing the crawl
-        # semaphore so asyncio.run() doesn't close the loop mid-ingest.
+        # Drain this call's periodic-sync tasks before returning so
+        # asyncio.run() doesn't close the loop with a pending sync.
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         if sem is not None:

--- a/src/lilbee/providers/llama_cpp/abort_signal.py
+++ b/src/lilbee/providers/llama_cpp/abort_signal.py
@@ -1,0 +1,28 @@
+"""Process-wide abort flag wired into llama_cpp.Llama's abort_callback."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+_abort = threading.Event()
+
+
+def request_abort() -> None:
+    """Set the process-wide abort flag. Polled by ggml every N tokens."""
+    _abort.set()
+
+
+def clear_abort() -> None:
+    """Clear the abort flag so the next inference runs to completion."""
+    _abort.clear()
+
+
+def is_abort_set() -> bool:
+    """Return True if request_abort() has been called and not cleared."""
+    return _abort.is_set()
+
+
+def abort_callback(_user_data: Any = None) -> bool:
+    """ggml abort_callback: returns True iff request_abort() has fired."""
+    return _abort.is_set()

--- a/src/lilbee/providers/llama_cpp/gguf_meta.py
+++ b/src/lilbee/providers/llama_cpp/gguf_meta.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from gguf import GGUFReader, GGUFValueType
 
 from lilbee.providers.base import ProviderError
+from lilbee.providers.llama_cpp.abort_signal import abort_callback
 from lilbee.providers.llama_cpp.log_dispatch import (
     import_llama_cpp,
     install_llama_log_handler,
@@ -34,7 +35,12 @@ def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
 
     install_llama_log_handler()
     llm = suppress_native_stderr(
-        Llama, model_path=str(model_path), vocab_only=True, verbose=False, n_gpu_layers=0
+        Llama,
+        model_path=str(model_path),
+        vocab_only=True,
+        verbose=False,
+        n_gpu_layers=0,
+        abort_callback=abort_callback,
     )
     try:
         raw = llm.metadata or {}

--- a/src/lilbee/providers/llama_cpp/gguf_meta.py
+++ b/src/lilbee/providers/llama_cpp/gguf_meta.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 from gguf import GGUFReader, GGUFValueType
 
 from lilbee.providers.base import ProviderError
-from lilbee.providers.llama_cpp.abort_signal import abort_callback
+from lilbee.providers.llama_cpp.abort_signal import abort_callback, clear_abort
 from lilbee.providers.llama_cpp.log_dispatch import (
     import_llama_cpp,
     install_llama_log_handler,
@@ -33,15 +34,18 @@ def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
     """
     Llama = import_llama_cpp().Llama  # noqa: N806
 
+    # Fresh abort flag: a prior request_abort() must not latch and break
+    # this metadata read, which is on the path of every model swap.
+    clear_abort()
     install_llama_log_handler()
-    llm = suppress_native_stderr(
-        Llama,
-        model_path=str(model_path),
-        vocab_only=True,
-        verbose=False,
-        n_gpu_layers=0,
-        abort_callback=abort_callback,
-    )
+    kwargs: dict[str, Any] = {
+        "model_path": str(model_path),
+        "vocab_only": True,
+        "verbose": False,
+        "n_gpu_layers": 0,
+    }
+    kwargs.setdefault("abort_callback", abort_callback)
+    llm = suppress_native_stderr(Llama, **kwargs)
     try:
         raw = llm.metadata or {}
         result: dict[str, str] = {}

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -22,7 +22,7 @@ from lilbee.core.config import DEFAULT_NUM_CTX, cfg
 from lilbee.core.config.enums import KV_CACHE_TYPE_BYTES, KvCacheType
 from lilbee.core.services import get_services
 from lilbee.providers.base import ClosableIterator, LLMProvider, ProviderError, filter_options
-from lilbee.providers.llama_cpp.abort_signal import abort_callback
+from lilbee.providers.llama_cpp.abort_signal import abort_callback, clear_abort
 from lilbee.providers.llama_cpp.batching import (
     BATCH_WINDOW_S,
     EMBED_FUTURE_TIMEOUT_S,
@@ -138,6 +138,10 @@ class LlamaCppProvider(LLMProvider):
         Embeds one text at a time because some model architectures (e.g.
         nomic-bert) fail with llama_decode -1 on multi-text batches.
         """
+        # Each new dispatch starts with a fresh abort flag: a previous
+        # request_abort() unblocks the prior in-flight call but must not
+        # latch and break this one.
+        clear_abort()
         try:
             llm = self._get_embed_llm()
         except Exception as exc:
@@ -170,6 +174,8 @@ class LlamaCppProvider(LLMProvider):
 
     def _dispatch_rerank(self, req: RerankRequest) -> None:
         """Run a single rerank request and resolve its future."""
+        # See ``_dispatch_batch`` for why we clear at the start of each dispatch.
+        clear_abort()
         try:
             llm = self._get_rerank_llm()
         except Exception as exc:
@@ -252,6 +258,8 @@ class LlamaCppProvider(LLMProvider):
         model: str | None = None,
     ) -> str | ClosableIterator[str]:
         """Chat completion: serialized via lock (Llama is not thread-safe)."""
+        # Fresh abort flag per chat: prior cancels must not latch into this one.
+        clear_abort()
         self._chat_lock.acquire()
         try:
             llm = self._get_chat_llm(model)
@@ -585,6 +593,9 @@ def _construct_llama(llama_cls: Any, model_path: Path, kwargs: dict[str, Any]) -
     or unrelated TypeError), or continues with halved n_ctx; the loop is
     therefore structurally exhaustive and never falls through.
     """
+    # Fresh abort flag per load: a prior request_abort() that interrupted
+    # an inference must not latch and abort the next model swap.
+    clear_abort()
     kwargs.setdefault("abort_callback", abort_callback)
     fa_dropped = False
     for attempt in range(_MAX_OOM_RETRIES + 1):

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -258,9 +258,10 @@ class LlamaCppProvider(LLMProvider):
         model: str | None = None,
     ) -> str | ClosableIterator[str]:
         """Chat completion: serialized via lock (Llama is not thread-safe)."""
-        # Fresh abort flag per chat: prior cancels must not latch into this one.
-        clear_abort()
         self._chat_lock.acquire()
+        # Clear AFTER the lock acquires so a concurrent chat can't clobber a
+        # mid-stream cancel still being honored by the prior holder.
+        clear_abort()
         try:
             llm = self._get_chat_llm(model)
             kwargs: dict[str, Any] = {}

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -22,6 +22,7 @@ from lilbee.core.config import DEFAULT_NUM_CTX, cfg
 from lilbee.core.config.enums import KV_CACHE_TYPE_BYTES, KvCacheType
 from lilbee.core.services import get_services
 from lilbee.providers.base import ClosableIterator, LLMProvider, ProviderError, filter_options
+from lilbee.providers.llama_cpp.abort_signal import abort_callback
 from lilbee.providers.llama_cpp.batching import (
     BATCH_WINDOW_S,
     EMBED_FUTURE_TIMEOUT_S,
@@ -584,6 +585,7 @@ def _construct_llama(llama_cls: Any, model_path: Path, kwargs: dict[str, Any]) -
     or unrelated TypeError), or continues with halved n_ctx; the loop is
     therefore structurally exhaustive and never falls through.
     """
+    kwargs.setdefault("abort_callback", abort_callback)
     fa_dropped = False
     for attempt in range(_MAX_OOM_RETRIES + 1):
         try:

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -11,6 +11,7 @@ from typing import Any
 from gguf import GGUFReader
 
 from lilbee.core.config.model import cfg
+from lilbee.providers.llama_cpp.abort_signal import abort_callback
 from lilbee.providers.llama_cpp.gguf_meta import find_mmproj_for_model, read_gguf_metadata
 from lilbee.providers.llama_cpp.log_dispatch import (
     import_llama_cpp,
@@ -115,6 +116,7 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
         "verbose": False,
         "n_gpu_layers": -1,
         "n_ctx": _resolve_vision_n_ctx(model_path),
+        "abort_callback": abort_callback,
     }
 
     llama = suppress_native_stderr(Llama, **kwargs)

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -116,8 +116,8 @@ def load_vision_llama(model_path: Path, mmproj_path: Path | None = None) -> Any:
         "verbose": False,
         "n_gpu_layers": -1,
         "n_ctx": _resolve_vision_n_ctx(model_path),
-        "abort_callback": abort_callback,
     }
+    kwargs.setdefault("abort_callback", abort_callback)
 
     llama = suppress_native_stderr(Llama, **kwargs)
     metadata = getattr(llama, "metadata", {}) or {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,7 +239,7 @@ def _default_clusterer_mock():
 def make_mock_services(**overrides):
     """Create a mock Services container. Override individual services via kwargs."""
     from lilbee.catalog.hf_client import HfClient
-    from lilbee.core.services import Services
+    from lilbee.core.services import CrawlerSyncState, Services
     from lilbee.providers.base import LLMProvider
     from lilbee.retrieval.query import Searcher
     from lilbee.runtime.ingest_lock import IngestLockRegistry
@@ -257,6 +257,8 @@ def make_mock_services(**overrides):
     hf_client = overrides.pop("hf_client", None) or HfClient()
     ingest_lock_registry = overrides.pop("ingest_lock_registry", None) or IngestLockRegistry()
     model_manager = overrides.pop("model_manager", None) or MagicMock()
+    crawler_semaphore = overrides.pop("crawler_semaphore", None)
+    crawler_sync_state = overrides.pop("crawler_sync_state", None) or CrawlerSyncState()
 
     return Services(
         provider=provider,
@@ -270,6 +272,8 @@ def make_mock_services(**overrides):
         hf_client=hf_client,
         ingest_lock_registry=ingest_lock_registry,
         model_manager=model_manager,
+        crawler_semaphore=crawler_semaphore,
+        crawler_sync_state=crawler_sync_state,
     )
 
 

--- a/tests/crawler/test_runner.py
+++ b/tests/crawler/test_runner.py
@@ -354,13 +354,6 @@ class TestCrawlAndSaveOrchestration:
             await crawl_and_save("https://example.com", depth=1)
         mock_sync.assert_awaited_once()
 
-    async def test_drain_background_tasks_deprecated_noop(self):
-        """``drain_background_tasks`` is a documented deprecated no-op."""
-        from lilbee.crawler.runner import drain_background_tasks
-
-        assert await drain_background_tasks() is None
-        assert "Deprecated" in (drain_background_tasks.__doc__ or "")
-
 
 class TestConcurrencySemaphore:
     """The process-wide crawl semaphore gates concurrent crawl_and_save calls."""
@@ -384,15 +377,19 @@ class TestConcurrencySemaphore:
         assert sem1 is sem2
 
     async def test_semaphore_rebuilt_on_reset_services(self):
-        """``reset_services`` rebuilds the semaphore on next access."""
+        """``reset_services`` rebuilds the semaphore reflecting the new cfg value."""
         from lilbee.core.services import reset_services
 
         cfg.crawl_max_concurrent = 2
         reset_services()
         first = runner_mod._get_crawl_semaphore()
+        assert first is not None
+        assert first._value == 2
         cfg.crawl_max_concurrent = 4
         reset_services()
         second = runner_mod._get_crawl_semaphore()
+        assert second is not None
+        assert second._value == 4
         assert first is not second
 
 

--- a/tests/crawler/test_runner.py
+++ b/tests/crawler/test_runner.py
@@ -354,38 +354,12 @@ class TestCrawlAndSaveOrchestration:
             await crawl_and_save("https://example.com", depth=1)
         mock_sync.assert_awaited_once()
 
-    async def test_drain_background_tasks_awaits_pending_sync(self):
-        """``drain_background_tasks`` awaits any in-flight ``_maybe_periodic_sync``
-        task so the CLI's event-loop teardown doesn't destroy a pending sync.
-        Long-lived HTTP/MCP loops don't call drain; their loops stay open long
-        enough for the fire-and-forget task to finish naturally.
-        """
-        import asyncio
-
-        sync_completed = asyncio.Event()
-
-        async def _slow_sync() -> None:
-            await asyncio.sleep(0.05)
-            sync_completed.set()
-
-        runner_mod._state.reset()
-        task = asyncio.create_task(_slow_sync())
-        runner_mod._state.background_tasks.add(task)
-        task.add_done_callback(runner_mod._state.background_tasks.discard)
-
+    async def test_drain_background_tasks_deprecated_noop(self):
+        """``drain_background_tasks`` is a documented deprecated no-op."""
         from lilbee.crawler.runner import drain_background_tasks
 
-        await drain_background_tasks()
-        assert sync_completed.is_set()
-        assert not runner_mod._state.background_tasks
-
-    async def test_drain_background_tasks_no_op_when_empty(self):
-        """``drain_background_tasks`` is a fast no-op when no tasks are pending."""
-        runner_mod._state.reset()
-        from lilbee.crawler.runner import drain_background_tasks
-
-        await drain_background_tasks()
-        assert not runner_mod._state.background_tasks
+        assert await drain_background_tasks() is None
+        assert "Deprecated" in (drain_background_tasks.__doc__ or "")
 
 
 class TestConcurrencySemaphore:
@@ -393,23 +367,31 @@ class TestConcurrencySemaphore:
 
     async def test_no_semaphore_when_unlimited(self, monkeypatch):
         """``crawl_max_concurrent <= 0`` means no semaphore construction."""
+        from lilbee.core.services import reset_services
+
         cfg.crawl_max_concurrent = 0
-        # Force fresh state so prior tests don't hide the branch.
-        runner_mod._state.reset()
+        reset_services()
         assert runner_mod._get_crawl_semaphore() is None
 
-    async def test_semaphore_reused_at_same_limit(self):
+    async def test_semaphore_reused_within_services_lifetime(self):
+        """Repeated ``_get_crawl_semaphore`` calls return the same Services-owned semaphore."""
+        from lilbee.core.services import reset_services
+
         cfg.crawl_max_concurrent = 2
-        runner_mod._state.reset()
+        reset_services()
         sem1 = runner_mod._get_crawl_semaphore()
         sem2 = runner_mod._get_crawl_semaphore()
         assert sem1 is sem2
 
-    async def test_semaphore_rebuilt_on_limit_change(self):
+    async def test_semaphore_rebuilt_on_reset_services(self):
+        """``reset_services`` rebuilds the semaphore on next access."""
+        from lilbee.core.services import reset_services
+
         cfg.crawl_max_concurrent = 2
-        runner_mod._state.reset()
+        reset_services()
         first = runner_mod._get_crawl_semaphore()
         cfg.crawl_max_concurrent = 4
+        reset_services()
         second = runner_mod._get_crawl_semaphore()
         assert first is not second
 

--- a/tests/integration/test_crawl_integration.py
+++ b/tests/integration/test_crawl_integration.py
@@ -21,7 +21,6 @@ from lilbee.crawler import (  # noqa: E402
     load_crawl_metadata,
     validate_crawl_url,
 )
-from lilbee.crawler import runner as crawler_runner  # noqa: E402
 from lilbee.crawler import url_filter as crawler_url_filter  # noqa: E402
 from lilbee.crawler.save import _save_single_result  # noqa: E402
 from lilbee.runtime.progress import EventType  # noqa: E402
@@ -69,13 +68,15 @@ def isolated_env(tmp_path):
     cfg.data_dir.mkdir()
     cfg.lancedb_dir = tmp_path / "data" / "lancedb"
     cfg.crawl_timeout = 15
-    # Fully reset crawler state (semaphore, sync timer, background tasks)
-    # so no integration test leaks mutable state into a neighbour.
-    crawler_runner._state.reset()
+    # Reset services so the crawler semaphore + sync state are fresh for
+    # every integration test.
+    from lilbee.core.services import reset_services
+
+    reset_services()
     yield tmp_path
     for name, val in snapshot.items():
         setattr(cfg, name, val)
-    crawler_runner._state.reset()
+    reset_services()
 
 
 @pytest.fixture()
@@ -304,7 +305,9 @@ class TestCrawlConcurrency:
             httpserver.expect_request(f"/conc{i}").respond_with_handler(slow_handler)
 
         cfg.crawl_max_concurrent = 2
-        crawler_runner._state.semaphore = None
+        from lilbee.core.services import reset_services
+
+        reset_services()
 
         urls = [str(httpserver.url_for(f"/conc{i}")) for i in range(3)]
         tasks = [asyncio.create_task(crawl_and_save(url, depth=0)) for url in urls]
@@ -328,7 +331,9 @@ class TestCrawlConcurrency:
             )
 
         cfg.crawl_max_concurrent = 0
-        crawler_runner._state.semaphore = None
+        from lilbee.core.services import reset_services
+
+        reset_services()
 
         urls = [str(httpserver.url_for(f"/par{i}")) for i in range(3)]
         tasks = [asyncio.create_task(crawl_and_save(url, depth=0)) for url in urls]

--- a/tests/test_abort_signal.py
+++ b/tests/test_abort_signal.py
@@ -1,0 +1,53 @@
+"""Tests for the process-wide abort flag wired into llama_cpp.Llama."""
+
+from __future__ import annotations
+
+import pytest
+
+from lilbee.providers.llama_cpp.abort_signal import (
+    abort_callback,
+    clear_abort,
+    is_abort_set,
+    request_abort,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_abort_flag() -> None:
+    """Each test starts and ends with a cleared flag."""
+    clear_abort()
+    yield
+    clear_abort()
+
+
+def test_request_abort_sets_flag() -> None:
+    """request_abort() flips the flag to True."""
+    assert is_abort_set() is False
+    request_abort()
+    assert is_abort_set() is True
+
+
+def test_clear_abort_resets_flag() -> None:
+    """clear_abort() flips the flag back to False."""
+    request_abort()
+    assert is_abort_set() is True
+    clear_abort()
+    assert is_abort_set() is False
+
+
+def test_abort_callback_returns_flag_state() -> None:
+    """abort_callback() mirrors is_abort_set() for ggml's poll loop."""
+    assert abort_callback() is False
+    request_abort()
+    assert abort_callback() is True
+    clear_abort()
+    assert abort_callback() is False
+
+
+def test_abort_callback_signature() -> None:
+    """ggml passes a user_data pointer; abort_callback accepts and ignores it."""
+    assert abort_callback(None) is False
+    assert abort_callback(object()) is False
+    request_abort()
+    assert abort_callback(None) is True
+    assert abort_callback("anything") is True

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -29,7 +29,6 @@ from lilbee.crawler.bootstrap import CrawlerBrowserError
 from lilbee.crawler.runner import (
     _get_crawl_semaphore,
     _maybe_periodic_sync,
-    drain_background_tasks,
 )
 from lilbee.crawler.save import _save_single_result, _update_single_metadata
 from lilbee.runtime.progress import EventType
@@ -1494,28 +1493,18 @@ class TestPeriodicSync:
         sync_state.lock.release()
 
 
-class TestDrainBackgroundTasksDeprecated:
-    """``drain_background_tasks`` survives as a deprecated no-op for one release."""
-
-    async def test_drain_background_tasks_deprecated_noop(self, isolated_env):
-        """The public helper returns ``None`` and does no work."""
-        assert await drain_background_tasks() is None
-
-    async def test_deprecation_documented(self):
-        """The public helper's docstring marks it as deprecated."""
-        assert "Deprecated" in (drain_background_tasks.__doc__ or "")
-
-
 class TestServicesCrawlerSemaphore:
     def test_services_crawler_semaphore_rebuilds_on_reset(self, isolated_env):
-        """``reset_services`` produces a fresh semaphore on next ``get_services``."""
+        """``reset_services`` produces a fresh semaphore matching the cfg limit."""
         cfg.crawl_max_concurrent = 3
         reset_services()
         first = get_services().crawler_semaphore
         assert first is not None
+        assert first._value == 3
         reset_services()
         second = get_services().crawler_semaphore
         assert second is not None
+        assert second._value == 3
         assert first is not second
 
     def test_services_crawler_semaphore_none_when_unlimited(self, isolated_env):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lilbee.core.config import cfg
+from lilbee.core.services import get_services, reset_services
 from lilbee.crawler import (
     CrawlMeta,
     CrawlResult,
@@ -26,12 +27,9 @@ from lilbee.crawler import (
 from lilbee.crawler import bootstrap as bootstrap_mod
 from lilbee.crawler.bootstrap import CrawlerBrowserError
 from lilbee.crawler.runner import (
-    _drain_background_tasks,
     _get_crawl_semaphore,
     _maybe_periodic_sync,
-)
-from lilbee.crawler.runner import (
-    _state as crawler_state,
+    drain_background_tasks,
 )
 from lilbee.crawler.save import _save_single_result, _update_single_metadata
 from lilbee.runtime.progress import EventType
@@ -1376,36 +1374,30 @@ class TestCrawlAndSave:
 
     async def test_semaphore_limits_concurrency(self, isolated_env):
         """The semaphore limits concurrent crawls based on config."""
-        from lilbee.crawler import runner as crawler_mod
-
-        crawler_mod._state.semaphore = None
         cfg.crawl_max_concurrent = 5
+        reset_services()
         sem = _get_crawl_semaphore()
         assert sem is not None
         assert sem._value == 5
-        crawler_mod._state.semaphore = None
+        reset_services()
 
     async def test_semaphore_defaults_to_cpu_count(self, isolated_env):
         """Default concurrency matches CPU count."""
         import os
 
-        from lilbee.crawler import runner as crawler_mod
-
-        crawler_mod._state.semaphore = None
         cfg.crawl_max_concurrent = os.cpu_count() or 4
+        reset_services()
         sem = _get_crawl_semaphore()
         assert sem is not None
         assert sem._value == (os.cpu_count() or 4)
-        crawler_mod._state.semaphore = None
+        reset_services()
 
     async def test_semaphore_unlimited_when_zero(self, isolated_env):
         """Setting crawl_max_concurrent=0 disables the semaphore."""
-        from lilbee.crawler import runner as crawler_mod
-
-        crawler_mod._state.semaphore = None
         cfg.crawl_max_concurrent = 0
+        reset_services()
         assert _get_crawl_semaphore() is None
-        crawler_mod._state.semaphore = None
+        reset_services()
 
     @patch("lilbee.crawler.runner.crawl_single")
     async def test_cancel_keeps_fetched_page(self, mock_crawl_single, isolated_env):
@@ -1428,209 +1420,127 @@ class TestCrawlAndSave:
 class TestPeriodicSync:
     async def test_sync_disabled_when_interval_zero(self, isolated_env):
         """No sync fires when crawl_sync_interval is 0."""
-        import threading
-
-        from lilbee.crawler import runner as crawler_mod
-
         cfg.crawl_sync_interval = 0
-        crawler_mod._state.last_sync_time = 0.0
-        crawler_mod._state.sync_running = threading.Lock()
+        reset_services()
+        sync_state = get_services().crawler_sync_state
+        sync_state.last_run = 0.0
 
+        tasks: set[asyncio.Task[None]] = set()
         with patch("lilbee.data.ingest.sync", new_callable=AsyncMock) as mock_sync:
-            await _maybe_periodic_sync()
+            await _maybe_periodic_sync(tasks)
             mock_sync.assert_not_awaited()
+        assert not tasks
 
     async def test_sync_skipped_when_already_running(self, isolated_env):
         """No new sync is started if one is already in progress."""
-        import threading
-
-        from lilbee.crawler import runner as crawler_mod
-
         cfg.crawl_sync_interval = 1
-        crawler_mod._state.last_sync_time = 0.0
-        lock = threading.Lock()
-        lock.acquire()  # simulate already-running
-        crawler_mod._state.sync_running = lock
+        reset_services()
+        sync_state = get_services().crawler_sync_state
+        sync_state.last_run = 0.0
+        sync_state.lock.acquire()  # simulate already-running
 
-        with patch("lilbee.data.ingest.sync", new_callable=AsyncMock) as mock_sync:
-            await _maybe_periodic_sync()
-            mock_sync.assert_not_awaited()
-
-        lock.release()
+        tasks: set[asyncio.Task[None]] = set()
+        try:
+            with patch("lilbee.data.ingest.sync", new_callable=AsyncMock) as mock_sync:
+                await _maybe_periodic_sync(tasks)
+                mock_sync.assert_not_awaited()
+        finally:
+            sync_state.lock.release()
 
     async def test_sync_skipped_when_interval_not_elapsed(self, isolated_env):
         """No sync fires if the interval hasn't elapsed since last sync."""
-        import threading
         import time
 
-        from lilbee.crawler import runner as crawler_mod
-
         cfg.crawl_sync_interval = 9999
-        crawler_mod._state.last_sync_time = time.monotonic()
-        crawler_mod._state.sync_running = threading.Lock()
+        reset_services()
+        sync_state = get_services().crawler_sync_state
+        sync_state.last_run = time.monotonic()
 
+        tasks: set[asyncio.Task[None]] = set()
         with patch("lilbee.data.ingest.sync", new_callable=AsyncMock) as mock_sync:
-            await _maybe_periodic_sync()
+            await _maybe_periodic_sync(tasks)
             mock_sync.assert_not_awaited()
 
     async def test_sync_fires_when_interval_elapsed(self, isolated_env):
         """Sync fires as a background task when interval has elapsed."""
-        import asyncio
-        import threading
-
-        from lilbee.crawler import runner as crawler_mod
-
         cfg.crawl_sync_interval = 1
-        crawler_mod._state.last_sync_time = 0.0
-        crawler_mod._state.sync_running = threading.Lock()
+        reset_services()
+        sync_state = get_services().crawler_sync_state
+        sync_state.last_run = 0.0
 
+        tasks: set[asyncio.Task[None]] = set()
         mock_sync = AsyncMock()
         with patch("lilbee.data.ingest.sync", mock_sync):
-            await _maybe_periodic_sync()
-            # Let the background task run
-            await asyncio.sleep(0)
+            await _maybe_periodic_sync(tasks)
+            # Drain the spawned task so the awaited assertion is deterministic.
+            await asyncio.gather(*tasks, return_exceptions=True)
             mock_sync.assert_awaited_once()
 
     async def test_sync_failure_resets_running_flag(self, isolated_env):
-        """If sync raises, _sync_running lock is released so future syncs can proceed."""
-        import asyncio
-        import threading
-
-        from lilbee.crawler import runner as crawler_mod
-
+        """If sync raises, the sync lock is released so future syncs can proceed."""
         cfg.crawl_sync_interval = 1
-        crawler_mod._state.last_sync_time = 0.0
-        lock = threading.Lock()
-        crawler_mod._state.sync_running = lock
+        reset_services()
+        sync_state = get_services().crawler_sync_state
+        sync_state.last_run = 0.0
 
+        tasks: set[asyncio.Task[None]] = set()
         mock_sync = AsyncMock(side_effect=RuntimeError("sync failed"))
         with patch("lilbee.data.ingest.sync", mock_sync):
-            await _maybe_periodic_sync()
-            await asyncio.sleep(0)
+            await _maybe_periodic_sync(tasks)
+            await asyncio.gather(*tasks, return_exceptions=True)
 
         # Lock should be released after failure
-        assert lock.acquire(blocking=False)
-        lock.release()
+        assert sync_state.lock.acquire(blocking=False)
+        sync_state.lock.release()
 
 
-class TestDrainBackgroundTasks:
-    """``_drain_background_tasks`` cancels periodic-sync tasks so crawl_and_save
-    can exit cleanly without 'destroyed but pending' warnings. (bb-zqws)"""
+class TestDrainBackgroundTasksDeprecated:
+    """``drain_background_tasks`` survives as a deprecated no-op for one release."""
 
-    async def test_no_pending_tasks_returns_immediately(self, isolated_env):
-        """With no spawned tasks, the helper is a fast no-op."""
-        crawler_state.background_tasks = set()
-        await _drain_background_tasks()
-        assert crawler_state.background_tasks == set()
+    async def test_drain_background_tasks_deprecated_noop(self, isolated_env):
+        """The public helper returns ``None`` and does no work."""
+        assert await drain_background_tasks() is None
 
-    async def test_cancels_pending_periodic_sync(self, isolated_env):
-        """The drain cancels (not awaits) so a slow sync can't block crawl_and_save's exit."""
-
-        async def _slow_sync() -> None:
-            await asyncio.sleep(60.0)  # would deadlock the test if awaited
-
-        task = asyncio.create_task(_slow_sync())
-        crawler_state.background_tasks = {task}
-        task.add_done_callback(crawler_state.background_tasks.discard)
-
-        await _drain_background_tasks()
-
-        assert task.done()
-        assert task.cancelled()
-
-    async def test_swallows_task_exception(self, isolated_env):
-        """A failing periodic-sync task must not bubble out of the drain."""
-
-        async def _boom() -> None:
-            await asyncio.sleep(0)
-            raise RuntimeError("sync exploded")
-
-        task = asyncio.create_task(_boom())
-        crawler_state.background_tasks = {task}
-        task.add_done_callback(crawler_state.background_tasks.discard)
-
-        await _drain_background_tasks()
-        assert task.done()
-
-    async def test_skips_already_done_task(self, isolated_env):
-        """A task that already finished is left untouched by the drain."""
-
-        async def _quick() -> str:
-            return "ok"
-
-        task = asyncio.create_task(_quick())
-        await task  # finish it before the drain sees it
-        # Re-add manually because add_done_callback already discarded it.
-        crawler_state.background_tasks = {task}
-
-        await _drain_background_tasks()
-        assert task.done()
-        assert not task.cancelled()
-        assert task.result() == "ok"
-
-    async def test_drops_cross_loop_task_from_registry(self, isolated_env):
-        """A task whose loop has closed gets dropped instead of awaited.
-
-        Mirrors what happens when an earlier asyncio.run() call left a task
-        in background_tasks: subsequent crawl_and_save() runs on a new loop
-        and must not try to cross-await it.
-        """
-        # MagicMock(spec=Task) lets us simulate a cross-loop entry without
-        # spawning a real task on a separate loop (which would be cleanup-heavy).
-        other_loop = asyncio.new_event_loop()
-        try:
-            stale_task = MagicMock(spec=asyncio.Task)
-            stale_task.done.return_value = False
-            stale_task.get_loop.return_value = other_loop
-
-            crawler_state.background_tasks = {stale_task}
-
-            await _drain_background_tasks()
-
-            assert stale_task not in crawler_state.background_tasks
-            stale_task.cancel.assert_not_called()  # never touched mid-flight
-        finally:
-            other_loop.close()
+    async def test_deprecation_documented(self):
+        """The public helper's docstring marks it as deprecated."""
+        assert "Deprecated" in (drain_background_tasks.__doc__ or "")
 
 
-class TestCrawlerStateReset:
-    def test_reset_clears_all_state(self, isolated_env):
-        """CrawlerState.reset() restores all fields to initial values."""
-        from lilbee.crawler import runner as crawler_mod
+class TestServicesCrawlerSemaphore:
+    def test_services_crawler_semaphore_rebuilds_on_reset(self, isolated_env):
+        """``reset_services`` produces a fresh semaphore on next ``get_services``."""
+        cfg.crawl_max_concurrent = 3
+        reset_services()
+        first = get_services().crawler_semaphore
+        assert first is not None
+        reset_services()
+        second = get_services().crawler_semaphore
+        assert second is not None
+        assert first is not second
 
-        state = crawler_mod._state
-        state.semaphore = asyncio.Semaphore(3)
-        state.semaphore_limit = 3
-        state.last_sync_time = 99.0
-
-        state.reset()
-
-        assert state.semaphore is None
-        assert state.semaphore_limit == 0
-        assert state.last_sync_time == 0.0
-        assert state.sync_running.acquire(blocking=False)
-        state.sync_running.release()
-        assert state.background_tasks == set()
+    def test_services_crawler_semaphore_none_when_unlimited(self, isolated_env):
+        """``crawl_max_concurrent <= 0`` leaves ``crawler_semaphore`` as ``None``."""
+        cfg.crawl_max_concurrent = 0
+        reset_services()
+        assert get_services().crawler_semaphore is None
 
 
 class TestCrawlAndSaveSemaphore:
     @patch("lilbee.crawler.runner.crawl_single")
     async def test_semaphore_acquired_and_released(self, mock_crawl_single, isolated_env):
         """When crawl_max_concurrent > 0, sem.acquire/release are called."""
-        from lilbee.crawler import runner as crawler_mod
-
         mock_crawl_single.return_value = CrawlResult(url="https://example.com", markdown="# Hello")
         cfg.crawl_max_concurrent = 2
-        crawler_mod._state.semaphore = None
+        reset_services()
 
         paths = await crawl_and_save("https://example.com", depth=0)
         assert len(paths) == 1
 
-        # Verify semaphore was created and is still available (released)
-        sem = crawler_mod._state.semaphore
+        # Verify semaphore is still at full capacity (released).
+        sem = get_services().crawler_semaphore
         assert sem is not None
         assert sem._value == 2
-        crawler_mod._state.semaphore = None
+        reset_services()
 
 
 class TestCrawlCancel:
@@ -2316,8 +2226,7 @@ class TestStreamingFlush:
         mock_sync.assert_awaited_once()
 
     async def test_crawl_and_save_drains_background_tasks(self, isolated_env):
-        """crawl_and_save cancels any spawned periodic-sync task before returning. (bb-zqws)"""
-        import threading
+        """crawl_and_save awaits its locally-spawned periodic-sync task before returning."""
 
         async def _gen():
             await asyncio.sleep(0)
@@ -2328,23 +2237,64 @@ class TestStreamingFlush:
         mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
         mock_instance.__aexit__ = AsyncMock(return_value=False)
 
-        async def _slow_sync(*_args, **_kwargs):
-            # Would deadlock the test if the drain awaited instead of cancelling.
-            await asyncio.sleep(60.0)
+        sync_completed = asyncio.Event()
+
+        async def _short_sync(*_args, **_kwargs):
+            await asyncio.sleep(0.05)
+            sync_completed.set()
 
         cfg.crawl_sync_interval = 1
-        crawler_state.last_sync_time = 0.0
-        crawler_state.sync_running = threading.Lock()
+        reset_services()
+        sync_state = get_services().crawler_sync_state
+        sync_state.last_run = 0.0
+
+        # Snapshot tasks currently on this loop so we can assert no
+        # crawler-spawned task survives the call.
+        before = set(asyncio.all_tasks())
 
         with (
             patch.dict("sys.modules", self._setup_crawl4ai(mock_instance)),
-            patch("lilbee.data.ingest.sync", _slow_sync),
+            patch("lilbee.data.ingest.sync", _short_sync),
         ):
             await crawl_and_save("https://example.com", depth=0)
 
-        # The done callback cleared the registry; any task that survived would
-        # mean the drain didn't await its cancellation.
-        assert all(t.done() for t in crawler_state.background_tasks)
+        # crawl_and_save must not return before its periodic-sync task finished.
+        assert sync_completed.is_set()
+        # No new pending tasks leak past the call.
+        leaked = {t for t in asyncio.all_tasks() if t not in before and not t.done()}
+        assert not leaked
+
+    async def test_concurrent_crawl_and_save_calls_isolated_tasks(self, isolated_env):
+        """Two concurrent crawl_and_save calls each own their own local task set."""
+        cfg.crawl_max_concurrent = 0  # don't serialize the two concurrent calls
+        cfg.crawl_sync_interval = 1  # spawn a periodic-sync per call
+        reset_services()
+        sync_state = get_services().crawler_sync_state
+        sync_state.last_run = 0.0
+
+        async def _short_sync(*_args, **_kwargs):
+            await asyncio.sleep(0)
+
+        async def _fake_single(url: str, *, quiet: bool = False) -> CrawlResult:
+            await asyncio.sleep(0)
+            return CrawlResult(url=url, markdown=f"# {url}")
+
+        before = set(asyncio.all_tasks())
+
+        with (
+            patch("lilbee.crawler.runner.crawl_single", side_effect=_fake_single),
+            patch("lilbee.data.ingest.sync", _short_sync),
+        ):
+            results = await asyncio.gather(
+                crawl_and_save("https://example.com/a", depth=0),
+                crawl_and_save("https://example.com/b", depth=0),
+            )
+        assert len(results) == 2
+        assert all(len(paths) == 1 for paths in results)
+        # Each call's local task set was drained before returning, so no
+        # crawler-spawned task leaks past either invocation.
+        leaked = {t for t in asyncio.all_tasks() if t not in before and not t.done()}
+        assert not leaked
 
     async def test_metadata_flush_is_batched(self, isolated_env):
         """_flush_metadata fires every METADATA_FLUSH_INTERVAL pages, not every page."""

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -894,3 +894,99 @@ class TestImportLlamaCpp:
 
         with pytest.raises(OSError, match="libsomethingelse"):
             import_llama_cpp()
+
+
+class TestAbortCallbackWiring:
+    """Every Llama construction site wires the abort_callback so Ctrl+C can interrupt ggml."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_abort_flag(self) -> None:
+        from lilbee.providers.llama_cpp.abort_signal import clear_abort
+
+        clear_abort()
+        yield
+        clear_abort()
+
+    def test_construct_llama_passes_abort_callback(
+        self, models_dir: Path, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """``_construct_llama`` injects ``abort_callback`` into every Llama() call."""
+        from lilbee.providers.llama_cpp.abort_signal import abort_callback as expected_cb
+        from lilbee.providers.llama_cpp.provider import load_llama
+        from lilbee.providers.model_cache import MODE_CHAT
+
+        cfg.num_ctx = 2048
+        mock_llama_cpp.Llama.return_value.metadata = {}
+
+        load_llama(models_dir / "test-model.gguf", mode=MODE_CHAT)
+
+        call_kwargs = mock_llama_cpp.Llama.call_args[1]
+        assert call_kwargs["abort_callback"] is expected_cb
+
+    def test_read_gguf_metadata_passes_abort_callback(
+        self, models_dir: Path, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """``read_gguf_metadata`` wires the abort flag into its vocab-only Llama load."""
+        from lilbee.providers.llama_cpp.abort_signal import abort_callback as expected_cb
+        from lilbee.providers.llama_cpp.gguf_meta import read_gguf_metadata
+
+        mock_llama_cpp.Llama.return_value.metadata = {}
+        read_gguf_metadata(models_dir / "test-model.gguf")
+
+        call_kwargs = mock_llama_cpp.Llama.call_args[1]
+        assert call_kwargs["abort_callback"] is expected_cb
+        assert call_kwargs["vocab_only"] is True
+
+    def test_load_vision_llama_passes_abort_callback(
+        self, models_dir: Path, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """``load_vision_llama`` wires the abort flag into the vision Llama load."""
+        from lilbee.providers.llama_cpp.abort_signal import abort_callback as expected_cb
+        from lilbee.providers.mtmd_backend import load_vision_llama
+
+        mmproj_path = models_dir / "test-mmproj-f16.gguf"
+        mmproj_path.write_bytes(b"fake-mmproj")
+        with mock.patch(
+            "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+            return_value=mock.MagicMock(),
+        ):
+            load_vision_llama(models_dir / "test-model.gguf", mmproj_path)
+
+        call_kwargs = mock_llama_cpp.Llama.call_args[1]
+        assert call_kwargs["abort_callback"] is expected_cb
+
+    def test_chat_when_abort_set_breaks_stream_cleanly(
+        self, models_dir: Path, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """Abort flag set mid-stream: a polling stream stops cleanly and releases the lock."""
+        from lilbee.providers.llama_cpp import LlamaCppProvider
+        from lilbee.providers.llama_cpp.abort_signal import (
+            abort_callback as cb,
+        )
+        from lilbee.providers.llama_cpp.abort_signal import (
+            request_abort,
+        )
+
+        def streaming_response() -> Any:
+            yield {"choices": [{"delta": {"content": "first"}}]}
+            # Simulate ggml polling abort_callback every chunk; flip the flag
+            # mid-stream and verify the next iteration honors it.
+            request_abort()
+            if cb():
+                return
+            yield {"choices": [{"delta": {"content": "should-not-emit"}}]}  # pragma: no cover
+
+        instance = mock.MagicMock()
+        instance.create_chat_completion.return_value = streaming_response()
+        mock_llama_cpp.Llama.return_value = instance
+
+        provider = LlamaCppProvider()
+        try:
+            result = provider.chat([{"role": "user", "content": "hi"}], stream=True)
+            tokens = list(result)
+            assert tokens == ["first"]
+            # Lock must be released after a clean stream stop.
+            assert provider._chat_lock.acquire(blocking=False)
+            provider._chat_lock.release()
+        finally:
+            provider.shutdown()

--- a/tests/test_llama_cpp_queue.py
+++ b/tests/test_llama_cpp_queue.py
@@ -955,10 +955,10 @@ class TestAbortCallbackWiring:
         call_kwargs = mock_llama_cpp.Llama.call_args[1]
         assert call_kwargs["abort_callback"] is expected_cb
 
-    def test_chat_when_abort_set_breaks_stream_cleanly(
+    def test_chat_iterator_releases_lock_when_stream_returns_early(
         self, models_dir: Path, mock_llama_cpp: mock.MagicMock
     ) -> None:
-        """Abort flag set mid-stream: a polling stream stops cleanly and releases the lock."""
+        """A stream that polls ``abort_callback`` and returns early frees the chat lock."""
         from lilbee.providers.llama_cpp import LlamaCppProvider
         from lilbee.providers.llama_cpp.abort_signal import (
             abort_callback as cb,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -19,7 +19,7 @@ def isolated_cfg():
 
 class TestServicesDataclass:
     def test_fields_are_immutable(self):
-        from lilbee.core.services import Services
+        from lilbee.core.services import CrawlerSyncState, Services
 
         services = Services(
             provider=MagicMock(),
@@ -33,6 +33,8 @@ class TestServicesDataclass:
             hf_client=MagicMock(),
             ingest_lock_registry=MagicMock(),
             model_manager=MagicMock(),
+            crawler_semaphore=None,
+            crawler_sync_state=CrawlerSyncState(),
         )
         with pytest.raises(AttributeError):
             services.clusterer = MagicMock()  # type: ignore[misc]

--- a/tests/test_tui_logging.py
+++ b/tests/test_tui_logging.py
@@ -1,0 +1,110 @@
+"""Tests for lilbee.cli.tui.log_routing: TUI rotating-file log routing."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+import pytest
+
+from lilbee.cli.tui import _silence_stderr_log_handlers
+from lilbee.cli.tui.log_routing import setup_tui_log_file
+from lilbee.core.config import cfg
+
+
+@pytest.fixture(autouse=True)
+def _isolated_root_logger():
+    """Snapshot root logger handlers; restore and close any added during the test."""
+    root = logging.getLogger()
+    before = list(root.handlers)
+    yield
+    added = [h for h in root.handlers if h not in before]
+    for handler in added:
+        root.removeHandler(handler)
+        with contextlib.suppress(Exception):
+            handler.close()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_data_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "data_root", tmp_path)
+
+
+def test_setup_tui_log_file_creates_dir(tmp_path):
+    assert not (tmp_path / "logs").exists()
+    setup_tui_log_file()
+    assert (tmp_path / "logs").is_dir()
+
+
+def test_setup_tui_log_file_returns_path(tmp_path):
+    log_path = setup_tui_log_file()
+    assert isinstance(log_path, Path)
+    assert log_path == tmp_path / "logs" / "tui.log"
+
+
+def test_setup_tui_log_file_attaches_handler():
+    root = logging.getLogger()
+    before = {id(h) for h in root.handlers}
+    setup_tui_log_file()
+    new_handlers = [h for h in root.handlers if id(h) not in before]
+    assert len(new_handlers) == 1
+    assert isinstance(new_handlers[0], RotatingFileHandler)
+
+
+def test_setup_tui_log_file_idempotent():
+    root = logging.getLogger()
+    setup_tui_log_file()
+    count_after_first = len(root.handlers)
+    setup_tui_log_file()
+    setup_tui_log_file()
+    assert len(root.handlers) == count_after_first
+
+
+def test_log_records_reach_file(tmp_path):
+    log_path = setup_tui_log_file()
+    logger = logging.getLogger("lilbee")
+    previous_level = logger.level
+    logger.setLevel(logging.WARNING)
+    try:
+        logger.warning("probe-12345")
+    finally:
+        logger.setLevel(previous_level)
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    content = log_path.read_text()
+    assert "probe-12345" in content
+    assert "WARNING" in content
+    assert "lilbee" in content
+
+
+def test_silencer_preserves_file_handler():
+    root = logging.getLogger()
+    setup_tui_log_file()
+    file_handlers_before = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+    assert len(file_handlers_before) == 1
+    _silence_stderr_log_handlers()
+    file_handlers_after = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+    assert file_handlers_after == file_handlers_before
+
+
+def test_rotation_caps_file_size(tmp_path, monkeypatch):
+    """A small maxBytes override forces rotation; tui.log.1 must appear."""
+    monkeypatch.setattr("lilbee.cli.tui.log_routing._MAX_BYTES", 512)
+    log_path = setup_tui_log_file()
+    logger = logging.getLogger("lilbee.test_rotation")
+    previous_level = logger.level
+    logger.setLevel(logging.WARNING)
+    try:
+        # Each record line is well under 512 bytes; 50 records guarantees rollover.
+        for i in range(50):
+            logger.warning("rotation-probe-%03d-%s", i, "x" * 80)
+    finally:
+        logger.setLevel(previous_level)
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    backup = log_path.parent / "tui.log.1"
+    assert backup.exists(), (
+        f"expected rotated backup at {backup}; logs dir: {list(log_path.parent.iterdir())}"
+    )

--- a/tests/test_tui_logging.py
+++ b/tests/test_tui_logging.py
@@ -81,12 +81,14 @@ def test_log_records_reach_file(tmp_path):
 
 def test_silencer_preserves_file_handler():
     root = logging.getLogger()
+    snapshot = set(root.handlers)
     setup_tui_log_file()
-    file_handlers_before = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
-    assert len(file_handlers_before) == 1
+    added_file_handlers = [
+        h for h in root.handlers if h not in snapshot and isinstance(h, RotatingFileHandler)
+    ]
+    assert len(added_file_handlers) == 1
     _silence_stderr_log_handlers()
-    file_handlers_after = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
-    assert file_handlers_after == file_handlers_before
+    assert all(h in root.handlers for h in added_file_handlers)
 
 
 def test_rotation_caps_file_size(tmp_path, monkeypatch):

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8010,17 +8010,24 @@ async def test_app_action_quit_routes_to_wizard_cancel():
             assert not isinstance(app.screen, SetupWizard)
 
 
-async def test_action_quit_calls_request_abort():
-    """Ctrl+C calls ``request_abort()`` first thing so ggml's poll loop wakes."""
+async def test_action_quit_calls_request_abort_before_exit():
+    """Ctrl+C calls ``request_abort()`` before ``exit`` so ggml unblocks first."""
     from lilbee.cli.tui.app import LilbeeApp
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        with patch("lilbee.cli.tui.app.request_abort") as mock_abort:
+        parent = MagicMock()
+        with (
+            patch("lilbee.cli.tui.app.request_abort", parent.request_abort),
+            patch.object(app, "exit", parent.exit),
+        ):
             await pilot.press("ctrl+c")
             await pilot.pause()
-            mock_abort.assert_called()
+            call_names = [c[0] for c in parent.mock_calls]
+            assert "request_abort" in call_names
+            # ``request_abort`` must come no later than ``exit`` in the call order.
+            assert call_names.index("request_abort") <= call_names.index("exit")
 
 
 async def test_no_force_quit_attribute():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8010,60 +8010,50 @@ async def test_app_action_quit_routes_to_wizard_cancel():
             assert not isinstance(app.screen, SetupWizard)
 
 
-async def test_app_action_quit_double_force_exits():
-    """Double Ctrl+C within 2s calls _force_quit."""
+async def test_action_quit_calls_request_abort():
+    """Ctrl+C calls ``request_abort()`` first thing so ggml's poll loop wakes."""
     from lilbee.cli.tui.app import LilbeeApp
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        # First quit sets last_quit_time
-        with patch.object(app, "exit"):
-            await app.action_quit()
-        # Second quit within 2s should force-quit
-        with patch.object(app, "_force_quit") as mock_fq:
-            await app.action_quit()
-            mock_fq.assert_called_once()
+        with patch("lilbee.cli.tui.app.request_abort") as mock_abort:
+            await pilot.press("ctrl+c")
+            await pilot.pause()
+            mock_abort.assert_called()
 
 
-async def test_app_force_quit_calls_os_exit():
-    """_force_quit resets services, runs Textual driver teardown, then calls os._exit."""
+async def test_no_force_quit_attribute():
+    """``LilbeeApp`` no longer carries the ``_force_quit`` GIL-block escape hatch."""
     from lilbee.cli.tui.app import LilbeeApp
 
     app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        await _pilot.pause()
-        with (
-            patch("lilbee.cli.tui.app.reset_services") as mock_reset,
-            patch("lilbee.cli.tui.app._restore_terminal_via_driver") as mock_restore,
-            patch("os._exit") as mock_exit,
-        ):
-            app._force_quit()
-            mock_reset.assert_called_once()
-            mock_restore.assert_called_once_with(app)
-            mock_exit.assert_called_once_with(1)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert not hasattr(app, "_force_quit")
 
 
-class TestRestoreTerminalViaDriver:
-    """``_restore_terminal_via_driver`` runs Textual's driver teardown before os._exit (bb-6b86)."""
+def test_no_restore_terminal_via_driver_module_attr():
+    """``_restore_terminal_via_driver`` was deleted along with ``_force_quit``."""
+    assert not hasattr(tui_app, "_restore_terminal_via_driver")
 
-    def test_calls_driver_stop_application_mode(self):
-        """Driver teardown is the path that emits Textual's full restore sequence."""
-        app = MagicMock()
-        tui_app._restore_terminal_via_driver(app)
-        app._driver.stop_application_mode.assert_called_once_with()
 
-    def test_no_op_when_driver_unset(self):
-        """Early-startup or post-teardown: ``_driver`` is None; no AttributeError."""
-        app = MagicMock()
-        app._driver = None
-        tui_app._restore_terminal_via_driver(app)  # must not raise
+async def test_action_quit_no_double_ctrl_c_window():
+    """Double Ctrl+C does not trigger any force-quit branch; both presses go through normal quit."""
+    from lilbee.cli.tui.app import LilbeeApp
 
-    def test_swallows_driver_teardown_failure(self):
-        """A driver mid-teardown that raises must not block ``os._exit``."""
-        app = MagicMock()
-        app._driver.stop_application_mode.side_effect = RuntimeError("boom")
-        tui_app._restore_terminal_via_driver(app)  # must not raise
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        # No state should track press timing any more.
+        assert not hasattr(app, "last_quit_time")
+        with patch.object(app, "exit") as mock_exit:
+            await pilot.press("ctrl+c")
+            await pilot.pause()
+            await pilot.press("ctrl+c")
+            await pilot.pause()
+        # Two normal quits, never an os._exit force-quit branch.
+        assert mock_exit.call_count >= 1
 
 
 class TestSilenceStderrLogHandlers:
@@ -8177,8 +8167,8 @@ async def test_command_provider_action_setup():
 # ---------------------------------------------------------------------------
 
 
-def test_run_tui_keyboard_interrupt_during_shutdown():
-    """run_tui handles KeyboardInterrupt during shutdown cleanup."""
+def test_run_tui_keyboard_interrupt_during_shutdown_propagates():
+    """KeyboardInterrupt during shutdown propagates instead of forcing os._exit."""
     from lilbee.cli.tui import run_tui
 
     mock_app = MagicMock()
@@ -8186,14 +8176,16 @@ def test_run_tui_keyboard_interrupt_during_shutdown():
     with (
         patch("lilbee.cli.tui.app.LilbeeApp", return_value=mock_app),
         patch("lilbee.cli.tui.shutdown_executor", side_effect=KeyboardInterrupt),
-        patch("os._exit") as mock_exit,
+        patch("lilbee.cli.tui.reset_services") as mock_reset,
+        pytest.raises(KeyboardInterrupt),
     ):
         run_tui()
-        mock_exit.assert_called_once_with(1)
+    # reset_services in finally was never reached because shutdown_executor raised first.
+    mock_reset.assert_not_called()
 
 
-def test_run_tui_exception_during_shutdown():
-    """run_tui handles generic Exception during shutdown cleanup."""
+def test_run_tui_exception_during_shutdown_propagates():
+    """A generic Exception during shutdown propagates without an os._exit fallback."""
     from lilbee.cli.tui import run_tui
 
     mock_app = MagicMock()
@@ -8201,10 +8193,9 @@ def test_run_tui_exception_during_shutdown():
     with (
         patch("lilbee.cli.tui.app.LilbeeApp", return_value=mock_app),
         patch("lilbee.cli.tui.shutdown_executor", side_effect=RuntimeError("fail")),
-        patch("os._exit") as mock_exit,
+        pytest.raises(RuntimeError, match="fail"),
     ):
         run_tui()
-        mock_exit.assert_called_once_with(1)
 
 
 async def test_chat_on_show_dismiss_with_fd():

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from lilbee.core.services import Services, set_services
+from lilbee.core.services import CrawlerSyncState, Services, set_services
 
 
 @pytest.fixture(autouse=True)
@@ -44,6 +44,8 @@ def mock_provider():
         hf_client=mock.MagicMock(),
         ingest_lock_registry=mock.MagicMock(),
         model_manager=mock.MagicMock(),
+        crawler_semaphore=None,
+        crawler_sync_state=CrawlerSyncState(),
     )
     set_services(services)
     yield provider
@@ -180,6 +182,8 @@ class TestExtractPageTextSubprocess:
             hf_client=mock.MagicMock(),
             ingest_lock_registry=mock.MagicMock(),
             model_manager=mock.MagicMock(),
+            crawler_semaphore=None,
+            crawler_sync_state=CrawlerSyncState(),
         )
         set_services(services)
 
@@ -205,6 +209,8 @@ class TestExtractPageTextSubprocess:
             hf_client=mock.MagicMock(),
             ingest_lock_registry=mock.MagicMock(),
             model_manager=mock.MagicMock(),
+            crawler_semaphore=None,
+            crawler_sync_state=CrawlerSyncState(),
         )
         set_services(services)
 


### PR DESCRIPTION
## Problem

- Logs from the TUI session were thrown away. If anything went wrong, there was nothing to debug from.
- Ctrl+C couldn't stop a running chat mid-generation. You had to press it twice, and the second press exited so abruptly that the terminal needed cleanup afterwards.
- The web crawler's task bookkeeping lived in a module-level global. Tasks leaked across event-loop boundaries and tests had to manually reset four fields between cases.

## Solution

- TUI logs now write to a rotating file at `<data_root>/logs/tui.log` (1 MiB, 5 backups). Debugging a session means tailing a file.
- One Ctrl+C now stops a running chat within a fraction of a second. The double-tap force-quit and the terminal-restore workaround are deleted.
- The crawler tracks its tasks per call. The semaphore and sync-coordination lock move into the singleton service container and rebuild cleanly between runs. The cross-loop filter from the prior PR is no longer needed.