### PR TITLE
Rebuild the marketing site; reframe the README and PyPI headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# lilbee — terminal-first local RAG for files, code, and the web
+# lilbee: a batteries-included terminal app for local AI
 
 [Project site](https://tobocop2.github.io/lilbee/) · [PyPI](https://pypi.org/project/lilbee/) · [Obsidian plugin](https://tobocop2.github.io/obsidian-lilbee/)
 
-A terminal-first local RAG and search engine for your own files, code, websites, and scanned documents. One install, no sidecar services, fully offline by default.
+lilbee is a terminal app: a model catalog, a search engine over your own files and code, and a chat, all in one program. The same program is also a CLI, an MCP server (point opencode or any AI agent at it), an HTTP API, and a Python library. One install command, sane defaults out of the box; it runs on your computer, and connects to cloud models only when you choose.
 
 <p align="center">
   <a href="https://github.com/tobocop2/lilbee/releases"><img src="https://img.shields.io/github/v/release/tobocop2/lilbee?include_prereleases&label=latest%20release" alt="Latest release (incl. pre-releases)"></a>
@@ -18,7 +18,7 @@ A terminal-first local RAG and search engine for your own files, code, websites,
 
 > ## ⚠️ Beta software
 >
-> lilbee is in **active beta** development. Every release on PyPI is a pre-release; you must use `--pre` (or uv's `--prerelease=allow`) when installing. Interfaces, command names, and on-disk formats may shift between betas. Feedback, bug reports, and issues are very welcome — that's the whole point of the beta.
+> lilbee is in **active beta** development. Every release on PyPI is a pre-release; you must use `--pre` (or uv's `--prerelease=allow`) when installing. Interfaces, command names, and on-disk formats may shift between betas. Feedback, bug reports, and issues are very welcome; that's the whole point of the beta.
 >
 > Latest pre-release (always): [lilbee on PyPI →](https://pypi.org/project/lilbee/)
 
@@ -44,9 +44,9 @@ Local AI tools have gotten great at getting you to a chat window fast. The first
 
 Local AI can be made more substantial than a chatbot. lilbee lets you pair the chatbot with a real search engine reviewing a curated set of documents. Make a library of what matters to you, let a local model reason over it, and get answers with citations you can click back to the source. Now the model knows your world.
 
-To acheive this in the past a user would manage a background daemon, a separate inference server, model files fetched by hand from the web, and a retrieval layer glued on top. lilbee bundles all of it into one install. Everything lives in one process, in the terminal; including a built-in model browser.
+To achieve this in the past a user would manage a background daemon, a separate inference server, model files fetched by hand from the web, and a retrieval layer glued on top. lilbee bundles all of it into one install. Everything lives in one process, in the terminal, including a built-in model catalog.
 
-The same executable ships a Textual TUI, a REST API, an MCP server for AI agents, and a Python library. It runs globally by default, or per-project by dropping a `.lilbee/` next to `.git/`, the same pattern git uses. Curated documents with topic-specificity produce better answers than a single catch-all vault of personal documents, white papers, instruction manuals, codebases, and so on.
+The same executable is a CLI and a Textual TUI, and it ships a REST API, an MCP server for AI agents, and a Python library. It runs globally by default, or per-project by dropping a `.lilbee/` next to `.git/`, the same pattern git uses. Curated documents with topic-specificity produce better answers than a single catch-all vault of personal documents, white papers, instruction manuals, codebases, and so on.
 
 An [Encarta 99](https://en.wikipedia.org/wiki/Encarta) you build for yourself, from your own files, shaped to your needs.
 
@@ -358,13 +358,13 @@ The Linux binary is built on `manylinux_2_28` and requires **glibc 2.28 or newer
 
 ### Optional extras
 
-lilbee works out of the box. Extras unlock additional capabilities. Both `pip` and `uv tool install` syntax shown:
+**lilbee works out of the box.** Three optional extras add more: `[crawler]` indexes websites, `[litellm]` bridges to popular hosted model providers, `[graph]` adds concept-graph search. Append the name in brackets to a `pip` or `uv tool install`:
 
-| Extra                                                                                                                           | What it adds                                                                                                                                                                                                                                                                                                                      |
-| ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Web crawling** — `pip install --pre 'lilbee[crawler]'` / `uv tool install --prerelease=allow 'lilbee[crawler]'`               | Index websites alongside local files. Recursive crawling with Playwright, live progress, cancel, hash-based change detection, SSRF protection, rate limits.                                                                                                                                                                       |
-| **Ollama and frontier models** — `pip install --pre 'lilbee[litellm]'` / `uv tool install --prerelease=allow 'lilbee[litellm]'` | Keep compatibility with existing Ollama setups, or use a popular frontier model (OpenAI, Anthropic, Gemini, etc.) for chat, vision, or embeddings while keeping other roles local. You provide the API key. Chunks sent to the provider leave your machine, and the TUI shows a persistent warning while a cloud model is active. |
-| **Concept graph** — `pip install --pre 'lilbee[graph]'` / `uv tool install --prerelease=allow 'lilbee[graph]'`                  | Topic clustering and search boosting. Extracts concepts from your documents and uses their relationships to find results pure text matching misses. Zero extra LLM calls.                                                                                                                                                         |
+| Extra            | What it does, and how to add it                                                                                                                                                                                                                                                            |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`[crawler]`**  | **Index websites alongside your files.** Recursive crawling with Playwright, live progress, cancel, hash-based change detection, SSRF protection, rate limits. `pip install --pre 'lilbee[crawler]'`                                                                                       |
+| **`[litellm]`**  | **Bridge to popular hosted model providers** for chat, vision, or embeddings while other roles stay local. You provide the API key; the TUI shows a persistent warning whenever a hosted model is active, and chunks sent to that provider leave your machine. `pip install --pre 'lilbee[litellm]'` |
+| **`[graph]`**    | **Concept-graph search.** Extracts the ideas in your documents and uses how they relate to surface results plain keyword matching misses. No extra model calls. `pip install --pre 'lilbee[graph]'`                                                                                        |
 
 Install multiple at once:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lilbee"
 version = "0.6.66b469"
-description = "Terminal-first local RAG and AI chat for your own documents, code, and crawled websites. Semantic and hybrid search, vision OCR, auto-built wiki, browsable GGUF model catalog. One install, no sidecars. CLI, TUI, MCP server, REST API, and Python library in one process."
+description = "A batteries-included terminal app for local AI: a browsable model catalog, a search engine over your own files and code, and a chat that cites its sources. Per-project libraries, semantic and hybrid search, vision OCR, auto-built wiki. CLI, TUI, MCP server, REST API, and Python library in one process; no model server, no database server."
 readme = "README.md"
 license = "Elastic-2.0"
 authors = [{ name = "tobocop2", email = "5562156+tobocop2@users.noreply.github.com" }]

--- a/site/index.html
+++ b/site/index.html
@@ -3,9 +3,10 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>lilbee: terminal-first local search engine</title>
-<meta name="description" content="A terminal-first local search engine for your files, code, the web, and scanned documents. One install, no sidecar services, fully offline by default. Ships a TUI, MCP server, REST API, and Python library.">
+<title>lilbee: a batteries-included terminal app for local AI</title>
+<meta name="description" content="A batteries-included terminal app for local AI: a browsable model catalog, a search engine over your own files and code, and a chat that cites its sources, in one program that's also a CLI, an MCP server, an HTTP API, and a Python library. One install, sane defaults out of the box.">
 <link rel="stylesheet" href="style.css">
+<script src="main.js" defer></script>
 </head>
 <body>
 <h1 class="sr">lilbee</h1>
@@ -30,8 +31,35 @@
 888 888 888 888  88888888888888888888
 888 888 888 888 d88PY8b.    Y8b.
 888 888 888 88888P"  "Y8888  "Y8888</pre>
-      <p class="tagline">A <strong>terminal-first local search engine</strong> for your files, code, the web, and scanned documents.</p>
-      <p class="sub">One install, no sidecar services, fully offline by default. Ships a TUI, MCP server, REST API, and Python library.</p>
+      <p class="tagline">A <strong>batteries-included terminal app</strong> for local AI.</p>
+      <p class="sub">One program with a model catalog, a search engine over your own files and code, and a chat. One install command, sane defaults out of the box. Pick a model, point it at a folder, ask.</p>
+    </section>
+
+    <section>
+      <div class="label">one program</div>
+      <div class="shape">
+        <div class="shape-box many">
+          <div class="shape-h">how local AI usually runs</div>
+          <ul>
+            <li>a model server, always running</li>
+            <li>model files fetched by hand</li>
+            <li>a vector database to stand up</li>
+            <li>a separate app for the interface</li>
+            <li>often a container around it all</li>
+          </ul>
+          <div class="shape-note">a deployment to stand up and keep alive.</div>
+        </div>
+        <div class="shape-box one">
+          <div class="shape-h">lilbee</div>
+          <ul>
+            <li>one program: a TUI, a CLI, an MCP server, an HTTP API, a Python library</li>
+            <li>no model server or database server to run; lilbee is the model runtime and the search index, in one process</li>
+            <li>a separate scoped library per project, so each domain stays its own clean encyclopedia</li>
+            <li>portable: runs on a laptop or headless over SSH, move it between machines</li>
+          </ul>
+          <div class="shape-note">one install command, sane defaults out of the box. point it at a folder, ask.</div>
+        </div>
+      </div>
     </section>
 
     <section>
@@ -56,38 +84,168 @@
       <div class="label">what it does</div>
       <div class="caps">
         <div class="cap">
-          <h3>personal encyclopedia</h3>
-          <p>Index PDFs, notes, ebooks, code. Every answer clicks back to the source line. Private Encarta you build from your own files.</p>
+          <h3>encyclopedias, plural</h3>
+          <p>A scoped library per project: your PDFs, notes, ebooks, and code, kept apart so results stay clean. Index with live progress in the TUI; every answer cites the source line.</p>
         </div>
         <div class="cap">
-          <h3>grounding for AI agents</h3>
-          <p>Plug into any MCP agent. It reads the code it's about to call, cites file and line, and says "I don't know" instead of guessing.</p>
+          <h3>pairs with your AI agent</h3>
+          <p>Point opencode or any MCP agent at a library: it reads the actual code and docs before answering, cites file and line, and says "I don't know" instead of guessing.</p>
         </div>
         <div class="cap">
           <h3>offline copies of websites</h3>
-          <p>One command to crawl a docs site or wiki, convert to markdown, and index. Search and chat with it offline, even if it goes down.</p>
+          <p>Crawl a docs site or wiki, convert it to markdown, and index it. Search and chat with it offline, even if it goes down.</p>
         </div>
         <div class="cap">
           <h3>scans &amp; OCR</h3>
-          <p>Paper archives and photos go through Tesseract or a local vision GGUF, landing as searchable markdown with layout preserved.</p>
+          <p>Paper archives and photos go through Tesseract or a local vision model, landing as searchable markdown with the layout kept.</p>
         </div>
       </div>
     </section>
 
     <section>
       <div class="label">install</div>
-      <div class="install">
-        <span class="prompt">$</span>
-        <span class="cmd" id="install-cmd">pip install --pre lilbee</span>
-        <button type="button" class="copy" id="copy-btn" aria-label="Copy install command">[ COPY ]</button>
+
+      <div class="installtabs" role="tablist" aria-label="Install methods">
+        <button type="button" class="tab" role="tab" id="tab-pip" aria-controls="pane-pip" aria-selected="true" tabindex="0">pip</button>
+        <button type="button" class="tab" role="tab" id="tab-uv" aria-controls="pane-uv" aria-selected="false" tabindex="-1">uv</button>
+        <button type="button" class="tab" role="tab" id="tab-brew" aria-controls="pane-brew" aria-selected="false" tabindex="-1">homebrew</button>
+        <button type="button" class="tab" role="tab" id="tab-aur" aria-controls="pane-aur" aria-selected="false" tabindex="-1">AUR</button>
+        <button type="button" class="tab" role="tab" id="tab-docker" aria-controls="pane-docker" aria-selected="false" tabindex="-1">docker</button>
+        <button type="button" class="tab" role="tab" id="tab-nix" aria-controls="pane-nix" aria-selected="false" tabindex="-1">nix</button>
+        <button type="button" class="tab" role="tab" id="tab-binary" aria-controls="pane-binary" aria-selected="false" tabindex="-1">binary</button>
+        <button type="button" class="tab" role="tab" id="tab-cuda" aria-controls="pane-cuda" aria-selected="false" tabindex="-1">CUDA</button>
+        <button type="button" class="tab" role="tab" id="tab-source" aria-controls="pane-source" aria-selected="false" tabindex="-1">source</button>
       </div>
-      <p class="extras">extras: <span class="tag">[crawler]</span> websites &nbsp; <span class="tag">[litellm]</span> frontier models &nbsp; <span class="tag">[graph]</span> concept-graph search</p>
-      <p class="extras"><span class="k">uv:</span> <code>uv tool install --prerelease=allow lilbee</code></p>
-      <p class="extras"><span class="k">homebrew:</span> <code>brew tap tobocop2/lilbee &amp;&amp; brew install lilbee</code></p>
-      <p class="extras"><span class="k">arch (AUR):</span> <code>paru -S lilbee</code></p>
-      <p class="extras"><span class="k">docker:</span> <code>docker run --rm ghcr.io/tobocop2/lilbee:latest</code></p>
-      <p class="extras"><span class="k">cuda (opt-in, NVIDIA-native):</span> <code>--extra-index-url https://tobocop2.github.io/lilbee/cu125/</code></p>
-      <p class="extras"><span class="k">beta:</span> every release is a pre-release. <a href="https://pypi.org/project/lilbee/#history">latest on pypi →</a></p>
+
+      <div class="installpane" role="tabpanel" id="pane-pip" aria-labelledby="tab-pip">
+        <div class="oschips"><span class="oschip">macOS</span><span class="oschip">Linux</span><span class="oschip">Windows</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">pip install --pre lilbee</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-pip">details</button>
+        <div class="notes-body" id="notes-pip" hidden>
+          <p class="extras">needs Python 3.11+ &nbsp;.&nbsp; intel mac: add <code>--extra-index-url https://tobocop2.github.io/lilbee/cpu/</code> &nbsp;.&nbsp; extras below, e.g. <code>pip install --pre 'lilbee[crawler,litellm]'</code></p>
+        </div>
+      </div>
+
+      <div class="installpane" role="tabpanel" id="pane-uv" aria-labelledby="tab-uv" hidden>
+        <div class="oschips"><span class="oschip">macOS</span><span class="oschip">Linux</span><span class="oschip">Windows</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">uv tool install --prerelease=allow lilbee</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-uv">details</button>
+        <div class="notes-body" id="notes-uv" hidden>
+          <p class="extras">uv fetches a Python for you if needed &nbsp;.&nbsp; extras: <code>uv tool install --prerelease=allow 'lilbee[crawler]'</code></p>
+        </div>
+      </div>
+
+      <div class="installpane" role="tabpanel" id="pane-brew" aria-labelledby="tab-brew" hidden>
+        <div class="oschips"><span class="oschip">macOS arm64</span><span class="oschip">Linux x86_64</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">brew tap tobocop2/lilbee &amp;&amp; brew install lilbee</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-brew">details</button>
+        <div class="notes-body" id="notes-brew" hidden>
+          <p class="extras">prebuilt bundle: its own Python interpreter and llama.cpp backend, nothing to compile &nbsp;.&nbsp; clears macOS quarantine for you &nbsp;.&nbsp; the <code>[crawler]</code> / <code>[litellm]</code> / <code>[graph]</code> extras need a <code>pip</code> or <code>uv</code> install</p>
+        </div>
+      </div>
+
+      <div class="installpane" role="tabpanel" id="pane-aur" aria-labelledby="tab-aur" hidden>
+        <div class="oschips"><span class="oschip">Arch Linux</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">paru -S lilbee</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-aur">details</button>
+        <div class="notes-body" id="notes-aur" hidden>
+          <p class="extras">package <code>lilbee</code> on the AUR &nbsp;.&nbsp; works with <code>yay</code> / <code>pacaur</code> / any helper &nbsp;.&nbsp; wraps the Linux x86_64 release binary</p>
+        </div>
+      </div>
+
+      <div class="installpane" role="tabpanel" id="pane-docker" aria-labelledby="tab-docker" hidden>
+        <div class="oschips"><span class="oschip">any host with Docker</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">docker run --rm -v lilbee-data:/home/lilbee/data ghcr.io/tobocop2/lilbee:latest --help</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-docker">details</button>
+        <div class="notes-body" id="notes-docker" hidden>
+          <p class="extras">image on the GitHub Container Registry &nbsp;.&nbsp; data lives at <code>/home/lilbee/data</code>, REST API on port 8000</p>
+        </div>
+      </div>
+
+      <div class="installpane" role="tabpanel" id="pane-nix" aria-labelledby="tab-nix" hidden>
+        <div class="oschips"><span class="oschip">NixOS</span><span class="oschip">nix-darwin</span><span class="oschip">any host with nix</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">nix run github:tobocop2/lilbee</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-nix">details</button>
+        <div class="notes-body" id="notes-nix" hidden>
+          <p class="extras">flake at <code>github:tobocop2/lilbee</code> &nbsp;.&nbsp; on Linux it bundles glibc and the Vulkan loader via an FHS env so it runs on bare NixOS</p>
+        </div>
+      </div>
+
+      <div class="installpane" role="tabpanel" id="pane-binary" aria-labelledby="tab-binary" hidden>
+        <div class="oschips"><span class="oschip">Linux x86_64</span><span class="oschip">macOS arm64</span><span class="oschip">Windows x86_64</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">curl -L https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-linux-x86_64 -o lilbee &amp;&amp; chmod +x lilbee</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-binary">details</button>
+        <div class="notes-body" id="notes-binary" hidden>
+          <p class="extras">single binary, bundles its own Python runtime, no <code>pip</code> needed &nbsp;.&nbsp; <a href="https://github.com/tobocop2/lilbee/releases">macOS arm64 and Windows builds on the releases page &rarr;</a></p>
+          <p class="extras"><span class="k">unsigned:</span> the macOS arm64 and Windows builds have no code-signing cert. On macOS, if Gatekeeper blocks it run <code>xattr -d com.apple.quarantine ./lilbee-macos-arm64</code> (or System Settings &rarr; Privacy &amp; Security &rarr; Open Anyway). Homebrew clears this for you.</p>
+        </div>
+      </div>
+
+      <div class="installpane" role="tabpanel" id="pane-cuda" aria-labelledby="tab-cuda" hidden>
+        <div class="oschips"><span class="oschip">Linux x86_64</span><span class="oschip">Windows x86_64</span><span class="oschip dim">NVIDIA GPU</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">pip install --pre lilbee --extra-index-url https://tobocop2.github.io/lilbee/cu125/</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-cuda">details</button>
+        <div class="notes-body" id="notes-cuda" hidden>
+          <p class="extras">only for the last bit of CUDA-native speed &nbsp;.&nbsp; the default wheel already uses your NVIDIA GPU through Vulkan &nbsp;.&nbsp; <code>cu121</code> / <code>cu124</code> indexes also available &nbsp;.&nbsp; works with <code>uv tool install</code> too</p>
+        </div>
+      </div>
+
+      <div class="installpane" role="tabpanel" id="pane-source" aria-labelledby="tab-source" hidden>
+        <div class="oschips"><span class="oschip">macOS</span><span class="oschip">Linux</span><span class="oschip">Windows</span></div>
+        <div class="install">
+          <span class="prompt">$</span>
+          <span class="cmd">git clone https://github.com/tobocop2/lilbee &amp;&amp; cd lilbee &amp;&amp; uv sync &amp;&amp; uv run lilbee</span>
+          <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+        </div>
+        <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-source">details</button>
+        <div class="notes-body" id="notes-source" hidden>
+          <p class="extras">for hacking on it or contributing &nbsp;.&nbsp; needs <code>git</code> and <code>uv</code></p>
+        </div>
+      </div>
+
+      <div class="installextras">
+        <div class="extras-h">optional extras</div>
+        <div class="extras-sub">add in brackets to a <code>pip</code> or <code>uv</code> install, e.g. <code>pip install --pre 'lilbee[crawler,litellm]'</code> &nbsp;.&nbsp; lilbee works without them</div>
+        <div class="extras-grid">
+          <div class="extra"><span class="tag">[crawler]</span><span>index websites too: crawl a docs site or wiki to markdown, then search it offline</span></div>
+          <div class="extra"><span class="tag">[litellm]</span><span>bridge to many popular hosted model providers for chat, vision, or embeddings; you bring the key, and the TUI flags when a hosted model is active</span></div>
+          <div class="extra"><span class="tag">[graph]</span><span>concept-graph search: finds matches plain keyword search misses, with no extra model calls</span></div>
+        </div>
+      </div>
+
+      <p class="installmeta">every release is a pre-release. <a href="https://pypi.org/project/lilbee/#history">latest on PyPI &rarr;</a> &nbsp;.&nbsp; <a href="https://github.com/tobocop2/lilbee/blob/main/README.md#install">full install guide &rarr;</a></p>
     </section>
 
     <section>
@@ -157,31 +315,5 @@
                              ZZ
                             Z</pre></aside>
 </div>
-<script>
-(function () {
-  var btn = document.getElementById('copy-btn');
-  if (!btn) return;
-  var cmd = document.getElementById('install-cmd');
-  btn.addEventListener('click', function () {
-    var text = cmd ? cmd.textContent : 'pip install --pre lilbee';
-    var done = function () {
-      var original = btn.textContent;
-      btn.textContent = '[ COPIED ]';
-      setTimeout(function () { btn.textContent = original; }, 1200);
-    };
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(done, done);
-    } else {
-      var ta = document.createElement('textarea');
-      ta.value = text;
-      document.body.appendChild(ta);
-      ta.select();
-      try { document.execCommand('copy'); } catch (e) {}
-      document.body.removeChild(ta);
-      done();
-    }
-  });
-})();
-</script>
 </body>
 </html>

--- a/site/main.js
+++ b/site/main.js
@@ -1,0 +1,89 @@
+// Interactivity for the lilbee landing page: the install-method tabs, the
+// per-method "details" disclosures, and the copy-to-clipboard buttons.
+
+(function () {
+  'use strict';
+
+  /** Wire the install-method tab strip: click selection and arrow-key navigation. */
+  function initInstallTabs() {
+    var tablist = document.querySelector('.installtabs');
+    if (!tablist) return;
+    var tabs = Array.prototype.slice.call(tablist.querySelectorAll('[role="tab"]'));
+
+    function select(tab) {
+      tabs.forEach(function (candidate) {
+        var active = candidate === tab;
+        candidate.setAttribute('aria-selected', active ? 'true' : 'false');
+        candidate.tabIndex = active ? 0 : -1;
+        var pane = document.getElementById(candidate.getAttribute('aria-controls'));
+        if (pane) pane.hidden = !active;
+      });
+    }
+
+    tablist.addEventListener('click', function (event) {
+      var tab = event.target.closest('[role="tab"]');
+      if (!tab) return;
+      select(tab);
+      tab.focus();
+    });
+
+    tablist.addEventListener('keydown', function (event) {
+      var index = tabs.indexOf(document.activeElement);
+      if (index < 0) return;
+      var step = event.key === 'ArrowRight' ? 1 : event.key === 'ArrowLeft' ? -1 : 0;
+      if (step === 0) return;
+      event.preventDefault();
+      var next = tabs[(index + step + tabs.length) % tabs.length];
+      select(next);
+      next.focus();
+    });
+  }
+
+  /** Toggle the per-method "details" notes when their disclosure button is clicked. */
+  function initDetailsToggles() {
+    document.addEventListener('click', function (event) {
+      var toggle = event.target.closest('.notes-toggle');
+      if (!toggle) return;
+      var open = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', open ? 'false' : 'true');
+      var body = document.getElementById(toggle.getAttribute('aria-controls'));
+      if (body) body.hidden = open;
+    });
+  }
+
+  /** Copy a command to the clipboard when its [ COPY ] button is clicked. */
+  function initCopyButtons() {
+    document.addEventListener('click', function (event) {
+      var button = event.target.closest('.copy');
+      if (!button) return;
+      var row = button.closest('.install');
+      var command = row ? row.querySelector('.cmd') : null;
+      copyText(command ? command.textContent : '', function () { flashCopied(button); });
+    });
+  }
+
+  function copyText(text, done) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(done, done);
+      return;
+    }
+    var area = document.createElement('textarea');
+    area.value = text;
+    document.body.appendChild(area);
+    area.select();
+    try { document.execCommand('copy'); } catch (error) { /* clipboard unavailable */ }
+    document.body.removeChild(area);
+    done();
+  }
+
+  function flashCopied(button) {
+    if (button.textContent.indexOf('COPIED') !== -1) return;
+    var original = button.textContent;
+    button.textContent = '[ COPIED ]';
+    setTimeout(function () { button.textContent = original; }, 1200);
+  }
+
+  initInstallTabs();
+  initDetailsToggles();
+  initCopyButtons();
+})();

--- a/site/style.css
+++ b/site/style.css
@@ -225,6 +225,46 @@ h1.sr {
   line-height: 1.6;
 }
 
+/* one-program comparison --------------------------------------------- */
+.shape {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.shape-box {
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+  padding: 0.9rem 1.05rem;
+}
+.shape-box.one { border-left: 2px solid var(--amber); }
+.shape-h {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  margin-bottom: 0.55rem;
+}
+.shape-box.many .shape-h { color: var(--ink-3); }
+.shape-box.one .shape-h { color: var(--amber); }
+.shape-box ul { list-style: none; }
+.shape-box li {
+  font-size: 13px;
+  color: var(--ink-2);
+  line-height: 1.55;
+  padding-left: 1.05em;
+  position: relative;
+  margin: 0.1rem 0;
+}
+.shape-box li::before { content: "·"; position: absolute; left: 0; color: var(--ink-3); }
+.shape-box.one li::before { color: var(--amber); }
+.shape-note {
+  font-size: 12px;
+  color: var(--ink-3);
+  margin-top: 0.6rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--rule);
+}
+
 /* install ------------------------------------------------------------ */
 .install {
   margin-top: 0.4rem;
@@ -243,6 +283,7 @@ h1.sr {
   padding: 0.7rem 0.4rem;
   color: var(--ink);
   font-weight: 500;
+  word-break: break-word;
 }
 .install .copy {
   font-family: var(--mono);
@@ -254,8 +295,129 @@ h1.sr {
   color: var(--ink-2);
   padding: 0 1.1rem;
   cursor: pointer;
+  white-space: nowrap;
 }
 .install .copy:hover { color: var(--amber-hot); background: rgba(255, 194, 74, 0.06); }
+
+/* install method tabs ------------------------------------------------ */
+.installtabs {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 0.3rem;
+  border-bottom: 1px solid var(--rule-2);
+}
+.installtabs .tab {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--ink-3);
+  padding: 0.5rem 0.85rem;
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition: color 140ms, border-color 140ms;
+}
+.installtabs .tab:hover { color: var(--ink-2); }
+.installtabs .tab[aria-selected="true"] {
+  color: var(--amber);
+  border-bottom-color: var(--amber);
+}
+.installpane { padding-top: 1rem; }
+.installpane[hidden] { display: none; }
+.oschips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 0.65rem;
+  font-size: 11.5px;
+}
+.oschip {
+  display: inline-block;
+  padding: 1px 8px;
+  border: 1px solid var(--rule-2);
+  border-radius: 3px;
+  color: var(--ink-2);
+  letter-spacing: 0.04em;
+}
+.oschip.dim { color: var(--ink-3); }
+.installmeta {
+  font-size: 12.5px;
+  color: var(--ink-3);
+  margin-top: 1.1rem;
+}
+
+/* per-method "details" disclosure ------------------------------------ */
+.notes-toggle {
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--ink-3);
+  padding: 0.6rem 0 0;
+  transition: color 140ms;
+}
+.notes-toggle::before {
+  content: "▸";
+  margin-right: 0.45em;
+  font-size: 10px;
+  display: inline-block;
+  transition: transform 140ms;
+}
+.notes-toggle[aria-expanded="true"]::before { transform: rotate(90deg); }
+.notes-toggle:hover { color: var(--amber); }
+.notes-body[hidden] { display: none; }
+.notes-body { padding-top: 0.1rem; }
+.notes-body .extras:first-child { margin-top: 0.4rem; }
+
+/* optional extras ---------------------------------------------------- */
+.installextras {
+  margin-top: 1.4rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid var(--rule);
+}
+.installextras .extras-h {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: 0.15rem;
+}
+.installextras .extras-sub {
+  font-size: 12.5px;
+  color: var(--ink-3);
+  margin-bottom: 0.7rem;
+}
+.installextras .extras-sub code {
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  padding: 0 0.35rem;
+  border-radius: 3px;
+  color: var(--ink-2);
+}
+.extras-grid { display: grid; gap: 7px; }
+.extra {
+  display: flex;
+  gap: 0.85rem;
+  align-items: baseline;
+  font-size: 13px;
+  color: var(--ink-2);
+  line-height: 1.55;
+  background: var(--bg-card);
+  border: 1px solid var(--rule);
+  border-left: 2px solid var(--amber);
+  border-radius: 3px;
+  padding: 0.5rem 0.8rem;
+  transition: border-color 160ms;
+}
+.extra:hover { border-color: var(--rule-2); border-left-color: var(--amber-hot); }
+.extra .tag { color: var(--amber); font-weight: 700; flex: none; min-width: 5.4em; }
 
 .extras {
   font-size: 13px;
@@ -353,6 +515,8 @@ footer .meta { text-align: right; font-size: 12px; }
 @media (max-width: 720px) {
   body { padding: 1.4rem 1.1rem 3rem; font-size: 14.5px; }
   .wordmark { font-size: 9.5px; }
-  .caps, .links { grid-template-columns: 1fr; }
+  .caps, .links, .shape { grid-template-columns: 1fr; }
   .tagline { font-size: 17px; }
+  .installtabs .tab { padding: 0.45rem 0.6rem; font-size: 12px; }
+  .extra { flex-direction: column; gap: 0.2rem; }
 }


### PR DESCRIPTION
## Problem

The site and the README led with "terminal-first local RAG" and a feature list. That undersells what lilbee is (one batteries-included program, not a stack you assemble), and it didn't make it easy to see how to install it per platform.

## Solution

The landing page is rebuilt around that: what lilbee is up front, a side-by-side "how local AI usually runs vs. lilbee", and an install section with a tab for each method (pip, uv, Homebrew, AUR, Docker, Nix, the standalone binary, CUDA wheels, from source) showing the platforms it covers, a copy button, and the rest tucked behind a "details" toggle. The README and the PyPI description get the same framing and drop "local RAG".