### PR TITLE
MCP over streamable-http: share one warm backend across agents

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -670,10 +670,51 @@ Launched by `lilbee` or `lilbee chat`. Screens: chat, task center, model catalog
 
 All chat-generating endpoints (`/api/ask`, `/api/chat`, both their `/stream` variants, and `POST /v1/chat/completions`) share a process-wide chat lock so only one inference call runs at a time per server. Concurrent requests queue server-side; if the wait exceeds the configured timeout the request returns 429 with a `Retry-After: 1` header.
 
-### MCP Server (`lilbee mcp`)
+### MCP Server
 - Search + lifecycle: `search(query, top_k, scope)`, `status`, `sync`, `add`, `crawl`, `crawl_status`, `init`, `remove`, `list_documents`, `reset`
 - Models: `model_list`, `model_show`, `model_pull`, `model_rm`
 - Wiki: `wiki_list`, `wiki_read`, `wiki_status`, `wiki_synthesize`, `wiki_lint`, `wiki_citations`, `wiki_drafts_list`, `wiki_drafts_diff`, `wiki_prune`
+
+#### Transports
+
+The same FastMCP tool server is reachable two ways:
+
+- **stdio** (`lilbee mcp`): the default for a single agent. The client spawns
+  the process, which loads its own in-process `Services` (its own model copy).
+  Zero configuration, no network.
+- **streamable-http** (on the `lilbee serve` daemon): for multiple agents
+  sharing one warm backend. The tool server mounts as a Litestar sub-app at
+  `/mcp`, behind the same bearer-token `AuthMiddleware` as `/v1/*` and REST, and
+  resolves the same process-wide `Services`. Sync tool handlers are offloaded
+  off the event loop so one slow call cannot stall the other connected agents.
+  Retrieval reads run concurrently; generation shares the chat lock above.
+
+```mermaid
+flowchart LR
+    A1[Agent A]
+    A2[Agent B]
+
+    subgraph stdio["stdio (default, single agent)"]
+        M1["lilbee mcp"]
+        S1[(Services + own model copy)]
+        M1 --> S1
+    end
+
+    subgraph daemon["lilbee serve daemon (shared)"]
+        AUTH["AuthMiddleware (bearer token)"]
+        MCPSUB["/mcp (FastMCP sub-app)"]
+        REST["/v1 + REST"]
+        SVC[(one warm Services)]
+        AUTH --> MCPSUB
+        AUTH --> REST
+        MCPSUB --> SVC
+        REST --> SVC
+    end
+
+    A1 -->|stdio| M1
+    A1 -.->|http + Bearer| AUTH
+    A2 -.->|http + Bearer| AUTH
+```
 
 #### Schema-size discipline
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -670,6 +670,14 @@ Launched by `lilbee` or `lilbee chat`. Screens: chat, task center, model catalog
 
 All chat-generating endpoints (`/api/ask`, `/api/chat`, both their `/stream` variants, and `POST /v1/chat/completions`) share a process-wide chat lock so only one inference call runs at a time per server. Concurrent requests queue server-side; if the wait exceeds the configured timeout the request returns 429 with a `Retry-After: 1` header.
 
+### Auth model
+
+All network surfaces, the `/v1/*` model runtime, the `/api/*` REST routes, and the `/mcp` streamable-http endpoint, share **one** bearer session token. The daemon generates it on startup, persists it to `server.json` (mode `0600`), and hands it to local clients through `lilbee agent-config` / `lilbee launch`. Clients send `Authorization: Bearer <token>`; `AuthMiddleware` (`src/lilbee/server/auth.py`) checks it on every mutating request.
+
+This is deliberately a single, unscoped token rather than a per-client or per-scope system. lilbee is a local-first, single-user tool: the daemon binds localhost only (with DNS-rebinding protection), and any process running as the user can read `server.json` regardless, so a per-agent token would not add a boundary that the filesystem doesn't already remove. The token exists to keep out other local users and drive-by browser requests, not to isolate the user's own agents from each other.
+
+The tradeoff is that the token is all-or-nothing: a client trusted with retrieval also gets generation and the mutating tools (`reset`, `remove`, `model_rm`, `settings_set`). That is acceptable for the user's own agents on localhost. Giving retrieval-only access to a less-trusted client would require a scoped token, which lilbee does not have today.
+
 ### MCP Server
 - Search + lifecycle: `search(query, top_k, scope)`, `status`, `sync`, `add`, `crawl`, `crawl_status`, `init`, `remove`, `list_documents`, `reset`
 - Models: `model_list`, `model_show`, `model_pull`, `model_rm`

