### PR TITLE
serve: ship daemon configs for brew/AUR/NixOS (b481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
+## 0.6.66b481
+
+You can now keep `lilbee serve` running in the background under your OS launcher: `brew services start lilbee` on macOS, `systemctl --user enable --now lilbee` on Arch, or import `nixosModules.lilbee` on NixOS. All three pin the HTTP server to `127.0.0.1:42697`. The daemon helps clients that hit the HTTP API (Obsidian, MCP); `lilbee chat` and the TUI are unchanged.
+
+## Module reorganization
+
 Module reorganization: top-level layout grouped under core/, data/, retrieval/, catalog/, modelhub/, runtime/. External users importing from old `lilbee.X` paths must update to the new package paths. No behavior change.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,37 @@ Every GIF on this page (plus the extras) is at [lilbee.sh/tutorial.html](https:/
 
 The [Obsidian plugin](https://obsidian.lilbee.sh/) is a GUI built on it: it runs `lilbee serve` in the background, and every citation opens a Source Preview scrolled to the exact passage. Install via [BRAT](https://github.com/TfTHacker/obsidian42-brat); the [plugin README](https://github.com/tobocop2/obsidian-lilbee#quick-start) has setup.
 
+### Running as a service (optional)
+
+If you keep the Obsidian plugin or an MCP client open all day, your OS launcher can keep `lilbee serve` warm in the background so HTTP requests skip the cold-start. `lilbee chat`, the TUI, and other CLI commands always cold-start their own process, so they are unaffected.
+
+Before enabling, pull at least one chat and embedding model with `lilbee model pull <name>`. The daemon will start either way, but requests fail until a model is available.
+
+All three recipes pin the server to `127.0.0.1:42697`.
+
+**macOS (Homebrew):**
+
+```bash
+brew services start lilbee
+```
+
+**Linux (Arch / AUR):**
+
+```bash
+systemctl --user enable --now lilbee
+```
+
+On a headless server (no graphical login session), also run `loginctl enable-linger $USER` so the service survives logout.
+
+**NixOS:** add the module to your `configuration.nix`:
+
+```nix
+{
+  imports = [ lilbee.nixosModules.lilbee ];
+  services.lilbee.enable = true;
+}
+```
+
 ## Supported formats
 
 Text extraction powered by [Kreuzberg], code chunking by [tree-sitter]. Structured formats (XML, JSON, CSV) get embedding-friendly preprocessing. This list is not exhaustive; Kreuzberg supports additional formats beyond what's listed here.

--- a/flake.nix
+++ b/flake.nix
@@ -158,5 +158,41 @@
       });
 
       formatter = forAllSystems (system: (mkPkgs system).nixfmt-rfc-style);
+
+      nixosModules.lilbee =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.services.lilbee;
+        in
+        {
+          options.services.lilbee = {
+            enable = lib.mkEnableOption "lilbee HTTP server as a user-level systemd service";
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.system}.default;
+              defaultText = lib.literalExpression "lilbee.packages.\${pkgs.system}.default";
+              description = "lilbee package to run.";
+            };
+          };
+          config = lib.mkIf cfg.enable {
+            systemd.user.services.lilbee = {
+              description = "lilbee HTTP server";
+              after = [ "network-online.target" ];
+              wants = [ "network-online.target" ];
+              wantedBy = [ "default.target" ];
+              serviceConfig = {
+                Type = "simple";
+                ExecStart = "${cfg.package}/bin/lilbee serve --host 127.0.0.1 --port 42697";
+                Restart = "on-failure";
+                RestartSec = 5;
+              };
+            };
+          };
+        };
     };
 }

--- a/packaging/aur/lilbee-cuda/.SRCINFO
+++ b/packaging/aur/lilbee-cuda/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lilbee-cuda
 	pkgdesc = Local search engine and personal encyclopedia for your notes, code, and PDFs (CUDA build)
-	pkgver = 0.6.66b456
+	pkgver = 0.6.66b481
 	pkgrel = 1
 	url = https://github.com/tobocop2/lilbee
 	arch = x86_64
@@ -9,9 +9,9 @@ pkgbase = lilbee-cuda
 	conflicts = lilbee
 	options = !strip
 	options = !debug
-	source = lilbee.service::https://github.com/tobocop2/lilbee/raw/v0.6.66b456/packaging/systemd/lilbee.service
+	source = lilbee.service::https://github.com/tobocop2/lilbee/raw/v0.6.66b481/packaging/systemd/lilbee.service
 	sha256sums = 0000000000000000000000000000000000000000000000000000000000000000
-	source_x86_64 = lilbee-0.6.66b456-cu125::https://github.com/tobocop2/lilbee/releases/download/v0.6.66b456/lilbee-linux-x86_64-cu125
+	source_x86_64 = lilbee-0.6.66b481-cu125::https://github.com/tobocop2/lilbee/releases/download/v0.6.66b481/lilbee-linux-x86_64-cu125
 	sha256sums_x86_64 = 0000000000000000000000000000000000000000000000000000000000000000
 
 pkgname = lilbee-cuda

