### PR TITLE
Support Ollama and LM Studio as read-only local model managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ A batteries-included local search engine you can talk to: it runs the AI models,
 
 It's all one program: you never stand up a separate model server, a [vector database](#built-on), or a container. lilbee runs the models and keeps the index itself. Reach it as a full-screen terminal app, a command-line tool, a Model Context Protocol server, an HTTP API, or a Python library. Close it and it's gone, or run it as a service if you'd rather keep it warm. It runs on your computer; lilbee uses a cloud model only when you pick one.
 
+Already running [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai)? Point lilbee at either one and keep managing your models there. lilbee also comes with first-class model management built in, so you can browse Hugging Face, download a model, and give it a role without leaving the app. Use whichever you prefer.
+
 > **Tutorial reel:** every demo on this page (and the extras) as a real video player at [**lilbee.sh/tutorial**](https://lilbee.sh/tutorial).
 
 > ## ⚠️ Beta software

--- a/src/lilbee/app/models.py
+++ b/src/lilbee/app/models.py
@@ -73,13 +73,12 @@ class ModelEntry(BaseModel):
         )
 
     @classmethod
-    def from_backend(cls, ref: str, remote: RemoteModel | None) -> ModelEntry:
-        # heavy: lilbee.modelhub.model_manager (>50ms; huggingface_hub fanout)
-        from lilbee.catalog.types import ModelSource
+    def from_backend(cls, ref: str, remote: RemoteModel | None, source: ModelSource) -> ModelEntry:
+        from lilbee.providers.local_servers import canonical_local_ref
 
         return cls(
-            name=ref,
-            source=ModelSource.REMOTE.value,
+            name=canonical_local_ref(ref, source.value),
+            source=source.value,
             task=remote.task if remote else None,
             size_gb=None,
             display_name=remote.parameter_size if remote else "",
@@ -214,11 +213,17 @@ def _collect_native_entries() -> list[ModelEntry]:
 
 def _collect_backend_entries() -> list[ModelEntry]:
     # heavy: lilbee.modelhub.model_manager (>50ms; huggingface_hub fanout)
+    from lilbee.catalog.types import ModelSource
     from lilbee.modelhub.model_manager import classify_remote_models
+    from lilbee.providers.local_servers import detect_local_server
 
+    server = detect_local_server(cfg.remote_base_url)
+    source = ModelSource(server.key) if server is not None else ModelSource.REMOTE
     remote_list = classify_remote_models(cfg.remote_base_url, timeout=_BACKEND_LIST_TIMEOUT_S)
     remote_by_name = {rm.name: rm for rm in remote_list}
-    return [ModelEntry.from_backend(ref, remote_by_name[ref]) for ref in sorted(remote_by_name)]
+    return [
+        ModelEntry.from_backend(ref, remote_by_name[ref], source) for ref in sorted(remote_by_name)
+    ]
 
 
 def list_models_data(
@@ -236,8 +241,13 @@ def list_models_data(
     entries: list[ModelEntry] = []
     if source is None or source is ModelSource.NATIVE:
         entries.extend(_collect_native_entries())
-    if source is None or source is ModelSource.REMOTE:
-        entries.extend(_collect_backend_entries())
+    if source is not ModelSource.NATIVE:
+        backend = _collect_backend_entries()
+        # A specific local-server source (ollama/lm_studio/frontier) narrows the
+        # backend list; REMOTE and None keep every backend entry.
+        if source not in (None, ModelSource.REMOTE):
+            backend = [e for e in backend if e.source == source.value]
+        entries.extend(backend)
     if task:
         entries = [e for e in entries if e.task == task]
     return ListModelsResult(models=entries, total=len(entries))

--- a/src/lilbee/app/models.py
+++ b/src/lilbee/app/models.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import functools
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
@@ -269,35 +268,6 @@ def show_model_data(ref: str) -> ShowModelResult:
     )
 
 
-def _backend_event_to_progress(
-    on_update: Callable[[DownloadProgress], None],
-    event: dict[str, Any],
-) -> None:
-    """Adapt an Ollama-style dict event into a DownloadProgress call."""
-    # heavy: lilbee.catalog (>50ms; huggingface_hub fanout)
-    from lilbee.catalog import DownloadProgress
-
-    total = event.get("total", 0) or 0
-    completed = event.get("completed", 0) or 0
-    detail = event.get("status", "") or ""
-    pct = int(completed * 100 / total) if total > 0 else 0
-    on_update(DownloadProgress(percent=pct, detail=detail, is_cache_hit=False))
-
-
-def _build_pull_callbacks(
-    on_update: Callable[[DownloadProgress], None] | None,
-) -> tuple[Callable[[dict[str, Any]], None] | None, Callable[[int, int], None] | None]:
-    """Build the (dict_cb, bytes_cb) pair for ModelManager.pull from on_update."""
-    # heavy: lilbee.catalog (>50ms; huggingface_hub fanout)
-    from lilbee.catalog import make_download_callback
-
-    if on_update is None:
-        return None, None
-    dict_cb = functools.partial(_backend_event_to_progress, on_update)
-    bytes_cb = make_download_callback(on_update)
-    return dict_cb, bytes_cb
-
-
 def pull_model_data(
     ref: str,
     source: ModelSource,
@@ -307,20 +277,23 @@ def pull_model_data(
 ) -> PullResult:
     """Pull *ref* from *source* and return a typed result.
 
-    Progress updates are throttled by
-    :func:`~lilbee.catalog.make_download_callback`, so callers see at
-    most roughly 10 Hz of progress events.
+    Only native models are downloadable; a non-native *source* is refused by
+    :meth:`ModelManager.pull`. Progress updates are throttled by
+    :func:`~lilbee.catalog.make_download_callback`, so callers see at most
+    roughly 10 Hz of progress events.
     """
+    # heavy: lilbee.catalog (>50ms; huggingface_hub fanout)
+    from lilbee.catalog import make_download_callback
+
     manager = get_services().model_manager
 
     if manager.is_installed(ref, source):
         return PullResult(model=ref, source=source.value, status=PullStatus.ALREADY_INSTALLED)
 
-    dict_cb, bytes_cb = _build_pull_callbacks(on_update)
+    bytes_cb = make_download_callback(on_update) if on_update is not None else None
     path = manager.pull(
         ref,
         source,
-        on_progress=dict_cb,
         on_bytes=bytes_cb,
         allow_unsupported=allow_unsupported,
     )

--- a/src/lilbee/app/models.py
+++ b/src/lilbee/app/models.py
@@ -245,7 +245,7 @@ def list_models_data(
         backend = _collect_backend_entries()
         # A specific local-server source (ollama/lm_studio/frontier) narrows the
         # backend list; REMOTE and None keep every backend entry.
-        if source not in (None, ModelSource.REMOTE):
+        if source is not None and source is not ModelSource.REMOTE:
             backend = [e for e in backend if e.source == source.value]
         entries.extend(backend)
     if task:

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -801,7 +801,10 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         str,
         nullable=False,
         group=SettingGroup.API_KEYS,
-        help_text="OpenAI-compatible base URL (Ollama default: http://localhost:11434)",
+        help_text=(
+            "OpenAI-compatible base URL "
+            "(Ollama: http://localhost:11434, LM Studio: http://localhost:1234/v1)"
+        ),
     ),
     "wiki_summary_max_tokens": SettingDef(
         int,

--- a/src/lilbee/catalog/types.py
+++ b/src/lilbee/catalog/types.py
@@ -25,6 +25,8 @@ class ModelSource(StrEnum):
 
     NATIVE = "native"  # lilbee's GGUF files in cfg.models_dir
     REMOTE = "remote"  # Models managed by a remote SDK-backed service
+    FRONTIER = "frontier"  # Cloud API-key models (Gemini/OpenAI/Anthropic/…)
+    OLLAMA = "ollama"  # Models served by a reachable Ollama endpoint
 
     @classmethod
     def parse(cls, value: str | None) -> ModelSource | None:
@@ -40,6 +42,13 @@ class ModelSource(StrEnum):
         except ValueError as exc:
             valid = ", ".join(s.value for s in cls)
             raise ValueError(f"invalid source {value!r}; expected one of: {valid}") from exc
+
+
+class KeyStatus(StrEnum):
+    """Whether a hosted provider's API key is configured."""
+
+    READY = "ready"
+    MISSING_KEY = "missing_key"
 
 
 class CatalogSize(StrEnum):

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -89,7 +89,7 @@ _source_option = typer.Option(
     None,
     "--source",
     "-s",
-    help="Filter by source: 'native' or 'remote' (default: all).",
+    help="Filter by source: native, remote, ollama, lm_studio, or frontier (default: all).",
 )
 _task_option = typer.Option(
     None,

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -289,7 +289,14 @@ def rm_cmd(
     apply_overrides(data_dir=data_dir, use_global=use_global)
     src = _parse_source_or_bad_param(source)
     _confirm_remove_or_exit(ref, yes)
-    data = remove_model_data(ref, source=src)
+    try:
+        data = remove_model_data(ref, source=src)
+    except ValueError as exc:
+        if cfg.json_mode:
+            json_output({"error": str(exc)})
+        else:
+            console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(1) from None
     if cfg.json_mode:
         json_output(data.model_dump())
         if not data.deleted:

--- a/src/lilbee/cli/tui/screens/catalog_utils.py
+++ b/src/lilbee/cli/tui/screens/catalog_utils.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from enum import Enum, StrEnum
+from enum import StrEnum
 from typing import Any, Literal
 
 from lilbee.catalog import PARAM_COUNT_RE, CatalogModel, ModelFamily, ModelVariant, extract_quant
-from lilbee.catalog.types import ModelCompat, ModelTask
+from lilbee.catalog.types import KeyStatus, ModelCompat, ModelTask
 from lilbee.modelhub.model_manager import RemoteModel
 from lilbee.providers.model_ref import format_remote_ref
 from lilbee.runtime.hardware import FitChip
@@ -160,13 +160,6 @@ class LocalCatalogRow:
     fit: FitChip | None = None
     compat: ModelCompat = ModelCompat.UNKNOWN
     kind: Literal[CatalogRowKind.LOCAL] = CatalogRowKind.LOCAL
-
-
-class KeyStatus(Enum):
-    """Whether the user has the API key needed to use a frontier model."""
-
-    READY = "ready"
-    MISSING_KEY = "missing_key"
 
 
 @dataclass

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -806,16 +806,17 @@ def model_rm(model: str, source: str = "") -> dict[str, Any]:
     """Remove an installed model.
 
     Args:
-        model: Model ref to remove.
-        source: Restrict to "native" or "remote"; empty = both.
+        model: Model ref to remove. lilbee removes only native models it
+            downloaded; Ollama and LM Studio models are read-only.
+        source: Restrict to a known source; empty = resolve from the ref.
     """
     from lilbee.app.models import remove_model_data
 
     try:
         src = ModelSource.parse(source)
+        return remove_model_data(model, source=src).model_dump()
     except ValueError as exc:
         return _error(str(exc))
-    return remove_model_data(model, source=src).model_dump()
 
 
 @mcp.tool()

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -122,7 +122,8 @@ class ModelManager:
         """
         from lilbee.modelhub.model_manager.discovery import classify_remote_models
 
-        return [m.name for m in classify_remote_models(self._remote_base_url)]
+        models = classify_remote_models(self._remote_base_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        return [m.name for m in models]
 
     def is_installed(self, model: str, source: ModelSource | None = None) -> bool:
         """Check if model exists in specified source."""

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -14,6 +14,7 @@ from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.core.security import validate_path_within
 from lilbee.modelhub.model_manager.types import ModelNotFoundError
 from lilbee.modelhub.registry import ModelRegistry
+from lilbee.providers.local_servers import detect_local_server
 
 log = logging.getLogger(__name__)
 
@@ -142,32 +143,30 @@ class ModelManager:
         model: str,
         source: ModelSource,
         *,
-        on_progress: Callable[[dict], None] | None = None,
         on_bytes: Callable[[int, int], None] | None = None,
         allow_unsupported: bool = False,
     ) -> Path | None:
-        """Pull/download model to specified source.
+        """Download a native GGUF model and return its path.
 
-        Returns the Path for native downloads, None for backend-managed pulls.
+        lilbee pulls native models only. Local servers (Ollama, LM Studio)
+        are read-only: their models are managed in their own app and surface
+        here once present, so a non-native *source* is refused.
 
         Native pulls of architectures the bundled llama.cpp doesn't support
         are refused with ``UnsupportedArchError`` unless *allow_unsupported*
-        is True. SDK-backed (REMOTE) pulls are not gated here: the remote
-        runtime owns the arch verdict.
-
-        *on_progress* receives dict events from the SDK backend.
-        *on_bytes* receives (downloaded_bytes, total_bytes) from native
-        HuggingFace downloads. The two sources report progress in different
-        shapes, so callers pass whichever matches the chosen source.
+        is True. *on_bytes* receives (downloaded_bytes, total_bytes) progress.
         """
-        if source is ModelSource.NATIVE and not allow_unsupported:
+        if source is not ModelSource.NATIVE:
+            server = detect_local_server(self._remote_base_url)
+            where = server.display_name if server is not None else "the configured server"
+            raise ValueError(
+                f"lilbee runs {where} models but doesn't download them. "
+                f"Add the model in {where}, then pick it here."
+            )
+        if not allow_unsupported:
             self._enforce_arch_compat(model)
-
         try:
-            if source is ModelSource.NATIVE:
-                return self._pull_native(model, on_bytes=on_bytes)
-            self._pull_remote(model, on_progress=on_progress)
-            return None
+            return self._pull_native(model, on_bytes=on_bytes)
         finally:
             self._invalidate_installed_cache()
 
@@ -205,34 +204,6 @@ class ModelManager:
         path = download_model(entry, on_progress=on_bytes, on_complete=register_downloaded_model)
         log.info("Downloaded %s to %s", model, path)
         return path
-
-    def _pull_remote(
-        self, model: str, *, on_progress: Callable[[dict], None] | None = None
-    ) -> None:
-        """Pull model via the SDK backend's HTTP API with streaming progress."""
-        url = f"{self._remote_base_url}/api/pull"
-        try:
-            with (
-                # Model pulls stream progress over minutes; an overall
-                # timeout would cut the download. Connect/write timeouts
-                # still apply via httpx defaults when timeout=None.
-                httpx.Client(timeout=None) as client,  # noqa: S113
-                client.stream("POST", url, json={"name": model, "stream": True}) as resp,
-            ):
-                resp.raise_for_status()
-                for line in resp.iter_lines():
-                    if not line:
-                        continue
-                    data = json.loads(line)
-                    if "error" in data:
-                        raise RuntimeError(f"Failed to pull '{model}': {data['error']}")
-                    if on_progress is not None:
-                        on_progress(data)
-        except httpx.ConnectError as exc:
-            raise RuntimeError(
-                f"Cannot connect to SDK backend: {exc}. Is the server running?"
-            ) from exc
-        log.info("Pulled %s via SDK backend", model)
 
     def remove(self, model: str, source: ModelSource | None = None) -> bool:
         """Remove installed model. Returns True if removed."""

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -28,15 +28,13 @@ def _prefixed_source(model: str) -> ModelSource | None:
     ``ollama/`` is OLLAMA. Bare names carry no prefix to classify on and
     return ``None`` so the caller can fall back to backend membership.
     """
+    if model.startswith(OLLAMA_PREFIX):
+        return ModelSource.OLLAMA
     try:
         ref = parse_model_ref(model)
     except ValueError:
         return None
-    if ref.is_api:
-        return ModelSource.FRONTIER
-    if ref.provider == "ollama":
-        return ModelSource.OLLAMA
-    return None
+    return ModelSource.FRONTIER if ref.is_api else None
 
 
 class ModelManager:
@@ -149,12 +147,12 @@ class ModelManager:
         return model in self.list_installed(ModelSource.REMOTE)
 
     def get_source(self, model: str) -> ModelSource | None:
-        """Find which granular source a model lives in. Native takes precedence.
+        """Return the granular source a model lives in. Native takes precedence.
 
-        Distinguishes OLLAMA and FRONTIER so the installed list agrees with
-        the catalog instead of flattening every remote model to ``remote``.
-        A provider-prefixed ref classifies without a network call; a bare
-        name is OLLAMA when the (Ollama) backend reports it installed.
+        A provider-prefixed ref classifies without a network call (API
+        prefixes are FRONTIER, ``ollama/`` is OLLAMA); a bare name is OLLAMA
+        when the Ollama backend reports it installed. ``None`` when the model
+        is in no known source.
         """
         if self._is_native(model):
             return ModelSource.NATIVE

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -120,6 +120,7 @@ class ModelManager:
         detected server (Ollama ``/api/tags`` vs LM Studio ``/v1/models``).
         Returns ``[]`` when the backend is unreachable.
         """
+        # circular: discovery -> app.services -> model_manager.__init__ -> core
         from lilbee.modelhub.model_manager.discovery import classify_remote_models
 
         models = classify_remote_models(self._remote_base_url, timeout=DEFAULT_HTTP_TIMEOUT)
@@ -259,9 +260,11 @@ class ModelManager:
 
     def _remove_remote(self, model: str) -> bool:
         url = f"{self._remote_base_url}/api/delete"
-        # Ollama's API keys models by bare name; strip the routing prefix the
-        # rest of lilbee carries.
-        backend_name = model.removeprefix(OLLAMA.wire_prefix)
+        # The local server keys models by bare name; strip the routing prefix
+        # lilbee carries for the detected server.
+        server = detect_local_server(self._remote_base_url)
+        prefix = server.wire_prefix if server is not None else OLLAMA.wire_prefix
+        backend_name = model.removeprefix(prefix)
         try:
             resp = httpx.request(
                 "DELETE",

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -1,20 +1,16 @@
 """ModelManager: native and SDK-backed model lifecycle operations."""
 
-import json
 import logging
 import time
 from collections.abc import Callable
-from http import HTTPStatus
 from pathlib import Path
-
-import httpx
 
 from lilbee.catalog.types import ModelSource
 from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.core.security import validate_path_within
 from lilbee.modelhub.model_manager.types import ModelNotFoundError
 from lilbee.modelhub.registry import ModelRegistry
-from lilbee.providers.local_servers import LOCAL_SERVERS, OLLAMA, detect_local_server
+from lilbee.providers.local_servers import LOCAL_SERVERS, detect_local_server
 from lilbee.providers.model_ref import parse_model_ref
 
 log = logging.getLogger(__name__)
@@ -231,15 +227,23 @@ class ModelManager:
         return path
 
     def remove(self, model: str, source: ModelSource | None = None) -> bool:
-        """Remove installed model. Returns True if removed."""
+        """Remove an installed native model. Returns True if removed.
+
+        lilbee removes only native GGUF models it downloaded. Local servers
+        (Ollama, LM Studio) are read-only: a model that lives on one is refused
+        (mirrors ``pull``), since its lifecycle is managed in that app. A bare
+        ``source`` is resolved so a local-server ref is caught either way.
+        """
+        effective = source if source is not None else self.get_source(model)
+        if effective is not None and effective is not ModelSource.NATIVE:
+            server = detect_local_server(self._remote_base_url)
+            where = server.display_name if server is not None else "the configured server"
+            raise ValueError(
+                f"lilbee runs {where} models but doesn't remove them. "
+                f"Manage them in {where} instead."
+            )
         try:
-            if source is None:
-                native_removed = self._remove_native(model)
-                backend_removed = self._remove_remote(model)
-                return native_removed or backend_removed
-            if source is ModelSource.NATIVE:
-                return self._remove_native(model)
-            return self._remove_remote(model)
+            return self._remove_native(model)
         finally:
             self._invalidate_installed_cache()
 
@@ -257,30 +261,3 @@ class ModelManager:
             log.info("Removed native model %s", model)
             return True
         return False
-
-    def _remove_remote(self, model: str) -> bool:
-        url = f"{self._remote_base_url}/api/delete"
-        # The local server keys models by bare name; strip the routing prefix
-        # lilbee carries for the detected server.
-        server = detect_local_server(self._remote_base_url)
-        prefix = server.wire_prefix if server is not None else OLLAMA.wire_prefix
-        backend_name = model.removeprefix(prefix)
-        try:
-            resp = httpx.request(
-                "DELETE",
-                url,
-                content=json.dumps({"model": backend_name}).encode(),
-                headers={"Content-Type": "application/json"},
-                timeout=DEFAULT_HTTP_TIMEOUT,
-            )
-            if resp.status_code == HTTPStatus.OK:
-                log.info("Removed backend model %s", model)
-                return True
-            if resp.status_code == HTTPStatus.NOT_FOUND:
-                return False
-            log.warning("Unexpected status %d removing %s", resp.status_code, model)
-            return False
-        except httpx.ConnectError as exc:
-            raise RuntimeError(
-                f"Cannot connect to SDK backend: {exc}. Is the server running?"
-            ) from exc

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -14,10 +14,29 @@ from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.core.security import validate_path_within
 from lilbee.modelhub.model_manager.types import ModelNotFoundError
 from lilbee.modelhub.registry import ModelRegistry
+from lilbee.providers.model_ref import OLLAMA_PREFIX, parse_model_ref
 
 log = logging.getLogger(__name__)
 
 _INSTALLED_CACHE_TTL_SECONDS = 30.0
+
+
+def _prefixed_source(model: str) -> ModelSource | None:
+    """Map a provider-prefixed ref to its source, or ``None`` for a bare ref.
+
+    API-provider prefixes (``gemini/``, ``openai/`` ...) are FRONTIER;
+    ``ollama/`` is OLLAMA. Bare names carry no prefix to classify on and
+    return ``None`` so the caller can fall back to backend membership.
+    """
+    try:
+        ref = parse_model_ref(model)
+    except ValueError:
+        return None
+    if ref.is_api:
+        return ModelSource.FRONTIER
+    if ref.provider == "ollama":
+        return ModelSource.OLLAMA
+    return None
 
 
 class ModelManager:
@@ -130,11 +149,20 @@ class ModelManager:
         return model in self.list_installed(ModelSource.REMOTE)
 
     def get_source(self, model: str) -> ModelSource | None:
-        """Find which source a model lives in. Native takes precedence."""
+        """Find which granular source a model lives in. Native takes precedence.
+
+        Distinguishes OLLAMA and FRONTIER so the installed list agrees with
+        the catalog instead of flattening every remote model to ``remote``.
+        A provider-prefixed ref classifies without a network call; a bare
+        name is OLLAMA when the (Ollama) backend reports it installed.
+        """
         if self._is_native(model):
             return ModelSource.NATIVE
+        prefixed = _prefixed_source(model)
+        if prefixed is not None:
+            return prefixed
         if self._is_remote(model):
-            return ModelSource.REMOTE
+            return ModelSource.OLLAMA
         return None
 
     def pull(
@@ -264,11 +292,14 @@ class ModelManager:
 
     def _remove_remote(self, model: str) -> bool:
         url = f"{self._remote_base_url}/api/delete"
+        # Ollama's API keys models by bare name; strip the canonical routing
+        # prefix the rest of lilbee carries.
+        backend_name = model.removeprefix(OLLAMA_PREFIX)
         try:
             resp = httpx.request(
                 "DELETE",
                 url,
-                content=json.dumps({"model": model}).encode(),
+                content=json.dumps({"model": backend_name}).encode(),
                 headers={"Content-Type": "application/json"},
                 timeout=DEFAULT_HTTP_TIMEOUT,
             )

--- a/src/lilbee/modelhub/model_manager/discovery.py
+++ b/src/lilbee/modelhub/model_manager/discovery.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from collections.abc import Callable
 
 import httpx
 
@@ -9,14 +10,25 @@ from lilbee.app.services import get_services
 from lilbee.catalog.types import ModelTask
 from lilbee.core.config.model import cfg
 from lilbee.modelhub.model_manager.types import RemoteModel
-from lilbee.providers.sdk_backend import (
-    PROVIDER_KEYS,
-    detect_backend_name,
+from lilbee.providers.backend_names import BackendName
+from lilbee.providers.local_servers import (
+    LM_STUDIO,
+    OLLAMA,
+    detect_local_server,
+    openai_models_url,
 )
+from lilbee.providers.sdk_backend import PROVIDER_KEYS, detect_backend_name
 
 log = logging.getLogger(__name__)
 
 _EMBEDDING_FAMILIES = frozenset({"bert", "nomic-bert", "e5", "bge"})
+# Embedding detection by name, for OpenAI-compatible servers (LM Studio) that
+# expose ids but no family metadata. ``embed`` covers the common naming, the
+# rest match family-named embedders (``bge-base``, ``multilingual-e5-large``,
+# ``gte-large``). The trailing hyphen on the family tags avoids matching a chat
+# model that merely contains the letters (``bge`` keeps ``bge-reranker`` out of
+# here too, though reranker detection already runs first).
+_EMBEDDING_NAME_PATTERNS = frozenset({"embed", "bge-", "e5-", "gte-"})
 _VISION_NAME_PATTERNS = frozenset({"llava", "vision", "moondream", "ocr", "minicpm-v"})
 # Reranker detection runs BEFORE embedding detection so ``bge-reranker-*``
 # (family "bge" but clearly a reranker) does not get misclassified as
@@ -31,15 +43,18 @@ def _classify_remote_task(name: str, family: str) -> ModelTask:
     """Classify a remote model as chat, embedding, vision, or rerank.
 
     Reranker detection runs first so ``bge-reranker-base`` (family
-    ``bge``) does not get dragged into the embedding bucket by the
-    family check. After reranker: embedding by family tag, vision by
-    name pattern, else chat.
+    ``bge``) does not get dragged into the embedding bucket. After
+    reranker: embedding by family tag OR by name pattern (the name path
+    covers servers like LM Studio that report no family), vision by name
+    pattern, else chat.
     """
     name_lower = name.lower()
     if any(rp in name_lower for rp in _RERANKER_NAME_PATTERNS):
         return ModelTask.RERANK
     family_lower = family.lower()
-    if any(ef in family_lower for ef in _EMBEDDING_FAMILIES):
+    if any(ef in family_lower for ef in _EMBEDDING_FAMILIES) or any(
+        ep in name_lower for ep in _EMBEDDING_NAME_PATTERNS
+    ):
         return ModelTask.EMBEDDING
     if any(vp in name_lower for vp in _VISION_NAME_PATTERNS):
         return ModelTask.VISION
@@ -67,13 +82,27 @@ def classify_remote_models(
     *,
     timeout: float = _CLASSIFY_DEFAULT_TIMEOUT_S,
 ) -> list[RemoteModel]:
-    """Discover and classify all models from the SDK backend by task.
+    """Discover and classify all models from the local server by task.
 
-    Uses /api/tags family metadata for embedding detection and name
-    patterns for reranker and vision detection. Returns an empty list
-    on any error (including timeout) so callers in read-only code paths
-    can stay responsive when the backend is down.
+    Dispatches the listing strategy off the server behind *base_url*:
+    Ollama's ``/api/tags`` (rich family metadata) or LM Studio's
+    OpenAI-compatible ``/v1/models``. Unknown URLs default to the Ollama
+    strategy. The provider label always comes from ``detect_backend_name``,
+    so a hosted API URL keeps its own name. Returns an empty list on any
+    error (including timeout) so read-only callers stay responsive when the
+    backend is down.
     """
+    spec = detect_local_server(base_url)
+    provider = detect_backend_name(base_url)
+    key = spec.key if spec is not None else OLLAMA.key
+    discover = _DISCOVERY_BY_KEY.get(key, _discover_via_ollama_tags)
+    return discover(base_url, provider, timeout)
+
+
+def _discover_via_ollama_tags(
+    base_url: str, provider: BackendName, timeout: float
+) -> list[RemoteModel]:
+    """Classify models from Ollama's ``/api/tags`` using family metadata."""
     try:
         resp = httpx.get(f"{base_url}/api/tags", timeout=timeout)
         resp.raise_for_status()
@@ -82,7 +111,6 @@ def classify_remote_models(
         log.debug("Failed to classify remote models", exc_info=True)
         return []
 
-    provider = detect_backend_name(base_url)
     result: list[RemoteModel] = []
     for model in raw_models:
         name = model.get("name", "")
@@ -92,10 +120,57 @@ def classify_remote_models(
         task = _classify_remote_task(name, family)
         result.append(
             RemoteModel(
-                name=name, task=task, family=family, parameter_size=param_size, provider=provider
+                name=name,
+                task=task,
+                family=family,
+                parameter_size=param_size,
+                provider=provider,
             )
         )
     return result
+
+
+def _discover_via_openai_models(
+    base_url: str, provider: BackendName, timeout: float
+) -> list[RemoteModel]:
+    """Classify models from an OpenAI-compatible ``/v1/models`` endpoint.
+
+    LM Studio exposes only model ids, no family metadata, so embedding /
+    reranker / vision detection falls back to the name patterns (which
+    LM Studio ids usually carry, e.g. ``nomic-embed``, ``bge-reranker``).
+    """
+    try:
+        resp = httpx.get(openai_models_url(base_url), timeout=timeout)
+        resp.raise_for_status()
+        raw_models = resp.json().get("data", [])
+    except Exception:
+        log.debug("Failed to classify remote models", exc_info=True)
+        return []
+
+    result: list[RemoteModel] = []
+    for model in raw_models:
+        name = model.get("id", "")
+        if not name:
+            continue
+        task = _classify_remote_task(name, "")
+        result.append(
+            RemoteModel(
+                name=name,
+                task=task,
+                family="",
+                parameter_size="",
+                provider=provider,
+            )
+        )
+    return result
+
+
+# Listing strategy per local-server routing key. Module-level so it stays a
+# single source of truth as servers are added to the registry.
+_DISCOVERY_BY_KEY: dict[str, Callable[[str, BackendName, float], list[RemoteModel]]] = {
+    OLLAMA.key: _discover_via_ollama_tags,
+    LM_STUDIO.key: _discover_via_openai_models,
+}
 
 
 def _has_provider_key(cfg_field: str, env_var: str) -> bool:

--- a/src/lilbee/modelhub/model_manager/discovery.py
+++ b/src/lilbee/modelhub/model_manager/discovery.py
@@ -123,7 +123,9 @@ def _discover_via_openai_models(
     """Classify models from an OpenAI-compatible ``/v1/models`` endpoint.
 
     These servers report only ids (no family), so task detection runs off the
-    name patterns, which LM Studio ids usually carry.
+    name patterns, which LM Studio ids usually carry. Every id is surfaced: LM
+    Studio presents LM Link remote/cloud models here as if local, so the list
+    is intentionally not filtered to locally-downloaded models.
     """
     try:
         resp = httpx.get(openai_models_url(base_url), timeout=timeout)

--- a/src/lilbee/modelhub/model_manager/discovery.py
+++ b/src/lilbee/modelhub/model_manager/discovery.py
@@ -22,31 +22,22 @@ from lilbee.providers.sdk_backend import PROVIDER_KEYS, detect_backend_name
 log = logging.getLogger(__name__)
 
 _EMBEDDING_FAMILIES = frozenset({"bert", "nomic-bert", "e5", "bge"})
-# Embedding detection by name, for OpenAI-compatible servers (LM Studio) that
-# expose ids but no family metadata. ``embed`` covers the common naming, the
-# rest match family-named embedders (``bge-base``, ``multilingual-e5-large``,
-# ``gte-large``). The trailing hyphen on the family tags avoids matching a chat
-# model that merely contains the letters (``bge`` keeps ``bge-reranker`` out of
-# here too, though reranker detection already runs first).
+# Embedding detection by name, for servers (LM Studio) that report ids but no
+# family. Trailing hyphens keep chat models that merely contain the letters out.
 _EMBEDDING_NAME_PATTERNS = frozenset({"embed", "bge-", "e5-", "gte-"})
 _VISION_NAME_PATTERNS = frozenset({"llava", "vision", "moondream", "ocr", "minicpm-v"})
-# Reranker detection runs BEFORE embedding detection so ``bge-reranker-*``
-# (family "bge" but clearly a reranker) does not get misclassified as
-# EMBEDDING. ``cross-encoder`` covers the SBERT-style naming convention
-# for cross-encoder rerankers.
+# Reranker detection runs before embedding detection so ``bge-reranker-*``
+# (family "bge") is not misclassified as EMBEDDING.
 _RERANKER_NAME_PATTERNS = frozenset({"reranker", "rerank", "cross-encoder"})
 
 _CLASSIFY_DEFAULT_TIMEOUT_S = 5.0
 
 
 def _classify_remote_task(name: str, family: str) -> ModelTask:
-    """Classify a remote model as chat, embedding, vision, or rerank.
+    """Classify a remote model as rerank, embedding, vision, or chat (in that order).
 
-    Reranker detection runs first so ``bge-reranker-base`` (family
-    ``bge``) does not get dragged into the embedding bucket. After
-    reranker: embedding by family tag OR by name pattern (the name path
-    covers servers like LM Studio that report no family), vision by name
-    pattern, else chat.
+    Embedding matches by family tag or name pattern; the name path covers
+    servers like LM Studio that report no family.
     """
     name_lower = name.lower()
     if any(rp in name_lower for rp in _RERANKER_NAME_PATTERNS):
@@ -84,13 +75,9 @@ def classify_remote_models(
 ) -> list[RemoteModel]:
     """Discover and classify all models from the local server by task.
 
-    Dispatches the listing strategy off the server behind *base_url*:
-    Ollama's ``/api/tags`` (rich family metadata) or LM Studio's
-    OpenAI-compatible ``/v1/models``. Unknown URLs default to the Ollama
-    strategy. The provider label always comes from ``detect_backend_name``,
-    so a hosted API URL keeps its own name. Returns an empty list on any
-    error (including timeout) so read-only callers stay responsive when the
-    backend is down.
+    Dispatches by detected server (Ollama ``/api/tags`` vs LM Studio
+    ``/v1/models``; unknown URLs use the Ollama strategy). Returns ``[]`` on
+    any error so read-only callers stay responsive when the backend is down.
     """
     spec = detect_local_server(base_url)
     provider = detect_backend_name(base_url)
@@ -135,9 +122,8 @@ def _discover_via_openai_models(
 ) -> list[RemoteModel]:
     """Classify models from an OpenAI-compatible ``/v1/models`` endpoint.
 
-    LM Studio exposes only model ids, no family metadata, so embedding /
-    reranker / vision detection falls back to the name patterns (which
-    LM Studio ids usually carry, e.g. ``nomic-embed``, ``bge-reranker``).
+    These servers report only ids (no family), so task detection runs off the
+    name patterns, which LM Studio ids usually carry.
     """
     try:
         resp = httpx.get(openai_models_url(base_url), timeout=timeout)

--- a/src/lilbee/providers/backend_names.py
+++ b/src/lilbee/providers/backend_names.py
@@ -12,6 +12,7 @@ class BackendName(StrEnum):
     """Display name shown in the UI for whichever backend the SDK is talking to."""
 
     OLLAMA = "Ollama"
+    LM_STUDIO = "LM Studio"
     OPENROUTER = "OpenRouter"
     GEMINI = "Gemini"
     ANTHROPIC = "Anthropic"

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import base64
 import functools
-import json
 import logging
 from collections.abc import Callable, Iterator
 from typing import Any
@@ -550,45 +549,18 @@ class LitellmSdkBackend:
         base_url: str,
         on_progress: Callable[..., Any] | None = None,
     ) -> None:
-        """Pull a model via the Ollama ``/api/pull`` endpoint.
+        """Refuse to pull: local servers (Ollama, LM Studio) are read-only.
 
-        Only servers that expose an HTTP pull endpoint are supported.
-        LM Studio has none; its models are downloaded in its own app and
-        appear here once present.
+        Their models are managed in their own app and surface here once
+        present, so lilbee never downloads them over the network.
         """
-        clean_base = base_url.rstrip("/")
-        spec = detect_local_server(clean_base)
-        if spec is None or not spec.supports_pull:
-            server = spec.display_name if spec is not None else "This server"
-            raise ProviderError(
-                f"{server} doesn't download models over the network. "
-                f"Add the model in its own app, then pick it here.",
-                provider=_PROVIDER_NAME,
-            )
-        try:
-            with (
-                # Streaming Ollama /api/pull; unbounded read is intentional
-                # since model downloads can exceed any wall-clock timeout.
-                httpx.Client(timeout=None) as client,  # noqa: S113
-                client.stream(
-                    "POST",
-                    f"{clean_base}/api/pull",
-                    json={"name": model, "stream": True},
-                ) as resp,
-            ):
-                resp.raise_for_status()
-                for line in resp.iter_lines():
-                    if not line:
-                        continue
-                    event = json.loads(line)
-                    if on_progress:
-                        on_progress(event)
-                    if event.get("status") == "success":
-                        break
-        except httpx.HTTPError as exc:
-            raise ProviderError(
-                f"Cannot pull model {model!r}: {exc}", provider=_PROVIDER_NAME
-            ) from exc
+        spec = detect_local_server(base_url.rstrip("/"))
+        server = spec.display_name if spec is not None else "This server"
+        raise ProviderError(
+            f"{server} doesn't download models over the network. "
+            f"Add the model in its own app, then pick it here.",
+            provider=_PROVIDER_NAME,
+        )
 
     def show_model(self, model: str, *, base_url: str) -> dict[str, Any] | None:
         """Get model info via the Ollama ``/api/show`` endpoint.

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -22,7 +22,13 @@ import httpx
 
 from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.providers.base import ProviderError, ProviderErrorKind
-from lilbee.providers.model_ref import OLLAMA_PREFIX, ProviderModelRef
+from lilbee.providers.local_servers import (
+    OLLAMA,
+    detect_local_server,
+    local_server_for_key,
+    openai_models_url,
+)
+from lilbee.providers.model_ref import ProviderModelRef
 from lilbee.providers.sdk_backend import (
     CompletionRequest,
     CompletionResult,
@@ -37,7 +43,6 @@ from lilbee.providers.sdk_backend import (
 log = logging.getLogger(__name__)
 
 _PROVIDER_NAME = "litellm"
-_OLLAMA_URL_PATTERNS = ("localhost:11434", "127.0.0.1:11434", "ollama")
 
 # Substrings dropped from the "LiteLLM" logger before they reach the user's
 # terminal. Two classes of noise: (1) the model-cost-map fetch failure that
@@ -135,12 +140,6 @@ class _LitellmResponseView:
         return getattr(choice, "finish_reason", None) if choice is not None else None
 
 
-def _is_ollama(base_url: str) -> bool:
-    """Return True if *base_url* looks like an Ollama instance."""
-    url_lower = base_url.lower()
-    return any(p in url_lower for p in _OLLAMA_URL_PATTERNS)
-
-
 @functools.cache
 def litellm_available() -> bool:
     """Return True if the ``litellm`` package is installed.
@@ -184,11 +183,16 @@ def _cache_ollama_defaults(model: str, params_text: str) -> None:
 
 
 def _route_model(ref: ProviderModelRef, api_base: str | None) -> str:
-    """Format *ref* for litellm using the OpenAI ``provider/model`` convention."""
-    if ref.is_api:
+    """Format *ref* for litellm using the OpenAI ``provider/model`` convention.
+
+    API and local-server refs already carry their canonical prefix. A bare
+    ``local`` ref forced through the SDK (``llm_provider=remote``) gets the
+    prefix of whichever local server its ``api_base`` points at.
+    """
+    if ref.is_api or local_server_for_key(ref.provider) is not None:
         return ref.for_openai_prefix()
-    if api_base and _is_ollama(api_base):
-        return f"{OLLAMA_PREFIX}{ref.name}"
+    if api_base and (spec := detect_local_server(api_base)) is not None:
+        return spec.qualify(ref.name)
     return ref.name
 
 
@@ -470,9 +474,10 @@ class LitellmSdkBackend:
         return RerankResult(scores=scores, model=model)
 
     def list_models(self, *, base_url: str, api_key: str) -> list[str]:
-        """List models from Ollama or an OpenAI-compatible server."""
+        """List models from Ollama (``/api/tags``) or an OpenAI-compatible ``/v1/models``."""
         clean_base = base_url.rstrip("/")
-        if _is_ollama(clean_base):
+        spec = detect_local_server(clean_base)
+        if spec is OLLAMA:
             return self._list_ollama_models(clean_base)
         return self._list_openai_models(clean_base, api_key)
 
@@ -528,7 +533,9 @@ class LitellmSdkBackend:
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
         try:
-            resp = httpx.get(f"{base_url}/v1/models", headers=headers, timeout=DEFAULT_HTTP_TIMEOUT)
+            resp = httpx.get(
+                openai_models_url(base_url), headers=headers, timeout=DEFAULT_HTTP_TIMEOUT
+            )
             resp.raise_for_status()
             data = resp.json()
             return [m["id"] for m in data.get("data", [])]
@@ -543,8 +550,21 @@ class LitellmSdkBackend:
         base_url: str,
         on_progress: Callable[..., Any] | None = None,
     ) -> None:
-        """Pull a model via the Ollama ``/api/pull`` endpoint."""
+        """Pull a model via the Ollama ``/api/pull`` endpoint.
+
+        Only servers that expose an HTTP pull endpoint are supported.
+        LM Studio has none; its models are downloaded in its own app and
+        appear here once present.
+        """
         clean_base = base_url.rstrip("/")
+        spec = detect_local_server(clean_base)
+        if spec is None or not spec.supports_pull:
+            server = spec.display_name if spec is not None else "This server"
+            raise ProviderError(
+                f"{server} doesn't download models over the network. "
+                f"Add the model in its own app, then pick it here.",
+                provider=_PROVIDER_NAME,
+            )
         try:
             with (
                 # Streaming Ollama /api/pull; unbounded read is intentional
@@ -576,11 +596,15 @@ class LitellmSdkBackend:
         Parses and caches per-model generation defaults from the
         ``parameters`` field. Also extracts the ``capabilities`` list
         (newer Ollama versions) so callers can check for vision support.
+        Returns ``None`` for servers without a metadata endpoint (LM Studio).
         """
         clean_base = base_url.rstrip("/")
+        spec = detect_local_server(clean_base)
+        if spec is None or not spec.supports_show:
+            return None
         # Ollama's API uses bare model names; the routing-layer prefix has
         # to come off before the request goes out.
-        ollama_name = model[len(OLLAMA_PREFIX) :] if model.startswith(OLLAMA_PREFIX) else model
+        ollama_name = model.removeprefix(OLLAMA.wire_prefix)
         try:
             resp = httpx.post(
                 f"{clean_base}/api/show",

--- a/src/lilbee/providers/local_servers.py
+++ b/src/lilbee/providers/local_servers.py
@@ -1,0 +1,131 @@
+"""Local OpenAI-compatible model servers (Ollama, LM Studio).
+
+One abstraction over the local servers lilbee can drive through the
+litellm SDK. Each server is described by a :class:`LocalServerSpec`
+carrying its routing key, litellm wire prefix, default base URL, the URL
+substrings that identify it, and which catalog operations it supports.
+
+Kept dependency-free on purpose so the routing layer (``model_ref``,
+``sdk_backend``) can import it without pulling in httpx or the modelhub.
+The HTTP behaviour (model discovery, pull) lives in the modelhub layer,
+dispatched off the spec returned here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lilbee.providers.backend_names import BackendName
+
+
+@dataclass(frozen=True)
+class LocalServerSpec:
+    """Identity and capabilities of one local model server."""
+
+    key: str
+    """Routing key and ref-prefix stem (``ollama``, ``lm_studio``)."""
+
+    display_name: BackendName
+    """Human-facing backend name shown in the UI."""
+
+    wire_prefix: str
+    """litellm ``provider/`` prefix the SDK routes on (``ollama/``)."""
+
+    default_base_url: str
+    """Base URL the server listens on out of the box."""
+
+    url_patterns: tuple[str, ...]
+    """Lowercase substrings that identify this server in a base URL."""
+
+    appends_latest_tag: bool
+    """Whether a bare model name gets a ``:latest`` tag (Ollama convention)."""
+
+    supports_pull: bool
+    """Whether the server exposes an HTTP model-pull endpoint."""
+
+    supports_show: bool
+    """Whether the server exposes an HTTP model-metadata endpoint."""
+
+    def qualify(self, name: str) -> str:
+        """Render *name* as a canonical ``<wire_prefix><name>`` ref."""
+        return f"{self.wire_prefix}{name}"
+
+    def normalize_name(self, name: str) -> str:
+        """Apply the server's bare-name convention (Ollama's ``:latest``)."""
+        if self.appends_latest_tag and ":" not in name:
+            return f"{name}:latest"
+        return name
+
+
+OLLAMA = LocalServerSpec(
+    key="ollama",
+    display_name=BackendName.OLLAMA,
+    wire_prefix="ollama/",
+    default_base_url="http://localhost:11434",
+    url_patterns=("localhost:11434", "127.0.0.1:11434", "ollama"),
+    appends_latest_tag=True,
+    supports_pull=True,
+    supports_show=True,
+)
+
+LM_STUDIO = LocalServerSpec(
+    # litellm's lm_studio provider posts to ``{api_base}/chat/completions``, so
+    # the base URL must carry ``/v1`` (matching what LM Studio's server panel
+    # shows). It also injects a placeholder key, so no API key is required.
+    key="lm_studio",
+    display_name=BackendName.LM_STUDIO,
+    wire_prefix="lm_studio/",
+    default_base_url="http://localhost:1234/v1",
+    url_patterns=("localhost:1234", "127.0.0.1:1234"),
+    appends_latest_tag=False,
+    supports_pull=False,
+    supports_show=False,
+)
+
+LOCAL_SERVERS: tuple[LocalServerSpec, ...] = (OLLAMA, LM_STUDIO)
+
+LOCAL_SERVER_KEYS: frozenset[str] = frozenset(spec.key for spec in LOCAL_SERVERS)
+
+
+def openai_models_url(base_url: str) -> str:
+    """Build the ``/v1/models`` listing URL, tolerating a trailing ``/v1``.
+
+    OpenAI-compatible servers are configured with the base that chat uses
+    (``.../v1`` for LM Studio) or without it (Ollama, generic). Both resolve
+    to a single ``/v1/models`` so the listing URL never doubles the segment.
+    """
+    trimmed = base_url.rstrip("/")
+    if trimmed.endswith("/v1"):
+        trimmed = trimmed[: -len("/v1")]
+    return f"{trimmed}/v1/models"
+
+
+def detect_local_server(base_url: str) -> LocalServerSpec | None:
+    """Return the local server whose URL patterns match *base_url*, if any."""
+    url_lower = base_url.lower()
+    for spec in LOCAL_SERVERS:
+        if any(pattern in url_lower for pattern in spec.url_patterns):
+            return spec
+    return None
+
+
+def local_server_for_key(key: str) -> LocalServerSpec | None:
+    """Return the spec with routing *key*, or ``None``."""
+    for spec in LOCAL_SERVERS:
+        if spec.key == key:
+            return spec
+    return None
+
+
+def local_server_for_label(label: str) -> LocalServerSpec | None:
+    """Return the spec matching *label* by routing key or display name.
+
+    Callers pass either form: discovery stamps the ``BackendName`` display
+    value (``"LM Studio"``) onto a model, while a parsed ref carries the
+    routing key (``"lm_studio"``). Both resolve to the same spec.
+    """
+    lowered = label.lower()
+    for spec in LOCAL_SERVERS:
+        if spec.key == lowered or spec.display_name.lower() == lowered:
+            return spec
+    return None

--- a/src/lilbee/providers/local_servers.py
+++ b/src/lilbee/providers/local_servers.py
@@ -58,13 +58,16 @@ class LocalServerSpec:
 
 
 OLLAMA = LocalServerSpec(
+    # Read-only, like LM Studio: lilbee runs and lists Ollama models but does
+    # not pull them. Models are managed in Ollama itself. ``supports_show`` is
+    # kept on because /api/show is a read used to surface generation defaults.
     key="ollama",
     display_name=BackendName.OLLAMA,
     wire_prefix="ollama/",
     default_base_url="http://localhost:11434",
     url_patterns=("localhost:11434", "127.0.0.1:11434", "ollama"),
     appends_latest_tag=True,
-    supports_pull=True,
+    supports_pull=False,
     supports_show=True,
 )
 

--- a/src/lilbee/providers/local_servers/__init__.py
+++ b/src/lilbee/providers/local_servers/__init__.py
@@ -12,6 +12,7 @@ from lilbee.providers.local_servers.ollama import OLLAMA
 from lilbee.providers.local_servers.registry import (
     LOCAL_SERVER_KEYS,
     LOCAL_SERVERS,
+    canonical_local_ref,
     detect_local_server,
     local_server_for_key,
     local_server_for_label,
@@ -25,6 +26,7 @@ __all__ = [
     "LOCAL_SERVER_KEYS",
     "OLLAMA",
     "LocalServerSpec",
+    "canonical_local_ref",
     "detect_local_server",
     "local_server_for_key",
     "local_server_for_label",

--- a/src/lilbee/providers/local_servers/registry.py
+++ b/src/lilbee/providers/local_servers/registry.py
@@ -36,6 +36,19 @@ def local_server_for_key(key: str) -> LocalServerSpec | None:
     return None
 
 
+def canonical_local_ref(name: str, source_key: str) -> str:
+    """Prefix a bare *name* with its local server's wire prefix.
+
+    *source_key* is a ModelSource value (``"ollama"``). No-op for non-local
+    sources and for names already carrying the prefix, so callers can dedup
+    the installed and catalog views.
+    """
+    spec = local_server_for_key(source_key)
+    if spec is None or name.startswith(spec.wire_prefix):
+        return name
+    return spec.qualify(name)
+
+
 def local_server_for_label(label: str) -> LocalServerSpec | None:
     """Return the spec matching *label* by routing key or display name.
 

--- a/src/lilbee/providers/model_ref.py
+++ b/src/lilbee/providers/model_ref.py
@@ -11,6 +11,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from lilbee.providers.base import filter_options
+from lilbee.providers.local_servers import (
+    LOCAL_SERVER_KEYS,
+    local_server_for_key,
+    local_server_for_label,
+)
 
 _API_PROVIDERS = frozenset(
     {
@@ -23,11 +28,9 @@ _API_PROVIDERS = frozenset(
     }
 )
 
-# All provider prefixes that route a ref away from the local registry.
-# Includes API providers and ollama (which keeps its own name:tag shape).
-PROVIDER_PREFIXES: frozenset[str] = frozenset(_API_PROVIDERS | {"ollama"})
-
-OLLAMA_PREFIX = "ollama/"
+# All provider prefixes that route a ref away from the local registry:
+# API providers plus the local OpenAI-compatible servers (ollama, lm_studio).
+PROVIDER_PREFIXES: frozenset[str] = frozenset(_API_PROVIDERS | LOCAL_SERVER_KEYS)
 
 
 @dataclass(frozen=True)
@@ -35,7 +38,7 @@ class ProviderModelRef:
     """Parsed model reference with provider routing information."""
 
     raw: str
-    provider: str  # "local", "ollama", or any value in PROVIDER_PREFIXES
+    provider: str  # "local" or any value in PROVIDER_PREFIXES
     name: str  # provider-specific name with tag normalization applied
 
     @property
@@ -64,8 +67,9 @@ class ProviderModelRef:
         SDKs: ``openai/gpt-4o``, ``ollama/llama3.2:1b``, etc. Every
         dispatching SDK accepts this shape.
         """
-        if self.provider == "ollama":
-            return f"{OLLAMA_PREFIX}{self.name}"
+        spec = local_server_for_key(self.provider)
+        if spec is not None:
+            return spec.qualify(self.name)
         if self.is_api:
             return f"{self.provider}/{self.name}"
         return self.name
@@ -81,16 +85,24 @@ class ProviderModelRef:
 
 
 def format_remote_ref(name: str, provider: str) -> str:
-    """Render a remote model as a canonical ``provider/name`` ref."""
-    return ProviderModelRef(raw=name, provider=provider.lower(), name=name).for_openai_prefix()
+    """Render a remote model as a canonical ``provider/name`` ref.
+
+    *provider* may be a routing key (``"ollama"``) or a backend display
+    name (``"LM Studio"``); local-server labels are normalised to the
+    routing key so the prefix survives. API providers fall through to
+    their lowercase key unchanged.
+    """
+    spec = local_server_for_label(provider)
+    key = spec.key if spec is not None else provider.lower()
+    return ProviderModelRef(raw=name, provider=key, name=name).for_openai_prefix()
 
 
 def parse_model_ref(raw: str) -> ProviderModelRef:
     """Classify a model string by its prefix and return the routing ref.
 
     Native HuggingFace refs are ``<org>/<repo>/<file>.gguf``. Remote
-    providers use prefixes from :data:`PROVIDER_PREFIXES` (``ollama/``
-    plus every API provider listed there).
+    providers use prefixes from :data:`PROVIDER_PREFIXES` (the local
+    servers ``ollama/`` and ``lm_studio/`` plus every API provider).
     """
     if "/" not in raw:
         known = ", ".join(f"{p}/" for p in sorted(PROVIDER_PREFIXES))
@@ -101,9 +113,9 @@ def parse_model_ref(raw: str) -> ProviderModelRef:
     prefix, rest = raw.split("/", 1)
     if prefix in _API_PROVIDERS:
         return ProviderModelRef(raw=raw, provider=prefix, name=rest)
-    if prefix == "ollama":
-        name = rest if ":" in rest else f"{rest}:latest"
-        return ProviderModelRef(raw=raw, provider="ollama", name=name)
+    spec = local_server_for_key(prefix)
+    if spec is not None:
+        return ProviderModelRef(raw=raw, provider=spec.key, name=spec.normalize_name(rest))
     return ProviderModelRef(raw=raw, provider="local", name=raw)
 
 

--- a/src/lilbee/providers/model_ref.py
+++ b/src/lilbee/providers/model_ref.py
@@ -51,22 +51,11 @@ class ProviderModelRef:
 
     @property
     def is_remote(self) -> bool:
-        """True if this model must route through a remote SDK (API or Ollama).
-
-        Remote means "not a locally-loaded GGUF". Both Ollama (HTTP
-        localhost server) and hosted API providers share the same
-        dispatch path; they go through whichever SDK backend is wired
-        up.
-        """
+        """True if this model routes through a remote SDK (any non-``local`` provider)."""
         return self.provider != "local"
 
     def for_openai_prefix(self) -> str:
-        """Name formatted with canonical ``provider/model`` prefix.
-
-        The prefix convention is the same one used by OpenAI-compatible
-        SDKs: ``openai/gpt-4o``, ``ollama/llama3.2:1b``, etc. Every
-        dispatching SDK accepts this shape.
-        """
+        """Name with its canonical ``provider/model`` prefix (``ollama/llama3.2:1b``)."""
         spec = local_server_for_key(self.provider)
         if spec is not None:
             return spec.qualify(self.name)

--- a/src/lilbee/providers/sdk_backend.py
+++ b/src/lilbee/providers/sdk_backend.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 # Display name for the active backend the SDK is talking to. The
 # adapter's own identity is exposed separately via provider_name.
 from lilbee.providers.backend_names import BackendName
+from lilbee.providers.local_servers import detect_local_server
 
 if TYPE_CHECKING:
     # circular: sdk_backend -> model_ref -> types -> sdk_backend (annotation-only)
@@ -61,9 +62,10 @@ def get_provider_api_key(provider: str) -> str | None:
     return value or None
 
 
-_BACKEND_URL_PATTERNS: tuple[tuple[str, BackendName], ...] = (
-    ("localhost:11434", BackendName.OLLAMA),
-    ("ollama", BackendName.OLLAMA),
+# Hosted API providers identified by URL substring. Local OpenAI-compatible
+# servers (Ollama, LM Studio) are matched ahead of this table via the
+# local-servers registry, so they are not listed here.
+_REMOTE_API_URL_PATTERNS: tuple[tuple[str, BackendName], ...] = (
     ("openrouter", BackendName.OPENROUTER),
     ("openai", BackendName.OPENAI),
     ("anthropic", BackendName.ANTHROPIC),
@@ -78,11 +80,14 @@ def detect_backend_name(base_url: str) -> BackendName:
     """Return the display name of the backend behind ``base_url``.
 
     Adapter-agnostic; any SDK implementation can delegate to this helper.
-    Falls back to ``BackendName.REMOTE`` when the URL matches none of
-    the known patterns.
+    Checks the local-server registry (Ollama, LM Studio) first, then the
+    hosted-API URL patterns, and falls back to ``BackendName.REMOTE``.
     """
+    local = detect_local_server(base_url)
+    if local is not None:
+        return local.display_name
     url_lower = base_url.lower()
-    for pattern, name in _BACKEND_URL_PATTERNS:
+    for pattern, name in _REMOTE_API_URL_PATTERNS:
         if pattern in url_lower:
             return name
     return BackendName.REMOTE

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -29,7 +29,7 @@ from lilbee.core.config import cfg
 from lilbee.modelhub.model_manager import classify_remote_models, discover_api_models
 from lilbee.modelhub.model_manager.types import RemoteModel
 from lilbee.modelhub.role_validator import _MODEL_FIELD_TO_TASK, validate_model_task_assignment
-from lilbee.providers.local_servers import detect_local_server, local_server_for_key
+from lilbee.providers.local_servers import canonical_local_ref, detect_local_server
 from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
 from lilbee.providers.sdk_backend import PROVIDER_KEYS, get_provider_api_key
 from lilbee.runtime.hardware import (
@@ -496,19 +496,6 @@ async def models_catalog(
     )
 
 
-def _canonical_installed_ref(name: str, source: ModelSource) -> str:
-    """Render a local-server model with its canonical ``<server>/<name>`` ref.
-
-    Local servers report bare names; the catalog reports the prefixed ref.
-    Reporting it here too lets clients dedup the installed and catalog views
-    instead of showing the model twice.
-    """
-    spec = local_server_for_key(source.value)
-    if spec is not None and not name.startswith(spec.wire_prefix):
-        return spec.qualify(name)
-    return name
-
-
 async def models_installed() -> ModelsInstalledResponse:
     """Return installed models with their granular source and canonical ref."""
     manager = get_services().model_manager
@@ -516,7 +503,7 @@ async def models_installed() -> ModelsInstalledResponse:
     for name in manager.list_installed():
         source = manager.get_source(name) or ModelSource.REMOTE
         models.append(
-            InstalledModelEntry(name=_canonical_installed_ref(name, source), source=source)
+            InstalledModelEntry(name=canonical_local_ref(name, source.value), source=source)
         )
     return ModelsInstalledResponse(models=models)
 

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -171,12 +171,9 @@ def _resolve_via_catalog(model: str, available: set[str]) -> str | None:
 def _resolve_via_parse(model: str, available: set[str]) -> str | None:
     """Resolve a provider-prefixed ref against *available*.
 
-    The backend lists hosted models under their bare provider names (e.g.
-    ``gemini-2.0-flash``, ``qwen3:0.6b``), while selections arrive carrying
-    the routing prefix (``gemini/gemini-2.0-flash``, ``ollama/qwen3:0.6b``).
-    When the bare name is visible, return the *prefixed* ref so it keeps its
-    provider routing and skips the native catalog/installed check downstream,
-    mirroring how the TUI persists a frontier/Ollama selection verbatim.
+    The backend lists hosted models under bare names while selections carry the
+    routing prefix. When the bare name is visible, return the prefixed ref so it
+    keeps provider routing instead of falling through to the native check.
     """
     try:
         parsed = parse_model_ref(model)
@@ -188,12 +185,9 @@ def _resolve_via_parse(model: str, available: set[str]) -> str | None:
 def _resolve_via_provider_key(model: str) -> str | None:
     """Accept an API-provider-prefixed ref when that provider's key is configured.
 
-    Frontier models surface through ``discover_api_models`` (a per-key listing),
-    not the default ``provider.list_models()``, so a ref like
-    ``gemini/gemini-2.0-flash`` never appears in *available* even when it is
-    perfectly routable. As long as the provider's key is set, litellm can route
-    it (and validates the exact model name at call time), so the prefixed ref is
-    accepted verbatim, matching how the TUI persists a frontier selection.
+    Frontier models surface through ``discover_api_models``, not the default
+    ``list_models()``, so they never appear in *available*. With the key set,
+    litellm routes the ref (and validates the model name at call time).
     """
     try:
         parsed = parse_model_ref(model)
@@ -402,11 +396,11 @@ _hosted_cache = _HostedModelsCache()
 
 
 def _discover_hosted_sync() -> list[CatalogEntryResponse]:
-    """All hosted rows (frontier + ollama), unfiltered. Blocking, call via to_thread.
+    """All hosted rows (frontier + the configured local server), unfiltered.
 
-    Both discovery calls fail soft (empty dict / list) when no keys are
-    configured or the Ollama endpoint is unreachable, so the catalog
-    degrades to native-only here without special-casing.
+    Blocking; call via to_thread. Local rows take the detected server's source
+    (Ollama or LM Studio). Both discovery calls fail soft when no keys are set
+    or the endpoint is unreachable, so the catalog degrades to native-only.
     """
     rows: list[CatalogEntryResponse] = []
     for models in discover_api_models().values():

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -29,7 +29,7 @@ from lilbee.core.config import cfg
 from lilbee.modelhub.model_manager import classify_remote_models, discover_api_models
 from lilbee.modelhub.model_manager.types import RemoteModel
 from lilbee.modelhub.role_validator import _MODEL_FIELD_TO_TASK, validate_model_task_assignment
-from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
+from lilbee.providers.model_ref import OLLAMA_PREFIX, format_remote_ref, parse_model_ref
 from lilbee.providers.sdk_backend import PROVIDER_KEYS, get_provider_api_key
 from lilbee.runtime.hardware import (
     FitLevel,
@@ -411,8 +411,7 @@ def _discover_hosted_sync() -> list[CatalogEntryResponse]:
     for models in discover_api_models().values():
         rows.extend(_hosted_entry(rm, ModelSource.FRONTIER) for rm in models)
     rows.extend(
-        _hosted_entry(rm, ModelSource.OLLAMA)
-        for rm in classify_remote_models(cfg.remote_base_url)
+        _hosted_entry(rm, ModelSource.OLLAMA) for rm in classify_remote_models(cfg.remote_base_url)
     )
     return rows
 
@@ -500,14 +499,27 @@ async def models_catalog(
     )
 
 
+def _canonical_installed_ref(name: str, source: ModelSource) -> str:
+    """Render an Ollama model with its ``ollama/<name>`` ref.
+
+    Ollama's ``/api/tags`` reports bare names; the catalog reports the
+    prefixed ref. Reporting the prefixed ref here too lets clients dedup the
+    installed and catalog views instead of showing the model twice.
+    """
+    if source is ModelSource.OLLAMA and not name.startswith(OLLAMA_PREFIX):
+        return format_remote_ref(name, ModelSource.OLLAMA.value)
+    return name
+
+
 async def models_installed() -> ModelsInstalledResponse:
-    """Return list of installed models with their source."""
+    """Return installed models with their granular source and canonical ref."""
     manager = get_services().model_manager
-    names = manager.list_installed()
     models = []
-    for name in names:
-        src = manager.get_source(name)
-        models.append(InstalledModelEntry(name=name, source=src or ModelSource.REMOTE))
+    for name in manager.list_installed():
+        source = manager.get_source(name) or ModelSource.REMOTE
+        models.append(
+            InstalledModelEntry(name=_canonical_installed_ref(name, source), source=source)
+        )
     return ModelsInstalledResponse(models=models)
 
 

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -567,10 +567,19 @@ async def models_pull(
 
 
 async def models_delete(model: str, *, source: str = "native") -> ModelsDeleteResponse:
-    """Delete a model. Returns deletion status, model name, and freed space."""
+    """Delete a model. Returns deletion status, model name, and freed space.
+
+    lilbee removes only native models it downloaded; removing a read-only
+    local-server model (Ollama, LM Studio) is refused with a 409.
+    """
+    from litestar.exceptions import HTTPException
+
     manager = get_services().model_manager
     src = _parse_source(source)
-    deleted = manager.remove(model, src)
+    try:
+        deleted = manager.remove(model, src)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return ModelsDeleteResponse(deleted=deleted, model=model, freed_gb=0.0)
 
 

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -24,10 +24,13 @@ from lilbee.catalog import (
     get_families,
 )
 from lilbee.catalog.refs import hf_repo_from_ref
-from lilbee.catalog.types import CatalogSize, CatalogSort, ModelSource, ModelTask
+from lilbee.catalog.types import CatalogSize, CatalogSort, KeyStatus, ModelSource, ModelTask
 from lilbee.core.config import cfg
+from lilbee.modelhub.model_manager import classify_remote_models, discover_api_models
+from lilbee.modelhub.model_manager.types import RemoteModel
 from lilbee.modelhub.role_validator import _MODEL_FIELD_TO_TASK, validate_model_task_assignment
-from lilbee.providers.model_ref import parse_model_ref
+from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
+from lilbee.providers.sdk_backend import PROVIDER_KEYS, get_provider_api_key
 from lilbee.runtime.hardware import (
     FitLevel,
     SizeVariantInfo,
@@ -165,12 +168,39 @@ def _resolve_via_catalog(model: str, available: set[str]) -> str | None:
 
 
 def _resolve_via_parse(model: str, available: set[str]) -> str | None:
-    """Resolve a provider-prefixed ref to its bare provider name in *available*."""
+    """Resolve a provider-prefixed ref against *available*.
+
+    The backend lists hosted models under their bare provider names (e.g.
+    ``gemini-2.0-flash``, ``qwen3:0.6b``), while selections arrive carrying
+    the routing prefix (``gemini/gemini-2.0-flash``, ``ollama/qwen3:0.6b``).
+    When the bare name is visible, return the *prefixed* ref so it keeps its
+    provider routing and skips the native catalog/installed check downstream,
+    mirroring how the TUI persists a frontier/Ollama selection verbatim.
+    """
     try:
         parsed = parse_model_ref(model)
     except ValueError:
         return None
-    return parsed.name if parsed.name in available else None
+    return model if parsed.name in available else None
+
+
+def _resolve_via_provider_key(model: str) -> str | None:
+    """Accept an API-provider-prefixed ref when that provider's key is configured.
+
+    Frontier models surface through ``discover_api_models`` (a per-key listing),
+    not the default ``provider.list_models()``, so a ref like
+    ``gemini/gemini-2.0-flash`` never appears in *available* even when it is
+    perfectly routable. As long as the provider's key is set, litellm can route
+    it (and validates the exact model name at call time), so the prefixed ref is
+    accepted verbatim, matching how the TUI persists a frontier selection.
+    """
+    try:
+        parsed = parse_model_ref(model)
+    except ValueError:
+        return None
+    if parsed.is_api and get_provider_api_key(parsed.provider) is not None:
+        return model
+    return None
 
 
 def _require_model_available(model: str) -> str:
@@ -183,7 +213,11 @@ def _require_model_available(model: str) -> str:
     available = set(get_services().provider.list_models())
     if model in available:
         return model
-    hit = _resolve_via_catalog(model, available) or _resolve_via_parse(model, available)
+    hit = (
+        _resolve_via_catalog(model, available)
+        or _resolve_via_parse(model, available)
+        or _resolve_via_provider_key(model)
+    )
     if hit is None:
         raise not_available
     return hit
@@ -316,6 +350,101 @@ def _build_catalog_entry(
     )
 
 
+def _hosted_entry(rm: RemoteModel, source: ModelSource) -> CatalogEntryResponse:
+    """Build a selectable, no-download catalog row for a discovered hosted model."""
+    return CatalogEntryResponse(
+        hf_repo=format_remote_ref(rm.name, rm.provider),
+        gguf_filename="",
+        task=rm.task,
+        display_name=rm.name,
+        param_count=rm.parameter_size,
+        size_gb=0,
+        min_ram_gb=0,
+        description="",
+        quality_tier="",
+        featured=False,
+        downloads=0,
+        installed=True,
+        source=source,
+        fit=None,
+        size_variants=[],
+        provider=rm.provider,
+        key_status=KeyStatus.READY if source is ModelSource.FRONTIER else None,
+    )
+
+
+_HOSTED_MODELS_TTL = 60
+
+
+class _HostedModelsCache:
+    """TTL cache for discovered hosted rows (no module-level mutable global)."""
+
+    def __init__(self) -> None:
+        self._time: float = 0.0
+        self._key: str = ""
+        self._result: list[CatalogEntryResponse] | None = None
+
+    def get(self, key: str) -> list[CatalogEntryResponse] | None:
+        now = time.monotonic()
+        fresh = (now - self._time) < _HOSTED_MODELS_TTL
+        if self._result is not None and key == self._key and fresh:
+            return self._result
+        return None
+
+    def set(self, key: str, result: list[CatalogEntryResponse]) -> None:
+        self._time = time.monotonic()
+        self._key = key
+        self._result = result
+
+
+_hosted_cache = _HostedModelsCache()
+
+
+def _discover_hosted_sync() -> list[CatalogEntryResponse]:
+    """All hosted rows (frontier + ollama), unfiltered. Blocking, call via to_thread.
+
+    Both discovery calls fail soft (empty dict / list) when no keys are
+    configured or the Ollama endpoint is unreachable, so the catalog
+    degrades to native-only here without special-casing.
+    """
+    rows: list[CatalogEntryResponse] = []
+    for models in discover_api_models().values():
+        rows.extend(_hosted_entry(rm, ModelSource.FRONTIER) for rm in models)
+    rows.extend(
+        _hosted_entry(rm, ModelSource.OLLAMA)
+        for rm in classify_remote_models(cfg.remote_base_url)
+    )
+    return rows
+
+
+def _hosted_cache_key() -> str:
+    """Cache key over the inputs that change discovery output.
+
+    Enumerates configured provider-key fields generically from
+    ``PROVIDER_KEYS`` so adding a provider does not silently reuse a
+    stale cache entry.
+    """
+    keys = ":".join(getattr(cfg, field, "") or "" for _, field, *_ in PROVIDER_KEYS)
+    return f"{cfg.remote_base_url}:{keys}"
+
+
+async def _collect_hosted_entries(
+    *, task: ModelTask | None, search: str
+) -> list[CatalogEntryResponse]:
+    """Hosted catalog rows filtered by task/search, off the event loop + TTL-cached."""
+    key = _hosted_cache_key()
+    rows = _hosted_cache.get(key)
+    if rows is None:
+        rows = await asyncio.to_thread(_discover_hosted_sync)
+        _hosted_cache.set(key, rows)
+    if task is not None:
+        rows = [r for r in rows if r.task == task]
+    if search:
+        needle = search.lower()
+        rows = [r for r in rows if needle in r.display_name.lower()]
+    return rows
+
+
 async def models_catalog(
     task: str | None = None,
     search: str = "",
@@ -350,17 +479,24 @@ async def models_catalog(
     available_bytes = available_memory_for_fit()
     families_by_repo = _families_by_repo()
 
+    native_rows = [
+        _build_catalog_entry(e, available_bytes=available_bytes, families_by_repo=families_by_repo)
+        for e in enriched
+    ]
+    # Hosted rows (frontier + ollama) are selectable and download-free, so
+    # they're shown on the first page only (mirrors the featured first-page
+    # convention), skipped for featured-only and installed=False filters, and
+    # counted toward ``total``.
+    hosted_rows: list[CatalogEntryResponse] = []
+    if offset == 0 and not featured and installed is not False:
+        hosted_rows = await _collect_hosted_entries(task=parsed_task, search=search)
+
     return ModelsCatalogResponse(
-        total=result.total,
+        total=result.total + len(hosted_rows),
         limit=result.limit,
         offset=result.offset,
         has_more=result.has_more,
-        models=[
-            _build_catalog_entry(
-                e, available_bytes=available_bytes, families_by_repo=families_by_repo
-            )
-            for e in enriched
-        ],
+        models=hosted_rows + native_rows,
     )
 
 

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -406,7 +406,7 @@ def _discover_hosted_sync() -> list[CatalogEntryResponse]:
     for models in discover_api_models().values():
         rows.extend(_hosted_entry(rm, ModelSource.FRONTIER) for rm in models)
     server = detect_local_server(cfg.remote_base_url)
-    local_source = ModelSource(server.key) if server is not None else ModelSource.OLLAMA
+    local_source = ModelSource(server.key) if server is not None else ModelSource.REMOTE
     rows.extend(
         _hosted_entry(rm, local_source) for rm in classify_remote_models(cfg.remote_base_url)
     )
@@ -420,7 +420,7 @@ def _hosted_cache_key() -> str:
     ``PROVIDER_KEYS`` so adding a provider does not silently reuse a
     stale cache entry.
     """
-    keys = ":".join(getattr(cfg, field, "") or "" for _, field, *_ in PROVIDER_KEYS)
+    keys = ":".join(getattr(cfg, field) or "" for _, field, *_ in PROVIDER_KEYS)
     return f"{cfg.remote_base_url}:{keys}"
 
 

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel
 
@@ -410,12 +410,6 @@ async def models_pull(
     sse = SseStream()
 
     def _pull_blocking() -> None:
-        def _on_progress(data: dict[str, Any]) -> None:
-            if sse.cancel.is_set():
-                return
-            payload = sse_event(SseEvent.PROGRESS, data)
-            sse.loop.call_soon_threadsafe(sse.queue.put_nowait, payload)
-
         def _on_bytes(downloaded: int, total: int) -> None:
             if sse.cancel.is_set():
                 return
@@ -426,7 +420,6 @@ async def models_pull(
             manager.pull(
                 model,
                 src,
-                on_progress=_on_progress,
                 on_bytes=_on_bytes,
                 allow_unsupported=allow_unsupported,
             )

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-from lilbee.catalog.types import ModelCompat, ModelSource, ModelTask
+from lilbee.catalog.types import KeyStatus, ModelCompat, ModelSource, ModelTask
 from lilbee.data.store import ChunkType, SearchScope
 from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 
@@ -272,6 +272,8 @@ class CatalogEntryResponse(BaseModel):
     size_variants: list[SizeVariantInfo] = []
     architecture: str = ""
     compat: ModelCompat = ModelCompat.UNKNOWN
+    provider: str = ""
+    key_status: KeyStatus | None = None
 
 
 class ModelsCatalogResponse(BaseModel):

--- a/tests/providers/test_sdk_backend_contract.py
+++ b/tests/providers/test_sdk_backend_contract.py
@@ -10,7 +10,6 @@ adapter lands (e.g. ``LiterLlmSdkBackend``), add it to the
 
 from __future__ import annotations
 
-import json
 import sys
 from collections.abc import Callable
 from typing import Any
@@ -406,39 +405,15 @@ class TestListChatModels:
 
 
 class TestPullModel:
-    def test_streams_progress_events(self, backend: LlmSdkBackend) -> None:
-        events: list[dict[str, Any]] = []
-        resp_ctx = mock.MagicMock()
-        resp_ctx.__enter__ = lambda self: resp_ctx
-        resp_ctx.__exit__ = lambda self, *a: None
-        resp_ctx.iter_lines.return_value = [
-            json.dumps({"status": "downloading"}),
-            "",  # empty lines skipped
-            json.dumps({"status": "success"}),
-        ]
-        resp_ctx.raise_for_status = mock.MagicMock()
-
-        client_ctx = mock.MagicMock()
-        client_ctx.__enter__ = lambda self: client_ctx
-        client_ctx.__exit__ = lambda self, *a: None
-        client_ctx.stream.return_value = resp_ctx
-
-        with mock.patch("httpx.Client", return_value=client_ctx):
-            backend.pull_model(
-                "m",
-                base_url="http://localhost:11434",
-                on_progress=events.append,
-            )
-        assert events == [{"status": "downloading"}, {"status": "success"}]
-
-    def test_http_error_wraps_in_provider_error(self, backend: LlmSdkBackend) -> None:
-        client_ctx = mock.MagicMock()
-        client_ctx.__enter__ = lambda self: client_ctx
-        client_ctx.__exit__ = lambda self, *a: None
-        client_ctx.stream.side_effect = httpx.ConnectError("refused")
-
+    def test_refused_for_read_only_ollama(self, backend: LlmSdkBackend) -> None:
+        """Ollama is read-only: pull is refused without any network call."""
         with (
-            mock.patch("httpx.Client", return_value=client_ctx),
-            pytest.raises(ProviderError, match="Cannot pull model"),
+            mock.patch("httpx.Client") as client,
+            pytest.raises(ProviderError, match="Ollama"),
         ):
             backend.pull_model("m", base_url="http://localhost:11434")
+        client.assert_not_called()
+
+    def test_refused_for_read_only_lm_studio(self, backend: LlmSdkBackend) -> None:
+        with pytest.raises(ProviderError, match="LM Studio"):
+            backend.pull_model("m", base_url="http://localhost:1234/v1")

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -114,12 +114,13 @@ class _FakeManager:
         return f"/fake/{model}.gguf"
 
     def remove(self, model, source=None) -> bool:
+        # Mirror ModelManager: only native models are removable; local servers
+        # are read-only, so a non-native source is refused.
         self.remove_calls.append((model, source))
-        if (source is ModelSource.NATIVE or source is None) and model in self._native:
+        if source is not None and source is not ModelSource.NATIVE:
+            raise ValueError("lilbee runs Ollama models but doesn't remove them.")
+        if model in self._native:
             self._native.remove(model)
-            return True
-        if (source is ModelSource.REMOTE or source is None) and model in self._litellm:
-            self._litellm.remove(model)
             return True
         return False
 
@@ -516,6 +517,20 @@ class TestRmCmd:
         assert result.exit_code == 1
         parsed = RemoveResult.model_validate_json(result.output)
         assert parsed.deleted is False
+
+    def test_read_only_refusal_exits_1(self, fake_manager, native_manifests):
+        msg = "lilbee runs Ollama models but doesn't remove them. Manage them in Ollama instead."
+        with patch("lilbee.cli.model.remove_model_data", side_effect=ValueError(msg)):
+            result = runner.invoke(app, ["model", "rm", "--yes", "ollama/llama3:latest"])
+        assert result.exit_code == 1
+        assert "doesn't remove them" in result.output
+
+    def test_json_read_only_refusal_exits_1(self, fake_manager, native_manifests):
+        msg = "lilbee runs Ollama models but doesn't remove them. Manage them in Ollama instead."
+        with patch("lilbee.cli.model.remove_model_data", side_effect=ValueError(msg)):
+            result = runner.invoke(app, ["--json", "model", "rm", "--yes", "ollama/llama3:latest"])
+        assert result.exit_code == 1
+        assert "doesn't remove them" in result.output
 
     def test_invalid_source(self, fake_manager):
         result = runner.invoke(app, ["model", "rm", "--yes", _CHAT_REF, "--source", "bad"])

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -107,7 +107,7 @@ class _FakeManager:
             return ModelSource.REMOTE
         return None
 
-    def pull(self, model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
+    def pull(self, model, source, *, on_bytes=None, allow_unsupported=False):
         self.pull_calls.append((model, source))
         if on_bytes is not None:
             on_bytes(50, 100)
@@ -391,34 +391,6 @@ class TestPullModelData:
         assert events
         assert events[0].percent == 50
         assert fake_manager.pull_calls == [(target, ModelSource.NATIVE)]
-
-    def test_build_pull_callbacks_none_when_no_on_update(self):
-        dict_cb, bytes_cb = model_mod._build_pull_callbacks(None)
-        assert dict_cb is None
-        assert bytes_cb is None
-
-    def test_pull_litellm_adapts_dict_events(self, native_manifests):
-        events = []
-
-        class _Litellm(_FakeManager):
-            def pull(
-                self, model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False
-            ):
-                self.pull_calls.append((model, source))
-                if on_progress is not None:
-                    on_progress({"status": "pulling", "completed": 25, "total": 100})
-                return
-
-        manager = _Litellm()
-        with patch("lilbee.app.models.get_services", return_value=MagicMock(model_manager=manager)):
-            result = model_mod.pull_model_data(
-                _OLLAMA_REF, ModelSource.REMOTE, on_update=events.append
-            )
-        assert result.status == PullStatus.OK
-        assert result.path is None
-        assert events
-        assert events[0].percent == 25
-        assert events[0].detail == "pulling"
 
 
 class TestPullCmd:

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -179,13 +179,20 @@ class TestModelEntryFactories:
 
     def test_from_backend_with_remote(self):
         remote = _remote(_OLLAMA_REF, task="chat", parameter_size="8B")
-        entry = ModelEntry.from_backend(_OLLAMA_REF, remote)
-        assert entry.source == "remote"
+        entry = ModelEntry.from_backend(_OLLAMA_REF, remote, ModelSource.OLLAMA)
+        assert entry.source == "ollama"
         assert entry.task == "chat"
         assert entry.display_name == "8B"
 
+    def test_from_backend_prefixes_bare_name(self):
+        remote = _remote("qwen2.5-coder", task="chat", parameter_size="7B")
+        entry = ModelEntry.from_backend("qwen2.5-coder", remote, ModelSource.LM_STUDIO)
+        assert entry.source == "lm_studio"
+        assert entry.name == "lm_studio/qwen2.5-coder"
+
     def test_from_backend_missing_remote(self):
-        entry = ModelEntry.from_backend(_OLLAMA_REF, None)
+        entry = ModelEntry.from_backend(_OLLAMA_REF, None, ModelSource.OLLAMA)
+        assert entry.source == "ollama"
         assert entry.task is None
         assert entry.display_name == ""
 
@@ -196,7 +203,7 @@ class TestListModelsData:
         assert isinstance(data, ListModelsResult)
         assert data.total == 2
         sources = {e.source for e in data.models}
-        assert sources == {"native", "remote"}
+        assert sources == {"native", "ollama"}
 
     def test_filter_source_native_skips_litellm_http(self, fake_manager, native_manifests):
         with patch("lilbee.modelhub.model_manager.classify_remote_models") as classify:
@@ -205,10 +212,26 @@ class TestListModelsData:
         assert data.total == 1
         assert data.models[0].name == _CHAT_REF
 
-    def test_filter_source_litellm(self, fake_manager, native_manifests, with_remote_classify):
+    def test_filter_source_remote_keeps_all_backend(
+        self, fake_manager, native_manifests, with_remote_classify
+    ):
+        # REMOTE is the generic backend bucket: every backend entry, granular source.
         data = model_mod.list_models_data(source=ModelSource.REMOTE)
         assert data.total == 1
-        assert data.models[0].source == "remote"
+        assert data.models[0].source == "ollama"
+
+    def test_filter_source_ollama_matches_backend(
+        self, fake_manager, native_manifests, with_remote_classify
+    ):
+        data = model_mod.list_models_data(source=ModelSource.OLLAMA)
+        assert {e.source for e in data.models} == {"ollama"}
+
+    def test_filter_source_lm_studio_empty_against_ollama_backend(
+        self, fake_manager, native_manifests, with_remote_classify
+    ):
+        # Backend is Ollama (default base url), so an LM Studio filter yields nothing.
+        data = model_mod.list_models_data(source=ModelSource.LM_STUDIO)
+        assert data.models == []
 
     def test_task_filter_drops_entries_without_matching_task(
         self, fake_manager, native_manifests, with_remote_classify

--- a/tests/test_mcp_model_tools.py
+++ b/tests/test_mcp_model_tools.py
@@ -54,7 +54,8 @@ class TestMcpList:
         with patch("lilbee.app.models.list_models_data") as fn:
             result = model_list(source="bogus")
         assert result == {
-            "error": "invalid source 'bogus'; expected one of: native, remote, frontier, ollama"
+            "error": "invalid source 'bogus'; expected one of: "
+            "native, remote, frontier, ollama, lm_studio"
         }
         fn.assert_not_called()
 
@@ -94,7 +95,8 @@ class TestMcpRemove:
         with patch("lilbee.app.models.remove_model_data") as fn:
             result = model_rm("qwen3:0.6b", source="bogus")
         assert result == {
-            "error": "invalid source 'bogus'; expected one of: native, remote, frontier, ollama"
+            "error": "invalid source 'bogus'; expected one of: "
+            "native, remote, frontier, ollama, lm_studio"
         }
         fn.assert_not_called()
 
@@ -177,7 +179,8 @@ class TestMcpPull:
     async def test_pull_invalid_source(self):
         result = await model_pull("qwen3:0.6b", source="bogus")
         assert result == {
-            "error": "invalid source 'bogus'; expected one of: native, remote, frontier, ollama"
+            "error": "invalid source 'bogus'; expected one of: "
+            "native, remote, frontier, ollama, lm_studio"
         }
 
 

--- a/tests/test_mcp_model_tools.py
+++ b/tests/test_mcp_model_tools.py
@@ -53,7 +53,9 @@ class TestMcpList:
     def test_invalid_source_returns_explicit_error(self):
         with patch("lilbee.app.models.list_models_data") as fn:
             result = model_list(source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, remote"}
+        assert result == {
+            "error": "invalid source 'bogus'; expected one of: native, remote, frontier, ollama"
+        }
         fn.assert_not_called()
 
 
@@ -91,7 +93,9 @@ class TestMcpRemove:
     def test_invalid_source_explicit_error(self):
         with patch("lilbee.app.models.remove_model_data") as fn:
             result = model_rm("qwen3:0.6b", source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, remote"}
+        assert result == {
+            "error": "invalid source 'bogus'; expected one of: native, remote, frontier, ollama"
+        }
         fn.assert_not_called()
 
 
@@ -172,7 +176,9 @@ class TestMcpPull:
     @pytest.mark.asyncio
     async def test_pull_invalid_source(self):
         result = await model_pull("qwen3:0.6b", source="bogus")
-        assert result == {"error": "invalid source 'bogus'; expected one of: native, remote"}
+        assert result == {
+            "error": "invalid source 'bogus'; expected one of: native, remote, frontier, ollama"
+        }
 
 
 class TestLogProgressFailure:

--- a/tests/test_mcp_model_tools.py
+++ b/tests/test_mcp_model_tools.py
@@ -100,6 +100,13 @@ class TestMcpRemove:
         }
         fn.assert_not_called()
 
+    def test_read_only_source_returns_error(self):
+        """A read-only local-server model surfaces the refusal as an MCP error."""
+        msg = "lilbee runs Ollama models but doesn't remove them. Manage them in Ollama instead."
+        with patch("lilbee.app.models.remove_model_data", side_effect=ValueError(msg)):
+            result = model_rm("ollama/llama3:latest", source="ollama")
+        assert result == {"error": msg}
+
 
 class TestMcpPull:
     @staticmethod

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -571,86 +571,74 @@ class TestModelManagerRemove:
         removed = mgr.remove("../../etc/passwd", ModelSource.NATIVE)
         assert removed is False
 
-    def test_litellm_remove_success(self) -> None:
-        mock_response = mock.Mock()
-        mock_response.status_code = 200
-
-        with mock.patch("httpx.request", return_value=mock_response) as mock_req:
+    def test_remove_refuses_ollama_source(self) -> None:
+        """Ollama is read-only: an explicit OLLAMA source is refused, never deleted."""
+        with mock.patch("httpx.request") as mock_req:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("llama3:latest", ModelSource.REMOTE)
+            with pytest.raises(ValueError, match="Ollama models but doesn't remove them"):
+                mgr.remove("ollama/llama3:latest", ModelSource.OLLAMA)
+        mock_req.assert_not_called()
 
-        mock_req.assert_called_once()
-        call_kwargs = mock_req.call_args[1]
-        assert call_kwargs["content"] == b'{"model": "llama3:latest"}'
-        assert call_kwargs["headers"]["Content-Type"] == "application/json"
-        assert result is True
+    def test_remove_refuses_lm_studio_source(self) -> None:
+        """LM Studio is read-only: an explicit LM_STUDIO source is refused."""
+        with mock.patch("httpx.request") as mock_req:
+            mgr = ModelManager(Path("/tmp"), "http://localhost:1234/v1")
+            with pytest.raises(ValueError, match="LM Studio models but doesn't remove them"):
+                mgr.remove("lm_studio/qwen2.5-coder", ModelSource.LM_STUDIO)
+        mock_req.assert_not_called()
 
-    def test_remove_strips_ollama_prefix_for_backend(self) -> None:
-        """A canonical ``ollama/<name>`` ref deletes by bare name on the backend."""
-        mock_response = mock.Mock()
-        mock_response.status_code = 200
+    def test_remove_refuses_generic_remote_source(self) -> None:
+        """A generic REMOTE source on an undetected backend is refused too."""
+        mgr = ModelManager(Path("/tmp"), "http://my-host.internal:9000")
+        with pytest.raises(ValueError, match="doesn't remove them"):
+            mgr.remove("custom-model", ModelSource.REMOTE)
 
-        with mock.patch("httpx.request", return_value=mock_response) as mock_req:
+    def test_remove_refuses_ollama_prefixed_ref_without_network(self) -> None:
+        """An ``ollama/`` ref with source=None resolves on the prefix, no network call."""
+        with mock.patch("httpx.get") as mock_get, mock.patch("httpx.request") as mock_req:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("ollama/llama3:latest", ModelSource.OLLAMA)
+            with pytest.raises(ValueError, match="doesn't remove them"):
+                mgr.remove("ollama/llama3:latest")
+        mock_get.assert_not_called()
+        mock_req.assert_not_called()
 
-        assert mock_req.call_args[1]["content"] == b'{"model": "llama3:latest"}'
-        assert result is True
-
-    def test_remove_unknown_backend_sends_name_unchanged(self) -> None:
-        """An unrecognized backend has no known prefix to strip, so the name passes through."""
+    def test_remove_refuses_bare_backend_model_with_source_none(self) -> None:
+        """A bare name the backend reports installed resolves to a read-only source."""
         mock_response = mock.Mock()
-        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": [{"name": "llama3:latest"}]}
+        mock_response.raise_for_status = mock.Mock()
 
-        with mock.patch("httpx.request", return_value=mock_response) as mock_req:
-            mgr = ModelManager(Path("/tmp"), "http://my-host.internal:9000")
-            result = mgr.remove("custom-model", ModelSource.REMOTE)
-
-        assert mock_req.call_args[1]["content"] == b'{"model": "custom-model"}'
-        assert result is True
-
-    def test_litellm_remove_not_found(self) -> None:
-        mock_response = mock.Mock()
-        mock_response.status_code = 404
-
-        with mock.patch("httpx.request", return_value=mock_response):
+        with mock.patch("httpx.get", return_value=mock_response):
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("nonexistent:latest", ModelSource.REMOTE)
+            with pytest.raises(ValueError, match="doesn't remove them"):
+                mgr.remove("llama3:latest")
 
-        assert result is False
-
-    def test_litellm_connection_error_during_remove(self) -> None:
-        with mock.patch("httpx.request", side_effect=httpx.ConnectError("Connection refused")):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            with pytest.raises(RuntimeError, match="Cannot connect to SDK backend"):
-                mgr.remove("llama3:latest", ModelSource.REMOTE)
-
-    def test_litellm_remove_unexpected_status(self) -> None:
-        mock_response = mock.Mock()
-        mock_response.status_code = 500
-
-        with mock.patch("httpx.request", return_value=mock_response):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
-            result = mgr.remove("llama3:latest", ModelSource.REMOTE)
-
-        assert result is False
-
-    def test_none_source_removes_from_all(self, tmp_path: Path) -> None:
-        """source=None tries native first, then litellm."""
+    def test_none_source_removes_native(self, tmp_path: Path) -> None:
+        """source=None removes a native model without touching any backend."""
         models_dir = tmp_path / "models"
         models_dir.mkdir()
         model_file = models_dir / "my-model.gguf"
         model_file.write_text("fake")
 
-        mock_response = mock.Mock()
-        mock_response.status_code = 200
-
-        with mock.patch("httpx.request", return_value=mock_response):
+        with mock.patch("httpx.request") as mock_req:
             mgr = ModelManager(models_dir, "http://localhost:11434")
             result = mgr.remove("my-model.gguf", None)
 
         assert result is True
         assert not model_file.exists()
+        mock_req.assert_not_called()
+
+    def test_remove_unknown_model_source_none_returns_false(self) -> None:
+        """source=None on a model in no known source is a no-op, not a refusal."""
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"models": []}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response):
+            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            result = mgr.remove("nonexistent.gguf")
+
+        assert result is False
 
 
 class TestServicesIntegration:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -448,130 +448,26 @@ class TestModelManagerPull:
         ):
             mgr.pull("nonexistent-model", ModelSource.NATIVE)
 
-    def test_litellm_pull_success(self, tmp_path: Path) -> None:
+    def test_remote_pull_refused_naming_the_server(self, tmp_path: Path) -> None:
+        """Local servers are read-only; a remote pull is refused without any HTTP call."""
         models_dir = tmp_path / "models"
         models_dir.mkdir()
-
-        events = [
-            {"status": "pulling manifest"},
-            {"status": "downloading", "digest": "sha256:abc", "total": 100, "completed": 50},
-            {"status": "downloading", "digest": "sha256:abc", "total": 100, "completed": 100},
-            {"status": "success"},
-        ]
-
-        mock_response = mock.Mock()
-        mock_response.iter_lines.return_value = iter([__import__("json").dumps(e) for e in events])
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.__enter__ = mock.Mock(return_value=mock_response)
-        mock_response.__exit__ = mock.Mock(return_value=False)
-
-        mock_client = mock.Mock()
-        mock_client.stream.return_value = mock_response
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
-
-        progress_calls: list[dict] = []
-
-        def on_progress(data: dict) -> None:
-            progress_calls.append(data)
-
-        mgr = ModelManager(models_dir, "http://localhost:11434")
-        with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.REMOTE, on_progress=on_progress)
-
-        mock_client.stream.assert_called_once()
-        call_args = mock_client.stream.call_args
-        assert call_args[0] == ("POST", "http://localhost:11434/api/pull")
-        assert call_args[1]["json"] == {"name": "llama3:latest", "stream": True}
-
-        assert result is None  # litellm pull doesn't return a path
-        assert len(progress_calls) > 0
-
-    def test_litellm_pull_error(self, tmp_path: Path) -> None:
-        models_dir = tmp_path / "models"
-        models_dir.mkdir()
-
-        mock_response = mock.Mock()
-        mock_response.iter_lines.return_value = iter(['{"error": "model not found"}'])
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.__enter__ = mock.Mock(return_value=mock_response)
-        mock_response.__exit__ = mock.Mock(return_value=False)
-
-        mock_client = mock.Mock()
-        mock_client.stream.return_value = mock_response
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
 
         mgr = ModelManager(models_dir, "http://localhost:11434")
         with (
-            mock.patch("httpx.Client", return_value=mock_client),
-            pytest.raises(RuntimeError, match="model not found"),
-        ):
-            mgr.pull("nonexistent:model", ModelSource.REMOTE)
-
-    def test_litellm_connection_error_during_pull(self, tmp_path: Path) -> None:
-        models_dir = tmp_path / "models"
-        models_dir.mkdir()
-
-        mock_client = mock.Mock()
-        mock_client.stream.side_effect = httpx.ConnectError("Connection refused")
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
-
-        mgr = ModelManager(models_dir, "http://localhost:11434")
-        with (
-            mock.patch("httpx.Client", return_value=mock_client),
-            pytest.raises(RuntimeError, match="Cannot connect to SDK backend"),
+            mock.patch("httpx.Client") as mock_client,
+            pytest.raises(ValueError, match="Ollama"),
         ):
             mgr.pull("llama3:latest", ModelSource.REMOTE)
+        mock_client.assert_not_called()
 
-    def test_litellm_pull_without_progress_callback(self, tmp_path: Path) -> None:
+    def test_remote_pull_refused_for_lm_studio(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        events = [
-            {"status": "pulling manifest"},
-            {"status": "success"},
-        ]
-
-        mock_response = mock.Mock()
-        mock_response.iter_lines.return_value = iter([__import__("json").dumps(e) for e in events])
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.__enter__ = mock.Mock(return_value=mock_response)
-        mock_response.__exit__ = mock.Mock(return_value=False)
-
-        mock_client = mock.Mock()
-        mock_client.stream.return_value = mock_response
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
-
-        mgr = ModelManager(models_dir, "http://localhost:11434")
-        with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.REMOTE)
-
-        assert result is None
-
-    def test_litellm_pull_skips_empty_lines(self, tmp_path: Path) -> None:
-        """Empty strings from iter_lines are skipped."""
-        models_dir = tmp_path / "models"
-        models_dir.mkdir()
-
-        mock_response = mock.Mock()
-        mock_response.iter_lines.return_value = iter(["", '{"status": "success"}'])
-        mock_response.raise_for_status = mock.Mock()
-        mock_response.__enter__ = mock.Mock(return_value=mock_response)
-        mock_response.__exit__ = mock.Mock(return_value=False)
-
-        mock_client = mock.Mock()
-        mock_client.stream.return_value = mock_response
-        mock_client.__enter__ = mock.Mock(return_value=mock_client)
-        mock_client.__exit__ = mock.Mock(return_value=False)
-
-        mgr = ModelManager(models_dir, "http://localhost:11434")
-        with mock.patch("httpx.Client", return_value=mock_client):
-            result = mgr.pull("llama3:latest", ModelSource.REMOTE)
-
-        assert result is None
+        mgr = ModelManager(models_dir, "http://localhost:1234/v1")
+        with pytest.raises(ValueError, match="LM Studio"):
+            mgr.pull("qwen2.5-7b-instruct", ModelSource.REMOTE)
 
 
 class TestModelManagerRemove:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -875,6 +875,22 @@ class TestRemoteModelProvider:
         assert by_name["nomic-embed-text-v1.5"] == ModelTask.EMBEDDING
         assert by_name["bge-reranker-v2-m3"] == ModelTask.RERANK
 
+    def test_classify_lm_studio_surfaces_remote_lm_link_models(self) -> None:
+        """LM Link remote/cloud models appear in /v1/models and are not filtered out."""
+        from lilbee.modelhub.model_manager import classify_remote_models
+
+        mock_response = mock.Mock()
+        # A cloud/remote id LM Studio exposes via LM Link, alongside a local one.
+        mock_response.json.return_value = {
+            "data": [{"id": "local-qwen2.5-7b"}, {"id": "openai/gpt-oss-120b"}]
+        }
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response):
+            result = classify_remote_models("http://localhost:1234/v1")
+
+        assert {m.name for m in result} == {"local-qwen2.5-7b", "openai/gpt-oss-120b"}
+
     def test_classify_lm_studio_skips_entries_without_id(self) -> None:
         """``/v1/models`` rows lacking an ``id`` are skipped, not crashed on."""
         from lilbee.modelhub.model_manager import classify_remote_models

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -862,6 +862,62 @@ class TestRemoteModelProvider:
         assert len(result) == 1
         assert result[0].provider == "OpenAI"
 
+    def test_classify_lm_studio_models_via_openai_endpoint(self) -> None:
+        """LM Studio is listed via ``/v1/models`` and labeled ``LM Studio``."""
+        from lilbee.catalog.types import ModelTask
+        from lilbee.modelhub.model_manager import classify_remote_models
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {
+            "data": [
+                {"id": "qwen2.5-7b-instruct"},
+                {"id": "nomic-embed-text-v1.5"},
+                {"id": "bge-reranker-v2-m3"},
+            ]
+        }
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response) as mock_get:
+            result = classify_remote_models("http://localhost:1234/v1")
+
+        # Hit the OpenAI-compatible endpoint (no doubled /v1), not Ollama's /api/tags.
+        assert mock_get.call_args.args[0] == "http://localhost:1234/v1/models"
+        assert [m.name for m in result] == [
+            "qwen2.5-7b-instruct",
+            "nomic-embed-text-v1.5",
+            "bge-reranker-v2-m3",
+        ]
+        assert all(m.provider == "LM Studio" for m in result)
+        # Name-pattern classification still works without family metadata.
+        by_name = {m.name: m.task for m in result}
+        assert by_name["qwen2.5-7b-instruct"] == ModelTask.CHAT
+        assert by_name["nomic-embed-text-v1.5"] == ModelTask.EMBEDDING
+        assert by_name["bge-reranker-v2-m3"] == ModelTask.RERANK
+
+    def test_classify_lm_studio_skips_entries_without_id(self) -> None:
+        """``/v1/models`` rows lacking an ``id`` are skipped, not crashed on."""
+        from lilbee.modelhub.model_manager import classify_remote_models
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"data": [{"id": ""}, {}, {"id": "qwen2.5-7b-instruct"}]}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response):
+            result = classify_remote_models("http://localhost:1234/v1")
+
+        assert [m.name for m in result] == ["qwen2.5-7b-instruct"]
+
+    def test_classify_lm_studio_returns_empty_on_http_error(self) -> None:
+        """A down LM Studio server yields [] so read-only callers stay responsive."""
+        import httpx
+
+        from lilbee.modelhub.model_manager import classify_remote_models
+
+        with mock.patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+            result = classify_remote_models("http://localhost:1234/v1")
+
+        assert result == []
+
     def test_remote_model_default_provider(self) -> None:
         model = RemoteModel(name="test", task="chat", family="llama", parameter_size="8B")
         assert model.provider == "Remote"

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -61,6 +61,7 @@ class TestModelSource:
             ModelSource.REMOTE,
             ModelSource.FRONTIER,
             ModelSource.OLLAMA,
+            ModelSource.LM_STUDIO,
         }
 
     def test_parse_none_and_empty_return_none(self) -> None:
@@ -82,6 +83,18 @@ class TestModelSource:
         assert ModelSource.OLLAMA == "ollama"
         assert ModelSource.parse("frontier") is ModelSource.FRONTIER
         assert ModelSource.parse("ollama") is ModelSource.OLLAMA
+
+    def test_local_server_keys_map_to_sources(self) -> None:
+        """Each local server's routing key is a valid ModelSource value.
+
+        ``get_source`` and the catalog derive a model's source via
+        ``ModelSource(spec.key)``; this contract keeps that mapping total.
+        """
+        from lilbee.providers.local_servers import LOCAL_SERVERS
+
+        for spec in LOCAL_SERVERS:
+            assert isinstance(ModelSource(spec.key), ModelSource)
+        assert ModelSource("lm_studio") is ModelSource.LM_STUDIO
 
 
 def _install_registry_model(
@@ -375,6 +388,38 @@ class TestModelManagerGetSource:
             result = mgr.get_source("gemini/gemini-2.5-pro")
         assert result == ModelSource.FRONTIER
         mock_get.assert_not_called()
+
+    def test_lm_studio_prefixed_ref_is_lm_studio_source_without_network(self) -> None:
+        """An ``lm_studio/`` ref classifies on the prefix, no network call."""
+        mgr = ModelManager(Path("/tmp"), "http://localhost:1234/v1")
+        with mock.patch("httpx.get") as mock_get:
+            result = mgr.get_source("lm_studio/qwen2.5-coder")
+        assert result == ModelSource.LM_STUDIO
+        mock_get.assert_not_called()
+
+    def test_bare_model_on_lm_studio_backend_is_lm_studio_source(self) -> None:
+        """A bare name an LM Studio backend reports installed classifies as LM_STUDIO."""
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"data": [{"id": "qwen2.5-coder"}]}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response):
+            mgr = ModelManager(Path("/tmp"), "http://localhost:1234/v1")
+            result = mgr.get_source("qwen2.5-coder")
+
+        assert result == ModelSource.LM_STUDIO
+
+    def test_bare_model_on_unknown_backend_is_remote_source(self) -> None:
+        """A bare name a non-Ollama/LM-Studio backend reports stays generic REMOTE."""
+        mock_response = mock.Mock()
+        mock_response.json.return_value = {"models": [{"name": "custom-model"}]}
+        mock_response.raise_for_status = mock.Mock()
+
+        with mock.patch("httpx.get", return_value=mock_response):
+            mgr = ModelManager(Path("/tmp"), "http://my-host.internal:9000")
+            result = mgr.get_source("custom-model")
+
+        assert result == ModelSource.REMOTE
 
     def test_native_takes_precedence(self, tmp_path: Path) -> None:
         """When model exists in both sources, NATIVE takes precedence."""

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -348,7 +348,8 @@ class TestModelManagerGetSource:
         mgr = ModelManager(models_dir, "http://localhost:11434")
         assert mgr.get_source("my-model.gguf") == ModelSource.NATIVE
 
-    def test_litellm_model(self) -> None:
+    def test_bare_ollama_model_is_ollama_source(self) -> None:
+        """A bare name the Ollama backend reports installed classifies as OLLAMA."""
         mock_response = mock.Mock()
         mock_response.json.return_value = {"models": [{"name": "llama3:latest"}]}
         mock_response.raise_for_status = mock.Mock()
@@ -357,7 +358,23 @@ class TestModelManagerGetSource:
             mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
             result = mgr.get_source("llama3:latest")
 
-        assert result == ModelSource.REMOTE
+        assert result == ModelSource.OLLAMA
+
+    def test_ollama_prefixed_ref_is_ollama_source_without_network(self) -> None:
+        """An ``ollama/`` ref classifies on the prefix, no /api/tags call."""
+        mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+        with mock.patch("httpx.get") as mock_get:
+            result = mgr.get_source("ollama/llama3:latest")
+        assert result == ModelSource.OLLAMA
+        mock_get.assert_not_called()
+
+    def test_api_prefixed_ref_is_frontier_source(self) -> None:
+        """A hosted API ref classifies as FRONTIER without a network call."""
+        mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+        with mock.patch("httpx.get") as mock_get:
+            result = mgr.get_source("gemini/gemini-2.5-pro")
+        assert result == ModelSource.FRONTIER
+        mock_get.assert_not_called()
 
     def test_native_takes_precedence(self, tmp_path: Path) -> None:
         """When model exists in both sources, NATIVE takes precedence."""
@@ -625,6 +642,18 @@ class TestModelManagerRemove:
         call_kwargs = mock_req.call_args[1]
         assert call_kwargs["content"] == b'{"model": "llama3:latest"}'
         assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        assert result is True
+
+    def test_remove_strips_ollama_prefix_for_backend(self) -> None:
+        """A canonical ``ollama/<name>`` ref deletes by bare name on the backend."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+
+        with mock.patch("httpx.request", return_value=mock_response) as mock_req:
+            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            result = mgr.remove("ollama/llama3:latest", ModelSource.OLLAMA)
+
+        assert mock_req.call_args[1]["content"] == b'{"model": "llama3:latest"}'
         assert result is True
 
     def test_litellm_remove_not_found(self) -> None:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -597,6 +597,18 @@ class TestModelManagerRemove:
         assert mock_req.call_args[1]["content"] == b'{"model": "llama3:latest"}'
         assert result is True
 
+    def test_remove_unknown_backend_sends_name_unchanged(self) -> None:
+        """An unrecognized backend has no known prefix to strip, so the name passes through."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+
+        with mock.patch("httpx.request", return_value=mock_response) as mock_req:
+            mgr = ModelManager(Path("/tmp"), "http://my-host.internal:9000")
+            result = mgr.remove("custom-model", ModelSource.REMOTE)
+
+        assert mock_req.call_args[1]["content"] == b'{"model": "custom-model"}'
+        assert result is True
+
     def test_litellm_remove_not_found(self) -> None:
         mock_response = mock.Mock()
         mock_response.status_code = 404

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -56,7 +56,12 @@ class TestModelSource:
         assert ModelSource.REMOTE.value == "remote"
 
     def test_members(self) -> None:
-        assert set(ModelSource) == {ModelSource.NATIVE, ModelSource.REMOTE}
+        assert set(ModelSource) == {
+            ModelSource.NATIVE,
+            ModelSource.REMOTE,
+            ModelSource.FRONTIER,
+            ModelSource.OLLAMA,
+        }
 
     def test_parse_none_and_empty_return_none(self) -> None:
         assert ModelSource.parse(None) is None
@@ -71,6 +76,12 @@ class TestModelSource:
 
         with pytest.raises(ValueError, match="invalid source 'bogus'"):
             ModelSource.parse("bogus")
+
+    def test_has_frontier_and_ollama(self) -> None:
+        assert ModelSource.FRONTIER == "frontier"
+        assert ModelSource.OLLAMA == "ollama"
+        assert ModelSource.parse("frontier") is ModelSource.FRONTIER
+        assert ModelSource.parse("ollama") is ModelSource.OLLAMA
 
 
 def _install_registry_model(

--- a/tests/test_model_manager_compat.py
+++ b/tests/test_model_manager_compat.py
@@ -87,13 +87,15 @@ def test_pull_proceeds_for_unknown_arch(tmp_path: Path, monkeypatch: pytest.Monk
     assert result is not None
 
 
-def test_pull_remote_source_skips_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """REMOTE source delegates to an SDK backend; lilbee's gate doesn't apply."""
-    mgr = ModelManager(tmp_path / "models")
-    monkeypatch.setattr(mgr, "_pull_remote", lambda model, on_progress: None)
+def test_pull_remote_source_refused_before_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REMOTE source is read-only: refused before the arch gate can run."""
+    mgr = ModelManager(tmp_path / "models", "http://localhost:11434")
 
     def _fail(_ref: str, _client: object) -> str:
-        raise AssertionError("gate must not fire for REMOTE source")
+        raise AssertionError("gate must not fire for a refused REMOTE pull")
 
     monkeypatch.setattr(compat, "resolve_arch_for_pull", _fail)
-    mgr.pull("ollama:llama3", ModelSource.REMOTE)
+    with pytest.raises(ValueError, match="Ollama"):
+        mgr.pull("ollama:llama3", ModelSource.REMOTE)

--- a/tests/test_model_ref.py
+++ b/tests/test_model_ref.py
@@ -34,6 +34,17 @@ class TestParseModelRef:
         assert ref.provider == "ollama"
         assert ref.name == "qwen3:latest"
 
+    def test_lm_studio_prefix(self) -> None:
+        ref = parse_model_ref("lm_studio/qwen2.5-7b-instruct")
+        assert ref.provider == "lm_studio"
+        assert ref.name == "qwen2.5-7b-instruct"
+
+    def test_lm_studio_prefix_does_not_append_latest_tag(self) -> None:
+        """LM Studio ids are used verbatim; only Ollama appends ``:latest``."""
+        ref = parse_model_ref("lm_studio/some-model")
+        assert ref.provider == "lm_studio"
+        assert ref.name == "some-model"
+
     def test_openai_prefix(self) -> None:
         ref = parse_model_ref("openai/gpt-4o")
         assert ref.provider == "openai"
@@ -115,6 +126,13 @@ class TestProviderModelRefProperties:
         ref = parse_model_ref("ollama/qwen3:8b")
         assert ref.needs_api_base is True
 
+    def test_lm_studio_model_is_remote_and_needs_api_base(self) -> None:
+        ref = parse_model_ref("lm_studio/qwen2.5-7b-instruct")
+        assert ref.is_remote is True
+        assert ref.is_api is False
+        assert ref.is_local is False
+        assert ref.needs_api_base is True
+
 
 class TestForOpenaiPrefix:
     def test_ollama_model(self) -> None:
@@ -128,6 +146,10 @@ class TestForOpenaiPrefix:
     def test_anthropic_model(self) -> None:
         ref = parse_model_ref("anthropic/claude-sonnet-4-20250514")
         assert ref.for_openai_prefix() == "anthropic/claude-sonnet-4-20250514"
+
+    def test_lm_studio_model(self) -> None:
+        ref = parse_model_ref("lm_studio/qwen2.5-7b-instruct")
+        assert ref.for_openai_prefix() == "lm_studio/qwen2.5-7b-instruct"
 
     def test_local_model(self) -> None:
         ref = parse_model_ref(_LOCAL_REF)
@@ -166,6 +188,28 @@ class TestFormatRemoteRef:
             provider="Ollama",
         )
         assert format_remote_ref(model.name, model.provider) == "ollama/qwen3:8b"
+
+    def test_lm_studio_display_name_normalizes_to_routing_key(self) -> None:
+        """The ``"LM Studio"`` display name must map to the ``lm_studio/`` prefix.
+
+        Lower-casing alone would yield ``"lm studio"`` and silently drop the
+        prefix, corrupting the stored ``chat_model`` ref; the display->key
+        normalization in ``format_remote_ref`` prevents that.
+        """
+        model = RemoteModel(
+            name="qwen2.5-7b-instruct",
+            task="chat",
+            family="",
+            parameter_size="",
+            provider="LM Studio",
+        )
+        ref = format_remote_ref(model.name, model.provider)
+        assert ref == "lm_studio/qwen2.5-7b-instruct"
+        # Round-trips back through the parser without losing the prefix.
+        assert parse_model_ref(ref).provider == "lm_studio"
+
+    def test_lm_studio_routing_key_form(self) -> None:
+        assert format_remote_ref("some-model", "lm_studio") == "lm_studio/some-model"
 
     def test_openrouter_with_nested_path(self) -> None:
         """OpenRouter model ids carry a vendor/model path that must round-trip."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1871,6 +1871,44 @@ class TestLiteLLMShowModelCapabilities:
         assert caps == []
 
 
+class TestLMStudioCapabilityGuards:
+    """LM Studio has no Ollama-style /api/pull or /api/show endpoints."""
+
+    _LM_STUDIO_BASE = "http://localhost:1234/v1"
+
+    def _backend(self):  # type: ignore[no-untyped-def]
+        from lilbee.providers.litellm_sdk import LitellmSdkBackend
+
+        return LitellmSdkBackend()
+
+    def test_pull_model_raises_user_facing_error(self) -> None:
+        from lilbee.providers.base import ProviderError
+
+        backend = self._backend()
+        with pytest.raises(ProviderError) as exc:
+            backend.pull_model("qwen2.5-7b-instruct", base_url=self._LM_STUDIO_BASE)
+        # User-facing message names LM Studio and the fix; no internal vocabulary.
+        assert "LM Studio" in str(exc.value)
+        assert "dispatch" not in str(exc.value).lower()
+
+    def test_pull_model_makes_no_http_call(self) -> None:
+        from lilbee.providers.base import ProviderError
+
+        backend = self._backend()
+        with mock.patch("httpx.Client") as client, pytest.raises(ProviderError):
+            backend.pull_model("qwen2.5-7b-instruct", base_url=self._LM_STUDIO_BASE)
+        client.assert_not_called()
+
+    def test_show_model_returns_none_without_http_call(self) -> None:
+        backend = self._backend()
+        with mock.patch("httpx.post") as post:
+            result = backend.show_model(
+                "lm_studio/qwen2.5-7b-instruct", base_url=self._LM_STUDIO_BASE
+            )
+        assert result is None
+        post.assert_not_called()
+
+
 class TestShowModelNotFound:
     def test_returns_none_for_missing_model(self) -> None:
         from lilbee.providers.llama_cpp import LlamaCppProvider
@@ -4164,31 +4202,64 @@ class TestReadMmprojProjectorTypePartial:
         assert result == "resampler"
 
 
-class TestIsOllama:
-    def test_localhost_default_port(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+class TestOpenAIModelsUrl:
+    def test_appends_v1_models_when_absent(self) -> None:
+        from lilbee.providers.local_servers import openai_models_url
 
-        assert _is_ollama("http://localhost:11434") is True
+        assert openai_models_url("http://localhost:11434") == "http://localhost:11434/v1/models"
 
-    def test_127_default_port(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+    def test_does_not_double_v1_when_present(self) -> None:
+        from lilbee.providers.local_servers import openai_models_url
 
-        assert _is_ollama("http://127.0.0.1:11434") is True
+        assert openai_models_url("http://localhost:1234/v1") == "http://localhost:1234/v1/models"
+
+    def test_tolerates_trailing_slash(self) -> None:
+        from lilbee.providers.local_servers import openai_models_url
+
+        assert openai_models_url("http://localhost:1234/v1/") == "http://localhost:1234/v1/models"
+
+
+class TestDetectLocalServer:
+    def test_ollama_default_port(self) -> None:
+        from lilbee.providers.local_servers import OLLAMA, detect_local_server
+
+        assert detect_local_server("http://localhost:11434") is OLLAMA
+
+    def test_ollama_127_default_port(self) -> None:
+        from lilbee.providers.local_servers import OLLAMA, detect_local_server
+
+        assert detect_local_server("http://127.0.0.1:11434") is OLLAMA
 
     def test_ollama_in_url(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+        from lilbee.providers.local_servers import OLLAMA, detect_local_server
 
-        assert _is_ollama("https://ollama.example.com") is True
+        assert detect_local_server("https://ollama.example.com") is OLLAMA
+
+    def test_lm_studio_default_port(self) -> None:
+        from lilbee.providers.local_servers import LM_STUDIO, detect_local_server
+
+        assert detect_local_server("http://localhost:1234") is LM_STUDIO
+
+    def test_lm_studio_127_with_v1(self) -> None:
+        from lilbee.providers.local_servers import LM_STUDIO, detect_local_server
+
+        assert detect_local_server("http://127.0.0.1:1234/v1") is LM_STUDIO
+
+    def test_lm_studio_port_not_confused_with_ollama(self) -> None:
+        """LM Studio's pattern must not match Ollama's longer port substring."""
+        from lilbee.providers.local_servers import OLLAMA, detect_local_server
+
+        assert detect_local_server("http://localhost:11434") is OLLAMA
 
     def test_openai_url(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+        from lilbee.providers.local_servers import detect_local_server
 
-        assert _is_ollama("https://api.openai.com") is False
+        assert detect_local_server("https://api.openai.com") is None
 
     def test_custom_url(self) -> None:
-        from lilbee.providers.litellm_sdk import _is_ollama
+        from lilbee.providers.local_servers import detect_local_server
 
-        assert _is_ollama("http://myserver:8080") is False
+        assert detect_local_server("http://myserver:8080") is None
 
 
 class TestRouteModel:
@@ -4237,6 +4308,30 @@ class TestRouteModel:
 
         ref = parse_model_ref("Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf")
         assert _route_model(ref, "https://example.com/v1") == ref.name
+
+    def test_lm_studio_ref_routes_to_lm_studio_prefix(self) -> None:
+        """LM Studio refs carry litellm's ``lm_studio/`` provider prefix."""
+        from lilbee.providers.litellm_sdk import _route_model
+        from lilbee.providers.model_ref import parse_model_ref
+
+        ref = parse_model_ref("lm_studio/qwen2.5-7b-instruct")
+        assert _route_model(ref, "http://localhost:1234/v1") == "lm_studio/qwen2.5-7b-instruct"
+
+    def test_local_ref_on_lm_studio_url_adds_prefix(self) -> None:
+        """A bare local ref forced through an LM Studio base URL gets prefixed."""
+        from lilbee.providers.litellm_sdk import _route_model
+        from lilbee.providers.model_ref import parse_model_ref
+
+        ref = parse_model_ref("Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf")
+        assert _route_model(ref, "http://localhost:1234/v1") == f"lm_studio/{ref.name}"
+
+    def test_lm_studio_ref_routes_regardless_of_api_base(self) -> None:
+        """An ``lm_studio/`` ref keeps its prefix even with no api_base set."""
+        from lilbee.providers.litellm_sdk import _route_model
+        from lilbee.providers.model_ref import parse_model_ref
+
+        ref = parse_model_ref("lm_studio/some-model")
+        assert _route_model(ref, None) == "lm_studio/some-model"
 
 
 class TestInjectProviderKeys:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1396,7 +1396,7 @@ class TestModelsPull:
     async def test_yields_progress_events_native(self):
         mock_manager = MagicMock()
 
-        def fake_pull(model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
+        def fake_pull(model, source, *, on_bytes=None, allow_unsupported=False):
             if on_bytes:
                 on_bytes(500, 1000)
                 on_bytes(1000, 1000)
@@ -1411,26 +1411,6 @@ class TestModelsPull:
         non_empty = [e for e in events if e]
         assert any('"current": 500' in e for e in non_empty)
         assert any('"total": 1000' in e for e in non_empty)
-
-    async def test_yields_progress_events_litellm(self):
-        """Litellm pulls use on_progress (dict), not on_bytes (int, int)."""
-        mock_manager = MagicMock()
-
-        def fake_pull(model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
-            if on_progress:
-                on_progress({"status": "downloading"})
-                on_progress({"status": "success"})
-            return
-
-        mock_manager.pull.side_effect = fake_pull
-        with patch(
-            "lilbee.server.handlers.models.get_services",
-            return_value=MagicMock(model_manager=mock_manager),
-        ):
-            events = [e async for e in handlers.models_pull("test", source="remote")]
-        non_empty = [e for e in events if e]
-        assert any("downloading" in e for e in non_empty)
-        assert any("success" in e for e in non_empty)
 
     async def test_error_yields_error_event(self):
         mock_manager = MagicMock()
@@ -1450,9 +1430,7 @@ class TestModelsPull:
         barrier = threading.Event()
         mock_manager = MagicMock()
 
-        def blocking_pull(
-            model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False
-        ):
+        def blocking_pull(model, source, *, on_bytes=None, allow_unsupported=False):
             if on_bytes:
                 on_bytes(100, 1000)
             barrier.wait(timeout=2)
@@ -2617,22 +2595,6 @@ class TestAddHandlerCancel:
 
 
 class TestModelPullProgressCancel:
-    async def test_cancel_skips_progress(self):
-        """When cancel is set, the progress callback returns early."""
-        from lilbee.server.handlers import SseStream
-
-        sse = SseStream()
-        sse.cancel.set()
-
-        # Simulate the progress callback pattern from models_pull
-        def _on_progress(data):
-            if sse.cancel.is_set():
-                return
-            sse.queue.put_nowait("should_not_appear")
-
-        _on_progress({"status": "downloading"})
-        assert sse.queue.empty()
-
     async def test_cancel_during_pull_skips_later_progress(self):
         """When cancel is set before pull starts, all progress calls return early."""
         import threading
@@ -2640,7 +2602,7 @@ class TestModelPullProgressCancel:
         mock_manager = MagicMock()
         progress_called = threading.Event()
 
-        def fake_pull(model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
+        def fake_pull(model, source, *, on_bytes=None, allow_unsupported=False):
             if on_bytes:
                 # All progress calls should see cancel already set
                 on_bytes(500, 1000)
@@ -2671,42 +2633,6 @@ class TestModelPullProgressCancel:
 
         assert progress_called.is_set()  # Pull did call on_bytes
         assert not any("current" in e for e in events if e)
-
-    async def test_cancel_during_litellm_pull_skips_progress(self):
-        """When cancel is set before litellm pull starts, on_progress returns early."""
-        import threading
-
-        mock_manager = MagicMock()
-        progress_called = threading.Event()
-
-        def fake_pull(model, source, *, on_progress=None, on_bytes=None, allow_unsupported=False):
-            if on_progress:
-                on_progress({"status": "should_be_suppressed"})
-                progress_called.set()
-
-        mock_manager.pull.side_effect = fake_pull
-
-        original_init = handlers.SseStream.__init__
-
-        def patched_init(self):
-            original_init(self)
-            self.cancel.set()
-
-        with (
-            patch(
-                "lilbee.server.handlers.models.get_services",
-                return_value=MagicMock(model_manager=mock_manager),
-            ),
-            patch.object(handlers.SseStream, "__init__", patched_init),
-        ):
-            gen = handlers.models_pull("test", source="remote")
-            events = []
-            async for event in gen:
-                events.append(event)
-            await asyncio.sleep(0.2)
-
-        assert progress_called.is_set()
-        assert not any("should_be_suppressed" in e for e in events if e)
 
 
 class TestSearchRouteErrors:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1898,7 +1898,7 @@ class TestModelsDelete:
             "lilbee.server.handlers.models.get_services",
             return_value=MagicMock(model_manager=mock_manager),
         ):
-            result = await handlers.models_delete("test", source="remote")
+            result = await handlers.models_delete("test", source="native")
         assert result.deleted is True
         assert result.model == "test"
 
@@ -1912,6 +1912,25 @@ class TestModelsDelete:
             result = await handlers.models_delete("missing", source="native")
         assert result.deleted is False
         assert result.freed_gb == 0.0
+
+    async def test_read_only_source_returns_409(self):
+        """Refusing to remove a read-only local-server model surfaces as a 409."""
+        from litestar.exceptions import HTTPException
+
+        mock_manager = MagicMock()
+        mock_manager.remove.side_effect = ValueError(
+            "lilbee runs Ollama models but doesn't remove them. Manage them in Ollama instead."
+        )
+        with (
+            patch(
+                "lilbee.server.handlers.models.get_services",
+                return_value=MagicMock(model_manager=mock_manager),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await handlers.models_delete("ollama/llama3:latest", source="ollama")
+        assert exc_info.value.status_code == 409
+        assert "doesn't remove them" in str(exc_info.value.detail)
 
 
 class TestModelsShow:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1213,8 +1213,11 @@ class TestHostedCatalogEntries:
             ("qwen2.5-coder", ModelSource.LM_STUDIO)
         ]
 
-    def test_discover_hosted_sync_unknown_backend_defaults_to_ollama(self, monkeypatch) -> None:
-        """An unrecognized backend URL keeps the generic OLLAMA local source."""
+    def test_discover_hosted_sync_unknown_backend_uses_generic_remote(self, monkeypatch) -> None:
+        """An unrecognized backend URL keeps the generic REMOTE source.
+
+        Matches the fallback get_source and the CLI use for an undetected server.
+        """
         import lilbee.server.handlers.models as h
         from lilbee.catalog.types import ModelSource, ModelTask
         from lilbee.modelhub.model_manager.types import RemoteModel
@@ -1235,7 +1238,7 @@ class TestHostedCatalogEntries:
             ],
         )
         rows = h._discover_hosted_sync()
-        assert rows[0].source == ModelSource.OLLAMA
+        assert rows[0].source == ModelSource.REMOTE
 
 
 class TestModelsCatalog:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1731,6 +1731,34 @@ class TestModelsInstalled:
             result = await handlers.models_installed()
         assert result.models[0].source == "remote"
 
+    async def test_ollama_model_reports_granular_source_and_canonical_ref(self):
+        """A bare Ollama name surfaces as source 'ollama' with the prefixed ref."""
+        from lilbee.catalog.types import ModelSource
+
+        mock_manager = MagicMock()
+        mock_manager.list_installed.return_value = ["qwen3:0.6b"]
+        mock_manager.get_source.return_value = ModelSource.OLLAMA
+        with patch(
+            "lilbee.server.handlers.models.get_services",
+            return_value=MagicMock(model_manager=mock_manager),
+        ):
+            result = await handlers.models_installed()
+        assert result.models[0].name == "ollama/qwen3:0.6b"
+        assert result.models[0].source == "ollama"
+
+    async def test_already_prefixed_ollama_ref_not_double_prefixed(self):
+        from lilbee.catalog.types import ModelSource
+
+        mock_manager = MagicMock()
+        mock_manager.list_installed.return_value = ["ollama/qwen3:0.6b"]
+        mock_manager.get_source.return_value = ModelSource.OLLAMA
+        with patch(
+            "lilbee.server.handlers.models.get_services",
+            return_value=MagicMock(model_manager=mock_manager),
+        ):
+            result = await handlers.models_installed()
+        assert result.models[0].name == "ollama/qwen3:0.6b"
+
 
 class TestModelsPull:
     async def test_yields_progress_events_native(self):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1187,6 +1187,56 @@ class TestHostedCatalogEntries:
         await h._collect_hosted_entries(task=ModelTask.CHAT, search="")
         assert calls["n"] == 1
 
+    def test_discover_hosted_sync_stamps_lm_studio_source(self, monkeypatch) -> None:
+        """When the backend is LM Studio, local rows carry the LM_STUDIO source."""
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        monkeypatch.setattr(h.cfg, "remote_base_url", "http://localhost:1234/v1")
+        monkeypatch.setattr(h, "discover_api_models", lambda: {})
+        monkeypatch.setattr(
+            h,
+            "classify_remote_models",
+            lambda *a, **k: [
+                RemoteModel(
+                    name="qwen2.5-coder",
+                    task=ModelTask.CHAT,
+                    family="",
+                    parameter_size="",
+                    provider="LM Studio",
+                )
+            ],
+        )
+        rows = h._discover_hosted_sync()
+        assert [(r.display_name, r.source) for r in rows] == [
+            ("qwen2.5-coder", ModelSource.LM_STUDIO)
+        ]
+
+    def test_discover_hosted_sync_unknown_backend_defaults_to_ollama(self, monkeypatch) -> None:
+        """An unrecognized backend URL keeps the generic OLLAMA local source."""
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        monkeypatch.setattr(h.cfg, "remote_base_url", "http://my-host.internal:9000")
+        monkeypatch.setattr(h, "discover_api_models", lambda: {})
+        monkeypatch.setattr(
+            h,
+            "classify_remote_models",
+            lambda *a, **k: [
+                RemoteModel(
+                    name="custom-model",
+                    task=ModelTask.CHAT,
+                    family="",
+                    parameter_size="",
+                    provider="Ollama",
+                )
+            ],
+        )
+        rows = h._discover_hosted_sync()
+        assert rows[0].source == ModelSource.OLLAMA
+
 
 class TestModelsCatalog:
     @pytest.fixture(autouse=True)
@@ -1758,6 +1808,21 @@ class TestModelsInstalled:
         ):
             result = await handlers.models_installed()
         assert result.models[0].name == "ollama/qwen3:0.6b"
+
+    async def test_lm_studio_model_reports_granular_source_and_canonical_ref(self):
+        """A bare LM Studio name surfaces as source 'lm_studio' with the prefixed ref."""
+        from lilbee.catalog.types import ModelSource
+
+        mock_manager = MagicMock()
+        mock_manager.list_installed.return_value = ["qwen2.5-coder"]
+        mock_manager.get_source.return_value = ModelSource.LM_STUDIO
+        with patch(
+            "lilbee.server.handlers.models.get_services",
+            return_value=MagicMock(model_manager=mock_manager),
+        ):
+            result = await handlers.models_installed()
+        assert result.models[0].name == "lm_studio/qwen2.5-coder"
+        assert result.models[0].source == "lm_studio"
 
 
 class TestModelsPull:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -970,16 +970,237 @@ class TestSetChatModel:
             await handlers.set_chat_model("qwen3:0.6b")
 
     async def test_provider_prefixed_bare_form_resolves_via_parse(self, tmp_path, mock_svc):
-        """An ``ollama/<name>`` resolves to bare ``<name>`` when that's what list_models returns."""
+        """An ``ollama/<name>`` whose bare form the backend lists is accepted verbatim.
+
+        The backend reports the bare ``qwen3:0.6b``; the prefixed selection
+        keeps its ``ollama/`` routing prefix (rather than collapsing to the
+        bare name), so validation skips the native catalog/installed check,
+        the same path the TUI takes when persisting an Ollama selection.
+        """
         mock_svc.provider.list_models.return_value = ["qwen3:0.6b"]
-        with pytest.raises(ValueError, match="not installed"):
-            # parse path: "ollama/qwen3:0.6b" -> name="qwen3:0.6b" which is in
-            # available; validate rejects the bare colon-form as not installed
-            # because no manifest exists for that ref in the native registry.
-            await handlers.set_chat_model("ollama/qwen3:0.6b")
+        result = await handlers.set_chat_model("ollama/qwen3:0.6b")
+        assert result.model == "ollama/qwen3:0.6b"
+        assert cfg.chat_model == "ollama/qwen3:0.6b"
+
+    async def test_accepts_frontier_ref(self, tmp_path, mock_svc):
+        """A discovered frontier ref (``gemini/gemini-2.0-flash``) is selectable.
+
+        Frontier models surface through ``discover_api_models`` (a per-key
+        listing), NOT ``provider.list_models()``, so the bare name is absent
+        from the routable set the validator checks. The ref is accepted because
+        the Gemini key is configured (litellm validates the exact name at call
+        time), and the ``gemini/`` prefix is persisted verbatim so it routes to
+        the provider. (The bare name is deliberately NOT in ``list_models`` here
+        so the test exercises the real path rather than a happy-path mock.)
+        """
+        cfg.gemini_api_key = "test-gemini-key"
+        mock_svc.provider.list_models.return_value = [_CHAT_REF]
+        result = await handlers.set_chat_model("gemini/gemini-2.0-flash")
+        assert result.model == "gemini/gemini-2.0-flash"
+        assert cfg.chat_model == "gemini/gemini-2.0-flash"
+
+    async def test_rejects_frontier_ref_without_key(self, tmp_path, mock_svc):
+        """A frontier ref is not routable when the provider's key is unset."""
+        cfg.gemini_api_key = ""
+        mock_svc.provider.list_models.return_value = [_CHAT_REF]
+        with pytest.raises(ValueError, match="not available"):
+            await handlers.set_chat_model("gemini/gemini-2.0-flash")
+
+
+class TestHostedCatalogEntries:
+    def test_catalog_entry_response_hosted_fields(self) -> None:
+        from lilbee.catalog.types import KeyStatus, ModelSource, ModelTask
+        from lilbee.server.models import CatalogEntryResponse
+
+        e = CatalogEntryResponse(
+            hf_repo="gemini/gemini-2.0-flash",
+            gguf_filename="",
+            task=ModelTask.CHAT,
+            display_name="gemini-2.0-flash",
+            param_count="",
+            size_gb=0,
+            min_ram_gb=0,
+            description="",
+            quality_tier="",
+            featured=False,
+            downloads=0,
+            installed=True,
+            source=ModelSource.FRONTIER,
+            provider="Gemini",
+            key_status=KeyStatus.READY,
+        )
+        assert e.provider == "Gemini"
+        assert e.key_status == KeyStatus.READY
+        native = CatalogEntryResponse(
+            hf_repo="r",
+            gguf_filename="f",
+            task=ModelTask.CHAT,
+            display_name="d",
+            param_count="",
+            size_gb=1,
+            min_ram_gb=1,
+            description="",
+            quality_tier="",
+            featured=False,
+            downloads=0,
+            installed=False,
+            source=ModelSource.NATIVE,
+        )
+        assert native.provider == "" and native.key_status is None
+
+    def test_hosted_entry_from_remote_frontier(self) -> None:
+        from lilbee.catalog.types import KeyStatus, ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+        from lilbee.providers.model_ref import format_remote_ref
+        from lilbee.server.handlers.models import _hosted_entry
+
+        rm = RemoteModel(
+            name="gemini-2.0-flash",
+            task=ModelTask.CHAT,
+            family="",
+            parameter_size="",
+            provider="Gemini",
+        )
+        row = _hosted_entry(rm, ModelSource.FRONTIER)
+        assert row.source == ModelSource.FRONTIER
+        assert row.hf_repo == format_remote_ref("gemini-2.0-flash", "Gemini")
+        assert row.display_name == "gemini-2.0-flash"
+        assert row.provider == "Gemini"
+        assert row.key_status == KeyStatus.READY
+        assert row.installed is True and row.fit is None and row.size_gb == 0
+
+    def test_hosted_entry_from_remote_ollama(self) -> None:
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+        from lilbee.server.handlers.models import _hosted_entry
+
+        rm = RemoteModel(
+            name="llama3.1:8b",
+            task=ModelTask.CHAT,
+            family="llama",
+            parameter_size="8B",
+            provider="Ollama",
+        )
+        row = _hosted_entry(rm, ModelSource.OLLAMA)
+        assert row.source == ModelSource.OLLAMA
+        assert row.key_status is None and row.provider == "Ollama"
+
+    async def test_collect_hosted_entries(self, monkeypatch) -> None:
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        h._hosted_cache.set("", [])  # prime then clear to defeat any prior TTL entry
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="gemini-2.0-flash",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        monkeypatch.setattr(
+            h,
+            "classify_remote_models",
+            lambda *a, **k: [
+                RemoteModel(
+                    name="llama3.1:8b",
+                    task=ModelTask.CHAT,
+                    family="llama",
+                    parameter_size="8B",
+                    provider="Ollama",
+                ),
+                RemoteModel(
+                    name="nomic-embed",
+                    task=ModelTask.EMBEDDING,
+                    family="nomic-bert",
+                    parameter_size="",
+                    provider="Ollama",
+                ),
+            ],
+        )
+        chat = await h._collect_hosted_entries(task=ModelTask.CHAT, search="")
+        sources = {(r.display_name, r.source) for r in chat}
+        assert ("gemini-2.0-flash", ModelSource.FRONTIER) in sources
+        assert ("llama3.1:8b", ModelSource.OLLAMA) in sources
+        assert all(r.task == ModelTask.CHAT for r in chat)
+        assert ("nomic-embed", ModelSource.OLLAMA) not in sources
+        searched = await h._collect_hosted_entries(task=ModelTask.CHAT, search="gemini")
+        assert {r.display_name for r in searched} == {"gemini-2.0-flash"}
+
+    async def test_collect_hosted_entries_no_task_filter(self, monkeypatch) -> None:
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog.types import ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        h._hosted_cache._result = None
+        monkeypatch.setattr(h, "discover_api_models", lambda: {})
+        monkeypatch.setattr(
+            h,
+            "classify_remote_models",
+            lambda *a, **k: [
+                RemoteModel(
+                    name="nomic-embed",
+                    task=ModelTask.EMBEDDING,
+                    family="nomic-bert",
+                    parameter_size="",
+                    provider="Ollama",
+                )
+            ],
+        )
+        rows = await h._collect_hosted_entries(task=None, search="")
+        assert {r.display_name for r in rows} == {"nomic-embed"}
+
+    async def test_collect_hosted_entries_uses_cache(self, monkeypatch) -> None:
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog.types import ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        h._hosted_cache._result = None
+        calls = {"n": 0}
+
+        def _discover():
+            calls["n"] += 1
+            return {
+                "Gemini": [
+                    RemoteModel(
+                        name="gemini-2.0-flash",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            }
+
+        monkeypatch.setattr(h, "discover_api_models", _discover)
+        monkeypatch.setattr(h, "classify_remote_models", lambda *a, **k: [])
+        await h._collect_hosted_entries(task=ModelTask.CHAT, search="")
+        await h._collect_hosted_entries(task=ModelTask.CHAT, search="")
+        assert calls["n"] == 1
 
 
 class TestModelsCatalog:
+    @pytest.fixture(autouse=True)
+    def _no_hosted_discovery(self, monkeypatch):
+        """Native-only by default: stub discovery empty + clear the hosted cache.
+
+        Individual tests that exercise hosted rows re-monkeypatch these.
+        """
+        import lilbee.server.handlers.models as h
+
+        h._hosted_cache._result = None
+        monkeypatch.setattr(h, "discover_api_models", lambda: {})
+        monkeypatch.setattr(h, "classify_remote_models", lambda *a, **k: [])
+
     @staticmethod
     def _manifest(hf_repo: str, gguf_filename: str, task: str = "chat"):
         from lilbee.modelhub.registry import ModelManifest
@@ -991,6 +1212,125 @@ class TestModelsCatalog:
             task=task,
             downloaded_at="2026-01-01T00:00:00+00:00",
         )
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_includes_hosted_on_first_page(self, mock_get_catalog, mock_svc, monkeypatch):
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog import CatalogResult
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        mock_svc.registry.list_installed.return_value = []
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="gemini-2.0-flash",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        resp = await handlers.models_catalog(task="chat")
+        frontier = [m for m in resp.models if m.source == ModelSource.FRONTIER]
+        assert frontier and frontier[0].display_name == "gemini-2.0-flash"
+        assert frontier[0].key_status == "ready"
+        assert resp.total == 1  # 0 native + 1 hosted
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_hosted_skipped_when_featured_filter(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog import CatalogResult
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        mock_svc.registry.list_installed.return_value = []
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="g",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        resp = await handlers.models_catalog(task="chat", featured=True)
+        assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_hosted_skipped_on_later_page(self, mock_get_catalog, mock_svc, monkeypatch):
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog import CatalogResult
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=20, models=[])
+        mock_svc.registry.list_installed.return_value = []
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="g",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        resp = await handlers.models_catalog(task="chat", offset=20)
+        assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
+
+    @patch("lilbee.server.handlers.models.get_catalog")
+    async def test_hosted_skipped_when_installed_false(
+        self, mock_get_catalog, mock_svc, monkeypatch
+    ):
+        import lilbee.server.handlers.models as h
+        from lilbee.catalog import CatalogResult
+        from lilbee.catalog.types import ModelSource, ModelTask
+        from lilbee.modelhub.model_manager.types import RemoteModel
+
+        mock_get_catalog.return_value = CatalogResult(total=0, limit=20, offset=0, models=[])
+        mock_svc.registry.list_installed.return_value = []
+        h._hosted_cache._result = None
+        monkeypatch.setattr(
+            h,
+            "discover_api_models",
+            lambda: {
+                "Gemini": [
+                    RemoteModel(
+                        name="g",
+                        task=ModelTask.CHAT,
+                        family="",
+                        parameter_size="",
+                        provider="Gemini",
+                    )
+                ]
+            },
+        )
+        resp = await handlers.models_catalog(task="chat", installed=False)
+        assert not [m for m in resp.models if m.source == ModelSource.FRONTIER]
 
     @patch("lilbee.server.handlers.models.get_catalog")
     async def test_returns_catalog_response(self, mock_get_catalog, mock_svc):


### PR DESCRIPTION
## Problem

lilbee only treated Ollama as a local model backend, and three in-flight branches overlapped heavily on the same files: one surfaced cloud (API-key) and Ollama models in the catalog, one made installed-model sources granular, and one added LM Studio behind a shared local-server abstraction. Landed separately they collided (the LM Studio branch removed the `OLLAMA_PREFIX` constant the others imported, and several sites hardcoded Ollama as the source). LM Studio was also only half-wired: its models could route, but they showed up mislabeled as Ollama in the catalog and installed views, and `lilbee model list` flattened every backend model to "remote".

## Solution

Fuse the three change sets into one branch and finish LM Studio as a read-only model manager alongside Ollama.

- A `LocalServerSpec` registry (one small module per server) drives routing, discovery, and listing. Ollama and LM Studio are both read-only: lilbee downloads native GGUF models only and surfaces the local server's own models once they're present.
- A model's source is derived from the detected server everywhere it matters (catalog, installed list, CLI `model list`), so Ollama and LM Studio models report and dedup correctly under canonical `ollama/` and `lm_studio/` refs. The `--source` filter now accepts the granular sources, not just native/remote.
- Listing dispatches per server: Ollama via `/api/tags`, LM Studio via the OpenAI-compatible `/v1/models`. LM Studio presents LM Link remote/cloud models through that same endpoint as if local, so those are surfaced too rather than filtered out.
- Frontier (API-key) and local-server models both appear in the catalog with the right source labels.

Removing a model from Ollama via lilbee keeps working (existing behavior); LM Studio has no delete endpoint, so removal there is a harmless no-op.

This supersedes the three stacked PRs (#299, #300, #301). Full suite green at 100% coverage.
