### PR TITLE
Skip conflicting Vulkan ICDs on dual-vendor Windows hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ No external services either way; lilbee downloads and runs models locally. Optio
 | **Docker** | `docker run --rm -v lilbee-data:/home/lilbee/data ghcr.io/tobocop2/lilbee:latest --help` | GHCR image, tagged by version and `latest`. Data lives at `/home/lilbee/data` — mount a volume there. |
 | **Nix** | `nix run github:tobocop2/lilbee` | NixOS, nix-darwin, or any host with nix. On Linux the flake bundles `glibc`, `libgomp`, and `vulkan-loader` so it runs on bare NixOS. |
 | **Standalone binary** | [download for your platform &rarr;](https://github.com/tobocop2/lilbee/releases/latest) | One file, own Python runtime, no `pip` needed. Linux needs glibc 2.28+; the macOS / Windows builds are unsigned (`xattr -d com.apple.quarantine ./lilbee-macos-arm64` if Gatekeeper blocks it). |
-| **CUDA-native** | `pip install --pre lilbee --extra-index-url https://tobocop2.github.io/lilbee/cu125/` | Only for the last bit of NVIDIA speed; the default wheel already uses your GPU via Vulkan. `cu121` / `cu124` / `cu125` — match `nvidia-smi`. |
+| **CUDA-native** | `pip install --pre lilbee --extra-index-url https://tobocop2.github.io/lilbee/cu125/` | Recommended for NVIDIA users on Windows, both for stability and speed. The default Vulkan wheel works for most setups, but on a Windows box with both an NVIDIA discrete GPU and an integrated AMD or Intel GPU the Vulkan loader has to load every vendor's driver into one process, and some vendor combinations crash. CUDA wheels skip Vulkan entirely. Pick `cu121` / `cu124` / `cu125` to match `nvidia-smi`. |
 | **From source** | `git clone https://github.com/tobocop2/lilbee && cd lilbee && uv sync && uv run lilbee` | For hacking on it. Needs `git` and `uv`. |
 
 Then check it runs and pick a model:

--- a/src/lilbee/providers/llama_cpp/gpu_select.py
+++ b/src/lilbee/providers/llama_cpp/gpu_select.py
@@ -35,7 +35,7 @@ import os
 import sys
 from ctypes import POINTER, byref, c_char, c_char_p, c_uint8, c_uint32, c_void_p
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 
 log = logging.getLogger(__name__)
 
@@ -121,21 +121,22 @@ _VENDOR_ICD_GLOBS: dict[PCIVendorID, tuple[str, ...]] = {
 }
 
 
-VK_LOADER_DRIVERS_DISABLE_ENV_VAR = "VK_LOADER_DRIVERS_DISABLE"
-"""Loader env var that names a comma-separated list of ICD manifest globs to disable."""
+class VulkanIcdEnvVar(StrEnum):
+    """Every documented Vulkan loader env var that influences ICD selection.
 
+    Names are the verbatim loader env vars from the Khronos
+    LoaderInterfaceArchitecture spec; the StrEnum lets each member be
+    used directly as a ``str`` argument to ``os.environ.get`` /
+    ``os.environ.setdefault`` without ``.value`` plumbing. Any value
+    being non-empty in the environment is treated as a user override
+    and suppresses the dual-vendor auto-pin.
+    """
 
-# Env vars that, when already set by the user, cause us to skip the dual-vendor
-# ICD-disable path entirely. The user has spoken; we don't second-guess. Covers
-# every documented Vulkan loader ICD-selection env var (see Vulkan-Loader
-# LoaderInterfaceArchitecture.md).
-_VK_USER_OVERRIDE_ENV_VARS = (
-    "VK_DRIVER_FILES",
-    "VK_ICD_FILENAMES",
-    "VK_ADD_DRIVER_FILES",
-    VK_LOADER_DRIVERS_DISABLE_ENV_VAR,
-    "VK_LOADER_DRIVERS_SELECT",
-)
+    DRIVER_FILES = "VK_DRIVER_FILES"
+    ICD_FILENAMES = "VK_ICD_FILENAMES"
+    ADD_DRIVER_FILES = "VK_ADD_DRIVER_FILES"
+    LOADER_DRIVERS_DISABLE = "VK_LOADER_DRIVERS_DISABLE"
+    LOADER_DRIVERS_SELECT = "VK_LOADER_DRIVERS_SELECT"
 
 
 # Field layouts from the Vulkan 1.0 spec. ctypes maps the C structs
@@ -410,34 +411,36 @@ def _icds_to_disable(best: PCIVendorID, all_vendors: set[PCIVendorID]) -> list[s
     return globs
 
 
+# References for the dual-vendor ICD mitigation below:
+#   - Khronos Vulkan-Loader env var spec (VK_LOADER_DRIVERS_DISABLE / VK_DRIVER_FILES):
+#     https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderInterfaceArchitecture.md
+#   - ICD manifest filename conventions:
+#     https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderDriverInterface.md
+#   - "Failure in one ICD causes total failure of vkEnumeratePhysicalDevices" (the failure mode):
+#     https://github.com/KhronosGroup/Vulkan-Loader/issues/1467
+#   - NVIDIA help article 5182, dual-vendor Vulkan apps on notebooks:
+#     https://nvidia.custhelp.com/app/answers/detail/a_id/5182/
+#   - Heroic Games Launcher ICD-selection issue (same mitigation pattern in prod):
+#     https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3796
+#   - Blender Vulkan backend startup failure on dual-vendor hosts:
+#     https://projects.blender.org/blender/blender/issues/129917
 def disable_conflicting_vulkan_icds() -> str | None:
     """Compute a ``VK_LOADER_DRIVERS_DISABLE`` value for dual-vendor Windows boxes.
 
-    When ``vkCreateInstance`` runs, the Vulkan loader loads every ICD
-    registered on the system into the process. On a dual-vendor box
-    (typical case: NVIDIA discrete + AMD integrated) both vendor
-    DLLs end up loaded side by side. The AMD ICD (``amdvlk64.dll``)
-    is known to corrupt the heap of host applications when this
-    happens, taking the worker subprocess down with
-    ``STATUS_HEAP_CORRUPTION``. NVIDIA documents the same workaround
-    for games on the same hardware combination (see help article 5182).
+    Returns a comma-separated glob list naming the ICD manifest filenames
+    of every vendor *except* the highest-ranked adapter's vendor, or
+    ``None`` when there's no conflict to resolve, the user has set any
+    Vulkan ICD-selection env var, or the probe fails. The caller writes
+    the returned value to ``VK_LOADER_DRIVERS_DISABLE`` so the Vulkan
+    loader skips those ICDs at the next ``vkCreateInstance``.
 
-    We probe the loader once, identify the highest-ranked adapter
-    (already discrete-over-integrated via ``_pick_best_device``), and
-    return a glob that disables the *other* vendors' ICDs. The caller
-    writes it to ``VK_LOADER_DRIVERS_DISABLE`` so the loader honors
-    it on the next ``vkCreateInstance``. Returns ``None`` when there's
-    no conflict to resolve, when the user has already set any Vulkan
-    ICD-selection env var, or when the probe fails. The "do nothing"
-    branches preserve today's behavior, so this is strictly additive.
-
-    Windows-only: macOS uses Metal (no Vulkan loader); Linux has the
-    same loader mechanism but no reproduced crashes yet, so we don't
-    pin there until a report drives it.
+    Windows-only: macOS uses Metal; Linux has the same loader mechanism
+    but no reported crashes, so we don't pin there until a report drives
+    it.
     """
     if sys.platform != "win32":
         return None
-    if any(os.environ.get(name) for name in _VK_USER_OVERRIDE_ENV_VARS):
+    if any(os.environ.get(env_var) for env_var in VulkanIcdEnvVar):
         return None
     devices = _enumerate_vulkan_devices() or []
     vendors = _known_vendors(devices)

--- a/src/lilbee/providers/llama_cpp/gpu_select.py
+++ b/src/lilbee/providers/llama_cpp/gpu_select.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import ctypes
 import ctypes.util
-import functools
 import logging
 import os
 import sys
@@ -220,15 +219,14 @@ def autoselect_best_gpu_index() -> str | None:
     return str(best.index)
 
 
-@functools.cache
 def _enumerate_vulkan_devices() -> list[VulkanDevice] | None:
     """Open libvulkan, create a throwaway instance, enumerate adapters.
 
     Returns ``None`` if the loader can't be found or any Vulkan call
     fails; empty list ("loader present, no adapters") is a distinct
-    outcome and propagates back. Cached for the process lifetime: the
-    bootstrap calls this twice (autoselect plus the dual-vendor ICD
-    pin) and the GPU set doesn't change at runtime.
+    outcome and propagates back. The bootstrap calls this twice
+    (autoselect plus the dual-vendor ICD pin) at process startup; the
+    Vulkan probe is ms-scale, no caching needed.
     """
     lib = _load_vulkan_loader()
     if lib is None:
@@ -453,5 +451,6 @@ def disable_conflicting_vulkan_icds() -> str | None:
         best_vendor = PCIVendorID(best.vendor_id)
     except ValueError:
         return None
-    globs = _icds_to_disable(best_vendor, vendors)
-    return ",".join(globs) if globs else None
+    # ``vendors`` has at least two members and we filter out ``best_vendor``,
+    # so ``_icds_to_disable`` always returns a non-empty list here.
+    return ",".join(_icds_to_disable(best_vendor, vendors))

--- a/src/lilbee/providers/llama_cpp/gpu_select.py
+++ b/src/lilbee/providers/llama_cpp/gpu_select.py
@@ -29,7 +29,9 @@ from __future__ import annotations
 
 import ctypes
 import ctypes.util
+import functools
 import logging
+import os
 import sys
 from ctypes import POINTER, byref, c_char, c_char_p, c_uint8, c_uint32, c_void_p
 from dataclasses import dataclass
@@ -91,6 +93,49 @@ class VulkanDevice:
     index: int
     device_type: int
     device_name: str
+    vendor_id: int
+
+
+class PCIVendorID(IntEnum):
+    """PCI-SIG vendor IDs for the GPU vendors that ship Vulkan ICDs.
+
+    Values are the canonical PCI vendor IDs that ``VkPhysicalDeviceProperties.vendorID``
+    surfaces. Only the vendors we have explicit ICD-disable globs for are
+    enumerated; unknown vendors fall through the dispatch as no-op.
+    """
+
+    NVIDIA = 0x10DE
+    AMD = 0x1002
+    INTEL = 0x8086
+
+
+# Vulkan loader manifest filename globs, per vendor. The loader matches these
+# against the JSON manifest filename in its known-drivers list (see
+# https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderInterfaceArchitecture.md).
+# Each vendor ships under multiple names across drivers/OSes; list every form
+# we may encounter so disabling one vendor's drivers doesn't half-disable them.
+_VENDOR_ICD_GLOBS: dict[PCIVendorID, tuple[str, ...]] = {
+    PCIVendorID.NVIDIA: ("nv*",),
+    PCIVendorID.AMD: ("amdvlk*", "amd-vulkan*", "radeon*"),
+    PCIVendorID.INTEL: ("intel*", "igvk*"),
+}
+
+
+VK_LOADER_DRIVERS_DISABLE_ENV_VAR = "VK_LOADER_DRIVERS_DISABLE"
+"""Loader env var that names a comma-separated list of ICD manifest globs to disable."""
+
+
+# Env vars that, when already set by the user, cause us to skip the dual-vendor
+# ICD-disable path entirely. The user has spoken; we don't second-guess. Covers
+# every documented Vulkan loader ICD-selection env var (see Vulkan-Loader
+# LoaderInterfaceArchitecture.md).
+_VK_USER_OVERRIDE_ENV_VARS = (
+    "VK_DRIVER_FILES",
+    "VK_ICD_FILENAMES",
+    "VK_ADD_DRIVER_FILES",
+    VK_LOADER_DRIVERS_DISABLE_ENV_VAR,
+    "VK_LOADER_DRIVERS_SELECT",
+)
 
 
 # Field layouts from the Vulkan 1.0 spec. ctypes maps the C structs
@@ -174,12 +219,15 @@ def autoselect_best_gpu_index() -> str | None:
     return str(best.index)
 
 
+@functools.cache
 def _enumerate_vulkan_devices() -> list[VulkanDevice] | None:
     """Open libvulkan, create a throwaway instance, enumerate adapters.
 
     Returns ``None`` if the loader can't be found or any Vulkan call
     fails; empty list ("loader present, no adapters") is a distinct
-    outcome and propagates back.
+    outcome and propagates back. Cached for the process lifetime: the
+    bootstrap calls this twice (autoselect plus the dual-vendor ICD
+    pin) and the GPU set doesn't change at runtime.
     """
     lib = _load_vulkan_loader()
     if lib is None:
@@ -277,6 +325,7 @@ def _list_devices_with_instance(lib: ctypes.CDLL) -> list[VulkanDevice]:
                     index=i,
                     device_type=int(props.deviceType),
                     device_name=props.deviceName.decode("utf-8", errors="replace"),
+                    vendor_id=int(props.vendorID),
                 )
             )
         return devices
