### PR TITLE
Support LM Studio alongside Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ A batteries-included local search engine you can talk to: it runs the AI models,
 
 It's all one program: you never stand up a separate model server, a [vector database](#built-on), or a container. lilbee runs the models and keeps the index itself. Reach it as a full-screen terminal app, a command-line tool, a Model Context Protocol server, an HTTP API, or a Python library. Close it and it's gone, or run it as a service if you'd rather keep it warm. It runs on your computer; lilbee uses a cloud model only when you pick one.
 
+Already running [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai)? Point lilbee at either one and keep managing your models there. lilbee also comes with first-class model management built in, so you can browse Hugging Face, download a model, and give it a role without leaving the app. Use whichever you prefer.
+
 > **Tutorial reel:** every demo on this page (and the extras) as a real video player at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial).
 
 > ## ⚠️ Beta software

--- a/src/lilbee/app/models.py
+++ b/src/lilbee/app/models.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import functools
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
@@ -269,35 +268,6 @@ def show_model_data(ref: str) -> ShowModelResult:
     )
 
 
-def _backend_event_to_progress(
-    on_update: Callable[[DownloadProgress], None],
-    event: dict[str, Any],
-) -> None:
-    """Adapt an Ollama-style dict event into a DownloadProgress call."""
-    # heavy: lilbee.catalog (>50ms; huggingface_hub fanout)
-    from lilbee.catalog import DownloadProgress
-
-    total = event.get("total", 0) or 0
-    completed = event.get("completed", 0) or 0
-    detail = event.get("status", "") or ""
-    pct = int(completed * 100 / total) if total > 0 else 0
-    on_update(DownloadProgress(percent=pct, detail=detail, is_cache_hit=False))
-
-
-def _build_pull_callbacks(
-    on_update: Callable[[DownloadProgress], None] | None,
-) -> tuple[Callable[[dict[str, Any]], None] | None, Callable[[int, int], None] | None]:
-    """Build the (dict_cb, bytes_cb) pair for ModelManager.pull from on_update."""
-    # heavy: lilbee.catalog (>50ms; huggingface_hub fanout)
-    from lilbee.catalog import make_download_callback
-
-    if on_update is None:
-        return None, None
-    dict_cb = functools.partial(_backend_event_to_progress, on_update)
-    bytes_cb = make_download_callback(on_update)
-    return dict_cb, bytes_cb
-
-
 def pull_model_data(
     ref: str,
     source: ModelSource,
@@ -307,20 +277,23 @@ def pull_model_data(
 ) -> PullResult:
     """Pull *ref* from *source* and return a typed result.
 
-    Progress updates are throttled by
-    :func:`~lilbee.catalog.make_download_callback`, so callers see at
-    most roughly 10 Hz of progress events.
+    Only native models are downloadable; a non-native *source* is refused by
+    :meth:`ModelManager.pull`. Progress updates are throttled by
+    :func:`~lilbee.catalog.make_download_callback`, so callers see at most
+    roughly 10 Hz of progress events.
     """
+    # heavy: lilbee.catalog (>50ms; huggingface_hub fanout)
+    from lilbee.catalog import make_download_callback
+
     manager = get_services().model_manager
 
     if manager.is_installed(ref, source):
         return PullResult(model=ref, source=source.value, status=PullStatus.ALREADY_INSTALLED)
 
-    dict_cb, bytes_cb = _build_pull_callbacks(on_update)
+    bytes_cb = make_download_callback(on_update) if on_update is not None else None
     path = manager.pull(
         ref,
         source,
-        on_progress=dict_cb,
         on_bytes=bytes_cb,
         allow_unsupported=allow_unsupported,
     )

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -801,7 +801,10 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         str,
         nullable=False,
         group=SettingGroup.API_KEYS,
-        help_text="OpenAI-compatible base URL (Ollama default: http://localhost:11434)",
+        help_text=(
+            "OpenAI-compatible base URL "
+            "(Ollama: http://localhost:11434, LM Studio: http://localhost:1234/v1)"
+        ),
     ),
     "wiki_summary_max_tokens": SettingDef(
         int,

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -14,6 +14,7 @@ from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.core.security import validate_path_within
 from lilbee.modelhub.model_manager.types import ModelNotFoundError
 from lilbee.modelhub.registry import ModelRegistry
+from lilbee.providers.local_servers import detect_local_server
 
 log = logging.getLogger(__name__)
 
@@ -142,32 +143,30 @@ class ModelManager:
         model: str,
         source: ModelSource,
         *,
-        on_progress: Callable[[dict], None] | None = None,
         on_bytes: Callable[[int, int], None] | None = None,
         allow_unsupported: bool = False,
     ) -> Path | None:
-        """Pull/download model to specified source.
+        """Download a native GGUF model and return its path.
 
-        Returns the Path for native downloads, None for backend-managed pulls.
+        lilbee pulls native models only. Local servers (Ollama, LM Studio)
+        are read-only: their models are managed in their own app and surface
+        here once present, so a non-native *source* is refused.
 
         Native pulls of architectures the bundled llama.cpp doesn't support
         are refused with ``UnsupportedArchError`` unless *allow_unsupported*
-        is True. SDK-backed (REMOTE) pulls are not gated here: the remote
-        runtime owns the arch verdict.
-
-        *on_progress* receives dict events from the SDK backend.
-        *on_bytes* receives (downloaded_bytes, total_bytes) from native
-        HuggingFace downloads. The two sources report progress in different
-        shapes, so callers pass whichever matches the chosen source.
+        is True. *on_bytes* receives (downloaded_bytes, total_bytes) progress.
         """
-        if source is ModelSource.NATIVE and not allow_unsupported:
+        if source is not ModelSource.NATIVE:
+            server = detect_local_server(self._remote_base_url)
+            where = server.display_name if server is not None else "the configured server"
+            raise ValueError(
+                f"lilbee runs {where} models but doesn't download them. "
+                f"Add the model in {where}, then pick it here."
+            )
+        if not allow_unsupported:
             self._enforce_arch_compat(model)
-
         try:
-            if source is ModelSource.NATIVE:
-                return self._pull_native(model, on_bytes=on_bytes)
-            self._pull_remote(model, on_progress=on_progress)
-            return None
+            return self._pull_native(model, on_bytes=on_bytes)
         finally:
             self._invalidate_installed_cache()
 
@@ -205,34 +204,6 @@ class ModelManager:
         path = download_model(entry, on_progress=on_bytes, on_complete=register_downloaded_model)
         log.info("Downloaded %s to %s", model, path)
         return path
-
-    def _pull_remote(
-        self, model: str, *, on_progress: Callable[[dict], None] | None = None
-    ) -> None:
-        """Pull model via the SDK backend's HTTP API with streaming progress."""
-        url = f"{self._remote_base_url}/api/pull"
-        try:
-            with (
-                # Model pulls stream progress over minutes; an overall
-                # timeout would cut the download. Connect/write timeouts
-                # still apply via httpx defaults when timeout=None.
-                httpx.Client(timeout=None) as client,  # noqa: S113
-                client.stream("POST", url, json={"name": model, "stream": True}) as resp,
-            ):
-                resp.raise_for_status()
-                for line in resp.iter_lines():
-                    if not line:
-                        continue
-                    data = json.loads(line)
-                    if "error" in data:
-                        raise RuntimeError(f"Failed to pull '{model}': {data['error']}")
-                    if on_progress is not None:
-                        on_progress(data)
-        except httpx.ConnectError as exc:
-            raise RuntimeError(
-                f"Cannot connect to SDK backend: {exc}. Is the server running?"
-            ) from exc
-        log.info("Pulled %s via SDK backend", model)
 
     def remove(self, model: str, source: ModelSource | None = None) -> bool:
         """Remove installed model. Returns True if removed."""

