### PR TITLE
Correctness & security audit of the non-multi-GPU paths

### DIFF
--- a/src/lilbee/api.py
+++ b/src/lilbee/api.py
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING
 from lilbee.app.ingest import copy_files
 from lilbee.app.services import reset_services
 from lilbee.core.config import Config, cfg
-from lilbee.core.security import validate_path_within
 from lilbee.data.store import Store
 from lilbee.providers.factory import create_provider
 from lilbee.retrieval.concepts import ConceptGraph
@@ -171,16 +170,7 @@ class Lilbee:
     def remove(self, name: str) -> None:
         """Remove a document from the index by source name."""
         with _swap_config(self._config):
-            self._store.delete_by_source(name)
-            self._store.delete_source(name)
-            try:
-                doc_path = validate_path_within(
-                    self._config.documents_dir / name, self._config.documents_dir
-                )
-            except ValueError:
-                return
-            if doc_path.exists():
-                doc_path.unlink()
+            self._store.remove_documents([name], delete_files=True)
 
     def status(self) -> dict[str, object]:
         """Return index stats (document count, data directory, etc.)."""

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -463,6 +463,13 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group=SettingGroup.CRAWLING,
         help_text="Optional global cap on total pages per crawl (blank = no cap).",
     ),
+    "crawl_safety_max_pages": SettingDef(
+        int,
+        nullable=False,
+        group=SettingGroup.CRAWLING,
+        help_text="Hard upper bound on pages per crawl, always enforced so a hostile site "
+        "cannot exhaust memory or disk.",
+    ),
     "crawl_timeout": SettingDef(
         int,
         nullable=False,

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -467,8 +467,9 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         int,
         nullable=False,
         group=SettingGroup.CRAWLING,
-        help_text="Hard upper bound on pages per crawl, always enforced so a hostile site "
-        "cannot exhaust memory or disk.",
+        help_text="Default page bound for an unbounded crawl, so a hostile site cannot "
+        "exhaust the disk. An explicit max-pages overrides it; raise this to crawl "
+        "larger sites unbounded.",
     ),
     "crawl_timeout": SettingDef(
         int,

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from lilbee.catalog.download_progress import ProgressCallback, _ProgressTracker
 from lilbee.catalog.featured import DEFAULT_MMPROJ_PATTERN, VISION_MMPROJ_FILES
-from lilbee.catalog.hf_client import DEFAULT_TIMEOUT, hf_headers, hf_token
+from lilbee.catalog.hf_client import DEFAULT_TIMEOUT, HF_API_URL, hf_headers, hf_token
 from lilbee.catalog.models import CatalogModel
 from lilbee.catalog.types import ModelTask
 from lilbee.core.config.model import cfg
@@ -170,7 +170,7 @@ def _resolve_mmproj_filename(hf_repo: str, pattern: str) -> str | None:
 
     try:
         resp = httpx.get(
-            f"https://huggingface.co/api/models/{hf_repo}",
+            f"{HF_API_URL}/{hf_repo}",
             timeout=DEFAULT_TIMEOUT,
             headers=hf_headers(),
         )
@@ -240,7 +240,7 @@ def resolve_filename(entry: CatalogModel) -> str:
 
     try:
         resp = httpx.get(
-            f"https://huggingface.co/api/models/{entry.hf_repo}",
+            f"{HF_API_URL}/{entry.hf_repo}",
             timeout=DEFAULT_TIMEOUT,
             headers=hf_headers(),
         )
@@ -301,27 +301,24 @@ def _cached_file_is_complete(hf_repo: str, filename: str, dest: Path) -> bool:
     return False
 
 
-def fetch_expected_file_size(hf_repo: str, filename: str) -> int:
-    """Return the byte size HuggingFace reports for *filename* in *hf_repo*.
+def _hf_file_size(hf_repo: str, filename: str) -> int | None:
+    """Byte size huggingface_hub resolves for *filename* (None if unreported)."""
+    from huggingface_hub import get_hf_file_metadata, hf_hub_url
 
-    Returns ``_SIZE_UNKNOWN`` (0) when the file isn't listed or the API
-    can't be reached. LFS-backed GGUFs carry the real size under ``lfs``.
+    return get_hf_file_metadata(hf_hub_url(hf_repo, filename), token=hf_token()).size
+
+
+def fetch_expected_file_size(hf_repo: str, filename: str) -> int:
+    """Return the byte size huggingface_hub reports for *filename*, or _SIZE_UNKNOWN.
+
+    Resolves via hf_hub's own file metadata (correct revision, redirects, and
+    LFS/Xet handled uniformly) instead of scraping the repo tree. Returns 0 when
+    offline or unresolvable, in which case the caller keeps the cached file.
     """
     try:
-        resp = httpx.get(
-            f"https://huggingface.co/api/models/{hf_repo}/tree/main",
-            timeout=DEFAULT_TIMEOUT,
-            headers=hf_headers(),
-        )
-        resp.raise_for_status()
-        files = resp.json()
+        return _hf_file_size(hf_repo, filename) or _SIZE_UNKNOWN
     except Exception:
         return _SIZE_UNKNOWN
-
-    for f in files:
-        if isinstance(f, dict) and f.get("path", "") == filename:
-            return int(f.get("lfs", {}).get("size", 0) or f.get("size", 0) or _SIZE_UNKNOWN)
-    return _SIZE_UNKNOWN
 
 
 def fetch_model_file_size(hf_repo: str) -> float:
@@ -330,7 +327,7 @@ def fetch_model_file_size(hf_repo: str) -> float:
     """
     try:
         resp = httpx.get(
-            f"https://huggingface.co/api/models/{hf_repo}/tree/main",
+            f"{HF_API_URL}/{hf_repo}/tree/main",
             timeout=DEFAULT_TIMEOUT,
             headers=hf_headers(),
         )

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -84,7 +84,7 @@ def download_model(
 
     filename = resolve_filename(entry)
     dest = cfg.models_dir / filename
-    if dest.exists():
+    if dest.exists() and _cached_file_is_complete(entry.hf_repo, filename, dest):
         log.info("Model already downloaded: %s", dest)
         if on_progress is not None:
             size = dest.stat().st_size
@@ -272,6 +272,56 @@ def _pick_best_gguf(filenames: list[str]) -> str:
             if quant in f:
                 return f
     return filenames[0]
+
+
+_SIZE_UNKNOWN = 0
+
+
+def _cached_file_is_complete(hf_repo: str, filename: str, dest: Path) -> bool:
+    """Decide whether an existing cached file may be accepted as complete.
+
+    Verifies the on-disk byte size against the size HuggingFace reports for
+    *filename*. A mismatch means a truncated / corrupt download, so the file
+    is rejected and re-fetched. When the size can't be fetched (offline, API
+    error) it stays unknown and the cached file is accepted: there's nothing
+    to verify against and refusing would block all offline reuse.
+    """
+    expected = fetch_expected_file_size(hf_repo, filename)
+    if expected == _SIZE_UNKNOWN:
+        return True
+    actual = dest.stat().st_size
+    if actual == expected:
+        return True
+    log.warning(
+        "Cached %s is %d bytes but HuggingFace reports %d; re-downloading",
+        dest,
+        actual,
+        expected,
+    )
+    return False
+
+
+def fetch_expected_file_size(hf_repo: str, filename: str) -> int:
+    """Return the byte size HuggingFace reports for *filename* in *hf_repo*.
+
+    Returns ``_SIZE_UNKNOWN`` (0) when the file isn't listed or the API
+    can't be reached. LFS-backed GGUFs carry the real size under ``lfs``.
+    """
+    try:
+        resp = httpx.get(
+            f"https://huggingface.co/api/models/{hf_repo}/tree/main",
+            timeout=DEFAULT_TIMEOUT,
+            headers=hf_headers(),
+        )
+        resp.raise_for_status()
+        files = resp.json()
+    except Exception:
+        return _SIZE_UNKNOWN
+
+    for f in files:
+        if isinstance(f, dict) and f.get("path", "") == filename:
+            return int(f.get("lfs", {}).get("size", 0) or f.get("size", 0) or _SIZE_UNKNOWN)
+    return _SIZE_UNKNOWN
 
 
 def fetch_model_file_size(hf_repo: str) -> float:

--- a/src/lilbee/catalog/header_probe.py
+++ b/src/lilbee/catalog/header_probe.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import struct
 import tempfile
@@ -61,9 +62,13 @@ def _parse_arch(blob: bytes) -> str:
         log.debug("GGUFReader parse failed: %s", exc)
         return ""
     finally:
-        # GGUFReader holds an open numpy.memmap on the file; release it before
-        # unlink or Windows raises PermissionError on the still-mapped handle.
+        # GGUFReader holds an open numpy.memmap on the file; close the underlying
+        # mmap before unlink or Windows raises PermissionError on the mapped handle.
+        # Cleanup must never mask the architecture already read above, so a failed
+        # unlink is tolerated (the OS reclaims the temp file).
         if reader is not None:
-            del reader.data
-            del reader
-        tmp.unlink(missing_ok=True)
+            mmap_obj = getattr(getattr(reader, "data", None), "_mmap", None)
+            if mmap_obj is not None:
+                mmap_obj.close()
+        with contextlib.suppress(OSError):
+            tmp.unlink(missing_ok=True)

--- a/src/lilbee/catalog/header_probe.py
+++ b/src/lilbee/catalog/header_probe.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import struct
 import tempfile
 from http import HTTPStatus
 from pathlib import Path
+from typing import Any
 
 import httpx
 from gguf import GGUFReader, GGUFValueType
@@ -62,13 +62,11 @@ def _parse_arch(blob: bytes) -> str:
         log.debug("GGUFReader parse failed: %s", exc)
         return ""
     finally:
-        # GGUFReader holds an open numpy.memmap on the file; close the underlying
-        # mmap before unlink or Windows raises PermissionError on the mapped handle.
-        # Cleanup must never mask the architecture already read above, so a failed
-        # unlink is tolerated (the OS reclaims the temp file).
+        # GGUFReader maps the file via numpy.memmap; close the underlying mmap so
+        # Windows can unlink (dropping the reference alone doesn't release the handle
+        # promptly). numpy exposes no public close, so reach the documented private
+        # handle through a typed-Any local; it fails loudly if numpy restructures.
         if reader is not None:
-            mmap_obj = getattr(getattr(reader, "data", None), "_mmap", None)
-            if mmap_obj is not None:
-                mmap_obj.close()
-        with contextlib.suppress(OSError):
-            tmp.unlink(missing_ok=True)
+            memmap: Any = reader.data
+            memmap._mmap.close()
+        tmp.unlink(missing_ok=True)

--- a/src/lilbee/catalog/header_probe.py
+++ b/src/lilbee/catalog/header_probe.py
@@ -48,6 +48,7 @@ def _parse_arch(blob: bytes) -> str:
     with tempfile.NamedTemporaryFile(suffix=".gguf", delete=False) as f:
         f.write(bytes(patched))
         tmp = Path(f.name)
+    reader: GGUFReader | None = None
     try:
         reader = GGUFReader(str(tmp))
         field = reader.fields.get(GGUF_ARCH_KEY)
@@ -60,4 +61,9 @@ def _parse_arch(blob: bytes) -> str:
         log.debug("GGUFReader parse failed: %s", exc)
         return ""
     finally:
+        # GGUFReader holds an open numpy.memmap on the file; release it before
+        # unlink or Windows raises PermissionError on the still-mapped handle.
+        if reader is not None:
+            del reader.data
+            del reader
         tmp.unlink(missing_ok=True)

--- a/src/lilbee/cli/commands/ingest_sync.py
+++ b/src/lilbee/cli/commands/ingest_sync.py
@@ -122,6 +122,7 @@ def _crawl_urls_blocking(
 
     from lilbee.crawler import crawl_and_save
     from lilbee.runtime.progress import (
+        CrawlDoneEvent,
         CrawlPageEvent,
         EventType,
         ProgressEvent,
@@ -151,8 +152,11 @@ def _crawl_urls_blocking(
             if cancel_event.is_set():
                 break
             ptask = progress.add_task(f"Crawling {url}...", total=None)
+            cap_hit: dict[str, int] = {}
 
-            def _make_callback(_t: TaskID = ptask) -> DetailedProgressCallback:
+            def _make_callback(
+                _t: TaskID = ptask, _cap: dict[str, int] = cap_hit
+            ) -> DetailedProgressCallback:
                 def on_progress(event_type: EventType, data: ProgressEvent) -> None:
                     if event_type == EventType.CRAWL_PAGE:
                         if not isinstance(data, CrawlPageEvent):
@@ -162,6 +166,13 @@ def _crawl_urls_blocking(
                             _t,
                             description=f"Crawled {data.current}/{total_str}: {data.url}",
                         )
+                    elif (
+                        event_type == EventType.CRAWL_DONE
+                        and isinstance(data, CrawlDoneEvent)
+                        and data.stopped_at_safety_cap
+                        and data.safety_cap is not None
+                    ):
+                        _cap["cap"] = data.safety_cap
 
                 return on_progress
 
@@ -176,6 +187,11 @@ def _crawl_urls_blocking(
             )
             all_paths.extend(paths)
             progress.update(ptask, description=f"Done: {url} ({len(paths)} pages)")
+            if "cap" in cap_hit and not cfg.json_mode:
+                err_console.print(
+                    f"Stopped at the {cap_hit['cap']}-page safety limit; more pages remain. "
+                    f"Re-run with --max-pages N (or raise crawl_max_pages) to crawl more."
+                )
     return all_paths
 
 

--- a/src/lilbee/cli/commands/ingest_sync.py
+++ b/src/lilbee/cli/commands/ingest_sync.py
@@ -73,7 +73,7 @@ _depth_option = typer.Option(
 _max_pages_option = typer.Option(
     None,
     "--max-pages",
-    help="Cap total pages for --crawl. Unset = no limit; positive int = hard cap.",
+    help="Cap pages for --crawl. Unset = protective default; 0 = unlimited; N = hard cap.",
 )
 _include_subdomains_option = typer.Option(
     False,
@@ -152,10 +152,10 @@ def _crawl_urls_blocking(
             if cancel_event.is_set():
                 break
             ptask = progress.add_task(f"Crawling {url}...", total=None)
-            cap_hit: dict[str, int] = {}
+            crawled: dict[str, int] = {}
 
             def _make_callback(
-                _t: TaskID = ptask, _cap: dict[str, int] = cap_hit
+                _t: TaskID = ptask, _crawled: dict[str, int] = crawled
             ) -> DetailedProgressCallback:
                 def on_progress(event_type: EventType, data: ProgressEvent) -> None:
                     if event_type == EventType.CRAWL_PAGE:
@@ -166,13 +166,8 @@ def _crawl_urls_blocking(
                             _t,
                             description=f"Crawled {data.current}/{total_str}: {data.url}",
                         )
-                    elif (
-                        event_type == EventType.CRAWL_DONE
-                        and isinstance(data, CrawlDoneEvent)
-                        and data.stopped_at_safety_cap
-                        and data.safety_cap is not None
-                    ):
-                        _cap["cap"] = data.safety_cap
+                    elif event_type == EventType.CRAWL_DONE and isinstance(data, CrawlDoneEvent):
+                        _crawled["n"] = data.pages_crawled
 
                 return on_progress
 
@@ -187,10 +182,13 @@ def _crawl_urls_blocking(
             )
             all_paths.extend(paths)
             progress.update(ptask, description=f"Done: {url} ({len(paths)} pages)")
-            if "cap" in cap_hit and not cfg.json_mode:
+            # No explicit cap given and the crawl filled the protective default:
+            # tell the user how to go unlimited without editing settings.
+            default_cap = cfg.crawl_max_pages or cfg.crawl_safety_max_pages
+            if crawl and max_pages is None and crawled.get("n", 0) >= default_cap:
                 err_console.print(
-                    f"Stopped at the {cap_hit['cap']}-page safety limit; more pages remain. "
-                    f"Re-run with --max-pages N (or raise crawl_max_pages) to crawl more."
+                    f"Stopped at the default {default_cap}-page limit; "
+                    f"pass --max-pages 0 to crawl unlimited (or --max-pages N for a higher cap)."
                 )
     return all_paths
 

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -113,9 +113,7 @@ class LilbeeCommandProvider(Provider):
             app.title = f"lilbee: {value}"
 
     def _delete_doc(self, name: str) -> None:
-        store = get_services().store
-        store.delete_by_source(name)
-        store.delete_source(name)
+        get_services().store.remove_documents([name])
         self.screen.app.notify(f"Deleted {name}")
 
     def _action_sync(self) -> None:

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -26,6 +26,11 @@ MODEL_FALLBACK_NOTICE = (
     "Pick a different model or restore the original to clear this notice."
 )
 CMD_CRAWL_SUCCESS = "Crawled {count} page(s) from {url}"
+CMD_CRAWL_CAP_TITLE = "Crawl limit reached"
+CMD_CRAWL_CAP_PROMPT = (
+    "Stopped at the {cap}-page safety limit ({count} saved). The site has more pages. "
+    "Open the crawl dialog to set a higher --max-pages and continue?"
+)
 CMD_CRAWL_FAILED = "Crawl failed: {error}"
 CMD_CRAWL_SYNCING = "Syncing crawled pages..."
 SETUP_CHROMIUM_NAME = "Install Chromium browser"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -26,11 +26,6 @@ MODEL_FALLBACK_NOTICE = (
     "Pick a different model or restore the original to clear this notice."
 )
 CMD_CRAWL_SUCCESS = "Crawled {count} page(s) from {url}"
-CMD_CRAWL_CAP_TITLE = "Crawl limit reached"
-CMD_CRAWL_CAP_PROMPT = (
-    "Stopped at the {cap}-page safety limit ({count} saved). The site has more pages. "
-    "Open the crawl dialog to set a higher --max-pages and continue?"
-)
 CMD_CRAWL_FAILED = "Crawl failed: {error}"
 CMD_CRAWL_SYNCING = "Syncing crawled pages..."
 SETUP_CHROMIUM_NAME = "Install Chromium browser"
@@ -112,12 +107,12 @@ CMD_CRAWL_UNAVAILABLE = "Web crawling is not available. Run 'uv sync --extra cra
 CRAWL_DIALOG_TITLE = "Crawl a URL"
 CRAWL_DIALOG_URL_PLACEHOLDER = "example.com (https:// added automatically)"
 CRAWL_DIALOG_DEPTH_PLACEHOLDER = "blank = no limit"
-CRAWL_DIALOG_MAX_PAGES_PLACEHOLDER = "blank = no limit"
+CRAWL_DIALOG_MAX_PAGES_PLACEHOLDER = "clear for unlimited"
 CRAWL_DIALOG_URL_LABEL = "URL"
 CRAWL_DIALOG_RECURSIVE_LABEL = "Recursive (crawl whole site)"
 CRAWL_DIALOG_ADVANCED_TITLE = "Advanced"
 CRAWL_DIALOG_DEPTH_LABEL = "Depth cap"
-CRAWL_DIALOG_MAX_PAGES_LABEL = "Max pages"
+CRAWL_DIALOG_MAX_PAGES_LABEL = "Max pages (clear for unlimited)"
 CRAWL_DIALOG_SUBMIT = "Crawl"
 CRAWL_DIALOG_CANCEL = "Cancel"
 CRAWL_DIALOG_URL_REQUIRED = "URL is required"

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -55,7 +55,7 @@ from lilbee.cli.tui.widgets.task_bar_controller import ProgressReporter
 from lilbee.core.config import cfg
 from lilbee.core.config.enums import ChatMode
 from lilbee.crawler import crawler_available, is_url, require_valid_crawl_url
-from lilbee.data.store import scope_to_chunk_type
+from lilbee.data.store import ChunkType, scope_to_chunk_type
 from lilbee.providers.model_ref import parse_model_ref
 from lilbee.retrieval.embedder import is_model_available
 from lilbee.retrieval.query import ChatMessage
@@ -1046,10 +1046,10 @@ class ChatScreen(Screen[None]):
         self.streaming = True
         self._stream_response(text, assistant_msg, self._current_chunk_type())
 
-    def _current_chunk_type(self) -> str | None:
+    def _current_chunk_type(self) -> ChunkType | None:
         """Translate the ScopeChip selection into a ``chunk_type`` arg.
 
-        Returns ``None`` for "both" (no filter) and the raw/wiki string
+        Returns ``None`` for "both" (no filter) and the raw/wiki ``ChunkType``
         otherwise. Defaults to ``None`` when the ScopeChip isn't mounted
         (e.g. test apps that compose the screen without it).
         """
@@ -1065,7 +1065,7 @@ class ChatScreen(Screen[None]):
 
     @work(thread=True)
     def _stream_response(
-        self, question: str, widget: AssistantMessage, chunk_type: str | None
+        self, question: str, widget: AssistantMessage, chunk_type: ChunkType | None
     ) -> None:
         """Stream LLM response in a background thread, coalescing UI updates."""
         response_parts: list[str] = []

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -738,19 +738,11 @@ class ChatScreen(Screen[None]):
     ) -> None:
         """Crawl body. Runs on worker thread; reporter handles progress + cancel."""
         from lilbee.crawler import crawl_and_save
-        from lilbee.runtime.progress import CrawlDoneEvent, CrawlPageEvent, SetupProgressEvent
+        from lilbee.runtime.progress import CrawlPageEvent, SetupProgressEvent
 
         reporter.update(0, msg.CMD_CRAWL_STARTED.format(url=url))
-        cap_hit: dict[str, int] = {}
 
         def on_progress(event_type: EventType, data: ProgressEvent) -> None:
-            if (
-                event_type == EventType.CRAWL_DONE
-                and isinstance(data, CrawlDoneEvent)
-                and data.stopped_at_safety_cap
-                and data.safety_cap is not None
-            ):
-                cap_hit["cap"] = data.safety_cap
             if event_type == EventType.SETUP_START:
                 reporter.update(0, msg.SETUP_CHROMIUM_NAME)
             elif event_type == EventType.SETUP_PROGRESS and isinstance(data, SetupProgressEvent):
@@ -798,24 +790,6 @@ class ChatScreen(Screen[None]):
             )
         )
         call_from_thread(self, self.notify, msg.CMD_CRAWL_SUCCESS.format(count=len(paths), url=url))
-        if "cap" in cap_hit:
-            call_from_thread(self, self._prompt_raise_crawl_cap, cap_hit["cap"], len(paths))
-
-    def _prompt_raise_crawl_cap(self, cap: int, count: int) -> None:
-        """Offer to re-open the crawl dialog when an unbounded crawl hit the safety cap."""
-        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
-
-        def _on_confirm(raise_it: bool | None) -> None:
-            if raise_it:
-                self._open_crawl_dialog()
-
-        self.app.push_screen(
-            ConfirmDialog(
-                msg.CMD_CRAWL_CAP_TITLE,
-                msg.CMD_CRAWL_CAP_PROMPT.format(cap=cap, count=count),
-            ),
-            _on_confirm,
-        )
 
     def _cmd_catalog(self, _args: str) -> None:
         self.app.switch_view("Catalog")

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -738,11 +738,19 @@ class ChatScreen(Screen[None]):
     ) -> None:
         """Crawl body. Runs on worker thread; reporter handles progress + cancel."""
         from lilbee.crawler import crawl_and_save
-        from lilbee.runtime.progress import CrawlPageEvent, SetupProgressEvent
+        from lilbee.runtime.progress import CrawlDoneEvent, CrawlPageEvent, SetupProgressEvent
 
         reporter.update(0, msg.CMD_CRAWL_STARTED.format(url=url))
+        cap_hit: dict[str, int] = {}
 
         def on_progress(event_type: EventType, data: ProgressEvent) -> None:
+            if (
+                event_type == EventType.CRAWL_DONE
+                and isinstance(data, CrawlDoneEvent)
+                and data.stopped_at_safety_cap
+                and data.safety_cap is not None
+            ):
+                cap_hit["cap"] = data.safety_cap
             if event_type == EventType.SETUP_START:
                 reporter.update(0, msg.SETUP_CHROMIUM_NAME)
             elif event_type == EventType.SETUP_PROGRESS and isinstance(data, SetupProgressEvent):
@@ -790,6 +798,24 @@ class ChatScreen(Screen[None]):
             )
         )
         call_from_thread(self, self.notify, msg.CMD_CRAWL_SUCCESS.format(count=len(paths), url=url))
+        if "cap" in cap_hit:
+            call_from_thread(self, self._prompt_raise_crawl_cap, cap_hit["cap"], len(paths))
+
+    def _prompt_raise_crawl_cap(self, cap: int, count: int) -> None:
+        """Offer to re-open the crawl dialog when an unbounded crawl hit the safety cap."""
+        from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+
+        def _on_confirm(raise_it: bool | None) -> None:
+            if raise_it:
+                self._open_crawl_dialog()
+
+        self.app.push_screen(
+            ConfirmDialog(
+                msg.CMD_CRAWL_CAP_TITLE,
+                msg.CMD_CRAWL_CAP_PROMPT.format(cap=cap, count=count),
+            ),
+            _on_confirm,
+        )
 
     def _cmd_catalog(self, _args: str) -> None:
         self.app.switch_view("Catalog")
@@ -830,9 +856,7 @@ class ChatScreen(Screen[None]):
             )
             return
 