@@ -330,3 +379,76 @@ def _pick_best_device(devices: list[VulkanDevice]) -> VulkanDevice | None:
     if _rank_for(best.device_type) <= 0:
         return None
     return best
+
+
+_MIN_VENDORS_FOR_CONFLICT = 2
+"""Number of distinct GPU vendors that must be present before pinning kicks in.
+
+A single-vendor box (e.g., laptop with one AMD iGPU only) is not at risk:
+only that vendor's ICD is loaded, no cross-vendor heap collision is possible.
+"""
+
+
+def _known_vendors(devices: list[VulkanDevice]) -> set[PCIVendorID]:
+    """Project the adapter list down to recognized PCI vendors only."""
+    vendors: set[PCIVendorID] = set()
+    for device in devices:
+        try:
+            vendors.add(PCIVendorID(device.vendor_id))
+        except ValueError:
+            continue
+    return vendors
+
+
+def _icds_to_disable(best: PCIVendorID, all_vendors: set[PCIVendorID]) -> list[str]:
+    """Return the manifest globs for every known vendor except *best*."""
+    globs: list[str] = []
+    for vendor in sorted(all_vendors, key=int):
+        if vendor is best:
+            continue
+        globs.extend(_VENDOR_ICD_GLOBS[vendor])
+    return globs
+
+
+def disable_conflicting_vulkan_icds() -> str | None:
+    """Compute a ``VK_LOADER_DRIVERS_DISABLE`` value for dual-vendor Windows boxes.
+
+    When ``vkCreateInstance`` runs, the Vulkan loader loads every ICD
+    registered on the system into the process. On a dual-vendor box
+    (typical case: NVIDIA discrete + AMD integrated) both vendor
+    DLLs end up loaded side by side. The AMD ICD (``amdvlk64.dll``)
+    is known to corrupt the heap of host applications when this
+    happens, taking the worker subprocess down with
+    ``STATUS_HEAP_CORRUPTION``. NVIDIA documents the same workaround
+    for games on the same hardware combination (see help article 5182).
+
+    We probe the loader once, identify the highest-ranked adapter
+    (already discrete-over-integrated via ``_pick_best_device``), and
+    return a glob that disables the *other* vendors' ICDs. The caller
+    writes it to ``VK_LOADER_DRIVERS_DISABLE`` so the loader honors
+    it on the next ``vkCreateInstance``. Returns ``None`` when there's
+    no conflict to resolve, when the user has already set any Vulkan
+    ICD-selection env var, or when the probe fails. The "do nothing"
+    branches preserve today's behavior, so this is strictly additive.
+
+    Windows-only: macOS uses Metal (no Vulkan loader); Linux has the
+    same loader mechanism but no reproduced crashes yet, so we don't
+    pin there until a report drives it.
+    """
+    if sys.platform != "win32":
+        return None
+    if any(os.environ.get(name) for name in _VK_USER_OVERRIDE_ENV_VARS):
+        return None
+    devices = _enumerate_vulkan_devices() or []
+    vendors = _known_vendors(devices)
+    if len(vendors) < _MIN_VENDORS_FOR_CONFLICT:
+        return None
+    best = _pick_best_device(devices)
+    if best is None:
+        return None
+    try:
+        best_vendor = PCIVendorID(best.vendor_id)
+    except ValueError:
+        return None
+    globs = _icds_to_disable(best_vendor, vendors)
+    return ",".join(globs) if globs else None

