### PR TITLE
Fix vision OCR routing in auto provider mode

### DIFF
--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -77,6 +77,17 @@ class LLMProvider(Protocol):
         """Chat completion. Returns str for non-stream, ClosableIterator[str] for stream."""
         ...
 
+    def vision_ocr(
+        self,
+        png_bytes: bytes,
+        model: str,
+        prompt: str = "",
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """OCR one page image; ``timeout`` seconds, ``None``/``0`` = no cap."""
+        ...
+
     def list_models(self) -> list[str]:
         """List available model identifiers."""
         ...

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -72,6 +72,18 @@ class RoutingProvider(LLMProvider):
         ref = parse_model_ref(model or cfg.chat_model)
         return self._pick_backend(ref).chat(messages, stream=stream, options=options, model=model)
 
+    def vision_ocr(
+        self,
+        png_bytes: bytes,
+        model: str,
+        prompt: str = "",
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """Dispatch by ``model``'s ref prefix, same rules as :meth:`chat`."""
+        ref = parse_model_ref(model)
+        return self._pick_backend(ref).vision_ocr(png_bytes, model, prompt, timeout=timeout)
+
     def list_models(self) -> list[str]:
         """Return the union of native and SDK-visible models.
 

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -152,6 +152,33 @@ class SdkLLMProvider(LLMProvider):
                 f"Chat failed: {exc}", provider=self._backend.provider_name
             ) from exc
 
+    def vision_ocr(
+        self,
+        png_bytes: bytes,
+        model: str,
+        prompt: str = "",
+        *,
+        timeout: float | None = None,
+    ) -> str:
+        """OCR via a multipart chat completion; ``timeout`` enforced via thread pool."""
+        from lilbee.vision import OCR_PROMPT, build_vision_messages
+
+        messages = build_vision_messages(prompt or OCR_PROMPT, png_bytes)
+        if timeout and timeout > 0:
+            from concurrent.futures import ThreadPoolExecutor
+
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(self.chat, messages, stream=False, model=model)
+                result = future.result(timeout=timeout)
+        else:
+            result = self.chat(messages, stream=False, model=model)
+        if not isinstance(result, str):
+            raise ProviderError(
+                f"Vision OCR returned non-text response ({type(result).__name__}).",
+                provider=self._backend.provider_name,
+            )
+        return result
+
     def list_models(self) -> list[str]:
         """List models from the backend (empty list on SDK errors)."""
         try:

--- a/src/lilbee/vision.py
+++ b/src/lilbee/vision.py
@@ -11,7 +11,7 @@ import sys
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple
 
 from lilbee.core.config import cfg
 from lilbee.core.services import get_services
@@ -110,32 +110,9 @@ def build_vision_messages(prompt: str, png_bytes: bytes) -> list[dict]:
 
 
 def extract_page_text(png_bytes: bytes, model: str, *, timeout: float | None = None) -> str | None:
-    """Send a page image to a vision model and return extracted text.
-    If the provider exposes a ``vision_ocr`` method (subprocess-isolated),
-    that path is preferred. Otherwise falls back to ``provider.chat``.
-    The *timeout* parameter (seconds) caps wall-clock time for the provider
-    call: routed natively into ``vision_ocr`` when supported, otherwise via
-    ``concurrent.futures`` around the ``chat`` fallback. ``None`` or ``0``
-    means no limit.
-    """
+    """OCR one page; returns ``None`` on provider failure so the caller skips it."""
     try:
-        provider = get_services().provider
-
-        # vision_ocr is optional; only the llama-cpp provider implements it.
-        if hasattr(provider, "vision_ocr"):
-            result: str = provider.vision_ocr(png_bytes, model, OCR_PROMPT, timeout=timeout)  # type: ignore[attr-defined]
-            return result
-
-        messages = build_vision_messages(OCR_PROMPT, png_bytes)
-
-        if timeout and timeout > 0:
-            from concurrent.futures import ThreadPoolExecutor
-
-            with ThreadPoolExecutor(max_workers=1) as pool:
-                future = pool.submit(provider.chat, messages, stream=False, model=model)
-                return cast(str, future.result(timeout=timeout))
-
-        return cast(str, provider.chat(messages, stream=False, model=model))
+        return get_services().provider.vision_ocr(png_bytes, model, OCR_PROMPT, timeout=timeout)
     except Exception as exc:
         log.warning("Vision OCR: page skipped (%s: %s)", type(exc).__name__, exc)
         log.debug("Vision OCR traceback for model %s", model, exc_info=True)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1056,6 +1056,42 @@ class TestRoutingProvider:
         assert result == "hello"
         mock_litellm.chat.assert_called_once()
 
+    def test_routes_vision_ocr_to_llama_cpp_for_native_ref(self) -> None:
+        """Native GGUF vision refs reach the llama-cpp vision worker pool."""
+        rp = self._make_provider()
+        mock_llama = mock.MagicMock()
+        mock_llama.vision_ocr.return_value = "page text"
+        mock_litellm = mock.MagicMock()
+        rp._llama_cpp = mock_llama
+        rp._sdk_provider = mock_litellm
+
+        result = rp.vision_ocr(
+            b"\x89PNG", "noctrex/LightOnOCR-2-1B-GGUF/LightOnOCR-2-1B-Q4_K_M.gguf", "ocr"
+        )
+        assert result == "page text"
+        mock_llama.vision_ocr.assert_called_once_with(
+            b"\x89PNG",
+            "noctrex/LightOnOCR-2-1B-GGUF/LightOnOCR-2-1B-Q4_K_M.gguf",
+            "ocr",
+            timeout=None,
+        )
+        mock_litellm.vision_ocr.assert_not_called()
+
+    def test_routes_vision_ocr_to_litellm_for_ollama_ref(self) -> None:
+        rp = self._make_provider()
+        mock_llama = mock.MagicMock()
+        mock_litellm = mock.MagicMock()
+        mock_litellm.vision_ocr.return_value = "remote text"
+        rp._llama_cpp = mock_llama
+        rp._sdk_provider = mock_litellm
+
+        result = rp.vision_ocr(b"\x89PNG", "ollama/llava:7b", "ocr", timeout=30.0)
+        assert result == "remote text"
+        mock_litellm.vision_ocr.assert_called_once_with(
+            b"\x89PNG", "ollama/llava:7b", "ocr", timeout=30.0
+        )
+        mock_llama.vision_ocr.assert_not_called()
+
     def test_routes_chat_to_llama_cpp_for_local_ref(self) -> None:
         """Local HF refs dispatch to llama-cpp regardless of registry contents.
 
@@ -2321,6 +2357,86 @@ class TestLiteLLMListModelsRouting:
 
         headers = mock_get.call_args[1].get("headers", {})
         assert headers.get("Authorization") == "Bearer sk-secret"
+
+
+class TestSdkLLMProviderVisionOcr:
+    """``SdkLLMProvider.vision_ocr`` translates to a multipart chat call."""
+
+    def _make_provider(self) -> SdkLLMProvider:
+        from lilbee.providers.litellm_sdk import LitellmSdkBackend
+        from lilbee.providers.sdk_llm_provider import SdkLLMProvider
+
+        return SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+
+    def test_builds_multipart_message_and_routes_to_chat(self) -> None:
+        provider = self._make_provider()
+        with mock.patch.object(provider, "chat", return_value="page text") as mock_chat:
+            result = provider.vision_ocr(b"\x89PNG", "ollama/llava:7b", "ocr please")
+
+        assert result == "page text"
+        mock_chat.assert_called_once()
+        messages = mock_chat.call_args[0][0]
+        assert len(messages) == 1
+        content = messages[0]["content"]
+        assert content[0]["type"] == "image_url"
+        assert content[0]["image_url"]["url"].startswith("data:image/png;base64,")
+        assert content[1]["type"] == "text"
+        assert content[1]["text"] == "ocr please"
+        assert mock_chat.call_args[1]["model"] == "ollama/llava:7b"
+        assert mock_chat.call_args[1]["stream"] is False
+
+    def test_empty_prompt_uses_default_ocr_prompt(self) -> None:
+        from lilbee.vision import OCR_PROMPT
+
+        provider = self._make_provider()
+        with mock.patch.object(provider, "chat", return_value="ok") as mock_chat:
+            provider.vision_ocr(b"\x89PNG", "ollama/llava:7b")
+
+        text_part = mock_chat.call_args[0][0][0]["content"][1]
+        assert text_part["text"] == OCR_PROMPT
+
+    def test_positive_timeout_returns_chat_result(self) -> None:
+        """A non-expiring positive timeout returns the chat response unchanged."""
+        provider = self._make_provider()
+        with mock.patch.object(provider, "chat", return_value="ok") as mock_chat:
+            result = provider.vision_ocr(b"\x89PNG", "ollama/llava:7b", "p", timeout=5.0)
+
+        assert result == "ok"
+        mock_chat.assert_called_once()
+
+    def test_timeout_expiry_raises_timeout_error(self) -> None:
+        import time
+
+        provider = self._make_provider()
+
+        def slow_chat(*args, **kwargs):
+            time.sleep(5)
+            return "too late"
+
+        with (
+            mock.patch.object(provider, "chat", side_effect=slow_chat),
+            pytest.raises(TimeoutError),
+        ):
+            provider.vision_ocr(b"\x89PNG", "ollama/llava:7b", "p", timeout=0.01)
+
+    def test_zero_timeout_returns_chat_result(self) -> None:
+        """``timeout=0`` skips the thread pool and returns chat's result."""
+        provider = self._make_provider()
+        with mock.patch.object(provider, "chat", return_value="ok") as mock_chat:
+            result = provider.vision_ocr(b"\x89PNG", "ollama/llava:7b", "p", timeout=0)
+
+        assert result == "ok"
+        mock_chat.assert_called_once()
+
+    def test_non_string_response_raises_provider_error(self) -> None:
+        from lilbee.providers.base import ProviderError
+
+        provider = self._make_provider()
+        with (
+            mock.patch.object(provider, "chat", return_value=iter(["streamed"])),
+            pytest.raises(ProviderError, match="non-text response"),
+        ):
+            provider.vision_ocr(b"\x89PNG", "ollama/llava:7b", "p")
 
 
 class TestNeedsApiBase:

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -20,12 +20,21 @@ def _clean_vision_module() -> None:
 
 @pytest.fixture()
 def mock_provider():
-    """Create a mock provider and inject it via Services.
-    Uses spec_set to exclude vision_ocr: tests that need the subprocess
-    path should set it explicitly on the mock.
+    """Create a mock provider with the full LLMProvider surface.
+
+    ``vision_ocr`` is part of the protocol now, so every concrete provider
+    implements it; tests mock it directly rather than the chat fallthrough.
     """
     provider = mock.MagicMock(
-        spec=["chat", "embed", "list_models", "pull_model", "show_model", "shutdown"]
+        spec=[
+            "chat",
+            "embed",
+            "vision_ocr",
+            "list_models",
+            "pull_model",
+            "show_model",
+            "shutdown",
+        ]
     )
     store = mock.MagicMock()
     embedder = mock.MagicMock()
@@ -138,102 +147,41 @@ class TestExtractPageText:
     def test_returns_text_on_success(self, mock_provider) -> None:
         from lilbee.vision import extract_page_text
 
-        mock_provider.chat.return_value = "extracted text"
+        mock_provider.vision_ocr.return_value = "extracted text"
         result = extract_page_text(b"fake-png", "test-model")
         assert result == "extracted text"
 
     def test_returns_none_on_error(self, mock_provider) -> None:
         from lilbee.vision import extract_page_text
 
-        mock_provider.chat.side_effect = RuntimeError("model error")
+        mock_provider.vision_ocr.side_effect = RuntimeError("model error")
         result = extract_page_text(b"fake-png", "test-model")
         assert result is None
 
-    def test_sends_ocr_prompt_and_image(self, mock_provider) -> None:
+    def test_passes_ocr_prompt_image_and_model(self, mock_provider) -> None:
         from lilbee.vision import OCR_PROMPT, extract_page_text
 
-        mock_provider.chat.return_value = "text"
-        extract_page_text(b"png-bytes", "my-model")
+        mock_provider.vision_ocr.return_value = "text"
+        extract_page_text(b"png-bytes", "my-model", timeout=12.5)
 
-        mock_provider.chat.assert_called_once()
-        call_args = mock_provider.chat.call_args
-        messages = call_args[0][0]
-        # OpenAI-compatible multipart content format
-        content = messages[0]["content"]
-        assert isinstance(content, list)
-        assert content[0]["type"] == "image_url"
-        assert content[0]["image_url"]["url"].startswith("data:image/png;base64,")
-        assert content[1]["type"] == "text"
-        assert content[1]["text"] == OCR_PROMPT
-        assert call_args[1]["model"] == "my-model"
-
-
-class TestExtractPageTextSubprocess:
-    """Test extract_page_text when provider has vision_ocr method."""
-
-    def test_delegates_to_vision_ocr(self) -> None:
-        provider = mock.MagicMock(spec=["chat", "embed", "vision_ocr", "shutdown"])
-        provider.vision_ocr.return_value = "subprocess text"
-        services = Services(
-            provider=provider,
-            store=mock.MagicMock(),
-            embedder=mock.MagicMock(),
-            reranker=mock.MagicMock(),
-            concepts=mock.MagicMock(),
-            clusterer=mock.MagicMock(),
-            searcher=mock.MagicMock(),
-            registry=mock.MagicMock(),
-            hf_client=mock.MagicMock(),
-            ingest_lock_registry=mock.MagicMock(),
-            model_manager=mock.MagicMock(),
-            crawler_semaphore=None,
-            crawler_sync_state=CrawlerSyncState(),
-            worker_pool=mock.MagicMock(),
-            pool_runtime=mock.MagicMock(),
-            pool_health_ticker=HealthTickerHandle(),
+        mock_provider.vision_ocr.assert_called_once_with(
+            b"png-bytes", "my-model", OCR_PROMPT, timeout=12.5
         )
-        set_services(services)
+        mock_provider.chat.assert_not_called()
 
+    def test_timeout_error_returns_none(self, mock_provider) -> None:
+        """Provider-raised TimeoutError surfaces as a per-page miss."""
         from lilbee.vision import extract_page_text
 
-        result = extract_page_text(b"png", "vision-model")
-        assert result == "subprocess text"
-        provider.vision_ocr.assert_called_once()
-        provider.chat.assert_not_called()
-
-    def test_vision_ocr_error_returns_none(self) -> None:
-        provider = mock.MagicMock(spec=["chat", "embed", "vision_ocr", "shutdown"])
-        provider.vision_ocr.side_effect = RuntimeError("worker died")
-        services = Services(
-            provider=provider,
-            store=mock.MagicMock(),
-            embedder=mock.MagicMock(),
-            reranker=mock.MagicMock(),
-            concepts=mock.MagicMock(),
-            clusterer=mock.MagicMock(),
-            searcher=mock.MagicMock(),
-            registry=mock.MagicMock(),
-            hf_client=mock.MagicMock(),
-            ingest_lock_registry=mock.MagicMock(),
-            model_manager=mock.MagicMock(),
-            crawler_semaphore=None,
-            crawler_sync_state=CrawlerSyncState(),
-            worker_pool=mock.MagicMock(),
-            pool_runtime=mock.MagicMock(),
-            pool_health_ticker=HealthTickerHandle(),
-        )
-        set_services(services)
-
-        from lilbee.vision import extract_page_text
-
-        result = extract_page_text(b"png", "vision-model")
+        mock_provider.vision_ocr.side_effect = TimeoutError("budget exceeded")
+        result = extract_page_text(b"png", "model", timeout=0.01)
         assert result is None
 
 
 class TestExtractPdfVision:
     def test_returns_page_texts(self, mock_provider) -> None:
         mock_iter = _mock_iterator(num_pages=2)
-        mock_provider.chat.return_value = "page text"
+        mock_provider.vision_ocr.return_value = "page text"
 
         with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import extract_pdf_vision
@@ -257,7 +205,7 @@ class TestExtractPdfVision:
 
     def test_skips_failed_pages(self, mock_provider) -> None:
         mock_iter = _mock_iterator(num_pages=2)
-        mock_provider.chat.side_effect = [RuntimeError("fail"), "success text"]
+        mock_provider.vision_ocr.side_effect = [RuntimeError("fail"), "success text"]
 
         with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import extract_pdf_vision
@@ -275,7 +223,7 @@ class TestExtractPdfVision:
 
         monkeypatch.setattr(cfg, "vision_concurrency", 1)
         mock_iter = _mock_iterator(num_pages=5)
-        mock_provider.chat.return_value = "ok"
+        mock_provider.vision_ocr.return_value = "ok"
         with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import extract_pdf_vision
 
@@ -285,7 +233,7 @@ class TestExtractPdfVision:
 
     def test_skips_empty_text(self, mock_provider) -> None:
         mock_iter = _mock_iterator(num_pages=2)
-        mock_provider.chat.side_effect = ["  \n  ", "real text"]
+        mock_provider.vision_ocr.side_effect = ["  \n  ", "real text"]
 
         with mock.patch("kreuzberg.PdfPageIterator", return_value=mock_iter):
             from lilbee.vision import extract_pdf_vision
@@ -297,7 +245,7 @@ class TestExtractPdfVision:
 
     def test_fires_progress_events(self, mock_provider) -> None:
         mock_iter = _mock_iterator(num_pages=1)
-        mock_provider.chat.return_value = "text"
+        mock_provider.vision_ocr.return_value = "text"
         progress_calls: list[tuple[str, dict]] = []
 
         def capture_progress(event_type: str, data: dict) -> None:
@@ -370,7 +318,7 @@ class TestMakeProgress:
 class TestExtractPdfVisionNonQuiet:
     def test_failed_pages_logs_warning_and_prints(self, mock_provider) -> None:
         mock_iter = _mock_iterator(num_pages=2)
-        mock_provider.chat.side_effect = [RuntimeError("fail"), RuntimeError("fail")]
+        mock_provider.vision_ocr.side_effect = [RuntimeError("fail"), RuntimeError("fail")]
 
         mock_console_instance = mock.MagicMock()
         mock_console_cls = mock.MagicMock(return_value=mock_console_instance)
@@ -389,7 +337,7 @@ class TestExtractPdfVisionNonQuiet:
 
     def test_progress_advance_called(self, mock_provider) -> None:
         mock_iter = _mock_iterator(num_pages=1)
-        mock_provider.chat.return_value = "text"
+        mock_provider.vision_ocr.return_value = "text"
 
         mock_progress = mock.MagicMock()
         mock_task = mock.MagicMock()
@@ -402,31 +350,6 @@ class TestExtractPdfVisionNonQuiet:
             from lilbee.vision import extract_pdf_vision
 
             extract_pdf_vision(Path("test.pdf"), "model", quiet=False)
-
-
-class TestExtractPageTextTimeout:
-    def test_timeout_path_uses_thread_pool(self, mock_provider) -> None:
-        """When timeout > 0, extract_page_text uses ThreadPoolExecutor."""
-        mock_provider.chat.return_value = "ocr result"
-        from lilbee.vision import extract_page_text
-
-        result = extract_page_text(b"fake-png", "model", timeout=30)
-        assert result == "ocr result"
-        mock_provider.chat.assert_called_once()
-
-    def test_timeout_expiry_returns_none(self, mock_provider) -> None:
-        """When the provider exceeds timeout, returns None (logs warning)."""
-        import time
-
-        def slow_chat(*args, **kwargs):
-            time.sleep(5)
-            return "too late"
-
-        mock_provider.chat.side_effect = slow_chat
-        from lilbee.vision import extract_page_text
-
-        result = extract_page_text(b"fake-png", "model", timeout=0.01)
-        assert result is None
 
 
 class TestPngToDataUrl:


### PR DESCRIPTION
## Problem

With `llm_provider=auto`, vision OCR for native GGUF models silently returned no text. Scanned PDFs came back empty even with a valid vision model configured, and a misconfigured chat model could break OCR end to end. Hosted vision via Ollama kept working, which masked the issue.

## Solution

Vision OCR is now a first-class capability on every provider, so the auto-routing layer dispatches it the same way it dispatches chat. Native models hit the vision worker; hosted models go through their chat endpoint. A misconfigured chat model can no longer affect vision OCR.