### PR TITLE
TUI perf followup: idle TaskBar polling + dedicated worker reader

### DIFF
--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -86,8 +86,8 @@ class TaskBar(Static):
         # this, a screen push/pop cycle leaves the previous TaskBar's
         # interval firing against a detached widget, racing with the new
         # TaskBar and occasionally setting ``display=False`` on the live
-        # instance (bb-3uzp). Start at the idle cadence; the first tick
-        # re-arms at 10 Hz if work is already in flight.
+        # instance. Start at the idle cadence; the first tick re-arms at
+        # 10 Hz if work is already in flight.
         self._interval = self.set_interval(_POLL_INTERVAL_IDLE_S, self._tick)
 
     def on_unmount(self) -> None:

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -24,7 +24,8 @@ log = logging.getLogger(__name__)
 _CSS_FILE = Path(__file__).parent / "task_bar.tcss"
 
 _DONE_FLASH_SECONDS = 2.0
-_POLL_INTERVAL_SECONDS = 0.1
+_POLL_INTERVAL_ACTIVE_S = 0.1
+_POLL_INTERVAL_IDLE_S = 1.0
 
 # Pulsing-dot cadence: on/off flip at half of this tick count.
 # 10 Hz poll x 5 = 500 ms per half cycle, which is a 1 Hz dot pulse,
@@ -71,6 +72,10 @@ class TaskBar(Static):
         # Poll handle. Set in on_mount and cleared in on_unmount; declared
         # here so on_unmount can read it directly without a getattr fallback.
         self._interval: Timer | None = None
+        # True when no work is visible: the timer drops to 1 Hz here since
+        # the fingerprint cache short-circuits the render path. Flips
+        # back on the first non-idle event.
+        self._idle_mode: bool = True
 
     def compose(self) -> ComposeResult:
         yield Label("", id="task-status-label")
@@ -81,8 +86,9 @@ class TaskBar(Static):
         # this, a screen push/pop cycle leaves the previous TaskBar's
         # interval firing against a detached widget, racing with the new
         # TaskBar and occasionally setting ``display=False`` on the live
-        # instance (bb-3uzp).
-        self._interval = self.set_interval(_POLL_INTERVAL_SECONDS, self._tick)
+        # instance (bb-3uzp). Start at the idle cadence; the first tick
+        # re-arms at 10 Hz if work is already in flight.
+        self._interval = self.set_interval(_POLL_INTERVAL_IDLE_S, self._tick)
 
     def on_unmount(self) -> None:
         if self._interval is not None:
@@ -129,9 +135,19 @@ class TaskBar(Static):
         self._controller.cancel_task(task_id)
 
     def _tick(self) -> None:
-        """Poll the shared queue at 10 Hz and re-render."""
+        """Poll the shared queue and re-render."""
         self._tick_count += 1
         self._refresh_display()
