### PR TITLE
Lower default sampling temperature from 0.2 to 0.1

### DIFF
--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -111,7 +111,7 @@ class Config(BaseSettings):
     # single long-running vision OCR page can't starve the client into aborting.
     sse_heartbeat_interval: float = ConfigField(default=30.0, ge=0.0, writable=True)
     json_mode: bool = False
-    temperature: float | None = ConfigField(default=0.2, ge=0.0, writable=True)
+    temperature: float | None = ConfigField(default=0.1, ge=0.0, writable=True)
     top_p: float | None = ConfigField(default=0.9, ge=0.0, le=1.0, writable=True)
     top_k_sampling: int | None = ConfigField(default=40, ge=1, writable=True)
     # 1.1 is llama.cpp's default. Leaving this at None caused n-gram loops

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1081,7 +1081,7 @@ class TestEmptyStringToNone:
         env["LILBEE_TEMPERATURE"] = ""
         with mock.patch.dict(os.environ, env, clear=True):
             c = Config()
-        assert c.temperature == 0.2
+        assert c.temperature == 0.1
 
     def test_whitespace_seed_becomes_none(self, tmp_path):
         env = _clean_env(tmp_path)


### PR DESCRIPTION
Aligns the global chat default with the wiki layer's existing 0.1. The 0.2 default produced visibly less deterministic answers in `ask` than in wiki generation for the same prompt, which wasn't intentional.