### PR TITLE
Support running Ollama and LM Studio at the same time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,8 @@ All settings override via environment variables:
 - `LILBEE_TESSERACT_TIMEOUT`: wall-clock timeout in seconds for the Tesseract OCR fallback (default: `60`, `0` = no limit). Only runs when no vision model is available.
 - `LILBEE_SSE_HEARTBEAT_INTERVAL` — seconds between SSE heartbeat events when the producer queue is idle (default: `30`). Set to `0` to disable.
 - `LILBEE_LLM_PROVIDER` — provider: `auto` (default), `llama-cpp`, `remote` (requires `pip install lilbee[litellm]`)
-- `LILBEE_REMOTE_BASE_URL` — SDK backend endpoint (default: `http://localhost:11434`)
+- `LILBEE_OLLAMA_BASE_URL` — Ollama server URL (blank uses `http://localhost:11434`)
+- `LILBEE_LM_STUDIO_BASE_URL` — LM Studio server URL (blank uses `http://localhost:1234/v1`)
 - `LILBEE_DIVERSITY_MAX_PER_SOURCE` — max chunks per source in results (default: `3`)
 - `LILBEE_MMR_LAMBDA` — MMR relevance/diversity tradeoff, 0-1 (default: `0.5`)
 - `LILBEE_CANDIDATE_MULTIPLIER` — extra candidates for MMR reranking (default: `3`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -570,7 +570,8 @@ All settings are configurable via `LILBEE_*` environment variables, `config.toml
 | Setting | Default | Description | Caveats |
 |---------|---------|-------------|---------|
 | `LILBEE_LLM_PROVIDER` | `auto` | Backend selection: auto, llama-cpp, remote | auto = use the SDK backend if installed and reachable, otherwise llama-cpp |
-| `LILBEE_REMOTE_BASE_URL` | `http://localhost:11434` | SDK backend endpoint | |
+| `LILBEE_OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server URL (blank uses the default) | |
+| `LILBEE_LM_STUDIO_BASE_URL` | `http://localhost:1234/v1` | LM Studio server URL (blank uses the default) | |
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -838,7 +838,8 @@ adapter library name).
 
 ```bash
 export LILBEE_LLM_PROVIDER=auto          # "auto" routes between local and remote
-export LILBEE_REMOTE_BASE_URL=http://localhost:11434  # local backend URL
+export LILBEE_OLLAMA_BASE_URL=http://localhost:11434  # Ollama URL (blank = default)
+export LILBEE_LM_STUDIO_BASE_URL=http://localhost:1234/v1  # LM Studio URL (blank = default)
 export LILBEE_LLM_API_KEY=sk-...         # API key for your provider
 export LILBEE_CHAT_MODEL=your-model      # any remotely-supported model name
 ```

--- a/src/lilbee/app/models.py
+++ b/src/lilbee/app/models.py
@@ -214,15 +214,19 @@ def _collect_native_entries() -> list[ModelEntry]:
 def _collect_backend_entries() -> list[ModelEntry]:
     # heavy: lilbee.modelhub.model_manager (>50ms; huggingface_hub fanout)
     from lilbee.catalog.types import ModelSource
-    from lilbee.modelhub.model_manager import classify_remote_models
-    from lilbee.providers.local_servers import detect_local_server
+    from lilbee.modelhub.model_manager import classify_all_remote_models
+    from lilbee.providers.local_servers import local_server_for_label
 
-    server = detect_local_server(cfg.remote_base_url)
-    source = ModelSource(server.key) if server is not None else ModelSource.REMOTE
-    remote_list = classify_remote_models(cfg.remote_base_url, timeout=_BACKEND_LIST_TIMEOUT_S)
-    remote_by_name = {rm.name: rm for rm in remote_list}
+    def _source(remote: RemoteModel) -> ModelSource:
+        spec = local_server_for_label(remote.provider)
+        return ModelSource(spec.key) if spec is not None else ModelSource.REMOTE
+
+    remote_by_name = {
+        rm.name: rm for rm in classify_all_remote_models(timeout=_BACKEND_LIST_TIMEOUT_S)
+    }
     return [
-        ModelEntry.from_backend(ref, remote_by_name[ref], source) for ref in sorted(remote_by_name)
+        ModelEntry.from_backend(name, rm, _source(rm))
+        for name, rm in sorted(remote_by_name.items())
     ]
 
 

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -177,7 +177,7 @@ def get_services() -> Services:
     searcher = Searcher(cfg, provider, store, embedder, reranker, concepts)
     hf_client = HfClient()
     ingest_lock_registry = IngestLockRegistry()
-    model_manager = ModelManager(cfg.models_dir, cfg.remote_base_url)
+    model_manager = ModelManager(cfg.models_dir)
     crawler_semaphore = (
         asyncio.Semaphore(cfg.crawl_max_concurrent) if cfg.crawl_max_concurrent > 0 else None
     )

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -30,6 +30,7 @@ class SettingGroup(StrEnum):
     INGEST = "Ingest"
     WIKI = "Wiki"
     CRAWLING = "Crawling"
+    LOCAL_SERVERS = "Local-Servers"
     API_KEYS = "API-Keys"
     SYSTEM = "System"
     DISPLAY = "Display"
@@ -797,14 +798,17 @@ SETTINGS_MAP: dict[str, SettingDef] = {
             "Provider routing: auto picks the first key present; force a specific one when set"
         ),
     ),
