### PR TITLE
Serialize the worker pipe channel per call

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,7 +158,7 @@ flowchart LR
     Cancel["Esc / Ctrl+C<br/>Services.cancel_inference()"] -->|flip shared abort flag| EW & RW & CW & VW
 ```
 
-Every byte across a pipe is a `(call_id, kind, payload)` tuple. The parent assigns a monotonic `call_id` per request; the worker echoes it on every response frame. The parent's reader silently discards any frame whose `call_id` does not match the current expected id, so leftover stream_chunk / result frames from a cancelled prior call cannot poison the next request. Control frames (`shutdown`, `ack`, `ping`, `pong`) use `call_id = 0`.
+Every byte across a pipe is a `(kind, payload)` tuple. The data pipe carries one call at a time: `PipeChannel.call` and `PipeChannel.stream` hold a channel-level `asyncio.Lock` for the full request/reply (or request/stream) window, so a frame the parent reads can only belong to the call that currently holds the lock. New callers queue on the lock until the active call returns. There is no per-frame routing id and no dispatcher thread; the call that holds the lock is the sole reader.
 
 Three patterns cover all traffic:
 
@@ -168,20 +168,22 @@ sequenceDiagram
     participant Worker as worker subprocess
 
     Note over Parent,Worker: Call / response (embed, rerank, vision)
-    Parent->>Worker: (42, embed, texts)
-    Worker-->>Parent: (42, result, vectors)
+    Parent->>Worker: (embed, texts)
+    Worker-->>Parent: (result, vectors)
 
-    Note over Parent,Worker: Streaming (chat) — token batching
-    Parent->>Worker: (43, chat, prompt)
-    Worker-->>Parent: (43, stream_chunk, "first token")
+    Note over Parent,Worker: Streaming (chat), token batching
+    Parent->>Worker: (chat, prompt)
+    Worker-->>Parent: (stream_chunk, "first token")
     loop batched: 16 tokens or 50ms whichever comes first
-        Worker-->>Parent: (43, stream_chunk, "batched tokens")
+        Worker-->>Parent: (stream_chunk, "batched tokens")
     end
-    Worker-->>Parent: (43, stream_end, None)
+    Worker-->>Parent: (stream_end, None)
 
-    Note over Parent,Worker: Liveness (dedicated thread)
-    Parent->>Worker: (0, ping, None)
-    Worker-->>Parent: (0, pong, None)
+    Note over Parent,Worker: Liveness and shutdown (dedicated thread)
+    Parent->>Worker: (ping, None)
+    Worker-->>Parent: (pong, None)
+    Parent->>Worker: (shutdown, None)
+    Worker-->>Parent: (ack, None)
 ```
 
 `WorkerPool` (in `providers/worker/pool.py`) owns lifecycle. `Services` constructs it once at startup with a `default_spawner()` from `providers/worker/transport.py`. The pool talks to workers exclusively through the `WorkerChannel` and `WorkerSpawner` Protocols; the only concrete impl today is `transport_pipe.PipeChannel` / `PipeSpawner`, backed by `multiprocessing.Pipe`.
@@ -210,9 +212,9 @@ If `cfg.worker_pool_max_idle_s > 0`, every successful round-trip stamps the role
 
 ### Health pipe isolation
 
-Health pings travel on a dedicated `mp.Pipe` per worker, separate from the data pipe that carries call/stream/shutdown. Pings cannot interleave with stream chunks by-construction; the parent reader on each pipe never sees frames meant for the other.
+The control plane (pings, shutdown) travels on a dedicated `mp.Pipe` per worker, separate from the data pipe that carries call/stream traffic. Control frames cannot interleave with stream chunks by construction; the parent reader on each pipe never sees frames meant for the other.
 
-The worker dedicates a daemon thread to the health pipe. The thread blocks in `health_conn.recv()`, answers `ping` with `pong`, and exits on `EOFError` when the parent closes the pipe at shutdown. This means a long-running data-frame handler (a chat stream that spends seconds inside `_handle_chat_streaming`, an embed batch chewing through a multi-thousand-vector payload) cannot starve the heartbeat, so the supervisor never declares a busy worker dead and force-terminates it.
+The worker dedicates a daemon thread to the health pipe. The thread blocks in `health_conn.recv()`, answers `ping` with `pong`, and on `shutdown` sends `ack` and sets a shared `shutdown_event` that the main data loop checks every `_DATA_POLL_INTERVAL_S` poll. This means a long-running data-frame handler (a chat stream that spends seconds inside `_handle_chat_streaming`, an embed batch chewing through a multi-thousand-vector payload) cannot starve the heartbeat or block shutdown: pings return promptly, and `close()` ack returns within the heartbeat thread's processing budget regardless of what the data loop is doing. The main data loop exits within one poll interval after the event fires.
 
 ### Cross-boundary cancel
 
