### PR TITLE
Lazy-import in cli.tui to skip pyarrow on `lilbee --help` (bb-oae5)

### DIFF
--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -6,7 +6,6 @@ import logging
 import os
 import sys
 
-from lilbee.cli.sync import shutdown_executor
 from lilbee.services import reset_services
 
 
@@ -38,6 +37,9 @@ def run_tui(*, auto_sync: bool = False, initial_view: str | None = None) -> None
     *initial_view* deep-links to a named view (e.g. ``"Catalog"``) after
     the default chat screen is mounted. Used by ``lilbee model browse``.
     """
+    # heavy: cli.sync transitively imports ingest -> store -> pyarrow (~1.8s
+    # cold-start on bare runners); only needed at TUI shutdown. (bb-oae5)
+    from lilbee.cli.sync import shutdown_executor
     from lilbee.cli.tui.app import LilbeeApp
 
     _silence_stderr_log_handlers()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8163,7 +8163,7 @@ def test_run_tui_keyboard_interrupt_during_shutdown():
     mock_app.run.return_value = None
     with (
         patch("lilbee.cli.tui.app.LilbeeApp", return_value=mock_app),
-        patch("lilbee.cli.tui.shutdown_executor", side_effect=KeyboardInterrupt),
+        patch("lilbee.cli.sync.shutdown_executor", side_effect=KeyboardInterrupt),
         patch("os._exit") as mock_exit,
     ):
         run_tui()
@@ -8178,7 +8178,7 @@ def test_run_tui_exception_during_shutdown():
     mock_app.run.return_value = None
     with (
         patch("lilbee.cli.tui.app.LilbeeApp", return_value=mock_app),
-        patch("lilbee.cli.tui.shutdown_executor", side_effect=RuntimeError("fail")),
+        patch("lilbee.cli.sync.shutdown_executor", side_effect=RuntimeError("fail")),
         patch("os._exit") as mock_exit,
     ):
         run_tui()

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1846,7 +1846,7 @@ class TestRunTuiKeyboardInterrupt:
         with mock.patch("lilbee.cli.tui.app.LilbeeApp") as MockApp:
             MockApp.return_value.run.side_effect = KeyboardInterrupt
             with (
-                mock.patch("lilbee.cli.tui.shutdown_executor"),
+                mock.patch("lilbee.cli.sync.shutdown_executor"),
                 mock.patch("lilbee.cli.tui.reset_services"),
             ):
                 from lilbee.cli.tui import run_tui
@@ -1858,7 +1858,7 @@ class TestRunTuiKeyboardInterrupt:
         with mock.patch("lilbee.cli.tui.app.LilbeeApp") as MockApp:
             MockApp.return_value.run.side_effect = KeyboardInterrupt
             with (
-                mock.patch("lilbee.cli.tui.shutdown_executor") as mock_shutdown,
+                mock.patch("lilbee.cli.sync.shutdown_executor") as mock_shutdown,
                 mock.patch("lilbee.cli.tui.reset_services") as mock_reset,
             ):
                 from lilbee.cli.tui import run_tui


### PR DESCRIPTION
## Problem

\`lilbee --help\` cold-starts in 30–60 s on bare GHA ubuntu-latest and macos-latest runners (vs <1 s in linux-distros Docker containers and on Windows). The QA matrix's CLI tests have a 60 s per-test budget; on those runners every \`run_lilbee\` invocation either just barely catches the timeout or just barely misses it. The two affected lanes (native ubuntu pypi, native macos pypi) had to be marked \`continue-on-error\` to keep the matrix green.

## Solution

\`python -X importtime\` showed the hot path: \`lilbee.cli.app\` → \`lilbee.cli.commands\` → (typer auto-discover) → \`lilbee.cli.tui\` (package) → \`cli/tui/__init__.py\` → \`lilbee.cli.sync\` → \`lilbee.ingest\` → \`lilbee.store\` → \`pyarrow\` (~1.8 s alone). pyarrow has no business loading on \`--help\`.

Move the \`from lilbee.cli.sync import shutdown_executor\` from \`cli/tui/__init__.py\` module-top into \`run_tui\`'s body, where it's actually used. The function only runs at TUI shutdown.

Cold-start of \`import lilbee.cli.app\` on a dev machine:
- Before: **3.6 s**
- After: **0.25 s**

Bare GHA runners are ~10× slower on import-heavy work, so the matrix's CLI tests should now finish in 2-5 s each instead of 30-60 s.

Two test files patched \`lilbee.cli.tui.shutdown_executor\` directly. Updated to patch where the symbol lives, \`lilbee.cli.sync.shutdown_executor\`, per AGENTS.md (don't anchor mocks to re-export sites).

## Follow-up

Once this lands and the qa-matrix branch picks it up, the \`continue-on-error\` markers on \`native (ubuntu, pypi)\` and \`native (macos, pypi)\` cells flip back off. Tracked in bb-oae5.