--- a/packaging/aur/lilbee-cuda/.SRCINFO
+++ b/packaging/aur/lilbee-cuda/.SRCINFO
@@ -9,6 +9,8 @@ pkgbase = lilbee-cuda
 	conflicts = lilbee
 	options = !strip
 	options = !debug
+	source = lilbee.service::https://github.com/tobocop2/lilbee/raw/v0.6.66b456/packaging/systemd/lilbee.service
+	sha256sums = 0000000000000000000000000000000000000000000000000000000000000000
 	source_x86_64 = lilbee-0.6.66b456-cu125::https://github.com/tobocop2/lilbee/releases/download/v0.6.66b456/lilbee-linux-x86_64-cu125
 	sha256sums_x86_64 = 0000000000000000000000000000000000000000000000000000000000000000
 

--- a/packaging/aur/lilbee-cuda/PKGBUILD
+++ b/packaging/aur/lilbee-cuda/PKGBUILD
@@ -11,7 +11,10 @@ provides=('lilbee')
 options=('!strip' '!debug')
 source_x86_64=("lilbee-${pkgver}-cu125::${url}/releases/download/v${pkgver}/lilbee-linux-${CARCH}-cu125")
 sha256sums_x86_64=('0000000000000000000000000000000000000000000000000000000000000000')
+source=("lilbee.service::${url}/raw/v${pkgver}/packaging/systemd/lilbee.service")
+sha256sums=('0000000000000000000000000000000000000000000000000000000000000000')
 
 package() {
     install -Dm755 "${srcdir}/lilbee-${pkgver}-cu125" "${pkgdir}/usr/bin/lilbee"
+    install -Dm644 "${srcdir}/lilbee.service" "${pkgdir}/usr/lib/systemd/user/lilbee.service"
 }

--- a/packaging/aur/lilbee-cuda/PKGBUILD
+++ b/packaging/aur/lilbee-cuda/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: tobocop <tobias.perelstein@gmail.com>
 pkgname=lilbee-cuda
-pkgver=0.6.66b456
+pkgver=0.6.66b481
 pkgrel=1
 pkgdesc="Local search engine and personal encyclopedia for your notes, code, and PDFs (CUDA build)"
 arch=('x86_64')

--- a/packaging/aur/lilbee/.SRCINFO
+++ b/packaging/aur/lilbee/.SRCINFO
@@ -8,6 +8,8 @@ pkgbase = lilbee
 	replaces = lilbee-bin
 	options = !strip
 	options = !debug
+	source = lilbee.service::https://github.com/tobocop2/lilbee/raw/v0.6.66b456/packaging/systemd/lilbee.service
+	sha256sums = 0000000000000000000000000000000000000000000000000000000000000000
 	source_x86_64 = lilbee-0.6.66b456::https://github.com/tobocop2/lilbee/releases/download/v0.6.66b456/lilbee-linux-x86_64
 	sha256sums_x86_64 = e6dc28e49a9bd9158eb217a47a278552f42195cae2cd68642413bf382ed0c54c
 

--- a/packaging/aur/lilbee/.SRCINFO
+++ b/packaging/aur/lilbee/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lilbee
 	pkgdesc = Local search engine and personal encyclopedia for your notes, code, and PDFs
-	pkgver = 0.6.66b456
+	pkgver = 0.6.66b481
 	pkgrel = 1
 	url = https://github.com/tobocop2/lilbee
 	arch = x86_64
@@ -8,9 +8,9 @@ pkgbase = lilbee
 	replaces = lilbee-bin
 	options = !strip
 	options = !debug
-	source = lilbee.service::https://github.com/tobocop2/lilbee/raw/v0.6.66b456/packaging/systemd/lilbee.service
+	source = lilbee.service::https://github.com/tobocop2/lilbee/raw/v0.6.66b481/packaging/systemd/lilbee.service
 	sha256sums = 0000000000000000000000000000000000000000000000000000000000000000
-	source_x86_64 = lilbee-0.6.66b456::https://github.com/tobocop2/lilbee/releases/download/v0.6.66b456/lilbee-linux-x86_64
-	sha256sums_x86_64 = e6dc28e49a9bd9158eb217a47a278552f42195cae2cd68642413bf382ed0c54c
+	source_x86_64 = lilbee-0.6.66b481::https://github.com/tobocop2/lilbee/releases/download/v0.6.66b481/lilbee-linux-x86_64
+	sha256sums_x86_64 = 0000000000000000000000000000000000000000000000000000000000000000
 
 pkgname = lilbee

--- a/packaging/aur/lilbee/PKGBUILD
+++ b/packaging/aur/lilbee/PKGBUILD
@@ -10,7 +10,10 @@ replaces=('lilbee-bin')
 options=('!strip' '!debug')
 source_x86_64=("lilbee-${pkgver}::${url}/releases/download/v${pkgver}/lilbee-linux-${CARCH}")
 sha256sums_x86_64=('e6dc28e49a9bd9158eb217a47a278552f42195cae2cd68642413bf382ed0c54c')
