### PR TITLE
Expand frontier model support

### DIFF
--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -452,11 +452,17 @@ SETTINGS_MAP: dict[str, SettingDef] = {
             "recursive crawls. One per line."
         ),
     ),
-    "openai_api_key": SettingDef(
+    "openrouter_api_key": SettingDef(
         str,
         nullable=False,
         group="API-Keys",
-        help_text="OpenAI API key (enables frontier models in chat picker)",
+        help_text="OpenRouter API key (enables frontier models in chat picker)",
+    ),
+    "gemini_api_key": SettingDef(
+        str,
+        nullable=False,
+        group="API-Keys",
+        help_text="Google Gemini API key (enables frontier models in chat picker)",
     ),
     "anthropic_api_key": SettingDef(
         str,
@@ -464,11 +470,23 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group="API-Keys",
         help_text="Anthropic API key (enables frontier models in chat picker)",
     ),
-    "gemini_api_key": SettingDef(
+    "openai_api_key": SettingDef(
         str,
         nullable=False,
         group="API-Keys",
-        help_text="Google Gemini API key (enables frontier models in chat picker)",
+        help_text="OpenAI API key (enables frontier models in chat picker)",
+    ),
+    "mistral_api_key": SettingDef(
+        str,
+        nullable=False,
+        group="API-Keys",
+        help_text="Mistral API key (enables frontier models in chat picker)",
+    ),
+    "deepseek_api_key": SettingDef(
+        str,
+        nullable=False,
+        group="API-Keys",
+        help_text="DeepSeek API key (enables frontier models in chat picker)",
     ),
     "chunk_size": SettingDef(
         int,

--- a/src/lilbee/cli/tui/screens/catalog_grouping.py
+++ b/src/lilbee/cli/tui/screens/catalog_grouping.py
@@ -61,14 +61,24 @@ def for_you_sort_key(row: LocalCatalogRow) -> tuple[int, str]:
 def group_frontier_rows(
     frontier_rows: list[FrontierCatalogRow],
 ) -> list[ModelListSection]:
-    """Group frontier rows into provider-headed sections, alphabetical within."""
+    """Group frontier rows into provider-headed sections.
+
+    Section order follows :data:`PROVIDER_KEYS` (the canonical display
+    order); providers absent from PROVIDER_KEYS land at the tail in
+    alphabetical order. Rows within each section are alphabetical.
+    """
     if not frontier_rows:
         return []
+    from lilbee.providers.sdk_backend import PROVIDER_KEYS
+
     per_provider: dict[str, list[FrontierCatalogRow]] = {}
     for row in frontier_rows:
         per_provider.setdefault(row.provider, []).append(row)
+    canonical_order = [label for _, _, _, label in PROVIDER_KEYS]
+    ordered = [p for p in canonical_order if p in per_provider]
+    extras = sorted(set(per_provider) - set(canonical_order))
     sections: list[ModelListSection] = []
-    for provider in sorted(per_provider):
+    for provider in [*ordered, *extras]:
         rows = sorted(per_provider[provider], key=lambda r: r.name.lower())
         sections.append(ModelListSection(heading=provider, rows=list(rows)))
     return sections

--- a/src/lilbee/core/config/keys.py
+++ b/src/lilbee/core/config/keys.py
@@ -4,6 +4,11 @@ Anything that wants to react to provider availability (e.g. the catalog
 and model picker refreshing their API-model rows after a key is added)
 keys off this set so the list does not drift from the canonical Config
 declaration.
+
+Layering note: ``core`` cannot import from ``providers``; that is why
+the provider-specific entries are listed here rather than derived from
+``providers.sdk_backend.API_KEY_FIELDS``. Keep both in sync when adding
+a new provider.
 """
 
 from __future__ import annotations
@@ -11,8 +16,11 @@ from __future__ import annotations
 PROVIDER_API_KEYS: frozenset[str] = frozenset(
     {
         "llm_api_key",
-        "openai_api_key",
-        "anthropic_api_key",
+        "openrouter_api_key",
         "gemini_api_key",
+        "anthropic_api_key",
+        "openai_api_key",
+        "mistral_api_key",
+        "deepseek_api_key",
     }
 )

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -119,9 +119,12 @@ class Config(BaseSettings):
     llm_provider: str = ConfigField(default="auto", writable=True)
     remote_base_url: str = ConfigField(default="http://localhost:11434", writable=True)
     llm_api_key: str = ConfigField(default="", writable=True, write_only=True)
-    openai_api_key: str = ConfigField(default="", writable=True, write_only=True)
-    anthropic_api_key: str = ConfigField(default="", writable=True, write_only=True)
+    openrouter_api_key: str = ConfigField(default="", writable=True, write_only=True)
     gemini_api_key: str = ConfigField(default="", writable=True, write_only=True)
+    anthropic_api_key: str = ConfigField(default="", writable=True, write_only=True)
+    openai_api_key: str = ConfigField(default="", writable=True, write_only=True)
+    mistral_api_key: str = ConfigField(default="", writable=True, write_only=True)
+    deepseek_api_key: str = ConfigField(default="", writable=True, write_only=True)
 
     # Retrieval quality knobs.
 

--- a/src/lilbee/providers/backend_names.py
+++ b/src/lilbee/providers/backend_names.py
@@ -12,7 +12,10 @@ class BackendName(StrEnum):
     """Display name shown in the UI for whichever backend the SDK is talking to."""
 
     OLLAMA = "Ollama"
-    OPENAI = "OpenAI"
-    ANTHROPIC = "Anthropic"
+    OPENROUTER = "OpenRouter"
     GEMINI = "Gemini"
+    ANTHROPIC = "Anthropic"
+    OPENAI = "OpenAI"
+    MISTRAL = "Mistral"
+    DEEPSEEK = "DeepSeek"
     REMOTE = "Remote"

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -335,15 +335,24 @@ class LitellmSdkBackend:
 
     @staticmethod
     def _all_chat_models_for(provider: str, litellm: Any) -> list[str]:
-        """Filter litellm's catalog down to chat-mode entries for ``provider``."""
+        """Filter litellm's catalog down to chat-mode entries for ``provider``.
+
+        litellm's catalog stores some providers' models bare (``gpt-4o``)
+        and others prefixed (``mistral/codestral-latest``,
+        ``openrouter/anthropic/claude-3.5-sonnet``). Strip any leading
+        ``{provider}/`` so callers see uniformly bare names; the canonical
+        ``provider/name`` form is reapplied at the routing layer via
+        :meth:`ProviderModelRef.for_openai_prefix`.
+        """
         models = litellm.models_by_provider.get(provider, set())
-        chat_models: list[str] = []
-        for model_name in sorted(models):
+        prefix = f"{provider}/"
+        bare: set[str] = set()
+        for model_name in models:
             info = litellm.model_cost.get(model_name, {})
             if info.get("mode") != "chat":
                 continue
-            chat_models.append(model_name)
-        return chat_models
+            bare.add(model_name.removeprefix(prefix))
+        return sorted(bare)
 
     @staticmethod
     def _list_ollama_models(base_url: str) -> list[str]:

--- a/src/lilbee/providers/model_ref.py
+++ b/src/lilbee/providers/model_ref.py
@@ -12,7 +12,16 @@ from typing import Any
 
 from lilbee.providers.base import filter_options
 
-_API_PROVIDERS = {"openai", "anthropic", "gemini"}
+_API_PROVIDERS = frozenset(
+    {
+        "openrouter",
+        "gemini",
+        "anthropic",
+        "openai",
+        "mistral",
+        "deepseek",
+    }
+)
 
 # All provider prefixes that route a ref away from the local registry.
 # Includes API providers and ollama (which keeps its own name:tag shape).
@@ -26,7 +35,7 @@ class ProviderModelRef:
     """Parsed model reference with provider routing information."""
 
     raw: str
-    provider: str  # "local", "ollama", "openai", "anthropic", "gemini"
+    provider: str  # "local", "ollama", or any value in PROVIDER_PREFIXES
     name: str  # provider-specific name with tag normalization applied
 
     @property
@@ -80,14 +89,14 @@ def parse_model_ref(raw: str) -> ProviderModelRef:
     """Classify a model string by its prefix and return the routing ref.
 
     Native HuggingFace refs are ``<org>/<repo>/<file>.gguf``. Remote
-    providers use prefixes: ``openai/``, ``anthropic/``, ``gemini/``,
-    ``ollama/``.
+    providers use prefixes from :data:`PROVIDER_PREFIXES` (``ollama/``
+    plus every API provider listed there).
     """
     if "/" not in raw:
+        known = ", ".join(f"{p}/" for p in sorted(PROVIDER_PREFIXES))
         raise ValueError(
             f"Model ref {raw!r} must be a HuggingFace ref "
-            "('<org>/<repo>/<filename>.gguf') or carry a provider prefix "
-            "('ollama/', 'openai/', 'anthropic/', 'gemini/')."
+            f"('<org>/<repo>/<filename>.gguf') or carry a known provider prefix ({known})."
         )
     prefix, rest = raw.split("/", 1)
     if prefix in _API_PROVIDERS:

--- a/src/lilbee/providers/sdk_backend.py
+++ b/src/lilbee/providers/sdk_backend.py
@@ -25,11 +25,16 @@ if TYPE_CHECKING:
 
 # Single source of truth for per-provider API key configuration.
 # Maps (provider_name, config_field, env_var, display_label). Backend-agnostic:
-# OpenAI-compatible SDKs all read these env vars at call time.
+# OpenAI-compatible SDKs all read these env vars at call time. Tuple order
+# is the canonical display order downstream consumers (TUI grouping, catalog
+# sections) honor when surfacing providers.
 PROVIDER_KEYS: tuple[tuple[str, str, str, str], ...] = (
-    ("openai", "openai_api_key", "OPENAI_API_KEY", "OpenAI"),
-    ("anthropic", "anthropic_api_key", "ANTHROPIC_API_KEY", "Anthropic"),
+    ("openrouter", "openrouter_api_key", "OPENROUTER_API_KEY", "OpenRouter"),
     ("gemini", "gemini_api_key", "GEMINI_API_KEY", "Gemini"),
+    ("anthropic", "anthropic_api_key", "ANTHROPIC_API_KEY", "Anthropic"),
+    ("openai", "openai_api_key", "OPENAI_API_KEY", "OpenAI"),
+    ("mistral", "mistral_api_key", "MISTRAL_API_KEY", "Mistral"),
+    ("deepseek", "deepseek_api_key", "DEEPSEEK_API_KEY", "DeepSeek"),
 )
 
 # Derived set of config field names (for checking which updates touch API keys).
@@ -59,10 +64,13 @@ def get_provider_api_key(provider: str) -> str | None:
 _BACKEND_URL_PATTERNS: tuple[tuple[str, BackendName], ...] = (
     ("localhost:11434", BackendName.OLLAMA),
     ("ollama", BackendName.OLLAMA),
+    ("openrouter", BackendName.OPENROUTER),
     ("openai", BackendName.OPENAI),
     ("anthropic", BackendName.ANTHROPIC),
     ("googleapis", BackendName.GEMINI),
     ("gemini", BackendName.GEMINI),
+    ("mistral", BackendName.MISTRAL),
+    ("deepseek", BackendName.DEEPSEEK),
 )
 
 

--- a/tests/test_catalog_frontier.py
+++ b/tests/test_catalog_frontier.py
@@ -113,18 +113,43 @@ class TestGroupRowsForGrid:
 
 
 class TestGroupFrontierRows:
-    def test_provider_sections_alphabetical_within_group(self) -> None:
+    def test_provider_sections_follow_provider_keys_order(self) -> None:
+        """Sections appear in PROVIDER_KEYS order; rows alphabetical within."""
         from lilbee.cli.tui.screens.catalog_grouping import group_frontier_rows
 
         rows = [
             _frontier("gpt-4o", provider="OpenAI"),
             _frontier("gemini-2.0-flash", provider="Gemini"),
             _frontier("gemini-1.5-pro", provider="Gemini"),
+            _frontier("claude-3-5-sonnet", provider="Anthropic"),
+            _frontier("openrouter/anthropic/claude-3-haiku", provider="OpenRouter"),
         ]
         sections = group_frontier_rows(rows)
-        assert [s.heading for s in sections] == ["Gemini", "OpenAI"]
-        assert [r.name for r in sections[0].rows] == ["gemini-1.5-pro", "gemini-2.0-flash"]
-        assert [r.name for r in sections[1].rows] == ["gpt-4o"]
+        # Canonical display order from PROVIDER_KEYS.
+        assert [s.heading for s in sections] == [
+            "OpenRouter",
+            "Gemini",
+            "Anthropic",
+            "OpenAI",
+        ]
+        gemini_section = next(s for s in sections if s.heading == "Gemini")
+        assert [r.name for r in gemini_section.rows] == [
+            "gemini-1.5-pro",
+            "gemini-2.0-flash",
+        ]
+
+    def test_unknown_provider_appears_at_tail_alphabetically(self) -> None:
+        """Providers absent from PROVIDER_KEYS sort to the tail alphabetically."""
+        from lilbee.cli.tui.screens.catalog_grouping import group_frontier_rows
+
+        rows = [
+            _frontier("custom-a", provider="ZZZ-Custom"),
+            _frontier("gpt-4o", provider="OpenAI"),
+            _frontier("custom-b", provider="AAA-Custom"),
+        ]
+        sections = group_frontier_rows(rows)
+        # OpenAI is canonical, AAA-Custom and ZZZ-Custom are extras (alphabetical).
+        assert [s.heading for s in sections] == ["OpenAI", "AAA-Custom", "ZZZ-Custom"]
 
     def test_empty_input_returns_empty_list(self) -> None:
         from lilbee.cli.tui.screens.catalog_grouping import group_frontier_rows

--- a/tests/test_model_ref.py
+++ b/tests/test_model_ref.py
@@ -49,6 +49,26 @@ class TestParseModelRef:
         assert ref.provider == "gemini"
         assert ref.name == "gemini-2.5-pro"
 
+    def test_openrouter_prefix_carries_nested_path(self) -> None:
+        """OpenRouter model ids embed a nested path; only the leading segment is the provider."""
+        ref = parse_model_ref("openrouter/anthropic/claude-3.5-sonnet")
+        assert ref.provider == "openrouter"
+        assert ref.name == "anthropic/claude-3.5-sonnet"
+        assert ref.is_api is True
+        assert ref.for_openai_prefix() == "openrouter/anthropic/claude-3.5-sonnet"
+
+    def test_mistral_prefix(self) -> None:
+        ref = parse_model_ref("mistral/codestral-latest")
+        assert ref.provider == "mistral"
+        assert ref.name == "codestral-latest"
+        assert ref.is_api is True
+
+    def test_deepseek_prefix(self) -> None:
+        ref = parse_model_ref("deepseek/deepseek-chat")
+        assert ref.provider == "deepseek"
+        assert ref.name == "deepseek-chat"
+        assert ref.is_api is True
+
     def test_bare_name_tag_rejected(self) -> None:
         """A bare ``name:tag`` lacks a provider prefix and is rejected."""
         with pytest.raises(ValueError, match="must be a HuggingFace ref"):
@@ -146,6 +166,23 @@ class TestFormatRemoteRef:
             provider="Ollama",
         )
         assert format_remote_ref(model.name, model.provider) == "ollama/qwen3:8b"
+
+    def test_openrouter_with_nested_path(self) -> None:
+        """OpenRouter model ids carry a vendor/model path that must round-trip."""
+        ref = format_remote_ref("anthropic/claude-3.5-sonnet", "OpenRouter")
+        assert ref == "openrouter/anthropic/claude-3.5-sonnet"
+        # Round-trip back through the parser without double-prefixing.
+        parsed = parse_model_ref(ref)
+        assert parsed.provider == "openrouter"
+        assert parsed.for_openai_prefix() == ref
+
+    def test_mistral_provider(self) -> None:
+        ref = format_remote_ref("codestral-latest", "Mistral")
+        assert ref == "mistral/codestral-latest"
+
+    def test_deepseek_provider(self) -> None:
+        ref = format_remote_ref("deepseek-chat", "DeepSeek")
+        assert ref == "deepseek/deepseek-chat"
 
 
 class TestTranslateOptions:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1366,6 +1366,79 @@ class TestRoutingProvider:
 # ---------------------------------------------------------------------------
 
 
+class TestAllChatModelsFor:
+    """Prefix-stripping and chat-mode filtering in litellm catalog reads."""
+
+    def _stub_litellm(
+        self, models_by_provider: dict[str, set[str]], model_cost: dict[str, dict[str, str]]
+    ) -> mock.MagicMock:
+        stub = mock.MagicMock()
+        stub.models_by_provider = models_by_provider
+        stub.model_cost = model_cost
+        return stub
+
+    def test_strips_provider_prefix_from_catalog_names(self) -> None:
+        """Names like ``mistral/codestral-latest`` come back bare."""
+        from lilbee.providers.litellm_sdk import LitellmSdkBackend
+
+        litellm = self._stub_litellm(
+            {"mistral": {"mistral/codestral-latest", "mistral/mistral-large"}},
+            {
+                "mistral/codestral-latest": {"mode": "chat"},
+                "mistral/mistral-large": {"mode": "chat"},
+            },
+        )
+        result = LitellmSdkBackend._all_chat_models_for("mistral", litellm)
+        assert result == ["codestral-latest", "mistral-large"]
+
+    def test_passes_through_bare_names_unchanged(self) -> None:
+        """OpenAI/Anthropic/Gemini names already lack a prefix and round-trip."""
+        from lilbee.providers.litellm_sdk import LitellmSdkBackend
+
+        litellm = self._stub_litellm(
+            {"openai": {"gpt-4o", "gpt-4o-mini"}},
+            {"gpt-4o": {"mode": "chat"}, "gpt-4o-mini": {"mode": "chat"}},
+        )
+        result = LitellmSdkBackend._all_chat_models_for("openai", litellm)
+        assert result == ["gpt-4o", "gpt-4o-mini"]
+
+    def test_dedupes_bare_and_prefixed_duplicates(self) -> None:
+        """``deepseek-chat`` and ``deepseek/deepseek-chat`` collapse to one entry."""
+        from lilbee.providers.litellm_sdk import LitellmSdkBackend
+
+        litellm = self._stub_litellm(
+            {"deepseek": {"deepseek-chat", "deepseek/deepseek-chat", "deepseek-reasoner"}},
+            {
+                "deepseek-chat": {"mode": "chat"},
+                "deepseek/deepseek-chat": {"mode": "chat"},
+                "deepseek-reasoner": {"mode": "chat"},
+            },
+        )
+        result = LitellmSdkBackend._all_chat_models_for("deepseek", litellm)
+        assert result == ["deepseek-chat", "deepseek-reasoner"]
+
+    def test_filters_out_non_chat_modes(self) -> None:
+        """Embedding-mode entries never appear in the chat catalog."""
+        from lilbee.providers.litellm_sdk import LitellmSdkBackend
+
+        litellm = self._stub_litellm(
+            {"mistral": {"mistral/mistral-large", "mistral/mistral-embed"}},
+            {
+                "mistral/mistral-large": {"mode": "chat"},
+                "mistral/mistral-embed": {"mode": "embedding"},
+            },
+        )
+        result = LitellmSdkBackend._all_chat_models_for("mistral", litellm)
+        assert result == ["mistral-large"]
+
+    def test_unknown_provider_returns_empty(self) -> None:
+        """A provider missing from the catalog yields ``[]`` without raising."""
+        from lilbee.providers.litellm_sdk import LitellmSdkBackend
+
+        litellm = self._stub_litellm({}, {})
+        assert LitellmSdkBackend._all_chat_models_for("nonexistent", litellm) == []
+
+
 class TestLitellmResponseView:
     """The shape adapter that owns getattr-default extraction over litellm responses."""
 
@@ -2359,6 +2432,29 @@ class TestInjectProviderKeys:
         import os
 
         assert os.environ["OPENAI_API_KEY"] == "sk-existing"
+
+    def test_every_provider_key_routes_to_its_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each PROVIDER_KEYS entry round-trips cfg field -> env var.
+
+        Iterates the canonical PROVIDER_KEYS tuple so a newly added
+        provider is exercised here without a hand-edited assertion.
+        """
+        import os
+
+        from lilbee.providers.sdk_backend import PROVIDER_KEYS
+        from lilbee.providers.sdk_llm_provider import inject_provider_keys
+
+        marker = "sk-pk-{}"
+        for _prov, cfg_field, env_var, _label in PROVIDER_KEYS:
+            monkeypatch.delenv(env_var, raising=False)
+            setattr(cfg, cfg_field, marker.format(env_var))
+
+        inject_provider_keys()
+
+        for _prov, _cfg_field, env_var, _label in PROVIDER_KEYS:
+            assert os.environ.get(env_var) == marker.format(env_var)
 
 
 class TestLiteLLMListModelsRouting:


### PR DESCRIPTION
## Problem

The chat picker only knew about a small set of frontier API providers, so users with accounts at additional litellm-native providers had no way to wire those keys in or pick from those catalogs. The Frontier section also sorted alphabetically, so the display order couldn't reflect a stable preference.

## Solution

Expand frontier model support to cover additional litellm-native providers. The Frontier section in the catalog now follows the canonical display order from PROVIDER_KEYS instead of sorting alphabetically, and the litellm catalog reader strips provider prefixes at the boundary so nested vendor/model paths round-trip through the chat picker without double-prefixing.