### PR TITLE
Fix chat auto-scroll stalling mid-stream

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -80,8 +80,9 @@ fraction so the assembled prompt never approaches ``n_ctx`` and llama-cpp
 never errors with "Requested tokens exceed context window."
 """
 
-# Treat the user as "still at the bottom" when within this many lines so a tiny
-# stray scroll doesn't disable auto-follow during streaming.
+# Keep auto-following unless the user scrolls up more than this many lines from
+# where the last auto-scroll parked them, so a tiny stray scroll doesn't disable
+# auto-follow during streaming.
 _AUTO_SCROLL_TAIL_LINES = 5
 
 # Coalesce per-token UI updates into ~50 ms windows. Tiny reasoning models can
@@ -197,6 +198,7 @@ class ChatScreen(Screen[None]):
         self._sync_active: bool = False
         self._input_history: list[str] = []
         self._history_index: int = -1
+        self._tail_scroll_y: float = 0.0
         self._command_handlers: dict[str, Callable[[str], None]] = self._build_command_handlers()
 
     def _build_command_handlers(self) -> dict[str, Callable[[str], None]]:
@@ -1040,6 +1042,9 @@ class ChatScreen(Screen[None]):
         assistant_msg = AssistantMessage()
         log.mount(assistant_msg)
         log.scroll_end(animate=False)
+        # A fresh turn always follows its own answer, even if the user had
+        # scrolled up during the previous response.
+        self._tail_scroll_y = 0.0
 
         with self._history_lock:
             self._history.append({"role": "user", "content": text})
@@ -1175,10 +1180,14 @@ class ChatScreen(Screen[None]):
 
     def _scroll_to_bottom(self) -> None:
         log_widget = self._chat_log
-        # Only auto-scroll while the user is still tailing the output.
-        # If they scrolled up to read, don't yank them back.
-        if log_widget.max_scroll_y - log_widget.scroll_y < _AUTO_SCROLL_TAIL_LINES:
+        # Keep tailing unless the user scrolled up from where the last auto-scroll
+        # parked them. Comparing the live max_scroll_y against scroll_y instead
+        # breaks during streaming: content is appended between scroll ticks, so
+        # max_scroll_y races ahead while scroll_y stays put, and the growing gap
+        # would look like a manual scroll-up and disable auto-follow for good.
+        if log_widget.scroll_y >= self._tail_scroll_y - _AUTO_SCROLL_TAIL_LINES:
             log_widget.scroll_end(animate=False)
+            self._tail_scroll_y = log_widget.max_scroll_y
 
     def action_scroll_up(self) -> None:
         self._chat_log.scroll_page_up()

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -80,9 +80,9 @@ fraction so the assembled prompt never approaches ``n_ctx`` and llama-cpp
 never errors with "Requested tokens exceed context window."
 """
 
-# Keep auto-following unless the user scrolls up more than this many lines from
-# where the last auto-scroll parked them, so a tiny stray scroll doesn't disable
-# auto-follow during streaming.
+# Auto-follow tolerance, in lines: the user counts as "at the bottom" within
+# this many lines of it, so a tiny stray scroll doesn't disable auto-follow and
+# scrolling back near the bottom re-engages it.
 _AUTO_SCROLL_TAIL_LINES = 5
 
 # Coalesce per-token UI updates into ~50 ms windows. Tiny reasoning models can
@@ -199,6 +199,7 @@ class ChatScreen(Screen[None]):
         self._input_history: list[str] = []
         self._history_index: int = -1
         self._tail_scroll_y: float = 0.0
+        self._auto_follow: bool = True
         self._command_handlers: dict[str, Callable[[str], None]] = self._build_command_handlers()
 
     def _build_command_handlers(self) -> dict[str, Callable[[str], None]]:
@@ -1044,6 +1045,7 @@ class ChatScreen(Screen[None]):
         log.scroll_end(animate=False)
         # A fresh turn always follows its own answer, even if the user had
         # scrolled up during the previous response.
+        self._auto_follow = True
         self._tail_scroll_y = 0.0
 
         with self._history_lock:
@@ -1180,12 +1182,17 @@ class ChatScreen(Screen[None]):
 
     def _scroll_to_bottom(self) -> None:
         log_widget = self._chat_log
-        # Keep tailing unless the user scrolled up from where the last auto-scroll
-        # parked them. Comparing the live max_scroll_y against scroll_y instead
-        # breaks during streaming: content is appended between scroll ticks, so
-        # max_scroll_y races ahead while scroll_y stays put, and the growing gap
-        # would look like a manual scroll-up and disable auto-follow for good.
-        if log_widget.scroll_y >= self._tail_scroll_y - _AUTO_SCROLL_TAIL_LINES:
+        # Re-engage auto-follow when the user is at the live bottom; disengage
+        # when they scroll up from where the last auto-scroll parked them. The
+        # disengage test compares against that parked position, not the live
+        # max_scroll_y: content is appended between scroll ticks, so max_scroll_y
+        # races ahead of a parked scroll_y, and a live-gap test would read that
+        # as a scroll-up and stop auto-follow for the rest of the response.
+        if log_widget.scroll_y >= log_widget.max_scroll_y - _AUTO_SCROLL_TAIL_LINES:
+            self._auto_follow = True
+        elif log_widget.scroll_y < self._tail_scroll_y - _AUTO_SCROLL_TAIL_LINES:
+            self._auto_follow = False
+        if self._auto_follow:
             log_widget.scroll_end(animate=False)
             self._tail_scroll_y = log_widget.max_scroll_y
 

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3524,6 +3524,65 @@ async def test_chat_scroll_to_bottom():
             assert mock_end.called or log.max_scroll_y - log.scroll_y >= 5
 
 
