### PR TITLE
wire up lilbee.sh as canonical domain

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,6 @@
 name: Pages
 
-# Marketing site at https://tobocop2.github.io/lilbee/ plus the per-backend
+# Marketing site at https://lilbee.sh/ plus the per-backend
 # PEP 503 wheel indexes under /<backend>/. Decoupled from package distribution:
 # it redeploys when site/ (or this workflow) changes on main, and after a
 # successful Release candidate run (which builds the full wheel-* set -- default

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ PLAN.md
 .DS_Store
 scripts/*
 !scripts/check_style_rules.py
+!scripts/porkbun-dns-setup.sh
 !scripts/qa/
 scripts/qa/*
 !scripts/qa/*.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format format-check typecheck test test-ci test-ci-serial test-ci-forked test-integration imports-check check clean install demo demo-prep demo-publish build publish docs docs-api docs-site site site-serve site-tar
+.PHONY: lint format format-check typecheck test test-ci test-ci-serial test-ci-forked test-integration imports-check check clean install demo demo-prep demo-publish build publish docs docs-api docs-site site site-serve site-tar dns-setup
 
 lint:
 	uv run ruff check src/ tests/ tools/qa/
@@ -38,6 +38,9 @@ install:
 
 crawl-setup:  ## Download Playwright Chromium for /crawl
 	uv run playwright install chromium
+
+dns-setup:  ## One-time DNS setup for lilbee.sh at Porkbun (reads creds from pass)
+	bash scripts/porkbun-dns-setup.sh
 
 demo-prep:  ## Pre-stage models, data dirs, man pages, opencode demo dirs for `make demo`
 	bash demos/_prep.sh

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 <p align="center"><strong>A batteries-included local search engine for your data and code that you can talk to.</strong></p>
 
-<p align="center"><a href="https://tobocop2.github.io/lilbee/">Project site</a> &nbsp;·&nbsp; <a href="https://pypi.org/project/lilbee/">PyPI</a> &nbsp;·&nbsp; <a href="https://tobocop2.github.io/obsidian-lilbee/">Obsidian plugin</a> &nbsp;·&nbsp; <a href="https://tobocop2.github.io/lilbee/api/">API docs</a></p>
+<p align="center"><a href="https://lilbee.sh/">Project site</a> &nbsp;·&nbsp; <a href="https://pypi.org/project/lilbee/">PyPI</a> &nbsp;·&nbsp; <a href="https://obsidian.lilbee.sh/">Obsidian plugin</a> &nbsp;·&nbsp; <a href="https://lilbee.sh/api/">API docs</a></p>
 
 <p align="center">
   <a href="https://github.com/tobocop2/lilbee/releases"><img src="https://img.shields.io/github/v/release/tobocop2/lilbee?include_prereleases&label=latest%20release" alt="Latest release (incl. pre-releases)"></a>
   <a href="https://pypi.org/project/lilbee/"><img src="https://img.shields.io/pypi/v/lilbee?include_prereleases&label=PyPI" alt="lilbee on PyPI"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+"></a>
   <a href="https://github.com/tobocop2/lilbee/actions/workflows/ci.yml"><img src="https://github.com/tobocop2/lilbee/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://tobocop2.github.io/lilbee/coverage/"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://lilbee.sh/coverage/"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen.svg" alt="Coverage"></a>
   <a href="https://mypy-lang.org/"><img src="https://img.shields.io/badge/typed-mypy-blue.svg" alt="Typed"></a>
   <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg" alt="Platforms">
@@ -44,7 +44,7 @@ It's all one program: a full-screen terminal app, a command-line tool, a Model C
 - [Hardware requirements](#hardware-requirements)
 - [Install](#install)
 - [Agent integration](#agent-integration)
-- [HTTP Server](#http-server) · [API reference](https://tobocop2.github.io/lilbee/api/)
+- [HTTP Server](#http-server) · [API reference](https://lilbee.sh/api/)
 - [Supported formats](#supported-formats)
 - [Experimental](#experimental)
 
@@ -171,14 +171,14 @@ No external services either way; lilbee downloads and runs models locally. Optio
 
 | How | Command | Notes |
 | --- | --- | --- |
-| **pip** | `pip install --pre lilbee` | Recommended. The default wheel runs on any x86_64 CPU and uses your GPU via Vulkan / Metal automatically. Intel Mac: add `--extra-index-url https://tobocop2.github.io/lilbee/cpu/`. |
+| **pip** | `pip install --pre lilbee` | Recommended. The default wheel runs on any x86_64 CPU and uses your GPU via Vulkan / Metal automatically. Intel Mac: add `--extra-index-url https://lilbee.sh/cpu/`. |
 | **uv** | `uv tool install --prerelease=allow lilbee` | Same wheel as pip; fetches a Python for you if you need one. |
 | **Homebrew** | `brew tap tobocop2/lilbee && brew install lilbee` | macOS arm64 / Linux x86_64. Bundled build; clears the macOS quarantine flag for you. |
 | **AUR** | `paru -S lilbee` | Arch Linux. Wraps the Linux x86_64 binary; works with `yay` / `pacaur` / any helper. |
 | **Docker** | `docker run --rm -v lilbee-data:/home/lilbee/data ghcr.io/tobocop2/lilbee:latest --help` | GHCR image, tagged by version and `latest`. Data lives at `/home/lilbee/data` — mount a volume there. |
 | **Nix** | `nix run github:tobocop2/lilbee` | NixOS, nix-darwin, or any host with nix. On Linux the flake bundles `glibc`, `libgomp`, and `vulkan-loader` so it runs on bare NixOS. |
 | **Standalone binary** | [download for your platform &rarr;](https://github.com/tobocop2/lilbee/releases/latest) | One file, own Python runtime, no `pip` needed. Linux needs glibc 2.28+; the macOS / Windows builds are unsigned (`xattr -d com.apple.quarantine ./lilbee-macos-arm64` if Gatekeeper blocks it). |
-| **CUDA-native** | `pip install --pre lilbee --extra-index-url https://tobocop2.github.io/lilbee/cu125/` | Recommended for NVIDIA users on Windows, both for stability and speed. The default Vulkan wheel works for most setups, but on a Windows box with both an NVIDIA discrete GPU and an integrated AMD or Intel GPU the Vulkan loader has to load every vendor's driver into one process, and some vendor combinations crash. CUDA wheels skip Vulkan entirely. Pick `cu121` / `cu124` / `cu125` to match `nvidia-smi`. |
+| **CUDA-native** | `pip install --pre lilbee --extra-index-url https://lilbee.sh/cu125/` | Recommended for NVIDIA users on Windows, both for stability and speed. The default Vulkan wheel works for most setups, but on a Windows box with both an NVIDIA discrete GPU and an integrated AMD or Intel GPU the Vulkan loader has to load every vendor's driver into one process, and some vendor combinations crash. CUDA wheels skip Vulkan entirely. Pick `cu121` / `cu124` / `cu125` to match `nvidia-smi`. |
 | **From source** | `git clone https://github.com/tobocop2/lilbee && cd lilbee && uv sync && uv run lilbee` | For hacking on it. Needs `git` and `uv`. |
 
 Then check it runs and pick a model:
@@ -226,9 +226,9 @@ The full reel (every TUI screen and the agent demos) is in [`docs/demos.md`](doc
 
 ## HTTP Server
 
-`lilbee serve` starts a REST API any tool or GUI can hit: search (with SSE streaming), document lifecycle, crawling, model management, configuration. See the [API reference](https://tobocop2.github.io/lilbee/api/) for the OpenAPI schema and the [usage guide](docs/usage.md) for options.
+`lilbee serve` starts a REST API any tool or GUI can hit: search (with SSE streaming), document lifecycle, crawling, model management, configuration. See the [API reference](https://lilbee.sh/api/) for the OpenAPI schema and the [usage guide](docs/usage.md) for options.
 
-The [Obsidian plugin](https://tobocop2.github.io/obsidian-lilbee/) is a GUI built on it: it runs `lilbee serve` in the background, and every citation opens a Source Preview scrolled to the exact passage. Install via [BRAT](https://github.com/TfTHacker/obsidian42-brat); the [plugin README](https://github.com/tobocop2/obsidian-lilbee#quick-start) has setup.
+The [Obsidian plugin](https://obsidian.lilbee.sh/) is a GUI built on it: it runs `lilbee serve` in the background, and every citation opens a Source Preview scrolled to the exact passage. Install via [BRAT](https://github.com/TfTHacker/obsidian42-brat); the [plugin README](https://github.com/tobocop2/obsidian-lilbee#quick-start) has setup.
 
 ## Supported formats
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -159,7 +159,7 @@ Every command returns a single JSON object on stdout. Errors return non-zero exi
 
 ## REST API
 
-The built-in HTTP server (`lilbee serve`) exposes a full REST API. Streaming endpoints use Server-Sent Events (SSE). See the [API reference](https://tobocop2.github.io/lilbee/api/) for the complete OpenAPI schema and [the usage guide](usage.md#http-server) for invocation options.
+The built-in HTTP server (`lilbee serve`) exposes a full REST API. Streaming endpoints use Server-Sent Events (SSE). See the [API reference](https://lilbee.sh/api/) for the complete OpenAPI schema and [the usage guide](usage.md#http-server) for invocation options.
 
 ### Crawl endpoint
 

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -1,6 +1,6 @@
 # The full reel
 
-Same demos as on [tobocop2.github.io/lilbee/](https://tobocop2.github.io/lilbee/),
+Same demos as on [lilbee.sh/](https://lilbee.sh/),
 with the captions long-form and a handful of extras that don't fit in the site's
 tab list.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -372,7 +372,7 @@ defaults endpoint that powers per-setting reset), and status/health. The
 Obsidian plugin uses the `/api/source` endpoint for vault-aware source
 retrieval. Interactive API docs live at `/schema/redoc` when the server is
 running, and the full OpenAPI schema is published at the
-[API reference](https://tobocop2.github.io/lilbee/api/).
+[API reference](https://lilbee.sh/api/).
 
 **Configuration via env vars:**
 
@@ -555,7 +555,7 @@ pip install --pre 'lilbee[graph,crawler,litellm]'
 uv tool install --prerelease=allow 'lilbee[graph,crawler,litellm]'
 ```
 
-For NVIDIA users wanting CUDA-native acceleration (default install already covers GPU via Vulkan), append `--extra-index-url https://tobocop2.github.io/lilbee/cu125/` (or `cu124/` for older drivers).
+For NVIDIA users wanting CUDA-native acceleration (default install already covers GPU via Vulkan), append `--extra-index-url https://lilbee.sh/cu125/` (or `cu124/` for older drivers).
 
 While 0.6.66 is in beta, the `--pre` flag (or uv's `--prerelease=allow`) is required on every install.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ crawler = ["crawl4ai>=0.8.6"]
 release = ["lilbee[crawler,litellm,graph]"]
 
 [project.urls]
-Homepage = "https://tobocop2.github.io/lilbee/"
+Homepage = "https://lilbee.sh/"
 Repository = "https://github.com/tobocop2/lilbee"
 Issues = "https://github.com/tobocop2/lilbee/issues"
 

--- a/scripts/porkbun-dns-setup.sh
+++ b/scripts/porkbun-dns-setup.sh
@@ -140,19 +140,19 @@ check_status "$(api "/dns/deleteByNameType/$DOMAIN/ALIAS")" "delete ALIAS @ apex
 check_status "$(api "/dns/deleteByNameType/$DOMAIN/CNAME/obsidian")" "delete CNAME @ obsidian" || true
 
 log "==> Deleting existing wildcard CNAME (Porkbun parking default)"
-api "/dns/retrieve/$DOMAIN" | jq -r '.records[]? | select(.type == "CNAME" and (.name | startswith("*."))) | .id' | while IFS= read -r rid; do
-  [[ -z "$rid" ]] && continue
-  check_status "$(api "/dns/delete/$DOMAIN/$rid")" "delete wildcard CNAME id=$rid" || true
+api "/dns/retrieve/$DOMAIN" | jq -r '.records[]? | select(.type == "CNAME" and (.name | startswith("*."))) | .id' | while IFS= read -r record_id; do
+  [[ -z "$record_id" ]] && continue
+  check_status "$(api "/dns/delete/$DOMAIN/$record_id")" "delete wildcard CNAME id=$record_id" || true
 done
 
 log "==> Deleting existing wildcard URL forwards"
-api "/domain/getUrlForwarding/$DOMAIN" | jq -r '.forwards[]? | select(.wildcard == "yes") | .id' | while IFS= read -r fid; do
-  [[ -z "$fid" ]] && continue
-  check_status "$(api "/domain/deleteUrlForward/$DOMAIN/$fid")" "delete URL forward id=$fid" || true
+api "/domain/getUrlForwarding/$DOMAIN" | jq -r '.forwards[]? | select(.wildcard == "yes") | .id' | while IFS= read -r forward_id; do
+  [[ -z "$forward_id" ]] && continue
+  check_status "$(api "/domain/deleteUrlForward/$DOMAIN/$forward_id")" "delete URL forward id=$forward_id" || true
 done
 
 log
-log "==> Creating 4 A records on apex (GitHub Pages)"
+log "==> Creating ${#GH_PAGES_IPS[@]} A records on apex (GitHub Pages)"
 for ip in "${GH_PAGES_IPS[@]}"; do
   log "  $ip"
   create_record "" "A" "$ip"

--- a/scripts/porkbun-dns-setup.sh
+++ b/scripts/porkbun-dns-setup.sh
@@ -32,6 +32,12 @@ GH_PAGES_IPS=(
   185.199.111.153
 )
 
+# Subdomains that resolve to GitHub Pages projects via CNAME. Each repo's
+# own site/CNAME file tells GH which repo to serve for each host. 'www' is
+# an apex alias whose CNAME lets GH issue a SAN HTTPS cert covering both
+# lilbee.sh and www.lilbee.sh.
+GH_PAGES_SUBDOMAINS=(obsidian www)
+
 # Wildcard URL forward: any *.lilbee.sh subdomain that isn't otherwise defined
 # 301-redirects to the canonical site, preserving the request path.
 WILDCARD_REDIRECT_TARGET="https://$DOMAIN"
@@ -137,7 +143,9 @@ log
 log "==> Deleting existing records"
 check_status "$(api "/dns/deleteByNameType/$DOMAIN/A")" "delete A @ apex" || true
 check_status "$(api "/dns/deleteByNameType/$DOMAIN/ALIAS")" "delete ALIAS @ apex" || true
-check_status "$(api "/dns/deleteByNameType/$DOMAIN/CNAME/obsidian")" "delete CNAME @ obsidian" || true
+for subdomain in "${GH_PAGES_SUBDOMAINS[@]}"; do
+  check_status "$(api "/dns/deleteByNameType/$DOMAIN/CNAME/$subdomain")" "delete CNAME @ $subdomain" || true
+done
 
 log "==> Deleting existing wildcard CNAME (Porkbun parking default)"
 api "/dns/retrieve/$DOMAIN" | jq -r '.records[]? | select(.type == "CNAME" and (.name | startswith("*."))) | .id' | while IFS= read -r record_id; do
@@ -158,9 +166,11 @@ for ip in "${GH_PAGES_IPS[@]}"; do
   create_record "" "A" "$ip"
 done
 
-log
-log "==> Creating CNAME obsidian.$DOMAIN -> $GH_PAGES_HOST"
-create_record "obsidian" "CNAME" "$GH_PAGES_HOST"
+for subdomain in "${GH_PAGES_SUBDOMAINS[@]}"; do
+  log
+  log "==> Creating CNAME $subdomain.$DOMAIN -> $GH_PAGES_HOST"
+  create_record "$subdomain" "CNAME" "$GH_PAGES_HOST"
+done
 
 log
 log "==> Creating wildcard URL forward *.$DOMAIN -> $WILDCARD_REDIRECT_TARGET (permanent, include path)"
@@ -181,11 +191,18 @@ print_forwards
 cat >&2 <<EOF
 
 Done. Wait 5-30 min for DNS to propagate, then verify externally:
-  dig lilbee.sh +short             # should return the 4 GitHub IPs
-  dig obsidian.lilbee.sh +short    # should return tobocop2.github.io, then IPs
-  curl -I https://www.lilbee.sh    # should 301 redirect to https://lilbee.sh/
+  dig lilbee.sh +short              # 4 GitHub IPs
+  dig www.lilbee.sh +short          # CNAME chain through tobocop2.github.io
+  dig obsidian.lilbee.sh +short     # CNAME chain through tobocop2.github.io
+  curl -I http://anything.lilbee.sh # 301 to https://lilbee.sh/ via Porkbun forward
 
 The repo's site/CNAME files activate the custom domains on the next Pages
 deploy. After GitHub provisions HTTPS certs (5-30 min post-deploy), enable
-"Enforce HTTPS" in each repo's Pages settings.
+"Enforce HTTPS" in each repo's Pages settings. The www alias gets covered
+by the same SAN cert as the apex automatically.
+
+Note: HTTPS to wildcard subdomains (https://foo.lilbee.sh) returns a cert
+error because Porkbun's URL forwarder doesn't ship a wildcard cert. HTTP
+works and redirects cleanly. Specific subdomains (www, obsidian) get real
+GH Pages HTTPS.
 EOF

--- a/scripts/porkbun-dns-setup.sh
+++ b/scripts/porkbun-dns-setup.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Porkbun DNS setup for lilbee.sh.
+#
+# Configures DNS at Porkbun for the marketing site (apex, GitHub Pages) and
+# the Obsidian plugin site (obsidian subdomain). Run once; idempotent.
+#
+# Credential resolution order:
+#   1. pass: `pass show porkbun/tobocop/api-key` and `pass show porkbun/tobocop/api-secret`
+#   2. env: PORKBUN_API_KEY and PORKBUN_SECRET_API_KEY
+#   3. interactive prompt (read -s)
+#
+# Requires: curl, jq. (`brew install jq` on macOS.)
+
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-lilbee.sh}"
+API_BASE="https://api.porkbun.com/api/json/v3"
+PASS_KEY_PATH="porkbun/tobocop/api-key"
+PASS_SECRET_PATH="porkbun/tobocop/api-secret"
+RECORD_TTL="600"
+OBSIDIAN_CNAME_TARGET="tobocop2.github.io"
+
+# GitHub Pages anycast IPs. Update if GH ever rotates them; see
+# https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site
+GH_PAGES_IPS=(
+  185.199.108.153
+  185.199.109.153
+  185.199.110.153
+  185.199.111.153
+)
+
+# log goes to stderr so command-substitution stdout stays clean for get_secret.
+log() { echo "$@" >&2; }
+
+get_secret() {
+  local label="$1" pass_path="$2" env_var="$3"
+
+  if command -v pass >/dev/null && pass show "$pass_path" >/dev/null 2>&1; then
+    log "  $label: read from pass ($pass_path)"
+    pass show "$pass_path" | head -n 1
+    return
+  fi
+
+  if [[ -n "${!env_var:-}" ]]; then
+    log "  $label: read from \$$env_var"
+    echo "${!env_var}"
+    return
+  fi
+
+  local val
+  read -r -s -p "$label: " val
+  echo >&2
+  echo "$val"
+}
+
+api() {
+  local path="$1" body="${2:-$AUTH_BODY}"
+  curl -sS -X POST -H "Content-Type: application/json" -d "$body" "$API_BASE$path"
+}
+
+check_status() {
+  local resp="$1" label="$2"
+  local status
+  status=$(echo "$resp" | jq -r '.status // "UNKNOWN"')
+  if [[ "$status" != "SUCCESS" ]]; then
+    log "  ! $label: $(echo "$resp" | jq -r '.message // "no message"')"
+    return 1
+  fi
+  log "  ok"
+}
+
+print_records() {
+  api "/dns/retrieve/$DOMAIN" | jq -r '
+    .records // []
+    | .[]
+    | "\(.type)\t\(.name)\t\(.content)\tttl=\(.ttl)"
+  ' | column -t -s $'\t' >&2
+}
+
+create_record() {
+  local name="$1" type="$2" content="$3"
+  local body
+  body=$(jq -n \
+    --arg k "$API_KEY" --arg s "$SECRET_KEY" \
+    --arg n "$name" --arg t "$type" --arg c "$content" \
+    --arg ttl "$RECORD_TTL" \
+    '{apikey:$k, secretapikey:$s, name:$n, type:$t, content:$c, ttl:$ttl}')
+  check_status "$(api "/dns/create/$DOMAIN" "$body")" "create $type ${name:-@} -> $content"
+}
+
+command -v curl >/dev/null || { log "curl is required"; exit 1; }
+command -v jq   >/dev/null || { log "jq is required (brew install jq)"; exit 1; }
+
+log "==> Resolving credentials"
+API_KEY="$(get_secret "API key"        "$PASS_KEY_PATH"    PORKBUN_API_KEY)"
+SECRET_KEY="$(get_secret "Secret API key" "$PASS_SECRET_PATH" PORKBUN_SECRET_API_KEY)"
+
+if [[ -z "$API_KEY" || -z "$SECRET_KEY" ]]; then
+  log "Missing credentials"; exit 1
+fi
+
+AUTH_BODY=$(jq -n --arg k "$API_KEY" --arg s "$SECRET_KEY" \
+  '{apikey:$k, secretapikey:$s}')
+
+log
+log "==> Verifying API credentials"
+check_status "$(api /ping)" "ping" || exit 1
+
+log
+log "==> Current DNS records for $DOMAIN:"
+print_records
+
+log
+read -r -p "Proceed: replace apex A/ALIAS and obsidian CNAME? [y/N] " confirm
+[[ "$confirm" =~ ^[Yy]$ ]] || { log "aborted"; exit 0; }
+
+log
+log "==> Deleting existing records"
+check_status "$(api "/dns/deleteByNameType/$DOMAIN/A")" "delete A @ apex" || true
+check_status "$(api "/dns/deleteByNameType/$DOMAIN/ALIAS")" "delete ALIAS @ apex" || true
+check_status "$(api "/dns/deleteByNameType/$DOMAIN/CNAME/obsidian")" "delete CNAME @ obsidian" || true
+
+log
+log "==> Creating 4 A records on apex (GitHub Pages)"
+for ip in "${GH_PAGES_IPS[@]}"; do
+  log "  $ip"
+  create_record "" "A" "$ip"
+done
+
+log
+log "==> Creating CNAME obsidian.$DOMAIN -> $OBSIDIAN_CNAME_TARGET"
+create_record "obsidian" "CNAME" "$OBSIDIAN_CNAME_TARGET"
+
+log
+log "==> Resulting DNS records:"
+print_records
+
+cat >&2 <<EOF
+
+Done. Wait 5-30 min for DNS to propagate, then verify externally:
+  dig lilbee.sh +short             # should return the 4 GitHub IPs
+  dig obsidian.lilbee.sh +short    # should return tobocop2.github.io, then IPs
+
+Once both resolve correctly, push the CNAME files to both repos and update
+the README / pyproject.toml URL references.
+EOF

--- a/scripts/porkbun-dns-setup.sh
+++ b/scripts/porkbun-dns-setup.sh
@@ -18,10 +18,11 @@ API_BASE="https://api.porkbun.com/api/json/v3"
 PASS_KEY_PATH="porkbun/tobocop/api-key"
 PASS_SECRET_PATH="porkbun/tobocop/api-secret"
 RECORD_TTL="600"
-OBSIDIAN_CNAME_TARGET="tobocop2.github.io"
 
-# GitHub Pages anycast IPs. Update if GH ever rotates them; see
+# GitHub Pages user-page host (CNAME target for project subdomains) and the
+# anycast IPs (A records for the apex). Update if GH ever rotates them; see
 # https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site
+GH_PAGES_HOST="tobocop2.github.io"
 GH_PAGES_IPS=(
   185.199.108.153
   185.199.109.153
@@ -128,8 +129,8 @@ for ip in "${GH_PAGES_IPS[@]}"; do
 done
 
 log
-log "==> Creating CNAME obsidian.$DOMAIN -> $OBSIDIAN_CNAME_TARGET"
-create_record "obsidian" "CNAME" "$OBSIDIAN_CNAME_TARGET"
+log "==> Creating CNAME obsidian.$DOMAIN -> $GH_PAGES_HOST"
+create_record "obsidian" "CNAME" "$GH_PAGES_HOST"
 
 log
 log "==> Resulting DNS records:"

--- a/scripts/porkbun-dns-setup.sh
+++ b/scripts/porkbun-dns-setup.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Porkbun DNS setup for lilbee.sh.
 #
-# Configures DNS at Porkbun for the marketing site (apex, GitHub Pages) and
-# the Obsidian plugin site (obsidian subdomain). Run once; idempotent.
+# Configures DNS at Porkbun for the marketing site (apex, GitHub Pages),
+# the Obsidian plugin site (obsidian subdomain), and a wildcard URL forward
+# that redirects any other subdomain to the canonical https://lilbee.sh.
+# Run once; idempotent.
 #
 # Credential resolution order:
 #   1. pass: `pass show porkbun/tobocop/api-key` and `pass show porkbun/tobocop/api-secret`
@@ -29,6 +31,10 @@ GH_PAGES_IPS=(
   185.199.110.153
   185.199.111.153
 )
+
+# Wildcard URL forward: any *.lilbee.sh subdomain that isn't otherwise defined
+# 301-redirects to the canonical site, preserving the request path.
+WILDCARD_REDIRECT_TARGET="https://$DOMAIN"
 
 # log goes to stderr so command-substitution stdout stays clean for get_secret.
 log() { echo "$@" >&2; }
@@ -78,6 +84,14 @@ print_records() {
   ' | column -t -s $'\t' >&2
 }
 
+print_forwards() {
+  api "/domain/getUrlForwarding/$DOMAIN" | jq -r --arg dom "$DOMAIN" '
+    .forwards // []
+    | .[]
+    | "\(if .wildcard == "yes" then "*" else (.subdomain // "") end).\($dom)\t\(.type)\t-> \(.location)\tincludePath=\(.includePath)"
+  ' | column -t -s $'\t' >&2
+}
+
 create_record() {
   local name="$1" type="$2" content="$3"
   local body
@@ -112,7 +126,11 @@ log "==> Current DNS records for $DOMAIN:"
 print_records
 
 log
-read -r -p "Proceed: replace apex A/ALIAS and obsidian CNAME? [y/N] " confirm
+log "==> Current URL forwards for $DOMAIN:"
+print_forwards
+
+log
+read -r -p "Proceed: replace records + wildcard forward to $WILDCARD_REDIRECT_TARGET? [y/N] " confirm
 [[ "$confirm" =~ ^[Yy]$ ]] || { log "aborted"; exit 0; }
 
 log
@@ -120,6 +138,18 @@ log "==> Deleting existing records"
 check_status "$(api "/dns/deleteByNameType/$DOMAIN/A")" "delete A @ apex" || true
 check_status "$(api "/dns/deleteByNameType/$DOMAIN/ALIAS")" "delete ALIAS @ apex" || true
 check_status "$(api "/dns/deleteByNameType/$DOMAIN/CNAME/obsidian")" "delete CNAME @ obsidian" || true
+
+log "==> Deleting existing wildcard CNAME (Porkbun parking default)"
+api "/dns/retrieve/$DOMAIN" | jq -r '.records[]? | select(.type == "CNAME" and (.name | startswith("*."))) | .id' | while IFS= read -r rid; do
+  [[ -z "$rid" ]] && continue
+  check_status "$(api "/dns/delete/$DOMAIN/$rid")" "delete wildcard CNAME id=$rid" || true
+done
+
+log "==> Deleting existing wildcard URL forwards"
+api "/domain/getUrlForwarding/$DOMAIN" | jq -r '.forwards[]? | select(.wildcard == "yes") | .id' | while IFS= read -r fid; do
+  [[ -z "$fid" ]] && continue
+  check_status "$(api "/domain/deleteUrlForward/$DOMAIN/$fid")" "delete URL forward id=$fid" || true
+done
 
 log
 log "==> Creating 4 A records on apex (GitHub Pages)"
@@ -133,15 +163,29 @@ log "==> Creating CNAME obsidian.$DOMAIN -> $GH_PAGES_HOST"
 create_record "obsidian" "CNAME" "$GH_PAGES_HOST"
 
 log
+log "==> Creating wildcard URL forward *.$DOMAIN -> $WILDCARD_REDIRECT_TARGET (permanent, include path)"
+forward_body=$(jq -n \
+  --arg k "$API_KEY" --arg s "$SECRET_KEY" \
+  --arg loc "$WILDCARD_REDIRECT_TARGET" \
+  '{apikey:$k, secretapikey:$s, subdomain:"", location:$loc, type:"permanent", includePath:"yes", wildcard:"yes"}')
+check_status "$(api "/domain/addUrlForward/$DOMAIN" "$forward_body")" "create wildcard URL forward"
+
+log
 log "==> Resulting DNS records:"
 print_records
+
+log
+log "==> Resulting URL forwards:"
+print_forwards
 
 cat >&2 <<EOF
 
 Done. Wait 5-30 min for DNS to propagate, then verify externally:
   dig lilbee.sh +short             # should return the 4 GitHub IPs
   dig obsidian.lilbee.sh +short    # should return tobocop2.github.io, then IPs
+  curl -I https://www.lilbee.sh    # should 301 redirect to https://lilbee.sh/
 
-Once both resolve correctly, push the CNAME files to both repos and update
-the README / pyproject.toml URL references.
+The repo's site/CNAME files activate the custom domains on the next Pages
+deploy. After GitHub provisions HTTPS certs (5-30 min post-deploy), enable
+"Enforce HTTPS" in each repo's Pages settings.
 EOF

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+lilbee.sh

--- a/site/index.html
+++ b/site/index.html
@@ -5,14 +5,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>lilbee: a batteries-included local search engine you can talk to</title>
 <meta name="description" content="A batteries-included local search engine for your data and code. Ask in plain English; every answer cites the file and line. CLI + TUI + MCP server.">
-<link rel="canonical" href="https://tobocop2.github.io/lilbee/">
+<link rel="canonical" href="https://lilbee.sh/">
 
 <!-- Open Graph: rich link previews for any client that reads the protocol. -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="lilbee">
 <meta property="og:title" content="lilbee: a batteries-included local search engine you can talk to">
 <meta property="og:description" content="A batteries-included local search engine for your data and code. Ask in plain English; every answer cites the file and line.">
-<meta property="og:url" content="https://tobocop2.github.io/lilbee/">
+<meta property="og:url" content="https://lilbee.sh/">
 <meta property="og:image" content="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.png">
 <meta property="og:image:width" content="1400">
 <meta property="og:image:height" content="900">
@@ -27,7 +27,7 @@
   "description": "A batteries-included local search engine for your data and code that you can talk to. Cited answers, local-first, with an MCP server for agent integration.",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "macOS, Linux, Windows",
-  "url": "https://tobocop2.github.io/lilbee/",
+  "url": "https://lilbee.sh/",
   "downloadUrl": "https://pypi.org/project/lilbee/",
   "license": "https://github.com/tobocop2/lilbee/blob/main/LICENSE",
   "softwareVersion": "0.6.66b",
@@ -179,7 +179,7 @@
         </div>
         <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-pip">details</button>
         <div class="notes-body" id="notes-pip" hidden>
-          <p class="extras">needs Python 3.11+ &nbsp;.&nbsp; intel mac: add <code>--extra-index-url https://tobocop2.github.io/lilbee/cpu/</code> &nbsp;.&nbsp; extras below, e.g. <code>pip install --pre 'lilbee[crawler,litellm]'</code></p>
+          <p class="extras">needs Python 3.11+ &nbsp;.&nbsp; intel mac: add <code>--extra-index-url https://lilbee.sh/cpu/</code> &nbsp;.&nbsp; extras below, e.g. <code>pip install --pre 'lilbee[crawler,litellm]'</code></p>
         </div>
       </div>
 
@@ -266,7 +266,7 @@
         <div class="oschips"><span class="oschip">Linux x86_64</span><span class="oschip">Windows x86_64</span><span class="oschip dim">NVIDIA GPU</span></div>
         <div class="install">
           <span class="prompt">$</span>
-          <span class="cmd">pip install --pre lilbee --extra-index-url https://tobocop2.github.io/lilbee/cu125/</span>
+          <span class="cmd">pip install --pre lilbee --extra-index-url https://lilbee.sh/cu125/</span>
           <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
         </div>
         <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-cuda">details</button>


### PR DESCRIPTION
Sets up `lilbee.sh` and `obsidian.lilbee.sh` as the public domains for the project.

Adds `make dns-setup` (script reads Porkbun credentials from `pass`) which configures DNS at Porkbun: GitHub Pages A records on the apex, CNAMEs for `www.lilbee.sh` and `obsidian.lilbee.sh`, and a wildcard URL forward so `*.lilbee.sh` 301s back to the canonical apex.

Adds `site/CNAME` (activates the custom domain on the next Pages deploy) and switches the README, pyproject Homepage, docs, and the site canonical/og:url to `https://lilbee.sh`.