--- a/src/lilbee/providers/llama_cpp/log_dispatch.py
+++ b/src/lilbee/providers/llama_cpp/log_dispatch.py
@@ -231,7 +231,7 @@ def _apply_gpu_device_env() -> None:
     """
     from lilbee.core.config import cfg
     from lilbee.providers.llama_cpp.gpu_select import (
-        VK_LOADER_DRIVERS_DISABLE_ENV_VAR,
+        VulkanIcdEnvVar,
         autoselect_best_gpu_index,
         disable_conflicting_vulkan_icds,
     )
@@ -242,7 +242,7 @@ def _apply_gpu_device_env() -> None:
     # prevent a buggy second-vendor ICD from corrupting the heap.
     disable_glob = disable_conflicting_vulkan_icds()
     if disable_glob is not None:
-        os.environ.setdefault(VK_LOADER_DRIVERS_DISABLE_ENV_VAR, disable_glob)
+        os.environ.setdefault(VulkanIcdEnvVar.LOADER_DRIVERS_DISABLE, disable_glob)
         log.info("Disabling conflicting Vulkan ICDs on Windows: %s", disable_glob)
 
     if cfg.gpu_devices:

--- a/src/lilbee/providers/llama_cpp/log_dispatch.py
+++ b/src/lilbee/providers/llama_cpp/log_dispatch.py
@@ -19,6 +19,7 @@ from typing import Any
 from lilbee.providers.base import ProviderError
 
 _llama_log = logging.getLogger("lilbee.llama_cpp")
+log = logging.getLogger(__name__)
 
 # ggml.h log levels (not exposed by llama-cpp-python).
 _GGML_LOG_LEVEL_INFO = 1
@@ -229,7 +230,20 @@ def _apply_gpu_device_env() -> None:
     environment, so step 1 is preserved.
     """
     from lilbee.core.config import cfg
