### PR TITLE
tui: drop the m footer keybinding for the model bar

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -170,10 +170,6 @@ class ChatScreen(Screen[None]):
         # nothing is streaming.
         Binding("ctrl+c", "cancel_stream", "Cancel stream", show=True, priority=True),
         Binding("ctrl+r", "toggle_markdown", "Markdown", show=False),
-        # `m` is a NORMAL-mode shortcut to the model bar; in INSERT mode the
-        # focused chat input types the literal "m". `check_action` hides it
-        # from the footer there so the hint matches what the key does.
-        Binding("m", "focus_model_bar", "Models", show=True),
         Binding("s", "cycle_scope", "Scope", show=False),
         # F2 opens the searchable list of every slash command
         # (SlashCommandCatalog) -- not the model catalog, which is `/models`.
@@ -1143,14 +1139,9 @@ class ChatScreen(Screen[None]):
 
         - ``cancel_stream`` (Ctrl+C) only does something while streaming in
           INSERT mode; otherwise the App's Quit binding takes the slot.
-        - ``focus_model_bar`` (``m``) is a NORMAL-mode shortcut; in INSERT
-          mode the focused chat input types the literal character, so the
-          ``m Models`` hint would lie.
         """
         if action == "cancel_stream":
             return self.streaming and self._insert_mode
-        if action == "focus_model_bar":
-            return not self._insert_mode
         return super().check_action(action, parameters)
 
     def action_enter_normal_mode(self) -> None:
@@ -1271,13 +1262,6 @@ class ChatScreen(Screen[None]):
         if not inp.value.startswith("/"):
             inp.value = "/"
             inp.action_end()
-
-    def action_focus_model_bar(self) -> None:
-        """Focus the chat-model picker button in the model bar (normal mode only)."""
-        if self._insert_mode:
-            raise SkipAction()
-        with contextlib.suppress(NoMatches):
-            self.query_one("#chat-model-button", ModelPickerButton).focus()
 
     def action_toggle_chat_mode(self) -> None:
         """F3: flip between Search and Chat mode."""

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -315,12 +315,7 @@ async def test_catalog_nav_noop_when_search_focused():
 
 
 async def test_chat_tab_outside_input_advances_focus():
-    """Tab from outside the chat input advances the focus chain.
-
-    The dedicated jump-to-model-bar shortcut is ``m`` (see
-    ``Binding("m", "focus_model_bar", ...)``); Tab is the universal
-    walk-the-chain key, not a shortcut to the model dropdown.
-    """
+    """Tab from outside the chat input advances the focus chain."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
@@ -345,7 +340,7 @@ async def test_chat_escape_from_model_picker_button():
 
         await pilot.press("escape")
         await pilot.pause()
-        screen.action_focus_model_bar()
+        screen.query_one("#chat-model-button", ModelPickerButton).focus()
         await pilot.pause()
 
         assert isinstance(screen.focused, ModelPickerButton)
@@ -354,39 +349,6 @@ async def test_chat_escape_from_model_picker_button():
         await pilot.pause()
         assert screen.focused is not None
         assert screen.focused.id == "chat-input"
-
-
-async def test_chat_m_key_skips_in_insert_mode():
-    """m key raises SkipAction in insert mode."""
-    from textual.actions import SkipAction
-
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        assert screen._insert_mode is True
-
-        try:
-            screen.action_focus_model_bar()
-            raised = False
-        except SkipAction:
-            raised = True
-        assert raised
-
-
-async def test_chat_footer_hides_models_hint_in_insert_mode():
-    """`m Models` is shown only in NORMAL mode -- in INSERT mode `m` types
-    a literal character, so the footer hint must disappear there."""
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        assert screen._insert_mode is True
-        assert screen.check_action("focus_model_bar", ()) is False
-        await pilot.press("escape")
-        await pilot.pause()
-        assert screen._insert_mode is False
-        assert screen.check_action("focus_model_bar", ()) is True
 
 
 async def test_app_footer_hides_tasks_hint_when_text_input_focused():


### PR DESCRIPTION
## Problem

The chat footer advertised `m Models` as a shortcut to the model picker, but the binding only fired in NORMAL mode. Most users live in INSERT mode, so pressing `m` did nothing (or typed a literal m in the prompt). The hint promised functionality the key didn't deliver.

## Solution

Remove the binding, its action, and the associated mode-aware footer juggling. Tab already walks focus into the model bar for users who want a keyboard path, so no functionality is lost.