--- a/src/lilbee/cli/agent_configs/opencode.py
+++ b/src/lilbee/cli/agent_configs/opencode.py
@@ -42,13 +42,17 @@ def opencode_config(
     api_key: str,
     model_refs: list[str],
     mcp_command: list[str] | None = None,
+    mcp_remote: bool = False,
 ) -> dict[str, Any]:
     """Return the opencode.json block wiring lilbee as a provider.
 
     ``base_url`` is the lilbee server origin (e.g. ``http://127.0.0.1:8080``);
     the chat-completions ``/v1`` suffix is appended here so callers pass a
-    single canonical URL. When ``mcp_command`` is given, the block also
-    registers a lilbee MCP server that runs that command.
+    single canonical URL. ``mcp_remote`` registers the daemon's
+    streamable-http MCP endpoint (``/mcp``) with the bearer token so opencode
+    shares the running daemon's warm models for retrieval. ``mcp_command``
+    instead registers a local MCP server that opencode spawns itself; pass at
+    most one.
     """
     block: dict[str, Any] = {
         "$schema": "https://opencode.ai/config.json",
@@ -64,7 +68,16 @@ def opencode_config(
             }
         },
     }
-    if mcp_command is not None:
+    if mcp_remote:
+        block["mcp"] = {
+            "lilbee": {
+                "type": "remote",
+                "url": f"{base_url}/mcp",
+                "enabled": True,
+                "headers": {"Authorization": f"Bearer {api_key}"},
+            }
+        }
+    elif mcp_command is not None:
         block["mcp"] = {
             "lilbee": {
                 "type": "local",

--- a/src/lilbee/cli/agent_configs/opencode.py
+++ b/src/lilbee/cli/agent_configs/opencode.py
@@ -41,20 +41,16 @@ def opencode_config(
     base_url: str,
     api_key: str,
     model_refs: list[str],
-    mcp_command: list[str] | None = None,
-    mcp_remote: bool = False,
 ) -> dict[str, Any]:
     """Return the opencode.json block wiring lilbee as a provider.
 
     ``base_url`` is the lilbee server origin (e.g. ``http://127.0.0.1:8080``);
-    the chat-completions ``/v1`` suffix is appended here so callers pass a
-    single canonical URL. ``mcp_remote`` registers the daemon's
-    streamable-http MCP endpoint (``/mcp``) with the bearer token so opencode
-    shares the running daemon's warm models for retrieval. ``mcp_command``
-    instead registers a local MCP server that opencode spawns itself; pass at
-    most one.
+    the chat-completions ``/v1`` and MCP ``/mcp`` suffixes are appended here.
+    The MCP block points opencode at the daemon's streamable-http endpoint with
+    the bearer token, so retrieval shares the daemon's warm models instead of
+    spawning a second process.
     """
-    block: dict[str, Any] = {
+    return {
         "$schema": "https://opencode.ai/config.json",
         "provider": {
             "lilbee": {
@@ -67,22 +63,12 @@ def opencode_config(
                 "models": {ref: {"name": display_name(ref)} for ref in sorted(model_refs)},
             }
         },
-    }
-    if mcp_remote:
-        block["mcp"] = {
+        "mcp": {
             "lilbee": {
                 "type": "remote",
                 "url": f"{base_url}/mcp",
                 "enabled": True,
                 "headers": {"Authorization": f"Bearer {api_key}"},
             }
-        }
-    elif mcp_command is not None:
-        block["mcp"] = {
-            "lilbee": {
-                "type": "local",
-                "command": list(mcp_command),
-                "enabled": True,
-            }
-        }
-    return block
+        },
+    }

--- a/src/lilbee/cli/commands/agent_config.py
+++ b/src/lilbee/cli/commands/agent_config.py
@@ -46,12 +46,8 @@ def _emit_block(builder: _JsonBuilder | _TextBuilder, **kwargs: Any) -> None:
 
 @agent_config_app.command("opencode")
 def _opencode_cmd() -> None:
-    """Print an opencode.json block (OpenAI-compatible provider + MCP server).
-
-    The MCP server points at the running daemon's streamable-http endpoint so
-    opencode shares its warm models instead of spawning a second process.
-    """
-    _emit_block(opencode.opencode_config, mcp_remote=True)
+    """Print an opencode.json block (OpenAI-compatible provider + MCP server)."""
+    _emit_block(opencode.opencode_config)
 
 
 @agent_config_app.command("litellm")

--- a/src/lilbee/cli/commands/agent_config.py
+++ b/src/lilbee/cli/commands/agent_config.py
@@ -17,7 +17,6 @@ from lilbee.cli.launchers.server import (
 
 agent_config_app = typer.Typer(help="Print a paste-ready config block for an AI client.")
 
-_MCP_COMMAND = ["lilbee", "mcp"]
 _SERVE_HINT = "Start `lilbee serve --port 8080` first, then re-run this command."
 
 
@@ -47,8 +46,12 @@ def _emit_block(builder: _JsonBuilder | _TextBuilder, **kwargs: Any) -> None:
 
 @agent_config_app.command("opencode")
 def _opencode_cmd() -> None:
-    """Print an opencode.json block (OpenAI-compatible provider + MCP server)."""
-    _emit_block(opencode.opencode_config, mcp_command=_MCP_COMMAND)
+    """Print an opencode.json block (OpenAI-compatible provider + MCP server).
+
+    The MCP server points at the running daemon's streamable-http endpoint so
+    opencode shares its warm models instead of spawning a second process.
+    """
+    _emit_block(opencode.opencode_config, mcp_remote=True)
 
 
 @agent_config_app.command("litellm")

--- a/src/lilbee/cli/launchers/opencode.py
+++ b/src/lilbee/cli/launchers/opencode.py
@@ -19,7 +19,6 @@ _SKILL_PACKAGE = "lilbee.skills.lilbee_mcp"
 _OPENCODE_PROVIDER_ID = "lilbee"
 _OPENCODE_CONFIG_ENV_VAR = "OPENCODE_CONFIG_CONTENT"
 _PICKER_STATE_RECENT_CAP = 10
-_MCP_COMMAND = ["lilbee", "mcp"]
 
 
 def _opencode_config_path() -> Path:
@@ -173,7 +172,6 @@ class OpencodeLauncher:
             base_url=f"http://{LOOPBACK}:{port}",
             api_key=token,
             model_refs=model_refs,
-            mcp_command=_MCP_COMMAND,
         )
         provider_block = block["provider"][_OPENCODE_PROVIDER_ID]
         _merge_lilbee_provider_into_config(

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import functools
+import inspect
 import logging
 import os
 import textwrap
@@ -11,6 +13,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
+import anyio
 from mcp.server.fastmcp import Context, FastMCP
 
 from lilbee.app.search import clean_result
@@ -41,8 +44,36 @@ mcp = FastMCP("lilbee", instructions="Local RAG knowledge base. Search indexed d
 _F = TypeVar("_F", bound=Callable[..., Any])
 
 
+def _offload_sync(fn: _F) -> _F:
+    """Run a sync tool handler off the event loop; async handlers pass through.
+
+    The bundled mcp SDK calls sync tool handlers directly on the event loop, so
+    under the shared streamable-http daemon one slow handler would stall every
+    connected agent. ``functools.wraps`` preserves the wrapped signature so the
+    generated tool schema is unchanged.
+    """
+    if inspect.iscoroutinefunction(fn):
+        return fn
+
+    @functools.wraps(fn)
+    async def _runner(*args: Any, **kwargs: Any) -> Any:
+        return await anyio.to_thread.run_sync(functools.partial(fn, *args, **kwargs))
+
+    return cast("_F", _runner)
+
+
+def _tool(fn: _F) -> _F:
+    """Register *fn* as an MCP tool with sync handlers offloaded off the loop.
+
+    Returns the original callable so in-process callers (tests, the stdio
+    fallback) keep the synchronous API while the schema sees the offloaded form.
+    """
+    mcp.tool()(_offload_sync(fn))
+    return fn
+
+
 def _tool_if(condition: bool) -> Callable[[_F], _F]:
-    """Register a function as an MCP tool only when *condition* is true.
+    """Register an MCP tool only when *condition* is true.
 
     The function stays importable so direct callers (tests, in-process
     fallback) can still reach it. Whether the tool appears in the MCP
@@ -50,9 +81,7 @@ def _tool_if(condition: bool) -> Callable[[_F], _F]:
     a server restart.
     """
     if condition:
-        # mcp.tool() returns Callable[[Callable[..., Any]], Callable[..., Any]];
-        # cast to the typed-callable shape so generic call sites narrow correctly.
-        return cast("Callable[[_F], _F]", mcp.tool())
+        return _tool
 
     def _passthrough(fn: _F) -> _F:
         return fn
@@ -70,7 +99,7 @@ def _error(msg: str) -> dict[str, Any]:
     return {"error": msg}
 
 
-@mcp.tool()
+@_tool
 def search(
     query: str, top_k: int | None = None, scope: str = SearchScope.BOTH.value
 ) -> list[dict[str, Any]] | dict[str, Any]:
@@ -100,7 +129,7 @@ def search(
         return _error(str(exc))
 
 
-@mcp.tool()
+@_tool
 def status() -> dict[str, Any]:
     """Show indexed documents, configuration, and chunk counts."""
     sources = get_services().store.get_sources()
@@ -130,7 +159,7 @@ def status() -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@_tool
 async def sync(force_rebuild: bool = False, retry_skipped: bool = False) -> dict[str, Any]:
     """Sync the documents directory into the vector store.
 
@@ -144,7 +173,7 @@ async def sync(force_rebuild: bool = False, retry_skipped: bool = False) -> dict
     ).model_dump()
 
 
-@mcp.tool()
+@_tool
 async def add(
     paths: list[str],
     force: bool = False,
@@ -253,7 +282,7 @@ def crawl_status(task_id: str) -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@_tool
 def init(path: str = "") -> dict[str, Any]:
     """Initialize a local ``.lilbee/`` knowledge base; empty path = cwd.
 
@@ -284,7 +313,7 @@ def init(path: str = "") -> dict[str, Any]:
     return {"command": "init", "path": str(root), "created": created}
 
 
-@mcp.tool()
+@_tool
 def remove(names: list[str], delete_files: bool = False) -> dict[str, Any]:
     """Remove documents by source name; ``delete_files=true`` also deletes the file on disk."""
     result = get_services().store.remove_documents(
@@ -293,7 +322,7 @@ def remove(names: list[str], delete_files: bool = False) -> dict[str, Any]:
     return {"command": "remove", "removed": result.removed, "not_found": result.not_found}
 
 
-@mcp.tool()
+@_tool
 def list_documents() -> dict[str, Any]:
     """List all indexed documents with their chunk counts."""
     sources = get_services().store.get_sources()
@@ -305,7 +334,7 @@ def list_documents() -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@_tool
 def reset(confirm: bool = False) -> dict[str, Any]:
     """Factory reset: delete all documents and indexed data. Requires ``confirm=true``."""
     if not confirm:
@@ -473,7 +502,7 @@ def _json_safe(value: Any) -> Any:
     return str(value)
 
 
-@mcp.tool()
+@_tool
 def settings_list(group: str = "") -> dict[str, Any]:
     """List writable lilbee settings (each with value, default, type, help, choices).
 
@@ -491,7 +520,7 @@ def settings_list(group: str = "") -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@_tool
 def settings_get(key: str) -> dict[str, Any]:
     """Get a single setting's current value + metadata."""
 
@@ -502,7 +531,7 @@ def settings_get(key: str) -> dict[str, Any]:
     return {"command": "settings_get", "setting": _setting_info_to_dict(info)}
 
 
-@mcp.tool()
+@_tool
 def settings_set(updates: dict[str, Any]) -> dict[str, Any]:
     """Atomically update writable settings; rolls back on any validation error.
 
@@ -522,7 +551,7 @@ def settings_set(updates: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@_tool
 def settings_reset(keys: list[str]) -> dict[str, Any]:
     """Reset writable settings to their built-in defaults."""
 
@@ -537,7 +566,7 @@ def settings_reset(keys: list[str]) -> dict[str, Any]:
     }
 
 
-@mcp.tool()
+@_tool
 def model_list(source: str = "", task: str = "") -> dict[str, Any]:
     """List installed models. ``source`` is ``native`` / ``remote``; ``task`` filters by role."""
     from lilbee.app.models import list_models_data
@@ -554,7 +583,7 @@ def model_list(source: str = "", task: str = "") -> dict[str, Any]:
     return list_models_data(source=src, task=parsed_task).model_dump()
 
 
-@mcp.tool()
+@_tool
 def catalog_browse(
     task: str = "",
     search: str = "",
@@ -620,7 +649,7 @@ def catalog_browse(
     }
 
 
-@mcp.tool()
+@_tool
 def model_show(model: str) -> dict[str, Any]:
     """Show catalog and installed metadata for a model ref."""
     from lilbee.app.models import show_model_data
@@ -644,7 +673,7 @@ def _log_progress_failure(future: concurrent.futures.Future[None]) -> None:
         log.warning("MCP report_progress failed", exc_info=True)
 
 
-@mcp.tool()
+@_tool
 async def model_pull(
     model: str,
     source: str = ModelSource.NATIVE.value,
@@ -697,7 +726,7 @@ async def model_pull(
     return result.model_dump()
 
 
-@mcp.tool()
+@_tool
 def model_rm(model: str, source: str = "") -> dict[str, Any]:
     """Remove an installed model.
 
@@ -787,7 +816,7 @@ def _strip_schema_noise() -> None:
     payload, which matters most for small-context (16K) chat models where
     the tools surface was previously eating ~60% of the budget.
 
-    Runs once after every ``@mcp.tool()`` decoration in this module has fired.
+    Runs once after every ``@_tool`` decoration in this module has fired.
     """
     for info in mcp._tool_manager._tools.values():
         params = info.parameters

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -17,6 +17,7 @@ from lilbee.core.config import cfg
 from lilbee.providers.sdk_llm_provider import inject_provider_keys
 from lilbee.server.auth import AuthMiddleware, session_manager
 from lilbee.server.chat_completions_api.routes import completions_router
+from lilbee.server.mcp_mount import build_mcp_mount
 from lilbee.server.routes.crawl import crawl_route
 from lilbee.server.routes.documents import (
     add_route,
@@ -106,10 +107,12 @@ def create_app() -> Litestar:
         allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
         allow_headers=["Content-Type", "Authorization"],
     )
+    mcp_route, mcp_session_lifespan = build_mcp_mount()
     return Litestar(
-        lifespan=[_lifespan],
+        lifespan=[_lifespan, mcp_session_lifespan],
         middleware=[DefineMiddleware(AuthMiddleware)],
         route_handlers=[
+            mcp_route,
             health_route,
             status_route,
             config_route,

--- a/src/lilbee/server/mcp_mount.py
+++ b/src/lilbee/server/mcp_mount.py
@@ -1,0 +1,57 @@
+"""Mount the FastMCP tool server over streamable-http on the Litestar daemon."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from typing import TYPE_CHECKING
+
+from litestar.handlers import asgi
+from litestar.types import Receive, Scope, Send
+from mcp.server.transport_security import TransportSecuritySettings
+
+from lilbee.mcp_server import mcp
+
+if TYPE_CHECKING:
+    from litestar import Litestar
+    from litestar.handlers import ASGIRouteHandler
+
+MCP_MOUNT_PATH = "/mcp"
+
+_Lifespan = Callable[["Litestar"], AbstractAsyncContextManager[None]]
+
+# The daemon binds localhost; agents reach it on 127.0.0.1/localhost with a
+# dynamic port. DNS-rebinding protection stays on, scoped to those hosts.
+_TRANSPORT_SECURITY = TransportSecuritySettings(
+    enable_dns_rebinding_protection=True,
+    allowed_hosts=["127.0.0.1:*", "localhost:*"],
+    allowed_origins=["http://127.0.0.1:*", "http://localhost:*"],
+)
+
+
+def build_mcp_mount() -> tuple[ASGIRouteHandler, _Lifespan]:
+    """Return the MCP route handler and the session-manager lifespan.
+
+    A fresh session manager is built per call: ``session_manager.run()`` can
+    only be entered once per instance, and the app factory runs once per
+    process in production but repeatedly across tests.
+    """
+    # FastMCP caches the session manager; clear it so each app owns its own,
+    # since run() is single-use per instance.
+    mcp._session_manager = None
+    mcp.settings.streamable_http_path = "/"
+    mcp.settings.transport_security = _TRANSPORT_SECURITY
+    asgi_app = mcp.streamable_http_app()
+    manager = mcp.session_manager
+
+    async def _forward(scope: Scope, receive: Receive, send: Send) -> None:
+        await asgi_app(scope, receive, send)
+
+    handler = asgi(MCP_MOUNT_PATH, is_mount=True, copy_scope=True)(_forward)
+
+    @asynccontextmanager
+    async def _session_lifespan(app: Litestar) -> AsyncIterator[None]:
+        async with manager.run():
+            yield
+
+    return handler, _session_lifespan

--- a/src/lilbee/server/mcp_mount.py
+++ b/src/lilbee/server/mcp_mount.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from litestar.handlers import asgi
-from litestar.types import Receive, Scope, Send
+from litestar.types import ASGIApp, Receive, Scope, Send
 from mcp.server.transport_security import TransportSecuritySettings
 
 from lilbee.mcp_server import mcp
@@ -41,7 +41,7 @@ def build_mcp_mount() -> tuple[ASGIRouteHandler, _Lifespan]:
     mcp._session_manager = None
     mcp.settings.streamable_http_path = "/"
     mcp.settings.transport_security = _TRANSPORT_SECURITY
-    asgi_app = mcp.streamable_http_app()
+    asgi_app = cast("ASGIApp", mcp.streamable_http_app())
     manager = mcp.session_manager
 
     async def _forward(scope: Scope, receive: Receive, send: Send) -> None:

--- a/tests/cli/test_agent_config_opencode.py
+++ b/tests/cli/test_agent_config_opencode.py
@@ -68,9 +68,11 @@ def test_opencode_config_prints_provider_with_real_port_and_token():
     assert set(payload["provider"]["lilbee"]["models"].keys()) == {_CHAT_REF_A}
     # opencode picker shows a cleaned label rather than the full /-/-/.gguf ref.
     assert payload["provider"]["lilbee"]["models"][_CHAT_REF_A] == {"name": "Qwen3-0.6B Q4_K_M"}
-    assert payload["mcp"]["lilbee"]["command"] == ["lilbee", "mcp"]
-    assert payload["mcp"]["lilbee"]["type"] == "local"
-    assert payload["mcp"]["lilbee"]["enabled"] is True
+    mcp_block = payload["mcp"]["lilbee"]
+    assert mcp_block["type"] == "remote"
+    assert mcp_block["url"] == "http://127.0.0.1:8765/mcp"
+    assert mcp_block["headers"]["Authorization"] == "Bearer test-token-abc"
+    assert mcp_block["enabled"] is True
     assert payload["$schema"] == "https://opencode.ai/config.json"
 
 

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -99,9 +99,10 @@ def test_launch_opencode_with_running_server_emits_inline_config_env(tmp_path):
     assert options["apiKey"] == _TOKEN
     assert _CHAT_REF in payload["provider"]["lilbee"]["models"]
     mcp_entry = payload["mcp"]["lilbee"]
-    assert mcp_entry["type"] == "local"
+    assert mcp_entry["type"] == "remote"
     assert mcp_entry["enabled"] is True
-    assert mcp_entry["command"] == ["lilbee", "mcp"]
+    assert mcp_entry["url"] == f"http://127.0.0.1:{_PORT}/mcp"
+    assert mcp_entry["headers"]["Authorization"] == f"Bearer {_TOKEN}"
 
 
 @pytest.mark.no_health_default

--- a/tests/server/test_mcp_mount.py
+++ b/tests/server/test_mcp_mount.py
@@ -1,0 +1,185 @@
+"""MCP-over-streamable-http mount: routing, shared auth, shared Services."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from litestar import Litestar
+from litestar.middleware.base import DefineMiddleware
+from litestar.testing import AsyncTestClient
+
+from lilbee.app.services import set_services
+from lilbee.mcp_server import mcp
+from lilbee.server import auth as auth_mod
+from lilbee.server.auth import AuthMiddleware
+from lilbee.server.mcp_mount import MCP_MOUNT_PATH, build_mcp_mount
+
+_HTTP_OK = 200
+_HTTP_UNAUTHORIZED = 401
+_ACCEPT = "application/json, text/event-stream"
+
+
+def test_configures_localhost_transport_security() -> None:
+    build_mcp_mount()
+    assert mcp.settings.streamable_http_path == "/"
+    security = mcp.settings.transport_security
+    assert security is not None
+    assert security.enable_dns_rebinding_protection
+    assert "127.0.0.1:*" in security.allowed_hosts
+
+
+def test_handler_mounts_at_mcp_path() -> None:
+    handler, _ = build_mcp_mount()
+    assert MCP_MOUNT_PATH in handler.paths
+
+
+def test_fresh_session_manager_per_build() -> None:
+    build_mcp_mount()
+    first = mcp.session_manager
+    build_mcp_mount()
+    second = mcp.session_manager
+    assert first is not second
+
+
+@pytest.fixture
+def auth_token():
+    previous = auth_mod.session_manager.token
+    auth_mod.session_manager.token = "mcp-token-" + "x" * 40
+    yield auth_mod.session_manager.token
+    auth_mod.session_manager.token = previous
+
+
+@pytest.fixture
+def mcp_app() -> Litestar:
+    handler, lifespan = build_mcp_mount()
+    return Litestar(
+        route_handlers=[handler],
+        middleware=[DefineMiddleware(AuthMiddleware)],
+        lifespan=[lifespan],
+    )
+
+
+def _client(app: Litestar) -> AsyncTestClient:
+    # Host must match the daemon's localhost transport-security allow-list.
+    return AsyncTestClient(app, base_url="http://127.0.0.1:8000")
+
+
+def _parse_sse(text: str) -> dict[str, Any]:
+    for line in text.splitlines():
+        if line.startswith("data:"):
+            return json.loads(line[len("data:") :].strip())
+    raise AssertionError(f"no SSE data frame in response: {text!r}")
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "Accept": _ACCEPT}
+
+
+async def _initialize(client: AsyncTestClient, token: str) -> str:
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "0"},
+        },
+    }
+    resp = await client.post(MCP_MOUNT_PATH, json=body, headers=_bearer(token))
+    assert resp.status_code == _HTTP_OK
+    session_id = resp.headers["mcp-session-id"]
+    await client.post(
+        MCP_MOUNT_PATH,
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers={**_bearer(token), "mcp-session-id": session_id},
+    )
+    return session_id
+
+
+async def _call(
+    client: AsyncTestClient, token: str, session_id: str, payload: dict[str, Any]
+) -> dict[str, Any]:
+    resp = await client.post(
+        MCP_MOUNT_PATH,
+        json=payload,
+        headers={**_bearer(token), "mcp-session-id": session_id},
+    )
+    assert resp.status_code == _HTTP_OK
+    return _parse_sse(resp.text)
+
+
+async def test_initialize_requires_the_same_bearer_token(
+    mcp_app: Litestar, auth_token: str
+) -> None:
+    """No bearer token is rejected by the shared AuthMiddleware."""
+    async with _client(mcp_app) as client:
+        resp = await client.post(
+            MCP_MOUNT_PATH,
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            headers={"Accept": _ACCEPT},
+        )
+    assert resp.status_code == _HTTP_UNAUTHORIZED
+
+
+async def test_initialize_succeeds_with_the_session_token(
+    mcp_app: Litestar, auth_token: str
+) -> None:
+    async with _client(mcp_app) as client:
+        body = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0"},
+            },
+        }
+        resp = await client.post(MCP_MOUNT_PATH, json=body, headers=_bearer(auth_token))
+    assert resp.status_code == _HTTP_OK
+    assert _parse_sse(resp.text)["result"]["serverInfo"]["name"] == "lilbee"
+
+
+async def test_tools_list_exposes_search_over_http(
+    mcp_app: Litestar, auth_token: str
+) -> None:
+    async with _client(mcp_app) as client:
+        session_id = await _initialize(client, auth_token)
+        result = await _call(
+            client, auth_token, session_id, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+        )
+    names = {tool["name"] for tool in result["result"]["tools"]}
+    assert "search" in names
+
+
+async def test_search_tool_uses_the_shared_services_singleton(
+    mcp_app: Litestar, auth_token: str
+) -> None:
+    """A tool call over http reads the same get_services() the REST routes use."""
+    from tests.conftest import make_mock_services
+
+    services = make_mock_services()
+    services.searcher.search = MagicMock(return_value=[])
+    set_services(services)
+    try:
+        async with _client(mcp_app) as client:
+            session_id = await _initialize(client, auth_token)
+            await _call(
+                client,
+                auth_token,
+                session_id,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {"name": "search", "arguments": {"query": "hello"}},
+                },
+            )
+    finally:
+        set_services(None)
+    services.searcher.search.assert_called_once()
+    assert services.searcher.search.call_args.args[0] == "hello"

--- a/tests/server/test_mcp_mount.py
+++ b/tests/server/test_mcp_mount.py
@@ -144,9 +144,7 @@ async def test_initialize_succeeds_with_the_session_token(
     assert _parse_sse(resp.text)["result"]["serverInfo"]["name"] == "lilbee"
 
 
-async def test_tools_list_exposes_search_over_http(
-    mcp_app: Litestar, auth_token: str
-) -> None:
+async def test_tools_list_exposes_search_over_http(mcp_app: Litestar, auth_token: str) -> None:
     async with _client(mcp_app) as client:
         session_id = await _initialize(client, auth_token)
         result = await _call(

--- a/tests/test_mcp_offload.py
+++ b/tests/test_mcp_offload.py
@@ -1,0 +1,83 @@
+"""Unit tests for the MCP sync-handler offload mechanism."""
+
+from __future__ import annotations
+
+import inspect
+import threading
+
+import pytest
+
+from lilbee import mcp_server as m
+
+
+def test_offload_passes_async_handlers_through() -> None:
+    async def handler() -> int:
+        return 1
+
+    assert m._offload_sync(handler) is handler
+
+
+async def test_offload_runs_sync_handler_off_the_event_loop() -> None:
+    main_thread = threading.current_thread()
+    seen: dict[str, threading.Thread] = {}
+
+    def probe(value: int) -> int:
+        seen["thread"] = threading.current_thread()
+        return value * 2
+
+    wrapped = m._offload_sync(probe)
+    assert inspect.iscoroutinefunction(wrapped)
+
+    result = await wrapped(21)
+
+    assert result == 42
+    assert seen["thread"] is not main_thread
+
+
+def test_offload_preserves_name_and_signature() -> None:
+    def handler(query: str, top_k: int = 5) -> dict[str, int]:
+        return {"n": top_k}
+
+    wrapped = m._offload_sync(handler)
+
+    assert wrapped.__name__ == "handler"
+    assert list(inspect.signature(wrapped).parameters) == ["query", "top_k"]
+
+
+def test_registered_tool_keeps_sync_callable_for_in_process_use() -> None:
+    assert not inspect.iscoroutinefunction(m.search)
+
+
+async def test_registered_tool_schema_preserves_parameters() -> None:
+    tools = {tool.name: tool for tool in await m.mcp.list_tools()}
+
+    properties = tools["search"].inputSchema["properties"]
+
+    assert {"query", "top_k", "scope"} <= set(properties)
+
+
+def test_tool_if_false_leaves_function_unregistered_but_callable() -> None:
+    decorator = m._tool_if(False)
+
+    def handler() -> int:
+        return 7
+
+    assert decorator(handler) is handler
+
+
+def test_tool_if_true_registers_and_returns_original() -> None:
+    decorator = m._tool_if(True)
+
+    def sample_unique_tool_name(value: int) -> int:
+        return value
+
+    returned = decorator(sample_unique_tool_name)
+
+    assert returned is sample_unique_tool_name
+
+
+@pytest.fixture(autouse=True)
+def _drop_test_tool() -> None:
+    """Remove any tool the registration tests add so the schema stays stable."""
+    yield
+    m.mcp._tool_manager._tools.pop("sample_unique_tool_name", None)


### PR DESCRIPTION
## Problem

An agent that talks to lilbee over MCP spawns its own `lilbee mcp` process over stdio. Each process loads its own copy of the models, so running two or three agents against one machine means two or three model copies in memory and, on a single GPU, hitting the VRAM wall. There was no way for multiple agents to share one warm backend for retrieval.

## Solution

Serve the same MCP tools over streamable-http from the running `lilbee serve` daemon, so agents can share a single warm backend instead of each spawning their own.

- **Shared warm models.** Multiple agents connect to one daemon and share one set of loaded models. stdio stays the default for the single-agent case, and the TUI is untouched.
- **Same auth as the rest of the server.** The MCP endpoint sits behind the existing bearer-token middleware, so it uses the same session token as the `/v1/*` and REST surfaces. No second auth scheme to configure.
- **Stays responsive under load.** Tool calls run off the event loop, so one slow call from one agent does not stall the others sharing the daemon. Retrieval reads run concurrently; generation keeps the existing single-flight queue.
- **`agent-config`/`launch opencode` point at the daemon.** Wiring opencode now reuses the running daemon for retrieval instead of spawning a second process.

## Architecture

```mermaid
flowchart LR
    A1[Agent A]
    A2[Agent B]

    subgraph stdio["stdio (default, single agent)"]
        M1["lilbee mcp"]
        S1[(Services + own model copy)]
        M1 --> S1
    end

    subgraph daemon["lilbee serve daemon (shared)"]
        AUTH["AuthMiddleware (bearer token)"]
        MCPSUB["/mcp (FastMCP sub-app)"]
        REST["/v1 + REST"]
        SVC[(one warm Services)]
        AUTH --> MCPSUB
        AUTH --> REST
        MCPSUB --> SVC
        REST --> SVC
    end

    A1 -->|stdio| M1
    A1 -.->|http + Bearer| AUTH
    A2 -.->|http + Bearer| AUTH
```