### PR TITLE
Classify provider errors into kinds, with clear user-facing messages

### DIFF
--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, overload, runtime_checkable
 
@@ -52,11 +53,40 @@ def filter_options(options: dict[str, Any]) -> dict[str, Any]:
     return LLMOptions(**options).to_dict()
 
 
-class ProviderError(Exception):
-    """Raised when an LLM provider operation fails."""
+class ProviderErrorKind(StrEnum):
+    """Provider-agnostic category of a failed provider call.
 
-    def __init__(self, message: str, *, provider: str = "") -> None:
+    Classified by exception type at each backend boundary so callers can
+    branch on the kind instead of matching message strings (which are
+    provider-specific and drift between SDK versions).
+    """
+
+    AUTH = "auth"
+    RATE_LIMIT = "rate_limit"
+    CONTEXT_OVERFLOW = "context_overflow"
+    NOT_FOUND = "not_found"
+    BAD_REQUEST = "bad_request"
+    CONNECTION = "connection"
+    SERVER = "server"
+    UNKNOWN = "unknown"
+
+
+class ProviderError(Exception):
+    """Raised when an LLM provider operation fails.
+
+    ``kind`` is the provider-agnostic category; backends that can't classify a
+    failure leave it ``UNKNOWN``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str = "",
+        kind: ProviderErrorKind = ProviderErrorKind.UNKNOWN,
+    ) -> None:
         self.provider = provider
+        self.kind = kind
         super().__init__(message)
 
 

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -21,7 +21,7 @@ from typing import Any
 import httpx
 
 from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
-from lilbee.providers.base import ProviderError
+from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.model_ref import OLLAMA_PREFIX, ProviderModelRef
 from lilbee.providers.sdk_backend import (
     CompletionRequest,
@@ -219,6 +219,109 @@ def _format_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return formatted
 
 
+# User-facing message per recognised error kind. Each names the problem against
+# {model} and makes clear the cause sits with the user's provider account or
+# network, not with lilbee. UNKNOWN has no entry and falls back to the raw error.
+_KIND_MESSAGES: dict[ProviderErrorKind, str] = {
+    ProviderErrorKind.RATE_LIMIT: (
+        "{model} is rate-limited or out of quota. That's a limit on your provider "
+        "API key, not a lilbee problem. Check your plan and billing with the "
+        "provider, or pick a different model."
+    ),
+    ProviderErrorKind.AUTH: (
+        "{model} rejected your API key. Check that the key is set correctly and has "
+        "access to this model. That's between your key and the provider, not a lilbee problem."
+    ),
+    ProviderErrorKind.NOT_FOUND: (
+        "The provider doesn't offer {model} on your account. "
+        "Pick a different model or check the name."
+    ),
+    ProviderErrorKind.CONTEXT_OVERFLOW: (
+        "This conversation is too long for {model}'s context window. "
+        "Start a new chat or pick a model with a larger context."
+    ),
+    ProviderErrorKind.BAD_REQUEST: (
+        "The provider rejected the request for {model}. Check the model name and your settings."
+    ),
+    ProviderErrorKind.CONNECTION: (
+        "Couldn't reach the provider for {model}, or it timed out. Check your "
+        "connection and base URL, then try again or pick a different model."
+    ),
+    ProviderErrorKind.SERVER: (
+        "The provider for {model} is unavailable right now. That's on the provider's "
+        "side, not a lilbee problem. Try again shortly or pick a different model."
+    ),
+}
+
+# Operation labels prefixed onto the fallback message for an unrecognised error.
+_CHAT_FAILED = "Chat failed"
+_EMBED_FAILED = "Embedding failed"
+_RERANK_FAILED = "Rerank failed"
+
+
+def _cause_chain(exc: BaseException) -> list[BaseException]:
+    """Return *exc* and its causes, root cause first.
+
+    litellm's mid-stream fallback keeps the real cause in ``original_exception``;
+    walking root-first stops a 503 wrapper from masking the 429 it carries.
+    """
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        chain.append(cur)
+        nxt = getattr(cur, "original_exception", None)
+        if not isinstance(nxt, BaseException):
+            nxt = cur.__cause__
+        cur = nxt if isinstance(nxt, BaseException) else None
+    chain.reverse()
+    return chain
+
+
+def _classify_litellm_error(exc: BaseException) -> ProviderErrorKind:
+    """Map a litellm exception to a ``ProviderErrorKind`` by type, never by message.
+
+    litellm normalises every backend's failures into one exception hierarchy, so
+    the same mapping covers all providers. The MRO walk picks the most specific
+    kind (``ContextWindowExceededError`` over its ``BadRequestError`` base).
+    """
+    try:
+        import litellm
+    except ImportError:  # pragma: no cover - unreachable after a real litellm call
+        return ProviderErrorKind.UNKNOWN
+    table: dict[type, ProviderErrorKind] = {
+        litellm.AuthenticationError: ProviderErrorKind.AUTH,
+        litellm.PermissionDeniedError: ProviderErrorKind.AUTH,
+        litellm.NotFoundError: ProviderErrorKind.NOT_FOUND,
+        litellm.RateLimitError: ProviderErrorKind.RATE_LIMIT,
+        litellm.ContextWindowExceededError: ProviderErrorKind.CONTEXT_OVERFLOW,
+        litellm.BadRequestError: ProviderErrorKind.BAD_REQUEST,
+        litellm.Timeout: ProviderErrorKind.CONNECTION,
+        litellm.APIConnectionError: ProviderErrorKind.CONNECTION,
+        litellm.ServiceUnavailableError: ProviderErrorKind.SERVER,
+        litellm.InternalServerError: ProviderErrorKind.SERVER,
+    }
+    for err in _cause_chain(exc):
+        for cls in type(err).__mro__:
+            kind = table.get(cls)
+            if kind is not None:
+                return kind
+    return ProviderErrorKind.UNKNOWN
+
+
+def _provider_error(fallback: str, exc: Exception, model: str) -> ProviderError:
+    """Wrap a litellm failure as a ``ProviderError`` classified by type.
+
+    Recognised kinds get a blob-free, user-facing message; unrecognised ones
+    keep the raw ``{fallback}: {exc}`` shape so nothing is lost when debugging.
+    """
+    kind = _classify_litellm_error(exc)
+    template = _KIND_MESSAGES.get(kind)
+    message = template.format(model=model) if template is not None else f"{fallback}: {exc}"
+    return ProviderError(message, provider=_PROVIDER_NAME, kind=kind)
+
+
 class LitellmSdkBackend:
     """``LlmSdkBackend`` adapter backed by the ``litellm`` SDK."""
 
@@ -253,7 +356,7 @@ class LitellmSdkBackend:
         try:
             response = litellm.completion(**kwargs)
         except Exception as exc:
-            raise ProviderError(f"Chat failed: {exc}", provider=_PROVIDER_NAME) from exc
+            raise _provider_error(_CHAT_FAILED, exc, request.ref.for_display()) from exc
         view = _LitellmResponseView(response)
         return CompletionResult(
             content=view.message_content,
@@ -265,17 +368,18 @@ class LitellmSdkBackend:
         """Stream a completion through ``litellm.completion(stream=True)``."""
         litellm = _require_litellm()
         kwargs = self._completion_kwargs(request, stream=True)
+        model = request.ref.for_display()
         try:
             response = litellm.completion(**kwargs)
         except Exception as exc:
-            raise ProviderError(f"Chat failed: {exc}", provider=_PROVIDER_NAME) from exc
-        return self._stream_chunks(response)
+            raise _provider_error(_CHAT_FAILED, exc, model) from exc
+        return self._stream_chunks(response, model)
 
     @staticmethod
-    def _stream_chunks(response: Any) -> Iterator[StreamChunk]:
+    def _stream_chunks(response: Any, model: str) -> Iterator[StreamChunk]:
         """Yield ``StreamChunk`` values from a litellm streaming response.
 
