### PR TITLE
TUI /add: pin progress filename to oldest in-flight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ CLI also accepts `--model` / `-m` for chat model, `--data-dir` / `-d`, `--ocr-ti
 - Type hints on all public functions
 - Dataclasses for structured return types (not raw dicts)
 - **Named constants for magic numbers AND magic strings** — never use raw string literals when a constant exists. Grep globally for the raw value of any new constant to ensure no duplicates remain.
+- **Closed value sets use `StrEnum` / `IntEnum`, not parallel module constants.** Two or more named values for the same field (status, mode, role, kind, event tag) is a sign of an enum. Define `class FooStatus(StrEnum)` so the field type can be `FooStatus` (Pydantic validates, mypy narrows, IDEs autocomplete) and the variants live in one namespace. Examples already in repo: `EventType`, `SseEvent`, `BatchStatus`, `WikiEntityMode`, `ChatMode`. A bare module-level constant is only correct when the value stands alone (sentinel like `CRAWL_TOTAL_UNKNOWN = -1`) — not when it's one of a small fixed set.
 - **No positional array indexes** — use named constants or membership checks, not `array[0]`
 - Descriptive variable names — `pending_segments` not `current`, `chunk_size` not `n`
 - Logging with `logging.getLogger(__name__)` — no bare `except: pass`

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -287,6 +287,9 @@ TASKBAR_FAILED = "[b]{count} task failed[/b]"
 TASKBAR_FAILED_PLURAL = "[b]{count} tasks failed[/b]"
 SYNC_EMBEDDING = "Embedding {file}"
 SYNC_FILE_DONE = "Done: {file}"
+ADD_SYNCING_FILE = "Syncing {file}..."
+ADD_PAGE_PROGRESS = "{status} page {current} of {total}"
+ADD_FILE_DONE = "Done {file}"
 
 SETTINGS_API_KEYS_WARNING = (
     "These keys are stored in plain text at {path}. "

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -51,7 +51,12 @@ from lilbee.providers.model_ref import parse_model_ref
 from lilbee.retrieval.embedder import is_model_available
 from lilbee.retrieval.query import ChatMessage
 from lilbee.runtime import asyncio_loop
-from lilbee.runtime.progress import EventType, ProgressEvent
+from lilbee.runtime.progress import (
+    BATCH_STATUS_RASTERIZING,
+    DetailedProgressCallback,
+    EventType,
+    ProgressEvent,
+)
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.widgets.task_bar import TaskBarController
@@ -80,6 +85,46 @@ def _close_stream(stream: Any) -> None:
     if isinstance(stream, ClosableIterator):
         with contextlib.suppress(Exception):
             stream.close()
+
+
+def _build_add_progress_callback(reporter: ProgressReporter) -> DetailedProgressCallback:
+    """Build the on_progress callback used by /add.
+
+    Tracks files in flight in start order so the displayed filename pins
+    to the oldest unfinished file. The pipeline runs files concurrently
+    and reports completions via asyncio.as_completed; without this, the
+    label flips to whatever just completed and flickers around the queue.
+    """
+    from lilbee.runtime.progress import BatchProgressEvent, FileDoneEvent, FileStartEvent
+
+    in_flight: list[str] = []
+
+    def on_progress(event_type: EventType, data: ProgressEvent) -> None:
+        # Polling point so /c in Task Center can stop a long ingest
+        # between file boundaries without having to kill the thread.
+        reporter.check_cancelled()
+        if event_type == EventType.FILE_START and isinstance(data, FileStartEvent):
+            in_flight.append(data.file)
+            reporter.update(0, f"Syncing {in_flight[0]}...", indeterminate=True)
+        elif event_type == EventType.FILE_DONE and isinstance(data, FileDoneEvent):
+            with contextlib.suppress(ValueError):
+                in_flight.remove(data.file)
+        elif event_type == EventType.BATCH_PROGRESS and isinstance(data, BatchProgressEvent):
+            pct = (data.current / data.total * 100.0) if data.total else 0.0
+            # Per-page rasterization (vision OCR) is the only producer that
+            # uses BATCH_STATUS_RASTERIZING; it emits an absolute path in
+            # data.file which never matches the relative source name kept
+            # in in_flight, so identity-based detection would never fire.
+            if data.status == BATCH_STATUS_RASTERIZING:
+                detail = f"{data.status.capitalize()} page {data.current} of {data.total}"
+            elif in_flight:
+                # Per-file batch tick: show the next oldest file still working.
+                detail = f"Syncing {in_flight[0]}..."
+            else:
+                detail = f"Done {data.file}"
+            reporter.update(pct, detail, indeterminate=False)
+
+    return on_progress
 
 
 def _remove_copied_files(names: list[str]) -> None:
@@ -490,7 +535,6 @@ class ChatScreen(Screen[None]):
         """Copy files and run sync. Called on worker thread with a reporter."""
         from lilbee.app.ingest import copy_files
         from lilbee.data.ingest import sync
-        from lilbee.runtime.progress import BatchProgressEvent, FileStartEvent
 
         reporter.update(0, f"Copying {path.name}...", indeterminate=True)
         copy_result = copy_files([path], force=force)
@@ -499,22 +543,10 @@ class ChatScreen(Screen[None]):
             call_from_thread(self, self.notify, f"{name} already exists (use --force to overwrite)")
         reporter.update(0, f"Copied {len(copied)} file(s), syncing...", indeterminate=True)
 
-        def on_progress(event_type: EventType, data: ProgressEvent) -> None:
-            # Polling point so /c in Task Center can stop a long ingest
-            # between file boundaries without having to kill the thread.
-            reporter.check_cancelled()
-            if event_type == EventType.FILE_START and isinstance(data, FileStartEvent):
-                reporter.update(0, f"Syncing {data.file}...", indeterminate=True)
-            elif event_type == EventType.BATCH_PROGRESS and isinstance(data, BatchProgressEvent):
-                pct = (data.current / data.total * 100.0) if data.total else 0.0
-                reporter.update(
-                    pct,
-                    f"{data.status.capitalize()} page {data.current} of {data.total}",
-                    indeterminate=False,
-                )
-
         try:
-            sync_result = asyncio_loop.run(sync(quiet=True, on_progress=on_progress))
+            sync_result = asyncio_loop.run(
+                sync(quiet=True, on_progress=_build_add_progress_callback(reporter))
+            )
         except BaseException:
             # On cancel or any failure, remove the files we copied into
             # documents/ so the next sync doesn't silently re-ingest the

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -52,9 +52,12 @@ from lilbee.retrieval.embedder import is_model_available
 from lilbee.retrieval.query import ChatMessage
 from lilbee.runtime import asyncio_loop
 from lilbee.runtime.progress import (
-    BATCH_STATUS_RASTERIZING,
+    BatchProgressEvent,
+    BatchStatus,
     DetailedProgressCallback,
     EventType,
+    FileDoneEvent,
+    FileStartEvent,
     ProgressEvent,
 )
 
@@ -87,6 +90,24 @@ def _close_stream(stream: Any) -> None:
             stream.close()
 
 
+def _detail_for_batch_progress(data: BatchProgressEvent, in_flight: list[str]) -> str:
+    """Pick the user-facing detail label for a BATCH_PROGRESS tick.
+
+    Per-page rasterization (vision OCR) is the only producer that uses
+    BatchStatus.RASTERIZING; it emits an absolute path in data.file
+    which never matches the relative source name kept in in_flight, so
+    identity-based detection would never fire. Status-based dispatch is
+    the reliable discriminator between per-page and per-file ticks.
+    """
+    if data.status == BatchStatus.RASTERIZING:
+        return msg.ADD_PAGE_PROGRESS.format(
+            status=data.status.capitalize(), current=data.current, total=data.total
+        )
+    if in_flight:
+        return msg.ADD_SYNCING_FILE.format(file=in_flight[0])
+    return msg.ADD_FILE_DONE.format(file=data.file)
+
+
 def _build_add_progress_callback(reporter: ProgressReporter) -> DetailedProgressCallback:
     """Build the on_progress callback used by /add.
 
@@ -95,34 +116,23 @@ def _build_add_progress_callback(reporter: ProgressReporter) -> DetailedProgress
     and reports completions via asyncio.as_completed; without this, the
     label flips to whatever just completed and flickers around the queue.
     """
-    from lilbee.runtime.progress import BatchProgressEvent, FileDoneEvent, FileStartEvent
-
     in_flight: list[str] = []
 
     def on_progress(event_type: EventType, data: ProgressEvent) -> None:
         # Polling point so /c in Task Center can stop a long ingest
         # between file boundaries without having to kill the thread.
         reporter.check_cancelled()
+        # isinstance guards type-narrow the ProgressEvent union for mypy.
+        # The EventType tag is the discriminator; isinstance is the runtime check.
         if event_type == EventType.FILE_START and isinstance(data, FileStartEvent):
             in_flight.append(data.file)
-            reporter.update(0, f"Syncing {in_flight[0]}...", indeterminate=True)
+            reporter.update(0, msg.ADD_SYNCING_FILE.format(file=in_flight[0]), indeterminate=True)
         elif event_type == EventType.FILE_DONE and isinstance(data, FileDoneEvent):
             with contextlib.suppress(ValueError):
                 in_flight.remove(data.file)
         elif event_type == EventType.BATCH_PROGRESS and isinstance(data, BatchProgressEvent):
             pct = (data.current / data.total * 100.0) if data.total else 0.0
-            # Per-page rasterization (vision OCR) is the only producer that
-            # uses BATCH_STATUS_RASTERIZING; it emits an absolute path in
-            # data.file which never matches the relative source name kept
-            # in in_flight, so identity-based detection would never fire.
-            if data.status == BATCH_STATUS_RASTERIZING:
-                detail = f"{data.status.capitalize()} page {data.current} of {data.total}"
-            elif in_flight:
-                # Per-file batch tick: show the next oldest file still working.
-                detail = f"Syncing {in_flight[0]}..."
-            else:
-                detail = f"Done {data.file}"
-            reporter.update(pct, detail, indeterminate=False)
+            reporter.update(pct, _detail_for_batch_progress(data, in_flight), indeterminate=False)
 
     return on_progress
 

--- a/src/lilbee/data/code_chunker.py
+++ b/src/lilbee/data/code_chunker.py
@@ -17,8 +17,8 @@ from tree_sitter_language_pack import (
     process,
 )
 
-from lilbee.data.chunk import chunk_text
 from lilbee.core.config import cfg
+from lilbee.data.chunk import chunk_text
 
 log = logging.getLogger(__name__)
 

--- a/src/lilbee/data/ingest/code.py
+++ b/src/lilbee/data/ingest/code.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from lilbee.data.code_chunker import CodeChunk, chunk_code
 from lilbee.core.services import get_services
+from lilbee.data.code_chunker import CodeChunk, chunk_code
 from lilbee.data.ingest.types import ChunkRecord
-from lilbee.runtime.progress import DetailedProgressCallback, noop_callback
 from lilbee.data.store import CHUNK_TYPE_RAW
+from lilbee.runtime.progress import DetailedProgressCallback, noop_callback
 
 
 def ingest_code_sync(

--- a/src/lilbee/data/ingest/discovery.py
+++ b/src/lilbee/data/ingest/discovery.py
@@ -7,10 +7,10 @@ import logging
 import os
 from pathlib import Path
 
-from lilbee.data.code_chunker import is_code_file
 from lilbee.core.config import cfg
-from lilbee.core.system import is_ignored_dir
 from lilbee.core.security import validate_path_within
+from lilbee.core.system import is_ignored_dir
+from lilbee.data.code_chunker import is_code_file
 from lilbee.data.ingest.types import _DOCUMENT_EXTENSION_MAP
 
 log = logging.getLogger(__name__)

--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -243,7 +243,7 @@ async def _pump_pdf_progress(
     path: Path,
 ) -> None:
     """Forward ``progress: page=N total=M`` lines from the subprocess to ``on_progress``."""
-    from lilbee.runtime.progress import BatchProgressEvent, EventType
+    from lilbee.runtime.progress import BATCH_STATUS_RASTERIZING, BatchProgressEvent, EventType
 
     while True:
         line = await stream.readline()
@@ -260,7 +260,9 @@ async def _pump_pdf_progress(
             continue
         on_progress(
             EventType.BATCH_PROGRESS,
-            BatchProgressEvent(file=str(path), status="rasterizing", current=page, total=total),
+            BatchProgressEvent(
+                file=str(path), status=BATCH_STATUS_RASTERIZING, current=page, total=total
+            ),
         )
 
 

--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -13,9 +13,9 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from kreuzberg import ExtractionConfig, ExtractionResult
 
-from lilbee.data.chunk import build_chunking_config, chunk_text
 from lilbee.core.config import cfg
 from lilbee.core.services import get_services
+from lilbee.data.chunk import build_chunking_config, chunk_text
 from lilbee.data.ingest.types import (
     _MARKDOWN_OUTPUT,
     _MIN_MEANINGFUL_CHARS,
@@ -24,8 +24,8 @@ from lilbee.data.ingest.types import (
     ChunkRecord,
     ExtractMode,
 )
-from lilbee.runtime.progress import DetailedProgressCallback, noop_callback
 from lilbee.data.store import CHUNK_TYPE_RAW
+from lilbee.runtime.progress import DetailedProgressCallback, noop_callback
 from lilbee.vision import PageText
 
 log = logging.getLogger(__name__)
@@ -200,9 +200,10 @@ async def _extract_pdf_vision_in_subprocess(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    assert proc.stdin is not None
-    assert proc.stdout is not None
-    assert proc.stderr is not None
+    if proc.stdin is None or proc.stdout is None or proc.stderr is None:  # pragma: no cover
+        # asyncio.create_subprocess_exec with PIPE for all three streams always
+        # populates them at runtime, but the type annotations are Optional.
+        raise RuntimeError("PDF extraction subprocess did not open stdio pipes")
     proc.stdin.write(payload.encode("utf-8"))
     await proc.stdin.drain()
     proc.stdin.close()

--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -243,7 +243,7 @@ async def _pump_pdf_progress(
     path: Path,
 ) -> None:
     """Forward ``progress: page=N total=M`` lines from the subprocess to ``on_progress``."""
-    from lilbee.runtime.progress import BATCH_STATUS_RASTERIZING, BatchProgressEvent, EventType
+    from lilbee.runtime.progress import BatchProgressEvent, BatchStatus, EventType
 
     while True:
         line = await stream.readline()
@@ -261,7 +261,7 @@ async def _pump_pdf_progress(
         on_progress(
             EventType.BATCH_PROGRESS,
             BatchProgressEvent(
-                file=str(path), status=BATCH_STATUS_RASTERIZING, current=page, total=total
+                file=str(path), status=BatchStatus.RASTERIZING, current=page, total=total
             ),
         )
 

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import os
 import threading
 from pathlib import Path
 from typing import Any, cast
@@ -25,6 +24,7 @@ from lilbee.data.ingest.code import ingest_code_sync
 from lilbee.data.ingest.discovery import classify_file, discover_files, file_hash
 from lilbee.data.ingest.extract import ingest_document, ingest_markdown
 from lilbee.data.ingest.types import ChunkRecord, FileToProcess, SyncResult, _IngestResult
+from lilbee.runtime.cpu import cpu_quota
 from lilbee.runtime.progress import (
     BatchProgressEvent,
     BatchStatus,
@@ -42,7 +42,6 @@ log = logging.getLogger(__name__)
 
 # Limit concurrent ingestion. Sourced from cpu_quota() so worker storms
 # can't starve the TUI's asyncio main thread on macOS.
-from lilbee.runtime.cpu import cpu_quota
 
 _MAX_CONCURRENT = cpu_quota()
 
@@ -200,6 +199,40 @@ async def _ingest_file(
     return chunk_count
 
 
+def _plan_file_changes(
+    disk_files: dict[str, Path],
+    existing_sources: dict[str, str],
+    cancel: threading.Event | None,
+) -> tuple[list[FileToProcess], list[str], list[str], int]:
+    """Diff disk against the store. Returns (to_process, added, updated, unchanged_count)."""
+    files_to_process: list[FileToProcess] = []
+    added: list[str] = []
+    updated: list[str] = []
+    unchanged = 0
+    for name, path in sorted(disk_files.items()):
+        if cancel and cancel.is_set():
+            break
+        content_type = classify_file(path)
+        if content_type is None:
+            raise ValueError(f"Unsupported file slipped through discovery: {name}")
+        old_hash = existing_sources.get(name)
+        current_hash = file_hash(path)
+        if old_hash == current_hash:
+            unchanged += 1
+            continue
+        # needs_cleanup=True unconditionally: delete_by_source is idempotent,
+        # and this closes the race where a prior ingest wrote chunks but died
+        # before upsert_source, leaving orphaned chunks that would duplicate.
+        files_to_process.append(
+            FileToProcess(name, path, content_type, current_hash, needs_cleanup=True)
+        )
+        if old_hash is not None:
+            updated.append(name)
+        else:
+            added.append(name)
+    return files_to_process, added, updated, unchanged
+
+
 async def sync(
     force_rebuild: bool = False,
     quiet: bool = False,
@@ -222,10 +255,7 @@ async def sync(
     disk_files = discover_files()
     existing_sources = {s["filename"]: s["file_hash"] for s in _store.get_sources()}
 
-    added: list[str] = []
-    updated: list[str] = []
     removed: list[str] = []
-    unchanged = 0
     failed: list[str] = []
     skipped: list[str] = []
 
@@ -236,34 +266,9 @@ async def sync(
             _store.delete_source(name)
             removed.append(name)
 
-    files_to_process: list[FileToProcess] = []
-
-    for name, path in sorted(disk_files.items()):
-        if cancel and cancel.is_set():
-            break
-
-        content_type = classify_file(path)
-        if content_type is None:
-            raise ValueError(f"Unsupported file slipped through discovery: {name}")
-
-        old_hash = existing_sources.get(name)
-
-        current_hash = file_hash(path)
-
-        if old_hash == current_hash:
-            unchanged += 1
-            continue
-
-        # needs_cleanup=True unconditionally: delete_by_source is idempotent,
-        # and this closes the race where a prior ingest wrote chunks but died
-        # before upsert_source, leaving orphaned chunks that would duplicate.
-        files_to_process.append(
-            FileToProcess(name, path, content_type, current_hash, needs_cleanup=True)
-        )
-        if old_hash is not None:
-            updated.append(name)
-        else:
-            added.append(name)
+    files_to_process, added, updated, unchanged = _plan_file_changes(
+        disk_files, existing_sources, cancel
+    )
 
     # Ingest files (with optional progress bar)
     if files_to_process:

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -26,6 +26,9 @@ from lilbee.data.ingest.discovery import classify_file, discover_files, file_has
 from lilbee.data.ingest.extract import ingest_document, ingest_markdown
 from lilbee.data.ingest.types import ChunkRecord, FileToProcess, SyncResult, _IngestResult
 from lilbee.runtime.progress import (
+    BATCH_STATUS_FAILED,
+    BATCH_STATUS_INGESTED,
+    BATCH_STATUS_SKIPPED,
     BatchProgressEvent,
     DetailedProgressCallback,
     EventType,
@@ -426,11 +429,11 @@ async def _collect_results(
             progress.update(ptask, description=desc)
             progress.advance(ptask)
         if result.error is not None:
-            progress_status = "failed"
+            progress_status = BATCH_STATUS_FAILED
         elif result.chunk_count == 0:
-            progress_status = "skipped"
+            progress_status = BATCH_STATUS_SKIPPED
         else:
-            progress_status = "ingested"
+            progress_status = BATCH_STATUS_INGESTED
         on_progress(
             EventType.BATCH_PROGRESS,
             BatchProgressEvent(

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -26,10 +26,8 @@ from lilbee.data.ingest.discovery import classify_file, discover_files, file_has
 from lilbee.data.ingest.extract import ingest_document, ingest_markdown
 from lilbee.data.ingest.types import ChunkRecord, FileToProcess, SyncResult, _IngestResult
 from lilbee.runtime.progress import (
-    BATCH_STATUS_FAILED,
-    BATCH_STATUS_INGESTED,
-    BATCH_STATUS_SKIPPED,
     BatchProgressEvent,
+    BatchStatus,
     DetailedProgressCallback,
     EventType,
     FileDoneEvent,
@@ -429,11 +427,11 @@ async def _collect_results(
             progress.update(ptask, description=desc)
             progress.advance(ptask)
         if result.error is not None:
-            progress_status = BATCH_STATUS_FAILED
+            progress_status = BatchStatus.FAILED
         elif result.chunk_count == 0:
-            progress_status = BATCH_STATUS_SKIPPED
+            progress_status = BatchStatus.SKIPPED
         else:
-            progress_status = BATCH_STATUS_INGESTED
+            progress_status = BatchStatus.INGESTED
         on_progress(
             EventType.BATCH_PROGRESS,
             BatchProgressEvent(

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -381,24 +381,31 @@ class Store:
             distances = [r.get("distance", 0) for r in rows[:5]]
             log.debug("Top 5 distances: %s", distances)
         results = [SearchChunk(**r) for r in rows]
+        return self._filter_and_rerank(results, query_vector, top_k, max_distance)
+
+    def _filter_and_rerank(
+        self,
+        results: list[SearchChunk],
+        query_vector: list[float],
+        top_k: int,
+        max_distance: float,
+    ) -> list[SearchChunk]:
+        """Apply the configured distance filter, then MMR-rerank down to top_k."""
         if max_distance > 0:
             before = len(results)
             if self._config.adaptive_threshold:
                 results = self._adaptive_filter(results, top_k, max_distance)
-                log.debug(
-                    "After adaptive filter: %d/%d results, threshold=%.2f",
-                    len(results),
-                    before,
-                    max_distance,
-                )
+                filter_name = "adaptive"
             else:
                 results = self._fixed_filter(results, max_distance)
-                log.debug(
-                    "After fixed filter: %d/%d results, threshold=%.2f",
-                    len(results),
-                    before,
-                    max_distance,
-                )
+                filter_name = "fixed"
+            log.debug(
+                "After %s filter: %d/%d results, threshold=%.2f",
+                filter_name,
+                len(results),
+                before,
+                max_distance,
+            )
         if len(results) > top_k:
             results = mmr_rerank(query_vector, results, top_k, self._config.mmr_lambda)
         return results

--- a/src/lilbee/runtime/progress/__init__.py
+++ b/src/lilbee/runtime/progress/__init__.py
@@ -7,6 +7,10 @@ from lilbee.runtime.progress.callbacks import (
     shared_progress,
 )
 from lilbee.runtime.progress.types import (
+    BATCH_STATUS_FAILED,
+    BATCH_STATUS_INGESTED,
+    BATCH_STATUS_RASTERIZING,
+    BATCH_STATUS_SKIPPED,
     CRAWL_TOTAL_UNKNOWN,
     BatchProgressEvent,
     CrawlDoneEvent,
@@ -25,6 +29,10 @@ from lilbee.runtime.progress.types import (
 )
 
 __all__ = [
+    "BATCH_STATUS_FAILED",
+    "BATCH_STATUS_INGESTED",
+    "BATCH_STATUS_RASTERIZING",
+    "BATCH_STATUS_SKIPPED",
     "CRAWL_TOTAL_UNKNOWN",
     "BatchProgressEvent",
     "CrawlDoneEvent",

--- a/src/lilbee/runtime/progress/__init__.py
+++ b/src/lilbee/runtime/progress/__init__.py
@@ -7,12 +7,9 @@ from lilbee.runtime.progress.callbacks import (
     shared_progress,
 )
 from lilbee.runtime.progress.types import (
-    BATCH_STATUS_FAILED,
-    BATCH_STATUS_INGESTED,
-    BATCH_STATUS_RASTERIZING,
-    BATCH_STATUS_SKIPPED,
     CRAWL_TOTAL_UNKNOWN,
     BatchProgressEvent,
+    BatchStatus,
     CrawlDoneEvent,
     CrawlPageEvent,
     CrawlStartEvent,
@@ -29,12 +26,9 @@ from lilbee.runtime.progress.types import (
 )
 
 __all__ = [
-    "BATCH_STATUS_FAILED",
-    "BATCH_STATUS_INGESTED",
-    "BATCH_STATUS_RASTERIZING",
-    "BATCH_STATUS_SKIPPED",
     "CRAWL_TOTAL_UNKNOWN",
     "BatchProgressEvent",
+    "BatchStatus",
     "CrawlDoneEvent",
     "CrawlPageEvent",
     "CrawlStartEvent",

--- a/src/lilbee/runtime/progress/types.py
+++ b/src/lilbee/runtime/progress/types.py
@@ -51,23 +51,20 @@ class FileDoneEvent(BaseModel):
     chunks: int
 
 
-# BatchProgressEvent.status values. Per-file ticks emitted from the ingest
-# pipeline use one of {INGESTED, SKIPPED, FAILED}; per-page rasterization
-# ticks emitted from the vision-OCR pump use RASTERIZING. Consumers
-# discriminate per-page from per-file ticks via this status field, since
-# the per-page producer carries an absolute path in `file` while per-file
-# carries the relative source name and the two never compare equal.
-BATCH_STATUS_INGESTED = "ingested"
-BATCH_STATUS_SKIPPED = "skipped"
-BATCH_STATUS_FAILED = "failed"
-BATCH_STATUS_RASTERIZING = "rasterizing"
+class BatchStatus(StrEnum):
+    """Status values for BatchProgressEvent.status."""
+
+    INGESTED = "ingested"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+    RASTERIZING = "rasterizing"
 
 
 class BatchProgressEvent(BaseModel):
     """Emitted after each file completes during batch ingestion."""
 
     file: str
-    status: str
+    status: BatchStatus
     current: int
     total: int
 

--- a/src/lilbee/runtime/progress/types.py
+++ b/src/lilbee/runtime/progress/types.py
@@ -51,6 +51,18 @@ class FileDoneEvent(BaseModel):
     chunks: int
 
 
+# BatchProgressEvent.status values. Per-file ticks emitted from the ingest
+# pipeline use one of {INGESTED, SKIPPED, FAILED}; per-page rasterization
+# ticks emitted from the vision-OCR pump use RASTERIZING. Consumers
+# discriminate per-page from per-file ticks via this status field, since
+# the per-page producer carries an absolute path in `file` while per-file
+# carries the relative source name and the two never compare equal.
+BATCH_STATUS_INGESTED = "ingested"
+BATCH_STATUS_SKIPPED = "skipped"
+BATCH_STATUS_FAILED = "failed"
+BATCH_STATUS_RASTERIZING = "rasterizing"
+
+
 class BatchProgressEvent(BaseModel):
     """Emitted after each file completes during batch ingestion."""
 

--- a/tests/test_chat_wiki_controller_integration.py
+++ b/tests/test_chat_wiki_controller_integration.py
@@ -743,7 +743,7 @@ def test_do_add_on_progress_surfaces_per_page_progress(tmp_path: Path) -> None:
 
     from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.data.ingest.types import SyncResult
-    from lilbee.runtime.progress import BatchProgressEvent, EventType
+    from lilbee.runtime.progress import BatchProgressEvent, EventType, FileStartEvent
 
     src = tmp_path / "doc.pdf"
     src.write_bytes(b"x")
@@ -755,9 +755,25 @@ def test_do_add_on_progress_surfaces_per_page_progress(tmp_path: Path) -> None:
     copy_result = CopyResult(copied=[str(src)], skipped=[])
 
     async def fake_sync(*, quiet, on_progress):
+        # Per-page rasterization progress fires while the file is being
+        # processed (FILE_START has already named it via the relative source
+        # name); the BATCH_PROGRESS event itself is emitted by the OCR
+        # subprocess pump with the *absolute* path in data.file (see
+        # data/ingest/extract.py:_pump_pdf_progress), so the two strings
+        # do not match and identity-based dispatch would skip the per-page
+        # branch entirely. The realistic shape catches that regression.
+        on_progress(
+            EventType.FILE_START,
+            FileStartEvent(file="a.pdf", current_file=1, total_files=1),
+        )
         on_progress(
             EventType.BATCH_PROGRESS,
-            BatchProgressEvent(file="a.pdf", status="rasterizing", current=2, total=10),
+            BatchProgressEvent(
+                file="/abs/path/to/documents/a.pdf",
+                status="rasterizing",
+                current=2,
+                total=10,
+            ),
         )
         return SyncResult()
 
@@ -777,6 +793,94 @@ def test_do_add_on_progress_surfaces_per_page_progress(tmp_path: Path) -> None:
     t.join(timeout=5)
     page_updates = [call for call in reporter.update.call_args_list if "page 2 of 10" in str(call)]
     assert page_updates
+
+
+def test_do_add_progress_label_pins_to_oldest_in_flight_file(tmp_path: Path) -> None:
+    """With concurrent file ingestion, the progress label pins to the oldest
+    file still in flight rather than tracking the just-completed file."""
+    import asyncio
+    import threading
+
+    from lilbee.cli.tui.screens.chat import ChatScreen
+    from lilbee.data.ingest.types import SyncResult
+    from lilbee.runtime.progress import (
+        BatchProgressEvent,
+        EventType,
+        FileDoneEvent,
+        FileStartEvent,
+    )
+
+    src = tmp_path / "doc.pdf"
+    src.write_bytes(b"x")
+    screen = ChatScreen.__new__(ChatScreen)
+    reporter = MagicMock(spec=ProgressReporter)
+
+    from lilbee.app.ingest import CopyResult
+
+    copy_result = CopyResult(copied=[str(src)], skipped=[])
+
+    async def fake_sync(*, quiet, on_progress):
+        # Three files start concurrently. The pipeline emits FILE_START for each.
+        on_progress(
+            EventType.FILE_START, FileStartEvent(file="a.pdf", current_file=1, total_files=3)
+        )
+        on_progress(
+            EventType.FILE_START, FileStartEvent(file="b.pdf", current_file=2, total_files=3)
+        )
+        on_progress(
+            EventType.FILE_START, FileStartEvent(file="c.pdf", current_file=3, total_files=3)
+        )
+        # b finishes first (out of order). Pipeline fires FILE_DONE then BATCH_PROGRESS.
+        on_progress(EventType.FILE_DONE, FileDoneEvent(file="b.pdf", status="ok", chunks=2))
+        on_progress(
+            EventType.BATCH_PROGRESS,
+            BatchProgressEvent(file="b.pdf", status="ingested", current=1, total=3),
+        )
+        # a finishes next.
+        on_progress(EventType.FILE_DONE, FileDoneEvent(file="a.pdf", status="ok", chunks=4))
+        on_progress(
+            EventType.BATCH_PROGRESS,
+            BatchProgressEvent(file="a.pdf", status="ingested", current=2, total=3),
+        )
+        # c finishes last (in-flight is now empty).
+        on_progress(EventType.FILE_DONE, FileDoneEvent(file="c.pdf", status="ok", chunks=1))
+        on_progress(
+            EventType.BATCH_PROGRESS,
+            BatchProgressEvent(file="c.pdf", status="ingested", current=3, total=3),
+        )
+        return SyncResult()
+
+    def _worker() -> None:
+        screen.notify = lambda *a, **kw: None  # type: ignore[assignment]
+        with (
+            patch("lilbee.app.ingest.copy_files", return_value=copy_result),
+            patch("lilbee.data.ingest.sync", side_effect=fake_sync),
+            patch("lilbee.runtime.asyncio_loop.run", side_effect=lambda coro: asyncio.run(coro)),
+        ):
+            screen._do_add(src, reporter)
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+    t.join(timeout=5)
+
+    # Reduce the call list to the detail strings reporter.update saw, in order.
+    details = [call.args[1] for call in reporter.update.call_args_list]
+
+    # All three FILE_STARTs reported "Syncing a.pdf...". Label never advanced
+    # to b or c just because they started, because a is the oldest.
+    sync_labels = [d for d in details if d.startswith("Syncing ")]
+    assert "Syncing a.pdf..." in sync_labels
+    assert "Syncing b.pdf..." not in sync_labels  # b never became oldest
+    assert "Syncing c.pdf..." in sync_labels  # c becomes oldest after a finishes
+
+    # b's BATCH_PROGRESS came in while a was still oldest, so the detail
+    # at that point must still point at a, not b.
+    a_still_oldest_idx = details.index("Syncing a.pdf...")
+    c_becomes_oldest_idx = details.index("Syncing c.pdf...")
+    assert a_still_oldest_idx < c_becomes_oldest_idx
+
+    # The very last batch tick (c done, in-flight empty) shows "Done c.pdf".
+    assert details[-1] == "Done c.pdf"
 
 
 def test_do_sync_notifies_on_skipped(tmp_path: Path) -> None:

--- a/tests/test_chat_wiki_controller_integration.py
+++ b/tests/test_chat_wiki_controller_integration.py
@@ -741,9 +741,15 @@ def test_do_add_on_progress_surfaces_per_page_progress(tmp_path: Path) -> None:
     import asyncio
     import threading
 
+    from lilbee.cli.tui import messages as msg
     from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.data.ingest.types import SyncResult
-    from lilbee.runtime.progress import BatchProgressEvent, EventType, FileStartEvent
+    from lilbee.runtime.progress import (
+        BatchProgressEvent,
+        BatchStatus,
+        EventType,
+        FileStartEvent,
+    )
 
     src = tmp_path / "doc.pdf"
     src.write_bytes(b"x")
@@ -770,7 +776,7 @@ def test_do_add_on_progress_surfaces_per_page_progress(tmp_path: Path) -> None:
             EventType.BATCH_PROGRESS,
             BatchProgressEvent(
                 file="/abs/path/to/documents/a.pdf",
-                status="rasterizing",
+                status=BatchStatus.RASTERIZING,
                 current=2,
                 total=10,
             ),
@@ -791,7 +797,10 @@ def test_do_add_on_progress_surfaces_per_page_progress(tmp_path: Path) -> None:
     t = threading.Thread(target=_worker, daemon=True)
     t.start()
     t.join(timeout=5)
-    page_updates = [call for call in reporter.update.call_args_list if "page 2 of 10" in str(call)]
+    expected_detail = msg.ADD_PAGE_PROGRESS.format(
+        status=BatchStatus.RASTERIZING.capitalize(), current=2, total=10
+    )
+    page_updates = [call for call in reporter.update.call_args_list if expected_detail in str(call)]
     assert page_updates
 
 
@@ -801,10 +810,12 @@ def test_do_add_progress_label_pins_to_oldest_in_flight_file(tmp_path: Path) -> 
     import asyncio
     import threading
 
+    from lilbee.cli.tui import messages as msg
     from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.data.ingest.types import SyncResult
     from lilbee.runtime.progress import (
         BatchProgressEvent,
+        BatchStatus,
         EventType,
         FileDoneEvent,
         FileStartEvent,
@@ -834,19 +845,19 @@ def test_do_add_progress_label_pins_to_oldest_in_flight_file(tmp_path: Path) -> 
         on_progress(EventType.FILE_DONE, FileDoneEvent(file="b.pdf", status="ok", chunks=2))
         on_progress(
             EventType.BATCH_PROGRESS,
-            BatchProgressEvent(file="b.pdf", status="ingested", current=1, total=3),
+            BatchProgressEvent(file="b.pdf", status=BatchStatus.INGESTED, current=1, total=3),
         )
         # a finishes next.
         on_progress(EventType.FILE_DONE, FileDoneEvent(file="a.pdf", status="ok", chunks=4))
         on_progress(
             EventType.BATCH_PROGRESS,
-            BatchProgressEvent(file="a.pdf", status="ingested", current=2, total=3),
+            BatchProgressEvent(file="a.pdf", status=BatchStatus.INGESTED, current=2, total=3),
         )
         # c finishes last (in-flight is now empty).
         on_progress(EventType.FILE_DONE, FileDoneEvent(file="c.pdf", status="ok", chunks=1))
         on_progress(
             EventType.BATCH_PROGRESS,
-            BatchProgressEvent(file="c.pdf", status="ingested", current=3, total=3),
+            BatchProgressEvent(file="c.pdf", status=BatchStatus.INGESTED, current=3, total=3),
         )
         return SyncResult()
 
@@ -866,21 +877,22 @@ def test_do_add_progress_label_pins_to_oldest_in_flight_file(tmp_path: Path) -> 
     # Reduce the call list to the detail strings reporter.update saw, in order.
     details = [call.args[1] for call in reporter.update.call_args_list]
 
-    # All three FILE_STARTs reported "Syncing a.pdf...". Label never advanced
+    syncing_a = msg.ADD_SYNCING_FILE.format(file="a.pdf")
+    syncing_b = msg.ADD_SYNCING_FILE.format(file="b.pdf")
+    syncing_c = msg.ADD_SYNCING_FILE.format(file="c.pdf")
+
+    # All three FILE_STARTs reported syncing_a. Label never advanced
     # to b or c just because they started, because a is the oldest.
-    sync_labels = [d for d in details if d.startswith("Syncing ")]
-    assert "Syncing a.pdf..." in sync_labels
-    assert "Syncing b.pdf..." not in sync_labels  # b never became oldest
-    assert "Syncing c.pdf..." in sync_labels  # c becomes oldest after a finishes
+    assert syncing_a in details
+    assert syncing_b not in details  # b never became oldest
+    assert syncing_c in details  # c becomes oldest after a finishes
 
     # b's BATCH_PROGRESS came in while a was still oldest, so the detail
     # at that point must still point at a, not b.
-    a_still_oldest_idx = details.index("Syncing a.pdf...")
-    c_becomes_oldest_idx = details.index("Syncing c.pdf...")
-    assert a_still_oldest_idx < c_becomes_oldest_idx
+    assert details.index(syncing_a) < details.index(syncing_c)
 
-    # The very last batch tick (c done, in-flight empty) shows "Done c.pdf".
-    assert details[-1] == "Done c.pdf"
+    # The very last batch tick (c done, in-flight empty) shows the done label.
+    assert details[-1] == msg.ADD_FILE_DONE.format(file="c.pdf")
 
 
 def test_do_sync_notifies_on_skipped(tmp_path: Path) -> None:

--- a/tests/test_chat_worker.py
+++ b/tests/test_chat_worker.py
@@ -703,6 +703,36 @@ def test_chat_session_ensure_loaded_swaps_on_per_call_model(monkeypatch, tmp_pat
     assert load_calls == [tmp_path / "default.gguf", tmp_path / "override.gguf"]
 
 
+def test_abort_bridge_forwards_parent_flag_to_request_abort(monkeypatch) -> None:
+    """The bridge thread polls the parent's mp.Value and calls request_abort.
+
+    Real chat-worker tests stub the loaded Llama and check the flag inline,
+    which bypasses the bridge thread; this exercises the bridge directly so
+    the poll loop's flag-detection branch is covered.
+    """
+    from lilbee.providers.worker import chat_worker
+
+    abort_flag = multiprocessing.Value("i", 0)
+    aborted: list[int] = []
+
+    monkeypatch.setattr(
+        "lilbee.providers.llama_cpp.abort_signal.request_abort",
+        lambda: aborted.append(1),
+    )
+    monkeypatch.setattr(
+        "lilbee.providers.llama_cpp.abort_signal.clear_abort",
+        lambda: None,
+    )
+
+    with chat_worker._AbortBridge(abort_flag):
+        abort_flag.value = 1
+        deadline = time.monotonic() + 1.0
+        while not aborted and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+    assert aborted, "abort bridge poll thread did not forward the parent flag"
+
+
 def test_chat_worker_main_routes_through_run_worker(monkeypatch) -> None:
     """``chat_worker_main`` passes both pipes + the chat handler to run_worker."""
     from lilbee.providers.worker import chat_worker


### PR DESCRIPTION
## Problem

When `/add` ingests multiple files, the progress label shows whichever file finished most recently. Files run concurrently and finish in unpredictable order, so the filename jumps around the queue and the label flickers.

## Solution

Pin the label to the *oldest* file still in flight. It only changes when that specific file finishes, so it advances forward through the queue instead of bouncing.

## Follow-ups

`/sync` and the chat-mode bottom toolbar have the same latent flicker but different existing UX shapes. Left for separate PRs.