### PR TITLE
crawler: strip reference-style [[N]](url) links from crawled markdown

### DIFF
--- a/src/lilbee/crawler/save.py
+++ b/src/lilbee/crawler/save.py
@@ -133,6 +133,23 @@ def content_hash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
+# Reference-style nested-bracket links, e.g. Wikipedia footnote markers like
+# ``[[1]](https://en.wikipedia.org/wiki/Foo#cite_note-1)``. The inner brackets
+# make this a normal Markdown link with the text ``[1]``, but readers that
+# treat ``[[...]]`` as a wikilink (Obsidian) mis-parse it as a broken wikilink
+# followed by the literal URL.
+_REFERENCE_LINK_RE = re.compile(r"\[\[([^\]]*)\]\]\(([^)]*)\)")
+
+
+def normalize_crawled_markdown(markdown: str) -> str:
+    """Collapse reference-style ``[[N]](url)`` links to plain ``[N](url)``.
+
+    This fixes the double-bracket/wikilink collision without dropping the
+    link text or URL. Ordinary single-bracket links are left untouched.
+    """
+    return _REFERENCE_LINK_RE.sub(r"[\1](\2)", markdown)
+
+
 @dataclass(frozen=True)
 class SaveOutcome:
     """Return value of ``_save_single_result``: written path and the hash/filename used."""
@@ -151,6 +168,7 @@ def _save_single_result(result: CrawlResult, meta: dict[str, CrawlMeta]) -> Save
     """
     if not result.success or not result.markdown.strip():
         return None
+    markdown = normalize_crawled_markdown(result.markdown)
     filename = url_to_filename(result.url)
     web_dir = _web_dir()
     file_path = web_dir / filename
@@ -160,13 +178,13 @@ def _save_single_result(result: CrawlResult, meta: dict[str, CrawlMeta]) -> Save
     except ValueError:
         log.warning("Path traversal blocked: %s -> %s", result.url, file_path)
         return None
-    new_hash = content_hash(result.markdown)
+    new_hash = content_hash(markdown)
     prev = meta.get(result.url)
     if prev is not None and prev.content_hash == new_hash and file_path.exists():
         log.info("Content unchanged, skipping save: %s", result.url)
         return None
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(result.markdown, encoding="utf-8")
+    file_path.write_text(markdown, encoding="utf-8")
     return SaveOutcome(path=file_path, filename=filename, content_hash=new_hash)
 
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -30,7 +30,11 @@ from lilbee.crawler.runner import (
     _get_crawl_semaphore,
     _maybe_periodic_sync,
 )
-from lilbee.crawler.save import _save_single_result, _update_single_metadata
+from lilbee.crawler.save import (
+    _save_single_result,
+    _update_single_metadata,
+    normalize_crawled_markdown,
+)
 from lilbee.runtime.progress import EventType
 
 
@@ -2138,6 +2142,28 @@ class TestSaveSingleResult:
         assert outcome.path.read_text(encoding="utf-8") == "# New"
         assert outcome.filename.endswith("index.md")
         assert outcome.content_hash == content_hash("# New")
+
+    def test_normalize_crawled_markdown_collapses_reference_links(self):
+        ref = "[[2]](https://en.wikipedia.org/wiki/Foo#cite_note-2)"
+        md = f"Car of the Year.{ref} Production ended."
+        # Double brackets collapse to single; text and URL are preserved.
+        expected = (
+            "Car of the Year.[2](https://en.wikipedia.org/wiki/Foo#cite_note-2) Production ended."
+        )
+        assert normalize_crawled_markdown(md) == expected
+        # Ordinary single-bracket links are left untouched.
+        keep = 'See the [trim package](https://en.wikipedia.org/wiki/Trim "title") here.'
+        assert normalize_crawled_markdown(keep) == keep
+
+    def test_writes_normalized_markdown(self, isolated_env):
+        from lilbee.crawler.save import _save_single_result
+
+        raw = "9C1[[1]](https://en.wikipedia.org/wiki/Caprice#cite_note-1) introduced for 1986."
+        expected = "9C1[1](https://en.wikipedia.org/wiki/Caprice#cite_note-1) introduced for 1986."
+        outcome = _save_single_result(CrawlResult(url="https://example.com/ref", markdown=raw), {})
+        assert outcome is not None
+        assert outcome.path.read_text(encoding="utf-8") == expected
+        assert outcome.content_hash == content_hash(expected)
 
     def test_returns_none_on_failure(self, isolated_env):
         from lilbee.crawler.save import _save_single_result


### PR DESCRIPTION
## Problem

Crawled pages from reference-heavy sites (Wikipedia, etc.) render badly in Obsidian. crawl4ai converts a page's footnote markers (the superscript `[1][2][3]`) into nested-bracket Markdown links — `[[2]](https://…#cite_note-2)`. The inner brackets make it a valid link with the text `[2]`, but Obsidian treats `[[…]]` as its own wikilink syntax, so it parses `[[2]]` as a broken link to a note named "2" and renders the trailing `(url)` as literal text. A Wikipedia article carries hundreds of these, so the body fills with broken wikilinks and inline URLs.

## Solution

Collapse the nested brackets to single ones at save time (`[[N]](url)` → `[N](url)`) so the reference renders as an ordinary link. This is non-lossy — the link text and URL are preserved, and ordinary `[text](url)` links are untouched — so it's a strict rendering-correctness improvement for every crawled page, not a content edit. The content-hash dedup runs on the normalized text so re-crawls stay consistent. Added unit tests for the normalizer and the save path; `tests/test_crawler.py` is green (176).