-        Exceptions raised mid-iteration are wrapped in ``ProviderError``
+        Exceptions raised mid-iteration are classified into ``ProviderError``
         so the semantic layer sees a consistent error type regardless of
         where the SDK failed.
         """
@@ -289,7 +393,7 @@ class LitellmSdkBackend:
         except ProviderError:
             raise
         except Exception as exc:
-            raise ProviderError(f"Chat failed: {exc}", provider=_PROVIDER_NAME) from exc
+            raise _provider_error(_CHAT_FAILED, exc, model) from exc
 
     @staticmethod
     def _completion_kwargs(request: CompletionRequest, *, stream: bool) -> dict[str, Any]:
@@ -321,7 +425,7 @@ class LitellmSdkBackend:
         try:
             response = litellm.embedding(**kwargs)
         except Exception as exc:
-            raise ProviderError(f"Embedding failed: {exc}", provider=_PROVIDER_NAME) from exc
+            raise _provider_error(_EMBED_FAILED, exc, request.ref.for_display()) from exc
         data = response["data"] if isinstance(response, dict) else response.data
         vectors = [item["embedding"] for item in data]
         if isinstance(response, dict):
@@ -352,7 +456,7 @@ class LitellmSdkBackend:
         try:
             response = litellm.rerank(**kwargs)
         except Exception as exc:
-            raise ProviderError(f"Rerank failed: {exc}", provider=_PROVIDER_NAME) from exc
+            raise _provider_error(_RERANK_FAILED, exc, request.ref.for_display()) from exc
         results = response["results"] if isinstance(response, dict) else response.results
         scores = [0.0] * len(request.candidates)
         for item in results:

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -12,6 +12,7 @@ from lilbee.app.search import clean_result
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
 from lilbee.core.results import DocumentResult, group
+from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.retrieval.reasoning import (
     CAP_NOTICE_TEMPLATE,
     CapNotice,
@@ -68,7 +69,7 @@ def _run_llm_stream(
     opts: dict[str, Any] | None,
     queue: asyncio.Queue[str | None],
     cancel: threading.Event,
-    error_holder: list[str],
+    error_holder: list[Exception],
 ) -> None:
     """Forward tokens from the cap-aware chat orchestrator into the SSE queue."""
     try:
@@ -95,9 +96,26 @@ def _run_llm_stream(
                 kind = SseEvent.REASONING if event.is_reasoning else SseEvent.TOKEN
                 queue.put_nowait(sse_event(kind, {"token": event.content}))
     except Exception as exc:
-        error_holder.append(str(exc))
+        error_holder.append(exc)
     finally:
         queue.put_nowait(None)
+
+
+def _error_event(exc: Exception) -> str:
+    """Build the SSE error event for a stream failure.
+
+    Provider errors already carry a user-facing message (rate limits, auth,
+    bad model), so surface it verbatim. Everything else goes through the
+    llama.cpp OOM classifier and otherwise collapses to a generic message.
+    """
+    if isinstance(exc, ProviderError):
+        log.warning("Provider error during stream: %s", exc)
+        kind_code = exc.kind if exc.kind is not ProviderErrorKind.UNKNOWN else None
+        return sse_error(str(exc), code=kind_code)
+    raw = str(exc)
+    code, user_message = classify_load_error(raw)
+    log.warning("Stream error: %s", raw)
+    return sse_error(user_message, code=code, detail=raw if code else None)
 
 
 async def _stream_rag_response(
@@ -121,7 +139,7 @@ async def _stream_rag_response(
     opts = _resolve_generation_options(options) or cfg.generation_options()
 
     sse = SseStream()
-    error_holder: list[str] = []
+    error_holder: list[Exception] = []
 
     executor_fut = sse.loop.run_in_executor(
         None, _run_llm_stream, messages, opts, sse.queue, sse.cancel, error_holder
@@ -131,10 +149,7 @@ async def _stream_rag_response(
         yield event
 
     if error_holder:
-        raw = error_holder[0]
-        code, user_message = classify_load_error(raw)
-        log.warning("Stream error: %s", raw)
-        yield sse_error(user_message, code=code, detail=raw if code else None)
+        yield _error_event(error_holder[0])
         sse.cancel.set()
         return
 

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -13,6 +13,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from lilbee.core.config import cfg
+from lilbee.providers.base import ProviderErrorKind
 from lilbee.runtime.progress import (
     DetailedProgressCallback,
     EventType,
@@ -23,13 +24,20 @@ from lilbee.runtime.progress import (
 
 log = logging.getLogger(__name__)
 
+# Machine-readable ``code`` on an SSE error event. Load-time failures use
+# SseErrorCode; failed provider calls reuse ProviderErrorKind directly rather
+# than mirroring it into a second enum.
+SseErrorCodeValue = SseErrorCode | ProviderErrorKind
+
 
 def sse_event(event: str, data: Any) -> str:
     """Format a single Server-Sent Event string."""
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
 
 
-def sse_error(message: str, *, code: SseErrorCode | None = None, detail: str | None = None) -> str:
+def sse_error(
+    message: str, *, code: SseErrorCodeValue | None = None, detail: str | None = None
+) -> str:
     """Format an SSE error event with optional structured ``code`` / ``detail``."""
     payload: dict[str, Any] = {"message": message}
     if code is not None:

--- a/tests/providers/test_litellm_error_classification.py
+++ b/tests/providers/test_litellm_error_classification.py
@@ -1,0 +1,146 @@
+"""litellm failures are classified into ``ProviderErrorKind`` by exception type.
+
+litellm is an optional extra, so a fake module mirroring its exception hierarchy
+is injected. The classifier only does MRO/isinstance checks, so the real litellm
+classes aren't required to verify the mapping.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Iterator
+from unittest import mock
+
+import pytest
+
+from lilbee.providers.base import ProviderError, ProviderErrorKind
+from lilbee.providers.litellm_sdk import _KIND_MESSAGES, _classify_litellm_error, _provider_error
+
+
+def test_every_actionable_kind_has_a_user_message() -> None:
+    # Adding a kind without a message would silently fall back to the raw error.
+    for kind in ProviderErrorKind:
+        if kind is ProviderErrorKind.UNKNOWN:
+            assert kind not in _KIND_MESSAGES
+        else:
+            assert kind in _KIND_MESSAGES, f"{kind} has no user-facing message"
+            assert "{model}" in _KIND_MESSAGES[kind]
+
+
+def _fake_litellm() -> types.ModuleType:
+    ns = types.ModuleType("litellm")
+    ns.APIError = type("APIError", (Exception,), {})
+    ns.AuthenticationError = type("AuthenticationError", (ns.APIError,), {})
+    ns.PermissionDeniedError = type("PermissionDeniedError", (ns.APIError,), {})
+    ns.NotFoundError = type("NotFoundError", (ns.APIError,), {})
+    ns.RateLimitError = type("RateLimitError", (ns.APIError,), {})
+    ns.BadRequestError = type("BadRequestError", (ns.APIError,), {})
+    # Mirrors litellm: ContextWindowExceededError subclasses BadRequestError.
+    ns.ContextWindowExceededError = type("ContextWindowExceededError", (ns.BadRequestError,), {})
+    ns.Timeout = type("Timeout", (ns.APIError,), {})
+    ns.APIConnectionError = type("APIConnectionError", (ns.APIError,), {})
+    ns.ServiceUnavailableError = type("ServiceUnavailableError", (ns.APIError,), {})
+    ns.InternalServerError = type("InternalServerError", (ns.APIError,), {})
+    return ns
+
+
+@pytest.fixture
+def fake_litellm() -> Iterator[types.ModuleType]:
+    ns = _fake_litellm()
+    with mock.patch.dict(sys.modules, {"litellm": ns}):
+        yield ns
+
+
+@pytest.mark.parametrize(
+    ("exc_name", "expected"),
+    [
+        ("AuthenticationError", ProviderErrorKind.AUTH),
+        ("PermissionDeniedError", ProviderErrorKind.AUTH),
+        ("NotFoundError", ProviderErrorKind.NOT_FOUND),
+        ("RateLimitError", ProviderErrorKind.RATE_LIMIT),
+        ("ContextWindowExceededError", ProviderErrorKind.CONTEXT_OVERFLOW),
+        ("BadRequestError", ProviderErrorKind.BAD_REQUEST),
+        ("Timeout", ProviderErrorKind.CONNECTION),
+        ("APIConnectionError", ProviderErrorKind.CONNECTION),
+        ("ServiceUnavailableError", ProviderErrorKind.SERVER),
+        ("InternalServerError", ProviderErrorKind.SERVER),
+    ],
+)
+def test_classifies_each_exception_type(
+    fake_litellm: types.ModuleType, exc_name: str, expected: ProviderErrorKind
+) -> None:
+    exc = getattr(fake_litellm, exc_name)("boom")
+    assert _classify_litellm_error(exc) == expected
+
+
+def test_context_overflow_beats_bad_request_base(fake_litellm: types.ModuleType) -> None:
+    # ContextWindowExceededError subclasses BadRequestError; the MRO walk must
+    # return the most specific kind, not the base.
+    exc = fake_litellm.ContextWindowExceededError("too long")
+    assert _classify_litellm_error(exc) == ProviderErrorKind.CONTEXT_OVERFLOW
+
+
+def test_unrecognized_exception_is_unknown(fake_litellm: types.ModuleType) -> None:
+    assert _classify_litellm_error(RuntimeError("???")) == ProviderErrorKind.UNKNOWN
+
+
+def test_mid_stream_fallback_unwraps_to_root_cause(fake_litellm: types.ModuleType) -> None:
+    # litellm wraps the real cause (a 429) inside a ServiceUnavailableError-shaped
+    # fallback. Classifying the wrapper alone would mislabel it SERVER; the cause
+    # chain must surface the underlying rate limit instead.
+    inner = fake_litellm.RateLimitError("quota exceeded")
+    outer = fake_litellm.ServiceUnavailableError("fallbacks exhausted")
+    outer.original_exception = inner  # type: ignore[attr-defined]
+    assert _classify_litellm_error(outer) == ProviderErrorKind.RATE_LIMIT
+
+
+def test_provider_error_recognized_kind_drops_raw_blob(fake_litellm: types.ModuleType) -> None:
+    # The whole point of the fix: the raw SDK blob must not reach the user.
+    blob = 'b\'{"error": {"code": 429, ...huge JSON dump...}}\''
+    err = _provider_error("Chat failed", fake_litellm.RateLimitError(blob), "gemini/gemini-3.1-pro")
+    assert err.kind == ProviderErrorKind.RATE_LIMIT
+    assert err.provider == "litellm"
+    assert "gemini-3.1-pro" in str(err)
+    assert "quota" in str(err).lower() or "rate" in str(err).lower()
+    assert "lilbee" in str(err).lower()
+    assert "huge JSON dump" not in str(err)
+
+
+def test_provider_error_unknown_keeps_raw_fallback(fake_litellm: types.ModuleType) -> None:
+    err = _provider_error("Embedding failed", RuntimeError("nope"), "openai/text-embedding-3-small")
+    assert err.kind == ProviderErrorKind.UNKNOWN
+    assert str(err) == "Embedding failed: nope"
+
+
+def test_provider_error_is_a_provider_error(fake_litellm: types.ModuleType) -> None:
+    err = _provider_error(
+        "Rerank failed", fake_litellm.AuthenticationError("bad key"), "cohere/rerank"
+    )
+    assert isinstance(err, ProviderError)
+    assert err.kind == ProviderErrorKind.AUTH
+
+
+def test_complete_surfaces_classified_message_end_to_end(fake_litellm: types.ModuleType) -> None:
+    # The reported bug: a Gemini 429 wrapped in a mid-stream fallback, driven
+    # all the way through backend.complete. The user must see the clean
+    # rate-limit message, never the raw blob.
+    from lilbee.providers.litellm_sdk import LitellmSdkBackend
+    from lilbee.providers.model_ref import parse_model_ref
+    from lilbee.providers.sdk_backend import CompletionRequest
+
+    inner = fake_litellm.RateLimitError('b\'{"error": {"code": 429, ...blob...}}\'')
+    outer = fake_litellm.ServiceUnavailableError("fallbacks exhausted")
+    outer.original_exception = inner  # type: ignore[attr-defined]
+    fake_litellm.completion = mock.MagicMock(side_effect=outer)
+
+    backend = LitellmSdkBackend()
+    req = CompletionRequest(
+        ref=parse_model_ref("gemini/gemini-3.1-pro"),
+        messages=[{"role": "user", "content": "test"}],
+    )
+    with pytest.raises(ProviderError) as caught:
+        backend.complete(req)
+    assert caught.value.kind == ProviderErrorKind.RATE_LIMIT
+    assert "gemini-3.1-pro" in str(caught.value)
+    assert "blob" not in str(caught.value)

