### PR TITLE
Pin llama.cpp to a chosen GPU and silence LiteLLM AWS noise

### DIFF
--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -114,12 +114,16 @@ def _install_chatty_dependency_filters() -> None:
     )
 
     class _SubstringFilter(logging.Filter):
-        def __init__(self, needles: tuple[str, ...]) -> None:
+        def __init__(self, needles: tuple[str, ...], *, case_insensitive: bool = False) -> None:
             super().__init__()
-            self._needles = needles
+            self._needles = tuple(n.lower() for n in needles) if case_insensitive else needles
+            self._case_insensitive = case_insensitive
 
         def filter(self, record: logging.LogRecord) -> bool:
-            return not any(n in record.getMessage() for n in self._needles)
+            msg = record.getMessage()
+            if self._case_insensitive:
+                msg = msg.lower()
+            return not any(n in msg for n in self._needles)
 
     hf_filter = _SubstringFilter(hf_suppress)
     for name in ("huggingface_hub.utils._http", "huggingface_hub.file_download"):
@@ -129,7 +133,22 @@ def _install_chatty_dependency_filters() -> None:
     # WARNING every chat call when offline. Pin a substring filter rather
     # than raising the whole logger's level so real LiteLLM warnings still
     # surface.
-    litellm_filter = _SubstringFilter(("Failed to fetch remote model cost map",))
+    #
+    # LiteLLM also lazy-routes some calls through AWS provider modules that
+    # warn when boto3 / botocore aren't installed. lilbee never targets
+    # Bedrock, SageMaker, or S3 (the litellm extra deliberately excludes
+    # boto3), so those warnings are pure noise for our users.
+    litellm_suppress = (
+        "Failed to fetch remote model cost map",
+        # AWS-related noise: lilbee's litellm extra does not pull boto3, so
+        # any "missing boto3 / botocore", sagemaker-runtime, or bedrock
+        # advisories surface as user-facing errors with no user action.
+        "boto3",
+        "botocore",
+        "sagemaker",
+        "bedrock",
+    )
+    litellm_filter = _SubstringFilter(litellm_suppress, case_insensitive=True)
     logging.getLogger("LiteLLM").addFilter(litellm_filter)
 
 

--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -93,66 +93,10 @@ def _shrink_hf_download_chunk_size() -> None:
 _shrink_hf_download_chunk_size()
 
 
-def _install_chatty_dependency_filters() -> None:
-    """Filter noise from huggingface_hub and litellm loggers.
-
-    These libraries log per-request advisories that aren't actionable in a
-    local TUI: HF prints an unauthenticated-requests notice on every public
-    pull, and LiteLLM prints a model-cost-map fetch warning on every chat
-    call when offline. Both are graceful (fall back to local data), but the
-    log spam buries real warnings.
-    """
-    import logging
-
-    hf_suppress = (
-        "unauthenticated requests to the HF Hub",
-        # File-download retry warnings: the library auto-resumes; the
-        # per-attempt warning is noise. The final failure surfaces through
-        # our catalog layer with a clear message.
-        "Error while downloading from",
-        "Trying to resume download",
-    )
-
-    class _SubstringFilter(logging.Filter):
-        def __init__(self, needles: tuple[str, ...], *, case_insensitive: bool = False) -> None:
-            super().__init__()
-            self._needles = tuple(n.lower() for n in needles) if case_insensitive else needles
-            self._case_insensitive = case_insensitive
-
-        def filter(self, record: logging.LogRecord) -> bool:
-            msg = record.getMessage()
-            if self._case_insensitive:
-                msg = msg.lower()
-            return not any(n in msg for n in self._needles)
-
-    hf_filter = _SubstringFilter(hf_suppress)
-    for name in ("huggingface_hub.utils._http", "huggingface_hub.file_download"):
-        logging.getLogger(name).addFilter(hf_filter)
-
-    # LiteLLM logs its model_prices_and_context_window.json fetch failure at
-    # WARNING every chat call when offline. Pin a substring filter rather
-    # than raising the whole logger's level so real LiteLLM warnings still
-    # surface.
-    #
-    # LiteLLM also lazy-routes some calls through AWS provider modules that
-    # warn when boto3 / botocore aren't installed. lilbee never targets
-    # Bedrock, SageMaker, or S3 (the litellm extra deliberately excludes
-    # boto3), so those warnings are pure noise for our users.
-    litellm_suppress = (
-        "Failed to fetch remote model cost map",
-        # AWS-related noise: lilbee's litellm extra does not pull boto3, so
-        # any "missing boto3 / botocore", sagemaker-runtime, or bedrock
-        # advisories surface as user-facing errors with no user action.
-        "boto3",
-        "botocore",
-        "sagemaker",
-        "bedrock",
-    )
-    litellm_filter = _SubstringFilter(litellm_suppress, case_insensitive=True)
-    logging.getLogger("LiteLLM").addFilter(litellm_filter)
-
-
-_install_chatty_dependency_filters()
+# HF and LiteLLM log filters live next to their respective implementations
+# (catalog/hf_client.py and providers/litellm_sdk.py). They install themselves
+# on module import; this package's __init__.py stays free of HF/LiteLLM
+# implementation detail.
 
 
 # Must follow HF environment / constants setup above.

--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -16,6 +16,52 @@ from lilbee.catalog.models import CatalogModel, HfGgufMeta, HfPage
 
 log = logging.getLogger(__name__)
 
+# Substrings dropped from huggingface_hub's request / file-download loggers.
+# These advisories aren't actionable in a local TUI: HF prints an
+# unauthenticated-requests notice on every public pull, and the file_download
+# logger re-warns on every retry the library schedules. The catalog surfaces
+# the final download failure with a clear message, so per-attempt warnings
+# are noise.
+_HF_SUPPRESS_SUBSTRINGS = (
+    "unauthenticated requests to the HF Hub",
+    "Error while downloading from",
+    "Trying to resume download",
+)
+
+_HF_FILTERED_LOGGER_NAMES = (
+    "huggingface_hub.utils._http",
+    "huggingface_hub.file_download",
+)
+
+
+class _HfSubstringFilter(logging.Filter):
+    """Drop huggingface_hub log records whose message contains a suppressed substring."""
+
+    def __init__(self, needles: tuple[str, ...]) -> None:
+        super().__init__()
+        self._needles = needles
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not any(n in record.getMessage() for n in self._needles)
+
+
+def install_hf_log_filter() -> None:
+    """Attach the substring filter to huggingface_hub's chatty loggers.
+
+    Called automatically when this module is imported (see the module-top
+    invocation below) so the filter is in place before any catalog HTTP
+    call can emit a warning. Exposed as a function so tests can re-apply.
+    """
+    hf_filter = _HfSubstringFilter(_HF_SUPPRESS_SUBSTRINGS)
+    for name in _HF_FILTERED_LOGGER_NAMES:
+        logging.getLogger(name).addFilter(hf_filter)
+
+
+# Install the filter at module import. All HF HTTP traffic in lilbee
+# routes through this module, so installing here always beats the first
+# huggingface_hub warning to the punch.
+install_hf_log_filter()
+
 HF_API_URL = "https://huggingface.co/api/models"
 
 DEFAULT_TIMEOUT = 30.0

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -94,6 +94,8 @@ def _resolved_provider_kwargs() -> dict[str, Any]:
         "flash_attention": cfg.flash_attention,
         "kv_cache_type": cfg.kv_cache_type.value,
         "n_gpu_layers": cfg.n_gpu_layers,
+        "main_gpu": cfg.main_gpu,
+        "gpu_devices": cfg.gpu_devices,
     }
 
 
@@ -193,7 +195,9 @@ def self_check_cmd(
             f"num_ctx_max={provider_kwargs['num_ctx_max']} "
             f"flash_attention={provider_kwargs['flash_attention']} "
             f"kv_cache_type={provider_kwargs['kv_cache_type']} "
-            f"n_gpu_layers={provider_kwargs['n_gpu_layers']}"
+            f"n_gpu_layers={provider_kwargs['n_gpu_layers']} "
+            f"main_gpu={provider_kwargs['main_gpu']} "
+            f"gpu_devices={provider_kwargs['gpu_devices']}"
         )
         console.print(f"[{theme.ACCENT}]SELF-CHECK PASSED[/{theme.ACCENT}]")
 

--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -183,6 +183,26 @@ SETTINGS_MAP: dict[str, SettingDef] = {
             "positive int = partial offload for tight VRAM."
         ),
     ),