-        store = get_services().store
-        store.delete_by_source(name)
-        store.delete_source(name)
+        get_services().store.remove_documents([name])
         from lilbee.cli.tui.widgets.autocomplete import invalidate_document_cache
 
         invalidate_document_cache()

--- a/src/lilbee/cli/tui/widgets/crawl_dialog.py
+++ b/src/lilbee/cli/tui/widgets/crawl_dialog.py
@@ -12,6 +12,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Collapsible, Input, Label, Static
 
 from lilbee.cli.tui import messages as msg
+from lilbee.core.config import cfg
 
 
 @dataclass(frozen=True)
@@ -19,13 +20,13 @@ class CrawlParams:
     """Validated crawl parameters returned by CrawlDialog.
 
     depth: None = whole-site unbounded. 0 = single URL only. Positive int =
-    explicit link-follow depth cap. max_pages: None = no cap. Positive int =
-    explicit page cap.
+    explicit link-follow depth cap. max_pages: CRAWL_PAGES_UNLIMITED (0) = no
+    limit (the user cleared the field); positive int = explicit page cap.
     """
 
     url: str
     depth: int | None
-    max_pages: int | None
+    max_pages: int
 
 
 class CrawlDialog(ModalScreen[CrawlParams | None]):
@@ -51,16 +52,20 @@ class CrawlDialog(ModalScreen[CrawlParams | None]):
                 value=True,
                 id="crawl-recursive-checkbox",
             )
+            # Max pages is the cap users actually reach for, so it sits at the top
+            # level (not behind Advanced) prefilled with the protective default;
+            # clearing it crawls unlimited without a trip to settings.
+            yield Label(msg.CRAWL_DIALOG_MAX_PAGES_LABEL, classes="crawl-field-label")
+            yield Input(
+                value=str(cfg.crawl_safety_max_pages),
+                placeholder=msg.CRAWL_DIALOG_MAX_PAGES_PLACEHOLDER,
+                id="crawl-max-pages-input",
+            )
             with Collapsible(title=msg.CRAWL_DIALOG_ADVANCED_TITLE, id="crawl-advanced"):
                 yield Label(msg.CRAWL_DIALOG_DEPTH_LABEL, classes="crawl-field-label")
                 yield Input(
                     placeholder=msg.CRAWL_DIALOG_DEPTH_PLACEHOLDER,
                     id="crawl-depth-input",
-                )
-                yield Label(msg.CRAWL_DIALOG_MAX_PAGES_LABEL, classes="crawl-field-label")
-                yield Input(
-                    placeholder=msg.CRAWL_DIALOG_MAX_PAGES_PLACEHOLDER,
-                    id="crawl-max-pages-input",
                 )
             yield Static("", id="crawl-error")
             with Center():
@@ -92,15 +97,16 @@ class CrawlDialog(ModalScreen[CrawlParams | None]):
         return n
 
     @staticmethod
-    def _parse_optional_positive_int(value: str) -> int | None:
-        """Parse a positive integer from *value*; empty string returns None.
+    def _parse_max_pages(value: str) -> int:
+        """Parse the max-pages field. Empty means unlimited (the user cleared it).
 
-        None means "no cap" in the crawl API. Raises ValueError on non-numeric
-        input or non-positive integers. Used for fields like max_pages where
-        zero has no useful meaning.
+        Returns ``CRAWL_PAGES_UNLIMITED`` (0) for empty input, a positive int for
+        an explicit cap. Raises ValueError on non-numeric or non-positive input.
         """
+        from lilbee.crawler.models import CRAWL_PAGES_UNLIMITED
+
         if not value:
-            return None
+            return CRAWL_PAGES_UNLIMITED
         n = int(value)
         if n <= 0:
             raise ValueError
@@ -109,6 +115,7 @@ class CrawlDialog(ModalScreen[CrawlParams | None]):
     def _validate(self) -> CrawlParams | str:
         """Validate inputs. Returns CrawlParams on success, error message on failure."""
         from lilbee.crawler import is_url, require_valid_crawl_url
+        from lilbee.crawler.models import CRAWL_PAGES_UNLIMITED
 
         url = self.query_one("#crawl-url-input", Input).value.strip()
         recursive = self.query_one("#crawl-recursive-checkbox", Checkbox).value
@@ -127,7 +134,7 @@ class CrawlDialog(ModalScreen[CrawlParams | None]):
             return msg.CRAWL_DIALOG_INVALID_URL.format(error=exc)
 
         if not recursive:
-            return CrawlParams(url=url, depth=0, max_pages=None)
+            return CrawlParams(url=url, depth=0, max_pages=CRAWL_PAGES_UNLIMITED)
 
         try:
             # depth=0 means "single URL" per the crawler contract; allow it.
@@ -136,7 +143,7 @@ class CrawlDialog(ModalScreen[CrawlParams | None]):
             return msg.CRAWL_DIALOG_INVALID_NUMBER.format(field=msg.CRAWL_DIALOG_DEPTH_LABEL)
 
         try:
-            max_pages = self._parse_optional_positive_int(max_pages_str)
+            max_pages = self._parse_max_pages(max_pages_str)
         except ValueError:
             return msg.CRAWL_DIALOG_INVALID_NUMBER.format(field=msg.CRAWL_DIALOG_MAX_PAGES_LABEL)
 

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -219,8 +219,9 @@ class Config(BaseSettings):
     crawl_max_depth: int | None = ConfigField(default=None, ge=0, writable=True)
     crawl_max_pages: int | None = ConfigField(default=None, ge=1, writable=True)
 
-    # Hard upper bound on pages fetched per crawl, always enforced even when
-    # crawl_max_pages is unset, so a hostile site can't exhaust memory/disk.
+    # Default page bound for an unbounded crawl (no explicit max_pages /
+    # crawl_max_pages), so a hostile site can't exhaust the disk by default.
+    # An explicit limit overrides it; raise this to crawl larger sites unbounded.
     crawl_safety_max_pages: int = ConfigField(default=5_000, ge=1, writable=True)
 
     # Per-URL fetch timeout, seconds.

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -219,6 +219,10 @@ class Config(BaseSettings):
     crawl_max_depth: int | None = ConfigField(default=None, ge=0, writable=True)
     crawl_max_pages: int | None = ConfigField(default=None, ge=1, writable=True)
 
+    # Hard upper bound on pages fetched per crawl, always enforced even when
+    # crawl_max_pages is unset, so a hostile site can't exhaust memory/disk.
+    crawl_safety_max_pages: int = ConfigField(default=5_000, ge=1, writable=True)
+
     # Per-URL fetch timeout, seconds.
     crawl_timeout: int = ConfigField(default=30, ge=1, writable=True)
 

--- a/src/lilbee/crawler/crawl4ai_fetcher.py
+++ b/src/lilbee/crawler/crawl4ai_fetcher.py
@@ -20,6 +20,7 @@ from lilbee.crawler.models import (
     FetchedPage,
     FilterSpec,
 )
+from lilbee.crawler.url_filter import validate_crawl_url
 
 if TYPE_CHECKING:
     from lilbee.crawler.fetcher import WebFetcher
@@ -148,35 +149,47 @@ async def _iter_crawl_stream(stream: Any) -> AsyncIterator[Any]:
     yield stream
 
 
+def _link_passes_ssrf(url: str) -> bool:
+    """Return True when a discovered link resolves to a public, http(s) target.
+
+    Re-validates every followed link against the IP blocklist so a discovered
+    or DNS-rebound link to a private/metadata host is dropped before fetch.
+    """
+    try:
+        validate_crawl_url(url)
+    except ValueError:
+        return False
+    return True
+
+
 def _host_scope_filter(start_url: str, *, include_subdomains: bool) -> Any:
     """Build a URLFilter that scopes a crawl to the starting URL's host.
 
     Default behavior (``include_subdomains=False``) restricts link-following to
-    the exact host of *start_url*. For ``https://en.wikipedia.org/...`` this
-    excludes ``af.wikipedia.org`` and every other language subdomain.
-
-    When ``include_subdomains=True``, crawl4ai's DomainFilter matches the host
-    plus any of its subdomains (``foo.example.com`` matches ``example.com``),
-    which is the loose "whole registrable domain" behavior users may want.
+    the exact host of *start_url*. When ``include_subdomains=True`` the host
+    plus any subdomain is in scope. Either way every followed link is also
+    re-validated against the SSRF blocklist, since the host scope check alone
+    would let a same-host link that resolves to a private IP through.
     """
-    from crawl4ai.deep_crawling.filters import DomainFilter, URLFilter
+    from crawl4ai.deep_crawling.filters import URLFilter
 
     host = (urlparse(start_url).hostname or "").lower()
-    if include_subdomains:
-        return DomainFilter(allowed_domains=host) if host else None
+    if not host:
+        return None
 
-    class _ExactHostFilter(URLFilter):  # type: ignore[misc]
-        def __init__(self, allowed_host: str) -> None:
-            super().__init__()
-            self._host = allowed_host
+    def _in_scope(link_host: str) -> bool:
+        if link_host == host:
+            return True
+        return include_subdomains and link_host.endswith(f".{host}")
 
+    class _ScopedSsrfFilter(URLFilter):  # type: ignore[misc]
         def apply(self, url: str) -> bool:
             link_host = (urlparse(url).hostname or "").lower()
-            ok = link_host == self._host
+            ok = _in_scope(link_host) and _link_passes_ssrf(url)
             self._update_stats(ok)
             return ok
 
-    return _ExactHostFilter(host) if host else None
+    return _ScopedSsrfFilter()
 
 
 class Crawl4aiFetcher:

--- a/src/lilbee/crawler/models.py
+++ b/src/lilbee/crawler/models.py
@@ -6,6 +6,10 @@ import threading
 from dataclasses import dataclass, field
 from typing import TypeAlias
 
+# Explicit "no page limit" for a crawl. Distinct from None, which means
+# "unspecified, use the protective default cfg.crawl_safety_max_pages".
+CRAWL_PAGES_UNLIMITED = 0
+
 
 @dataclass
 class CrawlResult:

--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -62,6 +62,19 @@ def _resolve_limit(value: int | None, cfg_ceiling: int | None) -> int | None:
     return effective
 
 
+def _clamp_to_safety_ceiling(pages: int | None) -> int:
+    """Clamp a resolved page count to ``cfg.crawl_safety_max_pages``.
+
+    ``None`` (caller asked for unbounded) becomes the ceiling, and any
+    explicit value above it is capped, so a hostile site can never exhaust
+    memory/disk regardless of caller or per-crawl settings.
+    """
+    ceiling = cfg.crawl_safety_max_pages
+    if pages is None:
+        return ceiling
+    return min(pages, ceiling)
+
+
 def _looks_like_missing_chromium(exc: BaseException) -> bool:
     """Heuristic for the Playwright "Executable doesn't exist" launch failure."""
     return "Executable doesn't exist" in str(exc)
@@ -117,11 +130,12 @@ async def crawl_recursive(
 ) -> list[CrawlResult]:
     """Crawl a URL recursively using BFS, streaming per-page progress.
 
-    None values for ``max_depth`` / ``max_pages`` mean unbounded (constrained
-    only by whatever ceiling the user has set in ``cfg.crawl_max_{depth,pages}``,
-    if any). Positive ints are explicit caps. ``CRAWL_PAGE`` events fire as
-    each page completes; total is ``CRAWL_TOTAL_UNKNOWN`` by default and
-    promoted to the sitemap count when available.
+    ``max_depth`` of None means unbounded depth. ``max_pages`` is always
+    bounded by ``cfg.crawl_safety_max_pages``; None / a higher value is
+    clamped to that ceiling so a hostile site can't exhaust memory/disk.
+    ``CRAWL_PAGE`` events fire as each page completes; total is
+    ``CRAWL_TOTAL_UNKNOWN`` by default and promoted to the sitemap count
+    when available.
 
     Pass ``include_subdomains=True`` to broaden scope from the exact host to the
     host plus any subdomains. If ``on_result`` is provided, it's called for each
