### PR TITLE
Fix Windows crash in GGUF architecture probe

### DIFF
--- a/src/lilbee/catalog/header_probe.py
+++ b/src/lilbee/catalog/header_probe.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import struct
 import tempfile
@@ -49,15 +50,29 @@ def _parse_arch(blob: bytes) -> str:
         f.write(bytes(patched))
         tmp = Path(f.name)
     try:
-        reader = GGUFReader(str(tmp))
-        field = reader.fields.get(GGUF_ARCH_KEY)
-        if field is None or not field.data:
-            return ""
-        if not field.types or field.types[-1] != GGUFValueType.STRING:
-            return ""
-        return bytes(field.parts[field.data[0]]).decode("utf-8", errors="replace")
+        return _read_architecture(tmp)
     except (ValueError, struct.error, IndexError, OSError, UnicodeDecodeError) as exc:
         log.debug("GGUFReader parse failed: %s", exc)
         return ""
     finally:
-        tmp.unlink(missing_ok=True)
+        # GGUFReader memory-maps the file; on Windows the mapping must be released
+        # before the file can be deleted (a held mapping raises PermissionError /
+        # WinError 32, which missing_ok does not cover). _read_architecture scopes
+        # the reader so it is freed on return; suppress is a best-effort backstop.
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+
+
+def _read_architecture(path: Path) -> str:
+    """Return general.architecture from the GGUF file at *path*, or empty string.
+
+    Kept separate so the ``GGUFReader`` (and its memory map of *path*) is released
+    when this returns, letting the caller delete the temp file on Windows.
+    """
+    reader = GGUFReader(str(path))
+    field = reader.fields.get(GGUF_ARCH_KEY)
+    if field is None or not field.data:
+        return ""
+    if not field.types or field.types[-1] != GGUFValueType.STRING:
+        return ""
+    return bytes(field.parts[field.data[0]]).decode("utf-8", errors="replace")

--- a/tests/test_catalog_header_probe.py
+++ b/tests/test_catalog_header_probe.py
@@ -18,6 +18,20 @@ def test_probe_reads_architecture(monkeypatch: pytest.MonkeyPatch) -> None:
     assert probe_architecture("https://example.test/model.gguf") == "llama"
 
 
+def test_probe_survives_tempfile_cleanup_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # On Windows the GGUFReader memory-map can keep the temp file locked, so the
+    # unlink raises PermissionError (WinError 32). The probe must still return the
+    # parsed architecture rather than propagating the cleanup error.
+    blob = make_minimal_gguf("llama")
+    monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob))
+
+    def _raise_unlink(self: object, *_a: object, **_k: object) -> None:
+        raise PermissionError("WinError 32 simulated")
+
+    monkeypatch.setattr(header_probe.Path, "unlink", _raise_unlink)
+    assert probe_architecture("https://example.test/model.gguf") == "llama"
+
+
 def test_probe_handles_truncated_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=b"GGUF\x03"))
     assert probe_architecture("https://example.test/model.gguf") == ""


### PR DESCRIPTION
## Problem

`catalog.header_probe.probe_architecture` writes a patched GGUF header to a temp file, reads it with `GGUFReader`, then deletes it. `GGUFReader` memory-maps the file, and Windows won't delete a file while a mapping is held — so the `unlink` raised `PermissionError` (WinError 32), which `missing_ok=True` doesn't cover, and it propagated out of the probe. The architecture probe failed on Windows at runtime, and the Windows test job was correctly flagging it (it's been red, not flaky).

## Solution

Scope the `GGUFReader` in a small helper so its memory map is released when the helper returns, letting Windows delete the temp file. The cleanup `unlink` is now best-effort (tolerates an `OSError` backstop) so a probe never crashes on temp-file teardown. Added a test that simulates the WinError-32 unlink failure and confirms the probe still returns the architecture.

This is the failure the multi-GPU branch's Windows CI kept surfacing as `test_catalog_header_probe`; it's a real product bug on `main`, independent of that work.