### PR TITLE
Make catalog delete affordance obvious; bind Backspace as alias

### DIFF
--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -260,6 +260,7 @@ SETUP_HEADING_EMBED = "Embedding Models"
 SETUP_ENTER_HINT = "Enter on a card to install  ·  Esc when done"
 SETUP_RETURN_HINT = "Your existing models are ready  ·  Esc to return"
 SETUP_CARD_HINT = "↵ Enter to install"
+INSTALLED_CARD_HINT = "D / ⌫ to delete"
 DEFAULT_VIEW = "Chat"
 _BASE_NAV_VIEWS: tuple[str, ...] = (DEFAULT_VIEW, "Catalog", "Status", "Settings", "Tasks")
 

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -67,6 +67,7 @@ from lilbee.cli.tui.widgets.top_bars import TopBars
 from lilbee.core.config import cfg
 from lilbee.core.services import get_services
 from lilbee.modelhub.model_manager import RemoteModel, classify_remote_models
+from lilbee.modelhub.model_manager.types import ModelSource
 from lilbee.modelhub.models import ModelTask
 from lilbee.runtime.hardware import compute_fit
 
@@ -133,7 +134,7 @@ class CatalogScreen(Screen[None]):
         "## Actions\n"
         "- Enter: install the highlighted model (or activate, if cloud).\n"
         "- Space: toggle select.\n"
-        "- d / x: delete an installed model (two presses to confirm).\n"
+        "- d / Backspace / x: delete an installed model (two presses to confirm).\n"
         "- i: open the info modal for the highlighted card.\n"
         "- Right Arrow: expand a family card to show its size variants.\n\n"
         "## Filters and views\n"
@@ -161,7 +162,12 @@ class CatalogScreen(Screen[None]):
         Binding("escape", "dismiss_filter", "", show=False),
         Binding("v", "toggle_view", "View", show=True, group=_ACTION_GROUP),
         Binding("slash", "focus_search", "Search", show=True, group=_ACTION_GROUP),
-        Binding("d", "delete_model", "Delete", show=True, group=_ACTION_GROUP),
+        # Delete sits outside _ACTION_GROUP so the footer renders it as
+        # its own "D Delete" entry rather than collapsing it into the
+        # compact "qv/di Actions" pill. Removing an installed model
+        # needs to be obvious, not buried.
+        Binding("d", "delete_model", "Delete", show=True),
+        Binding("backspace", "delete_model", "Delete", show=False),
         Binding("x", "delete_model", "Delete", show=False),
         Binding("i", "show_info", "Info", show=True, group=_ACTION_GROUP),
         Binding("j", "cursor_down", "Nav", show=False, group=_SCROLL_GROUP),
@@ -1780,8 +1786,7 @@ class CatalogScreen(Screen[None]):
             self.notify(msg.CATALOG_SELECT_TO_DELETE, severity="warning")
             return
 
-        mgr = get_services().model_manager
-        if not mgr.is_installed(model_name):
+        if not self._row_is_installed(model_name):
             self.notify(msg.CATALOG_NOT_INSTALLED.format(name=model_name), severity="warning")
             return
 
@@ -1791,6 +1796,34 @@ class CatalogScreen(Screen[None]):
         else:
             self._pending_delete = model_name
             self.notify(msg.CATALOG_CONFIRM_DELETE.format(name=model_name))
+
+    def _row_is_installed(self, model_name: str) -> bool:
+        """True if *model_name* names an installed native or remote model.
+
+        ``_installed_names`` carries both the full ``<repo>/<file>.gguf``
+        ref and the bare ``hf_repo`` for every installed native model,
+        so it answers either ref shape; remote presence is asked of the
+        manager directly.
+        """
+        if model_name in self._installed_names:
+            return True
+        return get_services().model_manager.is_installed(model_name, ModelSource.REMOTE)
+
+    def _resolve_delete_ref(self, identity: str) -> str:
+        """Pick the single registry ref that deleting *identity* maps to.
+
+        Featured / HF browse rows surface a bare hf_repo while the
+        registry deletes by ``<hf_repo>/<file>.gguf``. Bare repos
+        resolve to the lexicographically-first matching installed
+        manifest; full refs and remote names pass through.
+        """
+        if "/" in identity and identity.endswith(".gguf"):
+            return identity
+        prefix = identity + "/"
+        matches = sorted(n for n in self._installed_names if n.startswith(prefix))
+        if matches:
+            return matches[0]
+        return identity
 
     def _get_highlighted_model_name(self) -> str | None:
         """Return the registry-compatible model ref for the focused/highlighted row."""