-    from lilbee.providers.llama_cpp.gpu_select import autoselect_best_gpu_index
+    from lilbee.providers.llama_cpp.gpu_select import (
+        VK_LOADER_DRIVERS_DISABLE_ENV_VAR,
+        autoselect_best_gpu_index,
+        disable_conflicting_vulkan_icds,
+    )
+
+    # Dual-vendor Vulkan crash mitigation runs first and unconditionally:
+    # the loader loads every registered ICD at vkCreateInstance, before
+    # GGML_VK_VISIBLE_DEVICES is consulted, so device pinning alone cannot
+    # prevent a buggy second-vendor ICD from corrupting the heap.
+    disable_glob = disable_conflicting_vulkan_icds()
+    if disable_glob is not None:
+        os.environ.setdefault(VK_LOADER_DRIVERS_DISABLE_ENV_VAR, disable_glob)
+        log.info("Disabling conflicting Vulkan ICDs on Windows: %s", disable_glob)
 
     if cfg.gpu_devices:
         for name in _GPU_VISIBLE_ENV_VARS:

--- a/tests/test_outbound_hosts.py
+++ b/tests/test_outbound_hosts.py
@@ -28,6 +28,9 @@ ALLOWED_HOSTS: frozenset[str] = frozenset(
         "en.wikipedia.org",
         "example.com",
         "github.com",
+        # Citations for the dual-vendor Vulkan ICD workaround in gpu_select.py.
+        "nvidia.custhelp.com",
+        "projects.blender.org",
     }
 )
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2407,11 +2407,11 @@ class TestDisableConflictingVulkanIcds:
             ),
         ]
         monkeypatch.setattr(gpu_select, "_enumerate_vulkan_devices", lambda: devices)
