### PR TITLE
Fix model-swap mid-stream hang and add embed-swap confirm

### DIFF
--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -95,7 +95,11 @@ class Services:
         channel = self.worker_pool.detach_channel(role_name)
         if channel is None:
             return
-        self.pool_runtime.submit(channel.close(timeout=_RELOAD_CLOSE_TIMEOUT_S))
+
+        async def _close() -> None:
+            await channel.close(timeout=_RELOAD_CLOSE_TIMEOUT_S)
+
+        self.pool_runtime.submit(_close())
 
     def add_pool_listener(
         self,

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -17,6 +17,14 @@ from typing import TYPE_CHECKING
 
 from lilbee.providers.worker.pool import shutdown_pool_runtime
 
+_RELOAD_CLOSE_TIMEOUT_S = 5.0
+"""Wall-clock budget for closing a detached worker channel during reload_role.
+
+Matches ``_DEFAULT_SHUTDOWN_TIMEOUT_S`` in ``providers.worker.pool``: a worker
+that does not ack SHUTDOWN within this window is terminated so the new model
+load is not blocked.
+"""
+
 if TYPE_CHECKING:
     from lilbee.catalog.hf_client import HfClient
     from lilbee.data.store import Store
@@ -74,6 +82,20 @@ class Services:
         """Flip the abort flag on every registered worker pool role. Idempotent."""
         for role_name in self.worker_pool.registered_roles:
             self.worker_pool.accessor(role_name).cancel()
+
+    def reload_role(self, role_name: WorkerRole) -> None:
+        """Drop *role_name*'s current worker so the next call lazy-respawns with cfg.
+
+        Detaches the channel synchronously (subsequent calls see no live worker),
+        then closes the old channel in the background on the pool runtime so the
+        caller's event loop is not stalled. Other roles' workers and any
+        in-flight stream they own are untouched. Use when only one role-bound
+        model setting has changed (e.g. embedding_model).
+        """
+        channel = self.worker_pool.detach_channel(role_name)
+        if channel is None:
+            return
+        self.pool_runtime.submit(channel.close(timeout=_RELOAD_CLOSE_TIMEOUT_S))
 
     def add_pool_listener(
         self,

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -177,6 +177,16 @@ CHAT_RENDERING = "Rendering: {label}"
 SETTINGS_READ_ONLY = "read-only"
 SETTINGS_INVALID_VALUE = "Invalid value: {error}"
 SETTINGS_RESET_TO_DEFAULT_TOOLTIP = "Reset to default"
+
+EMBED_SWAP_CONFIRM_TITLE = "Switch embedding model?"
+EMBED_SWAP_CONFIRM_MESSAGE = (
+    "The vector store was built under a different embedder. "
+    "Switching invalidates it: search and ingest are disabled until you rebuild. "
+    "Run `lilbee rebuild` afterward (or press S to sync) to re-embed every document. "
+    "Continue?"
+)
+EMBED_SWAP_CANCELLED = "Embedding model swap cancelled"
+
 SETTINGS_RESET_ALL_LABEL = "Reset all defaults"
 SETTINGS_RESET_ALL_CONFIRM_TITLE = "Reset all settings?"
 SETTINGS_RESET_ALL_CONFIRM_MESSAGE = (

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -25,6 +25,7 @@ from textual.widgets import (
     TabPane,
 )
 
+from lilbee.app.services import get_services
 from lilbee.cli.settings_map import SETTINGS_MAP, SettingDef, get_default
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.screens.settings_widgets import (
@@ -52,6 +53,7 @@ from lilbee.cli.tui.screens.settings_widgets import (
 from lilbee.cli.tui.widgets.list_text_area import ListTextArea
 from lilbee.core import settings
 from lilbee.core.config import DEFAULT_CRAWL_EXCLUDE_PATTERNS, cfg
+from lilbee.providers.worker.transport import WorkerRole
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.app import LilbeeApp
@@ -59,6 +61,17 @@ if TYPE_CHECKING:
     from lilbee.cli.tui.widgets.model_bar import ModelOption
 
 log = logging.getLogger(__name__)
+
+
+_MODEL_KEY_TO_WORKER_ROLE: dict[str, WorkerRole] = {
+    "chat_model": WorkerRole.CHAT,
+    "embedding_model": WorkerRole.EMBED,
+    "reranker_model": WorkerRole.RERANK,
+    "vision_model": WorkerRole.VISION,
+}
+"""Picker key -> worker pool role. Lets the Settings picker respawn the right
+worker after a swap so the new ref actually takes effect on the next call.
+"""
 
 
 @dataclass(frozen=True)
@@ -506,6 +519,9 @@ class SettingsScreen(Screen[None]):
         from lilbee.cli.tui.app import apply_active_model
 
         apply_active_model(self.app, key, ref)
+        role = _MODEL_KEY_TO_WORKER_ROLE.get(key)
+        if role is not None:
+            get_services().reload_role(role)
         try:
             button = self.query_one(f"#{MODEL_PICKER_BUTTON_PREFIX}{key}", Button)
             button.label = model_picker_label(key)

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -509,12 +509,29 @@ class SettingsScreen(Screen[None]):
         ``ref is None`` means the user cancelled (Esc); leave the field
         alone. ``ref == ""`` for a nullable field means the user picked
         the explicit "disabled" row; clear the field. Any other value is
-        a real model ref.
+        a real model ref. Embedding-model swaps against a populated store
+        route through a confirm modal first so the user is not surprised
+        by the rebuild requirement.
         """
         if ref is None:
             return
         defn = SETTINGS_MAP.get(key)
         if not ref and (defn is None or not defn.nullable):
+            return
+        if key == "embedding_model" and ref and get_services().store.has_chunks():
+            from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+            self.app.push_screen(
+                ConfirmDialog(msg.EMBED_SWAP_CONFIRM_TITLE, msg.EMBED_SWAP_CONFIRM_MESSAGE),
+                lambda confirmed: self._apply_picker_choice(key, ref, confirmed),
+            )
+            return
+        self._apply_picker_choice(key, ref, True)
+
+    def _apply_picker_choice(self, key: str, ref: str, confirmed: bool | None) -> None:
+        """Commit the picker choice or notify cancel; ``confirmed`` mirrors ConfirmDialog."""
+        if not confirmed:
+            self.app.notify(msg.EMBED_SWAP_CANCELLED)
             return
         from lilbee.cli.tui.app import apply_active_model
 

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -286,11 +286,40 @@ class ModelPickerButton(Static, can_focus=True):
             if ref == cfg.chat_model:
                 return
             apply_active_model(self.app, "chat_model", ref)
-        else:
-            if ref == cfg.embedding_model:
-                return
-            get_services().store.initialize_meta_if_legacy()
-            apply_active_model(self.app, "embedding_model", ref)
+            self._commit_after_change()
+            return
+        if ref == cfg.embedding_model:
+            return
+        # Embed-model swap invalidates a populated vector store. Confirm first.
+        store = get_services().store
+        if store.has_chunks():
+            from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+            self.app.push_screen(
+                ConfirmDialog(
+                    msg.EMBED_SWAP_CONFIRM_TITLE,
+                    msg.EMBED_SWAP_CONFIRM_MESSAGE,
+                ),
+                lambda confirmed: self._on_embed_swap_confirmed(ref, confirmed),
+            )
+            return
+        self._apply_embed_change(ref)
+
+    def _on_embed_swap_confirmed(self, ref: str, confirmed: bool | None) -> None:
+        """Apply the embed swap or notify cancel; ``confirmed`` mirrors ConfirmDialog."""
+        if not confirmed:
+            self.app.notify(msg.EMBED_SWAP_CANCELLED)
+            return
+        self._apply_embed_change(ref)
+
+    def _apply_embed_change(self, ref: str) -> None:
+        """Persist the new embed ref, refresh the bar, and respawn the embed worker."""
+        get_services().store.initialize_meta_if_legacy()
+        apply_active_model(self.app, "embedding_model", ref)
+        self._commit_after_change()
+
+    def _commit_after_change(self) -> None:
+        """Repaint this button and fan ``_after_model_change`` for the scope."""
         self._refresh()
         bar = self.screen.query(ModelBar)
         for b in bar:

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -29,6 +29,7 @@ from lilbee.core.config import cfg
 from lilbee.core.config.enums import ChatMode
 from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
 from lilbee.providers.sdk_backend import PROVIDER_KEYS
+from lilbee.providers.worker.transport import WorkerRole
 from lilbee.retrieval.embedder import is_model_available
 
 log = logging.getLogger(__name__)
@@ -293,7 +294,7 @@ class ModelPickerButton(Static, can_focus=True):
         self._refresh()
         bar = self.screen.query(ModelBar)
         for b in bar:
-            b._after_model_change()
+            b._after_model_change(self._scope)
 
 
 class ChatModePill(Static, can_focus=True):
@@ -499,8 +500,21 @@ class ModelBar(Widget, can_focus=False):
         with contextlib.suppress(Exception):
             self.query_one(ChatModeToggle).refresh_state()
 
-    def _after_model_change(self) -> None:
-        """Shared post-change logic: cancel active stream and reset services safely."""
+    def _after_model_change(self, scope: Literal["chat", "embed"]) -> None:
+        """Apply the side-effect of the role's model swap.
+
+        Chat-scope swaps route through :meth:`ChatScreen.apply_model_change`
+        so the in-flight stream cancels under the same UX that ``/model``
+        provides. Embed-scope swaps respawn only the embed worker via
+        :meth:`Services.reload_role`; the chat worker and any active
+        stream are untouched. Off-chat-screen chat swaps fall through to
+        a full ``reset_services`` because the chat-cancel path needs the
+        ChatScreen state machine.
+        """
+        if scope == "embed":
+            get_services().reload_role(WorkerRole.EMBED)
+            return
+
         from lilbee.cli.tui.screens.chat import ChatScreen
 
         screen = self.app.screen

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -29,6 +29,7 @@ from .lance_helpers import (
     _table_names,
     ensure_table,
     escape_sql_string,
+    refs_compatible,
 )
 from .ranking import mmr_rerank
 from .schema import _citations_schema, _meta_schema, _sources_schema
@@ -217,9 +218,11 @@ class Store:
         """Raise when the persisted embedding identity drifts from cfg.
 
         Pure check, no side effects. Migration of legacy stores (chunks present,
-        no ``_meta``) is the caller's responsibility via ``initialize_meta_if_legacy``
-        so this method is safe to call from inside an existing ``write_lock()``
-        (no recursive lock attempt). cfg fields are snapshotted at entry so the
+        no ``_meta``) is the caller's responsibility via ``initialize_meta_if_legacy``;
+        rewriting a legacy bare-repo ``_meta`` row to the canonical full ref is
+        the caller's responsibility via ``canonicalize_meta_if_legacy``. This
+        method stays safe to call from inside an existing ``write_lock()`` (no
+        recursive lock attempt). cfg fields are snapshotted at entry so the
         comparison is coherent even if another thread mutates them mid-call.
         """
         current_model = self._config.embedding_model
@@ -227,7 +230,9 @@ class Store:
         meta = self.get_meta()
         if meta is None:
             return
-        if meta["embedding_model"] == current_model and meta["embedding_dim"] == current_dim:
+        if refs_compatible(
+            meta["embedding_model"], current_model, meta["embedding_dim"], current_dim
+        ):
             return
         raise EmbeddingModelMismatchError(
             _embedding_mismatch_message(
@@ -237,6 +242,47 @@ class Store:
                 current_dim=current_dim,
             )
         )
+
+    def canonicalize_meta_if_legacy(self) -> bool:
+        """Rewrite a legacy bare-repo ``_meta`` row to the canonical full ref.
+
+        Pre-canonical lilbee versions persisted only the ``<org>/<repo>`` portion
+        in ``_meta.embedding_model``. The current code persists the full
+        ``<org>/<repo>/<filename>.gguf``. When ``cfg.embedding_model`` and the
+        persisted ref resolve to the same model (via ``refs_compatible``) but
+        differ as raw strings, this overwrites the meta row with the current
+        canonical form so the legacy name never surfaces in error messages,
+        UI surfaces, or downstream inspections. Returns ``True`` when a write
+        happened, ``False`` when meta was missing, already canonical, or
+        incompatible (the gate handles incompatibility separately).
+        """
+        meta = self.get_meta()
+        if meta is None:
+            return False
+        current_model = self._config.embedding_model
+        current_dim = self._config.embedding_dim
+        if meta["embedding_model"] == current_model:
+            return False
+        if not refs_compatible(
+            meta["embedding_model"], current_model, meta["embedding_dim"], current_dim
+        ):
+            return False
+        with write_lock():
+            # Re-read meta under the lock so two callers do not race the rewrite.
+            meta = self.get_meta()
+            if meta is None or meta["embedding_model"] == current_model:
+                return False
+            if not refs_compatible(
+                meta["embedding_model"], current_model, meta["embedding_dim"], current_dim
+            ):
+                return False
+            log.info(
+                "Migrating legacy embedding ref in store meta: %r -> %r",
+                meta["embedding_model"],
+                current_model,
+            )
+            self._write_meta_unlocked(embedding_model=current_model, embedding_dim=current_dim)
+            return True
 
     def get_db(self) -> lancedb.DBConnection:
         if self._db is None:
@@ -355,6 +401,7 @@ class Store:
         if table is None:
             return []
         self.initialize_meta_if_legacy()
+        self.canonicalize_meta_if_legacy()
         self._ensure_embedding_compat()
 
         if query_text and not self._fts_ready:

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -247,39 +247,36 @@ class Store:
             )
         )
 
+    def _needs_canonical_meta_rewrite(
+        self, meta: StoreMeta | None, current_model: str, current_dim: int
+    ) -> bool:
+        """True iff *meta* is the legacy form and refs-compatible with current cfg."""
+        if meta is None or meta["embedding_model"] == current_model:
+            return False
+        return refs_compatible(
+            meta["embedding_model"], current_model, meta["embedding_dim"], current_dim
+        )
+
     def canonicalize_meta_if_legacy(self) -> bool:
         """Rewrite a legacy bare-repo ``_meta`` row to the canonical full ref.
 
-        Pre-canonical lilbee versions persisted only the ``<org>/<repo>`` portion
-        in ``_meta.embedding_model``. The current code persists the full
-        ``<org>/<repo>/<filename>.gguf``. When ``cfg.embedding_model`` and the
-        persisted ref resolve to the same model (via ``refs_compatible``) but
-        differ as raw strings, this overwrites the meta row with the current
-        canonical form so the legacy name never surfaces in error messages,
-        UI surfaces, or downstream inspections. Returns ``True`` when a write
-        happened, ``False`` when meta was missing, already canonical, or
-        incompatible (the gate handles incompatibility separately).
+        Pre-canonical lilbee persisted only ``<org>/<repo>`` in
+        ``_meta.embedding_model``. The current code persists the full
+        ``<org>/<repo>/<filename>.gguf``. When the two refer to the same
+        model under :func:`refs_compatible` but differ as raw strings, the
+        meta row is rewritten so the legacy name never surfaces. Returns
+        ``True`` on write; ``False`` when missing, already canonical, or
+        incompatible (the gate handles incompatibility).
         """
-        meta = self.get_meta()
-        if meta is None:
-            return False
         current_model = self._config.embedding_model
         current_dim = self._config.embedding_dim
-        if meta["embedding_model"] == current_model:
-            return False
-        if not refs_compatible(
-            meta["embedding_model"], current_model, meta["embedding_dim"], current_dim
-        ):
+        if not self._needs_canonical_meta_rewrite(self.get_meta(), current_model, current_dim):
             return False
         with write_lock():
-            # Re-read meta under the lock so two callers do not race the rewrite.
-            meta = self.get_meta()
-            if meta is None or meta["embedding_model"] == current_model:
+            meta = self.get_meta()  # re-read under the lock for racing callers
+            if not self._needs_canonical_meta_rewrite(meta, current_model, current_dim):
                 return False
-            if not refs_compatible(
-                meta["embedding_model"], current_model, meta["embedding_dim"], current_dim
-            ):
-                return False
+            assert meta is not None  # filtered above  # noqa: S101
             log.info(
                 "Migrating legacy embedding ref in store meta: %r -> %r",
                 meta["embedding_model"],

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -184,6 +184,10 @@ class Store:
         chunks = self.open_table(CHUNKS_TABLE)
         return chunks is not None and chunks.count_rows() > 0
 
+    def has_chunks(self) -> bool:
+        """Public predicate: True iff the store currently holds at least one chunk."""
+        return self._has_chunks()
+
     def initialize_meta_if_legacy(self) -> bool:
         """Pin a legacy store's identity to the current cfg if not already set.
 

--- a/src/lilbee/data/store/lance_helpers.py
+++ b/src/lilbee/data/store/lance_helpers.py
@@ -6,6 +6,7 @@ import logging
 import threading
 from typing import TYPE_CHECKING
 
+from lilbee.catalog.refs import hf_repo_from_ref
 from lilbee.runtime.lock import write_lock
 
 from .types import CHUNK_TYPE_RAW
@@ -103,6 +104,34 @@ def _sources_search_filter(search: str | None) -> str | None:
         return None
     escaped = escape_sql_string(search.lower())
     return f"LOWER(filename) LIKE '%{escaped}%'"
+
+
+def refs_compatible(
+    persisted_ref: str,
+    current_ref: str,
+    persisted_dim: int,
+    current_dim: int,
+) -> bool:
+    """Return True when *persisted_ref* and *current_ref* describe the same embedder.
+
+    Compatible iff dims match and either the raw refs are equal or the persisted
+    ref is the legacy bare-repo form (``<org>/<repo>`` without a ``.gguf``
+    filename) whose repo matches the current canonical full ref. The legacy
+    asymmetry exists because pre-canonical lilbee versions persisted only the
+    repo; the current code persists the full ``<org>/<repo>/<filename>.gguf``.
+    Two different ``.gguf`` files in the same repo are not lumped together
+    (different quantizations can produce subtly different vectors), so both-
+    full-ref strict identity is preserved.
+    """
+    if persisted_dim != current_dim:
+        return False
+    if persisted_ref == current_ref:
+        return True
+    if persisted_ref.endswith(".gguf"):
+        return False
+    if not current_ref.endswith(".gguf"):
+        return False
+    return hf_repo_from_ref(current_ref) == persisted_ref
 
 
 def _embedding_mismatch_message(

--- a/src/lilbee/providers/worker/pool.py
+++ b/src/lilbee/providers/worker/pool.py
@@ -366,6 +366,21 @@ class WorkerPool:
             return None
         return registration.channel
 
+    def detach_channel(self, role: WorkerRole) -> WorkerChannel | None:
+        """Atomically clear *role*'s channel and return the prior live channel or None.
+
+        The caller owns the returned channel and is responsible for closing it
+        (typically by submitting ``channel.close(...)`` onto the pool runtime).
+        Other roles' channels are untouched. The next ``_ensure_channel`` call
+        for this role lazy-respawns with the current ``config_factory()`` snapshot.
+        """
+        registration = self._roles.get(role)
+        if registration is None:
+            return None
+        channel = registration.channel
+        registration.channel = None
+        return channel
+
     def _refuse_or_clear_cooldown(self, role: WorkerRole, registration: _Role) -> None:
         """Raise ``RoleDegradedError`` if still cooling down; clear if past deadline.
 

--- a/src/lilbee/providers/worker/pool.py
+++ b/src/lilbee/providers/worker/pool.py
@@ -367,12 +367,12 @@ class WorkerPool:
         return registration.channel
 
     def detach_channel(self, role: WorkerRole) -> WorkerChannel | None:
-        """Atomically clear *role*'s channel and return the prior live channel or None.
+        """Atomically clear *role*'s channel; return the prior live channel or None.
 
-        The caller owns the returned channel and is responsible for closing it
-        (typically by submitting ``channel.close(...)`` onto the pool runtime).
-        Other roles' channels are untouched. The next ``_ensure_channel`` call
-        for this role lazy-respawns with the current ``config_factory()`` snapshot.
+        Caller owns the returned channel and closes it (typically by submitting
+        ``channel.close(...)`` on the pool runtime). Other roles are untouched.
+        The next ``_ensure_channel`` call for this role lazy-respawns with the
+        current ``config_factory()`` snapshot.
         """
         registration = self._roles.get(role)
         if registration is None:

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -231,12 +231,17 @@ async def set_embedding_model(model: str) -> SetModelResponse:
     its meta lazy-initialized from the NEW cfg on the next read, hiding the
     drift the caller just introduced.
     """
+    from lilbee.data.store.lance_helpers import refs_compatible
+
     normalized = _require_model_for_task(model, ModelTask.EMBEDDING)
     store = get_services().store
     store.initialize_meta_if_legacy()
     await _set_model("embedding_model", normalized)
+    store.canonicalize_meta_if_legacy()
     meta = store.get_meta()
-    reindex_required = meta is not None and meta["embedding_model"] != normalized
+    reindex_required = meta is not None and not refs_compatible(
+        meta["embedding_model"], normalized, meta["embedding_dim"], meta["embedding_dim"]
+    )
     return SetModelResponse(model=normalized, reindex_required=reindex_required)
 
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1706,6 +1706,27 @@ class TestSetEmbeddingModel:
         assert result.reindex_required is False
 
     @patch("lilbee.server.handlers.models.get_services")
+    async def test_returns_no_reindex_required_for_legacy_bare_repo(self, mock_svc):
+        """A bare-repo meta row that matches the new full ref does NOT need a rebuild.
+
+        Pre-canonical lilbee persisted only ``<org>/<repo>`` in ``_meta``. The
+        new full ref ``<org>/<repo>/<file>.gguf`` matches by canonical identity
+        when dims agree, so the swap is a no-op for the gate.
+        """
+        mock_svc.return_value.provider.list_models.return_value = [_EMBED_REF]
+        bare_repo = _EMBED_REF.rsplit("/", 1)[0]
+        mock_svc.return_value.store.get_meta.return_value = {
+            "embedding_model": bare_repo,
+            "embedding_dim": 768,
+            "schema_version": 1,
+            "updated_at": "2026-04-25T00:00:00+00:00",
+        }
+        result = await handlers.set_embedding_model(_EMBED_REF)
+        assert result.reindex_required is False
+        # Migration helper must be called so the meta row is rewritten silently.
+        mock_svc.return_value.store.canonicalize_meta_if_legacy.assert_called_once()
+
+    @patch("lilbee.server.handlers.models.get_services")
     async def test_pins_legacy_meta_before_cfg_mutation(self, mock_svc):
         """A pre-upgrade store with chunks but no _meta is pinned under the OLD cfg.
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -74,21 +74,23 @@ class TestReloadRole:
         """``reload_role`` detaches the named role's channel and leaves siblings alone."""
         detached: list[str] = []
 
+        from lilbee.providers.worker.transport import WorkerRole
+
         class _FakeChannel:
-            def __init__(self, role: str) -> None:
+            def __init__(self, role: WorkerRole) -> None:
                 self.role = role
                 self.closed = False
 
             async def close(self, *, timeout: float) -> None:
                 self.closed = True
 
-        chat_channel = _FakeChannel("chat")
-        embed_channel = _FakeChannel("embed")
+        chat_channel = _FakeChannel(WorkerRole.CHAT)
+        embed_channel = _FakeChannel(WorkerRole.EMBED)
 
         class _FakePool:
-            def detach_channel(self, role: str):
+            def detach_channel(self, role: WorkerRole) -> _FakeChannel | None:
                 detached.append(role)
-                return embed_channel if role == "embed" else chat_channel
+                return embed_channel if role == WorkerRole.EMBED else chat_channel
 
         class _FakeRuntime:
             def __init__(self) -> None:
@@ -104,15 +106,16 @@ class TestReloadRole:
 
         runtime = _FakeRuntime()
         services = make_mock_services(worker_pool=_FakePool(), pool_runtime=runtime)
-        services.reload_role("embed")
-        assert detached == ["embed"]
+        services.reload_role(WorkerRole.EMBED)
+        assert detached == [WorkerRole.EMBED]
         assert len(runtime.submitted) == 1
 
     def test_no_op_when_role_has_no_live_channel(self):
         """``reload_role`` is silent when the role has nothing to close."""
+        from lilbee.providers.worker.transport import WorkerRole
 
         class _FakePool:
-            def detach_channel(self, role):
+            def detach_channel(self, role: WorkerRole) -> None:
                 return None
 
         class _FakeRuntime:
@@ -128,7 +131,7 @@ class TestReloadRole:
 
         runtime = _FakeRuntime()
         services = make_mock_services(worker_pool=_FakePool(), pool_runtime=runtime)
-        services.reload_role("embed")
+        services.reload_role(WorkerRole.EMBED)
         assert runtime.submitted == []
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -92,14 +92,17 @@ class TestReloadRole:
                 detached.append(role)
                 return embed_channel if role == WorkerRole.EMBED else chat_channel
 
+        import asyncio
+
         class _FakeRuntime:
             def __init__(self) -> None:
                 self.submitted: list[object] = []
 
             def submit(self, coro):
                 self.submitted.append(coro)
-                # close coroutine so the test doesn't leak a pending awaitable
-                coro.close()
+                # Run the close coroutine inline so the test exercises the
+                # ``await channel.close(...)`` path inside ``reload_role``.
+                asyncio.new_event_loop().run_until_complete(coro)
                 return MagicMock()
 
         from tests.conftest import make_mock_services
@@ -109,6 +112,9 @@ class TestReloadRole:
         services.reload_role(WorkerRole.EMBED)
         assert detached == [WorkerRole.EMBED]
         assert len(runtime.submitted) == 1
+        # The wrapped coroutine must actually invoke channel.close.
+        assert embed_channel.closed is True
+        assert chat_channel.closed is False
 
     def test_no_op_when_role_has_no_live_channel(self):
         """``reload_role`` is silent when the role has nothing to close."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -69,6 +69,69 @@ class TestCancelInference:
         assert called == ["embed", "chat"]
 
 
+class TestReloadRole:
+    def test_detaches_only_the_requested_role(self):
+        """``reload_role`` detaches the named role's channel and leaves siblings alone."""
+        detached: list[str] = []
+
+        class _FakeChannel:
+            def __init__(self, role: str) -> None:
+                self.role = role
+                self.closed = False
+
+            async def close(self, *, timeout: float) -> None:
+                self.closed = True
+
+        chat_channel = _FakeChannel("chat")
+        embed_channel = _FakeChannel("embed")
+
+        class _FakePool:
+            def detach_channel(self, role: str):
+                detached.append(role)
+                return embed_channel if role == "embed" else chat_channel
+
+        class _FakeRuntime:
+            def __init__(self) -> None:
+                self.submitted: list[object] = []
+
+            def submit(self, coro):
+                self.submitted.append(coro)
+                # close coroutine so the test doesn't leak a pending awaitable
+                coro.close()
+                return MagicMock()
+
+        from tests.conftest import make_mock_services
+
+        runtime = _FakeRuntime()
+        services = make_mock_services(worker_pool=_FakePool(), pool_runtime=runtime)
+        services.reload_role("embed")
+        assert detached == ["embed"]
+        assert len(runtime.submitted) == 1
+
+    def test_no_op_when_role_has_no_live_channel(self):
+        """``reload_role`` is silent when the role has nothing to close."""
+
+        class _FakePool:
+            def detach_channel(self, role):
+                return None
+
+        class _FakeRuntime:
+            def __init__(self) -> None:
+                self.submitted: list[object] = []
+
+            def submit(self, coro):
+                self.submitted.append(coro)
+                coro.close()
+                return MagicMock()
+
+        from tests.conftest import make_mock_services
+
+        runtime = _FakeRuntime()
+        services = make_mock_services(worker_pool=_FakePool(), pool_runtime=runtime)
+        services.reload_role("embed")
+        assert runtime.submitted == []
+
+
 class TestEagerStartBranch:
     """``get_services`` triggers ``pool_runtime.start`` + ``start_eager`` when
     ``cfg.worker_pool_eager_start`` is True."""

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1159,6 +1159,53 @@ class TestEmbeddingModelGate:
         store.add_chunks(_make_records())
         assert store.canonicalize_meta_if_legacy() is False
 
+    def test_canonicalize_meta_if_legacy_skips_when_meta_changes_under_lock(
+        self, tmp_path, monkeypatch
+    ):
+        """Race path: another writer canonicalized between outer and inner check.
+
+        The outer (no-lock) check sees the rewrite is needed; the inner (under
+        write_lock) re-read sees it no longer is. Method short-circuits so the
+        racer's work isn't clobbered.
+        """
+        full_ref = "org/repo-GGUF/model.Q4_K_M.gguf"
+        cfg_local = cfg.model_copy(
+            update={"lancedb_dir": tmp_path / "lance_race", "embedding_model": full_ref}
+        )
+        local_store = Store(cfg_local)
+        local_store.add_chunks(_make_records(dim=cfg_local.embedding_dim))
+        with write_lock():
+            local_store._write_meta_unlocked(
+                embedding_model="org/repo-GGUF", embedding_dim=cfg_local.embedding_dim
+            )
+
+        # First check (outer) says yes; second check (inner, under lock) says no.
+        call_count = {"n": 0}
+        original = local_store._needs_canonical_meta_rewrite
+
+        def flipping_check(meta, current_model, current_dim):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return original(meta, current_model, current_dim)
+            return False
+
+        monkeypatch.setattr(local_store, "_needs_canonical_meta_rewrite", flipping_check)
+        assert local_store.canonicalize_meta_if_legacy() is False
+
+    def test_has_chunks_public_predicate(self, store):
+        """``has_chunks`` is True after add_chunks and False on an empty store."""
+        assert store.has_chunks() is False
+        store.add_chunks(_make_records())
+        assert store.has_chunks() is True
+
+    def test_refs_compatible_remote_refs_strict_equality(self):
+        """Two non-native refs (no ``.gguf``) require strict raw equality."""
+        from lilbee.data.store.lance_helpers import refs_compatible
+
+        assert refs_compatible("ollama/embed:a", "ollama/embed:a", 768, 768) is True
+        # Different non-native refs: not compatible even when dims match.
+        assert refs_compatible("ollama/embed:a", "ollama/embed:b", 768, 768) is False
+
     def test_canonicalize_meta_if_legacy_skips_on_genuine_mismatch(self, tmp_path):
         """Different file in the same repo is NOT a legacy match; gate still refuses."""
         from lilbee.data.store import EmbeddingModelMismatchError

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -15,6 +15,7 @@ from lilbee.data.store import (
     mmr_rerank,
     scope_to_chunk_type,
 )
+from lilbee.runtime.lock import write_lock
 
 
 @pytest.fixture()
@@ -1107,6 +1108,77 @@ class TestEmbeddingModelGate:
         """No chunks, no meta = nothing to pin."""
         assert store.initialize_meta_if_legacy() is False
         assert store.get_meta() is None
+
+    def test_legacy_bare_repo_meta_is_compatible_with_full_ref(self, tmp_path):
+        """A pre-canonical store meta (bare ``<org>/<repo>``) matches the new full ref.
+
+        Same repo, same dim: gating treats them as the same model so search and
+        ingest do not refuse, and the chat error stops showing the legacy name.
+        """
+        full_ref = "org/repo-GGUF/model.Q4_K_M.gguf"
+        cfg_local = cfg.model_copy(
+            update={"lancedb_dir": tmp_path / "lance_legacy", "embedding_model": full_ref}
+        )
+        local_store = Store(cfg_local)
+        local_store.add_chunks(_make_records(dim=cfg_local.embedding_dim))
+        with write_lock():
+            local_store._write_meta_unlocked(
+                embedding_model="org/repo-GGUF", embedding_dim=cfg_local.embedding_dim
+            )
+        # Search must NOT raise: legacy bare-repo + matching dim is compatible.
+        local_store.search([0.1] * cfg_local.embedding_dim)
+
+    def test_canonicalize_meta_if_legacy_rewrites_to_full_ref(self, tmp_path):
+        """Legacy bare-repo meta is rewritten to the canonical full ref on first call.
+
+        Once migrated, the legacy name never surfaces in error messages, the
+        UI, or downstream inspections of the meta row.
+        """
+        full_ref = "org/repo-GGUF/model.Q4_K_M.gguf"
+        cfg_local = cfg.model_copy(
+            update={"lancedb_dir": tmp_path / "lance_migrate", "embedding_model": full_ref}
+        )
+        local_store = Store(cfg_local)
+        local_store.add_chunks(_make_records(dim=cfg_local.embedding_dim))
+        with write_lock():
+            local_store._write_meta_unlocked(
+                embedding_model="org/repo-GGUF", embedding_dim=cfg_local.embedding_dim
+            )
+
+        wrote = local_store.canonicalize_meta_if_legacy()
+        assert wrote is True
+        meta = local_store.get_meta()
+        assert meta is not None
+        assert meta["embedding_model"] == full_ref
+
+        # Idempotent: a second call is a no-op.
+        assert local_store.canonicalize_meta_if_legacy() is False
+
+    def test_canonicalize_meta_if_legacy_skips_when_already_canonical(self, store):
+        """No write when meta is already the canonical full ref."""
+        store.add_chunks(_make_records())
+        assert store.canonicalize_meta_if_legacy() is False
+
+    def test_canonicalize_meta_if_legacy_skips_on_genuine_mismatch(self, tmp_path):
+        """Different file in the same repo is NOT a legacy match; gate still refuses."""
+        from lilbee.data.store import EmbeddingModelMismatchError
+
+        full_ref = "org/repo-GGUF/model.Q4_K_M.gguf"
+        cfg_local = cfg.model_copy(
+            update={"lancedb_dir": tmp_path / "lance_mismatch", "embedding_model": full_ref}
+        )
+        local_store = Store(cfg_local)
+        local_store.add_chunks(_make_records(dim=cfg_local.embedding_dim))
+        other_full = "org/repo-GGUF/model.Q8_0.gguf"
+        with write_lock():
+            local_store._write_meta_unlocked(
+                embedding_model=other_full, embedding_dim=cfg_local.embedding_dim
+            )
+        # canonicalize must not rewrite (refs are NOT compatible).
+        assert local_store.canonicalize_meta_if_legacy() is False
+        # And the gate still refuses.
+        with pytest.raises(EmbeddingModelMismatchError):
+            local_store.search([0.1] * cfg_local.embedding_dim)
 
     def test_initialize_meta_if_legacy_skips_when_another_caller_won_the_race(
         self, store, test_config

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -11861,6 +11861,33 @@ async def test_settings_model_picker_dismissed_persists_and_refreshes_label():
         assert str(button.label).strip() != ""
 
 
+async def test_settings_model_picker_dismissed_reloads_worker_for_role():
+    """Picking from Settings respawns just the role that changed.
+
+    Without this, the new model is written to cfg but the live worker
+    keeps the old model loaded until restart. With it, the rerank /
+    vision / embed worker reflects the new selection on the next call,
+    and an in-flight chat stream is unaffected.
+    """
+    from unittest.mock import patch
+
+    from lilbee.providers.worker.transport import WorkerRole
+
+    services_mock = MagicMock()
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        with (
+            patch("lilbee.cli.tui.app.apply_active_model"),
+            patch(
+                "lilbee.cli.tui.screens.settings.get_services",
+                return_value=services_mock,
+            ),
+        ):
+            screen._on_model_picker_dismissed("vision_model", "fake/vision.gguf")
+        services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
+
+
 def test_settings_model_picker_dismissed_no_op_on_blank_ref():
     """A blank/None ref short-circuits before reaching apply_active_model."""
     from unittest.mock import patch

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -11889,6 +11889,28 @@ async def test_settings_model_picker_dismissed_reloads_worker_for_role():
         services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
 
 
+async def test_settings_embed_swap_confirm_cancel_leaves_cfg_untouched():
+    """Cancelling the embed-swap confirm modal does NOT call apply_active_model or reload_role."""
+    from unittest.mock import patch
+
+    services_mock = MagicMock()
+    services_mock.store.has_chunks.return_value = True
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        with (
+            patch("lilbee.cli.tui.app.apply_active_model") as mock_apply,
+            patch(
+                "lilbee.cli.tui.screens.settings.get_services",
+                return_value=services_mock,
+            ),
+        ):
+            # Direct path: caller invokes _apply_picker_choice with confirmed=False.
+            screen._apply_picker_choice("embedding_model", "fake/new.gguf", False)
+        mock_apply.assert_not_called()
+        services_mock.reload_role.assert_not_called()
+
+
 async def test_settings_embed_picker_against_populated_store_pushes_confirm():
     """Embed swap from Settings against a populated store routes through the confirm modal."""
     from unittest.mock import patch

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -11874,6 +11874,7 @@ async def test_settings_model_picker_dismissed_reloads_worker_for_role():
     from lilbee.providers.worker.transport import WorkerRole
 
     services_mock = MagicMock()
+    services_mock.store.has_chunks.return_value = False
     app = SettingsTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
@@ -11886,6 +11887,31 @@ async def test_settings_model_picker_dismissed_reloads_worker_for_role():
         ):
             screen._on_model_picker_dismissed("vision_model", "fake/vision.gguf")
         services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
+
+
+async def test_settings_embed_picker_against_populated_store_pushes_confirm():
+    """Embed swap from Settings against a populated store routes through the confirm modal."""
+    from unittest.mock import patch
+
+    from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+    services_mock = MagicMock()
+    services_mock.store.has_chunks.return_value = True
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        with (
+            patch("lilbee.cli.tui.app.apply_active_model") as mock_apply,
+            patch(
+                "lilbee.cli.tui.screens.settings.get_services",
+                return_value=services_mock,
+            ),
+        ):
+            screen._on_model_picker_dismissed("embedding_model", "fake/new-embed.gguf")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmDialog)
+            # cfg path must NOT have been touched yet -- waiting on confirm.
+            mock_apply.assert_not_called()
 
 
 def test_settings_model_picker_dismissed_no_op_on_blank_ref():

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1023,6 +1023,66 @@ class TestModelPickerButton:
                 await pilot.pause()
             write_tracker.assert_not_called()
 
+    async def test_embed_picker_dismiss_reloads_only_embed_role(self) -> None:
+        """Embed swap respawns just the embed worker. Chat stream stays untouched.
+
+        Regression for the mid-stream embed-swap hang: the old code called
+        ``reset_services`` on every model change, which races the chat
+        worker if a stream is in flight. The fix scopes the reset to the
+        role that actually changed.
+        """
+        from lilbee.cli.tui.widgets.model_bar import ModelPickerButton
+        from lilbee.providers.worker.transport import WorkerRole
+
+        cfg.chat_model = TEST_LOCAL_REF
+        cfg.embedding_model = TEST_EMBED_REF
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            btn = app.query_one("#embed-model-button", ModelPickerButton)
+            new_ref = "ollama/new-embed:latest"
+            services_mock = mock.MagicMock()
+            with (
+                mock.patch("lilbee.core.settings.set_value"),
+                mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services") as mock_reset,
+                mock.patch(
+                    "lilbee.cli.tui.widgets.model_bar.get_services",
+                    return_value=services_mock,
+                ),
+            ):
+                btn._on_picker_dismissed(new_ref)
+                await pilot.pause()
+            services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED)
+            mock_reset.assert_not_called()
+
+    async def test_chat_picker_dismiss_does_not_reload_role(self) -> None:
+        """Chat scope still routes through ``apply_model_change`` (cancel + reset).
+
+        Chat-model swap is the legitimate cancel-and-restart UX. The new
+        per-role reload path is only for siblings whose change should not
+        disturb the in-flight chat stream.
+        """
+        from lilbee.cli.tui.widgets.model_bar import ModelPickerButton
+
+        cfg.chat_model = TEST_LOCAL_REF
+        cfg.embedding_model = TEST_EMBED_REF
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            btn = app.query_one("#chat-model-button", ModelPickerButton)
+            services_mock = mock.MagicMock()
+            with (
+                mock.patch("lilbee.core.settings.set_value"),
+                mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services"),
+                mock.patch(
+                    "lilbee.cli.tui.widgets.model_bar.get_services",
+                    return_value=services_mock,
+                ),
+            ):
+                btn._on_picker_dismissed("ollama/new-chat:latest")
+                await pilot.pause()
+            services_mock.reload_role.assert_not_called()
+
     async def test_picker_button_click_pushes_modal(self) -> None:
         from lilbee.cli.tui.screens.model_picker import ModelPickerModal
         from lilbee.cli.tui.widgets.model_bar import ModelPickerButton

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -995,6 +995,7 @@ class TestModelPickerButton:
             btn = app.query_one("#embed-model-button", ModelPickerButton)
             new_ref = "ollama/new-embed:latest"
             store_mock = mock.MagicMock()
+            store_mock.has_chunks.return_value = False
             with (
                 mock.patch("lilbee.core.settings.set_value"),
                 mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services"),
@@ -1023,6 +1024,125 @@ class TestModelPickerButton:
                 await pilot.pause()
             write_tracker.assert_not_called()
 
+    async def test_embed_picker_dismiss_against_populated_store_pushes_confirm(self) -> None:
+        """Picking a new embedder against a populated store shows the warning modal.
+
+        Without the modal, the next search raises EmbeddingModelMismatchError and
+        the user sees the failure only after the fact. The modal makes the
+        rebuild contract explicit before cfg is mutated.
+        """
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+        from lilbee.cli.tui.widgets.model_bar import ModelPickerButton
+
+        cfg.chat_model = TEST_LOCAL_REF
+        cfg.embedding_model = TEST_EMBED_REF
+        store_mock = mock.MagicMock()
+        store_mock.has_chunks.return_value = True
+        services_mock = mock.MagicMock(store=store_mock)
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            btn = app.query_one("#embed-model-button", ModelPickerButton)
+            with (
+                mock.patch("lilbee.core.settings.set_value"),
+                mock.patch(
+                    "lilbee.cli.tui.widgets.model_bar.get_services",
+                    return_value=services_mock,
+                ),
+            ):
+                btn._on_picker_dismissed("ollama/new-embed:latest")
+                await pilot.pause()
+                assert isinstance(app.screen, ConfirmDialog)
+            # cfg must NOT have been mutated yet -- waiting on the confirm.
+            assert cfg.embedding_model == TEST_EMBED_REF
+
+    async def test_embed_picker_dismiss_confirm_yes_applies(self) -> None:
+        """Pressing Yes on the confirm modal applies the swap and reloads embed."""
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+        from lilbee.cli.tui.widgets.model_bar import ModelPickerButton
+        from lilbee.providers.worker.transport import WorkerRole
+
+        cfg.chat_model = TEST_LOCAL_REF
+        cfg.embedding_model = TEST_EMBED_REF
+        store_mock = mock.MagicMock()
+        store_mock.has_chunks.return_value = True
+        services_mock = mock.MagicMock(store=store_mock)
+        new_ref = "ollama/new-embed:latest"
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            btn = app.query_one("#embed-model-button", ModelPickerButton)
+            with (
+                mock.patch("lilbee.core.settings.set_value"),
+                mock.patch(
+                    "lilbee.cli.tui.widgets.model_bar.get_services",
+                    return_value=services_mock,
+                ),
+            ):
+                btn._on_picker_dismissed(new_ref)
+                await pilot.pause()
+                assert isinstance(app.screen, ConfirmDialog)
+                await pilot.press("y")
+                await pilot.pause()
+            assert cfg.embedding_model == new_ref
+            services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED)
+
+    async def test_embed_picker_dismiss_confirm_no_keeps_old_ref(self) -> None:
+        """Pressing No on the confirm modal leaves cfg untouched and notifies cancel."""
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+        from lilbee.cli.tui.widgets.model_bar import ModelPickerButton
+
+        cfg.chat_model = TEST_LOCAL_REF
+        cfg.embedding_model = TEST_EMBED_REF
+        store_mock = mock.MagicMock()
+        store_mock.has_chunks.return_value = True
+        services_mock = mock.MagicMock(store=store_mock)
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            btn = app.query_one("#embed-model-button", ModelPickerButton)
+            with (
+                mock.patch("lilbee.core.settings.set_value"),
+                mock.patch(
+                    "lilbee.cli.tui.widgets.model_bar.get_services",
+                    return_value=services_mock,
+                ),
+            ):
+                btn._on_picker_dismissed("ollama/new-embed:latest")
+                await pilot.pause()
+                assert isinstance(app.screen, ConfirmDialog)
+                await pilot.press("n")
+                await pilot.pause()
+            assert cfg.embedding_model == TEST_EMBED_REF
+            services_mock.reload_role.assert_not_called()
+
+    async def test_embed_picker_dismiss_empty_store_skips_confirm(self) -> None:
+        """A store with no chunks (fresh install) swaps without the confirm modal."""
+        from lilbee.cli.tui.widgets.model_bar import ModelPickerButton
+        from lilbee.providers.worker.transport import WorkerRole
+
+        cfg.chat_model = TEST_LOCAL_REF
+        cfg.embedding_model = TEST_EMBED_REF
+        store_mock = mock.MagicMock()
+        store_mock.has_chunks.return_value = False
+        services_mock = mock.MagicMock(store=store_mock)
+        new_ref = "ollama/new-embed:latest"
+        app = _ModelBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            btn = app.query_one("#embed-model-button", ModelPickerButton)
+            with (
+                mock.patch("lilbee.core.settings.set_value"),
+                mock.patch(
+                    "lilbee.cli.tui.widgets.model_bar.get_services",
+                    return_value=services_mock,
+                ),
+            ):
+                btn._on_picker_dismissed(new_ref)
+                await pilot.pause()
+            assert cfg.embedding_model == new_ref
+            services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED)
+
     async def test_embed_picker_dismiss_reloads_only_embed_role(self) -> None:
         """Embed swap respawns just the embed worker. Chat stream stays untouched.
 
@@ -1042,6 +1162,7 @@ class TestModelPickerButton:
             btn = app.query_one("#embed-model-button", ModelPickerButton)
             new_ref = "ollama/new-embed:latest"
             services_mock = mock.MagicMock()
+            services_mock.store.has_chunks.return_value = False
             with (
                 mock.patch("lilbee.core.settings.set_value"),
                 mock.patch("lilbee.cli.tui.widgets.model_bar.reset_services") as mock_reset,

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -327,6 +328,51 @@ async def test_crashed_channel_is_dropped_and_next_call_respawns(tmp_path) -> No
         assert spawner.spawned[1].call_log[-1] == ("warm-again", None)
     finally:
         await pool.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_detach_channel_returns_prior_channel_and_drops_only_that_role(
+    tmp_path,
+) -> None:
+    """``detach_channel`` returns the live channel and leaves siblings spawned.
+
+    Regression for the model-swap path: respawning the embed worker after a
+    setting change must not touch the chat worker that may be mid-stream.
+    """
+    spawner = FakeSpawner()
+    pool = WorkerPool(spawner=spawner)
+    embed = pool.register("embed", _entrypoint, _config_factory("embed", tmp_path))
+    chat = pool.register("chat", _entrypoint, _config_factory("chat", tmp_path))
+    try:
+        await embed.call("warm", None)
+        await chat.call("warm", None)
+        chat_channel_before = pool._channel_if_alive("chat")
+
+        detached = pool.detach_channel("embed")
+        assert detached is spawner.spawned[0]
+        assert pool._channel_if_alive("embed") is None
+        # Chat must keep its channel unchanged.
+        assert pool._channel_if_alive("chat") is chat_channel_before
+
+        # Next embed call lazy-respawns a fresh channel.
+        await embed.call("warm-again", None)
+        assert len(spawner.spawned) == 3  # embed-1, chat-1, embed-2
+        assert spawner.spawned[2].call_log[-1] == ("warm-again", None)
+    finally:
+        await pool.shutdown()
+
+
+def test_detach_channel_returns_none_for_unregistered_role() -> None:
+    """``detach_channel`` is a no-op when the role isn't on the pool."""
+    pool = WorkerPool(spawner=FakeSpawner())
+    assert pool.detach_channel("vision") is None
+
+
+def test_detach_channel_returns_none_when_role_has_no_live_channel() -> None:
+    """``detach_channel`` is a no-op when the role is registered but never spawned."""
+    pool = WorkerPool(spawner=FakeSpawner())
+    pool.register("embed", _entrypoint, _config_factory("embed", Path("/tmp")))
+    assert pool.detach_channel("embed") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Switching the embedding model mid chat-stream hangs the TUI. The picker dismissal fires `apply_model_change`, which calls `cancel_inference()` on every worker role (including the chat that is actively streaming) and schedules `reset_services()` to tear down every worker pool. Rerank and vision swaps follow the same path. There is also no pre-switch warning when changing the embedder against a populated vector store, and the store-vs-config ref equality check is raw-string, so `org/repo` vs `org/repo/file.gguf` miscompares even when both resolve to the same model and dim.

## Solution

Scope `_after_model_change` to the role that changed: only chat-scope cancels an in-flight stream and resets services. Embed, rerank, and vision swaps respawn only the affected worker pool role and leave the chat stream untouched. Add a pre-switch confirm modal for embed swaps when the store already holds chunks. Fix store ref equality to compare resolved model identity, not raw strings.