### PR TITLE
Surface embedder/index mismatch as an actionable error

### DIFF
--- a/src/lilbee/runtime/progress/types.py
+++ b/src/lilbee/runtime/progress/types.py
@@ -40,6 +40,7 @@ class SseErrorCode(StrEnum):
 
     MODEL_TOO_LARGE = "model_too_large"
     MODEL_NOT_INSTALLED = "model_not_installed"
+    INDEX_EMBEDDER_MISMATCH = "index_embedder_mismatch"
 
 
 class FileStartEvent(BaseModel):

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -12,7 +12,7 @@ from lilbee.app.search import clean_result
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
 from lilbee.core.results import DocumentResult, group
-from lilbee.data.store import ChunkType
+from lilbee.data.store import ChunkType, EmbeddingModelMismatchError
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.retrieval.reasoning import (
     CAP_NOTICE_TEMPLATE,
@@ -20,7 +20,7 @@ from lilbee.retrieval.reasoning import (
     effective_reasoning_cap,
     stream_chat_with_cap,
 )
-from lilbee.runtime.progress import SseEvent
+from lilbee.runtime.progress import SseErrorCode, SseEvent
 from lilbee.server.handlers.sse import (
     SseStream,
     _resolve_generation_options,
@@ -131,9 +131,13 @@ async def _stream_rag_response(
     """Shared SSE streaming for ask_stream and chat_stream."""
     yield ""  # force generator
 
-    rag = get_services().searcher.build_rag_context(
-        question, top_k=top_k, history=history, chunk_type=chunk_type
-    )
+    try:
+        rag = get_services().searcher.build_rag_context(
+            question, top_k=top_k, history=history, chunk_type=chunk_type
+        )
+    except EmbeddingModelMismatchError as exc:
+        yield sse_error(str(exc), code=SseErrorCode.INDEX_EMBEDDER_MISMATCH)
+        return
     if rag is None:
         yield sse_error("No relevant documents found.")
         return

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -11,7 +11,7 @@ from litestar.params import Parameter
 from litestar.response import Stream
 
 from lilbee.core.results import DocumentResult
-from lilbee.data.store import scope_to_chunk_type
+from lilbee.data.store import EmbeddingModelMismatchError, scope_to_chunk_type
 from lilbee.retrieval.query import ChatMessage as ChatMessageDict
 from lilbee.server import handlers
 from lilbee.server.auth import read_only
@@ -72,6 +72,8 @@ async def search_route(
         raise ValidationException(str(exc)) from exc
     try:
         return await handlers.search(q, top_k=top_k, chunk_type=chunk_type)
+    except EmbeddingModelMismatchError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
     except Exception as exc:
@@ -88,6 +90,8 @@ async def ask_route(data: AskRequest) -> AskResponse:
             options=data.options,
             chunk_type=data.chunk_type,
         )
+    except EmbeddingModelMismatchError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
     except Exception as exc:
@@ -118,13 +122,16 @@ async def chat_route(data: ChatRequest) -> AskResponse:
     history: list[ChatMessageDict] = [
         ChatMessageDict(role=m.role, content=m.content) for m in data.history
     ]
-    return await handlers.chat(
-        question=data.question,
-        history=history,
-        top_k=data.top_k,
-        options=data.options,
-        chunk_type=data.chunk_type,
-    )
+    try:
+        return await handlers.chat(
+            question=data.question,
+            history=history,
+            top_k=data.top_k,
+            options=data.options,
+            chunk_type=data.chunk_type,
+        )
+    except EmbeddingModelMismatchError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @post("/api/chat/stream")

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -316,6 +316,59 @@ class TestStreamSingleFlightGate:
         assert search_routes._chat_inflight_lock.locked() is False
 
 
+class TestEmbeddingMismatchSurfacing:
+    """A stale index (embedder changed without a rebuild) surfaces as an actionable
+    error, not a generic 503/stream failure. The store raises
+    EmbeddingModelMismatchError; routes translate it to 409 and the streaming path
+    emits an SSE error carrying the INDEX_EMBEDDER_MISMATCH code."""
+
+    MESSAGE = "built with model A (dim 768), now configured for B (dim 384). Run `lilbee rebuild`."
+
+    def _mismatch(self):
+        from lilbee.data.store import EmbeddingModelMismatchError
+
+        return EmbeddingModelMismatchError(self.MESSAGE)
+
+    @mock.patch("lilbee.server.handlers.search", new_callable=AsyncMock)
+    def test_search_route_returns_409(self, mock_search, client):
+        mock_search.side_effect = self._mismatch()
+        resp = client.get("/api/search", params={"q": "x"})
+        assert resp.status_code == 409
+        assert "rebuild" in resp.json()["detail"].lower()
+
+    @mock.patch("lilbee.server.handlers.ask", new_callable=AsyncMock)
+    def test_ask_route_returns_409(self, mock_ask, client):
+        mock_ask.side_effect = self._mismatch()
+        resp = client.post("/api/ask", json={"question": "q"})
+        assert resp.status_code == 409
+        assert "rebuild" in resp.json()["detail"].lower()
+
+    @mock.patch("lilbee.server.handlers.chat", new_callable=AsyncMock)
+    def test_chat_route_returns_409(self, mock_chat, client):
+        mock_chat.side_effect = self._mismatch()
+        resp = client.post("/api/chat", json={"question": "q", "history": []})
+        assert resp.status_code == 409
+        assert "rebuild" in resp.json()["detail"].lower()
+
+    def test_stream_emits_index_embedder_mismatch_code(self):
+        """_stream_rag_response catches the mismatch and emits a coded SSE error."""
+        from lilbee.runtime.progress import SseErrorCode
+        from lilbee.server.handlers import rag
+
+        async def _collect():
+            with mock.patch.object(rag, "get_services") as mock_services:
+                mock_services.return_value.searcher.build_rag_context.side_effect = self._mismatch()
+                return [event async for event in rag.chat_stream(question="q", history=[])]
+
+        events = asyncio.run(_collect())
+        payloads = [
+            json.loads(e.split("data: ", 1)[1]) for e in events if e.startswith("event: error")
+        ]
+        assert len(payloads) == 1
+        assert payloads[0]["code"] == SseErrorCode.INDEX_EMBEDDER_MISMATCH
+        assert "rebuild" in payloads[0]["message"].lower()
+
+
 class TestSyncRoute:
     @mock.patch("lilbee.server.handlers.sync_stream")
     def test_returns_sse(self, mock_stream, client):


### PR DESCRIPTION
## Problem

Switch the embedding model without rebuilding the index, then chat or search, and lilbee returns a generic server error that gives the user no idea what went wrong or that a rebuild is the fix.

## Solution

Surface the clear, actionable error the server already produces for this case. The non-streaming search/ask/chat routes now return a 409 with the "rebuild required" message, and the streaming chat path emits it as a proper error event the plugin can show. No behavior change for a healthy index.