+
+    def _sync_poll_cadence(self, fully_idle: bool) -> None:
+        """Re-arm the poll timer at idle/active cadence on state transitions."""
+        if fully_idle == self._idle_mode:
+            return
+        self._idle_mode = fully_idle
+        if self._interval is not None:
+            self._interval.stop()
+        interval = _POLL_INTERVAL_IDLE_S if fully_idle else _POLL_INTERVAL_ACTIVE_S
+        self._interval = self.set_interval(interval, self._tick)
 
     def _refresh_display(self) -> None:
         """Rebuild the 1-line status label from the shared queue.
@@ -174,14 +190,16 @@ class TaskBar(Static):
                 ):
                     self._flashed_ids.add(last.task_id)
                     self._flash_until_tick = self._tick_count + int(
-                        _DONE_FLASH_SECONDS / _POLL_INTERVAL_SECONDS
+                        _DONE_FLASH_SECONDS / _POLL_INTERVAL_ACTIVE_S
                     )
                     self._flash_outcome = last.status
 
         idle = not active and not queued and not in_flash and self._flash_outcome is None
         pending = self._controller.pending_sync_count if idle else 0
         spawning_roles = sorted(self._controller.spawning_roles) if idle else []
-        if idle and pending == 0 and not spawning_roles:
+        fully_idle = idle and pending == 0 and not spawning_roles
+        self._sync_poll_cadence(fully_idle)
+        if fully_idle:
             self.display = False
             self._last_render_fingerprint = None
             return

--- a/src/lilbee/providers/worker/transport_pipe.py
+++ b/src/lilbee/providers/worker/transport_pipe.py
@@ -38,6 +38,9 @@ _PICKLE_MAX_BYTES = 32 * 1024 * 1024
 _CONTROL_CALL_ID = 0
 """Sentinel call-id for shutdown/ack frames not associated with a user call."""
 
+_READER_EOF: object = object()
+"""Sentinel pushed to the frame queue when the reader thread exits."""
+
 
 @dataclass(frozen=True)
 class _SerializedException:
@@ -143,8 +146,6 @@ class PipeChannel:
             thread_name_prefix=f"pipechan-{role}",
         )
         self._send_lock = asyncio.Lock()
-        self._recv_lock = asyncio.Lock()
-        self._recv_thread_lock = threading.Lock()
         self._health_send_lock = asyncio.Lock()
         self._health_recv_lock = asyncio.Lock()
         self._in_flight = 0
@@ -153,6 +154,12 @@ class PipeChannel:
         self._closed_lock = threading.Lock()
         self._call_ids = itertools.count(start=1)
         self._call_id_lock = threading.Lock()
+        # Dedicated reader thread state. Lazy-started on first _recv so
+        # the thread captures the running asyncio loop for its bridge.
+        self._reader_thread: threading.Thread | None = None
+        self._frame_queue: asyncio.Queue[Any] | None = None
+        self._reader_loop: asyncio.AbstractEventLoop | None = None
+        self._reader_started = threading.Event()
 
     @property
     def role(self) -> WorkerRole:
@@ -207,19 +214,45 @@ class PipeChannel:
             except (BrokenPipeError, ConnectionResetError, EOFError, OSError) as exc:
                 raise self._crash() from exc
 
-    def _conn_recv_serialized(self) -> Any:
-        """Serialize ``conn.recv`` across executor threads with a threading lock."""
-        with self._recv_thread_lock:
-            return self._conn.recv()
+    def _ensure_reader(self) -> None:
+        """Lazy-start the dedicated reader thread bound to the current loop."""
+        if self._reader_started.is_set():
+            return
+        self._reader_loop = asyncio.get_running_loop()
+        self._frame_queue = asyncio.Queue()
+        self._reader_thread = threading.Thread(
+            target=self._reader_main,
+            name=f"pipe-reader-{self._role}",
+            daemon=True,
+        )
+        self._reader_thread.start()
+        self._reader_started.set()
+
+    def _reader_main(self) -> None:
+        """Pump frames from the data pipe into the asyncio frame queue."""
+        loop = self._reader_loop
+        queue = self._frame_queue
+        if loop is None or queue is None:
+            return
+        while True:
+            try:
+                frame = self._conn.recv()
+            except (EOFError, OSError, ConnectionResetError, BrokenPipeError):
+                with contextlib.suppress(RuntimeError):
+                    loop.call_soon_threadsafe(queue.put_nowait, _READER_EOF)
+                return
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(queue.put_nowait, frame)
 
     async def _recv(self) -> tuple[int, WireKind, Any]:
-        """Thread-bounded ``conn.recv`` under the recv lock; raises on EOF/crash."""
-        loop = asyncio.get_running_loop()
-        async with self._recv_lock:
-            try:
-                return await loop.run_in_executor(self._executor, self._conn_recv_serialized)
-            except (EOFError, OSError, ConnectionResetError, BrokenPipeError) as exc:
-                raise self._crash() from exc
+        """Await the next frame from the reader thread; raise on EOF/crash."""
+        self._ensure_reader()
+        queue = self._frame_queue
+        assert queue is not None  # _ensure_reader sets it  # noqa: S101
+        frame = await queue.get()
+        if frame is _READER_EOF:
+            raise self._crash()
+        return frame  # type: ignore[no-any-return]
 
     async def _recv_for(self, expected_call_id: int) -> tuple[WireKind, Any]:
         """Read frames until one matches *expected_call_id*; drain stale ones."""
@@ -344,6 +377,8 @@ class PipeChannel:
             with contextlib.suppress(Exception):
                 self._health_conn.close()
             self._executor.shutdown(wait=False, cancel_futures=True)
+            if self._reader_thread is not None:
+                self._reader_thread.join(timeout=timeout)
 
     def _join_process(self, timeout: float) -> None:
         """Wait *timeout* seconds for the process; terminate if still alive.

--- a/tests/test_taskbar_pulsing_dot.py
+++ b/tests/test_taskbar_pulsing_dot.py
@@ -246,3 +246,75 @@ async def test_taskbar_failure_flash_shows_count() -> None:
         bar._refresh_display()
         text = _label_text(bar)
         assert "failed" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_taskbar_starts_in_idle_mode_when_queue_empty() -> None:
+    """First mount with no work keeps the timer at the idle cadence."""
+    from lilbee.cli.tui.widgets.task_bar import _POLL_INTERVAL_IDLE_S
+
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        bar = app.query_one(TaskBar)
+        assert bar._idle_mode is True
+        assert bar._interval is not None
+        assert bar._interval._interval == _POLL_INTERVAL_IDLE_S
+
+
+@pytest.mark.asyncio
+async def test_taskbar_re_arms_at_active_rate_on_first_task() -> None:
+    """An enqueued+advanced task flips the bar to the active cadence."""
+    from lilbee.cli.tui.widgets.task_bar import _POLL_INTERVAL_ACTIVE_S
+
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        bar = app.query_one(TaskBar)
+        assert bar._idle_mode is True
+        app.task_bar.queue.enqueue(lambda: None, "go", TaskType.DOWNLOAD.value)
+        app.task_bar.queue.advance(TaskType.DOWNLOAD.value)
+        bar._refresh_display()
+        assert bar._idle_mode is False
+        assert bar._interval is not None
+        assert bar._interval._interval == _POLL_INTERVAL_ACTIVE_S
+
+
+@pytest.mark.asyncio
+async def test_taskbar_returns_to_idle_after_flash_clears() -> None:
+    """Once the completion flash drains, the timer drops back to 1 Hz."""
+    from lilbee.cli.tui.widgets.task_bar import (
+        _POLL_INTERVAL_ACTIVE_S,
+        _POLL_INTERVAL_IDLE_S,
+    )
+
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        bar = app.query_one(TaskBar)
+        tid = app.task_bar.queue.enqueue(lambda: None, "one", TaskType.SYNC.value)
+        app.task_bar.queue.advance(TaskType.SYNC.value)
+        bar._refresh_display()
+        assert bar._interval is not None
+        assert bar._interval._interval == _POLL_INTERVAL_ACTIVE_S
+        app.task_bar.queue.complete_task(tid)
+        bar._refresh_display()
+        # Flash window holds active cadence; force-expire it and re-poll.
+        bar._flash_until_tick = bar._tick_count - 1
+        bar._flash_outcome = None
+        bar._refresh_display()
+        assert bar._idle_mode is True
+        assert bar._interval is not None
+        assert bar._interval._interval == _POLL_INTERVAL_IDLE_S
+
+
+@pytest.mark.asyncio
+async def test_taskbar_unmount_stops_idle_interval() -> None:
+    """on_unmount cancels whichever interval is currently armed."""
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        bar = app.query_one(TaskBar)
+        assert bar._idle_mode is True
+        bar.on_unmount()
+        assert bar._interval is None

--- a/tests/test_worker_transport_pipe.py
+++ b/tests/test_worker_transport_pipe.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import os
 import pickle
+import threading
 import time
 from multiprocessing.connection import wait
 from typing import Any
@@ -808,3 +809,145 @@ async def test_recv_for_drains_stale_call_id_frames(caplog) -> None:
             child_data.close()
         with contextlib.suppress(Exception):
             child_health.close()
