### PR TITLE
Fix test-drive rough edges: model recovery, docs, TUI polish, OSV

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -97,6 +97,10 @@ jobs:
           #   LiteLLM Proxy MCP stdio test endpoints. Requires a valid proxy
           #   API key and a running proxy; lilbee uses the SDK only. Same
           #   1.83.7 click pin issue blocks the bump.
+          # - GHSA-wxxx-gvqv-xp7p: Sandbox escape in the LiteLLM Proxy's
+          #   `POST /guardrails/test_custom_code` endpoint. Needs a proxy-admin
+          #   credential and a running proxy; lilbee uses the SDK only. Patched
+          #   in 1.83.10/1.83.11; same click pin issue blocks the bump.
           ignore-vulns: |
             CVE-2025-69872
             PYSEC-2022-42969
@@ -104,6 +108,7 @@ jobs:
             GHSA-xqmj-j6mv-4862
             GHSA-r75f-5x8p-qvmc
             GHSA-v4p8-mg3p-g94g
+            GHSA-wxxx-gvqv-xp7p
 
   osv-scan:
     name: OSV-Scanner (multi-ecosystem CVEs)

--- a/README.md
+++ b/README.md
@@ -245,7 +245,12 @@ Verify the install works on your hardware:
 lilbee self-check
 ```
 
-This downloads a tiny model (~90 MB), runs an inference, and an embedding. Exits 0 with `SELF-CHECK PASSED` on success.
+This downloads a tiny model (~90 MB), runs an inference, and an embedding. Exits 0 with `SELF-CHECK PASSED` on success. It only verifies your hardware; it does not configure a working model. Launch the TUI (`lilbee`) and pick a chat + embedding model on the welcome screen, or from the CLI install an embedding model (required before `lilbee add`) and a chat model:
+
+```bash
+lilbee model pull nomic-ai/nomic-embed-text-v1.5-GGUF   # embedding model; needed to index/search
+lilbee model browse                                     # pick a chat model interactively
+```
 
 ### Homebrew (macOS arm64, Linux x86_64)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -95,11 +95,10 @@ lilbee add manual.pdf --force
 
 ## OCR
 
-OCR is about *getting text out of* scanned PDFs and images; it's a separate
-step from indexing. However the text is extracted (native parsers for files with
-embedded text, Tesseract, or a vision model), it still has to be embedded to be
-searchable, so you always need the embedding model from
-[Getting started](#getting-started); Tesseract does not replace it.
+OCR is how lilbee gets text out of scanned PDFs and images. It's one step in
+indexing, not a substitute for it: however the text comes out (a native parser,
+Tesseract, or a vision model), it still gets embedded, so you still need an
+embedding model installed (see [Getting started](#getting-started)).
 
 For PDFs without embedded text, lilbee supports two OCR backends. When a vision model is configured, it takes precedence.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,12 +27,24 @@
 
 ## Getting started
 
+**Install an embedding model first.** Indexing turns every document chunk into a
+vector, so before `lilbee add` will work you need an embedding model on disk.
+Either launch the TUI (`lilbee`) and pick one on the welcome screen, or from the
+CLI:
+
+```bash
+lilbee model pull nomic-ai/nomic-embed-text-v1.5-GGUF
+```
+
+A *chat* model is only needed for `/chat` and `lilbee ask`, not for indexing or
+`lilbee search`. Browse everything available with `lilbee model browse`.
+
 lilbee uses a git-like per-project model. Running `lilbee init` creates a `.lilbee/` directory in the current folder, just like `git init` creates `.git/`. Once initialized, every lilbee command you run from that directory (or any subdirectory) automatically uses the local database:
 
 ```bash
 cd ~/projects/my-engine
 lilbee init                  # creates .lilbee/ here
-lilbee add docs/manual.pdf   # indexes into .lilbee/
+lilbee add docs/manual.pdf   # indexes into .lilbee/  (needs the embedding model above)
 lilbee search "oil change"   # searches .lilbee/
 ```
 
@@ -52,6 +64,10 @@ lilbee --global status
 
 ## Adding documents
 
+`add` extracts text from each file and embeds it, so an embedding model must be
+installed first (see [Getting started](#getting-started)). Without one, every
+file is reported as `failed` with `Model '…' not found in registry`.
+
 Add files, directories, or a mix:
 
 ```bash
@@ -67,6 +83,12 @@ lilbee add manual.pdf --force
 ```
 
 ## OCR
+
+OCR is about *getting text out of* scanned PDFs and images; it's a separate
+step from indexing. However the text is extracted (native parsers for files with
+embedded text, Tesseract, or a vision model), it still has to be embedded to be
+searchable, so you always need the embedding model from
+[Getting started](#getting-started); Tesseract does not replace it.
 
 For PDFs without embedded text, lilbee supports two OCR backends. When a vision model is configured, it takes precedence.
 
@@ -112,7 +134,7 @@ TUI; the selection is saved to `config.toml` and persists across sessions.
 
 ## Querying
 
-Search returns relevant chunks from your indexed documents. No LLM needed; `search` works without any model loaded:
+Search returns relevant chunks from your indexed documents. No *chat* model is needed for `search`, only the embedding model (the same one indexing used; see [Getting started](#getting-started)):
 
 ```bash
 lilbee search "oil change interval"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,17 +27,28 @@
 
 ## Getting started
 
-**Install an embedding model first.** Indexing turns every document chunk into a
-vector, so before `lilbee add` will work you need an embedding model on disk.
-Either launch the TUI (`lilbee`) and pick one on the welcome screen, or from the
-CLI:
+The easiest way in is the TUI. Run:
 
 ```bash
-lilbee model pull nomic-ai/nomic-embed-text-v1.5-GGUF
+lilbee
 ```
 