--- a/tests/providers/test_provider_error.py
+++ b/tests/providers/test_provider_error.py
@@ -1,0 +1,20 @@
+"""ProviderError carries a provider-agnostic ``kind`` for callers to branch on."""
+
+from __future__ import annotations
+
+from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+
+def test_default_kind_is_unknown() -> None:
+    err = ProviderError("boom")
+    assert err.kind == ProviderErrorKind.UNKNOWN
+    assert err.provider == ""
+    assert str(err) == "boom"
+
+
+def test_kind_and_provider_are_carried() -> None:
+    err = ProviderError("rate limited", provider="litellm", kind=ProviderErrorKind.RATE_LIMIT)
+    assert err.kind == ProviderErrorKind.RATE_LIMIT
+    assert err.provider == "litellm"
+    # The message is unchanged; kind is metadata, not appended to str().
+    assert str(err) == "rate limited"

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -11,6 +11,7 @@ import lilbee.app.services as svc_mod
 from lilbee.core.config import cfg
 from lilbee.data.ingest import SyncResult
 from lilbee.data.store import SearchChunk
+from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.runtime.progress import SseErrorCode
 from lilbee.server import handlers
 from lilbee.server.handlers import (
@@ -246,7 +247,7 @@ class TestAskStream:
             pass
         assert mock_svc.searcher.build_rag_context.call_args.kwargs.get("chunk_type") == "wiki"
 
-    async def test_provider_error_yields_error_event(self, mock_svc):
+    async def test_unknown_error_yields_internal_error(self, mock_svc):
         mock_svc.searcher.build_rag_context.return_value = _rag_return()
         mock_svc.provider.chat.side_effect = RuntimeError("model missing")
         events = [e async for e in handlers.ask_stream("question")]
@@ -256,6 +257,41 @@ class TestAskStream:
         assert len(error_events) == 1
         assert "Internal error" in error_events[0]
         parsed = json.loads(error_events[0].split("data: ")[1].strip())
+        assert "code" not in parsed
+
+    async def test_provider_error_surfaces_its_message(self, mock_svc):
+        # A ProviderError already carries a user-facing message (rate limit,
+        # bad key, ...); it must reach the client, not collapse to "Internal error".
+        mock_svc.searcher.build_rag_context.return_value = _rag_return()
+        mock_svc.provider.chat.side_effect = ProviderError(
+            "gemini/m is rate-limited or out of quota. That's a limit on your "
+            "provider API key, not a lilbee problem.",
+            provider="litellm",
+            kind=ProviderErrorKind.RATE_LIMIT,
+        )
+        events = [e async for e in handlers.ask_stream("question")]
+
+        error_events = [e for e in events if e and e.startswith("event: error")]
+        assert len(error_events) == 1
+        parsed = json.loads(error_events[0].split("data: ")[1].strip())
+        assert "rate-limited or out of quota" in parsed["message"]
+        assert "lilbee" in parsed["message"]
+        assert "Internal error" not in parsed["message"]
+        # The kind reaches the client as a machine-readable code to branch on.
+        assert parsed["code"] == "rate_limit"
+
+    async def test_unclassified_provider_error_has_message_but_no_code(self, mock_svc):
+        # An UNKNOWN-kind ProviderError still surfaces its message, with no code.
+        mock_svc.searcher.build_rag_context.return_value = _rag_return()
+        mock_svc.provider.chat.side_effect = ProviderError(
+            "Chat failed: something odd", provider="litellm"
+        )
+        events = [e async for e in handlers.ask_stream("question")]
+
+        error_events = [e for e in events if e and e.startswith("event: error")]
+        assert len(error_events) == 1
+        parsed = json.loads(error_events[0].split("data: ")[1].strip())
+        assert "something odd" in parsed["message"]
         assert "code" not in parsed
 
     async def test_oom_load_error_yields_structured_code(self, mock_svc):
@@ -380,7 +416,7 @@ class TestChatStream:
             pass
         assert mock_svc.searcher.build_rag_context.call_args.kwargs.get("chunk_type") == "raw"
 
-    async def test_provider_error_yields_error_event(self, mock_svc):
+    async def test_unknown_error_yields_internal_error(self, mock_svc):
         mock_svc.searcher.build_rag_context.return_value = _rag_return()
         mock_svc.provider.chat.side_effect = ConnectionError("provider down")
         events = [e async for e in handlers.chat_stream("q", [])]
@@ -389,6 +425,19 @@ class TestChatStream:
         error_events = [e for e in non_empty if e.startswith("event: error")]
         assert len(error_events) == 1
         assert "Internal error" in error_events[0]
+
+    async def test_provider_error_surfaces_its_message(self, mock_svc):
+        mock_svc.searcher.build_rag_context.return_value = _rag_return()
+        mock_svc.provider.chat.side_effect = ProviderError(
+            "gemini/m rejected your API key.", provider="litellm", kind=ProviderErrorKind.AUTH
+        )
+        events = [e async for e in handlers.chat_stream("q", [])]
+
+        error_events = [e for e in events if e and e.startswith("event: error")]
+        assert len(error_events) == 1
+        parsed = json.loads(error_events[0].split("data: ")[1].strip())
+        assert "rejected your API key" in parsed["message"]
+        assert parsed["code"] == "auth"
 
     async def test_cancel_sets_cancel_event(self, mock_svc):
         """Closing the chat_stream generator mid-stream signals the thread to stop."""
@@ -2317,7 +2366,7 @@ class TestRunLlmStreamCancel:
         cancel.set()  # pre-set cancel
 
         queue: asyncio.Queue[str | None] = asyncio.Queue()
-        error_holder: list[str] = []
+        error_holder: list[Exception] = []
 
         mock_provider = MagicMock()
         # Return some stream tokens that would normally be emitted
@@ -2370,7 +2419,7 @@ class TestReasoningCapHandling:
 
             queue: asyncio.Queue[str | None] = asyncio.Queue()
             cancel = threading.Event()
-            error_holder: list[str] = []
+            error_holder: list[Exception] = []
 
             with patch("lilbee.server.handlers.rag.get_services") as mock_svc:
                 mock_svc.return_value.provider = mock_provider
@@ -2405,7 +2454,7 @@ class TestReasoningCapHandling:
 
             queue: asyncio.Queue[str | None] = asyncio.Queue()
             cancel = threading.Event()
-            error_holder: list[str] = []
+            error_holder: list[Exception] = []
 
             with patch("lilbee.server.handlers.rag.get_services") as mock_svc:
                 mock_svc.return_value.provider = mock_provider
@@ -2445,7 +2494,7 @@ class TestReasoningCapHandling:
             queue: asyncio.Queue[str | None] = asyncio.Queue()
             cancel = threading.Event()
             cancel.set()
-            error_holder: list[str] = []
+            error_holder: list[Exception] = []
 
             with patch("lilbee.server.handlers.rag.get_services") as mock_svc:
                 mock_svc.return_value.provider = mock_provider
@@ -2479,7 +2528,7 @@ class TestReasoningCapHandling:
 
             mock_provider.chat.side_effect = [iter([long_reasoning]), second_pass()]
             queue: asyncio.Queue[str | None] = asyncio.Queue()
-            error_holder: list[str] = []
+            error_holder: list[Exception] = []
 
             with patch("lilbee.server.handlers.rag.get_services") as mock_svc:
                 mock_svc.return_value.provider = mock_provider


### PR DESCRIPTION
## Problem

Picking a remote model whose API key has no quota or access (for example a Gemini free-tier model that returns a 429) dumped the entire provider exception into the chat. The user saw a wall of raw JSON with no indication of what went wrong or that the cause was their own API key, not a bug in lilbee. Telling failures apart at all meant matching provider-specific message strings, which drift between SDK versions.

## Solution

Failures are now classified by exception type into a small provider-agnostic set of kinds (auth, rate limit, context overflow, not found, bad request, connection, server) carried on the error. Recognised kinds get a short message that names the problem against the model and makes clear the cause sits with the user's provider account, not lilbee. The raw blob is dropped for recognised kinds and kept only for unknown ones, so nothing is lost when debugging.

Classification happens once, at the boundary where lilbee talks to the model, and the same mapping covers every provider. When a failure arrives wrapped in a mid-stream fallback, the real underlying cause is unwrapped so a transient-looking wrapper doesn't mask the real reason. Chat, embeddings, and reranking share the handling, and the server stream now surfaces these messages to clients instead of collapsing them to a generic "Internal error".