### PR TITLE
Surface worker crashes and clamp bad embedding metadata

### DIFF
--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -60,12 +60,10 @@ seed_option = typer.Option(None, "--seed", help="Random seed for reproducibility
 
 
 def _apply_data_root(root: Path) -> None:
-    """Point cfg paths at *root* and overlay its config.toml onto cfg.
+    """Point cfg paths at *root*, export ``LILBEE_DATA``, overlay config.toml.
 
-    Exports ``LILBEE_DATA`` to the process env as well, so spawned worker
-    subprocesses (which re-import lilbee with a fresh cfg) see the same
-    data root and route their log files into ``<root>/logs/worker-*.log``
-    instead of dropping them on the floor.
+    Exporting the env var keeps spawn-context worker subprocesses on the
+    same data root after their fresh ``import lilbee``.
     """
     cfg.data_root = root
     cfg.documents_dir = root / "documents"

--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -60,11 +60,18 @@ seed_option = typer.Option(None, "--seed", help="Random seed for reproducibility
 
 
 def _apply_data_root(root: Path) -> None:
-    """Point cfg paths at *root* and overlay its config.toml onto cfg."""
+    """Point cfg paths at *root* and overlay its config.toml onto cfg.
+
+    Exports ``LILBEE_DATA`` to the process env as well, so spawned worker
+    subprocesses (which re-import lilbee with a fresh cfg) see the same
+    data root and route their log files into ``<root>/logs/worker-*.log``
+    instead of dropping them on the floor.
+    """
     cfg.data_root = root
     cfg.documents_dir = root / "documents"
     cfg.data_dir = root / "data"
     cfg.lancedb_dir = root / "data" / "lancedb"
+    os.environ["LILBEE_DATA"] = str(root)
     overlay_persisted_settings(root)
 
 

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -897,3 +897,10 @@ def _build_cfg() -> tuple[Config, Exception | None]:
 
 
 cfg, config_load_error = _build_cfg()
+
+# Canonicalize LILBEE_DATA so worker subprocesses (multiprocessing.spawn
+# re-imports lilbee in a fresh process) inherit the same data root the
+# parent's cfg just resolved. ``setdefault`` preserves a user-set value
+# while filling in the no-flag path where the validator landed on
+# ``find_local_root()`` or ``default_data_dir()``.
+os.environ.setdefault("LILBEE_DATA", str(cfg.data_root))

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -898,9 +898,7 @@ def _build_cfg() -> tuple[Config, Exception | None]:
 
 cfg, config_load_error = _build_cfg()
 
-# Canonicalize LILBEE_DATA so worker subprocesses (multiprocessing.spawn
-# re-imports lilbee in a fresh process) inherit the same data root the
-# parent's cfg just resolved. ``setdefault`` preserves a user-set value
-# while filling in the no-flag path where the validator landed on
-# ``find_local_root()`` or ``default_data_dir()``.
+# Canonicalize LILBEE_DATA at the cfg.data_root resolution boundary so
+# spawn-context worker subprocesses inherit the same data root.
+# ``setdefault`` preserves a user-set value.
 os.environ.setdefault("LILBEE_DATA", str(cfg.data_root))

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -269,10 +269,14 @@ def init(path: str = "") -> dict[str, Any]:
     # Switch MCP session to this project's KB. Overlay any persisted
     # config.toml in the project base so per-vault model / generation
     # settings take effect, matching the CLI's --data-dir behaviour.
+    # Exporting LILBEE_DATA keeps parity with cli/app.py::_apply_data_root
+    # so spawned worker subprocesses route their logs to the right
+    # location regardless of which entry point switched the data root.
     cfg.data_root = base
     cfg.documents_dir = root / "documents"
     cfg.data_dir = root / "data"
     cfg.lancedb_dir = root / "data" / "lancedb"
+    os.environ["LILBEE_DATA"] = str(base)
     overlay_persisted_settings(base)
     reset_services()
 

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -267,11 +267,9 @@ def init(path: str = "") -> dict[str, Any]:
         created = True
 
     # Switch MCP session to this project's KB. Overlay any persisted
-    # config.toml in the project base so per-vault model / generation
-    # settings take effect, matching the CLI's --data-dir behaviour.
-    # Exporting LILBEE_DATA keeps parity with cli/app.py::_apply_data_root
-    # so spawned worker subprocesses route their logs to the right
-    # location regardless of which entry point switched the data root.
+    # config.toml so per-vault model / generation settings take effect,
+    # matching the CLI's --data-dir behaviour. Env export mirrors
+    # cli/app.py::_apply_data_root for worker-log parity.
     cfg.data_root = base
     cfg.documents_dir = root / "documents"
     cfg.data_dir = root / "data"

--- a/src/lilbee/providers/llama_cpp/gguf_meta.py
+++ b/src/lilbee/providers/llama_cpp/gguf_meta.py
@@ -23,6 +23,56 @@ _HF_SNAPSHOTS_DIR_NAME = "snapshots"
 _CLIP_PROJECTOR_TYPE_KEY = "clip.projector_type"
 
 
+def train_ctx_from_meta(
+    meta: dict[str, str] | None,
+    *,
+    fallback: int,
+    model_path: Path,
+) -> int:
+    """Resolve ``<arch>.context_length`` from GGUF metadata, with a safe floor.
+
+    Several published GGUFs (nomic-embed, some Qwen3 variants, certain
+    vision models) report ``context_length=0`` in their headers. Passing
+    zero into ``Llama(n_ctx=...)`` for an embedding or vision loader
+    cascades into ``n_batch=0`` / ``n_ubatch=0`` and trips ggml's Vulkan
+    dispatch into undefined behaviour, surfacing as STATUS_HEAP_CORRUPTION
+    on Windows. Unparseable values (any non-integer string) raised
+    ``ValueError`` in three independent call sites before this helper
+    consolidated them.
+
+    Args:
+        meta: GGUF metadata dict from :func:`read_gguf_metadata`, or
+            ``None`` when the read itself failed.
+        fallback: Value to return when metadata is missing, unparseable,
+            or non-positive. Each loader picks the value appropriate for
+            its task (chat / embed / vision).
+        model_path: Used purely for the warning message so the user knows
+            which model produced the junk metadata.
+    """
+    if not meta:
+        return fallback
+    raw = meta.get("context_length", str(fallback))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        log.warning(
+            "GGUF %s has unparseable context_length=%r; using %d",
+            model_path.name,
+            raw,
+            fallback,
+        )
+        return fallback
+    if value <= 0:
+        log.warning(
+            "GGUF %s reports context_length=%d; using %d to avoid n_batch=0 crash",
+            model_path.name,
+            value,
+            fallback,
+        )
+        return fallback
+    return value
+
+
 def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
     """Read metadata from a GGUF file's headers via llama-cpp-python.
 

--- a/src/lilbee/providers/llama_cpp/gguf_meta.py
+++ b/src/lilbee/providers/llama_cpp/gguf_meta.py
@@ -29,25 +29,14 @@ def train_ctx_from_meta(
     fallback: int,
     model_path: Path,
 ) -> int:
-    """Resolve ``<arch>.context_length`` from GGUF metadata, with a safe floor.
+    """Resolve ``<arch>.context_length`` from GGUF metadata, clamping junk to ``fallback``.
 
-    Several published GGUFs (nomic-embed, some Qwen3 variants, certain
-    vision models) report ``context_length=0`` in their headers. Passing
-    zero into ``Llama(n_ctx=...)`` for an embedding or vision loader
-    cascades into ``n_batch=0`` / ``n_ubatch=0`` and trips ggml's Vulkan
-    dispatch into undefined behaviour, surfacing as STATUS_HEAP_CORRUPTION
-    on Windows. Unparseable values (any non-integer string) raised
-    ``ValueError`` in three independent call sites before this helper
-    consolidated them.
-
-    Args:
-        meta: GGUF metadata dict from :func:`read_gguf_metadata`, or
-            ``None`` when the read itself failed.
-        fallback: Value to return when metadata is missing, unparseable,
-            or non-positive. Each loader picks the value appropriate for
-            its task (chat / embed / vision).
-        model_path: Used purely for the warning message so the user knows
-            which model produced the junk metadata.
+    Some published GGUFs (nomic-embed, certain Qwen3 and vision builds)
+    report ``context_length=0`` in their headers. Passing zero into
+    ``Llama(n_ctx=...)`` cascades into ``n_batch=0`` / ``n_ubatch=0``,
+    which trips ggml's Vulkan dispatch into undefined behaviour and
+    surfaces as STATUS_HEAP_CORRUPTION on Windows. Unparseable values
+    and non-positive integers both route to ``fallback``.
     """
     if not meta:
         return fallback

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -19,6 +19,7 @@ from lilbee.providers.llama_cpp.abort_signal import abort_callback, clear_abort
 from lilbee.providers.llama_cpp.gguf_meta import (
     find_mmproj_for_model,
     read_gguf_metadata,
+    train_ctx_from_meta,
 )
 from lilbee.providers.llama_cpp.log_dispatch import (
     import_llama_cpp,
@@ -755,7 +756,9 @@ def load_llama(
         # default") keeps the OOM-retry path working: ``_halve_ctx_for_retry``
         # cannot bisect from 0.
         embed_meta = _safe_read_gguf_metadata(model_path)
-        embed_train_ctx = _safe_embed_ctx(embed_meta, model_path)
+        embed_train_ctx = train_ctx_from_meta(
+            embed_meta, fallback=_EMBED_FALLBACK_CTX, model_path=model_path
+        )
         kwargs["n_ctx"] = embed_train_ctx
     elif cfg.num_ctx is not None:
         kwargs["n_ctx"] = cfg.num_ctx
@@ -808,46 +811,14 @@ def _safe_read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
 # Fallback used when an embedding GGUF reports zero, negative, or
 # unparseable ``context_length`` in its metadata header. Some published
 # nomic-embed and Qwen3 GGUFs in the wild report ``0`` (the b473 QA dump
-# logged ``n_ctx_seq (512) > n_ctx_train (0)``). With ``n_ctx=0`` the
-# embed loader sets ``n_batch=0`` / ``n_ubatch=0``, which trips ggml's
-# Vulkan dispatch into undefined behaviour and surfaces as
-# STATUS_HEAP_CORRUPTION on Windows. 2048 matches the bare-metal default
-# every supported embedding model trains against.
+# logged ``n_ctx_seq (512) > n_ctx_train (0)``). 2048 matches the
+# bare-metal default every supported embedding model trains against.
 _EMBED_FALLBACK_CTX = 2048
-
-
-def _safe_embed_ctx(meta: dict[str, str] | None, model_path: Path) -> int:
-    """Resolve an embed-loader ``n_ctx``, clamping junk metadata to a safe floor."""
-    raw = (meta or {}).get("context_length", str(_EMBED_FALLBACK_CTX))
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        log.warning(
-            "Embed GGUF %s has unparseable context_length=%r; using %d",
-            model_path.name,
-            raw,
-            _EMBED_FALLBACK_CTX,
-        )
-        return _EMBED_FALLBACK_CTX
-    if value <= 0:
-        log.warning(
-            "Embed GGUF %s reports context_length=%d; using %d to avoid n_batch=0 crash",
-            model_path.name,
-            value,
-            _EMBED_FALLBACK_CTX,
-        )
-        return _EMBED_FALLBACK_CTX
-    return value
 
 
 def _resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
     """Pick the largest 256-multiple n_ctx that fits in available memory."""
-    training_ctx = DEFAULT_NUM_CTX
-    if meta:
-        try:
-            training_ctx = int(meta.get("context_length", DEFAULT_NUM_CTX))
-        except (TypeError, ValueError):
-            training_ctx = DEFAULT_NUM_CTX
+    training_ctx = train_ctx_from_meta(meta, fallback=DEFAULT_NUM_CTX, model_path=model_path)
     ceiling = cfg.num_ctx_max
 
     try:

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -755,7 +755,7 @@ def load_llama(
         # default") keeps the OOM-retry path working: ``_halve_ctx_for_retry``
         # cannot bisect from 0.
         embed_meta = _safe_read_gguf_metadata(model_path)
-        embed_train_ctx = int((embed_meta or {}).get("context_length", "2048"))
+        embed_train_ctx = _safe_embed_ctx(embed_meta, model_path)
         kwargs["n_ctx"] = embed_train_ctx
     elif cfg.num_ctx is not None:
         kwargs["n_ctx"] = cfg.num_ctx
@@ -803,6 +803,41 @@ def _safe_read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
     except Exception:
         log.debug("read_gguf_metadata failed for %s", model_path, exc_info=True)
         return None
+
+
+# Fallback used when an embedding GGUF reports zero, negative, or
+# unparseable ``context_length`` in its metadata header. Some published
+# nomic-embed and Qwen3 GGUFs in the wild report ``0`` (the b473 QA dump
+# logged ``n_ctx_seq (512) > n_ctx_train (0)``). With ``n_ctx=0`` the
+# embed loader sets ``n_batch=0`` / ``n_ubatch=0``, which trips ggml's
+# Vulkan dispatch into undefined behaviour and surfaces as
+# STATUS_HEAP_CORRUPTION on Windows. 2048 matches the bare-metal default
+# every supported embedding model trains against.
+_EMBED_FALLBACK_CTX = 2048
+
+
+def _safe_embed_ctx(meta: dict[str, str] | None, model_path: Path) -> int:
+    """Resolve an embed-loader ``n_ctx``, clamping junk metadata to a safe floor."""
+    raw = (meta or {}).get("context_length", str(_EMBED_FALLBACK_CTX))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        log.warning(
+            "Embed GGUF %s has unparseable context_length=%r; using %d",
+            model_path.name,
+            raw,
+            _EMBED_FALLBACK_CTX,
+        )
+        return _EMBED_FALLBACK_CTX
+    if value <= 0:
+        log.warning(
+            "Embed GGUF %s reports context_length=%d; using %d to avoid n_batch=0 crash",
+            model_path.name,
+            value,
+            _EMBED_FALLBACK_CTX,
+        )
+        return _EMBED_FALLBACK_CTX
+    return value
 
 
 def _resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -811,8 +811,12 @@ def _safe_read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
 # Fallback used when an embedding GGUF reports zero, negative, or
 # unparseable ``context_length`` in its metadata header. Some published
 # nomic-embed and Qwen3 GGUFs in the wild report ``0`` (the b473 QA dump
-# logged ``n_ctx_seq (512) > n_ctx_train (0)``). 2048 matches the
-# bare-metal default every supported embedding model trains against.
+# logged ``n_ctx_seq (512) > n_ctx_train (0)``). 2048 is the documented
+# training-context for the smallest featured embedder that uses it
+# (Google's EmbeddingGemma-300m, see
+# https://huggingface.co/google/embeddinggemma-300m), and llama.cpp
+# tolerates n_ctx > n_ctx_train with a warning, so the larger nomic
+# embedder still loads cleanly under the same fallback.
 _EMBED_FALLBACK_CTX = 2048
 
 

--- a/src/lilbee/providers/model_defaults.py
+++ b/src/lilbee/providers/model_defaults.py
@@ -120,7 +120,9 @@ def read_gguf_defaults(metadata: dict[str, str]) -> ModelDefaults:
                 log.debug("Skipping unparseable GGUF key %s=%r", gguf_key, metadata[gguf_key])
     if "context_length" in metadata:
         with contextlib.suppress(ValueError, TypeError):
-            values["num_ctx"] = int(metadata["context_length"])
+            ctx = int(metadata["context_length"])
+            if ctx > 0:
+                values["num_ctx"] = ctx
     return ModelDefaults(**values)
 
 

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -12,7 +12,11 @@ from gguf import GGUFReader
 
 from lilbee.core.config import cfg
 from lilbee.providers.llama_cpp.abort_signal import abort_callback
-from lilbee.providers.llama_cpp.gguf_meta import find_mmproj_for_model, read_gguf_metadata
+from lilbee.providers.llama_cpp.gguf_meta import (
+    find_mmproj_for_model,
+    read_gguf_metadata,
+    train_ctx_from_meta,
+)
 from lilbee.providers.llama_cpp.log_dispatch import (
     import_llama_cpp,
     install_llama_log_handler,
@@ -179,5 +183,4 @@ def _resolve_vision_n_ctx(model_path: Path) -> int:
     except Exception:
         log.debug("read_gguf_metadata failed for vision %s", model_path, exc_info=True)
         meta = None
-    train_ctx = int((meta or {}).get("context_length", "0"))
-    return train_ctx if train_ctx > 0 else _VISION_FALLBACK_N_CTX
+    return train_ctx_from_meta(meta, fallback=_VISION_FALLBACK_N_CTX, model_path=model_path)

--- a/src/lilbee/providers/worker/transport_pipe.py
+++ b/src/lilbee/providers/worker/transport_pipe.py
@@ -90,16 +90,15 @@ file into a single error message.
 """
 
 
-def _read_log_tail(log_path: str | None) -> str:
+def _read_log_tail(log_path: str) -> str:
     """Return the last ``_LOG_TAIL_BYTES`` of *log_path*, or ``""`` on any error.
 
     Best-effort: a missing or unreadable log file must not turn a worker
     crash into a different unrelated exception. Decoded as utf-8 with
     ``errors="replace"`` so the Tesseract diacritic bytes that leak into
-    fd 2 on Windows do not crash the error path itself.
+    fd 2 on Windows do not crash the error path itself. The caller has
+    already verified ``log_path`` is non-empty.
     """
-    if not log_path:
-        return ""
     try:
         import os as _os
 
@@ -143,22 +142,23 @@ def _check_pickle_size(payload: Any, kind: WireKind) -> None:
 
 
 def _worker_log_path(role: WorkerRole) -> str | None:
-    """Return the worker's log file path. Falls back to ``cfg.data_root``.
+    """Return the worker's log file path, or ``None`` if no data root is set.
 
     Mirrors :func:`lilbee.providers.worker.worker_runtime.configure_worker_logging`
-    so the parent's :class:`WorkerCrashError` can point at the same file
-    the worker wrote, even when ``LILBEE_DATA`` was never set in env.
+    so the parent's :class:`WorkerCrashError` points at the file the worker
+    wrote. ``LILBEE_DATA`` is canonicalized at cfg construction, so this
+    only returns ``None`` in tests that explicitly clear the env.
     """
     import os
 
+    # circular: worker_runtime imports transport_pipe._serialize_exception at
+    # module top, so the constant import lives inline at the one call site.
+    from lilbee.providers.worker.worker_runtime import WORKER_LOGS_DIR_NAME
+
     data_dir = os.environ.get("LILBEE_DATA")
     if not data_dir:
-        from lilbee.core.config import cfg
-
-        if not cfg.data_root:
-            return None
-        data_dir = str(cfg.data_root)
-    return os.path.join(data_dir, "logs", f"worker-{role}.log")
+        return None
+    return os.path.join(data_dir, WORKER_LOGS_DIR_NAME, f"worker-{role}.log")
 
 
 class PipeChannel:

--- a/src/lilbee/providers/worker/transport_pipe.py
+++ b/src/lilbee/providers/worker/transport_pipe.py
@@ -143,7 +143,7 @@ def _check_pickle_size(payload: Any, kind: WireKind) -> None:
 
 
 def _worker_log_path(role: WorkerRole) -> str | None:
-    """Return the worker's log file path. Falls back to cfg.data_root.
+    """Return the worker's log file path. Falls back to ``cfg.data_root``.
 
     Mirrors :func:`lilbee.providers.worker.worker_runtime.configure_worker_logging`
     so the parent's :class:`WorkerCrashError` can point at the same file
@@ -153,14 +153,11 @@ def _worker_log_path(role: WorkerRole) -> str | None:
 
     data_dir = os.environ.get("LILBEE_DATA")
     if not data_dir:
-        try:
-            from lilbee.core.config import cfg
-        except ImportError:  # pragma: no cover - defensive
+        from lilbee.core.config import cfg
+
+        if not cfg.data_root:
             return None
-        root = getattr(cfg, "data_root", None)
-        if not root:
-            return None
-        data_dir = str(root)
+        data_dir = str(cfg.data_root)
     return os.path.join(data_dir, "logs", f"worker-{role}.log")
 
 

--- a/src/lilbee/providers/worker/transport_pipe.py
+++ b/src/lilbee/providers/worker/transport_pipe.py
@@ -58,18 +58,59 @@ class WorkerCrashError(WorkerError):
 
     Carries an optional ``log_path`` so the surfaced message can point the
     user at the worker log file that contains the underlying traceback or
-    signal info.
+    signal info, plus a tail of that log inlined into the message so the
+    user does not have to hunt for the file (the Windows heap-corruption
+    path produces no Python-level exception to serialize, so the only
+    diagnostic trail lives in the worker's log file).
     """
 
     def __init__(self, role: WorkerRole, *, log_path: str | None = None) -> None:
-        suffix = f" See {log_path} for details." if log_path else ""
+        tail = _read_log_tail(log_path) if log_path else ""
+        suffix_parts: list[str] = []
+        if log_path:
+            suffix_parts.append(f" See {log_path} for details.")
+        if tail:
+            suffix_parts.append(f"\nLast log lines:\n{tail}")
         super().__init__(
             "WorkerCrashError",
-            f"Worker '{role}' subprocess exited unexpectedly.{suffix}",
+            f"Worker '{role}' subprocess exited unexpectedly.{''.join(suffix_parts)}",
             "",
         )
         self.role = role
         self.log_path = log_path
+        self.log_tail = tail
+
+
+_LOG_TAIL_BYTES = 4096
+"""Read at most this many bytes from the end of a worker log on crash.
+
+A llama.cpp init that aborts emits a few dozen lines tops; 4 KiB leaves
+enough room for a stack-like trace without pulling a multi-megabyte log
+file into a single error message.
+"""
+
+
+def _read_log_tail(log_path: str | None) -> str:
+    """Return the last ``_LOG_TAIL_BYTES`` of *log_path*, or ``""`` on any error.
+
+    Best-effort: a missing or unreadable log file must not turn a worker
+    crash into a different unrelated exception. Decoded as utf-8 with
+    ``errors="replace"`` so the Tesseract diacritic bytes that leak into
+    fd 2 on Windows do not crash the error path itself.
+    """
+    if not log_path:
+        return ""
+    try:
+        import os as _os
+
+        size = _os.path.getsize(log_path)
+        offset = max(0, size - _LOG_TAIL_BYTES)
+        with open(log_path, "rb") as handle:
+            handle.seek(offset)
+            data = handle.read()
+    except OSError:
+        return ""
+    return data.decode("utf-8", errors="replace")
 
 
 def _serialize_exception(exc: BaseException) -> _SerializedException:
@@ -102,12 +143,24 @@ def _check_pickle_size(payload: Any, kind: WireKind) -> None:
 
 
 def _worker_log_path(role: WorkerRole) -> str | None:
-    """Return the worker's log file path if ``LILBEE_DATA`` is set."""
+    """Return the worker's log file path. Falls back to cfg.data_root.
+
+    Mirrors :func:`lilbee.providers.worker.worker_runtime.configure_worker_logging`
+    so the parent's :class:`WorkerCrashError` can point at the same file
+    the worker wrote, even when ``LILBEE_DATA`` was never set in env.
+    """
     import os
 
     data_dir = os.environ.get("LILBEE_DATA")
     if not data_dir:
-        return None
+        try:
+            from lilbee.core.config import cfg
+        except ImportError:  # pragma: no cover - defensive
+            return None
+        root = getattr(cfg, "data_root", None)
+        if not root:
+            return None
+        data_dir = str(root)
     return os.path.join(data_dir, "logs", f"worker-{role}.log")
 
 

--- a/src/lilbee/providers/worker/transport_pipe.py
+++ b/src/lilbee/providers/worker/transport_pipe.py
@@ -56,12 +56,9 @@ class WorkerError(RuntimeError):
 class WorkerCrashError(WorkerError):
     """Raised when a worker process dies mid-request (EOF on the pipe).
 
-    Carries an optional ``log_path`` so the surfaced message can point the
-    user at the worker log file that contains the underlying traceback or
-    signal info, plus a tail of that log inlined into the message so the
-    user does not have to hunt for the file (the Windows heap-corruption
-    path produces no Python-level exception to serialize, so the only
-    diagnostic trail lives in the worker's log file).
+    The error message embeds both ``log_path`` and the tail of that log so
+    a native-side crash (no Python exception to serialize) still surfaces
+    a diagnostic trail.
     """
 
     def __init__(self, role: WorkerRole, *, log_path: str | None = None) -> None:

--- a/src/lilbee/providers/worker/worker_runtime.py
+++ b/src/lilbee/providers/worker/worker_runtime.py
@@ -40,8 +40,18 @@ def redirect_stdio_to_devnull() -> None:  # pragma: no cover - subprocess fd swa
 
 
 def configure_worker_logging(role: WorkerRole) -> None:
-    """Append worker logs to ``$LILBEE_DATA/logs/worker-<role>.log`` if set."""
-    data_dir = os.environ.get("LILBEE_DATA")
+    """Append worker logs to ``<data_root>/logs/worker-<role>.log``.
+
+    Reads ``LILBEE_DATA`` first (set by the parent's ``_apply_data_root``),
+    then falls back to ``cfg.data_root`` so the no-flag invocation path
+    (where the user has neither ``--data-dir`` nor ``LILBEE_DATA`` in
+    their shell) still produces worker logs. Both processes resolve to
+    the same path via the cfg validator's walk-up / platform-default
+    chain. Without this, a Windows worker that crashes during ``Llama()``
+    construction surfaces only as "subprocess exited unexpectedly" with
+    no trail to investigate.
+    """
+    data_dir = _resolve_data_root()
     if not data_dir:
         return
     logs_dir = os.path.join(data_dir, "logs")
@@ -53,6 +63,24 @@ def configure_worker_logging(role: WorkerRole) -> None:
     root = logging.getLogger()
     root.addHandler(handler)
     root.setLevel(logging.INFO)
+
+
+def _resolve_data_root() -> str | None:
+    """Return the data root for worker log paths: env var first, then cfg.
+
+    Function-local cfg import: this module is loaded inside the spawned
+    worker process, and the cfg singleton's heavy validators only matter
+    when log paths actually need to resolve.
+    """
+    env_value = os.environ.get("LILBEE_DATA")
+    if env_value:
+        return env_value
+    try:
+        from lilbee.core.config import cfg
+    except ImportError:  # pragma: no cover - defensive
+        return None
+    root = getattr(cfg, "data_root", None)
+    return str(root) if root else None
 
 
 class Reply:

--- a/src/lilbee/providers/worker/worker_runtime.py
+++ b/src/lilbee/providers/worker/worker_runtime.py
@@ -68,19 +68,15 @@ def configure_worker_logging(role: WorkerRole) -> None:
 def _resolve_data_root() -> str | None:
     """Return the data root for worker log paths: env var first, then cfg.
 
-    Function-local cfg import: this module is loaded inside the spawned
-    worker process, and the cfg singleton's heavy validators only matter
-    when log paths actually need to resolve.
+    Function-local cfg import: this module loads inside the spawned
+    worker process and only needs cfg when the env-var fast path misses.
     """
     env_value = os.environ.get("LILBEE_DATA")
     if env_value:
         return env_value
-    try:
-        from lilbee.core.config import cfg
-    except ImportError:  # pragma: no cover - defensive
-        return None
-    root = getattr(cfg, "data_root", None)
-    return str(root) if root else None
+    from lilbee.core.config import cfg
+
+    return str(cfg.data_root) if cfg.data_root else None
 
 
 class Reply:

--- a/src/lilbee/providers/worker/worker_runtime.py
+++ b/src/lilbee/providers/worker/worker_runtime.py
@@ -28,6 +28,11 @@ log = logging.getLogger(__name__)
 # not to show up as CPU noise.
 _DATA_POLL_INTERVAL_S = 0.1
 
+#: Subdirectory of ``cfg.data_root`` where per-role worker logs land.
+#: Shared with :mod:`lilbee.providers.worker.transport_pipe` so the parent's
+#: :class:`WorkerCrashError` points at the exact file the worker wrote.
+WORKER_LOGS_DIR_NAME = "logs"
+
 
 def redirect_stdio_to_devnull() -> None:  # pragma: no cover - subprocess fd swap
     """Send stdout/stderr to /dev/null so llama-cpp's C-level prints stay quiet."""
@@ -40,21 +45,17 @@ def redirect_stdio_to_devnull() -> None:  # pragma: no cover - subprocess fd swa
 
 
 def configure_worker_logging(role: WorkerRole) -> None:
-    """Append worker logs to ``<data_root>/logs/worker-<role>.log``.
+    """Append worker logs to ``$LILBEE_DATA/logs/worker-<role>.log``.
 
-    Reads ``LILBEE_DATA`` first (set by the parent's ``_apply_data_root``),
-    then falls back to ``cfg.data_root`` so the no-flag invocation path
-    (where the user has neither ``--data-dir`` nor ``LILBEE_DATA`` in
-    their shell) still produces worker logs. Both processes resolve to
-    the same path via the cfg validator's walk-up / platform-default
-    chain. Without this, a Windows worker that crashes during ``Llama()``
-    construction surfaces only as "subprocess exited unexpectedly" with
-    no trail to investigate.
+    ``LILBEE_DATA`` is canonicalized at cfg construction
+    (:func:`lilbee.core.config.model._build_cfg`) and at every write
+    site that switches the data root, so the env is the single source
+    of truth.
     """
-    data_dir = _resolve_data_root()
+    data_dir = os.environ.get("LILBEE_DATA")
     if not data_dir:
         return
-    logs_dir = os.path.join(data_dir, "logs")
+    logs_dir = os.path.join(data_dir, WORKER_LOGS_DIR_NAME)
     with contextlib.suppress(OSError):
         os.makedirs(logs_dir, exist_ok=True)
     log_path = os.path.join(logs_dir, f"worker-{role}.log")
@@ -63,20 +64,6 @@ def configure_worker_logging(role: WorkerRole) -> None:
     root = logging.getLogger()
     root.addHandler(handler)
     root.setLevel(logging.INFO)
-
-
-def _resolve_data_root() -> str | None:
-    """Return the data root for worker log paths: env var first, then cfg.
-
-    Function-local cfg import: this module loads inside the spawned
-    worker process and only needs cfg when the env-var fast path misses.
-    """
-    env_value = os.environ.get("LILBEE_DATA")
-    if env_value:
-        return env_value
-    from lilbee.core.config import cfg
-
-    return str(cfg.data_root) if cfg.data_root else None
 
 
 class Reply:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import shutil
 from pathlib import Path
 from unittest import mock
@@ -610,6 +611,35 @@ class TestApplyOverrides:
 
         assert cfg.data_root == env_dir
         assert cfg.chat_model == "ollama/from-env:latest"
+
+    def test_apply_data_root_exports_lilbee_data_env(self, tmp_path, monkeypatch):
+        """``_apply_data_root`` exports ``LILBEE_DATA`` so workers can find log files.
+
+        Worker subprocesses (multiprocessing.spawn) re-import lilbee in a
+        fresh process with no inherited cfg state, so without this export
+        the worker's ``configure_worker_logging`` and the supervisor's
+        ``_worker_log_path`` would silently skip log-file creation when a
+        user invoked lilbee with ``--data-dir`` instead of via the env.
+        On Windows this turns an embed-worker heap-corruption crash into
+        an opaque "subprocess exited unexpectedly" with no trail.
+        """
+        from lilbee.cli import apply_overrides
+
+        monkeypatch.delenv("LILBEE_DATA", raising=False)
+        apply_overrides(data_dir=tmp_path)
+        assert os.environ.get("LILBEE_DATA") == str(tmp_path)
+
+    def test_apply_data_root_exports_lilbee_data_env_global(self, tmp_path, monkeypatch):
+        """``--global`` also exports ``LILBEE_DATA`` for worker visibility."""
+        from lilbee.cli import apply_overrides
+
+        fake_global = tmp_path / "global"
+        fake_global.mkdir()
+        monkeypatch.setattr("lilbee.core.system.default_data_dir", lambda: fake_global)
+        monkeypatch.delenv("LILBEE_DATA", raising=False)
+
+        apply_overrides(use_global=True)
+        assert os.environ.get("LILBEE_DATA") == str(fake_global)
 
     def test_data_dir_overlay_skips_unknown_keys(self, tmp_path):
         """Stale or unrecognised keys in config.toml don't blow up startup."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,6 +86,18 @@ class TestEnvVarOverrides:
             c = Config()
             assert str(c.data_root).endswith("lilbee")
 
+    def test_module_import_canonicalizes_lilbee_data_env(self):
+        """``lilbee.core.config`` exports ``LILBEE_DATA`` so spawned workers inherit it.
+
+        Spawn-context workers re-import lilbee in a fresh process. The
+        canonicalization at cfg construction means a worker spawned
+        after lilbee has been imported once always sees a populated
+        ``LILBEE_DATA`` and routes ``worker-*.log`` accordingly.
+        """
+        import lilbee.core.config  # noqa: F401  # ensure module-level side effect ran
+
+        assert os.environ.get("LILBEE_DATA")
+
     def test_chat_model_override(self):
         with mock.patch.dict(os.environ, {"LILBEE_CHAT_MODEL": "ollama/llama3:8b"}):
             c = Config()

--- a/tests/test_embed_worker.py
+++ b/tests/test_embed_worker.py
@@ -340,16 +340,39 @@ def test_configure_worker_logging_writes_to_logs_dir(tmp_path, monkeypatch) -> N
                 handler.close()
 
 
-def test_configure_worker_logging_noop_when_lilbee_data_unset(monkeypatch) -> None:
-    monkeypatch.delenv("LILBEE_DATA", raising=False)
+def test_configure_worker_logging_falls_back_to_cfg_data_root(monkeypatch, tmp_path) -> None:
+    """When ``LILBEE_DATA`` env is unset, the worker still logs under cfg.data_root.
+
+    Worker subprocesses spawned via ``multiprocessing.spawn`` re-import
+    lilbee in a fresh process, so without this fallback a user running
+    ``lilbee chat`` (with no explicit ``--data-dir`` and no env var) used
+    to get no worker logs at all. On Windows that turns an embed-worker
+    heap-corruption crash into an opaque "subprocess exited unexpectedly"
+    with no diagnostic trail.
+    """
     import logging as _logging
 
+    from lilbee.core.config import cfg
     from lilbee.providers.worker.worker_runtime import configure_worker_logging
 
+    monkeypatch.delenv("LILBEE_DATA", raising=False)
+    monkeypatch.setattr(cfg, "data_root", tmp_path)
+
     root = _logging.getLogger()
-    handlers_before = len(root.handlers)
-    configure_worker_logging("embed")
-    assert len(root.handlers) == handlers_before
+    handlers_before = list(root.handlers)
+    try:
+        configure_worker_logging("embed")
+        log_path = tmp_path / "logs" / "worker-embed.log"
+        assert log_path.parent.is_dir()
+        _logging.getLogger("lilbee.test").info("hello-from-cfg-fallback")
+        for handler in root.handlers:
+            handler.flush()
+        assert "hello-from-cfg-fallback" in log_path.read_text()
+    finally:
+        for handler in list(root.handlers):
+            if handler not in handlers_before:
+                root.removeHandler(handler)
+                handler.close()
 
 
 def test_handle_embed_rejects_non_list_payload_in_process() -> None:

--- a/tests/test_embed_worker.py
+++ b/tests/test_embed_worker.py
@@ -340,39 +340,22 @@ def test_configure_worker_logging_writes_to_logs_dir(tmp_path, monkeypatch) -> N
                 handler.close()
 
 
-def test_configure_worker_logging_falls_back_to_cfg_data_root(monkeypatch, tmp_path) -> None:
-    """When ``LILBEE_DATA`` env is unset, the worker still logs under cfg.data_root.
+def test_configure_worker_logging_noop_when_lilbee_data_unset(monkeypatch) -> None:
+    """Without ``LILBEE_DATA`` the worker installs no log handler.
 
-    Worker subprocesses spawned via ``multiprocessing.spawn`` re-import
-    lilbee in a fresh process, so without this fallback a user running
-    ``lilbee chat`` (with no explicit ``--data-dir`` and no env var) used
-    to get no worker logs at all. On Windows that turns an embed-worker
-    heap-corruption crash into an opaque "subprocess exited unexpectedly"
-    with no diagnostic trail.
+    Production never sees this state because ``_build_cfg`` canonicalizes
+    the env at cfg construction; the test pins the contract for tests that
+    explicitly clear the variable.
     """
     import logging as _logging
 
-    from lilbee.core.config import cfg
     from lilbee.providers.worker.worker_runtime import configure_worker_logging
 
     monkeypatch.delenv("LILBEE_DATA", raising=False)
-    monkeypatch.setattr(cfg, "data_root", tmp_path)
-
     root = _logging.getLogger()
-    handlers_before = list(root.handlers)
-    try:
-        configure_worker_logging("embed")
-        log_path = tmp_path / "logs" / "worker-embed.log"
-        assert log_path.parent.is_dir()
-        _logging.getLogger("lilbee.test").info("hello-from-cfg-fallback")
-        for handler in root.handlers:
-            handler.flush()
-        assert "hello-from-cfg-fallback" in log_path.read_text()
-    finally:
-        for handler in list(root.handlers):
-            if handler not in handlers_before:
-                root.removeHandler(handler)
-                handler.close()
+    handlers_before = len(root.handlers)
+    configure_worker_logging("embed")
+    assert len(root.handlers) == handlers_before
 
 
 def test_handle_embed_rejects_non_list_payload_in_process() -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,5 +1,6 @@
 """Tests for the MCP server tools."""
 
+import os
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -420,6 +421,23 @@ class TestInit:
 
         with pytest.raises(ValidationError, match="must be a HuggingFace ref"):
             cfg.chat_model = "qwen3:0.6b"
+
+    def test_init_exports_lilbee_data_env(self, tmp_path, monkeypatch):
+        """``init`` exports ``LILBEE_DATA`` so MCP-spawned workers can write logs.
+
+        Parity with ``cli/app.py::_apply_data_root``. Without this, worker
+        subprocesses spawned during an MCP session (chat / embed / vision)
+        re-import lilbee with a fresh cfg, lose the project's data root,
+        and silently drop their log files on the floor. On Windows this
+        turns a worker heap-corruption crash into an opaque "subprocess
+        exited unexpectedly" with no diagnostic trail.
+        """
+        target = tmp_path / "myproject"
+        target.mkdir()
+        monkeypatch.delenv("LILBEE_DATA", raising=False)
+
+        init(str(target))
+        assert os.environ.get("LILBEE_DATA") == str(target)
 
     def test_init_overlays_per_root_config_toml(self, tmp_path):
         """init() must re-read the project base's config.toml, the same fix as

--- a/tests/test_model_defaults.py
+++ b/tests/test_model_defaults.py
@@ -133,6 +133,19 @@ class TestReadGgufDefaults:
         result = read_gguf_defaults(metadata)
         assert result.num_ctx is None
 
+    def test_zero_context_length_skipped(self):
+        """Published GGUFs reporting ``context_length=0`` must not seed num_ctx=0,
+        which would propagate through to ``Llama(n_ctx=0)`` and trip ggml's
+        Vulkan dispatch into STATUS_HEAP_CORRUPTION on Windows."""
+        metadata = {"context_length": "0"}
+        result = read_gguf_defaults(metadata)
+        assert result.num_ctx is None
+
+    def test_negative_context_length_skipped(self):
+        metadata = {"context_length": "-1"}
+        result = read_gguf_defaults(metadata)
+        assert result.num_ctx is None
+
     def test_max_reasoning_chars_from_gguf(self):
         metadata = {"general.max_reasoning_chars": "120000"}
         result = read_gguf_defaults(metadata)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
@@ -3506,6 +3507,66 @@ class TestFilterOptions:
 
         result = filter_options({"temperature": 0.5})
         assert "top_p" not in result
+
+
+class TestTrainCtxFromMeta:
+    """``train_ctx_from_meta`` is the single guard against ``context_length=0``.
+
+    All three native llama-cpp loaders (chat, embed, vision) route through
+    it. Each verifies its own integration test in TestLoadLlama /
+    TestMtmdBackend; these tests cover the helper in isolation so an
+    edge case can be added here without instantiating a Llama mock.
+    """
+
+    @staticmethod
+    def _path() -> Path:
+        return Path("/tmp/test-model.gguf")
+
+    def test_returns_metadata_value_when_positive(self) -> None:
+        from lilbee.providers.llama_cpp.gguf_meta import train_ctx_from_meta
+
+        meta = {"context_length": "8192"}
+        assert train_ctx_from_meta(meta, fallback=2048, model_path=self._path()) == 8192
+
+    def test_returns_fallback_when_meta_is_none(self) -> None:
+        from lilbee.providers.llama_cpp.gguf_meta import train_ctx_from_meta
+
+        assert train_ctx_from_meta(None, fallback=2048, model_path=self._path()) == 2048
+
+    def test_returns_fallback_when_context_length_missing(self) -> None:
+        from lilbee.providers.llama_cpp.gguf_meta import train_ctx_from_meta
+
+        assert train_ctx_from_meta({}, fallback=4096, model_path=self._path()) == 4096
+
+    def test_clamps_zero_to_fallback(self) -> None:
+        from lilbee.providers.llama_cpp.gguf_meta import train_ctx_from_meta
+
+        meta = {"context_length": "0"}
+        assert train_ctx_from_meta(meta, fallback=2048, model_path=self._path()) == 2048
+
+    def test_clamps_negative_to_fallback(self) -> None:
+        from lilbee.providers.llama_cpp.gguf_meta import train_ctx_from_meta
+
+        meta = {"context_length": "-1"}
+        assert train_ctx_from_meta(meta, fallback=2048, model_path=self._path()) == 2048
+
+    def test_clamps_unparseable_to_fallback(self, caplog) -> None:
+        from lilbee.providers.llama_cpp.gguf_meta import train_ctx_from_meta
+
+        meta = {"context_length": "garbage"}
+        with caplog.at_level(logging.WARNING, logger="lilbee.providers.llama_cpp.gguf_meta"):
+            assert train_ctx_from_meta(meta, fallback=2048, model_path=self._path()) == 2048
+        assert any("unparseable" in rec.message for rec in caplog.records)
+
+    def test_each_loader_uses_its_own_fallback(self) -> None:
+        """Embed / chat / vision picks reflect their respective task budgets."""
+        from lilbee.providers.llama_cpp.gguf_meta import train_ctx_from_meta
+
+        zero = {"context_length": "0"}
+        path = self._path()
+        assert train_ctx_from_meta(zero, fallback=2048, model_path=path) == 2048  # embed
+        assert train_ctx_from_meta(zero, fallback=8192, model_path=path) == 8192  # chat
+        assert train_ctx_from_meta(zero, fallback=4096, model_path=path) == 4096  # vision
 
 
 class TestReadGgufMetadata:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3630,6 +3630,68 @@ class TestLoadLlama:
         assert call_kwargs["embedding"] is False
         assert "n_batch" not in call_kwargs
 
+    def test_embedding_clamps_zero_context_length_metadata(
+        self, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """GGUF metadata reporting context_length=0 falls back to the safe default.
+
+        Several published GGUFs (nomic-embed, some Qwen3 variants) emit a
+        zero training context in their headers. Passing ``n_ctx=0`` into
+        ``Llama(embedding=True)`` propagates as ``n_batch=0`` /
+        ``n_ubatch=0``, which trips ggml's Vulkan dispatch into UB and
+        surfaces as STATUS_HEAP_CORRUPTION on Windows.
+        """
+        from lilbee.providers.llama_cpp.provider import load_llama
+
+        cfg.num_ctx = None
+
+        with mock.patch(
+            "lilbee.providers.llama_cpp.provider.read_gguf_metadata",
+            return_value={"context_length": "0"},
+        ):
+            load_llama(Path("/test.gguf"), mode="embed")
+
+        call_kwargs = mock_llama_cpp.Llama.call_args[1]
+        assert call_kwargs["n_ctx"] == 2048
+        assert call_kwargs["n_batch"] == 2048
+        assert call_kwargs["n_ubatch"] == 2048
+
+    def test_embedding_clamps_negative_context_length_metadata(
+        self, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """Negative ``context_length`` (corrupt metadata) also falls back."""
+        from lilbee.providers.llama_cpp.provider import load_llama
+
+        cfg.num_ctx = None
+
+        with mock.patch(
+            "lilbee.providers.llama_cpp.provider.read_gguf_metadata",
+            return_value={"context_length": "-1"},
+        ):
+            load_llama(Path("/test.gguf"), mode="embed")
+
+        call_kwargs = mock_llama_cpp.Llama.call_args[1]
+        assert call_kwargs["n_ctx"] == 2048
+        assert call_kwargs["n_batch"] == 2048
+
+    def test_embedding_clamps_unparseable_context_length_metadata(
+        self, mock_llama_cpp: mock.MagicMock
+    ) -> None:
+        """Non-numeric ``context_length`` falls back rather than crashing the loader."""
+        from lilbee.providers.llama_cpp.provider import load_llama
+
+        cfg.num_ctx = None
+
+        with mock.patch(
+            "lilbee.providers.llama_cpp.provider.read_gguf_metadata",
+            return_value={"context_length": "garbage"},
+        ):
+            load_llama(Path("/test.gguf"), mode="embed")
+
+        call_kwargs = mock_llama_cpp.Llama.call_args[1]
+        assert call_kwargs["n_ctx"] == 2048
+        assert call_kwargs["n_batch"] == 2048
+
 
 class TestFindMmprojForModel:
     def test_catalog_lookup(self) -> None:

--- a/tests/test_worker_transport_pipe.py
+++ b/tests/test_worker_transport_pipe.py
@@ -746,16 +746,6 @@ async def test_ping_raises_worker_crash_when_health_send_fails() -> None:
             child_health.close()
 
 
-def test_worker_log_path_falls_back_to_cfg_when_env_unset(monkeypatch, tmp_path) -> None:
-    """Without LILBEE_DATA the resolver uses cfg.data_root, not None."""
-    from lilbee.core.config import cfg
-    from lilbee.providers.worker.transport_pipe import _worker_log_path
-
-    monkeypatch.delenv("LILBEE_DATA", raising=False)
-    monkeypatch.setattr(cfg, "data_root", tmp_path)
-    assert _worker_log_path("embed") == str(tmp_path / "logs" / "worker-embed.log")
-
-
 def test_worker_log_path_joins_data_dir_when_env_set(monkeypatch, tmp_path) -> None:
     """With LILBEE_DATA set, the path lands under <data>/logs/worker-<role>.log."""
     from lilbee.providers.worker.transport_pipe import _worker_log_path
@@ -764,16 +754,17 @@ def test_worker_log_path_joins_data_dir_when_env_set(monkeypatch, tmp_path) -> N
     assert _worker_log_path("chat") == str(tmp_path / "logs" / "worker-chat.log")
 
 
-def test_worker_log_path_env_wins_over_cfg(monkeypatch, tmp_path) -> None:
-    """Env takes precedence over cfg.data_root when both resolve."""
-    from lilbee.core.config import cfg
+def test_worker_log_path_returns_none_when_env_unset(monkeypatch) -> None:
+    """The env-only resolver returns None when ``LILBEE_DATA`` is missing.
+
+    In production this is unreachable because ``_build_cfg`` exports the
+    env var at cfg construction. The test covers the explicit-delenv
+    contract used by other tests that need a "no log path" state.
+    """
     from lilbee.providers.worker.transport_pipe import _worker_log_path
 
-    env_dir = tmp_path / "env_root"
-    cfg_dir = tmp_path / "cfg_root"
-    monkeypatch.setenv("LILBEE_DATA", str(env_dir))
-    monkeypatch.setattr(cfg, "data_root", cfg_dir)
-    assert _worker_log_path("rerank") == str(env_dir / "logs" / "worker-rerank.log")
+    monkeypatch.delenv("LILBEE_DATA", raising=False)
+    assert _worker_log_path("embed") is None
 
 
 def test_format_exit_reason_for_normal_exit_code() -> None:
@@ -837,17 +828,11 @@ def test_record_exit_reason_writes_to_worker_log(monkeypatch, tmp_path) -> None:
     assert "SIGTERM" in body
 
 
-def test_record_exit_reason_falls_back_to_cfg_data_root(monkeypatch, tmp_path, caplog) -> None:
-    """When LILBEE_DATA env is unset, the supervisor reaches cfg.data_root for the log path."""
+def test_record_exit_reason_skips_when_log_path_unset(monkeypatch, caplog) -> None:
+    """Without LILBEE_DATA the reason logs to stderr but no file is touched."""
     import multiprocessing
 
-    from lilbee.core.config import cfg
-
     monkeypatch.delenv("LILBEE_DATA", raising=False)
-    monkeypatch.setattr(cfg, "data_root", tmp_path)
-    (tmp_path / "logs").mkdir()
-    log_file = tmp_path / "logs" / "worker-chat.log"
-    log_file.write_text("preexisting\n")
 
     class _FakeProcess:
         @property
@@ -878,6 +863,3 @@ def test_record_exit_reason_falls_back_to_cfg_data_root(monkeypatch, tmp_path, c
         with contextlib.suppress(Exception):
             child_health.close()
     assert any("exited with code 7" in rec.message for rec in caplog.records)
-    body = log_file.read_text()
-    assert "[supervisor]" in body
-    assert "exited with code 7" in body

--- a/tests/test_worker_transport_pipe.py
+++ b/tests/test_worker_transport_pipe.py
@@ -504,6 +504,43 @@ def test_worker_crash_error_carries_role_name() -> None:
     assert "embed" in str(err)
 
 
+def test_worker_crash_error_inlines_log_tail(tmp_path) -> None:
+    """When ``log_path`` exists, the crash message inlines its last bytes.
+
+    Verifies the field-debugging hook for the Windows heap-corruption path:
+    no Python exception serializes through the pipe, so the only signal a
+    user sees comes from the worker's own log tail.
+    """
+    log_file = tmp_path / "worker-embed.log"
+    log_file.write_text(
+        "boot\nload model\nLLAMA_ASSERT failed: n_batch == 0\nworker dying\n",
+        encoding="utf-8",
+    )
+    err = WorkerCrashError("embed", log_path=str(log_file))
+    assert err.log_tail
+    assert "LLAMA_ASSERT" in str(err)
+    assert "worker dying" in err.log_tail
+    assert str(log_file) in str(err)
+
+
+def test_worker_crash_error_handles_missing_log_file(tmp_path) -> None:
+    """A non-existent log path leaves ``log_tail`` empty without raising."""
+    missing = tmp_path / "absent.log"
+    err = WorkerCrashError("embed", log_path=str(missing))
+    assert err.log_tail == ""
+    assert "Last log lines" not in str(err)
+    assert str(missing) in str(err)
+
+
+def test_worker_crash_error_caps_log_tail_size(tmp_path) -> None:
+    """Long worker logs get tail-clamped instead of dumping the whole file."""
+    log_file = tmp_path / "worker-embed.log"
+    log_file.write_bytes(b"X" * (16 * 1024) + b"\nTAIL_MARKER\n")
+    err = WorkerCrashError("embed", log_path=str(log_file))
+    assert "TAIL_MARKER" in err.log_tail
+    assert len(err.log_tail) < 16 * 1024
+
+
 def test_pipe_spawner_uses_spawn_context() -> None:
     """The pipe spawner pins the multiprocessing context to spawn."""
     spawner = PipeSpawner()
@@ -709,12 +746,14 @@ async def test_ping_raises_worker_crash_when_health_send_fails() -> None:
             child_health.close()
 
 
-def test_worker_log_path_returns_none_when_env_unset(monkeypatch) -> None:
-    """Without LILBEE_DATA the log path resolver returns None."""
+def test_worker_log_path_falls_back_to_cfg_when_env_unset(monkeypatch, tmp_path) -> None:
+    """Without LILBEE_DATA the resolver uses cfg.data_root, not None."""
+    from lilbee.core.config import cfg
     from lilbee.providers.worker.transport_pipe import _worker_log_path
 
     monkeypatch.delenv("LILBEE_DATA", raising=False)
-    assert _worker_log_path("embed") is None
+    monkeypatch.setattr(cfg, "data_root", tmp_path)
+    assert _worker_log_path("embed") == str(tmp_path / "logs" / "worker-embed.log")
 
 
 def test_worker_log_path_joins_data_dir_when_env_set(monkeypatch, tmp_path) -> None:
@@ -723,6 +762,18 @@ def test_worker_log_path_joins_data_dir_when_env_set(monkeypatch, tmp_path) -> N
 
     monkeypatch.setenv("LILBEE_DATA", str(tmp_path))
     assert _worker_log_path("chat") == str(tmp_path / "logs" / "worker-chat.log")
+
+
+def test_worker_log_path_env_wins_over_cfg(monkeypatch, tmp_path) -> None:
+    """Env takes precedence over cfg.data_root when both resolve."""
+    from lilbee.core.config import cfg
+    from lilbee.providers.worker.transport_pipe import _worker_log_path
+
+    env_dir = tmp_path / "env_root"
+    cfg_dir = tmp_path / "cfg_root"
+    monkeypatch.setenv("LILBEE_DATA", str(env_dir))
+    monkeypatch.setattr(cfg, "data_root", cfg_dir)
+    assert _worker_log_path("rerank") == str(env_dir / "logs" / "worker-rerank.log")
 
 
 def test_format_exit_reason_for_normal_exit_code() -> None:
@@ -786,11 +837,17 @@ def test_record_exit_reason_writes_to_worker_log(monkeypatch, tmp_path) -> None:
     assert "SIGTERM" in body
 
 
-def test_record_exit_reason_skips_when_log_path_unset(monkeypatch, caplog) -> None:
-    """Without LILBEE_DATA the reason logs to stderr but no file is touched."""
+def test_record_exit_reason_falls_back_to_cfg_data_root(monkeypatch, tmp_path, caplog) -> None:
+    """When LILBEE_DATA env is unset, the supervisor reaches cfg.data_root for the log path."""
     import multiprocessing
 
+    from lilbee.core.config import cfg
+
     monkeypatch.delenv("LILBEE_DATA", raising=False)
+    monkeypatch.setattr(cfg, "data_root", tmp_path)
+    (tmp_path / "logs").mkdir()
+    log_file = tmp_path / "logs" / "worker-chat.log"
+    log_file.write_text("preexisting\n")
 
     class _FakeProcess:
         @property
@@ -821,3 +878,6 @@ def test_record_exit_reason_skips_when_log_path_unset(monkeypatch, caplog) -> No
         with contextlib.suppress(Exception):
             child_health.close()
     assert any("exited with code 7" in rec.message for rec in caplog.records)
+    body = log_file.read_text()
+    assert "[supervisor]" in body
+    assert "exited with code 7" in body


### PR DESCRIPTION
## Problem

On Windows, when an embed worker crashed lilbee surfaced only "subprocess exited unexpectedly" with no log path and no way to investigate. Worker logs were silently dropped when `LILBEE_DATA` wasn't in the user's shell, so even motivated users had nothing to file a bug with. Independently, a published nomic-embed GGUF in the b473 QA dump reports `context_length=0` in its metadata, which cascaded into `n_batch=0` inside llama-cpp and tripped ggml's Vulkan dispatch into heap corruption.

## Solution

1. Worker logs always land at `<data_root>/logs/worker-*.log`. `LILBEE_DATA` is canonicalized at cfg construction and at every entry point that switches the data root (CLI `--data-dir`, `--global`, MCP `init`).
2. `WorkerCrashError` inlines the tail of the worker log into the user-facing message, so a crash that produces no Python exception still tells the user what the worker said before dying.
3. A single helper guards `context_length` parsing across all three llama-cpp loaders (chat, embed, vision). Zero, negative, and unparseable values fall back to a per-task default instead of driving `n_batch=0` into native code.

PR #242 already covers the original heap-corruption surface via implicit Vulkan layer disables and dual-vendor ICD mitigations. This PR is what lets users investigate when crashes still happen and what defends against bad-metadata cascades.