### PR TITLE
Host wheels on GitHub releases; let the extra-index actually serve them

### DIFF
--- a/.github/actions/attach-prerelease/action.yml
+++ b/.github/actions/attach-prerelease/action.yml
@@ -1,5 +1,5 @@
-name: Attach binaries to GH pre-release
-description: "Attach lilbee-* binary artifacts from this run to a pre-release at the given tag (caller needs contents:write)."
+name: Attach binaries and wheels to GH pre-release
+description: "Attach this run's standalone executables and per-backend wheel artifacts to a pre-release at the given tag. Caller needs contents:write."
 
 inputs:
   tag:
@@ -16,17 +16,38 @@ runs:
       uses: actions/download-artifact@v4
       with:
         pattern: lilbee-*
-        path: bins/
+        path: assets/
         merge-multiple: true
 
-    - name: List binary artifacts
-      shell: bash
-      run: ls -lh bins/
+    # Default-backend wheels (Linux/Win Vulkan, macOS Metal) ship to PyPI as
+    # well, but attaching them to the release keeps a single discoverable
+    # download surface and lets the PEP 503 index link to one place.
+    - name: Download default wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: wheel-default-*
+        path: assets/
+        merge-multiple: true
 
-    - name: Create GH pre-release with binaries
+    # Extra-backend wheels (cu121/cu124/cu125, Intel-Mac CPU) only live here.
+    # GitHub Pages has a 1 GB per-deploy cap; GitHub releases do not, so
+    # the wheels themselves get hosted on the release and the PEP 503 index
+    # at lilbee.sh/<backend>/lilbee/ links to these URLs.
+    - name: Download extra wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: wheel-extra-*
+        path: assets/
+        merge-multiple: true
+
+    - name: List release assets
+      shell: bash
+      run: ls -lh assets/
+
+    - name: Create GH pre-release with binaries and wheels
       uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ inputs.tag }}
