### PR TITLE
Classify provider errors by type, not message strings

### DIFF
--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, overload, runtime_checkable
 
@@ -52,12 +53,62 @@ def filter_options(options: dict[str, Any]) -> dict[str, Any]:
     return LLMOptions(**options).to_dict()
 
 
-class ProviderError(Exception):
-    """Raised when an LLM provider operation fails."""
+class ProviderErrorKind(StrEnum):
+    """Provider-agnostic error categories, each mapping to one user action.
 
-    def __init__(self, message: str, *, provider: str = "") -> None:
+    Classified at each backend boundary by exception type or status code, so
+    callers branch on the kind, not on message strings (which never generalize).
+    """
+
+    AUTH = "auth"
+    RATE_LIMIT = "rate_limit"
+    CONTEXT_OVERFLOW = "context_overflow"
+    NOT_FOUND = "not_found"
+    BAD_REQUEST = "bad_request"
+    CONNECTION = "connection"
+    SERVER = "server"
+    UNKNOWN = "unknown"
+
+
+_ERROR_HINTS: dict[ProviderErrorKind, str] = {
+    ProviderErrorKind.AUTH: "Check the API key configured for this provider.",
+    ProviderErrorKind.RATE_LIMIT: "The provider is rate-limiting requests; wait and retry.",
+    ProviderErrorKind.CONTEXT_OVERFLOW: (
+        "The prompt exceeds the model's context window; shorten it or use a larger-context model."
+    ),
+    ProviderErrorKind.NOT_FOUND: "The model or endpoint was not found; check the model name.",
+    ProviderErrorKind.BAD_REQUEST: "The provider rejected the request as invalid.",
+    ProviderErrorKind.CONNECTION: "Could not reach the provider; check the connection or base URL.",
+    ProviderErrorKind.SERVER: "The provider reported a server error; retry shortly.",
+}
+
+
+class ProviderError(Exception):
+    """Raised when an LLM provider operation fails.
+
+    ``kind`` is the provider-agnostic category; ``str()`` appends an actionable
+    hint for it so every display surface gets the guidance without re-deriving it.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str = "",
+        kind: ProviderErrorKind = ProviderErrorKind.UNKNOWN,
+    ) -> None:
+        self.message = message
         self.provider = provider
+        self.kind = kind
         super().__init__(message)
+
+    @property
+    def hint(self) -> str:
+        """Actionable guidance for ``kind``, or ``""`` when there is none."""
+        return _ERROR_HINTS.get(self.kind, "")
+
+    def __str__(self) -> str:
+        return f"{self.message} {self.hint}" if self.hint else self.message
 
 
 ChatMessage = dict[str, str]

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -21,7 +21,7 @@ from typing import Any
 import httpx
 
 from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
-from lilbee.providers.base import ProviderError
+from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.model_ref import OLLAMA_PREFIX, ProviderModelRef
 from lilbee.providers.sdk_backend import (
     CompletionRequest,
@@ -37,6 +37,44 @@ from lilbee.providers.sdk_backend import (
 log = logging.getLogger(__name__)
 
 _PROVIDER_NAME = "litellm"
+
+
+def _classify_litellm_error(exc: Exception) -> ProviderErrorKind:
+    """Map a litellm exception to a ``ProviderErrorKind`` by type, never by message.
+
+    Universal across backends (litellm normalizes errors into one hierarchy); the
+    MRO walk picks the most specific kind (ContextWindowExceeded over BadRequest).
+    """
+    try:
+        import litellm
+    except ImportError:  # pragma: no cover - unreachable after a successful litellm call
+        return ProviderErrorKind.UNKNOWN
+    table: dict[type, ProviderErrorKind] = {
+        litellm.AuthenticationError: ProviderErrorKind.AUTH,
+        litellm.PermissionDeniedError: ProviderErrorKind.AUTH,
+        litellm.NotFoundError: ProviderErrorKind.NOT_FOUND,
+        litellm.RateLimitError: ProviderErrorKind.RATE_LIMIT,
+        litellm.ContextWindowExceededError: ProviderErrorKind.CONTEXT_OVERFLOW,
+        litellm.BadRequestError: ProviderErrorKind.BAD_REQUEST,
+        litellm.Timeout: ProviderErrorKind.CONNECTION,
+        litellm.APIConnectionError: ProviderErrorKind.CONNECTION,
+        litellm.ServiceUnavailableError: ProviderErrorKind.SERVER,
+        litellm.InternalServerError: ProviderErrorKind.SERVER,
+    }
+    for cls in type(exc).__mro__:
+        kind = table.get(cls)
+        if kind is not None:
+            return kind
+    return ProviderErrorKind.UNKNOWN
+
+
+def _provider_error(prefix: str, exc: Exception) -> ProviderError:
+    """Wrap a backend exception as a ``ProviderError`` classified by type."""
+    return ProviderError(
+        f"{prefix} failed: {exc}", provider=_PROVIDER_NAME, kind=_classify_litellm_error(exc)
+    )
+
+
 _OLLAMA_URL_PATTERNS = ("localhost:11434", "127.0.0.1:11434", "ollama")
 
 # Substrings dropped from the "LiteLLM" logger before they reach the user's
@@ -253,7 +291,7 @@ class LitellmSdkBackend:
         try:
             response = litellm.completion(**kwargs)
         except Exception as exc:
-            raise ProviderError(f"Chat failed: {exc}", provider=_PROVIDER_NAME) from exc
+            raise _provider_error("Chat", exc) from exc
         view = _LitellmResponseView(response)
         return CompletionResult(
             content=view.message_content,
@@ -268,7 +306,7 @@ class LitellmSdkBackend:
         try:
             response = litellm.completion(**kwargs)
         except Exception as exc:
-            raise ProviderError(f"Chat failed: {exc}", provider=_PROVIDER_NAME) from exc
+            raise _provider_error("Chat", exc) from exc
         return self._stream_chunks(response)
 
     @staticmethod
@@ -289,7 +327,7 @@ class LitellmSdkBackend:
         except ProviderError:
             raise
         except Exception as exc:
-            raise ProviderError(f"Chat failed: {exc}", provider=_PROVIDER_NAME) from exc
+            raise _provider_error("Chat", exc) from exc
 
     @staticmethod
     def _completion_kwargs(request: CompletionRequest, *, stream: bool) -> dict[str, Any]:
@@ -321,7 +359,7 @@ class LitellmSdkBackend:
         try:
             response = litellm.embedding(**kwargs)
         except Exception as exc:
-            raise ProviderError(f"Embedding failed: {exc}", provider=_PROVIDER_NAME) from exc
+            raise _provider_error("Embedding", exc) from exc
         data = response["data"] if isinstance(response, dict) else response.data
         vectors = [item["embedding"] for item in data]
         if isinstance(response, dict):
@@ -352,7 +390,7 @@ class LitellmSdkBackend:
         try:
             response = litellm.rerank(**kwargs)
         except Exception as exc:
-            raise ProviderError(f"Rerank failed: {exc}", provider=_PROVIDER_NAME) from exc
+            raise _provider_error("Rerank", exc) from exc
         results = response["results"] if isinstance(response, dict) else response.results
         scores = [0.0] * len(request.candidates)
         for item in results:

--- a/tests/providers/test_litellm_error_classification.py
+++ b/tests/providers/test_litellm_error_classification.py
@@ -1,0 +1,82 @@
+"""Tests that litellm exceptions are classified into ProviderErrorKind by type.
+
+litellm is an optional extra, so a fake module mirroring litellm's exception
+hierarchy is injected; the classifier only does isinstance/MRO checks, so real
+litellm classes are not required to verify the mapping.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+from lilbee.providers.base import ProviderErrorKind
+from lilbee.providers.litellm_sdk import _classify_litellm_error, _provider_error
+
+
+def _fake_litellm() -> types.ModuleType:
+    ns = types.ModuleType("litellm")
+    ns.APIError = type("APIError", (Exception,), {})
+    ns.AuthenticationError = type("AuthenticationError", (ns.APIError,), {})
+    ns.PermissionDeniedError = type("PermissionDeniedError", (ns.APIError,), {})
+    ns.NotFoundError = type("NotFoundError", (ns.APIError,), {})
+    ns.RateLimitError = type("RateLimitError", (ns.APIError,), {})
+    ns.BadRequestError = type("BadRequestError", (ns.APIError,), {})
+    # Mirrors litellm: ContextWindowExceededError subclasses BadRequestError.
+    ns.ContextWindowExceededError = type("ContextWindowExceededError", (ns.BadRequestError,), {})
+    ns.Timeout = type("Timeout", (ns.APIError,), {})
+    ns.APIConnectionError = type("APIConnectionError", (ns.APIError,), {})
+    ns.ServiceUnavailableError = type("ServiceUnavailableError", (ns.APIError,), {})
+    ns.InternalServerError = type("InternalServerError", (ns.APIError,), {})
+    return ns
+
+
+@pytest.fixture
+def fake_litellm() -> types.ModuleType:
+    ns = _fake_litellm()
+    with mock.patch.dict(sys.modules, {"litellm": ns}):
+        yield ns
+
+
+@pytest.mark.parametrize(
+    ("exc_name", "expected"),
+    [
+        ("AuthenticationError", ProviderErrorKind.AUTH),
+        ("PermissionDeniedError", ProviderErrorKind.AUTH),
+        ("NotFoundError", ProviderErrorKind.NOT_FOUND),
+        ("RateLimitError", ProviderErrorKind.RATE_LIMIT),
+        ("ContextWindowExceededError", ProviderErrorKind.CONTEXT_OVERFLOW),
+        ("BadRequestError", ProviderErrorKind.BAD_REQUEST),
+        ("Timeout", ProviderErrorKind.CONNECTION),
+        ("APIConnectionError", ProviderErrorKind.CONNECTION),
+        ("ServiceUnavailableError", ProviderErrorKind.SERVER),
+        ("InternalServerError", ProviderErrorKind.SERVER),
+    ],
+)
+def test_classifies_each_exception_type(
+    fake_litellm: types.ModuleType, exc_name: str, expected: ProviderErrorKind
+) -> None:
+    exc = getattr(fake_litellm, exc_name)("boom")
+    assert _classify_litellm_error(exc) == expected
+
+
+def test_context_overflow_beats_bad_request_base(fake_litellm: types.ModuleType) -> None:
+    # ContextWindowExceededError subclasses BadRequestError; the MRO walk must
+    # return the most specific kind, not the base.
+    exc = fake_litellm.ContextWindowExceededError("too long")
+    assert _classify_litellm_error(exc) == ProviderErrorKind.CONTEXT_OVERFLOW
+
+
+def test_unrecognized_exception_is_unknown(fake_litellm: types.ModuleType) -> None:
+    assert _classify_litellm_error(RuntimeError("???")) == ProviderErrorKind.UNKNOWN
+
+
+def test_provider_error_carries_kind_and_hint(fake_litellm: types.ModuleType) -> None:
+    err = _provider_error("Chat", fake_litellm.AuthenticationError("bad key"))
+    assert err.kind == ProviderErrorKind.AUTH
+    assert err.provider == "litellm"
+    assert "Chat failed: bad key" in str(err)
+    assert err.hint and err.hint in str(err)