+async def test_chat_auto_scroll_stays_pinned_as_content_grows():
+    """Regression: streamed content grows between scroll ticks. scroll_end does
+    not move scroll_y synchronously and Textual keeps scroll_y put as content
+    grows above it, so max_scroll_y races ahead of scroll_y. Auto-follow must
+    stay pinned to the bottom instead of disabling itself once that gap exceeds
+    the tail tolerance.
+    """
+    from textual.containers import VerticalScroll
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        log = app.screen.query_one("#chat-log", VerticalScroll)
+        with (
+            patch.object(type(log), "max_scroll_y", new_callable=PropertyMock) as max_y,
+            patch.object(type(log), "scroll_y", new_callable=PropertyMock) as scroll_y,
+            patch.object(log, "scroll_end") as mock_end,
+        ):
+            # Tick 1: user parked at the bottom (10/10), auto-scroll fires.
+            max_y.return_value = 10
+            scroll_y.return_value = 10.0
+            app.screen._scroll_to_bottom()
+            assert mock_end.call_count == 1
+
+            # 70 more lines stream in before the next tick. scroll_y stays at
+            # the parked spot (10) while max_scroll_y races to 80.
+            max_y.return_value = 80
+            scroll_y.return_value = 10.0
+            app.screen._scroll_to_bottom()
+            # Comparing the live gap (80 - 10 = 70 >= 5) would suppress this and
+            # never recover. The user never scrolled up, so we must still follow.
+            assert mock_end.call_count == 2
+
+
+async def test_chat_auto_scroll_stops_when_user_scrolls_up():
+    """Auto-follow must release the bottom once the user scrolls up to read."""
+    from textual.containers import VerticalScroll
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        log = app.screen.query_one("#chat-log", VerticalScroll)
+        with (
+            patch.object(type(log), "max_scroll_y", new_callable=PropertyMock) as max_y,
+            patch.object(type(log), "scroll_y", new_callable=PropertyMock) as scroll_y,
+            patch.object(log, "scroll_end") as mock_end,
+        ):
+            # Park at the bottom.
+            max_y.return_value = 80
+            scroll_y.return_value = 80.0
+            app.screen._scroll_to_bottom()
+            assert mock_end.call_count == 1
+
+            # User scrolls well up from the parked bottom; more content arrives.
+            max_y.return_value = 120
+            scroll_y.return_value = 20.0
+            app.screen._scroll_to_bottom()
+            # We must not yank the reader back down.
+            assert mock_end.call_count == 1
+
+
 async def test_chat_trim_history_drops_oldest_pairs_over_token_budget():
     """History windows by token budget, dropping oldest user/assistant pairs."""
     from lilbee.core.config import cfg

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3583,6 +3583,43 @@ async def test_chat_auto_scroll_stops_when_user_scrolls_up():
             assert mock_end.call_count == 1
 
 
+async def test_chat_auto_scroll_resumes_only_at_live_bottom():
+    """After a scroll-up, auto-follow re-engages only at the live bottom, not at
+    the stale position the previous response was parked at.
+    """
+    from textual.containers import VerticalScroll
+
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        log = app.screen.query_one("#chat-log", VerticalScroll)
+        with (
+            patch.object(type(log), "max_scroll_y", new_callable=PropertyMock) as max_y,
+            patch.object(type(log), "scroll_y", new_callable=PropertyMock) as scroll_y,
+            patch.object(log, "scroll_end") as mock_end,
+        ):
+            # Park at the bottom (80), then the user scrolls up while more
+            # content streams in and pushes the bottom to 120.
+            max_y.return_value = 80
+            scroll_y.return_value = 80.0
+            app.screen._scroll_to_bottom()
+            assert mock_end.call_count == 1
+            max_y.return_value = 120
+            scroll_y.return_value = 20.0
+            app.screen._scroll_to_bottom()
+            assert mock_end.call_count == 1
+
+            # Scrolling back to the old parked spot (80) must NOT resume: the
+            # live bottom is now 120, so 80 is still 40 lines short.
+            scroll_y.return_value = 80.0
+            app.screen._scroll_to_bottom()
+            assert mock_end.call_count == 1
+
+            # Reaching the live bottom re-engages auto-follow.
+            scroll_y.return_value = 118.0
+            app.screen._scroll_to_bottom()
+            assert mock_end.call_count == 2
+
+
 async def test_chat_trim_history_drops_oldest_pairs_over_token_budget():
     """History windows by token budget, dropping oldest user/assistant pairs."""
     from lilbee.core.config import cfg


### PR DESCRIPTION
## Problem

While the assistant streams a reply, the chat log stops following the bottom partway through. The newest text keeps arriving below the fold and the user has to scroll down to read the rest of their answer.

## Solution

The auto-scroll decided whether to keep tailing by comparing the live `max_scroll_y` against `scroll_y`. Content is appended between scroll ticks, so `max_scroll_y` runs ahead while `scroll_y` stays put, and once that gap crossed the tolerance the check mistook it for a manual scroll-up and disabled auto-follow for the rest of the response.

Now it tracks where the last auto-scroll parked the view and keeps following unless the user actually scrolls up from there, and the anchor resets each turn so a new question always follows its own answer. Verified in a tmux session: the view tails a long streamed reply to the end, respects a manual scroll-up, and re-follows on the next question.