--- a/src/lilbee/modelhub/model_manager/discovery.py
+++ b/src/lilbee/modelhub/model_manager/discovery.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from collections.abc import Callable
 
 import httpx
 
@@ -9,14 +10,25 @@ from lilbee.app.services import get_services
 from lilbee.catalog.types import ModelTask
 from lilbee.core.config.model import cfg
 from lilbee.modelhub.model_manager.types import RemoteModel
-from lilbee.providers.sdk_backend import (
-    PROVIDER_KEYS,
-    detect_backend_name,
+from lilbee.providers.backend_names import BackendName
+from lilbee.providers.local_servers import (
+    LM_STUDIO,
+    OLLAMA,
+    detect_local_server,
+    openai_models_url,
 )
+from lilbee.providers.sdk_backend import PROVIDER_KEYS, detect_backend_name
 
 log = logging.getLogger(__name__)
 
 _EMBEDDING_FAMILIES = frozenset({"bert", "nomic-bert", "e5", "bge"})
+# Embedding detection by name, for OpenAI-compatible servers (LM Studio) that
+# expose ids but no family metadata. ``embed`` covers the common naming, the
+# rest match family-named embedders (``bge-base``, ``multilingual-e5-large``,
+# ``gte-large``). The trailing hyphen on the family tags avoids matching a chat
+# model that merely contains the letters (``bge`` keeps ``bge-reranker`` out of
+# here too, though reranker detection already runs first).
+_EMBEDDING_NAME_PATTERNS = frozenset({"embed", "bge-", "e5-", "gte-"})
 _VISION_NAME_PATTERNS = frozenset({"llava", "vision", "moondream", "ocr", "minicpm-v"})
 # Reranker detection runs BEFORE embedding detection so ``bge-reranker-*``
 # (family "bge" but clearly a reranker) does not get misclassified as
@@ -31,15 +43,18 @@ def _classify_remote_task(name: str, family: str) -> ModelTask:
     """Classify a remote model as chat, embedding, vision, or rerank.
 
     Reranker detection runs first so ``bge-reranker-base`` (family
-    ``bge``) does not get dragged into the embedding bucket by the
-    family check. After reranker: embedding by family tag, vision by
-    name pattern, else chat.
+    ``bge``) does not get dragged into the embedding bucket. After
+    reranker: embedding by family tag OR by name pattern (the name path
+    covers servers like LM Studio that report no family), vision by name
+    pattern, else chat.
     """
     name_lower = name.lower()
     if any(rp in name_lower for rp in _RERANKER_NAME_PATTERNS):
         return ModelTask.RERANK
     family_lower = family.lower()
-    if any(ef in family_lower for ef in _EMBEDDING_FAMILIES):
+    if any(ef in family_lower for ef in _EMBEDDING_FAMILIES) or any(
+        ep in name_lower for ep in _EMBEDDING_NAME_PATTERNS
+    ):
         return ModelTask.EMBEDDING
     if any(vp in name_lower for vp in _VISION_NAME_PATTERNS):
         return ModelTask.VISION
@@ -67,13 +82,27 @@ def classify_remote_models(
     *,
     timeout: float = _CLASSIFY_DEFAULT_TIMEOUT_S,
 ) -> list[RemoteModel]:
-    """Discover and classify all models from the SDK backend by task.
+    """Discover and classify all models from the local server by task.
 
-    Uses /api/tags family metadata for embedding detection and name
-    patterns for reranker and vision detection. Returns an empty list
-    on any error (including timeout) so callers in read-only code paths
-    can stay responsive when the backend is down.
+    Dispatches the listing strategy off the server behind *base_url*:
+    Ollama's ``/api/tags`` (rich family metadata) or LM Studio's
+    OpenAI-compatible ``/v1/models``. Unknown URLs default to the Ollama
+    strategy. The provider label always comes from ``detect_backend_name``,
+    so a hosted API URL keeps its own name. Returns an empty list on any
+    error (including timeout) so read-only callers stay responsive when the
+    backend is down.
     """
+    spec = detect_local_server(base_url)
+    provider = detect_backend_name(base_url)
+    key = spec.key if spec is not None else OLLAMA.key
+    discover = _DISCOVERY_BY_KEY.get(key, _discover_via_ollama_tags)
+    return discover(base_url, provider, timeout)
+
+
+def _discover_via_ollama_tags(
+    base_url: str, provider: BackendName, timeout: float
+) -> list[RemoteModel]:
+    """Classify models from Ollama's ``/api/tags`` using family metadata."""
     try:
         resp = httpx.get(f"{base_url}/api/tags", timeout=timeout)
         resp.raise_for_status()
@@ -82,7 +111,6 @@ def classify_remote_models(
         log.debug("Failed to classify remote models", exc_info=True)
         return []
 
-    provider = detect_backend_name(base_url)
     result: list[RemoteModel] = []
     for model in raw_models:
         name = model.get("name", "")
@@ -92,10 +120,57 @@ def classify_remote_models(
         task = _classify_remote_task(name, family)
         result.append(
             RemoteModel(
-                name=name, task=task, family=family, parameter_size=param_size, provider=provider
+                name=name,
+                task=task,
+                family=family,
+                parameter_size=param_size,
+                provider=provider,
             )
         )
     return result
+
+
+def _discover_via_openai_models(
+    base_url: str, provider: BackendName, timeout: float
+) -> list[RemoteModel]:
+    """Classify models from an OpenAI-compatible ``/v1/models`` endpoint.
+
+    LM Studio exposes only model ids, no family metadata, so embedding /
+    reranker / vision detection falls back to the name patterns (which
+    LM Studio ids usually carry, e.g. ``nomic-embed``, ``bge-reranker``).
+    """
+    try:
+        resp = httpx.get(openai_models_url(base_url), timeout=timeout)
+        resp.raise_for_status()
+        raw_models = resp.json().get("data", [])
+    except Exception:
+        log.debug("Failed to classify remote models", exc_info=True)
+        return []
+
+    result: list[RemoteModel] = []
+    for model in raw_models:
+        name = model.get("id", "")
+        if not name:
+            continue
+        task = _classify_remote_task(name, "")
+        result.append(
+            RemoteModel(
+                name=name,
+                task=task,
+                family="",
+                parameter_size="",
+                provider=provider,
+            )
+        )
+    return result
+
+
+# Listing strategy per local-server routing key. Module-level so it stays a
+# single source of truth as servers are added to the registry.
+_DISCOVERY_BY_KEY: dict[str, Callable[[str, BackendName, float], list[RemoteModel]]] = {
+    OLLAMA.key: _discover_via_ollama_tags,
+    LM_STUDIO.key: _discover_via_openai_models,
+}
 
 
 def _has_provider_key(cfg_field: str, env_var: str) -> bool:

--- a/src/lilbee/providers/backend_names.py
+++ b/src/lilbee/providers/backend_names.py
@@ -12,6 +12,7 @@ class BackendName(StrEnum):
     """Display name shown in the UI for whichever backend the SDK is talking to."""
 
     OLLAMA = "Ollama"
+    LM_STUDIO = "LM Studio"
     OPENROUTER = "OpenRouter"
     GEMINI = "Gemini"
     ANTHROPIC = "Anthropic"

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import base64
 import functools
-import json
 import logging
 from collections.abc import Callable, Iterator
 from typing import Any
@@ -550,45 +549,18 @@ class LitellmSdkBackend:
         base_url: str,
         on_progress: Callable[..., Any] | None = None,
     ) -> None:
-        """Pull a model via the Ollama ``/api/pull`` endpoint.
+        """Refuse to pull: local servers (Ollama, LM Studio) are read-only.
 
-        Only servers that expose an HTTP pull endpoint are supported.
-        LM Studio has none; its models are downloaded in its own app and
-        appear here once present.
+        Their models are managed in their own app and surface here once
+        present, so lilbee never downloads them over the network.
         """
-        clean_base = base_url.rstrip("/")
-        spec = detect_local_server(clean_base)
-        if spec is None or not spec.supports_pull:
-            server = spec.display_name if spec is not None else "This server"
-            raise ProviderError(
-                f"{server} doesn't download models over the network. "
-                f"Add the model in its own app, then pick it here.",
-                provider=_PROVIDER_NAME,
-            )
-        try:
-            with (
-                # Streaming Ollama /api/pull; unbounded read is intentional
-                # since model downloads can exceed any wall-clock timeout.
-                httpx.Client(timeout=None) as client,  # noqa: S113
-                client.stream(
-                    "POST",
-                    f"{clean_base}/api/pull",
-                    json={"name": model, "stream": True},
-                ) as resp,
-            ):
-                resp.raise_for_status()
-                for line in resp.iter_lines():
-                    if not line:
-                        continue
-                    event = json.loads(line)
-                    if on_progress:
-                        on_progress(event)
-                    if event.get("status") == "success":
-                        break
-        except httpx.HTTPError as exc:
-            raise ProviderError(
-                f"Cannot pull model {model!r}: {exc}", provider=_PROVIDER_NAME
-            ) from exc
+        spec = detect_local_server(base_url.rstrip("/"))
+        server = spec.display_name if spec is not None else "This server"
+        raise ProviderError(
+            f"{server} doesn't download models over the network. "
+            f"Add the model in its own app, then pick it here.",
+            provider=_PROVIDER_NAME,
+        )
 
     def show_model(self, model: str, *, base_url: str) -> dict[str, Any] | None:
         """Get model info via the Ollama ``/api/show`` endpoint.

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -22,7 +22,13 @@ import httpx
 
 from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.providers.base import ProviderError, ProviderErrorKind
-from lilbee.providers.model_ref import OLLAMA_PREFIX, ProviderModelRef
+from lilbee.providers.local_servers import (
+    OLLAMA,
+    detect_local_server,
+    local_server_for_key,
+    openai_models_url,
+)
+from lilbee.providers.model_ref import ProviderModelRef
 from lilbee.providers.sdk_backend import (
     CompletionRequest,
     CompletionResult,
@@ -37,7 +43,6 @@ from lilbee.providers.sdk_backend import (
 log = logging.getLogger(__name__)
 
 _PROVIDER_NAME = "litellm"
-_OLLAMA_URL_PATTERNS = ("localhost:11434", "127.0.0.1:11434", "ollama")
 
 # Substrings dropped from the "LiteLLM" logger before they reach the user's
 # terminal. Two classes of noise: (1) the model-cost-map fetch failure that
@@ -135,12 +140,6 @@ class _LitellmResponseView:
         return getattr(choice, "finish_reason", None) if choice is not None else None
 
 
-def _is_ollama(base_url: str) -> bool:
-    """Return True if *base_url* looks like an Ollama instance."""
-    url_lower = base_url.lower()
-    return any(p in url_lower for p in _OLLAMA_URL_PATTERNS)
-
-
 @functools.cache
 def litellm_available() -> bool:
     """Return True if the ``litellm`` package is installed.
@@ -184,11 +183,16 @@ def _cache_ollama_defaults(model: str, params_text: str) -> None:
 
 
 def _route_model(ref: ProviderModelRef, api_base: str | None) -> str:
-    """Format *ref* for litellm using the OpenAI ``provider/model`` convention."""
-    if ref.is_api:
+    """Format *ref* for litellm using the OpenAI ``provider/model`` convention.
+
+    API and local-server refs already carry their canonical prefix. A bare
+    ``local`` ref forced through the SDK (``llm_provider=remote``) gets the
+    prefix of whichever local server its ``api_base`` points at.
+    """
+    if ref.is_api or local_server_for_key(ref.provider) is not None:
         return ref.for_openai_prefix()
-    if api_base and _is_ollama(api_base):
-        return f"{OLLAMA_PREFIX}{ref.name}"
+    if api_base and (spec := detect_local_server(api_base)) is not None:
+        return spec.qualify(ref.name)
     return ref.name
 
 
@@ -470,9 +474,10 @@ class LitellmSdkBackend:
         return RerankResult(scores=scores, model=model)
 
     def list_models(self, *, base_url: str, api_key: str) -> list[str]:
-        """List models from Ollama or an OpenAI-compatible server."""
+        """List models from Ollama (``/api/tags``) or an OpenAI-compatible ``/v1/models``."""
         clean_base = base_url.rstrip("/")
-        if _is_ollama(clean_base):
+        spec = detect_local_server(clean_base)
+        if spec is OLLAMA:
             return self._list_ollama_models(clean_base)
         return self._list_openai_models(clean_base, api_key)
 
@@ -528,7 +533,9 @@ class LitellmSdkBackend:
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
         try:
-            resp = httpx.get(f"{base_url}/v1/models", headers=headers, timeout=DEFAULT_HTTP_TIMEOUT)
+            resp = httpx.get(
+                openai_models_url(base_url), headers=headers, timeout=DEFAULT_HTTP_TIMEOUT
+            )
             resp.raise_for_status()
             data = resp.json()
             return [m["id"] for m in data.get("data", [])]
@@ -543,8 +550,21 @@ class LitellmSdkBackend:
         base_url: str,
         on_progress: Callable[..., Any] | None = None,
     ) -> None:
-        """Pull a model via the Ollama ``/api/pull`` endpoint."""
+        """Pull a model via the Ollama ``/api/pull`` endpoint.
+
+        Only servers that expose an HTTP pull endpoint are supported.
+        LM Studio has none; its models are downloaded in its own app and
+        appear here once present.
+        """
         clean_base = base_url.rstrip("/")
+        spec = detect_local_server(clean_base)
+        if spec is None or not spec.supports_pull:
+            server = spec.display_name if spec is not None else "This server"
+            raise ProviderError(
+                f"{server} doesn't download models over the network. "
+                f"Add the model in its own app, then pick it here.",
+                provider=_PROVIDER_NAME,
+            )
         try:
             with (
                 # Streaming Ollama /api/pull; unbounded read is intentional
@@ -576,11 +596,15 @@ class LitellmSdkBackend:
         Parses and caches per-model generation defaults from the
         ``parameters`` field. Also extracts the ``capabilities`` list
         (newer Ollama versions) so callers can check for vision support.
+        Returns ``None`` for servers without a metadata endpoint (LM Studio).
         """
         clean_base = base_url.rstrip("/")
+        spec = detect_local_server(clean_base)
+        if spec is None or not spec.supports_show:
+            return None
         # Ollama's API uses bare model names; the routing-layer prefix has
         # to come off before the request goes out.
-        ollama_name = model[len(OLLAMA_PREFIX) :] if model.startswith(OLLAMA_PREFIX) else model
+        ollama_name = model.removeprefix(OLLAMA.wire_prefix)
         try:
             resp = httpx.post(
                 f"{clean_base}/api/show",

--- a/src/lilbee/providers/local_servers.py
+++ b/src/lilbee/providers/local_servers.py
@@ -1,0 +1,131 @@
+"""Local OpenAI-compatible model servers (Ollama, LM Studio).
+
+One abstraction over the local servers lilbee can drive through the
+litellm SDK. Each server is described by a :class:`LocalServerSpec`
+carrying its routing key, litellm wire prefix, default base URL, the URL
+substrings that identify it, and which catalog operations it supports.
+
+Kept dependency-free on purpose so the routing layer (``model_ref``,
+``sdk_backend``) can import it without pulling in httpx or the modelhub.
+The HTTP behaviour (model discovery, pull) lives in the modelhub layer,
+dispatched off the spec returned here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lilbee.providers.backend_names import BackendName
+
+
+@dataclass(frozen=True)
+class LocalServerSpec:
+    """Identity and capabilities of one local model server."""
+
+    key: str
+    """Routing key and ref-prefix stem (``ollama``, ``lm_studio``)."""
+
+    display_name: BackendName
+    """Human-facing backend name shown in the UI."""
+
+    wire_prefix: str
+    """litellm ``provider/`` prefix the SDK routes on (``ollama/``)."""
+
+    default_base_url: str
+    """Base URL the server listens on out of the box."""
+
+    url_patterns: tuple[str, ...]
+    """Lowercase substrings that identify this server in a base URL."""
+
+    appends_latest_tag: bool
+    """Whether a bare model name gets a ``:latest`` tag (Ollama convention)."""
+
+    supports_pull: bool
+    """Whether the server exposes an HTTP model-pull endpoint."""
+
+    supports_show: bool
+    """Whether the server exposes an HTTP model-metadata endpoint."""
+
+    def qualify(self, name: str) -> str:
+        """Render *name* as a canonical ``<wire_prefix><name>`` ref."""
+        return f"{self.wire_prefix}{name}"
+
+    def normalize_name(self, name: str) -> str:
+        """Apply the server's bare-name convention (Ollama's ``:latest``)."""
+        if self.appends_latest_tag and ":" not in name:
+            return f"{name}:latest"
+        return name
+
+
+OLLAMA = LocalServerSpec(
+    key="ollama",
+    display_name=BackendName.OLLAMA,
+    wire_prefix="ollama/",
+    default_base_url="http://localhost:11434",
+    url_patterns=("localhost:11434", "127.0.0.1:11434", "ollama"),
+    appends_latest_tag=True,
+    supports_pull=True,
+    supports_show=True,
+)
+
+LM_STUDIO = LocalServerSpec(
+    # litellm's lm_studio provider posts to ``{api_base}/chat/completions``, so
+    # the base URL must carry ``/v1`` (matching what LM Studio's server panel
+    # shows). It also injects a placeholder key, so no API key is required.
+    key="lm_studio",
+    display_name=BackendName.LM_STUDIO,
+    wire_prefix="lm_studio/",
+    default_base_url="http://localhost:1234/v1",
+    url_patterns=("localhost:1234", "127.0.0.1:1234"),
+    appends_latest_tag=False,
+    supports_pull=False,
+    supports_show=False,
+)
+
+LOCAL_SERVERS: tuple[LocalServerSpec, ...] = (OLLAMA, LM_STUDIO)
+
+LOCAL_SERVER_KEYS: frozenset[str] = frozenset(spec.key for spec in LOCAL_SERVERS)
+
+
+def openai_models_url(base_url: str) -> str:
+    """Build the ``/v1/models`` listing URL, tolerating a trailing ``/v1``.
+
+    OpenAI-compatible servers are configured with the base that chat uses
+    (``.../v1`` for LM Studio) or without it (Ollama, generic). Both resolve
+    to a single ``/v1/models`` so the listing URL never doubles the segment.
+    """
+    trimmed = base_url.rstrip("/")
+    if trimmed.endswith("/v1"):
+        trimmed = trimmed[: -len("/v1")]
+    return f"{trimmed}/v1/models"
+
+
+def detect_local_server(base_url: str) -> LocalServerSpec | None:
+    """Return the local server whose URL patterns match *base_url*, if any."""
+    url_lower = base_url.lower()
+    for spec in LOCAL_SERVERS:
+        if any(pattern in url_lower for pattern in spec.url_patterns):
+            return spec
+    return None
+
+
+def local_server_for_key(key: str) -> LocalServerSpec | None:
+    """Return the spec with routing *key*, or ``None``."""
+    for spec in LOCAL_SERVERS:
+        if spec.key == key:
+            return spec
+    return None
+
+
+def local_server_for_label(label: str) -> LocalServerSpec | None:
+    """Return the spec matching *label* by routing key or display name.
+
+    Callers pass either form: discovery stamps the ``BackendName`` display
+    value (``"LM Studio"``) onto a model, while a parsed ref carries the
+    routing key (``"lm_studio"``). Both resolve to the same spec.
+    """
+    lowered = label.lower()
+    for spec in LOCAL_SERVERS:
+        if spec.key == lowered or spec.display_name.lower() == lowered:
+            return spec
+    return None

--- a/src/lilbee/providers/local_servers.py
+++ b/src/lilbee/providers/local_servers.py
@@ -58,13 +58,16 @@ class LocalServerSpec:
 
 
 OLLAMA = LocalServerSpec(
+    # Read-only, like LM Studio: lilbee runs and lists Ollama models but does
+    # not pull them. Models are managed in Ollama itself. ``supports_show`` is
+    # kept on because /api/show is a read used to surface generation defaults.
     key="ollama",
     display_name=BackendName.OLLAMA,
     wire_prefix="ollama/",
     default_base_url="http://localhost:11434",
     url_patterns=("localhost:11434", "127.0.0.1:11434", "ollama"),
     appends_latest_tag=True,
-    supports_pull=True,
+    supports_pull=False,
     supports_show=True,
 )
 

--- a/src/lilbee/providers/model_ref.py
+++ b/src/lilbee/providers/model_ref.py
@@ -11,6 +11,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from lilbee.providers.base import filter_options
+from lilbee.providers.local_servers import (
+    LOCAL_SERVER_KEYS,
+    local_server_for_key,
+    local_server_for_label,
+)
 
 _API_PROVIDERS = frozenset(
     {
@@ -23,11 +28,9 @@ _API_PROVIDERS = frozenset(
     }
 )
 
-# All provider prefixes that route a ref away from the local registry.
-# Includes API providers and ollama (which keeps its own name:tag shape).
-PROVIDER_PREFIXES: frozenset[str] = frozenset(_API_PROVIDERS | {"ollama"})
-
-OLLAMA_PREFIX = "ollama/"
+# All provider prefixes that route a ref away from the local registry:
+# API providers plus the local OpenAI-compatible servers (ollama, lm_studio).
+PROVIDER_PREFIXES: frozenset[str] = frozenset(_API_PROVIDERS | LOCAL_SERVER_KEYS)
 
 
 @dataclass(frozen=True)
@@ -35,7 +38,7 @@ class ProviderModelRef:
     """Parsed model reference with provider routing information."""
 
     raw: str
-    provider: str  # "local", "ollama", or any value in PROVIDER_PREFIXES
+    provider: str  # "local" or any value in PROVIDER_PREFIXES
     name: str  # provider-specific name with tag normalization applied
 
     @property
@@ -64,8 +67,9 @@ class ProviderModelRef:
         SDKs: ``openai/gpt-4o``, ``ollama/llama3.2:1b``, etc. Every
         dispatching SDK accepts this shape.
         """
-        if self.provider == "ollama":
-            return f"{OLLAMA_PREFIX}{self.name}"
+        spec = local_server_for_key(self.provider)
+        if spec is not None:
+            return spec.qualify(self.name)
         if self.is_api:
             return f"{self.provider}/{self.name}"
         return self.name
@@ -81,16 +85,24 @@ class ProviderModelRef:
 
 
 def format_remote_ref(name: str, provider: str) -> str:
-    """Render a remote model as a canonical ``provider/name`` ref."""
-    return ProviderModelRef(raw=name, provider=provider.lower(), name=name).for_openai_prefix()
+    """Render a remote model as a canonical ``provider/name`` ref.
+
+    *provider* may be a routing key (``"ollama"``) or a backend display
+    name (``"LM Studio"``); local-server labels are normalised to the
+    routing key so the prefix survives. API providers fall through to
+    their lowercase key unchanged.
+    """
+    spec = local_server_for_label(provider)
+    key = spec.key if spec is not None else provider.lower()
+    return ProviderModelRef(raw=name, provider=key, name=name).for_openai_prefix()
 
 
 def parse_model_ref(raw: str) -> ProviderModelRef:
     """Classify a model string by its prefix and return the routing ref.
 
     Native HuggingFace refs are ``<org>/<repo>/<file>.gguf``. Remote
-    providers use prefixes from :data:`PROVIDER_PREFIXES` (``ollama/``
-    plus every API provider listed there).
+    providers use prefixes from :data:`PROVIDER_PREFIXES` (the local
+    servers ``ollama/`` and ``lm_studio/`` plus every API provider).
     """
     if "/" not in raw:
         known = ", ".join(f"{p}/" for p in sorted(PROVIDER_PREFIXES))
@@ -101,9 +113,9 @@ def parse_model_ref(raw: str) -> ProviderModelRef:
     prefix, rest = raw.split("/", 1)
     if prefix in _API_PROVIDERS:
         return ProviderModelRef(raw=raw, provider=prefix, name=rest)
-    if prefix == "ollama":
-        name = rest if ":" in rest else f"{rest}:latest"
-        return ProviderModelRef(raw=raw, provider="ollama", name=name)
+    spec = local_server_for_key(prefix)
+    if spec is not None:
+        return ProviderModelRef(raw=raw, provider=spec.key, name=spec.normalize_name(rest))
     return ProviderModelRef(raw=raw, provider="local", name=raw)
 
 

--- a/src/lilbee/providers/sdk_backend.py
+++ b/src/lilbee/providers/sdk_backend.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 # Display name for the active backend the SDK is talking to. The
 # adapter's own identity is exposed separately via provider_name.
 from lilbee.providers.backend_names import BackendName
+from lilbee.providers.local_servers import detect_local_server
 
 if TYPE_CHECKING:
     # circular: sdk_backend -> model_ref -> types -> sdk_backend (annotation-only)
@@ -61,9 +62,10 @@ def get_provider_api_key(provider: str) -> str | None:
     return value or None
 
 
-_BACKEND_URL_PATTERNS: tuple[tuple[str, BackendName], ...] = (
-    ("localhost:11434", BackendName.OLLAMA),
-    ("ollama", BackendName.OLLAMA),
+# Hosted API providers identified by URL substring. Local OpenAI-compatible
+# servers (Ollama, LM Studio) are matched ahead of this table via the
+# local-servers registry, so they are not listed here.
+_REMOTE_API_URL_PATTERNS: tuple[tuple[str, BackendName], ...] = (
     ("openrouter", BackendName.OPENROUTER),
     ("openai", BackendName.OPENAI),
     ("anthropic", BackendName.ANTHROPIC),
@@ -78,11 +80,14 @@ def detect_backend_name(base_url: str) -> BackendName:
     """Return the display name of the backend behind ``base_url``.
 
     Adapter-agnostic; any SDK implementation can delegate to this helper.
-    Falls back to ``BackendName.REMOTE`` when the URL matches none of
-    the known patterns.
+    Checks the local-server registry (Ollama, LM Studio) first, then the
+    hosted-API URL patterns, and falls back to ``BackendName.REMOTE``.
     """
+    local = detect_local_server(base_url)
+    if local is not None:
+        return local.display_name
     url_lower = base_url.lower()
-    for pattern, name in _BACKEND_URL_PATTERNS:
+    for pattern, name in _REMOTE_API_URL_PATTERNS:
         if pattern in url_lower:
             return name
     return BackendName.REMOTE

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel
 
@@ -410,12 +410,6 @@ async def models_pull(
     sse = SseStream()
 
     def _pull_blocking() -> None:
-        def _on_progress(data: dict[str, Any]) -> None:
-            if sse.cancel.is_set():
-                return
-            payload = sse_event(SseEvent.PROGRESS, data)
-            sse.loop.call_soon_threadsafe(sse.queue.put_nowait, payload)
-
         def _on_bytes(downloaded: int, total: int) -> None:
             if sse.cancel.is_set():
                 return
@@ -426,7 +420,6 @@ async def models_pull(
             manager.pull(
                 model,
                 src,
-                on_progress=_on_progress,
                 on_bytes=_on_bytes,
                 allow_unsupported=allow_unsupported,
             )

--- a/tests/providers/test_sdk_backend_contract.py
+++ b/tests/providers/test_sdk_backend_contract.py
@@ -10,7 +10,6 @@ adapter lands (e.g. ``LiterLlmSdkBackend``), add it to the
 
 from __future__ import annotations
 
-import json
 import sys
 from collections.abc import Callable
 from typing import Any
@@ -406,39 +405,15 @@ class TestListChatModels:
 
 
 class TestPullModel:
-    def test_streams_progress_events(self, backend: LlmSdkBackend) -> None:
-        events: list[dict[str, Any]] = []
-        resp_ctx = mock.MagicMock()
-        resp_ctx.__enter__ = lambda self: resp_ctx
-        resp_ctx.__exit__ = lambda self, *a: None
-        resp_ctx.iter_lines.return_value = [
-            json.dumps({"status": "downloading"}),
-            "",  # empty lines skipped
-            json.dumps({"status": "success"}),
-        ]
-        resp_ctx.raise_for_status = mock.MagicMock()
-
-        client_ctx = mock.MagicMock()
-        client_ctx.__enter__ = lambda self: client_ctx
-        client_ctx.__exit__ = lambda self, *a: None
-        client_ctx.stream.return_value = resp_ctx
-
-        with mock.patch("httpx.Client", return_value=client_ctx):
-            backend.pull_model(
-                "m",
-                base_url="http://localhost:11434",
-                on_progress=events.append,
-            )
-        assert events == [{"status": "downloading"}, {"status": "success"}]
-
-    def test_http_error_wraps_in_provider_error(self, backend: LlmSdkBackend) -> None:
-        client_ctx = mock.MagicMock()
-        client_ctx.__enter__ = lambda self: client_ctx
-        client_ctx.__exit__ = lambda self, *a: None
-        client_ctx.stream.side_effect = httpx.ConnectError("refused")
-
+    def test_refused_for_read_only_ollama(self, backend: LlmSdkBackend) -> None:
+        """Ollama is read-only: pull is refused without any network call."""
         with (
-            mock.patch("httpx.Client", return_value=client_ctx),
-            pytest.raises(ProviderError, match="Cannot pull model"),
+            mock.patch("httpx.Client") as client,
+            pytest.raises(ProviderError, match="Ollama"),
         ):
             backend.pull_model("m", base_url="http://localhost:11434")
+        client.assert_not_called()
+
+    def test_refused_for_read_only_lm_studio(self, backend: LlmSdkBackend) -> None:
+        with pytest.raises(ProviderError, match="LM Studio"):
+            backend.pull_model("m", base_url="http://localhost:1234/v1")

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -107,7 +107,7 @@ class _FakeManager:
             return ModelSource.REMOTE
         return None
 
-    def pull(self, model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
+    def pull(self, model, source, *, on_bytes=None, allow_unsupported=False):
         self.pull_calls.append((model, source))
         if on_bytes is not None:
             on_bytes(50, 100)
@@ -391,34 +391,6 @@ class TestPullModelData:
         assert events
         assert events[0].percent == 50
         assert fake_manager.pull_calls == [(target, ModelSource.NATIVE)]
-
-    def test_build_pull_callbacks_none_when_no_on_update(self):
-        dict_cb, bytes_cb = model_mod._build_pull_callbacks(None)
-        assert dict_cb is None
-        assert bytes_cb is None
-
-    def test_pull_litellm_adapts_dict_events(self, native_manifests):
-        events = []
-
-        class _Litellm(_FakeManager):
-            def pull(
-                self, model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False
-            ):
-                self.pull_calls.append((model, source))
-                if on_progress is not None:
-                    on_progress({"status": "pulling", "completed": 25, "total": 100})
-                return
-
-        manager = _Litellm()
-        with patch("lilbee.app.models.get_services", return_value=MagicMock(model_manager=manager)):
-            result = model_mod.pull_model_data(
-                _OLLAMA_REF, ModelSource.REMOTE, on_update=events.append
-            )
-        assert result.status == PullStatus.OK
-        assert result.path is None
-        assert events
-        assert events[0].percent == 25
-        assert events[0].detail == "pulling"
 
 
 class TestPullCmd:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -448,130 +448,26 @@ class TestModelManagerPull:
         ):
             mgr.pull("nonexistent-model", ModelSource.NATIVE)
 
-    def test_litellm_pull_success(self, tmp_path: Path) -> None:
+    def test_remote_pull_refused_naming_the_server(self, tmp_path: Path) -> None:
+        """Local servers are read-only; a remote pull is refused without any HTTP call."""
         models_dir = tmp_path / "models"
         models_dir.mkdir()
-
-        events = [
-            {"status": "pulling manifest"},
-            {"status": "downloading", "digest": "sha256:abc", "total": 100, "completed": 50},
-            {"status": "downloading", "digest": "sha256:abc", "total": 100, "completed": 100},
-            {"status": "success"},
-        ]
-
-        mock_response = mock.Mock()
-        mock_response.iter_lines.return_value = iter([__import__("json").dumps(e) for e in events])
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.__enter__ = mock.Mock(return_value=mock_response)
-        mock_response.__exit__ = mock.Mock(return_value=False)
-
-        mock_client = mock.Mock()
-        mock_client.stream.return_value = mock_response
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
-
-        progress_calls: list[dict] = []
-
-        def on_progress(data: dict) -> None:
-            progress_calls.append(data)
-
-        mgr = ModelManager(models_dir, "http://localhost:11434")
-        with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.REMOTE, on_progress=on_progress)
-
-        mock_client.stream.assert_called_once()
-        call_args = mock_client.stream.call_args
-        assert call_args[0] == ("POST", "http://localhost:11434/api/pull")
-        assert call_args[1]["json"] == {"name": "llama3:latest", "stream": True}
-
-        assert result is None  # litellm pull doesn't return a path
-        assert len(progress_calls) > 0
-
-    def test_litellm_pull_error(self, tmp_path: Path) -> None:
-        models_dir = tmp_path / "models"
-        models_dir.mkdir()
-
-        mock_response = mock.Mock()
-        mock_response.iter_lines.return_value = iter(['{"error": "model not found"}'])
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.__enter__ = mock.Mock(return_value=mock_response)
-        mock_response.__exit__ = mock.Mock(return_value=False)
-
-        mock_client = mock.Mock()
-        mock_client.stream.return_value = mock_response
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with (
-            mock.patch("httpx.Client", return_value=mock_client),
-            pytest.raises(RuntimeError, match="model not found"),
-        ):
-            mgr.pull("nonexistent:model", ModelSource.REMOTE)
-
-    def test_litellm_connection_error_during_pull(self, tmp_path: Path) -> None:
-        models_dir = tmp_path / "models"
-        models_dir.mkdir()
-
-        mock_client = mock.Mock()
-        mock_client.stream.side_effect = httpx.ConnectError("Connection refused")
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
-
-        mgr = ModelManager(models_dir, "http://localhost:11434")
-        with (
-            mock.patch("httpx.Client", return_value=mock_client),
-            pytest.raises(RuntimeError, match="Cannot connect to SDK backend"),
+            mock.patch("httpx.Client") as mock_client,
+            pytest.raises(ValueError, match="Ollama"),
         ):
             mgr.pull("llama3:latest", ModelSource.REMOTE)
+        mock_client.assert_not_called()
 
-    def test_litellm_pull_without_progress_callback(self, tmp_path: Path) -> None:
+    def test_remote_pull_refused_for_lm_studio(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        events = [
-            {"status": "pulling manifest"},
-            {"status": "success"},
-        ]
-
-        mock_response = mock.Mock()
-        mock_response.iter_lines.return_value = iter([__import__("json").dumps(e) for e in events])
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.__enter__ = mock.Mock(return_value=mock_response)
-        mock_response.__exit__ = mock.Mock(return_value=False)
-
-        mock_client = mock.Mock()
-        mock_client.stream.return_value = mock_response
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
-
-        mgr = ModelManager(models_dir, "http://localhost:11434")
-        with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.REMOTE)
-
-        assert result is None
-
-    def test_litellm_pull_skips_empty_lines(self, tmp_path: Path) -> None:
-        """Empty strings from iter_lines are skipped."""
-        models_dir = tmp_path / "models"
-        models_dir.mkdir()
-
-        mock_response = mock.Mock()
-        mock_response.iter_lines.return_value = iter(["", '{"status": "success"}'])
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.__enter__ = mock.Mock(return_value=mock_response)
-        mock_response.__exit__ = mock.Mock(return_value=False)
-
-        mock_client = mock.Mock()
-        mock_client.stream.return_value = mock_response
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
-
-        mgr = ModelManager(models_dir, "http://localhost:11434")
-        with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.REMOTE)
-
-        assert result is None
+        mgr = ModelManager(models_dir, "http://localhost:1234/v1")
+        with pytest.raises(ValueError, match="LM Studio"):
+            mgr.pull("qwen2.5-7b-instruct", ModelSource.REMOTE)
 
 
 class TestModelManagerRemove:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -862,6 +862,62 @@ class TestRemoteModelProvider:
         assert len(result) == 1
         assert result[0].provider == "OpenAI"
 
+    def test_classify_lm_studio_models_via_openai_endpoint(self) -> None:
+        """LM Studio is listed via ``/v1/models`` and labeled ``LM Studio``."""
+        from lilbee.catalog.types import ModelTask
+        from lilbee.modelhub.model_manager import classify_remote_models
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {
+            "data": [
+                {"id": "qwen2.5-7b-instruct"},
+                {"id": "nomic-embed-text-v1.5"},
+                {"id": "bge-reranker-v2-m3"},
+            ]
+        }
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response) as mock_get:
+            result = classify_remote_models("http://localhost:1234/v1")
+
+        # Hit the OpenAI-compatible endpoint (no doubled /v1), not Ollama's /api/tags.
+        assert mock_get.call_args.args[0] == "http://localhost:1234/v1/models"
+        assert [m.name for m in result] == [
+            "qwen2.5-7b-instruct",
+            "nomic-embed-text-v1.5",
+            "bge-reranker-v2-m3",
+        ]
+        assert all(m.provider == "LM Studio" for m in result)
+        # Name-pattern classification still works without family metadata.
+        by_name = {m.name: m.task for m in result}
+        assert by_name["qwen2.5-7b-instruct"] == ModelTask.CHAT
+        assert by_name["nomic-embed-text-v1.5"] == ModelTask.EMBEDDING
+        assert by_name["bge-reranker-v2-m3"] == ModelTask.RERANK
+
+    def test_classify_lm_studio_skips_entries_without_id(self) -> None:
+        """``/v1/models`` rows lacking an ``id`` are skipped, not crashed on."""
+        from lilbee.modelhub.model_manager import classify_remote_models
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"data": [{"id": ""}, {}, {"id": "qwen2.5-7b-instruct"}]}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response):
+            result = classify_remote_models("http://localhost:1234/v1")
+
+        assert [m.name for m in result] == ["qwen2.5-7b-instruct"]
+
+    def test_classify_lm_studio_returns_empty_on_http_error(self) -> None:
+        """A down LM Studio server yields [] so read-only callers stay responsive."""
+        import httpx
+
+        from lilbee.modelhub.model_manager import classify_remote_models
+
+        with mock.patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+            result = classify_remote_models("http://localhost:1234/v1")
+
+        assert result == []
+
     def test_remote_model_default_provider(self) -> None:
         model = RemoteModel(name="test", task="chat", family="llama", parameter_size="8B")
         assert model.provider == "Remote"

--- a/tests/test_model_manager_compat.py
+++ b/tests/test_model_manager_compat.py
@@ -87,13 +87,15 @@ def test_pull_proceeds_for_unknown_arch(tmp_path: Path, monkeypatch: pytest.Monk
     assert result is not None
 
 
-def test_pull_remote_source_skips_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """REMOTE source delegates to an SDK backend; lilbee's gate doesn't apply."""
-    mgr = ModelManager(tmp_path / "models")
-    monkeypatch.setattr(mgr, "_pull_remote", lambda model, on_progress: None)
+def test_pull_remote_source_refused_before_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REMOTE source is read-only: refused before the arch gate can run."""
+    mgr = ModelManager(tmp_path / "models", "http://localhost:11434")
 
     def _fail(_ref: str, _client: object) -> str:
-        raise AssertionError("gate must not fire for REMOTE source")
+        raise AssertionError("gate must not fire for a refused REMOTE pull")
 
     monkeypatch.setattr(compat, "resolve_arch_for_pull", _fail)
-    mgr.pull("ollama:llama3", ModelSource.REMOTE)
+    with pytest.raises(ValueError, match="Ollama"):
+        mgr.pull("ollama:llama3", ModelSource.REMOTE)

--- a/tests/test_model_ref.py
+++ b/tests/test_model_ref.py
@@ -34,6 +34,17 @@ class TestParseModelRef:
         assert ref.provider == "ollama"
         assert ref.name == "qwen3:latest"
 
+    def test_lm_studio_prefix(self) -> None:
+        ref = parse_model_ref("lm_studio/qwen2.5-7b-instruct")
+        assert ref.provider == "lm_studio"
+        assert ref.name == "qwen2.5-7b-instruct"
+
+    def test_lm_studio_prefix_does_not_append_latest_tag(self) -> None:
+        """LM Studio ids are used verbatim; only Ollama appends ``:latest``."""
+        ref = parse_model_ref("lm_studio/some-model")
+        assert ref.provider == "lm_studio"
+        assert ref.name == "some-model"
+
     def test_openai_prefix(self) -> None:
         ref = parse_model_ref("openai/gpt-4o")
         assert ref.provider == "openai"
@@ -115,6 +126,13 @@ class TestProviderModelRefProperties:
         ref = parse_model_ref("ollama/qwen3:8b")
         assert ref.needs_api_base is True
 
+    def test_lm_studio_model_is_remote_and_needs_api_base(self) -> None:
+        ref = parse_model_ref("lm_studio/qwen2.5-7b-instruct")
+        assert ref.is_remote is True
+        assert ref.is_api is False
+        assert ref.is_local is False
+        assert ref.needs_api_base is True
+
 
 class TestForOpenaiPrefix:
     def test_ollama_model(self) -> None:
@@ -128,6 +146,10 @@ class TestForOpenaiPrefix:
     def test_anthropic_model(self) -> None:
         ref = parse_model_ref("anthropic/claude-sonnet-4-20250514")
         assert ref.for_openai_prefix() == "anthropic/claude-sonnet-4-20250514"
+
+    def test_lm_studio_model(self) -> None:
+        ref = parse_model_ref("lm_studio/qwen2.5-7b-instruct")
+        assert ref.for_openai_prefix() == "lm_studio/qwen2.5-7b-instruct"
 
     def test_local_model(self) -> None:
         ref = parse_model_ref(_LOCAL_REF)
@@ -166,6 +188,28 @@ class TestFormatRemoteRef:
             provider="Ollama",
         )
         assert format_remote_ref(model.name, model.provider) == "ollama/qwen3:8b"
+
+    def test_lm_studio_display_name_normalizes_to_routing_key(self) -> None:
+        """The ``"LM Studio"`` display name must map to the ``lm_studio/`` prefix.
+
+        Lower-casing alone would yield ``"lm studio"`` and silently drop the
+        prefix, corrupting the stored ``chat_model`` ref; the display->key
+        normalization in ``format_remote_ref`` prevents that.
+        """
+        model = RemoteModel(
+            name="qwen2.5-7b-instruct",
+            task="chat",
+            family="",
+            parameter_size="",
+            provider="LM Studio",
+        )
+        ref = format_remote_ref(model.name, model.provider)
+        assert ref == "lm_studio/qwen2.5-7b-instruct"
+        # Round-trips back through the parser without losing the prefix.
+        assert parse_model_ref(ref).provider == "lm_studio"
+
+    def test_lm_studio_routing_key_form(self) -> None:
+        assert format_remote_ref("some-model", "lm_studio") == "lm_studio/some-model"
 
     def test_openrouter_with_nested_path(self) -> None:
         """OpenRouter model ids carry a vendor/model path that must round-trip."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1871,6 +1871,44 @@ class TestLiteLLMShowModelCapabilities:
         assert caps == []
 
 
+class TestLMStudioCapabilityGuards:
+    """LM Studio has no Ollama-style /api/pull or /api/show endpoints."""
+
+    _LM_STUDIO_BASE = "http://localhost:1234/v1"
+
+    def _backend(self):  # type: ignore[no-untyped-def]
+        from lilbee.providers.litellm_sdk import LitellmSdkBackend
+
+        return LitellmSdkBackend()
+
+    def test_pull_model_raises_user_facing_error(self) -> None:
+        from lilbee.providers.base import ProviderError
+
+        backend = self._backend()
+        with pytest.raises(ProviderError) as exc:
+            backend.pull_model("qwen2.5-7b-instruct", base_url=self._LM_STUDIO_BASE)
+        # User-facing message names LM Studio and the fix; no internal vocabulary.
+        assert "LM Studio" in str(exc.value)
+        assert "dispatch" not in str(exc.value).lower()
+
+    def test_pull_model_makes_no_http_call(self) -> None:
+        from lilbee.providers.base import ProviderError
+
+        backend = self._backend()
+        with mock.patch("httpx.Client") as client, pytest.raises(ProviderError):
+            backend.pull_model("qwen2.5-7b-instruct", base_url=self._LM_STUDIO_BASE)
+        client.assert_not_called()
+
+    def test_show_model_returns_none_without_http_call(self) -> None:
+        backend = self._backend()
+        with mock.patch("httpx.post") as post:
+            result = backend.show_model(
+                "lm_studio/qwen2.5-7b-instruct", base_url=self._LM_STUDIO_BASE
+            )
+        assert result is None
+        post.assert_not_called()
+
+
 class TestShowModelNotFound:
     def test_returns_none_for_missing_model(self) -> None:
         from lilbee.providers.llama_cpp import LlamaCppProvider
@@ -4164,31 +4202,64 @@ class TestReadMmprojProjectorTypePartial:
         assert result == "resampler"
 
 
-class TestIsOllama:
-    def test_localhost_default_port(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+class TestOpenAIModelsUrl:
+    def test_appends_v1_models_when_absent(self) -> None:
+        from lilbee.providers.local_servers import openai_models_url
 
-        assert _is_ollama("http://localhost:11434") is True
+        assert openai_models_url("http://localhost:11434") == "http://localhost:11434/v1/models"
 
-    def test_127_default_port(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+    def test_does_not_double_v1_when_present(self) -> None:
+        from lilbee.providers.local_servers import openai_models_url
 
-        assert _is_ollama("http://127.0.0.1:11434") is True
+        assert openai_models_url("http://localhost:1234/v1") == "http://localhost:1234/v1/models"
+
+    def test_tolerates_trailing_slash(self) -> None:
+        from lilbee.providers.local_servers import openai_models_url
+
+        assert openai_models_url("http://localhost:1234/v1/") == "http://localhost:1234/v1/models"
+
+
+class TestDetectLocalServer:
+    def test_ollama_default_port(self) -> None:
+        from lilbee.providers.local_servers import OLLAMA, detect_local_server
+
+        assert detect_local_server("http://localhost:11434") is OLLAMA
+
+    def test_ollama_127_default_port(self) -> None:
+        from lilbee.providers.local_servers import OLLAMA, detect_local_server
+
+        assert detect_local_server("http://127.0.0.1:11434") is OLLAMA
 
     def test_ollama_in_url(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+        from lilbee.providers.local_servers import OLLAMA, detect_local_server
 
-        assert _is_ollama("https://ollama.example.com") is True
+        assert detect_local_server("https://ollama.example.com") is OLLAMA
+
+    def test_lm_studio_default_port(self) -> None:
+        from lilbee.providers.local_servers import LM_STUDIO, detect_local_server
+
+        assert detect_local_server("http://localhost:1234") is LM_STUDIO
+
+    def test_lm_studio_127_with_v1(self) -> None:
+        from lilbee.providers.local_servers import LM_STUDIO, detect_local_server
+
+        assert detect_local_server("http://127.0.0.1:1234/v1") is LM_STUDIO
+
+    def test_lm_studio_port_not_confused_with_ollama(self) -> None:
+        """LM Studio's pattern must not match Ollama's longer port substring."""
+        from lilbee.providers.local_servers import OLLAMA, detect_local_server
+
+        assert detect_local_server("http://localhost:11434") is OLLAMA
 
     def test_openai_url(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+        from lilbee.providers.local_servers import detect_local_server
 
-        assert _is_ollama("https://api.openai.com") is False
+        assert detect_local_server("https://api.openai.com") is None
 
     def test_custom_url(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+        from lilbee.providers.local_servers import detect_local_server
 
-        assert _is_ollama("http://myserver:8080") is False
+        assert detect_local_server("http://myserver:8080") is None
 
 
 class TestRouteModel:
@@ -4237,6 +4308,30 @@ class TestRouteModel:
 
         ref = parse_model_ref("Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf")
         assert _route_model(ref, "https://example.com/v1") == ref.name
+
+    def test_lm_studio_ref_routes_to_lm_studio_prefix(self) -> None:
+        """LM Studio refs carry litellm's ``lm_studio/`` provider prefix."""
+        from lilbee.providers.litellm_sdk import _route_model
+        from lilbee.providers.model_ref import parse_model_ref
+
+        ref = parse_model_ref("lm_studio/qwen2.5-7b-instruct")
+        assert _route_model(ref, "http://localhost:1234/v1") == "lm_studio/qwen2.5-7b-instruct"
+
+    def test_local_ref_on_lm_studio_url_adds_prefix(self) -> None:
+        """A bare local ref forced through an LM Studio base URL gets prefixed."""
+        from lilbee.providers.litellm_sdk import _route_model
+        from lilbee.providers.model_ref import parse_model_ref
+
+        ref = parse_model_ref("Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf")
+        assert _route_model(ref, "http://localhost:1234/v1") == f"lm_studio/{ref.name}"
+
+    def test_lm_studio_ref_routes_regardless_of_api_base(self) -> None:
+        """An ``lm_studio/`` ref keeps its prefix even with no api_base set."""
+        from lilbee.providers.litellm_sdk import _route_model
+        from lilbee.providers.model_ref import parse_model_ref
+
+        ref = parse_model_ref("lm_studio/some-model")
+        assert _route_model(ref, None) == "lm_studio/some-model"
 
 
 class TestInjectProviderKeys:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1396,7 +1396,7 @@ class TestModelsPull:
     async def test_yields_progress_events_native(self):
         mock_manager = MagicMock()
 
-        def fake_pull(model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
+        def fake_pull(model, source, *, on_bytes=None, allow_unsupported=False):
             if on_bytes:
                 on_bytes(500, 1000)
                 on_bytes(1000, 1000)
@@ -1411,26 +1411,6 @@ class TestModelsPull:
         non_empty = [e for e in events if e]
         assert any('"current": 500' in e for e in non_empty)
         assert any('"total": 1000' in e for e in non_empty)
-
-    async def test_yields_progress_events_litellm(self):
-        """Litellm pulls use on_progress (dict), not on_bytes (int, int)."""
-        mock_manager = MagicMock()
-
-        def fake_pull(model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
-            if on_progress:
-                on_progress({"status": "downloading"})
-                on_progress({"status": "success"})
-            return
-
-        mock_manager.pull.side_effect = fake_pull
-        with patch(
-            "lilbee.server.handlers.models.get_services",
-            return_value=MagicMock(model_manager=mock_manager),
-        ):
-            events = [e async for e in handlers.models_pull("test", source="remote")]
-        non_empty = [e for e in events if e]
-        assert any("downloading" in e for e in non_empty)
-        assert any("success" in e for e in non_empty)
 
     async def test_error_yields_error_event(self):
         mock_manager = MagicMock()
@@ -1450,9 +1430,7 @@ class TestModelsPull:
         barrier = threading.Event()
         mock_manager = MagicMock()
 
-        def blocking_pull(
-            model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False
-        ):
+        def blocking_pull(model, source, *, on_bytes=None, allow_unsupported=False):
             if on_bytes:
                 on_bytes(100, 1000)
             barrier.wait(timeout=2)
@@ -2617,22 +2595,6 @@ class TestAddHandlerCancel:
 
 
 class TestModelPullProgressCancel:
-    async def test_cancel_skips_progress(self):
-        """When cancel is set, the progress callback returns early."""
-        from lilbee.server.handlers import SseStream
-
-        sse = SseStream()
-        sse.cancel.set()
-
-        # Simulate the progress callback pattern from models_pull
-        def _on_progress(data):
-            if sse.cancel.is_set():
-                return
-            sse.queue.put_nowait("should_not_appear")
-
-        _on_progress({"status": "downloading"})
-        assert sse.queue.empty()
-
     async def test_cancel_during_pull_skips_later_progress(self):
         """When cancel is set before pull starts, all progress calls return early."""
         import threading
@@ -2640,7 +2602,7 @@ class TestModelPullProgressCancel:
         mock_manager = MagicMock()
         progress_called = threading.Event()
 
-        def fake_pull(model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
+        def fake_pull(model, source, *, on_bytes=None, allow_unsupported=False):
             if on_bytes:
                 # All progress calls should see cancel already set
                 on_bytes(500, 1000)
@@ -2671,42 +2633,6 @@ class TestModelPullProgressCancel:
 
         assert progress_called.is_set()  # Pull did call on_bytes
         assert not any("current" in e for e in events if e)
-
-    async def test_cancel_during_litellm_pull_skips_progress(self):
-        """When cancel is set before litellm pull starts, on_progress returns early."""
-        import threading
-
-        mock_manager = MagicMock()
-        progress_called = threading.Event()
-
-        def fake_pull(model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
-            if on_progress:
-                on_progress({"status": "should_be_suppressed"})
-                progress_called.set()
-
-        mock_manager.pull.side_effect = fake_pull
-
-        original_init = handlers.SseStream.__init__
-
-        def patched_init(self):
-            original_init(self)
-            self.cancel.set()
-
-        with (
-            patch(
-                "lilbee.server.handlers.models.get_services",
-                return_value=MagicMock(model_manager=mock_manager),
-            ),
-            patch.object(handlers.SseStream, "__init__", patched_init),
-        ):
-            gen = handlers.models_pull("test", source="remote")
-            events = []
-            async for event in gen:
-                events.append(event)
-            await asyncio.sleep(0.2)
-
-        assert progress_called.is_set()
-        assert not any("should_be_suppressed" in e for e in events if e)
 
 
 class TestSearchRouteErrors:


### PR DESCRIPTION
## Problem

Ollama was hardcoded across the routing and discovery layers, so there was no clean way to support another local OpenAI-compatible server like LM Studio.

## Solution

Add a small local-server registry (Ollama, LM Studio) that drives URL detection, the litellm wire prefix, model listing, and read-only capability. Both servers work for chat, embedding, and rerank, and their models are listed from the catalog. Neither is pulled by lilbee: models are managed in their own app and surface here once present. lilbee downloads native GGUF models only.

The README and the base-URL setting now mention both.