@@ -130,7 +144,7 @@ async def crawl_recursive(
     """
     validate_crawl_url(url)
     depth = _resolve_limit(max_depth, cfg.crawl_max_depth)
-    pages = _resolve_limit(max_pages, cfg.crawl_max_pages)
+    pages = _clamp_to_safety_ceiling(_resolve_limit(max_pages, cfg.crawl_max_pages))
 
     # Fail fast when the ``crawler`` extra wasn't installed so SSE
     # callers see ``event: error`` instead of a silent zero-results run.

--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -28,7 +28,7 @@ from lilbee.crawler.events import (
     _handle_crawl_teardown_error,
     _pages_cap,
 )
-from lilbee.crawler.models import CrawlResult
+from lilbee.crawler.models import CRAWL_PAGES_UNLIMITED, CrawlResult
 from lilbee.crawler.save import METADATA_FLUSH_INTERVAL, CrawlMeta
 from lilbee.crawler.url_filter import validate_crawl_url
 from lilbee.runtime.progress import (
@@ -62,21 +62,22 @@ def _resolve_limit(value: int | None, cfg_ceiling: int | None) -> int | None:
     return effective
 
 
-def _resolve_page_limit(max_pages: int | None) -> tuple[int, int | None]:
-    """Resolve the page count to crawl and the safety cap, if one applies.
+def _resolve_page_limit(max_pages: int | None) -> int | None:
+    """Resolve the page bound the fetcher consumes (None means unbounded).
 
-    An explicit limit (caller ``max_pages`` or ``cfg.crawl_max_pages``) is the
-    user's choice and is honored as-is, even above ``cfg.crawl_safety_max_pages``.
-    Only a fully unbounded crawl (both unset) is bounded by the safety cap, so a
-    hostile site can't exhaust the disk by default while an explicit request can
-    still exceed it. The second element is the safety cap when it was the source
-    of the bound (so a caller can tell the user it was hit), else ``None``.
+    ``CRAWL_PAGES_UNLIMITED`` (0) is an explicit "no limit" and returns None.
+    ``None`` is unspecified: it falls back to ``cfg.crawl_max_pages`` if set,
+    else the protective default ``cfg.crawl_safety_max_pages`` so a hostile site
+    can't exhaust the disk on a crawl nobody bounded. A positive int is honored
+    as-is, even above the default.
     """
-    explicit = _resolve_limit(max_pages, cfg.crawl_max_pages)
-    if explicit is not None:
-        return explicit, None
-    cap = cfg.crawl_safety_max_pages
-    return cap, cap
+    if max_pages == CRAWL_PAGES_UNLIMITED:
+        return None
+    if max_pages is not None:
+        return max_pages
+    if cfg.crawl_max_pages is not None:
+        return cfg.crawl_max_pages
+    return cfg.crawl_safety_max_pages
 
 
 def _looks_like_missing_chromium(exc: BaseException) -> bool:
@@ -134,10 +135,11 @@ async def crawl_recursive(
 ) -> list[CrawlResult]:
     """Crawl a URL recursively using BFS, streaming per-page progress.
 
-    ``max_depth`` of None means unbounded depth. An explicit ``max_pages``
-    (or ``cfg.crawl_max_pages``) is honored as-is; only a fully unbounded
-    crawl is bounded by ``cfg.crawl_safety_max_pages`` so a hostile site can't
-    exhaust the disk by default. ``CRAWL_PAGE`` events fire as each page completes; total is
+    ``max_depth`` of None means unbounded depth. ``max_pages`` of
+    ``CRAWL_PAGES_UNLIMITED`` (0) means no page limit; a positive int is that
+    cap; None is unspecified and falls back to ``cfg.crawl_safety_max_pages`` so
+    a hostile site can't exhaust the disk on a crawl nobody bounded.
+    ``CRAWL_PAGE`` events fire as each page completes; total is
     ``CRAWL_TOTAL_UNKNOWN`` by default and promoted to the sitemap count
     when available.
 
@@ -148,7 +150,7 @@ async def crawl_recursive(
     """
     validate_crawl_url(url)
     depth = _resolve_limit(max_depth, cfg.crawl_max_depth)
-    pages, _ = _resolve_page_limit(max_pages)
+    pages = _resolve_page_limit(max_pages)
 
     # Fail fast when the ``crawler`` extra wasn't installed so SSE
     # callers see ``event: error`` instead of a silent zero-results run.
@@ -388,16 +390,9 @@ async def crawl_and_save(
             await _maybe_periodic_sync(tasks)
 
         if on_progress:
-            _, safety_cap = _resolve_page_limit(max_pages)
-            stopped_at_cap = safety_cap is not None and pages_seen >= safety_cap
             on_progress(
                 EventType.CRAWL_DONE,
-                CrawlDoneEvent(
-                    pages_crawled=pages_seen,
-                    files_written=len(written_paths),
-                    stopped_at_safety_cap=stopped_at_cap,
-                    safety_cap=safety_cap if stopped_at_cap else None,
-                ),
+                CrawlDoneEvent(pages_crawled=pages_seen, files_written=len(written_paths)),
             )
 
         return written_paths

--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -62,17 +62,21 @@ def _resolve_limit(value: int | None, cfg_ceiling: int | None) -> int | None:
     return effective
 
 
-def _clamp_to_safety_ceiling(pages: int | None) -> int:
-    """Clamp a resolved page count to ``cfg.crawl_safety_max_pages``.
+def _resolve_page_limit(max_pages: int | None) -> tuple[int, int | None]:
+    """Resolve the page count to crawl and the safety cap, if one applies.
 
-    ``None`` (caller asked for unbounded) becomes the ceiling, and any
-    explicit value above it is capped, so a hostile site can never exhaust
-    memory/disk regardless of caller or per-crawl settings.
+    An explicit limit (caller ``max_pages`` or ``cfg.crawl_max_pages``) is the
+    user's choice and is honored as-is, even above ``cfg.crawl_safety_max_pages``.
+    Only a fully unbounded crawl (both unset) is bounded by the safety cap, so a
+    hostile site can't exhaust the disk by default while an explicit request can
+    still exceed it. The second element is the safety cap when it was the source
+    of the bound (so a caller can tell the user it was hit), else ``None``.
     """
-    ceiling = cfg.crawl_safety_max_pages
-    if pages is None:
-        return ceiling
-    return min(pages, ceiling)
+    explicit = _resolve_limit(max_pages, cfg.crawl_max_pages)
+    if explicit is not None:
+        return explicit, None
+    cap = cfg.crawl_safety_max_pages
+    return cap, cap
 
 
 def _looks_like_missing_chromium(exc: BaseException) -> bool:
@@ -130,10 +134,10 @@ async def crawl_recursive(
 ) -> list[CrawlResult]:
     """Crawl a URL recursively using BFS, streaming per-page progress.
 
-    ``max_depth`` of None means unbounded depth. ``max_pages`` is always
-    bounded by ``cfg.crawl_safety_max_pages``; None / a higher value is
-    clamped to that ceiling so a hostile site can't exhaust memory/disk.
-    ``CRAWL_PAGE`` events fire as each page completes; total is
+    ``max_depth`` of None means unbounded depth. An explicit ``max_pages``
+    (or ``cfg.crawl_max_pages``) is honored as-is; only a fully unbounded
+    crawl is bounded by ``cfg.crawl_safety_max_pages`` so a hostile site can't
+    exhaust the disk by default. ``CRAWL_PAGE`` events fire as each page completes; total is
     ``CRAWL_TOTAL_UNKNOWN`` by default and promoted to the sitemap count
     when available.
 
@@ -144,7 +148,7 @@ async def crawl_recursive(
     """
     validate_crawl_url(url)
     depth = _resolve_limit(max_depth, cfg.crawl_max_depth)
-    pages = _clamp_to_safety_ceiling(_resolve_limit(max_pages, cfg.crawl_max_pages))
+    pages, _ = _resolve_page_limit(max_pages)
 
     # Fail fast when the ``crawler`` extra wasn't installed so SSE
     # callers see ``event: error`` instead of a silent zero-results run.
@@ -384,9 +388,16 @@ async def crawl_and_save(
             await _maybe_periodic_sync(tasks)
 
         if on_progress:
+            _, safety_cap = _resolve_page_limit(max_pages)
+            stopped_at_cap = safety_cap is not None and pages_seen >= safety_cap
             on_progress(
                 EventType.CRAWL_DONE,
-                CrawlDoneEvent(pages_crawled=pages_seen, files_written=len(written_paths)),
+                CrawlDoneEvent(
+                    pages_crawled=pages_seen,
+                    files_written=len(written_paths),
+                    stopped_at_safety_cap=stopped_at_cap,
+                    safety_cap=safety_cap if stopped_at_cap else None,
+                ),
             )
 
         return written_paths

--- a/src/lilbee/crawler/sitemap.py
+++ b/src/lilbee/crawler/sitemap.py
@@ -6,7 +6,7 @@ import re
 from http import HTTPStatus
 from urllib.parse import urlparse
 
-from lilbee.crawler.url_filter import host_in_scope
+from lilbee.crawler.url_filter import host_in_scope, require_valid_crawl_url
 from lilbee.runtime.progress import CRAWL_TOTAL_UNKNOWN
 
 # Sitemap lookups are best-effort progress hints; never block the actual crawl.
@@ -26,6 +26,12 @@ def _fetch_sitemap_text(start_url: str) -> str | None:
     except (httpx.HTTPError, OSError):
         return None
     if resp.status_code >= HTTPStatus.BAD_REQUEST:
+        return None
+    # Redirects can steer the fetch to a private/metadata host (SSRF), so
+    # re-validate the final resolved URL before trusting the body.
+    try:
+        require_valid_crawl_url(str(resp.url))
+    except ValueError:
         return None
     return resp.text
 

--- a/src/lilbee/crawler/url_filter.py
+++ b/src/lilbee/crawler/url_filter.py
@@ -13,6 +13,9 @@ _BLOCKED_NETWORKS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
     ipaddress.ip_network("192.168.0.0/16"),
     ipaddress.ip_network("169.254.0.0/16"),
     ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
+    ipaddress.ip_network("fc00::/7"),  # IPv6 unique-local (ULA)
+    ipaddress.ip_network("ff00::/8"),  # IPv6 multicast
 )
 
 

--- a/src/lilbee/data/ingest/code.py
+++ b/src/lilbee/data/ingest/code.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from lilbee.app.services import get_services
 from lilbee.data.code_chunker import CodeChunk, chunk_code
 from lilbee.data.ingest.types import ChunkRecord
-from lilbee.data.store import CHUNK_TYPE_RAW
+from lilbee.data.store import ChunkType
 from lilbee.runtime.progress import DetailedProgressCallback, noop_callback
 
 
@@ -29,7 +29,7 @@ def ingest_code_sync(
         ChunkRecord(
             source=source_name,
             content_type="code",
-            chunk_type=CHUNK_TYPE_RAW,
+            chunk_type=ChunkType.RAW,
             page_start=0,
             page_end=0,
             line_start=cc.line_start,

--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -22,7 +22,7 @@ from lilbee.data.ingest.types import (
     ChunkRecord,
     ExtractMode,
 )
-from lilbee.data.store import CHUNK_TYPE_RAW
+from lilbee.data.store import ChunkType
 from lilbee.runtime.cpu import cpu_quota
 from lilbee.runtime.progress import (
     DetailedProgressCallback,
@@ -207,7 +207,7 @@ async def _chunk_and_embed_pages(
         ChunkRecord(
             source=source_name,
             content_type=content_type,
-            chunk_type=CHUNK_TYPE_RAW,
+            chunk_type=ChunkType.RAW,
             page_start=page_num,
             page_end=page_num,
             line_start=0,
@@ -320,7 +320,7 @@ async def ingest_document(
         ChunkRecord(
             source=source_name,
             content_type=content_type,
-            chunk_type=CHUNK_TYPE_RAW,
+            chunk_type=ChunkType.RAW,
             page_start=chunk.metadata.get("first_page") or 0,
             page_end=chunk.metadata.get("last_page") or 0,
             line_start=0,
@@ -357,7 +357,7 @@ async def ingest_markdown(
         ChunkRecord(
             source=source_name,
             content_type="text",
-            chunk_type=CHUNK_TYPE_RAW,
+            chunk_type=ChunkType.RAW,
             page_start=0,
             page_end=0,
             line_start=0,

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -256,6 +256,10 @@ async def sync(
     # Track skip markers for files processed this run, keyed by name → hash.
     pending_hashes = {entry.name: entry.file_hash for entry in files_to_process}
 
+    # Snapshot the cumulative truncation counter so the delta over this sync can
+    # surface "N chunks truncated" instead of being lost in per-chunk debug logs.
+    truncated_before = get_services().embedder.truncated_total
+
     # Ingest files (with optional progress bar)
     if files_to_process:
         get_services().embedder.validate_model()
@@ -290,6 +294,7 @@ async def sync(
         unchanged=unchanged,
         failed=failed,
         skipped=skipped,
+        truncated=get_services().embedder.truncated_total - truncated_before,
     )
     on_progress(
         EventType.DONE,

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -244,11 +244,10 @@ async def sync(
     skipped: list[str] = []
 
     # Find files to remove (in DB but not on disk)
-    for name in existing_sources:
-        if name not in disk_files:
-            _store.delete_by_source(name)
-            _store.delete_source(name)
-            removed.append(name)
+    to_remove = [name for name in existing_sources if name not in disk_files]
+    if to_remove:
+        _store.remove_documents(to_remove)
+        removed.extend(to_remove)
 
     files_to_process, added, updated, unchanged = _plan_file_changes(
         disk_files, existing_sources, cancel, skip_markers=skip_markers

--- a/src/lilbee/data/ingest/types.py
+++ b/src/lilbee/data/ingest/types.py
@@ -63,6 +63,9 @@ class SyncResult(BaseModel):
     unchanged: int = 0
     failed: list[str] = []
     skipped: list[str] = []
+    # Chunks whose text exceeded the embedder's char budget and were truncated
+    # before embedding. Non-zero means some tail content did not reach the index.
+    truncated: int = 0
 
     def __str__(self) -> str:
         lines = [
@@ -72,6 +75,7 @@ class SyncResult(BaseModel):
             f"Unchanged: {self.unchanged}",
             f"Skipped: {len(self.skipped)}",
             f"Failed: {len(self.failed)}",
+            f"Truncated: {self.truncated}",
         ]
         for f in self.skipped:
             lines.append(f"  [yellow]{f}[/yellow]")
@@ -83,7 +87,8 @@ class SyncResult(BaseModel):
         return (
             f"SyncResult(added={len(self.added)}, updated={len(self.updated)}, "
             f"removed={len(self.removed)}, unchanged={self.unchanged}, "
-            f"skipped={len(self.skipped)}, failed={len(self.failed)})"
+            f"skipped={len(self.skipped)}, failed={len(self.failed)}, "
+            f"truncated={self.truncated})"
         )
 
     def __rich__(self) -> str:

--- a/src/lilbee/data/ingest/types.py
+++ b/src/lilbee/data/ingest/types.py
@@ -9,6 +9,8 @@ from typing import NamedTuple, TypedDict
 
 from pydantic import BaseModel
 
+from lilbee.data.store import ChunkType
+
 
 class FileToProcess(NamedTuple):
     """A file queued for ingestion with its metadata."""
@@ -44,7 +46,7 @@ class ChunkRecord(TypedDict):
 
     source: str
     content_type: str
-    chunk_type: str
+    chunk_type: ChunkType
     page_start: int
     page_end: int
     line_start: int

--- a/src/lilbee/data/store/__init__.py
+++ b/src/lilbee/data/store/__init__.py
@@ -11,8 +11,7 @@ from .lance_helpers import (
 )
 from .ranking import cosine_sim, mmr_rerank
 from .types import (
-    CHUNK_TYPE_RAW,
-    CHUNK_TYPE_WIKI,
+    ChunkType,
     CitationRecord,
     EmbeddingModelMismatchError,
     RemoveResult,
@@ -23,8 +22,7 @@ from .types import (
 )
 
 __all__ = [
-    "CHUNK_TYPE_RAW",
-    "CHUNK_TYPE_WIKI",
+    "ChunkType",
     "CitationRecord",
     "EmbeddingModelMismatchError",
     "RemoveResult",

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -37,6 +37,7 @@ from .types import (
     META_DELETE_ALL_PREDICATE,
     META_SCHEMA_VERSION,
     READ_CONSISTENCY_INTERVAL,
+    ChunkType,
     CitationRecord,
     EmbeddingModelMismatchError,
     RemoveResult,
@@ -57,7 +58,7 @@ def _hybrid_search(
     query_text: str,
     query_vector: list[float],
     top_k: int,
-    chunk_type: str | None = None,
+    chunk_type: ChunkType | None = None,
 ) -> list[SearchChunk]:
     """Run hybrid (vector + FTS) search with RRF reranking.
 
@@ -383,7 +384,7 @@ class Store:
         top_k: int | None = None,
         max_distance: float | None = None,
         query_text: str | None = None,
-        chunk_type: str | None = None,
+        chunk_type: ChunkType | None = None,
     ) -> list[SearchChunk]:
         """Search for similar chunks. Hybrid when FTS available, else vector-only.
 

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -509,12 +509,16 @@ class Store:
             rows = filtered.to_pylist()
         return [SearchChunk(**r) for r in rows]
 
+    def _delete_by_source_unlocked(self, source: str) -> None:
+        """Delete all chunks from *source*. Caller must hold ``write_lock()``."""
+        table = self.open_table(CHUNKS_TABLE)
+        if table is not None:
+            _safe_delete_unlocked(table, f"source = '{escape_sql_string(source)}'")
+
     def delete_by_source(self, source: str) -> None:
         """Delete all chunks from a given source file."""
         with write_lock():
-            table = self.open_table(CHUNKS_TABLE)
-            if table is not None:
-                _safe_delete_unlocked(table, f"source = '{escape_sql_string(source)}'")
+            self._delete_by_source_unlocked(source)
         self._invalidate_source_cache()
 
     def get_sources(
@@ -572,13 +576,26 @@ class Store:
             )
         self._invalidate_source_cache()
 
+    def _delete_source_unlocked(self, filename: str) -> None:
+        """Remove the *filename* source record. Caller must hold ``write_lock()``."""
+        table = self.open_table(SOURCES_TABLE)
+        if table is not None:
+            _safe_delete_unlocked(table, f"filename = '{escape_sql_string(filename)}'")
+
     def delete_source(self, filename: str) -> None:
         """Remove a source file tracking record."""
         with write_lock():
-            table = self.open_table(SOURCES_TABLE)
-            if table is not None:
-                _safe_delete_unlocked(table, f"filename = '{escape_sql_string(filename)}'")
+            self._delete_source_unlocked(filename)
         self._invalidate_source_cache()
+
+    def _remove_one_unlocked(self, name: str) -> None:
+        """Delete a document's chunks and its source record together.
+
+        Both deletes run under the caller's single ``write_lock()`` so no
+        reader can observe chunks whose source record is already gone.
+        """
+        self._delete_by_source_unlocked(name)
+        self._delete_source_unlocked(name)
 
     def remove_documents(
         self,
@@ -605,8 +622,9 @@ class Store:
             if name not in known:
                 not_found.append(name)
                 continue
-            self.delete_by_source(name)
-            self.delete_source(name)
+            with write_lock():
+                self._remove_one_unlocked(name)
+            self._invalidate_source_cache()
             removed.append(name)
             if delete_files:
                 try:

--- a/src/lilbee/data/store/lance_helpers.py
+++ b/src/lilbee/data/store/lance_helpers.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from lilbee.catalog.refs import hf_repo_from_ref
 from lilbee.runtime.lock import write_lock
 
-from .types import CHUNK_TYPE_RAW
+from .types import ChunkType
 
 if TYPE_CHECKING:
     import lancedb
@@ -74,7 +74,7 @@ def escape_sql_string(value: str) -> str:
     return value.replace("\\", "\\\\").replace("'", "''")
 
 
-def _chunk_type_predicate(chunk_type: str) -> str:
+def _chunk_type_predicate(chunk_type: ChunkType | str) -> str:
     """SQL predicate that matches ``chunk_type`` while tolerating NULL rows.
 
     Rows written before ``chunk_type`` was populated land as NULL. They
@@ -82,7 +82,7 @@ def _chunk_type_predicate(chunk_type: str) -> str:
     ``'wiki'`` filter excludes them.
     """
     escaped = escape_sql_string(chunk_type)
-    if chunk_type == CHUNK_TYPE_RAW:
+    if chunk_type == ChunkType.RAW:
         return f"(chunk_type = '{escaped}' OR chunk_type IS NULL)"
     return f"chunk_type = '{escaped}'"
 

--- a/src/lilbee/data/store/types.py
+++ b/src/lilbee/data/store/types.py
@@ -14,10 +14,17 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 # on slow media (HDD) at the cost of serving slightly stale data.
 READ_CONSISTENCY_INTERVAL = timedelta(seconds=5)
 
-# Values for the ``chunk_type`` column. Everything goes in as raw except wiki
-# pages written by the wiki producer; callers filter with ``Store.search(chunk_type=...)``.
-CHUNK_TYPE_RAW = "raw"
-CHUNK_TYPE_WIKI = "wiki"
+
+class ChunkType(StrEnum):
+    """Values for the ``chunk_type`` column.
+
+    Everything ingests as ``RAW`` except wiki pages written by the wiki
+    producer; callers filter with ``Store.search(chunk_type=...)``.
+    """
+
+    RAW = "raw"
+    WIKI = "wiki"
+
 
 # ``schema_version`` is an integer for forward-compat. Bump only if we ever need to
 # add or rename a meta column without forcing every store to drop_all.
@@ -37,23 +44,23 @@ class SearchScope(StrEnum):
     others map 1:1 to the chunks-table values.
     """
 
-    RAW = CHUNK_TYPE_RAW
-    WIKI = CHUNK_TYPE_WIKI
+    RAW = ChunkType.RAW
+    WIKI = ChunkType.WIKI
     BOTH = "both"
 
 
-def scope_to_chunk_type(scope: SearchScope | str | None) -> str | None:
+def scope_to_chunk_type(scope: SearchScope | str | None) -> ChunkType | None:
     """Translate a user-facing scope into a ``Store.search`` ``chunk_type`` arg.
 
     ``None``/``"both"`` → no filter. ``"raw"`` / ``"wiki"`` → the matching
-    chunks-table value. Raises ``ValueError`` on any other string.
+    ``ChunkType``. Raises ``ValueError`` on any other string.
     """
     if scope is None:
         return None
     normalized = SearchScope(scope)
     if normalized is SearchScope.BOTH:
         return None
-    return normalized.value
+    return ChunkType(normalized.value)
 
 
 class SearchChunk(BaseModel):
@@ -66,13 +73,13 @@ class SearchChunk(BaseModel):
 
     source: str
     content_type: str
-    chunk_type: str = CHUNK_TYPE_RAW
+    chunk_type: ChunkType = ChunkType.RAW
 
     @field_validator("chunk_type", mode="before")
     @classmethod
     def _coerce_none_chunk_type(cls, v: str | None) -> str:
         """LanceDB rows from before the chunk_type column was added return None."""
-        return v if v is not None else CHUNK_TYPE_RAW
+        return v if v is not None else ChunkType.RAW
 
     page_start: int
     page_end: int

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -82,6 +82,35 @@ class ModelManifest:
         return format_native_gguf_ref(self.hf_repo, self.gguf_filename)
 
 
+def _copy_atomic(source_path: Path, blob_path: Path) -> None:
+    """Copy *source_path* to *blob_path* via a temp file + atomic rename.
+
+    A crash mid-copy leaves only the temp file, never a partial blob at
+    the final digest path that callers would treat as complete.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=str(blob_path.parent), suffix=".part")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as dst, source_path.open("rb") as src:
+            shutil.copyfileobj(src, dst)
+        os.replace(tmp_path, blob_path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _blob_size_matches(blob_file: Path, expected_size: int) -> bool:
+    """True iff *blob_file* exists and its byte size equals *expected_size*.
+
+    A blob shorter than the manifest's recorded size is a truncated /
+    interrupted download and must not count as installed.
+    """
+    try:
+        return blob_file.stat().st_size == expected_size
+    except OSError:
+        return False
+
+
 def _sha256_file(path: Path) -> str:
     """Compute SHA-256 hex digest of a file."""
     h = hashlib.sha256()
@@ -125,7 +154,7 @@ class ModelRegistry:
         manifest = self._read_manifest(hf_repo, gguf_filename)
         if manifest is not None and manifest.blob is not None:
             blob_file = self._repo_cache_dir(manifest.hf_repo) / "blobs" / manifest.blob
-            if blob_file.exists():
+            if _blob_size_matches(blob_file, manifest.size_bytes):
                 return blob_file
         recovered = self._find_cached_gguf(hf_repo, gguf_filename)
         if recovered is not None:
@@ -140,6 +169,12 @@ class ModelRegistry:
             raise KeyError(f"Cache folder missing for {ref}: {cache_path.name}")
         if manifest.blob is None:
             raise KeyError(f"Manifest for {ref} has no blob hash; install incomplete")
+        blob_file = cache_path / "blobs" / manifest.blob
+        if blob_file.exists():
+            raise KeyError(
+                f"Blob for {ref} is truncated: {blob_file.stat().st_size} of "
+                f"{manifest.size_bytes} bytes; re-download required"
+            )
         raise KeyError(f"Blob file missing for {ref}: {manifest.blob}")
 
     def _resolve_repo_only(self, hf_repo: str) -> Path:
@@ -255,20 +290,20 @@ class ModelRegistry:
         manifest: ModelManifest,
     ) -> Path:
         """Write a manifest, copying *source_path* into the HF cache if needed."""
-        import shutil
-
         digest = _sha256_file(source_path)
         cache_path = self._repo_cache_dir(hf_repo)
         blobs_dir = cache_path / "blobs"
         blob_path = blobs_dir / digest
         if not blob_path.exists():
             blobs_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source_path, blob_path)
+            _copy_atomic(source_path, blob_path)
 
         updated = ModelManifest(
             hf_repo=hf_repo,
             gguf_filename=gguf_filename,
-            size_bytes=manifest.size_bytes,
+            # Record the size install actually wrote, not the caller's claim,
+            # so the on-disk size check has a trustworthy reference.
+            size_bytes=source_path.stat().st_size,
             task=manifest.task,
             downloaded_at=manifest.downloaded_at,
             blob=digest,
@@ -350,11 +385,11 @@ class ModelRegistry:
         return manifests
 
     def _blob_present(self, manifest: ModelManifest) -> bool:
-        """True iff *manifest* points at an existing blob file."""
+        """True iff *manifest* points at a blob whose on-disk size matches."""
         if manifest.blob is None:
             return False
         blob_file = self._repo_cache_dir(manifest.hf_repo) / "blobs" / manifest.blob
-        return blob_file.exists()
+        return _blob_size_matches(blob_file, manifest.size_bytes)
 
     def get_manifest(self, ref: str) -> ModelManifest | None:
         """Return the manifest for *ref* or None if not installed."""

--- a/src/lilbee/providers/llama_cpp/batching.py
+++ b/src/lilbee/providers/llama_cpp/batching.py
@@ -109,6 +109,12 @@ def compute_rerank_scores(llm: Any, query: str, candidates: list[str]) -> list[f
 def _embed_one_call(llm: Any, sub_batch: list[str]) -> list[list[float]]:
     response = llm.create_embedding(input=sub_batch)
     data = response.get("data") or []
+    if len(data) != len(sub_batch):
+        raise ProviderError(
+            f"Embedder returned {len(data)} vectors for {len(sub_batch)} inputs; "
+            "llama-cpp-python may have changed its response format",
+            provider="llama-cpp",
+        )
     return [item["embedding"] for item in data]
 
 

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -114,18 +114,23 @@ _SINGLE_CLASS_RERANK = 1
 
 
 def _read_context_n_seq_max(llm: Any) -> int | None:
-    """Read ``n_seq_max`` back off a constructed Llama, or None if unreadable."""
-    context_params = getattr(llm, "context_params", None)
-    if context_params is None:
+    """Read ``n_seq_max`` back off a constructed Llama, or None if unreadable.
+
+    AttributeError means llama-cpp restructured its internals (the signal to
+    revisit against the pin); the caller treats None as "could not verify".
+    """
+    try:
+        value = llm.context_params.n_seq_max
+    except AttributeError:
         return None
-    value = getattr(context_params, "n_seq_max", None)
     return int(value) if isinstance(value, int) else None
 
 
 def _read_rerank_class_count(llm: Any) -> int | None:
     """Read a reranker's classifier-output count, or None if unreadable."""
-    model = getattr(getattr(llm, "_model", None), "model", None)
-    if model is None:
+    try:
+        model = llm._model.model
+    except AttributeError:
         return None
     from llama_cpp import llama_cpp as _llc
 

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -422,6 +422,8 @@ class LlamaCppProvider(LLMProvider):
         if "num_predict" in filtered:
             filtered["max_tokens"] = filtered.pop("num_predict")
         filtered.pop("num_ctx", None)  # model-load param, not per-call
+        # top_k kept here (local llama.cpp honors it); the API path in
+        # translate_options strips it since hosted providers ignore it.
         return filtered
 
     def list_models(self) -> list[str]:

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -106,10 +106,9 @@ _CTX_FLOOR = 512
 # Sentinel passed to ``llama-cpp-python`` for "offload all layers".
 _N_GPU_LAYERS_AUTO = -1
 
-# Classifier-output count a reranker must have for lilbee's single-scalar
-# score extraction (batching._extract_rerank_score reads embedding[0]).
-# llama-cpp-python's RANK pooling slices ptr[:n_embd] regardless of n_cls_out,
-# so the response gives no in-band signal; the model's count is the only check.
+# lilbee extracts a single scalar rerank score, so a multi-class reranker would
+# be silently scored on one logit. The response can't reveal the class count, so
+# it's checked at load.
 _SINGLE_CLASS_RERANK = 1
 
 

--- a/src/lilbee/providers/llama_cpp/provider.py
+++ b/src/lilbee/providers/llama_cpp/provider.py
@@ -106,6 +106,66 @@ _CTX_FLOOR = 512
 # Sentinel passed to ``llama-cpp-python`` for "offload all layers".
 _N_GPU_LAYERS_AUTO = -1
 
+# Classifier-output count a reranker must have for lilbee's single-scalar
+# score extraction (batching._extract_rerank_score reads embedding[0]).
+# llama-cpp-python's RANK pooling slices ptr[:n_embd] regardless of n_cls_out,
+# so the response gives no in-band signal; the model's count is the only check.
+_SINGLE_CLASS_RERANK = 1
+
+
+def _read_context_n_seq_max(llm: Any) -> int | None:
+    """Read ``n_seq_max`` back off a constructed Llama, or None if unreadable."""
+    context_params = getattr(llm, "context_params", None)
+    if context_params is None:
+        return None
+    value = getattr(context_params, "n_seq_max", None)
+    return int(value) if isinstance(value, int) else None
+
+
+def _read_rerank_class_count(llm: Any) -> int | None:
+    """Read a reranker's classifier-output count, or None if unreadable."""
+    model = getattr(getattr(llm, "_model", None), "model", None)
+    if model is None:
+        return None
+    from llama_cpp import llama_cpp as _llc
+
+    return int(_llc.llama_model_n_cls_out(model))
+
+
+def _verify_embed_n_seq_max(llm: Any, expected: int) -> None:
+    """Fail loudly if the ``_llama_n_seq_max`` shim did not take effect.
+
+    Without this, a future llama-cpp-python that moves ``LlamaContext``
+    internals leaves ``n_seq_max`` at the C default (1) and batched 2+ embed
+    silently returns ``llama_decode -1`` at inference time instead of here.
+    """
+    applied = _read_context_n_seq_max(llm)
+    if applied is not None and applied != expected:
+        raise ProviderError(
+            f"Embedding context n_seq_max={applied}, expected {expected}; "
+            "the llama-cpp-python n_seq_max workaround did not apply "
+            "(internals may have changed). Batched embed would fail at decode.",
+            provider="llama-cpp",
+        )
+
+
+def _verify_single_class_reranker(llm: Any) -> None:
+    """Fail loudly if the reranker emits more than one classifier output.
+
+    lilbee reads ``embedding[0]`` as the relevance score, which is the model's
+    only output for a single-class cross-encoder. A multi-class reranker would
+    silently score on class 0 alone, so reject it instead of producing
+    plausible-but-wrong rankings.
+    """
+    count = _read_rerank_class_count(llm)
+    if count is not None and count != _SINGLE_CLASS_RERANK:
+        raise ProviderError(
+            f"Reranker has {count} classifier outputs; lilbee supports only "
+            "single-class (n_cls_out=1) rerankers. A multi-class model would "
+            "be scored on class 0 alone and rank incorrectly.",
+            provider="llama-cpp",
+        )
+
 
 class LlamaCppProvider(LLMProvider):
     """Provider backed by llama-cpp-python for local GGUF model inference."""
@@ -775,7 +835,11 @@ def load_llama(
         from lilbee.providers.llama_cpp.batching import EMBED_N_SEQ_MAX
 
         with _llama_n_seq_max(EMBED_N_SEQ_MAX):
-            return _construct_llama(Llama, model_path, kwargs)
+            llm = _construct_llama(Llama, model_path, kwargs)
+        _verify_embed_n_seq_max(llm, EMBED_N_SEQ_MAX)
+        if mode == LoaderMode.RERANK:
+            _verify_single_class_reranker(llm)
+        return llm
     return _construct_llama(Llama, model_path, kwargs)
 
 

--- a/src/lilbee/providers/model_ref.py
+++ b/src/lilbee/providers/model_ref.py
@@ -116,6 +116,8 @@ def translate_options(options: dict[str, Any], ref: ProviderModelRef) -> dict[st
             filtered["max_tokens"] = filtered.pop("num_predict")
         # num_ctx is a model-load param, not per-call
         filtered.pop("num_ctx", None)
-        # top_k not supported by most API providers
+        # top_k kept for local llama.cpp, stripped for API providers: litellm
+        # forwards it (into extra_body for OpenAI-compatible) without erroring,
+        # but hosted APIs ignore it, so dropping it keeps the wire request clean.
         filtered.pop("top_k", None)
     return filtered

--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -5,6 +5,7 @@ own chat template, so there's no projector-type-to-handler lookup table.
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +43,14 @@ _GGUF_IMAGE_TOKENS: tuple[str, ...] = (
 )
 _IMAGE_URL_JINJA = "{{ content.image_url.url }}"
 
+# Angle-bracket placeholder whose inner text names an image/media slot, e.g.
+# ``<start_of_image>`` or ``<media>``. Used after the known-token rewrite to
+# catch an unrecognized image placeholder; the adapted ``{{ ... }}`` Jinja marker
+# uses braces, not angle brackets, so it never matches here.
+_UNKNOWN_IMAGE_TOKEN_RE = re.compile(
+    r"<\|?[^<>]*(?:image|img|media|vision)[^<>]*\|?>", re.IGNORECASE
+)
+
 _TOKENIZER_CHAT_TEMPLATE_KEY = "tokenizer.chat_template"
 
 _VISION_FALLBACK_N_CTX = 4096
@@ -67,10 +76,21 @@ def read_chat_template(model_path: Path) -> str | None:
 
 
 def adapt_gguf_template_for_mtmd(template: str) -> str:
-    """Rewrite known image-placeholder tokens to ``{{ content.image_url.url }}``."""
+    """Rewrite known image-placeholder tokens to ``{{ content.image_url.url }}``.
+
+    Raises ``ValueError`` if an unrecognized image/media placeholder survives,
+    so a corrupted vision prompt fails at load rather than degrading OCR silently.
+    """
     for token in _GGUF_IMAGE_TOKENS:
         if token in template:
             template = template.replace(token, _IMAGE_URL_JINJA)
+    leftover = _UNKNOWN_IMAGE_TOKEN_RE.search(template)
+    if leftover is not None:
+        supported = ", ".join(_GGUF_IMAGE_TOKENS)
+        raise ValueError(
+            f"Unrecognized image placeholder {leftover.group()!r} in GGUF chat template; "
+            f"supported tokens are: {supported}"
+        )
     return template
 
 

--- a/src/lilbee/providers/worker/transport.py
+++ b/src/lilbee/providers/worker/transport.py
@@ -184,8 +184,10 @@ class WorkerChannel(Protocol):
         """Send one request, await one reply. Raises on worker error or timeout."""
         ...
 
-    def stream(self, kind: WireKind, payload: Any) -> AsyncIterator[Any]:
-        """Send one request, yield streamed chunks until the worker terminates the stream."""
+    def stream(
+        self, kind: WireKind, payload: Any, *, stream_chunk_timeout: float = ...
+    ) -> AsyncIterator[Any]:
+        """Stream chunks until the worker ends the stream; a per-chunk stall raises."""
         ...
 
     def ping(self, *, timeout: float) -> Awaitable[None]:

--- a/src/lilbee/providers/worker/transport_pipe.py
+++ b/src/lilbee/providers/worker/transport_pipe.py
@@ -399,9 +399,12 @@ class PipeChannel:
         try:
             with contextlib.suppress(TimeoutError, WorkerError):
                 await self._health_round_trip(WireKind.SHUTDOWN, None, timeout=timeout)
-            await asyncio.get_running_loop().run_in_executor(
-                self._executor, self._join_process, timeout
-            )
+            # Join on the loop's default executor, never the channel's own:
+            # a stalled stream / timed-out health recv leaves the channel
+            # executor's threads blocked in conn.recv until the process dies,
+            # and terminate() is what unblocks them. Scheduling the join there
+            # too would deadlock when both worker threads are saturated.
+            await asyncio.get_running_loop().run_in_executor(None, self._join_process, timeout)
         finally:
             with contextlib.suppress(Exception):
                 self._conn.close()

--- a/src/lilbee/providers/worker/transport_pipe.py
+++ b/src/lilbee/providers/worker/transport_pipe.py
@@ -35,6 +35,17 @@ _PICKLE_MAX_BYTES = 32 * 1024 * 1024
 """``Connection.send`` raises past about 32 MiB on POSIX."""
 
 
+_STREAM_CHUNK_TIMEOUT_S = 300.0
+"""Max wait for the next frame of an in-flight stream before declaring a stall.
+
+A stalled worker keeps pinging alive on the health pipe, so without this the
+consumer would hang forever on a silent data pipe. The ceiling sits above the
+slowest legitimate single-chunk gap: PDF-OCR streams one page per chunk and a
+page can take up to ``LILBEE_OCR_TIMEOUT`` (120s default) on a cold model, so
+300s leaves headroom while still releasing the caller on a genuine hang.
+"""
+
+
 @dataclass(frozen=True)
 class _SerializedException:
     """Pickle-friendly stand-in for an exception that crossed the wire."""
@@ -276,12 +287,32 @@ class PipeChannel:
             finally:
                 self._bump_in_flight(-1)
 
-    async def stream(self, kind: WireKind, payload: Any) -> AsyncIterator[Any]:
+    async def _recv_chunk(self, timeout: float) -> tuple[WireKind, Any]:
+        """Recv the next stream frame within *timeout*; a stall is a crash.
+
+        A worker that stops emitting frames keeps the health pipe alive, so
+        a bare ``recv`` would hang the consumer forever. Bounding each frame
+        turns that silent stall into a :class:`WorkerCrashError` the pool can
+        recycle from.
+        """
+        try:
+            return await asyncio.wait_for(self._recv_data(), timeout=timeout)
+        except TimeoutError as exc:
+            raise self._crash() from exc
+
+    async def stream(
+        self,
+        kind: WireKind,
+        payload: Any,
+        *,
+        stream_chunk_timeout: float = _STREAM_CHUNK_TIMEOUT_S,
+    ) -> AsyncIterator[Any]:
         """Send one request, yield streamed chunks until the terminator arrives.
 
         The ``_call_lock`` is held for the full stream lifetime, so frames
         recv'd by this coroutine belong to this stream by construction.
-        New callers queue behind the active stream.
+        New callers queue behind the active stream. Each frame is bounded by
+        ``stream_chunk_timeout`` so a mid-stream stall releases the caller.
         """
         self._ensure_open()
         async with self._call_lock:
@@ -289,7 +320,7 @@ class PipeChannel:
             try:
                 await self._send_data(kind, payload)
                 while True:
-                    msg_kind, value = await self._recv_data()
+                    msg_kind, value = await self._recv_chunk(stream_chunk_timeout)
                     if msg_kind == WireKind.STREAM_CHUNK:
                         yield value
                     elif msg_kind == WireKind.STREAM_END:

--- a/src/lilbee/retrieval/embedder.py
+++ b/src/lilbee/retrieval/embedder.py
@@ -1,10 +1,12 @@
 """Thin wrapper around LLM provider embeddings API."""
 
 import logging
+import threading
 
 import numpy as np
 
 from lilbee.core.config import Config
+from lilbee.data.chunk import CHARS_PER_TOKEN
 from lilbee.providers.base import LLMProvider
 from lilbee.providers.model_ref import ProviderModelRef, parse_model_ref
 from lilbee.runtime.progress import DetailedProgressCallback, EmbedEvent, EventType, noop_callback
@@ -55,22 +57,40 @@ def is_model_available(model: str, provider: LLMProvider) -> bool:
 
 
 class Embedder:
-    """Embedding wrapper: truncates, batches, and validates vectors."""
+    """Embedding wrapper: truncates, batches, validates vectors, and counts truncations."""
 
     def __init__(self, config: Config, provider: LLMProvider) -> None:
         self._config = config
         self._provider = provider
+        self.last_batch_truncated = 0
+        self._truncated_total = 0
+        self._truncated_lock = threading.Lock()
+
+    @property
+    def embed_char_budget(self) -> int:
+        """Effective char limit, never below the chunker's max chunk size.
+
+        ``max_embed_chars`` guards the embed model's context; clamping it up to
+        ``chunk_size * CHARS_PER_TOKEN`` stops a finished full-budget chunk from
+        silently losing its tail to a limit set below what the chunker emits.
+        """
+        return max(self._config.max_embed_chars, self._config.chunk_size * CHARS_PER_TOKEN)
+
+    @property
+    def truncated_total(self) -> int:
+        """Cumulative count of chunks truncated since process start (thread-safe read)."""
+        with self._truncated_lock:
+            return self._truncated_total
 
     def truncate(self, text: str) -> str:
-        """Truncate text to stay within the embedding model's context window."""
-        if len(text) <= self._config.max_embed_chars:
+        """Truncate text to the embed char budget, counting any truncation."""
+        budget = self.embed_char_budget
+        if len(text) <= budget:
             return text
-        log.debug(
-            "Truncating chunk from %d to %d chars for embedding",
-            len(text),
-            self._config.max_embed_chars,
-        )
-        return text[: self._config.max_embed_chars]
+        log.debug("Truncating chunk from %d to %d chars for embedding", len(text), budget)
+        with self._truncated_lock:
+            self._truncated_total += 1
+        return text[:budget]
 
     def validate_vector(self, vector: list[float]) -> None:
         """Validate embedding vector dimension and values."""
@@ -115,7 +135,9 @@ class Embedder:
         Fires ``embed`` progress events per batch when *on_progress* is provided.
         """
         if not texts:
+            self.last_batch_truncated = 0
             return []
+        truncated_before = self.truncated_total
         total_chunks = len(texts)
         vectors: list[list[float]] = []
         batch: list[str] = []
@@ -141,4 +163,5 @@ class Embedder:
             )
         for vec in vectors:
             self.validate_vector(vec)
+        self.last_batch_truncated = self.truncated_total - truncated_before
         return vectors

--- a/src/lilbee/retrieval/query/formatting.py
+++ b/src/lilbee/retrieval/query/formatting.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 from lilbee.core.config import cfg
-from lilbee.data.store import CHUNK_TYPE_WIKI, CitationRecord, SearchChunk
+from lilbee.data.store import ChunkType, CitationRecord, SearchChunk
 
 CONTEXT_TEMPLATE = """Context:
 {context}
@@ -66,7 +66,7 @@ def format_source(result: SearchChunk, citations: list[CitationRecord] | None = 
     For wiki chunks, shows the wiki page path followed by indented transitive citations.
     """
     source_display = display_source_path(result.source)
-    if result.chunk_type == CHUNK_TYPE_WIKI and citations:
+    if result.chunk_type is ChunkType.WIKI and citations:
         parts = [f"  → {source_display}"]
         for cit in citations:
             parts.append(_format_citation(cit))

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -13,8 +13,7 @@ from typing_extensions import TypedDict
 from lilbee.core.config import Config
 from lilbee.core.config.enums import ChatMode
 from lilbee.data.store import (
-    CHUNK_TYPE_RAW,
-    CHUNK_TYPE_WIKI,
+    ChunkType,
     SearchChunk,
     Store,
     cosine_sim,
@@ -236,14 +235,14 @@ class Searcher:
             log.debug("HyDE search failed", exc_info=True)
             return []
 
-    def _normalize_chunk_type(self, chunk_type: str | None) -> str | None:
-        """Drop ``chunk_type="wiki"`` when wiki generation is disabled.
+    def _normalize_chunk_type(self, chunk_type: ChunkType | None) -> ChunkType | None:
+        """Drop ``chunk_type=ChunkType.WIKI`` when wiki generation is disabled.
 
         With wiki off the chunks table contains only raw rows, so the
         filter would return empty. Logging once keeps the surprise out
         of the user's way while surfacing the misuse in logs.
         """
-        if chunk_type == CHUNK_TYPE_WIKI and not self._config.wiki:
+        if chunk_type == ChunkType.WIKI and not self._config.wiki:
             log.warning(
                 "wiki scope requested but wiki is disabled; searching the full pool instead"
             )
@@ -261,7 +260,7 @@ class Searcher:
         mode: str,
         query: str,
         top_k: int,
-        chunk_type: str | None = None,
+        chunk_type: ChunkType | None = None,
     ) -> list[SearchChunk]:
         if mode == "term":
             return self._store.bm25_probe(query, top_k=top_k)
@@ -270,9 +269,9 @@ class Searcher:
             return self._store.search(query_vec, top_k=top_k, query_text=None)
         if mode == "hyde":
             return self._hyde_search(query, top_k)
-        if mode in (CHUNK_TYPE_WIKI, CHUNK_TYPE_RAW):
-            # Explicit ``chunk_type`` arg beats the prefix shortcut.
-            effective = chunk_type if chunk_type is not None else mode
+        if mode in (ChunkType.WIKI, ChunkType.RAW):
+            # Explicit ``chunk_type`` arg beats the ``wiki:``/``raw:`` prefix shortcut.
+            effective = chunk_type if chunk_type is not None else ChunkType(mode)
             query_vec = self._embedder.embed(query)
             return self._store.search(
                 query_vec, top_k=top_k, query_text=query, chunk_type=effective
@@ -309,7 +308,7 @@ class Searcher:
         results: list[SearchChunk],
         seen: set[tuple[str, int]],
         top_k: int,
-        chunk_type: str | None,
+        chunk_type: ChunkType | None,
     ) -> None:
         """Append unseen variant-search hits to ``results`` (in place)."""
         for variant, variant_vec in self._expand_query(question, query_vec):
@@ -347,7 +346,7 @@ class Searcher:
         question: str,
         top_k: int = 0,
         *,
-        chunk_type: str | None = None,
+        chunk_type: ChunkType | None = None,
     ) -> list[SearchChunk]:
         """Embed question and search with expansion, HyDE, and concept boost.
         Returns up to top_k*2 candidates for downstream filtering.
@@ -390,7 +389,7 @@ class Searcher:
         top_k: int = 0,
         history: list[ChatMessage] | None = None,
         *,
-        chunk_type: str | None = None,
+        chunk_type: ChunkType | None = None,
     ) -> tuple[list[SearchChunk], list[ChatMessage]] | None:
         """Build RAG context from search results.
 
@@ -454,7 +453,7 @@ class Searcher:
         history: list[ChatMessage] | None = None,
         options: dict[str, Any] | None = None,
         *,
-        chunk_type: str | None = None,
+        chunk_type: ChunkType | None = None,
     ) -> AskResult:
         """Ask a question. Skips retrieval when chat_mode is 'chat' or
         when no embedding model is configured."""
@@ -480,7 +479,7 @@ class Searcher:
         history: list[ChatMessage] | None = None,
         options: dict[str, Any] | None = None,
         *,
-        chunk_type: str | None = None,
+        chunk_type: ChunkType | None = None,
     ) -> str:
         """Ask a question and get a formatted answer with citations."""
         result = self.ask_raw(
@@ -525,7 +524,7 @@ class Searcher:
         history: list[ChatMessage] | None = None,
         options: dict[str, Any] | None = None,
         *,
-        chunk_type: str | None = None,
+        chunk_type: ChunkType | None = None,
     ) -> Generator[StreamToken, None, None]:
         """Stream answer tokens with citations appended at the end."""
         if (

--- a/src/lilbee/runtime/progress/types.py
+++ b/src/lilbee/runtime/progress/types.py
@@ -124,10 +124,6 @@ class CrawlDoneEvent(BaseModel):
 
     pages_crawled: int
     files_written: int
-    # Set when an unbounded crawl stopped at cfg.crawl_safety_max_pages with more
-    # pages likely available; surfaces tell the user how to raise it.
-    stopped_at_safety_cap: bool = False
-    safety_cap: int | None = None
 
 
 class SyncDoneEvent(BaseModel):

--- a/src/lilbee/runtime/progress/types.py
+++ b/src/lilbee/runtime/progress/types.py
@@ -124,6 +124,10 @@ class CrawlDoneEvent(BaseModel):
 
     pages_crawled: int
     files_written: int
+    # Set when an unbounded crawl stopped at cfg.crawl_safety_max_pages with more
+    # pages likely available; surfaces tell the user how to raise it.
+    stopped_at_safety_cap: bool = False
+    safety_cap: int | None = None
 
 
 class SyncDoneEvent(BaseModel):

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -12,6 +12,7 @@ from lilbee.app.search import clean_result
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
 from lilbee.core.results import DocumentResult, group
+from lilbee.data.store import ChunkType
 from lilbee.retrieval.reasoning import (
     CAP_NOTICE_TEMPLATE,
     CapNotice,
@@ -35,7 +36,9 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-async def search(q: str, top_k: int = 5, chunk_type: str | None = None) -> list[DocumentResult]:
+async def search(
+    q: str, top_k: int = 5, chunk_type: ChunkType | None = None
+) -> list[DocumentResult]:
     """Search and return grouped DocumentResults."""
     if not q or not q.strip():
         raise ValueError("query must not be empty")
@@ -48,7 +51,7 @@ async def ask(
     question: str,
     top_k: int = 0,
     options: dict[str, Any] | None = None,
-    chunk_type: str | None = None,
+    chunk_type: ChunkType | None = None,
 ) -> AskResponse:
     """One-shot RAG answer. Returns answer and sources."""
     if not question or not question.strip():
@@ -105,7 +108,7 @@ async def _stream_rag_response(
     history: list[ChatMessage] | None = None,
     top_k: int = 0,
     options: dict[str, Any] | None = None,
-    chunk_type: str | None = None,
+    chunk_type: ChunkType | None = None,
 ) -> AsyncGenerator[str, None]:
     """Shared SSE streaming for ask_stream and chat_stream."""
     yield ""  # force generator
@@ -149,7 +152,7 @@ def ask_stream(
     question: str,
     top_k: int = 0,
     options: dict[str, Any] | None = None,
-    chunk_type: str | None = None,
+    chunk_type: ChunkType | None = None,
 ) -> AsyncGenerator[str, None]:
     """Yield SSE events: token, sources, done."""
     return _stream_rag_response(question, top_k=top_k, options=options, chunk_type=chunk_type)
@@ -160,7 +163,7 @@ async def chat(
     history: list[ChatMessage],
     top_k: int = 0,
     options: dict[str, Any] | None = None,
-    chunk_type: str | None = None,
+    chunk_type: ChunkType | None = None,
 ) -> AskResponse:
     """Chat with history. Returns answer and sources."""
     opts = _resolve_generation_options(options)
@@ -178,7 +181,7 @@ def chat_stream(
     history: list[ChatMessage],
     top_k: int = 0,
     options: dict[str, Any] | None = None,
-    chunk_type: str | None = None,
+    chunk_type: ChunkType | None = None,
 ) -> AsyncGenerator[str, None]:
     """Yield SSE events with chat history support."""
     return _stream_rag_response(

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -13,6 +13,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from lilbee.core.config import cfg
+from lilbee.providers.base import filter_options
 from lilbee.runtime.progress import DetailedProgressCallback, EventType, ProgressEvent, SseEvent
 
 log = logging.getLogger(__name__)
@@ -54,8 +55,13 @@ def sse_done(data: dict[str, Any]) -> str:
 
 
 def _resolve_generation_options(options: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Convert raw options dict to GenerationOptions, or None."""
-    return cfg.generation_options(**options) if options else None
+    """Merge HTTP-supplied options with config, allowlisting sampling keys only.
+
+    ``filter_options`` is the validation boundary for untrusted callers: it
+    drops anything outside the sampling allowlist (e.g. injected ``api_base`` /
+    ``api_key``) before the values reach a provider.
+    """
+    return cfg.generation_options(**filter_options(options)) if options else None
 
 
 class SseStream:

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -322,6 +322,7 @@ class SyncSummary(BaseModel):
     unchanged: int = 0
     failed: list[str] = []
     skipped: list[str] = []
+    truncated: int = 0
 
 
 class AddSummary(BaseModel):

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -10,26 +10,25 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator
 
 from lilbee.catalog.types import ModelCompat, ModelSource, ModelTask
-from lilbee.data.store import SearchScope
+from lilbee.data.store import ChunkType, SearchScope
 from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 
-_VALID_CHUNK_TYPES = frozenset({SearchScope.RAW.value, SearchScope.WIKI.value})
 
-
-def _validate_chunk_type(value: str | None) -> str | None:
-    """Reject unknown ``chunk_type`` values at the HTTP boundary.
+def _validate_chunk_type(value: str | None) -> ChunkType | None:
+    """Decode a ``chunk_type`` string into a ``ChunkType`` at the HTTP boundary.
 
     Matches the CLI/MCP behaviour: only ``"raw"`` or ``"wiki"`` filter the
     pool; everything else (including ``None`` and the UI-side ``"both"``)
-    means no filter.
+    means no filter. Any other string raises ``ValueError``.
     """
     if value is None or value == SearchScope.BOTH.value:
         return None
-    if value not in _VALID_CHUNK_TYPES:
+    try:
+        return ChunkType(value)
+    except ValueError as exc:
         raise ValueError(
             f"chunk_type must be one of 'raw', 'wiki', 'both', or omitted; got {value!r}"
-        )
-    return value
+        ) from exc
 
 
 class AskRequest(BaseModel):
@@ -38,11 +37,11 @@ class AskRequest(BaseModel):
     question: str
     top_k: int = Field(default=0, le=100)
     options: dict[str, Any] | None = None
-    chunk_type: str | None = None
+    chunk_type: ChunkType | None = None
 
-    @field_validator("chunk_type")
+    @field_validator("chunk_type", mode="before")
     @classmethod
-    def _check_chunk_type(cls, v: str | None) -> str | None:
+    def _check_chunk_type(cls, v: str | None) -> ChunkType | None:
         return _validate_chunk_type(v)
 
 
@@ -53,11 +52,11 @@ class ChatRequest(BaseModel):
     history: list[ChatMessage] = []
     top_k: int = Field(default=0, le=100)
     options: dict[str, Any] | None = None
-    chunk_type: str | None = None
+    chunk_type: ChunkType | None = None
 
-    @field_validator("chunk_type")
+    @field_validator("chunk_type", mode="before")
     @classmethod
-    def _check_chunk_type(cls, v: str | None) -> str | None:
+    def _check_chunk_type(cls, v: str | None) -> ChunkType | None:
         return _validate_chunk_type(v)
 
 

--- a/src/lilbee/wiki/page.py
+++ b/src/lilbee/wiki/page.py
@@ -20,7 +20,7 @@ from lilbee.app.services import get_services
 from lilbee.core.config import CHUNKS_TABLE, DEFAULT_NUM_CTX, Config
 from lilbee.data.chunk import chunk_text
 from lilbee.data.store import (
-    CHUNK_TYPE_WIKI,
+    ChunkType,
     CitationRecord,
     SearchChunk,
     Store,
@@ -233,7 +233,7 @@ def index_wiki_page(content: str, wiki_source: str, store: Store) -> int:
     body = extract_body(content).strip()
     store.clear_table(
         CHUNKS_TABLE,
-        f"source = '{escape_sql_string(wiki_source)}' AND chunk_type = '{CHUNK_TYPE_WIKI}'",
+        f"source = '{escape_sql_string(wiki_source)}' AND chunk_type = '{ChunkType.WIKI}'",
     )
     if not body:
         return 0
@@ -247,7 +247,7 @@ def index_wiki_page(content: str, wiki_source: str, store: Store) -> int:
         {
             "source": wiki_source,
             "content_type": "text",
-            "chunk_type": CHUNK_TYPE_WIKI,
+            "chunk_type": ChunkType.WIKI,
             "page_start": 0,
             "page_end": 0,
             "line_start": 0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,6 +252,9 @@ def _default_embedder_mock():
     embedder = MagicMock()
     embedder.embed.return_value = [0.1] * 768
     embedder.embed_batch.side_effect = lambda texts, **kw: [[0.1] * 768 for _ in texts]
+    # Production reads embedder.truncated_total to compute the per-sync delta; the
+    # mock never truncates, so it must report a real 0 rather than a MagicMock.
+    embedder.truncated_total = 0
     return embedder
 
 

--- a/tests/crawler/test_runner.py
+++ b/tests/crawler/test_runner.py
@@ -256,6 +256,44 @@ class TestCrawlRecursiveOrchestration:
         with pytest.raises(ValueError, match="http"):
             await crawl_recursive("ftp://example.com", max_depth=1)
 
+    async def test_unbounded_request_is_clamped_to_safety_ceiling(self):
+        """A hostile site requested with no caps cannot exceed the safety ceiling."""
+        cfg.crawl_max_pages = None
+        cfg.crawl_safety_max_pages = 4
+        # The fetcher would happily stream forever; the orchestrator must hand
+        # it a bounded ``max_pages`` and stop draining at the cap.
+        pages = [
+            FetchedPage(url=f"https://example.com/p{i}", markdown=f"# P{i}") for i in range(1, 50)
+        ]
+        fake = FakeFetcher(pages=pages)
+        with patch.object(runner_mod, "Crawl4aiFetcher", return_value=fake):
+            results = await crawl_recursive("https://example.com", max_depth=None, max_pages=None)
+        assert fake.recursive_calls[0]["max_pages"] == 4
+        assert len(results) == 4
+
+    async def test_explicit_request_above_ceiling_is_clamped(self):
+        """An explicit caller cap above the safety ceiling is still clamped down."""
+        cfg.crawl_safety_max_pages = 3
+        pages = [
+            FetchedPage(url=f"https://example.com/p{i}", markdown=f"# P{i}") for i in range(1, 20)
+        ]
+        fake = FakeFetcher(pages=pages)
+        with patch.object(runner_mod, "Crawl4aiFetcher", return_value=fake):
+            results = await crawl_recursive("https://example.com", max_depth=1, max_pages=100)
+        assert fake.recursive_calls[0]["max_pages"] == 3
+        assert len(results) == 3
+
+    async def test_request_below_ceiling_is_respected(self):
+        """A caller cap below the safety ceiling wins (the ceiling is only an upper bound)."""
+        cfg.crawl_safety_max_pages = 100
+        pages = [
+            FetchedPage(url=f"https://example.com/p{i}", markdown=f"# P{i}") for i in range(1, 20)
+        ]
+        fake = FakeFetcher(pages=pages)
+        with patch.object(runner_mod, "Crawl4aiFetcher", return_value=fake):
+            await crawl_recursive("https://example.com", max_depth=1, max_pages=5)
+        assert fake.recursive_calls[0]["max_pages"] == 5
+
     async def test_raises_when_chromium_missing(self, monkeypatch):
         monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: False)
         from lilbee.crawler import CrawlerBrowserError

--- a/tests/crawler/test_runner.py
+++ b/tests/crawler/test_runner.py
@@ -256,8 +256,8 @@ class TestCrawlRecursiveOrchestration:
         with pytest.raises(ValueError, match="http"):
             await crawl_recursive("ftp://example.com", max_depth=1)
 
-    async def test_unbounded_request_is_bounded_by_safety_cap(self):
-        """A hostile site requested with no caps is bounded by the safety cap."""
+    async def test_unspecified_request_falls_back_to_safety_default(self):
+        """max_pages=None is unspecified, so a crawl nobody bounded uses the default."""
         cfg.crawl_max_pages = None
         cfg.crawl_safety_max_pages = 4
         # The fetcher would happily stream forever; the orchestrator must hand
@@ -293,6 +293,22 @@ class TestCrawlRecursiveOrchestration:
         with patch.object(runner_mod, "Crawl4aiFetcher", return_value=fake):
             await crawl_recursive("https://example.com", max_depth=1, max_pages=5)
         assert fake.recursive_calls[0]["max_pages"] == 5
+
+    async def test_unlimited_sentinel_crawls_unbounded(self):
+        """CRAWL_PAGES_UNLIMITED (0) is explicit no-limit and bypasses the default cap."""
+        from lilbee.crawler.models import CRAWL_PAGES_UNLIMITED
+
+        cfg.crawl_safety_max_pages = 3
+        pages = [
+            FetchedPage(url=f"https://example.com/p{i}", markdown=f"# P{i}") for i in range(1, 20)
+        ]
+        fake = FakeFetcher(pages=pages)
+        with patch.object(runner_mod, "Crawl4aiFetcher", return_value=fake):
+            results = await crawl_recursive(
+                "https://example.com", max_depth=1, max_pages=CRAWL_PAGES_UNLIMITED
+            )
+        assert fake.recursive_calls[0]["max_pages"] is None
+        assert len(results) == 19
 
     async def test_raises_when_chromium_missing(self, monkeypatch):
         monkeypatch.setattr("lilbee.crawler.bootstrap.chromium_installed", lambda: False)
@@ -362,44 +378,6 @@ class TestCrawlAndSaveOrchestration:
         done = events[-1][1]
         assert isinstance(done, CrawlDoneEvent)
         assert done.pages_crawled == 0
-
-    async def test_done_event_flags_safety_cap_when_unbounded_hits_it(self):
-        """An unbounded crawl that reaches the safety cap flags it so a surface can prompt."""
-        cfg.crawl_max_pages = None
-        cfg.crawl_safety_max_pages = 3
-        events: list[tuple[EventType, Any]] = []
-
-        async def _full_recursive(*args: Any, **kwargs: Any) -> list[CrawlResult]:
-            return [
-                CrawlResult(url=f"https://example.com/p{i}", markdown=f"# {i}") for i in range(3)
-            ]
-
-        with patch("lilbee.crawler.runner.crawl_recursive", side_effect=_full_recursive):
-            await crawl_and_save(
-                "https://example.com", depth=1, on_progress=lambda t, d: events.append((t, d))
-            )
-        done = events[-1][1]
-        assert done.stopped_at_safety_cap is True
-        assert done.safety_cap == 3
-
-    async def test_done_event_no_cap_flag_for_explicit_request(self):
-        """An explicit max_pages is the user's choice; the cap flag stays off."""
-        cfg.crawl_safety_max_pages = 3
-        events: list[tuple[EventType, Any]] = []
-
-        async def _two_recursive(*args: Any, **kwargs: Any) -> list[CrawlResult]:
-            return [CrawlResult(url="https://example.com/a", markdown="# A")]
-
-        with patch("lilbee.crawler.runner.crawl_recursive", side_effect=_two_recursive):
-            await crawl_and_save(
-                "https://example.com",
-                depth=1,
-                max_pages=100,
-                on_progress=lambda t, d: events.append((t, d)),
-            )
-        done = events[-1][1]
-        assert done.stopped_at_safety_cap is False
-        assert done.safety_cap is None
 
     async def test_cancel_skips_periodic_sync(self):
         cancel = threading.Event()

--- a/tests/crawler/test_runner.py
+++ b/tests/crawler/test_runner.py
@@ -256,8 +256,8 @@ class TestCrawlRecursiveOrchestration:
         with pytest.raises(ValueError, match="http"):
             await crawl_recursive("ftp://example.com", max_depth=1)
 
-    async def test_unbounded_request_is_clamped_to_safety_ceiling(self):
-        """A hostile site requested with no caps cannot exceed the safety ceiling."""
+    async def test_unbounded_request_is_bounded_by_safety_cap(self):
+        """A hostile site requested with no caps is bounded by the safety cap."""
         cfg.crawl_max_pages = None
         cfg.crawl_safety_max_pages = 4
         # The fetcher would happily stream forever; the orchestrator must hand
@@ -271,8 +271,8 @@ class TestCrawlRecursiveOrchestration:
         assert fake.recursive_calls[0]["max_pages"] == 4
         assert len(results) == 4
 
-    async def test_explicit_request_above_ceiling_is_clamped(self):
-        """An explicit caller cap above the safety ceiling is still clamped down."""
+    async def test_explicit_request_above_cap_is_honored(self):
+        """An explicit caller cap above the safety cap is the user's choice, not clamped."""
         cfg.crawl_safety_max_pages = 3
         pages = [
             FetchedPage(url=f"https://example.com/p{i}", markdown=f"# P{i}") for i in range(1, 20)
@@ -280,8 +280,8 @@ class TestCrawlRecursiveOrchestration:
         fake = FakeFetcher(pages=pages)
         with patch.object(runner_mod, "Crawl4aiFetcher", return_value=fake):
             results = await crawl_recursive("https://example.com", max_depth=1, max_pages=100)
-        assert fake.recursive_calls[0]["max_pages"] == 3
-        assert len(results) == 3
+        assert fake.recursive_calls[0]["max_pages"] == 100
+        assert len(results) == 19
 
     async def test_request_below_ceiling_is_respected(self):
         """A caller cap below the safety ceiling wins (the ceiling is only an upper bound)."""
@@ -362,6 +362,44 @@ class TestCrawlAndSaveOrchestration:
         done = events[-1][1]
         assert isinstance(done, CrawlDoneEvent)
         assert done.pages_crawled == 0
+
+    async def test_done_event_flags_safety_cap_when_unbounded_hits_it(self):
+        """An unbounded crawl that reaches the safety cap flags it so a surface can prompt."""
+        cfg.crawl_max_pages = None
+        cfg.crawl_safety_max_pages = 3
+        events: list[tuple[EventType, Any]] = []
+
+        async def _full_recursive(*args: Any, **kwargs: Any) -> list[CrawlResult]:
+            return [
+                CrawlResult(url=f"https://example.com/p{i}", markdown=f"# {i}") for i in range(3)
+            ]
+
+        with patch("lilbee.crawler.runner.crawl_recursive", side_effect=_full_recursive):
+            await crawl_and_save(
+                "https://example.com", depth=1, on_progress=lambda t, d: events.append((t, d))
+            )
+        done = events[-1][1]
+        assert done.stopped_at_safety_cap is True
+        assert done.safety_cap == 3
+
+    async def test_done_event_no_cap_flag_for_explicit_request(self):
+        """An explicit max_pages is the user's choice; the cap flag stays off."""
+        cfg.crawl_safety_max_pages = 3
+        events: list[tuple[EventType, Any]] = []
+
+        async def _two_recursive(*args: Any, **kwargs: Any) -> list[CrawlResult]:
+            return [CrawlResult(url="https://example.com/a", markdown="# A")]
+
+        with patch("lilbee.crawler.runner.crawl_recursive", side_effect=_two_recursive):
+            await crawl_and_save(
+                "https://example.com",
+                depth=1,
+                max_pages=100,
+                on_progress=lambda t, d: events.append((t, d)),
+            )
+        done = events[-1][1]
+        assert done.stopped_at_safety_cap is False
+        assert done.safety_cap is None
 
     async def test_cancel_skips_periodic_sync(self):
         cancel = threading.Event()

--- a/tests/crawler/test_url_filter.py
+++ b/tests/crawler/test_url_filter.py
@@ -107,6 +107,33 @@ class TestBlockedNetworks:
         networks = get_blocked_networks()
         assert any(_ip.ip_address("10.1.2.3") in n for n in networks)
 
+    @pytest.mark.parametrize(
+        "addr",
+        [
+            "fe80::1",  # link-local (fe80::/10)
+            "fc00::1",  # unique local address (fc00::/7)
+            "fd12:3456:789a::1",  # ULA inside fc00::/7
+            "ff02::1",  # multicast (ff00::/8)
+        ],
+    )
+    def test_contains_ipv6_reserved_ranges(self, addr):
+        import ipaddress as _ip
+
+        networks = get_blocked_networks()
+        assert any(_ip.ip_address(addr) in n for n in networks)
+
+    @pytest.mark.parametrize(
+        "addr",
+        ["fe80::dead:beef", "fc00::5", "ff00::abcd"],
+    )
+    def test_rejects_ipv6_reserved_targets(self, monkeypatch, addr):
+        monkeypatch.setattr(
+            "lilbee.crawler.url_filter.socket.getaddrinfo",
+            lambda *a, **kw: [(10, 1, 6, "", (addr, 0, 0, 0))],
+        )
+        with pytest.raises(ValueError, match="private/reserved"):
+            validate_crawl_url("http://ipv6.example.com")
+
 
 class TestHostInScope:
     def test_exact_match(self):
@@ -142,8 +169,31 @@ class TestSitemapFetch:
 
     def test_returns_body_on_success(self, monkeypatch):
         fake = MagicMock(status_code=200, text="<urlset></urlset>")
+        fake.url = "https://example.com/sitemap.xml"
         monkeypatch.setattr("httpx.get", lambda *a, **kw: fake)
         assert _fetch_sitemap_text("https://example.com/start") == "<urlset></urlset>"
+
+    def test_rejects_redirect_to_private_ip(self, monkeypatch):
+        """A 30x to a private/metadata host must drop the body (SSRF)."""
+        fake = MagicMock(status_code=200, text="<urlset></urlset>")
+        # httpx exposes the FINAL resolved URL after following redirects.
+        fake.url = "http://169.254.169.254/latest/meta-data/"
+        monkeypatch.setattr("httpx.get", lambda *a, **kw: fake)
+
+        def _resolve(host, *a, **kw):
+            if host == "169.254.169.254":
+                return [(2, 1, 6, "", ("169.254.169.254", 0))]
+            return [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+        monkeypatch.setattr("lilbee.crawler.url_filter.socket.getaddrinfo", _resolve)
+        assert _fetch_sitemap_text("https://example.com/start") is None
+
+    def test_rejects_redirect_to_non_http_scheme(self, monkeypatch):
+        """A redirect that lands on a file:// target is rejected."""
+        fake = MagicMock(status_code=200, text="<urlset></urlset>")
+        fake.url = "file:///etc/passwd"
+        monkeypatch.setattr("httpx.get", lambda *a, **kw: fake)
+        assert _fetch_sitemap_text("https://example.com/start") is None
 
 
 class TestSitemapCount:

--- a/tests/crawler/test_url_filter.py
+++ b/tests/crawler/test_url_filter.py
@@ -215,7 +215,12 @@ class TestSitemapCount:
             "<url><loc>https://other.com/c</loc></url>"
             "</urlset>"
         )
-        monkeypatch.setattr("httpx.get", lambda *a, **kw: MagicMock(status_code=200, text=body))
+        monkeypatch.setattr(
+            "httpx.get",
+            lambda *a, **kw: MagicMock(
+                status_code=200, text=body, url="https://example.com/sitemap.xml"
+            ),
+        )
         count = _count_sitemap_urls("https://example.com/start", include_subdomains=False)
         assert count == 2
 
@@ -226,7 +231,12 @@ class TestSitemapCount:
             "<url><loc>https://sub.example.com/d</loc></url>"
             "</urlset>"
         )
-        monkeypatch.setattr("httpx.get", lambda *a, **kw: MagicMock(status_code=200, text=body))
+        monkeypatch.setattr(
+            "httpx.get",
+            lambda *a, **kw: MagicMock(
+                status_code=200, text=body, url="https://example.com/sitemap.xml"
+            ),
+        )
         count = _count_sitemap_urls("https://example.com/start", include_subdomains=True)
         assert count == 2
 
@@ -246,7 +256,11 @@ class TestSitemapCount:
         body = "".join(f"<url><loc>https://example.com/{i}</loc></url>" for i in range(10))
         monkeypatch.setattr(
             "httpx.get",
-            lambda *a, **kw: MagicMock(status_code=200, text=f"<urlset>{body}</urlset>"),
+            lambda *a, **kw: MagicMock(
+                status_code=200,
+                text=f"<urlset>{body}</urlset>",
+                url="https://example.com/sitemap.xml",
+            ),
         )
         count = _count_sitemap_urls("https://example.com/start", include_subdomains=False)
         assert count == 2

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -245,7 +245,7 @@ class TestPropertyAccessors:
 
 class TestRemovePathTraversal:
     def test_remove_path_traversal_skips(self, tmp_path):
-        """remove() with a traversal name catches ValueError and returns."""
+        """remove() with an unknown/traversal name is a no-op and deletes nothing."""
         from lilbee import Lilbee
 
         bee = Lilbee(tmp_path / "proj")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -847,7 +847,12 @@ class TestDownloadModel:
         monkeypatch.setattr(cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
         existing = tmp_path / entry.gguf_filename
-        existing.write_bytes(b"fake model")
+        content = b"fake model"
+        existing.write_bytes(content)
+        # Cached file matches HF-reported size: accepted as complete, no re-download.
+        monkeypatch.setattr(
+            catalog.download, "fetch_expected_file_size", lambda repo, name: len(content)
+        )
         result = download_model(entry)
         assert result == existing
 
@@ -858,7 +863,11 @@ class TestDownloadModel:
         monkeypatch.setattr(cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
         existing = tmp_path / entry.gguf_filename
-        existing.write_bytes(b"fake model")
+        content = b"fake model"
+        existing.write_bytes(content)
+        monkeypatch.setattr(
+            catalog.download, "fetch_expected_file_size", lambda repo, name: len(content)
+        )
 
         progress_calls: list[tuple[int, int]] = []
 

--- a/tests/test_catalog_header_probe.py
+++ b/tests/test_catalog_header_probe.py
@@ -121,7 +121,9 @@ def test_probe_releases_memmap_before_unlink(monkeypatch: pytest.MonkeyPatch) ->
     the reader's memmap is released.
     """
     blob = make_minimal_gguf("llama")
-    monkeypatch.setattr(header_probe.httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob))
+    monkeypatch.setattr(
+        header_probe.httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob)
+    )
 
     captured: dict[str, object] = {}
     real_reader = header_probe.GGUFReader

--- a/tests/test_catalog_header_probe.py
+++ b/tests/test_catalog_header_probe.py
@@ -113,6 +113,39 @@ def test_probe_handles_array_value_in_skip(monkeypatch: pytest.MonkeyPatch) -> N
     assert probe_architecture("https://example.test/model.gguf") == "gemma3"
 
 
+def test_probe_releases_memmap_before_unlink(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The GGUFReader memmap must be closed before the tempfile is unlinked.
+
+    On Windows an open numpy.memmap blocks os.unlink with PermissionError
+    (the historically flaky test). We assert the unlink happens only after
+    the reader's memmap is released.
+    """
+    blob = make_minimal_gguf("llama")
+    monkeypatch.setattr(header_probe.httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob))
+
+    captured: dict[str, object] = {}
+    real_reader = header_probe.GGUFReader
+
+    def _capturing_reader(path: str, *args: object, **kwargs: object) -> object:
+        reader = real_reader(path, *args, **kwargs)
+        captured["reader"] = reader
+        return reader
+
+    monkeypatch.setattr(header_probe, "GGUFReader", _capturing_reader)
+
+    real_unlink = header_probe.Path.unlink
+
+    def _checking_unlink(self: header_probe.Path, *args: object, **kwargs: object) -> None:
+        reader = captured.get("reader")
+        # Reader must have had its memmap released before unlink runs.
+        assert reader is None or not hasattr(reader, "data")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(header_probe.Path, "unlink", _checking_unlink)
+
+    assert probe_architecture("https://example.test/model.gguf") == "llama"
+
+
 def test_probe_returns_empty_on_unknown_value_type_in_skip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_catalog_header_probe.py
+++ b/tests/test_catalog_header_probe.py
@@ -139,8 +139,9 @@ def test_probe_releases_memmap_before_unlink(monkeypatch: pytest.MonkeyPatch) ->
 
     def _checking_unlink(self: header_probe.Path, *args: object, **kwargs: object) -> None:
         reader = captured.get("reader")
-        # Reader must have had its memmap released before unlink runs.
-        assert reader is None or not hasattr(reader, "data")
+        # The memmap must be closed before unlink runs (Windows file-lock fix).
+        mmap_obj = getattr(getattr(reader, "data", None), "_mmap", None)
+        assert mmap_obj is None or mmap_obj.closed
         return real_unlink(self, *args, **kwargs)
 
     monkeypatch.setattr(header_probe.Path, "unlink", _checking_unlink)

--- a/tests/test_catalog_header_probe.py
+++ b/tests/test_catalog_header_probe.py
@@ -114,11 +114,10 @@ def test_probe_handles_array_value_in_skip(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_probe_releases_memmap_before_unlink(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The GGUFReader memmap must be closed before the tempfile is unlinked.
+    """The GGUFReader memmap is closed before the tempfile is unlinked.
 
-    On Windows an open numpy.memmap blocks os.unlink with PermissionError
-    (the historically flaky test). We assert the unlink happens only after
-    the reader's memmap is released.
+    An open numpy.memmap blocks os.unlink with PermissionError on Windows, so
+    this asserts the unlink runs only after the reader's memmap is released.
     """
     blob = make_minimal_gguf("llama")
     monkeypatch.setattr(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3846,3 +3846,40 @@ class TestDownloadSelfCheckModel:
 
         assert urlopen.call_count == 2
         assert path.read_bytes() == b"ok"
+
+
+class TestCrawlSafetyCapNotice:
+    """The CLI tells the user how to crawl more when the safety cap is hit."""
+
+    def test_prints_notice_when_cap_hit(self, monkeypatch, capsys) -> None:
+        from pathlib import Path
+
+        from lilbee.cli.commands.ingest_sync import _crawl_urls_blocking
+        from lilbee.runtime.progress import CrawlDoneEvent, EventType
+
+        async def fake_crawl_and_save(url, *, on_progress, **kwargs):
+            on_progress(
+                EventType.CRAWL_DONE,
+                CrawlDoneEvent(
+                    pages_crawled=5, files_written=5, stopped_at_safety_cap=True, safety_cap=5
+                ),
+            )
+            return [Path("p0.md")]
+
+        monkeypatch.setattr("lilbee.crawler.crawl_and_save", fake_crawl_and_save)
+        _crawl_urls_blocking(["https://example.com"], crawl=True, depth=None, max_pages=None)
+        assert "safety limit" in capsys.readouterr().err
+
+    def test_no_notice_when_cap_not_hit(self, monkeypatch, capsys) -> None:
+        from pathlib import Path
+
+        from lilbee.cli.commands.ingest_sync import _crawl_urls_blocking
+        from lilbee.runtime.progress import CrawlDoneEvent, EventType
+
+        async def fake_crawl_and_save(url, *, on_progress, **kwargs):
+            on_progress(EventType.CRAWL_DONE, CrawlDoneEvent(pages_crawled=2, files_written=2))
+            return [Path("p0.md")]
+
+        monkeypatch.setattr("lilbee.crawler.crawl_and_save", fake_crawl_and_save)
+        _crawl_urls_blocking(["https://example.com"], crawl=True, depth=None, max_pages=None)
+        assert "safety limit" not in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3848,33 +3848,37 @@ class TestDownloadSelfCheckModel:
         assert path.read_bytes() == b"ok"
 
 
-class TestCrawlSafetyCapNotice:
-    """The CLI tells the user how to crawl more when the safety cap is hit."""
+class TestCrawlDefaultCapNotice:
+    """A bare --crawl that fills the protective default tells the user how to go unlimited."""
 
-    def test_prints_notice_when_cap_hit(self, monkeypatch, capsys) -> None:
+    def test_prints_notice_when_default_filled(self, monkeypatch, capsys) -> None:
         from pathlib import Path
 
         from lilbee.cli.commands.ingest_sync import _crawl_urls_blocking
+        from lilbee.core.config import cfg
         from lilbee.runtime.progress import CrawlDoneEvent, EventType
 
+        cfg.crawl_max_pages = None
+        cfg.crawl_safety_max_pages = 5
+
         async def fake_crawl_and_save(url, *, on_progress, **kwargs):
-            on_progress(
-                EventType.CRAWL_DONE,
-                CrawlDoneEvent(
-                    pages_crawled=5, files_written=5, stopped_at_safety_cap=True, safety_cap=5
-                ),
-            )
+            on_progress(EventType.CRAWL_DONE, CrawlDoneEvent(pages_crawled=5, files_written=5))
             return [Path("p0.md")]
 
         monkeypatch.setattr("lilbee.crawler.crawl_and_save", fake_crawl_and_save)
         _crawl_urls_blocking(["https://example.com"], crawl=True, depth=None, max_pages=None)
-        assert "safety limit" in capsys.readouterr().err
+        out = capsys.readouterr().err
+        assert "--max-pages 0" in out and "5-page" in out
 
-    def test_no_notice_when_cap_not_hit(self, monkeypatch, capsys) -> None:
+    def test_no_notice_when_under_default(self, monkeypatch, capsys) -> None:
         from pathlib import Path
 
         from lilbee.cli.commands.ingest_sync import _crawl_urls_blocking
+        from lilbee.core.config import cfg
         from lilbee.runtime.progress import CrawlDoneEvent, EventType
+
+        cfg.crawl_max_pages = None
+        cfg.crawl_safety_max_pages = 5
 
         async def fake_crawl_and_save(url, *, on_progress, **kwargs):
             on_progress(EventType.CRAWL_DONE, CrawlDoneEvent(pages_crawled=2, files_written=2))
@@ -3882,4 +3886,21 @@ class TestCrawlSafetyCapNotice:
 
         monkeypatch.setattr("lilbee.crawler.crawl_and_save", fake_crawl_and_save)
         _crawl_urls_blocking(["https://example.com"], crawl=True, depth=None, max_pages=None)
-        assert "safety limit" not in capsys.readouterr().err
+        assert "--max-pages 0" not in capsys.readouterr().err
+
+    def test_no_notice_when_explicit_max_pages(self, monkeypatch, capsys) -> None:
+        from pathlib import Path
+
+        from lilbee.cli.commands.ingest_sync import _crawl_urls_blocking
+        from lilbee.core.config import cfg
+        from lilbee.runtime.progress import CrawlDoneEvent, EventType
+
+        cfg.crawl_safety_max_pages = 5
+
+        async def fake_crawl_and_save(url, *, on_progress, **kwargs):
+            on_progress(EventType.CRAWL_DONE, CrawlDoneEvent(pages_crawled=9, files_written=9))
+            return [Path("p0.md")]
+
+        monkeypatch.setattr("lilbee.crawler.crawl_and_save", fake_crawl_and_save)
+        _crawl_urls_blocking(["https://example.com"], crawl=True, depth=None, max_pages=9)
+        assert "--max-pages 0" not in capsys.readouterr().err

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,6 +1,7 @@
 """Tests for the web crawling module."""
 
 import asyncio
+import math
 import sys
 import types
 from pathlib import Path
@@ -1197,10 +1198,20 @@ class TestCrawlRecursive:
             await crawl_recursive("https://example.com", max_depth=1, max_pages=None)
         assert bfs.call_args.kwargs["max_pages"] == 10
 
-    async def test_zero_max_pages_raises(self):
-        """max_pages=0 is invalid (callers should pass None for unbounded)."""
-        with pytest.raises(ValueError, match="positive"):
+    async def test_zero_max_pages_is_unlimited(self):
+        """max_pages=0 (CRAWL_PAGES_UNLIMITED) is an explicit no-limit, even past cfg."""
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=[])
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+
+        cfg.crawl_max_pages = 10
+        modules = self._setup_crawl4ai(mock_instance)
+        bfs = modules["crawl4ai.deep_crawling"].BFSDeepCrawlStrategy
+        with patch.dict("sys.modules", modules):
             await crawl_recursive("https://example.com", max_depth=1, max_pages=0)
+        # Unbounded reaches the BFS strategy as inf, the same convention as depth.
+        assert bfs.call_args.kwargs["max_pages"] == math.inf
 
     async def test_quiet_passes_verbose_false(self):
         """quiet=True passes verbose=False to AsyncWebCrawler."""

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1149,8 +1149,8 @@ class TestCrawlRecursive:
         assert len(results) == 1
         assert not results[0].success
 
-    async def test_defaults_to_unbounded(self):
-        """With no max_depth / max_pages and no cfg ceiling, strategy gets math.inf."""
+    async def test_defaults_to_unbounded_depth_but_capped_pages(self):
+        """No max_depth / max_pages: depth is math.inf, pages clamps to the safety ceiling."""
         import math
 
         mock_instance = AsyncMock()
@@ -1160,13 +1160,14 @@ class TestCrawlRecursive:
 
         cfg.crawl_max_depth = None
         cfg.crawl_max_pages = None
+        cfg.crawl_safety_max_pages = 5_000
         modules = self._setup_crawl4ai(mock_instance)
         bfs = modules["crawl4ai.deep_crawling"].BFSDeepCrawlStrategy
         with patch.dict("sys.modules", modules):
             await crawl_recursive("https://example.com")
         kwargs = bfs.call_args.kwargs
         assert kwargs["max_depth"] == math.inf
-        assert kwargs["max_pages"] == math.inf
+        assert kwargs["max_pages"] == 5_000
 
     async def test_explicit_cap_overrides_cfg_ceiling(self):
         """An explicit int wins even when cfg sets a lower ceiling."""
@@ -1385,6 +1386,14 @@ class TestHostScopeFilter:
 class TestSitemapCounting:
     """best-effort sitemap lookup bounds the crawl progress total."""
 
+    @pytest.fixture(autouse=True)
+    def _public_dns(self, monkeypatch):
+        """The fetch re-validates the resolved sitemap URL; resolve to a public IP."""
+        monkeypatch.setattr(
+            "lilbee.crawler.url_filter.socket.getaddrinfo",
+            lambda *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))],
+        )
+
     def test_returns_unknown_on_http_error(self, monkeypatch):
         import httpx
 
@@ -1422,7 +1431,7 @@ class TestSitemapCounting:
             "<url><loc>https://sub.example.com/d</loc></url>"
             "</urlset>"
         )
-        fake = MagicMock(status_code=200, text=body)
+        fake = MagicMock(status_code=200, text=body, url="https://example.com/sitemap.xml")
         monkeypatch.setattr("httpx.get", lambda *a, **kw: fake)
         count = _count_sitemap_urls("https://example.com/start", include_subdomains=False)
         assert count == 2
@@ -1437,7 +1446,7 @@ class TestSitemapCounting:
             "<url><loc>https://other.com/c</loc></url>"
             "</urlset>"
         )
-        fake = MagicMock(status_code=200, text=body)
+        fake = MagicMock(status_code=200, text=body, url="https://example.com/sitemap.xml")
         monkeypatch.setattr("httpx.get", lambda *a, **kw: fake)
         count = _count_sitemap_urls("https://example.com/start", include_subdomains=True)
         assert count == 2
@@ -1463,7 +1472,7 @@ class TestSitemapCounting:
             "<url><loc>https://example.com/a</loc></url>"
             "</urlset>"
         )
-        fake = MagicMock(status_code=200, text=body)
+        fake = MagicMock(status_code=200, text=body, url="https://example.com/sitemap.xml")
         monkeypatch.setattr("httpx.get", lambda *a, **kw: fake)
         count = _count_sitemap_urls("https://example.com/start", include_subdomains=False)
         assert count == 1
@@ -1475,7 +1484,11 @@ class TestSitemapCounting:
 
         monkeypatch.setattr(sitemap_mod, "_SITEMAP_MAX_URLS", 3)
         entries = "".join(f"<url><loc>https://example.com/{i}</loc></url>" for i in range(10))
-        fake = MagicMock(status_code=200, text=f"<urlset>{entries}</urlset>")
+        fake = MagicMock(
+            status_code=200,
+            text=f"<urlset>{entries}</urlset>",
+            url="https://example.com/sitemap.xml",
+        )
         monkeypatch.setattr("httpx.get", lambda *a, **kw: fake)
         count = _count_sitemap_urls("https://example.com/start", include_subdomains=False)
         assert count == 3

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1311,6 +1311,14 @@ def _stub_crawl4ai_filters(monkeypatch):
 class TestHostScopeFilter:
     """whole-site crawl must scope to the exact host by default."""
 
+    @pytest.fixture(autouse=True)
+    def _public_dns(self, monkeypatch):
+        """The filter re-validates each link's IP; resolve to a public IP by default."""
+        monkeypatch.setattr(
+            "lilbee.crawler.url_filter.socket.getaddrinfo",
+            lambda *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))],
+        )
+
     def test_exact_host_rejects_other_subdomains(self, _stub_crawl4ai_filters):
         from lilbee.crawler.crawl4ai_fetcher import _host_scope_filter
 