-    "remote_base_url": SettingDef(
+    "ollama_base_url": SettingDef(
         str,
         nullable=False,
-        group=SettingGroup.API_KEYS,
-        help_text=(
-            "OpenAI-compatible base URL "
-            "(Ollama: http://localhost:11434, LM Studio: http://localhost:1234/v1)"
-        ),
+        group=SettingGroup.LOCAL_SERVERS,
+        help_text="Ollama server URL (blank uses http://localhost:11434)",
+    ),
+    "lm_studio_base_url": SettingDef(
+        str,
+        nullable=False,
+        group=SettingGroup.LOCAL_SERVERS,
+        help_text="LM Studio server URL (blank uses http://localhost:1234/v1)",
     ),
     "wiki_summary_max_tokens": SettingDef(
         int,

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -77,7 +77,7 @@ from lilbee.cli.tui.widgets.status_bar import ViewTabs
 from lilbee.cli.tui.widgets.task_bar import TaskBar
 from lilbee.cli.tui.widgets.top_bars import TopBars
 from lilbee.core.config import cfg
-from lilbee.modelhub.model_manager import RemoteModel, classify_remote_models
+from lilbee.modelhub.model_manager import RemoteModel, classify_all_remote_models
 from lilbee.providers.sdk_backend import get_provider_api_key
 from lilbee.runtime.hardware import available_memory_for_fit, compute_fit
 
@@ -708,7 +708,7 @@ class CatalogScreen(Screen[None]):
 
     @work(thread=True, name=_WORKER_FETCH_REMOTE)
     def _fetch_remote_models(self) -> list[RemoteModel]:
-        return classify_remote_models(cfg.remote_base_url)
+        return classify_all_remote_models()
 
     @work(thread=True, name=_WORKER_FETCH_FRONTIER, exit_on_error=False)
     def _fetch_frontier_models(self) -> list[FrontierCatalogRow]:

--- a/src/lilbee/cli/tui/screens/settings_widgets.py
+++ b/src/lilbee/cli/tui/screens/settings_widgets.py
@@ -192,6 +192,7 @@ def _wiki_enabled() -> bool:
 
 _FEATURE_GATED_GROUPS: dict[SettingGroup, Callable[[], bool]] = {
     SettingGroup.API_KEYS: _litellm_installed,
+    SettingGroup.LOCAL_SERVERS: _litellm_installed,
     SettingGroup.CRAWLING: _crawler_installed,
     SettingGroup.WIKI: _wiki_enabled,
 }

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -160,9 +160,9 @@ def _collect_remote_models(buckets: dict[ModelTask, list[ModelOption]], seen: se
     if not litellm_available():
         return
     try:
-        from lilbee.modelhub.model_manager import classify_remote_models
+        from lilbee.modelhub.model_manager import classify_all_remote_models
 
-        for model in classify_remote_models(cfg.remote_base_url):
+        for model in classify_all_remote_models():
             # Skip backend rows with a blank model name so the picker
             # doesn't render an empty " (Ollama)" row.
             if not model.name.strip():

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -132,7 +132,11 @@ class Config(BaseSettings):
     max_tokens: int | None = ConfigField(default=4096, ge=1, writable=True)
     seed: int | None = ConfigField(default=None, writable=True)
     llm_provider: str = ConfigField(default="auto", writable=True)
-    remote_base_url: str = ConfigField(default="http://localhost:11434", writable=True)
+    # Per-server local model-manager URLs. Blank means "use the server's spec
+    # default" (resolved in providers.local_servers.config_urls); the default
+    # URL literal lives only in the spec, which core must not import.
+    ollama_base_url: str = ConfigField(default="", writable=True)
+    lm_studio_base_url: str = ConfigField(default="", writable=True)
     llm_api_key: str = ConfigField(default="", writable=True, write_only=True)
     openrouter_api_key: str = ConfigField(default="", writable=True, write_only=True)
     gemini_api_key: str = ConfigField(default="", writable=True, write_only=True)
@@ -699,6 +703,12 @@ class Config(BaseSettings):
         from lilbee.providers.model_ref import parse_model_ref
 
         return parse_model_ref(v).for_openai_prefix()
+
+    @field_validator("ollama_base_url", "lm_studio_base_url", mode="after")
+    @classmethod
+    def _strip_trailing_slash(cls, v: str) -> str:
+        """Canonicalize a local-server URL once at the write boundary."""
+        return v.rstrip("/")
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/src/lilbee/modelhub/model_manager/__init__.py
+++ b/src/lilbee/modelhub/model_manager/__init__.py
@@ -2,6 +2,7 @@
 
 from lilbee.modelhub.model_manager.core import ModelManager
 from lilbee.modelhub.model_manager.discovery import (
+    classify_all_remote_models,
     classify_remote_models,
     detect_remote_embedding_models,
     discover_api_models,
@@ -26,6 +27,7 @@ __all__ = [
     "ValidationResult",
     "canonicalize_chat_model",
     "canonicalize_embedding_model",
+    "classify_all_remote_models",
     "classify_remote_models",
     "detect_remote_embedding_models",
     "discover_api_models",

--- a/src/lilbee/modelhub/model_manager/core.py
+++ b/src/lilbee/modelhub/model_manager/core.py
@@ -10,7 +10,7 @@ from lilbee.core.config import DEFAULT_HTTP_TIMEOUT
 from lilbee.core.security import validate_path_within
 from lilbee.modelhub.model_manager.types import ModelNotFoundError
 from lilbee.modelhub.registry import ModelRegistry
-from lilbee.providers.local_servers import LOCAL_SERVERS, detect_local_server
+from lilbee.providers.local_servers import LOCAL_SERVERS, local_server_for_key
 from lilbee.providers.model_ref import parse_model_ref
 
 log = logging.getLogger(__name__)
@@ -38,9 +38,8 @@ def _prefixed_source(model: str) -> ModelSource | None:
 class ModelManager:
     """Manages model lifecycle with distinct sources."""
 
-    def __init__(self, models_dir: Path, remote_base_url: str = "http://localhost:11434") -> None:
+    def __init__(self, models_dir: Path) -> None:
         self._models_dir = models_dir
-        self._remote_base_url = remote_base_url.rstrip("/")
         self._registry = ModelRegistry(self._models_dir)
         # Memoize list_installed results to avoid walking the registry
         # filesystem and hitting the backend HTTP endpoint on every call.
@@ -110,16 +109,16 @@ class ModelManager:
         return sorted(m.ref for m in self._registry.list_installed())
 
     def _list_remote(self) -> list[str]:
-        """List model names from the configured local server (Ollama or LM Studio).
+        """List model names across every configured local server (Ollama, LM Studio).
 
-        Reuses the discovery dispatch so the listing endpoint matches the
-        detected server (Ollama ``/api/tags`` vs LM Studio ``/v1/models``).
-        Returns ``[]`` when the backend is unreachable.
+        Reuses the discovery dispatch so each listing endpoint matches its
+        server (Ollama ``/api/tags`` vs LM Studio ``/v1/models``). Returns
+        ``[]`` when the backends are unreachable.
         """
         # circular: discovery -> app.services -> model_manager.__init__ -> core
-        from lilbee.modelhub.model_manager.discovery import classify_remote_models
+        from lilbee.modelhub.model_manager.discovery import classify_all_remote_models
 
-        models = classify_remote_models(self._remote_base_url, timeout=DEFAULT_HTTP_TIMEOUT)
+        models = classify_all_remote_models(timeout=DEFAULT_HTTP_TIMEOUT)
         return [m.name for m in models]
 
     def is_installed(self, model: str, source: ModelSource | None = None) -> bool:
@@ -146,8 +145,8 @@ class ModelManager:
         """Return the granular source a model lives in. Native takes precedence.
 
         A provider-prefixed ref classifies without a network call; a bare name
-        gets the configured local server's source when that backend reports it
-        installed. ``None`` when the model is in no known source.
+        that a backend reports installed is ``REMOTE`` (the prefix is what names
+        the specific server). ``None`` when the model is in no known source.
         """
         if self._is_native(model):
             return ModelSource.NATIVE
@@ -155,8 +154,7 @@ class ModelManager:
         if prefixed is not None:
             return prefixed
         if self._is_remote(model):
-            server = detect_local_server(self._remote_base_url)
-            return ModelSource(server.key) if server is not None else ModelSource.REMOTE
+            return ModelSource.REMOTE
         return None
 
     def pull(
@@ -178,8 +176,8 @@ class ModelManager:
         is True. *on_bytes* receives (downloaded_bytes, total_bytes) progress.
         """
         if source is not ModelSource.NATIVE:
-            server = detect_local_server(self._remote_base_url)
-            where = server.display_name if server is not None else "the configured server"
+            spec = local_server_for_key(source.value)
+            where = spec.display_name if spec is not None else "the configured server"
             raise ValueError(
                 f"lilbee runs {where} models but doesn't download them. "
                 f"Add the model in {where}, then pick it here."
@@ -236,8 +234,8 @@ class ModelManager:
         """
         effective = source if source is not None else self.get_source(model)
         if effective is not None and effective is not ModelSource.NATIVE:
-            server = detect_local_server(self._remote_base_url)
-            where = server.display_name if server is not None else "the configured server"
+            spec = local_server_for_key(effective.value)
+            where = spec.display_name if spec is not None else "the configured server"
             raise ValueError(
                 f"lilbee runs {where} models but doesn't remove them. "
                 f"Manage them in {where} instead."

--- a/src/lilbee/modelhub/model_manager/discovery.py
+++ b/src/lilbee/modelhub/model_manager/discovery.py
@@ -14,10 +14,11 @@ from lilbee.providers.backend_names import BackendName
 from lilbee.providers.local_servers import (
     LM_STUDIO,
     OLLAMA,
-    detect_local_server,
+    LocalServerSpec,
     openai_models_url,
 )
-from lilbee.providers.sdk_backend import PROVIDER_KEYS, detect_backend_name
+from lilbee.providers.local_servers.config_urls import configured_local_servers
+from lilbee.providers.sdk_backend import PROVIDER_KEYS
 
 log = logging.getLogger(__name__)
 
@@ -69,21 +70,31 @@ def reclassify_by_name(ref: str, declared_task: str) -> str:
 
 
 def classify_remote_models(
-    base_url: str = "http://localhost:11434",
+    base_url: str,
+    spec: LocalServerSpec,
     *,
     timeout: float = _CLASSIFY_DEFAULT_TIMEOUT_S,
 ) -> list[RemoteModel]:
-    """Discover and classify all models from the local server by task.
+    """Discover and classify all models from one local server by task.
 
-    Dispatches by detected server (Ollama ``/api/tags`` vs LM Studio
-    ``/v1/models``; unknown URLs use the Ollama strategy). Returns ``[]`` on
-    any error so read-only callers stay responsive when the backend is down.
+    The strategy and provider label come from *spec* (Ollama ``/api/tags`` vs
+    LM Studio ``/v1/models``), so a server reached at a non-default host is
+    classified correctly. Returns ``[]`` on any error so read-only callers stay
+    responsive when the backend is down.
     """
-    spec = detect_local_server(base_url)
-    provider = detect_backend_name(base_url)
-    key = spec.key if spec is not None else OLLAMA.key
-    discover = _DISCOVERY_BY_KEY.get(key, _discover_via_ollama_tags)
-    return discover(base_url, provider, timeout)
+    discover = _DISCOVERY_BY_KEY[spec.key]
+    return discover(base_url, spec.display_name, timeout)
+
+
+def classify_all_remote_models(
+    *,
+    timeout: float = _CLASSIFY_DEFAULT_TIMEOUT_S,
+) -> list[RemoteModel]:
+    """Classify models across every configured local server, source-labeled."""
+    result: list[RemoteModel] = []
+    for spec, base_url in configured_local_servers():
+        result.extend(classify_remote_models(base_url, spec, timeout=timeout))
+    return result
 
 
 def _discover_via_ollama_tags(
@@ -202,6 +213,6 @@ def discover_api_models() -> dict[str, list[RemoteModel]]:
     return result
 
 
-def detect_remote_embedding_models(base_url: str = "http://localhost:11434") -> list[str]:
-    """Return names of models classified as embedding from the SDK backend."""
-    return [m.name for m in classify_remote_models(base_url) if m.task == ModelTask.EMBEDDING]
+def detect_remote_embedding_models() -> list[str]:
+    """Return embedding-model names across every configured local server."""
+    return [m.name for m in classify_all_remote_models() if m.task == ModelTask.EMBEDDING]

--- a/src/lilbee/modelhub/models.py
+++ b/src/lilbee/modelhub/models.py
@@ -274,7 +274,7 @@ def list_installed_models() -> list[str]:
     refs that fail pydantic task validation at assignment time.
     """
     # circular: modelhub.model_manager.discovery imports modelhub.models at top
-    from lilbee.modelhub.model_manager import classify_remote_models
+    from lilbee.modelhub.model_manager import classify_all_remote_models
     from lilbee.modelhub.model_manager.discovery import reclassify_by_name
 
     try:
@@ -283,7 +283,7 @@ def list_installed_models() -> list[str]:
         for manifest in registry.list_installed():
             if reclassify_by_name(manifest.ref, manifest.task) == ModelTask.CHAT:
                 names.append(manifest.ref)
-        for remote in classify_remote_models(cfg.remote_base_url):
+        for remote in classify_all_remote_models():
             if remote.task == ModelTask.CHAT:
                 names.append(remote.name)
         return sorted(set(names))

--- a/src/lilbee/providers/factory.py
+++ b/src/lilbee/providers/factory.py
@@ -42,7 +42,6 @@ def create_provider(config: Config) -> LLMProvider:
             )
         return SdkLLMProvider(
             backend,
-            base_url=config.remote_base_url,
             api_key=config.llm_api_key,
         )  # pragma: no cover
 

--- a/src/lilbee/providers/local_servers/config_urls.py
+++ b/src/lilbee/providers/local_servers/config_urls.py
@@ -1,0 +1,33 @@
+"""Resolve each local server's configured base URL, with spec-default fallback."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from lilbee.core.config.model import cfg
+from lilbee.providers.local_servers.lm_studio import LM_STUDIO
+from lilbee.providers.local_servers.ollama import OLLAMA
+from lilbee.providers.local_servers.registry import LOCAL_SERVERS, local_server_for_key
+from lilbee.providers.local_servers.spec import LocalServerSpec
+
+_URL_ACCESSOR_BY_KEY: dict[str, Callable[[], str]] = {
+    OLLAMA.key: lambda: cfg.ollama_base_url,
+    LM_STUDIO.key: lambda: cfg.lm_studio_base_url,
+}
+
+
+def _configured_url(spec: LocalServerSpec) -> str:
+    return _URL_ACCESSOR_BY_KEY[spec.key]().strip() or spec.default_base_url
+
+
+def base_url_for(server_key: str) -> str:
+    """Configured URL for a server key, falling back to its spec default."""
+    spec = local_server_for_key(server_key)
+    if spec is None:
+        raise KeyError(f"Unknown local server: {server_key!r}")
+    return _configured_url(spec)
+
+
+def configured_local_servers() -> list[tuple[LocalServerSpec, str]]:
+    """Return (spec, resolved-url) for every known local server."""
+    return [(spec, _configured_url(spec)) for spec in LOCAL_SERVERS]

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -48,7 +48,6 @@ class RoutingProvider(LLMProvider):
         if self._sdk_provider is None:
             self._sdk_provider = SdkLLMProvider(
                 LitellmSdkBackend(),
-                base_url=cfg.remote_base_url,
                 api_key=cfg.llm_api_key,
             )
         return self._sdk_provider

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -21,7 +21,9 @@ from typing import Any, Literal, overload
 
 from lilbee.core.config import cfg
 from lilbee.providers.base import ClosableIterator, LLMProvider, ProviderError
-from lilbee.providers.model_ref import parse_model_ref, translate_options
+from lilbee.providers.local_servers import LOCAL_SERVER_KEYS
+from lilbee.providers.local_servers.config_urls import base_url_for, configured_local_servers
+from lilbee.providers.model_ref import ProviderModelRef, parse_model_ref, translate_options
 from lilbee.providers.sdk_backend import (
     PROVIDER_KEYS,
     CompletionRequest,
@@ -33,6 +35,13 @@ from lilbee.providers.worker.transport import OcrBackend
 from lilbee.vision import PageText
 
 log = logging.getLogger(__name__)
+
+
+def _api_base_for(ref: ProviderModelRef) -> str | None:
+    """Endpoint for a local-server ref; ``None`` for hosted APIs (no base needed)."""
+    if ref.provider in LOCAL_SERVER_KEYS:
+        return base_url_for(ref.provider)
+    return None
 
 
 def inject_provider_keys() -> None:
@@ -57,11 +66,9 @@ class SdkLLMProvider(LLMProvider):
         self,
         backend: LlmSdkBackend,
         *,
-        base_url: str = "http://localhost:11434",
         api_key: str = "",
     ) -> None:
         self._backend = backend
-        self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._initialized = False
 
@@ -91,7 +98,7 @@ class SdkLLMProvider(LLMProvider):
         request = EmbeddingRequest(
             ref=ref,
             inputs=texts,
-            api_base=self._base_url if ref.needs_api_base else None,
+            api_base=_api_base_for(ref),
             api_key=self._api_key or None,
         )
         try:
@@ -140,7 +147,7 @@ class SdkLLMProvider(LLMProvider):
             ref=ref,
             messages=list(messages),
             options=translated,
-            api_base=self._base_url if ref.needs_api_base else None,
+            api_base=_api_base_for(ref),
             api_key=self._api_key or None,
         )
         if stream:
@@ -219,17 +226,20 @@ class SdkLLMProvider(LLMProvider):
         )
 
     def list_models(self) -> list[str]:
-        """List models from the backend (empty list on SDK errors)."""
-        try:
-            return self._backend.list_models(base_url=self._base_url, api_key=self._api_key)
-        except NotImplementedError:
-            return []
-        except ProviderError:
-            raise
-        except Exception as exc:
-            raise ProviderError(
-                f"Listing models failed: {exc}", provider=self._backend.provider_name
-            ) from exc
+        """List models across every configured local server (empty list on SDK errors)."""
+        names: list[str] = []
+        for _spec, base_url in configured_local_servers():
+            try:
+                names.extend(self._backend.list_models(base_url=base_url, api_key=self._api_key))
+            except NotImplementedError:
+                continue
+            except ProviderError:
+                raise
+            except Exception as exc:
+                raise ProviderError(
+                    f"Listing models failed: {exc}", provider=self._backend.provider_name
+                ) from exc
+        return names
 
     def list_chat_models(self, provider: str) -> list[str]:
         """List frontier chat models known to the backend for *provider*.
@@ -252,7 +262,8 @@ class SdkLLMProvider(LLMProvider):
     def pull_model(self, model: str, *, on_progress: Callable[..., Any] | None = None) -> None:
         """Pull a model via the backend."""
         try:
-            self._backend.pull_model(model, base_url=self._base_url, on_progress=on_progress)
+            base_url = _api_base_for(parse_model_ref(model)) or ""
+            self._backend.pull_model(model, base_url=base_url, on_progress=on_progress)
         except NotImplementedError as exc:
             raise ProviderError(
                 f"Cannot pull model {model!r}: backend does not support pulling",
@@ -268,7 +279,8 @@ class SdkLLMProvider(LLMProvider):
     def show_model(self, model: str) -> dict[str, Any] | None:
         """Return model metadata, or None when unsupported or not found."""
         try:
-            return self._backend.show_model(model, base_url=self._base_url)
+            base_url = _api_base_for(parse_model_ref(model)) or ""
+            return self._backend.show_model(model, base_url=base_url)
         except NotImplementedError:
             return None
         except ProviderError:
@@ -296,7 +308,7 @@ class SdkLLMProvider(LLMProvider):
             ref=ref,
             query=query,
             candidates=candidates,
-            api_base=self._base_url if ref.needs_api_base else None,
+            api_base=_api_base_for(ref),
             api_key=self._api_key or None,
         )
         try:

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -26,10 +26,10 @@ from lilbee.catalog import (
 from lilbee.catalog.refs import hf_repo_from_ref
 from lilbee.catalog.types import CatalogSize, CatalogSort, KeyStatus, ModelSource, ModelTask
 from lilbee.core.config import cfg
-from lilbee.modelhub.model_manager import classify_remote_models, discover_api_models
+from lilbee.modelhub.model_manager import classify_all_remote_models, discover_api_models
 from lilbee.modelhub.model_manager.types import RemoteModel
 from lilbee.modelhub.role_validator import _MODEL_FIELD_TO_TASK, validate_model_task_assignment
-from lilbee.providers.local_servers import canonical_local_ref, detect_local_server
+from lilbee.providers.local_servers import canonical_local_ref, local_server_for_label
 from lilbee.providers.model_ref import format_remote_ref, parse_model_ref
 from lilbee.providers.sdk_backend import PROVIDER_KEYS, get_provider_api_key
 from lilbee.runtime.hardware import (
@@ -405,11 +405,10 @@ def _discover_hosted_sync() -> list[CatalogEntryResponse]:
     rows: list[CatalogEntryResponse] = []
     for models in discover_api_models().values():
         rows.extend(_hosted_entry(rm, ModelSource.FRONTIER) for rm in models)
-    server = detect_local_server(cfg.remote_base_url)
-    local_source = ModelSource(server.key) if server is not None else ModelSource.REMOTE
-    rows.extend(
-        _hosted_entry(rm, local_source) for rm in classify_remote_models(cfg.remote_base_url)
-    )
+    for rm in classify_all_remote_models():
+        spec = local_server_for_label(rm.provider)
+        source = ModelSource(spec.key) if spec is not None else ModelSource.REMOTE
+        rows.append(_hosted_entry(rm, source))
     return rows
 
 
@@ -421,7 +420,7 @@ def _hosted_cache_key() -> str:
     stale cache entry.
     """
     keys = ":".join(getattr(cfg, field) or "" for _, field, *_ in PROVIDER_KEYS)
-    return f"{cfg.remote_base_url}:{keys}"
+    return f"{cfg.ollama_base_url}:{cfg.lm_studio_base_url}:{keys}"
 
 
 async def _collect_hosted_entries(
@@ -611,7 +610,7 @@ _external_cache = _ExternalModelsCache()
 
 async def list_external_models() -> ExternalModelsResponse:
     """Query the provider for available models via its list_models() API."""
-    key = f"{cfg.remote_base_url}:{cfg.llm_api_key or ''}"
+    key = f"{cfg.ollama_base_url}:{cfg.lm_studio_base_url}:{cfg.llm_api_key or ''}"
     cached = _external_cache.get(key)
     if cached:
         return cached

--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -42,6 +42,9 @@ pytestmark = [
 @pytest.fixture(autouse=True)
 def _isolate_cfg():
     snapshot = {name: getattr(cfg, name) for name in type(cfg).model_fields}
+    # ollama/ refs resolve their api_base from this field, so point it at the
+    # real server for the duration of each test.
+    cfg.ollama_base_url = OLLAMA_HOST
     yield
     for name, val in snapshot.items():
         setattr(cfg, name, val)
@@ -51,7 +54,7 @@ class TestSdkEmbed:
     def test_embed_returns_vectors(self) -> None:
         """Real embedding via Ollama returns float vectors."""
         cfg.embedding_model = OLLAMA_EMBED_MODEL
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url=OLLAMA_HOST)
+        provider = SdkLLMProvider(LitellmSdkBackend())
         result = provider.embed(["hello world"])
 
         assert len(result) == 1
@@ -61,7 +64,7 @@ class TestSdkEmbed:
     def test_embed_batch(self) -> None:
         """Batch embedding returns one vector per input."""
         cfg.embedding_model = OLLAMA_EMBED_MODEL
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url=OLLAMA_HOST)
+        provider = SdkLLMProvider(LitellmSdkBackend())
         texts = ["hello", "world", "test"]
         result = provider.embed(texts)
 
@@ -73,7 +76,7 @@ class TestSdkChat:
     def test_chat_returns_response(self) -> None:
         """Real chat completion via Ollama returns non-empty text."""
         cfg.chat_model = OLLAMA_MODEL
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url=OLLAMA_HOST)
+        provider = SdkLLMProvider(LitellmSdkBackend())
         result = provider.chat(
             [{"role": "user", "content": "Say hello in exactly one word."}],
             options={"temperature": 0},
@@ -85,7 +88,7 @@ class TestSdkChat:
     def test_chat_stream_yields_tokens(self) -> None:
         """Streaming chat yields string tokens."""
         cfg.chat_model = OLLAMA_MODEL
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url=OLLAMA_HOST)
+        provider = SdkLLMProvider(LitellmSdkBackend())
         result = provider.chat(
             [{"role": "user", "content": "Count from 1 to 3."}],
             stream=True,
@@ -101,7 +104,7 @@ class TestSdkChat:
     def test_chat_with_model_override(self) -> None:
         """Model override in chat() works."""
         cfg.chat_model = OLLAMA_MODEL
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url=OLLAMA_HOST)
+        provider = SdkLLMProvider(LitellmSdkBackend())
         result = provider.chat(
             [{"role": "user", "content": "Say yes."}],
             model=OLLAMA_MODEL,
@@ -115,7 +118,7 @@ class TestSdkChat:
 class TestSdkModelManagement:
     def test_list_models(self) -> None:
         """list_models returns models from Ollama."""
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url=OLLAMA_HOST)
+        provider = SdkLLMProvider(LitellmSdkBackend())
         models = provider.list_models()
 
         assert isinstance(models, list)
@@ -124,7 +127,7 @@ class TestSdkModelManagement:
 
     def test_show_model(self) -> None:
         """show_model returns model info dict."""
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url=OLLAMA_HOST)
+        provider = SdkLLMProvider(LitellmSdkBackend())
         info = provider.show_model(OLLAMA_MODEL)
 
         assert info is not None
@@ -137,7 +140,7 @@ class TestSdkFactory:
         from lilbee.providers.factory import create_provider
 
         cfg.llm_provider = "remote"
-        cfg.remote_base_url = OLLAMA_HOST
+        cfg.ollama_base_url = OLLAMA_HOST
         provider = create_provider(cfg)
 
         assert isinstance(provider, SdkLLMProvider)
@@ -148,6 +151,6 @@ class TestSdkFactory:
         from lilbee.providers.factory import create_provider
 
         cfg.llm_provider = "ollama"
-        cfg.remote_base_url = OLLAMA_HOST
+        cfg.ollama_base_url = OLLAMA_HOST
         with pytest.raises(ProviderError, match="Unknown LLM provider"):
             create_provider(cfg)

--- a/tests/providers/test_config_urls.py
+++ b/tests/providers/test_config_urls.py
@@ -1,0 +1,36 @@
+"""Tests for per-server local-model-server URL resolution."""
+
+import pytest
+
+from lilbee.core.config import cfg
+from lilbee.providers.local_servers import LM_STUDIO, OLLAMA
+from lilbee.providers.local_servers.config_urls import base_url_for, configured_local_servers
+
+
+class TestBaseUrlFor:
+    def test_blank_ollama_uses_spec_default(self, monkeypatch):
+        monkeypatch.setattr(cfg, "ollama_base_url", "")
+        assert base_url_for("ollama") == OLLAMA.default_base_url
+
+    def test_blank_lm_studio_uses_spec_default(self, monkeypatch):
+        monkeypatch.setattr(cfg, "lm_studio_base_url", "")
+        assert base_url_for("lm_studio") == LM_STUDIO.default_base_url
+
+    def test_configured_value_overrides_default(self, monkeypatch):
+        monkeypatch.setattr(cfg, "ollama_base_url", "http://box:11434")
+        assert base_url_for("ollama") == "http://box:11434"
+
+    def test_unknown_server_key_raises(self):
+        with pytest.raises(KeyError):
+            base_url_for("not-a-server")
+
+
+class TestConfiguredLocalServers:
+    def test_resolves_url_for_every_server(self, monkeypatch):
+        monkeypatch.setattr(cfg, "ollama_base_url", "http://box:11434")
+        monkeypatch.setattr(cfg, "lm_studio_base_url", "")
+        resolved = {spec.key: url for spec, url in configured_local_servers()}
+        assert resolved == {
+            "ollama": "http://box:11434",
+            "lm_studio": LM_STUDIO.default_base_url,
+        }

--- a/tests/providers/test_sdk_llm_provider.py
+++ b/tests/providers/test_sdk_llm_provider.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -123,14 +124,18 @@ class FakeBackend:
 
 @pytest.fixture(autouse=True)
 def _reset_chat_model() -> Iterator[None]:
-    """Preserve ``cfg.chat_model``, ``cfg.embedding_model``, and ``cfg.json_mode`` per test."""
+    """Preserve model, json-mode, and local-server URL config per test."""
     chat_snapshot = cfg.chat_model
     embed_snapshot = cfg.embedding_model
     json_snapshot = cfg.json_mode
+    ollama_snapshot = cfg.ollama_base_url
+    lm_studio_snapshot = cfg.lm_studio_base_url
     yield
     cfg.chat_model = chat_snapshot
     cfg.embedding_model = embed_snapshot
     cfg.json_mode = json_snapshot
+    cfg.ollama_base_url = ollama_snapshot
+    cfg.lm_studio_base_url = lm_studio_snapshot
 
 
 class TestInjectProviderKeys:
@@ -154,12 +159,12 @@ class TestInjectProviderKeys:
 class TestChatNonStream:
     def test_returns_content_string(self) -> None:
         backend = FakeBackend(complete_result=CompletionResult(content="hi"))
-        provider = SdkLLMProvider(backend, base_url="http://localhost:11434")
+        provider = SdkLLMProvider(backend)
         assert provider.chat([{"role": "user", "content": "hey"}]) == "hi"
 
     def test_builds_completion_request_with_parsed_ref(self) -> None:
         backend = FakeBackend()
-        provider = SdkLLMProvider(backend, base_url="http://localhost:11434")
+        provider = SdkLLMProvider(backend)
         ref = "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf"
         provider.chat([{"role": "user", "content": "hey"}], model=ref)
         req = backend.complete_calls[-1]
@@ -168,11 +173,12 @@ class TestChatNonStream:
         assert req.ref.raw == ref
         assert req.ref.name == ref
         assert req.ref.provider == "local"
-        assert req.api_base == "http://localhost:11434"
+        # A local HF ref is not a local-server ref, so it carries no api_base.
+        assert req.api_base is None
 
     def test_api_model_omits_api_base(self) -> None:
         backend = FakeBackend()
-        provider = SdkLLMProvider(backend, base_url="http://localhost:11434")
+        provider = SdkLLMProvider(backend)
         provider.chat([{"role": "user", "content": "hi"}], model="openai/gpt-4o")
         req = backend.complete_calls[-1]
         assert req.ref.provider == "openai"
@@ -181,13 +187,13 @@ class TestChatNonStream:
 
     def test_passes_api_key_when_configured(self) -> None:
         backend = FakeBackend()
-        provider = SdkLLMProvider(backend, base_url="https://api.openai.com", api_key="sk-x")
+        provider = SdkLLMProvider(backend, api_key="sk-x")
         provider.chat([{"role": "user", "content": "hi"}], model="openai/gpt-4o")
         assert backend.complete_calls[-1].api_key == "sk-x"
 
     def test_options_are_translated_per_ref(self) -> None:
         backend = FakeBackend()
-        provider = SdkLLMProvider(backend, base_url="https://api.openai.com")
+        provider = SdkLLMProvider(backend)
         provider.chat(
             [{"role": "user", "content": "hi"}],
             model="openai/gpt-4o",
@@ -303,27 +309,29 @@ class TestEmbed:
     def test_request_includes_api_base_for_ollama(self) -> None:
         backend = FakeBackend()
         cfg.embedding_model = "ollama/nomic-embed-text:latest"
-        provider = SdkLLMProvider(backend, base_url="http://localhost:11434")
+        cfg.ollama_base_url = "http://localhost:11434"
+        provider = SdkLLMProvider(backend)
         provider.embed(["hello"])
         assert backend.embed_calls[-1].api_base == "http://localhost:11434"
 
     def test_request_omits_api_base_for_api_model(self) -> None:
         backend = FakeBackend()
         cfg.embedding_model = "openai/text-embedding-3-small"
-        provider = SdkLLMProvider(backend, base_url="http://localhost:11434")
+        provider = SdkLLMProvider(backend)
         provider.embed(["hello"])
         assert backend.embed_calls[-1].api_base is None
 
-    def test_local_embed_model_with_non_ollama_base_url(self) -> None:
+    def test_local_embed_model_omits_api_base(self) -> None:
         backend = FakeBackend()
         cfg.embedding_model = "org/Custom-Embed-GGUF/custom-Q4_K_M.gguf"
-        provider = SdkLLMProvider(backend, base_url="https://self-hosted:8000")
+        provider = SdkLLMProvider(backend)
         provider.embed(["hello"])
-        # Local HF refs keep their raw name and still pass api_base.
+        # Local HF refs keep their raw name; they are not local-server refs,
+        # so api_base is resolved from the ref and stays None.
         req = backend.embed_calls[-1]
         assert req.ref.name == "org/Custom-Embed-GGUF/custom-Q4_K_M.gguf"
         assert req.ref.provider == "local"
-        assert req.api_base == "https://self-hosted:8000"
+        assert req.api_base is None
 
     def test_wraps_backend_errors(self) -> None:
         backend = FakeBackend(raise_embed=RuntimeError("oops"))
@@ -354,9 +362,17 @@ class TestEmbed:
 
 class TestListModels:
     def test_returns_backend_models(self) -> None:
+        from lilbee.providers.local_servers import OLLAMA
+
         backend = FakeBackend(list_models_result=["a", "b"])
         provider = SdkLLMProvider(backend)
-        assert provider.list_models() == ["a", "b"]
+        # list_models merges across configured servers; pin one so the
+        # backend's result passes through unduplicated.
+        with mock.patch(
+            "lilbee.providers.sdk_llm_provider.configured_local_servers",
+            return_value=[(OLLAMA, "http://localhost:11434")],
+        ):
+            assert provider.list_models() == ["a", "b"]
 
     def test_returns_empty_when_backend_says_not_supported(self) -> None:
         backend = FakeBackend(list_not_supported=True)
@@ -425,15 +441,16 @@ class TestListChatModels:
 class TestPullModel:
     def test_forwards_to_backend(self) -> None:
         backend = FakeBackend()
-        provider = SdkLLMProvider(backend, base_url="http://localhost:11434")
-        provider.pull_model("m")
-        assert backend.pull_calls[-1] == ("m", "http://localhost:11434")
+        cfg.ollama_base_url = "http://localhost:11434"
+        provider = SdkLLMProvider(backend)
+        provider.pull_model("ollama/m")
+        assert backend.pull_calls[-1] == ("ollama/m", "http://localhost:11434")
 
     def test_not_supported_raises_provider_error(self) -> None:
         backend = FakeBackend(pull_not_supported=True)
         provider = SdkLLMProvider(backend)
         with pytest.raises(ProviderError, match="does not support pulling"):
-            provider.pull_model("m")
+            provider.pull_model("ollama/m")
 
     def test_wraps_unexpected_errors(self) -> None:
         class _FailingBackend(FakeBackend):
@@ -447,8 +464,8 @@ class TestPullModel:
                 raise RuntimeError("network boom")
 
         provider = SdkLLMProvider(_FailingBackend())
-        with pytest.raises(ProviderError, match="Cannot pull model 'm': network boom"):
-            provider.pull_model("m")
+        with pytest.raises(ProviderError, match="Cannot pull model 'ollama/m': network boom"):
+            provider.pull_model("ollama/m")
 
     def test_propagates_provider_error_unchanged(self) -> None:
         class _WrappedError(FakeBackend):
@@ -463,19 +480,19 @@ class TestPullModel:
 
         provider = SdkLLMProvider(_WrappedError())
         with pytest.raises(ProviderError, match="already-typed"):
-            provider.pull_model("m")
+            provider.pull_model("ollama/m")
 
 
 class TestShowModel:
     def test_forwards_result(self) -> None:
         backend = FakeBackend(show_model_result={"parameters": "t 0.1"})
         provider = SdkLLMProvider(backend)
-        assert provider.show_model("m") == {"parameters": "t 0.1"}
+        assert provider.show_model("ollama/m") == {"parameters": "t 0.1"}
 
     def test_not_supported_returns_none(self) -> None:
         backend = FakeBackend(show_not_supported=True)
         provider = SdkLLMProvider(backend)
-        assert provider.show_model("m") is None
+        assert provider.show_model("ollama/m") is None
 
     def test_wraps_unexpected_errors(self) -> None:
         class _FailingBackend(FakeBackend):
@@ -483,8 +500,8 @@ class TestShowModel:
                 raise RuntimeError("metadata boom")
 
         provider = SdkLLMProvider(_FailingBackend())
-        with pytest.raises(ProviderError, match="Showing model 'm' failed: metadata boom"):
-            provider.show_model("m")
+        with pytest.raises(ProviderError, match="Showing model 'ollama/m' failed: metadata boom"):
+            provider.show_model("ollama/m")
 
     def test_propagates_provider_error_unchanged(self) -> None:
         class _WrappedError(FakeBackend):
@@ -493,29 +510,29 @@ class TestShowModel:
 
         provider = SdkLLMProvider(_WrappedError())
         with pytest.raises(ProviderError, match="already-typed"):
-            provider.show_model("m")
+            provider.show_model("ollama/m")
 
 
 class TestGetCapabilities:
     def test_returns_backend_capabilities_list(self) -> None:
         backend = FakeBackend(show_model_result={"capabilities": ["completion", "vision"]})
         provider = SdkLLMProvider(backend)
-        assert provider.get_capabilities("m") == ["completion", "vision"]
+        assert provider.get_capabilities("ollama/m") == ["completion", "vision"]
 
     def test_empty_when_show_model_returns_none(self) -> None:
         backend = FakeBackend(show_model_result=None)
         provider = SdkLLMProvider(backend)
-        assert provider.get_capabilities("m") == []
+        assert provider.get_capabilities("ollama/m") == []
 
     def test_empty_when_capabilities_not_a_list(self) -> None:
         backend = FakeBackend(show_model_result={"capabilities": "something"})
         provider = SdkLLMProvider(backend)
-        assert provider.get_capabilities("m") == []
+        assert provider.get_capabilities("ollama/m") == []
 
     def test_missing_capabilities_key_returns_empty(self) -> None:
         backend = FakeBackend(show_model_result={"parameters": "x"})
         provider = SdkLLMProvider(backend)
-        assert provider.get_capabilities("m") == []
+        assert provider.get_capabilities("ollama/m") == []
 
 
 class TestShutdown:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -850,7 +850,7 @@ class TestListInstalledModels:
     def test_returns_only_chat_task_models(self):
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry.list_installed") as mock_reg,
-            mock.patch("lilbee.modelhub.model_manager.classify_remote_models") as mock_remote,
+            mock.patch("lilbee.modelhub.model_manager.classify_all_remote_models") as mock_remote,
         ):
             mock_reg.return_value = [self._manifest(self._CHAT_REPO, self._CHAT_FILE, "chat")]
             mock_remote.return_value = []
@@ -866,7 +866,7 @@ class TestListInstalledModels:
     def test_excludes_non_chat_registry_tasks(self):
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry.list_installed") as mock_reg,
-            mock.patch("lilbee.modelhub.model_manager.classify_remote_models") as mock_remote,
+            mock.patch("lilbee.modelhub.model_manager.classify_all_remote_models") as mock_remote,
         ):
             mock_reg.return_value = [
                 self._manifest(self._CHAT_REPO, self._CHAT_FILE, "chat"),
@@ -885,7 +885,7 @@ class TestListInstalledModels:
 
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry.list_installed") as mock_reg,
-            mock.patch("lilbee.modelhub.model_manager.classify_remote_models") as mock_remote,
+            mock.patch("lilbee.modelhub.model_manager.classify_all_remote_models") as mock_remote,
         ):
             mock_reg.return_value = []
             mock_remote.return_value = [
@@ -900,7 +900,7 @@ class TestListInstalledModels:
     def test_dedupes_native_and_remote_overlap(self):
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry.list_installed") as mock_reg,
-            mock.patch("lilbee.modelhub.model_manager.classify_remote_models") as mock_remote,
+            mock.patch("lilbee.modelhub.model_manager.classify_all_remote_models") as mock_remote,
         ):
             mock_reg.return_value = [self._manifest(self._CHAT_REPO, self._CHAT_FILE, "chat")]
             # Remote backend reports the same canonical ref string.

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -38,11 +38,15 @@ def _manifest(hf_repo: str, gguf_filename: str, *, size: int, task: str) -> Mode
     )
 
 
-def _remote(name: str, task: str, parameter_size: str = "8B") -> MagicMock:
+def _remote(
+    name: str, task: str, parameter_size: str = "8B", provider: str = "Ollama"
+) -> MagicMock:
     rm = MagicMock()
     rm.name = name
     rm.task = task
     rm.parameter_size = parameter_size
+    # Source is derived from the provider label, so it must be a real string.
+    rm.provider = provider
     return rm
 
 
@@ -150,14 +154,14 @@ def native_manifests():
 
 @pytest.fixture
 def no_remote_classify():
-    with patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]):
+    with patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]):
         yield
 
 
 @pytest.fixture
 def with_remote_classify():
     remote = [_remote(_OLLAMA_REF, task="chat", parameter_size="8B")]