-        # Source the override-var list from the module so the test moves in
-        # lockstep with the production tuple (e.g., when a new loader env var
-        # joins the set).
-        for override_var in gpu_select._VK_USER_OVERRIDE_ENV_VARS:
-            monkeypatch.setattr(gpu_select.os, "environ", {override_var: "user-set"})
+        # Source the override-var list from the enum so the test moves in
+        # lockstep with the production set (e.g., when a new loader env var
+        # joins the spec).
+        for env_var in gpu_select.VulkanIcdEnvVar:
+            monkeypatch.setattr(gpu_select.os, "environ", {env_var.value: "user-set"})
             assert gpu_select.disable_conflicting_vulkan_icds() is None
 
     def test_empty_probe_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1923,8 +1923,12 @@ class TestVulkanGpuSelect:
         )
 
         devices = [
-            VulkanDevice(index=0, device_type=VkDeviceType.INTEGRATED_GPU, device_name="iGPU"),
-            VulkanDevice(index=1, device_type=VkDeviceType.DISCRETE_GPU, device_name="dGPU"),
+            VulkanDevice(
+                index=0, device_type=VkDeviceType.INTEGRATED_GPU, device_name="iGPU", vendor_id=0
+            ),
+            VulkanDevice(
+                index=1, device_type=VkDeviceType.DISCRETE_GPU, device_name="dGPU", vendor_id=0
+            ),
         ]
         best = _pick_best_device(devices)
         assert best is not None
@@ -1938,7 +1942,9 @@ class TestVulkanGpuSelect:
         )
 
         devices = [
-            VulkanDevice(index=0, device_type=VkDeviceType.CPU, device_name="llvmpipe"),
+            VulkanDevice(
+                index=0, device_type=VkDeviceType.CPU, device_name="llvmpipe", vendor_id=0
+            ),
         ]
         assert _pick_best_device(devices) is None
 
