### PR TITLE
Surface cloud (API-key) and Ollama models in the HTTP model catalog

### DIFF
--- a/src/lilbee/catalog/types.py
+++ b/src/lilbee/catalog/types.py
@@ -25,6 +25,8 @@ class ModelSource(StrEnum):
 
     NATIVE = "native"  # lilbee's GGUF files in cfg.models_dir
     REMOTE = "remote"  # Models managed by a remote SDK-backed service
+    FRONTIER = "frontier"  # Cloud API-key models (Gemini/OpenAI/Anthropic/…)
+    OLLAMA = "ollama"  # Models served by a reachable Ollama endpoint
 
     @classmethod
     def parse(cls, value: str | None) -> ModelSource | None:
@@ -40,6 +42,13 @@ class ModelSource(StrEnum):
         except ValueError as exc:
             valid = ", ".join(s.value for s in cls)
             raise ValueError(f"invalid source {value!r}; expected one of: {valid}") from exc
+
+
+class KeyStatus(StrEnum):
+    """Whether a hosted provider's API key is configured."""
+
+    READY = "ready"
+    MISSING_KEY = "missing_key"
 
 
 class CatalogSize(StrEnum):

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -14,10 +14,27 @@ from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.core.security import validate_path_within
 from lilbee.modelhub.model_manager.types import ModelNotFoundError
 from lilbee.modelhub.registry import ModelRegistry
+from lilbee.providers.model_ref import OLLAMA_PREFIX, parse_model_ref
 
 log = logging.getLogger(__name__)
 
 _INSTALLED_CACHE_TTL_SECONDS = 30.0
+
+
+def _prefixed_source(model: str) -> ModelSource | None:
+    """Map a provider-prefixed ref to its source, or ``None`` for a bare ref.
+
+    API-provider prefixes (``gemini/``, ``openai/`` ...) are FRONTIER;
+    ``ollama/`` is OLLAMA. Bare names carry no prefix to classify on and
+    return ``None`` so the caller can fall back to backend membership.
+    """
+    if model.startswith(OLLAMA_PREFIX):
+        return ModelSource.OLLAMA
+    try:
+        ref = parse_model_ref(model)
+    except ValueError:
+        return None
+    return ModelSource.FRONTIER if ref.is_api else None
 
 
 class ModelManager:
@@ -130,11 +147,20 @@ class ModelManager:
         return model in self.list_installed(ModelSource.REMOTE)
 
     def get_source(self, model: str) -> ModelSource | None:
-        """Find which source a model lives in. Native takes precedence."""
+        """Return the granular source a model lives in. Native takes precedence.
+
+        A provider-prefixed ref classifies without a network call (API
+        prefixes are FRONTIER, ``ollama/`` is OLLAMA); a bare name is OLLAMA
+        when the Ollama backend reports it installed. ``None`` when the model
+        is in no known source.
+        """
         if self._is_native(model):
             return ModelSource.NATIVE
+        prefixed = _prefixed_source(model)
+        if prefixed is not None:
+            return prefixed
         if self._is_remote(model):