-    with patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=remote):
+    with patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=remote):
         yield remote
 
 
@@ -207,7 +211,7 @@ class TestListModelsData:
         assert sources == {"native", "ollama"}
 
     def test_filter_source_native_skips_litellm_http(self, fake_manager, native_manifests):
-        with patch("lilbee.modelhub.model_manager.classify_remote_models") as classify:
+        with patch("lilbee.modelhub.model_manager.classify_all_remote_models") as classify:
             data = model_mod.list_models_data(source=ModelSource.NATIVE)
         classify.assert_not_called()
         assert data.total == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,18 @@ class TestFromEnvDefaults:
             # Wiki is opt-in: the Wiki view tab and the chat ModelBar's
             # scope picker only appear when the user explicitly enables it.
             assert c.wiki is False
+            # Local-server URLs default blank; the resolver fills the spec
+            # default so the literal lives only in the spec.
+            assert c.ollama_base_url == ""
+            assert c.lm_studio_base_url == ""
+
+    def test_local_server_urls_strip_trailing_slash(self):
+        c = Config(
+            ollama_base_url="http://box:11434/",
+            lm_studio_base_url="http://lm:1234/v1/",
+        )
+        assert c.ollama_base_url == "http://box:11434"
+        assert c.lm_studio_base_url == "http://lm:1234/v1"
 
     def test_constants_unchanged(self):
         assert CHUNKS_TABLE == "chunks"