-A *chat* model is only needed for `/chat` and `lilbee ask`, not for indexing or
-`lilbee search`. Browse everything available with `lilbee model browse`.
+The welcome screen walks you through picking an **embedding model** (used to index
+your documents) and, optionally, a **chat model** (used for `/chat` and `lilbee
+ask`). From there you can add documents, search, and chat without leaving the TUI.
+See [Interactive chat](#interactive-chat) for a tour of the screens.
+
+Prefer to drive it headless? Everything the TUI does is also a plain CLI command
+(`lilbee add`, `lilbee search`, `lilbee ask`, and so on), and lilbee runs as an
+[MCP server](#agent-integration) so editors and agents can search your documents
+directly. From the CLI you install an embedding model yourself before indexing
+anything (a chat model is only needed for `/chat` and `lilbee ask`, not for
+indexing or `lilbee search`):
+
+```bash
+lilbee model pull nomic-ai/nomic-embed-text-v1.5-GGUF   # required before `lilbee add`
+lilbee model browse                                     # pick a chat model interactively
+```
 
 lilbee uses a git-like per-project model. Running `lilbee init` creates a `.lilbee/` directory in the current folder, just like `git init` creates `.git/`. Once initialized, every lilbee command you run from that directory (or any subdirectory) automatically uses the local database:
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -28,6 +28,10 @@ reason = "SQL injection in the LiteLLM Proxy server's API-key verification path.
 id = "GHSA-v4p8-mg3p-g94g"
 reason = "Authenticated command execution via the LiteLLM Proxy MCP stdio test endpoints (POST /mcp-rest/test/connection and /mcp-rest/test/tools/list). Requires a valid proxy API key and only triggers when the proxy is running. lilbee uses litellm only as an SDK (litellm.completion in src/lilbee/providers/litellm_sdk.py) and never starts the proxy, so neither endpoint is exposed. Patched in 1.83.7; bump is blocked by the same click==8.1.8 vs typer click>=8.2.1 conflict noted on GHSA-xqmj-j6mv-4862."
 
+[[IgnoredVulns]]
+id = "GHSA-wxxx-gvqv-xp7p"
+reason = "Sandbox escape in the LiteLLM Proxy server's `POST /guardrails/test_custom_code` endpoint (bytecode-level escape from a hand-rolled Python sandbox). Reaching it requires a proxy-admin credential and a running proxy. lilbee uses litellm only as an SDK (litellm.completion in src/lilbee/providers/litellm_sdk.py) and never starts the proxy, so the endpoint is not exposed. Patched in 1.83.10/1.83.11; bump is blocked by the same click==8.1.8 vs typer click>=8.2.1 conflict noted on GHSA-xqmj-j6mv-4862."
+
 # pygments is never a runtime or dev dependency; it is only resolved
 # transitively under tools/qa/requirements.txt (the QA-matrix runner venv,
 # pulled in via pytest). That harness is not published to PyPI or shipped to

--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -44,9 +44,10 @@ def _prestart_mp_resource_tracker() -> None:
 
     Later ``Process.start()`` calls reuse the cached tracker fd and
     never hit the fork_exec with a bad fd. No-op on Windows, which
-    doesn't use ``_posixsubprocess``, and no-op under PyInstaller frozen
-    bundles, where ``sys.executable`` is the lilbee exe itself and the
-    tracker's spawn would re-enter typer with ``-B -s -E`` as CLI args.
+    doesn't use ``_posixsubprocess``, and no-op under a frozen build
+    (Nuitka onefile), where ``sys.executable`` is the lilbee exe itself
+    and the tracker's spawn would re-enter typer with ``-B -s -E`` as
+    CLI args (``__main__._dispatch_frozen_child`` handles that case).
     """
     import sys as _sys
 

--- a/src/lilbee/__main__.py
+++ b/src/lilbee/__main__.py
@@ -12,10 +12,11 @@ def _multiprocessing_child_code(argv: list[str]) -> str | None:
     Python's ``multiprocessing.resource_tracker`` respawns ``sys.executable``
     with interpreter flags followed by ``-c "<code>"`` (e.g.
     ``-B -s -E -c "from multiprocessing.resource_tracker import main;main(7)"``).
-    Under a PyInstaller ``--onefile`` bundle ``sys.executable`` is this exe,
-    so those interpreter flags leak into the typer parser and raise
-    ``No such option: -B``. The stdlib ``freeze_support()`` hook only covers
-    spawn children (``--multiprocessing-fork``), not resource_tracker.
+    In a frozen build (Nuitka onefile) ``sys.executable`` is this exe, so those
+    interpreter flags leak into the typer parser and raise ``No such option: -B``
+    (or, once typer has eaten the flags, ``No such command '<N>'`` for the
+    leftover fd number). The stdlib ``freeze_support()`` hook only covers spawn
+    children (``--multiprocessing-fork``), not resource_tracker.
 
     Require the payload to mention ``multiprocessing`` or ``spawn_main`` so a
     stray ``lilbee -c …`` typed by a human never reaches ``exec``.
@@ -40,7 +41,7 @@ def _dispatch_frozen_child() -> bool:
     if code is None:
         return False
     exec(  # noqa: S102  payload is emitted by Python's own stdlib into sys.executable
-        compile(code, "<pyi-mp-child>", "exec"),
+        compile(code, "<frozen-mp-child>", "exec"),
         {"__name__": "__main__", "__builtins__": __builtins__},
     )
     return True

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -32,8 +32,8 @@ _SELF_CHECK_EMBED_FILE = "nomic-embed-text-v1.5.Q4_K_M.gguf"
 def _download_self_check_model(repo: str, filename: str) -> Path:
     """Fetch a GGUF from the HuggingFace CDN via urllib (stdlib only).
 
-    Avoids huggingface_hub / httpx entirely. Inside the PyInstaller --onefile
-    bundle, huggingface_hub's retry path has re-entered a closed httpx client
+    Avoids huggingface_hub / httpx entirely. Inside the Nuitka --onefile
+    binary, huggingface_hub's retry path has re-entered a closed httpx client
     after transient DNS failures on macOS runners. urllib is synchronous,
     lives in the stdlib, and has no long-lived client to close.
     """

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -25,7 +25,7 @@ from lilbee.providers.worker.transport import WorkerRole
 
 log = logging.getLogger(__name__)
 
-_DEFAULT_THEME = "gruvbox"  # warm retro CRT aesthetic
+_DEFAULT_THEME = "rose-pine"  # muted, low-glare; easier on the eyes than the warmer themes
 _CHAT_SCREEN_NAME = "chat"
 DARK_THEMES = (
     "monokai",
@@ -198,7 +198,7 @@ class LilbeeApp(App[None]):
         self._canonicalize_persisted_models()
         self.title = f"lilbee: {cfg.chat_model}"
         # Restore the persisted theme so the TUI opens in whatever the user
-        # picked last session, not always the gruvbox default.
+        # picked last session, not always the default.
         persisted = cfg.theme or _DEFAULT_THEME
         self.theme = persisted if persisted in self.available_themes else _DEFAULT_THEME
         self._sync_theme_index_to_current()

--- a/src/lilbee/cli/tui/pill.py
+++ b/src/lilbee/cli/tui/pill.py
@@ -1,9 +1,9 @@
-"""Pill badge: a colored inline label with a single space of padding each side.
+"""Pill badge: a colored inline label with one space of ``{background}``-fill padding each side.
 
-The padding is part of the ``{background}`` fill, not a separate styled cap:
-half-block caps over a ``transparent`` background take their color from whatever
-is behind the pill, which on a near-black terminal reads as a black sliver. A
-flat fill renders the same on any terminal and theme.
+Adapted from toad (https://github.com/batrachianai/toad); the padding is part
+of the solid fill rather than toad's reversed half-block caps, which take their
+color from the cell behind the pill and read as a black sliver on a near-black
+terminal.
 """
 
 from textual.content import Content

--- a/src/lilbee/cli/tui/pill.py
+++ b/src/lilbee/cli/tui/pill.py
@@ -1,30 +1,27 @@
-"""Pill badge: colored inline label using half-block characters.
+"""Pill badge: a colored inline label with a single space of padding each side.
 
-Ported from toad (https://github.com/batrachianai/toad).
+The padding is part of the ``{background}`` fill, not a separate styled cap:
+half-block caps over a ``transparent`` background take their color from whatever
+is behind the pill, which on a near-black terminal reads as a black sliver. A
+flat fill renders the same on any terminal and theme.
 """
 
 from textual.content import Content
 
-PILL_LEFT = "▌"  # left half block
-PILL_RIGHT = "▐"  # right half block
-DOT_SEP = " \u00b7 "  # middle dot separator for inline dividers
+DOT_SEP = " · "  # middle-dot separator for inline dividers
 
 
 def pill(text: Content | str, background: str, foreground: str) -> Content:
-    """Format text as a pill badge with rounded half-block ends.
+    """Format *text* as a colored pill badge: the label on a ``{background}`` fill.
+
     Args:
         text: Pill contents.
-        background: Background color (Textual color string, e.g. "$primary").
-        foreground: Foreground color (Textual color string, e.g. "$text").
+        background: Background color (Textual color string, e.g. ``"$primary"``).
+        foreground: Foreground color (Textual color string, e.g. ``"$text"``).
 
     Returns:
-        Styled Content with half-block ends.
+        Styled ``Content`` with one space of padding on each side.
     """
     content = Content(text) if isinstance(text, str) else text
-    main_style = f"{foreground} on {background}"
-    end_style = f"{background} on transparent r"
-    return Content.assemble(
-        (PILL_LEFT, end_style),
-        content.stylize(main_style),
-        (PILL_RIGHT, end_style),
-    )
+    style = f"{foreground} on {background}"
+    return Content.assemble((" ", style), content.stylize(style), (" ", style))

--- a/src/lilbee/cli/tui/screens/task_center.tcss
+++ b/src/lilbee/cli/tui/screens/task_center.tcss
@@ -1,9 +1,10 @@
 /* Task Center — flight-deck aesthetic.
  *
- * Each task is a TaskRow: thick left rail in the state's color,
- * three stacked lines (title + elapsed, detail + percent, block bar).
- * Active rows pulse the rail at 1 Hz via an alternating -pulse class
- * toggled by TaskCenter's poll. */
+ * Each task is a TaskRow: heavy left rail in the state's color (the
+ * `┃` line tiles seamlessly; the `█` of a `thick` border shows sub-cell
+ * gaps in some terminal fonts), three stacked lines (title + elapsed,
+ * detail + percent, block bar). Active rows pulse the rail at 1 Hz via
+ * an alternating -pulse class toggled by TaskCenter's poll. */
 
 TaskCenter {
     #task-center-title {
@@ -49,13 +50,13 @@ TaskRow {
     height: auto;
     padding: 0 1;
     margin-bottom: 1;
-    border-left: thick $surface-lighten-2;
+    border-left: heavy $surface-lighten-2;
 
-    &.-active { border-left: thick $primary; }
-    &.-active.-pulse { border-left: thick $primary-lighten-3; }
-    &.-done { border-left: thick $success; }
-    &.-failed { border-left: thick $error; }
-    &.-cancelled { border-left: thick $warning; }
+    &.-active { border-left: heavy $primary; }
+    &.-active.-pulse { border-left: heavy $primary-lighten-3; }
+    &.-done { border-left: heavy $success; }
+    &.-failed { border-left: heavy $error; }
+    &.-cancelled { border-left: heavy $warning; }
     &.-just-completed { background: $primary 20%; }
 
     .row-head { padding: 0 0 0 1; }

--- a/src/lilbee/cli/tui/screens/wiki_drafts.py
+++ b/src/lilbee/cli/tui/screens/wiki_drafts.py
@@ -222,8 +222,9 @@ class WikiDraftsScreen(Screen[None]):
         self.action_go_back()
 
     def action_go_back(self) -> None:
-        """Pop back to the wiki screen (or the previous screen in tests)."""
-        self.app.pop_screen()
+        """Pop back to the wiki screen, unless this is the only screen on the stack."""
+        if len(self.app.screen_stack) > 1:
+            self.app.pop_screen()
 
     def _table_or_none(self) -> DataTable[str] | None:
         """Return the drafts table unless an Input is focused."""

--- a/src/lilbee/cli/tui/widgets/status_bar.py
+++ b/src/lilbee/cli/tui/widgets/status_bar.py
@@ -151,9 +151,9 @@ class ViewTabs(Widget):
         if cfg.chat_model and self.active_view != msg.DEFAULT_VIEW:
             label = display_label_for_ref(cfg.chat_model) or cfg.chat_model
             parts.append("  ")
-            parts.append(pill(f" {label} ", "$accent", "$text"))
+            parts.append(pill(label, "$accent", "$text"))
         if self.mode_text:
             color = _MODE_COLORS.get(self.mode_text, _DEFAULT_MODE_COLOR)
             parts.append("  ")
-            parts.append(pill(f" {self.mode_text} ", color, "$text"))
+            parts.append(pill(self.mode_text, color, "$text"))
         self.query_one("#view-tabs-trailing", Static).update(Content.assemble(*parts))

--- a/src/lilbee/cli/tui/widgets/task_row.py
+++ b/src/lilbee/cli/tui/widgets/task_row.py
@@ -158,10 +158,13 @@ class TaskRow(Widget, can_focus=True):
         elapsed = _format_elapsed(task)
         head.update(_build_head(task, elapsed))
 
-        detail = task.detail or ""
-        pct = "" if task.indeterminate else f"[b]{task.progress:.1f}%[/b]"
-        meta_parts = [detail, pct]
-        meta.update("  ".join(p for p in meta_parts if p))
+        # A DONE task's detail is whatever the last progress tick wrote
+        # ("442/610 MB", "Syncing foo.md..."): stale and confusing now that the
+        # bar reads 100%. FAILED / CANCELLED keep their detail: it's the reason.
+        is_done = task.status == TaskStatus.DONE
+        detail = "" if is_done else (task.detail or "")
+        pct = "" if task.indeterminate or is_done else f"[b]{task.progress:.1f}%[/b]"
+        meta.update("  ".join(p for p in (detail, pct) if p))
 
         if task.indeterminate:
             # Terminal rows freeze the bar so a cancelled/failed/done

--- a/src/lilbee/core/config/validators.py
+++ b/src/lilbee/core/config/validators.py
@@ -107,8 +107,8 @@ def validate_model_task_assignment(field_name: str, ref: str, *, allow_bypass: b
     if entry is None:
         raise ValueError(
             f"Model '{ref}' is not in the featured catalog. "
-            "Pick a featured model for this role, or install one via "
-            "POST /api/models/pull with a known catalog ref."
+            "Pick a featured model for this role, or install one with "
+            "'lilbee model pull <ref>' (or POST /api/models/pull) using a known catalog ref."
         )
     _enforce_role_match(ref, entry, field_name)
     # Keep a full ``<repo>/<file>.gguf`` so resolve_model_path lands on

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -171,8 +171,8 @@ def _resolve_playwright_runner() -> tuple[list[str], dict[str, str]]:
     """Return ``(argv_prefix, env)`` for invoking ``playwright install chromium``.
 
     Spawns Playwright's bundled Node driver directly so the call works under a
-    pip install, ``uv tool install``, or a PyInstaller frozen binary. Falls back
-    to ``[sys.executable, '-m', 'playwright']`` for unfrozen builds when the
+    pip install, ``uv tool install``, or a frozen (Nuitka onefile) binary. Falls
+    back to ``[sys.executable, '-m', 'playwright']`` for unfrozen builds when the
     driver lookup fails; re-raises for frozen builds.
     """
     try:

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -101,21 +101,113 @@ class ModelRegistry:
         self._root = models_dir
         self._manifests_dir = models_dir / "manifests"
 
+    def _repo_cache_dir(self, hf_repo: str) -> Path:
+        """The HuggingFace cache directory for *hf_repo* under this registry root."""
+        return self._root / f"models--{repo_to_dir(hf_repo)}"
+
     def resolve(self, ref: str) -> Path:
-        """Return the blob path for *ref*; ``KeyError`` if not installed."""
+        """Return the blob path for *ref*; ``KeyError`` if not installed.
+
+        The canonical *ref* shape is ``<org>/<repo>/<file>.gguf`` resolved via
+        the lilbee manifest. The two other shapes handled here are **deliberate
+        backwards-compatibility concessions** for builds already in the wild,
+        not the intended contract:
+
+        * a bare ``<org>/<repo>`` (older builds persisted these into
+          ``config.toml`` for the chat / embedding model) resolves to the one
+          quant of that repo that's installed; and
+        * if the lilbee manifest is missing / unparseable (an older build's
+          format) / blob-less, ``resolve`` falls back to whatever GGUF
+          ``huggingface_hub`` says is in the cache for that ref.
+
+        The HF cache layout is stable, so upgrading lilbee never strands an
+        already-downloaded model. This is the exception, not the rule, and it
+        stays here because the alternative is telling users to wipe their
+        lilbee data directory after an upgrade. It's a small amount of code to
+        carry for that.
+        """
+        if not ref.endswith(".gguf") and ref.count("/") == 1:
+            return self._resolve_repo_only(_validate_hf_repo(ref))
         hf_repo, gguf_filename = parse_hf_ref(ref)
         manifest = self._read_manifest(hf_repo, gguf_filename)
+        if manifest is not None and manifest.blob is not None:
+            blob_file = self._repo_cache_dir(manifest.hf_repo) / "blobs" / manifest.blob
+            if blob_file.exists():
+                return blob_file
+        recovered = self._find_cached_gguf(hf_repo, gguf_filename)
+        if recovered is not None:
+            return recovered
         if manifest is None:
             raise KeyError(f"Model {ref} not installed")
-        cache_path = self._root / f"models--{repo_to_dir(manifest.hf_repo)}"
+        # Manifest present but neither it nor the cache yields a blob; keep the
+        # specific diagnostic so a corrupted cache stays debuggable.
+        cache_path = self._repo_cache_dir(manifest.hf_repo)
         if not cache_path.exists():
             raise KeyError(f"Cache folder missing for {ref}: {cache_path.name}")
         if manifest.blob is None:
             raise KeyError(f"Manifest for {ref} has no blob hash; install incomplete")
-        blob_file = cache_path / "blobs" / manifest.blob
-        if not blob_file.exists():
-            raise KeyError(f"Blob file missing for {ref}: {manifest.blob}")
-        return blob_file
+        raise KeyError(f"Blob file missing for {ref}: {manifest.blob}")
+
+    def _resolve_repo_only(self, hf_repo: str) -> Path:
+        """Resolve a bare ``<org>/<repo>`` ref to the GGUF of that repo on disk.
+
+        Older builds persisted bare repo refs for the chat / embedding model.
+        Prefers a current-format manifest under the repo; otherwise asks
+        ``huggingface_hub`` what GGUFs the cache holds for the repo and returns
+        the first one (alphabetical for determinism if more than one quant is
+        installed).
+        """
+        manifest_dir = self._manifests_dir / repo_to_dir(hf_repo)
+        if manifest_dir.is_dir():
+            for mf in sorted(manifest_dir.glob("*.gguf.json")):
+                manifest = self._load_manifest_file(mf)
+                if manifest is None or manifest.blob is None:
+                    continue
+                blob = self._repo_cache_dir(hf_repo) / "blobs" / manifest.blob
+                if blob.exists():
+                    return blob
+        for filename in sorted(self._cached_gguf_names(hf_repo)):
+            recovered = self._find_cached_gguf(hf_repo, filename)
+            if recovered is not None:
+                return recovered
+        raise KeyError(f"Model {hf_repo} not installed")
+
+    def _cached_gguf_names(self, hf_repo: str) -> set[str]:
+        """``.gguf`` filenames the HuggingFace cache holds for *hf_repo*."""
+        if not self._root.is_dir():
+            return set()
+        from huggingface_hub import scan_cache_dir
+
+        info = scan_cache_dir(self._root)
+        return {
+            f.file_name
+            for repo in info.repos
+            if repo.repo_id == hf_repo
+            for rev in repo.revisions
+            for f in rev.files
+            if f.file_name.endswith(".gguf")
+        }
+
+    def _find_cached_gguf(self, hf_repo: str, gguf_filename: str) -> Path | None:
+        """Return the cached blob path for ``hf_repo``/``gguf_filename``, or None.
+
+        Uses ``huggingface_hub.try_to_load_from_cache`` so we honor whatever
+        cache layout HF uses, then resolves the returned snapshot symlink to the
+        blob, bounded to the cache directory.
+        """
+        from huggingface_hub import try_to_load_from_cache
+
+        hit = try_to_load_from_cache(
+            repo_id=hf_repo, filename=gguf_filename, cache_dir=str(self._root)
+        )
+        if not isinstance(hit, str):  # None (not cached) or the _CACHED_NO_EXIST sentinel
+            return None
+        resolved = Path(hit).resolve()
+        try:
+            validate_path_within(resolved, self._root)
+        except ValueError:
+            return None
+        return resolved
 
     def is_installed(self, ref: str) -> bool:
         """Return True if a model is installed and its blob is present."""
@@ -136,7 +228,7 @@ class ModelRegistry:
         import shutil
 
         digest = _sha256_file(source_path)
-        cache_path = self._root / f"models--{repo_to_dir(hf_repo)}"
+        cache_path = self._repo_cache_dir(hf_repo)
         blobs_dir = cache_path / "blobs"
         blob_path = blobs_dir / digest
         if not blob_path.exists():
@@ -190,7 +282,7 @@ class ModelRegistry:
         only the specific blob file is removed when no remaining
         manifest still references its digest.
         """
-        cache_path = self._root / f"models--{repo_to_dir(hf_repo)}"
+        cache_path = self._repo_cache_dir(hf_repo)
         try:
             validate_path_within(cache_path, self._root)
         except ValueError:
@@ -231,9 +323,7 @@ class ModelRegistry:
         """True iff *manifest* points at an existing blob file."""
         if manifest.blob is None:
             return False
-        blob_file = (
-            self._root / f"models--{repo_to_dir(manifest.hf_repo)}" / "blobs" / manifest.blob
-        )
+        blob_file = self._repo_cache_dir(manifest.hf_repo) / "blobs" / manifest.blob
         return blob_file.exists()
 
     def get_manifest(self, ref: str) -> ModelManifest | None:
@@ -285,8 +375,11 @@ class ModelRegistry:
 def register_downloaded_model(entry: CatalogModel, file_path: Path) -> None:
     """Write a registry manifest for a freshly downloaded GGUF.
 
-    Best-effort: a failed manifest write logs and swallows so the
-    pulled bytes still count as a successful download.
+    The bytes are already in the HF cache (the caller just downloaded them
+    there), and ``ModelRegistry.resolve`` falls back to the cache when the
+    manifest is absent, so a manifest-write hiccup leaves the model usable and
+    is logged, not raised. If the GGUF can't even be found in the cache the
+    download itself is broken; that re-raises so the caller reports a failure.
     """
     from datetime import UTC, datetime
 
@@ -302,4 +395,9 @@ def register_downloaded_model(entry: CatalogModel, file_path: Path) -> None:
         registry.install(entry.hf_repo, file_path.name, file_path, manifest)
         log.info("Registered %s/%s in manifest", entry.hf_repo, file_path.name)
     except Exception:
-        log.warning("Failed to register manifest for %s", entry.hf_repo, exc_info=True)
+        ref = format_native_gguf_ref(entry.hf_repo, file_path.name)
+        if not registry.is_installed(ref):
+            raise
+        log.warning(
+            "Manifest write failed for %s; recovered via the model cache", ref, exc_info=True
+        )

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -108,23 +108,16 @@ class ModelRegistry:
     def resolve(self, ref: str) -> Path:
         """Return the blob path for *ref*; ``KeyError`` if not installed.
 
-        The canonical *ref* shape is ``<org>/<repo>/<file>.gguf`` resolved via
-        the lilbee manifest. The two other shapes handled here are **deliberate
-        backwards-compatibility concessions** for builds already in the wild,
-        not the intended contract:
-
-        * a bare ``<org>/<repo>`` (older builds persisted these into
-          ``config.toml`` for the chat / embedding model) resolves to the one
-          quant of that repo that's installed; and
-        * if the lilbee manifest is missing / unparseable (an older build's
-          format) / blob-less, ``resolve`` falls back to whatever GGUF
-          ``huggingface_hub`` says is in the cache for that ref.
-
-        The HF cache layout is stable, so upgrading lilbee never strands an
-        already-downloaded model. This is the exception, not the rule, and it
-        stays here because the alternative is telling users to wipe their
-        lilbee data directory after an upgrade. It's a small amount of code to
-        carry for that.
+        The canonical *ref* is ``<org>/<repo>/<file>.gguf`` resolved via the
+        lilbee manifest. Two other shapes are accepted as a backwards-compat
+        concession for builds already published (whose on-disk layout differs),
+        not as the intended contract: a bare ``<org>/<repo>`` (older builds
+        persisted these into ``config.toml``) resolves to the one quant of that
+        repo that's installed, and a manifest that's missing / unparseable /
+        blob-less falls back to whatever GGUF ``huggingface_hub`` reports the
+        cache holds for that ref. The HF cache layout is stable, so this lets an
+        upgrade keep working without anyone purging their lilbee data dir; it is
+        deliberately the exception here, not a pattern to follow elsewhere.
         """
         if not ref.endswith(".gguf") and ref.count("/") == 1:
             return self._resolve_repo_only(_validate_hf_repo(ref))
@@ -212,22 +205,22 @@ class ModelRegistry:
         return resolved
 
     def _reregister_from_cache(self, hf_repo: str, gguf_filename: str, blob_path: Path) -> None:
-        """After recovering a model from the HF cache, write a fresh manifest for it.
+        """Write a fresh manifest for a model just recovered from the HF cache.
 
-        ``resolve`` works without the manifest, but ``list_installed`` (and
-        therefore ``lilbee model list``, the TUI catalog, and the "already
-        installed" check the pull command uses) only walks ``manifests/``, so
-        without this a recovered model would be resolvable but invisible. The
-        ``task`` comes from the featured catalog; for a ref that isn't a catalog
-        entry it's unknown, so the rewrite is skipped. The write is best-effort:
-        a read-only models dir or a write race must not break the resolve that
-        already succeeded.
+        ``list_installed`` only walks ``manifests/``, so a cache-recovered model
+        is resolvable but otherwise invisible (``lilbee model list``, the TUI
+        catalog, the pull command's "already installed" check) until a manifest
+        exists. The ``task`` comes from the featured catalog; for a non-catalog
+        ref it's unknown, so the rewrite is skipped. Best-effort: a read-only
+        models dir or a write race must not break the resolve that succeeded.
         """
         from datetime import UTC, datetime
 
         ref = format_native_gguf_ref(hf_repo, gguf_filename)
         try:
-            from lilbee.catalog import find_catalog_entry  # function-local: catalog imports cfg
+            from lilbee.catalog import (
+                find_catalog_entry,
+            )  # deferred: lilbee.catalog is a heavy import
 
             entry = find_catalog_entry(ref)
             if entry is None:
@@ -412,11 +405,9 @@ class ModelRegistry:
 def register_downloaded_model(entry: CatalogModel, file_path: Path) -> None:
     """Write a registry manifest for a freshly downloaded GGUF.
 
-    The bytes are already in the HF cache (the caller just downloaded them
-    there), and ``ModelRegistry.resolve`` falls back to the cache when the
-    manifest is absent, so a manifest-write hiccup leaves the model usable and
-    is logged, not raised. If the GGUF can't even be found in the cache the
-    download itself is broken; that re-raises so the caller reports a failure.
+    A failed manifest write is logged, not raised, when the GGUF is still in the
+    HF cache (``resolve`` recovers from it); if it isn't, the download itself is
+    broken and the failure propagates so the caller reports it.
     """
     from datetime import UTC, datetime
 

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -136,6 +136,7 @@ class ModelRegistry:
                 return blob_file
         recovered = self._find_cached_gguf(hf_repo, gguf_filename)
         if recovered is not None:
+            self._reregister_from_cache(hf_repo, gguf_filename, recovered)
             return recovered
         if manifest is None:
             raise KeyError(f"Model {ref} not installed")
@@ -169,6 +170,7 @@ class ModelRegistry:
         for filename in sorted(self._cached_gguf_names(hf_repo)):
             recovered = self._find_cached_gguf(hf_repo, filename)
             if recovered is not None:
+                self._reregister_from_cache(hf_repo, filename, recovered)
                 return recovered
         raise KeyError(f"Model {hf_repo} not installed")
 
@@ -208,6 +210,41 @@ class ModelRegistry:
         except ValueError:
             return None
         return resolved
+
+    def _reregister_from_cache(self, hf_repo: str, gguf_filename: str, blob_path: Path) -> None:
+        """After recovering a model from the HF cache, write a fresh manifest for it.
+
+        ``resolve`` works without the manifest, but ``list_installed`` (and
+        therefore ``lilbee model list``, the TUI catalog, and the "already
+        installed" check the pull command uses) only walks ``manifests/``, so
+        without this a recovered model would be resolvable but invisible. The
+        ``task`` comes from the featured catalog; for a ref that isn't a catalog
+        entry it's unknown, so the rewrite is skipped. The write is best-effort:
+        a read-only models dir or a write race must not break the resolve that
+        already succeeded.
+        """
+        from datetime import UTC, datetime
+
+        ref = format_native_gguf_ref(hf_repo, gguf_filename)
+        try:
+            from lilbee.catalog import find_catalog_entry  # function-local: catalog imports cfg
+
+            entry = find_catalog_entry(ref)
+            if entry is None:
+                return
+            self._write_manifest(
+                ModelManifest(
+                    hf_repo=hf_repo,
+                    gguf_filename=gguf_filename,
+                    size_bytes=blob_path.stat().st_size,
+                    task=entry.task,
+                    downloaded_at=datetime.now(UTC).isoformat(),
+                    blob=blob_path.name,  # the blob's filename is its sha in the HF cache
+                )
+            )
+            log.info("Recovered manifest for %s from the model cache", ref)
+        except Exception:  # cache-warming write; the resolve already returned a path
+            log.debug("Could not re-register %s from the model cache", ref, exc_info=True)
 
     def is_installed(self, ref: str) -> bool:
         """Return True if a model is installed and its blob is present."""

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -142,9 +142,12 @@ class LlamaCppProvider(LLMProvider):
         a malformed reply) the surfaced text is the worker's exception
         repr so the user sees enough to file a bug report.
         """
+        detail = str(exc)
+        if detail.endswith("."):  # the wrapper supplies its own sentence-final period
+            detail = detail[:-1]
         if isinstance(exc, WorkerCrashError):
-            return f"{role_label} worker exited unexpectedly. {exc}. Please try again."
-        return f"{role_label} worker reported an error: {exc}. Please try again."
+            return f"{role_label} worker exited unexpectedly. {detail}. Please try again."
+        return f"{role_label} worker reported an error: {detail}. Please try again."
 
     def _pool_runtime(self) -> PoolRuntime:
         """Return the Services-owned :class:`PoolRuntime`, starting it lazily."""

--- a/tests/test_bottom_bar_affordances.py
+++ b/tests/test_bottom_bar_affordances.py
@@ -320,8 +320,10 @@ async def test_app_falls_back_when_persisted_theme_invalid(_patch_chat_setup) ->
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        # Falls back to gruvbox (the module-level default), not the bad value.
-        assert app.theme != "not-a-real-theme"
+        # Falls back to the module-level default, not the bad value.
+        from lilbee.cli.tui.app import _DEFAULT_THEME
+
+        assert app.theme == _DEFAULT_THEME
 
 
 async def test_sync_theme_index_handles_non_dark_theme(_patch_chat_setup) -> None:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2071,24 +2071,59 @@ class TestRegisterDownloadedModel:
         refs = [m.ref for m in installed]
         assert "user/test/test.gguf" in refs
 
-    def test_manifest_install_exception_is_logged(self, tmp_path: Path) -> None:
-        """When registry.install raises, register_downloaded_model logs but doesn't crash."""
-        from unittest.mock import patch
+    def _seed_hf_cache(self, models_dir: Path, content: bytes = b"fake") -> Path:
+        """Lay down a faithful HuggingFace cache entry; return the snapshot file path."""
+        import hashlib
 
+        from lilbee.modelhub.registry import repo_to_dir
+
+        rev = "0" * 40
+        cache = models_dir / f"models--{repo_to_dir('user/test')}"
+        (cache / "blobs").mkdir(parents=True)
+        blob = cache / "blobs" / hashlib.sha256(content).hexdigest()
+        blob.write_bytes(content)
+        snap = cache / "snapshots" / rev
+        snap.mkdir(parents=True)
+        (snap / "test.gguf").symlink_to(blob)
+        (cache / "refs").mkdir(parents=True)
+        (cache / "refs" / "main").write_text(rev)
+        return snap / "test.gguf"
+
+    def test_manifest_write_failure_recovers_via_cache(self, tmp_path: Path) -> None:
+        """A manifest-write hiccup is logged, not raised: the bytes are in the HF cache."""
         from lilbee.core.config import cfg
-        from lilbee.modelhub.registry import register_downloaded_model
+        from lilbee.modelhub.registry import ModelRegistry, register_downloaded_model
 
-        file_path = tmp_path / "test.gguf"
-        file_path.write_bytes(b"fake")
-
+        file_path = self._seed_hf_cache(tmp_path)
         old_models_dir = cfg.models_dir
         cfg.models_dir = tmp_path
         try:
             with patch(
-                "lilbee.modelhub.registry.ModelRegistry.install",
-                side_effect=RuntimeError("disk full"),
+                "lilbee.modelhub.registry.ModelRegistry._write_manifest",
+                side_effect=OSError("disk full"),
             ):
-                # Should not raise
+                register_downloaded_model(self._entry(), file_path)  # must not raise
+            assert ModelRegistry(tmp_path).is_installed("user/test/test.gguf")
+        finally:
+            cfg.models_dir = old_models_dir
+
+    def test_broken_download_re_raises(self, tmp_path: Path) -> None:
+        """If the GGUF isn't even in the cache the download is broken; the failure propagates."""
+        from lilbee.core.config import cfg
+        from lilbee.modelhub.registry import register_downloaded_model
+
+        file_path = tmp_path / "test.gguf"
+        file_path.write_bytes(b"fake")  # not in the HF cache layout
+        old_models_dir = cfg.models_dir
+        cfg.models_dir = tmp_path
+        try:
+            with (
+                patch(
+                    "lilbee.modelhub.registry.ModelRegistry.install",
+                    side_effect=RuntimeError("disk full"),
+                ),
+                pytest.raises(RuntimeError, match="disk full"),
+            ):
                 register_downloaded_model(self._entry(), file_path)
         finally:
             cfg.models_dir = old_models_dir

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -99,6 +99,33 @@ class TestProviderError:
         assert err.provider == "test"
 
 
+class TestWorkerErrorMessage:
+    """`_worker_error_message` must not double-period when the inner message ends with one."""
+
+    def test_no_double_period_when_exc_ends_with_period(self) -> None:
+        from lilbee.providers.llama_cpp import LlamaCppProvider
+        from lilbee.providers.worker.transport_pipe import WorkerError
+
+        exc = WorkerError(
+            "ProviderError",
+            "Model 'X' not found in registry. Install it via the catalog or 'lilbee model pull'.",
+            "",
+        )
+        msg = LlamaCppProvider._worker_error_message("Chat", exc)
+        assert ".." not in msg
+        assert msg.endswith(". Please try again.")
+        assert "'lilbee model pull'. Please try again." in msg
+
+    def test_appends_period_when_exc_has_none(self) -> None:
+        from lilbee.providers.llama_cpp import LlamaCppProvider
+        from lilbee.providers.worker.transport_pipe import WorkerError
+
+        msg = LlamaCppProvider._worker_error_message(
+            "Embed", WorkerError("RuntimeError", "boom", "")
+        )
+        assert msg == "Embed worker reported an error: RuntimeError: boom. Please try again."
+
+
 # ---------------------------------------------------------------------------
 # LlamaCppProvider
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -276,6 +276,23 @@ class TestModelRegistryResolve:
         assert registry.resolve(_REF) == blob.resolve()
         assert registry.is_installed(_REF)
 
+    def test_resolve_recovery_writes_a_fresh_manifest(self, tmp_path: Path) -> None:
+        """Recovering a featured model from the cache also re-registers it, so it
+        shows up in ``list_installed`` (and ``lilbee model list`` / the TUI catalog)."""
+        registry = ModelRegistry(tmp_path)
+        _seed_hf_cache(tmp_path)
+        assert not registry.list_installed()  # no manifest yet
+        registry.resolve(_REF)
+        assert any(m.ref == _REF for m in registry.list_installed())
+
+    def test_resolve_recovery_survives_manifest_write_failure(self, tmp_path: Path) -> None:
+        """If re-registering after a cache recovery fails, ``resolve`` still returns the path."""
+        registry = ModelRegistry(tmp_path)
+        blob = _seed_hf_cache(tmp_path)
+        with mock.patch.object(ModelRegistry, "_write_manifest", side_effect=OSError("disk full")):
+            assert registry.resolve(_REF) == blob.resolve()
+        assert not registry.list_installed()  # the write failed, so still no manifest
+
     def test_resolve_bare_repo_ref_recovers_from_cache(self, tmp_path: Path) -> None:
         """A bare ``<org>/<repo>`` ref (older builds persisted these) resolves via the HF cache."""
         registry = ModelRegistry(tmp_path)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -50,6 +50,34 @@ def _write_source(tmp_path: Path, content: bytes = b"GGUF\x00\x00") -> Path:
     return src
 
 
+_FAKE_REV = "0123456789abcdef0123456789abcdef01234567"  # 40-hex commit-hash-shaped revision
+
+
+def _seed_hf_cache(
+    models_dir: Path,
+    *,
+    repo: str = _REPO,
+    filename: str = _FILENAME,
+    content: bytes = b"GGUF\x00\x00",
+) -> Path:
+    """Lay down a faithful HuggingFace cache entry (blobs/ + snapshots/<rev>/ symlink + refs/main).
+
+    Returns the blob path. Mirrors what ``huggingface_hub`` writes so its cache
+    helpers (``try_to_load_from_cache`` / ``scan_cache_dir``) resolve it.
+    """
+    digest = hashlib.sha256(content).hexdigest()
+    cache = models_dir / f"models--{repo_to_dir(repo)}"
+    (cache / "blobs").mkdir(parents=True, exist_ok=True)
+    blob = cache / "blobs" / digest
+    blob.write_bytes(content)
+    snap = cache / "snapshots" / _FAKE_REV
+    snap.mkdir(parents=True, exist_ok=True)
+    (snap / filename).symlink_to(blob)
+    (cache / "refs").mkdir(parents=True, exist_ok=True)
+    (cache / "refs" / "main").write_text(_FAKE_REV)
+    return blob
+
+
 class TestParseHfRef:
     def test_canonical_shape(self) -> None:
         repo, filename = parse_hf_ref(_REF)
@@ -239,6 +267,66 @@ class TestModelRegistryResolve:
         data["blob"] = None
         manifest_file.write_text(json.dumps(data))
         with pytest.raises(KeyError, match="install incomplete"):
+            registry.resolve(_REF)
+
+    def test_resolve_recovers_from_cache_without_manifest(self, tmp_path: Path) -> None:
+        """A GGUF in the HF cache resolves even with no lilbee manifest (e.g. after an upgrade)."""
+        registry = ModelRegistry(tmp_path)
+        blob = _seed_hf_cache(tmp_path)
+        assert registry.resolve(_REF) == blob.resolve()
+        assert registry.is_installed(_REF)
+
+    def test_resolve_bare_repo_ref_recovers_from_cache(self, tmp_path: Path) -> None:
+        """A bare ``<org>/<repo>`` ref (older builds persisted these) resolves via the HF cache."""
+        registry = ModelRegistry(tmp_path)
+        blob = _seed_hf_cache(tmp_path)
+        assert registry.resolve(_REPO) == blob.resolve()
+        assert registry.is_installed(_REPO)
+
+    def test_resolve_bare_repo_ref_uses_manifest_when_present(self, tmp_path: Path) -> None:
+        """A bare repo ref prefers a current-format manifest under that repo."""
+        registry = ModelRegistry(tmp_path)
+        src = _write_source(tmp_path)
+        blob_path = registry.install(_REPO, _FILENAME, src, _make_manifest())
+        assert registry.resolve(_REPO) == blob_path
+
+    def test_resolve_bare_repo_ref_skips_unparseable_manifest(self, tmp_path: Path) -> None:
+        """A bare repo ref skips an unreadable per-repo manifest and falls back to the cache."""
+        registry = ModelRegistry(tmp_path)
+        blob = _seed_hf_cache(tmp_path)
+        bad = tmp_path / "manifests" / repo_to_dir(_REPO) / f"{_FILENAME}.json"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text("not valid json at all")
+        assert registry.resolve(_REPO) == blob.resolve()
+
+    def test_resolve_bare_repo_ref_not_installed(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        with pytest.raises(KeyError, match="not installed"):
+            registry.resolve(_REPO)
+
+    def test_resolve_recovers_when_manifest_unparseable(self, tmp_path: Path) -> None:
+        """An unreadable / older-format manifest is ignored; the cache is the source of truth."""
+        registry = ModelRegistry(tmp_path)
+        blob = _seed_hf_cache(tmp_path)
+        bad = tmp_path / "manifests" / repo_to_dir(_REPO) / f"{_FILENAME}.json"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text('{"repo": "old-format", "extra": "fields the current schema lacks"}')
+        assert registry.resolve(_REF) == blob.resolve()
+
+    def test_recovery_ignores_snapshot_symlink_escaping_root(self, tmp_path: Path) -> None:
+        """A snapshot entry symlinking outside the registry root is not followed."""
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        registry = ModelRegistry(models_dir)
+        outside = tmp_path / "outside.gguf"  # not under models_dir
+        outside.write_bytes(b"escaped the cache")
+        cache = models_dir / f"models--{repo_to_dir(_REPO)}"
+        snap = cache / "snapshots" / _FAKE_REV
+        snap.mkdir(parents=True)
+        (snap / _FILENAME).symlink_to(outside)
+        (cache / "refs").mkdir(parents=True)
+        (cache / "refs" / "main").write_text(_FAKE_REV)
+        with pytest.raises(KeyError, match="not installed"):
             registry.resolve(_REF)
 
 

--- a/tests/test_task_row.py
+++ b/tests/test_task_row.py
@@ -141,6 +141,26 @@ async def test_update_applies_active_class_and_bar_percent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_update_blanks_stale_detail_on_done_keeps_it_on_failed() -> None:
+    """A DONE row drops its last-tick detail (it'd read "441/610 MB" beside 100%);
+    FAILED keeps it, since there the detail is the failure reason."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        host = app.query_one("#host", VerticalScroll)
+        row = TaskRow("t1")
+        await host.mount(row)
+        for _ in range(3):
+            await pilot.pause()
+        row.update(_task(status=TaskStatus.DONE, progress=100.0, detail="441/610 MB"), 0)
+        meta_widget = row.query_one("#row-meta")
+        done_meta = str(meta_widget._Static__content)  # type: ignore[attr-defined]
+        assert "441/610 MB" not in done_meta
+        assert "%" not in done_meta
+        row.update(_task(status=TaskStatus.FAILED, progress=12.0, detail="connection reset"), 0)
+        assert "connection reset" in str(meta_widget._Static__content)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_update_pulse_toggles_on_active_across_ticks() -> None:
     app = _Host()
     async with app.run_test() as pilot:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -572,8 +572,9 @@ class TestThemes:
         app = LilbeeApp()
         async with app.run_test() as pilot:
             await pilot.pause()
+            before = app.theme
             app.action_cycle_theme()
-            assert app.theme != "gruvbox"  # cycled to next
+            assert app.theme != before  # cycled to the next theme
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
     async def test_set_theme(self, mock_catalog: mock.MagicMock) -> None:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -7918,6 +7918,25 @@ def _write_published(wiki_root, slug: str, body: str) -> None:
     (summaries / f"{slug}.md").write_text(f"---\n---\n\n{body}\n", encoding="utf-8")
 
 
+def test_wiki_drafts_go_back_guarded_against_empty_stack() -> None:
+    """action_go_back must not ScreenStackError when the drafts screen is the only screen.
+
+    Regression: escape on the drafts screen called ``app.pop_screen()``
+    unconditionally; if it was the base screen that raised ``ScreenStackError``.
+    """
+    from lilbee.cli.tui.screens.wiki_drafts import WikiDraftsScreen
+
+    screen = WikiDraftsScreen()
+    fake_app = MagicMock()
+    fake_app.screen_stack = [screen]  # base screen; a pop here would raise
+    with patch.object(WikiDraftsScreen, "app", new_callable=PropertyMock, return_value=fake_app):
+        screen.action_go_back()
+        fake_app.pop_screen.assert_not_called()
+        fake_app.screen_stack = [object(), screen]  # something underneath now
+        screen.action_go_back()
+        fake_app.pop_screen.assert_called_once()
+
+
 class TestWikiDraftsScreen:
     """Wiki drafts review screen: list, diff, accept, reject."""
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -647,8 +647,8 @@ class TestModelBar:
         async with app.run_test() as pilot:
             await pilot.pause()
             pills = [str(s.render()) for s in app.query(Static) if "model-bar-pill" in s.classes]
-            assert any("Chat" in p and "▌" in p and "▐" in p for p in pills)
-            assert any("Embed" in p and "▌" in p and "▐" in p for p in pills)
+            assert any("Chat" in p for p in pills)
+            assert any("Embed" in p for p in pills)
 
     async def test_chat_mode_toggle_renders_search_when_embedding_ready(self) -> None:
         from lilbee.cli.tui.widgets.model_bar import ChatModeToggle
@@ -3436,8 +3436,7 @@ class TestPill:
         result = pill("chat", "$primary", "$text")
         text = str(result)
         assert "chat" in text
-        assert "\u258c" in text  # left half-block
-        assert "\u2590" in text  # right half-block
+        assert text == " chat "  # a space of padding on each side, no half-block ends
 
     def test_pill_from_content(self) -> None:
         from textual.content import Content
@@ -3449,12 +3448,13 @@ class TestPill:
         assert "embed" in str(result)
 
     def test_pill_empty_string(self) -> None:
+        from textual.content import Content
+
         from lilbee.cli.tui.pill import pill
 
         result = pill("", "$primary", "$text")
-        text = str(result)
-        assert "\u258c" in text
-        assert "\u2590" in text
+        assert isinstance(result, Content)
+        assert str(result) == "  "  # just the padding
 
     def test_pill_returns_content(self) -> None:
         from textual.content import Content

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -638,7 +638,7 @@ class TestModelBar:
             assert app.query_one("#embed-model-button", ModelPickerButton) is not None
 
     async def test_labels_rendered(self) -> None:
-        """Chat/Embed labels render as pills, not plain text."""
+        """Chat/Embed labels render as pills (label inside the styled-space padding)."""
         from textual.widgets import Static
 
         cfg.chat_model = TEST_LOCAL_REF
@@ -647,8 +647,8 @@ class TestModelBar:
         async with app.run_test() as pilot:
             await pilot.pause()
             pills = [str(s.render()) for s in app.query(Static) if "model-bar-pill" in s.classes]
-            assert any("Chat" in p for p in pills)
-            assert any("Embed" in p for p in pills)
+            assert any(" Chat " in p for p in pills)
+            assert any(" Embed " in p for p in pills)
 
     async def test_chat_mode_toggle_renders_search_when_embedding_ready(self) -> None:
         from lilbee.cli.tui.widgets.model_bar import ChatModeToggle

--- a/uv.lock
+++ b/uv.lock
@@ -4198,11 +4198,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

A user hit a string of issues trying lilbee on a fresh machine. CI was also failing for an unrelated reason, fixed here too.

**Models downloaded by a currently-published release stop working after you upgrade.** Every lilbee release that's published right now (the ones you get from your package manager) writes its model metadata in an older format, and saves the chat and embedding model as a bare `org/repo` name (no `/<file>.gguf` on the end) in `config.toml`. [v0.6.66b469](https://github.com/tobocop2/lilbee/releases/tag/v0.6.66b469) reworked the model catalog and the new code can't read that older metadata format and rejects the bare-name refs. So as things stand, if you installed any published release, downloaded a model, and then upgrade, you get `Model 'X' not found in registry` when you run `lilbee add` or chat, even though the model file is still sitting in the HuggingFace cache on your disk. The only fix was to delete the lilbee data directory and re-download everything. This PR adds the compatibility layer so that upgrade just works.

**The docs tell you to do things in an order that fails.** "Getting started" has you run `lilbee init`, then `lilbee add`, then `lilbee search`, but with no model installed `lilbee add` fails on every file with `Model '…' not found in registry`. Nothing told you that you have to install an embedding model first, and the OCR section read like you didn't need a model at all.

**A handful of smaller bugs:**
- Some error messages came out with a double period: `'lilbee model pull'.. Please try again.`
- The "that model isn't in the catalog" message only mentioned the HTTP API, not the `lilbee model pull` command.
- Pressing Escape on the wiki-drafts screen could crash with `ScreenStackError`.
- On a dark terminal, the colored pills in the task list had black bars on each end.
- A finished download showed a stale byte count next to `100%` (e.g. `441/610 MB 100.0%`).

**CI was red.** OSV-Scanner flagged `urllib3` 2.6.3 and a LiteLLM advisory.

## Solution

### Models: read the HuggingFace cache directly when the metadata file is stale or missing

The model files actually live in the HuggingFace cache on disk: `models--<org--repo>/snapshots/<rev>/<file>.gguf`, which is a symlink to `blobs/<sha>`. lilbee's own manifest (`manifests/<org--repo>/<file>.gguf.json`) is just a quick index over that. Before, lilbee trusted the manifest completely, so a manifest in an older version's format, or one the new code can't read, or a missing one, all meant "model not installed" even with the file right there.

Now:
- If the manifest is missing, unreadable, or doesn't list a file hash, lilbee asks `huggingface_hub` what model file the cache holds for that ref and uses it. When that recovery succeeds it also writes a fresh manifest, so the rest of the app (`lilbee model list`, the TUI catalog, the integration tests, etc.) sees the model too.
- A bare `org/repo` ref (the shape older versions saved) resolves to whichever quant of that repo is installed.

The HuggingFace cache layout hasn't changed, so upgrading to the b469 catalog just works: no deleting your data directory, no re-downloading. `register_downloaded_model` also now tells the difference between a manifest write that failed but is recoverable (the file is in the cache, so it logs and moves on) and a download that genuinely didn't land (no file in the cache, so it reports the failure).

### Docs: say up front that you need a model, and lead with the TUI

README and `docs/usage.md`:
- "Getting started" now leads with the TUI (`lilbee`) and its welcome-screen model picker, with the CLI and MCP server as the headless alternatives, instead of opening on `lilbee model pull`.
- It's explicit that you need an embedding model before `lilbee add`, and that the chat model is only for `/chat` and `lilbee ask`, not for indexing or `lilbee search`.
- The OCR section now says that Tesseract (or a vision model) only pulls *text out of* a scanned file; that text still has to be embedded, so you still need the embedding model.

### Smaller fixes

- Error messages no longer double up the period.
- The "not in the catalog" message now mentions `lilbee model pull <ref>` as well as the HTTP API.
- The wiki-drafts screen no longer crashes when you press Escape on the base screen.
- The task-list pills are a solid colored block end to end now, instead of using the half-block end characters that showed up as black bars on dark terminals. The default theme is also `rose-pine` now (muted, easy on the eyes) instead of `gruvbox`.
- A finished download stops showing the stale byte count next to `100%`.

### Dependencies

- `urllib3` bumped to 2.7.0.
- The LiteLLM advisory (`GHSA-wxxx-gvqv-xp7p`) is suppressed for the same reason as the other LiteLLM proxy advisories already listed: lilbee only uses LiteLLM as a library and never starts the proxy server the advisory is about, and the version bump that fixes it is blocked by a `click` / `typer` pin conflict.

`make test` passes with 100% coverage.

Note: one of the changes here is just a comment refresh for the frozen-binary `No such command '<N>'` path; the actual behavior can only be checked against a release build, so it won't be verified until the next binary build.
