### PR TITLE
demos: tui-setup with Hide 1000s

### DIFF
--- a/demos/_prep.sh
+++ b/demos/_prep.sh
@@ -78,18 +78,12 @@ reset_clean_slate() {
     mkdir -p "$data"
 }
 
-seed_setup_models() {
-    # Pre-pull the chat + embedding models into the tui-setup tape's
-    # isolated LILBEE_MODELS_DIR so the wizard reliably shows "Your
-    # existing models are ready". Real cold-pull renders are too
-    # sensitive to bandwidth -- a slow connection leaves the wizard at
-    # <100% when the chat fires and the demo captures a "Model not
-    # found in registry" error.
-    local setup_models="$ROOT/setup-models"
-    mkdir -p "$setup_models"
-    log "pre-pulling models into setup-models"
-    LILBEE_MODELS_DIR="$setup_models" "$LILBEE" model pull "$CHAT_MODEL" || true
-    LILBEE_MODELS_DIR="$setup_models" "$LILBEE" model pull "$EMBED_MODEL" || true
+wipe_setup_models() {
+    # The tui-setup tape renders a REAL cold pull of Qwen3 0.6B + Nomic.
+    # Wipe between renders so the wizard kicks off real downloads in
+    # the Task Center every time.
+    rm -rf "$ROOT/setup-models"
+    mkdir -p "$ROOT/setup-models"
 }
 
 page_cache_model() {
@@ -198,7 +192,7 @@ main() {
     # tui-setup's first chat is `/add ./README.md` against lilbee's own README,
     # so stage it in the demo's data dir after the clean-slate reset.
     cp "$REPO_DIR/README.md" "$ROOT/tui-setup/README.md"
-    seed_setup_models
+    wipe_setup_models
 
     for tape in "${OPENCODE_TAPES[@]}"; do
         setup_opencode_dir "$tape"

--- a/demos/tui-setup.tape
+++ b/demos/tui-setup.tape
@@ -1,14 +1,19 @@
 Source demos/_shared.tape
 Output demos/_out/tui-setup.gif
 
-# First-run wizard. Models are pre-pulled into setup-models by
-# demos/_prep.sh so the wizard reliably shows "Your existing models
-# are ready" -- a real cold pull of Qwen3 4B Q8_0 (2.5 GB) over a
-# 240s Hide previously failed on slower connections and the demo
-# captured a "Model not found in registry" error.
+# First-run wizard with a REAL cold pull on camera. setup-models is wiped
+# by demos/_prep.sh so the wizard kicks off two parallel downloads in the
+# Task Center. Hide elides the slow middle; Show resumes ONLY after both
+# downloads are guaranteed to be at "done".
+#
+# Empirical baseline today: Qwen3 0.6B Q8_0 (~500 MB) + Nomic v1.5
+# (~85 MB) reached "done" at t+419s. Bandwidth fluctuates run-to-run
+# (a prior render captured Qwen at 93% when chat fired), so Hide is
+# sized at a hard 1000s -- ~2.4x the measured time. The question
+# absolutely never fires before both downloads complete.
 Env LILBEE_DATA "/tmp/lilbee-demo/tui-setup"
 Env LILBEE_MODELS_DIR "/tmp/lilbee-demo/setup-models"
-Env LILBEE_CHAT_MODEL "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf"
+Env LILBEE_CHAT_MODEL "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf"
 Env LILBEE_THEME "rose-pine"
 Env LILBEE_SKIP_TOML_CONFIG "1"
 Env LILBEE_NO_SPLASH "1"
@@ -28,37 +33,59 @@ Sleep 300ms
 Enter
 Sleep 2500ms
 
-# Wizard appears with the curated catalog. The footer reads
-# "Your existing models are ready - Esc to return". Esc drops into chat.
+# Wizard appears with Qwen3 0.6B auto-focused on the chat row. Enter
+# picks it; Tab into the Embedding row and Enter picks Nomic v1.5.
 Sleep 1500ms
+Enter
+Sleep 1200ms
+Tab
+Sleep 300ms
+Enter
+Sleep 800ms
+
+# Jump to Task Center; show the two parallel downloads kick off briefly,
+# then Hide elides the entire ~7 minute cold-pull middle, then resume
+# at "done" state. Hide is sized for worst-case bandwidth so the demo
+# NEVER captures a mid-download chat.
+Type "t"
+Sleep 8s
+
+Hide
+Sleep 1000s
+Show
+Sleep 4s
+
+# Back to the wizard so the user sees the cards now marked installed.
+Type "q"
+Sleep 1500ms
+
+# Dismiss into Chat.
 Escape
 Sleep 1500ms
 
 # First chat: index lilbee's own README and ask a starter question.
-# Hide the embedder warmup and the cold first-token wait so the chat
-# prompt isn't on camera doing nothing.
+# Hide the embedder warmup so the chat prompt isn't on camera idle.
 Type "/add ./README.md"
 Sleep 600ms
 Enter
 Sleep 800ms
 Hide
-Sleep 22s
+Sleep 10s
 Show
 Sleep 400ms
 
-Type "What is lilbee and how do I use it?"
+Type "What is lilbee?"
 Sleep 1500ms
 Enter
 Sleep 800ms
 Hide
-Sleep 28s
+Sleep 12s
 Show
-Sleep 14s
+Sleep 6s
 
-# Overwrite the wizard still with the cited-answer screen -- that's the
-# moment the demo lands on.
+# Overwrite any wizard still with the cited-answer screen.
 Screenshot demos/_out/tui-setup.png
-Sleep 500ms
+Sleep 400ms
 
 Type "/quit"
 Enter


### PR DESCRIPTION
Bumps Hide to 1000s (~2.4x the empirical 419s done time). Downloads are guaranteed to be at done before the question fires.