### PR TITLE
tui: expose HF token as a writable setting

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -447,6 +447,7 @@ The ones most users set at least once.
 | `LILBEE_LOG_LEVEL` | `WARNING` | Logging level (DEBUG, INFO, WARNING, ERROR) |
 | `LILBEE_SYSTEM_PROMPT` | *(built-in)* | Custom system prompt for RAG answers |
 | `LILBEE_SHOW_REASONING` | `false` | Show the model's `<think>` reasoning tokens in chat output. Useful with Qwen3, DeepSeek-R1, and other reasoning models |
+| `LILBEE_HF_TOKEN` | *(none)* | HuggingFace access token. Avoids the unauthenticated download rate limit and unlocks gated repos. Same token can be persisted via the `System` tab in `/settings` (stored in plain text at `config.toml`). `HF_TOKEN` env var also accepted |
 
 ### Retrieval tuning
 

--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -13,6 +13,7 @@ from huggingface_hub import ModelInfo
 from huggingface_hub.hf_api import RepoSibling
 
 from lilbee.catalog.models import CatalogModel, HfGgufMeta, HfPage
+from lilbee.core.config import cfg
 
 log = logging.getLogger(__name__)
 
@@ -81,10 +82,12 @@ _BYTES_PER_GB = 1024**3
 
 
 def hf_token() -> str | None:
-    """Read HuggingFace token from env vars or huggingface_hub login cache."""
+    """Resolve the HuggingFace token in priority order: env > cfg > hub cache."""
     token = os.environ.get("LILBEE_HF_TOKEN") or os.environ.get("HF_TOKEN") or None
     if token:
         return token
+    if cfg.hf_token:
+        return cfg.hf_token
     try:
         from huggingface_hub import get_token
 

--- a/src/lilbee/cli/settings_map.py
+++ b/src/lilbee/cli/settings_map.py
@@ -514,6 +514,16 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group="API-Keys",
         help_text="DeepSeek API key (enables frontier models in chat picker)",
     ),
+    "hf_token": SettingDef(
+        str,
+        nullable=False,
+        group="System",
+        help_text=(
+            "HuggingFace access token. Avoids the unauthenticated download "
+            "rate limit and unlocks gated repos. Stored in plain text in "
+            "config.toml. Env vars (LILBEE_HF_TOKEN, HF_TOKEN) override."
+        ),
+    ),
     "chunk_size": SettingDef(
         int,
         nullable=False,

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -129,6 +129,7 @@ class Config(BaseSettings):
     openai_api_key: str = ConfigField(default="", writable=True, write_only=True)
     mistral_api_key: str = ConfigField(default="", writable=True, write_only=True)
     deepseek_api_key: str = ConfigField(default="", writable=True, write_only=True)
+    hf_token: str = ConfigField(default="", writable=True, write_only=True)
 
     # Retrieval quality knobs.
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -130,17 +130,38 @@ class TestHfToken:
         monkeypatch.setenv("HF_TOKEN", "hf-env-token")
         assert hf_token() == "hf-env-token"
 
-    def test_falls_back_to_huggingface_hub_get_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_falls_back_to_cfg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.core.config import cfg
+
         monkeypatch.delenv("LILBEE_HF_TOKEN", raising=False)
         monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr(cfg, "hf_token", "cfg-token")
+        assert hf_token() == "cfg-token"
+
+    def test_env_var_overrides_cfg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.core.config import cfg
+
+        monkeypatch.setenv("LILBEE_HF_TOKEN", "env-token")
+        monkeypatch.setattr(cfg, "hf_token", "cfg-token")
+        assert hf_token() == "env-token"
+
+    def test_falls_back_to_huggingface_hub_get_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.core.config import cfg
+
+        monkeypatch.delenv("LILBEE_HF_TOKEN", raising=False)
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr(cfg, "hf_token", "")
         fake_hf_hub = MagicMock()
         fake_hf_hub.get_token.return_value = "cached-token"
         monkeypatch.setitem(__import__("sys").modules, "huggingface_hub", fake_hf_hub)
         assert hf_token() == "cached-token"
 
     def test_returns_none_when_all_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.core.config import cfg
+
         monkeypatch.delenv("LILBEE_HF_TOKEN", raising=False)
         monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr(cfg, "hf_token", "")
         fake_hf_hub = MagicMock()
         fake_hf_hub.get_token.side_effect = Exception("no token")
         monkeypatch.setitem(__import__("sys").modules, "huggingface_hub", fake_hf_hub)

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -586,6 +586,22 @@ async def test_settings_api_keys_group_shows_plaintext_warning():
         assert "sensitive" in rendered.lower()
 
 
+async def test_settings_hf_token_help_warns_plaintext():
+    """hf_token row in the System tab warns the user about plain-text storage."""
+    from textual.widgets import Static, TabbedContent
+
+    app = SettingsTestApp()
+    async with app.run_test(size=(120, 60)) as pilot:
+        tabbed = app.screen.query_one("#settings-tabs", TabbedContent)
+        tabbed.active = "settings-tab-system"
+        await pilot.pause(0.2)
+        row = app.screen.query_one("#row-hf_token")
+        help_widget = row.query_one(".setting-help", Static)
+        rendered = str(help_widget.render())
+        assert "plain text" in rendered.lower()
+        assert "config.toml" in rendered.lower()
+
+
 async def test_settings_tab_activation_populates_pane():
     """Activating a settings tab mounts its rows.
 


### PR DESCRIPTION
## Problem

The TUI had no way to set a HuggingFace token. Users hit the unauthenticated download rate limit on the catalog and got opaque permission errors on gated repos, with no in-app surface to fix it short of an env var.

## Solution

A new `hf_token` row in the `System` tab of `/settings`. The help text rendered right above the editor calls out plain-text-in-config.toml storage so the storage tradeoff is obvious before the user pastes anything in. Env vars still win; the catalog resolver picks them up first, then the persisted setting, then the existing huggingface_hub login cache.