@@ -91,6 +103,15 @@ class TestEnvVarOverrides:
             assert c.documents_dir == tmp_path / "documents"
             assert c.data_dir == tmp_path / "data"
             assert c.lancedb_dir == tmp_path / "data" / "lancedb"
+
+    def test_local_server_urls_from_env(self, tmp_path):
+        env = _clean_env(tmp_path)
+        env["LILBEE_OLLAMA_BASE_URL"] = "http://box:11434"
+        env["LILBEE_LM_STUDIO_BASE_URL"] = "http://lm:1234/v1"
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.ollama_base_url == "http://box:11434"
+            assert c.lm_studio_base_url == "http://lm:1234/v1"
 
     def test_data_root_default_uses_platform(self):
         env = _clean_env()

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -253,7 +253,9 @@ class TestCatalogVimNavListView:
                 self.push_screen(CatalogScreen())
 
         with (
-            mock.patch("lilbee.cli.tui.screens.catalog.classify_remote_models", return_value=[]),
+            mock.patch(
+                "lilbee.cli.tui.screens.catalog.classify_all_remote_models", return_value=[]
+            ),
             mock.patch(
                 "lilbee.cli.tui.screens.catalog.get_catalog",
                 return_value=mock.MagicMock(models=[], total=0, has_more=False),
@@ -607,7 +609,9 @@ class TestCatalogSelectFrontierRow:
         # through Config.chat_model's validator (a bare ref would raise
         # and regress b3a36798).
         with (
-            mock.patch("lilbee.cli.tui.screens.catalog.classify_remote_models", return_value=[]),
+            mock.patch(
+                "lilbee.cli.tui.screens.catalog.classify_all_remote_models", return_value=[]
+            ),
             mock.patch(
                 "lilbee.cli.tui.screens.catalog.get_catalog",
                 return_value=mock.MagicMock(models=[], total=0, has_more=False),
@@ -643,7 +647,9 @@ class TestCatalogSelectFrontierRow:
                 self.push_screen(CatalogScreen())
 
         with (
-            mock.patch("lilbee.cli.tui.screens.catalog.classify_remote_models", return_value=[]),
+            mock.patch(
+                "lilbee.cli.tui.screens.catalog.classify_all_remote_models", return_value=[]
+            ),
             mock.patch(
                 "lilbee.cli.tui.screens.catalog.get_catalog",
                 return_value=mock.MagicMock(models=[], total=0, has_more=False),
@@ -684,7 +690,9 @@ class TestCatalogProviderAvailabilityDebounce:
                 self.push_screen(CatalogScreen())
 
         with (
-            mock.patch("lilbee.cli.tui.screens.catalog.classify_remote_models", return_value=[]),
+            mock.patch(
+                "lilbee.cli.tui.screens.catalog.classify_all_remote_models", return_value=[]
+            ),
             mock.patch(
                 "lilbee.cli.tui.screens.catalog.get_catalog",
                 return_value=mock.MagicMock(models=[], total=0, has_more=False),

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -133,7 +133,7 @@ class TestModelManagerListInstalled:
             models_dir, tmp_path, "mistral-7b.gguf", b"mistral-data", repo="org/mistral-7b-GGUF"
         )
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         result = mgr.list_installed(ModelSource.NATIVE)
 
         assert set(result) == {ref_a, ref_b}
@@ -142,13 +142,13 @@ class TestModelManagerListInstalled:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         assert mgr.list_installed(ModelSource.NATIVE) == []
 
     def test_native_missing_dir(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "nonexistent"
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         assert mgr.list_installed(ModelSource.NATIVE) == []
 
     def test_litellm_lists_models(self) -> None:
@@ -162,15 +162,17 @@ class TestModelManagerListInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response) as mock_get:
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             result = mgr.list_installed(ModelSource.REMOTE)
 
-        mock_get.assert_called_once_with("http://localhost:11434/api/tags", timeout=30.0)
+        # REMOTE now spans every configured server; Ollama is probed via /api/tags.
+        called_urls = [call.args[0] for call in mock_get.call_args_list]
+        assert "http://localhost:11434/api/tags" in called_urls
         assert set(result) == {"llama3:latest", "nomic-embed-text:latest"}
 
     def test_litellm_connection_error(self) -> None:
         with mock.patch("httpx.get", side_effect=httpx.ConnectError("Connection refused")):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             result = mgr.list_installed(ModelSource.REMOTE)
 
         assert result == []
@@ -181,7 +183,7 @@ class TestModelManagerListInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             result = mgr.list_installed(ModelSource.REMOTE)
 
         assert result == []
@@ -198,7 +200,7 @@ class TestModelManagerListInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr = ModelManager(models_dir)
             result = mgr.list_installed(None)
 
         assert set(result) == {native_ref, "remote-model:latest"}
@@ -217,7 +219,7 @@ class TestModelManagerListInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr = ModelManager(models_dir)
             result = mgr.list_installed(None)
 
         assert result.count(native_ref) == 1
@@ -229,11 +231,14 @@ class TestModelManagerListInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response) as mock_get:
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             mgr.list_installed(ModelSource.REMOTE)
+            after_first = mock_get.call_count
             mgr.list_installed(ModelSource.REMOTE)
 
-        assert mock_get.call_count == 1
+        # The second call is served from cache: no additional network calls,
+        # regardless of how many servers the first fetch probed.
+        assert mock_get.call_count == after_first
 
     def test_cache_expires_after_ttl(self) -> None:
         """After the TTL window elapses, list_installed refetches."""
@@ -249,11 +254,13 @@ class TestModelManagerListInstalled:
         ):
             # One clock tick per list_installed call: second tick is past TTL.
             mock_clock.side_effect = [0.0, 100.0]
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             mgr.list_installed(ModelSource.REMOTE)
+            after_first = mock_get.call_count
             mgr.list_installed(ModelSource.REMOTE)
 
-        assert mock_get.call_count == 2
+        # Past the TTL the second call refetches, doubling the per-fetch calls.
+        assert mock_get.call_count == 2 * after_first
 
     def test_pull_invalidates_cache(self, tmp_path: Path) -> None:
         """After pull(), the next list_installed must refetch."""
@@ -268,7 +275,7 @@ class TestModelManagerListInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr = ModelManager(models_dir)
             mgr.list_installed(ModelSource.NATIVE)  # populate cache
             assert mgr._installed_cache
 
@@ -291,7 +298,7 @@ class TestModelManagerListInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr = ModelManager(models_dir)
             mgr.list_installed(None)  # populate cache
             assert mgr._installed_cache
 
@@ -305,14 +312,14 @@ class TestModelManagerIsInstalled:
         models_dir.mkdir()
         (models_dir / "llama3-8b.gguf").touch()
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         assert mgr.is_installed("llama3-8b.gguf", ModelSource.NATIVE) is True
 
     def test_native_not_installed(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         assert mgr.is_installed("missing.gguf", ModelSource.NATIVE) is False
 
     def test_litellm_installed(self) -> None:
@@ -321,7 +328,7 @@ class TestModelManagerIsInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             result = mgr.is_installed("llama3:latest", ModelSource.REMOTE)
 
         assert result is True
@@ -332,7 +339,7 @@ class TestModelManagerIsInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             result = mgr.is_installed("missing:latest", ModelSource.REMOTE)
 
         assert result is False
@@ -347,7 +354,7 @@ class TestModelManagerIsInstalled:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr = ModelManager(models_dir)
             assert mgr.is_installed("native-model.gguf", None) is True
             assert mgr.is_installed("remote-model:latest", None) is False
 
@@ -358,24 +365,28 @@ class TestModelManagerGetSource:
         models_dir.mkdir()
         (models_dir / "my-model.gguf").touch()
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         assert mgr.get_source("my-model.gguf") == ModelSource.NATIVE
 
-    def test_bare_ollama_model_is_ollama_source(self) -> None:
-        """A bare name the Ollama backend reports installed classifies as OLLAMA."""
+    def test_bare_ollama_model_is_remote_source(self) -> None:
+        """A bare name a backend reports installed is generic REMOTE.
+
+        Granular source comes only from a provider prefix; a bare name names
+        no specific server, so it stays REMOTE.
+        """
         mock_response = mock.Mock()
         mock_response.json.return_value = {"models": [{"name": "llama3:latest"}]}
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             result = mgr.get_source("llama3:latest")
 
-        assert result == ModelSource.OLLAMA
+        assert result == ModelSource.REMOTE
 
     def test_ollama_prefixed_ref_is_ollama_source_without_network(self) -> None:
         """An ``ollama/`` ref classifies on the prefix, no /api/tags call."""
-        mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+        mgr = ModelManager(Path("/tmp"))
         with mock.patch("httpx.get") as mock_get:
             result = mgr.get_source("ollama/llama3:latest")
         assert result == ModelSource.OLLAMA
@@ -383,7 +394,7 @@ class TestModelManagerGetSource:
 
     def test_api_prefixed_ref_is_frontier_source(self) -> None:
         """A hosted API ref classifies as FRONTIER without a network call."""
-        mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+        mgr = ModelManager(Path("/tmp"))
         with mock.patch("httpx.get") as mock_get:
             result = mgr.get_source("gemini/gemini-2.5-pro")
         assert result == ModelSource.FRONTIER
@@ -391,23 +402,26 @@ class TestModelManagerGetSource:
 
     def test_lm_studio_prefixed_ref_is_lm_studio_source_without_network(self) -> None:
         """An ``lm_studio/`` ref classifies on the prefix, no network call."""
-        mgr = ModelManager(Path("/tmp"), "http://localhost:1234/v1")
+        mgr = ModelManager(Path("/tmp"))
         with mock.patch("httpx.get") as mock_get:
             result = mgr.get_source("lm_studio/qwen2.5-coder")
         assert result == ModelSource.LM_STUDIO
         mock_get.assert_not_called()
 
-    def test_bare_model_on_lm_studio_backend_is_lm_studio_source(self) -> None:
-        """A bare name an LM Studio backend reports installed classifies as LM_STUDIO."""
+    def test_bare_model_on_lm_studio_backend_is_remote_source(self) -> None:
+        """A bare name an LM Studio backend reports installed stays generic REMOTE.
+
+        Without a provider prefix the source is not specialized to a server.
+        """
         mock_response = mock.Mock()
         mock_response.json.return_value = {"data": [{"id": "qwen2.5-coder"}]}
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:1234/v1")
+            mgr = ModelManager(Path("/tmp"))
             result = mgr.get_source("qwen2.5-coder")
 
-        assert result == ModelSource.LM_STUDIO
+        assert result == ModelSource.REMOTE
 
     def test_bare_model_on_unknown_backend_is_remote_source(self) -> None:
         """A bare name a non-Ollama/LM-Studio backend reports stays generic REMOTE."""
@@ -416,7 +430,7 @@ class TestModelManagerGetSource:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(Path("/tmp"), "http://my-host.internal:9000")
+            mgr = ModelManager(Path("/tmp"))
             result = mgr.get_source("custom-model")
 
         assert result == ModelSource.REMOTE
@@ -432,7 +446,7 @@ class TestModelManagerGetSource:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr = ModelManager(models_dir)
             result = mgr.get_source("shared:latest.gguf")
 
         assert result == ModelSource.NATIVE
@@ -446,7 +460,7 @@ class TestModelManagerGetSource:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr = ModelManager(models_dir)
             result = mgr.get_source("nonexistent.gguf")
 
         assert result is None
@@ -467,7 +481,7 @@ class TestModelManagerPull:
             path.write_text("fake model")
             return path
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         with (
             mock.patch(
                 "lilbee.catalog.resolve_pull_target", return_value=fake_entry
@@ -500,7 +514,7 @@ class TestModelManagerPull:
             path.write_text("fake model")
             return path
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         with mock.patch("lilbee.catalog.download_model", side_effect=fake_download):
             mgr.pull("bartowski/gemma-2-2b-it-GGUF", ModelSource.NATIVE)
 
@@ -514,7 +528,7 @@ class TestModelManagerPull:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         with (
             mock.patch("lilbee.catalog.resolve_pull_target", return_value=None),
             pytest.raises(RuntimeError, match="HuggingFace repo id"),
@@ -526,21 +540,21 @@ class TestModelManagerPull:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         with (
             mock.patch("httpx.Client") as mock_client,
             pytest.raises(ValueError, match="Ollama"),
         ):
-            mgr.pull("llama3:latest", ModelSource.REMOTE)
+            mgr.pull("llama3:latest", ModelSource.OLLAMA)
         mock_client.assert_not_called()
 
     def test_remote_pull_refused_for_lm_studio(self, tmp_path: Path) -> None:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        mgr = ModelManager(models_dir, "http://localhost:1234/v1")
+        mgr = ModelManager(models_dir)
         with pytest.raises(ValueError, match="LM Studio"):
-            mgr.pull("qwen2.5-7b-instruct", ModelSource.REMOTE)
+            mgr.pull("qwen2.5-7b-instruct", ModelSource.LM_STUDIO)
 
 
 class TestModelManagerRemove:
@@ -550,7 +564,7 @@ class TestModelManagerRemove:
         model_file = models_dir / "llama3-8b.gguf"
         model_file.write_text("fake model data")
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         removed = mgr.remove("llama3-8b.gguf", ModelSource.NATIVE)
         assert removed is True
         assert not model_file.exists()
@@ -559,7 +573,7 @@ class TestModelManagerRemove:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         removed = mgr.remove("missing.gguf", ModelSource.NATIVE)
         assert removed is False
 
@@ -567,14 +581,14 @@ class TestModelManagerRemove:
         models_dir = tmp_path / "models"
         models_dir.mkdir()
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         removed = mgr.remove("../../etc/passwd", ModelSource.NATIVE)
         assert removed is False
 
     def test_remove_refuses_ollama_source(self) -> None:
         """Ollama is read-only: an explicit OLLAMA source is refused, never deleted."""
         with mock.patch("httpx.request") as mock_req:
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             with pytest.raises(ValueError, match="Ollama models but doesn't remove them"):
                 mgr.remove("ollama/llama3:latest", ModelSource.OLLAMA)
         mock_req.assert_not_called()
@@ -582,21 +596,21 @@ class TestModelManagerRemove:
     def test_remove_refuses_lm_studio_source(self) -> None:
         """LM Studio is read-only: an explicit LM_STUDIO source is refused."""
         with mock.patch("httpx.request") as mock_req:
-            mgr = ModelManager(Path("/tmp"), "http://localhost:1234/v1")
+            mgr = ModelManager(Path("/tmp"))
             with pytest.raises(ValueError, match="LM Studio models but doesn't remove them"):
                 mgr.remove("lm_studio/qwen2.5-coder", ModelSource.LM_STUDIO)
         mock_req.assert_not_called()
 
     def test_remove_refuses_generic_remote_source(self) -> None:
         """A generic REMOTE source on an undetected backend is refused too."""
-        mgr = ModelManager(Path("/tmp"), "http://my-host.internal:9000")
+        mgr = ModelManager(Path("/tmp"))
         with pytest.raises(ValueError, match="doesn't remove them"):
             mgr.remove("custom-model", ModelSource.REMOTE)
 
     def test_remove_refuses_ollama_prefixed_ref_without_network(self) -> None:
         """An ``ollama/`` ref with source=None resolves on the prefix, no network call."""
         with mock.patch("httpx.get") as mock_get, mock.patch("httpx.request") as mock_req:
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             with pytest.raises(ValueError, match="doesn't remove them"):
                 mgr.remove("ollama/llama3:latest")
         mock_get.assert_not_called()
@@ -609,7 +623,7 @@ class TestModelManagerRemove:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             with pytest.raises(ValueError, match="doesn't remove them"):
                 mgr.remove("llama3:latest")
 
@@ -621,7 +635,7 @@ class TestModelManagerRemove:
         model_file.write_text("fake")
 
         with mock.patch("httpx.request") as mock_req:
-            mgr = ModelManager(models_dir, "http://localhost:11434")
+            mgr = ModelManager(models_dir)
             result = mgr.remove("my-model.gguf", None)
 
         assert result is True
@@ -635,7 +649,7 @@ class TestModelManagerRemove:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(Path("/tmp"), "http://localhost:11434")
+            mgr = ModelManager(Path("/tmp"))
             result = mgr.remove("nonexistent.gguf")
 
         assert result is False
@@ -659,18 +673,15 @@ class TestServicesIntegration:
         from lilbee.core.config import cfg
 
         cfg.models_dir = tmp_path / "models"
-        cfg.remote_base_url = "http://localhost:11434"
         mgr = get_services().model_manager
         assert isinstance(mgr, ModelManager)
         assert mgr._models_dir == tmp_path / "models"
-        assert mgr._remote_base_url == "http://localhost:11434"
 
     def test_services_returns_same_model_manager(self, tmp_path: Path) -> None:
         from lilbee.app.services import get_services
         from lilbee.core.config import cfg
 
         cfg.models_dir = tmp_path / "models"
-        cfg.remote_base_url = "http://localhost:11434"
         mgr1 = get_services().model_manager
         mgr2 = get_services().model_manager
         assert mgr1 is mgr2
@@ -680,7 +691,6 @@ class TestServicesIntegration:
         from lilbee.core.config import cfg
 
         cfg.models_dir = tmp_path / "models"
-        cfg.remote_base_url = "http://localhost:11434"
         mgr1 = get_services().model_manager
         reset_services()
         mgr2 = get_services().model_manager
@@ -697,14 +707,14 @@ class TestLitellmEdgeCases:
         )
 
         with mock.patch("httpx.get", return_value=mock_response):
-            mgr = ModelManager(models_dir=tmp_path, remote_base_url="http://localhost:11434")
+            mgr = ModelManager(models_dir=tmp_path)
             result = mgr.list_installed(ModelSource.REMOTE)
 
         assert result == []
 
     def test_litellm_timeout(self, tmp_path: Path) -> None:
         with mock.patch("httpx.get", side_effect=httpx.TimeoutException("timeout")):
-            mgr = ModelManager(models_dir=tmp_path, remote_base_url="http://localhost:11434")
+            mgr = ModelManager(models_dir=tmp_path)
             result = mgr.list_installed(ModelSource.REMOTE)
 
         assert result == []
@@ -713,7 +723,7 @@ class TestLitellmEdgeCases:
 class TestIsNativePathTraversal:
     def test_path_traversal_returns_false(self, tmp_path: Path) -> None:
         """_is_native returns False for path traversal attempts."""
-        mgr = ModelManager(models_dir=tmp_path, remote_base_url="http://localhost:11434")
+        mgr = ModelManager(models_dir=tmp_path)
         assert not mgr._is_native("../../etc/passwd")
 
 
@@ -726,7 +736,7 @@ class TestIsNativeRegistry:
             models_dir, tmp_path, "my-reg.gguf", b"data", repo="org/my-reg-GGUF"
         )
 
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         assert mgr._is_native(ref) is True
 
 
@@ -742,7 +752,7 @@ class TestRemoveNativeRegistry:
         )
 
         registry = ModelRegistry(models_dir)
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         assert mgr._remove_native(ref) is True
         assert not registry.is_installed(ref)
 
@@ -813,6 +823,7 @@ class TestClassifyRemoteTask:
 class TestRemoteModelProvider:
     def test_classify_remote_models_sets_provider(self) -> None:
         from lilbee.modelhub.model_manager import classify_remote_models
+        from lilbee.providers.local_servers import OLLAMA
 
         mock_response = mock.Mock()
         mock_response.json.return_value = {
@@ -823,30 +834,32 @@ class TestRemoteModelProvider:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            result = classify_remote_models("http://localhost:11434")
+            result = classify_remote_models("http://localhost:11434", OLLAMA)
 
         assert len(result) == 1
         assert result[0].provider == "Ollama"
 
-    def test_classify_remote_models_openai_provider(self) -> None:
+    def test_classify_remote_models_openai_compatible_endpoint(self) -> None:
+        """An OpenAI-compatible ``/v1/models`` endpoint is parsed via the LM Studio spec."""
         from lilbee.modelhub.model_manager import classify_remote_models
+        from lilbee.providers.local_servers import LM_STUDIO
 
         mock_response = mock.Mock()
-        mock_response.json.return_value = {
-            "models": [{"name": "gpt-4", "details": {"family": "gpt", "parameter_size": ""}}]
-        }
+        mock_response.json.return_value = {"data": [{"id": "gpt-4"}]}
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            result = classify_remote_models("https://api.openai.com/v1")
+            result = classify_remote_models("https://api.openai.com/v1", LM_STUDIO)
 
         assert len(result) == 1
-        assert result[0].provider == "OpenAI"
+        assert result[0].name == "gpt-4"
+        assert result[0].provider == "LM Studio"
 
     def test_classify_lm_studio_models_via_openai_endpoint(self) -> None:
         """LM Studio is listed via ``/v1/models`` and labeled ``LM Studio``."""
         from lilbee.catalog.types import ModelTask
         from lilbee.modelhub.model_manager import classify_remote_models
+        from lilbee.providers.local_servers import LM_STUDIO
 
         mock_response = mock.Mock()
         mock_response.json.return_value = {
@@ -859,7 +872,7 @@ class TestRemoteModelProvider:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response) as mock_get:
-            result = classify_remote_models("http://localhost:1234/v1")
+            result = classify_remote_models("http://localhost:1234/v1", LM_STUDIO)
 
         # Hit the OpenAI-compatible endpoint (no doubled /v1), not Ollama's /api/tags.
         assert mock_get.call_args.args[0] == "http://localhost:1234/v1/models"
@@ -878,6 +891,7 @@ class TestRemoteModelProvider:
     def test_classify_lm_studio_surfaces_remote_lm_link_models(self) -> None:
         """LM Link remote/cloud models appear in /v1/models and are not filtered out."""
         from lilbee.modelhub.model_manager import classify_remote_models
+        from lilbee.providers.local_servers import LM_STUDIO
 
         mock_response = mock.Mock()
         # A cloud/remote id LM Studio exposes via LM Link, alongside a local one.
@@ -887,20 +901,21 @@ class TestRemoteModelProvider:
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            result = classify_remote_models("http://localhost:1234/v1")
+            result = classify_remote_models("http://localhost:1234/v1", LM_STUDIO)
 
         assert {m.name for m in result} == {"local-qwen2.5-7b", "openai/gpt-oss-120b"}
 
     def test_classify_lm_studio_skips_entries_without_id(self) -> None:
         """``/v1/models`` rows lacking an ``id`` are skipped, not crashed on."""
         from lilbee.modelhub.model_manager import classify_remote_models
+        from lilbee.providers.local_servers import LM_STUDIO
 
         mock_response = mock.Mock()
         mock_response.json.return_value = {"data": [{"id": ""}, {}, {"id": "qwen2.5-7b-instruct"}]}
         mock_response.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.get", return_value=mock_response):
-            result = classify_remote_models("http://localhost:1234/v1")
+            result = classify_remote_models("http://localhost:1234/v1", LM_STUDIO)
 
         assert [m.name for m in result] == ["qwen2.5-7b-instruct"]
 
@@ -909,15 +924,45 @@ class TestRemoteModelProvider:
         import httpx
 
         from lilbee.modelhub.model_manager import classify_remote_models
+        from lilbee.providers.local_servers import LM_STUDIO
 
         with mock.patch("httpx.get", side_effect=httpx.ConnectError("refused")):
-            result = classify_remote_models("http://localhost:1234/v1")
+            result = classify_remote_models("http://localhost:1234/v1", LM_STUDIO)
 
         assert result == []
 
     def test_remote_model_default_provider(self) -> None:
         model = RemoteModel(name="test", task="chat", family="llama", parameter_size="8B")
         assert model.provider == "Remote"
+
+    def test_classify_all_merges_configured_servers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Both servers are probed and results are merged, source-labeled per server."""
+        from lilbee.core.config import cfg
+        from lilbee.modelhub.model_manager import classify_all_remote_models
+
+        monkeypatch.setattr(cfg, "ollama_base_url", "")
+        monkeypatch.setattr(cfg, "lm_studio_base_url", "")
+
+        def fake_get(url: str, timeout: float) -> mock.Mock:
+            resp = mock.Mock()
+            resp.raise_for_status = mock.Mock()
+            if "/api/tags" in url:
+                resp.json.return_value = {
+                    "models": [
+                        {"name": "llama3:latest", "details": {"family": "llama"}},
+                    ]
+                }
+            else:
+                resp.json.return_value = {"data": [{"id": "qwen2.5-7b"}]}
+            return resp
+
+        with mock.patch("httpx.get", side_effect=fake_get):
+            result = classify_all_remote_models()
+
+        assert {m.name: m.provider for m in result} == {
+            "llama3:latest": "Ollama",
+            "qwen2.5-7b": "LM Studio",
+        }
 
 
 class TestHasProviderKey:

--- a/tests/test_model_manager_compat.py
+++ b/tests/test_model_manager_compat.py
@@ -91,11 +91,13 @@ def test_pull_remote_source_refused_before_gate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """REMOTE source is read-only: refused before the arch gate can run."""
-    mgr = ModelManager(tmp_path / "models", "http://localhost:11434")
+    mgr = ModelManager(tmp_path / "models")
 
     def _fail(_ref: str, _client: object) -> str:
         raise AssertionError("gate must not fire for a refused REMOTE pull")
 
     monkeypatch.setattr(compat, "resolve_arch_for_pull", _fail)
-    with pytest.raises(ValueError, match="Ollama"):
+    # Generic REMOTE source maps to no specific server, so the refusal names
+    # "the configured server" rather than Ollama/LM Studio.
+    with pytest.raises(ValueError, match="the configured server"):
         mgr.pull("ollama:llama3", ModelSource.REMOTE)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1178,7 +1178,8 @@ class TestConfigProvider:
 
             c = Config()
             assert c.llm_provider == "auto"
-            assert c.remote_base_url == "http://localhost:11434"
+            # Blank by default; the resolved fallback is http://localhost:11434.
+            assert c.ollama_base_url == ""
             assert c.llm_api_key == ""
 
     def test_provider_env_override(self) -> None:
@@ -1188,7 +1189,7 @@ class TestConfigProvider:
             os.environ,
             {
                 "LILBEE_LLM_PROVIDER": "remote",
-                "LILBEE_REMOTE_BASE_URL": "http://myhost:11434",
+                "LILBEE_OLLAMA_BASE_URL": "http://myhost:11434",
                 "LILBEE_LLM_API_KEY": "sk-key",
             },
         ):
@@ -1196,7 +1197,7 @@ class TestConfigProvider:
 
             c = Config()
             assert c.llm_provider == "remote"
-            assert c.remote_base_url == "http://myhost:11434"
+            assert c.ollama_base_url == "http://myhost:11434"
             assert c.llm_api_key == "sk-key"
 
     def test_models_dir_uses_canonical_location(self, tmp_path: Path) -> None:
@@ -1780,7 +1781,7 @@ class TestLiteLLMShowModelCapabilities:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        return SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        return SdkLLMProvider(LitellmSdkBackend())
 
     def test_show_model_returns_capabilities(self) -> None:
         provider = self._make_provider()
@@ -1792,7 +1793,7 @@ class TestLiteLLMShowModelCapabilities:
         mock_resp.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.post", return_value=mock_resp):
-            result = provider.show_model("llava:7b")
+            result = provider.show_model("ollama/llava:7b")
 
         assert result is not None
         assert result["capabilities"] == ["completion", "vision"]
@@ -1805,7 +1806,7 @@ class TestLiteLLMShowModelCapabilities:
         mock_resp.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.post", return_value=mock_resp):
-            result = provider.show_model("qwen3:8b")
+            result = provider.show_model("ollama/qwen3:8b")
 
         assert result is not None
         assert "capabilities" not in result
@@ -1818,7 +1819,7 @@ class TestLiteLLMShowModelCapabilities:
         mock_resp.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.post", return_value=mock_resp):
-            result = provider.show_model("some-model")
+            result = provider.show_model("ollama/some-model")
 
         assert result is not None
         assert result["capabilities"] == ["completion"]
@@ -1830,14 +1831,14 @@ class TestLiteLLMShowModelCapabilities:
         mock_resp.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.post", return_value=mock_resp):
-            result = provider.show_model("empty-model")
+            result = provider.show_model("ollama/empty-model")
 
         assert result is None
 
     def test_show_model_http_error(self) -> None:
         provider = self._make_provider()
         with mock.patch("httpx.post", side_effect=httpx.HTTPError("fail")):
-            result = provider.show_model("bad-model")
+            result = provider.show_model("ollama/bad-model")
 
         assert result is None
 
@@ -1848,14 +1849,14 @@ class TestLiteLLMShowModelCapabilities:
         mock_resp.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.post", return_value=mock_resp):
-            caps = provider.get_capabilities("llava:7b")
+            caps = provider.get_capabilities("ollama/llava:7b")
 
         assert caps == ["completion", "vision", "tools"]
 
     def test_get_capabilities_returns_empty_on_error(self) -> None:
         provider = self._make_provider()
         with mock.patch("httpx.post", side_effect=httpx.HTTPError("fail")):
-            caps = provider.get_capabilities("bad-model")
+            caps = provider.get_capabilities("ollama/bad-model")
 
         assert caps == []
 
@@ -1866,7 +1867,7 @@ class TestLiteLLMShowModelCapabilities:
         mock_resp.raise_for_status = mock.Mock()
 
         with mock.patch("httpx.post", return_value=mock_resp):
-            caps = provider.get_capabilities("qwen3:8b")
+            caps = provider.get_capabilities("ollama/qwen3:8b")
 
         assert caps == []
 
@@ -4390,16 +4391,27 @@ class TestInjectProviderKeys:
 
 
 class TestLiteLLMListModelsRouting:
+    """``list_models`` merges across configured local servers; each server's
+    URL selects its listing endpoint in the backend. Pinning a single
+    configured server keeps the per-endpoint routing assertions sharp."""
+
     def test_ollama_url_uses_api_tags(self) -> None:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
+        from lilbee.providers.local_servers import OLLAMA
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        provider = SdkLLMProvider(LitellmSdkBackend())
         mock_resp = mock.MagicMock()
         mock_resp.json.return_value = {"models": [{"name": "llama3:8b"}]}
         mock_resp.raise_for_status = mock.MagicMock()
 
-        with mock.patch("httpx.get", return_value=mock_resp) as mock_get:
+        with (
+            mock.patch(
+                "lilbee.providers.sdk_llm_provider.configured_local_servers",
+                return_value=[(OLLAMA, "http://localhost:11434")],
+            ),
+            mock.patch("httpx.get", return_value=mock_resp) as mock_get,
+        ):
             result = provider.list_models()
 
         mock_get.assert_called_once()
@@ -4408,16 +4420,21 @@ class TestLiteLLMListModelsRouting:
 
     def test_non_ollama_url_uses_v1_models(self) -> None:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
+        from lilbee.providers.local_servers import LM_STUDIO
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(
-            LitellmSdkBackend(), base_url="https://api.openai.com", api_key="sk-test"
-        )
+        provider = SdkLLMProvider(LitellmSdkBackend(), api_key="sk-test")
         mock_resp = mock.MagicMock()
         mock_resp.json.return_value = {"data": [{"id": "gpt-4o"}, {"id": "gpt-4o-mini"}]}
         mock_resp.raise_for_status = mock.MagicMock()
 
-        with mock.patch("httpx.get", return_value=mock_resp) as mock_get:
+        with (
+            mock.patch(
+                "lilbee.providers.sdk_llm_provider.configured_local_servers",
+                return_value=[(LM_STUDIO, "https://api.openai.com")],
+            ),
+            mock.patch("httpx.get", return_value=mock_resp) as mock_get,
+        ):
             result = provider.list_models()
 
         mock_get.assert_called_once()
@@ -4426,27 +4443,39 @@ class TestLiteLLMListModelsRouting:
 
     def test_non_ollama_returns_empty_on_error(self) -> None:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
+        from lilbee.providers.local_servers import LM_STUDIO
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url="https://api.openai.com")
+        provider = SdkLLMProvider(LitellmSdkBackend())
 
-        with mock.patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+        with (
+            mock.patch(
+                "lilbee.providers.sdk_llm_provider.configured_local_servers",
+                return_value=[(LM_STUDIO, "https://api.openai.com")],
+            ),
+            mock.patch("httpx.get", side_effect=httpx.ConnectError("refused")),
+        ):
             result = provider.list_models()
 
         assert result == []
 
     def test_v1_models_sends_auth_header(self) -> None:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
+        from lilbee.providers.local_servers import LM_STUDIO
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(
-            LitellmSdkBackend(), base_url="https://api.openai.com", api_key="sk-secret"
-        )
+        provider = SdkLLMProvider(LitellmSdkBackend(), api_key="sk-secret")
         mock_resp = mock.MagicMock()
         mock_resp.json.return_value = {"data": []}
         mock_resp.raise_for_status = mock.MagicMock()
 
-        with mock.patch("httpx.get", return_value=mock_resp) as mock_get:
+        with (
+            mock.patch(
+                "lilbee.providers.sdk_llm_provider.configured_local_servers",
+                return_value=[(LM_STUDIO, "https://api.openai.com")],
+            ),
+            mock.patch("httpx.get", return_value=mock_resp) as mock_get,
+        ):
             provider.list_models()
 
         headers = mock_get.call_args[1].get("headers", {})
@@ -4460,7 +4489,7 @@ class TestSdkLLMProviderVisionOcr:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        return SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        return SdkLLMProvider(LitellmSdkBackend())
 
     def test_builds_multipart_message_and_routes_to_chat(self) -> None:
         provider = self._make_provider()
@@ -4575,7 +4604,8 @@ class TestChatApiBaseRouting:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        cfg.ollama_base_url = "http://localhost:11434"
+        provider = SdkLLMProvider(LitellmSdkBackend())
         fake = self._make_fake_litellm()
 
         with mock.patch.dict("sys.modules", {"litellm": fake}):
@@ -4589,7 +4619,7 @@ class TestChatApiBaseRouting:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        provider = SdkLLMProvider(LitellmSdkBackend())
         fake = self._make_fake_litellm()
 
         with mock.patch.dict("sys.modules", {"litellm": fake}):
@@ -4603,7 +4633,7 @@ class TestChatApiBaseRouting:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        provider = SdkLLMProvider(LitellmSdkBackend())
         fake = self._make_fake_litellm()
 
         with mock.patch.dict("sys.modules", {"litellm": fake}):
@@ -4616,7 +4646,7 @@ class TestChatApiBaseRouting:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        provider = SdkLLMProvider(LitellmSdkBackend())
         fake = self._make_fake_litellm()
 
         with (
@@ -4635,7 +4665,8 @@ class TestEmbedApiBaseRouting:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        cfg.ollama_base_url = "http://localhost:11434"
+        provider = SdkLLMProvider(LitellmSdkBackend())
         cfg.embedding_model = "ollama/nomic-embed-text:latest"
         fake = mock.MagicMock()
         fake.embedding.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
@@ -4650,7 +4681,7 @@ class TestEmbedApiBaseRouting:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        provider = SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        provider = SdkLLMProvider(LitellmSdkBackend())
         cfg.embedding_model = "openai/text-embedding-3-small"
         fake = mock.MagicMock()
         fake.embedding.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
@@ -4669,7 +4700,7 @@ class TestSdkRerank:
         from lilbee.providers.litellm_sdk import LitellmSdkBackend
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 
-        return SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        return SdkLLMProvider(LitellmSdkBackend())
 
     def test_rerank_returns_scores_in_candidate_order(self) -> None:
         cfg.reranker_model = "cohere/rerank-english-v3.0"
@@ -4776,7 +4807,7 @@ class TestSdkRerank:
         from lilbee.providers.sdk_llm_provider import SdkLLMProvider as _SdkLLMProvider
 
         cfg.reranker_model = "cohere/rerank-english-v3.0"
-        provider = _SdkLLMProvider(LitellmSdkBackend(), base_url="http://localhost:11434")
+        provider = _SdkLLMProvider(LitellmSdkBackend())
         with (
             mock.patch.object(provider._backend, "rerank", side_effect=RuntimeError("wire error")),
             pytest.raises(ProviderError, match="Rerank failed: wire error"),

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1109,7 +1109,7 @@ class TestHostedCatalogEntries:
         )
         monkeypatch.setattr(
             h,
-            "classify_remote_models",
+            "classify_all_remote_models",
             lambda *a, **k: [
                 RemoteModel(
                     name="llama3.1:8b",
@@ -1145,7 +1145,7 @@ class TestHostedCatalogEntries:
         monkeypatch.setattr(h, "discover_api_models", lambda: {})
         monkeypatch.setattr(
             h,
-            "classify_remote_models",
+            "classify_all_remote_models",
             lambda *a, **k: [
                 RemoteModel(
                     name="nomic-embed",
@@ -1182,7 +1182,7 @@ class TestHostedCatalogEntries:
             }
 
         monkeypatch.setattr(h, "discover_api_models", _discover)
-        monkeypatch.setattr(h, "classify_remote_models", lambda *a, **k: [])
+        monkeypatch.setattr(h, "classify_all_remote_models", lambda *a, **k: [])
         await h._collect_hosted_entries(task=ModelTask.CHAT, search="")
         await h._collect_hosted_entries(task=ModelTask.CHAT, search="")
         assert calls["n"] == 1
@@ -1193,11 +1193,11 @@ class TestHostedCatalogEntries:
         from lilbee.catalog.types import ModelSource, ModelTask
         from lilbee.modelhub.model_manager.types import RemoteModel
 
-        monkeypatch.setattr(h.cfg, "remote_base_url", "http://localhost:1234/v1")
+        monkeypatch.setattr(h.cfg, "lm_studio_base_url", "http://localhost:1234/v1")
         monkeypatch.setattr(h, "discover_api_models", lambda: {})
         monkeypatch.setattr(
             h,
-            "classify_remote_models",
+            "classify_all_remote_models",
             lambda *a, **k: [
                 RemoteModel(
                     name="qwen2.5-coder",
@@ -1213,8 +1213,8 @@ class TestHostedCatalogEntries:
             ("qwen2.5-coder", ModelSource.LM_STUDIO)
         ]
 
-    def test_discover_hosted_sync_unknown_backend_uses_generic_remote(self, monkeypatch) -> None:
-        """An unrecognized backend URL keeps the generic REMOTE source.
+    def test_discover_hosted_sync_unknown_provider_uses_generic_remote(self, monkeypatch) -> None:
+        """A row whose provider label maps to no known local server stays generic REMOTE.
 
         Matches the fallback get_source and the CLI use for an undetected server.
         """
@@ -1222,18 +1222,18 @@ class TestHostedCatalogEntries:
         from lilbee.catalog.types import ModelSource, ModelTask
         from lilbee.modelhub.model_manager.types import RemoteModel
 
-        monkeypatch.setattr(h.cfg, "remote_base_url", "http://my-host.internal:9000")
+        monkeypatch.setattr(h.cfg, "ollama_base_url", "http://my-host.internal:9000")
         monkeypatch.setattr(h, "discover_api_models", lambda: {})
         monkeypatch.setattr(
             h,
-            "classify_remote_models",
+            "classify_all_remote_models",
             lambda *a, **k: [
                 RemoteModel(
                     name="custom-model",
                     task=ModelTask.CHAT,
                     family="",
                     parameter_size="",
-                    provider="Ollama",
+                    provider="Remote",
                 )
             ],
         )
@@ -1252,7 +1252,7 @@ class TestModelsCatalog:
 
         h._hosted_cache._result = None
         monkeypatch.setattr(h, "discover_api_models", lambda: {})
-        monkeypatch.setattr(h, "classify_remote_models", lambda *a, **k: [])
+        monkeypatch.setattr(h, "classify_all_remote_models", lambda *a, **k: [])
 
     @staticmethod
     def _manifest(hf_repo: str, gguf_filename: str, task: str = "chat"):
@@ -2275,7 +2275,8 @@ class TestGetConfig:
         dumped = result.model_dump()
         assert "chat_model" in dumped
         assert "rag_system_prompt" in dumped
-        assert "remote_base_url" in dumped
+        assert "ollama_base_url" in dumped
+        assert "lm_studio_base_url" in dumped
         assert "diversity_max_per_source" in dumped
         assert "mmr_lambda" in dumped
         assert "query_expansion_count" in dumped
@@ -2812,10 +2813,10 @@ class TestListExternalModels:
     @patch("lilbee.server.handlers.models.get_services")
     async def test_cache_invalidates_on_config_change(self, mock_svc):
         mock_svc.return_value.provider.list_models.return_value = ["model-a"]
-        cfg.remote_base_url = "https://provider-a.example"
+        cfg.ollama_base_url = "https://provider-a.example"
         await handlers.list_external_models()
 
-        cfg.remote_base_url = "https://provider-b.example"
+        cfg.ollama_base_url = "https://provider-b.example"
         await handlers.list_external_models()
 
         assert mock_svc.return_value.provider.list_models.call_count == 2

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -156,6 +156,7 @@ class TestRemoteClassification:
     @mock.patch("httpx.get")
     def test_classifies_models(self, mock_get: mock.MagicMock) -> None:
         from lilbee.modelhub.model_manager import classify_remote_models
+        from lilbee.providers.local_servers import OLLAMA
 
         mock_get.return_value = mock.MagicMock(
             status_code=200,
@@ -174,7 +175,7 @@ class TestRemoteClassification:
             },
         )
         mock_get.return_value.raise_for_status = lambda: None
-        result = classify_remote_models()
+        result = classify_remote_models("http://localhost:11434", OLLAMA)
         by_task = {m.task: m.name for m in result}
         assert by_task["embedding"] == "nomic-embed-text:latest"
         assert by_task["chat"] == "qwen3:8b"

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -442,9 +442,9 @@ def _mock_catalog_deps():
 
 
 def _mock_remote_models():
-    """Mock classify_remote_models to return empty list."""
+    """Mock classify_all_remote_models to return empty list."""
     return mock.patch(
-        "lilbee.cli.tui.screens.catalog.classify_remote_models",
+        "lilbee.cli.tui.screens.catalog.classify_all_remote_models",
         return_value=[],
     )
 

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2482,7 +2482,7 @@ async def test_app_switch_to_catalog():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
         ):
             app.switch_view("Catalog")
             await _pilot.pause()
@@ -2701,7 +2701,7 @@ async def test_chat_slash_model_no_arg():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
         ):
             app.screen._handle_slash("/model")
             await _pilot.pause()
@@ -3067,7 +3067,7 @@ async def test_chat_slash_models():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
         ):
             app.screen._handle_slash("/models")
             await _pilot.pause()
@@ -3326,7 +3326,7 @@ async def test_chat_slash_m():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
         ):
             app.screen._handle_slash("/m")
             await _pilot.pause()
@@ -3902,7 +3902,7 @@ def _patch_catalog():
     """Context manager to patch catalog screen's network calls."""
     return (
         patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-        patch("lilbee.cli.tui.screens.catalog.classify_remote_models", return_value=[]),
+        patch("lilbee.cli.tui.screens.catalog.classify_all_remote_models", return_value=[]),
         patch(
             "lilbee.cli.tui.screens.catalog.get_services",
             return_value=MagicMock(
@@ -6032,7 +6032,7 @@ def test_check_embedding_model_remote_available():
         manager = get_services().model_manager
         assert not manager.is_installed(cfg.embedding_model)
 
-        remote_embeds = detect_remote_embedding_models(cfg.remote_base_url)
+        remote_embeds = detect_remote_embedding_models()
         assert cfg.embedding_model in remote_embeds
 
 
@@ -6050,7 +6050,7 @@ def test_check_embedding_model_not_found():
         manager = get_services().model_manager
         assert not manager.is_installed(cfg.embedding_model)
 
-        remote_embeds = detect_remote_embedding_models(cfg.remote_base_url)
+        remote_embeds = detect_remote_embedding_models()
         assert cfg.embedding_model not in remote_embeds
 
 
@@ -6293,7 +6293,7 @@ async def test_catalog_delete_installed_model_confirmation():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
             patch("lilbee.cli.tui.screens.catalog.get_services") as mock_mgr,
         ):
             mock_mgr.return_value.model_manager.is_installed.return_value = True
@@ -6329,7 +6329,7 @@ async def test_catalog_action_show_info_toasts_with_no_highlight():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
         ):
             screen = CatalogScreen()
             app.push_screen(screen)
@@ -6354,7 +6354,7 @@ async def test_catalog_action_show_info_pushes_modal_for_local_row():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
         ):
             screen = CatalogScreen()
             app.push_screen(screen)
@@ -6393,7 +6393,7 @@ async def test_catalog_delete_with_no_highlight_warns():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
         ):
             screen = CatalogScreen()
             app.push_screen(screen)
@@ -6438,7 +6438,7 @@ async def test_catalog_grid_renders_hf_overflow_cta():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
         ):
             screen = CatalogScreen()
             app.push_screen(screen)