@@ -1966,8 +1972,18 @@ class TestVulkanGpuSelect:
             gpu_select,
             "_enumerate_vulkan_devices",
             lambda: [
-                VulkanDevice(index=0, device_type=VkDeviceType.INTEGRATED_GPU, device_name="iGPU"),
-                VulkanDevice(index=1, device_type=VkDeviceType.DISCRETE_GPU, device_name="dGPU"),
+                VulkanDevice(
+                    index=0,
+                    device_type=VkDeviceType.INTEGRATED_GPU,
+                    device_name="iGPU",
+                    vendor_id=0,
+                ),
+                VulkanDevice(
+                    index=1,
+                    device_type=VkDeviceType.DISCRETE_GPU,
+                    device_name="dGPU",
+                    vendor_id=0,
+                ),
             ],
         )
         assert gpu_select.autoselect_best_gpu_index() == "1"
@@ -1990,6 +2006,7 @@ class TestVulkanGpuSelect:
                     index=0,
                     device_type=VkDeviceType.DISCRETE_GPU,
                     device_name="RTX 4090",
+                    vendor_id=0,
                 ),
             ],
         )
@@ -2017,8 +2034,12 @@ class TestVulkanGpuSelect:
             gpu_select,
             "_enumerate_vulkan_devices",
             lambda: [
-                VulkanDevice(index=0, device_type=VkDeviceType.CPU, device_name="cpu0"),
-                VulkanDevice(index=1, device_type=VkDeviceType.CPU, device_name="cpu1"),
+                VulkanDevice(
+                    index=0, device_type=VkDeviceType.CPU, device_name="cpu0", vendor_id=0
+                ),
+                VulkanDevice(
+                    index=1, device_type=VkDeviceType.CPU, device_name="cpu1", vendor_id=0
+                ),
             ],
         )
         assert gpu_select.autoselect_best_gpu_index() is None
@@ -2037,8 +2058,18 @@ class TestVulkanGpuSelect:
             gpu_select,
             "_enumerate_vulkan_devices",
             lambda: [
-                VulkanDevice(index=0, device_type=VkDeviceType.DISCRETE_GPU, device_name="dgpu0"),
-                VulkanDevice(index=1, device_type=VkDeviceType.DISCRETE_GPU, device_name="dgpu1"),
+                VulkanDevice(
+                    index=0,
+                    device_type=VkDeviceType.DISCRETE_GPU,
+                    device_name="dgpu0",
+                    vendor_id=0,
+                ),
+                VulkanDevice(
+                    index=1,
+                    device_type=VkDeviceType.DISCRETE_GPU,
+                    device_name="dgpu1",
+                    vendor_id=0,
+                ),
             ],
         )
         assert gpu_select.autoselect_best_gpu_index() is None
@@ -2266,6 +2297,163 @@ class TestVulkanGpuSelect:
         monkeypatch.setattr(gpu_select.ctypes, "CDLL", _cdll)
         monkeypatch.setattr(gpu_select.ctypes.util, "find_library", lambda _n: "/lib/libvulkan.so")
         assert gpu_select._load_vulkan_loader() is None
