### PR TITLE
Configurable reasoning cap; on cap, force the model to answer

### DIFF
--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -545,7 +545,7 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group="Generation",
         help_text=(
             "Maximum reasoning characters before lilbee forces the model to answer "
-            "(per-model overrides apply on top)"
+            "(0 = unlimited; per-model overrides apply on top)"
         ),
     ),
     "model_keep_alive": SettingDef(

--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -539,6 +539,15 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group="Generation",
         help_text="Hard cap on generated tokens per response (blank = no cap)",
     ),
+    "max_reasoning_chars": SettingDef(
+        int,
+        nullable=False,
+        group="Generation",
+        help_text=(
+            "Maximum reasoning characters before lilbee forces the model to answer "
+            "(per-model overrides apply on top)"
+        ),
+    ),
     "model_keep_alive": SettingDef(
         int,
         nullable=False,

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -194,7 +194,8 @@ class Config(BaseSettings):
 
     # Maximum reasoning characters before lilbee forces the model to answer.
     # Per-model overrides apply on top of this default. Approx N/4 tokens.
-    max_reasoning_chars: int = ConfigField(default=64_000, ge=512, writable=True)
+    # 0 disables the cap (unlimited reasoning; accept the runaway-loop risk).
+    max_reasoning_chars: int = ConfigField(default=64_000, ge=0, writable=True)
 
     # Web crawling.
 

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -192,6 +192,10 @@ class Config(BaseSettings):
     # if False, strip it silently.
     show_reasoning: bool = ConfigField(default=False, writable=True)
 
+    # Maximum reasoning characters before lilbee forces the model to answer.
+    # Per-model overrides apply on top of this default. Approx N/4 tokens.
+    max_reasoning_chars: int = ConfigField(default=64_000, ge=512, writable=True)
+
     # Web crawling.
 
     # Optional global ceilings. None = no ceiling.

--- a/src/lilbee/providers/model_defaults.py
+++ b/src/lilbee/providers/model_defaults.py
@@ -22,6 +22,7 @@ _KNOWN_PARAM_TYPES: dict[str, type] = {
     "repeat_penalty": float,
     "num_ctx": int,
     "max_tokens": int,
+    "max_reasoning_chars": int,
 }
 
 # GGUF metadata keys mapped to ModelDefaults field names
@@ -30,6 +31,7 @@ _GGUF_KEY_MAP: dict[str, str] = {
     "general.top_p": "top_p",
     "general.top_k": "top_k",
     "general.repeat_penalty": "repeat_penalty",
+    "general.max_reasoning_chars": "max_reasoning_chars",
 }
 
 # ``str.split(None, 1)`` returns at most this many tokens for valid ``key value`` lines.
@@ -46,6 +48,7 @@ class ModelDefaults:
     repeat_penalty: float | None = None
     num_ctx: int | None = None
     max_tokens: int | None = None
+    max_reasoning_chars: int | None = None
 
 
 class _DefaultsCache:

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Generator
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import BaseModel
 from typing_extensions import TypedDict
@@ -19,7 +19,7 @@ from lilbee.data.store import (
     Store,
     cosine_sim,
 )
-from lilbee.providers.base import ClosableIterator, LLMProvider
+from lilbee.providers.base import LLMProvider
 from lilbee.retrieval.embedder import Embedder
 from lilbee.retrieval.query.dedup import (
     _greedy_cover,
@@ -497,25 +497,36 @@ class Searcher:
         options: dict[str, Any] | None,
     ) -> Generator[StreamToken, None, None]:
         """Streaming branch with the general system prompt (no RAG context)."""
-        from lilbee.retrieval.reasoning import StreamToken, filter_reasoning
+        from lilbee.retrieval.reasoning import (
+            CapNotice,
+            StreamToken,
+            effective_reasoning_cap,
+            stream_chat_with_cap,
+        )
 
         messages = self._direct_messages(question, history)
         provider_messages = self._messages_for_provider(messages)
         opts = options if options is not None else self._config.generation_options()
-        raw = self._provider.chat(provider_messages, stream=True, options=opts or None)
         try:
-            for st in filter_reasoning(
-                raw,
-                show=self._config.show_reasoning,
-                cap_chars=self._config.max_reasoning_chars,
+            for event in stream_chat_with_cap(
+                self._provider,
+                cast("list[dict[str, Any]]", provider_messages),
+                options=opts,
+                model=self._config.chat_model,
+                show_reasoning=self._config.show_reasoning,
+                cap_chars=effective_reasoning_cap(),
             ):
-                if st.content:
-                    yield st
+                if isinstance(event, CapNotice):
+                    yield StreamToken(
+                        content=f"\n[reasoning capped at {event.cap_chars} chars, "
+                        "asking for a direct answer]\n",
+                        is_reasoning=True,
+                    )
+                    continue
+                if event.content:
+                    yield event
         except (ConnectionError, OSError) as exc:
             yield StreamToken(content=f"\n\n[Connection lost: {exc}]", is_reasoning=False)
-        finally:
-            if isinstance(raw, ClosableIterator):
-                raw.close()
 
     def ask_stream(
         self,
@@ -527,7 +538,12 @@ class Searcher:
         chunk_type: str | None = None,
     ) -> Generator[StreamToken, None, None]:
         """Stream answer tokens with citations appended at the end."""
-        from lilbee.retrieval.reasoning import StreamToken, filter_reasoning
+        from lilbee.retrieval.reasoning import (
+            CapNotice,
+            StreamToken,
+            effective_reasoning_cap,
+            stream_chat_with_cap,
+        )
 
         if (
             self._config.chat_mode == ChatMode.CHAT.value
@@ -543,22 +559,29 @@ class Searcher:
         results, messages = rag
         provider_messages = self._messages_for_provider(messages)
         opts = options if options is not None else self._config.generation_options()
-        raw_stream = self._provider.chat(provider_messages, stream=True, options=opts or None)
         answer_parts: list[str] = []
         try:
-            for st in filter_reasoning(
-                raw_stream,
-                show=self._config.show_reasoning,
-                cap_chars=self._config.max_reasoning_chars,
+            for event in stream_chat_with_cap(
+                self._provider,
+                cast("list[dict[str, Any]]", provider_messages),
+                options=opts,
+                model=self._config.chat_model,
+                show_reasoning=self._config.show_reasoning,
+                cap_chars=effective_reasoning_cap(),
             ):
-                if st.content:
-                    answer_parts.append(st.content)
-                    yield st
+                if isinstance(event, CapNotice):
+                    yield StreamToken(
+                        content=f"\n[reasoning capped at {event.cap_chars} chars, "
+                        "asking for a direct answer]\n",
+                        is_reasoning=True,
+                    )
+                    continue
+                if event.content:
+                    if not event.is_reasoning:
+                        answer_parts.append(event.content)
+                    yield event
         except (ConnectionError, OSError) as exc:
             yield StreamToken(content=f"\n\n[Connection lost: {exc}]", is_reasoning=False)
-        finally:
-            if isinstance(raw_stream, ClosableIterator):
-                raw_stream.close()
         # LLM-generated citation blocks in streamed tokens cannot be
         # retroactively stripped. The system prompt discourages them; this
         # only filters the code-appended Sources block to cited chunks.

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -504,7 +504,11 @@ class Searcher:
         opts = options if options is not None else self._config.generation_options()
         raw = self._provider.chat(provider_messages, stream=True, options=opts or None)
         try:
-            for st in filter_reasoning(raw, show=self._config.show_reasoning):
+            for st in filter_reasoning(
+                raw,
+                show=self._config.show_reasoning,
+                cap_chars=self._config.max_reasoning_chars,
+            ):
                 if st.content:
                     yield st
         except (ConnectionError, OSError) as exc:
@@ -542,7 +546,11 @@ class Searcher:
         raw_stream = self._provider.chat(provider_messages, stream=True, options=opts or None)
         answer_parts: list[str] = []
         try:
-            for st in filter_reasoning(raw_stream, show=self._config.show_reasoning):
+            for st in filter_reasoning(
+                raw_stream,
+                show=self._config.show_reasoning,
+                cap_chars=self._config.max_reasoning_chars,
+            ):
                 if st.content:
                     answer_parts.append(st.content)
                     yield st

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -36,11 +36,16 @@ from lilbee.retrieval.query.formatting import (
     strip_llm_citations,
 )
 from lilbee.retrieval.query.tokenize import _idf_weights, _tokenize
-from lilbee.retrieval.reasoning import strip_reasoning
+from lilbee.retrieval.reasoning import (
+    StreamToken,
+    cap_events_as_stream_tokens,
+    effective_reasoning_cap,
+    stream_chat_with_cap,
+    strip_reasoning,
+)
 
 if TYPE_CHECKING:
     from lilbee.retrieval.concepts import ConceptGraph
-    from lilbee.retrieval.reasoning import StreamToken
     from lilbee.retrieval.reranker import Reranker
 
 log = logging.getLogger(__name__)
@@ -497,34 +502,19 @@ class Searcher:
         options: dict[str, Any] | None,
     ) -> Generator[StreamToken, None, None]:
         """Streaming branch with the general system prompt (no RAG context)."""
-        from lilbee.retrieval.reasoning import (
-            CapNotice,
-            StreamToken,
-            effective_reasoning_cap,
-            stream_chat_with_cap,
-        )
-
         messages = self._direct_messages(question, history)
         provider_messages = self._messages_for_provider(messages)
         opts = options if options is not None else self._config.generation_options()
+        events = stream_chat_with_cap(
+            self._provider,
+            cast("list[dict[str, Any]]", provider_messages),
+            options=opts,
+            model=self._config.chat_model,
+            show_reasoning=self._config.show_reasoning,
+            cap_chars=effective_reasoning_cap(),
+        )
         try:
-            for event in stream_chat_with_cap(
-                self._provider,
-                cast("list[dict[str, Any]]", provider_messages),
-                options=opts,
-                model=self._config.chat_model,
-                show_reasoning=self._config.show_reasoning,
-                cap_chars=effective_reasoning_cap(),
-            ):
-                if isinstance(event, CapNotice):
-                    yield StreamToken(
-                        content=f"\n[reasoning capped at {event.cap_chars} chars, "
-                        "asking for a direct answer]\n",
-                        is_reasoning=True,
-                    )
-                    continue
-                if event.content:
-                    yield event
+            yield from cap_events_as_stream_tokens(events)
         except (ConnectionError, OSError) as exc:
             yield StreamToken(content=f"\n\n[Connection lost: {exc}]", is_reasoning=False)
 
@@ -538,13 +528,6 @@ class Searcher:
         chunk_type: str | None = None,
     ) -> Generator[StreamToken, None, None]:
         """Stream answer tokens with citations appended at the end."""
-        from lilbee.retrieval.reasoning import (
-            CapNotice,
-            StreamToken,
-            effective_reasoning_cap,
-            stream_chat_with_cap,
-        )
-
         if (
             self._config.chat_mode == ChatMode.CHAT.value
             or not self._embedder.embedding_available()
@@ -560,26 +543,19 @@ class Searcher:
         provider_messages = self._messages_for_provider(messages)
         opts = options if options is not None else self._config.generation_options()
         answer_parts: list[str] = []
+        events = stream_chat_with_cap(
+            self._provider,
+            cast("list[dict[str, Any]]", provider_messages),
+            options=opts,
+            model=self._config.chat_model,
+            show_reasoning=self._config.show_reasoning,
+            cap_chars=effective_reasoning_cap(),
+        )
         try:
-            for event in stream_chat_with_cap(
-                self._provider,
-                cast("list[dict[str, Any]]", provider_messages),
-                options=opts,
-                model=self._config.chat_model,
-                show_reasoning=self._config.show_reasoning,
-                cap_chars=effective_reasoning_cap(),
-            ):
-                if isinstance(event, CapNotice):
-                    yield StreamToken(
-                        content=f"\n[reasoning capped at {event.cap_chars} chars, "
-                        "asking for a direct answer]\n",
-                        is_reasoning=True,
-                    )
-                    continue
-                if event.content:
-                    if not event.is_reasoning:
-                        answer_parts.append(event.content)
-                    yield event
+            for token in cap_events_as_stream_tokens(events):
+                if not token.is_reasoning:
+                    answer_parts.append(token.content)
+                yield token
         except (ConnectionError, OSError) as exc:
             yield StreamToken(content=f"\n\n[Connection lost: {exc}]", is_reasoning=False)
         # LLM-generated citation blocks in streamed tokens cannot be

--- a/src/lilbee/retrieval/reasoning.py
+++ b/src/lilbee/retrieval/reasoning.py
@@ -2,21 +2,24 @@
 
 Reasoning models (Qwen3, DeepSeek-R1) wrap their thinking process in
 ``<think>...</think>`` tags. This module provides a stateful filter that
-classifies tokens as reasoning or response content.
+classifies tokens as reasoning or response content and notifies the
+caller when reasoning exceeds a caller-supplied cap.
 """
 
 from __future__ import annotations
 
 import contextlib
 import re
-from collections.abc import Generator, Iterator
-from dataclasses import dataclass
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
 
 from lilbee.providers.base import ClosableIterator
 
 _OPEN_TAG = "<think>"
 _CLOSE_TAG = "</think>"
 _THINK_BLOCK_RE = re.compile(r"<think>[\s\S]*?</think>\s*|<think>[\s\S]*$")
+_PROGRESS_TICK_CHARS = 256
+"""Coarseness of the progress callback: fire when reasoning grows by at least this many chars."""
 
 
 @dataclass
@@ -27,14 +30,19 @@ class StreamToken:
     is_reasoning: bool
 
 
+@dataclass
 class _TagParser:
     """Stateful parser that tracks whether we're inside a thinking block."""
 
-    def __init__(self, *, show: bool) -> None:
-        self.show = show
-        self.buf = ""
-        self.in_thinking = False
-        self.reasoning_chars = 0
+    show: bool
+    buf: str = ""
+    in_thinking: bool = False
+    reasoning_chars: int = 0
+    reasoning_text: list[str] = field(default_factory=list)
+
+    def captured_reasoning(self) -> str:
+        """Concatenated reasoning text seen so far, regardless of ``show``."""
+        return "".join(self.reasoning_text)
 
     def feed(self, token: str) -> list[StreamToken]:
         """Feed a token and return any complete StreamTokens."""
@@ -43,7 +51,7 @@ class _TagParser:
         while self.buf:
             emitted = self._process_thinking() if self.in_thinking else self._process_normal()
             if emitted is None:
-                break  # waiting for more data (partial tag)
+                break
             if emitted.content:
                 result.append(emitted)
         return result
@@ -53,26 +61,29 @@ class _TagParser:
         if not self.buf:
             return None
         if self.in_thinking:
+            self._absorb_reasoning(self.buf)
             return StreamToken(content=self.buf, is_reasoning=True) if self.show else None
         return StreamToken(content=self.buf, is_reasoning=False)
 
+    def _absorb_reasoning(self, content: str) -> None:
+        self.reasoning_chars += len(content)
+        self.reasoning_text.append(content)
+
     def _process_thinking(self) -> StreamToken | None:
-        """Process buffer while inside a <think> block. Returns None if waiting."""
         close_idx = self.buf.find(_CLOSE_TAG)
         if close_idx == -1:
             if _could_be_partial(_CLOSE_TAG, self.buf):
-                return None  # wait for more
+                return None
             content = self.buf
-            self.reasoning_chars += len(content)
+            self._absorb_reasoning(content)
             self.buf = ""
             return (
                 StreamToken(content=content, is_reasoning=True)
                 if self.show
                 else StreamToken(content="", is_reasoning=True)
             )
-
         thinking_content = self.buf[:close_idx]
-        self.reasoning_chars += len(thinking_content)
+        self._absorb_reasoning(thinking_content)
         self.buf = self.buf[close_idx + len(_CLOSE_TAG) :]
         self.in_thinking = False
         if thinking_content and self.show:
@@ -80,76 +91,62 @@ class _TagParser:
         return StreamToken(content="", is_reasoning=True)
 
     def _process_normal(self) -> StreamToken | None:
-        """Process buffer while outside thinking blocks. Returns None if waiting."""
         open_idx = self.buf.find(_OPEN_TAG)
         if open_idx == -1:
             if _could_be_partial(_OPEN_TAG, self.buf):
-                return None  # wait for more
+                return None
             content = self.buf
             self.buf = ""
             return StreamToken(content=content, is_reasoning=False)
-
         before = self.buf[:open_idx]
         self.buf = self.buf[open_idx + len(_OPEN_TAG) :]
         self.in_thinking = True
         return StreamToken(content=before, is_reasoning=False)
 
 
-_MAX_REASONING_CHARS = 16_000  # ~4K tokens, safety limit for runaway reasoning
-# Drain cap kept low: each token pull triggers a model inference step, so a
-# large cap hangs on slow CI runners after a `</think>` truncation.
-_DRAIN_CAP = 512
+def filter_reasoning(
+    tokens: Iterator[str],
+    *,
+    show: bool,
+    cap_chars: int,
+    on_cap: Callable[[str], None] | None = None,
+    on_progress: Callable[[int], None] | None = None,
+) -> Iterator[StreamToken]:
+    """Filter ``<think>...</think>`` tags and signal when reasoning exceeds the cap.
 
+    *cap_chars* bounds reasoning content. When exceeded, ``on_cap`` is
+    called with the captured reasoning text, the upstream iterator is
+    closed, and iteration stops; the caller decides what to do next
+    (stop the response, re-issue the chat with a continuation prompt,
+    etc.). *on_progress* is fired with the running reasoning-chars count
+    each time it grows by at least 256 characters.
 
-def filter_reasoning(tokens: Iterator[str], *, show: bool) -> Iterator[StreamToken]:
-    """Filter ``<think>...</think>`` tags from a token stream; cap runaway reasoning.
-
-    When *show* is True, yields thinking content as ``StreamToken(is_reasoning=True)``;
-    when False, strips it. Always closes the upstream iterator on exit so a
-    runaway think loop doesn't leave llama.cpp holding the chat lock.
+    A non-positive *cap_chars* disables the cap.
     """
     parser = _TagParser(show=show)
+    last_progress_tick = 0
     try:
-        truncated = yield from _stream_until_cap(parser, tokens)
-        if truncated:
-            yield from _drain_after_truncation(parser, tokens)
+        for token in tokens:
+            for st in parser.feed(token):
+                if st.content:
+                    yield st
+            if (
+                on_progress is not None
+                and parser.reasoning_chars >= last_progress_tick + _PROGRESS_TICK_CHARS
+            ):
+                last_progress_tick = parser.reasoning_chars
+                on_progress(parser.reasoning_chars)
+            if cap_chars > 0 and parser.reasoning_chars > cap_chars:
+                if on_cap is not None:
+                    on_cap(parser.captured_reasoning())
+                return
         final = parser.flush()
         if final and final.content:
             yield final
+        if on_progress is not None and parser.reasoning_chars > last_progress_tick:
+            on_progress(parser.reasoning_chars)
     finally:
         _close_iterator(tokens)
-
-
-def _stream_until_cap(
-    parser: _TagParser, tokens: Iterator[str]
-) -> Generator[StreamToken, None, bool]:
-    """Yield from *tokens* until the reasoning cap fires. Returns True if truncated."""
-    for token in tokens:
-        for st in parser.feed(token):
-            if st.content:
-                yield st
-        if parser.reasoning_chars > _MAX_REASONING_CHARS:
-            parser.in_thinking = False
-            parser.buf = ""
-            yield StreamToken(content="\n[reasoning truncated]", is_reasoning=True)
-            return True
-    return False
-
-
-def _drain_after_truncation(parser: _TagParser, tokens: Iterator[str]) -> Iterator[StreamToken]:
-    """Drain a bounded suffix after a ``</think>`` truncation.
-
-    Captures response content that follows a closed ``</think>`` tag without
-    pulling the whole stream; bounded by ``_DRAIN_CAP`` characters.
-    """
-    drain_chars = 0
-    for token in tokens:
-        drain_chars += len(token)
-        if drain_chars > _DRAIN_CAP:
-            return
-        for st in parser.feed(token):
-            if st.content and not st.is_reasoning:
-                yield st
 
 
 def _close_iterator(tokens: Iterator[str]) -> None:

--- a/src/lilbee/retrieval/reasoning.py
+++ b/src/lilbee/retrieval/reasoning.py
@@ -39,6 +39,9 @@ CAP_CONTINUATION_PROMPT = (
 )
 """The user-message nudge appended on the continuation call after the cap fires."""
 
+CAP_NOTICE_TEMPLATE = "\n[reasoning capped at {chars} chars, asking for a direct answer]\n"
+"""User-visible marker emitted between the truncated reasoning and the continuation answer."""
+
 
 @dataclass
 class StreamToken:
@@ -219,6 +222,25 @@ def stream_chat_with_cap(
                 yield StreamToken(content=chunk, is_reasoning=False)
     finally:
         _close_iterator(second_stream)
+
+
+def cap_events_as_stream_tokens(
+    events: Iterator[StreamToken | CapNotice],
+) -> Iterator[StreamToken]:
+    """Render ``CapNotice`` events as user-visible reasoning ``StreamToken``s.
+
+    Library and CLI surfaces speak ``StreamToken`` only. This helper lets
+    them consume the orchestrator's union output without a per-call
+    isinstance dance for the cap notice.
+    """
+    for event in events:
+        if isinstance(event, CapNotice):
+            yield StreamToken(
+                content=CAP_NOTICE_TEMPLATE.format(chars=event.cap_chars),
+                is_reasoning=True,
+            )
+        elif event.content:
+            yield event
 
 
 def _close_iterator(tokens: Iterator[str]) -> None:

--- a/src/lilbee/retrieval/reasoning.py
+++ b/src/lilbee/retrieval/reasoning.py
@@ -1,25 +1,43 @@
-"""Reasoning token filter: detects <think>...</think> tags in streaming output.
+"""Reasoning token filter and cap-aware chat orchestrator.
 
 Reasoning models (Qwen3, DeepSeek-R1) wrap their thinking process in
-``<think>...</think>`` tags. This module provides a stateful filter that
-classifies tokens as reasoning or response content and notifies the
-caller when reasoning exceeds a caller-supplied cap.
+``<think>...</think>`` tags. This module provides:
+
+- ``filter_reasoning``: a stateful streaming filter that classifies
+  tokens as reasoning vs response and signals when reasoning exceeds a
+  caller-supplied cap.
+- ``stream_chat_with_cap``: the high-level orchestrator. Wraps a
+  provider call with the filter; when the cap fires, re-issues the
+  chat with a "stop thinking, answer directly" nudge. All chat surfaces
+  (HTTP/SSE, CLI, TUI) consume this so cap behavior is uniform.
+- ``effective_reasoning_cap``: resolves the cap from the global config
+  with per-model ``ModelDefaults`` overrides.
 """
 
 from __future__ import annotations
 
 import contextlib
 import re
-from collections.abc import Callable, Iterator
-from dataclasses import dataclass, field
+from collections.abc import Callable, Generator, Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
+from lilbee.core.config import cfg
 from lilbee.providers.base import ClosableIterator
+
+if TYPE_CHECKING:
+    from lilbee.providers.base import LLMProvider
 
 _OPEN_TAG = "<think>"
 _CLOSE_TAG = "</think>"
 _THINK_BLOCK_RE = re.compile(r"<think>[\s\S]*?</think>\s*|<think>[\s\S]*$")
 _PROGRESS_TICK_CHARS = 256
 """Coarseness of the progress callback: fire when reasoning grows by at least this many chars."""
+
+CAP_CONTINUATION_PROMPT = (
+    "Stop thinking now. Give your final answer directly, without any further <think> blocks."
+)
+"""The user-message nudge appended on the continuation call after the cap fires."""
 
 
 @dataclass
@@ -31,6 +49,13 @@ class StreamToken:
 
 
 @dataclass
+class CapNotice:
+    """Emitted once when the reasoning cap fires, before the continuation stream."""
+
+    cap_chars: int
+
+
+@dataclass
 class _TagParser:
     """Stateful parser that tracks whether we're inside a thinking block."""
 
@@ -38,11 +63,6 @@ class _TagParser:
     buf: str = ""
     in_thinking: bool = False
     reasoning_chars: int = 0
-    reasoning_text: list[str] = field(default_factory=list)
-
-    def captured_reasoning(self) -> str:
-        """Concatenated reasoning text seen so far, regardless of ``show``."""
-        return "".join(self.reasoning_text)
 
     def feed(self, token: str) -> list[StreamToken]:
         """Feed a token and return any complete StreamTokens."""
@@ -61,13 +81,9 @@ class _TagParser:
         if not self.buf:
             return None
         if self.in_thinking:
-            self._absorb_reasoning(self.buf)
+            self.reasoning_chars += len(self.buf)
             return StreamToken(content=self.buf, is_reasoning=True) if self.show else None
         return StreamToken(content=self.buf, is_reasoning=False)
-
-    def _absorb_reasoning(self, content: str) -> None:
-        self.reasoning_chars += len(content)
-        self.reasoning_text.append(content)
 
     def _process_thinking(self) -> StreamToken | None:
         close_idx = self.buf.find(_CLOSE_TAG)
@@ -75,7 +91,7 @@ class _TagParser:
             if _could_be_partial(_CLOSE_TAG, self.buf):
                 return None
             content = self.buf
-            self._absorb_reasoning(content)
+            self.reasoning_chars += len(content)
             self.buf = ""
             return (
                 StreamToken(content=content, is_reasoning=True)
@@ -83,7 +99,7 @@ class _TagParser:
                 else StreamToken(content="", is_reasoning=True)
             )
         thinking_content = self.buf[:close_idx]
-        self._absorb_reasoning(thinking_content)
+        self.reasoning_chars += len(thinking_content)
         self.buf = self.buf[close_idx + len(_CLOSE_TAG) :]
         self.in_thinking = False
         if thinking_content and self.show:
@@ -109,19 +125,17 @@ def filter_reasoning(
     *,
     show: bool,
     cap_chars: int,
-    on_cap: Callable[[str], None] | None = None,
+    on_cap: Callable[[], None] | None = None,
     on_progress: Callable[[int], None] | None = None,
 ) -> Iterator[StreamToken]:
-    """Filter ``<think>...</think>`` tags and signal when reasoning exceeds the cap.
+    """Classify ``<think>...</think>`` tokens and stop when reasoning exceeds the cap.
 
     *cap_chars* bounds reasoning content. When exceeded, ``on_cap`` is
-    called with the captured reasoning text, the upstream iterator is
-    closed, and iteration stops; the caller decides what to do next
-    (stop the response, re-issue the chat with a continuation prompt,
-    etc.). *on_progress* is fired with the running reasoning-chars count
-    each time it grows by at least 256 characters.
-
-    A non-positive *cap_chars* disables the cap.
+    fired (no payload), the upstream iterator is closed, and iteration
+    stops. The caller decides what to do next via the higher-level
+    ``stream_chat_with_cap`` orchestrator. *on_progress* is fired with
+    the running reasoning-chars count each time it grows by at least 256
+    characters. A non-positive *cap_chars* disables the cap.
     """
     parser = _TagParser(show=show)
     last_progress_tick = 0
@@ -138,7 +152,7 @@ def filter_reasoning(
                 on_progress(parser.reasoning_chars)
             if cap_chars > 0 and parser.reasoning_chars > cap_chars:
                 if on_cap is not None:
-                    on_cap(parser.captured_reasoning())
+                    on_cap()
                 return
         final = parser.flush()
         if final and final.content:
@@ -147,6 +161,64 @@ def filter_reasoning(
             on_progress(parser.reasoning_chars)
     finally:
         _close_iterator(tokens)
+
+
+def effective_reasoning_cap() -> int:
+    """Return the active reasoning cap; 0 means unlimited.
+
+    A per-model ``ModelDefaults.max_reasoning_chars`` value (including
+    ``0`` for "this model is allowed to think forever") beats the global
+    ``cfg.max_reasoning_chars`` setting. Only ``None`` falls through to
+    the global, so a per-model 0 means the user explicitly opted that
+    model out of the cap.
+    """
+    defaults = cfg.model_defaults
+    override = defaults.max_reasoning_chars if defaults is not None else None
+    return override if isinstance(override, int) and override >= 0 else cfg.max_reasoning_chars
+
+
+def stream_chat_with_cap(
+    provider: LLMProvider,
+    messages: list[dict[str, Any]],
+    *,
+    options: dict[str, Any] | None,
+    model: str,
+    show_reasoning: bool,
+    cap_chars: int,
+) -> Generator[StreamToken | CapNotice, None, None]:
+    """Stream chat tokens; on cap-fire, re-issue with a stop-thinking nudge.
+
+    Yields ``StreamToken`` events for both reasoning and response tokens
+    in the first pass. If reasoning exceeds *cap_chars*, the upstream
+    iterator is closed, a single ``CapNotice`` is yielded, and the
+    continuation stream starts (same messages plus a user message asking
+    the model to answer directly). Continuation tokens stream as
+    ``StreamToken(is_reasoning=False)``.
+    """
+    cap_fired = False
+
+    def _on_cap() -> None:
+        nonlocal cap_fired
+        cap_fired = True
+
+    first_stream = provider.chat(messages, stream=True, options=options or None, model=model)
+    yield from filter_reasoning(
+        first_stream,
+        show=show_reasoning,
+        cap_chars=cap_chars,
+        on_cap=_on_cap,
+    )
+    if not cap_fired:
+        return
+    yield CapNotice(cap_chars=cap_chars)
+    nudged = [*messages, {"role": "user", "content": CAP_CONTINUATION_PROMPT}]
+    second_stream = provider.chat(nudged, stream=True, options=options or None, model=model)
+    try:
+        for chunk in second_stream:
+            if chunk:
+                yield StreamToken(content=chunk, is_reasoning=False)
+    finally:
+        _close_iterator(second_stream)
 
 
 def _close_iterator(tokens: Iterator[str]) -> None:

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import threading
 from collections.abc import AsyncGenerator
@@ -57,6 +58,56 @@ async def ask(
     )
 
 
+_CAP_NOTICE_TEMPLATE = "\n[reasoning capped at {chars} chars, asking for a direct answer]\n"
+_CAP_CONTINUATION_PROMPT = (
+    "Stop thinking now. Give your final answer directly, without any further <think> blocks."
+)
+
+
+def _resolve_reasoning_cap() -> int:
+    """Effective reasoning cap: per-model override beats the global setting."""
+    defaults = cfg.model_defaults
+    override = getattr(defaults, "max_reasoning_chars", None) if defaults is not None else None
+    return override if isinstance(override, int) and override > 0 else cfg.max_reasoning_chars
+
+
+def _stream_continuation(
+    messages: list[ChatMessage],
+    opts: dict[str, Any] | None,
+    queue: asyncio.Queue[str | None],
+    cancel: threading.Event,
+    captured_reasoning: str,
+) -> None:
+    """Re-issue the chat with a 'stop thinking' nudge after the cap fires.
+
+    Sends the full original turn back to the model with the partial reasoning
+    surfaced as the previous assistant turn so the user can read what was
+    captured, then a fresh user message asking for a direct answer. Tokens
+    from the second pass stream as plain TOKEN events.
+    """
+    provider = get_services().provider
+    nudged_messages: list[dict[str, Any]] = [
+        *cast("list[dict[str, Any]]", messages),
+        {"role": "assistant", "content": f"<think>{captured_reasoning}</think>"},
+        {"role": "user", "content": _CAP_CONTINUATION_PROMPT},
+    ]
+    second_stream = provider.chat(
+        nudged_messages,
+        stream=True,
+        options=opts or None,
+        model=cfg.chat_model,
+    )
+    try:
+        for chunk in second_stream:
+            if cancel.is_set():
+                break
+            if chunk:
+                queue.put_nowait(sse_event(SseEvent.TOKEN, {"token": chunk}))
+    finally:
+        with contextlib.suppress(Exception):
+            second_stream.close()
+
+
 def _run_llm_stream(
     messages: list[ChatMessage],
     opts: dict[str, Any] | None,
@@ -67,6 +118,9 @@ def _run_llm_stream(
     """Stream LLM tokens into a queue from a worker thread."""
     from lilbee.retrieval.reasoning import filter_reasoning
 
+    cap_chars = _resolve_reasoning_cap()
+    cap_holder: list[str] = []
+
     try:
         provider = get_services().provider
         stream = provider.chat(
@@ -75,12 +129,26 @@ def _run_llm_stream(
             options=opts or None,
             model=cfg.chat_model,
         )
-        for st in filter_reasoning(stream, show=cfg.show_reasoning):
+        for st in filter_reasoning(
+            stream,
+            show=cfg.show_reasoning,
+            cap_chars=cap_chars,
+            on_cap=cap_holder.append,
+        ):
             if cancel.is_set():
                 break
             if st.content:
                 event_type = SseEvent.REASONING if st.is_reasoning else SseEvent.TOKEN
                 queue.put_nowait(sse_event(event_type, {"token": st.content}))
+
+        if cap_holder and not cancel.is_set():
+            queue.put_nowait(
+                sse_event(
+                    SseEvent.REASONING,
+                    {"token": _CAP_NOTICE_TEMPLATE.format(chars=cap_chars)},
+                )
+            )
+            _stream_continuation(messages, opts, queue, cancel, cap_holder[0])
     except Exception as exc:
         error_holder.append(str(exc))
     finally:

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -12,6 +12,12 @@ from lilbee.app.search import clean_result
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
 from lilbee.core.results import DocumentResult, group
+from lilbee.retrieval.reasoning import (
+    CAP_NOTICE_TEMPLATE,
+    CapNotice,
+    effective_reasoning_cap,
+    stream_chat_with_cap,
+)
 from lilbee.runtime.progress import SseEvent
 from lilbee.server.handlers.sse import (
     SseStream,
@@ -57,9 +63,6 @@ async def ask(
     )
 
 
-_CAP_NOTICE_TEMPLATE = "\n[reasoning capped at {chars} chars, asking for a direct answer]\n"
-
-
 def _run_llm_stream(
     messages: list[ChatMessage],
     opts: dict[str, Any] | None,
@@ -68,12 +71,6 @@ def _run_llm_stream(
     error_holder: list[str],
 ) -> None:
     """Forward tokens from the cap-aware chat orchestrator into the SSE queue."""
-    from lilbee.retrieval.reasoning import (
-        CapNotice,
-        effective_reasoning_cap,
-        stream_chat_with_cap,
-    )
-
     try:
         events = stream_chat_with_cap(
             get_services().provider,
@@ -91,7 +88,7 @@ def _run_llm_stream(
                 queue.put_nowait(
                     sse_event(
                         SseEvent.REASONING,
-                        {"token": _CAP_NOTICE_TEMPLATE.format(chars=event.cap_chars)},
+                        {"token": CAP_NOTICE_TEMPLATE.format(chars=event.cap_chars)},
                     )
                 )
             elif event.content:

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import threading
 from collections.abc import AsyncGenerator
@@ -59,53 +58,6 @@ async def ask(
 
 
 _CAP_NOTICE_TEMPLATE = "\n[reasoning capped at {chars} chars, asking for a direct answer]\n"
-_CAP_CONTINUATION_PROMPT = (
-    "Stop thinking now. Give your final answer directly, without any further <think> blocks."
-)
-
-
-def _resolve_reasoning_cap() -> int:
-    """Effective reasoning cap: per-model override beats the global setting."""
-    defaults = cfg.model_defaults
-    override = defaults.max_reasoning_chars if defaults is not None else None
-    return override if isinstance(override, int) and override > 0 else cfg.max_reasoning_chars
-
-
-def _stream_continuation(
-    messages: list[ChatMessage],
-    opts: dict[str, Any] | None,
-    queue: asyncio.Queue[str | None],
-    cancel: threading.Event,
-    captured_reasoning: str,
-) -> None:
-    """Re-issue the chat with a 'stop thinking' nudge after the cap fires.
-
-    Sends the full original turn back to the model with the partial reasoning
-    surfaced as the previous assistant turn so the user can read what was
-    captured, then a fresh user message asking for a direct answer. Tokens
-    from the second pass stream as plain TOKEN events.
-    """
-    provider = get_services().provider
-    nudged_messages: list[dict[str, Any]] = [
-        *cast("list[dict[str, Any]]", messages),
-        {"role": "assistant", "content": f"<think>{captured_reasoning}</think>"},
-        {"role": "user", "content": _CAP_CONTINUATION_PROMPT},
-    ]
-    second_stream = provider.chat(
-        nudged_messages,
-        stream=True,
-        options=opts or None,
-        model=cfg.chat_model,
-    )
-    try:
-        for chunk in second_stream:
-            if cancel.is_set():
-                break
-            if chunk:
-                queue.put_nowait(sse_event(SseEvent.TOKEN, {"token": chunk}))
-    finally:
-        with contextlib.suppress(Exception):
-            second_stream.close()
 
 
 def _run_llm_stream(
@@ -115,40 +67,36 @@ def _run_llm_stream(
     cancel: threading.Event,
     error_holder: list[str],
 ) -> None:
-    """Stream LLM tokens into a queue from a worker thread."""
-    from lilbee.retrieval.reasoning import filter_reasoning
-
-    cap_chars = _resolve_reasoning_cap()
-    cap_holder: list[str] = []
+    """Forward tokens from the cap-aware chat orchestrator into the SSE queue."""
+    from lilbee.retrieval.reasoning import (
+        CapNotice,
+        effective_reasoning_cap,
+        stream_chat_with_cap,
+    )
 
     try:
-        provider = get_services().provider
-        stream = provider.chat(
+        events = stream_chat_with_cap(
+            get_services().provider,
             cast("list[dict[str, Any]]", messages),
-            stream=True,
-            options=opts or None,
+            options=opts,
             model=cfg.chat_model,
+            show_reasoning=cfg.show_reasoning,
+            cap_chars=effective_reasoning_cap(),
         )
-        for st in filter_reasoning(
-            stream,
-            show=cfg.show_reasoning,
-            cap_chars=cap_chars,
-            on_cap=cap_holder.append,
-        ):
+        for event in events:
             if cancel.is_set():
+                events.close()
                 break
-            if st.content:
-                event_type = SseEvent.REASONING if st.is_reasoning else SseEvent.TOKEN
-                queue.put_nowait(sse_event(event_type, {"token": st.content}))
-
-        if cap_holder and not cancel.is_set():
-            queue.put_nowait(
-                sse_event(
-                    SseEvent.REASONING,
-                    {"token": _CAP_NOTICE_TEMPLATE.format(chars=cap_chars)},
+            if isinstance(event, CapNotice):
+                queue.put_nowait(
+                    sse_event(
+                        SseEvent.REASONING,
+                        {"token": _CAP_NOTICE_TEMPLATE.format(chars=event.cap_chars)},
+                    )
                 )
-            )
-            _stream_continuation(messages, opts, queue, cancel, cap_holder[0])
+            elif event.content:
+                kind = SseEvent.REASONING if event.is_reasoning else SseEvent.TOKEN
+                queue.put_nowait(sse_event(kind, {"token": event.content}))
     except Exception as exc:
         error_holder.append(str(exc))
     finally:

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -67,7 +67,7 @@ _CAP_CONTINUATION_PROMPT = (
 def _resolve_reasoning_cap() -> int:
     """Effective reasoning cap: per-model override beats the global setting."""
     defaults = cfg.model_defaults
-    override = getattr(defaults, "max_reasoning_chars", None) if defaults is not None else None
+    override = defaults.max_reasoning_chars if defaults is not None else None
     return override if isinstance(override, int) and override > 0 else cfg.max_reasoning_chars
 
 

--- a/tests/test_model_defaults.py
+++ b/tests/test_model_defaults.py
@@ -86,6 +86,10 @@ class TestParseKvParameters:
         result = parse_kv_parameters("max_tokens 2048")
         assert result.max_tokens == 2048
 
+    def test_max_reasoning_chars_parsed(self):
+        result = parse_kv_parameters("max_reasoning_chars 80000")
+        assert result.max_reasoning_chars == 80_000
+
 
 class TestReadGgufDefaults:
     def test_empty_dict(self):
@@ -128,6 +132,11 @@ class TestReadGgufDefaults:
         metadata = {"context_length": "abc"}
         result = read_gguf_defaults(metadata)
         assert result.num_ctx is None
+
+    def test_max_reasoning_chars_from_gguf(self):
+        metadata = {"general.max_reasoning_chars": "120000"}
+        result = read_gguf_defaults(metadata)
+        assert result.max_reasoning_chars == 120_000
 
 
 class TestCache:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -715,6 +715,8 @@ class TestAskStreamCapNotice:
     """Cap-fire surfaces a reasoning notice + the continuation answer in both streaming paths."""
 
     def test_ask_stream_emits_cap_notice_then_answer(self, mock_svc):
+        from lilbee.retrieval.reasoning import CAP_NOTICE_TEMPLATE
+
         mock_svc.store.search.return_value = [_make_result()]
         long_reasoning = "<think>" + ("x " * 400) + "</think>"
         mock_svc.provider.chat.side_effect = [
@@ -728,13 +730,14 @@ class TestAskStreamCapNotice:
         finally:
             cfg.max_reasoning_chars = snapshot
         body = "".join(st.content for st in stream_tokens)
-        assert "reasoning capped at 512 chars" in body
+        assert CAP_NOTICE_TEMPLATE.format(chars=512) in body
         assert "final answer" in body
         assert mock_svc.provider.chat.call_count == 2
 
     def test_direct_stream_emits_cap_notice_then_answer(self, mock_svc):
         """When the searcher takes the no-RAG branch (chat mode), cap-fire still surfaces."""
         from lilbee.core.config.enums import ChatMode
+        from lilbee.retrieval.reasoning import CAP_NOTICE_TEMPLATE
 
         mock_svc.store.search.return_value = []  # forces fall-through to direct
         long_reasoning = "<think>" + ("x " * 400) + "</think>"
@@ -752,7 +755,7 @@ class TestAskStreamCapNotice:
             cfg.max_reasoning_chars = snapshot_cap
             cfg.chat_mode = snapshot_mode
         body = "".join(st.content for st in stream_tokens)
-        assert "reasoning capped at 512 chars" in body
+        assert CAP_NOTICE_TEMPLATE.format(chars=512) in body
         assert "direct answer" in body
         assert mock_svc.provider.chat.call_count == 2
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -711,6 +711,52 @@ class TestAskStreamError:
         assert "Connection lost" in combined
 
 
+class TestAskStreamCapNotice:
+    """Cap-fire surfaces a reasoning notice + the continuation answer in both streaming paths."""
+
+    def test_ask_stream_emits_cap_notice_then_answer(self, mock_svc):
+        mock_svc.store.search.return_value = [_make_result()]
+        long_reasoning = "<think>" + ("x " * 400) + "</think>"
+        mock_svc.provider.chat.side_effect = [
+            iter([long_reasoning]),
+            iter(["final ", "answer"]),
+        ]
+        snapshot = cfg.max_reasoning_chars
+        try:
+            cfg.max_reasoning_chars = 512
+            stream_tokens = list(get_services().searcher.ask_stream("q"))
+        finally:
+            cfg.max_reasoning_chars = snapshot
+        body = "".join(st.content for st in stream_tokens)
+        assert "reasoning capped at 512 chars" in body
+        assert "final answer" in body
+        assert mock_svc.provider.chat.call_count == 2
+
+    def test_direct_stream_emits_cap_notice_then_answer(self, mock_svc):
+        """When the searcher takes the no-RAG branch (chat mode), cap-fire still surfaces."""
+        from lilbee.core.config.enums import ChatMode
+
+        mock_svc.store.search.return_value = []  # forces fall-through to direct
+        long_reasoning = "<think>" + ("x " * 400) + "</think>"
+        mock_svc.provider.chat.side_effect = [
+            iter([long_reasoning]),
+            iter(["direct ", "answer"]),
+        ]
+        snapshot_cap = cfg.max_reasoning_chars
+        snapshot_mode = cfg.chat_mode
+        try:
+            cfg.max_reasoning_chars = 512
+            cfg.chat_mode = ChatMode.CHAT.value
+            stream_tokens = list(get_services().searcher.ask_stream("q"))
+        finally:
+            cfg.max_reasoning_chars = snapshot_cap
+            cfg.chat_mode = snapshot_mode
+        body = "".join(st.content for st in stream_tokens)
+        assert "reasoning capped at 512 chars" in body
+        assert "direct answer" in body
+        assert mock_svc.provider.chat.call_count == 2
+
+
 class TestProviderError:
     """ProviderError from the provider should propagate."""
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -711,10 +711,22 @@ class TestAskStreamError:
         assert "Connection lost" in combined
 
 
+@pytest.fixture
+def _disable_pre_chat_llm_calls():
+    """Pin ``query_expansion_count`` and ``hyde`` so RAG setup doesn't burn provider.chat calls."""
+    snapshot_expand = cfg.query_expansion_count
+    snapshot_hyde = cfg.hyde
+    cfg.query_expansion_count = 0
+    cfg.hyde = False
+    yield
+    cfg.query_expansion_count = snapshot_expand
+    cfg.hyde = snapshot_hyde
+
+
 class TestAskStreamCapNotice:
     """Cap-fire surfaces a reasoning notice + the continuation answer in both streaming paths."""
 
-    def test_ask_stream_emits_cap_notice_then_answer(self, mock_svc):
+    def test_ask_stream_emits_cap_notice_then_answer(self, mock_svc, _disable_pre_chat_llm_calls):
         from lilbee.retrieval.reasoning import CAP_NOTICE_TEMPLATE
 
         mock_svc.store.search.return_value = [_make_result()]
@@ -723,23 +735,25 @@ class TestAskStreamCapNotice:
             iter([long_reasoning]),
             iter(["final ", "answer"]),
         ]
-        snapshot = cfg.max_reasoning_chars
+        snapshot_cap = cfg.max_reasoning_chars
         try:
             cfg.max_reasoning_chars = 512
             stream_tokens = list(get_services().searcher.ask_stream("q"))
         finally:
-            cfg.max_reasoning_chars = snapshot
+            cfg.max_reasoning_chars = snapshot_cap
         body = "".join(st.content for st in stream_tokens)
         assert CAP_NOTICE_TEMPLATE.format(chars=512) in body
         assert "final answer" in body
         assert mock_svc.provider.chat.call_count == 2
 
-    def test_direct_stream_emits_cap_notice_then_answer(self, mock_svc):
+    def test_direct_stream_emits_cap_notice_then_answer(
+        self, mock_svc, _disable_pre_chat_llm_calls
+    ):
         """When the searcher takes the no-RAG branch (chat mode), cap-fire still surfaces."""
         from lilbee.core.config.enums import ChatMode
         from lilbee.retrieval.reasoning import CAP_NOTICE_TEMPLATE
 
-        mock_svc.store.search.return_value = []  # forces fall-through to direct
+        mock_svc.store.search.return_value = []
         long_reasoning = "<think>" + ("x " * 400) + "</think>"
         mock_svc.provider.chat.side_effect = [
             iter([long_reasoning]),

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -2,9 +2,16 @@
 
 from lilbee.retrieval.reasoning import StreamToken, filter_reasoning, strip_reasoning
 
+_NO_CAP = 1_000_000
 
-def _collect(tokens: list[str], *, show: bool) -> list[StreamToken]:
-    return list(filter_reasoning(iter(tokens), show=show))
+
+def _collect(
+    tokens: list[str],
+    *,
+    show: bool,
+    cap_chars: int = _NO_CAP,
+) -> list[StreamToken]:
+    return list(filter_reasoning(iter(tokens), show=show, cap_chars=cap_chars))
 
 
 class TestFilterReasoningShowFalse:
@@ -88,7 +95,6 @@ class TestFilterReasoningShowTrue:
 
 class TestCouldBePartial:
     def test_partial_open_tag(self):
-        """Token ending with '<thi' should wait for more data."""
         result = _collect(["text<thi", "nk>reasoning</think>done"], show=False)
         content = "".join(st.content for st in result)
         assert "reasoning" not in content
@@ -96,147 +102,155 @@ class TestCouldBePartial:
         assert "done" in content
 
     def test_partial_close_tag(self):
-        """Token ending with '</thi' inside thinking should wait."""
         result = _collect(["<think>thought</thi", "nk>done"], show=True)
         reasoning = "".join(st.content for st in result if st.is_reasoning)
         assert "thought" in reasoning
 
     def test_false_partial_not_tag(self):
-        """'<' at end that doesn't match tag prefix should not stall."""
         result = _collect(["text<", "b>not a tag"], show=False)
         content = "".join(st.content for st in result)
         assert "text" in content
 
     def test_unterminated_thinking_flushed_when_show(self):
-        """Thinking block never closed: buffer flushed as reasoning at end."""
         result = _collect(["<think>unterminated"], show=True)
         reasoning = [st for st in result if st.is_reasoning]
         assert len(reasoning) >= 1
         assert "unterminated" in "".join(st.content for st in reasoning)
 
     def test_unterminated_thinking_with_partial_close(self):
-        """Thinking with partial close tag at end: flushed as reasoning."""
         result = _collect(["<think>deep thought</thi"], show=True)
         reasoning = "".join(st.content for st in result if st.is_reasoning)
         assert "deep thought" in reasoning
 
     def test_unterminated_thinking_stripped_when_hidden(self):
-        """Thinking block never closed: buffer discarded when show=False."""
         result = _collect(["<think>unterminated"], show=False)
         content = "".join(st.content for st in result)
         assert content == ""
 
     def test_trailing_text_after_thinking(self):
-        """Normal text at end of stream flushed correctly."""
         result = _collect(["<think>thought</think>trailing"], show=True)
         response = "".join(st.content for st in result if not st.is_reasoning)
         assert "trailing" in response
 
     def test_normal_text_ending_with_partial_tag(self):
-        """Buffer has normal text ending with '<t': flushed as normal at end."""
         result = _collect(["hello<t"], show=False)
         content = "".join(st.content for st in result)
         assert "hello<t" in content
 
 
-class TestReasoningTruncation:
-    def test_runaway_reasoning_truncated(self):
-        """Reasoning exceeding _MAX_REASONING_CHARS is cut off."""
-        from lilbee.retrieval.reasoning import _MAX_REASONING_CHARS
-
-        long_think = "x" * (_MAX_REASONING_CHARS + 1000)
-        # Simulate realistic streaming: one char per token so the cap
-        # triggers mid-stream rather than after one giant token.
+class TestReasoningCap:
+    def test_cap_fires_on_long_reasoning(self):
+        """Cap callback fires when reasoning exceeds cap_chars."""
+        captured: list[str] = []
+        long_think = "x" * 1500
         tokens = list(f"<think>{long_think}</think>answer")
-        result = _collect(tokens, show=True)
-        reasoning = "".join(st.content for st in result if st.is_reasoning)
-        assert "[reasoning truncated]" in reasoning
-        assert len(reasoning) <= _MAX_REASONING_CHARS + 200
+        list(
+            filter_reasoning(
+                iter(tokens),
+                show=True,
+                cap_chars=1024,
+                on_cap=captured.append,
+            )
+        )
+        assert captured, "on_cap should fire when reasoning exceeds cap"
+        assert "x" in captured[0]
 
-    def test_content_after_truncated_reasoning(self):
-        """Content tokens after truncated reasoning are still yielded."""
-        from lilbee.retrieval.reasoning import _MAX_REASONING_CHARS
-
-        long_think = "x" * (_MAX_REASONING_CHARS + 500)
-        tokens = [f"<think>{long_think}</think>", "the answer"]
-        result = _collect(tokens, show=True)
+    def test_cap_yields_no_response_after_fire(self):
+        """When the cap fires, iteration stops; later tokens don't reach the consumer."""
+        long_think = "x" * 1500
+        tokens = list(f"<think>{long_think}</think>answer")
+        result = list(
+            filter_reasoning(
+                iter(tokens),
+                show=True,
+                cap_chars=1024,
+                on_cap=lambda _: None,
+            )
+        )
         response = "".join(st.content for st in result if not st.is_reasoning)
-        assert "the answer" in response
+        assert "answer" not in response
 
-    def test_re_entered_thinking_is_not_yielded_as_response(self):
-        """After truncation, content the model emits inside a fresh <think>
-        tag is tagged as reasoning and excluded from the response stream."""
-        from lilbee.retrieval.reasoning import _MAX_REASONING_CHARS
+    def test_no_cap_when_zero(self):
+        """cap_chars=0 disables the cap entirely; no on_cap fires."""
+        captured: list[str] = []
+        long_think = "x" * 5000
+        tokens = list(f"<think>{long_think}</think>answer")
+        list(
+            filter_reasoning(
+                iter(tokens),
+                show=False,
+                cap_chars=0,
+                on_cap=captured.append,
+            )
+        )
+        assert captured == []
 
-        long_think = "x" * (_MAX_REASONING_CHARS + 500)
-        tokens = [f"<think>{long_think}", "</think>", "<think>", "more thinking"]
-        result = _collect(tokens, show=True)
+    def test_on_cap_optional(self):
+        """Cap firing without an on_cap callback still terminates cleanly."""
+        long_think = "x" * 1500
+        tokens = list(f"<think>{long_think}</think>answer")
+        result = list(filter_reasoning(iter(tokens), show=False, cap_chars=512))
         response = "".join(st.content for st in result if not st.is_reasoning)
-        assert "more thinking" not in response
+        assert response == ""
 
-    def test_runaway_reasoning_truncated_show_false(self):
-        """Reasoning cap works even when show_reasoning=False.
+    def test_on_progress_fires_during_reasoning(self):
+        """on_progress receives running reasoning-chars counts as content arrives."""
+        progress: list[int] = []
+        # Ten tokens of 100 chars each: enough to cross the 256-char tick boundary.
+        chunks = ["<think>"] + ["x" * 100 for _ in range(10)] + ["</think>", "answer"]
+        list(
+            filter_reasoning(
+                iter(chunks),
+                show=False,
+                cap_chars=_NO_CAP,
+                on_progress=progress.append,
+            )
+        )
+        assert progress, "on_progress should fire as reasoning accumulates"
+        assert progress == sorted(progress), "progress values should be monotonic"
+        assert progress[-1] >= 1000
 
-        Previously, the cap only tracked visible reasoning content.
-        With show=False, reasoning tokens have empty content, so the
-        cap never triggered and the stream could loop forever.
-        """
-        from lilbee.retrieval.reasoning import _MAX_REASONING_CHARS
+    def test_on_progress_optional(self):
+        """Stream completes cleanly when on_progress is omitted."""
+        result = _collect(["<think>x" * 200 + "</think>answer"], show=False)
+        response = "".join(st.content for st in result if not st.is_reasoning)
+        assert response == "answer"
 
-        long_think = "x" * (_MAX_REASONING_CHARS + 1000)
-        tokens = list(f"<think>{long_think}")  # no closing tag: infinite reasoning
-        result = _collect(tokens, show=False)
-        # Should terminate (not hang) and yield the truncation marker
-        truncation_markers = [st for st in result if "truncated" in st.content]
-        assert len(truncation_markers) == 1
+    def test_captured_text_matches_partial_reasoning(self):
+        """on_cap's payload is the reasoning content seen so far, not the cap value."""
+        captured: list[str] = []
+        partial = "thinking step one. " * 80
+        tokens = [f"<think>{partial}"]
+        list(
+            filter_reasoning(
+                iter(tokens),
+                show=False,
+                cap_chars=512,
+                on_cap=captured.append,
+            )
+        )
+        assert captured
+        assert "thinking step one" in captured[0]
 
     def test_unclosed_think_terminates_show_false(self):
-        """An unclosed <think> block with show=False terminates at the cap."""
-        from lilbee.retrieval.reasoning import _MAX_REASONING_CHARS
+        """An unclosed <think> with show=False still hits the cap, no hang."""
+        captured: list[str] = []
+        tokens = ["<think>"] + ["x"] * 2000
+        list(
+            filter_reasoning(
+                iter(tokens),
+                show=False,
+                cap_chars=512,
+                on_cap=captured.append,
+            )
+        )
+        assert captured
 
-        # Simulate streaming: chars come one at a time, never closing the tag
-        tokens = ["<think>"] + ["x"] * (_MAX_REASONING_CHARS + 100)
-        result = _collect(tokens, show=False)
-        # Must not hang, and must contain truncation marker
-        assert any("truncated" in st.content for st in result)
-
-    def test_drain_flushes_trailing_content(self):
-        """After truncation, trailing non-reasoning content in buffer is flushed."""
-        from lilbee.retrieval.reasoning import _MAX_REASONING_CHARS
-
-        long_think = "x" * (_MAX_REASONING_CHARS + 100)
-        # Reasoning truncated, then more tokens arrive with trailing content.
-        # End with a partial tag prefix so the parser buffers it until flush.
-        tokens = [*f"<think>{long_think}</think>", "final", "<th"]
-        result = _collect(tokens, show=True)
-        response = "".join(st.content for st in result if not st.is_reasoning)
-        assert "final" in response
-        assert "<th" in response  # flushed by final flush()
-
-    def test_drain_cap_prevents_infinite_post_truncation(self):
-        """Drain loop stops after _MAX_REASONING_CHARS even if model keeps generating."""
-        from lilbee.retrieval.reasoning import _MAX_REASONING_CHARS
-
-        long_think = "x" * (_MAX_REASONING_CHARS + 100)
-        # After truncation, model keeps generating reasoning (no closing tag)
-        post_tokens = ["y"] * (_MAX_REASONING_CHARS + 100)
-        tokens = [*f"<think>{long_think}", *post_tokens]
-        result = _collect(tokens, show=True)
-        assert any("truncated" in st.content for st in result)
-
-    def test_upstream_generator_closed_on_truncation(self):
-        """Truncation closes the upstream iterator so llama.cpp doesn't hang.
-
-        Without this, a runaway think loop leaves llama.cpp suspended at
-        its yield point and the chat lock isn't released until garbage
-        collection eventually fires __del__.
-        """
-        from lilbee.retrieval.reasoning import filter_reasoning
-
+    def test_upstream_generator_closed_on_cap(self):
+        """Cap firing closes the upstream iterator, releasing llama.cpp's chat lock."""
         closed = {"value": False}
 
         def runaway_tokens():
-            """Yields forever; never emits </think>. Simulates a stuck model."""
             try:
                 yield "<think>"
                 while True:
@@ -245,18 +259,22 @@ class TestReasoningTruncation:
                 closed["value"] = True
                 raise
 
-        # Drive the filter to completion. Truncation should fire and the
-        # generator must be left in a suspended state for close() to act on.
-        list(filter_reasoning(runaway_tokens(), show=True))
+        list(
+            filter_reasoning(
+                runaway_tokens(),
+                show=True,
+                cap_chars=512,
+                on_cap=lambda _: None,
+            )
+        )
         assert closed["value"], "filter_reasoning must close upstream iterator"
 
     def test_close_called_on_stream_wrapper_early_exit(self):
-        """A stream-wrapper iterator with a ``close()`` method has it called."""
-        from lilbee.retrieval.reasoning import _MAX_REASONING_CHARS, filter_reasoning
+        """A stream wrapper exposing close() has it called when the cap fires."""
 
         class FakeStream:
             def __init__(self) -> None:
-                self.tokens = iter(["<think>"] + ["x"] * (_MAX_REASONING_CHARS + 100))
+                self.tokens = iter(["<think>"] + ["x"] * 2000)
                 self.closed = False
 
             def __iter__(self):
@@ -269,8 +287,15 @@ class TestReasoningTruncation:
                 self.closed = True
 
         stream = FakeStream()
-        list(filter_reasoning(stream, show=True))
-        assert stream.closed, "filter_reasoning must call close() on stream wrapper"
+        list(
+            filter_reasoning(
+                stream,
+                show=True,
+                cap_chars=512,
+                on_cap=lambda _: None,
+            )
+        )
+        assert stream.closed
 
 
 class TestStripReasoning:

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,6 +1,20 @@
-"""Tests for reasoning token filter: <think>...</think> tag detection."""
+"""Tests for reasoning token filter and cap-aware chat orchestrator."""
 
-from lilbee.retrieval.reasoning import StreamToken, filter_reasoning, strip_reasoning
+from unittest.mock import MagicMock
+
+import pytest
+
+from lilbee.core.config import cfg
+from lilbee.providers.model_defaults import ModelDefaults
+from lilbee.retrieval.reasoning import (
+    CAP_CONTINUATION_PROMPT,
+    CapNotice,
+    StreamToken,
+    effective_reasoning_cap,
+    filter_reasoning,
+    stream_chat_with_cap,
+    strip_reasoning,
+)
 
 _NO_CAP = 1_000_000
 
@@ -140,50 +154,38 @@ class TestCouldBePartial:
 
 class TestReasoningCap:
     def test_cap_fires_on_long_reasoning(self):
-        """Cap callback fires when reasoning exceeds cap_chars."""
-        captured: list[str] = []
+        """on_cap is invoked when reasoning exceeds cap_chars."""
+        fired = [False]
+
+        def _on_cap() -> None:
+            fired[0] = True
+
         long_think = "x" * 1500
         tokens = list(f"<think>{long_think}</think>answer")
-        list(
-            filter_reasoning(
-                iter(tokens),
-                show=True,
-                cap_chars=1024,
-                on_cap=captured.append,
-            )
-        )
-        assert captured, "on_cap should fire when reasoning exceeds cap"
-        assert "x" in captured[0]
+        list(filter_reasoning(iter(tokens), show=True, cap_chars=1024, on_cap=_on_cap))
+        assert fired[0]
 
     def test_cap_yields_no_response_after_fire(self):
         """When the cap fires, iteration stops; later tokens don't reach the consumer."""
         long_think = "x" * 1500
         tokens = list(f"<think>{long_think}</think>answer")
         result = list(
-            filter_reasoning(
-                iter(tokens),
-                show=True,
-                cap_chars=1024,
-                on_cap=lambda _: None,
-            )
+            filter_reasoning(iter(tokens), show=True, cap_chars=1024, on_cap=lambda: None)
         )
         response = "".join(st.content for st in result if not st.is_reasoning)
         assert "answer" not in response
 
     def test_no_cap_when_zero(self):
-        """cap_chars=0 disables the cap entirely; no on_cap fires."""
-        captured: list[str] = []
+        """cap_chars=0 disables the cap entirely; on_cap never fires."""
+        fired = [False]
+
+        def _on_cap() -> None:
+            fired[0] = True
+
         long_think = "x" * 5000
         tokens = list(f"<think>{long_think}</think>answer")
-        list(
-            filter_reasoning(
-                iter(tokens),
-                show=False,
-                cap_chars=0,
-                on_cap=captured.append,
-            )
-        )
-        assert captured == []
+        list(filter_reasoning(iter(tokens), show=False, cap_chars=0, on_cap=_on_cap))
+        assert fired == [False]
 
     def test_on_cap_optional(self):
         """Cap firing without an on_cap callback still terminates cleanly."""
@@ -196,18 +198,14 @@ class TestReasoningCap:
     def test_on_progress_fires_during_reasoning(self):
         """on_progress receives running reasoning-chars counts as content arrives."""
         progress: list[int] = []
-        # Ten tokens of 100 chars each: enough to cross the 256-char tick boundary.
         chunks = ["<think>"] + ["x" * 100 for _ in range(10)] + ["</think>", "answer"]
         list(
             filter_reasoning(
-                iter(chunks),
-                show=False,
-                cap_chars=_NO_CAP,
-                on_progress=progress.append,
+                iter(chunks), show=False, cap_chars=_NO_CAP, on_progress=progress.append
             )
         )
-        assert progress, "on_progress should fire as reasoning accumulates"
-        assert progress == sorted(progress), "progress values should be monotonic"
+        assert progress
+        assert progress == sorted(progress)
         assert progress[-1] >= 1000
 
     def test_on_progress_optional(self):
@@ -216,35 +214,16 @@ class TestReasoningCap:
         response = "".join(st.content for st in result if not st.is_reasoning)
         assert response == "answer"
 
-    def test_captured_text_matches_partial_reasoning(self):
-        """on_cap's payload is the reasoning content seen so far, not the cap value."""
-        captured: list[str] = []
-        partial = "thinking step one. " * 80
-        tokens = [f"<think>{partial}"]
-        list(
-            filter_reasoning(
-                iter(tokens),
-                show=False,
-                cap_chars=512,
-                on_cap=captured.append,
-            )
-        )
-        assert captured
-        assert "thinking step one" in captured[0]
-
     def test_unclosed_think_terminates_show_false(self):
         """An unclosed <think> with show=False still hits the cap, no hang."""
-        captured: list[str] = []
+        fired = [False]
+
+        def _on_cap() -> None:
+            fired[0] = True
+
         tokens = ["<think>"] + ["x"] * 2000
-        list(
-            filter_reasoning(
-                iter(tokens),
-                show=False,
-                cap_chars=512,
-                on_cap=captured.append,
-            )
-        )
-        assert captured
+        list(filter_reasoning(iter(tokens), show=False, cap_chars=512, on_cap=_on_cap))
+        assert fired[0]
 
     def test_upstream_generator_closed_on_cap(self):
         """Cap firing closes the upstream iterator, releasing llama.cpp's chat lock."""
@@ -259,15 +238,8 @@ class TestReasoningCap:
                 closed["value"] = True
                 raise
 
-        list(
-            filter_reasoning(
-                runaway_tokens(),
-                show=True,
-                cap_chars=512,
-                on_cap=lambda _: None,
-            )
-        )
-        assert closed["value"], "filter_reasoning must close upstream iterator"
+        list(filter_reasoning(runaway_tokens(), show=True, cap_chars=512, on_cap=lambda: None))
+        assert closed["value"]
 
     def test_close_called_on_stream_wrapper_early_exit(self):
         """A stream wrapper exposing close() has it called when the cap fires."""
@@ -287,15 +259,164 @@ class TestReasoningCap:
                 self.closed = True
 
         stream = FakeStream()
-        list(
-            filter_reasoning(
-                stream,
-                show=True,
-                cap_chars=512,
-                on_cap=lambda _: None,
+        list(filter_reasoning(stream, show=True, cap_chars=512, on_cap=lambda: None))
+        assert stream.closed
+
+
+class TestEffectiveReasoningCap:
+    """The single source of truth for which cap value applies right now."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated(self):
+        snapshot_cap = cfg.max_reasoning_chars
+        snapshot_defaults = cfg.model_defaults
+        cfg.clear_model_defaults()
+        yield
+        cfg.max_reasoning_chars = snapshot_cap
+        cfg.apply_model_defaults(snapshot_defaults)
+
+    def test_uses_cfg_when_no_per_model_override(self):
+        cfg.max_reasoning_chars = 8000
+        assert effective_reasoning_cap() == 8000
+
+    def test_per_model_override_wins(self):
+        cfg.max_reasoning_chars = 8000
+        cfg.apply_model_defaults(ModelDefaults(max_reasoning_chars=20_000))
+        assert effective_reasoning_cap() == 20_000
+
+    def test_per_model_zero_means_unlimited_for_that_model(self):
+        """A per-model 0 is an explicit opt-out, not 'fall through to global'."""
+        cfg.max_reasoning_chars = 8000
+        cfg.apply_model_defaults(ModelDefaults(max_reasoning_chars=0))
+        assert effective_reasoning_cap() == 0
+
+    def test_no_override_field_falls_through(self):
+        cfg.max_reasoning_chars = 8000
+        cfg.apply_model_defaults(ModelDefaults(temperature=0.7))
+        assert effective_reasoning_cap() == 8000
+
+    def test_global_zero_means_unlimited(self):
+        cfg.max_reasoning_chars = 0
+        assert effective_reasoning_cap() == 0
+
+
+class TestStreamChatWithCap:
+    """End-to-end orchestrator: filter + cap-fire + continuation re-issue."""
+
+    def _make_provider(self, *responses: object) -> MagicMock:
+        provider = MagicMock()
+        provider.chat.side_effect = [iter(r) if not callable(r) else r() for r in responses]
+        return provider
+
+    def test_no_cap_fire_yields_only_stream_tokens(self):
+        provider = self._make_provider(["<think>brief</think>", "the answer"])
+        events = list(
+            stream_chat_with_cap(
+                provider,
+                [{"role": "user", "content": "hi"}],
+                options=None,
+                model="test-model",
+                show_reasoning=True,
+                cap_chars=64_000,
             )
         )
-        assert stream.closed
+        assert not any(isinstance(e, CapNotice) for e in events)
+        assert provider.chat.call_count == 1
+        response = "".join(
+            e.content for e in events if isinstance(e, StreamToken) and not e.is_reasoning
+        )
+        assert "the answer" in response
+
+    def test_cap_fire_emits_notice_then_continuation_tokens(self):
+        long_think = "<think>" + ("x " * 400) + "</think>not reached"
+        provider = self._make_provider([long_think], ["final ", "answer."])
+        events = list(
+            stream_chat_with_cap(
+                provider,
+                [{"role": "user", "content": "explain X"}],
+                options=None,
+                model="test-model",
+                show_reasoning=True,
+                cap_chars=512,
+            )
+        )
+        notices = [e for e in events if isinstance(e, CapNotice)]
+        assert len(notices) == 1
+        assert notices[0].cap_chars == 512
+        response = "".join(
+            e.content for e in events if isinstance(e, StreamToken) and not e.is_reasoning
+        )
+        assert "final " in response and "answer." in response
+        assert provider.chat.call_count == 2
+
+    def test_continuation_call_appends_user_nudge(self):
+        long_think = "<think>" + ("x " * 400) + "</think>"
+        provider = self._make_provider([long_think], ["done"])
+        list(
+            stream_chat_with_cap(
+                provider,
+                [{"role": "user", "content": "q"}],
+                options=None,
+                model="test-model",
+                show_reasoning=False,
+                cap_chars=512,
+            )
+        )
+        nudged = provider.chat.call_args_list[1].args[0]
+        assert nudged[-1] == {"role": "user", "content": CAP_CONTINUATION_PROMPT}
+        assert nudged[0] == {"role": "user", "content": "q"}
+
+    def test_unlimited_cap_skips_continuation_even_for_long_reasoning(self):
+        """cap_chars=0 disables the cap; the orchestrator never re-issues."""
+        very_long = "<think>" + ("x " * 5000) + "</think>real answer"
+        provider = self._make_provider([very_long])
+        events = list(
+            stream_chat_with_cap(
+                provider,
+                [{"role": "user", "content": "go deep"}],
+                options=None,
+                model="test-model",
+                show_reasoning=False,
+                cap_chars=0,
+            )
+        )
+        assert not any(isinstance(e, CapNotice) for e in events)
+        assert provider.chat.call_count == 1
+        response = "".join(
+            e.content for e in events if isinstance(e, StreamToken) and not e.is_reasoning
+        )
+        assert "real answer" in response
+
+    def test_consumer_close_propagates_to_continuation_stream(self):
+        """If the consumer stops iterating, the continuation stream is closed too."""
+        long_think = "<think>" + ("x " * 400) + "</think>"
+        second_closed = {"value": False}
+
+        def second_pass():
+            try:
+                yield "first "
+                yield "second"
+            except GeneratorExit:
+                second_closed["value"] = True
+                raise
+
+        provider = MagicMock()
+        provider.chat.side_effect = [iter([long_think]), second_pass()]
+        gen = stream_chat_with_cap(
+            provider,
+            [{"role": "user", "content": "q"}],
+            options=None,
+            model="test-model",
+            show_reasoning=False,
+            cap_chars=512,
+        )
+        produced: list[object] = []
+        for event in gen:
+            produced.append(event)
+            if isinstance(event, StreamToken) and event.content == "first ":
+                gen.close()
+                break
+        assert second_closed["value"]
 
 
 class TestStripReasoning:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2231,7 +2231,7 @@ class TestRunLlmStreamCancel:
 
 
 class TestReasoningCapHandling:
-    """Cap-fire path: re-issue with a continuation nudge so the user gets an answer."""
+    """SSE handler forwards events from the shared cap-aware orchestrator."""
 
     def _drain(self, queue: asyncio.Queue[str | None]) -> list[str]:
         items: list[str] = []
@@ -2242,36 +2242,8 @@ class TestReasoningCapHandling:
             items.append(value)
         return items
 
-    def test_resolve_cap_uses_global_when_no_override(self):
-        """Cap resolver returns the global cfg setting when no per-model override exists."""
-        from lilbee.providers.model_defaults import ModelDefaults
-
-        snapshot_cap = cfg.max_reasoning_chars
-        snapshot_defaults = cfg.model_defaults
-        try:
-            cfg.max_reasoning_chars = 8000
-            cfg.apply_model_defaults(ModelDefaults())
-            assert _rag_h._resolve_reasoning_cap() == 8000
-        finally:
-            cfg.max_reasoning_chars = snapshot_cap
-            cfg.apply_model_defaults(snapshot_defaults)
-
-    def test_resolve_cap_per_model_override_wins(self):
-        """A per-model max_reasoning_chars on ModelDefaults beats the global cap."""
-        from lilbee.providers.model_defaults import ModelDefaults
-
-        snapshot_cap = cfg.max_reasoning_chars
-        snapshot_defaults = cfg.model_defaults
-        try:
-            cfg.max_reasoning_chars = 8000
-            cfg.apply_model_defaults(ModelDefaults(max_reasoning_chars=20_000))
-            assert _rag_h._resolve_reasoning_cap() == 20_000
-        finally:
-            cfg.max_reasoning_chars = snapshot_cap
-            cfg.apply_model_defaults(snapshot_defaults)
-
-    def test_cap_fire_emits_notice_and_reissues(self):
-        """When reasoning exceeds the cap, the handler emits a notice and re-issues."""
+    def test_cap_fire_emits_notice_event(self):
+        """When the orchestrator yields a CapNotice, the handler turns it into an SSE event."""
         import threading
 
         snapshot_cap = cfg.max_reasoning_chars
@@ -2279,12 +2251,8 @@ class TestReasoningCapHandling:
             cfg.max_reasoning_chars = 512
 
             mock_provider = MagicMock()
-            long_reasoning = "<think>" + ("x " * 400) + "</think>answer never reached"
-            second_wave = ["final ", "answer."]
-            mock_provider.chat.side_effect = [
-                iter([long_reasoning]),
-                iter(second_wave),
-            ]
+            long_reasoning = "<think>" + ("x " * 400) + "</think>not reached"
+            mock_provider.chat.side_effect = [iter([long_reasoning]), iter(["final ", "answer."])]
 
             queue: asyncio.Queue[str | None] = asyncio.Queue()
             cancel = threading.Event()
@@ -2305,11 +2273,6 @@ class TestReasoningCapHandling:
             assert any("final " in e for e in events)
             assert any("answer." in e for e in events)
             assert mock_provider.chat.call_count == 2
-            second_call_messages = mock_provider.chat.call_args_list[1].args[0]
-            assert second_call_messages[-1]["role"] == "user"
-            assert "Stop thinking" in second_call_messages[-1]["content"]
-            assert second_call_messages[-2]["role"] == "assistant"
-            assert "<think>" in second_call_messages[-2]["content"]
         finally:
             cfg.max_reasoning_chars = snapshot_cap
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2381,6 +2381,42 @@ class TestReasoningCapHandling:
         finally:
             cfg.max_reasoning_chars = snapshot_cap
 
+    def test_cancel_during_continuation_stops_emitting(self):
+        """Cancel set mid-second-wave breaks the continuation loop without crashing."""
+        import threading
+
+        snapshot_cap = cfg.max_reasoning_chars
+        try:
+            cfg.max_reasoning_chars = 512
+            cancel = threading.Event()
+            mock_provider = MagicMock()
+            long_reasoning = "<think>" + ("x " * 400) + "</think>"
+
+            def second_pass():
+                yield "first chunk "
+                cancel.set()
+                yield "second chunk should be ignored"
+
+            mock_provider.chat.side_effect = [iter([long_reasoning]), second_pass()]
+            queue: asyncio.Queue[str | None] = asyncio.Queue()
+            error_holder: list[str] = []
+
+            with patch("lilbee.server.handlers.rag.get_services") as mock_svc:
+                mock_svc.return_value.provider = mock_provider
+                _rag_h._run_llm_stream(
+                    [{"role": "user", "content": "long question"}],
+                    None,
+                    queue,
+                    cancel,
+                    error_holder,
+                )
+
+            events = self._drain(queue)
+            assert any("first chunk" in e for e in events)
+            assert not any("second chunk" in e for e in events)
+        finally:
+            cfg.max_reasoning_chars = snapshot_cap
+
 
 class TestParseOcrParams:
     def test_ocr_timeout_coerced_to_float(self):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2230,6 +2230,158 @@ class TestRunLlmStreamCancel:
         assert items[-1] is None
 
 
+class TestReasoningCapHandling:
+    """Cap-fire path: re-issue with a continuation nudge so the user gets an answer."""
+
+    def _drain(self, queue: asyncio.Queue[str | None]) -> list[str]:
+        items: list[str] = []
+        while not queue.empty():
+            value = queue.get_nowait()
+            if value is None:
+                break
+            items.append(value)
+        return items
+
+    def test_resolve_cap_uses_global_when_no_override(self):
+        """Cap resolver returns the global cfg setting when no per-model override exists."""
+        from lilbee.providers.model_defaults import ModelDefaults
+
+        snapshot_cap = cfg.max_reasoning_chars
+        snapshot_defaults = cfg.model_defaults
+        try:
+            cfg.max_reasoning_chars = 8000
+            cfg.apply_model_defaults(ModelDefaults())
+            assert _rag_h._resolve_reasoning_cap() == 8000
+        finally:
+            cfg.max_reasoning_chars = snapshot_cap
+            cfg.apply_model_defaults(snapshot_defaults)
+
+    def test_resolve_cap_per_model_override_wins(self):
+        """A per-model max_reasoning_chars on ModelDefaults beats the global cap."""
+        from lilbee.providers.model_defaults import ModelDefaults
+
+        snapshot_cap = cfg.max_reasoning_chars
+        snapshot_defaults = cfg.model_defaults
+        try:
+            cfg.max_reasoning_chars = 8000
+            cfg.apply_model_defaults(ModelDefaults(max_reasoning_chars=20_000))
+            assert _rag_h._resolve_reasoning_cap() == 20_000
+        finally:
+            cfg.max_reasoning_chars = snapshot_cap
+            cfg.apply_model_defaults(snapshot_defaults)
+
+    def test_cap_fire_emits_notice_and_reissues(self):
+        """When reasoning exceeds the cap, the handler emits a notice and re-issues."""
+        import threading
+
+        snapshot_cap = cfg.max_reasoning_chars
+        try:
+            cfg.max_reasoning_chars = 512
+
+            mock_provider = MagicMock()
+            long_reasoning = "<think>" + ("x " * 400) + "</think>answer never reached"
+            second_wave = ["final ", "answer."]
+            mock_provider.chat.side_effect = [
+                iter([long_reasoning]),
+                iter(second_wave),
+            ]
+
+            queue: asyncio.Queue[str | None] = asyncio.Queue()
+            cancel = threading.Event()
+            error_holder: list[str] = []
+
+            with patch("lilbee.server.handlers.rag.get_services") as mock_svc:
+                mock_svc.return_value.provider = mock_provider
+                _rag_h._run_llm_stream(
+                    [{"role": "user", "content": "explain quantum tunneling"}],
+                    None,
+                    queue,
+                    cancel,
+                    error_holder,
+                )
+
+            events = self._drain(queue)
+            assert any("reasoning capped" in e for e in events)
+            assert any("final " in e for e in events)
+            assert any("answer." in e for e in events)
+            assert mock_provider.chat.call_count == 2
+            second_call_messages = mock_provider.chat.call_args_list[1].args[0]
+            assert second_call_messages[-1]["role"] == "user"
+            assert "Stop thinking" in second_call_messages[-1]["content"]
+            assert second_call_messages[-2]["role"] == "assistant"
+            assert "<think>" in second_call_messages[-2]["content"]
+        finally:
+            cfg.max_reasoning_chars = snapshot_cap
+
+    def test_cap_does_not_fire_under_threshold(self):
+        """Short reasoning skips the re-issue path entirely."""
+        import threading
+
+        snapshot_cap = cfg.max_reasoning_chars
+        try:
+            cfg.max_reasoning_chars = 64_000
+
+            mock_provider = MagicMock()
+            mock_provider.chat.return_value = iter(["<think>brief</think>", "the ", "answer"])
+
+            queue: asyncio.Queue[str | None] = asyncio.Queue()
+            cancel = threading.Event()
+            error_holder: list[str] = []
+
+            with patch("lilbee.server.handlers.rag.get_services") as mock_svc:
+                mock_svc.return_value.provider = mock_provider
+                _rag_h._run_llm_stream(
+                    [{"role": "user", "content": "hi"}],
+                    None,
+                    queue,
+                    cancel,
+                    error_holder,
+                )
+
+            assert mock_provider.chat.call_count == 1
+            events = self._drain(queue)
+            assert not any("reasoning capped" in e for e in events)
+        finally:
+            cfg.max_reasoning_chars = snapshot_cap
+
+    def test_cap_fire_with_cancel_skips_continuation(self):
+        """If the user cancels mid-stream, the continuation re-issue does not run."""
+        import threading
+
+        snapshot_cap = cfg.max_reasoning_chars
+        try:
+            cfg.max_reasoning_chars = 512
+
+            mock_provider = MagicMock()
+
+            def first_pass():
+                yield "<think>"
+                for _ in range(400):
+                    yield "x "
+                yield "</think>"
+
+            mock_provider.chat.return_value = first_pass()
+
+            queue: asyncio.Queue[str | None] = asyncio.Queue()
+            cancel = threading.Event()
+            cancel.set()
+            error_holder: list[str] = []
+
+            with patch("lilbee.server.handlers.rag.get_services") as mock_svc:
+                mock_svc.return_value.provider = mock_provider
+                _rag_h._run_llm_stream(
+                    [{"role": "user", "content": "hi"}],
+                    None,
+                    queue,
+                    cancel,
+                    error_holder,
+                )
+
+            assert mock_provider.chat.call_count == 1
+        finally:
+            cfg.max_reasoning_chars = snapshot_cap
+
+
 class TestParseOcrParams:
     def test_ocr_timeout_coerced_to_float(self):
         """_parse_ocr_params coerces ocr_timeout to float."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2246,6 +2246,10 @@ class TestReasoningCapHandling:
         """When the orchestrator yields a CapNotice, the handler turns it into an SSE event."""
         import threading
 
+        from lilbee.retrieval.reasoning import CAP_NOTICE_TEMPLATE
+
+        notice_marker = CAP_NOTICE_TEMPLATE.format(chars=512).strip()
+
         snapshot_cap = cfg.max_reasoning_chars
         try:
             cfg.max_reasoning_chars = 512
@@ -2269,7 +2273,7 @@ class TestReasoningCapHandling:
                 )
 
             events = self._drain(queue)
-            assert any("reasoning capped" in e for e in events)
+            assert any(notice_marker in e for e in events)
             assert any("final " in e for e in events)
             assert any("answer." in e for e in events)
             assert mock_provider.chat.call_count == 2
@@ -2279,6 +2283,8 @@ class TestReasoningCapHandling:
     def test_cap_does_not_fire_under_threshold(self):
         """Short reasoning skips the re-issue path entirely."""
         import threading
+
+        from lilbee.retrieval.reasoning import CAP_NOTICE_TEMPLATE
 
         snapshot_cap = cfg.max_reasoning_chars
         try:
@@ -2303,7 +2309,8 @@ class TestReasoningCapHandling:
 
             assert mock_provider.chat.call_count == 1
             events = self._drain(queue)
-            assert not any("reasoning capped" in e for e in events)
+            notice_marker = CAP_NOTICE_TEMPLATE.format(chars=64_000).strip()
+            assert not any(notice_marker in e for e in events)
         finally:
             cfg.max_reasoning_chars = snapshot_cap
 


### PR DESCRIPTION
## Problem

Reasoning models (Qwen3, DeepSeek-R1) wrap thinking in `<think>...</think>` tags. lilbee streamed those through a hard-coded 16,000-character cap. When the cap fired, it flipped a local flag and tried to drain the next 512 chars as the response. The model was still in thinking mode at that point, so what got drained was leaked thinking tokens, mislabeled as the answer. The user saw a cut-off ramble that did not address the prompt, and there was no way to raise the cap short of editing the source.

## Solution

The cap is configurable globally, overridable per model, can be disabled entirely, and behaves identically across HTTP, CLI, and TUI surfaces because the orchestration lives in one shared helper.

### Configurable cap

`cfg.max_reasoning_chars` (default 64,000, `0` = unlimited) tunable via:
- `LILBEE_MAX_REASONING_CHARS` env var
- TOML config
- The `/settings` UI
- The HTTP `/set` route

`ModelDefaults.max_reasoning_chars` slot beats the global. A per-model `0` is an explicit "this model can think forever" opt-out (does not fall through to the global). Loaded from GGUF metadata (`general.max_reasoning_chars`) and KV-text params, same path as `temperature` / `max_tokens`.

### Cap-fire behavior

When reasoning exceeds the cap on any surface (HTTP, CLI, TUI), the user sees:

1. The reasoning that was captured (live, as it streamed).
2. A one-line notice: `[reasoning capped at 64000 chars, asking for a direct answer]`.
3. The model's answer streaming back into the same chat bubble, produced from a continuation call where one user message has been appended: "Stop thinking now. Give your final answer directly, without any further `<think>` blocks."

If the cap is set to `0`, none of step 2 or 3 happens; reasoning runs unbounded.

### Architecture

- `retrieval/reasoning.py:stream_chat_with_cap()` is the single orchestrator. Yields `StreamToken | CapNotice`. Internally: opens the provider stream, filters reasoning, on cap-fire closes the stream, emits a `CapNotice`, opens the continuation stream, yields its tokens.
- `retrieval/reasoning.py:effective_reasoning_cap()` is the single cap resolver.
- `server/handlers/rag.py` (HTTP/SSE), `searcher.py:_stream_direct` (TUI direct chat), and `searcher.py:ask_stream` (CLI/TUI RAG) all consume the same orchestrator. Each surface forwards events to its own protocol; the cap-fire UX is the same everywhere.

### Notes

- The Obsidian plugin needs to surface the new setting and handle the continuation seam in its renderer; context note has been handed off for that work to land in the plugin repo separately.
- 100% coverage, mypy clean, ruff clean, AGENTS.md smell sweep clean.