### PR TITLE
Report installed models with granular source

### DIFF
--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -28,15 +28,13 @@ def _prefixed_source(model: str) -> ModelSource | None:
     ``ollama/`` is OLLAMA. Bare names carry no prefix to classify on and
     return ``None`` so the caller can fall back to backend membership.
     """
+    if model.startswith(OLLAMA_PREFIX):
+        return ModelSource.OLLAMA
     try:
         ref = parse_model_ref(model)
     except ValueError:
         return None
-    if ref.is_api:
-        return ModelSource.FRONTIER
-    if ref.provider == "ollama":
-        return ModelSource.OLLAMA
-    return None
+    return ModelSource.FRONTIER if ref.is_api else None
 
 
 class ModelManager:
@@ -149,12 +147,12 @@ class ModelManager:
         return model in self.list_installed(ModelSource.REMOTE)
 
     def get_source(self, model: str) -> ModelSource | None:
-        """Find which granular source a model lives in. Native takes precedence.
+        """Return the granular source a model lives in. Native takes precedence.
 
-        Distinguishes OLLAMA and FRONTIER so the installed list agrees with
-        the catalog instead of flattening every remote model to ``remote``.
-        A provider-prefixed ref classifies without a network call; a bare
-        name is OLLAMA when the (Ollama) backend reports it installed.
+        A provider-prefixed ref classifies without a network call (API
+        prefixes are FRONTIER, ``ollama/`` is OLLAMA); a bare name is OLLAMA
+        when the Ollama backend reports it installed. ``None`` when the model
+        is in no known source.
         """
         if self._is_native(model):
             return ModelSource.NATIVE

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -14,10 +14,29 @@ from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.core.security import validate_path_within
 from lilbee.modelhub.model_manager.types import ModelNotFoundError
 from lilbee.modelhub.registry import ModelRegistry
+from lilbee.providers.model_ref import OLLAMA_PREFIX, parse_model_ref
 
 log = logging.getLogger(__name__)
 
 _INSTALLED_CACHE_TTL_SECONDS = 30.0
+
+
+def _prefixed_source(model: str) -> ModelSource | None:
+    """Map a provider-prefixed ref to its source, or ``None`` for a bare ref.
+
+    API-provider prefixes (``gemini/``, ``openai/`` ...) are FRONTIER;
+    ``ollama/`` is OLLAMA. Bare names carry no prefix to classify on and
+    return ``None`` so the caller can fall back to backend membership.
+    """
+    try:
+        ref = parse_model_ref(model)
+    except ValueError:
+        return None
+    if ref.is_api:
+        return ModelSource.FRONTIER
+    if ref.provider == "ollama":
+        return ModelSource.OLLAMA
+    return None
 
 
 class ModelManager:
@@ -130,11 +149,20 @@ class ModelManager:
         return model in self.list_installed(ModelSource.REMOTE)
 
     def get_source(self, model: str) -> ModelSource | None:
-        """Find which source a model lives in. Native takes precedence."""
+        """Find which granular source a model lives in. Native takes precedence.
+
+        Distinguishes OLLAMA and FRONTIER so the installed list agrees with
+        the catalog instead of flattening every remote model to ``remote``.
+        A provider-prefixed ref classifies without a network call; a bare
+        name is OLLAMA when the (Ollama) backend reports it installed.
+        """
         if self._is_native(model):
             return ModelSource.NATIVE
+        prefixed = _prefixed_source(model)
+        if prefixed is not None:
+            return prefixed
         if self._is_remote(model):