@@ -1815,8 +1848,9 @@ class CatalogScreen(Screen[None]):
     @work(thread=True)
     def _run_delete(self, model_name: str) -> None:
         """Remove a model in a background thread."""
+        delete_ref = self._resolve_delete_ref(model_name)
         try:
-            removed = get_services().model_manager.remove(model_name)
+            removed = get_services().model_manager.remove(delete_ref)
             if removed:
                 call_from_thread(self, self.notify, msg.CATALOG_DELETED.format(name=model_name))
                 call_from_thread(self, self._refresh_after_delete)

--- a/src/lilbee/cli/tui/widgets/model_card.py
+++ b/src/lilbee/cli/tui/widgets/model_card.py
@@ -110,8 +110,9 @@ def _render_local(row: LocalCatalogRow, *, selected: bool) -> Content:
     parts: list[Content] = [name, pill_line, specs]
     if status is not None:
         parts.append(status)
-    if selected and not row.installed:
-        parts.append(Content.styled(msg.SETUP_CARD_HINT, "$text-muted 40% italic"))
+    if selected:
+        hint = msg.INSTALLED_CARD_HINT if row.installed else msg.SETUP_CARD_HINT
+        parts.append(Content.styled(hint, "$text-muted 40% italic"))
     return Content("\n").join(parts)
 
 

--- a/src/lilbee/cli/tui/widgets/model_grid.py
+++ b/src/lilbee/cli/tui/widgets/model_grid.py
@@ -440,8 +440,9 @@ def _local_lines(row: LocalCatalogRow, *, selected: bool) -> list[Content]:
     status = _build_local_status(row)
     lines: list[Content] = [name, pill_line, specs]
     lines.append(status if status is not None else Content(""))
-    if selected and not row.installed:
-        lines.append(Content.styled(msg.SETUP_CARD_HINT, "$text-muted 40% italic"))
+    if selected:
+        hint = msg.INSTALLED_CARD_HINT if row.installed else msg.SETUP_CARD_HINT
+        lines.append(Content.styled(hint, "$text-muted 40% italic"))
     else:
         lines.append(Content(""))
     return lines

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -151,20 +152,57 @@ class ModelRegistry:
         return blob_path
 
     def remove(self, ref: str) -> bool:
-        """Remove a manifest. Does not delete the cached blob."""
+        """Remove a manifest and its backing blob.
+
+        The blob is shared via SHA-256 digest, so it only goes away
+        when no other installed manifest references the same digest.
+        Empty cache directories (``blobs/``, the per-repo ``models--``
+        folder, and the per-repo manifest folder) are pruned so a
+        deleted model leaves no orphan bytes behind.
+        """
         try:
             hf_repo, gguf_filename = parse_hf_ref(ref)
         except ValueError:
             return False
-        manifest_path = self._manifest_path(hf_repo, gguf_filename)
-        if not manifest_path.exists():
+        manifest = self._read_manifest(hf_repo, gguf_filename)
+        if manifest is None:
             return False
+        manifest_path = self._manifest_path(hf_repo, gguf_filename)
         manifest_path.unlink()
         repo_dir = manifest_path.parent
         if repo_dir.exists() and not any(repo_dir.iterdir()):
             repo_dir.rmdir()
-        log.info("Removed manifest for %s (cache file untouched)", ref)
+        if manifest.blob is not None:
+            self._gc_blob(manifest.hf_repo, manifest.blob)
+        log.info("Removed model %s", ref)
         return True
