### PR TITLE
Bump llama-cpp-python to 0.3.23

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1762,7 +1762,7 @@ wheels = [
 
 [[package]]
 name = "llama-cpp-python"
-version = "0.3.20"
+version = "0.3.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
@@ -1770,7 +1770,7 @@ dependencies = [
     { name = "numpy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/95/c69c47c9c8dda97f712f5864688d13a22b0159aa9adae91a69067a728532/llama_cpp_python-0.3.20.tar.gz", hash = "sha256:70f01b7d915d31c617dc66610a332cb2d51cde84c8b152d09a352206323616f5", size = 59323017 }
+sdist = { url = "https://files.pythonhosted.org/packages/61/fb/3932d67b89eb7d8f451719b40b67034e031e04b8b598a7f65d13e255ebfb/llama_cpp_python-0.3.23.tar.gz", hash = "sha256:85493cd887b543588941e8704640fef6a54c057443292e527559c30728375ffd", size = 68300621 }
 
 [[package]]
 name = "lxml"


### PR DESCRIPTION
## Problem

We're pinned to llama-cpp-python 0.3.20. 0.3.23 (the current release) carries embedding-correctness fixes that land right where lilbee does the most work: batched embedding.

## Solution

Bump the lock to 0.3.23. This picks up corrected batched multi-sequence `embed()` outputs (#2205), enough sequence slots for batched embed calls, and marking all embedding input tokens as outputs to avoid llama.cpp override warnings (#2212), plus the llama.cpp syncs from 0.3.21 and 0.3.22.

Lock-only change; `pyproject.toml` leaves the dependency unpinned. The full provider, pool-routing, and batching suites pass on 0.3.23 and mypy is clean. The vendored llama.cpp commit (7d442abf) keeps the same server CLI surface the multi-GPU work relies on, so it doesn't disturb that branch.