+source=("lilbee.service::${url}/raw/v${pkgver}/packaging/systemd/lilbee.service")
+sha256sums=('0000000000000000000000000000000000000000000000000000000000000000')
 
 package() {
     install -Dm755 "${srcdir}/lilbee-${pkgver}" "${pkgdir}/usr/bin/lilbee"
+    install -Dm644 "${srcdir}/lilbee.service" "${pkgdir}/usr/lib/systemd/user/lilbee.service"
 }

--- a/packaging/aur/lilbee/PKGBUILD
+++ b/packaging/aur/lilbee/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: tobocop <tobias.perelstein@gmail.com>
 pkgname=lilbee
-pkgver=0.6.66b456
+pkgver=0.6.66b481
 pkgrel=1
 pkgdesc="Local search engine and personal encyclopedia for your notes, code, and PDFs"
 arch=('x86_64')
@@ -9,7 +9,7 @@ license=('custom:Elastic-2.0')
 replaces=('lilbee-bin')
 options=('!strip' '!debug')
 source_x86_64=("lilbee-${pkgver}::${url}/releases/download/v${pkgver}/lilbee-linux-${CARCH}")
-sha256sums_x86_64=('e6dc28e49a9bd9158eb217a47a278552f42195cae2cd68642413bf382ed0c54c')
+sha256sums_x86_64=('0000000000000000000000000000000000000000000000000000000000000000')
 source=("lilbee.service::${url}/raw/v${pkgver}/packaging/systemd/lilbee.service")
 sha256sums=('0000000000000000000000000000000000000000000000000000000000000000')
 

--- a/packaging/systemd/lilbee.service
+++ b/packaging/systemd/lilbee.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=lilbee HTTP server
+Documentation=https://github.com/tobocop2/lilbee
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/lilbee serve --host 127.0.0.1 --port 42697
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/packaging/tools/render_pkgbuild.sh
+++ b/packaging/tools/render_pkgbuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Update version + sha256 in the AUR PKGBUILD in place.
+# Update version + sha256s in the AUR PKGBUILD in place.
 set -euo pipefail
 
 if [ "$#" -ne 3 ]; then
@@ -11,9 +11,14 @@ pkgbuild="$1"
 version="$2"
 sha_linux="$3"
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+service_path="${script_dir}/../systemd/lilbee.service"
+sha_service=$(sha256sum "$service_path" | awk '{print $1}')
+
 sed -i.bak \
     -e "s|^pkgver=.*|pkgver=${version}|" \
     -e "s|^pkgrel=.*|pkgrel=1|" \
     -e "s|^sha256sums_x86_64=.*|sha256sums_x86_64=('${sha_linux}')|" \
+    -e "s|^sha256sums=.*|sha256sums=('${sha_service}')|" \
     "$pkgbuild"
 rm -f "${pkgbuild}.bak"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lilbee"
-version = "0.6.66b480"
+version = "0.6.66b481"
 description = "A batteries-included terminal app for local AI: a browsable model catalog, a search engine over your own files and code, and a chat that cites its sources. Per-project libraries, semantic and hybrid search, vision OCR, auto-built wiki. CLI, TUI, MCP server, REST API, and Python library in one process; no model server, no database server."
 readme = "README.md"
 license = "Elastic-2.0"

--- a/sources.json
+++ b/sources.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.66b481",
+  "version": "0.6.66b480",
   "systems": {
     "x86_64-linux": {
       "asset": "lilbee-linux-x86_64",

--- a/sources.json
+++ b/sources.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.66b480",
+  "version": "0.6.66b481",
   "systems": {
     "x86_64-linux": {
       "asset": "lilbee-linux-x86_64",

--- a/uv.lock
+++ b/uv.lock
@@ -1585,7 +1585,7 @@ wheels = [
 
 [[package]]
 name = "lilbee"
-version = "0.6.66b480"
+version = "0.6.66b481"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
## Problem

No native way to keep `lilbee serve` running in the background for HTTP clients (Obsidian plugin, MCP). 

## Solution

Per-platform service definitions that pin `lilbee serve` to `127.0.0.1:42697`:

- **AUR**: user-level systemd unit (`packaging/systemd/lilbee.service`), installed to `/usr/lib/systemd/user/lilbee.service`. Enable with `systemctl --user enable --now lilbee`.
- **NixOS**: `nixosModules.lilbee` exposed by the flake. Import and `services.lilbee.enable = true`.
- **macOS**: `brew services start lilbee`. Needs a one-time service block added to the `homebrew-lilbee` tap formula (see below).

CLI and TUI are unchanged. Version bumped to `0.6.66b481`.

### Homebrew tap follow-up

Add to `Formula/lilbee.rb`:

```ruby
service do
  run [opt_bin/"lilbee", "serve", "--host", "127.0.0.1", "--port", "42697"]
  keep_alive true
  log_path var/"log/lilbee/serve.log"
  error_log_path var/"log/lilbee/serve.err.log"
end
```