+    "gpu_devices": SettingDef(
+        str,
+        nullable=True,
+        group="Generation",
+        help_text=(
+            "Restrict llama.cpp to specific GPU indexes on dual-GPU machines "
+            "(e.g. NVIDIA dGPU + integrated). Comma-separated, like '0' or '0,1'. "
+            "Applies to Vulkan, CUDA, and ROCm. Requires a restart to take effect."
+        ),
+    ),
+    "main_gpu": SettingDef(
+        int,
+        nullable=True,
+        group="Generation",
+        help_text=(
+            "Primary GPU index for llama.cpp when multiple devices are visible. "
+            "Empty = let llama.cpp pick (index 0). Set this together with "
+            "gpu_devices to pin inference to a specific card."
+        ),
+    ),
     "seed": SettingDef(
         int,
         nullable=True,

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -281,6 +281,32 @@ class Config(BaseSettings):
     # discrete GPU has less VRAM than the model needs.
     n_gpu_layers: int | None = ConfigField(default=None, writable=True)
 
+    # GPU device picker for dual-GPU machines (typical laptop case:
+    # discrete NVIDIA + integrated Intel/AMD). The Vulkan backend
+    # enumerates every adapter the system exposes and may pick the
+    # integrated one first, producing stalls or OOMs that look like
+    # llama.cpp bugs. Setting ``gpu_devices`` constrains visibility
+    # before llama_cpp loads, pinning inference to the chosen device(s).
+    #
+    # Accepts a comma-separated list of device indexes ("0", "1",
+    # "0,1") and applies it to every backend simultaneously:
+    # ``GGML_VK_VISIBLE_DEVICES`` for Vulkan, ``CUDA_VISIBLE_DEVICES``
+    # for CUDA, ``HIP_VISIBLE_DEVICES`` / ``ROCR_VISIBLE_DEVICES`` for
+    # ROCm. Setting one variable that the active backend ignores is
+    # harmless, so we set all four rather than detecting the build.
+    #
+    # Must be set before the first llama.cpp call; in practice that
+    # means via ``LILBEE_GPU_DEVICES`` or ``config.toml`` (TUI edits
+    # only take effect after a restart). ``None`` (default) leaves
+    # device visibility untouched.
+    gpu_devices: str | None = ConfigField(default=None, writable=True)
+
+    # Primary GPU index passed to ``Llama(main_gpu=...)``. Only matters
+    # when multiple devices remain visible after ``gpu_devices``; with
+    # a single visible device, llama.cpp ignores this. ``None``
+    # (default) lets llama.cpp pick (index 0).
+    main_gpu: int | None = ConfigField(default=None, writable=True)
+
     # True = Markdown widget for chat; False = plain Static (faster).
     markdown_rendering: bool = True
 
@@ -565,6 +591,43 @@ class Config(BaseSettings):
                 log.warning("Invalid LILBEE_N_GPU_LAYERS=%r, using auto", v)
                 return None
         return int(v)
+
+    @field_validator("main_gpu", mode="before")
+    @classmethod
+    def _parse_main_gpu(cls, v: Any) -> int | None:
+        """Empty/auto strings -> None, integers parsed verbatim."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            label = v.strip().lower()
+            if label in ("", "auto", "none"):
+                return None
+            try:
+                return int(label)
+            except ValueError:
+                log.warning("Invalid LILBEE_MAIN_GPU=%r, using auto", v)
+                return None
+        return int(v)
+
+    @field_validator("gpu_devices", mode="before")
+    @classmethod
+    def _parse_gpu_devices(cls, v: Any) -> str | None:
+        """Normalize device list: strip whitespace, drop empties, keep order."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            label = v.strip().lower()
+            if label in ("", "auto", "all", "none"):
+                return None
+            parts = [p.strip() for p in v.split(",") if p.strip()]
+            if not parts:
+                return None
+            for part in parts:
+                if not part.lstrip("-").isdigit():
+                    log.warning("Invalid LILBEE_GPU_DEVICES=%r, ignoring", v)
+                    return None
+            return ",".join(parts)
+        return str(v)
 
     @field_validator("semantic_chunking", mode="before")
     @classmethod

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -297,8 +297,12 @@ class Config(BaseSettings):
     #
     # Must be set before the first llama.cpp call; in practice that
     # means via ``LILBEE_GPU_DEVICES`` or ``config.toml`` (TUI edits
-    # only take effect after a restart). ``None`` (default) leaves
-    # device visibility untouched.
+    # only take effect after a restart). ``None`` (default) hands off
+    # to the autodetect in ``providers/llama_cpp/gpu_select.py``,
+    # which parses ``vulkaninfo --summary`` and pins the discrete
+    # adapter when one is present. The autodetect is silent on failure
+    # (no vulkaninfo, single device, parse error), leaving the
+    # Vulkan-loader's default ordering in place.
     gpu_devices: str | None = ConfigField(default=None, writable=True)
 
     # Primary GPU index passed to ``Llama(main_gpu=...)``. Only matters

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -90,6 +90,8 @@ def status() -> dict[str, Any]:
             "flash_attention": cfg.flash_attention,
             "kv_cache_type": cfg.kv_cache_type.value,
             "n_gpu_layers": cfg.n_gpu_layers,
+            "main_gpu": cfg.main_gpu,
+            "gpu_devices": cfg.gpu_devices,
         },
         "sources": [
             {"filename": s["filename"], "chunk_count": s["chunk_count"]}

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -39,6 +39,49 @@ log = logging.getLogger(__name__)
 _PROVIDER_NAME = "litellm"
 _OLLAMA_URL_PATTERNS = ("localhost:11434", "127.0.0.1:11434", "ollama")
 
+# Substrings dropped from the "LiteLLM" logger before they reach the user's
+# terminal. Two classes of noise: (1) the model-cost-map fetch failure that
+# LiteLLM logs at WARNING on every offline chat call, and (2) AWS-flavored
+# advisories from sagemaker / bedrock / boto3 / botocore. lilbee's litellm
+# extra deliberately excludes boto3, so the AWS warnings aren't actionable.
+# Compared case-insensitively to catch the mixed-case variants LiteLLM emits.
+_LITELLM_SUPPRESS_SUBSTRINGS = (
+    "failed to fetch remote model cost map",
+    "boto3",
+    "botocore",
+    "sagemaker",
+    "bedrock",
+)
+
+
+class _LitellmSubstringFilter(logging.Filter):
+    """Drop ``LiteLLM`` log records whose message contains a suppressed substring."""
+
+    def __init__(self, needles: tuple[str, ...]) -> None:
+        super().__init__()
+        self._needles = tuple(n.lower() for n in needles)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage().lower()
+        return not any(n in msg for n in self._needles)
+
+
+def install_litellm_log_filter() -> None:
+    """Attach the ``LiteLLM`` substring filter to the package logger.
+
+    Called automatically when this module is imported (see the module-top
+    invocation below) so the filter is in place before any litellm call
+    can emit a warning. Exposed as a function so tests can re-apply after
+    clearing the logger.
+    """
+    logging.getLogger("LiteLLM").addFilter(_LitellmSubstringFilter(_LITELLM_SUPPRESS_SUBSTRINGS))
+
+
+# Install the filter at module import. lilbee never touches litellm before
+# importing this module, so installing here always beats litellm's first
+# warning to the punch.
+install_litellm_log_filter()
+
 
 class _LitellmResponseView:
     """Typed read-only view over a litellm completion-response object.

--- a/src/lilbee/providers/llama_cpp/gpu_select.py
+++ b/src/lilbee/providers/llama_cpp/gpu_select.py
@@ -1,149 +1,307 @@
-"""Best-GPU autodetection for the Vulkan / CUDA / ROCm backends.
+"""Best-GPU autodetection for the Vulkan backend.
 
 On a host with multiple GPUs (typical dual-GPU laptop: discrete NVIDIA
 plus integrated AMD/Intel), Vulkan device ordering is driver- and
-OS-dependent. llama.cpp's Vulkan backend doesn't sort by device type,
+OS-dependent. llama.cpp's Vulkan backend enumerates all discrete AND
+integrated adapters in the order Vulkan's ICD loader returns them
+(see ``ggml-vulkan.cpp::ggml_vk_instance_init``: both
+``eDiscreteGpu`` and ``eIntegratedGpu`` are added without sorting),
 so a model can land on the integrated GPU and stall against shared
 system memory.
 
-This module probes the host's adapter list (via ``vulkaninfo --summary``
-or NVIDIA's ``pynvml`` / ``nvidia-smi`` binding) and returns a string
-suitable for ``GGML_VK_VISIBLE_DEVICES`` / ``CUDA_VISIBLE_DEVICES``,
-pinning inference to the best-available discrete GPU. The detection is
-best-effort and silent on failure: when no probe succeeds, the caller
-keeps the default Vulkan-loader ordering.
+This module probes the Vulkan loader directly via ``ctypes`` to
+enumerate adapters, ranks them by ``VkPhysicalDeviceType`` (discrete
+> integrated > virtual > CPU), and returns the index that should be
+pinned via ``GGML_VK_VISIBLE_DEVICES``. Going through ``ctypes``
+instead of a subprocess avoids any dependency on the Vulkan SDK
+(``vulkaninfo`` isn't installed on stock Windows or macOS), so the
+autodetect works on every machine that already has a Vulkan driver.
+
+CUDA and ROCm enumeration are deliberately out of scope: CUDA only
+sees NVIDIA devices and HIP/ROCm only sees AMD devices, so neither
+backend exhibits the dual-GPU mis-pick problem. The Vulkan probe
+result is applied to ``GGML_VK_VISIBLE_DEVICES`` alone; applying it
+to ``CUDA_VISIBLE_DEVICES`` would risk hiding the only CUDA device
+on a CUDA wheel + dual-GPU host.
 """
 
 from __future__ import annotations
 
+import ctypes
+import ctypes.util
 import logging
-import re
-import shutil
-import subprocess
+import sys
+from ctypes import POINTER, byref, c_char, c_char_p, c_uint8, c_uint32, c_void_p
 from dataclasses import dataclass
 
 log = logging.getLogger(__name__)
 
-# Probe timeout for the external GPU enumeration tools. 3 s is more than
-# enough for vulkaninfo / nvidia-smi on a healthy system and short enough
-# that a hung driver doesn't slow the first inference call.
-_PROBE_TIMEOUT_S = 3.0
+# vk.h constants. Mirrored here so we don't drag a vulkan-headers
+# dependency in for four magic numbers.
+_VK_STRUCTURE_TYPE_APPLICATION_INFO = 0
+_VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1
+_VK_SUCCESS = 0
+_VK_API_VERSION_1_0 = (1 << 22) | (0 << 12) | 0
 
-# vulkaninfo summary device-type tokens. Score order picks discrete > integrated
-# > virtual / CPU (CPU softpipe is never what a user wants for inference).
-_DEVICE_TYPE_RANK: dict[str, int] = {
-    "PHYSICAL_DEVICE_TYPE_DISCRETE_GPU": 3,
-    "PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU": 2,
-    "PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU": 1,
-    "PHYSICAL_DEVICE_TYPE_CPU": 0,
-    "PHYSICAL_DEVICE_TYPE_OTHER": 0,
+# VkPhysicalDeviceType enum values from vulkan_core.h. Mapped to a
+# preference rank so callers can pick the best adapter; higher is
+# better. Software rendering (CPU) is never the right pick.
+_VK_PHYSICAL_DEVICE_TYPE_OTHER = 0
+_VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = 1
+_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU = 2
+_VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU = 3
+_VK_PHYSICAL_DEVICE_TYPE_CPU = 4
+
+_DEVICE_TYPE_RANK: dict[int, int] = {
+    _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU: 4,
+    _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: 3,
+    _VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU: 2,
+    _VK_PHYSICAL_DEVICE_TYPE_OTHER: 1,
+    _VK_PHYSICAL_DEVICE_TYPE_CPU: 0,
 }
 
-_VULKANINFO_GPU_HEADER_RE = re.compile(r"^GPU(\d+):")
-_VULKANINFO_KV_RE = re.compile(r"^\s*(\w+)\s*=\s*(\S+)")
+# vk.h sizes for the inline char arrays inside VkPhysicalDeviceProperties.
+_VK_MAX_PHYSICAL_DEVICE_NAME_SIZE = 256
+_VK_UUID_SIZE = 16
 
 
 @dataclass(frozen=True)
 class VulkanDevice:
-    """One Vulkan adapter as reported by vulkaninfo."""
+    """One Vulkan adapter as reported by the loader."""
 
     index: int
-    device_type: str
+    device_type: int
     device_name: str
 
 
-def autoselect_best_gpu_index() -> str | None:
-    """Return a comma-separated index list pinning inference to the best GPU.
+# Field layouts from the Vulkan 1.0 spec. ctypes maps the C structs
+# verbatim so the loader populates them directly; only the prefix
+# fields we read are commented (the trailing fields are kept for ABI
+# alignment, not consumed).
 
-    Returns ``None`` when no probe succeeds (vulkaninfo missing,
-    parsing failed, only one device, etc.) so the caller knows to
-    leave device visibility untouched. The result format matches
-    ``GGML_VK_VISIBLE_DEVICES`` (``"0"`` or ``"0,1"``).
+
+class _VkApplicationInfo(ctypes.Structure):
+    _fields_ = [
+        ("sType", c_uint32),
+        ("pNext", c_void_p),
+        ("pApplicationName", c_char_p),
+        ("applicationVersion", c_uint32),
+        ("pEngineName", c_char_p),
+        ("engineVersion", c_uint32),
+        ("apiVersion", c_uint32),
+    ]
+
+
+class _VkInstanceCreateInfo(ctypes.Structure):
+    _fields_ = [
+        ("sType", c_uint32),
+        ("pNext", c_void_p),
+        ("flags", c_uint32),
+        ("pApplicationInfo", POINTER(_VkApplicationInfo)),
+        ("enabledLayerCount", c_uint32),
+        ("ppEnabledLayerNames", POINTER(c_char_p)),
+        ("enabledExtensionCount", c_uint32),
+        ("ppEnabledExtensionNames", POINTER(c_char_p)),
+    ]
+
+
+class _VkPhysicalDeviceLimits(ctypes.Structure):
+    # Opaque to us; size pulled from vulkan_core.h so the parent struct
+    # layout matches the driver-populated bytes.
+    _fields_ = [("_opaque", c_uint8 * 504)]
+
+
+class _VkPhysicalDeviceSparseProperties(ctypes.Structure):
+    _fields_ = [("_opaque", c_uint32 * 5)]
+
+
+class _VkPhysicalDeviceProperties(ctypes.Structure):
+    _fields_ = [
+        ("apiVersion", c_uint32),
+        ("driverVersion", c_uint32),
+        ("vendorID", c_uint32),
+        ("deviceID", c_uint32),
+        ("deviceType", c_uint32),
+        ("deviceName", c_char * _VK_MAX_PHYSICAL_DEVICE_NAME_SIZE),
+        ("pipelineCacheUUID", c_uint8 * _VK_UUID_SIZE),
+        ("limits", _VkPhysicalDeviceLimits),
+        ("sparseProperties", _VkPhysicalDeviceSparseProperties),
+    ]
+
+
+def autoselect_best_gpu_index() -> str | None:
+    """Return the Vulkan device index of the best-available adapter, or ``None``.
+
+    Returns ``None`` when the Vulkan loader is unavailable, the probe
+    fails, or only one adapter is visible (no decision to make). The
+    string format matches ``GGML_VK_VISIBLE_DEVICES`` (``"0"`` /
+    ``"1"`` etc.). CUDA / HIP / ROCm enumeration are out of scope:
+    those backends are single-vendor and the env vars don't mean the
+    same thing as the Vulkan loader's enumeration order.
     """
-    devices = _list_vulkan_devices()
+    devices = _enumerate_vulkan_devices()
     if devices is None:
         return None
     best = _pick_best_device(devices)
     if best is None:
         return None
-    # Only emit a pin when there's a real choice to make: if every visible
-    # device is the same type, the default ordering is already correct and
-    # forcing the index would only hide a user's manual override on rebuild.
-    if len(devices) == 1:
+    # Only emit a pin when there's a real choice between adapter types:
+    # if every visible device has the same rank, the loader's default
+    # ordering is already correct and forcing the index would hide a
+    # user's manual override on rebuild.
+    ranks = {_DEVICE_TYPE_RANK.get(d.device_type, 0) for d in devices}
+    if len(ranks) <= 1:
         return None
     return str(best.index)
 
 
-def _list_vulkan_devices() -> list[VulkanDevice] | None:
-    """Run ``vulkaninfo --summary`` and parse the device list.
+def _enumerate_vulkan_devices() -> list[VulkanDevice] | None:
+    """Open libvulkan, create a throwaway instance, enumerate adapters.
 
-    Returns ``None`` on any failure (binary missing, non-zero exit,
-    timeout, unparseable output). Empty list is a distinct outcome
-    ("ran fine, found no devices") and propagates back.
+    Returns ``None`` if the loader can't be found or any Vulkan call
+    fails; empty list ("loader present, no adapters") is a distinct
+    outcome and propagates back.
     """
-    if shutil.which("vulkaninfo") is None:
+    lib = _load_vulkan_loader()
+    if lib is None:
         return None
     try:
-        result = subprocess.run(
-            ["vulkaninfo", "--summary"],  # noqa: S607 -- vulkaninfo on PATH is the contract
-            capture_output=True,
-            text=True,
-            timeout=_PROBE_TIMEOUT_S,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
+        return _list_devices_with_instance(lib)
+    except OSError:
+        # ctypes argument / call-site errors land here; treat as
+        # "probe failed" rather than crashing the host process.
         return None
-    if result.returncode != 0:
-        return None
-    return _parse_vulkaninfo_summary(result.stdout)
 
 
-def _parse_vulkaninfo_summary(output: str) -> list[VulkanDevice]:
-    """Extract one :class:`VulkanDevice` per ``GPU<N>:`` block in the summary.
+def _load_vulkan_loader() -> ctypes.CDLL | None:
+    """Locate and load the Vulkan loader for the current platform.
 
-    The summary format groups device fields under a ``GPU<index>:``
-    header, with ``key = value`` pairs indented underneath. We only
-    pull ``deviceType`` and ``deviceName`` (the rest is informational).
-    Blocks missing ``deviceType`` are skipped: an unparseable device
-    can't be ranked.
+    Returns ``None`` when the loader isn't installed, which is the
+    expected outcome on stock macOS (we ship a Metal wheel there) and
+    on hosts without a Vulkan-capable driver.
     """
-    devices: list[VulkanDevice] = []
-    current_index: int | None = None
-    current_fields: dict[str, str] = {}
+    candidates: tuple[str, ...]
+    if sys.platform == "win32":
+        candidates = ("vulkan-1.dll",)
+    elif sys.platform == "darwin":
+        # MoltenVK exposes a different ABI than libvulkan; lilbee's
+        # macOS wheel uses Metal directly, so skipping the probe on
+        # Darwin is correct.
+        return None
+    else:
+        candidates = ("libvulkan.so.1", "libvulkan.so")
 
-    def flush() -> None:
-        if current_index is None:
-            return
-        dtype = current_fields.get("deviceType")
-        if not dtype:
-            return
-        devices.append(
-            VulkanDevice(
-                index=current_index,
-                device_type=dtype,
-                device_name=current_fields.get("deviceName", ""),
-            )
-        )
-
-    for line in output.splitlines():
-        header = _VULKANINFO_GPU_HEADER_RE.match(line)
-        if header is not None:
-            flush()
-            current_index = int(header.group(1))
-            current_fields = {}
+    for name in candidates:
+        try:
+            return ctypes.CDLL(name)
+        except OSError:
             continue
-        kv = _VULKANINFO_KV_RE.match(line)
-        if kv is not None and current_index is not None:
-            current_fields[kv.group(1)] = kv.group(2)
-    flush()
-    return devices
+    # ctypes.util.find_library is a last-resort fallback for distros
+    # where the soname isn't directly loadable.
+    resolved = ctypes.util.find_library("vulkan")
+    if resolved is not None:
+        try:
+            return ctypes.CDLL(resolved)
+        except OSError:
+            return None
+    return None
+
+
+def _list_devices_with_instance(lib: ctypes.CDLL) -> list[VulkanDevice]:
+    """Create a temporary VkInstance, enumerate physical devices, destroy.
+
+    Mirrors what ``vulkaninfo --summary`` does internally. The
+    instance is short-lived (created and destroyed in the same call)
+    so the probe leaves no driver state behind.
+    """
+    create_instance, destroy_instance, enum_physical, get_properties = _resolve_vk_symbols(lib)
+
+    app_info = _VkApplicationInfo(
+        sType=_VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        pNext=None,
+        pApplicationName=b"lilbee-gpu-probe",
+        applicationVersion=0,
+        pEngineName=b"lilbee",
+        engineVersion=0,
+        apiVersion=_VK_API_VERSION_1_0,
+    )
+    create_info = _VkInstanceCreateInfo(
+        sType=_VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        pNext=None,
+        flags=0,
+        pApplicationInfo=ctypes.pointer(app_info),
+        enabledLayerCount=0,
+        ppEnabledLayerNames=None,
+        enabledExtensionCount=0,
+        ppEnabledExtensionNames=None,
+    )
+    instance = c_void_p()
+    result = create_instance(byref(create_info), None, byref(instance))
+    if result != _VK_SUCCESS or not instance.value:
+        return []
+
+    try:
+        count = c_uint32(0)
+        result = enum_physical(instance, byref(count), None)
+        if result != _VK_SUCCESS or count.value == 0:
+            return []
+        handles = (c_void_p * count.value)()
+        result = enum_physical(instance, byref(count), handles)
+        if result != _VK_SUCCESS:
+            return []
+        devices: list[VulkanDevice] = []
+        for i in range(count.value):
+            props = _VkPhysicalDeviceProperties()
+            get_properties(handles[i], byref(props))
+            devices.append(
+                VulkanDevice(
+                    index=i,
+                    device_type=int(props.deviceType),
+                    device_name=props.deviceName.decode("utf-8", errors="replace"),
+                )
+            )
+        return devices
+    finally:
+        destroy_instance(instance, None)
+
+
+def _resolve_vk_symbols(
+    lib: ctypes.CDLL,
+) -> tuple[ctypes._FuncPointer, ctypes._FuncPointer, ctypes._FuncPointer, ctypes._FuncPointer]:
+    """Look up the four Vulkan symbols this probe needs and stamp argtypes.
+
+    All argtypes / restypes are set here so ctypes uses the same
+    calling convention as the C ABI; missing this on Windows produces
+    silent stack corruption.
+    """
+    create_instance = lib.vkCreateInstance
+    create_instance.argtypes = [
+        POINTER(_VkInstanceCreateInfo),
+        c_void_p,
+        POINTER(c_void_p),
+    ]
+    create_instance.restype = c_uint32
+
+    destroy_instance = lib.vkDestroyInstance
+    destroy_instance.argtypes = [c_void_p, c_void_p]
+    destroy_instance.restype = None
+
+    enum_physical = lib.vkEnumeratePhysicalDevices
+    enum_physical.argtypes = [c_void_p, POINTER(c_uint32), POINTER(c_void_p)]
+    enum_physical.restype = c_uint32
+
+    get_properties = lib.vkGetPhysicalDeviceProperties
+    get_properties.argtypes = [c_void_p, POINTER(_VkPhysicalDeviceProperties)]
+    get_properties.restype = None
+
+    return create_instance, destroy_instance, enum_physical, get_properties
 
 
 def _pick_best_device(devices: list[VulkanDevice]) -> VulkanDevice | None:
     """Return the highest-ranked device, preferring lower indexes on ties.
 
-    Sort is stable so the original enumeration order acts as the
-    tie-breaker; this matches the user's expectation that "GPU0" wins
+    Sort is stable so the loader's enumeration order acts as the
+    tie-breaker; this matches user expectation that "device 0" wins
     when two adapters are the same type.
     """
     if not devices:

--- a/src/lilbee/providers/llama_cpp/gpu_select.py
+++ b/src/lilbee/providers/llama_cpp/gpu_select.py
@@ -33,6 +33,7 @@ import logging
 import sys
 from ctypes import POINTER, byref, c_char, c_char_p, c_uint8, c_uint32, c_void_p
 from dataclasses import dataclass
+from enum import IntEnum
 
 log = logging.getLogger(__name__)
 
@@ -43,22 +44,40 @@ _VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1
 _VK_SUCCESS = 0
 _VK_API_VERSION_1_0 = (1 << 22) | (0 << 12) | 0
 
-# VkPhysicalDeviceType enum values from vulkan_core.h. Mapped to a
-# preference rank so callers can pick the best adapter; higher is
-# better. Software rendering (CPU) is never the right pick.
-_VK_PHYSICAL_DEVICE_TYPE_OTHER = 0
-_VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = 1
-_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU = 2
-_VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU = 3
-_VK_PHYSICAL_DEVICE_TYPE_CPU = 4
 
-_DEVICE_TYPE_RANK: dict[int, int] = {
-    _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU: 4,
-    _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: 3,
-    _VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU: 2,
-    _VK_PHYSICAL_DEVICE_TYPE_OTHER: 1,
-    _VK_PHYSICAL_DEVICE_TYPE_CPU: 0,
+class VkDeviceType(IntEnum):
+    """``VkPhysicalDeviceType`` enum from vulkan_core.h.
+
+    Values match the C ABI verbatim; the loader writes one of these
+    into the ``deviceType`` field of ``VkPhysicalDeviceProperties``.
+    """
+
+    OTHER = 0
+    INTEGRATED_GPU = 1
+    DISCRETE_GPU = 2
+    VIRTUAL_GPU = 3
+    CPU = 4
+
+
+# Preference order for picking the best adapter; higher is better.
+# Software rendering (CPU) is never the right pick, so it ranks 0
+# and ``_pick_best_device`` rejects it.
+_DEVICE_TYPE_RANK: dict[VkDeviceType, int] = {
+    VkDeviceType.DISCRETE_GPU: 4,
+    VkDeviceType.INTEGRATED_GPU: 3,
+    VkDeviceType.VIRTUAL_GPU: 2,
+    VkDeviceType.OTHER: 1,
+    VkDeviceType.CPU: 0,
 }
+
+
+def _rank_for(device_type: int) -> int:
+    """Lookup the rank for a ``deviceType`` value, ``0`` if the driver returns an unknown one."""
+    try:
+        return _DEVICE_TYPE_RANK[VkDeviceType(device_type)]
+    except ValueError:
+        return 0
+
 
 # vk.h sizes for the inline char arrays inside VkPhysicalDeviceProperties.
 _VK_MAX_PHYSICAL_DEVICE_NAME_SIZE = 256
@@ -149,7 +168,7 @@ def autoselect_best_gpu_index() -> str | None:
     # if every visible device has the same rank, the loader's default
     # ordering is already correct and forcing the index would hide a
     # user's manual override on rebuild.
-    ranks = {_DEVICE_TYPE_RANK.get(d.device_type, 0) for d in devices}
+    ranks = {_rank_for(d.device_type) for d in devices}
     if len(ranks) <= 1:
         return None
     return str(best.index)
@@ -306,11 +325,8 @@ def _pick_best_device(devices: list[VulkanDevice]) -> VulkanDevice | None:
     """
     if not devices:
         return None
-    ranked = sorted(
-        devices,
-        key=lambda d: (-_DEVICE_TYPE_RANK.get(d.device_type, 0), d.index),
-    )
+    ranked = sorted(devices, key=lambda d: (-_rank_for(d.device_type), d.index))
     best = ranked[0]
-    if _DEVICE_TYPE_RANK.get(best.device_type, 0) <= 0:
+    if _rank_for(best.device_type) <= 0:
         return None
     return best

--- a/src/lilbee/providers/llama_cpp/gpu_select.py
+++ b/src/lilbee/providers/llama_cpp/gpu_select.py
@@ -1,0 +1,158 @@
+"""Best-GPU autodetection for the Vulkan / CUDA / ROCm backends.
+
+On a host with multiple GPUs (typical dual-GPU laptop: discrete NVIDIA
+plus integrated AMD/Intel), Vulkan device ordering is driver- and
+OS-dependent. llama.cpp's Vulkan backend doesn't sort by device type,
+so a model can land on the integrated GPU and stall against shared
+system memory.
+
+This module probes the host's adapter list (via ``vulkaninfo --summary``
+or NVIDIA's ``pynvml`` / ``nvidia-smi`` binding) and returns a string
+suitable for ``GGML_VK_VISIBLE_DEVICES`` / ``CUDA_VISIBLE_DEVICES``,
+pinning inference to the best-available discrete GPU. The detection is
+best-effort and silent on failure: when no probe succeeds, the caller
+keeps the default Vulkan-loader ordering.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
+
+# Probe timeout for the external GPU enumeration tools. 3 s is more than
+# enough for vulkaninfo / nvidia-smi on a healthy system and short enough
+# that a hung driver doesn't slow the first inference call.
+_PROBE_TIMEOUT_S = 3.0
+
+# vulkaninfo summary device-type tokens. Score order picks discrete > integrated
+# > virtual / CPU (CPU softpipe is never what a user wants for inference).
+_DEVICE_TYPE_RANK: dict[str, int] = {
+    "PHYSICAL_DEVICE_TYPE_DISCRETE_GPU": 3,
+    "PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU": 2,
+    "PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU": 1,
+    "PHYSICAL_DEVICE_TYPE_CPU": 0,
+    "PHYSICAL_DEVICE_TYPE_OTHER": 0,
+}
+
+_VULKANINFO_GPU_HEADER_RE = re.compile(r"^GPU(\d+):")
+_VULKANINFO_KV_RE = re.compile(r"^\s*(\w+)\s*=\s*(\S+)")
+
+
+@dataclass(frozen=True)
+class VulkanDevice:
+    """One Vulkan adapter as reported by vulkaninfo."""
+
+    index: int
+    device_type: str
+    device_name: str
+
+
+def autoselect_best_gpu_index() -> str | None:
+    """Return a comma-separated index list pinning inference to the best GPU.
+
+    Returns ``None`` when no probe succeeds (vulkaninfo missing,
+    parsing failed, only one device, etc.) so the caller knows to
+    leave device visibility untouched. The result format matches
+    ``GGML_VK_VISIBLE_DEVICES`` (``"0"`` or ``"0,1"``).
+    """
+    devices = _list_vulkan_devices()
+    if devices is None:
+        return None
+    best = _pick_best_device(devices)
+    if best is None:
+        return None
+    # Only emit a pin when there's a real choice to make: if every visible
+    # device is the same type, the default ordering is already correct and
+    # forcing the index would only hide a user's manual override on rebuild.
+    if len(devices) == 1:
+        return None
+    return str(best.index)
+
+
+def _list_vulkan_devices() -> list[VulkanDevice] | None:
+    """Run ``vulkaninfo --summary`` and parse the device list.
+
+    Returns ``None`` on any failure (binary missing, non-zero exit,
+    timeout, unparseable output). Empty list is a distinct outcome
+    ("ran fine, found no devices") and propagates back.
+    """
+    if shutil.which("vulkaninfo") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["vulkaninfo", "--summary"],  # noqa: S607 -- vulkaninfo on PATH is the contract
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_vulkaninfo_summary(result.stdout)
+
+
+def _parse_vulkaninfo_summary(output: str) -> list[VulkanDevice]:
+    """Extract one :class:`VulkanDevice` per ``GPU<N>:`` block in the summary.
+
+    The summary format groups device fields under a ``GPU<index>:``
+    header, with ``key = value`` pairs indented underneath. We only
+    pull ``deviceType`` and ``deviceName`` (the rest is informational).
+    Blocks missing ``deviceType`` are skipped: an unparseable device
+    can't be ranked.
+    """
+    devices: list[VulkanDevice] = []
+    current_index: int | None = None
+    current_fields: dict[str, str] = {}
+
+    def flush() -> None:
+        if current_index is None:
+            return
+        dtype = current_fields.get("deviceType")
+        if not dtype:
+            return
+        devices.append(
+            VulkanDevice(
+                index=current_index,
+                device_type=dtype,
+                device_name=current_fields.get("deviceName", ""),
+            )
+        )
+
+    for line in output.splitlines():
+        header = _VULKANINFO_GPU_HEADER_RE.match(line)
+        if header is not None:
+            flush()
+            current_index = int(header.group(1))
+            current_fields = {}
+            continue
+        kv = _VULKANINFO_KV_RE.match(line)
+        if kv is not None and current_index is not None:
+            current_fields[kv.group(1)] = kv.group(2)
+    flush()
+    return devices
+
+
+def _pick_best_device(devices: list[VulkanDevice]) -> VulkanDevice | None:
+    """Return the highest-ranked device, preferring lower indexes on ties.
+
+    Sort is stable so the original enumeration order acts as the
+    tie-breaker; this matches the user's expectation that "GPU0" wins
+    when two adapters are the same type.
+    """
+    if not devices:
+        return None
+    ranked = sorted(
+        devices,
+        key=lambda d: (-_DEVICE_TYPE_RANK.get(d.device_type, 0), d.index),
+    )
+    best = ranked[0]
+    if _DEVICE_TYPE_RANK.get(best.device_type, 0) <= 0:
+        return None
+    return best

--- a/src/lilbee/providers/llama_cpp/log_dispatch.py
+++ b/src/lilbee/providers/llama_cpp/log_dispatch.py
@@ -187,8 +187,9 @@ def import_llama_cpp() -> Any:
 
 
 # Backend env vars set from ``cfg.gpu_devices`` before the first llama_cpp
-# import. Vulkan, CUDA, and ROCm each read their own; setting all four
-# lets the same config field work across every wheel flavor lilbee ships.
+# import. Vulkan, CUDA, and ROCm each read their own; a user-set
+# ``cfg.gpu_devices`` is applied to all four because the user is
+# specifying their own indexes and opting in to all wheel flavors.
 _GPU_VISIBLE_ENV_VARS = (
     "GGML_VK_VISIBLE_DEVICES",
     "CUDA_VISIBLE_DEVICES",
@@ -196,19 +197,33 @@ _GPU_VISIBLE_ENV_VARS = (
     "ROCR_VISIBLE_DEVICES",
 )
 
+# Subset of the above that the Vulkan autodetect applies to. CUDA and
+# HIP/ROCm enumerate single-vendor adapter sets (NVIDIA-only,
+# AMD-only); a Vulkan device index doesn't translate, so writing the
+# autodetect result to ``CUDA_VISIBLE_DEVICES`` on a CUDA wheel +
+# dual-GPU host would hide the only NVIDIA card and silently fall
+# back to CPU.
+_VULKAN_AUTODETECT_ENV_VARS = ("GGML_VK_VISIBLE_DEVICES",)
+
 
 def _apply_gpu_device_env() -> None:
-    """Apply ``cfg.gpu_devices`` (or autodetect) to every backend's visibility env var.
+    """Apply ``cfg.gpu_devices`` (or autodetect) to backend visibility env vars.
 
     Must run before ``import llama_cpp``: the Vulkan / CUDA / ROCm
     runtimes snapshot their visible-device lists at library load time
     and ignore subsequent changes. Resolution order:
 
     1. Explicit env var (``GGML_VK_VISIBLE_DEVICES`` etc.) -- always
-       wins, including when the user set it intentionally to empty.
-    2. ``cfg.gpu_devices`` -- the user's lilbee-level pin.
-    3. Autodetection -- pick the highest-ranked Vulkan device
-       (discrete > integrated) when more than one is visible.
+       wins, including when the user intentionally set it empty.
+    2. ``cfg.gpu_devices`` -- the user's lilbee-level pin. Applied to
+       every backend (the user is opting in and naming indexes that
+       match their wheel's enumeration).
+    3. Vulkan autodetection -- pick the highest-ranked Vulkan device
+       (discrete > integrated). Applied **only** to
+       ``GGML_VK_VISIBLE_DEVICES``; the Vulkan index doesn't translate
+       to CUDA / HIP / ROCm enumeration order, so writing it there
+       could mask the only visible NVIDIA / AMD card on a single-
+       vendor wheel.
 
     Steps 2 and 3 only set vars that aren't already in the
     environment, so step 1 is preserved.
@@ -216,11 +231,15 @@ def _apply_gpu_device_env() -> None:
     from lilbee.core.config import cfg
     from lilbee.providers.llama_cpp.gpu_select import autoselect_best_gpu_index
 
-    devices = cfg.gpu_devices or autoselect_best_gpu_index()
-    if not devices:
+    if cfg.gpu_devices:
+        for name in _GPU_VISIBLE_ENV_VARS:
+            os.environ.setdefault(name, cfg.gpu_devices)
         return
-    for name in _GPU_VISIBLE_ENV_VARS:
-        os.environ.setdefault(name, devices)
+    autoselected = autoselect_best_gpu_index()
+    if not autoselected:
+        return
+    for name in _VULKAN_AUTODETECT_ENV_VARS:
+        os.environ.setdefault(name, autoselected)
 
 
 def install_llama_log_handler() -> None:

--- a/src/lilbee/providers/llama_cpp/log_dispatch.py
+++ b/src/lilbee/providers/llama_cpp/log_dispatch.py
@@ -175,6 +175,7 @@ def import_llama_cpp() -> Any:
     after the first successful import (Python caches it in ``sys.modules``),
     so callers can sprinkle it at every llama_cpp entry point cheaply.
     """
+    _apply_gpu_device_env()
     try:
         import llama_cpp
 
@@ -183,6 +184,35 @@ def import_llama_cpp() -> Any:
         if "libvulkan" in str(exc):
             raise ProviderError(_MISSING_VULKAN_HINT, provider="llama-cpp") from exc
         raise
+
+
+# Backend env vars set from ``cfg.gpu_devices`` before the first llama_cpp
+# import. Vulkan, CUDA, and ROCm each read their own; setting all four
+# lets the same config field work across every wheel flavor lilbee ships.
+_GPU_VISIBLE_ENV_VARS = (
+    "GGML_VK_VISIBLE_DEVICES",
+    "CUDA_VISIBLE_DEVICES",
+    "HIP_VISIBLE_DEVICES",
+    "ROCR_VISIBLE_DEVICES",
+)
+
+
+def _apply_gpu_device_env() -> None:
+    """Apply ``cfg.gpu_devices`` to every backend's visibility env var.
+
+    Must run before ``import llama_cpp``: the Vulkan / CUDA / ROCm
+    runtimes snapshot their visible-device lists at library load time
+    and ignore subsequent changes. ``cfg.gpu_devices`` is a no-op when
+    ``None``; an explicit user-set env var always wins so power users
+    can still override per-shell.
+    """
+    from lilbee.core.config import cfg
+
+    devices = cfg.gpu_devices
+    if not devices:
+        return
+    for name in _GPU_VISIBLE_ENV_VARS:
+        os.environ.setdefault(name, devices)
 
 
 def install_llama_log_handler() -> None:

--- a/src/lilbee/providers/llama_cpp/log_dispatch.py
+++ b/src/lilbee/providers/llama_cpp/log_dispatch.py
@@ -198,17 +198,25 @@ _GPU_VISIBLE_ENV_VARS = (
 
 
 def _apply_gpu_device_env() -> None:
-    """Apply ``cfg.gpu_devices`` to every backend's visibility env var.
+    """Apply ``cfg.gpu_devices`` (or autodetect) to every backend's visibility env var.
 
     Must run before ``import llama_cpp``: the Vulkan / CUDA / ROCm
     runtimes snapshot their visible-device lists at library load time
-    and ignore subsequent changes. ``cfg.gpu_devices`` is a no-op when
-    ``None``; an explicit user-set env var always wins so power users
-    can still override per-shell.
+    and ignore subsequent changes. Resolution order:
+
+    1. Explicit env var (``GGML_VK_VISIBLE_DEVICES`` etc.) -- always
+       wins, including when the user set it intentionally to empty.
+    2. ``cfg.gpu_devices`` -- the user's lilbee-level pin.
+    3. Autodetection -- pick the highest-ranked Vulkan device
+       (discrete > integrated) when more than one is visible.
+
+    Steps 2 and 3 only set vars that aren't already in the
+    environment, so step 1 is preserved.
     """
     from lilbee.core.config import cfg
+    from lilbee.providers.llama_cpp.gpu_select import autoselect_best_gpu_index
 
-    devices = cfg.gpu_devices
+    devices = cfg.gpu_devices or autoselect_best_gpu_index()
     if not devices:
         return
     for name in _GPU_VISIBLE_ENV_VARS:

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -742,6 +742,8 @@ def load_llama(
         "verbose": False,
         "n_gpu_layers": _resolve_n_gpu_layers(embedding=embedding),
     }
+    if cfg.main_gpu is not None:
+        kwargs["main_gpu"] = cfg.main_gpu
 
     if embedding:
         # Embedding/rerank uses the model's training context unconditionally.

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from gguf import GGUFReader
 
+from lilbee.core.config import cfg
 from lilbee.providers.llama_cpp.abort_signal import abort_callback
 from lilbee.providers.llama_cpp.gguf_meta import find_mmproj_for_model, read_gguf_metadata
 from lilbee.providers.llama_cpp.log_dispatch import (
@@ -142,6 +143,8 @@ def load_vision_llama(
         "n_threads": n_threads,
         "n_threads_batch": n_threads,
     }
+    if cfg.main_gpu is not None:
+        kwargs["main_gpu"] = cfg.main_gpu
     if abort_callback_override is not None:
         kwargs["abort_callback"] = abort_callback_override
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3429,6 +3429,8 @@ class TestSelfCheck:
             "flash_attention",
             "kv_cache_type",
             "n_gpu_layers",
+            "main_gpu",
+            "gpu_devices",
         }
 
     def test_downloads_when_paths_missing(self, tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -480,6 +480,83 @@ class TestNGpuLayersConfig:
             assert c.n_gpu_layers == 3
 
 
+class TestMainGpuConfig:
+    def test_default_is_none(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            assert c.main_gpu is None
+
+    def test_explicit_int_from_env(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_MAIN_GPU": "1"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.main_gpu == 1
+
+    def test_auto_string_means_none(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_MAIN_GPU": "auto"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.main_gpu is None
+
+    def test_invalid_string_falls_back_to_none(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_MAIN_GPU": "garbage"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.main_gpu is None
+
+    def test_non_string_input_coerces_to_int(self, tmp_path) -> None:
+        """Direct assignment with a non-string value falls through to int(v)."""
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            c.main_gpu = 2.0  # type: ignore[assignment]
+            assert c.main_gpu == 2
+
+
+class TestGpuDevicesConfig:
+    def test_default_is_none(self, tmp_path) -> None:
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            assert c.gpu_devices is None
+
+    def test_single_index_from_env(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_GPU_DEVICES": "0"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.gpu_devices == "0"
+
+    def test_multi_index_from_env(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_GPU_DEVICES": " 0, 1 "}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.gpu_devices == "0,1"
+
+    def test_all_alias_means_none(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_GPU_DEVICES": "all"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.gpu_devices is None
+
+    def test_non_numeric_falls_back_to_none(self, tmp_path) -> None:
+        env = {**_clean_env(tmp_path), "LILBEE_GPU_DEVICES": "rtx-4060"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.gpu_devices is None
+
+    def test_only_separators_falls_back_to_none(self, tmp_path) -> None:
+        """A string that splits into zero parts ('  ,  ,') normalizes to None."""
+        env = {**_clean_env(tmp_path), "LILBEE_GPU_DEVICES": " , ,"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.gpu_devices is None
+
+    def test_non_string_input_coerces_to_str(self, tmp_path) -> None:
+        """Direct assignment with a non-string value falls through to str(v)."""
+        with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
+            c = Config()
+            c.gpu_devices = 0  # type: ignore[assignment]
+            assert c.gpu_devices == "0"
+
+
 class TestSemanticChunkingConfig:
     def test_default_is_false(self, tmp_path) -> None:
         """Semantic chunking is opt-in: default False, enabled via env/config."""

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -1265,13 +1265,19 @@ class TestSyncSkippedMessageBranches:
 
 
 class TestChattyDependencyFilters:
-    """`lilbee/__init__.py` installs substring filters on noisy upstream loggers."""
+    """Each lib's substring filter lives next to that lib's adapter module
+    and installs on import (catalog/hf_client.py for HF,
+    providers/litellm_sdk.py for LiteLLM). Importing the adapter module is
+    what attaches the filter to the upstream logger.
+    """
 
     @staticmethod
     def _record(name: str, msg: str) -> logging.LogRecord:
         return logging.LogRecord(name, logging.WARNING, __file__, 0, msg, (), None)
 
     def test_hf_unauthenticated_notice_is_dropped(self) -> None:
+        import lilbee.catalog.hf_client  # noqa: F401  -- import for filter install
+
         hf_logger = logging.getLogger("huggingface_hub.utils._http")
         noisy = self._record(
             hf_logger.name, "Sending unauthenticated requests to the HF Hub; rate limits apply."
@@ -1279,11 +1285,15 @@ class TestChattyDependencyFilters:
         assert any(f.filter(noisy) is False for f in hf_logger.filters)
 
     def test_unrelated_hf_message_passes_through(self) -> None:
+        import lilbee.catalog.hf_client  # noqa: F401  -- import for filter install
+
         hf_logger = logging.getLogger("huggingface_hub.utils._http")
         keep = self._record(hf_logger.name, "Downloaded model.gguf in 12s")
         assert all(f.filter(keep) is True for f in hf_logger.filters)
 
     def test_litellm_cost_map_warning_is_dropped(self) -> None:
+        import lilbee.providers.litellm_sdk  # noqa: F401  -- import for filter install
+
         litellm_logger = logging.getLogger("LiteLLM")
         noisy = self._record(
             litellm_logger.name, "Failed to fetch remote model cost map. Using local copy."
@@ -1301,12 +1311,16 @@ class TestChattyDependencyFilters:
     )
     def test_litellm_aws_messages_are_dropped(self, aws_message: str) -> None:
         """AWS-related LiteLLM advisories are filtered: lilbee never supports AWS."""
+        import lilbee.providers.litellm_sdk  # noqa: F401  -- import for filter install
+
         litellm_logger = logging.getLogger("LiteLLM")
         noisy = self._record(litellm_logger.name, aws_message)
         assert any(f.filter(noisy) is False for f in litellm_logger.filters)
 
     def test_litellm_unrelated_message_passes_through(self) -> None:
         """Filter is targeted: a generic LiteLLM warning still surfaces."""
+        import lilbee.providers.litellm_sdk  # noqa: F401  -- import for filter install
+
         litellm_logger = logging.getLogger("LiteLLM")
         keep = self._record(litellm_logger.name, "Rate limit hit, retrying in 5s")
         assert all(f.filter(keep) is True for f in litellm_logger.filters)

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -1290,6 +1290,27 @@ class TestChattyDependencyFilters:
         )
         assert any(f.filter(noisy) is False for f in litellm_logger.filters)
 
+    @pytest.mark.parametrize(
+        "aws_message",
+        [
+            "Missing boto3 to call bedrock. Run 'pip install boto3'.",
+            "Could not load response stream shape: botocore not available",
+            "sagemaker-runtime endpoint unreachable",
+            "bedrock invoke failed",
+        ],
+    )
+    def test_litellm_aws_messages_are_dropped(self, aws_message: str) -> None:
+        """AWS-related LiteLLM advisories are filtered: lilbee never supports AWS."""
+        litellm_logger = logging.getLogger("LiteLLM")
+        noisy = self._record(litellm_logger.name, aws_message)
+        assert any(f.filter(noisy) is False for f in litellm_logger.filters)
+
+    def test_litellm_unrelated_message_passes_through(self) -> None:
+        """Filter is targeted: a generic LiteLLM warning still surfaces."""
+        litellm_logger = logging.getLogger("LiteLLM")
+        keep = self._record(litellm_logger.name, "Rate limit hit, retrying in 5s")
+        assert all(f.filter(keep) is True for f in litellm_logger.filters)
+
 
 class TestWikiEmptyStateSpacyBranches:
     """Wiki-empty-state messages have a spaCy-unavailable branch."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -532,6 +533,28 @@ class TestLlamaCppProvider:
                     assert mock_llama_cls.call_args[1]["n_gpu_layers"] == expected
         finally:
             cfg.n_gpu_layers = "auto"
+            cfg.flash_attention = "auto"
+
+    def testload_llama_threads_main_gpu_when_set(self, models_dir: Path) -> None:
+        """``cfg.main_gpu`` reaches the Llama() constructor; default leaves it absent."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp.provider import load_llama
+
+        cfg.num_ctx = 4096
+        cfg.flash_attention = "0"
+        try:
+            cfg.main_gpu = None
+            with patch("llama_cpp.Llama") as mock_llama_cls:
+                load_llama(models_dir / "test-model.gguf", mode="chat")
+                assert "main_gpu" not in mock_llama_cls.call_args[1]
+
+            cfg.main_gpu = 1
+            with patch("llama_cpp.Llama") as mock_llama_cls:
+                load_llama(models_dir / "test-model.gguf", mode="chat")
+                assert mock_llama_cls.call_args[1]["main_gpu"] == 1
+        finally:
+            cfg.main_gpu = None
             cfg.flash_attention = "auto"
 
     def testapply_kv_cache_type_skips_when_internal_module_missing(self) -> None:
@@ -1768,6 +1791,28 @@ class TestMtmdLoadVisionLlama:
         assert call_kwargs["n_ctx"] == 8192
         assert call_kwargs["n_gpu_layers"] == -1
 
+    def test_vision_threads_main_gpu_when_set(self, mock_llama_cpp: mock.MagicMock) -> None:
+        """``cfg.main_gpu`` reaches the vision Llama() constructor when set."""
+        from lilbee.providers.mtmd_backend import load_vision_llama
+
+        cfg.num_ctx = None
+        cfg.main_gpu = 1
+        try:
+            with (
+                mock.patch(
+                    "lilbee.providers.mtmd_backend.read_gguf_metadata",
+                    return_value={"context_length": "8192"},
+                ),
+                mock.patch(
+                    "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+                    return_value=mock.MagicMock(),
+                ),
+            ):
+                load_vision_llama(Path("model.gguf"), mmproj_path=Path("mmproj.gguf"))
+            assert mock_llama_cpp.Llama.call_args[1]["main_gpu"] == 1
+        finally:
+            cfg.main_gpu = None
+
     def test_vision_falls_back_to_default_when_metadata_missing(
         self, mock_llama_cpp: mock.MagicMock
     ) -> None:
@@ -1916,6 +1961,52 @@ class TestImportLlamaCpp:
         monkeypatch.delitem(sys.modules, "llama_cpp", raising=False)
         with pytest.raises(OSError, match="libsomethingelse"):
             import_llama_cpp()
+
+    def test_gpu_devices_sets_visibility_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``cfg.gpu_devices`` propagates to every backend's visible-devices env var."""
+        from lilbee.core.config import cfg
+        from lilbee.providers.llama_cpp.log_dispatch import (
+            _GPU_VISIBLE_ENV_VARS,
+            import_llama_cpp,
+        )
+
+        for name in _GPU_VISIBLE_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setattr(cfg, "gpu_devices", "0")
+        monkeypatch.setitem(sys.modules, "llama_cpp", mock.MagicMock())
+
+        import_llama_cpp()
+        for name in _GPU_VISIBLE_ENV_VARS:
+            assert os.environ.get(name) == "0", name
+
+    def test_gpu_devices_none_leaves_env_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With ``gpu_devices=None`` the visibility env vars are not set."""
+        from lilbee.core.config import cfg
+        from lilbee.providers.llama_cpp.log_dispatch import (
+            _GPU_VISIBLE_ENV_VARS,
+            import_llama_cpp,
+        )
+
+        for name in _GPU_VISIBLE_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setattr(cfg, "gpu_devices", None)
+        monkeypatch.setitem(sys.modules, "llama_cpp", mock.MagicMock())
+
+        import_llama_cpp()
+        for name in _GPU_VISIBLE_ENV_VARS:
+            assert name not in os.environ, name
+
+    def test_user_env_var_wins_over_cfg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A pre-set ``GGML_VK_VISIBLE_DEVICES`` is preserved even when cfg has a value."""
+        from lilbee.core.config import cfg
+        from lilbee.providers.llama_cpp.log_dispatch import import_llama_cpp
+
+        monkeypatch.setenv("GGML_VK_VISIBLE_DEVICES", "1")
+        monkeypatch.setattr(cfg, "gpu_devices", "0")
+        monkeypatch.setitem(sys.modules, "llama_cpp", mock.MagicMock())
+
+        import_llama_cpp()
+        assert os.environ["GGML_VK_VISIBLE_DEVICES"] == "1"
 
 
 class TestReadChatTemplate:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2056,7 +2056,7 @@ class TestVulkanGpuSelect:
     def test_autoselect_returns_none_when_only_cpu_devices(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """All-CPU adapter list shouldn't force a pin: software rendering is never the right pick."""
+        """All-CPU adapter list shouldn't force a pin: software rendering is never right."""
         from lilbee.providers.llama_cpp import gpu_select
 
         monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1917,19 +1917,14 @@ class TestVulkanGpuSelect:
 
     def test_pick_best_prefers_discrete_over_integrated(self) -> None:
         from lilbee.providers.llama_cpp.gpu_select import (
-            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-            _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
+            VkDeviceType,
             VulkanDevice,
             _pick_best_device,
         )
 
         devices = [
-            VulkanDevice(
-                index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, device_name="iGPU"
-            ),
-            VulkanDevice(
-                index=1, device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, device_name="dGPU"
-            ),
+            VulkanDevice(index=0, device_type=VkDeviceType.INTEGRATED_GPU, device_name="iGPU"),
+            VulkanDevice(index=1, device_type=VkDeviceType.DISCRETE_GPU, device_name="dGPU"),
         ]
         best = _pick_best_device(devices)
         assert best is not None
@@ -1937,13 +1932,13 @@ class TestVulkanGpuSelect:
 
     def test_pick_best_returns_none_for_cpu_only(self) -> None:
         from lilbee.providers.llama_cpp.gpu_select import (
-            _VK_PHYSICAL_DEVICE_TYPE_CPU,
+            VkDeviceType,
             VulkanDevice,
             _pick_best_device,
         )
 
         devices = [
-            VulkanDevice(index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_CPU, device_name="llvmpipe"),
+            VulkanDevice(index=0, device_type=VkDeviceType.CPU, device_name="llvmpipe"),
         ]
         assert _pick_best_device(devices) is None
 
@@ -1952,13 +1947,18 @@ class TestVulkanGpuSelect:
 
         assert _pick_best_device([]) is None
 
+    def test_rank_for_unknown_device_type_returns_zero(self) -> None:
+        """Drivers may report a deviceType outside the Vulkan 1.0 enum; we treat as CPU-rank."""
+        from lilbee.providers.llama_cpp.gpu_select import _rank_for
+
+        assert _rank_for(999) == 0
+
     def test_autoselect_returns_discrete_index_for_dual_gpu(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from lilbee.providers.llama_cpp import gpu_select
         from lilbee.providers.llama_cpp.gpu_select import (
-            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-            _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
+            VkDeviceType,
             VulkanDevice,
         )
 
@@ -1966,12 +1966,8 @@ class TestVulkanGpuSelect:
             gpu_select,
             "_enumerate_vulkan_devices",
             lambda: [
-                VulkanDevice(
-                    index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, device_name="iGPU"
-                ),
-                VulkanDevice(
-                    index=1, device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, device_name="dGPU"
-                ),
+                VulkanDevice(index=0, device_type=VkDeviceType.INTEGRATED_GPU, device_name="iGPU"),
+                VulkanDevice(index=1, device_type=VkDeviceType.DISCRETE_GPU, device_name="dGPU"),
             ],
         )
         assert gpu_select.autoselect_best_gpu_index() == "1"
@@ -1982,7 +1978,7 @@ class TestVulkanGpuSelect:
         """Single-device hosts keep the default ordering; auto-pin would be churn."""
         from lilbee.providers.llama_cpp import gpu_select
         from lilbee.providers.llama_cpp.gpu_select import (
-            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
+            VkDeviceType,
             VulkanDevice,
         )
 
@@ -1992,7 +1988,7 @@ class TestVulkanGpuSelect:
             lambda: [
                 VulkanDevice(
                     index=0,
-                    device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
+                    device_type=VkDeviceType.DISCRETE_GPU,
                     device_name="RTX 4090",
                 ),
             ],
@@ -2013,7 +2009,7 @@ class TestVulkanGpuSelect:
         """All-CPU adapter list shouldn't force a pin: software rendering is never right."""
         from lilbee.providers.llama_cpp import gpu_select
         from lilbee.providers.llama_cpp.gpu_select import (
-            _VK_PHYSICAL_DEVICE_TYPE_CPU,
+            VkDeviceType,
             VulkanDevice,
         )
 
@@ -2021,8 +2017,8 @@ class TestVulkanGpuSelect:
             gpu_select,
             "_enumerate_vulkan_devices",
             lambda: [
-                VulkanDevice(index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_CPU, device_name="cpu0"),
-                VulkanDevice(index=1, device_type=_VK_PHYSICAL_DEVICE_TYPE_CPU, device_name="cpu1"),
+                VulkanDevice(index=0, device_type=VkDeviceType.CPU, device_name="cpu0"),
+                VulkanDevice(index=1, device_type=VkDeviceType.CPU, device_name="cpu1"),
             ],
         )
         assert gpu_select.autoselect_best_gpu_index() is None
@@ -2033,7 +2029,7 @@ class TestVulkanGpuSelect:
         """Two discrete GPUs of equal rank: no auto-pin (no decision to make)."""
         from lilbee.providers.llama_cpp import gpu_select
         from lilbee.providers.llama_cpp.gpu_select import (
-            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
+            VkDeviceType,
             VulkanDevice,
         )
 
@@ -2041,12 +2037,8 @@ class TestVulkanGpuSelect:
             gpu_select,
             "_enumerate_vulkan_devices",
             lambda: [
-                VulkanDevice(
-                    index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, device_name="dgpu0"
-                ),
-                VulkanDevice(
-                    index=1, device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, device_name="dgpu1"
-                ),
+                VulkanDevice(index=0, device_type=VkDeviceType.DISCRETE_GPU, device_name="dgpu0"),
+                VulkanDevice(index=1, device_type=VkDeviceType.DISCRETE_GPU, device_name="dgpu1"),
             ],
         )
         assert gpu_select.autoselect_best_gpu_index() is None
@@ -2127,14 +2119,13 @@ class TestVulkanGpuSelect:
         """Happy path: simulated VK calls populate the device list."""
         from lilbee.providers.llama_cpp import gpu_select
         from lilbee.providers.llama_cpp.gpu_select import (
-            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
-            _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
+            VkDeviceType,
             _list_devices_with_instance,
         )
 
         fake_props = [
-            (_VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, b"iGPU"),
-            (_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, b"NVIDIA RTX"),
+            (VkDeviceType.INTEGRATED_GPU, b"iGPU"),
+            (VkDeviceType.DISCRETE_GPU, b"NVIDIA RTX"),
         ]
         device_count = len(fake_props)
 
@@ -2163,8 +2154,8 @@ class TestVulkanGpuSelect:
         )
         devices = _list_devices_with_instance(object())
         assert len(devices) == device_count
-        assert devices[0].device_type == _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
-        assert devices[1].device_type == _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
+        assert devices[0].device_type == VkDeviceType.INTEGRATED_GPU
+        assert devices[1].device_type == VkDeviceType.DISCRETE_GPU
         assert devices[1].device_name == "NVIDIA RTX"
 
     def test_list_devices_returns_empty_when_create_instance_fails(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1912,60 +1912,23 @@ class TestMtmdLoadVisionLlama:
         assert mock_llama_cpp.Llama.call_args[1]["n_ctx"] == _VISION_FALLBACK_N_CTX
 
 
-_VULKANINFO_DUAL_GPU = """\
-GPU0:
-        apiVersion         = 1.3.250
-        driverVersion      = 23.0.0
-        vendorID           = 0x1002
-        deviceID           = 0x15bf
-        deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
-        deviceName         = AMD Radeon Graphics
-GPU1:
-        apiVersion         = 1.3.250
-        driverVersion      = 535.183.1
-        vendorID           = 0x10de
-        deviceID           = 0x2509
-        deviceType         = PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
-        deviceName         = NVIDIA GeForce RTX 3050
-"""
-
-_VULKANINFO_SINGLE_GPU = """\
-GPU0:
-        deviceType         = PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
-        deviceName         = NVIDIA GeForce RTX 4090
-"""
-
-_VULKANINFO_CPU_ONLY = """\
-GPU0:
-        deviceType         = PHYSICAL_DEVICE_TYPE_CPU
-        deviceName         = llvmpipe
-"""
-
-
 class TestVulkanGpuSelect:
-    """``autoselect_best_gpu_index`` parses vulkaninfo --summary and picks discrete."""
-
-    def test_parses_dual_gpu_and_picks_discrete(self) -> None:
-        from lilbee.providers.llama_cpp.gpu_select import _parse_vulkaninfo_summary
-
-        devices = _parse_vulkaninfo_summary(_VULKANINFO_DUAL_GPU)
-        assert len(devices) == 2
-        assert devices[0].device_type == "PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU"
-        assert devices[1].device_type == "PHYSICAL_DEVICE_TYPE_DISCRETE_GPU"
+    """``autoselect_best_gpu_index`` probes libvulkan via ctypes and picks discrete."""
 
     def test_pick_best_prefers_discrete_over_integrated(self) -> None:
-        from lilbee.providers.llama_cpp.gpu_select import VulkanDevice, _pick_best_device
+        from lilbee.providers.llama_cpp.gpu_select import (
+            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
+            _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
+            VulkanDevice,
+            _pick_best_device,
+        )
 
         devices = [
             VulkanDevice(
-                index=0,
-                device_type="PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
-                device_name="iGPU",
+                index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, device_name="iGPU"
             ),
             VulkanDevice(
-                index=1,
-                device_type="PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
-                device_name="dGPU",
+                index=1, device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, device_name="dGPU"
             ),
         ]
         best = _pick_best_device(devices)
@@ -1974,25 +1937,42 @@ class TestVulkanGpuSelect:
 
     def test_pick_best_returns_none_for_cpu_only(self) -> None:
         from lilbee.providers.llama_cpp.gpu_select import (
-            _parse_vulkaninfo_summary,
+            _VK_PHYSICAL_DEVICE_TYPE_CPU,
+            VulkanDevice,
             _pick_best_device,
         )
 
-        devices = _parse_vulkaninfo_summary(_VULKANINFO_CPU_ONLY)
+        devices = [
+            VulkanDevice(index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_CPU, device_name="llvmpipe"),
+        ]
         assert _pick_best_device(devices) is None
+
+    def test_pick_best_returns_none_for_empty_list(self) -> None:
+        from lilbee.providers.llama_cpp.gpu_select import _pick_best_device
+
+        assert _pick_best_device([]) is None
 
     def test_autoselect_returns_discrete_index_for_dual_gpu(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
+            _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
+            VulkanDevice,
+        )
 
-        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
         monkeypatch.setattr(
-            gpu_select.subprocess,
-            "run",
-            lambda *_args, **_kwargs: type(
-                "_R", (), {"returncode": 0, "stdout": _VULKANINFO_DUAL_GPU}
-            )(),
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                VulkanDevice(
+                    index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, device_name="iGPU"
+                ),
+                VulkanDevice(
+                    index=1, device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, device_name="dGPU"
+                ),
+            ],
         )
         assert gpu_select.autoselect_best_gpu_index() == "1"
 
@@ -2001,56 +1981,30 @@ class TestVulkanGpuSelect:
     ) -> None:
         """Single-device hosts keep the default ordering; auto-pin would be churn."""
         from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
+            VulkanDevice,
+        )
 