-            return ModelSource.REMOTE
+            return ModelSource.OLLAMA
         return None
 
     def pull(
@@ -264,11 +292,14 @@ class ModelManager:
 
     def _remove_remote(self, model: str) -> bool:
         url = f"{self._remote_base_url}/api/delete"
+        # Ollama's API keys models by bare name; strip the canonical routing
+        # prefix the rest of lilbee carries.
+        backend_name = model.removeprefix(OLLAMA_PREFIX)
         try:
             resp = httpx.request(
                 "DELETE",
                 url,
-                content=json.dumps({"model": model}).encode(),
+                content=json.dumps({"model": backend_name}).encode(),
                 headers={"Content-Type": "application/json"},
                 timeout=DEFAULT_HTTP_TIMEOUT,
             )

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -29,7 +29,7 @@ from lilbee.core.config import cfg
 from lilbee.modelhub.model_manager import classify_remote_models, discover_api_models
 from lilbee.modelhub.model_manager.types import RemoteModel
 from lilbee.modelhub.role_validator import _MODEL_FIELD_TO_TASK, validate_model_task_assignment
-from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
+from lilbee.providers.model_ref import OLLAMA_PREFIX, format_remote_ref, parse_model_ref
 from lilbee.providers.sdk_backend import PROVIDER_KEYS, get_provider_api_key
 from lilbee.runtime.hardware import (
     FitLevel,
@@ -411,8 +411,7 @@ def _discover_hosted_sync() -> list[CatalogEntryResponse]:
     for models in discover_api_models().values():
         rows.extend(_hosted_entry(rm, ModelSource.FRONTIER) for rm in models)
     rows.extend(
-        _hosted_entry(rm, ModelSource.OLLAMA)
-        for rm in classify_remote_models(cfg.remote_base_url)
+        _hosted_entry(rm, ModelSource.OLLAMA) for rm in classify_remote_models(cfg.remote_base_url)
     )
     return rows
 
@@ -500,14 +499,27 @@ async def models_catalog(
     )
 
 
+def _canonical_installed_ref(name: str, source: ModelSource) -> str:
+    """Render an Ollama model with its ``ollama/<name>`` ref.
+
+    Ollama's ``/api/tags`` reports bare names; the catalog reports the
+    prefixed ref. Reporting the prefixed ref here too lets clients dedup the
+    installed and catalog views instead of showing the model twice.
+    """
+    if source is ModelSource.OLLAMA and not name.startswith(OLLAMA_PREFIX):
+        return format_remote_ref(name, ModelSource.OLLAMA.value)
+    return name
+
+
 async def models_installed() -> ModelsInstalledResponse:
-    """Return list of installed models with their source."""
+    """Return installed models with their granular source and canonical ref."""
     manager = get_services().model_manager
-    names = manager.list_installed()
     models = []
-    for name in names:
-        src = manager.get_source(name)
-        models.append(InstalledModelEntry(name=name, source=src or ModelSource.REMOTE))
+    for name in manager.list_installed():
+        source = manager.get_source(name) or ModelSource.REMOTE
+        models.append(
+            InstalledModelEntry(name=_canonical_installed_ref(name, source), source=source)
+        )
     return ModelsInstalledResponse(models=models)
 
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -348,7 +348,8 @@ class TestModelManagerGetSource:
         mgr = ModelManager(models_dir, "http://localhost:11434")
         assert mgr.get_source("my-model.gguf") == ModelSource.NATIVE
 
-    def test_litellm_model(self) -> None:
+    def test_bare_ollama_model_is_ollama_source(self) -> None:
+        """A bare name the Ollama backend reports installed classifies as OLLAMA."""
         mock_response = mock.Mock()
         mock_response.json.return_value = {"models": [{"name": "llama3:latest"}]}
         mock_response.raise_for_status = mock.Mock()
@@ -357,7 +358,23 @@ class TestModelManagerGetSource:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
             result = mgr.get_source("llama3:latest")
 
-        assert result == ModelSource.REMOTE
+        assert result == ModelSource.OLLAMA
+
+    def test_ollama_prefixed_ref_is_ollama_source_without_network(self) -> None:
+        """An ``ollama/`` ref classifies on the prefix, no /api/tags call."""
+        mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+        with mock.patch("httpx.get") as mock_get:
+            result = mgr.get_source("ollama/llama3:latest")
+        assert result == ModelSource.OLLAMA
+        mock_get.assert_not_called()
+
+    def test_api_prefixed_ref_is_frontier_source(self) -> None:
+        """A hosted API ref classifies as FRONTIER without a network call."""
+        mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+        with mock.patch("httpx.get") as mock_get:
+            result = mgr.get_source("gemini/gemini-2.5-pro")
+        assert result == ModelSource.FRONTIER
+        mock_get.assert_not_called()
 
     def test_native_takes_precedence(self, tmp_path: Path) -> None:
         """When model exists in both sources, NATIVE takes precedence."""
@@ -625,6 +642,18 @@ class TestModelManagerRemove:
         call_kwargs = mock_req.call_args[1]
         assert call_kwargs["content"] == b'{"model": "llama3:latest"}'
         assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        assert result is True
+
+    def test_remove_strips_ollama_prefix_for_backend(self) -> None:
+        """A canonical ``ollama/<name>`` ref deletes by bare name on the backend."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+
+        with mock.patch("httpx.request", return_value=mock_response) as mock_req:
+            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            result = mgr.remove("ollama/llama3:latest", ModelSource.OLLAMA)
+
+        assert mock_req.call_args[1]["content"] == b'{"model": "llama3:latest"}'
         assert result is True
 
     def test_litellm_remove_not_found(self) -> None:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1731,6 +1731,34 @@ class TestModelsInstalled:
             result = await handlers.models_installed()
         assert result.models[0].source == "remote"
 
+    async def test_ollama_model_reports_granular_source_and_canonical_ref(self):
+        """A bare Ollama name surfaces as source 'ollama' with the prefixed ref."""
+        from lilbee.catalog.types import ModelSource
+
+        mock_manager = MagicMock()
+        mock_manager.list_installed.return_value = ["qwen3:0.6b"]
+        mock_manager.get_source.return_value = ModelSource.OLLAMA
+        with patch(
+            "lilbee.server.handlers.models.get_services",
+            return_value=MagicMock(model_manager=mock_manager),
+        ):
+            result = await handlers.models_installed()
+        assert result.models[0].name == "ollama/qwen3:0.6b"
+        assert result.models[0].source == "ollama"
+
+    async def test_already_prefixed_ollama_ref_not_double_prefixed(self):
+        from lilbee.catalog.types import ModelSource
+
+        mock_manager = MagicMock()
+        mock_manager.list_installed.return_value = ["ollama/qwen3:0.6b"]
+        mock_manager.get_source.return_value = ModelSource.OLLAMA
+        with patch(
+            "lilbee.server.handlers.models.get_services",
+            return_value=MagicMock(model_manager=mock_manager),
+        ):
+            result = await handlers.models_installed()
+        assert result.models[0].name == "ollama/qwen3:0.6b"
+
 
 class TestModelsPull:
     async def test_yields_progress_events_native(self):


### PR DESCRIPTION
## Problem

Installed models all reported source 'remote', so Ollama models showed as '[remote]' (not '[ollama]') and appeared twice in the plugin: once as a catalog row (ollama/<name>) and once as an installed row (bare name).

## Solution

get_source distinguishes ollama and frontier, and the installed list reports the canonical ollama/<name> ref so it matches the catalog and dedups. Delete still works by stripping the prefix at the Ollama wire boundary.

Stacked on #299 (which adds the granular source values).