### PR TITLE
Round recommended-RAM in catalog so '12.45000000000001 GB' stops appearing

### DIFF
--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -166,7 +166,7 @@ class HfClient:
                     hf_repo=item.id,
                     gguf_filename="*.gguf",
                     size_gb=size_gb,
-                    min_ram_gb=max(2.0, size_gb * 1.5),
+                    min_ram_gb=round(max(2.0, size_gb * 1.5), 1),
                     description=card_desc[:120] if card_desc else "",
                     featured=False,
                     downloads=item.downloads or 0,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -332,7 +332,7 @@ class TestFetchHfModels:
         models = page.models
         # gguf.total = 7_000_000_000 bytes -> ~6.5 GB
         assert models[0].size_gb == round(7_000_000_000 / (1024**3), 1)
-        assert models[0].min_ram_gb == max(2.0, models[0].size_gb * 1.5)
+        assert models[0].min_ram_gb == round(max(2.0, models[0].size_gb * 1.5), 1)
 
     def test_empty_gguf_meta_falls_back_to_siblings(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_resp = httpx.Response(200, json=self._mock_hf_response())


### PR DESCRIPTION
Catalog rows for HuggingFace GGUF models are showing recommended-RAM values like 12.45000000000001 GB. The wire field is computed as size_gb * 1.5 and the binary float artefact is sent verbatim, so every client (plugin, TUI, future SDK consumer) has to defend against it.

Round once at the source. size_gb is already rounded to 1 decimal place; mirror that for min_ram_gb so the catalog response carries a clean number.

Reported during plugin QA after the catalog redesign made the field prominent on each card.