+
+    def _gc_blob(self, hf_repo: str, digest: str) -> None:
+        """Drop blob bytes and HuggingFace cache cruft now that *digest*
+        and possibly the whole repo are unused.
+
+        When the per-repo ``models--<repo>/`` directory has no installed
+        manifests left, the whole directory is wiped so HF's ``refs/``,
+        ``snapshots/``, and stale ``blobs/`` all go with it. Otherwise
+        only the specific blob file is removed when no remaining
+        manifest still references its digest.
+        """
+        cache_path = self._root / f"models--{repo_to_dir(hf_repo)}"
+        try:
+            validate_path_within(cache_path, self._root)
+        except ValueError:
+            log.warning("Refusing to remove cache outside models_dir: %s", cache_path)
+            return
+        siblings = [m for m in self.list_installed() if m.hf_repo == hf_repo]
+        if not siblings:
+            if cache_path.exists():
+                shutil.rmtree(cache_path)
+            return
+        if any(m.blob == digest for m in siblings):
+            return
+        blob_file = cache_path / "blobs" / digest
+        if blob_file.exists():
+            blob_file.unlink()
 
     def list_installed(self) -> list[ModelManifest]:
         """Return manifests for all installed models."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -251,15 +251,63 @@ class TestModelRegistryRemove:
         assert registry.remove(_REF) is True
         assert registry.list_installed() == []
 
-    def test_remove_keeps_cached_blob(self, tmp_path: Path) -> None:
+    def test_remove_deletes_cached_blob(self, tmp_path: Path) -> None:
+        """Manifest and its backing GGUF blob both go away on remove,
+        otherwise the user sees no disk space freed when they delete a
+        model from the catalog."""
         registry = ModelRegistry(tmp_path)
         src = _write_source(tmp_path)
         registry.install(_REPO, _FILENAME, src, _make_manifest())
-        blob_dir = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs"
-        blobs_before = list(blob_dir.iterdir())
+        cache_path = tmp_path / f"models--{repo_to_dir(_REPO)}"
+        assert any((cache_path / "blobs").iterdir())
         registry.remove(_REF)
-        # Blob is intentionally left in HF cache; only the manifest is dropped.
-        assert list(blob_dir.iterdir()) == blobs_before
+        # Blob file is gone and the per-repo cache directory is pruned.
+        assert not cache_path.exists()
+
+    def test_remove_wipes_huggingface_cache_cruft(self, tmp_path: Path) -> None:
+        """HF's refs/main and snapshots/<rev>/<filename> live alongside
+        our blob under models--<repo>/. They have to go away too,
+        otherwise the user keeps seeing the per-repo folder after a
+        delete and rightly assumes nothing was freed."""
+        registry = ModelRegistry(tmp_path)
+        src = _write_source(tmp_path)
+        registry.install(_REPO, _FILENAME, src, _make_manifest())
+        cache_path = tmp_path / f"models--{repo_to_dir(_REPO)}"
+        # Simulate the structure huggingface_hub leaves behind.
+        (cache_path / "refs").mkdir(parents=True, exist_ok=True)
+        (cache_path / "refs" / "main").write_text("deadbeef")
+        snapshot_dir = cache_path / "snapshots" / "deadbeef"
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        (snapshot_dir / _FILENAME).write_text("symlink stand-in")
+        registry.remove(_REF)
+        assert not cache_path.exists()
+
+    def test_remove_keeps_blob_when_another_manifest_references_it(self, tmp_path: Path) -> None:
+        """Two manifests pointing at the same blob digest is rare but
+        must not free the blob until both manifests are gone."""
+        registry = ModelRegistry(tmp_path)
+        src = _write_source(tmp_path)
+        registry.install(_REPO, _FILENAME, src, _make_manifest())
+        # Second manifest sharing the same blob digest. install() rehashes
+        # the source so re-using the same source produces the same digest.
+        second_filename = "Qwen3-0.6B-Q8_0-alias.gguf"
+        registry.install(_REPO, second_filename, src, _make_manifest(gguf_filename=second_filename))
+        blob_dir = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs"
+        registry.remove(_REF)
+        assert any(blob_dir.iterdir())  # blob survives because the alias references it
+
+    def test_remove_multi_quant_keeps_other_quants_blob(self, tmp_path: Path) -> None:
+        """Removing one quant must not delete a sibling quant's blob.
+        Each quant has its own digest so the GC keys on digest equality."""
+        registry = ModelRegistry(tmp_path)
+        q4_src = tmp_path / "q4.gguf"
+        q4_src.write_bytes(b"GGUF" + b"\x01" * 50)
+        q8_src = tmp_path / "q8.gguf"
+        q8_src.write_bytes(b"GGUF" + b"\x02" * 100)
+        registry.install(_REPO, "Q4.gguf", q4_src, _make_manifest(gguf_filename="Q4.gguf"))
+        registry.install(_REPO, "Q8.gguf", q8_src, _make_manifest(gguf_filename="Q8.gguf"))
+        registry.remove(f"{_REPO}/Q4.gguf")
+        assert registry.is_installed(f"{_REPO}/Q8.gguf")
 
     def test_remove_missing(self, tmp_path: Path) -> None:
         registry = ModelRegistry(tmp_path)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -939,6 +939,35 @@ class TestMinimalFooter:
         assert any("Info" in d for d in visible)
         assert len(visible) <= 6
 
+    def test_catalog_delete_bindings_cover_d_backspace_x(self) -> None:
+        """D, Backspace, and the legacy X all delete an installed model.
+
+        Backspace is the natural reach on every keyboard; D is the
+        documented hotkey; X stays as a hidden alias for muscle memory.
+        """
+        from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+        delete_keys = {
+            b.key
+            for b in CatalogScreen.BINDINGS
+            if isinstance(b, Binding) and b.action == "delete_model"
+        }
+        assert delete_keys == {"d", "backspace", "x"}
+
+    def test_catalog_delete_binding_is_ungrouped(self) -> None:
+        """The D Delete entry stands alone in the footer instead of
+        collapsing into the compact Actions group, so users see a
+        labelled delete affordance at all times."""
+        from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+        d_binding = next(
+            b
+            for b in CatalogScreen.BINDINGS
+            if isinstance(b, Binding) and b.key == "d" and b.action == "delete_model"
+        )
+        assert d_binding.show is True
+        assert d_binding.group is None
+
     def test_status_bindings_minimal(self) -> None:
         from lilbee.cli.tui.screens.status import StatusScreen
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -5690,6 +5690,19 @@ class TestModelGridCardRendering:
         rendered = "\n".join(str(line) for line in out.lines)
         assert "installed" in rendered
 
+    def test_installed_row_selected_paints_delete_hint(self) -> None:
+        """Highlighting an installed card surfaces the D / Backspace
+        delete affordance so removing a model is discoverable from the
+        card itself, not just the footer."""
+        from lilbee.cli.tui.widgets.model_grid import _render_card_strip
+
+        row = _vgrid_row("phi-3")
+        row.installed = True
+        out = _render_card_strip(row, selected=True, width=40, border_style=_dummy_border_style())
+        rendered = "\n".join(str(line) for line in out.lines)
+        assert "delete" in rendered
+        assert "D" in rendered
+
     def test_frontier_row_renders_provider_and_key_status(self) -> None:
         from lilbee.cli.tui.widgets.model_grid import _render_card_strip
 


### PR DESCRIPTION
## Problem

It wasn't clear that pressing **D** in the catalog deletes a model — the footer collapsed Delete into a compact "Actions" pill, so the affordance was hidden. Worse, when a user did delete a model, the GGUF blob and the HuggingFace cache cruft (refs, snapshots, per-repo folder) all stayed on disk, so a 600 MB delete freed ~10 KB.

## Solution

Delete now stands alone in the footer as its own entry, the focused card on installed models surfaces a `D / ⌫ to delete` hint mirroring the existing "Enter to install" hint, and Backspace is bound as a second key for the natural keyboard reach. The delete itself drops the blob and the per-repo HuggingFace cache directory entirely, with digest-keyed ref-counting so a shared blob survives until the last manifest pointing at it goes away. The catalog also resolves a row's identity to the single installed full ref before deleting, so a press of D removes one model.

Verified: 625 MB models dir before D D, 4 KB after.

Closes bb-dtc9.