-            return ModelSource.REMOTE
+            return ModelSource.OLLAMA
         return None
 
     def pull(
@@ -264,11 +290,14 @@ class ModelManager:
 
     def _remove_remote(self, model: str) -> bool:
         url = f"{self._remote_base_url}/api/delete"
+        # Ollama's API keys models by bare name; strip the canonical routing
+        # prefix the rest of lilbee carries.
+        backend_name = model.removeprefix(OLLAMA_PREFIX)
         try:
             resp = httpx.request(
                 "DELETE",
                 url,
-                content=json.dumps({"model": model}).encode(),
+                content=json.dumps({"model": backend_name}).encode(),
                 headers={"Content-Type": "application/json"},
                 timeout=DEFAULT_HTTP_TIMEOUT,
             )

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -29,7 +29,7 @@ from lilbee.core.config import cfg
 from lilbee.modelhub.model_manager import classify_remote_models, discover_api_models
 from lilbee.modelhub.model_manager.types import RemoteModel
 from lilbee.modelhub.role_validator import _MODEL_FIELD_TO_TASK, validate_model_task_assignment
-from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
+from lilbee.providers.model_ref import OLLAMA_PREFIX, format_remote_ref, parse_model_ref
 from lilbee.providers.sdk_backend import PROVIDER_KEYS, get_provider_api_key
 from lilbee.runtime.hardware import (
     FitLevel,
@@ -411,8 +411,7 @@ def _discover_hosted_sync() -> list[CatalogEntryResponse]:
     for models in discover_api_models().values():
         rows.extend(_hosted_entry(rm, ModelSource.FRONTIER) for rm in models)
     rows.extend(
-        _hosted_entry(rm, ModelSource.OLLAMA)
-        for rm in classify_remote_models(cfg.remote_base_url)
+        _hosted_entry(rm, ModelSource.OLLAMA) for rm in classify_remote_models(cfg.remote_base_url)
     )
     return rows
 
@@ -500,14 +499,27 @@ async def models_catalog(
     )
 
 
+def _canonical_installed_ref(name: str, source: ModelSource) -> str:
+    """Render an Ollama model with its ``ollama/<name>`` ref.
+
+    Ollama's ``/api/tags`` reports bare names; the catalog reports the
+    prefixed ref. Reporting the prefixed ref here too lets clients dedup the
+    installed and catalog views instead of showing the model twice.
+    """
+    if source is ModelSource.OLLAMA and not name.startswith(OLLAMA_PREFIX):
+        return format_remote_ref(name, ModelSource.OLLAMA.value)
+    return name
+
+
 async def models_installed() -> ModelsInstalledResponse:
-    """Return list of installed models with their source."""
+    """Return installed models with their granular source and canonical ref."""
     manager = get_services().model_manager
-    names = manager.list_installed()
     models = []
-    for name in names:
-        src = manager.get_source(name)
-        models.append(InstalledModelEntry(name=name, source=src or ModelSource.REMOTE))
+    for name in manager.list_installed():
+        source = manager.get_source(name) or ModelSource.REMOTE
+        models.append(
+            InstalledModelEntry(name=_canonical_installed_ref(name, source), source=source)
+        )
     return ModelsInstalledResponse(models=models)
 
 

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -24,10 +24,13 @@ from lilbee.catalog import (
     get_families,
 )
 from lilbee.catalog.refs import hf_repo_from_ref
-from lilbee.catalog.types import CatalogSize, CatalogSort, ModelSource, ModelTask
+from lilbee.catalog.types import CatalogSize, CatalogSort, KeyStatus, ModelSource, ModelTask
 from lilbee.core.config import cfg
+from lilbee.modelhub.model_manager import classify_remote_models, discover_api_models
+from lilbee.modelhub.model_manager.types import RemoteModel
 from lilbee.modelhub.role_validator import _MODEL_FIELD_TO_TASK, validate_model_task_assignment
-from lilbee.providers.model_ref import parse_model_ref
+from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
+from lilbee.providers.sdk_backend import PROVIDER_KEYS, get_provider_api_key
 from lilbee.runtime.hardware import (
     FitLevel,
     SizeVariantInfo,
@@ -165,12 +168,39 @@ def _resolve_via_catalog(model: str, available: set[str]) -> str | None:
 
 
 def _resolve_via_parse(model: str, available: set[str]) -> str | None:
-    """Resolve a provider-prefixed ref to its bare provider name in *available*."""
+    """Resolve a provider-prefixed ref against *available*.
+
+    The backend lists hosted models under their bare provider names (e.g.
+    ``gemini-2.0-flash``, ``qwen3:0.6b``), while selections arrive carrying
+    the routing prefix (``gemini/gemini-2.0-flash``, ``ollama/qwen3:0.6b``).
+    When the bare name is visible, return the *prefixed* ref so it keeps its
+    provider routing and skips the native catalog/installed check downstream,
+    mirroring how the TUI persists a frontier/Ollama selection verbatim.
+    """
     try:
         parsed = parse_model_ref(model)
     except ValueError:
         return None
-    return parsed.name if parsed.name in available else None
+    return model if parsed.name in available else None
+
+
+def _resolve_via_provider_key(model: str) -> str | None:
+    """Accept an API-provider-prefixed ref when that provider's key is configured.
+
+    Frontier models surface through ``discover_api_models`` (a per-key listing),
+    not the default ``provider.list_models()``, so a ref like
+    ``gemini/gemini-2.0-flash`` never appears in *available* even when it is
+    perfectly routable. As long as the provider's key is set, litellm can route
+    it (and validates the exact model name at call time), so the prefixed ref is
+    accepted verbatim, matching how the TUI persists a frontier selection.
+    """
+    try:
+        parsed = parse_model_ref(model)
+    except ValueError:
+        return None
+    if parsed.is_api and get_provider_api_key(parsed.provider) is not None:
+        return model
+    return None
 
 
 def _require_model_available(model: str) -> str:
@@ -183,7 +213,11 @@ def _require_model_available(model: str) -> str:
     available = set(get_services().provider.list_models())
     if model in available:
         return model
-    hit = _resolve_via_catalog(model, available) or _resolve_via_parse(model, available)
+    hit = (
+        _resolve_via_catalog(model, available)
+        or _resolve_via_parse(model, available)
+        or _resolve_via_provider_key(model)
+    )
     if hit is None:
         raise not_available
     return hit
@@ -316,6 +350,101 @@ def _build_catalog_entry(
     )
 
 
+def _hosted_entry(rm: RemoteModel, source: ModelSource) -> CatalogEntryResponse:
+    """Build a selectable, no-download catalog row for a discovered hosted model."""
+    return CatalogEntryResponse(
+        hf_repo=format_remote_ref(rm.name, rm.provider),
+        gguf_filename="",
+        task=rm.task,
+        display_name=rm.name,
+        param_count=rm.parameter_size,
+        size_gb=0,
+        min_ram_gb=0,
+        description="",
+        quality_tier="",
+        featured=False,
+        downloads=0,
+        installed=True,
+        source=source,
+        fit=None,
+        size_variants=[],
+        provider=rm.provider,
+        key_status=KeyStatus.READY if source is ModelSource.FRONTIER else None,
+    )
+
+
+_HOSTED_MODELS_TTL = 60
+
+
+class _HostedModelsCache:
+    """TTL cache for discovered hosted rows (no module-level mutable global)."""
+
+    def __init__(self) -> None:
+        self._time: float = 0.0
+        self._key: str = ""
+        self._result: list[CatalogEntryResponse] | None = None
+
+    def get(self, key: str) -> list[CatalogEntryResponse] | None:
+        now = time.monotonic()
+        fresh = (now - self._time) < _HOSTED_MODELS_TTL
+        if self._result is not None and key == self._key and fresh:
+            return self._result
+        return None
+
+    def set(self, key: str, result: list[CatalogEntryResponse]) -> None:
+        self._time = time.monotonic()
+        self._key = key
+        self._result = result
+
+
+_hosted_cache = _HostedModelsCache()
+
+
+def _discover_hosted_sync() -> list[CatalogEntryResponse]:
+    """All hosted rows (frontier + ollama), unfiltered. Blocking, call via to_thread.
+
+    Both discovery calls fail soft (empty dict / list) when no keys are
+    configured or the Ollama endpoint is unreachable, so the catalog
+    degrades to native-only here without special-casing.
+    """
+    rows: list[CatalogEntryResponse] = []
+    for models in discover_api_models().values():
+        rows.extend(_hosted_entry(rm, ModelSource.FRONTIER) for rm in models)
+    rows.extend(
+        _hosted_entry(rm, ModelSource.OLLAMA)
+        for rm in classify_remote_models(cfg.remote_base_url)
+    )
+    return rows
+
+
+def _hosted_cache_key() -> str:
+    """Cache key over the inputs that change discovery output.
+
+    Enumerates configured provider-key fields generically from
+    ``PROVIDER_KEYS`` so adding a provider does not silently reuse a
+    stale cache entry.
+    """
+    keys = ":".join(getattr(cfg, field, "") or "" for _, field, *_ in PROVIDER_KEYS)
+    return f"{cfg.remote_base_url}:{keys}"
+
+
+async def _collect_hosted_entries(
+    *, task: ModelTask | None, search: str
+) -> list[CatalogEntryResponse]:
+    """Hosted catalog rows filtered by task/search, off the event loop + TTL-cached."""
+    key = _hosted_cache_key()
+    rows = _hosted_cache.get(key)
+    if rows is None:
+        rows = await asyncio.to_thread(_discover_hosted_sync)
+        _hosted_cache.set(key, rows)
+    if task is not None:
+        rows = [r for r in rows if r.task == task]
+    if search:
+        needle = search.lower()
+        rows = [r for r in rows if needle in r.display_name.lower()]
+    return rows
+
+
 async def models_catalog(
     task: str | None = None,
     search: str = "",
@@ -350,17 +479,24 @@ async def models_catalog(
     available_bytes = available_memory_for_fit()
     families_by_repo = _families_by_repo()
 
+    native_rows = [
+        _build_catalog_entry(e, available_bytes=available_bytes, families_by_repo=families_by_repo)
+        for e in enriched
+    ]
+    # Hosted rows (frontier + ollama) are selectable and download-free, so
+    # they're shown on the first page only (mirrors the featured first-page
+    # convention), skipped for featured-only and installed=False filters, and
+    # counted toward ``total``.
+    hosted_rows: list[CatalogEntryResponse] = []
+    if offset == 0 and not featured and installed is not False:
+        hosted_rows = await _collect_hosted_entries(task=parsed_task, search=search)
+
     return ModelsCatalogResponse(
-        total=result.total,
+        total=result.total + len(hosted_rows),
         limit=result.limit,
         offset=result.offset,
         has_more=result.has_more,
-        models=[
-            _build_catalog_entry(
-                e, available_bytes=available_bytes, families_by_repo=families_by_repo
-            )
-            for e in enriched
-        ],
+        models=hosted_rows + native_rows,
     )
 
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-from lilbee.catalog.types import ModelCompat, ModelSource, ModelTask
+from lilbee.catalog.types import KeyStatus, ModelCompat, ModelSource, ModelTask
 from lilbee.data.store import ChunkType, SearchScope
 from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 
@@ -272,6 +272,8 @@ class CatalogEntryResponse(BaseModel):
     size_variants: list[SizeVariantInfo] = []
     architecture: str = ""
     compat: ModelCompat = ModelCompat.UNKNOWN
+    provider: str = ""
+    key_status: KeyStatus | None = None
 
 
 class ModelsCatalogResponse(BaseModel):

--- a/tests/test_mcp_model_tools.py
+++ b/tests/test_mcp_model_tools.py
@@ -53,7 +53,9 @@ class TestMcpList:
     def test_invalid_source_returns_explicit_error(self):
         with patch("lilbee.app.models.list_models_data") as fn:
             result = model_list(source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, remote"}
+        assert result == {
+            "error": "invalid source 'bogus'; expected one of: native, remote, frontier, ollama"
+        }
         fn.assert_not_called()
 
 
@@ -91,7 +93,9 @@ class TestMcpRemove:
     def test_invalid_source_explicit_error(self):
         with patch("lilbee.app.models.remove_model_data") as fn:
             result = model_rm("qwen3:0.6b", source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, remote"}
+        assert result == {
+            "error": "invalid source 'bogus'; expected one of: native, remote, frontier, ollama"
+        }
         fn.assert_not_called()
 
 
@@ -172,7 +176,9 @@ class TestMcpPull:
     @pytest.mark.asyncio
     async def test_pull_invalid_source(self):
         result = await model_pull("qwen3:0.6b", source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, remote"}
+        assert result == {
+            "error": "invalid source 'bogus'; expected one of: native, remote, frontier, ollama"
+        }
 
 
 class TestLogProgressFailure:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -348,7 +348,8 @@ class TestModelManagerGetSource:
         mgr = ModelManager(models_dir, "http://localhost:11434")
         assert mgr.get_source("my-model.gguf") == ModelSource.NATIVE
 
-    def test_litellm_model(self) -> None:
+    def test_bare_ollama_model_is_ollama_source(self) -> None:
+        """A bare name the Ollama backend reports installed classifies as OLLAMA."""
         mock_response = mock.Mock()
         mock_response.json.return_value = {"models": [{"name": "llama3:latest"}]}
         mock_response.raise_for_status = mock.Mock()
@@ -357,7 +358,23 @@ class TestModelManagerGetSource:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
             result = mgr.get_source("llama3:latest")
 
-        assert result == ModelSource.REMOTE
+        assert result == ModelSource.OLLAMA
+
+    def test_ollama_prefixed_ref_is_ollama_source_without_network(self) -> None:
+        """An ``ollama/`` ref classifies on the prefix, no /api/tags call."""
+        mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+        with mock.patch("httpx.get") as mock_get:
+            result = mgr.get_source("ollama/llama3:latest")
+        assert result == ModelSource.OLLAMA
+        mock_get.assert_not_called()
+
+    def test_api_prefixed_ref_is_frontier_source(self) -> None:
+        """A hosted API ref classifies as FRONTIER without a network call."""
+        mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+        with mock.patch("httpx.get") as mock_get:
+            result = mgr.get_source("gemini/gemini-2.5-pro")
+        assert result == ModelSource.FRONTIER
+        mock_get.assert_not_called()
 
     def test_native_takes_precedence(self, tmp_path: Path) -> None:
         """When model exists in both sources, NATIVE takes precedence."""
@@ -625,6 +642,18 @@ class TestModelManagerRemove:
         call_kwargs = mock_req.call_args[1]
         assert call_kwargs["content"] == b'{"model": "llama3:latest"}'
         assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        assert result is True
+
+    def test_remove_strips_ollama_prefix_for_backend(self) -> None:
+        """A canonical ``ollama/<name>`` ref deletes by bare name on the backend."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+
+        with mock.patch("httpx.request", return_value=mock_response) as mock_req:
+            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            result = mgr.remove("ollama/llama3:latest", ModelSource.OLLAMA)
+
+        assert mock_req.call_args[1]["content"] == b'{"model": "llama3:latest"}'
         assert result is True
 
     def test_litellm_remove_not_found(self) -> None:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -56,7 +56,12 @@ class TestModelSource:
         assert ModelSource.REMOTE.value == "remote"
 
     def test_members(self) -> None:
-        assert set(ModelSource) == {ModelSource.NATIVE, ModelSource.REMOTE}
+        assert set(ModelSource) == {
+            ModelSource.NATIVE,
+            ModelSource.REMOTE,
+            ModelSource.FRONTIER,
+            ModelSource.OLLAMA,
+        }
 
     def test_parse_none_and_empty_return_none(self) -> None:
         assert ModelSource.parse(None) is None
@@ -71,6 +76,12 @@ class TestModelSource:
 
         with pytest.raises(ValueError, match="invalid source 'bogus'"):
             ModelSource.parse("bogus")
+
+    def test_has_frontier_and_ollama(self) -> None:
+        assert ModelSource.FRONTIER == "frontier"
+        assert ModelSource.OLLAMA == "ollama"
+        assert ModelSource.parse("frontier") is ModelSource.FRONTIER
+        assert ModelSource.parse("ollama") is ModelSource.OLLAMA
 
 
 def _install_registry_model(

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1731,6 +1731,34 @@ class TestModelsInstalled:
             result = await handlers.models_installed()
         assert result.models[0].source == "remote"
 
+    async def test_ollama_model_reports_granular_source_and_canonical_ref(self):
+        """A bare Ollama name surfaces as source 'ollama' with the prefixed ref."""
+        from lilbee.catalog.types import ModelSource
+
+        mock_manager = MagicMock()
+        mock_manager.list_installed.return_value = ["qwen3:0.6b"]
+        mock_manager.get_source.return_value = ModelSource.OLLAMA
+        with patch(
+            "lilbee.server.handlers.models.get_services",
+            return_value=MagicMock(model_manager=mock_manager),
+        ):
+            result = await handlers.models_installed()
+        assert result.models[0].name == "ollama/qwen3:0.6b"
+        assert result.models[0].source == "ollama"
+
+    async def test_already_prefixed_ollama_ref_not_double_prefixed(self):
+        from lilbee.catalog.types import ModelSource
+
+        mock_manager = MagicMock()
+        mock_manager.list_installed.return_value = ["ollama/qwen3:0.6b"]
+        mock_manager.get_source.return_value = ModelSource.OLLAMA
+        with patch(
+            "lilbee.server.handlers.models.get_services",
+            return_value=MagicMock(model_manager=mock_manager),
+        ):
+            result = await handlers.models_installed()
+        assert result.models[0].name == "ollama/qwen3:0.6b"
+
 
 class TestModelsPull:
     async def test_yields_progress_events_native(self):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -970,16 +970,237 @@ class TestSetChatModel:
             await handlers.set_chat_model("qwen3:0.6b")
 
     async def test_provider_prefixed_bare_form_resolves_via_parse(self, tmp_path, mock_svc):
-        """An ``ollama/<name>`` resolves to bare ``<name>`` when that's what list_models returns."""
+        """An ``ollama/<name>`` whose bare form the backend lists is accepted verbatim.
+
+        The backend reports the bare ``qwen3:0.6b``; the prefixed selection
+        keeps its ``ollama/`` routing prefix (rather than collapsing to the
+        bare name), so validation skips the native catalog/installed check,
+        the same path the TUI takes when persisting an Ollama selection.
+        """
         mock_svc.provider.list_models.return_value = ["qwen3:0.6b"]
-        with pytest.raises(ValueError, match="not installed"):
-            # parse path: "ollama/qwen3:0.6b" -> name="qwen3:0.6b" which is in
-            # available; validate rejects the bare colon-form as not installed
-            # because no manifest exists for that ref in the native registry.
-            await handlers.set_chat_model("ollama/qwen3:0.6b")
+        result = await handlers.set_chat_model("ollama/qwen3:0.6b")
+        assert result.model == "ollama/qwen3:0.6b"
+        assert cfg.chat_model == "ollama/qwen3:0.6b"
+
+    async def test_accepts_frontier_ref(self, tmp_path, mock_svc):
+        """A discovered frontier ref (``gemini/gemini-2.0-flash``) is selectable.
+
+        Frontier models surface through ``discover_api_models`` (a per-key
+        listing), NOT ``provider.list_models()``, so the bare name is absent
+        from the routable set the validator checks. The ref is accepted because
+        the Gemini key is configured (litellm validates the exact name at call
+        time), and the ``gemini/`` prefix is persisted verbatim so it routes to
+        the provider. (The bare name is deliberately NOT in ``list_models`` here
+        so the test exercises the real path rather than a happy-path mock.)
+        """
+        cfg.gemini_api_key = "test-gemini-key"
+        mock_svc.provider.list_models.return_value = [_CHAT_REF]
+        result = await handlers.set_chat_model("gemini/gemini-2.0-flash")
+        assert result.model == "gemini/gemini-2.0-flash"
+        assert cfg.chat_model == "gemini/gemini-2.0-flash"
+
+    async def test_rejects_frontier_ref_without_key(self, tmp_path, mock_svc):
+        """A frontier ref is not routable when the provider's key is unset."""
+        cfg.gemini_api_key = ""
+        mock_svc.provider.list_models.return_value = [_CHAT_REF]
+        with pytest.raises(ValueError, match="not available"):
+            await handlers.set_chat_model("gemini/gemini-2.0-flash")
+
+
+class TestHostedCatalogEntries:
+    def test_catalog_entry_response_hosted_fields(self) -> None:
+        from lilbee.catalog.types import KeyStatus, ModelSource, ModelTask
+        from lilbee.server.models import CatalogEntryResponse
+
+        e = CatalogEntryResponse(
+            hf_repo="gemini/gemini-2.0-flash",
+            gguf_filename="",
+            task=ModelTask.CHAT,
+            display_name="gemini-2.0-flash",
+            param_count="",
+            size_gb=0,
+            min_ram_gb=0,
+            description="",
+            quality_tier="",
+            featured=False,
+            downloads=0,
+            installed=True,
+            source=ModelSource.FRONTIER,
+            provider="Gemini",
+            key_status=KeyStatus.READY,
+        )
+        assert e.provider == "Gemini"
+        assert e.key_status == KeyStatus.READY
+        native = CatalogEntryResponse(
+            hf_repo="r",
+            gguf_filename="f",
+            task=ModelTask.CHAT,
+            display_name="d",
+            param_count="",
+            size_gb=1,
+            min_ram_gb=1,
+            description="",
+            quality_tier="",
+            featured=False,
+            downloads=0,
+            installed=False,
+            source=ModelSource.NATIVE,
+        )
+        assert native.provider == "" and native.key_status is None
+
+    def test_hosted_entry_from_remote_frontier(self) -> None:
+        from lilbee.catalog.types import KeyStatus, ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+        from lilbee.providers.model_ref import format_remote_ref
+        from lilbee.server.handlers.models import _hosted_entry
+
+        rm = RemoteModel(
+            name="gemini-2.0-flash",
+            task=ModelTask.CHAT,
+            family="",
+            parameter_size="",
+            provider="Gemini",
+        )
+        row = _hosted_entry(rm, ModelSource.FRONTIER)
+        assert row.source == ModelSource.FRONTIER
+        assert row.hf_repo == format_remote_ref("gemini-2.0-flash", "Gemini")
+        assert row.display_name == "gemini-2.0-flash"
+        assert row.provider == "Gemini"
+        assert row.key_status == KeyStatus.READY
+        assert row.installed is True and row.fit is None and row.size_gb == 0
+
+    def test_hosted_entry_from_remote_ollama(self) -> None:
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+        from lilbee.server.handlers.models import _hosted_entry
+
+        rm = RemoteModel(
+            name="llama3.1:8b",
+            task=ModelTask.CHAT,
+            family="llama",
+            parameter_size="8B",
+            provider="Ollama",
+        )
+        row = _hosted_entry(rm, ModelSource.OLLAMA)
+        assert row.source == ModelSource.OLLAMA
+        assert row.key_status is None and row.provider == "Ollama"
+
+    async def test_collect_hosted_entries(self, monkeypatch) -> None:
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        h._hosted_cache.set("", [])  # prime then clear to defeat any prior TTL entry
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="gemini-2.0-flash",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        monkeypatch.setattr(
+            h,
+            "classify_remote_models",
+            lambda *a, **k: [
+                RemoteModel(
+                    name="llama3.1:8b",
+                    task=ModelTask.CHAT,
+                    family="llama",
+                    parameter_size="8B",
+                    provider="Ollama",
+                ),
+                RemoteModel(
+                    name="nomic-embed",
+                    task=ModelTask.EMBEDDING,
+                    family="nomic-bert",
+                    parameter_size="",
+                    provider="Ollama",
+                ),
+            ],
+        )
+        chat = await h._collect_hosted_entries(task=ModelTask.CHAT, search="")
+        sources = {(r.display_name, r.source) for r in chat}
+        assert ("gemini-2.0-flash", ModelSource.FRONTIER) in sources
+        assert ("llama3.1:8b", ModelSource.OLLAMA) in sources
+        assert all(r.task == ModelTask.CHAT for r in chat)
+        assert ("nomic-embed", ModelSource.OLLAMA) not in sources
+        searched = await h._collect_hosted_entries(task=ModelTask.CHAT, search="gemini")
+        assert {r.display_name for r in searched} == {"gemini-2.0-flash"}
+
+    async def test_collect_hosted_entries_no_task_filter(self, monkeypatch) -> None:
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog.types import ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        h._hosted_cache._result = None
+        monkeypatch.setattr(h, "discover_api_models", lambda: {})
+        monkeypatch.setattr(
+            h,
+            "classify_remote_models",
+            lambda *a, **k: [
+                RemoteModel(
+                    name="nomic-embed",
+                    task=ModelTask.EMBEDDING,
+                    family="nomic-bert",
+                    parameter_size="",
+                    provider="Ollama",
+                )
+            ],
+        )
+        rows = await h._collect_hosted_entries(task=None, search="")
+        assert {r.display_name for r in rows} == {"nomic-embed"}
+
+    async def test_collect_hosted_entries_uses_cache(self, monkeypatch) -> None:
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog.types import ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        h._hosted_cache._result = None
+        calls = {"n": 0}
+
+        def _discover():
+            calls["n"] += 1
+            return {
+                "Gemini": [
+                    RemoteModel(
+                        name="gemini-2.0-flash",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            }
+
+        monkeypatch.setattr(h, "discover_api_models", _discover)
+        monkeypatch.setattr(h, "classify_remote_models", lambda *a, **k: [])
+        await h._collect_hosted_entries(task=ModelTask.CHAT, search="")
+        await h._collect_hosted_entries(task=ModelTask.CHAT, search="")
+        assert calls["n"] == 1
 
 
 class TestModelsCatalog:
+    @pytest.fixture(autouse=True)
+    def _no_hosted_discovery(self, monkeypatch):
+        """Native-only by default: stub discovery empty + clear the hosted cache.
+
+        Individual tests that exercise hosted rows re-monkeypatch these.
+        """
+        import lilbee.server.handlers.models as h
+
+        h._hosted_cache._result = None
+        monkeypatch.setattr(h, "discover_api_models", lambda: {})
+        monkeypatch.setattr(h, "classify_remote_models", lambda *a, **k: [])
+
     @staticmethod
     def _manifest(hf_repo: str, gguf_filename: str, task: str = "chat"):
         from lilbee.modelhub.registry import ModelManifest
@@ -991,6 +1212,125 @@ class TestModelsCatalog:
             task=task,
             downloaded_at="2026-01-01T00:00:00+00:00",
         )
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_includes_hosted_on_first_page(self, mock_get_catalog, mock_svc, monkeypatch):
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog import CatalogResult
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        mock_svc.registry.list_installed.return_value = []
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="gemini-2.0-flash",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        resp = await handlers.models_catalog(task="chat")
+        frontier = [m for m in resp.models if m.source == ModelSource.FRONTIER]
+        assert frontier and frontier[0].display_name == "gemini-2.0-flash"
+        assert frontier[0].key_status == "ready"
+        assert resp.total == 1  # 0 native + 1 hosted
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_hosted_skipped_when_featured_filter(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog import CatalogResult
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        mock_svc.registry.list_installed.return_value = []
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="g",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        resp = await handlers.models_catalog(task="chat", featured=True)
+        assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_hosted_skipped_on_later_page(self, mock_get_catalog, mock_svc, monkeypatch):
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog import CatalogResult
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=20, models=[])
+        mock_svc.registry.list_installed.return_value = []
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="g",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        resp = await handlers.models_catalog(task="chat", offset=20)
+        assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_hosted_skipped_when_installed_false(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog import CatalogResult
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        mock_svc.registry.list_installed.return_value = []
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="g",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        resp = await handlers.models_catalog(task="chat", installed=False)
+        assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_returns_catalog_response(self, mock_get_catalog, mock_svc):


### PR DESCRIPTION
## Problem
With a cloud API key configured — Gemini, OpenAI, Anthropic — none of those models showed up in the model catalog over the HTTP API, and neither did Ollama-managed models. The terminal UI listed them, but anything talking to the server over HTTP (the Obsidian plugin in particular) only ever saw local models.

## Solution
The catalog now includes cloud models, grouped by provider with a key-ready indicator, and Ollama models, alongside local ones. They come back ready to use with no download, since they run off-box. Selecting a cloud model as the chat model works now too — it was previously rejected as 'not available.' Discovery is cached briefly so browsing the catalog stays responsive.