@@ -6470,7 +6470,7 @@ async def test_catalog_delete_second_press_confirms():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
             patch("lilbee.cli.tui.screens.catalog.get_services") as mock_mgr,
         ):
             mock_mgr.return_value.model_manager.is_installed.return_value = True
@@ -6534,7 +6534,7 @@ async def test_catalog_delete_accepts_bare_hf_repo_row():
                 downloaded_at=datetime.now(UTC).isoformat(),
             ),
         )
-        mgr = ModelManager(models_dir, "http://localhost:11434")
+        mgr = ModelManager(models_dir)
         services = MagicMock()
         services.model_manager = mgr
 
@@ -6543,7 +6543,7 @@ async def test_catalog_delete_accepts_bare_hf_repo_row():
             with (
                 patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
                 patch(
-                    "lilbee.modelhub.model_manager.classify_remote_models",
+                    "lilbee.modelhub.model_manager.classify_all_remote_models",
                     return_value=[],
                 ),
                 patch(
@@ -6577,7 +6577,7 @@ async def test_catalog_resolve_delete_ref_picks_one_quant():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
         ):
             screen = CatalogScreen()
             app.push_screen(screen)
@@ -6605,7 +6605,7 @@ async def test_catalog_delete_not_installed():
     async with app.run_test(size=(120, 40)) as _pilot:
         with (
             patch("lilbee.cli.tui.screens.catalog.get_catalog", return_value=_EMPTY_CATALOG),
-            patch("lilbee.modelhub.model_manager.classify_remote_models", return_value=[]),
+            patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
             patch("lilbee.cli.tui.screens.catalog.get_services") as mock_mgr,
         ):
             mock_mgr.return_value.model_manager.is_installed.return_value = False

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1934,7 +1934,7 @@ class TestClassifyInstalledModels:
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry") as MockRegistry,
             mock.patch(
-                "lilbee.modelhub.model_manager.classify_remote_models",
+                "lilbee.modelhub.model_manager.classify_all_remote_models",
                 return_value=[],
             ),
         ):
