### PR TITLE
Server-side hardware-fit on /api/models/catalog

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -78,7 +78,7 @@ from lilbee.cli.tui.widgets.top_bars import TopBars
 from lilbee.core.config import cfg
 from lilbee.modelhub.model_manager import RemoteModel, classify_remote_models
 from lilbee.providers.sdk_backend import get_provider_api_key
-from lilbee.runtime.hardware import compute_fit
+from lilbee.runtime.hardware import available_memory_for_fit, compute_fit
 
 log = logging.getLogger(__name__)
 
@@ -278,29 +278,9 @@ class CatalogScreen(Screen[None]):
             tab_id: SourceMode.LOCAL for tab_id in TASK_TAB_IDS
         }
         # Hardware-fit baseline. Captured once at construction so the
-        # row-build path (cached, only re-runs when _data_version moves)
-        # can stamp each row's fit chip without re-probing on every refresh.
-        # None when the probe failed or psutil is unavailable; rows render
-        # without a fit chip in that case.
-        self._available_memory_bytes: int | None = self._probe_available_memory()
-
-    @staticmethod
-    def _probe_available_memory() -> int | None:
-        """One-shot hardware probe used to compute per-row fit chips.
-
-        Wraps ``providers.model_cache.get_available_memory`` so test envs
-        without a usable psutil/pynvml install fall back to a chip-less
-        catalog instead of crashing. The fraction follows the configured
-        ``gpu_memory_fraction`` so the fit signal matches what the
-        runtime would actually leave for the model after KV cache + OS
-        overhead.
-        """
-        try:
-            from lilbee.providers.model_cache import get_available_memory
-
-            return get_available_memory(cfg.gpu_memory_fraction)
-        except Exception:
-            return None
+        # cached row-build path can stamp each row's fit chip without
+        # re-probing on every refresh.
+        self._available_memory_bytes: int | None = available_memory_for_fit()
 
     def _grid_for_tab(self, tab_id: str) -> VerticalScroll:
         """Return (and memoize) the VerticalScroll for *tab_id*.

--- a/src/lilbee/runtime/hardware.py
+++ b/src/lilbee/runtime/hardware.py
@@ -1,21 +1,14 @@
-"""Hardware-fit signaling for the catalog UI.
-
-`compute_fit` reports whether a model's footprint fits the host's
-available memory and how much headroom or shortfall remains. The
-catalog renders this as a per-card chip (`fits +N GB`, `tight +N GB`,
-`won't run -N GB`) so users can tell at a glance whether a model
-will run before they download it.
-
-Hardware probing lives in `lilbee.providers.model_cache.get_available_memory`
-(macOS unified memory, NVIDIA GPU, system RAM fallback). This module
-only owns the fit semantics so it stays free of provider/runtime
-layering concerns.
-"""
+"""Hardware-fit signaling and per-row size-variant grouping for the catalog."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+
+from pydantic import BaseModel
+
+from lilbee.catalog.models import ModelFamily
+from lilbee.core.config import cfg
 
 _BYTES_PER_GB = 1024**3
 _FITS_HEADROOM_BYTES = 1 * _BYTES_PER_GB
