### PR TITLE
crawler: clean reference links + surface first-run browser setup

### DIFF
--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -37,7 +37,15 @@ from lilbee.runtime.progress import (
     CrawlStartEvent,
     DetailedProgressCallback,
     EventType,
+    SetupDoneEvent,
+    SetupStartEvent,
 )
+
+# Component name for the browser-warmup setup phase (distinct from the
+# Chromium download, whose component is "chromium"). The crawl emits a
+# start/done bracket around opening the crawler so the Task Center shows a
+# "preparing crawler" stage instead of a silent stall on first use.
+_BROWSER_SETUP_COMPONENT = "browser"
 
 log = logging.getLogger(__name__)
 
@@ -160,8 +168,19 @@ async def crawl_recursive(
     filters = build_filter_spec(include_subdomains=include_subdomains)
 
     results: list[CrawlResult] = []
+    # Opening the crawler launches the browser; on first use crawl4ai's
+    # one-time warmup can take many seconds with no other signal. Bracket it
+    # with setup events (no size estimate -> indeterminate) so the Task
+    # Center shows a "preparing crawler" stage instead of a silent stall.
+    if on_progress:
+        on_progress(EventType.SETUP_START, SetupStartEvent(component=_BROWSER_SETUP_COMPONENT))
     try:
         async with Crawl4aiFetcher(quiet=quiet) as fetcher:
+            if on_progress:
+                on_progress(
+                    EventType.SETUP_DONE,
+                    SetupDoneEvent(component=_BROWSER_SETUP_COMPONENT, success=True),
+                )
             # Hold an explicit reference to the generator so we can aclose
             # it deterministically on break. Without this, the generator's
             # finally block (which also short-circuits the BFS strategy) only

--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -75,7 +75,9 @@ def _looks_like_missing_chromium(exc: BaseException) -> bool:
     return "Executable doesn't exist" in str(exc)
 
 
-async def crawl_single(url: str, *, quiet: bool = False) -> CrawlResult:
+async def crawl_single(
+    url: str, *, quiet: bool = False, on_progress: DetailedProgressCallback | None = None
+) -> CrawlResult:
     """Fetch a single URL.
 
     Raises :class:`CrawlerBackendError` if the crawler extra isn't installed.
@@ -83,6 +85,10 @@ async def crawl_single(url: str, *, quiet: bool = False) -> CrawlResult:
     bootstrap once and retries -- ``chromium_installed()`` can return True
     when the wrong revision lives in the cache root, in which case the
     launch fails the first attempt.
+
+    ``on_progress`` receives a setup_start/setup_done bracket around opening
+    the crawler so the first crawl's browser warmup is visible rather than a
+    silent stall.
     """
     validate_crawl_url(url)
     from lilbee.crawler import crawler_available
@@ -91,8 +97,15 @@ async def crawl_single(url: str, *, quiet: bool = False) -> CrawlResult:
         raise bootstrap.CrawlerBackendError(
             "Web crawling is not available. Run 'uv sync --extra crawler' to enable it."
         )
+    if on_progress:
+        on_progress(EventType.SETUP_START, SetupStartEvent(component=_BROWSER_SETUP_COMPONENT))
     try:
         async with Crawl4aiFetcher(quiet=quiet) as fetcher:
+            if on_progress:
+                on_progress(
+                    EventType.SETUP_DONE,
+                    SetupDoneEvent(component=_BROWSER_SETUP_COMPONENT, success=True),
+                )
             page = await fetcher.fetch_single(url, timeout=cfg.crawl_timeout)
         return _fetched_to_result(page)
     except CrawlerBrowserError:
@@ -309,7 +322,7 @@ async def _run_crawl(
 ) -> int:
     """Run the single-URL or recursive crawl. Returns ``pages_seen``."""
     if depth == 0:
-        result = await crawl_single(url, quiet=quiet)
+        result = await crawl_single(url, quiet=quiet, on_progress=on_progress)
         try:
             await flush_page(result)
         except OSError:

--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -181,10 +181,10 @@ async def crawl_recursive(
     filters = build_filter_spec(include_subdomains=include_subdomains)
 
     results: list[CrawlResult] = []
-    # Opening the crawler launches the browser; on first use crawl4ai's
-    # one-time warmup can take many seconds with no other signal. Bracket it
-    # with setup events (no size estimate -> indeterminate) so the Task
-    # Center shows a "preparing crawler" stage instead of a silent stall.
+    # Opening the crawler launches the browser; on first use its one-time
+    # warmup can take many seconds with no other signal. Bracket it with
+    # setup events (no size estimate -> indeterminate) so the Task Center
+    # shows a "preparing crawler" stage instead of a silent stall.
     if on_progress:
         on_progress(EventType.SETUP_START, SetupStartEvent(component=_BROWSER_SETUP_COMPONENT))
     try:

--- a/src/lilbee/crawler/save.py
+++ b/src/lilbee/crawler/save.py
@@ -133,6 +133,23 @@ def content_hash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
+# Reference-style nested-bracket links, e.g. Wikipedia footnote markers like
+# ``[[1]](https://en.wikipedia.org/wiki/Foo#cite_note-1)``. The inner brackets
+# make this a normal Markdown link with the text ``[1]``, but readers that
+# treat ``[[...]]`` as a wikilink (Obsidian) mis-parse it as a broken wikilink
+# followed by the literal URL.
+_REFERENCE_LINK_RE = re.compile(r"\[\[([^\]]*)\]\]\(([^)]*)\)")
+
+
+def normalize_crawled_markdown(markdown: str) -> str:
+    """Collapse reference-style ``[[N]](url)`` links to plain ``[N](url)``.
+
+    This fixes the double-bracket/wikilink collision without dropping the
+    link text or URL. Ordinary single-bracket links are left untouched.
+    """
+    return _REFERENCE_LINK_RE.sub(r"[\1](\2)", markdown)
+
+
 @dataclass(frozen=True)
 class SaveOutcome:
     """Return value of ``_save_single_result``: written path and the hash/filename used."""
@@ -151,6 +168,7 @@ def _save_single_result(result: CrawlResult, meta: dict[str, CrawlMeta]) -> Save
     """
     if not result.success or not result.markdown.strip():
         return None
+    markdown = normalize_crawled_markdown(result.markdown)
     filename = url_to_filename(result.url)
     web_dir = _web_dir()
     file_path = web_dir / filename
@@ -160,13 +178,13 @@ def _save_single_result(result: CrawlResult, meta: dict[str, CrawlMeta]) -> Save
     except ValueError:
         log.warning("Path traversal blocked: %s -> %s", result.url, file_path)
         return None
-    new_hash = content_hash(result.markdown)
+    new_hash = content_hash(markdown)
     prev = meta.get(result.url)
     if prev is not None and prev.content_hash == new_hash and file_path.exists():
         log.info("Content unchanged, skipping save: %s", result.url)
         return None
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(result.markdown, encoding="utf-8")
+    file_path.write_text(markdown, encoding="utf-8")
     return SaveOutcome(path=file_path, filename=filename, content_hash=new_hash)
 
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -30,7 +30,11 @@ from lilbee.crawler.runner import (
     _get_crawl_semaphore,
     _maybe_periodic_sync,
 )
-from lilbee.crawler.save import _save_single_result, _update_single_metadata
+from lilbee.crawler.save import (
+    _save_single_result,
+    _update_single_metadata,
+    normalize_crawled_markdown,
+)
 from lilbee.runtime.progress import EventType
 
 
@@ -2138,6 +2142,28 @@ class TestSaveSingleResult:
         assert outcome.path.read_text(encoding="utf-8") == "# New"
         assert outcome.filename.endswith("index.md")
         assert outcome.content_hash == content_hash("# New")
+
+    def test_normalize_crawled_markdown_collapses_reference_links(self):
+        ref = "[[2]](https://en.wikipedia.org/wiki/Foo#cite_note-2)"
+        md = f"Car of the Year.{ref} Production ended."
+        # Double brackets collapse to single; text and URL are preserved.
+        expected = (
+            "Car of the Year.[2](https://en.wikipedia.org/wiki/Foo#cite_note-2) Production ended."
+        )
+        assert normalize_crawled_markdown(md) == expected
+        # Ordinary single-bracket links are left untouched.
+        keep = 'See the [trim package](https://en.wikipedia.org/wiki/Trim "title") here.'
+        assert normalize_crawled_markdown(keep) == keep
+
+    def test_writes_normalized_markdown(self, isolated_env):
+        from lilbee.crawler.save import _save_single_result
+
+        raw = "9C1[[1]](https://en.wikipedia.org/wiki/Caprice#cite_note-1) introduced for 1986."
+        expected = "9C1[1](https://en.wikipedia.org/wiki/Caprice#cite_note-1) introduced for 1986."
+        outcome = _save_single_result(CrawlResult(url="https://example.com/ref", markdown=raw), {})
+        assert outcome is not None
+        assert outcome.path.read_text(encoding="utf-8") == expected
+        assert outcome.content_hash == content_hash(expected)
 
     def test_returns_none_on_failure(self, isolated_env):
         from lilbee.crawler.save import _save_single_result

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -412,6 +412,26 @@ class TestCrawlSingle:
         assert result.success
         assert result.markdown == "# Test"
 
+    async def test_emits_setup_bracket_around_warmup(self):
+        """The browser warmup is bracketed by setup events so the Task Center
+        shows a 'preparing crawler' stage instead of a silent stall."""
+        mock_result = _make_crawl4ai_result()
+        mock_instance = AsyncMock()
+        mock_instance.arun = AsyncMock(return_value=mock_result)
+        mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+        mock_instance.__aexit__ = AsyncMock(return_value=False)
+        mock_crawler_cls = MagicMock(return_value=mock_instance)
+        mock_mod = _mock_crawl4ai(mock_crawler_cls)
+
+        events: list[tuple] = []
+        with patch.dict("sys.modules", {"crawl4ai": mock_mod}):
+            result = await crawl_single(
+                "https://example.com", on_progress=lambda e, d: events.append((e, d))
+            )
+        assert result.success
+        setup_types = [e for e, _ in events if e in (EventType.SETUP_START, EventType.SETUP_DONE)]
+        assert setup_types == [EventType.SETUP_START, EventType.SETUP_DONE]
+
     async def test_failure(self):
         mock_result = _make_crawl4ai_result(success=False, markdown="", error="Connection refused")
         mock_instance = AsyncMock()
@@ -1520,7 +1540,9 @@ class TestCrawlAndSave:
         """quiet=True is forwarded to crawl_single (depth=0 path)."""
         mock_crawl_single.return_value = CrawlResult(url="https://example.com", markdown="# Hi")
         await crawl_and_save("https://example.com", depth=0, quiet=True)
-        mock_crawl_single.assert_awaited_once_with("https://example.com", quiet=True)
+        mock_crawl_single.assert_awaited_once()
+        assert mock_crawl_single.await_args.args == ("https://example.com",)
+        assert mock_crawl_single.await_args.kwargs["quiet"] is True
 
     @patch("lilbee.crawler.runner.crawl_recursive")
     async def test_quiet_forwarded_to_crawl_recursive(self, mock_crawl_recursive, isolated_env):
@@ -2528,7 +2550,7 @@ class TestStreamingFlush:
         async def _short_sync(*_args, **_kwargs):
             await asyncio.sleep(0)
 
-        async def _fake_single(url: str, *, quiet: bool = False) -> CrawlResult:
+        async def _fake_single(url: str, *, quiet: bool = False, on_progress=None) -> CrawlResult:
             await asyncio.sleep(0)
             return CrawlResult(url=url, markdown=f"# {url}")
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1050,12 +1050,18 @@ class TestCrawlRecursive:
         assert len(results) == 2
         assert results[0].url == "https://example.com"
         assert results[1].url == "https://example.com/about"
-        assert len(progress_calls) == 2
         # Streaming semantics: total is unknown during BFS, counter advances per page.
         from lilbee.runtime.progress import CRAWL_TOTAL_UNKNOWN
 
-        assert [c[1].current for c in progress_calls] == [1, 2]
-        assert all(c[1].total == CRAWL_TOTAL_UNKNOWN for c in progress_calls)
+        page_events = [c for c in progress_calls if c[0] == EventType.CRAWL_PAGE]
+        assert [c[1].current for c in page_events] == [1, 2]
+        assert all(c[1].total == CRAWL_TOTAL_UNKNOWN for c in page_events)
+        # The browser warmup is bracketed by setup events so the Task Center
+        # shows a "preparing crawler" stage instead of a silent stall.
+        setup_types = [
+            e for e, _ in progress_calls if e in (EventType.SETUP_START, EventType.SETUP_DONE)
+        ]
+        assert setup_types == [EventType.SETUP_START, EventType.SETUP_DONE]
 
     async def test_emits_events_before_stream_exhausted(self):
         """CRAWL_PAGE fires per page as it arrives, not only after the full list."""


### PR DESCRIPTION
Two related fixes for crawled-page quality and crawl UX, combined so they're easy to test together.

## Problem

1. **Reference-link clutter.** Sites like Wikipedia render footnote markers as nested-bracket links — `[[2]](https://…#cite_note-2)`. The inner brackets make it a valid Markdown link with text `[2]`, but Obsidian treats `[[…]]` as its own wikilink syntax, so it parses `[[2]]` as a broken wikilink and renders the trailing `(url)` as literal text. A Wikipedia article carries hundreds of these, so the body fills with broken links and inline URLs.
2. **Invisible first-run setup.** The first crawl on a fresh install stalls with no feedback: the one-time browser warmup (opening the browser) can take many seconds, and the crawl emits no progress during it, so the UI sits blank and the crawl looks hung. Setup progress was only emitted when the browser binary had to be *downloaded*; once present, the warmup was silent.

## Solution

1. Collapse the nested brackets to single ones at save time (`[[N]](url)` → `[N](url)`) so the reference renders as an ordinary link. Non-lossy — text and URL are preserved, ordinary `[text](url)` links are untouched — and the content-hash dedup runs on the normalized text so re-crawls stay consistent.
2. Bracket the crawler open in both the single-page and recursive crawl paths with `setup_start`/`setup_done` (a "browser" component, no size estimate so it reads as indeterminate). Both the Obsidian Task Center and the TUI task bar already render setup events, so the first crawl now shows a "preparing crawler" stage instead of a silent stall; the browser-download path keeps its own granular progress.

Tests added for both (the normalizer + save path, and the warmup setup bracket on both crawl paths); `tests/test_crawler.py` is green (177), ruff + style checks pass. Validated end-to-end: the Obsidian Task Center shows the Chromium download + "preparing crawler", and the TUI shows "Install Chromium browser" on a first crawl.