@@ -1975,7 +1975,7 @@ class TestClassifyInstalledModels:
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry") as MockRegistry,
             mock.patch(
-                "lilbee.modelhub.model_manager.classify_remote_models",
+                "lilbee.modelhub.model_manager.classify_all_remote_models",
                 return_value=[remote_mmproj],
             ),
         ):
@@ -2010,12 +2010,12 @@ class TestClassifyInstalledModels:
         )
         cfg.models_dir = tmp_path / "models"
         cfg.models_dir.mkdir()
-        cfg.remote_base_url = "http://localhost:11434"
+        cfg.ollama_base_url = "http://localhost:11434"
 
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry") as MockRegistry,
             mock.patch(
-                "lilbee.modelhub.model_manager.classify_remote_models",
+                "lilbee.modelhub.model_manager.classify_all_remote_models",
                 return_value=[remote_chat, remote_embed],
             ),
         ):
@@ -2054,12 +2054,12 @@ class TestClassifyInstalledModels:
         )
         cfg.models_dir = tmp_path / "models"
         cfg.models_dir.mkdir()
-        cfg.remote_base_url = "http://localhost:11434"
+        cfg.ollama_base_url = "http://localhost:11434"
 
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry") as MockRegistry,
             mock.patch(
-                "lilbee.modelhub.model_manager.classify_remote_models",
+                "lilbee.modelhub.model_manager.classify_all_remote_models",
                 return_value=[remote],
             ),
         ):