@@ -1330,6 +1338,48 @@ class TestHostScopeFilter:
         from lilbee.crawler.crawl4ai_fetcher import _host_scope_filter
 
         assert _host_scope_filter("not-a-url", include_subdomains=False) is None
+
+    def test_exact_host_rejects_link_resolving_to_private_ip(
+        self, _stub_crawl4ai_filters, monkeypatch
+    ):
+        """A discovered in-host link that resolves to a private IP is dropped (DNS-rebind)."""
+        from lilbee.crawler.crawl4ai_fetcher import _host_scope_filter
+
+        def _resolve(host, *a, **kw):
+            if host == "internal.example.com":
+                return [(2, 1, 6, "", ("10.0.0.9", 0))]
+            return [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+        monkeypatch.setattr("lilbee.crawler.url_filter.socket.getaddrinfo", _resolve)
+        f = _host_scope_filter("https://internal.example.com/a", include_subdomains=False)
+        # Same host, but it resolves to a private IP: must be rejected.
+        assert f.apply("https://internal.example.com/b") is False
+
+    def test_include_subdomains_rejects_link_resolving_to_private_ip(
+        self, _stub_crawl4ai_filters, monkeypatch
+    ):
+        """Subdomain-scope crawls also re-validate each discovered link's IP."""
+        from lilbee.crawler.crawl4ai_fetcher import _host_scope_filter
+
+        def _resolve(host, *a, **kw):
+            if host == "rebind.example.com":
+                return [(2, 1, 6, "", ("127.0.0.1", 0))]
+            return [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+        monkeypatch.setattr("lilbee.crawler.url_filter.socket.getaddrinfo", _resolve)
+        f = _host_scope_filter("https://example.com/a", include_subdomains=True)
+        assert f.apply("https://rebind.example.com/x") is False
+
+    def test_public_in_host_link_still_allowed(self, _stub_crawl4ai_filters, monkeypatch):
+        """A normal public in-host link passes both scope and IP checks."""
+        from lilbee.crawler.crawl4ai_fetcher import _host_scope_filter
+
+        monkeypatch.setattr(
+            "lilbee.crawler.url_filter.socket.getaddrinfo",
+            lambda *a, **kw: [(2, 1, 6, "", ("93.184.216.34", 0))],
+        )
+        f = _host_scope_filter("https://example.com/a", include_subdomains=False)
+        assert f.apply("https://example.com/b") is True
 
 
 class TestSitemapCounting:

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -417,9 +417,7 @@ class TestDownloadModelProgressChain:
         monkeypatch.setattr(cfg, "models_dir", tmp_path)
         monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
         # HF says the file is 1000 bytes; the cached copy is truncated to 10.
-        monkeypatch.setattr(
-            download_mod, "fetch_expected_file_size", lambda repo, name: 1000
-        )
+        monkeypatch.setattr(download_mod, "fetch_expected_file_size", lambda repo, name: 1000)
 
         entry = _test_entry()
         truncated = tmp_path / entry.gguf_filename

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -684,41 +684,32 @@ class TestProgressTracker:
 
 
 class TestFetchExpectedFileSize:
-    """fetch_expected_file_size parses the HF tree API and degrades to unknown."""
+    """fetch_expected_file_size reads hf_hub file metadata and degrades to unknown."""
 
-    def _patch_tree(
-        self, monkeypatch: pytest.MonkeyPatch, *, payload: Any = None, raises: bool = False
+    def _patch_meta(
+        self, monkeypatch: pytest.MonkeyPatch, *, size: int | None = None, raises: bool = False
     ) -> None:
-        import lilbee.catalog.download as dl
-
-        class _Resp:
-            def raise_for_status(self) -> None:
-                pass
-
-            def json(self) -> Any:
-                return payload
-
-        def _get(*_a: Any, **_kw: Any) -> Any:
+        def _size(*_a: Any, **_kw: Any) -> int | None:
             if raises:
                 raise RuntimeError("offline")
-            return _Resp()
+            return size
 
-        monkeypatch.setattr(dl.httpx, "get", _get)
+        monkeypatch.setattr("lilbee.catalog.download._hf_file_size", _size)
 
-    def test_returns_lfs_size_for_listed_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_reported_size(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from lilbee.catalog.download import fetch_expected_file_size
 
-        self._patch_tree(monkeypatch, payload=[{"path": "m.gguf", "lfs": {"size": 4096}}])
+        self._patch_meta(monkeypatch, size=4096)
         assert fetch_expected_file_size("org/repo", "m.gguf") == 4096
 
-    def test_unknown_when_file_not_listed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unknown_when_size_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from lilbee.catalog.download import _SIZE_UNKNOWN, fetch_expected_file_size
 
-        self._patch_tree(monkeypatch, payload=[{"path": "other.gguf"}])
+        self._patch_meta(monkeypatch, size=None)
         assert fetch_expected_file_size("org/repo", "m.gguf") == _SIZE_UNKNOWN
 
-    def test_unknown_when_api_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unknown_when_metadata_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from lilbee.catalog.download import _SIZE_UNKNOWN, fetch_expected_file_size
 
-        self._patch_tree(monkeypatch, raises=True)
+        self._patch_meta(monkeypatch, raises=True)
         assert fetch_expected_file_size("org/repo", "m.gguf") == _SIZE_UNKNOWN

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -402,6 +402,69 @@ class TestDownloadModelProgressChain:
         assert len(calls) == 1
         assert calls[0][0] == calls[0][1]  # downloaded == total
 
+    def test_truncated_cached_file_is_re_downloaded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cached file shorter than the HF-reported size is re-fetched, not accepted.
+
+        The fast-path must verify the on-disk size against HuggingFace
+        metadata; a truncated/corrupt cached file must not be reported as
+        100% complete.
+        """
+        from lilbee import catalog
+        from lilbee.catalog import download as download_mod
+
+        monkeypatch.setattr(cfg, "models_dir", tmp_path)
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
+        # HF says the file is 1000 bytes; the cached copy is truncated to 10.
+        monkeypatch.setattr(
+            download_mod, "fetch_expected_file_size", lambda repo, name: 1000
+        )
+
+        entry = _test_entry()
+        truncated = tmp_path / entry.gguf_filename
+        truncated.write_bytes(b"x" * 10)
+
+        downloaded: dict[str, bool] = {"called": False}
+
+        def fake_download(**kwargs: Any) -> str:
+            downloaded["called"] = True
+            content = b"x" * 1000
+            digest = __import__("hashlib").sha256(content).hexdigest()
+            repo_id = kwargs.get("repo_id", "")
+            model_dir = Path(kwargs["cache_dir"]) / f"models--{repo_id.replace('/', '--')}"
+            blobs = model_dir / "blobs"
+            blobs.mkdir(parents=True, exist_ok=True)
+            dest = blobs / digest
+            dest.write_bytes(content)
+            return str(dest)
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_download)
+        download_model(entry, on_progress=lambda d, t: None)
+        assert downloaded["called"]  # truncated cache was rejected and re-fetched
+
+    def test_intact_cached_file_is_not_re_downloaded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cached file whose size matches HF metadata is accepted without re-fetching."""
+        from lilbee import catalog
+        from lilbee.catalog import download as download_mod
+
+        monkeypatch.setattr(cfg, "models_dir", tmp_path)
+        monkeypatch.setattr(catalog, "resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(download_mod, "fetch_expected_file_size", lambda repo, name: 1000)
+
+        entry = _test_entry()
+        (tmp_path / entry.gguf_filename).write_bytes(b"x" * 1000)
+
+        def fail_download(**kwargs: Any) -> str:
+            raise AssertionError("intact cache must not trigger a re-download")
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fail_download)
+        calls: list[tuple[int, int]] = []
+        download_model(entry, on_progress=lambda d, t: calls.append((d, t)))
+        assert calls and calls[-1][0] == calls[-1][1]
+
     def test_hf_cache_hit_detected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """When hf_hub_download returns instantly (HF cache hit), progress still reports."""
         import hashlib

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -681,3 +681,44 @@ class TestProgressTracker:
         bar.update(50)
         bar.close()
         assert tracker.was_used is True
+
+
+class TestFetchExpectedFileSize:
+    """fetch_expected_file_size parses the HF tree API and degrades to unknown."""
+
+    def _patch_tree(
+        self, monkeypatch: pytest.MonkeyPatch, *, payload: Any = None, raises: bool = False
+    ) -> None:
+        import lilbee.catalog.download as dl
+
+        class _Resp:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> Any:
+                return payload
+
+        def _get(*_a: Any, **_kw: Any) -> Any:
+            if raises:
+                raise RuntimeError("offline")
+            return _Resp()
+
+        monkeypatch.setattr(dl.httpx, "get", _get)
+
+    def test_returns_lfs_size_for_listed_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.catalog.download import fetch_expected_file_size
+
+        self._patch_tree(monkeypatch, payload=[{"path": "m.gguf", "lfs": {"size": 4096}}])
+        assert fetch_expected_file_size("org/repo", "m.gguf") == 4096
+
+    def test_unknown_when_file_not_listed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.catalog.download import _SIZE_UNKNOWN, fetch_expected_file_size
+
+        self._patch_tree(monkeypatch, payload=[{"path": "other.gguf"}])
+        assert fetch_expected_file_size("org/repo", "m.gguf") == _SIZE_UNKNOWN
+
+    def test_unknown_when_api_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.catalog.download import _SIZE_UNKNOWN, fetch_expected_file_size
+
+        self._patch_tree(monkeypatch, raises=True)
+        assert fetch_expected_file_size("org/repo", "m.gguf") == _SIZE_UNKNOWN

--- a/tests/test_embed_truncation_surfacing.py
+++ b/tests/test_embed_truncation_surfacing.py
@@ -1,0 +1,64 @@
+"""Truncation is observable, not silent, and the char limit never clips a full-budget chunk.
+
+Token-dense input (minified JSON, dense code, CJK) underestimates under the
+4-chars/token heuristic, so a finished chunk can land over the embedder's char
+limit. These tests pin two correctness invariants:
+
+1. The embedder's char limit is never below the chunker's max chunk size, so a
+   full-budget chunk is embedded whole rather than silently losing its tail.
+2. When the embedder does truncate, it reports a count that the ingest pipeline
+   surfaces in ``SyncResult`` instead of swallowing it in a log line.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lilbee.core.config import cfg
+from lilbee.data.chunk import CHARS_PER_TOKEN
+from lilbee.data.ingest.types import SyncResult
+from lilbee.retrieval.embedder import Embedder
+
+
+@pytest.fixture()
+def mock_provider():
+    provider = MagicMock()
+    provider.embed.side_effect = lambda texts: [[0.0] * cfg.embedding_dim for _ in texts]
+    return provider
+
+
+@pytest.fixture()
+def embedder(mock_provider):
+    return Embedder(cfg, mock_provider)
+
+
+class TestCharBudgetCoversChunkBudget:
+    """A finished full-budget chunk must not be clipped at the embedder char limit."""
+
+    def test_full_budget_chunk_not_truncated(self, embedder):
+        chunk_budget = cfg.chunk_size * CHARS_PER_TOKEN
+        text = "a" * chunk_budget
+        assert embedder.truncate(text) == text
+
+    def test_effective_limit_at_least_chunk_budget(self, embedder):
+        assert embedder.embed_char_budget >= cfg.chunk_size * CHARS_PER_TOKEN
+
+
+class TestTruncationIsSurfaced:
+    """Over-budget input is counted and the count reaches the caller."""
+
+    def test_embed_batch_reports_truncated_count(self, embedder):
+        over = "x" * (embedder.embed_char_budget + 500)
+        embedder.embed_batch(["short", over, over])
+        assert embedder.last_batch_truncated == 2
+
+    def test_no_truncation_reports_zero(self, embedder):
+        embedder.embed_batch(["short", "also short"])
+        assert embedder.last_batch_truncated == 0
+
+
+class TestSyncResultCarriesTruncation:
+    def test_sync_result_has_truncated_field(self):
+        result = SyncResult(truncated=3)
+        assert result.truncated == 3
+        assert "Truncated: 3" in str(result)

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -25,12 +25,12 @@ class TestTruncate:
         assert embedder.truncate(text) == text
 
     def test_long_text_truncated(self, embedder):
-        text = "x" * (cfg.max_embed_chars + 500)
+        text = "x" * (embedder.embed_char_budget + 500)
         result = embedder.truncate(text)
-        assert len(result) == cfg.max_embed_chars
+        assert len(result) == embedder.embed_char_budget
 
     def test_exact_limit_unchanged(self, embedder):
-        text = "a" * cfg.max_embed_chars
+        text = "a" * embedder.embed_char_budget
         assert embedder.truncate(text) == text
 
 
@@ -47,10 +47,10 @@ class TestEmbed:
 
     def test_truncates_long_input(self, embedder, mock_provider):
         mock_provider.embed.return_value = [[0.0] * 768]
-        long_text = "a" * (cfg.max_embed_chars + 1000)
+        long_text = "a" * (embedder.embed_char_budget + 1000)
         embedder.embed(long_text)
         call_args = mock_provider.embed.call_args[0][0]
-        assert len(call_args[0]) == cfg.max_embed_chars
+        assert len(call_args[0]) == embedder.embed_char_budget
 
 
 class TestEmbedBatch:
@@ -82,12 +82,12 @@ class TestEmbedBatch:
 
     def test_truncates_long_texts_in_batch(self, embedder, mock_provider):
         mock_provider.embed.return_value = [[0.0] * 768, [0.0] * 768]
-        texts = ["short", "x" * (cfg.max_embed_chars + 500)]
+        texts = ["short", "x" * (embedder.embed_char_budget + 500)]
         embedder.embed_batch(texts)
         mock_provider.embed.assert_called_once()
         call_input = mock_provider.embed.call_args[0][0]
         assert call_input[0] == "short"
-        assert len(call_input[1]) == cfg.max_embed_chars
+        assert len(call_input[1]) == embedder.embed_char_budget
 
 
 class TestValidateVector:

--- a/tests/test_embedder_consistency.py
+++ b/tests/test_embedder_consistency.py
@@ -51,14 +51,14 @@ class TestQueryIndexConsistency:
         assert provider.calls == [[text], [text]]
 
     def test_both_paths_apply_identical_truncation(self, embedder, provider):
-        """No path embeds beyond max_embed_chars; truncation is symmetric."""
-        long_text = "a" * (cfg.max_embed_chars + 2000)
+        """No path embeds beyond the shared char budget; truncation is symmetric."""
+        long_text = "a" * (embedder.embed_char_budget + 2000)
         embedder.embed(long_text)
         embedder.embed_batch([long_text])
         query_arg = provider.calls[0][0]
         ingest_arg = provider.calls[1][0]
         assert query_arg == ingest_arg
-        assert len(query_arg) == cfg.max_embed_chars
+        assert len(query_arg) == embedder.embed_char_budget
 
     def test_no_extra_normalization_in_either_path(self, embedder, provider):
         """Neither path post-processes the provider vector (no silent renorm)."""

--- a/tests/test_embedder_consistency.py
+++ b/tests/test_embedder_consistency.py
@@ -1,0 +1,95 @@
+"""Empirical gate: query and ingest embedding paths must stay identical.
+
+A query/index embedder mismatch (different model, different normalization,
+different truncation) silently destroys relevance. These tests pin the
+structural guarantee that both paths route through one Embedder instance
+with the same provider call and the same truncation.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lilbee.core.config import cfg
+from lilbee.retrieval.embedder import Embedder
+
+
+class _RecordingProvider:
+    """Records every embed() input and echoes a deterministic vector per text."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        return [[float(len(t))] * cfg.embedding_dim for t in texts]
+
+
+@pytest.fixture()
+def provider() -> _RecordingProvider:
+    return _RecordingProvider()
+
+
+@pytest.fixture()
+def embedder(provider: _RecordingProvider) -> Embedder:
+    return Embedder(cfg, provider)
+
+
+class TestQueryIndexConsistency:
+    def test_same_text_same_vector_both_paths(self, embedder, provider):
+        """Query path (embed) and ingest path (embed_batch) yield one vector."""
+        text = "the quick brown fox jumps over the lazy dog"
+        query_vec = embedder.embed(text)
+        ingest_vec = embedder.embed_batch([text])[0]
+        assert query_vec == ingest_vec
+
+    def test_both_paths_call_same_provider_with_same_arg(self, embedder, provider):
+        """Both paths hand the identical (truncated) text to the same provider."""
+        text = "shared text"
+        embedder.embed(text)
+        embedder.embed_batch([text])
+        assert provider.calls == [[text], [text]]
+
+    def test_both_paths_apply_identical_truncation(self, embedder, provider):
+        """No path embeds beyond max_embed_chars; truncation is symmetric."""
+        long_text = "a" * (cfg.max_embed_chars + 2000)
+        embedder.embed(long_text)
+        embedder.embed_batch([long_text])
+        query_arg = provider.calls[0][0]
+        ingest_arg = provider.calls[1][0]
+        assert query_arg == ingest_arg
+        assert len(query_arg) == cfg.max_embed_chars
+
+    def test_no_extra_normalization_in_either_path(self, embedder, provider):
+        """Neither path post-processes the provider vector (no silent renorm)."""
+        text = "normalize me"
+        raw = provider.embed([text])[0]
+        provider.calls.clear()
+        assert embedder.embed(text) == raw
+        assert embedder.embed_batch([text])[0] == raw
+
+
+class TestSharedEmbedderInstance:
+    """The query searcher and the ingest path must use ONE embedder, so a
+    config change can never leave the two paths on different models.
+    """
+
+    def test_services_wires_one_embedder_into_searcher(self):
+        """get_services().embedder is the exact instance the Searcher holds."""
+        mock_provider = MagicMock()
+        embedder = Embedder(cfg, mock_provider)
+        from lilbee.data.store import Store
+        from lilbee.retrieval.concepts import ConceptGraph
+        from lilbee.retrieval.query import Searcher
+        from lilbee.retrieval.reranker import Reranker
+
+        store = Store(cfg)
+        try:
+            searcher = Searcher(
+                cfg, mock_provider, store, embedder, Reranker(cfg), ConceptGraph(cfg, store)
+            )
+            # Ingest reads get_services().embedder; query reads the searcher's
+            # embedder. Constructed from the same instance, they cannot diverge.
+            assert searcher._embedder is embedder
+        finally:
+            store.close()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -66,6 +66,8 @@ def mock_svc():
     embedder = MagicMock()
     embedder.embed.side_effect = lambda text, **kw: [0.1] * 768
     embedder.embed_batch.side_effect = lambda texts, **kw: [[0.1] * 768 for _ in texts]
+    # Real int so sync()'s truncated_total delta is 0, not a coerced MagicMock.
+    embedder.truncated_total = 0
     searcher = MagicMock()
     services = make_mock_services(store=store, embedder=embedder, searcher=searcher)
     svc_mod.set_services(services)

--- a/tests/test_llama_cpp_batching.py
+++ b/tests/test_llama_cpp_batching.py
@@ -150,6 +150,30 @@ def test_compute_rerank_scores_raises_on_response_size_mismatch() -> None:
         compute_rerank_scores(_BadLlama(), "q", ["a", "b"])
 
 
+def test_embed_batch_raises_on_response_size_mismatch() -> None:
+    """A short embed response (fewer vectors than inputs) fails loudly, not silently.
+
+    llama-cpp-python returns one embedding per input; a count mismatch means the
+    SDK response format drifted and silently dropped vectors. Without the guard
+    the caller would map the wrong vector to the wrong chunk.
+    """
+
+    class _BadLlama:
+        n_batch = 8192
+
+        def tokenize(
+            self, text: bytes, *, add_bos: bool = True, special: bool = False
+        ) -> list[int]:
+            return [0] * 4
+
+        def create_embedding(self, *, input: list[str]) -> dict[str, Any]:
+            # Returns one vector for two inputs.
+            return {"data": [{"embedding": [1.0, 2.0]}]}
+
+    with pytest.raises(ProviderError, match="returned 1 vectors for 2 inputs"):
+        embed_batch(_BadLlama(), ["a", "b"])
+
+
 def test_compute_rerank_scores_raises_on_unexpected_score_shape() -> None:
     class _BadLlama:
         n_batch = 8192

--- a/tests/test_model_ref.py
+++ b/tests/test_model_ref.py
@@ -211,3 +211,85 @@ class TestTranslateOptions:
         ref = parse_model_ref("openai/gpt-4o")
         result = translate_options({}, ref)
         assert result == {}
+
+
+# Options a chat caller can supply; both backends must agree on num_predict and
+# never emit a key the receiving SDK errors on.
+_SHARED_OPTIONS = {
+    "temperature": 0.7,
+    "top_p": 0.9,
+    "top_k": 40,
+    "seed": 123,
+    "num_predict": 1024,
+    "repeat_penalty": 1.1,
+    "num_ctx": 4096,
+}
+
+# llama_cpp.Llama.create_chat_completion accepts these and nothing else from the
+# option set; the in-process worker splats kwargs straight into it, so any extra
+# key (num_ctx, num_predict) would raise TypeError.
+_LLAMA_CPP_ACCEPTED = frozenset(
+    {"temperature", "top_p", "top_k", "seed", "max_tokens", "repeat_penalty"}
+)
+
+
+class TestChatOptionTranslationParity:
+    """Differential gate: same options through in-process vs API translation.
+
+    Pins the intentional divergence so the two paths can't silently drift:
+    the local llama.cpp path keeps top_k/repeat_penalty and renames
+    num_predict->max_tokens; the API path additionally strips top_k/num_ctx.
+    Both rename num_predict consistently and neither leaks a key its backend
+    would reject.
+    """
+
+    def _in_process(self) -> dict[str, object]:
+        from lilbee.providers.llama_cpp.provider import LlamaCppProvider
+
+        return LlamaCppProvider._chat_kwargs_from_options(dict(_SHARED_OPTIONS))
+
+    def _api(self) -> dict[str, object]:
+        ref = parse_model_ref("openai/gpt-4o")
+        return translate_options(dict(_SHARED_OPTIONS), ref)
+
+    def test_num_predict_renamed_consistently(self) -> None:
+        """Both backends speak max_tokens, not num_predict."""
+        for translated in (self._in_process(), self._api()):
+            assert translated["max_tokens"] == 1024
+            assert "num_predict" not in translated
+
+    def test_in_process_keeps_local_only_params(self) -> None:
+        """Local llama.cpp honors top_k and repeat_penalty, so they survive."""
+        translated = self._in_process()
+        assert translated["top_k"] == 40
+        assert translated["repeat_penalty"] == 1.1
+
+    def test_api_drops_top_k(self) -> None:
+        """Hosted providers ignore top_k, so the API path strips it."""
+        assert "top_k" not in self._api()
+
+    def test_neither_path_leaks_num_ctx(self) -> None:
+        """num_ctx is a model-load param; it must never reach a per-call request."""
+        assert "num_ctx" not in self._in_process()
+        assert "num_ctx" not in self._api()
+
+    def test_in_process_emits_no_key_create_chat_completion_rejects(self) -> None:
+        """Every emitted key is a real create_chat_completion kwarg."""
+        translated = self._in_process()
+        assert set(translated) <= _LLAMA_CPP_ACCEPTED
+
+    def test_api_translation_does_not_error_in_litellm(self) -> None:
+        """litellm accepts the API-translated kwargs without raising.
+
+        Confirms the audit finding empirically: litellm 1.x forwards
+        repeat_penalty (into extra_body for OpenAI-compatible providers)
+        rather than rejecting it, so keeping it is not a correctness bug.
+        """
+        litellm = pytest.importorskip("litellm")
+        translated = self._api()
+        params = litellm.utils.get_optional_params(
+            model="gpt-4o", custom_llm_provider="openai", **translated
+        )
+        assert params["max_tokens"] == 1024
+        # repeat_penalty is forwarded, not dropped or errored on.
+        assert params.get("extra_body", {}).get("repeat_penalty") == 1.1

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3501,6 +3501,39 @@ class TestAdaptGgufTemplate:
         template = "plain {{ content.image_url.url }} template"
         assert adapt_gguf_template_for_mtmd(template) == template
 
+    def test_text_only_template_unaffected(self) -> None:
+        from lilbee.providers.mtmd_backend import adapt_gguf_template_for_mtmd
+
+        template = "<|im_start|>user\n{{ content.text }}<|im_end|>"
+        assert adapt_gguf_template_for_mtmd(template) == template
+
+    def test_unknown_image_token_raises(self) -> None:
+        from lilbee.providers.mtmd_backend import adapt_gguf_template_for_mtmd
+
+        template = "<|im_start|>user\n<vision_pad>{{ content.text }}<|im_end|>"
+        with pytest.raises(ValueError, match="<vision_pad>") as exc:
+            adapt_gguf_template_for_mtmd(template)
+        assert "<|image_pad|>" in str(exc.value)
+
+    def test_unknown_media_token_raises(self) -> None:
+        from lilbee.providers.mtmd_backend import adapt_gguf_template_for_mtmd
+
+        with pytest.raises(ValueError, match="<media>"):
+            adapt_gguf_template_for_mtmd("A <media> B")
+
+    def test_build_handler_raises_on_unknown_token(self, tmp_path: Path) -> None:
+        from lilbee.providers.mtmd_backend import build_vision_chat_handler
+
+        template = "<|im_start|>user\n<vision_pad>{{ content.text }}<|im_end|>"
+        with (
+            mock.patch(
+                "lilbee.providers.mtmd_backend.read_chat_template",
+                return_value=template,
+            ),
+            pytest.raises(ValueError, match="<vision_pad>"),
+        ):
+            build_vision_chat_handler(tmp_path / "model.gguf", tmp_path / "mmproj.gguf")
+
 
 # ---------------------------------------------------------------------------
 # LLMOptions / filter_options

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -388,6 +388,125 @@ class TestLlamaCppProvider:
             load_llama(models_dir / "test-model.gguf", mode="rerank")
             assert fake_llama.call_args[1]["pooling_type"] == 4
 
+    def testload_llama_embedding_asserts_n_seq_max_applied(self, models_dir: Path) -> None:
+        """A successful embed load reads ``n_seq_max`` back and accepts the expected value.
+
+        The ``_llama_n_seq_max`` shim mutates ``LlamaContext.__init__`` to set
+        ``context_params.n_seq_max``; this load-time readback proves the shim
+        took effect instead of silently leaving the C default (1), which would
+        make batched 2+ embed return ``llama_decode -1`` at inference time.
+        """
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp.batching import EMBED_N_SEQ_MAX
+        from lilbee.providers.llama_cpp.provider import load_llama
+
+        cfg.num_ctx = None
+        llm = mock.MagicMock()
+        llm.context_params.n_seq_max = EMBED_N_SEQ_MAX
+        with (
+            patch("llama_cpp.Llama", return_value=llm),
+            patch(
+                "lilbee.providers.llama_cpp.provider.read_gguf_metadata",
+                return_value={"context_length": "2048"},
+            ),
+        ):
+            assert load_llama(models_dir / "test-model.gguf", mode="embed") is llm
+
+    def testload_llama_embedding_raises_when_n_seq_max_not_applied(self, models_dir: Path) -> None:
+        """If the shim silently fails to apply, load fails loudly instead of at decode."""
+        from unittest.mock import patch
+
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.llama_cpp.provider import load_llama
+
+        cfg.num_ctx = None
+        llm = mock.MagicMock()
+        llm.context_params.n_seq_max = 1  # C default: shim did not take effect.
+        with (
+            patch("llama_cpp.Llama", return_value=llm),
+            patch(
+                "lilbee.providers.llama_cpp.provider.read_gguf_metadata",
+                return_value={"context_length": "2048"},
+            ),
+            pytest.raises(ProviderError, match="n_seq_max"),
+        ):
+            load_llama(models_dir / "test-model.gguf", mode="embed")
+
+    def testload_llama_rerank_raises_on_multi_class_reranker(self, models_dir: Path) -> None:
+        """A multi-class reranker fails loudly: ``embedding[0]`` is not its score.
+
+        llama-cpp-python's RANK pooling path slices ``ptr[:n_embd]`` regardless
+        of ``n_cls_out``, so the response gives no in-band signal. The only
+        reliable check is the model's classifier-output count at load time;
+        lilbee's single-scalar extraction is valid only for ``n_cls_out == 1``.
+        """
+        from unittest.mock import patch
+
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.llama_cpp.provider import load_llama
+
+        fake_llama = mock.MagicMock()
+        fake_module = mock.MagicMock()
+        fake_module.Llama = fake_llama
+        fake_module.LLAMA_POOLING_TYPE_RANK = 4
+        fake_module.llama_cpp.llama_model_n_cls_out.return_value = 3
+
+        class _StubCtx:
+            def __init__(self, *_a, **_kw) -> None:
+                pass
+
+        fake_module.internals.LlamaContext = _StubCtx
+        llm = mock.MagicMock()
+        llm.context_params.n_seq_max = 64
+        fake_llama.return_value = llm
+        with (
+            patch(
+                "lilbee.providers.llama_cpp.provider.import_llama_cpp",
+                return_value=fake_module,
+            ),
+            patch.dict("sys.modules", {"llama_cpp": fake_module}),
+            patch(
+                "lilbee.providers.llama_cpp.provider.read_gguf_metadata",
+                return_value={"context_length": "2048"},
+            ),
+            pytest.raises(ProviderError, match="classifier outputs"),
+        ):
+            load_llama(models_dir / "test-model.gguf", mode="rerank")
+
+    def testload_llama_rerank_accepts_single_class_reranker(self, models_dir: Path) -> None:
+        """A standard single-class reranker (``n_cls_out == 1``) loads cleanly."""
+        from unittest.mock import patch
+
+        from lilbee.providers.llama_cpp.provider import load_llama
+
+        fake_llama = mock.MagicMock()
+        fake_module = mock.MagicMock()
+        fake_module.Llama = fake_llama
+        fake_module.LLAMA_POOLING_TYPE_RANK = 4
+        fake_module.llama_cpp.llama_model_n_cls_out.return_value = 1
+
+        class _StubCtx:
+            def __init__(self, *_a, **_kw) -> None:
+                pass
+
+        fake_module.internals.LlamaContext = _StubCtx
+        llm = mock.MagicMock()
+        llm.context_params.n_seq_max = 64
+        fake_llama.return_value = llm
+        with (
+            patch(
+                "lilbee.providers.llama_cpp.provider.import_llama_cpp",
+                return_value=fake_module,
+            ),
+            patch.dict("sys.modules", {"llama_cpp": fake_module}),
+            patch(
+                "lilbee.providers.llama_cpp.provider.read_gguf_metadata",
+                return_value={"context_length": "2048"},
+            ),
+        ):
+            assert load_llama(models_dir / "test-model.gguf", mode="rerank") is llm
+
     def testload_llama_abort_callback_override_replaces_default(self, models_dir: Path) -> None:
         """abort_callback_override threads a worker-side callback into Llama kwargs."""
         from unittest.mock import patch

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -5174,3 +5174,17 @@ class TestSdkLLMProviderPdfOcr:
         provider = SdkLLMProvider(LitellmSdkBackend())
         with pytest.raises(NotImplementedError, match="LILBEE_VISION_MODEL"):
             provider.pdf_ocr(Path("/scan.pdf"), backend="vision")
+
+
+class TestProviderReadHelpers:
+    """The SDK-shape readers degrade to None when the attribute is unreadable."""
+
+    def test_read_context_n_seq_max_none_without_context_params(self) -> None:
+        from lilbee.providers.llama_cpp.provider import _read_context_n_seq_max
+
+        assert _read_context_n_seq_max(object()) is None
+
+    def test_read_rerank_class_count_none_without_model(self) -> None:
+        from lilbee.providers.llama_cpp.provider import _read_rerank_class_count
+
+        assert _read_rerank_class_count(object()) is None

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -201,6 +201,30 @@ class TestModelRegistryInstall:
         second = registry.install(_REPO, _FILENAME, src, manifest)
         assert first == second
 
+    def test_install_blob_copy_is_atomic(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash mid-copy leaves no partial blob at the final blob path.
+
+        The blob is written to a temp path and atomically renamed, so an
+        interrupted install never exposes a truncated blob under its digest.
+        """
+        from lilbee.modelhub import registry as registry_mod
+
+        registry = ModelRegistry(tmp_path)
+        src = _write_source(tmp_path, content=b"GGUF" + b"\x07" * 256)
+        digest = _sha256_file(src)
+
+        def boom(*_a: object, **_k: object) -> None:
+            raise OSError("disk full mid-copy")
+
+        monkeypatch.setattr(registry_mod.shutil, "copyfileobj", boom)
+        with pytest.raises(OSError, match="disk full mid-copy"):
+            registry.install(_REPO, _FILENAME, src, _make_manifest())
+
+        blob_path = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs" / digest
+        assert not blob_path.exists()  # no partial blob at the final path
+
     def test_install_records_blob_digest(self, tmp_path: Path) -> None:
         registry = ModelRegistry(tmp_path)
         content = b"GGUF" + b"\x00" * 256
@@ -362,6 +386,22 @@ class TestModelRegistryIsInstalled:
         registry = ModelRegistry(tmp_path)
         # resolve() raises on unparseable refs; is_installed swallows that.
         assert not registry.is_installed("qwen3:0.6b")
+
+    def test_is_installed_false_for_truncated_blob(self, tmp_path: Path) -> None:
+        """A blob truncated below its manifest size_bytes is not 'installed'.
+
+        A partial/corrupt blob on disk must not count as usable, otherwise
+        the runtime loads a truncated GGUF and fails far from the cause.
+        """
+        registry = ModelRegistry(tmp_path)
+        content = b"GGUF" + b"\x00" * 512
+        src = tmp_path / "source.gguf"
+        src.write_bytes(content)
+        registry.install(_REPO, _FILENAME, src, _make_manifest(size_bytes=len(content)))
+        blob_dir = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs"
+        blob = next(blob_dir.iterdir())
+        blob.write_bytes(content[: len(content) // 2])  # truncate on disk
+        assert not registry.is_installed(_REF)
 
 
 class TestModelRegistryRemove:
@@ -536,6 +576,17 @@ class TestModelRegistryList:
         blob_dir = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs"
         for blob in blob_dir.iterdir():
             blob.unlink()
+        assert registry.list_installed() == []
+
+    def test_list_skips_truncated_blob(self, tmp_path: Path) -> None:
+        """A blob truncated below its recorded size_bytes is hidden from pickers."""
+        registry = ModelRegistry(tmp_path)
+        content = b"GGUF" + b"\x01" * 512
+        src = tmp_path / "source.gguf"
+        src.write_bytes(content)
+        registry.install(_REPO, _FILENAME, src, _make_manifest(size_bytes=len(content)))
+        blob_dir = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs"
+        next(blob_dir.iterdir()).write_bytes(content[:10])
         assert registry.list_installed() == []
 
     def test_list_skips_manifest_when_cache_dir_missing(self, tmp_path: Path) -> None:

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -166,6 +166,59 @@ class TestRerankerBlendPositions:
         assert reranked[0].chunk == "high rerank"
 
 
+class TestGoldenOrdering:
+    """Empirical gate: controlled scores -> asserted output order.
+
+    Higher rerank score sorts first; all-equal scores preserve input
+    order; both-scores-None falls back to the 0.5 fusion default.
+    """
+
+    def test_higher_rerank_score_sorts_first(self, reranker):
+        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        results = [
+            _chunk("a.md", "least", relevance=0.5),
+            _chunk("b.md", "most", relevance=0.5),
+            _chunk("c.md", "middle", relevance=0.5),
+        ]
+        # Equal fusion isolates the reranker signal: 0.2 < 0.6 < 0.95.
+        with _patch_provider(lambda query, cands: [0.2, 0.95, 0.6]):
+            reranked = reranker.rerank("test", results)
+        assert [c.chunk for c in reranked] == ["most", "middle", "least"]
+
+    def test_all_equal_scores_preserve_input_order(self, reranker):
+        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.expansion_skip_threshold = 0.6  # above chunk relevance: no BM25 pin
+        results = [_chunk(f"{i}.md", f"chunk {i}", relevance=0.5) for i in range(5)]
+        with _patch_provider(lambda query, cands: [0.5] * len(cands)):
+            reranked = reranker.rerank("test", results)
+        # Stable sort on equal blended scores keeps retrieval order intact.
+        assert [c.chunk for c in reranked] == [f"chunk {i}" for i in range(5)]
+
+    def test_both_scores_none_uses_fusion_default(self, reranker):
+        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.expansion_skip_threshold = 0.6  # top relevance is None->0: no pin
+
+        def _bare(source: str, chunk: str) -> SearchChunk:
+            return SearchChunk(
+                source=source,
+                content_type="text",
+                page_start=0,
+                page_end=0,
+                line_start=0,
+                line_end=0,
+                chunk=chunk,
+                chunk_index=0,
+                vector=[0.1],
+            )
+
+        results = [_bare("a.md", "A"), _bare("b.md", "B")]
+        # relevance_score and distance both None -> fusion_score == 0.5
+        # (reranker.py:57). Reranker scores then decide order: B over A.
+        with _patch_provider(lambda query, cands: [0.1, 0.9]):
+            reranked = reranker.rerank("test", results)
+        assert [c.chunk for c in reranked] == ["B", "A"]
+
+
 class TestMixedPoolBias:
     """A mixed wiki+raw pool shouldn't drop one side entirely when the
     reranker returns ambiguous scores. Regression guard against a future

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2226,6 +2226,41 @@ class TestResolveGenerationOptions:
         result = _sse_h._resolve_generation_options(None)
         assert result is None
 
+    def test_strips_injected_endpoint_keys(self):
+        result = _sse_h._resolve_generation_options(
+            {"api_base": "http://evil", "api_key": "x", "temperature": 0.5}
+        )
+        assert result is not None
+        assert "api_base" not in result
+        assert "api_key" not in result
+        assert result["temperature"] == 0.5
+
+
+class TestOptionInjectionBoundary:
+    """HTTP-supplied options must not smuggle endpoint/credential keys to a provider."""
+
+    _INJECTED = {"api_base": "http://evil", "api_key": "x", "temperature": 0.5}
+
+    async def test_ask_strips_injected_keys(self, mock_svc):
+        from lilbee.retrieval.query import AskResult
+
+        mock_svc.searcher.ask_raw.return_value = AskResult(answer="ok", sources=[])
+        await handlers.ask("q", options=dict(self._INJECTED))
+        forwarded = mock_svc.searcher.ask_raw.call_args.kwargs["options"]
+        assert "api_base" not in forwarded
+        assert "api_key" not in forwarded
+        assert forwarded["temperature"] == 0.5
+
+    async def test_chat_strips_injected_keys(self, mock_svc):
+        from lilbee.retrieval.query import AskResult
+
+        mock_svc.searcher.ask_raw.return_value = AskResult(answer="ok", sources=[])
+        await handlers.chat("q", history=[], options=dict(self._INJECTED))
+        forwarded = mock_svc.searcher.ask_raw.call_args.kwargs["options"]
+        assert "api_base" not in forwarded
+        assert "api_key" not in forwarded
+        assert forwarded["temperature"] == 0.5
+
 
 class TestListExternalModels:
     """Tests for the external model discovery handler."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2236,16 +2236,17 @@ class TestResolveGenerationOptions:
         assert result["temperature"] == 0.5
 
 
+_INJECTED_OPTIONS = {"api_base": "http://evil", "api_key": "x", "temperature": 0.5}
+
+
 class TestOptionInjectionBoundary:
     """HTTP-supplied options must not smuggle endpoint/credential keys to a provider."""
-
-    _INJECTED = {"api_base": "http://evil", "api_key": "x", "temperature": 0.5}
 
     async def test_ask_strips_injected_keys(self, mock_svc):
         from lilbee.retrieval.query import AskResult
 
         mock_svc.searcher.ask_raw.return_value = AskResult(answer="ok", sources=[])
-        await handlers.ask("q", options=dict(self._INJECTED))
+        await handlers.ask("q", options=dict(_INJECTED_OPTIONS))
         forwarded = mock_svc.searcher.ask_raw.call_args.kwargs["options"]
         assert "api_base" not in forwarded
         assert "api_key" not in forwarded
@@ -2255,7 +2256,7 @@ class TestOptionInjectionBoundary:
         from lilbee.retrieval.query import AskResult
 
         mock_svc.searcher.ask_raw.return_value = AskResult(answer="ok", sources=[])
-        await handlers.chat("q", history=[], options=dict(self._INJECTED))
+        await handlers.chat("q", history=[], options=dict(_INJECTED_OPTIONS))
         forwarded = mock_svc.searcher.ask_raw.call_args.kwargs["options"]
         assert "api_base" not in forwarded
         assert "api_key" not in forwarded

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -7,6 +7,7 @@ import pytest
 
 from lilbee.core.config import META_TABLE, cfg
 from lilbee.data.store import (
+    ChunkType,
     CitationRecord,
     SearchChunk,
     SearchScope,
@@ -992,16 +993,55 @@ class TestScopeResolution:
         assert scope_to_chunk_type(SearchScope.BOTH) is None
 
     def test_raw_maps_to_raw(self):
-        assert scope_to_chunk_type("raw") == "raw"
-        assert scope_to_chunk_type(SearchScope.RAW) == "raw"
+        assert scope_to_chunk_type("raw") is ChunkType.RAW
+        assert scope_to_chunk_type(SearchScope.RAW) is ChunkType.RAW
 
     def test_wiki_maps_to_wiki(self):
-        assert scope_to_chunk_type("wiki") == "wiki"
-        assert scope_to_chunk_type(SearchScope.WIKI) == "wiki"
+        assert scope_to_chunk_type("wiki") is ChunkType.WIKI
+        assert scope_to_chunk_type(SearchScope.WIKI) is ChunkType.WIKI
 
     def test_invalid_scope_raises(self):
         with pytest.raises(ValueError):
             scope_to_chunk_type("bogus")
+
+
+class TestChunkTypeEnum:
+    """ChunkType is a closed StrEnum whose members serialize as their values."""
+
+    def test_members_are_str_values(self):
+        assert ChunkType.RAW == "raw"
+        assert ChunkType.WIKI == "wiki"
+        assert f"{ChunkType.WIKI}" == "wiki"
+
+    def test_decode_round_trip(self):
+        assert ChunkType("raw") is ChunkType.RAW
+        assert ChunkType("wiki") is ChunkType.WIKI
+
+    def test_unknown_value_raises(self):
+        with pytest.raises(ValueError):
+            ChunkType("bogus")
+
+
+class TestHttpChunkTypeBoundary:
+    """The HTTP request models decode chunk_type into ChunkType, rejecting junk."""
+
+    def test_ask_request_decodes_wiki(self):
+        from lilbee.server.models import AskRequest
+
+        assert AskRequest(question="q", chunk_type="wiki").chunk_type is ChunkType.WIKI
+
+    def test_ask_request_both_means_no_filter(self):
+        from lilbee.server.models import AskRequest
+
+        assert AskRequest(question="q", chunk_type="both").chunk_type is None
+
+    def test_ask_request_rejects_unknown(self):
+        from pydantic import ValidationError
+
+        from lilbee.server.models import AskRequest
+
+        with pytest.raises(ValidationError):
+            AskRequest(question="q", chunk_type="bogus")
 
 
 class TestChunkTypePredicate:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,5 +1,6 @@
 """Tests for LanceDB store operations: hybrid search + FTS index lifecycle."""
 
+from contextlib import contextmanager
 from unittest import mock
 
 import pytest
@@ -463,8 +464,7 @@ class TestRemoveDocuments:
     def test_removes_known_files(self, store):
         with (
             mock.patch.object(store, "get_sources", return_value=[{"filename": "a.md"}]),
-            mock.patch.object(store, "delete_by_source") as mock_del,
-            mock.patch.object(store, "delete_source"),
+            mock.patch.object(store, "_remove_one_unlocked") as mock_del,
         ):
             result = store.remove_documents(["a.md"])
             assert result.removed == ["a.md"]
@@ -480,8 +480,7 @@ class TestRemoveDocuments:
     def test_deletes_physical_file(self, store, tmp_path):
         with (
             mock.patch.object(store, "get_sources", return_value=[{"filename": "a.md"}]),
-            mock.patch.object(store, "delete_by_source"),
-            mock.patch.object(store, "delete_source"),
+            mock.patch.object(store, "_remove_one_unlocked"),
         ):
             f = tmp_path / "a.md"
             f.write_text("content")
@@ -494,8 +493,7 @@ class TestRemoveDocuments:
             mock.patch.object(
                 store, "get_sources", return_value=[{"filename": "../../../etc/passwd"}]
             ),
-            mock.patch.object(store, "delete_by_source"),
-            mock.patch.object(store, "delete_source"),
+            mock.patch.object(store, "_remove_one_unlocked"),
         ):
             secret = tmp_path.parent / "secret.txt"
             secret.write_text("don't delete me")
@@ -508,8 +506,7 @@ class TestRemoveDocuments:
     def test_nonexistent_file_still_removes_from_store(self, store, tmp_path):
         with (
             mock.patch.object(store, "get_sources", return_value=[{"filename": "gone.md"}]),
-            mock.patch.object(store, "delete_by_source") as mock_del,
-            mock.patch.object(store, "delete_source"),
+            mock.patch.object(store, "_remove_one_unlocked") as mock_del,
         ):
             result = store.remove_documents(["gone.md"], delete_files=True, documents_dir=tmp_path)
             assert result.removed == ["gone.md"]
@@ -518,11 +515,50 @@ class TestRemoveDocuments:
     def test_uses_default_documents_dir(self, store):
         with (
             mock.patch.object(store, "get_sources", return_value=[{"filename": "a.md"}]),
-            mock.patch.object(store, "delete_by_source"),
-            mock.patch.object(store, "delete_source"),
+            mock.patch.object(store, "_remove_one_unlocked"),
         ):
             result = store.remove_documents(["a.md"])
             assert result.removed == ["a.md"]
+
+    def test_chunk_and_source_deleted_under_single_lock(self, store):
+        """Both deletes for one document run inside one write_lock acquisition.
+
+        Guards against the inconsistency window where chunks were visible
+        after their source record had already been deleted.
+        """
+        acquisitions: list[str] = []
+
+        @contextmanager
+        def _tracking_lock(*args, **kwargs):
+            acquisitions.append("acquire")
+            yield
+
+        with (
+            mock.patch.object(store, "get_sources", return_value=[{"filename": "a.md"}]),
+            mock.patch.object(store, "_delete_by_source_unlocked") as mock_chunks,
+            mock.patch.object(store, "_delete_source_unlocked") as mock_source,
+            mock.patch("lilbee.data.store.core.write_lock", _tracking_lock),
+        ):
+            result = store.remove_documents(["a.md"])
+
+        assert result.removed == ["a.md"]
+        mock_chunks.assert_called_once_with("a.md")
+        mock_source.assert_called_once_with("a.md")
+        # Exactly one lock acquisition covers both deletes for the document.
+        assert acquisitions == ["acquire"]
+
+    def test_removes_chunks_and_source_atomically(self, store):
+        """End-to-end: a real removal clears both the chunk and source rows."""
+        store.add_chunks(_make_records(n=2))
+        store.upsert_source("doc0.md", "hash0", chunk_count=1)
+        store.upsert_source("doc1.md", "hash1", chunk_count=1)
+
+        result = store.remove_documents(["doc0.md"])
+
+        assert result.removed == ["doc0.md"]
+        assert {s["filename"] for s in store.get_sources()} == {"doc1.md"}
+        assert store.get_chunks_by_source("doc0.md") == []
+        assert len(store.get_chunks_by_source("doc1.md")) == 1
 
 
 class TestBm25Probe:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2751,8 +2751,7 @@ async def test_chat_slash_delete_with_match(mock_svc):
         app.screen._cmd_delete("notes.md")
         await app.screen.workers.wait_for_complete()
         await _pilot.pause()
-        mock_svc.store.delete_by_source.assert_called_once_with("notes.md")
-        mock_svc.store.delete_source.assert_called_once_with("notes.md")
+        mock_svc.store.remove_documents.assert_called_once_with(["notes.md"])
 
 
 async def test_chat_slash_delete_not_found(mock_svc):
@@ -3648,8 +3647,7 @@ async def test_command_provider_delete_doc(mock_svc):
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
         provider._delete_doc("notes.md")
-        mock_svc.store.delete_by_source.assert_called_once_with("notes.md")
-        mock_svc.store.delete_source.assert_called_once_with("notes.md")
+        mock_svc.store.remove_documents.assert_called_once_with(["notes.md"])
 
 
 async def test_command_provider_action_sync():
@@ -6800,6 +6798,46 @@ async def test_do_add_raises_on_sync_failed(tmp_path):
         assert "exc" in captured
         assert isinstance(captured["exc"], RuntimeError)
         assert "doc.txt" in str(captured["exc"])
+
+
+async def test_do_crawl_prompts_to_raise_safety_cap(monkeypatch):
+    """Hitting the safety cap pushes a ConfirmDialog that re-opens the crawl dialog."""
+    import threading
+    from pathlib import Path
+
+    from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
+    from lilbee.cli.tui.widgets.task_bar_controller import ProgressReporter
+    from lilbee.runtime.progress import CrawlDoneEvent, EventType
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        chat = app.screen
+        opened = {"n": 0}
+        monkeypatch.setattr(
+            chat, "_open_crawl_dialog", lambda: opened.__setitem__("n", opened["n"] + 1)
+        )
+
+        async def fake_crawl_and_save(url, *, on_progress, **kwargs):
+            on_progress(
+                EventType.CRAWL_DONE,
+                CrawlDoneEvent(
+                    pages_crawled=5, files_written=5, stopped_at_safety_cap=True, safety_cap=5
+                ),
+            )
+            return [Path("p0.md")]
+
+        reporter = ProgressReporter(app.task_bar, "fake-id")
+        with patch("lilbee.crawler.crawl_and_save", fake_crawl_and_save):
+            thread = threading.Thread(
+                target=lambda: chat._do_crawl("https://example.com", None, None, reporter)
+            )
+            thread.start()
+            thread.join(timeout=5)
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmDialog)
+        await pilot.press("y")
+        await pilot.pause()
+        assert opened["n"] == 1
 
 
 async def test_sync_called_with_quiet_true():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -6800,46 +6800,6 @@ async def test_do_add_raises_on_sync_failed(tmp_path):
         assert "doc.txt" in str(captured["exc"])
 
 
-async def test_do_crawl_prompts_to_raise_safety_cap(monkeypatch):
-    """Hitting the safety cap pushes a ConfirmDialog that re-opens the crawl dialog."""
-    import threading
-    from pathlib import Path
-
-    from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
-    from lilbee.cli.tui.widgets.task_bar_controller import ProgressReporter
-    from lilbee.runtime.progress import CrawlDoneEvent, EventType
-
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        chat = app.screen
-        opened = {"n": 0}
-        monkeypatch.setattr(
-            chat, "_open_crawl_dialog", lambda: opened.__setitem__("n", opened["n"] + 1)
-        )
-
-        async def fake_crawl_and_save(url, *, on_progress, **kwargs):
-            on_progress(
-                EventType.CRAWL_DONE,
-                CrawlDoneEvent(
-                    pages_crawled=5, files_written=5, stopped_at_safety_cap=True, safety_cap=5
-                ),
-            )
-            return [Path("p0.md")]
-
-        reporter = ProgressReporter(app.task_bar, "fake-id")
-        with patch("lilbee.crawler.crawl_and_save", fake_crawl_and_save):
-            thread = threading.Thread(
-                target=lambda: chat._do_crawl("https://example.com", None, None, reporter)
-            )
-            thread.start()
-            thread.join(timeout=5)
-        await pilot.pause()
-        assert isinstance(app.screen, ConfirmDialog)
-        await pilot.press("y")
-        await pilot.pause()
-        assert opened["n"] == 1
-
-
 async def test_sync_called_with_quiet_true():
     """B2: _run_sync_worker passes quiet=True to suppress Rich progress bar."""
     app = ChatTestApp()

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -5279,8 +5279,9 @@ async def test_crawl_dialog_input_submitted():
 
 
 async def test_crawl_dialog_defaults():
-    """Default submit (recursive checked, advanced blank) yields None caps."""
+    """Default submit uses the prefilled safety cap for max pages, unbounded depth."""
     from lilbee.cli.tui.widgets.crawl_dialog import CrawlParams
+    from lilbee.core.config import cfg
 
     app = CrawlDialogTestApp()
     async with app.run_test(size=(80, 30)) as pilot:
@@ -5295,7 +5296,7 @@ async def test_crawl_dialog_defaults():
     result = app.results[0]
     assert isinstance(result, CrawlParams)
     assert result.depth is None
-    assert result.max_pages is None
+    assert result.max_pages == cfg.crawl_safety_max_pages
 
 
 async def test_crawl_dialog_negative_max_pages_shows_error():
@@ -5316,7 +5317,7 @@ async def test_crawl_dialog_negative_max_pages_shows_error():
 
 
 async def test_crawl_dialog_zero_max_pages_shows_error():
-    """Zero max pages is invalid (blank means unbounded; 0 is nonsense)."""
+    """Typing 0 is invalid; unlimited is expressed by clearing the field, not typing 0."""
     app = CrawlDialogTestApp()
     async with app.run_test(size=(80, 30)) as pilot:
         await pilot.pause()
@@ -5332,9 +5333,10 @@ async def test_crawl_dialog_zero_max_pages_shows_error():
             assert "max pages" in str(error.render()).lower()
 
 
-async def test_crawl_dialog_empty_advanced_fields_are_unbounded():
-    """Empty Advanced fields submit as None (unbounded)."""
+async def test_crawl_dialog_cleared_max_pages_is_unlimited():
+    """Clearing the max-pages field submits the unlimited sentinel; blank depth is unbounded."""
     from lilbee.cli.tui.widgets.crawl_dialog import CrawlParams
+    from lilbee.crawler.models import CRAWL_PAGES_UNLIMITED
 
     app = CrawlDialogTestApp()
     async with app.run_test(size=(80, 30)) as pilot:
@@ -5353,7 +5355,7 @@ async def test_crawl_dialog_empty_advanced_fields_are_unbounded():
     result = app.results[0]
     assert isinstance(result, CrawlParams)
     assert result.depth is None
-    assert result.max_pages is None
+    assert result.max_pages == CRAWL_PAGES_UNLIMITED
 
 
 async def test_crawl_dialog_unchecking_recursive_submits_depth_zero():
@@ -5361,6 +5363,7 @@ async def test_crawl_dialog_unchecking_recursive_submits_depth_zero():
     from textual.widgets import Checkbox
 
     from lilbee.cli.tui.widgets.crawl_dialog import CrawlParams
+    from lilbee.crawler.models import CRAWL_PAGES_UNLIMITED
 
     app = CrawlDialogTestApp()
     async with app.run_test(size=(80, 30)) as pilot:
@@ -5377,7 +5380,7 @@ async def test_crawl_dialog_unchecking_recursive_submits_depth_zero():
     result = app.results[0]
     assert isinstance(result, CrawlParams)
     assert result.depth == 0
-    assert result.max_pages is None
+    assert result.max_pages == CRAWL_PAGES_UNLIMITED
 
 
 async def test_crawl_dialog_recursive_checkbox_default_checked():

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -9,7 +9,7 @@ import pytest
 
 from lilbee.core.config import CHUNKS_TABLE, cfg
 from lilbee.core.text import make_slug
-from lilbee.data.store import CHUNK_TYPE_WIKI, SearchChunk, Store
+from lilbee.data.store import ChunkType, SearchChunk, Store
 from lilbee.wiki.batch import (
     _group_chunks_by_page,
     _unwrap_archived_links,
@@ -1172,13 +1172,13 @@ class TestWikiIndexing:
         assert call_args.args[0] == CHUNKS_TABLE
         predicate = call_args.args[1]
         assert target.wiki_source in predicate
-        assert CHUNK_TYPE_WIKI in predicate
+        assert ChunkType.WIKI in predicate
 
         store.add_chunks.assert_called_once()
         records = store.add_chunks.call_args.args[0]
         assert len(records) == 1
         rec = records[0]
-        assert rec["chunk_type"] == CHUNK_TYPE_WIKI
+        assert rec["chunk_type"] == ChunkType.WIKI
         assert rec["source"] == target.wiki_source
         assert rec["content_type"] == "text"
         # page/line positions follow the markdown ingest convention: all zero

--- a/tests/test_worker_transport_pipe.py
+++ b/tests/test_worker_transport_pipe.py
@@ -114,6 +114,13 @@ def _handle_stream(conn: Any, payload: Any, _abort: Any) -> None:
     conn.send(("stream_end", None))
 
 
+def _handle_stream_then_stall(conn: Any, _payload: Any, _abort: Any) -> None:
+    """Emit one chunk, then block forever without sending the terminator."""
+    conn.send(("stream_chunk", "first"))
+    while True:
+        time.sleep(60.0)
+
+
 def _handle_abort_loop(conn: Any, _payload: Any, abort: Any) -> None:
     deadline = time.monotonic() + 5.0
     while time.monotonic() < deadline:
@@ -133,6 +140,7 @@ _ECHO_DISPATCH = {
     "raise": _handle_raise,
     "stream": _handle_stream,
     "stream_error": _handle_stream_error,
+    "stream_then_stall": _handle_stream_then_stall,
     "abort_loop": _handle_abort_loop,
     "bad_kind": _handle_bad_kind,
 }
@@ -290,6 +298,30 @@ async def test_ping_roundtrips(echo_channel: PipeChannel) -> None:
 async def test_stream_yields_chunks_then_terminates(echo_channel: PipeChannel) -> None:
     chunks = [chunk async for chunk in echo_channel.stream("stream", (3, "tok-"))]
     assert chunks == ["tok-0", "tok-1", "tok-2"]
+    assert echo_channel.in_flight == 0
+
+
+@pytest.mark.asyncio
+async def test_stream_raises_when_worker_stalls_mid_stream(
+    echo_channel: PipeChannel,
+) -> None:
+    """A worker that stops emitting frames mid-stream must release the consumer.
+
+    Without a per-chunk timeout the consumer hangs forever (the health pipe
+    still pongs alive). With the timeout the stall surfaces as
+    ``WorkerCrashError`` within ``stream_chunk_timeout`` seconds, so the pool
+    can recycle the worker instead of deadlocking the caller.
+    """
+    seen: list[Any] = []
+    start = time.monotonic()
+    with pytest.raises(WorkerCrashError):
+        async for chunk in echo_channel.stream(
+            "stream_then_stall", None, stream_chunk_timeout=0.5
+        ):
+            seen.append(chunk)
+    elapsed = time.monotonic() - start
+    assert seen == ["first"]
+    assert elapsed < 5.0
     assert echo_channel.in_flight == 0
 
 

--- a/tests/test_worker_transport_pipe.py
+++ b/tests/test_worker_transport_pipe.py
@@ -457,6 +457,29 @@ async def test_close_terminates_hung_worker_within_timeout(
 
 
 @pytest.mark.asyncio
+async def test_close_after_stream_stall_does_not_deadlock(
+    spawner: PipeSpawner,
+    role_config: RoleConfig,
+) -> None:
+    """Closing a channel whose stream stalled must terminate within the timeout.
+
+    A stalled stream leaves an executor thread blocked in ``conn.recv``; the
+    timed-out health shutdown leaves a second one blocked too. ``close`` must
+    still make progress (it joins on the loop default executor, not the
+    saturated channel executor) and bring the worker down.
+    """
+    channel, _handle = spawner.spawn(_echo_worker_main, role_config)
+    with pytest.raises(WorkerCrashError):
+        async for _chunk in channel.stream("stream_then_stall", None, stream_chunk_timeout=0.5):
+            pass
+    start = time.monotonic()
+    await channel.close(timeout=1.0)
+    elapsed = time.monotonic() - start
+    assert elapsed < 8.0
+    assert channel.is_alive is False
+
+
+@pytest.mark.asyncio
 async def test_close_is_idempotent(echo_channel: PipeChannel) -> None:
     await echo_channel.close(timeout=_TEST_SHUTDOWN_TIMEOUT_S)
     # Second call must be a no-op (no error).

--- a/tests/test_worker_transport_pipe.py
+++ b/tests/test_worker_transport_pipe.py
@@ -315,9 +315,7 @@ async def test_stream_raises_when_worker_stalls_mid_stream(
     seen: list[Any] = []
     start = time.monotonic()
     with pytest.raises(WorkerCrashError):
-        async for chunk in echo_channel.stream(
-            "stream_then_stall", None, stream_chunk_timeout=0.5
-        ):
+        async for chunk in echo_channel.stream("stream_then_stall", None, stream_chunk_timeout=0.5):
             seen.append(chunk)
     elapsed = time.monotonic() - start
     assert seen == ["first"]


### PR DESCRIPTION
## Problem

The single-GPU and in-process code paths had never been audited against a reference the way the multi-GPU fleet was. Going through them subsystem by subsystem and diffing each against its source of truth (the existing implementation, the stored schema, the pinned library source, or a security contract) turned up a set of bugs that all fail quietly. They return wrong results, accept or store bad data, or let untrusted input through, without ever raising an error. Those are the ones that rot a knowledge base or expose an endpoint without anyone noticing.

## What was wrong, and the fix

**Security**
- The crawler accepted URLs resolving to private and cloud-metadata addresses over IPv6, followed sitemap redirects without re-checking where they landed, and an unbounded crawl had no page limit at all. A hostile page could reach internal services or fill the disk. The blocklist now covers the IPv6 ranges, and redirect targets and discovered links are re-validated before any fetch. For the page limit: the crawl dialog sets it upfront, prefilled with a protective default and cleared for unlimited, so you choose the limit (including none) at crawl time without opening settings. Bare CLI, API, and auto-sync crawls stay bounded by that default unless you ask otherwise (`--max-pages 0` for unlimited), so a hostile site can't fill the disk on a crawl nobody bounded.
- Generation options posted to the chat API were merged in unfiltered, so a request could smuggle `api_base` or `api_key` through to the provider. They now pass through the same allowlist as every other entry point, applied once at the HTTP boundary.

**Data integrity**
- A model file already on disk was treated as a finished download with no size check, and a partial blob counted as installed, so a truncated model failed later, far from the cause. Both paths now verify the size before trusting the file.
- Removing a document deleted its chunks and its source record under two separate locks, leaving a window where chunks existed with no source. The removal is now atomic, and every delete path (library API, CLI, TUI, and the sync cleanup of vanished files) routes through it rather than repeating the two-step delete.
- Oversized chunks were truncated silently during indexing. The truncation count is now reported in the sync summary.

**Inference correctness**
- A reranker with more than one output class was scored on a single value, silently producing wrong rankings. It is now rejected at load time.
- The batched-embedding workaround had no check that it actually took effect. If it silently stopped working, embeddings would fail in bulk. It now verifies itself on load.
- A vision model whose chat template used an unrecognized image token rendered the token as literal text, quietly degrading OCR. It now raises at load instead of producing bad output.

**Reliability**
- A worker that stalled mid-stream hung the caller forever. Streaming now times out per chunk, and a related teardown deadlock on that path is fixed.
- On Windows the GGUF header probe left a memory-mapped file open and crashed on cleanup. It now closes the map before unlinking.

## Checked and ruled out

Three plausible problems were investigated and disproven with tests, so nothing changed for them: worker subprocesses do not orphan native child processes, the "split-shard" import the audit suspected does not exist on this branch, and litellm forwards the extra sampling options rather than rejecting them.

Every fix landed with a test that reproduces the bug first. Also added regression tests for search ranking and for query/index embedding consistency, and made `chunk_type` a typed enum.