### PR TITLE
demos: tui-setup with pre-cached chat + live SmolLM download

### DIFF
--- a/demos/_prep.sh
+++ b/demos/_prep.sh
@@ -87,9 +87,12 @@ seed_setup_models() {
     # found in registry" error.
     local setup_models="$ROOT/setup-models"
     mkdir -p "$setup_models"
-    log "pre-pulling models into setup-models"
+    log "pre-caching chat + embedder in setup-models"
     LILBEE_MODELS_DIR="$setup_models" "$LILBEE" model pull "$CHAT_MODEL" || true
     LILBEE_MODELS_DIR="$setup_models" "$LILBEE" model pull "$EMBED_MODEL" || true
+    # Drop any prior SmolLM cache so the tape demonstrates a real pull
+    # of SmolLM2 135M live in the Task Center.
+    rm -rf "$setup_models/models--bartowski--SmolLM2-135M-Instruct-GGUF"
 }
 
 page_cache_model() {

--- a/demos/tui-setup.tape
+++ b/demos/tui-setup.tape
@@ -1,11 +1,29 @@
 Source demos/_shared.tape
 Output demos/_out/tui-setup.gif
 
-# First-run wizard. Models are pre-pulled into setup-models by
-# demos/_prep.sh so the wizard reliably shows "Your existing models
-# are ready" -- a real cold pull of Qwen3 4B Q8_0 (2.5 GB) over a
-# 240s Hide previously failed on slower connections and the demo
-# captured a "Model not found in registry" error.
+# First-run wizard. Qwen3 4B + Nomic v1.5 are pre-cached in setup-models
+# by demos/_prep.sh so the wizard reports "Your existing models are
+# ready" -- the chat model is real and works for the answer at the end.
+# Then the demo demonstrates the Task Center download flow by pulling
+# SmolLM2 135M (~100 MB) live from the catalog. SmolLM is NOT set as
+# the chat model; chat continues to use the pre-cached Qwen 4B.
+#
+# Insert/normal mode flow (empirically verified in tmux):
+#   wizard Esc        -> chat INSERT
+#   Esc               -> NORMAL (necessary for `]` navigation)
+#   `]` `2` `/`       -> Catalog, Chat tab, filter search
+#   "smol" Enter      -> HuggingFace search returns SmolLM cards
+#   Right Right Enter -> pick SmolLM2 135M, install
+#   Esc               -> close filter
+#   `t`               -> Tasks Center (download visible)
+#   `]`               -> back to Chat in NORMAL
+#   `i`               -> INSERT (necessary for typing /add)
+#   /add typed+Enter  -> stays INSERT
+#   Esc               -> NORMAL (necessary for `t`)
+#   `t`               -> Tasks Center (see /add done)
+#   `]`               -> back to Chat in NORMAL
+#   `i`               -> INSERT (necessary for typing the question)
+# Four mode toggles total. Each is necessary.
 Env LILBEE_DATA "/tmp/lilbee-demo/tui-setup"
 Env LILBEE_MODELS_DIR "/tmp/lilbee-demo/setup-models"
 Env LILBEE_CHAT_MODEL "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf"
@@ -16,8 +34,6 @@ Env LILBEE_NO_SPLASH "1"
 # installed Ollama models.
 Env OLLAMA_HOST "http://127.0.0.1:65535"
 
-# cd into the data dir so `/add ./README.md` after the wizard resolves
-# to the staged README (lilbee's own, pre-copied by demos/_prep.sh).
 Type "cd /tmp/lilbee-demo/tui-setup"
 Sleep 300ms
 Enter
@@ -28,37 +44,89 @@ Sleep 300ms
 Enter
 Sleep 2500ms
 
-# Wizard appears with the curated catalog. The footer reads
-# "Your existing models are ready - Esc to return". Esc drops into chat.
+# Wizard appears. Models are pre-cached so the footer reads "Your
+# existing models are ready - Esc to return". Esc dismisses into chat.
 Sleep 1500ms
 Escape
-Sleep 1500ms
+Sleep 1000ms
 
-# First chat: index lilbee's own README and ask a starter question.
-# Hide the embedder warmup and the cold first-token wait so the chat
-# prompt isn't on camera doing nothing.
-Type "/add ./README.md"
+# Drop chat from INSERT to NORMAL so `]` works as screen navigation.
+Escape
+Sleep 600ms
+
+# `]` Catalog. `2` selects the Chat tab. `/` opens the filter input.
+Type "]"
+Sleep 1200ms
+Type "2"
+Sleep 1200ms
+Type "/"
+Sleep 400ms
+Type "smol"
+Sleep 800ms
+Enter
+Sleep 5s
+
+# Two Rights focus the SmolLM2 135M card (the smallest, fastest pull).
+# Enter kicks off the install.
+Right
+Sleep 500ms
+Right
 Sleep 600ms
 Enter
-Sleep 800ms
-Hide
-Sleep 22s
-Show
-Sleep 400ms
+Sleep 1500ms
 
-Type "What is lilbee and how do I use it?"
+# Close the filter, drop to NORMAL.
+Escape
+Sleep 500ms
+
+# Tasks Center to watch the SmolLM2 135M download. Hide the slow
+# middle of the ~60s pull; Show resumes at "done".
+Type "t"
+Sleep 8s
+Hide
+Sleep 55s
+Show
+Sleep 4s
+
+# Back to Chat. `]` from Tasks wraps to Chat, lands in NORMAL.
+Type "]"
+Sleep 1200ms
+
+# INSERT for typing the /add command.
+Type "i"
+Sleep 400ms
+Type "/add ./README.md"
 Sleep 1500ms
 Enter
-Sleep 800ms
-Hide
-Sleep 28s
-Show
-Sleep 14s
+Sleep 1500ms
 
-# Overwrite the wizard still with the cited-answer screen -- that's the
-# moment the demo lands on.
+# Drop to NORMAL for `t`.
+Escape
+Sleep 400ms
+Type "t"
+Sleep 4s
+
+# Back to Chat via `]`.
+Type "]"
+Sleep 1000ms
+
+# INSERT for typing the question.
+Type "i"
+Sleep 400ms
+Type "What is lilbee?"
+Sleep 1500ms
+Enter
+Sleep 1500ms
+
+# Hide the cold first-token wait for Qwen3 4B (~30-60s on M1 fresh
+# process). Show resumes for the visible streamed answer.
+Hide
+Sleep 80s
+Show
+Sleep 10s
+
 Screenshot demos/_out/tui-setup.png
-Sleep 500ms
+Sleep 400ms
 
 Type "/quit"
 Enter


### PR DESCRIPTION
Wizard reports models ready (chat + embedder pre-cached). Demo pulls SmolLM2 135M (~100MB, ~60s) live from catalog to demonstrate Task Center. /add visible in Tasks. Chat uses pre-cached Qwen3 4B.