--- a/tests/providers/test_provider_error.py
+++ b/tests/providers/test_provider_error.py
@@ -1,0 +1,32 @@
+"""Tests for ProviderError kinds and the actionable hint surfaced via str()."""
+
+from __future__ import annotations
+
+import pytest
+
+from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+_ACTIONABLE = [k for k in ProviderErrorKind if k != ProviderErrorKind.UNKNOWN]
+
+
+def test_default_kind_is_unknown_with_no_hint() -> None:
+    err = ProviderError("boom")
+    assert err.kind == ProviderErrorKind.UNKNOWN
+    assert err.hint == ""
+    assert str(err) == "boom"
+    assert err.message == "boom"
+
+
+@pytest.mark.parametrize("kind", _ACTIONABLE)
+def test_actionable_kinds_append_a_hint_to_str(kind: ProviderErrorKind) -> None:
+    err = ProviderError("boom", provider="litellm", kind=kind)
+    assert err.hint  # every actionable kind has guidance
+    assert str(err) == f"boom {err.hint}"
+    assert err.provider == "litellm"
+
+
+def test_raw_message_is_preserved_separately_from_str() -> None:
+    err = ProviderError("raw message", kind=ProviderErrorKind.AUTH)
+    assert err.message == "raw message"
+    assert str(err) != err.message  # str() carries the extra hint
+    assert err.message in str(err)


### PR DESCRIPTION
## Problem

When a remote model call failed, the SDK path flattened every backend exception into a single `ProviderError` carrying only a stringified message. To tell *why* it failed (bad key vs. rate limit vs. prompt too long vs. model not found), the only option was to match substrings of that message. Those wordings are provider-specific and change between SDK versions, so any such matching is brittle and does not generalize across models.

## Solution

Errors are now classified by *type* into a small provider-agnostic set of kinds, and callers branch on the kind instead of the message. `ProviderError` carries a `kind`, and its string form appends an actionable hint for that kind, so the TUI, HTTP, and MCP surfaces all get the guidance without any per-surface wiring.

The litellm boundary does the classification by exception type. litellm already normalizes every backend's errors into one exception hierarchy, so the same mapping covers Gemini, OpenAI, Anthropic, Ollama, and the rest identically. The mapping walks the class hierarchy so a context-window error is recognized as exactly that rather than a generic bad request.

Errors that aren't recognized stay `unknown` and behave exactly as before, so nothing downstream changes for them. The local in-process engine is intentionally left as-is: its failures are raised inside a worker process and serialized to text across the transport, so they can't carry a kind without a much larger change.