@@ -2076,7 +2076,7 @@ class TestClassifyInstalledModels:
 
         cfg.models_dir = tmp_path / "models"
         cfg.models_dir.mkdir()
-        cfg.remote_base_url = "http://localhost:11434"
+        cfg.ollama_base_url = "http://localhost:11434"
 
         blank = RemoteModel(
             name="",
@@ -2095,7 +2095,7 @@ class TestClassifyInstalledModels:
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry") as MockRegistry,
             mock.patch(
-                "lilbee.modelhub.model_manager.classify_remote_models",
+                "lilbee.modelhub.model_manager.classify_all_remote_models",
                 return_value=[blank, good],
             ),
         ):
@@ -2132,7 +2132,7 @@ class TestClassifyInstalledModels:
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry") as MockRegistry,
             mock.patch(
-                "lilbee.modelhub.model_manager.classify_remote_models",
+                "lilbee.modelhub.model_manager.classify_all_remote_models",
                 return_value=[],
             ),
         ):
@@ -2152,7 +2152,7 @@ class TestClassifyInstalledModels:
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry") as MockRegistry,
             mock.patch(
-                "lilbee.modelhub.model_manager.classify_remote_models",
+                "lilbee.modelhub.model_manager.classify_all_remote_models",
                 return_value=[],
             ),
             mock.patch(
@@ -2189,7 +2189,7 @@ class TestClassifyInstalledModels:
         with (
             mock.patch("lilbee.modelhub.registry.ModelRegistry") as MockRegistry,
             mock.patch(
-                "lilbee.modelhub.model_manager.classify_remote_models",
+                "lilbee.modelhub.model_manager.classify_all_remote_models",
                 return_value=[],
             ),
             mock.patch(
@@ -4089,7 +4089,7 @@ class TestCollectNativeModelsError:
         }
         seen: set[str] = set()
         with mock.patch(
-            "lilbee.modelhub.model_manager.classify_remote_models",
+            "lilbee.modelhub.model_manager.classify_all_remote_models",
             side_effect=RuntimeError("boom"),
         ):
             _collect_remote_models(buckets, seen)
@@ -4106,7 +4106,7 @@ class TestCollectNativeModelsError:
         }
         seen: set[str] = set()
         with mock.patch(
-            "lilbee.modelhub.model_manager.classify_remote_models",
+            "lilbee.modelhub.model_manager.classify_all_remote_models",
             return_value=[
                 RemoteModel(
                     name="llama3:8b",
@@ -4135,7 +4135,7 @@ class TestCollectNativeModelsError:
         }
         seen: set[str] = set()
         with mock.patch(
-            "lilbee.modelhub.model_manager.classify_remote_models",
+            "lilbee.modelhub.model_manager.classify_all_remote_models",
             return_value=[
                 RemoteModel(
                     name="mystery:latest",
@@ -4188,7 +4188,7 @@ class TestCollectNativeModelsError:
         monkeypatch.setattr("lilbee.providers.litellm_sdk.litellm_available", lambda: False)
         buckets: dict[str, list[ModelOption]] = {"chat": [], "embedding": [], "vision": []}
         seen: set[str] = set()
-        with mock.patch("lilbee.modelhub.model_manager.classify_remote_models") as classify:
+        with mock.patch("lilbee.modelhub.model_manager.classify_all_remote_models") as classify:
             _collect_remote_models(buckets, seen)
         classify.assert_not_called()
         assert buckets["chat"] == []

--- a/tools/qa/test_e2e_litellm_ollama.py
+++ b/tools/qa/test_e2e_litellm_ollama.py
@@ -112,7 +112,7 @@ def lilbee_env_with_ollama(
         lilbee_data,
         extra={
             "LILBEE_LLM_PROVIDER": "remote",
-            "LILBEE_REMOTE_BASE_URL": ollama_url,
+            "LILBEE_OLLAMA_BASE_URL": ollama_url,
             "LILBEE_CHAT_MODEL": chat_ref,
         },
     )


### PR DESCRIPTION
## Problem

lilbee reached an external model manager through a single `remote_base_url`, so someone running both Ollama and LM Studio could only ever see one of them. Discovery probed one URL, and routing sent every remote model to that one endpoint, so an LM Studio model couldn't be reached while Ollama was the configured server. The setting also lived under "API Keys", which isn't where you'd look for a local server URL.

## Solution

`remote_base_url` is replaced by two per-server settings, `ollama_base_url` and `lm_studio_base_url`, living in a new "Local servers" group. Each is blank by default and falls back to that server's standard URL, so nothing needs configuring unless you've moved a server.

Discovery now probes every configured server and merges the results, and a model's request is routed to the URL of the server named in its ref. The upshot: both managers' models show up in the catalog and pickers together, and chatting with either one reaches the right place.

Closes bb-65qe. The matching Obsidian plugin change is tobocop2/obsidian-lilbee#per-server-urls.