### PR TITLE
Harden PDF OCR gate to key off extracted text content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,28 @@
 # lilbee — Development Guide
 
+## Before You Write Code (read this every time)
+
+This file is long and the operational rules sit far down. These are the misses
+that have cost the most review cycles. Apply them BEFORE writing, not after:
+
+1. **Type external objects precisely.** Never `getattr(obj, "field", default)`
+   on a field the object's type guarantees. Annotate the parameter with the
+   real type and read the attribute directly. `getattr`-with-default is only
+   for attributes that genuinely may not exist (dynamic reflection).
+2. **Don't inherit the surrounding code's pattern without checking it against
+   these rules.** Nearby code may predate a rule. Copying an adjacent
+   `getattr` / `isinstance(self.app, ...)` / `: str` shape just propagates the
+   smell into your diff.
+3. **One-line docstrings by default.** Describe what the code IS, not how it
+   got there. No "previously", "now also", "some versions", "kept for".
+4. **The smell gate runs in `make lint`.** `scripts/check_style_rules.py` fails
+   on any NEW Code-Smell Trigger (see that section) on lines your diff adds vs
+   `main`. Run `make lint` before committing; a genuinely dynamic case opts out
+   inline with `# style-check: allow-smell` plus a written reason.
+
+The full rules follow; this block is the part that gets skipped under time
+pressure, so it leads.
+
 ## Project
 Local search engine you can talk to. Python 3.11+, pluggable LLM providers (llama-cpp default, Ollama/OpenAI via litellm), LanceDB for vectors. Managed with `uv`. Task tracking with `beads` (`bd`). Learned behaviors with `floop`.
 
@@ -342,6 +365,13 @@ Each of these is a fast-grep that surfaces the patterns we've burned cycles
 on in past reviews. A reviewer (and the author, before requesting review)
 runs them. A non-empty result is either fixed or has a written justification
 in the PR body.
+
+A subset is enforced automatically: `scripts/check_style_rules.py` (run by
+`make lint`) fails when a line ADDED in `src/` vs `main` introduces a
+getattr-by-name, getattr-with-default, owned-attribute `type: ignore`,
+`isinstance(self.app, LilbeeApp)`, string-typed closed set, or module-level
+`global`. It scopes to added lines so pre-existing hits don't block unrelated
+work; the greps below remain the full set a reviewer still runs by eye.
 
 - `grep -rnE "isinstance\(self\.app, LilbeeApp\)" src/` — production host-narrowing for tests. Fix via `app: LilbeeApp` declaration + LilbeeAppHost in tests.
 - `grep -rn "getattr(self, \"" src/` — getattr-by-name for owned attributes. Declare in `__init__`.

