### PR TITLE
Validate model task at the TUI write boundary

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -20,7 +20,7 @@ from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.commands import LilbeeCommandProvider
 from lilbee.cli.tui.widgets.status_bar import ViewTabs
 from lilbee.core import settings
-from lilbee.core.config import cfg
+from lilbee.core.config import cfg, validate_model_task_assignment
 from lilbee.providers.worker.transport import WorkerRole
 
 log = logging.getLogger(__name__)
@@ -291,8 +291,18 @@ class LilbeeApp(App[None]):
         settings.set_value(cfg.data_root, "theme", name)
 
     def set_active_model(self, key: str, value: str) -> None:
-        """Single write boundary for active model refs."""
-        setattr(cfg, key, value)
+        """Single write boundary for active model refs.
+
+        Validates the ref's catalog task matches the field, so a chat-only
+        model cannot land in the embedding slot (and equivalents for vision /
+        rerank). Provider-prefixed refs and the empty string pass through.
+        """
+        try:
+            canonical = validate_model_task_assignment(key, value)
+        except ValueError as exc:
+            self.notify(msg.MODEL_ASSIGN_REJECTED.format(error=exc), severity="error")
+            return
+        setattr(cfg, key, canonical)
         normalized = getattr(cfg, key)
         settings.set_value(cfg.data_root, key, normalized)
         self.settings_changed_signal.publish((key, normalized))

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -186,6 +186,7 @@ EMBED_SWAP_CONFIRM_MESSAGE = (
     "Continue?"
 )
 EMBED_SWAP_CANCELLED = "Embedding model swap cancelled"
+MODEL_ASSIGN_REJECTED = "Model not set: {error}"
 
 SETTINGS_RESET_ALL_LABEL = "Reset all defaults"
 SETTINGS_RESET_ALL_CONFIRM_TITLE = "Reset all settings?"

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -10,6 +10,7 @@ see why it exists.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 from unittest import mock
 
@@ -2172,3 +2173,50 @@ class TestCatalogSmallEdgeBranches:
             with mock.patch.object(screen, "_fetch_initial_hf_models_for_task") as mock_fetch:
                 screen.action_toggle_view()
                 mock_fetch.assert_called_once_with(ModelTask.CHAT)
+
+
+class TestAppSetActiveModelTaskGuard:
+    """`set_active_model` rejects refs whose catalog task does not match
+    the field, so a chat-only model cannot land in the embedding slot.
+    """
+
+    @pytest.fixture()
+    def _validation_enabled(self):
+        """Pop the conftest-level bypass so the validator actually fires."""
+        prev = os.environ.pop("LILBEE_SKIP_MODEL_TASK_VALIDATION", None)
+        try:
+            yield
+        finally:
+            if prev is not None:
+                os.environ["LILBEE_SKIP_MODEL_TASK_VALIDATION"] = prev
+
+    async def test_chat_ref_assigned_to_embedding_slot_is_rejected(
+        self, _validation_enabled
+    ) -> None:
+        from lilbee.cli.tui.app import LilbeeApp
+        from lilbee.core.config import cfg
+
+        chat_ref = "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf"
+        embed_default = cfg.embedding_model
+        notifications: list[tuple[Any, ...]] = []
+        notify_kwargs: list[dict[str, Any]] = []
+        app = LilbeeApp()
+        try:
+            with (
+                mock.patch.object(
+                    app,
+                    "notify",
+                    side_effect=lambda *a, **kw: (
+                        notifications.append(a),
+                        notify_kwargs.append(kw),
+                    ),
+                ),
+                mock.patch("lilbee.cli.tui.app.settings.set_value") as mock_set_value,
+            ):
+                app.set_active_model("embedding_model", chat_ref)
+            assert cfg.embedding_model == embed_default, "rejected assignment must not mutate cfg"
+            mock_set_value.assert_not_called()
+            assert len(notifications) == 1
+            assert notify_kwargs[-1].get("severity") == "error"
+        finally:
+            cfg.embedding_model = embed_default


### PR DESCRIPTION
## Problem

A chat-only model could land in `cfg.embedding_model` through the TUI. Embedding then failed at use time with a cryptic llama-cpp error. The server's HTTP handler already rejected this, but the TUI write path skipped the same check.

## Solution

Route TUI model assignments through the existing catalog/task validator. Mismatched assignments are rejected with a toast and config is left unchanged.