### PR TITLE
Bundle en_core_web_sm into the Nuitka binary so wiki entity extraction works (bb-eiib)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ lilbee is a terminal app: a model catalog, a search engine over your own files a
 
 <p align="center">
   <a href="https://github.com/tobocop2/lilbee/releases"><img src="https://img.shields.io/github/v/release/tobocop2/lilbee?include_prereleases&label=latest%20release" alt="Latest release (incl. pre-releases)"></a>
+  <a href="https://pypi.org/project/lilbee/"><img src="https://img.shields.io/pypi/v/lilbee?include_prereleases&label=PyPI" alt="lilbee on PyPI"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+"></a>
   <a href="https://github.com/tobocop2/lilbee/actions/workflows/ci.yml"><img src="https://github.com/tobocop2/lilbee/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://tobocop2.github.io/lilbee/coverage/"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen.svg" alt="Coverage"></a>

--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -18,6 +18,8 @@ PRODUCT_VERSION="${PRODUCT_VERSION:?PRODUCT_VERSION is required (int-tuple, e.g.
 uv pip uninstall python-multipart >/dev/null 2>&1 || true
 
 # Bundle en_core_web_sm so concept extraction works in the frozen binary.
+# It is loaded by name (spacy.load), never imported, so the Nuitka run below
+# pulls in the package, its model data, and its distribution metadata.
 # uv-managed Python ships without pip; install the matching wheel directly.
 if ! uv run --no-sync python -c "import en_core_web_sm" >/dev/null 2>&1; then
     SPACY_VER=$(uv run --no-sync python -c "import spacy; print(spacy.__version__)")
@@ -63,7 +65,9 @@ uv run --no-sync python -m nuitka \
     --include-package=crawl4ai           --include-package-data=crawl4ai \
     --include-package=fake_useragent     --include-package-data=fake_useragent \
     --include-package=playwright \
+    --enable-plugin=spacy \
     --include-package=spacy              --include-package-data=spacy \
+    --include-package=en_core_web_sm     --include-package-data=en_core_web_sm \
     --spacy-language-model=en_core_web_sm \
     --include-package=graspologic_native --include-package-data=graspologic_native \
     --include-package=textual            --include-package-data=textual \
@@ -74,6 +78,7 @@ uv run --no-sync python -m nuitka \
     --include-distribution-metadata=litellm \
     --include-distribution-metadata=Crawl4AI \
     --include-distribution-metadata=spacy \
+    --include-distribution-metadata=en_core_web_sm \
     --include-distribution-metadata=catalogue \
     --include-data-dir=src/lilbee/cli/tui=lilbee/cli/tui \
     --include-data-files=src/lilbee/featured_models.toml=lilbee/featured_models.toml \


### PR DESCRIPTION
## Problem

The standalone binaries shipped spaCy but couldn't load `en_core_web_sm` at runtime, so the wiki pipeline degraded to zero entities: `wiki build` / `wiki synthesize` produced nothing on every binary lane (and the Docker image, which curls the Linux binary). The pip wheels are unaffected.

## Solution

Enable Nuitka's spaCy plugin and explicitly bundle the `en_core_web_sm` package, its model data, and its distribution metadata so `spacy.load("en_core_web_sm")` resolves in the frozen binary. Also adds a PyPI version pill to the README badge row.

Verified by the binary-lane wiki cell in qa-matrix.yml. After merge, cut a fresh `v0.6.66bN+1` tag to rebuild the binaries; don't run publish-pypi.yml (wheels don't change).