@@ -36,7 +29,7 @@ class FitChip:
 def compute_fit(model_size_bytes: int, available_bytes: int) -> FitChip:
     """Classify how a model footprint fits the available memory budget.
 
-    `headroom_gb` is positive when the model fits and negative when it
+    Headroom_gb is positive when the model fits and negative when it
     won't. The 1 GB band between FITS and TIGHT leaves room for the
     inference runtime, KV cache, and OS overhead beyond the raw weight
     file.
@@ -50,3 +43,47 @@ def compute_fit(model_size_bytes: int, available_bytes: int) -> FitChip:
     else:
         level = FitLevel.WONT_RUN
     return FitChip(level=level, headroom_gb=headroom_gb)
+
+
+def available_memory_for_fit() -> int | None:
+    """Bytes available to a model after ``cfg.gpu_memory_fraction``, or None on probe failure.
+
+    Single entry point so the TUI and the HTTP catalog handler classify fit
+    against the same number; otherwise the same model would chip differently in
+    each surface.
+    """
+    try:
+        from lilbee.providers.model_cache import get_available_memory
+
+        return get_available_memory(cfg.gpu_memory_fraction)
+    except Exception:
+        return None
+
+
+class SizeVariantInfo(BaseModel):
+    """One size/quant of a model family, serialised for HTTP responses."""
+
+    size_label: str
+    params: str
+    size_gb: float
+    ref: str
+
+
+def family_size_variants(family: ModelFamily) -> list[SizeVariantInfo]:
+    """Build the per-row size-variant strip for a featured ModelFamily, smallest first."""
+    variants = sorted(family.variants, key=lambda v: v.size_mb)
+    return [
+        SizeVariantInfo(
+            size_label=_size_variant_label(v.param_count, v.quant),
+            params=v.param_count,
+            size_gb=v.size_mb / 1024,
+            ref=v.hf_repo,
+        )
+        for v in variants
+    ]
+
+
+def _size_variant_label(param_count: str, quant: str) -> str:
+    """Render the compact label for one size variant (``8B Q4_K_M``)."""
+    pieces = [p for p in (param_count, quant) if p]
+    return " ".join(pieces) if pieces else "--"

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -16,9 +16,11 @@ from lilbee.catalog import (
     FEATURED_EMBEDDING,
     FEATURED_RERANK,
     FEATURED_VISION,
+    ModelFamily,
     enrich_catalog,
     find_catalog_entry,
     get_catalog,
+    get_families,
 )
 from lilbee.catalog.refs import hf_repo_from_ref
 from lilbee.catalog.types import ModelSource, ModelTask
@@ -26,6 +28,13 @@ from lilbee.core import settings
 from lilbee.core.config import cfg, validate_model_task_assignment
 from lilbee.core.config.validators import _MODEL_FIELD_TO_TASK
 from lilbee.providers.model_ref import parse_model_ref
+from lilbee.runtime.hardware import (
+    FitLevel,
+    SizeVariantInfo,
+    available_memory_for_fit,
+    compute_fit,
+    family_size_variants,
+)
 from lilbee.runtime.progress import SseEvent
 from lilbee.server.handlers.sse import SseStream, sse_error, sse_event
 from lilbee.server.models import (
@@ -41,6 +50,7 @@ from lilbee.server.models import (
 
 if TYPE_CHECKING:
     from lilbee.catalog import CatalogModel
+    from lilbee.catalog.formatting import EnrichedModel
 
 log = logging.getLogger(__name__)
 
@@ -254,6 +264,65 @@ def _parse_source(source: str) -> ModelSource:
     return ModelSource(source)
 
 
+_BYTES_PER_GB = 1024**3
+
+
+def _row_fit(enriched: EnrichedModel, available_bytes: int | None) -> FitLevel | None:
+    """Fit level for *enriched*, or None when host memory or row size can't be measured."""
+    if available_bytes is None:
+        return None
+    if enriched.source != ModelSource.NATIVE.value:
+        return None
+    if enriched.size_gb <= 0:
+        return None
+    return compute_fit(int(enriched.size_gb * _BYTES_PER_GB), available_bytes).level
+
+
+def _families_by_repo() -> dict[str, ModelFamily]:
+    """Index featured ModelFamilies by every variant's ``hf_repo`` for size-variant lookup."""
+    index: dict[str, ModelFamily] = {}
+    for family in get_families():
+        for variant in family.variants:
+            index[variant.hf_repo] = family
+    return index
+
+
+def _row_size_variants(
+    enriched: EnrichedModel, families_by_repo: dict[str, ModelFamily]
+) -> list[SizeVariantInfo]:
+    """Size-variant strip for *enriched*; empty when the row isn't part of a family."""
+    family = families_by_repo.get(enriched.hf_repo)
+    if family is None:
+        return []
+    return family_size_variants(family)
+
+
+def _build_catalog_entry(
+    enriched: EnrichedModel,
+    *,
+    available_bytes: int | None,
+    families_by_repo: dict[str, ModelFamily],
+) -> CatalogEntryResponse:
+    """Translate one enriched catalog model into its HTTP response row."""
+    return CatalogEntryResponse(
+        hf_repo=enriched.hf_repo,
+        gguf_filename=enriched.gguf_filename,
+        task=enriched.task,
+        display_name=enriched.display_name,
+        param_count=enriched.param_count,
+        size_gb=enriched.size_gb,
+        min_ram_gb=enriched.min_ram_gb,
+        description=enriched.description,
+        quality_tier=enriched.quality_tier,
+        featured=enriched.featured,
+        downloads=enriched.downloads,
+        installed=enriched.installed,
+        source=enriched.source,
+        fit=_row_fit(enriched, available_bytes),
+        size_variants=_row_size_variants(enriched, families_by_repo),
+    )
+
+
 async def models_catalog(
     task: str | None = None,
     search: str = "",
@@ -284,26 +353,17 @@ async def models_catalog(
     installed_refs = {m.ref for m in registry.list_installed()}
     enriched = enrich_catalog(result, installed_refs)
 
+    available_bytes = available_memory_for_fit()
+    families_by_repo = _families_by_repo()
+
     return ModelsCatalogResponse(
         total=result.total,
         limit=result.limit,
         offset=result.offset,
         has_more=result.has_more,
         models=[
-            CatalogEntryResponse(
-                hf_repo=e.hf_repo,
-                gguf_filename=e.gguf_filename,
-                task=e.task,
-                display_name=e.display_name,
-                param_count=e.param_count,
-                size_gb=e.size_gb,
-                min_ram_gb=e.min_ram_gb,
-                description=e.description,
-                quality_tier=e.quality_tier,
-                featured=e.featured,
-                downloads=e.downloads,
-                installed=e.installed,
-                source=e.source,
+            _build_catalog_entry(
+                e, available_bytes=available_bytes, families_by_repo=families_by_repo
             )
             for e in enriched
         ],

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from lilbee.catalog.types import ModelSource, ModelTask
 from lilbee.data.store import SearchScope
+from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 
 _VALID_CHUNK_TYPES = frozenset({SearchScope.RAW.value, SearchScope.WIKI.value})
 
@@ -242,7 +243,14 @@ class ModelsShowResponse(BaseModel):
 
 
 class CatalogEntryResponse(BaseModel):
-    """A single model in the catalog browser."""
+    """A single model in the catalog browser.
+
+    ``fit`` and ``size_variants`` carry server-computed hardware-fit
+    data so clients (TUI, plugin) can render fit chips and size strips
+    without probing local memory themselves. ``fit`` is ``None`` when
+    the row's footprint cannot be assessed against host memory (e.g.
+    a future cloud-only entry whose weights live off-host).
+    """
 
     hf_repo: str
     gguf_filename: str
@@ -257,6 +265,8 @@ class CatalogEntryResponse(BaseModel):
     downloads: int
     installed: bool
     source: ModelSource
+    fit: FitLevel | None = None
+    size_variants: list[SizeVariantInfo] = []
 
 
 class ModelsCatalogResponse(BaseModel):

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -284,15 +284,16 @@ def test_for_you_sort_key_orders_fit_levels_then_name() -> None:
     assert [r.name for r in ordered] == ["a-fits", "b-tight", "c-wont", "d-none"]
 
 
-def test_probe_available_memory_returns_none_on_failure(monkeypatch) -> None:
+def test_available_memory_for_fit_returns_none_on_failure(monkeypatch) -> None:
     """Hardware probe failures fall through chip-less, never crash."""
     import lilbee.providers.model_cache as mc
+    from lilbee.runtime.hardware import available_memory_for_fit
 
     def boom(_fraction: float) -> int:
         raise RuntimeError("psutil missing")
 
     monkeypatch.setattr(mc, "get_available_memory", boom)
-    assert CatalogScreen._probe_available_memory() is None
+    assert available_memory_for_fit() is None
 
 
 def test_stamp_fit_no_op_without_probe() -> None:

--- a/tests/test_runtime_hardware.py
+++ b/tests/test_runtime_hardware.py
@@ -1,8 +1,15 @@
-"""Tests for ``lilbee.runtime.hardware.compute_fit``."""
+"""Tests for ``lilbee.runtime.hardware``."""
 
 from __future__ import annotations
 
-from lilbee.runtime.hardware import FitLevel, compute_fit
+from lilbee.catalog.models import ModelFamily, ModelVariant
+from lilbee.runtime.hardware import (
+    FitLevel,
+    SizeVariantInfo,
+    available_memory_for_fit,
+    compute_fit,
+    family_size_variants,
+)
 
 _GB = 1024**3
 
@@ -46,3 +53,65 @@ def test_chip_is_immutable() -> None:
     except dataclasses.FrozenInstanceError:
         return
     raise AssertionError("FitChip should be frozen")
+
+
+def test_available_memory_for_fit_returns_bytes_from_probe(monkeypatch) -> None:
+    import lilbee.providers.model_cache as mc
+    from lilbee.core.config import cfg
+
+    cfg.gpu_memory_fraction = 0.5
+    monkeypatch.setattr(mc, "get_available_memory", lambda fraction: int(16 * _GB * fraction))
+    assert available_memory_for_fit() == 8 * _GB
+
+
+def test_available_memory_for_fit_returns_none_when_probe_raises(monkeypatch) -> None:
+    import lilbee.providers.model_cache as mc
+
+    def boom(_fraction: float) -> int:
+        raise RuntimeError("psutil missing")
+
+    monkeypatch.setattr(mc, "get_available_memory", boom)
+    assert available_memory_for_fit() is None
+
+
+def _variant(repo: str, params: str, quant: str, size_mb: int) -> ModelVariant:
+    return ModelVariant(
+        hf_repo=repo,
+        filename="*.gguf",
+        param_count=params,
+        quant=quant,
+        size_mb=size_mb,
+        recommended=False,
+    )
+
+
+def test_family_size_variants_orders_by_size_and_builds_label() -> None:
+    family = ModelFamily(
+        slug="qwen3",
+        name="Qwen3",
+        task="chat",
+        description="",
+        variants=(
+            _variant("Qwen/Qwen3-8B-GGUF", "8B", "Q4_K_M", 5 * 1024),
+            _variant("Qwen/Qwen3-0.6B-GGUF", "0.6B", "Q4_K_M", 512),
+        ),
+    )
+    out = family_size_variants(family)
+    assert [v.params for v in out] == ["0.6B", "8B"]
+    assert out[0] == SizeVariantInfo(
+        size_label="0.6B Q4_K_M", params="0.6B", size_gb=0.5, ref="Qwen/Qwen3-0.6B-GGUF"
+    )
+    assert out[1].size_label == "8B Q4_K_M"
+
+
+def test_family_size_variants_handles_missing_param_or_quant() -> None:
+    family = ModelFamily(
+        slug="anon",
+        name="Anon",
+        task="chat",
+        description="",
+        variants=(_variant("anon/repo", "", "", 100),),
+    )
+    [only] = family_size_variants(family)
+    assert only.size_label == "--"
+    assert only.params == ""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1067,6 +1067,209 @@ class TestModelsCatalog:
         assert by_repo["Qwen/Qwen3-8B-GGUF"].installed is True
         assert by_repo["TheBloke/Mistral-7B-GGUF"].installed is False
 
+    @patch("lilbee.server.handlers.models.available_memory_for_fit", return_value=16 * 1024**3)
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_fit_set_for_native_installed_row(self, mock_get_catalog, _mock_mem, mock_svc):
+        """A native row with a known footprint gets a server-computed fit level."""
+        from lilbee.catalog import CatalogModel, CatalogResult
+        from lilbee.runtime.hardware import FitLevel
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[
+                CatalogModel(
+                    hf_repo="Qwen/Qwen3-8B-GGUF",
+                    gguf_filename="*Q4_K_M.gguf",
+                    size_gb=5.0,
+                    min_ram_gb=8.0,
+                    description="",
+                    featured=True,
+                    downloads=0,
+                    task="chat",
+                )
+            ],
+        )
+        mock_svc.registry.list_installed.return_value = [
+            self._manifest("Qwen/Qwen3-8B-GGUF", "Qwen3-8B-Q4_K_M.gguf")
+        ]
+        result = await handlers.models_catalog()
+        assert result.models[0].fit is FitLevel.FITS
+
+    @patch("lilbee.server.handlers.models.available_memory_for_fit", return_value=4 * 1024**3)
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_fit_set_for_native_not_installed_row(
+        self, mock_get_catalog, _mock_mem, mock_svc
+    ):
+        """A native, not-yet-installed row still carries fit so users see it before pulling."""
+        from lilbee.catalog import CatalogModel, CatalogResult
+        from lilbee.runtime.hardware import FitLevel
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[
+                CatalogModel(
+                    hf_repo="Qwen/Qwen3-8B-GGUF",
+                    gguf_filename="*Q4_K_M.gguf",
+                    size_gb=5.0,
+                    min_ram_gb=8.0,
+                    description="",
+                    featured=True,
+                    downloads=0,
+                    task="chat",
+                )
+            ],
+        )
+        mock_svc.registry.list_installed.return_value = []
+        result = await handlers.models_catalog()
+        assert result.models[0].installed is False
+        assert result.models[0].fit is FitLevel.WONT_RUN
+
+    @patch("lilbee.server.handlers.models.available_memory_for_fit", return_value=None)
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_fit_none_when_memory_probe_unavailable(
+        self, mock_get_catalog, _mock_mem, mock_svc
+    ):
+        """When the host probe fails, every row degrades to fit=None instead of guessing."""
+        from lilbee.catalog import CatalogModel, CatalogResult
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[
+                CatalogModel(
+                    hf_repo="Qwen/Qwen3-8B-GGUF",
+                    gguf_filename="*Q4_K_M.gguf",
+                    size_gb=5.0,
+                    min_ram_gb=8.0,
+                    description="",
+                    featured=True,
+                    downloads=0,
+                    task="chat",
+                )
+            ],
+        )
+        mock_svc.registry.list_installed.return_value = []
+        result = await handlers.models_catalog()
+        assert result.models[0].fit is None
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_fit_none_when_size_unknown(self, mock_get_catalog, mock_svc):
+        """Rows without a resolved footprint cannot be assessed against host memory."""
+        from lilbee.catalog import CatalogModel, CatalogResult
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[
+                CatalogModel(
+                    hf_repo="adhoc/repo",
+                    gguf_filename="*.gguf",
+                    size_gb=0.0,
+                    min_ram_gb=2.0,
+                    description="",
+                    featured=False,
+                    downloads=0,
+                    task="chat",
+                )
+            ],
+        )
+        mock_svc.registry.list_installed.return_value = []
+        result = await handlers.models_catalog()
+        assert result.models[0].fit is None
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_size_variants_attached_for_featured_family(self, mock_get_catalog, mock_svc):
+        """A featured row exposes its sibling family variants on the response."""
+        from lilbee.catalog import FEATURED_CHAT, CatalogResult
+
+        # Pick the first featured chat repo; its family should yield at least
+        # one SizeVariantInfo regardless of how many siblings it has.
+        anchor = FEATURED_CHAT[0]
+        mock_get_catalog.return_value = CatalogResult(total=1, limit=20, offset=0, models=[anchor])
+        mock_svc.registry.list_installed.return_value = []
+        result = await handlers.models_catalog()
+        variants = result.models[0].size_variants
+        assert len(variants) >= 1
+        assert all(v.size_gb >= 0 for v in variants)
+        assert anchor.hf_repo in {v.ref for v in variants}
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_size_variants_empty_for_non_family_row(self, mock_get_catalog, mock_svc):
+        """An ad-hoc HF row with no family grouping returns an empty variant strip."""
+        from lilbee.catalog import CatalogModel, CatalogResult
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[
+                CatalogModel(
+                    hf_repo="adhoc/some-repo",
+                    gguf_filename="*.gguf",
+                    size_gb=2.0,
+                    min_ram_gb=4.0,
+                    description="",
+                    featured=False,
+                    downloads=0,
+                    task="chat",
+                )
+            ],
+        )
+        mock_svc.registry.list_installed.return_value = []
+        result = await handlers.models_catalog()
+        assert result.models[0].size_variants == []
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_fit_none_for_non_native_source(self, mock_get_catalog, mock_svc):
+        """Non-native (off-host) rows leave fit unset since the footprint isn't local.
+
+        ``enrich_catalog`` currently always emits ``source="native"``, but the
+        handler must still return ``fit=None`` for any row whose source is not
+        native so a future router that mixes cloud rows in this response keeps
+        the contract (cloud rows have no on-host footprint to assess).
+        """
+        from dataclasses import replace
+
+        from lilbee.catalog import CatalogModel, CatalogResult, enrich_catalog
+        from lilbee.catalog.types import ModelSource
+
+        mock_get_catalog.return_value = CatalogResult(
+            total=1,
+            limit=20,
+            offset=0,
+            models=[
+                CatalogModel(
+                    hf_repo="cloud/example",
+                    gguf_filename="",
+                    size_gb=0.0,
+                    min_ram_gb=0.0,
+                    description="cloud chat model",
+                    featured=False,
+                    downloads=0,
+                    task="chat",
+                )
+            ],
+        )
+        mock_svc.registry.list_installed.return_value = []
+
+        def _enrich_as_remote(result, installed_refs):
+            enriched = enrich_catalog(result, installed_refs)
+            return [replace(e, source=ModelSource.REMOTE.value) for e in enriched]
+
+        with patch(
+            "lilbee.server.handlers.models.enrich_catalog",
+            side_effect=_enrich_as_remote,
+        ):
+            result = await handlers.models_catalog()
+        assert result.models[0].source == "remote"
+        assert result.models[0].fit is None
+
 
 class TestModelsInstalled:
     async def test_returns_installed_models(self):

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -6658,9 +6658,7 @@ async def test_action_command_palette_falls_through_when_overlay_missing():
         # native palette behaviour.
         with (
             patch.object(app.screen, "query_one", side_effect=NoMatches("test")),
-            patch.object(
-                LilbeeApp.__bases__[0], "action_command_palette"
-            ) as super_palette,
+            patch.object(LilbeeApp.__bases__[0], "action_command_palette") as super_palette,
         ):
             _ = Static  # silence "imported but unused"
             app.action_command_palette()


### PR DESCRIPTION
## Problem

The catalog UI's hardware-fit chip ("fits", "tight", "won't run") was computed by each client against the client's own RAM. That's correct only when the client and the server live on the same machine — which the TUI guarantees but the Obsidian plugin does not. With a remote `lilbee serve`, the chip on the plugin's catalog meant "fits this laptop", not "fits the GPU box that will actually load the model". Two surfaces, two answers, only one of them right.

The server also wasn't surfacing per-row size-variant data, so clients that wanted to render the variant strip on family-aggregated rows had to recompute the grouping themselves.

## Solution

The catalog response now carries `fit` and `size_variants` per row, computed once per request from the host the server is actually running on. The TUI catalog screen and the HTTP handler share a single memory probe, so the same model classifies the same way in either surface. Clients render whatever the server sends; chip semantics no longer depend on where the client runs.
