### PR TITLE
crawler: surface first-run browser setup in the Task Center

### DIFF
--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -37,7 +37,15 @@ from lilbee.runtime.progress import (
     CrawlStartEvent,
     DetailedProgressCallback,
     EventType,
+    SetupDoneEvent,
+    SetupStartEvent,
 )
+
+# Component name for the browser-warmup setup phase (distinct from the
+# Chromium download, whose component is "chromium"). The crawl emits a
+# start/done bracket around opening the crawler so the Task Center shows a
+# "preparing crawler" stage instead of a silent stall on first use.
+_BROWSER_SETUP_COMPONENT = "browser"
 
 log = logging.getLogger(__name__)
 
@@ -160,8 +168,19 @@ async def crawl_recursive(
     filters = build_filter_spec(include_subdomains=include_subdomains)
 
     results: list[CrawlResult] = []
+    # Opening the crawler launches the browser; on first use crawl4ai's
+    # one-time warmup can take many seconds with no other signal. Bracket it
+    # with setup events (no size estimate -> indeterminate) so the Task
+    # Center shows a "preparing crawler" stage instead of a silent stall.
+    if on_progress:
+        on_progress(EventType.SETUP_START, SetupStartEvent(component=_BROWSER_SETUP_COMPONENT))
     try:
         async with Crawl4aiFetcher(quiet=quiet) as fetcher:
+            if on_progress:
+                on_progress(
+                    EventType.SETUP_DONE,
+                    SetupDoneEvent(component=_BROWSER_SETUP_COMPONENT, success=True),
+                )
             # Hold an explicit reference to the generator so we can aclose
             # it deterministically on break. Without this, the generator's
             # finally block (which also short-circuits the BFS strategy) only

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1046,12 +1046,18 @@ class TestCrawlRecursive:
         assert len(results) == 2
         assert results[0].url == "https://example.com"
         assert results[1].url == "https://example.com/about"
-        assert len(progress_calls) == 2
         # Streaming semantics: total is unknown during BFS, counter advances per page.
         from lilbee.runtime.progress import CRAWL_TOTAL_UNKNOWN
 
-        assert [c[1].current for c in progress_calls] == [1, 2]
-        assert all(c[1].total == CRAWL_TOTAL_UNKNOWN for c in progress_calls)
+        page_events = [c for c in progress_calls if c[0] == EventType.CRAWL_PAGE]
+        assert [c[1].current for c in page_events] == [1, 2]
+        assert all(c[1].total == CRAWL_TOTAL_UNKNOWN for c in page_events)
+        # The browser warmup is bracketed by setup events so the Task Center
+        # shows a "preparing crawler" stage instead of a silent stall.
+        setup_types = [
+            e for e, _ in progress_calls if e in (EventType.SETUP_START, EventType.SETUP_DONE)
+        ]
+        assert setup_types == [EventType.SETUP_START, EventType.SETUP_DONE]
 
     async def test_emits_events_before_stream_exhausted(self):
         """CRAWL_PAGE fires per page as it arrives, not only after the full list."""


### PR DESCRIPTION
## Problem

The first crawl on a fresh install stalls with no feedback. crawl4ai's one-time browser warmup (opening the browser the first time) can take many seconds, and the crawl flow emits no progress during it, so the Task Center sits blank and the crawl looks hung. Setup progress was only emitted when Chromium had to be *downloaded*; once it's present, the warmup is silent.

## Solution

Bracket the crawler open in `crawl_recursive` with `setup_start`/`setup_done` events (a "browser" component, no size estimate so it reads as indeterminate). The plugin already renders setup events as a "preparing crawler" stage, so the first crawl now shows that stage instead of a silent stall. The Chromium-download path keeps its own granular progress. Added a test that the warmup is bracketed by setup events; `tests/test_crawler.py` is green (174).