+
+
+class TestDisableConflictingVulkanIcds:
+    """``disable_conflicting_vulkan_icds`` automates the NVIDIA-recommended ICD pin on Windows.
+
+    On a dual-vendor Windows box (NVIDIA dGPU + AMD/Intel iGPU) the
+    Vulkan loader loads every registered ICD into the process at
+    ``vkCreateInstance`` time. The AMD ICD has a known heap-corruption
+    interaction with this layout that takes the worker subprocess down
+    with ``STATUS_HEAP_CORRUPTION``. The helper picks the discrete
+    adapter's vendor and returns a ``VK_LOADER_DRIVERS_DISABLE`` glob
+    that keeps that vendor's ICD only.
+    """
+
+    def test_pins_nvidia_when_amd_igpu_also_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NVIDIA dGPU + AMD iGPU on Windows -> disable AMD ICD globs."""
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            PCIVendorID,
+            VkDeviceType,
+            VulkanDevice,
+        )
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "win32")
+        monkeypatch.setattr(gpu_select.os, "environ", {})
+        monkeypatch.setattr(
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                VulkanDevice(
+                    index=0,
+                    device_type=VkDeviceType.INTEGRATED_GPU,
+                    device_name="AMD Radeon Graphics",
+                    vendor_id=PCIVendorID.AMD,
+                ),
+                VulkanDevice(
+                    index=1,
+                    device_type=VkDeviceType.DISCRETE_GPU,
+                    device_name="NVIDIA GeForce RTX 4090",
+                    vendor_id=PCIVendorID.NVIDIA,
+                ),
+            ],
+        )
+        result = gpu_select.disable_conflicting_vulkan_icds()
+        assert result is not None
+        assert "amdvlk*" in result
+        assert "radeon*" in result
+        # NVIDIA's own ICD must NOT be disabled -- it's the one we're keeping.
+        assert "nv*" not in result
+
+    def test_returns_none_on_non_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Linux and macOS keep today's behavior; no env var is set."""
+        from lilbee.providers.llama_cpp import gpu_select
+
+        for platform_name in ("linux", "darwin"):
+            monkeypatch.setattr(gpu_select.sys, "platform", platform_name)
+            assert gpu_select.disable_conflicting_vulkan_icds() is None
+
+    def test_returns_none_when_only_one_vendor_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Single-vendor systems aren't at risk; no pin needed."""
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            PCIVendorID,
+            VkDeviceType,
+            VulkanDevice,
+        )
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "win32")
+        monkeypatch.setattr(gpu_select.os, "environ", {})
+        monkeypatch.setattr(
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                VulkanDevice(
+                    index=0,
+                    device_type=VkDeviceType.DISCRETE_GPU,
+                    device_name="NVIDIA GeForce RTX 4090",
+                    vendor_id=PCIVendorID.NVIDIA,
+                ),
+            ],
+        )
+        assert gpu_select.disable_conflicting_vulkan_icds() is None
+
+    def test_user_override_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If the user set any Vulkan ICD-selection env var, we don't override it."""
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            PCIVendorID,
+            VkDeviceType,
+            VulkanDevice,
+        )
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "win32")
+        devices = [
+            VulkanDevice(
+                index=0,
+                device_type=VkDeviceType.INTEGRATED_GPU,
+                device_name="AMD Radeon",
+                vendor_id=PCIVendorID.AMD,
+            ),
+            VulkanDevice(
+                index=1,
+                device_type=VkDeviceType.DISCRETE_GPU,
+                device_name="NVIDIA",
+                vendor_id=PCIVendorID.NVIDIA,
+            ),
+        ]
+        monkeypatch.setattr(gpu_select, "_enumerate_vulkan_devices", lambda: devices)
+        # Source the override-var list from the module so the test moves in
+        # lockstep with the production tuple (e.g., when a new loader env var
+        # joins the set).
+        for override_var in gpu_select._VK_USER_OVERRIDE_ENV_VARS:
+            monkeypatch.setattr(gpu_select.os, "environ", {override_var: "user-set"})
+            assert gpu_select.disable_conflicting_vulkan_icds() is None
+
+    def test_empty_probe_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A loader that returns no adapters yields no pin."""
+        from lilbee.providers.llama_cpp import gpu_select
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "win32")
+        monkeypatch.setattr(gpu_select.os, "environ", {})
+        monkeypatch.setattr(gpu_select, "_enumerate_vulkan_devices", lambda: [])
+        assert gpu_select.disable_conflicting_vulkan_icds() is None
+
+    def test_unknown_vendor_ids_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Adapters with vendor IDs we don't recognize don't trigger a pin alone."""
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            PCIVendorID,
+            VkDeviceType,
+            VulkanDevice,
+        )
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "win32")
+        monkeypatch.setattr(gpu_select.os, "environ", {})
+        monkeypatch.setattr(
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                VulkanDevice(
+                    index=0,
+                    device_type=VkDeviceType.DISCRETE_GPU,
+                    device_name="NVIDIA",
+                    vendor_id=PCIVendorID.NVIDIA,
+                ),
+                VulkanDevice(
+                    index=1,
+                    device_type=VkDeviceType.INTEGRATED_GPU,
+                    device_name="Mystery Vendor",
+                    vendor_id=0xDEAD,
+                ),
+            ],
+        )
+        # Only one *known* vendor present -> no conflict to resolve.
+        assert gpu_select.disable_conflicting_vulkan_icds() is None
 
 
 class TestImportLlamaCpp:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2455,6 +2455,79 @@ class TestDisableConflictingVulkanIcds:
         # Only one *known* vendor present -> no conflict to resolve.
         assert gpu_select.disable_conflicting_vulkan_icds() is None
 