@@ -224,16 +226,18 @@ Per-token `conn.send()` was the largest non-inference cost in the chat worker (9
 
 ### IPC discipline rules (pipe transport)
 
-The pipe transport (`transport_pipe.py`) enforces eight rules that keep the parent and worker in lockstep:
+The pipe transport (`transport_pipe.py`) enforces these rules that keep the parent and worker in lockstep:
 
-1. **Pull-based backpressure.** Pipe buffers are ~64 KiB on Linux; `conn.send()` blocks once full. The streaming consumer is the only awaiter on `recv` for that channel and yields chunks directly off the pipe. Slow consumers cannot starve the recv loop because the recv loop only fires when the consumer awaits the next chunk.
-2. **Pickle size cap.** `Connection.send()` raises `ValueError` past about 32 MiB on POSIX. `call` and `stream` enforce the cap (`_PICKLE_MAX_BYTES`) with a clear `PayloadTooLarge` error before the pickle round-trip.
-3. **Bounded poll.** Worker main loops use `conn.poll(timeout=...)` not bare `recv` so SIGTERM and shutdown timeouts fire (bare `recv` ignores signals). Lives in `worker_runtime.run_worker`.
-4. **Picklable error wire.** Exceptions are serialized through `_serialize_exception` to a `(type_name, message, traceback)` triple, which falls back gracefully when the live exception is not picklable (`_thread.RLock` references in tracebacks, several `OSError` subclasses, structlog wrappers).
-5. **In-flight counter for idle reaping.** Idle reaping checks `PipeChannel.in_flight` is zero, not "no recent message". A pending `recv` in the middle of a request stays in-flight until the terminator arrives.
-6. **xdist isolation.** `pytest-xdist` parallelism nests with our spawn; integration tests that exercise the pool annotate themselves with `pytest.mark.xdist_group(...)` so two pool tests do not race.
-7. **Daemon flag.** `daemon=True` workers cannot spawn children. `PipeSpawner` defaults to `daemon=True`; vision/mtmd workers that ever shell out to ffmpeg etc. must override via `PipeSpawner(daemon=False)` and rely on the pool's `atexit` shutdown.
-8. **Best-effort abort.** Once the parent flips the abort flag, in-flight `stream_chunk` messages already in the pipe still drain (a few extra tokens). The user-facing toast should say "Cancelling..." until the worker emits its terminator.
+1. **Channel-level serialization.** A single `asyncio.Lock` (`_call_lock`) per channel is held for the full request/reply or request/stream lifetime. Concurrent callers queue on the lock; the call that holds the lock is the sole reader of the data pipe. A reply or stream frame can only belong to the active call by construction, so no frame-routing id is needed and no stale-frame discard is possible.
+2. **Pull-based backpressure.** Pipe buffers are ~64 KiB on Linux; `conn.send()` blocks once full. Because there is only one in-flight call at a time, the worker's reply send never queues behind earlier pending replies, and a slow consumer applies backpressure naturally.
+3. **Pickle size cap.** `Connection.send()` raises `ValueError` past about 32 MiB on POSIX. `call` and `stream` enforce the cap (`_PICKLE_MAX_BYTES`) with a clear `PayloadTooLarge` error before the pickle round-trip.
+4. **Bounded poll.** Worker main loops use `conn.poll(timeout=...)` not bare `recv` so the shutdown event set by the heartbeat thread (and SIGTERM in real deployments) fires within `_DATA_POLL_INTERVAL_S`. Bare `recv` ignores both signals and event flags.
+5. **Picklable error wire.** Exceptions are serialized through `_serialize_exception` to a `(type_name, message, traceback)` triple, which falls back gracefully when the live exception is not picklable (`_thread.RLock` references in tracebacks, several `OSError` subclasses, structlog wrappers).
+6. **In-flight counter for idle reaping.** Idle reaping checks `PipeChannel.in_flight` is zero, not "no recent message". A pending `recv` in the middle of a request stays in-flight until the terminator arrives.
+7. **Control plane on the health pipe.** Ping/pong and shutdown/ack travel on a dedicated `mp.Pipe`, served by a worker-side daemon thread. A long inference on the data pipe never blocks liveness checks or process termination.
+8. **xdist isolation.** `pytest-xdist` parallelism nests with our spawn; integration tests that exercise the pool annotate themselves with `pytest.mark.xdist_group(...)` so two pool tests do not race.
+9. **Daemon flag.** `daemon=True` workers cannot spawn children. `PipeSpawner` defaults to `daemon=True`; vision/mtmd workers that ever shell out to ffmpeg etc. must override via `PipeSpawner(daemon=False)` and rely on the pool's `atexit` shutdown.
+10. **Best-effort abort.** Once the parent flips the abort flag, in-flight `stream_chunk` messages already in the pipe still drain (a few extra tokens). The user-facing toast should say "Cancelling..." until the worker emits its terminator.
 
 ### Spawn context must be spawn
 

--- a/src/lilbee/providers/worker/transport_pipe.py
+++ b/src/lilbee/providers/worker/transport_pipe.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import itertools
 import logging
 import multiprocessing
 import pickle
@@ -34,12 +33,6 @@ log = logging.getLogger(__name__)
 
 _PICKLE_MAX_BYTES = 32 * 1024 * 1024
 """``Connection.send`` raises past about 32 MiB on POSIX."""
-
-_CONTROL_CALL_ID = 0
-"""Sentinel call-id for shutdown/ack frames not associated with a user call."""
-
-_READER_EOF: object = object()
-"""Sentinel pushed to the frame queue when the reader thread exits."""
 
 
 @dataclass(frozen=True)
@@ -94,10 +87,10 @@ def _deserialize_exception(payload: _SerializedException) -> WorkerError:
     return WorkerError(payload.type_name, payload.message, payload.traceback_str)
 
 
-def _check_pickle_size(payload: Any, kind: WireKind, call_id: int) -> None:
-    """Raise ``ValueError`` early if *payload* would exceed the pipe send cap."""
+def _check_pickle_size(payload: Any, kind: WireKind) -> None:
+    """Raise ``WorkerError`` early if *payload* would exceed the pipe send cap."""
     try:
-        size = len(pickle.dumps((call_id, kind, payload)))
+        size = len(pickle.dumps((kind, payload)))
     except Exception as exc:
         raise WorkerError("PickleError", f"Failed to pickle {kind!r} payload: {exc}", "") from exc
     if size > _PICKLE_MAX_BYTES:
@@ -122,9 +115,13 @@ class PipeChannel:
     """One worker process talked to via a duplex :class:`multiprocessing.Pipe`.
 
     Owns the parent end of two pipes (data and health), the abort flag,
-    and a per-channel :class:`ThreadPoolExecutor`. Frames carry a monotonic
-    ``call_id`` so leftover frames from a cancelled prior call can be
-    discarded by the next call's reader instead of poisoning the protocol.
+    and a per-channel :class:`ThreadPoolExecutor`. The data pipe carries
+    one call at a time: ``call`` and ``stream`` acquire ``_call_lock`` for
+    their full request/reply or request/stream lifetime, so a reply (or
+    stream chunk) can only ever belong to the call currently holding the
+    lock. The health pipe carries ping/pong and shutdown/ack and is
+    served by a dedicated daemon thread on the worker side, so a long
+    inference never starves liveness or shutdown.
     """
 
     def __init__(
@@ -142,24 +139,15 @@ class PipeChannel:
         self._health_conn = health_conn
         self._abort = abort_flag
         self._executor = ThreadPoolExecutor(
-            max_workers=4,
+            max_workers=2,
             thread_name_prefix=f"pipechan-{role}",
         )
-        self._send_lock = asyncio.Lock()
-        self._health_send_lock = asyncio.Lock()
-        self._health_recv_lock = asyncio.Lock()
+        self._call_lock = asyncio.Lock()
+        self._health_lock = asyncio.Lock()
         self._in_flight = 0
         self._in_flight_lock = threading.Lock()
         self._closed = False
         self._closed_lock = threading.Lock()
-        self._call_ids = itertools.count(start=1)
-        self._call_id_lock = threading.Lock()
-        # Dedicated reader thread state. Lazy-started on first _recv so
-        # the thread captures the running asyncio loop for its bridge.
-        self._reader_thread: threading.Thread | None = None
-        self._frame_queue: asyncio.Queue[Any] | None = None
-        self._reader_loop: asyncio.AbstractEventLoop | None = None
-        self._reader_started = threading.Event()
 
     @property
     def role(self) -> WorkerRole:
@@ -186,10 +174,6 @@ class PipeChannel:
         with self._in_flight_lock:
             self._in_flight += delta
 
-    def _next_call_id(self) -> int:
-        with self._call_id_lock:
-            return next(self._call_ids)
-
     def _ensure_open(self) -> None:
         with self._closed_lock:
             if self._closed:
@@ -202,152 +186,115 @@ class PipeChannel:
     def _crash(self) -> WorkerCrashError:
         return WorkerCrashError(self._role, log_path=_worker_log_path(self._role))
 
-    async def _send(self, call_id: int, kind: WireKind, payload: Any) -> None:
-        """Pickle-pre-check + thread-bounded ``conn.send`` under the send lock."""
-        _check_pickle_size(payload, kind, call_id)
+    async def _send_data(self, kind: WireKind, payload: Any) -> None:
+        """Pickle-pre-check + thread-bounded ``conn.send`` on the data pipe."""
+        _check_pickle_size(payload, kind)
         loop = asyncio.get_running_loop()
-        async with self._send_lock:
-            try:
-                await loop.run_in_executor(
-                    self._executor, self._conn.send, (call_id, kind, payload)
-                )
-            except (BrokenPipeError, ConnectionResetError, EOFError, OSError) as exc:
-                raise self._crash() from exc
+        try:
+            await loop.run_in_executor(self._executor, self._conn.send, (kind, payload))
+        except (BrokenPipeError, ConnectionResetError, EOFError, OSError) as exc:
+            raise self._crash() from exc
 
-    def _ensure_reader(self) -> None:
-        """Lazy-start the dedicated reader thread bound to the current loop."""
-        if self._reader_started.is_set():
-            return
-        self._reader_loop = asyncio.get_running_loop()
-        self._frame_queue = asyncio.Queue()
-        self._reader_thread = threading.Thread(
-            target=self._reader_main,
-            name=f"pipe-reader-{self._role}",
-            daemon=True,
-        )
-        self._reader_thread.start()
-        self._reader_started.set()
-
-    def _reader_main(self) -> None:
-        """Pump frames from the data pipe into the asyncio frame queue."""
-        loop = self._reader_loop
-        queue = self._frame_queue
-        if loop is None or queue is None:
-            return
-        while True:
-            try:
-                frame = self._conn.recv()
-            except (EOFError, OSError, ConnectionResetError, BrokenPipeError):
-                with contextlib.suppress(RuntimeError):
-                    loop.call_soon_threadsafe(queue.put_nowait, _READER_EOF)
-                return
-            with contextlib.suppress(RuntimeError):
-                loop.call_soon_threadsafe(queue.put_nowait, frame)
-
-    async def _recv(self) -> tuple[int, WireKind, Any]:
-        """Await the next frame from the reader thread; raise on EOF/crash."""
-        self._ensure_reader()
-        queue = self._frame_queue
-        assert queue is not None  # _ensure_reader sets it  # noqa: S101
-        frame = await queue.get()
-        if frame is _READER_EOF:
-            raise self._crash()
+    async def _recv_data(self) -> tuple[WireKind, Any]:
+        """Block in a worker thread until the next ``(kind, payload)`` frame arrives."""
+        loop = asyncio.get_running_loop()
+        try:
+            frame = await loop.run_in_executor(self._executor, self._conn.recv)
+        except (EOFError, OSError, ConnectionResetError, BrokenPipeError) as exc:
+            raise self._crash() from exc
         return frame  # type: ignore[no-any-return]
-
-    async def _recv_for(self, expected_call_id: int) -> tuple[WireKind, Any]:
-        """Read frames until one matches *expected_call_id*; drain stale ones."""
-        while True:
-            call_id, kind, value = await self._recv()
-            if call_id == expected_call_id:
-                return kind, value
-            log.debug(
-                "Worker %s: discarding stale frame call_id=%s kind=%s (expected %s)",
-                self._role,
-                call_id,
-                kind,
-                expected_call_id,
-            )
 
     async def call(self, kind: WireKind, payload: Any, *, timeout: float) -> Any:
         """Send one request, await one reply on the data pipe.
 
-        Frames carry a per-call id; leftover frames from a cancelled prior
-        call are silently drained instead of raising :class:`ProtocolError`.
+        The ``_call_lock`` is held for the full request/reply window so a
+        reply that lands on the pipe can only belong to the call holding
+        the lock. New callers queue on the lock behind the in-flight one.
         """
         self._ensure_open()
-        call_id = self._next_call_id()
-        self._bump_in_flight(1)
-        try:
-            await self._send(call_id, kind, payload)
-            msg_kind, value = await asyncio.wait_for(self._recv_for(call_id), timeout=timeout)
-            if msg_kind == WireKind.ERROR:
-                raise _deserialize_exception(value)
-            if msg_kind != WireKind.RESULT:
-                raise WorkerError(
-                    "ProtocolError",
-                    f"Worker '{self._role}' replied with unexpected kind {msg_kind!r}.",
-                    "",
-                )
-            return value
-        finally:
-            self._bump_in_flight(-1)
-
-    async def stream(self, kind: WireKind, payload: Any) -> AsyncIterator[Any]:
-        """Send one request, yield streamed chunks on the data pipe."""
-        self._ensure_open()
-        call_id = self._next_call_id()
-        self._bump_in_flight(1)
-        await self._send(call_id, kind, payload)
-        try:
-            while True:
-                msg_kind, value = await self._recv_for(call_id)
-                if msg_kind == WireKind.STREAM_CHUNK:
-                    yield value
-                elif msg_kind == WireKind.STREAM_END:
-                    return
-                elif msg_kind == WireKind.ERROR:
+        async with self._call_lock:
+            self._bump_in_flight(1)
+            try:
+                await self._send_data(kind, payload)
+                msg_kind, value = await asyncio.wait_for(self._recv_data(), timeout=timeout)
+                if msg_kind == WireKind.ERROR:
                     raise _deserialize_exception(value)
-                else:
+                if msg_kind != WireKind.RESULT:
                     raise WorkerError(
                         "ProtocolError",
-                        f"Worker '{self._role}' streamed unexpected kind {msg_kind!r}.",
+                        f"Worker '{self._role}' replied with unexpected kind {msg_kind!r}.",
                         "",
                     )
-        finally:
-            self._bump_in_flight(-1)
+                return value
+            finally:
+                self._bump_in_flight(-1)
 
-    async def ping(self, *, timeout: float) -> None:
-        """Round-trip a ping over the dedicated health pipe; raise on timeout.
+    async def stream(self, kind: WireKind, payload: Any) -> AsyncIterator[Any]:
+        """Send one request, yield streamed chunks until the terminator arrives.
 
-        The health pipe is owned by a worker-side daemon thread that
-        answers ping → pong without depending on the data-frame handler,
-        so a long inference cannot starve the heartbeat.
+        The ``_call_lock`` is held for the full stream lifetime, so frames
+        recv'd by this coroutine belong to this stream by construction.
+        New callers queue behind the active stream.
         """
         self._ensure_open()
-        loop = asyncio.get_running_loop()
-        try:
-            async with self._health_send_lock:
-                await loop.run_in_executor(
-                    self._executor,
-                    self._health_conn.send,
-                    (_CONTROL_CALL_ID, WireKind.PING, None),
-                )
-        except (BrokenPipeError, ConnectionResetError, EOFError, OSError) as exc:
-            raise self._crash() from exc
-        async with self._health_recv_lock:
+        async with self._call_lock:
+            self._bump_in_flight(1)
             try:
-                _call_id, msg_kind, _ = await asyncio.wait_for(
+                await self._send_data(kind, payload)
+                while True:
+                    msg_kind, value = await self._recv_data()
+                    if msg_kind == WireKind.STREAM_CHUNK:
+                        yield value
+                    elif msg_kind == WireKind.STREAM_END:
+                        return
+                    elif msg_kind == WireKind.ERROR:
+                        raise _deserialize_exception(value)
+                    else:
+                        raise WorkerError(
+                            "ProtocolError",
+                            f"Worker '{self._role}' streamed unexpected kind {msg_kind!r}.",
+                            "",
+                        )
+            finally:
+                self._bump_in_flight(-1)
+
+    async def ping(self, *, timeout: float) -> None:
+        """Round-trip a ping over the health pipe; raise on timeout / crash.
+
+        The worker dedicates a daemon thread to the health pipe so pings
+        and shutdown can be served while the data loop is busy in
+        ``session.embed`` / ``create_chat_completion``.
+        """
+        self._ensure_open()
+        kind = await self._health_round_trip(WireKind.PING, None, timeout=timeout)
+        if kind != WireKind.PONG:
+            raise WorkerError(
+                "ProtocolError",
+                f"Worker '{self._role}' ping reply was {kind!r}, want 'pong'.",
+                "",
+            )
+
+    async def _health_round_trip(
+        self, send_kind: WireKind, send_payload: Any, *, timeout: float
+    ) -> WireKind:
+        """Send one frame on the health pipe and await its reply within *timeout*."""
+        loop = asyncio.get_running_loop()
+        async with self._health_lock:
+            try:
+                await loop.run_in_executor(
+                    self._executor, self._health_conn.send, (send_kind, send_payload)
+                )
+            except (BrokenPipeError, ConnectionResetError, EOFError, OSError) as exc:
+                raise self._crash() from exc
+            try:
+                frame = await asyncio.wait_for(
                     loop.run_in_executor(self._executor, self._health_conn.recv),
                     timeout=timeout,
                 )
             except (EOFError, OSError, ConnectionResetError, BrokenPipeError) as exc:
                 raise self._crash() from exc
-        if msg_kind != WireKind.PONG:
-            raise WorkerError(
-                "ProtocolError",
-                f"Worker '{self._role}' ping reply was {msg_kind!r}, want 'pong'.",
-                "",
-            )
+        reply_kind, _ = frame
+        return reply_kind  # type: ignore[no-any-return]
 
     def cancel(self) -> None:
         """Flip the abort flag to 1; in-flight tokens may still drain."""
@@ -358,16 +305,22 @@ class PipeChannel:
         self._abort.value = 0
 
     async def close(self, *, timeout: float) -> None:
-        """Send shutdown, await ack, terminate if it overruns *timeout*."""
+        """Send shutdown on the health pipe, await ack, then join the process.
+
+        The data pipe is never used for shutdown: a long in-flight call
+        on the data pipe would otherwise serialize behind a shutdown
+        request. Health-pipe shutdown is served by the worker's
+        dedicated heartbeat thread, so this returns within the timeout
+        regardless of what the data loop is doing. Any in-flight data
+        call sees the process exit and surfaces as :class:`WorkerCrashError`.
+        """
         with self._closed_lock:
             if self._closed:
                 return
             self._closed = True
         try:
-            with contextlib.suppress(asyncio.TimeoutError, WorkerError):
-                await self._send(_CONTROL_CALL_ID, WireKind.SHUTDOWN, None)
-                with contextlib.suppress(asyncio.TimeoutError, WorkerError):
-                    await asyncio.wait_for(self._recv(), timeout=timeout)
+            with contextlib.suppress(TimeoutError, WorkerError):
+                await self._health_round_trip(WireKind.SHUTDOWN, None, timeout=timeout)
             await asyncio.get_running_loop().run_in_executor(
                 self._executor, self._join_process, timeout
             )
@@ -377,8 +330,6 @@ class PipeChannel:
             with contextlib.suppress(Exception):
                 self._health_conn.close()
             self._executor.shutdown(wait=False, cancel_futures=True)
-            if self._reader_thread is not None:
-                self._reader_thread.join(timeout=timeout)
 
     def _join_process(self, timeout: float) -> None:
         """Wait *timeout* seconds for the process; terminate if still alive.
@@ -434,10 +385,10 @@ class PipeSpawner:
     ) -> tuple[WorkerChannel, WorkerHandle]:
         """Start a worker subprocess and return its channel + handle.
 
-        Two pipes per worker: ``data_pipe`` carries call/stream/shutdown
-        traffic, ``health_pipe`` carries ping/pong. The worker dedicates a
-        daemon thread to the health pipe so heartbeats stay live during
-        long inference.
+        Two pipes per worker: ``data_pipe`` carries call/stream traffic,
+        ``health_pipe`` carries ping/pong and shutdown/ack. The worker
+        dedicates a daemon thread to the health pipe so heartbeats and
+        shutdown stay live during long inference.
         """
         parent_data, child_data = self._ctx.Pipe(duplex=True)
         parent_health, child_health = self._ctx.Pipe(duplex=True)

--- a/src/lilbee/providers/worker/worker_runtime.py
+++ b/src/lilbee/providers/worker/worker_runtime.py
@@ -1,8 +1,9 @@
 """Cross-role helpers for worker subprocesses.
 
 Bootstraps the per-role workers (embed, chat, rerank, vision) and runs
-the recv loop. Health pings live on a dedicated daemon thread so a long
-inference call cannot starve heartbeats.
+the recv loop. Health pings and graceful shutdown live on a dedicated
+daemon thread so a long inference call cannot starve liveness or stop
+the parent from terminating the worker.
 """
 
 from __future__ import annotations
@@ -22,8 +23,10 @@ from lilbee.providers.worker.wire_kinds import WireKind
 
 log = logging.getLogger(__name__)
 
-_CONTROL_CALL_ID = 0
-"""Sentinel call-id for shutdown/ack/ping/pong frames."""
+# How often the main data loop wakes from poll() to re-check the shutdown
+# flag. 100 ms is well under any user-visible cancel budget but rare enough
+# not to show up as CPU noise.
+_DATA_POLL_INTERVAL_S = 0.1
 
 
 def redirect_stdio_to_devnull() -> None:  # pragma: no cover - subprocess fd swap
@@ -53,20 +56,21 @@ def configure_worker_logging(role: WorkerRole) -> None:
 
 
 class Reply:
-    """Per-call sender bound to one ``call_id`` on the data pipe.
+    """Sender for the in-flight call's response frames on the data pipe.
 
     Handlers receive a Reply instance and emit response frames via
-    ``reply.send(KIND, payload)``. The call_id is injected transparently so
-    handlers do not need to thread it through their internal logic.
+    ``reply.send(kind, payload)``. The parent's :class:`PipeChannel`
+    holds the call lock for the full request/reply or request/stream
+    window, so a frame sent here belongs to the call the worker is
+    currently servicing by construction.
     """
 
-    def __init__(self, conn: Any, call_id: int) -> None:
+    def __init__(self, conn: Any) -> None:
         self._conn = conn
-        self._call_id = call_id
 
     def send(self, kind: WireKind, payload: Any) -> None:
-        """Send one response frame tagged with this Reply's call_id."""
-        self._conn.send((self._call_id, kind, payload))
+        """Send one response frame on the data pipe."""
+        self._conn.send((kind, payload))
 
 
 @dataclass
@@ -99,11 +103,11 @@ def run_worker(
 ) -> None:
     """Bootstrap stdio + logging, then run the recv loop until shutdown.
 
-    Health pings travel on a separate pipe owned by a daemon thread that
-    answers ping → pong without depending on the data-frame handler. The
-    main loop reads frames as ``(call_id, kind, payload)`` and dispatches
-    role-specific kinds via *kind_handlers*. Unknown kinds reply with a
-    serialized ``ValueError``.
+    The control plane (ping, shutdown) travels on the health pipe and is
+    served by a daemon thread. The main loop polls the data pipe with a
+    short timeout so the shutdown flag set by the heartbeat thread fires
+    promptly even when no data frame is pending. Unknown data-pipe kinds
+    reply with a serialized ``ValueError``.
     """
     redirect_stdio_to_devnull()
     configure_worker_logging(role_config.role)
@@ -114,11 +118,20 @@ def run_worker(
         role_config.model_path,
     )
     state = WorkerLoopState(session=session_factory(role_config, abort_flag))
-    heartbeat = _start_heartbeat_thread(health_conn, role_config.role)
+    shutdown_event = threading.Event()
+    heartbeat = _start_heartbeat_thread(health_conn, role_config.role, shutdown_event)
     try:
-        while _handle_data_frame(data_conn, state, kind_handlers, role_config.role):
-            pass
+        while not shutdown_event.is_set():
+            if not _handle_data_frame(
+                data_conn,
+                state,
+                kind_handlers,
+                role_config.role,
+                shutdown_event,
+            ):
+                break
     finally:
+        shutdown_event.set()
         state.session.close()
         with contextlib.suppress(Exception):
             data_conn.close()
@@ -127,11 +140,13 @@ def run_worker(
         heartbeat.join(timeout=1.0)
 
 
-def _start_heartbeat_thread(health_conn: Any, role: WorkerRole) -> threading.Thread:
+def _start_heartbeat_thread(
+    health_conn: Any, role: WorkerRole, shutdown_event: threading.Event
+) -> threading.Thread:
     """Spawn the daemon thread that owns the health pipe."""
     thread = threading.Thread(
         target=_heartbeat_loop,
-        args=(health_conn, role),
+        args=(health_conn, role, shutdown_event),
         name=f"lilbee-worker-{role}-heartbeat",
         daemon=True,
     )
@@ -139,19 +154,33 @@ def _start_heartbeat_thread(health_conn: Any, role: WorkerRole) -> threading.Thr
     return thread
 
 
-def _heartbeat_loop(health_conn: Any, role: WorkerRole) -> None:
-    """Respond to ping → pong on the health pipe until the parent closes it."""
+def _heartbeat_loop(health_conn: Any, role: WorkerRole, shutdown_event: threading.Event) -> None:
+    """Serve ping/shutdown on the health pipe until the parent closes it.
+
+    On SHUTDOWN, sets the shutdown event so the main thread exits its
+    poll loop within ``_DATA_POLL_INTERVAL_S`` regardless of whether a
+    data frame is pending. The ACK reply is best-effort: the parent's
+    close() suppresses pipe errors so a torn-down health connection
+    does not surface as a noisy supervisor warning.
+    """
     while True:
         try:
-            _call_id, kind, _ = health_conn.recv()
+            kind, _ = health_conn.recv()
         except (EOFError, OSError):
+            shutdown_event.set()
             return
         if kind == WireKind.PING:
             try:
-                health_conn.send((_CONTROL_CALL_ID, WireKind.PONG, None))
+                health_conn.send((WireKind.PONG, None))
             except (BrokenPipeError, OSError):
+                shutdown_event.set()
                 return
             continue
+        if kind == WireKind.SHUTDOWN:
+            with contextlib.suppress(BrokenPipeError, OSError):
+                health_conn.send((WireKind.ACK, None))
+            shutdown_event.set()
+            return
         log.warning("%s worker dropped unexpected health-pipe kind %r", role, kind)
 
 
@@ -160,16 +189,25 @@ def _handle_data_frame(
     state: WorkerLoopState,
     kind_handlers: dict[WireKind, KindHandler],
     role: WorkerRole,
+    shutdown_event: threading.Event,
 ) -> bool:
-    """Read and dispatch one data-pipe frame. Return False to stop the loop."""
+    """Read and dispatch one data-pipe frame. Return False to stop the loop.
+
+    Uses ``poll()`` with a short timeout so a shutdown flag set by the
+    heartbeat thread takes effect within one poll interval even when the
+    data pipe is idle. A long-running handler (a multi-second chat stream)
+    is interrupted only after the handler returns; the join in
+    ``PipeChannel.close`` falls back to ``terminate()`` past the close
+    timeout for that case.
+    """
+    while not data_conn.poll(_DATA_POLL_INTERVAL_S):
+        if shutdown_event.is_set():
+            return False
     try:
-        call_id, kind, payload = data_conn.recv()
+        kind, payload = data_conn.recv()
     except EOFError:
         return False
-    if kind == WireKind.SHUTDOWN:
-        data_conn.send((call_id, WireKind.ACK, None))
-        return False
-    reply = Reply(data_conn, call_id)
+    reply = Reply(data_conn)
     handler = kind_handlers.get(kind)
     if handler is not None:
         handler(reply, payload, state)

--- a/tests/test_chat_worker.py
+++ b/tests/test_chat_worker.py
@@ -329,24 +329,24 @@ def test_extract_stream_content_handles_non_dict() -> None:
 
 
 class _RecordingConn:
-    """Captures raw ``(call_id, kind, payload)`` 3-tuples sent through Reply."""
+    """Captures ``(kind, payload)`` frames sent through Reply."""
 
     def __init__(self) -> None:
-        self.sent: list[tuple[int, str, Any]] = []
+        self.sent: list[tuple[str, Any]] = []
 
-    def send(self, message: tuple[int, str, Any]) -> None:
+    def send(self, message: tuple[str, Any]) -> None:
         self.sent.append(message)
 
 
-def _make_reply(call_id: int = 1) -> tuple[Reply, _RecordingConn]:
+def _make_reply() -> tuple[Reply, _RecordingConn]:
     """Build a Reply bound to a recording conn so tests can inspect emitted frames."""
     conn = _RecordingConn()
-    return Reply(conn, call_id), conn
+    return Reply(conn), conn
 
 
 def _kinds_payloads(conn: _RecordingConn) -> list[tuple[str, Any]]:
-    """Drop the call_id from captured frames so tests can compare on (kind, payload)."""
-    return [(kind, payload) for _call_id, kind, payload in conn.sent]
+    """Surface the captured ``(kind, payload)`` frames for assertion."""
+    return list(conn.sent)
 
 
 class _FlagStub:

--- a/tests/test_embed_worker.py
+++ b/tests/test_embed_worker.py
@@ -173,24 +173,24 @@ async def test_embed_worker_surfaces_load_failure(
 
 
 class _RecordingConn:
-    """Captures raw ``(call_id, kind, payload)`` 3-tuples sent through Reply."""
+    """Captures ``(kind, payload)`` frames sent through Reply."""
 
     def __init__(self) -> None:
-        self.sent: list[tuple[int, str, Any]] = []
+        self.sent: list[tuple[str, Any]] = []
 
-    def send(self, message: tuple[int, str, Any]) -> None:
+    def send(self, message: tuple[str, Any]) -> None:
         self.sent.append(message)
 
 
-def _make_reply(call_id: int = 1):
+def _make_reply():
     from lilbee.providers.worker.worker_runtime import Reply
 
     conn = _RecordingConn()
-    return Reply(conn, call_id), conn
+    return Reply(conn), conn
 
 
 def _kinds_payloads(conn: _RecordingConn) -> list[tuple[str, Any]]:
-    return [(kind, payload) for _call_id, kind, payload in conn.sent]
+    return list(conn.sent)
 
 
 class _StubSession:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -126,6 +126,17 @@ class TestWorkerErrorMessage:
         )
         assert msg == "Embed worker reported an error: RuntimeError: boom. Please try again."
 
+    def test_worker_crash_error_uses_exited_phrasing(self) -> None:
+        """``WorkerCrashError`` renders with 'exited unexpectedly' framing rather
+        than the generic 'reported an error' template, so the user can tell a
+        crash apart from a worker-side exception."""
+        from lilbee.providers.llama_cpp import LlamaCppProvider
+        from lilbee.providers.worker.transport_pipe import WorkerCrashError
+
+        msg = LlamaCppProvider._worker_error_message("Embedding", WorkerCrashError("embed"))
+        assert msg.startswith("Embedding worker exited unexpectedly.")
+        assert msg.endswith(". Please try again.")
+
 
 # ---------------------------------------------------------------------------
 # LlamaCppProvider

--- a/tests/test_rerank_worker.py
+++ b/tests/test_rerank_worker.py
@@ -120,24 +120,24 @@ async def test_rerank_worker_unknown_kind_returns_error(
 
 
 class _RecordingConn:
-    """Captures raw ``(call_id, kind, payload)`` 3-tuples sent through Reply."""
+    """Captures ``(kind, payload)`` frames sent through Reply."""
 
     def __init__(self) -> None:
-        self.sent: list[tuple[int, str, Any]] = []
+        self.sent: list[tuple[str, Any]] = []
 
-    def send(self, message: tuple[int, str, Any]) -> None:
+    def send(self, message: tuple[str, Any]) -> None:
         self.sent.append(message)
 
 
-def _make_reply(call_id: int = 1):
+def _make_reply():
     from lilbee.providers.worker.worker_runtime import Reply
 
     conn = _RecordingConn()
-    return Reply(conn, call_id), conn
+    return Reply(conn), conn
 
 
 def _kinds_payloads(conn: _RecordingConn) -> list[tuple[str, Any]]:
-    return [(kind, payload) for _call_id, kind, payload in conn.sent]
+    return list(conn.sent)
 
 
 class _StubSession:

--- a/tests/test_vision_worker.py
+++ b/tests/test_vision_worker.py
@@ -128,24 +128,24 @@ async def test_vision_worker_unknown_kind_returns_error(
 
 
 class _RecordingConn:
-    """Captures raw ``(call_id, kind, payload)`` 3-tuples sent through Reply."""
+    """Captures ``(kind, payload)`` frames sent through Reply."""
 
     def __init__(self) -> None:
-        self.sent: list[tuple[int, str, Any]] = []
+        self.sent: list[tuple[str, Any]] = []
 
-    def send(self, message: tuple[int, str, Any]) -> None:
+    def send(self, message: tuple[str, Any]) -> None:
         self.sent.append(message)
 
 
-def _make_reply(call_id: int = 1):
+def _make_reply():
     from lilbee.providers.worker.worker_runtime import Reply
 
     conn = _RecordingConn()
-    return Reply(conn, call_id), conn
+    return Reply(conn), conn
 
 
 def _kinds_payloads(conn: _RecordingConn) -> list[tuple[str, Any]]:
-    return [(kind, payload) for _call_id, kind, payload in conn.sent]
+    return list(conn.sent)
 
 
 class _StubSession:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -21,16 +21,23 @@ from lilbee.providers.worker.worker_runtime import (
 
 
 class _RecordingConn:
-    """In-process stand-in for multiprocessing.Connection."""
+    """In-process stand-in for multiprocessing.Connection.
 
-    def __init__(self, incoming: list[tuple[int, str, Any]] | None = None) -> None:
+    ``poll`` is wired so the data loop test cases return True immediately
+    when an incoming frame is queued.
+    """
+
+    def __init__(self, incoming: list[tuple[str, Any]] | None = None) -> None:
         self._incoming = list(incoming or [])
-        self.sent: list[tuple[int, str, Any]] = []
+        self.sent: list[tuple[str, Any]] = []
 
-    def send(self, message: tuple[int, str, Any]) -> None:
+    def poll(self, _timeout: float = 0.0) -> bool:
+        return bool(self._incoming)
+
+    def send(self, message: tuple[str, Any]) -> None:
         self.sent.append(message)
 
-    def recv(self) -> tuple[int, str, Any]:
+    def recv(self) -> tuple[str, Any]:
         return self._incoming.pop(0)
 
 
@@ -38,16 +45,9 @@ def _state() -> WorkerLoopState:
     return WorkerLoopState(session=object())
 
 
-def test_handle_data_frame_shutdown_returns_false() -> None:
-    """Shutdown frame on the data pipe acks (echoing call_id) and stops the loop."""
-    conn = _RecordingConn(incoming=[(7, "shutdown", None)])
-    assert _handle_data_frame(conn, _state(), {}, "embed") is False
-    assert conn.sent == [(7, "ack", None)]
-
-
 def test_handle_data_frame_routes_to_role_handler() -> None:
-    """Recognized role kinds get a Reply bound to the request's call_id."""
-    conn = _RecordingConn(incoming=[(42, "embed", ["x"])])
+    """Recognized role kinds get a Reply that sends on the same data pipe."""
+    conn = _RecordingConn(incoming=[("embed", ["x"])])
     seen: list[tuple[Any, Any, WorkerLoopState]] = []
 
     def _handler(reply: Reply, payload: Any, state: WorkerLoopState) -> None:
@@ -55,20 +55,19 @@ def test_handle_data_frame_routes_to_role_handler() -> None:
         reply.send("result", [[1.0]])
 
     state = WorkerLoopState(session="session-marker")
-    assert _handle_data_frame(conn, state, {"embed": _handler}, "embed") is True
+    assert _handle_data_frame(conn, state, {"embed": _handler}, "embed", threading.Event()) is True
     assert len(seen) == 1
     assert seen[0][1] == ["x"]
     assert seen[0][2] is state
-    assert conn.sent == [(42, "result", [[1.0]])]
+    assert conn.sent == [("result", [[1.0]])]
 
 
 def test_handle_data_frame_unknown_emits_serialized_value_error() -> None:
-    """Unknown kinds reply with a serialized ValueError tagged with the call_id."""
-    conn = _RecordingConn(incoming=[(99, "totally_unknown", None)])
-    assert _handle_data_frame(conn, _state(), {}, "embed") is True
+    """Unknown kinds reply with a serialized ValueError on the data pipe."""
+    conn = _RecordingConn(incoming=[("totally_unknown", None)])
+    assert _handle_data_frame(conn, _state(), {}, "embed", threading.Event()) is True
     assert len(conn.sent) == 1
-    call_id, kind, payload = conn.sent[0]
-    assert call_id == 99
+    kind, payload = conn.sent[0]
     assert kind == "error"
     assert payload.type_name == "ValueError"
     assert "totally_unknown" in payload.message
@@ -79,13 +78,38 @@ def test_handle_data_frame_eof_returns_false() -> None:
     """Pipe EOF on the data side stops the worker loop cleanly."""
 
     class _EOFConn:
-        def recv(self) -> tuple[int, str, Any]:
+        def poll(self, _timeout: float = 0.0) -> bool:
+            return True
+
+        def recv(self) -> tuple[str, Any]:
             raise EOFError
 
-        def send(self, message: tuple[int, str, Any]) -> None:
+        def send(self, message: tuple[str, Any]) -> None:
             raise AssertionError("worker must not send after EOF")
 
-    assert _handle_data_frame(_EOFConn(), _state(), {}, "embed") is False
+    assert _handle_data_frame(_EOFConn(), _state(), {}, "embed", threading.Event()) is False
+
+
+def test_handle_data_frame_idle_poll_returns_on_shutdown_event() -> None:
+    """When no frame is pending and shutdown_event fires, the loop exits."""
+
+    class _IdleConn:
+        polls: int = 0
+
+        def poll(self, _timeout: float = 0.0) -> bool:
+            _IdleConn.polls += 1
+            return False
+
+        def recv(self) -> tuple[str, Any]:
+            raise AssertionError("recv must not be called when poll returns False")
+
+        def send(self, message: tuple[str, Any]) -> None:
+            raise AssertionError("worker must not send during idle shutdown")
+
+    event = threading.Event()
+    event.set()
+    assert _handle_data_frame(_IdleConn(), _state(), {}, "embed", event) is False
+    assert _IdleConn.polls == 1
 
 
 def test_heartbeat_loop_pongs_pings() -> None:
@@ -94,61 +118,171 @@ def test_heartbeat_loop_pongs_pings() -> None:
     class _EOFAfterFirst(_RecordingConn):
         """RecordingConn that raises EOF after the first recv, to exit the loop."""
 
-        def recv(self) -> tuple[int, str, Any]:
+        def recv(self) -> tuple[str, Any]:
             if self._incoming:
                 return self._incoming.pop(0)
             raise EOFError
 
-    health = _EOFAfterFirst(incoming=[(0, "ping", None)])
-    _heartbeat_loop(health, "embed")
-    assert health.sent == [(0, "pong", None)]
+    health = _EOFAfterFirst(incoming=[("ping", None)])
+    event = threading.Event()
+    _heartbeat_loop(health, "embed", event)
+    assert health.sent == [("pong", None)]
+    assert event.is_set()
 
 
-def test_heartbeat_loop_drops_unexpected_kind(caplog) -> None:
-    """Anything other than ping on the health pipe logs a warning and drops."""
+def test_heartbeat_loop_acks_shutdown_and_sets_event() -> None:
+    """SHUTDOWN on the health pipe acks back and signals the data loop to stop."""
 
     class _Pump:
         def __init__(self) -> None:
-            self._pending = [(0, "garbage", None)]
-            self.sent: list[tuple[int, str, Any]] = []
+            self._pending = [("shutdown", None)]
+            self.sent: list[tuple[str, Any]] = []
 
-        def recv(self) -> tuple[int, str, Any]:
+        def recv(self) -> tuple[str, Any]:
             if self._pending:
                 return self._pending.pop(0)
             raise EOFError
 
-        def send(self, message: tuple[int, str, Any]) -> None:
+        def send(self, message: tuple[str, Any]) -> None:
             self.sent.append(message)
 
     health = _Pump()
+    event = threading.Event()
+    _heartbeat_loop(health, "embed", event)
+    assert health.sent == [("ack", None)]
+    assert event.is_set()
+
+
+def test_heartbeat_loop_shutdown_survives_send_error() -> None:
+    """If the ack send fails because the parent already closed, exit quietly."""
+
+    class _Pump:
+        def __init__(self) -> None:
+            self._pending = [("shutdown", None)]
+
+        def recv(self) -> tuple[str, Any]:
+            if self._pending:
+                return self._pending.pop(0)
+            raise EOFError
+
+        def send(self, _message: tuple[str, Any]) -> None:
+            raise BrokenPipeError("parent gone")
+
+    event = threading.Event()
+    _heartbeat_loop(_Pump(), "embed", event)  # must not raise
+    assert event.is_set()
+
+
+def test_heartbeat_loop_drops_unexpected_kind(caplog) -> None:
+    """Anything other than ping or shutdown on the health pipe logs a warning."""
+
+    class _Pump:
+        def __init__(self) -> None:
+            self._pending = [("garbage", None)]
+            self.sent: list[tuple[str, Any]] = []
+
+        def recv(self) -> tuple[str, Any]:
+            if self._pending:
+                return self._pending.pop(0)
+            raise EOFError
+
+        def send(self, message: tuple[str, Any]) -> None:
+            self.sent.append(message)
+
+    health = _Pump()
+    event = threading.Event()
     with caplog.at_level("WARNING", logger="lilbee.providers.worker.worker_runtime"):
-        _heartbeat_loop(health, "embed")
+        _heartbeat_loop(health, "embed", event)
     assert health.sent == []
+    assert event.is_set()  # set on EOF after the warning frame
     assert any("unexpected health-pipe kind" in rec.message for rec in caplog.records)
 
 
-def test_heartbeat_loop_returns_on_send_error() -> None:
+def test_heartbeat_loop_returns_on_ping_send_error() -> None:
     """Pong send that fails (parent already closed) exits the loop quietly."""
 
     class _BadSend:
         def __init__(self) -> None:
-            self._pending = [(0, "ping", None)]
+            self._pending = [("ping", None)]
 
-        def recv(self) -> tuple[int, str, Any]:
+        def recv(self) -> tuple[str, Any]:
             if self._pending:
                 return self._pending.pop(0)
             raise EOFError
 
-        def send(self, _message: tuple[int, str, Any]) -> None:
+        def send(self, _message: tuple[str, Any]) -> None:
             raise BrokenPipeError("parent gone")
 
-    _heartbeat_loop(_BadSend(), "embed")  # must not raise
+    event = threading.Event()
+    _heartbeat_loop(_BadSend(), "embed", event)  # must not raise
+    assert event.is_set()
 
 
-def test_run_worker_dispatches_data_then_shutdown(monkeypatch) -> None:
-    """End-to-end: run_worker reads data frames, dispatches handler, exits on shutdown."""
-    from collections import deque
+class _FakeDataConn:
+    """Module-level fake data conn for the run_worker integration test."""
 
+    def __init__(self, incoming: list[tuple[str, Any]]) -> None:
+        from collections import deque
+
+        self._incoming = deque(incoming)
+        self.sent: list[tuple[str, Any]] = []
+        self.closed = False
+
+    def poll(self, _timeout: float = 0.0) -> bool:
+        return bool(self._incoming)
+
+    def recv(self) -> tuple[str, Any]:
+        if self._incoming:
+            return self._incoming.popleft()
+        raise EOFError
+
+    def send(self, message: tuple[str, Any]) -> None:
+        self.sent.append(message)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _GatedHealthConn:
+    """Health pipe that delivers SHUTDOWN only after a gating event fires.
+
+    Gating eliminates the race between the heartbeat daemon thread and
+    the main data loop so the test deterministically observes that
+    run_worker dispatched the data frame before exiting on shutdown.
+    """
+
+    def __init__(self, gate: threading.Event) -> None:
+        self._gate = gate
+        self._sent_shutdown = False
+        self.sent: list[tuple[str, Any]] = []
+        self.closed = False
+
+    def recv(self) -> tuple[str, Any]:
+        if not self._sent_shutdown:
+            self._gate.wait(timeout=2.0)
+            self._sent_shutdown = True
+            return ("shutdown", None)
+        raise EOFError
+
+    def send(self, message: tuple[str, Any]) -> None:
+        self.sent.append(message)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RecordingSession:
+    """Session stub that records ``close()`` for assertion in run_worker tests."""
+
+    def __init__(self, log: list[bool]) -> None:
+        self._log = log
+
+    def close(self) -> None:
+        self._log.append(True)
+
+
+def test_run_worker_dispatches_data_then_health_shutdown(monkeypatch) -> None:
+    """run_worker reads data frames, dispatches handler, exits on health shutdown."""
     from lilbee.providers.worker import worker_runtime
     from lilbee.providers.worker.transport import RoleConfig
 
@@ -159,40 +293,18 @@ def test_run_worker_dispatches_data_then_shutdown(monkeypatch) -> None:
         "lilbee.providers.worker.worker_runtime.configure_worker_logging", lambda _r: None
     )
 
-    class _FakeConn:
-        def __init__(self, incoming: list[tuple[int, str, Any]]) -> None:
-            self._incoming = deque(incoming)
-            self.sent: list[tuple[int, str, Any]] = []
-            self.closed = False
-
-        def recv(self) -> tuple[int, str, Any]:
-            if self._incoming:
-                return self._incoming.popleft()
-            raise EOFError
-
-        def send(self, message: tuple[int, str, Any]) -> None:
-            self.sent.append(message)
-
-        def close(self) -> None:
-            self.closed = True
-
-    data = _FakeConn(incoming=[(11, "embed", ["x"]), (0, "shutdown", None)])
-    health = _FakeConn(incoming=[])  # heartbeat thread will get EOF and exit
+    data = _FakeDataConn(incoming=[("embed", ["x"])])
+    handler_done = threading.Event()
+    health = _GatedHealthConn(gate=handler_done)
 
     seen_payloads: list[Any] = []
-    handler_started = threading.Event()
 
     def _embed_handler(reply: Reply, payload: Any, _state: WorkerLoopState) -> None:
         seen_payloads.append(payload)
         reply.send("result", [[1.0]])
-        handler_started.set()
+        handler_done.set()
 
     closed_sessions: list[bool] = []
-
-    class _Session:
-        def close(self) -> None:
-            closed_sessions.append(True)
-
     role_config = RoleConfig(
         role="embed", model_path=__import__("pathlib").Path("/nope"), mode="embed"
     )
@@ -201,15 +313,15 @@ def test_run_worker_dispatches_data_then_shutdown(monkeypatch) -> None:
         health,
         None,
         role_config,
-        session_factory=lambda *_a: _Session(),
+        session_factory=lambda *_a: _RecordingSession(closed_sessions),
         kind_handlers={"embed": _embed_handler},
     )
-    assert handler_started.is_set()
-    # Brief wait so the heartbeat daemon thread can observe the EOF on health.
+    assert handler_done.is_set()
+    # Brief wait so heartbeat daemon thread is observably finished.
     time.sleep(0.05)
     assert seen_payloads == [["x"]]
-    assert (11, "result", [[1.0]]) in data.sent
-    assert (0, "ack", None) in data.sent
+    assert ("result", [[1.0]]) in data.sent
+    assert ("ack", None) in health.sent
     assert closed_sessions == [True]
     assert data.closed
     assert health.closed

--- a/tests/test_worker_transport_pipe.py
+++ b/tests/test_worker_transport_pipe.py
@@ -612,6 +612,54 @@ async def test_ping_raises_worker_crash_when_health_pipe_dies(
 
 
 @pytest.mark.asyncio
+async def test_call_raises_worker_crash_when_data_send_fails() -> None:
+    """If the data-pipe send raises, ``call`` surfaces ``WorkerCrashError``.
+
+    Closes the parent end of the data pipe before issuing the call so the
+    parent's ``_conn.send`` hits BrokenPipeError / OSError on its way out.
+    """
+    import multiprocessing
+
+    ctx = multiprocessing.get_context("spawn")
+    parent_data, child_data = ctx.Pipe(duplex=True)
+    parent_health, child_health = ctx.Pipe(duplex=True)
+    abort_flag = ctx.Value("b", 0, lock=True)
+
+    class _FakeProcess:
+        def is_alive(self) -> bool:
+            return True
+
+        @property
+        def pid(self) -> int:
+            return -1
+
+        def join(self, timeout: float | None = None) -> None:
+            return None
+
+        def terminate(self) -> None:
+            return None
+
+    channel = PipeChannel(
+        role="echo",
+        process=_FakeProcess(),
+        parent_conn=parent_data,
+        health_conn=parent_health,
+        abort_flag=abort_flag,
+    )
+    parent_data.close()
+    try:
+        with pytest.raises(WorkerCrashError):
+            await channel.call("echo", "x", timeout=1.0)
+    finally:
+        with contextlib.suppress(Exception):
+            child_data.close()
+        with contextlib.suppress(Exception):
+            parent_health.close()
+        with contextlib.suppress(Exception):
+            child_health.close()
+
+
+@pytest.mark.asyncio
 async def test_ping_raises_worker_crash_when_health_send_fails() -> None:
     """If the health-pipe send itself raises, ping surfaces WorkerCrashError.
 

--- a/tests/test_worker_transport_pipe.py
+++ b/tests/test_worker_transport_pipe.py
@@ -12,7 +12,6 @@ import asyncio
 import contextlib
 import os
 import pickle
-import threading
 import time
 from multiprocessing.connection import wait
 from typing import Any
@@ -54,33 +53,34 @@ def _drive_test_worker(
     abort_flag: Any,
     on_data: Any,
 ) -> None:
-    """Test-worker multiplexer using the new ``(call_id, kind, payload)`` frame format.
+    """Test-worker multiplexer for the ``(kind, payload)`` wire format.
 
-    The dedicated heartbeat thread responsibility lives in real workers via
+    The dedicated heartbeat-thread responsibility lives in real workers via
     ``worker_runtime.run_worker``; tests bake an inline equivalent so each
     test worker stays self-contained. *on_data* signature is
-    ``(conn, call_id, kind, payload, abort_flag) -> None`` and it owns
-    sending response frames with the right call_id echoed back.
+    ``(conn, kind, payload, abort_flag) -> None`` and it owns sending
+    response frames on the data pipe. SHUTDOWN arrives on the health pipe.
     """
     try:
         while True:
             ready = wait([data_conn, health_conn], timeout=_POLL_TIMEOUT_S)
             if data_conn in ready:
                 try:
-                    call_id, kind, payload = data_conn.recv()
+                    kind, payload = data_conn.recv()
                 except EOFError:
                     return
-                if kind == "shutdown":
-                    data_conn.send((call_id, "ack", None))
-                    return
-                on_data(data_conn, call_id, kind, payload, abort_flag)
+                on_data(data_conn, kind, payload, abort_flag)
             if health_conn in ready:
                 try:
-                    hcall_id, hkind, _ = health_conn.recv()
+                    hkind, _ = health_conn.recv()
                 except EOFError:
                     continue
                 if hkind == "ping":
-                    health_conn.send((hcall_id, "pong", None))
+                    health_conn.send(("pong", None))
+                elif hkind == "shutdown":
+                    with contextlib.suppress(BrokenPipeError, OSError):
+                        health_conn.send(("ack", None))
+                    return
     finally:  # pragma: no cover - cleanup runs in subprocess
         with contextlib.suppress(Exception):
             data_conn.close()
@@ -88,54 +88,44 @@ def _drive_test_worker(
             health_conn.close()
 
 
-def _handle_echo(conn: Any, call_id: int, payload: Any, _abort: Any) -> None:
-    conn.send((call_id, "result", payload))
+def _handle_echo(conn: Any, payload: Any, _abort: Any) -> None:
+    conn.send(("result", payload))
 
 
-def _handle_raise(conn: Any, call_id: int, payload: Any, _abort: Any) -> None:
+def _handle_raise(conn: Any, payload: Any, _abort: Any) -> None:
     try:
         raise RuntimeError(payload)
     except RuntimeError as exc:
-        conn.send((call_id, "error", _serialize_exception(exc)))
+        conn.send(("error", _serialize_exception(exc)))
 
 
-def _handle_stream_error(conn: Any, call_id: int, payload: Any, _abort: Any) -> None:
-    conn.send((call_id, "stream_chunk", "first"))
+def _handle_stream_error(conn: Any, payload: Any, _abort: Any) -> None:
+    conn.send(("stream_chunk", "first"))
     try:
         raise ValueError(payload)
     except ValueError as exc:
-        conn.send((call_id, "error", _serialize_exception(exc)))
+        conn.send(("error", _serialize_exception(exc)))
 
 
-def _handle_stream(conn: Any, call_id: int, payload: Any, _abort: Any) -> None:
+def _handle_stream(conn: Any, payload: Any, _abort: Any) -> None:
     count, suffix = payload
     for i in range(count):
-        conn.send((call_id, "stream_chunk", f"{suffix}{i}"))
-    conn.send((call_id, "stream_end", None))
+        conn.send(("stream_chunk", f"{suffix}{i}"))
+    conn.send(("stream_end", None))
 
 
-def _handle_abort_loop(conn: Any, call_id: int, _payload: Any, abort: Any) -> None:
+def _handle_abort_loop(conn: Any, _payload: Any, abort: Any) -> None:
     deadline = time.monotonic() + 5.0
     while time.monotonic() < deadline:
         if abort.value:
-            conn.send((call_id, "result", "aborted"))
+            conn.send(("result", "aborted"))
             return
         time.sleep(0.01)
-    conn.send((call_id, "result", "timeout"))
+    conn.send(("result", "timeout"))
 
 
-def _handle_bad_kind(conn: Any, call_id: int, _payload: Any, _abort: Any) -> None:
-    conn.send((call_id, "not_a_known_kind", None))
-
-
-def _handle_bad_stream_kind(conn: Any, call_id: int, _payload: Any, _abort: Any) -> None:
-    conn.send((call_id, "totally_bogus_kind", None))
-
-
-def _handle_bad_ping_kind(conn: Any, _call_id: int, _payload: Any, _abort: Any) -> None:
-    """Reply to ping with non-pong kind on the health pipe (separate driver)."""
-    # Unused. bad_ping behavior lives in _ping_replies_garbage_main.
-    raise NotImplementedError
+def _handle_bad_kind(conn: Any, _payload: Any, _abort: Any) -> None:
+    conn.send(("not_a_known_kind", None))
 
 
 _ECHO_DISPATCH = {
@@ -145,20 +135,18 @@ _ECHO_DISPATCH = {
     "stream_error": _handle_stream_error,
     "abort_loop": _handle_abort_loop,
     "bad_kind": _handle_bad_kind,
-    "bad_stream_kind": _handle_bad_stream_kind,
-    "bad_ping_kind": _handle_bad_ping_kind,
 }
 
 
 def _echo_worker_main(
     data_conn: Any, health_conn: Any, abort_flag: Any, _role_config: RoleConfig
 ) -> None:
-    """Worker that dispatches data-pipe kinds via _ECHO_DISPATCH and pings on health."""
+    """Worker that dispatches data-pipe kinds via _ECHO_DISPATCH; pings + shutdown on health."""
 
-    def _on_data(conn: Any, call_id: int, kind: str, payload: Any, abort: Any) -> None:
+    def _on_data(conn: Any, kind: str, payload: Any, abort: Any) -> None:
         handler = _ECHO_DISPATCH.get(kind)
         if handler is not None:
-            handler(conn, call_id, payload, abort)
+            handler(conn, payload, abort)
 
     _drive_test_worker(data_conn, health_conn, abort_flag, _on_data)
 
@@ -166,7 +154,7 @@ def _echo_worker_main(
 def _crash_worker_main(
     data_conn: Any, _health_conn: Any, _abort_flag: Any, _role_config: RoleConfig
 ) -> None:
-    """Worker that exits abruptly on the first request, simulating a crash."""
+    """Worker that exits abruptly on the first data frame, simulating a crash."""
     if data_conn.poll(timeout=_POLL_TIMEOUT_S * 50):
         with contextlib.suppress(EOFError):
             data_conn.recv()
@@ -176,7 +164,7 @@ def _crash_worker_main(
 def _hang_worker_main(
     data_conn: Any, _health_conn: Any, _abort_flag: Any, _role_config: RoleConfig
 ) -> None:
-    """Worker that polls the data pipe forever; never replies. Used for timeout paths."""
+    """Worker that polls the data pipe forever; never replies. Used for shutdown-on-hang paths."""
     while True:
         if data_conn.poll(timeout=_POLL_TIMEOUT_S):
             with contextlib.suppress(EOFError):
@@ -191,10 +179,14 @@ def _ping_replies_garbage_main(
         if not health_conn.poll(timeout=_POLL_TIMEOUT_S):
             continue
         try:
-            call_id, _kind, _ = health_conn.recv()
+            kind, _ = health_conn.recv()
         except EOFError:
             return
-        health_conn.send((call_id, "not_a_known_reply", None))
+        if kind == "shutdown":
+            with contextlib.suppress(BrokenPipeError, OSError):
+                health_conn.send(("ack", None))
+            return
+        health_conn.send(("not_a_known_reply", None))
 
 
 def _stream_replies_garbage_main(
@@ -202,10 +194,23 @@ def _stream_replies_garbage_main(
 ) -> None:
     """Worker that replies to a streaming kind with a non-stream message."""
 
-    def _on_data(conn: Any, call_id: int, _kind: str, _payload: Any, _abort: Any) -> None:
-        conn.send((call_id, "totally_bogus_kind", None))
+    def _on_data(conn: Any, _kind: str, _payload: Any, _abort: Any) -> None:
+        conn.send(("totally_bogus_kind", None))
 
     _drive_test_worker(data_conn, health_conn, abort_flag, _on_data)
+
+
+def _crashing_health_pipe_main(
+    data_conn: Any, health_conn: Any, _abort_flag: Any, _role_config: RoleConfig
+) -> None:
+    """Worker that closes the health pipe immediately, leaves data alive."""
+    health_conn.close()
+    while True:
+        if data_conn.poll(timeout=_POLL_TIMEOUT_S):
+            try:
+                _kind, _payload = data_conn.recv()
+            except EOFError:
+                return
 
 
 # =====================================================================
@@ -302,6 +307,38 @@ async def test_stream_raises_on_worker_error_terminator(
 
 
 # =====================================================================
+# Channel-level serialization: only one call in flight at a time.
+# =====================================================================
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_serialize_on_channel_lock(
+    echo_channel: PipeChannel,
+) -> None:
+    """Concurrent ``call()`` coroutines must complete one at a time and each
+    one must observe the exact payload it sent. With the old multiplexed
+    design, a reply could land on the wrong waiter; with channel-level
+    serialization this is impossible by construction."""
+
+    async def _one(value: int) -> int:
+        return await echo_channel.call("echo", value, timeout=_TEST_CALL_TIMEOUT_S)
+
+    results = await asyncio.gather(*(_one(i) for i in range(20)))
+    assert results == list(range(20))
+
+
+@pytest.mark.asyncio
+async def test_call_after_stream_sees_fresh_reply(
+    echo_channel: PipeChannel,
+) -> None:
+    """A non-empty stream followed by a call must not get a leftover stream chunk."""
+    chunks = [chunk async for chunk in echo_channel.stream("stream", (3, "x"))]
+    assert chunks == ["x0", "x1", "x2"]
+    result = await echo_channel.call("echo", "after-stream", timeout=_TEST_CALL_TIMEOUT_S)
+    assert result == "after-stream"
+
+
+# =====================================================================
 # Cancellation: parent flips the abort flag, worker observes it.
 # =====================================================================
 
@@ -319,8 +356,7 @@ async def test_cancel_sets_abort_flag_and_worker_observes_it(
     await cancel_task
     assert result == "aborted"
     echo_channel.clear_abort()
-    # After clear_abort, the worker should run to its 5s timeout instead.
-    # Re-running the abort loop and not flipping anything proves the reset.
+    # After clear_abort, subsequent calls must work normally.
     result_after = await asyncio.wait_for(
         echo_channel.call("echo", "post-abort", timeout=_TEST_CALL_TIMEOUT_S),
         timeout=_TEST_CALL_TIMEOUT_S,
@@ -515,9 +551,8 @@ async def test_concurrent_ping_and_stream_do_not_interfere(
 
     Spawn a long-running stream, fire several pings while it's emitting,
     confirm the stream still produces every chunk in order and every ping
-    completes without raising. This is the architectural fix for bb-ubnm:
-    pings and streams travel on separate pipes by construction, so no
-    orphan-pong defenses are needed in PipeChannel.
+    completes without raising. Pings and streams travel on separate pipes
+    by construction, so they cannot interfere.
     """
     chunks: list[str] = []
     ping_count = 0
@@ -549,7 +584,6 @@ async def test_ping_raises_on_non_pong_reply(
         with pytest.raises(WorkerError) as excinfo:
             await channel.ping(timeout=_TEST_PING_TIMEOUT_S)
         assert excinfo.value.original_type == "ProtocolError"
-        assert "not_a_known_reply" in str(excinfo.value)
     finally:
         await channel.close(timeout=_TEST_SHUTDOWN_TIMEOUT_S)
 
@@ -560,24 +594,8 @@ def test_check_pickle_size_wraps_pickle_failure() -> None:
 
     # Lambda is famously unpicklable; pickle.dumps raises immediately.
     with pytest.raises(WorkerError) as excinfo:
-        _check_pickle_size(lambda: None, "echo", call_id=1)
+        _check_pickle_size(lambda: None, "echo")
     assert excinfo.value.original_type == "PickleError"
-
-
-def _crashing_health_pipe_main(
-    data_conn: Any, health_conn: Any, _abort_flag: Any, _role_config: RoleConfig
-) -> None:
-    """Worker that closes the health pipe immediately, leaves data alive."""
-    health_conn.close()
-    while True:
-        if data_conn.poll(timeout=_POLL_TIMEOUT_S):
-            try:
-                call_id, kind, _ = data_conn.recv()
-            except EOFError:
-                return
-            if kind == "shutdown":
-                data_conn.send((call_id, "ack", None))
-                return
 
 
 @pytest.mark.asyncio
@@ -643,20 +661,6 @@ async def test_ping_raises_worker_crash_when_health_send_fails() -> None:
             child_health.close()
 
 
-def test_reader_main_short_circuits_when_async_setup_incomplete() -> None:
-    """``_reader_main`` returns immediately when ``_reader_loop`` /
-    ``_frame_queue`` haven't been wired up yet. Without this guard a thread
-    would spin on a recv() against the data pipe with no consumer."""
-
-    class _DummyChannel:
-        _reader_loop: Any = None
-        _frame_queue: Any = None
-        _conn: Any = None  # never read because we early-return
-
-    # Bind the real method to the dummy via descriptor protocol.
-    PipeChannel._reader_main(_DummyChannel())  # must return cleanly
-
-
 def test_worker_log_path_returns_none_when_env_unset(monkeypatch) -> None:
     """Without LILBEE_DATA the log path resolver returns None."""
     from lilbee.providers.worker.transport_pipe import _worker_log_path
@@ -675,16 +679,12 @@ def test_worker_log_path_joins_data_dir_when_env_set(monkeypatch, tmp_path) -> N
 
 def test_format_exit_reason_for_normal_exit_code() -> None:
     """Non-zero code surfaces as 'exited with code N'."""
-    from lilbee.providers.worker.transport_pipe import PipeChannel
-
     assert PipeChannel._format_exit_reason(2) == "exited with code 2"
 
 
 def test_format_exit_reason_for_known_signal() -> None:
     """Negative exit code maps to the signal name."""
     import signal as _signal
-
-    from lilbee.providers.worker.transport_pipe import PipeChannel
 
     msg = PipeChannel._format_exit_reason(-_signal.SIGTERM)
     assert "SIGTERM" in msg
@@ -693,8 +693,6 @@ def test_format_exit_reason_for_known_signal() -> None:
 
 def test_format_exit_reason_for_unknown_signal() -> None:
     """Unrecognised signum (no Signals enum entry) falls back to SIG<num>."""
-    from lilbee.providers.worker.transport_pipe import PipeChannel
-
     msg = PipeChannel._format_exit_reason(-9999)
     assert "SIG9999" in msg
 
@@ -775,193 +773,3 @@ def test_record_exit_reason_skips_when_log_path_unset(monkeypatch, caplog) -> No
         with contextlib.suppress(Exception):
             child_health.close()
     assert any("exited with code 7" in rec.message for rec in caplog.records)
-
-
-@pytest.mark.asyncio
-async def test_recv_for_drains_stale_call_id_frames(caplog) -> None:
-    """Frames with mismatched call_id are silently discarded; the right one wins."""
-    import multiprocessing as _mp
-
-    ctx = _mp.get_context("spawn")
-    parent_data, child_data = ctx.Pipe(duplex=True)
-    parent_health, child_health = ctx.Pipe(duplex=True)
-    abort_flag = ctx.Value("b", 0, lock=True)
-
-    class _FakeProcess:
-        def is_alive(self) -> bool:
-            return True
-
-        @property
-        def pid(self) -> int:
-            return -1
-
-    channel = PipeChannel(
-        role="echo",
-        process=_FakeProcess(),  # type: ignore[arg-type]
-        parent_conn=parent_data,
-        health_conn=parent_health,
-        abort_flag=abort_flag,
-    )
-    # Stuff three frames into the parent end via the child side: stale,
-    # stale, then matching call_id=42.
-    child_data.send((1, "result", "stale-1"))
-    child_data.send((2, "result", "stale-2"))
-    child_data.send((42, "result", "winner"))
-    try:
-        with caplog.at_level("DEBUG", logger="lilbee.providers.worker.transport_pipe"):
-            kind, value = await channel._recv_for(42)
-        assert kind == "result"
-        assert value == "winner"
-        assert any("discarding stale frame" in rec.message for rec in caplog.records)
-    finally:
-        channel._executor.shutdown(wait=False, cancel_futures=True)
-        with contextlib.suppress(Exception):
-            parent_data.close()
-        with contextlib.suppress(Exception):
-            parent_health.close()
-        with contextlib.suppress(Exception):
-            child_data.close()
-        with contextlib.suppress(Exception):
-            child_health.close()
-
-
-@pytest.mark.asyncio
-async def test_reader_thread_starts_lazily_on_first_recv() -> None:
-    """No reader thread spins up until a coroutine awaits a frame."""
-    import multiprocessing as _mp
-
-    ctx = _mp.get_context("spawn")
-    parent_data, child_data = ctx.Pipe(duplex=True)
-    parent_health, child_health = ctx.Pipe(duplex=True)
-    abort_flag = ctx.Value("b", 0, lock=True)
-
-    class _FakeProcess:
-        def is_alive(self) -> bool:
-            return True
-
-        @property
-        def pid(self) -> int:
-            return -1
-
-    channel = PipeChannel(
-        role="echo",
-        process=_FakeProcess(),  # type: ignore[arg-type]
-        parent_conn=parent_data,
-        health_conn=parent_health,
-        abort_flag=abort_flag,
-    )
-    try:
-        assert channel._reader_thread is None
-        assert not channel._reader_started.is_set()
-        child_data.send((1, "result", "go"))
-        _, _, value = await channel._recv()
-        assert value == "go"
-        assert channel._reader_started.is_set()
-        assert channel._reader_thread is not None
-        assert channel._reader_thread.is_alive()
-    finally:
-        channel._executor.shutdown(wait=False, cancel_futures=True)
-        for handle in (parent_data, parent_health, child_data, child_health):
-            with contextlib.suppress(Exception):
-                handle.close()
-
-
-@pytest.mark.asyncio
-async def test_reader_thread_surfaces_eof_as_worker_crash() -> None:
-    """Closing the parent conn drains EOF into a WorkerCrashError on next recv."""
-    import multiprocessing as _mp
-
-    ctx = _mp.get_context("spawn")
-    parent_data, child_data = ctx.Pipe(duplex=True)
-    parent_health, child_health = ctx.Pipe(duplex=True)
-    abort_flag = ctx.Value("b", 0, lock=True)
-
-    class _FakeProcess:
-        def is_alive(self) -> bool:
-            return True
-
-        @property
-        def pid(self) -> int:
-            return -1
-
-    channel = PipeChannel(
-        role="echo",
-        process=_FakeProcess(),  # type: ignore[arg-type]
-        parent_conn=parent_data,
-        health_conn=parent_health,
-        abort_flag=abort_flag,
-    )
-    try:
-        child_data.send((1, "result", "primer"))
-        await channel._recv()
-        # Close both ends so the reader's blocking recv() raises EOFError;
-        # the next _recv() should then surface the crash to the caller.
-        with contextlib.suppress(Exception):
-            child_data.close()
-        with contextlib.suppress(Exception):
-            parent_data.close()
-        with pytest.raises(WorkerCrashError):
-            await asyncio.wait_for(channel._recv(), timeout=2.0)
-    finally:
-        channel._executor.shutdown(wait=False, cancel_futures=True)
-        for handle in (parent_health, child_health):
-            with contextlib.suppress(Exception):
-                handle.close()
-
-
-@pytest.mark.asyncio
-async def test_stream_preserves_frame_ordering_under_burst() -> None:
-    """A burst of stream_chunks is delivered to stream() in send order."""
-    import multiprocessing as _mp
-
-    from lilbee.providers.worker.wire_kinds import WireKind
-
-    ctx = _mp.get_context("spawn")
-    parent_data, child_data = ctx.Pipe(duplex=True)
-    parent_health, child_health = ctx.Pipe(duplex=True)
-    abort_flag = ctx.Value("b", 0, lock=True)
-
-    class _FakeProcess:
-        def is_alive(self) -> bool:
-            return True
-
-        @property
-        def pid(self) -> int:
-            return -1
-
-    channel = PipeChannel(
-        role="echo",
-        process=_FakeProcess(),  # type: ignore[arg-type]
-        parent_conn=parent_data,
-        health_conn=parent_health,
-        abort_flag=abort_flag,
-    )
-    burst_count = 250
-    try:
-        # Start the reader first so the OS pipe buffer drains as we send;
-        # otherwise child_data.send() blocks once the buffer fills.
-        channel._ensure_reader()
-
-        def _produce() -> None:
-            for i in range(burst_count):
-                child_data.send((7, WireKind.STREAM_CHUNK, f"chunk-{i}"))
-            child_data.send((7, WireKind.STREAM_END, None))
-
-        producer = threading.Thread(target=_produce, daemon=True)
-        producer.start()
-
-        received: list[str] = []
-        seen_end = False
-        while not seen_end:
-            kind, value = await asyncio.wait_for(channel._recv_for(7), timeout=5.0)
-            if kind == WireKind.STREAM_END:
-                seen_end = True
-            else:
-                received.append(value)
-        producer.join(timeout=1.0)
-        assert received == [f"chunk-{i}" for i in range(burst_count)]
-    finally:
-        channel._executor.shutdown(wait=False, cancel_futures=True)
-        for handle in (parent_data, parent_health, child_data, child_health):
-            with contextlib.suppress(Exception):
-                handle.close()


### PR DESCRIPTION
## Problem

Indexing a large directory would intermittently fail. A wave of files all errored with "Embedding worker timed out. Please try again." about five minutes into the sync, and the corpus would never finish indexing.

The root cause was on the parent side. When several embed calls ran at the same time, replies coming back from the worker could land in a different order than the order callers were waiting in. The pipe layer silently discarded any reply whose id did not match the waiting call, and the call whose reply got dropped hung until its 300 second timeout fired.

## Solution

Hold one lock per channel for the duration of each call. Only one call can be in flight at a time, so a reply landing on the pipe can only belong to the call currently waiting for it. No routing ids, no shared queue, no chance of a misrouted reply.

Verified end to end by indexing 810 Godot doc files: every file indexed, zero timeouts.

Closes #240