-        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
         monkeypatch.setattr(
-            gpu_select.subprocess,
-            "run",
-            lambda *_args, **_kwargs: type(
-                "_R", (), {"returncode": 0, "stdout": _VULKANINFO_SINGLE_GPU}
-            )(),
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                VulkanDevice(
+                    index=0,
+                    device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
+                    device_name="RTX 4090",
+                ),
+            ],
         )
         assert gpu_select.autoselect_best_gpu_index() is None
 
-    def test_autoselect_returns_none_when_vulkaninfo_missing(
+    def test_autoselect_returns_none_when_loader_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from lilbee.providers.llama_cpp import gpu_select
 
-        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: None)
-        assert gpu_select.autoselect_best_gpu_index() is None
-
-    def test_autoselect_returns_none_when_vulkaninfo_nonzero_exit(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from lilbee.providers.llama_cpp import gpu_select
-
-        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
-        monkeypatch.setattr(
-            gpu_select.subprocess,
-            "run",
-            lambda *_args, **_kwargs: type("_R", (), {"returncode": 1, "stdout": ""})(),
-        )
-        assert gpu_select.autoselect_best_gpu_index() is None
-
-    def test_autoselect_returns_none_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from lilbee.providers.llama_cpp import gpu_select
-
-        def _raises(*_args: object, **_kwargs: object) -> object:
-            raise gpu_select.subprocess.TimeoutExpired(cmd="vulkaninfo", timeout=3.0)
-
-        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
-        monkeypatch.setattr(gpu_select.subprocess, "run", _raises)
-        assert gpu_select.autoselect_best_gpu_index() is None
-
-    def test_autoselect_returns_none_on_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from lilbee.providers.llama_cpp import gpu_select
-
-        def _raises(*_args: object, **_kwargs: object) -> object:
-            raise OSError("permission denied")
-
-        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
-        monkeypatch.setattr(gpu_select.subprocess, "run", _raises)
+        monkeypatch.setattr(gpu_select, "_enumerate_vulkan_devices", lambda: None)
         assert gpu_select.autoselect_best_gpu_index() is None
 
     def test_autoselect_returns_none_when_only_cpu_devices(
@@ -2058,27 +2012,269 @@ class TestVulkanGpuSelect:
     ) -> None:
         """All-CPU adapter list shouldn't force a pin: software rendering is never right."""
         from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            _VK_PHYSICAL_DEVICE_TYPE_CPU,
+            VulkanDevice,
+        )
 