+    def test_unknown_best_vendor_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Multi-vendor list where the discrete (best) adapter is an unknown vendor.
+
+        ``_known_vendors`` sees AMD + NVIDIA (both integrated), but the
+        highest-ranked adapter is the discrete mystery vendor. Pinning to
+        an ICD we can't name is worse than not pinning, so we bail.
+        """
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            PCIVendorID,
+            VkDeviceType,
+            VulkanDevice,
+        )
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "win32")
+        monkeypatch.setattr(gpu_select.os, "environ", {})
+        monkeypatch.setattr(
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                VulkanDevice(
+                    index=0,
+                    device_type=VkDeviceType.INTEGRATED_GPU,
+                    device_name="AMD Radeon",
+                    vendor_id=PCIVendorID.AMD,
+                ),
+                VulkanDevice(
+                    index=1,
+                    device_type=VkDeviceType.INTEGRATED_GPU,
+                    device_name="NVIDIA",
+                    vendor_id=PCIVendorID.NVIDIA,
+                ),
+                VulkanDevice(
+                    index=2,
+                    device_type=VkDeviceType.DISCRETE_GPU,
+                    device_name="Mystery Discrete",
+                    vendor_id=0xDEAD,
+                ),
+            ],
+        )
+        assert gpu_select.disable_conflicting_vulkan_icds() is None
+
+    def test_no_rank_eligible_adapter_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If every adapter is CPU-rank, ``_pick_best_device`` returns None and we bail."""
+        from lilbee.providers.llama_cpp import gpu_select
+        from lilbee.providers.llama_cpp.gpu_select import (
+            PCIVendorID,
+            VkDeviceType,
+            VulkanDevice,
+        )
+
+        monkeypatch.setattr(gpu_select.sys, "platform", "win32")
+        monkeypatch.setattr(gpu_select.os, "environ", {})
+        monkeypatch.setattr(
+            gpu_select,
+            "_enumerate_vulkan_devices",
+            lambda: [
+                VulkanDevice(
+                    index=0,
+                    device_type=VkDeviceType.CPU,
+                    device_name="AMD software fallback",
+                    vendor_id=PCIVendorID.AMD,
+                ),
+                VulkanDevice(
+                    index=1,
+                    device_type=VkDeviceType.CPU,
+                    device_name="NVIDIA software fallback",
+                    vendor_id=PCIVendorID.NVIDIA,
+                ),
+            ],
+        )
+        assert gpu_select.disable_conflicting_vulkan_icds() is None
+
 
 class TestImportLlamaCpp:
     """``import_llama_cpp`` converts a missing-libvulkan OSError into a ProviderError."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2662,6 +2662,27 @@ class TestImportLlamaCpp:
         import_llama_cpp()
         assert os.environ["GGML_VK_VISIBLE_DEVICES"] == "1"
 
+    def test_conflicting_icd_glob_writes_loader_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the dual-vendor probe returns a glob, it lands in VK_LOADER_DRIVERS_DISABLE."""
+        from lilbee.providers.llama_cpp.gpu_select import VulkanIcdEnvVar
+        from lilbee.providers.llama_cpp.log_dispatch import import_llama_cpp
+
+        monkeypatch.delenv(VulkanIcdEnvVar.LOADER_DRIVERS_DISABLE, raising=False)
+        monkeypatch.setattr(
+            "lilbee.providers.llama_cpp.gpu_select.disable_conflicting_vulkan_icds",
+            lambda: "amdvlk*,radeon*",
+        )
+        monkeypatch.setattr(
+            "lilbee.providers.llama_cpp.gpu_select.autoselect_best_gpu_index",
+            lambda: None,
+        )
+        monkeypatch.setitem(sys.modules, "llama_cpp", mock.MagicMock())
+
+        import_llama_cpp()
+        assert os.environ[VulkanIcdEnvVar.LOADER_DRIVERS_DISABLE] == "amdvlk*,radeon*"
+
 
 class TestReadChatTemplate:
     def test_reads_chat_template(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

On Windows boxes with NVIDIA + an integrated AMD or Intel GPU, lilbee crashes with `STATUS_HEAP_CORRUPTION`. The Vulkan loader pulls every vendor's driver into the process at startup and some pairings corrupt the heap. Ollama avoids it by shipping CUDA for NVIDIA hosts.

## Solution

When more than one GPU vendor is present on Windows, set `VK_LOADER_DRIVERS_DISABLE` so the loader skips the non-preferred vendor's ICD. Only one vendor's driver enters the process. Same fix Heroic Games Launcher and DXVK use; NVIDIA documents it too.

User env vars still win. macOS and Linux untouched. README also points NVIDIA-on-Windows users at the CUDA wheel.

## Inspirations

- [Khronos `VK_LOADER_DRIVERS_DISABLE` spec](https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderInterfaceArchitecture.md)
- [Vulkan-Loader Issue #1467](https://github.com/KhronosGroup/Vulkan-Loader/issues/1467)
- [NVIDIA help article 5182](https://nvidia.custhelp.com/app/answers/detail/a_id/5182/)
- [Heroic Games Launcher #3796](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3796)
- [Blender #129917](https://projects.blender.org/blender/blender/issues/129917)