### PR TITLE
Enable flash attention for vision OCR

### DIFF
--- a/src/lilbee/providers/mtmd_backend.py
+++ b/src/lilbee/providers/mtmd_backend.py
@@ -134,10 +134,10 @@ def load_vision_llama(
 
     import os
 
-    # llama-cpp-python defaults n_threads to ~cpu_count()//2 which leaves the
-    # GPU starved on prompt-eval work (image projection through the vision
-    # adapter is CPU-bound on the encode side even with all layers on GPU).
-    # Ollama runs full-core. Match that here for perf parity.
+    # mtmd offloads the vision encoder to the GPU (use_gpu=True), but the
+    # CPU side still runs image preprocessing, tokenization, and sampling.
+    # llama-cpp-python defaults n_threads to ~cpu_count()//2, which starves
+    # those steps; Ollama runs full-core, so match that here.
     n_threads = os.cpu_count() or 4
     kwargs: dict[str, Any] = {
         "model_path": str(model_path),
@@ -148,6 +148,12 @@ def load_vision_llama(
         "n_threads": n_threads,
         "n_threads_batch": n_threads,
     }
+    # mtmd only enables flash attention for the vision pass when the backing
+    # Llama already has it ENABLED; left unset it defaults to DISABLED, which
+    # makes the image-token prefill (thousands of tokens per page) far slower.
+    # Mirror the chat loader and honor cfg.flash_attention (None/auto -> on).
+    if cfg.flash_attention is not False:
+        kwargs["flash_attn"] = True
     if cfg.main_gpu is not None:
         kwargs["main_gpu"] = cfg.main_gpu
     if abort_callback_override is not None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1887,6 +1887,50 @@ class TestMtmdLoadVisionLlama:
         finally:
             cfg.main_gpu = None
 
+    def test_vision_passes_flash_attn_by_default(self, mock_llama_cpp: mock.MagicMock) -> None:
+        """mtmd only enables FA when the backing Llama has it on, so vision must opt in."""
+        from lilbee.providers.mtmd_backend import load_vision_llama
+
+        cfg.num_ctx = None
+        cfg.flash_attention = None  # auto
+        try:
+            with (
+                mock.patch(
+                    "lilbee.providers.mtmd_backend.read_gguf_metadata",
+                    return_value={"context_length": "8192"},
+                ),
+                mock.patch(
+                    "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+                    return_value=mock.MagicMock(),
+                ),
+            ):
+                load_vision_llama(Path("model.gguf"), mmproj_path=Path("mmproj.gguf"))
+            assert mock_llama_cpp.Llama.call_args[1].get("flash_attn") is True
+        finally:
+            cfg.flash_attention = None
+
+    def test_vision_skips_flash_attn_when_disabled(self, mock_llama_cpp: mock.MagicMock) -> None:
+        """``cfg.flash_attention = False`` keeps FA off the vision Llama kwargs."""
+        from lilbee.providers.mtmd_backend import load_vision_llama
+
+        cfg.num_ctx = None
+        cfg.flash_attention = False
+        try:
+            with (
+                mock.patch(
+                    "lilbee.providers.mtmd_backend.read_gguf_metadata",
+                    return_value={"context_length": "8192"},
+                ),
+                mock.patch(
+                    "lilbee.providers.mtmd_backend.build_vision_chat_handler",
+                    return_value=mock.MagicMock(),
+                ),
+            ):
+                load_vision_llama(Path("model.gguf"), mmproj_path=Path("mmproj.gguf"))
+            assert "flash_attn" not in mock_llama_cpp.Llama.call_args[1]
+        finally:
+            cfg.flash_attention = None
+
     def test_vision_falls_back_to_default_when_metadata_missing(
         self, mock_llama_cpp: mock.MagicMock
     ) -> None:


### PR DESCRIPTION
## Problem

Vision OCR ran far slower than it should. The cause was flash attention being disabled on the vision path. `load_vision_llama` never passed `flash_attn`, so the vision `Llama` was built with `flash_attn_type=DISABLED`, and llama-cpp-python's mtmd handler only turns FA on when the backing Llama already has it ENABLED. So the whole OCR pass (the few-thousand-token image prefill per page plus the decode) ran without flash attention, while the chat loader had been enabling it all along.

## Solution

Set `flash_attn` in the vision loader, honoring `cfg.flash_attention` (None/auto and True enable it, False leaves it off), mirroring the chat loader. Also corrected the stale comment claiming the encoder is CPU-bound: mtmd offloads it to the GPU (`use_gpu=True`), so the full-core `n_threads` is for CPU-side preprocessing and sampling.

Measured on an M-series mac with LightOnOCR-2-1B, one scanned page, identical token counts (2412 prompt / 51 completion):

| | OCR wall |
|---|---|
| Before (FA off) | 23.8s |
| After (FA on) | 9.7s |

Added vision-loader tests for the default-on and disabled cases.