-        files: bins/*
+        files: assets/*
         generate_release_notes: true
         prerelease: ${{ contains(inputs.version, 'a') || contains(inputs.version, 'b') || contains(inputs.version, 'rc') }}

--- a/.github/actions/attach-prerelease/action.yml
+++ b/.github/actions/attach-prerelease/action.yml
@@ -16,38 +16,47 @@ runs:
       uses: actions/download-artifact@v4
       with:
         pattern: lilbee-*
-        path: assets/
+        path: bins/
         merge-multiple: true
 
-    # Default-backend wheels (Linux/Win Vulkan, macOS Metal) ship to PyPI as
-    # well, but attaching them to the release keeps a single discoverable
-    # download surface and lets the PEP 503 index link to one place.
+    # Default-backend wheels (Linux/Win Vulkan, macOS Metal) keep their
+    # original PyPI-published filenames -- they also ship to PyPI and a
+    # renamed copy here would diverge from the pinned canonical name.
     - name: Download default wheels
       uses: actions/download-artifact@v4
       with:
         pattern: wheel-default-*
-        path: assets/
+        path: default-wheels/
         merge-multiple: true
 
-    # Extra-backend wheels (cu121/cu124/cu125, Intel-Mac CPU) only live here.
-    # GitHub Pages has a 1 GB per-deploy cap; GitHub releases do not, so
-    # the wheels themselves get hosted on the release and the PEP 503 index
-    # at lilbee.sh/<backend>/lilbee/ links to these URLs.
-    - name: Download extra wheels
+    # Extra-backend wheels (cu121/cu124/cu125, cpu) share PEP 427 filenames
+    # with each other and with the default wheels -- the backend lives
+    # inside the wheel, not in its filename. Stage them through
+    # tools/stage_release_assets.py which inserts a backend build tag
+    # (1.cu125 etc.) so all variants can coexist on a single GH release.
+    - name: Download extra wheels (staging tree)
       uses: actions/download-artifact@v4
       with:
         pattern: wheel-extra-*
-        path: assets/
-        merge-multiple: true
+        path: extra-wheels-staging/
+
+    - name: Stage extra wheels with backend build tag
+      shell: bash
+      run: |
+        python3 -m tools.stage_release_assets extra-wheels-staging/ extra-wheels/
 
     - name: List release assets
       shell: bash
-      run: ls -lh assets/
+      run: |
+        ls -lh bins/ default-wheels/ extra-wheels/
 
     - name: Create GH pre-release with binaries and wheels
       uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ inputs.tag }}
-        files: assets/*
+        files: |
+          bins/*
+          default-wheels/*
+          extra-wheels/*
         generate_release_notes: true
         prerelease: ${{ contains(inputs.version, 'a') || contains(inputs.version, 'b') || contains(inputs.version, 'rc') }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -98,12 +98,15 @@ jobs:
       skip_tests: ${{ inputs.skip_tests || false }}
     secrets: inherit
 
-  # Attach binaries to a GH pre-release as soon as they're built, before QA
-  # runs. A GH release is reversible (delete + retag) so this is safe to do
-  # eagerly; the irreversible step (PyPI) waits for a human to run
-  # publish.yml after reviewing QA.
-  attach-binaries-prerelease:
-    needs: [resolve, build-binaries]
+  # Attach this run's executables AND every wheel to a GH pre-release. The
+  # wheels live on the release page because GitHub Pages has a 1 GB per-deploy
+  # cap that the full default + extra wheel set (~6 GB) blows through; the
+  # PEP 503 index at lilbee.sh/<backend>/lilbee/ now links to these release
+  # asset URLs instead of trying to host the wheels itself. A GH release is
+  # reversible (delete + retag) so this is safe to do eagerly; the
+  # irreversible step (PyPI) waits for a human to run publish.yml.
+  attach-prerelease:
+    needs: [resolve, build-default-wheels, build-extra-wheels, build-binaries]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/tools/build_pep503_indexes.py
+++ b/tools/build_pep503_indexes.py
@@ -9,6 +9,15 @@ site itself doesn't need to host multi-gigabyte wheels. GitHub Pages has
 a 1 GB per-deployment cap, which makes self-hosting cu121/cu124/cu125 +
 cpu wheels (~6 GB total) infeasible; GitHub releases have no such cap.
 
+Backend disambiguation. The wheel files for cu121, cu124, cu125, and the
+Intel-Mac/Win cpu builds all share the same PEP 427 filename (project +
+version + python + abi + platform) as the default vulkan/metal wheels --
+the backend lives inside the wheel, not in its name. GitHub releases use
+a flat filename namespace, so each non-default wheel gets a PEP 427
+build-tag inserted (``1.cu125``, ``1.cu124``, ``1.cu121``, ``1.cpu``).
+Defaults stay unchanged because they also ship to PyPI, where build tags
+would break the existing pin.
+
 Input layout (artifact-dir mode):
 
     <input>/wheel-default-<os>-<backend>-py<ver>/lilbee-*.whl
@@ -40,6 +49,14 @@ ARTIFACT_DIR_RE = re.compile(r"^wheel-(?:default|extra)-(?P<rest>.+)-py\d+\.\d+$
 WHEEL_FILENAME_RE = re.compile(r"^lilbee-(?P<version>[^-]+)-")
 _DEFAULT_RELEASE_BASE_URL = "https://github.com/tobocop2/lilbee/releases/download"
 
+# Backends whose wheels ship under the default filename (also on PyPI; renaming
+# would break the PyPI pin). Everything else gets a PEP 427 build tag inserted
+# so the GH release can hold every variant without filename collisions.
+_DEFAULT_BACKENDS: frozenset[str] = frozenset({"vulkan", "metal"})
+
+# Wheel filename layout (PEP 427): project-version[-buildtag]-python-abi-platform.whl
+_WHEEL_FILENAME_PARTS_NO_BUILDTAG = 5
+
 
 def backend_from_artifact_dir(name: str) -> str | None:
     """Extract backend tag from a wheel artifact directory name.
@@ -59,6 +76,32 @@ def version_from_wheel_filename(name: str) -> str | None:
     return m.group("version") if m else None
 
 
+def build_tag_for_backend(backend: str) -> str | None:
+    """PEP 427 build tag used to disambiguate non-default backend variants."""
+    if backend in _DEFAULT_BACKENDS:
+        return None
+    return f"1.{backend}"
+
+
+def rename_for_release(wheel_name: str, backend: str) -> str:
+    """Return the wheel filename as published on the GH release.
+
+    Default backends (vulkan/metal) keep their original name. Extra backends
+    get a build tag inserted after the version per PEP 427.
+    """
+    build_tag = build_tag_for_backend(backend)
+    if build_tag is None:
+        return wheel_name
+    parts = wheel_name.removesuffix(".whl").split("-")
+    if len(parts) != _WHEEL_FILENAME_PARTS_NO_BUILDTAG:
+        raise ValueError(
+            f"wheel filename {wheel_name!r} does not match the no-buildtag layout "
+            f"(project-version-python-abi-platform.whl)"
+        )
+    project, version, python, abi, platform = parts
+    return f"{project}-{version}-{build_tag}-{python}-{abi}-{platform}.whl"
+
+
 def collect_wheels(input_dir: Path) -> dict[str, list[Path]]:
     """Group wheel files by backend tag."""
     by_backend: dict[str, list[Path]] = {}
@@ -75,8 +118,8 @@ def collect_wheels(input_dir: Path) -> dict[str, list[Path]]:
     return by_backend
 
 
-def _wheel_href(release_base_url: str, version: str, wheel_name: str) -> str:
-    return f"{release_base_url.rstrip('/')}/v{version}/{wheel_name}"
+def _wheel_href(release_base_url: str, version: str, asset_name: str) -> str:
+    return f"{release_base_url.rstrip('/')}/v{version}/{asset_name}"
 
 
 def write_backend_indexes(
@@ -95,8 +138,9 @@ def write_backend_indexes(
             if version is None:
                 print(f"skipping unparseable wheel filename: {whl.name}", file=sys.stderr)
                 continue
-            href = _wheel_href(release_base_url, version, whl.name)
-            wheel_lines.append(f'<a href="{href}">{whl.name}</a><br>')
+            asset_name = rename_for_release(whl.name, backend)
+            href = _wheel_href(release_base_url, version, asset_name)
+            wheel_lines.append(f'<a href="{href}">{asset_name}</a><br>')
 
         (pkg_dir / "index.html").write_text(
             "<!DOCTYPE html><html><body>\n" + "\n".join(wheel_lines) + "\n</body></html>\n"

--- a/tools/build_pep503_indexes.py
+++ b/tools/build_pep503_indexes.py
@@ -2,39 +2,43 @@
 """Emit PEP 503 simple-repository indexes for lilbee per-backend wheels.
 
 Reads wheel artifacts produced by the build-default-wheels.yml /
-build-extra-wheels.yml reusable workflows, groups by backend tag, copies
-wheels into <site>/<backend>/lilbee/, and writes the per-directory index.html
-files pip's --extra-index-url expects.
+build-extra-wheels.yml reusable workflows, groups by backend tag, and
+writes per-directory ``index.html`` files. Each wheel link is rendered as
+an absolute URL into the wheel's GitHub release assets, so the static
+site itself doesn't need to host multi-gigabyte wheels. GitHub Pages has
+a 1 GB per-deployment cap, which makes self-hosting cu121/cu124/cu125 +
+cpu wheels (~6 GB total) infeasible; GitHub releases have no such cap.
 
-Input layout (artifact-dir mode, default):
+Input layout (artifact-dir mode):
 
     <input>/wheel-default-<os>-<backend>-py<ver>/lilbee-*.whl
     <input>/wheel-extra-<os>-<backend>-py<ver>/lilbee-*.whl
 
-The os segment may itself contain dashes (e.g. ubuntu-22.04, ubuntu-latest,
-windows-2022). Backend is parsed by stripping the wheel-{default,extra}-
-prefix and the trailing -py<ver> suffix, then taking the last remaining
-dash-segment.
+Backend is parsed by stripping the wheel-{default,extra}- prefix and the
+trailing -py<ver> suffix, then taking the last remaining dash-segment.
+The wheel's version is parsed from its filename so the release URL can
+be constructed without an extra CLI flag for the tag.
 
 Output layout:
 
-    <site>/<backend>/lilbee/<wheel>.whl
-    <site>/<backend>/lilbee/index.html      # links to each wheel
-    <site>/<backend>/index.html             # links to lilbee/
+    <site>/<backend>/lilbee/index.html      # absolute hrefs to <release>/<whl>
+    <site>/<backend>/index.html             # link to lilbee/
 
 Usage:
-    python tools/build_pep503_indexes.py <artifacts-dir> <site-dir>
+    python tools/build_pep503_indexes.py <artifacts-dir> <site-dir> \\
+        [--release-base-url https://github.com/owner/repo/releases/download]
 """
 
 from __future__ import annotations
 
 import argparse
 import re
-import shutil
 import sys
 from pathlib import Path
 
 ARTIFACT_DIR_RE = re.compile(r"^wheel-(?:default|extra)-(?P<rest>.+)-py\d+\.\d+$")
+WHEEL_FILENAME_RE = re.compile(r"^lilbee-(?P<version>[^-]+)-")
+_DEFAULT_RELEASE_BASE_URL = "https://github.com/tobocop2/lilbee/releases/download"
 
 
 def backend_from_artifact_dir(name: str) -> str | None:
@@ -47,6 +51,12 @@ def backend_from_artifact_dir(name: str) -> str | None:
         return None
     rest = m.group("rest")
     return rest.rsplit("-", 1)[-1]
+
+
+def version_from_wheel_filename(name: str) -> str | None:
+    """Extract the lilbee version from ``lilbee-<version>-<rest>.whl``."""
+    m = WHEEL_FILENAME_RE.match(name)
+    return m.group("version") if m else None
 
 
 def collect_wheels(input_dir: Path) -> dict[str, list[Path]]:
@@ -65,15 +75,29 @@ def collect_wheels(input_dir: Path) -> dict[str, list[Path]]:
     return by_backend
 
 
-def write_backend_indexes(site: Path, by_backend: dict[str, list[Path]]) -> None:
-    """Copy wheels and write PEP 503 index pages under site/<backend>/."""
+def _wheel_href(release_base_url: str, version: str, wheel_name: str) -> str:
+    return f"{release_base_url.rstrip('/')}/v{version}/{wheel_name}"
+
+
+def write_backend_indexes(
+    site: Path,
+    by_backend: dict[str, list[Path]],
+    release_base_url: str,
+) -> None:
+    """Write PEP 503 index pages under site/<backend>/, linking to release assets."""
     for backend, wheels in by_backend.items():
         pkg_dir = site / backend / "lilbee"
         pkg_dir.mkdir(parents=True, exist_ok=True)
-        for whl in wheels:
-            shutil.copy2(whl, pkg_dir / whl.name)
 
-        wheel_lines = [f'<a href="{whl.name}">{whl.name}</a><br>' for whl in wheels]
+        wheel_lines: list[str] = []
+        for whl in wheels:
+            version = version_from_wheel_filename(whl.name)
+            if version is None:
+                print(f"skipping unparseable wheel filename: {whl.name}", file=sys.stderr)
+                continue
+            href = _wheel_href(release_base_url, version, whl.name)
+            wheel_lines.append(f'<a href="{href}">{whl.name}</a><br>')
+
         (pkg_dir / "index.html").write_text(
             "<!DOCTYPE html><html><body>\n" + "\n".join(wheel_lines) + "\n</body></html>\n"
         )
@@ -95,6 +119,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "site", type=Path, help="Output site root; backend subdirs are written under here"
     )
+    parser.add_argument(
+        "--release-base-url",
+        default=_DEFAULT_RELEASE_BASE_URL,
+        help="GitHub release-asset base URL (default: lilbee's release-download root).",
+    )
     args = parser.parse_args(argv)
 
     if not args.input.is_dir():
@@ -106,7 +135,7 @@ def main(argv: list[str] | None = None) -> int:
     if not by_backend:
         print("no wheel artifacts found; nothing to index", file=sys.stderr)
         return 0
-    write_backend_indexes(args.site, by_backend)
+    write_backend_indexes(args.site, by_backend, args.release_base_url)
     return 0
 
 

--- a/tools/stage_release_assets.py
+++ b/tools/stage_release_assets.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Copy wheel artifacts into a flat staging dir under their release-asset names.
+
+Each ``wheel-{default,extra}-<os>-<backend>-py<ver>/`` artifact subdir holds
+one wheel. The default-backend wheels (vulkan / metal) keep their original
+name -- those also ship to PyPI and a build tag would break the PyPI pin.
+Every other backend (cu121, cu124, cu125, cpu) gets a PEP 427 build tag
+inserted into the wheel filename so multiple variants of the same
+(project, version, python, abi, platform) tuple can coexist on a single
+GitHub release. ``build_pep503_indexes.py`` uses the same rename so the
+index hrefs match the release-asset names.
+
+Usage:
+    python tools/stage_release_assets.py <input-dir> <output-dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+from tools.build_pep503_indexes import backend_from_artifact_dir, rename_for_release
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "input", type=Path, help="Directory containing wheel-*-<backend>-py* artifact subdirs"
+    )
+    parser.add_argument(
+        "output", type=Path, help="Flat output directory to receive the renamed wheels"
+    )
+    args = parser.parse_args(argv)
+
+    if not args.input.is_dir():
+        print(f"input directory does not exist: {args.input}", file=sys.stderr)
+        return 1
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    staged = 0
+    for subdir in sorted(args.input.iterdir()):
+        if not subdir.is_dir():
+            continue
+        backend = backend_from_artifact_dir(subdir.name)
+        if backend is None:
+            continue
+        for whl in sorted(subdir.glob("lilbee-*.whl")):
+            asset_name = rename_for_release(whl.name, backend)
+            target = args.output / asset_name
+            if target.exists():
+                print(f"asset name collision: {asset_name} already staged", file=sys.stderr)
+                return 1
+            shutil.copy2(whl, target)
+            staged += 1
+            print(asset_name)
+    print(f"staged {staged} wheels", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

`pip install --pre lilbee --extra-index-url https://lilbee.sh/cu125/` (and `cu124`, `cu121`, `cpu`) returns a working PEP 503 index page, but every wheel link inside it returns 404. The CUDA / Intel-Mac / CPU wheels have never been reachable for end users.

GitHub Pages caps each deploy at 1 GB. A full wheel matrix (default Vulkan/Metal + cu121 + cu124 + cu125 + cpu, three Python versions each) is ~6 GB. The deploy step reports success, the index HTML lands, but the wheel files themselves are silently dropped.

## Solution

Move the wheels onto the GitHub release page (no size cap) and have the PEP 503 index link to those release-asset URLs instead of trying to host the wheels itself.

- attach-prerelease now also pulls `wheel-default-*` and `wheel-extra-*` artifacts and uploads them as release assets.
- The release-candidate's attach job waits on the wheel builds in addition to the binaries (wheels finish much earlier so this doesn't push the critical path out).
- `build_pep503_indexes.py` no longer copies wheels into the site; it parses the version from the wheel filename and writes absolute hrefs into the release assets.

Net effect: the deployed site goes from ~6 GB to a few KB of HTML. `pip install --pre lilbee --extra-index-url https://lilbee.sh/cu125/` follows the index, hits a GitHub-release URL, and downloads successfully.