### PR TITLE
Live-filter the chat completion dropdown as you type

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -373,7 +373,7 @@ class LilbeeApp(App[None]):
             except NoMatches:
                 overlay = None
             if overlay is not None and overlay.is_visible:
-                overlay.cycle_prev()
+                screen.action_complete_prev()
                 return
         super().action_command_palette()
 

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -243,8 +243,10 @@ class ChatScreen(Screen[None]):
             ChatWelcome(id="chat-welcome"),
             id="chat-log",
         )
-        yield CompletionOverlay(id="completion-overlay")
         with BottomBars():
+            # Sits directly above the prompt area so it never covers the line
+            # you're typing (the input stays pinned to the bottom edge).
+            yield CompletionOverlay(id="completion-overlay")
             with PromptArea(id="chat-prompt-area"):
                 yield ScopeChip(id="scope-chip")
                 yield ChatInput(

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -473,7 +473,12 @@ class ChatScreen(Screen[None]):
         return None
 
     def _accept_overlay_selection_on_enter(self) -> bool:
-        """Accept the highlight as ``<selection> ``; True if Enter was consumed."""
+        """Accept the highlighted completion into the input; True if it was consumed.
+
+        Directory completions (trailing ``/``) keep the cursor on the slash
+        so the user can descend further; everything else gets a trailing
+        space inviting the next argument.
+        """
         overlay = self._completion_overlay
         if not overlay.is_visible:
             return False
@@ -483,8 +488,9 @@ class ChatScreen(Screen[None]):
             overlay.hide()
             return False
         cmd_prefix = inp.value.split()[0] + " " if " " in inp.value else ""
+        suffix = "" if selection.endswith("/") else " "
         self._completing = True
-        inp.value = f"{cmd_prefix}{selection} "
+        inp.value = f"{cmd_prefix}{selection}{suffix}"
         self._completing = False
         inp.action_end()
         overlay.hide()
@@ -1360,12 +1366,14 @@ class ChatScreen(Screen[None]):
         chip.cycle_scope()
 
     def action_complete(self) -> None:
-        """Tab: cycle autocomplete, insert a literal tab, or advance focus.
+        """Tab: accept the highlight, open the dropdown, insert a tab, or advance focus.
 
-        - Insert mode + chat input focused + completion overlay open:
-          cycle the next completion candidate.
-        - Insert mode + chat input focused + no completion: insert
-          ``\\t`` so users can type tab characters directly.
+        - Insert mode + chat input focused + dropdown open: accept the
+          highlighted completion.
+        - Insert mode + chat input focused + dropdown closed but matches
+          exist: open the dropdown on the first match.
+        - Insert mode + chat input focused + no matches: insert ``\\t`` so
+          users can type tab characters directly.
         - Normal mode or focus elsewhere: advance through the focus
           chain so Tab still walks every focusable widget.
         """
@@ -1373,75 +1381,40 @@ class ChatScreen(Screen[None]):
         if not self._insert_mode or not inp.has_focus:
             self.screen.focus_next()
             return
-        if self._cycle_completion_forward(inp):
+        if self._completion_overlay.is_visible:
+            self._accept_overlay_selection_on_enter()
+            return
+        if self._open_completions():
             return
         inp.insert("\t")
 
     def action_complete_next(self) -> None:
-        """Ctrl+N: highlight-only nav when open, else show + insert (vim ``<C-n>``)."""
-        inp = self._chat_input
-        if not inp.has_focus:
+        """Ctrl+N: highlight the next match, opening the dropdown if it is closed."""
+        if not self._chat_input.has_focus:
             return
         overlay = self._completion_overlay
         if overlay.is_visible:
             overlay.cycle_next()
-            return
-        self._cycle_completion_forward(inp)
+        else:
+            self._open_completions()
 
-    def _cycle_completion_forward(self, inp: ChatInput) -> bool:
-        """Show or cycle forward through autocomplete; returns True if it acted."""
-        overlay = self._completion_overlay
-
-        if overlay.is_visible:
-            selection = overlay.cycle_next()
-            if selection:
-                cmd_prefix = inp.value.split()[0] + " " if " " in inp.value else ""
-                self._completing = True
-                inp.value = cmd_prefix + selection
-                self._completing = False
-                inp.action_end()
-            return True
-
-        options = get_completions(inp.value)
-        if options:
-            overlay.show_completions(options)
-            first = overlay.get_current()
-            self._completing = True
-            if first and " " in inp.value:
-                cmd_prefix = inp.value.split()[0] + " "
-                inp.value = cmd_prefix + first
-                inp.action_end()
-            elif first:
-                inp.value = first
-                inp.action_end()
-            self._completing = False
-            return True
-
-        return False
+    def _open_completions(self) -> bool:
+        """Show the dropdown for the current input without rewriting it; True if shown."""
+        options = get_completions(self._chat_input.value)
+        if not options:
+            return False
+        self._completion_overlay.show_completions(options)
+        return True
 
     def action_complete_prev(self) -> None:
-        """Highlight-only nav when open, else show + insert (mirror of complete_next)."""
-        inp = self._chat_input
-        if not inp.has_focus:
+        """Ctrl+P: highlight the previous match, opening the dropdown if it is closed."""
+        if not self._chat_input.has_focus:
             return
         overlay = self._completion_overlay
-        if overlay.is_visible:
+        # Opening on Ctrl+P lands on the last match; an already-open overlay
+        # just steps the highlight back.
+        if overlay.is_visible or self._open_completions():
             overlay.cycle_prev()
-            return
-
-        options = get_completions(inp.value)
-        if options:
-            overlay.show_completions(options)
-            last = overlay.get_current()
-            self._completing = True
-            if last and " " in inp.value:
-                cmd_prefix = inp.value.split()[0] + " "
-                inp.value = cmd_prefix + last
-                inp.action_end()
-            elif last:
-                inp.value = last
-                inp.action_end()
-            self._completing = False
 
     def action_history_prev(self) -> None:
         """Up arrow: cycle the dropdown if visible, else recall previous history entry."""
@@ -1493,21 +1466,17 @@ class ChatScreen(Screen[None]):
     def _on_chat_input_changed(self, event: ChatInput.Changed) -> None:
         """Refresh arg-hint and auto-show or hide the completion dropdown."""
         if self._completing:
-            # Tab-completion is mid-flight; the cycler manages overlay state.
+            # An accept is mid-flight rewriting the input; it manages the
+            # overlay itself, so skip the live refresh for this change.
             self._refresh_arg_hint()
             return
         self._refresh_completion_overlay()
         self._refresh_arg_hint()
 
     def _refresh_completion_overlay(self) -> None:
-        """Auto-show the dropdown for COMMAND discovery only; arg completions stay on Tab."""
+        """Live-filter the dropdown against the current input, in command and arg modes alike."""
         overlay = self._completion_overlay
-        text = self._chat_input.value
-        # Once the user has typed a space, they are in arg-completion mode.
-        # Leave any Tab-triggered overlay alone and don't auto-pop one.
-        if " " in text:
-            return
-        options = get_completions(text)
+        options = get_completions(self._chat_input.value)
         if options:
             overlay.show_completions(options)
         elif overlay.is_visible:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -43,7 +43,11 @@ from lilbee.cli.tui.screens.chat_helpers import (
 )
 from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.cli.tui.widgets.arg_hint import ArgHintLine
-from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay, get_completions
+from lilbee.cli.tui.widgets.autocomplete import (
+    CompletionOverlay,
+    get_completions,
+    longest_common_prefix,
+)
 from lilbee.cli.tui.widgets.chat_input import ChatInput
 from lilbee.cli.tui.widgets.help_hint import HelpHint
 from lilbee.cli.tui.widgets.message import AssistantMessage, UserMessage
@@ -194,7 +198,13 @@ class ChatScreen(Screen[None]):
         self._history: list[ChatMessage] = []
         self._history_lock = threading.Lock()
         self._insert_mode: bool = True
-        self._completing = False
+        # Count of programmatic input edits whose (async) Changed events should
+        # not re-filter the dropdown. The setter posts Changed after our flag
+        # window would close, so a counter consumed in the handler is used.
+        self._suppress_refresh = 0
+        # The user-typed text the open dropdown is filtering against. While
+        # navigating, the input holds a previewed candidate; Esc restores this.
+        self._completion_origin: str | None = None
         self._sync_active: bool = False
         self._input_history: list[str] = []
         self._history_index: int = -1
@@ -473,28 +483,27 @@ class ChatScreen(Screen[None]):
         return None
 
     def _accept_overlay_selection_on_enter(self) -> bool:
-        """Accept the highlighted completion into the input; True if it was consumed.
+        """Accept the highlighted completion on Enter; True if Enter was consumed.
 
-        Directory completions (trailing ``/``) keep the cursor on the slash
-        so the user can descend further; everything else gets a trailing
-        space inviting the next argument.
+        If the input already holds the highlighted candidate (the user cycled
+        to it), Enter falls through to submit. Otherwise the candidate is
+        filled in and Enter is consumed so a second Enter submits.
         """
         overlay = self._completion_overlay
         if not overlay.is_visible:
             return False
-        selection = overlay.get_current()
-        inp = self._chat_input
-        if not selection or selection == inp.value.rstrip():
+        display = overlay.get_current()
+        if display is None:
             overlay.hide()
+            self._completion_origin = None
             return False
-        cmd_prefix = inp.value.split()[0] + " " if " " in inp.value else ""
-        suffix = "" if selection.endswith("/") else " "
-        self._completing = True
-        inp.value = f"{cmd_prefix}{selection}{suffix}"
-        self._completing = False
-        inp.action_end()
+        target = self._completion_value(display)
+        consumed = self._chat_input.value != target
+        if consumed:
+            self._set_input(target)
         overlay.hide()
-        return True
+        self._completion_origin = None
+        return consumed
 
     def _handle_slash(self, text: str) -> None:
         """Dispatch slash commands via the per-instance handler registry."""
@@ -1220,6 +1229,12 @@ class ChatScreen(Screen[None]):
         """Esc dismisses the overlay if visible; otherwise drops into NORMAL mode."""
         overlay = self._completion_overlay
         if overlay.is_visible:
+            # Revert any previewed candidate back to what the user typed.
+            if self._completion_origin is not None and self._chat_input.value != (
+                self._completion_origin
+            ):
+                self._set_input(self._completion_origin)
+            self._completion_origin = None
             overlay.hide()
             return
         if isinstance(self.focused, (Select, ModelPickerButton)):
@@ -1366,12 +1381,13 @@ class ChatScreen(Screen[None]):
         chip.cycle_scope()
 
     def action_complete(self) -> None:
-        """Tab: accept the highlight, open the dropdown, insert a tab, or advance focus.
+        """Tab: fill the shared prefix, then cycle matches (readline / vim style).
 
-        - Insert mode + chat input focused + dropdown open: accept the
-          highlighted completion.
         - Insert mode + chat input focused + dropdown closed but matches
-          exist: open the dropdown on the first match.
+          exist: open it, fill the longest common prefix, else preview the
+          first match.
+        - Insert mode + chat input focused + dropdown open: fill any further
+          shared prefix, otherwise preview the next match.
         - Insert mode + chat input focused + no matches: insert ``\\t`` so
           users can type tab characters directly.
         - Normal mode or focus elsewhere: advance through the focus
@@ -1381,40 +1397,100 @@ class ChatScreen(Screen[None]):
         if not self._insert_mode or not inp.has_focus:
             self.screen.focus_next()
             return
-        if self._completion_overlay.is_visible:
-            self._accept_overlay_selection_on_enter()
+        overlay = self._completion_overlay
+        if not overlay.is_visible and not self._open_completions():
+            inp.insert("\t")
             return
-        if self._open_completions():
+        if self._fill_common_prefix():
             return
-        inp.insert("\t")
+        self._preview_next()
 
     def action_complete_next(self) -> None:
-        """Ctrl+N: highlight the next match, opening the dropdown if it is closed."""
+        """Ctrl+N: preview the next match, opening the dropdown if it is closed (vim ``<C-n>``)."""
         if not self._chat_input.has_focus:
             return
+        if self._completion_overlay.is_visible or self._open_completions():
+            self._preview_next()
+
+    def action_complete_prev(self) -> None:
+        """Ctrl+P: preview the previous match, opening the dropdown if it is closed."""
+        if not self._chat_input.has_focus:
+            return
+        if self._completion_overlay.is_visible or self._open_completions():
+            self._preview_prev()
+
+    def _preview_next(self) -> None:
+        """Preview the highlighted match if none is previewed yet, else step forward."""
         overlay = self._completion_overlay
-        if overlay.is_visible:
-            overlay.cycle_next()
+        if self._chat_input.value == self._completion_origin:
+            display = overlay.get_current()
         else:
-            self._open_completions()
+            display = overlay.cycle_next()
+        if display is not None:
+            self._preview_completion(display)
+
+    def _preview_prev(self) -> None:
+        """Step the highlight backward (wrapping to the last match) and preview it."""
+        display = self._completion_overlay.cycle_prev()
+        if display is not None:
+            self._preview_completion(display)
 
     def _open_completions(self) -> bool:
-        """Show the dropdown for the current input without rewriting it; True if shown."""
+        """Show the dropdown for the current input and remember it as the origin."""
         options = get_completions(self._chat_input.value)
         if not options:
             return False
+        self._completion_origin = self._chat_input.value
         self._completion_overlay.show_completions(options)
         return True
 
-    def action_complete_prev(self) -> None:
-        """Ctrl+P: highlight the previous match, opening the dropdown if it is closed."""
-        if not self._chat_input.has_focus:
+    def _completion_value(self, display: str) -> str:
+        """Full input text produced by accepting ``display``, keeping the typed prefix.
+
+        Path completions are basenames, so the directory the user already
+        typed (``~/``, ``./``, absolute) is preserved and only the final
+        segment is replaced.
+        """
+        text = (
+            self._completion_origin
+            if self._completion_origin is not None
+            else (self._chat_input.value)
+        )
+        if " " not in text:
+            return display
+        cmd, _, partial = text.partition(" ")
+        if cmd.lower() == "/add":
+            head = partial[: partial.rfind("/") + 1]
+            return f"{cmd} {head}{display}"
+        return f"{cmd} {display}"
+
+    def _set_input(self, value: str) -> None:
+        """Replace the input value without triggering the live-refresh of the dropdown."""
+        inp = self._chat_input
+        if inp.value == value:
             return
+        # The setter posts Changed asynchronously; flag one event to ignore so
+        # the previewed candidate doesn't re-filter (and collapse) the dropdown.
+        # (The value setter already moves the cursor to the end.)
+        self._suppress_refresh += 1
+        inp.value = value
+
+    def _preview_completion(self, display: str) -> None:
+        """Write the highlighted candidate into the input, leaving the dropdown open."""
+        self._set_input(self._completion_value(display))
+
+    def _fill_common_prefix(self) -> bool:
+        """Extend the input to the longest prefix shared by all matches; True if it grew."""
         overlay = self._completion_overlay
-        # Opening on Ctrl+P lands on the last match; an already-open overlay
-        # just steps the highlight back.
-        if overlay.is_visible or self._open_completions():
-            overlay.cycle_prev()
+        values = [self._completion_value(d) for d in overlay.options]
+        shared = longest_common_prefix(values)
+        if len(shared) <= len(self._chat_input.value):
+            return False
+        self._set_input(shared)
+        # Re-filter for the newly completed prefix (descends into a directory,
+        # narrows the model list, etc.).
+        self._refresh_completion_overlay()
+        return True
 
     def action_history_prev(self) -> None:
         """Up arrow: cycle the dropdown if visible, else recall previous history entry."""
@@ -1427,7 +1503,7 @@ class ChatScreen(Screen[None]):
         # (vim/Emacs-style) rather than recalling history.
         overlay = self._completion_overlay
         if overlay.is_visible:
-            overlay.cycle_prev()
+            self._preview_prev()
             return
         if not self._input_history:
             raise SkipAction()
@@ -1450,7 +1526,7 @@ class ChatScreen(Screen[None]):
         # When the completion dropdown is up, Down navigates the dropdown.
         overlay = self._completion_overlay
         if overlay.is_visible:
-            overlay.cycle_next()
+            self._preview_next()
             return
         if self._history_index == -1:
             raise SkipAction()
@@ -1465,9 +1541,10 @@ class ChatScreen(Screen[None]):
     @on(ChatInput.Changed, "#chat-input")
     def _on_chat_input_changed(self, event: ChatInput.Changed) -> None:
         """Refresh arg-hint and auto-show or hide the completion dropdown."""
-        if self._completing:
-            # An accept is mid-flight rewriting the input; it manages the
-            # overlay itself, so skip the live refresh for this change.
+        if self._suppress_refresh > 0:
+            # A programmatic edit (preview / accept / revert) is managing the
+            # overlay itself; consume one Changed and skip the live refresh.
+            self._suppress_refresh -= 1
             self._refresh_arg_hint()
             return
         self._refresh_completion_overlay()
@@ -1476,11 +1553,14 @@ class ChatScreen(Screen[None]):
     def _refresh_completion_overlay(self) -> None:
         """Live-filter the dropdown against the current input, in command and arg modes alike."""
         overlay = self._completion_overlay
-        options = get_completions(self._chat_input.value)
+        text = self._chat_input.value
+        options = get_completions(text)
         if options:
+            self._completion_origin = text
             overlay.show_completions(options)
         elif overlay.is_visible:
             overlay.hide()
+            self._completion_origin = None
 
     def _refresh_arg_hint(self) -> None:
         """Push the current input value into the ArgHintLine."""

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -50,16 +50,20 @@ def get_completions(text: str) -> list[str]:
 
 
 def _get_arg_completions(cmd: str, partial: str) -> list[str]:
-    """Get argument completions for a specific command."""
+    """Get argument completions for a specific command.
+
+    Drops the option that exactly equals what the user has typed so a
+    fully-typed argument collapses the dropdown and lets Enter submit,
+    mirroring the command-discovery rule for slash commands.
+    """
     sources = _ARG_SOURCES.get(cmd)
     if sources is None:
         return []
-    if cmd == "/add":
-        return _path_options(partial)
-    options = sources()
+    options = _path_options(partial) if cmd == "/add" else sources()
     if partial:
-        return [o for o in options if o.lower().startswith(partial.lower())]
-    return options
+        low = partial.lower()
+        options = [o for o in options if o.lower().startswith(low)]
+    return [o for o in options if o.lower() != partial.lower()]
 
 
 def _model_options() -> list[str]:

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -59,10 +59,16 @@ def _get_arg_completions(cmd: str, partial: str) -> list[str]:
     sources = _ARG_SOURCES.get(cmd)
     if sources is None:
         return []
-    options = _path_options(partial) if cmd == "/add" else sources()
-    if partial:
-        low = partial.lower()
-        options = [o for o in options if o.lower().startswith(low)]
+    if cmd == "/add":
+        # _path_options already prefix-filters against the basename and returns
+        # bare segment names (not the typed prefix), so the generic startswith
+        # filter below would wrongly wipe them.
+        options = _path_options(partial)
+    else:
+        options = sources()
+        if partial:
+            low = partial.lower()
+            options = [o for o in options if o.lower().startswith(low)]
     return [o for o in options if o.lower() != partial.lower()]
 
 
@@ -105,9 +111,11 @@ def _theme_options() -> list[str]:
 
 
 def _path_options(partial: str = "") -> list[str]:
-    """Return filesystem completions for a partial path.
-    Handles relative paths, absolute paths, and ~ expansion.
-    Directories get a trailing / so the user knows to keep typing.
+    """Return basename completions for the path segment being typed.
+
+    Handles relative paths, absolute paths, and ~ expansion. Only the final
+    segment is returned (the caller keeps whatever prefix the user typed, so
+    ``~/`` stays ``~/``); directories get a trailing ``/`` to invite descent.
     """
     try:
         expanded = Path(partial).expanduser() if partial else Path(".")
@@ -127,16 +135,24 @@ def _path_options(partial: str = "") -> list[str]:
                 continue
             if prefix and not p.name.lower().startswith(prefix):
                 continue
-            display = str(p) if partial and Path(partial) != Path(".") else p.name
-            if p.is_dir():
-                display = display.rstrip("/") + "/"
-            results.append(display)
+            results.append(p.name + "/" if p.is_dir() else p.name)
             if len(results) >= _MAX_PATH_COMPLETIONS:
                 break
         return results
     except Exception:
         log.debug("Failed to list paths for autocomplete", exc_info=True)
         return []
+
+
+def longest_common_prefix(values: list[str]) -> str:
+    """Return the longest string that prefixes every value (``""`` if none)."""
+    if not values:
+        return ""
+    shortest = min(values, key=len)
+    for i, ch in enumerate(shortest):
+        if any(v[i] != ch for v in values):
+            return shortest[:i]
+    return shortest
 
 
 _ARG_SOURCES: dict[str, Callable[[], list[str]]] = {
@@ -203,6 +219,11 @@ class CompletionOverlay(Vertical):
         if not self._options or self._index >= len(self._options):
             return None
         return self._options[self._index]
+
+    @property
+    def options(self) -> list[str]:
+        """The currently shown completion options."""
+        return list(self._options)
 
     def hide(self) -> None:
         """Hide the overlay."""

--- a/src/lilbee/cli/tui/widgets/autocomplete.tcss
+++ b/src/lilbee/cli/tui/widgets/autocomplete.tcss
@@ -1,9 +1,7 @@
 CompletionOverlay {
-    dock: bottom;
     height: auto;
     max-height: 10;
-    layer: overlay;
-    offset-y: -3;
+    width: 100%;
     background: $surface;
     border: tall $primary;
     display: none;

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3365,56 +3365,69 @@ async def test_chat_action_complete_no_options_inserts_tab():
         assert inp.value == "hello\t"
 
 
-async def test_chat_action_complete_with_options():
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        inp = app.screen.query_one("#chat-input", ChatInput)
-        inp.value = "/he"
-        with patch(
-            "lilbee.cli.tui.screens.chat.get_completions",
-            return_value=["/help"],
-        ):
-            app.screen.action_complete()
-            assert inp.value == "/help"
-
-
-async def test_chat_action_complete_with_space():
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        inp = app.screen.query_one("#chat-input", ChatInput)
-        inp.value = "/model q"
-        with patch(
-            "lilbee.cli.tui.screens.chat.get_completions",
-            return_value=["qwen:latest"],
-        ):
-            app.screen.action_complete()
-            assert inp.value == "/model qwen:latest"
-
-
-async def test_chat_action_complete_cycle():
+async def test_chat_action_complete_opens_then_accepts():
+    """Tab opens the dropdown without rewriting the input, then accepts on the next press."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
         inp = app.screen.query_one("#chat-input", ChatInput)
         overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
-
         inp.value = "/he"
         with patch(
             "lilbee.cli.tui.screens.chat.get_completions",
             return_value=["/help"],
         ):
             app.screen.action_complete()
+            assert overlay.is_visible
+            assert inp.value == "/he"
+            app.screen.action_complete()
+            assert inp.value == "/help "
+            assert not overlay.is_visible
 
-        if overlay.is_visible:
-            inp.value = "/model "
-            with patch.object(overlay, "cycle_next", return_value="qwen:latest"):
-                app.screen.action_complete()
-                assert "qwen:latest" in inp.value
+
+async def test_chat_action_complete_with_space_opens_then_accepts():
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        inp = app.screen.query_one("#chat-input", ChatInput)
+        overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
+        inp.value = "/model q"
+        with patch(
+            "lilbee.cli.tui.screens.chat.get_completions",
+            return_value=["qwen:latest"],
+        ):
+            app.screen.action_complete()
+            assert overlay.is_visible
+            assert inp.value == "/model q"
+            app.screen.action_complete()
+            assert inp.value == "/model qwen:latest "
+
+
+async def test_chat_action_complete_accepts_highlighted_after_nav():
+    """Ctrl+N moves the highlight; Tab then accepts the highlighted option."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        inp = app.screen.query_one("#chat-input", ChatInput)
+        overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
+        inp.value = "/model "
+        with patch(
+            "lilbee.cli.tui.screens.chat.get_completions",
+            return_value=["qwen:8b", "mistral:7b"],
+        ):
+            app.screen.action_complete()
+            assert overlay.is_visible
+            app.screen.action_complete_next()
+            assert overlay.get_current() == "mistral:7b"
+            app.screen.action_complete()
+            assert inp.value == "/model mistral:7b "
 
 
 async def test_chat_tab_completes_alias_prefix():
-    """Pressing Tab on '/cat' expands to the /catalog alias."""
+    """Pressing Tab on '/cat' accepts the /catalog alias (with a trailing space)."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         inp = app.screen.query_one("#chat-input", ChatInput)
@@ -3425,10 +3438,11 @@ async def test_chat_tab_completes_alias_prefix():
         assert inp.value == "/cat"
         await pilot.press("tab")
         await pilot.pause()
-        assert inp.value == "/catalog"
+        assert inp.value == "/catalog "
 
 
-async def test_chat_action_complete_cycle_no_selection():
+async def test_chat_action_complete_no_highlight_leaves_input():
+    """Tab on a visible overlay with no highlighted option leaves the input untouched."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -3437,10 +3451,12 @@ async def test_chat_action_complete_cycle_no_selection():
         overlay.show_completions(["a", "b"])
 
         inp = app.screen.query_one("#chat-input", ChatInput)
+        inp.focus()
         original = inp.value
-        with patch.object(overlay, "cycle_next", return_value=None):
+        with patch.object(overlay, "get_current", return_value=None):
             app.screen.action_complete()
             assert inp.value == original
+            assert not overlay.is_visible
 
 
 async def test_chat_send_message():
@@ -7371,17 +7387,21 @@ async def test_chat_sync_gating_rejects_sync():
 
 
 async def test_chat_action_complete_next():
-    """Ctrl+N (action_complete_next) delegates to action_complete."""
+    """Ctrl+N opens the dropdown on the current input without rewriting it."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
         inp = app.screen.query_one("#chat-input", ChatInput)
+        overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
         inp.value = "/he"
         with patch(
             "lilbee.cli.tui.screens.chat.get_completions",
             return_value=["/help"],
         ):
             app.screen.action_complete_next()
-            assert inp.value == "/help"
+            assert overlay.is_visible
+            assert inp.value == "/he"
 
 
 async def test_chat_action_complete_next_noop_when_input_unfocused():
@@ -7403,7 +7423,7 @@ async def test_chat_action_complete_next_noop_when_input_unfocused():
 
 
 async def test_chat_action_complete_prev_opens_overlay():
-    """Ctrl+P (action_complete_prev) opens overlay when not visible."""
+    """Ctrl+P opens the dropdown when closed without rewriting the input."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -7417,7 +7437,7 @@ async def test_chat_action_complete_prev_opens_overlay():
         ):
             app.screen.action_complete_prev()
             assert overlay.is_visible
-            assert inp.value == "/help"
+            assert inp.value == "/he"
 
 
 async def test_chat_action_complete_prev_cycles_backward():
@@ -7444,17 +7464,21 @@ async def test_chat_action_complete_prev_cycles_backward():
 
 
 async def test_chat_action_complete_prev_with_space():
-    """Ctrl+P with argument completions sets cmd + selection."""
+    """Ctrl+P in arg mode opens the dropdown without rewriting the input."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
         inp = app.screen.query_one("#chat-input", ChatInput)
+        overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
         inp.value = "/model q"
         with patch(
             "lilbee.cli.tui.screens.chat.get_completions",
             return_value=["qwen:latest", "qwen:8b"],
         ):
             app.screen.action_complete_prev()
-            assert "qwen" in inp.value
+            assert overlay.is_visible
+            assert inp.value == "/model q"
 
 
 async def test_app_switch_to_tasks():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3365,69 +3365,68 @@ async def test_chat_action_complete_no_options_inserts_tab():
         assert inp.value == "hello\t"
 
 
-async def test_chat_action_complete_opens_then_accepts():
-    """Tab opens the dropdown without rewriting the input, then accepts on the next press."""
+async def test_chat_action_complete_fills_prefix():
+    """Tab completes the longest shared prefix straight to a unique match."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
-
         inp = app.screen.query_one("#chat-input", ChatInput)
-        overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
         inp.value = "/he"
         with patch(
             "lilbee.cli.tui.screens.chat.get_completions",
             return_value=["/help"],
         ):
             app.screen.action_complete()
-            assert overlay.is_visible
-            assert inp.value == "/he"
-            app.screen.action_complete()
-            assert inp.value == "/help "
-            assert not overlay.is_visible
+            assert inp.value == "/help"
 
 
-async def test_chat_action_complete_with_space_opens_then_accepts():
+async def test_chat_action_complete_with_space_fills_prefix():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
-
         inp = app.screen.query_one("#chat-input", ChatInput)
-        overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
         inp.value = "/model q"
         with patch(
             "lilbee.cli.tui.screens.chat.get_completions",
             return_value=["qwen:latest"],
         ):
             app.screen.action_complete()
-            assert overlay.is_visible
-            assert inp.value == "/model q"
-            app.screen.action_complete()
-            assert inp.value == "/model qwen:latest "
+            assert inp.value == "/model qwen:latest"
 
 
-async def test_chat_action_complete_accepts_highlighted_after_nav():
-    """Ctrl+N moves the highlight; Tab then accepts the highlighted option."""
+async def test_chat_action_complete_previews_then_steps():
+    """With no further shared prefix, Tab previews the first match and Ctrl+N steps on."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
-        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
-
         inp = app.screen.query_one("#chat-input", ChatInput)
-        overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
         inp.value = "/model "
         with patch(
             "lilbee.cli.tui.screens.chat.get_completions",
             return_value=["qwen:8b", "mistral:7b"],
         ):
             app.screen.action_complete()
-            assert overlay.is_visible
+            assert inp.value == "/model qwen:8b"
             app.screen.action_complete_next()
-            assert overlay.get_current() == "mistral:7b"
-            app.screen.action_complete()
-            assert inp.value == "/model mistral:7b "
+            assert inp.value == "/model mistral:7b"
+
+
+async def test_chat_preview_same_single_match_is_noop():
+    """Re-previewing the only match (Ctrl+N wrapping to it) leaves the input unchanged."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        inp = app.screen.query_one("#chat-input", ChatInput)
+        inp.value = "/he"
+        with patch(
+            "lilbee.cli.tui.screens.chat.get_completions",
+            return_value=["/help"],
+        ):
+            app.screen.action_complete_next()
+            assert inp.value == "/help"
+            # Wrapping back onto the same single match is a no-op set.
+            app.screen.action_complete_next()
+            assert inp.value == "/help"
 
 
 async def test_chat_tab_completes_alias_prefix():
-    """Pressing Tab on '/cat' accepts the /catalog alias (with a trailing space)."""
+    """Pressing Tab on '/cat' completes the /catalog alias."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         inp = app.screen.query_one("#chat-input", ChatInput)
@@ -3438,25 +3437,21 @@ async def test_chat_tab_completes_alias_prefix():
         assert inp.value == "/cat"
         await pilot.press("tab")
         await pilot.pause()
-        assert inp.value == "/catalog "
+        assert inp.value == "/catalog"
 
 
-async def test_chat_action_complete_no_highlight_leaves_input():
-    """Tab on a visible overlay with no highlighted option leaves the input untouched."""
+async def test_chat_accept_on_enter_with_no_highlight_hides():
+    """Enter on a visible overlay whose highlight is None hides it and falls through to submit."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
         overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
         overlay.show_completions(["a", "b"])
-
-        inp = app.screen.query_one("#chat-input", ChatInput)
-        inp.focus()
-        original = inp.value
         with patch.object(overlay, "get_current", return_value=None):
-            app.screen.action_complete()
-            assert inp.value == original
-            assert not overlay.is_visible
+            consumed = app.screen._accept_overlay_selection_on_enter()
+        assert consumed is False
+        assert not overlay.is_visible
 
 
 async def test_chat_send_message():
@@ -7387,7 +7382,7 @@ async def test_chat_sync_gating_rejects_sync():
 
 
 async def test_chat_action_complete_next():
-    """Ctrl+N opens the dropdown on the current input without rewriting it."""
+    """Ctrl+N opens the dropdown and previews the first match into the input."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -7401,7 +7396,7 @@ async def test_chat_action_complete_next():
         ):
             app.screen.action_complete_next()
             assert overlay.is_visible