--- a/scripts/check_style_rules.py
+++ b/scripts/check_style_rules.py
@@ -1,6 +1,9 @@
 """Project style-rule checker invoked by ``make lint``.
 
-Catches four classes of drift that ruff cannot express:
+Catches drift that ruff cannot express. The first four checks run across the
+whole tree (a pattern is forbidden everywhere); the fifth runs only on lines
+added relative to the base branch (it stops NEW smells without forcing a
+cleanup of pre-existing ones).
 
 1. Em dashes (``—``) in ``src/`` or ``tests/``. Project rule from AGENTS.md.
 2. Divider comments (``# ----`` / ``# ====``) used to group code in ``src/``.
@@ -13,9 +16,17 @@ Catches four classes of drift that ruff cannot express:
    ``commands.py``, ``handlers.py``, ``api.py``, ``clustering_embedding.py``,
    ``worker_process.py``, ``llama_cpp_provider.py``), and the phrase
    ``original X.py``. Project rule: docstrings name the current path.
+5. New occurrences of the AGENTS.md "Code-Smell Triggers" (getattr-by-name on
+   owned attributes, getattr-with-default on typed fields, owned-attribute
+   type-ignores, production host-narrowing, string-typed closed sets,
+   module-level mutable globals) on lines added in ``src/`` vs the base
+   branch. Resolving the base is best-effort: when git history is unavailable
+   (shallow CI checkout, no ``origin/main``) the check is skipped, not failed.
 
-Lines tagged with the inline opt-out comment ``# style-check: allow-history``
-are skipped for the historical-narrative check (only).
+Inline opt-out comments: ``# style-check: allow-history`` skips the
+historical-narrative check on that line; ``# style-check: allow-smell`` skips
+the code-smell check on that added line (use it with a written justification
+for genuinely dynamic reflection).
 
 Exits 0 when clean, 1 with one ``path:line:reason`` per finding when violations
 are found.
@@ -24,6 +35,7 @@ are found.
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from collections.abc import Iterable, Iterator
 from pathlib import Path
@@ -141,6 +153,121 @@ def _check_stale_single_file_paths(paths: Iterable[Path]) -> Iterator[str]:
                 )
 
 
+ALLOW_SMELL_TAG = "# style-check: allow-smell"
+
+# getattr-with-default on an object field. Named so the dunder exclusion below
+# (a legitimate getattr on `__dunder__` attributes) can reference it directly.
+_GETATTR_DEFAULT_RE = re.compile(r'getattr\([^,]+, "[^"]+",')
+
+# Each entry mirrors one AGENTS.md "Code-Smell Triggers" grep. Patterns match
+# the added line's content (the leading ``+`` already stripped).
+SMELL_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r'getattr\(self, "'),
+        "getattr-by-name on an owned attribute (declare it in __init__ with a type)",
+    ),
+    (
+        _GETATTR_DEFAULT_RE,
+        "getattr-with-default on an object field (tighten the type, don't paper over it)",
+    ),
+    (
+        re.compile(r"# type: ignore\[attr-defined\]"),
+        "type-ignore on an owned attribute (declare the attribute on the class)",
+    ),
+    (
+        re.compile(r"isinstance\(self\.app, LilbeeApp\)"),
+        "production host-narrowing for tests (declare `app: LilbeeApp`, use LilbeeAppHost)",
+    ),
+    (
+        re.compile(r"\b(?:task|kind|role|event_type|status|mode): str\b"),
+        "string-typed closed set (convert to a StrEnum at the boundary)",
+    ),
+    (
+        re.compile(r"^\s*global \w+"),
+        "module-level mutable global (encapsulate on a class)",
+    ),
+)
+
+_DIFF_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$")
+_DIFF_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def _smell_base_ref() -> str | None:
+    """Return the merge-base sha with the upstream default branch, or None.
+
+    Tries ``origin/main`` then ``main``; returns None when neither resolves so
+    the caller can skip the diff-scoped check instead of failing.
+    """
+    for branch in ("origin/main", "main"):
+        try:
+            out = subprocess.run(
+                ["git", "merge-base", "HEAD", branch],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+        ref = out.stdout.strip()
+        if ref:
+            return ref
+    return None
+
+
+def _git_diff_src(base: str) -> str:
+    """Return ``git diff --unified=0`` of ``src/`` against the base sha."""
+    out = subprocess.run(
+        ["git", "diff", "--unified=0", base, "--", "src"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout
+
+
+def _parse_added_lines(diff_text: str) -> Iterator[tuple[str, int, str]]:
+    """Yield ``(path, new_line_number, content)`` for each added line.
+
+    Parses ``git diff --unified=0`` output: ``+`` lines (excluding the ``+++``
+    header) are additions, ``-`` lines never advance the new-file counter, and
+    ``+++ /dev/null`` deletions are skipped.
+    """
+    path: str | None = None
+    lineno = 0
+    for line in diff_text.splitlines():
+        file_match = _DIFF_FILE_RE.match(line)
+        if file_match is not None:
+            target = file_match.group(1)
+            path = None if target == "/dev/null" else target
+            continue
+        hunk_match = _DIFF_HUNK_RE.match(line)
+        if hunk_match is not None:
+            lineno = int(hunk_match.group(1))
+            continue
+        if path is None or not line.startswith("+"):
+            continue
+        yield path, lineno, line[1:]
+        lineno += 1
+
+
+def _check_code_smells(added: Iterable[tuple[str, int, str]]) -> Iterator[str]:
+    """Yield findings for AGENTS.md code-smell triggers on added Python lines."""
+    for path, lineno, content in added:
+        if not path.endswith(".py") or ALLOW_SMELL_TAG in content:
+            continue
+        for pattern, reason in SMELL_PATTERNS:
+            match = pattern.search(content)
+            if match is None:
+                continue
+            # getattr on a dunder attribute is legitimate dynamic reflection.
+            if pattern is _GETATTR_DEFAULT_RE and '"__' in match.group(0):
+                continue
+            yield f"{path}:{lineno}: code smell -- {reason}"
+            break
+
+
 def main() -> int:
     src_files = list(_iter_python_files(SRC_DIR))
     test_files = list(_iter_python_files(TESTS_DIR))
@@ -150,6 +277,10 @@ def main() -> int:
     findings.extend(_check_divider_comments(src_files))
     findings.extend(_check_historical_narrative(src_files))
     findings.extend(_check_stale_single_file_paths(src_files))
+
+    base = _smell_base_ref()
+    if base is not None:
+        findings.extend(_check_code_smells(_parse_added_lines(_git_diff_src(base))))
 
     for finding in findings:
         print(finding)

--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -34,13 +34,11 @@ from lilbee.runtime.progress import (
 log = logging.getLogger(__name__)
 
 
-def _has_meaningful_text(result: Any) -> bool:
-    """Check if extraction produced meaningful text."""
-    chunks = getattr(result, "chunks", None)
-    if chunks:
-        total = sum(len(c.content.strip()) for c in chunks)
-        return total > MIN_MEANINGFUL_CHARS
-    return False
+def _has_meaningful_text(result: ExtractionResult) -> bool:
+    """True when extraction yielded real text; content is primary, chunks the fallback."""
+    if len(result.content.strip()) > MIN_MEANINGFUL_CHARS:
+        return True
+    return sum(len(c.content.strip()) for c in result.chunks or []) > MIN_MEANINGFUL_CHARS
 
 
 def content_type_to_mode(content_type: str) -> ExtractMode:

--- a/tests/test_check_style_rules.py
+++ b/tests/test_check_style_rules.py
@@ -1,0 +1,113 @@
+"""Tests for the diff-scoped code-smell gate in ``scripts/check_style_rules.py``.
+
+The script lives outside the ``lilbee`` package (not import-installed), so it is
+loaded by path. Only the pure functions are exercised here; the git plumbing
+(`_smell_base_ref`, `_git_diff_src`) is environment-dependent and covered by
+running ``make lint`` itself.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_style_rules.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_style_rules", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+csr = _load_module()
+
+
+class TestParseAddedLines:
+    def test_tracks_path_and_new_line_numbers(self):
+        diff = (
+            "diff --git a/src/x.py b/src/x.py\n"
+            "--- a/src/x.py\n"
+            "+++ b/src/x.py\n"
+            "@@ -10,0 +11,2 @@ def f():\n"
+            "+    first = 1\n"
+            "+    second = 2\n"
+        )
+        assert list(csr._parse_added_lines(diff)) == [
+            ("src/x.py", 11, "    first = 1"),
+            ("src/x.py", 12, "    second = 2"),
+        ]
+
+    def test_minus_lines_do_not_advance_counter(self):
+        diff = "+++ b/src/x.py\n@@ -20,2 +25,1 @@\n-old one\n-old two\n+replacement\n"
+        assert list(csr._parse_added_lines(diff)) == [("src/x.py", 25, "replacement")]
+
+    def test_deletion_target_is_skipped(self):
+        diff = "+++ /dev/null\n@@ -1,1 +0,0 @@\n+ignored\n"
+        assert list(csr._parse_added_lines(diff)) == []
+
+    def test_single_line_hunk_header_without_count(self):
+        diff = "+++ b/src/x.py\n@@ -3 +7 @@\n+added\n"
+        assert list(csr._parse_added_lines(diff)) == [("src/x.py", 7, "added")]
+
+
+class TestCheckCodeSmells:
+    def test_flags_getattr_with_default(self):
+        added = [("src/x.py", 11, '    content = getattr(result, "content", None)')]
+        findings = list(csr._check_code_smells(added))
+        assert len(findings) == 1
+        assert "src/x.py:11" in findings[0]
+        assert "getattr-with-default" in findings[0]
+
+    def test_skips_dunder_getattr(self):
+        added = [("src/x.py", 5, '    klass = getattr(obj, "__class__", None)')]
+        assert list(csr._check_code_smells(added)) == []
+
+    def test_flags_getattr_self(self):
+        added = [("src/x.py", 1, '        self._flag = getattr(self, "_flag", False)')]
+        findings = list(csr._check_code_smells(added))
+        assert len(findings) == 1
+        assert "getattr-by-name" in findings[0]
+
+    def test_flags_type_ignore_attr_defined(self):
+        added = [("src/x.py", 2, "        self.app.task_bar  # type: ignore[attr-defined]")]
+        findings = list(csr._check_code_smells(added))
+        assert "type-ignore on an owned attribute" in findings[0]
+
+    def test_flags_host_narrowing(self):
+        added = [("src/x.py", 3, "        if isinstance(self.app, LilbeeApp):")]
+        findings = list(csr._check_code_smells(added))
+        assert "production host-narrowing" in findings[0]
+
+    @pytest.mark.parametrize("field", ["task", "kind", "role", "event_type", "status", "mode"])
+    def test_flags_string_typed_closed_set(self, field):
+        added = [("src/x.py", 4, f"    {field}: str = default")]
+        findings = list(csr._check_code_smells(added))
+        assert "string-typed closed set" in findings[0]
+
+    def test_flags_module_level_global(self):
+        added = [("src/x.py", 6, "    global _cache")]
+        findings = list(csr._check_code_smells(added))
+        assert "module-level mutable global" in findings[0]
+
+    def test_allow_smell_tag_opts_out(self):
+        added = [
+            (
+                "src/x.py",
+                7,
+                '    x = getattr(row, "field", None)  # style-check: allow-smell',
+            )
+        ]
+        assert list(csr._check_code_smells(added)) == []
+
+    def test_non_python_added_lines_ignored(self):
+        added = [("docs/x.md", 1, '    getattr(result, "content", None)')]
+        assert list(csr._check_code_smells(added)) == []
+
+    def test_clean_line_yields_nothing(self):
+        added = [("src/x.py", 1, "    return result.content")]
+        assert list(csr._check_code_smells(added)) == []

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1115,10 +1115,10 @@ class TestSyncStructuredFormats:
 
 
 class TestHasMeaningfulText:
-    def test_empty_chunks_returns_false(self):
+    def test_empty_content_and_chunks_returns_false(self):
         from lilbee.data.ingest.extract import _has_meaningful_text
 
-        result = mock.MagicMock(chunks=[])
+        result = mock.MagicMock(content="", chunks=[])
         assert _has_meaningful_text(result) is False
 
     def test_short_text_returns_false(self):
@@ -1126,15 +1126,23 @@ class TestHasMeaningfulText:
 
         chunk = mock.MagicMock()
         chunk.content = "short"
-        result = mock.MagicMock(chunks=[chunk])
+        result = mock.MagicMock(content="short", chunks=[chunk])
         assert _has_meaningful_text(result) is False
 
-    def test_meaningful_text_returns_true(self):
+    def test_meaningful_chunks_returns_true(self):
         from lilbee.data.ingest.extract import _has_meaningful_text
 
         chunk = mock.MagicMock()
         chunk.content = "A" * 100
-        result = mock.MagicMock(chunks=[chunk])
+        result = mock.MagicMock(content="", chunks=[chunk])
+        assert _has_meaningful_text(result) is True
+
+    def test_content_rich_empty_chunks_returns_true(self):
+        """A text PDF whose extractor populated content but no chunks must
+        take the text path, not vision OCR (bb-4u58)."""
+        from lilbee.data.ingest.extract import _has_meaningful_text
+
+        result = mock.MagicMock(content="A" * 100, chunks=[])
         assert _has_meaningful_text(result) is True
 
 


### PR DESCRIPTION
## Problem

A text PDF with a real text layer (e.g. a long manual) was being pushed through vision OCR. The scanned-vs-text gate only looked at extraction chunks and forced OCR whenever chunks came back empty, even when the extractor had populated the full text content.

## Solution

The gate now keys off the extracted text content first, falling back to chunks. A PDF with real text takes the fast native path; a genuinely empty result still routes to OCR.

Also adds a diff-scoped code-smell gate to `scripts/check_style_rules.py` (run by `make lint`) that fails when a newly added line in `src/` introduces one of the AGENTS.md Code-Smell Triggers, plus a short "Before You Write Code" preamble at the top of AGENTS.md.