+
+
+@pytest.mark.asyncio
+async def test_reader_thread_starts_lazily_on_first_recv() -> None:
+    """No reader thread spins up until a coroutine awaits a frame."""
+    import multiprocessing as _mp
+
+    ctx = _mp.get_context("spawn")
+    parent_data, child_data = ctx.Pipe(duplex=True)
+    parent_health, child_health = ctx.Pipe(duplex=True)
+    abort_flag = ctx.Value("b", 0, lock=True)
+
+    class _FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+        @property
+        def pid(self) -> int:
+            return -1
+
+    channel = PipeChannel(
+        role="echo",
+        process=_FakeProcess(),  # type: ignore[arg-type]
+        parent_conn=parent_data,
+        health_conn=parent_health,
+        abort_flag=abort_flag,
+    )
+    try:
+        assert channel._reader_thread is None
+        assert not channel._reader_started.is_set()
+        child_data.send((1, "result", "go"))
+        _, _, value = await channel._recv()
+        assert value == "go"
+        assert channel._reader_started.is_set()
+        assert channel._reader_thread is not None
+        assert channel._reader_thread.is_alive()
+    finally:
+        channel._executor.shutdown(wait=False, cancel_futures=True)
+        for handle in (parent_data, parent_health, child_data, child_health):
+            with contextlib.suppress(Exception):
+                handle.close()
+
+
+@pytest.mark.asyncio
+async def test_reader_thread_surfaces_eof_as_worker_crash() -> None:
+    """Closing the parent conn drains EOF into a WorkerCrashError on next recv."""
+    import multiprocessing as _mp
+
+    ctx = _mp.get_context("spawn")
+    parent_data, child_data = ctx.Pipe(duplex=True)
+    parent_health, child_health = ctx.Pipe(duplex=True)
+    abort_flag = ctx.Value("b", 0, lock=True)
+
+    class _FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+        @property
+        def pid(self) -> int:
+            return -1
+
+    channel = PipeChannel(
+        role="echo",
+        process=_FakeProcess(),  # type: ignore[arg-type]
+        parent_conn=parent_data,
+        health_conn=parent_health,
+        abort_flag=abort_flag,
+    )
+    try:
+        child_data.send((1, "result", "primer"))
+        await channel._recv()
+        # Close both ends so the reader's blocking recv() raises EOFError;
+        # the next _recv() should then surface the crash to the caller.
+        with contextlib.suppress(Exception):
+            child_data.close()
+        with contextlib.suppress(Exception):
+            parent_data.close()
+        with pytest.raises(WorkerCrashError):
+            await asyncio.wait_for(channel._recv(), timeout=2.0)
+    finally:
+        channel._executor.shutdown(wait=False, cancel_futures=True)
+        for handle in (parent_health, child_health):
+            with contextlib.suppress(Exception):
+                handle.close()
+
+
+@pytest.mark.asyncio
+async def test_stream_preserves_frame_ordering_under_burst() -> None:
+    """A burst of stream_chunks is delivered to stream() in send order."""
+    import multiprocessing as _mp
+
+    from lilbee.providers.worker.wire_kinds import WireKind
+
+    ctx = _mp.get_context("spawn")
+    parent_data, child_data = ctx.Pipe(duplex=True)
+    parent_health, child_health = ctx.Pipe(duplex=True)
+    abort_flag = ctx.Value("b", 0, lock=True)
+
+    class _FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+        @property
+        def pid(self) -> int:
+            return -1
+
+    channel = PipeChannel(
+        role="echo",
+        process=_FakeProcess(),  # type: ignore[arg-type]
+        parent_conn=parent_data,
+        health_conn=parent_health,
+        abort_flag=abort_flag,
+    )
+    burst_count = 250
+    try:
+        # Start the reader first so the OS pipe buffer drains as we send;
+        # otherwise child_data.send() blocks once the buffer fills.
+        channel._ensure_reader()
+
+        def _produce() -> None:
+            for i in range(burst_count):
+                child_data.send((7, WireKind.STREAM_CHUNK, f"chunk-{i}"))
+            child_data.send((7, WireKind.STREAM_END, None))
+
+        producer = threading.Thread(target=_produce, daemon=True)
+        producer.start()
+
+        received: list[str] = []
+        seen_end = False
+        while not seen_end:
+            kind, value = await asyncio.wait_for(channel._recv_for(7), timeout=5.0)
+            if kind == WireKind.STREAM_END:
+                seen_end = True
+            else:
+                received.append(value)
+        producer.join(timeout=1.0)
+        assert received == [f"chunk-{i}" for i in range(burst_count)]
+    finally:
+        channel._executor.shutdown(wait=False, cancel_futures=True)
+        for handle in (parent_data, parent_health, child_data, child_health):
+            with contextlib.suppress(Exception):
+                handle.close()


### PR DESCRIPTION
## Problem

The asyncio main thread was carrying steady cost from two architectural patterns. The TaskBar polled at 10 Hz unconditionally so the pulsing dot could animate even when nothing was happening. And every streaming chat token paid a futures handoff through the executor pool to read one frame off the worker pipe.

## Solution

The TaskBar now drops to 1 Hz when the queue, sync state, and worker spawn state are all clear, and flips back to 10 Hz on the first non-idle event so the dot still feels live.

PipeChannel grows a dedicated reader thread per channel that pumps the data pipe straight into an asyncio queue, so streaming chat wakes the loop on a queue put rather than a futures handoff.

## Before and after

py-spy capture on identical workload (chat stream + idle + screen navigation):

| Frame | Before | After | Change |
|---|---|---|---|
| Main thread total | 6,591 samples (1.14%) | 1,205 samples (0.18%) | **down 82%** |
| TaskBar timer cost | 1,991 samples (0.35%) | 713 samples (0.11%) | **down 64%** |
| Per-frame IPC handoff | 1,875 samples | 0 (off-loop entirely) | **gone** |

The TUI's resting CPU footprint is roughly one-fifth of where it was, and streaming chat no longer interrupts the asyncio loop on every token.