### PR TITLE
serve: skip shutdown when startup never completed

### DIFF
--- a/src/lilbee/cli/commands/servers.py
+++ b/src/lilbee/cli/commands/servers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -38,18 +39,27 @@ async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str)
     if not config.loaded:
         config.load()
     server.lifespan = config.lifespan_class(config)
-    await server.startup()
 
-    parent_pid = parse_parent_pid()
+    started = False
     parent_watcher: asyncio.Task[None] | None = None
-    if parent_pid is not None:
-
-        def _on_parent_death() -> None:
-            server.should_exit = True
-
-        parent_watcher = asyncio.create_task(watch_parent_async(parent_pid, _on_parent_death))
-
     try:
+        # `server.servers` is only assigned inside `startup()`. If startup
+        # raises (e.g. the FastAPI lifespan handler explodes because the
+        # configured data-dir is missing or unreadable), control jumps to the
+        # finally below, and we must NOT call `server.shutdown()` there.
+        # uvicorn dereferences `self.servers` in shutdown and would crash with
+        # AttributeError, masking the real error the user needs to see.
+        await server.startup()
+        started = True
+
+        parent_pid = parse_parent_pid()
+        if parent_pid is not None:
+
+            def _on_parent_death() -> None:
+                server.should_exit = True
+
+            parent_watcher = asyncio.create_task(watch_parent_async(parent_pid, _on_parent_death))
+
         if server.servers:
             sock = server.servers[0].sockets[0]
             actual_port = sock.getsockname()[1]
@@ -62,7 +72,12 @@ async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str)
         if parent_watcher is not None and not parent_watcher.done():
             parent_watcher.cancel()
         port_path.unlink(missing_ok=True)
-        await server.shutdown()
+        if started:
+            # uvicorn occasionally dereferences `self.servers` during shutdown
+            # even after partial startup; swallow so the original exception
+            # surfaces unchanged.
+            with contextlib.suppress(AttributeError):
+                await server.shutdown()
 
 
 def serve(

--- a/src/lilbee/cli/commands/servers.py
+++ b/src/lilbee/cli/commands/servers.py
@@ -40,15 +40,12 @@ async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str)
         config.load()
     server.lifespan = config.lifespan_class(config)
 
+    # `server.servers` is set inside `startup()`. The finally below must skip
+    # `shutdown()` when startup never ran: uvicorn dereferences `self.servers`
+    # there and the resulting AttributeError would mask the original failure.
     started = False
     parent_watcher: asyncio.Task[None] | None = None
     try:
-        # `server.servers` is only assigned inside `startup()`. If startup
-        # raises (e.g. the FastAPI lifespan handler explodes because the
-        # configured data-dir is missing or unreadable), control jumps to the
-        # finally below, and we must NOT call `server.shutdown()` there.
-        # uvicorn dereferences `self.servers` in shutdown and would crash with
-        # AttributeError, masking the real error the user needs to see.
         await server.startup()
         started = True
 
@@ -73,9 +70,8 @@ async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str)
             parent_watcher.cancel()
         port_path.unlink(missing_ok=True)
         if started:
-            # uvicorn occasionally dereferences `self.servers` during shutdown
-            # even after partial startup; swallow so the original exception
-            # surfaces unchanged.
+            # Suppress AttributeError from a partial uvicorn bring-up so any
+            # original exception from main_loop reaches the caller intact.
             with contextlib.suppress(AttributeError):
                 await server.shutdown()
 

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -269,3 +269,48 @@ class TestRunServer:
         port_path.write_text("11111")
         cleanup_fn()
         assert not port_path.exists()
+
+    def test_does_not_call_shutdown_when_startup_fails(self):
+        """If `startup()` raises, `server.servers` was never assigned. Calling
+        `shutdown()` then would crash inside uvicorn (`AttributeError: 'Server'
+        object has no attribute 'servers'`) and mask the real error. We must
+        skip shutdown entirely when startup never completed."""
+        from lilbee.cli.commands.servers import _run_server
+
+        fake_server_obj = mock.MagicMock()
+        fake_server_obj.startup = mock.AsyncMock(side_effect=RuntimeError("lifespan failed"))
+        fake_server_obj.main_loop = mock.AsyncMock()
+        fake_server_obj.shutdown = mock.AsyncMock()
+
+        fake_config = mock.MagicMock()
+
+        with pytest.raises(RuntimeError, match="lifespan failed"):
+            asyncio.run(_run_server(fake_server_obj, fake_config, "127.0.0.1"))
+
+        fake_server_obj.shutdown.assert_not_awaited()
+        fake_server_obj.main_loop.assert_not_awaited()
+
+    def test_swallows_attributeerror_from_shutdown(self):
+        """When `main_loop` raises and the subsequent `shutdown()` itself
+        raises `AttributeError` (uvicorn dereferences `self.servers` even after
+        partial bring-up), the original failure must propagate, not the
+        shutdown crash that would otherwise mask it."""
+        from lilbee.cli.commands.servers import _run_server
+
+        sock = mock.MagicMock()
+        sock.getsockname.return_value = ("127.0.0.1", 1234)
+
+        fake_server_obj = mock.MagicMock()
+        fake_server_obj.servers = [mock.MagicMock(sockets=[sock])]
+        fake_server_obj.startup = mock.AsyncMock()
+        fake_server_obj.main_loop = mock.AsyncMock(side_effect=RuntimeError("real failure"))
+        fake_server_obj.shutdown = mock.AsyncMock(
+            side_effect=AttributeError("'Server' object has no attribute 'servers'")
+        )
+
+        fake_config = mock.MagicMock()
+
+        with pytest.raises(RuntimeError, match="real failure"):
+            asyncio.run(_run_server(fake_server_obj, fake_config, "127.0.0.1"))
+
+        fake_server_obj.shutdown.assert_awaited_once()


### PR DESCRIPTION
## Problem

Pointing `lilbee serve` at a bad data-dir surfaces `AttributeError: 'Server' object has no attribute 'servers'` instead of the actual error. The plugin reproduced this when adopting a nonexistent path; the misleading error masked the real failure across multiple restart attempts.

## Solution

Only call `server.shutdown()` after `server.startup()` has completed. uvicorn assigns `self.servers` inside `startup()`, so a partial bring-up trips an AttributeError in shutdown that hides the original cause.