-            assert inp.value == "/he"
+            assert inp.value == "/help"
 
 
 async def test_chat_action_complete_next_noop_when_input_unfocused():
@@ -7423,7 +7418,7 @@ async def test_chat_action_complete_next_noop_when_input_unfocused():
 
 
 async def test_chat_action_complete_prev_opens_overlay():
-    """Ctrl+P opens the dropdown when closed without rewriting the input."""
+    """Ctrl+P opens the dropdown when closed and previews the last match."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -7437,7 +7432,7 @@ async def test_chat_action_complete_prev_opens_overlay():
         ):
             app.screen.action_complete_prev()
             assert overlay.is_visible
-            assert inp.value == "/he"
+            assert inp.value == "/help"
 
 
 async def test_chat_action_complete_prev_cycles_backward():
@@ -7464,7 +7459,7 @@ async def test_chat_action_complete_prev_cycles_backward():
 
 
 async def test_chat_action_complete_prev_with_space():
-    """Ctrl+P in arg mode opens the dropdown without rewriting the input."""
+    """Ctrl+P in arg mode opens the dropdown and previews the last match."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -7478,7 +7473,7 @@ async def test_chat_action_complete_prev_with_space():
         ):
             app.screen.action_complete_prev()
             assert overlay.is_visible
-            assert inp.value == "/model q"
+            assert inp.value == "/model qwen:8b"
 
 
 async def test_app_switch_to_tasks():