-        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
         monkeypatch.setattr(
-            gpu_select.subprocess,
-            "run",
-            lambda *_args, **_kwargs: type(
-                "_R", (), {"returncode": 0, "stdout": _VULKANINFO_CPU_ONLY}
-            )(),
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                VulkanDevice(index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_CPU, device_name="cpu0"),
+                VulkanDevice(index=1, device_type=_VK_PHYSICAL_DEVICE_TYPE_CPU, device_name="cpu1"),
+            ],
         )
         assert gpu_select.autoselect_best_gpu_index() is None
 
-    def test_parse_skips_block_without_device_type(self) -> None:
-        from lilbee.providers.llama_cpp.gpu_select import _parse_vulkaninfo_summary
+    def test_autoselect_returns_none_when_all_devices_same_rank(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two discrete GPUs of equal rank: no auto-pin (no decision to make)."""
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
+            VulkanDevice,
+        )
 
-        broken = "GPU0:\n        deviceName         = NoTypeHere\n"
-        assert _parse_vulkaninfo_summary(broken) == []
+        monkeypatch.setattr(
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                VulkanDevice(
+                    index=0, device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, device_name="dgpu0"
+                ),
+                VulkanDevice(
+                    index=1, device_type=_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, device_name="dgpu1"
+                ),
+            ],
+        )
+        assert gpu_select.autoselect_best_gpu_index() is None
 
-    def test_pick_best_returns_none_for_empty_list(self) -> None:
-        from lilbee.providers.llama_cpp.gpu_select import _pick_best_device
+    def test_loader_returns_none_on_darwin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """macOS uses Metal; the Vulkan probe explicitly skips."""
+        from lilbee.providers.llama_cpp import gpu_select
 
-        assert _pick_best_device([]) is None
+        monkeypatch.setattr(gpu_select.sys, "platform", "darwin")
+        assert gpu_select._load_vulkan_loader() is None
+
+    def test_loader_returns_none_when_library_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "linux")
+
+        def _raises(_name: str) -> object:
+            raise OSError("cannot find vulkan loader")
+
+        monkeypatch.setattr(gpu_select.ctypes, "CDLL", _raises)
+        monkeypatch.setattr(gpu_select.ctypes.util, "find_library", lambda _name: None)
+        assert gpu_select._load_vulkan_loader() is None
+
+    def test_loader_falls_back_to_find_library(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "linux")
+        attempts: list[str] = []
+
+        def _cdll(name: str) -> object:
+            attempts.append(name)
+            if name == "/resolved/libvulkan.so":
+                return "loaded"
+            raise OSError("not on direct path")
+
+        monkeypatch.setattr(gpu_select.ctypes, "CDLL", _cdll)
+        monkeypatch.setattr(
+            gpu_select.ctypes.util, "find_library", lambda _name: "/resolved/libvulkan.so"
+        )
+        assert gpu_select._load_vulkan_loader() == "loaded"
+        assert "libvulkan.so.1" in attempts
+
+    def test_enumerate_returns_none_when_loader_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select, "_load_vulkan_loader", lambda: None)
+        assert gpu_select._enumerate_vulkan_devices() is None
+
+    def test_enumerate_catches_oserror_from_ctypes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select, "_load_vulkan_loader", lambda: object())
+
+        def _raises(_lib: object) -> object:
+            raise OSError("symbol not found")
+
+        monkeypatch.setattr(gpu_select, "_list_devices_with_instance", _raises)
+        assert gpu_select._enumerate_vulkan_devices() is None
+
+    def test_resolve_vk_symbols_stamps_argtypes(self) -> None:
+        """``_resolve_vk_symbols`` reads four named attributes off the loader."""
+        from lilbee.providers.llama_cpp.gpu_select import _resolve_vk_symbols
+
+        fake_lib = mock.MagicMock()
+        create, destroy, enum_phys, get_props = _resolve_vk_symbols(fake_lib)
+        assert create is fake_lib.vkCreateInstance
+        assert destroy is fake_lib.vkDestroyInstance
+        assert enum_phys is fake_lib.vkEnumeratePhysicalDevices
+        assert get_props is fake_lib.vkGetPhysicalDeviceProperties
+
+    def test_list_devices_with_instance_returns_parsed_devices(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Happy path: simulated VK calls populate the device list."""
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
+            _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU,
+            _list_devices_with_instance,
+        )
+
+        fake_props = [
+            (_VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, b"iGPU"),
+            (_VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, b"NVIDIA RTX"),
+        ]
+        device_count = len(fake_props)
+
+        def _create_instance(_info_ref: object, _alloc: object, instance_ref: object) -> int:
+            instance_ref._obj.value = 0xDEADBEEF
+            return 0
+
+        def _enum_physical(_instance: object, count_ref: object, handles_arr: object) -> int:
+            if handles_arr is None:
+                count_ref._obj.value = device_count
+            else:
+                for i in range(device_count):
+                    handles_arr[i] = 0xCAFE + i
+            return 0
+
+        def _get_properties(handle: object, props_ref: object) -> None:
+            i = handle - 0xCAFE
+            dtype, name = fake_props[i]
+            props_ref._obj.deviceType = dtype
+            props_ref._obj.deviceName = name
+
+        monkeypatch.setattr(
+            gpu_select,
+            "_resolve_vk_symbols",
+            lambda _lib: (_create_instance, lambda *_: None, _enum_physical, _get_properties),
+        )
+        devices = _list_devices_with_instance(object())
+        assert len(devices) == device_count
+        assert devices[0].device_type == _VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
+        assert devices[1].device_type == _VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
+        assert devices[1].device_name == "NVIDIA RTX"
+
+    def test_list_devices_returns_empty_when_create_instance_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import _list_devices_with_instance
+
+        monkeypatch.setattr(
+            gpu_select,
+            "_resolve_vk_symbols",
+            lambda _lib: (
+                lambda *_a: 1,  # VK_ERROR
+                lambda *_a: None,
+                lambda *_a: 0,
+                lambda *_a: None,
+            ),
+        )
+        assert _list_devices_with_instance(object()) == []
+
+    def test_list_devices_returns_empty_when_first_enum_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import _list_devices_with_instance
+
+        def _create_instance(_info: object, _alloc: object, instance_ref: object) -> int:
+            instance_ref._obj.value = 0x1
+            return 0
+
+        monkeypatch.setattr(
+            gpu_select,
+            "_resolve_vk_symbols",
+            lambda _lib: (
+                _create_instance,
+                lambda *_a: None,
+                lambda *_a: 1,  # enum fails
+                lambda *_a: None,
+            ),
+        )
+        assert _list_devices_with_instance(object()) == []
+
+    def test_list_devices_returns_empty_when_count_is_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import _list_devices_with_instance
+
+        def _create_instance(_info: object, _alloc: object, instance_ref: object) -> int:
+            instance_ref._obj.value = 0x1
+            return 0
+
+        def _enum_physical(_instance: object, count_ref: object, _handles: object) -> int:
+            count_ref._obj.value = 0
+            return 0
+
+        monkeypatch.setattr(
+            gpu_select,
+            "_resolve_vk_symbols",
+            lambda _lib: (
+                _create_instance,
+                lambda *_a: None,
+                _enum_physical,
+                lambda *_a: None,
+            ),
+        )
+        assert _list_devices_with_instance(object()) == []
+
+    def test_list_devices_returns_empty_when_second_enum_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import _list_devices_with_instance
+
+        def _create_instance(_info: object, _alloc: object, instance_ref: object) -> int:
+            instance_ref._obj.value = 0x1
+            return 0
+
+        def _enum_physical(_instance: object, count_ref: object, handles: object) -> int:
+            if handles is None:
+                count_ref._obj.value = 1
+                return 0
+            return 1  # second call fails
+
+        monkeypatch.setattr(
+            gpu_select,
+            "_resolve_vk_symbols",
+            lambda _lib: (
+                _create_instance,
+                lambda *_a: None,
+                _enum_physical,
+                lambda *_a: None,
+            ),
+        )
+        assert _list_devices_with_instance(object()) == []
+
+    def test_loader_find_library_returns_none_after_oserror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """find_library succeeds but CDLL on that path still raises -> overall None."""
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "linux")
+
+        def _cdll(_name: str) -> object:
+            raise OSError("loader unhappy")
+
+        monkeypatch.setattr(gpu_select.ctypes, "CDLL", _cdll)
+        monkeypatch.setattr(gpu_select.ctypes.util, "find_library", lambda _n: "/lib/libvulkan.so")
+        assert gpu_select._load_vulkan_loader() is None
 
 
 class TestImportLlamaCpp:
@@ -2171,13 +2367,16 @@ class TestImportLlamaCpp:
         for name in _GPU_VISIBLE_ENV_VARS:
             assert name not in os.environ, name
 
-    def test_gpu_devices_autoselect_fills_env_when_cfg_unset(
+    def test_gpu_devices_autoselect_only_sets_vulkan_var(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When ``cfg.gpu_devices`` is None, autoselect's result populates the env vars."""
+        """Autodetect targets Vulkan only: a CUDA wheel must not have its visible-devices
+        list silently rewritten from a Vulkan-loader index.
+        """
         from lilbee.core.config import cfg
         from lilbee.providers.llama_cpp.log_dispatch import (
             _GPU_VISIBLE_ENV_VARS,
+            _VULKAN_AUTODETECT_ENV_VARS,
             import_llama_cpp,
         )
 
@@ -2191,8 +2390,9 @@ class TestImportLlamaCpp:
         monkeypatch.setitem(sys.modules, "llama_cpp", mock.MagicMock())
 
         import_llama_cpp()
-        for name in _GPU_VISIBLE_ENV_VARS:
-            assert os.environ.get(name) == "1", name
+        assert os.environ["GGML_VK_VISIBLE_DEVICES"] == "1"
+        for name in set(_GPU_VISIBLE_ENV_VARS) - set(_VULKAN_AUTODETECT_ENV_VARS):
+            assert name not in os.environ, name
 
     def test_user_env_var_wins_over_cfg(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A pre-set ``GGML_VK_VISIBLE_DEVICES`` is preserved even when cfg has a value."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1912,6 +1912,175 @@ class TestMtmdLoadVisionLlama:
         assert mock_llama_cpp.Llama.call_args[1]["n_ctx"] == _VISION_FALLBACK_N_CTX
 
 
+_VULKANINFO_DUAL_GPU = """\
+GPU0:
+        apiVersion         = 1.3.250
+        driverVersion      = 23.0.0
+        vendorID           = 0x1002
+        deviceID           = 0x15bf
+        deviceType         = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
+        deviceName         = AMD Radeon Graphics
+GPU1:
+        apiVersion         = 1.3.250
+        driverVersion      = 535.183.1
+        vendorID           = 0x10de
+        deviceID           = 0x2509
+        deviceType         = PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
+        deviceName         = NVIDIA GeForce RTX 3050
+"""
+
+_VULKANINFO_SINGLE_GPU = """\
+GPU0:
+        deviceType         = PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
+        deviceName         = NVIDIA GeForce RTX 4090
+"""
+
+_VULKANINFO_CPU_ONLY = """\
+GPU0:
+        deviceType         = PHYSICAL_DEVICE_TYPE_CPU
+        deviceName         = llvmpipe
+"""
+
+
+class TestVulkanGpuSelect:
+    """``autoselect_best_gpu_index`` parses vulkaninfo --summary and picks discrete."""
+
+    def test_parses_dual_gpu_and_picks_discrete(self) -> None:
+        from lilbee.providers.llama_cpp.gpu_select import _parse_vulkaninfo_summary
+
+        devices = _parse_vulkaninfo_summary(_VULKANINFO_DUAL_GPU)
+        assert len(devices) == 2
+        assert devices[0].device_type == "PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU"
+        assert devices[1].device_type == "PHYSICAL_DEVICE_TYPE_DISCRETE_GPU"
+
+    def test_pick_best_prefers_discrete_over_integrated(self) -> None:
+        from lilbee.providers.llama_cpp.gpu_select import VulkanDevice, _pick_best_device
+
+        devices = [
+            VulkanDevice(
+                index=0,
+                device_type="PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                device_name="iGPU",
+            ),
+            VulkanDevice(
+                index=1,
+                device_type="PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                device_name="dGPU",
+            ),
+        ]
+        best = _pick_best_device(devices)
+        assert best is not None
+        assert best.index == 1
+
+    def test_pick_best_returns_none_for_cpu_only(self) -> None:
+        from lilbee.providers.llama_cpp.gpu_select import (
+            _parse_vulkaninfo_summary,
+            _pick_best_device,
+        )
+
+        devices = _parse_vulkaninfo_summary(_VULKANINFO_CPU_ONLY)
+        assert _pick_best_device(devices) is None
+
+    def test_autoselect_returns_discrete_index_for_dual_gpu(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
+        monkeypatch.setattr(
+            gpu_select.subprocess,
+            "run",
+            lambda *_args, **_kwargs: type(
+                "_R", (), {"returncode": 0, "stdout": _VULKANINFO_DUAL_GPU}
+            )(),
+        )
+        assert gpu_select.autoselect_best_gpu_index() == "1"
+
+    def test_autoselect_returns_none_when_single_visible_device(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Single-device hosts keep the default ordering; auto-pin would be churn."""
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
+        monkeypatch.setattr(
+            gpu_select.subprocess,
+            "run",
+            lambda *_args, **_kwargs: type(
+                "_R", (), {"returncode": 0, "stdout": _VULKANINFO_SINGLE_GPU}
+            )(),
+        )
+        assert gpu_select.autoselect_best_gpu_index() is None
+
+    def test_autoselect_returns_none_when_vulkaninfo_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: None)
+        assert gpu_select.autoselect_best_gpu_index() is None
+
+    def test_autoselect_returns_none_when_vulkaninfo_nonzero_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
+        monkeypatch.setattr(
+            gpu_select.subprocess,
+            "run",
+            lambda *_args, **_kwargs: type("_R", (), {"returncode": 1, "stdout": ""})(),
+        )
+        assert gpu_select.autoselect_best_gpu_index() is None
+
+    def test_autoselect_returns_none_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+
+        def _raises(*_args: object, **_kwargs: object) -> object:
+            raise gpu_select.subprocess.TimeoutExpired(cmd="vulkaninfo", timeout=3.0)
+
+        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
+        monkeypatch.setattr(gpu_select.subprocess, "run", _raises)
+        assert gpu_select.autoselect_best_gpu_index() is None
+
+    def test_autoselect_returns_none_on_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.providers.llama_cpp import gpu_select
+
+        def _raises(*_args: object, **_kwargs: object) -> object:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
+        monkeypatch.setattr(gpu_select.subprocess, "run", _raises)
+        assert gpu_select.autoselect_best_gpu_index() is None
+
+    def test_autoselect_returns_none_when_only_cpu_devices(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All-CPU adapter list shouldn't force a pin: software rendering is never the right pick."""
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select.shutil, "which", lambda _name: "/usr/bin/vulkaninfo")
+        monkeypatch.setattr(
+            gpu_select.subprocess,
+            "run",
+            lambda *_args, **_kwargs: type(
+                "_R", (), {"returncode": 0, "stdout": _VULKANINFO_CPU_ONLY}
+            )(),
+        )
+        assert gpu_select.autoselect_best_gpu_index() is None
+
+    def test_parse_skips_block_without_device_type(self) -> None:
+        from lilbee.providers.llama_cpp.gpu_select import _parse_vulkaninfo_summary
+
+        broken = "GPU0:\n        deviceName         = NoTypeHere\n"
+        assert _parse_vulkaninfo_summary(broken) == []
+
+    def test_pick_best_returns_none_for_empty_list(self) -> None:
+        from lilbee.providers.llama_cpp.gpu_select import _pick_best_device
+
+        assert _pick_best_device([]) is None
+
+
 class TestImportLlamaCpp:
     """``import_llama_cpp`` converts a missing-libvulkan OSError into a ProviderError."""
 
@@ -1979,8 +2148,10 @@ class TestImportLlamaCpp:
         for name in _GPU_VISIBLE_ENV_VARS:
             assert os.environ.get(name) == "0", name
 
-    def test_gpu_devices_none_leaves_env_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """With ``gpu_devices=None`` the visibility env vars are not set."""
+    def test_gpu_devices_none_leaves_env_untouched_when_autoselect_silent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With ``gpu_devices=None`` and autoselect returning None, env stays clean."""
         from lilbee.core.config import cfg
         from lilbee.providers.llama_cpp.log_dispatch import (
             _GPU_VISIBLE_ENV_VARS,
@@ -1990,11 +2161,38 @@ class TestImportLlamaCpp:
         for name in _GPU_VISIBLE_ENV_VARS:
             monkeypatch.delenv(name, raising=False)
         monkeypatch.setattr(cfg, "gpu_devices", None)
+        monkeypatch.setattr(
+            "lilbee.providers.llama_cpp.gpu_select.autoselect_best_gpu_index",
+            lambda: None,
+        )
         monkeypatch.setitem(sys.modules, "llama_cpp", mock.MagicMock())
 
         import_llama_cpp()
         for name in _GPU_VISIBLE_ENV_VARS:
             assert name not in os.environ, name
+
+    def test_gpu_devices_autoselect_fills_env_when_cfg_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ``cfg.gpu_devices`` is None, autoselect's result populates the env vars."""
+        from lilbee.core.config import cfg
+        from lilbee.providers.llama_cpp.log_dispatch import (
+            _GPU_VISIBLE_ENV_VARS,
+            import_llama_cpp,
+        )
+
+        for name in _GPU_VISIBLE_ENV_VARS:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setattr(cfg, "gpu_devices", None)
+        monkeypatch.setattr(
+            "lilbee.providers.llama_cpp.gpu_select.autoselect_best_gpu_index",
+            lambda: "1",
+        )
+        monkeypatch.setitem(sys.modules, "llama_cpp", mock.MagicMock())
+
+        import_llama_cpp()
+        for name in _GPU_VISIBLE_ENV_VARS:
+            assert os.environ.get(name) == "1", name
 
     def test_user_env_var_wins_over_cfg(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A pre-set ``GGML_VK_VISIBLE_DEVICES`` is preserved even when cfg has a value."""
@@ -2003,6 +2201,10 @@ class TestImportLlamaCpp:
 
         monkeypatch.setenv("GGML_VK_VISIBLE_DEVICES", "1")
         monkeypatch.setattr(cfg, "gpu_devices", "0")
+        monkeypatch.setattr(
+            "lilbee.providers.llama_cpp.gpu_select.autoselect_best_gpu_index",
+            lambda: None,
+        )
         monkeypatch.setitem(sys.modules, "llama_cpp", mock.MagicMock())
 
         import_llama_cpp()


### PR DESCRIPTION
## Problem

Two issues hitting users running lilbee on dual-GPU machines (typical case: discrete NVIDIA + integrated Intel/AMD on a laptop):

1. **Dependency log noise leaks through the CLI.** LiteLLM lazy-loads AWS provider modules and warns about missing `boto3` / `botocore` even when traffic only goes to Ollama or an OpenAI-compatible endpoint; lilbee never ships `boto3` and never targets AWS. HuggingFace Hub re-warns about unauthenticated pulls and download retries on every download. Both filters lived in `lilbee/__init__.py`, mixing library implementation detail into the package facade.
2. **Native llama.cpp stalls when Vulkan picks the integrated GPU.** llama.cpp's Vulkan backend enumerates discrete AND integrated adapters in the order the Vulkan loader returns them (verified in `ggml/src/ggml-vulkan/ggml-vulkan.cpp::ggml_vk_instance_init`). On a dual-GPU laptop the integrated GPU can land at index 0 and inference either stalls or OOMs against shared system memory. Users see "hit and miss" hardware acceleration and fall back to Ollama.

## Solution

Move each dependency's log filter next to that library's adapter so the package init stays free of HF / LiteLLM implementation detail. The HF filter lives in `catalog/hf_client.py` and the LiteLLM filter in `providers/litellm_sdk.py`; each installs on module import.

Filter the AWS-flavored LiteLLM messages so they never reach the user.

Add automatic best-GPU selection. When the user hasn't pinned devices manually, lilbee opens `libvulkan-1.dll` / `libvulkan.so.1` directly via `ctypes`, enumerates adapters through `vkEnumeratePhysicalDevices`, ranks them by `VkPhysicalDeviceType` (discrete > integrated > virtual > CPU), and pins inference to the discrete index via `GGML_VK_VISIBLE_DEVICES`. The probe needs no Vulkan SDK install, so it works on stock Windows and Linux. macOS short-circuits because the Metal wheel doesn't use Vulkan.

The autodetect deliberately writes only `GGML_VK_VISIBLE_DEVICES`. CUDA and HIP/ROCm wheels enumerate single-vendor adapter lists and don't exhibit the dual-GPU mis-pick problem; writing a Vulkan-loader index to `CUDA_VISIBLE_DEVICES` on a CUDA wheel would mask the only NVIDIA card.

Manual knobs for when autodetect can't help:

- `gpu_devices` (env: `LILBEE_GPU_DEVICES`): comma-separated indexes that bypass autodetect and apply to all four backend env vars (`GGML_VK_VISIBLE_DEVICES`, `CUDA_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`).
- `main_gpu` (env: `LILBEE_MAIN_GPU`): primary device index threaded through to `Llama(main_gpu=...)` for the chat, embed, rerank, and vision loaders.

Pre-set env vars always win over the config field and autodetect. Both fields show up in `/settings`, `lilbee status`, `lilbee self-check`, and the MCP `status` tool.
