### PR TITLE
Surface 'model not installed' instead of generic Internal error in chat stream

### DIFF
--- a/src/lilbee/runtime/progress/__init__.py
+++ b/src/lilbee/runtime/progress/__init__.py
@@ -21,6 +21,7 @@ from lilbee.runtime.progress.types import (
     SetupDoneEvent,
     SetupProgressEvent,
     SetupStartEvent,
+    SseErrorCode,
     SseEvent,
     SyncDoneEvent,
 )
@@ -42,6 +43,7 @@ __all__ = [
     "SetupDoneEvent",
     "SetupProgressEvent",
     "SetupStartEvent",
+    "SseErrorCode",
     "SseEvent",
     "SyncDoneEvent",
     "noop_callback",

--- a/src/lilbee/runtime/progress/types.py
+++ b/src/lilbee/runtime/progress/types.py
@@ -35,6 +35,13 @@ class SseEvent(StrEnum):
     ALREADY_INGESTING = "already_ingesting"
 
 
+class SseErrorCode(StrEnum):
+    """Stable ``code`` values on SSE error events for clients to branch on."""
+
+    MODEL_TOO_LARGE = "model_too_large"
+    MODEL_NOT_INSTALLED = "model_not_installed"
+
+
 class FileStartEvent(BaseModel):
     """Emitted when a file begins ingestion."""
 

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -34,17 +34,22 @@ def sse_error(message: str, *, code: str | None = None, detail: str | None = Non
 
 
 _OOM_MARKERS = ("failed to load", "free ram", "try a smaller model", "llama_context")
+_NOT_INSTALLED_MARKERS = ("not found in registry", "is not available", "pull it first")
 
 
 def classify_load_error(message: str) -> tuple[str | None, str]:
     """Return ``(code, user_message)`` for an SSE error event.
 
-    Recognises the llama.cpp OOM diagnostic and maps it to a stable code; any
-    other input falls back to the legacy generic shape.
+    Recognises two known failure shapes and maps each to a stable code:
+    the llama.cpp OOM diagnostic, and the "configured model isn't installed"
+    case (e.g. the active chat model was uninstalled, leaving a stale ref in
+    config). Anything else falls back to the legacy generic shape.
     """
     lowered = message.lower()
     if any(marker in lowered for marker in _OOM_MARKERS):
         return "model_too_large", "Model too large for available RAM"
+    if any(marker in lowered for marker in _NOT_INSTALLED_MARKERS):
+        return "model_not_installed", "Active model isn't installed — pull it from the catalog"
     return None, "Internal error"
 
 

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -13,7 +13,13 @@ from typing import Any
 from pydantic import BaseModel
 
 from lilbee.core.config import cfg
-from lilbee.runtime.progress import DetailedProgressCallback, EventType, ProgressEvent, SseEvent
+from lilbee.runtime.progress import (
+    DetailedProgressCallback,
+    EventType,
+    ProgressEvent,
+    SseErrorCode,
+    SseEvent,
+)
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +29,7 @@ def sse_event(event: str, data: Any) -> str:
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
 
 
-def sse_error(message: str, *, code: str | None = None, detail: str | None = None) -> str:
+def sse_error(message: str, *, code: SseErrorCode | None = None, detail: str | None = None) -> str:
     """Format an SSE error event with optional structured ``code`` / ``detail``."""
     payload: dict[str, Any] = {"message": message}
     if code is not None:
@@ -37,19 +43,21 @@ _OOM_MARKERS = ("failed to load", "free ram", "try a smaller model", "llama_cont
 _NOT_INSTALLED_MARKERS = ("not found in registry", "is not available", "pull it first")
 
 
-def classify_load_error(message: str) -> tuple[str | None, str]:
+def classify_load_error(message: str) -> tuple[SseErrorCode | None, str]:
     """Return ``(code, user_message)`` for an SSE error event.
 
-    Recognises two known failure shapes and maps each to a stable code:
-    the llama.cpp OOM diagnostic, and the "configured model isn't installed"
-    case (e.g. the active chat model was uninstalled, leaving a stale ref in
-    config). Anything else falls back to the legacy generic shape.
+    Maps the llama.cpp out-of-memory diagnostic and the "configured model
+    isn't installed" failure to stable codes. Anything else returns a generic
+    code-less message.
     """
     lowered = message.lower()
     if any(marker in lowered for marker in _OOM_MARKERS):
-        return "model_too_large", "Model too large for available RAM"
+        return SseErrorCode.MODEL_TOO_LARGE, "Model too large for available RAM"
     if any(marker in lowered for marker in _NOT_INSTALLED_MARKERS):
-        return "model_not_installed", "Active model isn't installed — pull it from the catalog"
+        return (
+            SseErrorCode.MODEL_NOT_INSTALLED,
+            "Active model isn't installed. Pull it from the catalog.",
+        )
     return None, "Internal error"
 
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2212,6 +2212,22 @@ class TestClassifyLoadError:
         assert code is None
         assert user_message == "Internal error"
 
+    def test_not_in_registry_is_classified_as_model_not_installed(self):
+        msg = (
+            "Model 'Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf' not found in registry. "
+            "Install it via the catalog or 'lilbee model pull'."
+        )
+        code, user_message = handlers.classify_load_error(msg)
+        assert code == "model_not_installed"
+        assert user_message == "Active model isn't installed — pull it from the catalog"
+
+    def test_not_available_is_classified_as_model_not_installed(self):
+        code, user_message = handlers.classify_load_error(
+            "Model 'foo' is not available. Pull it first or check the name."
+        )
+        assert code == "model_not_installed"
+        assert user_message == "Active model isn't installed — pull it from the catalog"
+
     def test_classifier_is_case_insensitive(self):
         code, _ = handlers.classify_load_error("FAILED TO LOAD model.gguf")
         assert code == "model_too_large"

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -11,6 +11,7 @@ import lilbee.app.services as svc_mod
 from lilbee.core.config import cfg
 from lilbee.data.ingest import SyncResult
 from lilbee.data.store import SearchChunk
+from lilbee.runtime.progress import SseErrorCode
 from lilbee.server import handlers
 from lilbee.server.handlers import (
     ingest as _ingest_h,
@@ -2200,12 +2201,12 @@ class TestClassifyLoadError:
             "Host has 1.2 GB free RAM. Try a smaller model."
         )
         code, user_message = handlers.classify_load_error(msg)
-        assert code == "model_too_large"
+        assert code == SseErrorCode.MODEL_TOO_LARGE
         assert user_message == "Model too large for available RAM"
 
     def test_llama_context_signature_is_classified(self):
         code, _ = handlers.classify_load_error("llama_context: failed to allocate")
-        assert code == "model_too_large"
+        assert code == SseErrorCode.MODEL_TOO_LARGE
 
     def test_unknown_message_falls_back_to_internal(self):
         code, user_message = handlers.classify_load_error("Network unreachable")
@@ -2218,19 +2219,19 @@ class TestClassifyLoadError:
             "Install it via the catalog or 'lilbee model pull'."
         )
         code, user_message = handlers.classify_load_error(msg)
-        assert code == "model_not_installed"
-        assert user_message == "Active model isn't installed — pull it from the catalog"
+        assert code == SseErrorCode.MODEL_NOT_INSTALLED
+        assert user_message == "Active model isn't installed. Pull it from the catalog."
 
     def test_not_available_is_classified_as_model_not_installed(self):
         code, user_message = handlers.classify_load_error(
             "Model 'foo' is not available. Pull it first or check the name."
         )
-        assert code == "model_not_installed"
-        assert user_message == "Active model isn't installed — pull it from the catalog"
+        assert code == SseErrorCode.MODEL_NOT_INSTALLED
+        assert user_message == "Active model isn't installed. Pull it from the catalog."
 
     def test_classifier_is_case_insensitive(self):
         code, _ = handlers.classify_load_error("FAILED TO LOAD model.gguf")
-        assert code == "model_too_large"
+        assert code == SseErrorCode.MODEL_TOO_LARGE
 
 
 class TestResolveGenerationOptions:


### PR DESCRIPTION
## Problem

When the active chat model isn't in the installed registry (for example it was uninstalled but config still points at it), the chat stream failed with a generic "Internal error" and gave the user no idea what went wrong or how to fix it.

## Solution

Recognise the "model isn't installed" failure in the SSE error classifier and surface an actionable message telling the user to pull the model from the catalog. The error codes are now a small StrEnum so clients have a stable value to branch on.