@@ -10138,21 +10133,22 @@ async def test_chat_enter_normal_mode_while_streaming_drops_to_normal():
         assert app.screen._insert_mode is False
 
 
-async def test_chat_on_chat_input_changed_completing():
-    """_on_chat_input_changed is no-op when _completing is True."""
+async def test_chat_on_chat_input_changed_suppressed():
+    """A suppressed Changed (programmatic edit) skips the live refresh and is consumed."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
         overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
         overlay.show_completions(["/help"])
-        app.screen._completing = True
+        app.screen._suppress_refresh = 1
 
         inp = app.screen.query_one("#chat-input", ChatInput)
         inp.value = "/test"
         await pilot.pause()
-        # Overlay should still be visible since _completing skips hide
+        # The overlay stays as-is (refresh skipped) and the counter is consumed.
         assert overlay.is_visible
+        assert app.screen._suppress_refresh == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_slash_discoverability.py
+++ b/tests/test_tui_slash_discoverability.py
@@ -632,10 +632,10 @@ class TestDiscoveryBindingsAsync:
 
 
 class TestDropdownNavigationAsync:
-    """Ctrl+N / Ctrl+P / Down / Up cycle the visible dropdown without
-    disturbing the input value or collapsing the option list."""
+    """Ctrl+N / Ctrl+P / Down / Up preview matches into the input (vim
+    ``<C-n>`` insert-completion) while the dropdown stays open; Esc reverts."""
 
-    async def test_ctrl_n_moves_highlight_without_touching_input(
+    async def test_ctrl_n_previews_first_then_steps_forward(
         self, _mock_resolve, _mock_services
     ) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -654,14 +654,17 @@ class TestDropdownNavigationAsync:
             first = overlay.get_current()
             await pilot.press("ctrl+n")
             await pilot.pause()
-            second = overlay.get_current()
-            # Input is untouched; highlight moved to the next option;
-            # dropdown stays open with the same option list.
-            assert inp.value == "/"
+            # First Ctrl+N previews the highlighted (first) command; for a
+            # command the previewed value is the command name itself.
+            assert inp.value == first
             assert overlay.is_visible
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+            second = overlay.get_current()
             assert second != first
+            assert inp.value == second
 
-    async def test_ctrl_p_moves_highlight_back(self, _mock_resolve, _mock_services) -> None:
+    async def test_ctrl_p_steps_back_and_previews(self, _mock_resolve, _mock_services) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
         app = _ChatHostApp()
@@ -674,18 +677,17 @@ class TestDropdownNavigationAsync:
             overlay = screen.query_one("#completion-overlay", CompletionOverlay)
             inp.value = "/"
             await pilot.pause()
-            first = overlay.get_current()
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+            first = inp.value
             await pilot.press("ctrl+n")
             await pilot.pause()
             await pilot.press("ctrl+p")
             await pilot.pause()
-            assert overlay.get_current() == first
-            assert inp.value == "/"
+            assert inp.value == first
             assert overlay.is_visible
 
-    async def test_down_navigates_dropdown_when_visible(
-        self, _mock_resolve, _mock_services
-    ) -> None:
+    async def test_down_previews_into_input(self, _mock_resolve, _mock_services) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
         app = _ChatHostApp()
@@ -701,9 +703,31 @@ class TestDropdownNavigationAsync:
             first = overlay.get_current()
             await pilot.press("down")
             await pilot.pause()
-            assert overlay.get_current() != first
-            assert inp.value == "/"
+            assert inp.value == first
+            assert inp.value != "/"
             assert overlay.is_visible
+
+    async def test_esc_reverts_previewed_candidate(self, _mock_resolve, _mock_services) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            inp = screen.query_one("#chat-input")
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            inp.value = "/"
+            await pilot.pause()
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+            assert inp.value != "/"
+            await pilot.press("escape")
+            await pilot.pause()
+            # Esc restores exactly what the user had typed and closes the menu.
+            assert inp.value == "/"
+            assert not overlay.is_visible
 
     async def test_ctrl_p_opens_palette_when_overlay_hidden(
         self, _mock_resolve, _mock_services
@@ -723,7 +747,7 @@ class TestDropdownNavigationAsync:
                 await pilot.pause()
             palette.assert_called_once()
 
-    async def test_up_navigates_dropdown_when_visible(self, _mock_resolve, _mock_services) -> None:
+    async def test_up_steps_back_and_previews(self, _mock_resolve, _mock_services) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
         app = _ChatHostApp()
@@ -738,11 +762,12 @@ class TestDropdownNavigationAsync:
             await pilot.pause()
             await pilot.press("down")
             await pilot.pause()
-            mid = overlay.get_current()
+            await pilot.press("down")
+            await pilot.pause()
+            stepped = inp.value
             await pilot.press("up")
             await pilot.pause()
-            assert overlay.get_current() != mid
-            assert inp.value == "/"
+            assert inp.value != stepped
             assert overlay.is_visible
 
 
@@ -769,10 +794,11 @@ class TestEnterAcceptsHighlightAsync:
             assert highlighted is not None and highlighted.startswith("/")
             await pilot.press("enter")
             await pilot.pause()
-            # Input now holds "<command> " (trailing space invites args), and
-            # the message was NOT submitted because Enter was consumed by the
-            # accept-on-overlay path.
-            assert inp.value == f"{highlighted} "
+            # Enter fills the highlighted command (nothing was previewed yet)
+            # and is consumed, so the message is NOT submitted; a second Enter
+            # would submit.
+            assert inp.value == highlighted
+            assert not overlay.is_visible
 
     async def test_enter_submits_when_selection_matches_input(
         self, _mock_resolve, _mock_services
@@ -957,9 +983,7 @@ class TestArgCompletionsLiveFilterAsync:
                 await pilot.pause()
                 assert not overlay.is_visible
 
-    async def test_ctrl_n_in_arg_mode_is_highlight_only(
-        self, _mock_resolve, _mock_services
-    ) -> None:
+    async def test_ctrl_n_in_arg_mode_previews_model(self, _mock_resolve, _mock_services) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
         app = _ChatHostApp()
@@ -978,11 +1002,14 @@ class TestArgCompletionsLiveFilterAsync:
                 first = overlay.get_current()
                 await pilot.press("ctrl+n")
                 await pilot.pause()
-                # Highlight advanced; the input the user typed is untouched.
-                assert overlay.get_current() != first
-                assert inp.value == "/model "
+                # Ctrl+N previews the highlighted model into the input,
+                # preserving the "/model " prefix, and the menu stays open.
+                assert inp.value == f"/model {first}"
+                assert overlay.is_visible
 
-    async def test_tab_in_arg_mode_accepts_highlight(self, _mock_resolve, _mock_services) -> None:
+    async def test_tab_in_arg_mode_completes_unique_model(
+        self, _mock_resolve, _mock_services
+    ) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
         app = _ChatHostApp()
@@ -998,19 +1025,19 @@ class TestArgCompletionsLiveFilterAsync:
             ):
                 inp.value = "/model qw"
                 await pilot.pause()
-                highlighted = overlay.get_current()
-                assert highlighted == "qwen3:8b"
+                # "qw" matches only qwen3:8b; Tab fills the shared (full) prefix,
+                # which then collapses the now fully-typed dropdown.
                 await pilot.press("tab")
                 await pilot.pause()
-                assert inp.value == f"/model {highlighted} "
+                assert inp.value == "/model qwen3:8b"
                 assert not overlay.is_visible
 
 
 class TestCompletionOpenAndAcceptAsync:
-    """Opening a closed dropdown leaves the typed text intact; accepting a
+    """Opening a closed dropdown previews the first match; accepting a
     directory keeps the cursor on the slash so the user can keep descending."""
 
