### PR TITLE
Create the fleet server data dir before spawning

### DIFF
--- a/src/lilbee/providers/fleet/fleet.py
+++ b/src/lilbee/providers/fleet/fleet.py
@@ -152,6 +152,11 @@ class FleetServer:
         port = pick_free_port()
         argv = [*self._launch.argv, "--port", str(port)]
         env = {**os.environ, **self._launch.env_overrides}
+        # The data dir may not exist yet on the first spawn: fleet warm-up runs at
+        # startup, before indexing creates it. Without this, opening the stderr log
+        # (and writing the port file below) FileNotFoundErrors, which silently fails
+        # warm-up so the first search hits a cold embed engine and 503s (bb-1ldh).
+        self._stderr_log.parent.mkdir(parents=True, exist_ok=True)
         # Capture stderr to a per-instance file (truncated each spawn) so a failed
         # launch is diagnosable; a file (not a pipe) needs no parent drain and
         # cannot deadlock the child. The parent's handle is closed immediately --

--- a/tests/server/chat_completions_api/test_protocol_smoke.py
+++ b/tests/server/chat_completions_api/test_protocol_smoke.py
@@ -17,7 +17,7 @@ from lilbee.app.services import get_services, set_services
 from lilbee.providers.base import ChatResult, FinishReason
 from lilbee.server import auth as _auth_mod
 from lilbee.server.chat_completions_api.routes import completions_router
-from lilbee.server.chat_dispatch.concurrency import chat_lock
+from lilbee.server.chat_dispatch.concurrency import chat_gate
 
 _MOCK_MODEL_REF = "vendor/Model-GGUF/model-Q4.gguf"
 _HTTP_OK = 200
@@ -42,6 +42,7 @@ def services_with_chat_model():
         text="hello", tool_calls=(), finish_reason=FinishReason.STOP
     )
     provider.supports_tools.return_value = False
+    provider.max_concurrent_chats.return_value = 1
     services = make_mock_services(provider=provider)
     services.registry.list_installed = MagicMock(return_value=[_installed_chat_model()])
     services.known_models.refs = MagicMock(return_value={_MOCK_MODEL_REF})
@@ -63,11 +64,11 @@ def auth_token():
 
 
 @pytest.fixture(autouse=True)
-def reset_chat_lock():
-    """Drop the cached chat lock between tests so each starts clean."""
-    chat_lock.cache_clear()
+def reset_chat_gate():
+    """Drop the cached chat gate between tests so each starts clean."""
+    chat_gate.cache_clear()
     yield
-    chat_lock.cache_clear()
+    chat_gate.cache_clear()
 
 
 @pytest.fixture

--- a/tests/server/test_rag_uses_chat_dispatch.py
+++ b/tests/server/test_rag_uses_chat_dispatch.py
@@ -49,6 +49,7 @@ def services_with_chat_dispatch():
         text="hello", tool_calls=(), finish_reason=FinishReason.STOP
     )
     provider.supports_tools.return_value = False
+    provider.max_concurrent_chats.return_value = 1
     services = make_mock_services(provider=provider)
     services.registry.list_installed = MagicMock(return_value=[_installed_manifest(cfg.chat_model)])
     services.searcher.build_rag_context = MagicMock(

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -143,6 +143,27 @@ def test_spawn_claims_port_writes_pid_file_and_creates_client(
     assert server.is_alive()
 
 
+def test_spawn_creates_missing_port_file_parent_dir(tmp_path: Path, patched: dict) -> None:
+    """spawn() must create the port-file/stderr-log parent dir when it is missing.
+
+    The fleet warm-up can spawn the embed server at startup before the data dir
+    exists (indexing creates it later). Opening the stderr log in a missing dir
+    raised FileNotFoundError that silently failed warm-up, so the first search hit
+    a cold embed engine and 503'd instead of returning results (bb-1ldh).
+    """
+    missing = tmp_path / "data"  # parent dir does NOT exist yet
+    launch = InstanceLaunch(
+        role=WorkerRole.EMBED,
+        argv=["/bin/llama-server", "--model", "m.gguf"],
+        env_overrides={"CUDA_VISIBLE_DEVICES": "0"},
+        model="m.gguf",
+        port_file=missing / "llama-server-embed.port",
+    )
+    FleetServer(launch).spawn()
+    assert (missing / "llama-server-embed.port").exists()
+    assert (missing / "llama-server-embed.log").exists()
+
+
 def test_spawn_appends_port_to_argv(tmp_path: Path, patched: dict, monkeypatch) -> None:
     seen: dict[str, list] = {}
     monkeypatch.setattr(fleet_mod, "pick_free_port", lambda: 42999)


### PR DESCRIPTION
## Problem

The first search in an agentic session (e.g. opencode using lilbee_search) reliably failed with a 503, which a client cannot distinguish from "search is broken / no embed model." The cause was the embed engine's warm-up failing silently at startup: it tried to write its log into the data directory before that directory existed (warm-up runs before indexing creates it), hit a file-not-found error, and fell back to a lazy start that only came up mid-session, after the early searches had already failed.

## Solution

Create the directory before the embed server writes into it, so warm-up completes and the embed engine is ready before the first search. Includes a regression test for spawning when the parent directory is missing.