-    async def test_tab_opens_closed_overlay_without_mutation(
+    async def test_tab_opens_closed_overlay_and_previews_first(
         self, _mock_resolve, _mock_services
     ) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -1031,9 +1058,11 @@ class TestCompletionOpenAndAcceptAsync:
             await pilot.press("tab")
             await pilot.pause()
             assert overlay.is_visible
-            assert inp.value == "/"
+            # Commands share only "/", so Tab previews the first match.
+            assert inp.value == overlay.get_current()
+            assert inp.value != "/"
 
-    async def test_ctrl_n_opens_closed_overlay_without_mutation(
+    async def test_ctrl_n_opens_closed_overlay_and_previews_first(
         self, _mock_resolve, _mock_services
     ) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -1054,7 +1083,8 @@ class TestCompletionOpenAndAcceptAsync:
             await pilot.press("ctrl+n")
             await pilot.pause()
             assert overlay.is_visible
-            assert inp.value == "/"
+            assert inp.value == overlay.get_current()
+            assert inp.value != "/"
 
     async def test_directory_accept_omits_trailing_space(
         self, _mock_resolve, _mock_services

--- a/tests/test_tui_slash_discoverability.py
+++ b/tests/test_tui_slash_discoverability.py
@@ -880,12 +880,37 @@ class TestOverlayBackoutAsync:
             assert screen._insert_mode is False
 
 
-class TestArgCompletionsNotAutoShownAsync:
-    """Once the user has entered arg-completion mode (typed a space), the
-    overlay must NOT auto-show. Paths and other long lists are intrusive
-    and should stay Tab-triggered."""
+_LIVE_FILTER_MODELS = ["qwen3:8b", "mistral:7b"]
 
-    async def test_typing_arg_partial_does_not_auto_show(
+
+class TestArgCompletionsLiveFilterAsync:
+    """Argument completion (after the space) auto-shows and re-filters on
+    every keystroke, just like command discovery. A fully-typed argument
+    collapses the dropdown so Enter submits."""
+
+    _MODELS = _LIVE_FILTER_MODELS
+
+    async def test_typing_arg_partial_auto_shows(self, _mock_resolve, _mock_services) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            inp = screen.query_one("#chat-input")
+            with mock.patch(
+                "lilbee.modelhub.models.list_installed_models", return_value=self._MODELS
+            ):
+                # Land in arg-completion mode without going through any Tab.
+                inp.value = "/model "
+                await pilot.pause()
+                assert overlay.is_visible
+                assert set(overlay._options) == set(self._MODELS)
+
+    async def test_arg_overlay_filters_live_as_user_types(
         self, _mock_resolve, _mock_services
     ) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -898,7 +923,160 @@ class TestArgCompletionsNotAutoShownAsync:
             assert isinstance(screen, ChatScreen)
             overlay = screen.query_one("#completion-overlay", CompletionOverlay)
             inp = screen.query_one("#chat-input")
-            # Land in arg-completion mode without going through any Tab.
+            with mock.patch(
+                "lilbee.modelhub.models.list_installed_models", return_value=self._MODELS
+            ):
+                inp.value = "/model "
+                await pilot.pause()
+                full = list(overlay._options)
+                inp.value = "/model qw"
+                await pilot.pause()
+                assert overlay.is_visible
+                assert overlay._options == ["qwen3:8b"]
+                assert len(overlay._options) < len(full)
+
+    async def test_fully_typed_arg_collapses_overlay(self, _mock_resolve, _mock_services) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            inp = screen.query_one("#chat-input")
+            with mock.patch(
+                "lilbee.modelhub.models.list_installed_models", return_value=self._MODELS
+            ):
+                inp.value = "/model qw"
+                await pilot.pause()
+                assert overlay.is_visible
+                # Typing the option in full leaves nothing left to complete.
+                inp.value = "/model qwen3:8b"
+                await pilot.pause()
+                assert not overlay.is_visible
+
+    async def test_ctrl_n_in_arg_mode_is_highlight_only(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            inp = screen.query_one("#chat-input")
+            with mock.patch(
+                "lilbee.modelhub.models.list_installed_models", return_value=self._MODELS
+            ):
+                inp.value = "/model "
+                await pilot.pause()
+                first = overlay.get_current()
+                await pilot.press("ctrl+n")
+                await pilot.pause()
+                # Highlight advanced; the input the user typed is untouched.
+                assert overlay.get_current() != first
+                assert inp.value == "/model "
+
+    async def test_tab_in_arg_mode_accepts_highlight(self, _mock_resolve, _mock_services) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            inp = screen.query_one("#chat-input")
+            with mock.patch(
+                "lilbee.modelhub.models.list_installed_models", return_value=self._MODELS
+            ):
+                inp.value = "/model qw"
+                await pilot.pause()
+                highlighted = overlay.get_current()
+                assert highlighted == "qwen3:8b"
+                await pilot.press("tab")
+                await pilot.pause()
+                assert inp.value == f"/model {highlighted} "
+                assert not overlay.is_visible
+
+
+class TestCompletionOpenAndAcceptAsync:
+    """Opening a closed dropdown leaves the typed text intact; accepting a
+    directory keeps the cursor on the slash so the user can keep descending."""
+
+    async def test_tab_opens_closed_overlay_without_mutation(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            inp = screen.query_one("#chat-input")
+            inp.value = "/"
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert not overlay.is_visible
+            await pilot.press("tab")
+            await pilot.pause()
+            assert overlay.is_visible
+            assert inp.value == "/"
+
+    async def test_ctrl_n_opens_closed_overlay_without_mutation(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            inp = screen.query_one("#chat-input")
+            inp.value = "/"
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert not overlay.is_visible
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+            assert overlay.is_visible
+            assert inp.value == "/"
+
+    async def test_directory_accept_omits_trailing_space(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            inp = screen.query_one("#chat-input")
             inp.value = "/add "
             await pilot.pause()
+            # Pin a directory option so the assertion doesn't depend on cwd.
+            overlay.show_completions(["mydir/"])
+            await pilot.pause()
+            await pilot.press("tab")
+            await pilot.pause()
+            # No trailing space after a directory so the user can keep typing
+            # the next path segment.
+            assert inp.value == "/add mydir/"
             assert not overlay.is_visible

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2415,7 +2415,9 @@ class TestGetCompletions:
         d = P(str(tmp_path))
         (d / "alpha.txt").touch()
         (d / "subdir").mkdir()
+        # POSIX expanduser reads HOME; Windows reads USERPROFILE.
         monkeypatch.setenv("HOME", str(d))
+        monkeypatch.setenv("USERPROFILE", str(d))
         r = get_completions("/add ~/")
         assert any("alpha.txt" in x for x in r)
         assert any("subdir/" in x for x in r)

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2405,6 +2405,61 @@ class TestGetCompletions:
         r = get_completions(f"/add {d}/")
         assert any("testfile.txt" in x for x in r)
 
+    def test_add_tilde_completions_not_filtered_out(self, tmp_path, monkeypatch) -> None:
+        """Regression: ``~/`` expands to absolute paths that do not start with
+        the raw ``~/`` partial, so the arg filter must not wipe them."""
+        from pathlib import Path as P
+
+        from lilbee.cli.tui.widgets.autocomplete import get_completions
+
+        d = P(str(tmp_path))
+        (d / "alpha.txt").touch()
+        (d / "subdir").mkdir()
+        monkeypatch.setenv("HOME", str(d))
+        r = get_completions("/add ~/")
+        assert any("alpha.txt" in x for x in r)
+        assert any("subdir/" in x for x in r)
+
+    def test_add_relative_dot_completions_not_filtered_out(self, tmp_path, monkeypatch) -> None:
+        """Regression: ``./`` lists entries by basename, which don't start with
+        ``./``; the arg filter must not wipe them."""
+        from pathlib import Path as P
+
+        from lilbee.cli.tui.widgets.autocomplete import get_completions
+
+        d = P(str(tmp_path))
+        (d / "beta.txt").touch()
+        monkeypatch.chdir(d)
+        r = get_completions("/add ./")
+        assert any("beta.txt" in x for x in r)
+
+
+class TestLongestCommonPrefix:
+    def test_empty_list(self) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import longest_common_prefix
+
+        assert longest_common_prefix([]) == ""
+
+    def test_single_value(self) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import longest_common_prefix
+
+        assert longest_common_prefix(["/model qwen"]) == "/model qwen"
+
+    def test_shared_prefix(self) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import longest_common_prefix
+
+        assert longest_common_prefix(["/add Documents/", "/add Downloads/"]) == "/add Do"
+
+    def test_no_shared_prefix(self) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import longest_common_prefix
+
+        assert longest_common_prefix(["abc", "xyz"]) == ""
+
+    def test_prefix_is_full_shortest(self) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import longest_common_prefix
+
+        assert longest_common_prefix(["/add foo", "/add foobar"]) == "/add foo"
+
 
 class TestModelOptions:
     def test_returns_models(self) -> None:


### PR DESCRIPTION
## Problem

The chat input's completion dropdown only stayed responsive while you were still typing a slash-command name. The moment you hit space and moved into argument completion (model names, file paths, settings, themes), it stopped updating: it popped open once on Tab and then froze, so you couldn't refine it by typing. Navigation also rewrote your input as you cycled, clobbering what you'd typed.

## Solution

The dropdown now filters in place on every keystroke in every context, command and argument alike. Ctrl+N / Ctrl+P and the arrows move the highlight only, leaving your text intact, and Tab or Enter commits the highlighted option. A fully-typed argument collapses the dropdown so Enter submits, and accepting a directory keeps the cursor on the slash so you can keep descending a path.

Tests cover live argument filtering, highlight-only navigation, and commit-on-Tab.