### PR TITLE
opencode QA harness + reel-generation pipeline 

### DIFF
--- a/demos-src/opencode-model-reel/build_reel.sh
+++ b/demos-src/opencode-model-reel/build_reel.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Build one warm-first opencode demo end to end:
+#   1. giant_demo.sh        -> warm the model, MEASURE the cold start, write sidecar
+#   2. vhs <tape>           -> record opencode (warm, streaming, clean session name)
+#   3. cold-start intro card -> a short labeled card built from the MEASURED time,
+#                               concatenated in front (the honest "fast-forwarded
+#                               cold start"); never real-time dead air
+#   4. review_demo.py       -> timeline review gate (prompt + answer + quality)
+#
+# Runs on the pod (needs the GPUs + ffmpeg + vhs). The final demos/opencode-<full>.{gif,mp4}
+# are produced under OUT_DIR for transfer to the reel.
+#
+# Usage: build_reel.sh <family> <full-name> <gguf_path> <prompt> [stream_sleep_s] [multigpu]
+set -euo pipefail
+
+FAMILY="$1"; FULL="$2"; GGUF="$3"; PROMPT="$4"
+STREAM_SLEEP="${5:-45}"          # seconds to let the warm answer stream on screen
+export MULTIGPU="${6:-0}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WS=/root/demo-ws
+OUT_DIR="${OUT_DIR:-/root/demos}"
+INTRO_SECONDS="${INTRO_SECONDS:-2.6}"
+mkdir -p "$OUT_DIR"
+
+# Pick a monospace font for the intro card; fail loudly if none (don't guess).
+FONT=""
+for f in /usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf \
+         /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf; do
+  [ -f "$f" ] && { FONT="$f"; break; }
+done
+[ -n "$FONT" ] || { echo "no usable font for intro card" >&2; exit 4; }
+
+# 1) warm + measure (writes $WS/coldstart-$FAMILY.txt)
+"$HERE/giant_demo.sh" "$FAMILY" "$GGUF"
+
+# 2) render the streaming tape
+# VHS's Output path MUST be relative (an absolute path trips its parser), so the
+# tape gets a bare basename and VHS runs from OUT_DIR; STEM stays absolute for the
+# ffmpeg steps below. VHS_NO_SANDBOX is required for headless chromium on the pod.
+RAW="_raw-$FAMILY"
+STEM="$OUT_DIR/$RAW"
+sed -e "s#__OUT__#$RAW#g" \
+    -e "s#__PROMPT__#$PROMPT#g" \
+    -e "s#__SESSION__#$FULL#g" \
+    -e "s#__STREAMSLEEP__#${STREAM_SLEEP}s#g" \
+    "$HERE/giant_demo.tape.tmpl" > "/tmp/tape-$FAMILY.tape"
+( cd "$OUT_DIR" && VHS_NO_SANDBOX=true vhs "/tmp/tape-$FAMILY.tape" )
+
+# 3) cold-start intro card from the MEASURED numbers
+# shellcheck disable=SC1090
+. "$WS/coldstart-$FAMILY.txt"   # -> model, size_gb, cold_s, devices
+INTRO="/tmp/intro-$FAMILY.mp4"
+LABEL="Cold start: loading ${model} (${size_gb} GB) on ${devices}"
+SUB="measured ${cold_s}s to first token, fast-forwarded   then: warm + streaming"
+ffmpeg -nostdin -y -loglevel error -f lavfi -i "color=c=0x232136:s=1600x1000:d=${INTRO_SECONDS}:r=60" \
+  -vf "drawtext=fontfile=${FONT}:text='${LABEL}':fontcolor=0xe0def4:fontsize=34:x=(w-text_w)/2:y=420,\
+drawtext=fontfile=${FONT}:text='${SUB}':fontcolor=0x908caa:fontsize=22:x=(w-text_w)/2:y=480" \
+  -c:v libx264 -pix_fmt yuv420p -r 60 "$INTRO"
+
+# 4) concat intro + demo into the final mp4, then derive a high-quality gif
+DEMO_MP4="/tmp/demo-$FAMILY.mp4"
+ffmpeg -nostdin -y -loglevel error -i "$STEM.webm" -c:v libx264 -pix_fmt yuv420p -r 60 -vf scale=1600:1000 "$DEMO_MP4"
+FINAL_MP4="$OUT_DIR/opencode-$FULL.mp4"
+printf "file '%s'\nfile '%s'\n" "$INTRO" "$DEMO_MP4" > "/tmp/concat-$FAMILY.txt"
+ffmpeg -nostdin -y -loglevel error -f concat -safe 0 -i "/tmp/concat-$FAMILY.txt" -c:v libx264 -pix_fmt yuv420p -movflags +faststart "$FINAL_MP4"
+PAL="/tmp/pal-$FAMILY.png"
+ffmpeg -nostdin -y -loglevel error -i "$FINAL_MP4" -vf "fps=20,scale=1600:-1:flags=lanczos,palettegen" "$PAL"
+ffmpeg -nostdin -y -loglevel error -i "$FINAL_MP4" -i "$PAL" -lavfi "fps=20,scale=1600:-1:flags=lanczos[x];[x][1:v]paletteuse" "$OUT_DIR/opencode-$FULL.gif"
+cp -f "$STEM.png" "$OUT_DIR/opencode-$FULL.png"
+
+# 5) timeline review gate
+echo "[review] $FULL"
+python3 "$HERE/review_demo.py" "$FINAL_MP4" --frames 8 || {
+  echo "[review] $FULL flagged DEAD-SCREEN RISK -- inspect frames before publishing" >&2
+}
+echo "DONE opencode-$FULL  (cold_s=${cold_s}, size=${size_gb}GB)"

--- a/demos-src/opencode-model-reel/gate.py
+++ b/demos-src/opencode-model-reel/gate.py
@@ -1,0 +1,49 @@
+"""Demo-readiness gate: does the freshly built index ground every probe?
+
+Searches each probe against a running ``lilbee serve`` and fails (exit 1) unless
+every probe's expected file surfaces. ingest_corpus.sh runs this before any model
+work so a stale or empty corpus is caught here, not three giants into the matrix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from lilbee_http import LilbeeClient
+from score_retrieval import budget_for_context, load_probes, score_pass
+
+# Generous fixed top_k for the gate: we only ask "is the expected file reachable
+# at all", not "is it optimally ranked" (that is tune_run's job per model).
+_GATE_TOP_K = 20
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", default="http://127.0.0.1:8080")
+    ap.add_argument("--token", required=True)
+    ap.add_argument("--probes", type=Path, default=Path(__file__).with_name("probes.toml"))
+    ap.add_argument("--n-ctx", type=int, default=8192)
+    args = ap.parse_args()
+
+    client = LilbeeClient(base_url=args.base_url, token=args.token)
+    probes = load_probes(args.probes)
+    results = {p.query: client.search(p.query, top_k=_GATE_TOP_K) for p in probes}
+    score = score_pass(probes, results, budget_for_context(args.n_ctx))
+
+    for o in score.outcomes:
+        mark = "ok " if o.hit else "MISS"
+        where = ", ".join(o.citations) if o.hit else f"missing {', '.join(o.missed)}"
+        print(f"  [{mark}] {o.query}  ->  {where}")
+    print(f"recall={score.recall:.0%}  mrr={score.mrr:.2f}")
+
+    if score.recall < 1.0:
+        print("GATE FAIL: index does not ground every probe; not demo-ready.", file=sys.stderr)
+        return 1
+    print("GATE PASS: index grounds every probe.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos-src/opencode-model-reel/giant_demo.sh
+++ b/demos-src/opencode-model-reel/giant_demo.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Stand up an opencode demo of a giant model doing RAG over lilbee's own source:
+#   opencode  --(model)-->  llama-server --jinja  (the giant, native tool calls)
+#             --(MCP)----->  lilbee serve /mcp  (lilbee_search over src/lilbee/)
+#
+# Idempotent prep (workspace + index + lilbee serve) runs once; the per-giant
+# part launches llama-server for the requested giant and writes opencode.json.
+#
+# Usage: giant_demo.sh <family> <gguf_path> [chat_template_file]
+set -euo pipefail
+
+FAMILY="$1"
+GGUF="$2"
+TEMPLATE="${3:-}"
+
+LC=/root/llama.cpp            # CUDA llama.cpp built by pod_bootstrap.sh
+LM=/root/lilbee               # lilbee checkout (feat/local-model-api) from pod_bootstrap.sh
+WS="${WS:-/root/demo-ws}"     # data dir (index + lilbee data); the model driver points
+                              # this at /workspace so the index lives on the big volume
+mkdir -p "$WS"
+LS_PORT=8090                      # llama-server (the giant)
+EMBED_REF="nomic-ai/nomic-embed-text-v1.5-GGUF"
+TINY_CHAT="Qwen/Qwen3-4B-GGUF"    # only so lilbee serve starts; opencode never uses it
+export PATH="$HOME/.local/bin:$HOME/.opencode/bin:$PATH"
+export LD_LIBRARY_PATH="$LC/build/bin:$LC/build/src:${LD_LIBRARY_PATH:-}"
+export LILBEE_DATA="$WS/.lilbee"
+
+cd "$LM"
+LILBEE=".venv/bin/lilbee"
+
+# --- one-time prep: workspace + index + serve ---
+if [ ! -f "$WS/.lilbee/.demo_indexed" ]; then
+  echo "[prep] workspace + models + index"
+  mkdir -p "$WS/.lilbee"
+  cat > "$WS/.lilbee/config.toml" <<TOML
+chat_model = "$TINY_CHAT"
+embedding_model = "$EMBED_REF"
+TOML
+  "$LILBEE" model pull "$EMBED_REF"
+  "$LILBEE" model pull "$TINY_CHAT"
+  # Index the modules a coding agent needs to answer questions about lilbee's chat
+  # + tool-call handling. Paths are verified against the indexed branch's real
+  # layout (the old providers/worker, providers/llama_cpp, providers/families dirs
+  # were removed in the fleet/llama-server migration). A missing path is logged
+  # LOUDLY, never silently skipped, so a stale layout can't quietly empty the corpus
+  # and leave the demo asking for a file that was never indexed.
+  for d in providers server/chat_dispatch server/chat_completions_api retrieval; do
+    if [ -d "$LM/src/lilbee/$d" ]; then
+      echo "[prep] indexing src/lilbee/$d"
+      "$LILBEE" add "$LM/src/lilbee/$d"
+    else
+      echo "[prep] WARNING: index path missing on this branch, skipped: src/lilbee/$d" >&2
+    fi
+  done
+  touch "$WS/.lilbee/.demo_indexed"
+fi
+
+# opencode runs in an EMPTY project dir so its file tools can't read the source
+# directly -- the lilbee source lives ONLY in lilbee's index, forcing lilbee_search
+# (the godot-demo dynamic). AGENTS.md carries the grounding directive so the prompt
+# stays a natural dev task.
+PROJ=/root/demo-proj
+mkdir -p "$PROJ"
+cat > "$PROJ/AGENTS.md" <<'AGENTS'
+# Working on the lilbee codebase
+
+lilbee is a local-first RAG engine with an OpenAI-compatible server and an
+opencode/MCP integration. Your training data does not include lilbee's internals,
+and the lilbee source is NOT in this directory.
+
+- The ONLY way to see lilbee's code is the `lilbee_search` tool. Use it to look up
+  lilbee's modules, classes, and conventions before writing code. Query the
+  class/function/concept; do not guess APIs.
+- Cite the files you rely on as `path:Lstart-Lend`.
+- No clarifying questions: make reasonable assumptions and implement.
+AGENTS
+
+# --- lilbee serve (background, for /mcp) ---
+# tmux new-session inherits the tmux SERVER's start-time environment, not this
+# script's, so LILBEE_MODELS_DIR (which the `lilbee model pull` above honoured to
+# place nomic on /workspace) would be lost here -- serve would resolve models
+# against the default global dir, report them "not installed", skip the embed
+# sidecar, and 503 every search. Inline the var into the command (like LILBEE_DATA)
+# so it reaches serve regardless of the server env.
+MODELS_DIR_ENV="${LILBEE_MODELS_DIR:+LILBEE_MODELS_DIR=$LILBEE_MODELS_DIR}"
+if ! curl -s "http://127.0.0.1:8080/api/health" >/dev/null 2>&1; then
+  echo "[prep] starting lilbee serve"
+  tmux kill-session -t lilbeeserve 2>/dev/null || true
+  tmux new-session -d -s lilbeeserve \
+    "cd $LM && LILBEE_DATA=$WS/.lilbee $MODELS_DIR_ENV $LILBEE serve --port 8080 > /tmp/lilbee-serve.log 2>&1"
+  for _ in $(seq 1 60); do
+    curl -s "http://127.0.0.1:8080/api/health" >/dev/null 2>&1 && break; sleep 2
+  done
+fi
+TOKEN=$(python3 -c "import json;print(json.load(open('$WS/.lilbee/data/server.json'))['token'])")
+echo "[prep] lilbee serve up; token read"
+
+# Pre-warm the embed engine and verify a real search returns hits BEFORE recording.
+# lilbee's fleet warms the embed role lazily and swallows warm-up failures, so the
+# first lilbee_search can hit a cold engine and 503 -- which the agent misreads as
+# "no embed model installed" and wastes the whole session bootstrapping search.
+# Force the embed role warm via the exact path the MCP tool uses (/api/search), and
+# abort rather than record a broken demo. (The proper fix is await-embed-warm in
+# lilbee itself; this gate guarantees a clean demo regardless.)
+echo "[prep] warming embed engine + verifying lilbee_search returns hits"
+WARM_OK=0
+for _ in $(seq 1 40); do
+  if curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://127.0.0.1:8080/api/search?q=tool%20call%20parsing&top_k=3" 2>/dev/null \
+       | grep -qiE '"source"|\.py'; then
+    WARM_OK=1; break
+  fi
+  sleep 3
+done
+if [ "$WARM_OK" = "1" ]; then
+  echo "[prep] embed engine warm; lilbee_search returns hits -> safe to record"
+else
+  echo "[giant] ERROR: lilbee_search never returned hits (embed engine did not warm); aborting" >&2
+  exit 6
+fi
+
+# --- llama-server for the giant ---
+echo "[giant] launching llama-server for $FAMILY"
+tmux kill-session -t giantsrv 2>/dev/null || true
+# Wait for any prior giant to release :LS_PORT before launching the new one, so the
+# readiness gate below can't read a stale server's 200 and start recording against
+# a model that has not finished loading.
+for _ in $(seq 1 30); do
+  curl -fsS -m1 "http://127.0.0.1:$LS_PORT/health" >/dev/null 2>&1 && sleep 1 || break
+done
+TMPL_ARG=""
+[ -n "$TEMPLATE" ] && TMPL_ARG="--chat-template-file $TEMPLATE"
+# Only the 200GB giants need both GPUs. Force-splitting a small model across both
+# (-ngl 999 with 2 visible devices) trips llama.cpp's scheduler assert
+# (GGML_SCHED_MAX_SPLIT_INPUTS) during the device-memory fit, e.g. gemma-4-E2B.
+# Default to a single GPU; set MULTIGPU=1 for the giants that genuinely span both.
+GPU_ENV="CUDA_VISIBLE_DEVICES=0"
+[ "${MULTIGPU:-0}" = "1" ] && GPU_ENV=""
+# --alias makes /v1/models advertise the same id opencode is configured with, so
+# the picker shows one "lilbee" model, not a duplicate from auto-discovery.
+tmux new-session -d -s giantsrv \
+  "$GPU_ENV LD_LIBRARY_PATH=$LC/build/bin:$LC/build/src $LC/build/bin/llama-server --jinja -m '$GGUF' --alias '$FAMILY' -ngl 999 --host 127.0.0.1 --port $LS_PORT -c 131072 -fa on --no-webui $TMPL_ARG > /tmp/giant-srv.log 2>&1"
+# Measure the cold start empirically: wall time from launch until /health reports
+# the model loaded. This is the real number the demo's cold-start intro card shows
+# (build_reel.sh reads the sidecar), so the "fast-forwarded cold start" is honest,
+# never an invented duration. Use curl -fsS (NOT -s): while the model is still
+# loading, /health returns 503 "Loading model", and a bare `curl -s` exits 0 on a
+# 503 -- so the gate would pass instantly and record against a not-yet-loaded
+# giant (empty demo). -fsS only exits 0 on a 2xx, i.e. weights resident. The 400x3s
+# budget (20min) covers a 200GB+ giant loading across both GPUs from the volume.
+COLD_START_TS=$SECONDS
+UP=0
+for _ in $(seq 1 400); do
+  curl -fsS -m2 "http://127.0.0.1:$LS_PORT/health" >/dev/null 2>&1 && { UP=1; break; }; sleep 3
+done
+COLD_S=$((SECONDS - COLD_START_TS))
+if [ "$UP" != "1" ]; then
+  echo "[giant] ERROR: $FAMILY llama-server did not come up (see /tmp/giant-srv.log)" >&2
+  exit 3
+fi
+# Sum every shard in the model dir (a sharded giant's first shard alone understates
+# the real size the cold-start card reports).
+GGUF_BYTES=$(find "$(dirname "$GGUF")" -iname '*.gguf' ! -name '*.lock' -printf '%s\n' 2>/dev/null | awk '{s+=$1} END{print s+0}')
+SIZE_GB=$(awk "BEGIN{printf \"%.0f\", $GGUF_BYTES / 1073741824}")
+# Sidecar consumed by build_reel.sh to render the cold-start intro card.
+printf 'model=%s\nsize_gb=%s\ncold_s=%s\ndevices="%s"\n' \
+  "$FAMILY" "$SIZE_GB" "$COLD_S" "$([ "${MULTIGPU:-0}" = "1" ] && echo "2x H200" || echo "1x H200")" \
+  > "$WS/coldstart-$FAMILY.txt"
+echo "[giant] $FAMILY served on :$LS_PORT (cold start ${COLD_S}s, ${SIZE_GB}GB) -> warm; safe to record"
+
+# --- opencode.json: model from llama-server, lilbee_search from lilbee MCP ---
+mkdir -p "$WS/.config/opencode"
+cat > "$PROJ/opencode.json" <<JSON
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "model": "lilbee/$FAMILY",
+  "provider": {
+    "lilbee": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "lilbee",
+      "options": { "baseURL": "http://127.0.0.1:$LS_PORT/v1", "apiKey": "sk-noauth" },
+      "models": { "$FAMILY": { "name": "$FAMILY" } }
+    }
+  },
+  "tools": { "bash": false, "grep": false, "glob": false, "list": false, "read": false, "webfetch": false, "task": false },
+  "permission": { "edit": "allow", "external_directory": "deny" },
+  "mcp": {
+    "lilbee": {
+      "type": "remote",
+      "url": "http://127.0.0.1:8080/mcp",
+      "enabled": true,
+      "headers": { "Authorization": "Bearer $TOKEN" }
+    }
+  }
+}
+JSON
+echo "READY: opencode cwd=$PROJ (empty, forces lilbee_search) ; provider=lilbee model=$FAMILY@:$LS_PORT ; mcp=lilbee@:8080"

--- a/demos-src/opencode-model-reel/giant_demo.tape.tmpl
+++ b/demos-src/opencode-model-reel/giant_demo.tape.tmpl
@@ -1,0 +1,64 @@
+# VHS tape template for an opencode demo (full TUI), warm-first.
+#
+# The model is ALREADY loaded before this tape runs (giant_demo.sh polls the
+# llama-server /health until ready and records the cold-start time separately),
+# so there is NO dead blinking-cursor boot here: opencode connects to a warm
+# server and the first turn responds immediately. The cold start is shown as a
+# short labeled, time-compressed intro card prepended in post (build_reel.sh),
+# using the empirically measured load time -- never as real-time dead air.
+#
+# Substituted per model: __OUT__ (output stem), __PROMPT__, __SESSION__ (a clean
+# fixed session title so the header never shows opencode's random name),
+# __STREAMSLEEP__ (seconds to let the warm answer stream on screen).
+# Rose-pine + dimensions mirror the lilbee demo reel (_shared.tape).
+
+Set Shell "bash"
+Set Width 1600
+Set Height 1000
+Set FontSize 18
+Set Padding 30
+Set TypingSpeed 30ms
+Set Framerate 60
+Set Theme "rose-pine-moon"
+Set WindowBar Colorful
+
+Output "__OUT__.gif"
+Output "__OUT__.webm"
+
+# Launch opencode against the warm server. OPENCODE_SESSION_TITLE pins the header
+# name so it never renders opencode's random "Big Pickle"-style session label.
+Hide
+Type "cd /root/demo-proj && export OPENCODE_SESSION_TITLE='__SESSION__'"
+Enter
+Type "clear"
+Enter
+Type "opencode"
+Enter
+# Warm server -> the TUI is interactive in a couple of seconds, not 45s.
+Sleep 4s
+Show
+Sleep 1500ms
+
+# The agentic RAG turn. The model is warm, so generation streams on screen here:
+# we do NOT Hide it -- the tool call(s) and the answer render live, which is the
+# whole point of the demo. Pace gives the viewer time to read the prompt, watch
+# lilbee_search fire, then read the streamed answer.
+Type "__PROMPT__"
+Sleep 1200ms
+Enter
+# Let the tool call + streamed answer play out on screen (warm = seconds, not minutes).
+Sleep __STREAMSLEEP__
+# Scroll through the rendered answer so the full response is visible.
+PageUp
+Sleep 2500ms
+PageUp
+Sleep 2500ms
+PageDown
+Sleep 2000ms
+PageDown
+Sleep 2000ms
+
+Screenshot "__OUT__.png"
+Sleep 800ms
+Ctrl+C
+Sleep 800ms

--- a/demos-src/opencode-model-reel/ingest_corpus.sh
+++ b/demos-src/opencode-model-reel/ingest_corpus.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Build the SHARED, model-agnostic corpus index for the opencode demo using the
+# real product path (lilbee add -> sync), then verify it grounds every probe
+# BEFORE any model or GPU work. Run once per pod; every model's
+# `lilbee launch opencode` reads this same data dir afterwards.
+#
+# This replaces the old inline indexing block in giant_demo.sh (hardcoded source
+# dirs, no readiness check) that let a stale path quietly empty the corpus and
+# leave the demo asking for a file that was never indexed.
+#
+#   cd /root/reel && git pull -q origin demo-reel/opencode-model-matrix
+#   /root/reel/demos-src/opencode-model-reel/ingest_corpus.sh
+set -uo pipefail
+export PATH=$HOME/.local/bin:/usr/local/bin:$PATH
+export HF_HUB_DISABLE_XET=1 HF_HUB_DISABLE_PROGRESS_BARS=1
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LM="${LM:-/root/lilbee}"                                # lilbee checkout on the pod
+# Data + models live on the network volume so they survive a pod stop/start and
+# don't fill the small root overlay.
+export LILBEE_DATA="${LILBEE_DATA:-/workspace/.lilbee}"
+export LILBEE_MODELS_DIR="${LILBEE_MODELS_DIR:-/workspace/models}"
+LILBEE="${LILBEE:-$LM/.venv/bin/lilbee}"
+PORT="${PORT:-8080}"
+
+# Featured retrieval models (real product defaults). The chat model is NOT set
+# here: this index is model-agnostic, and the matrix sets chat_model per giant.
+EMBED_REF="nomic-ai/nomic-embed-text-v1.5-GGUF"
+RERANK_REF="gpustack/bge-reranker-v2-m3-GGUF"
+CHUNK_SIZE=320
+
+DATA="$LILBEE_DATA/data"
+say(){ echo "[ingest $(date -u +%H:%M:%S)] $*"; }
+say "data=$LILBEE_DATA models=$LILBEE_MODELS_DIR lilbee=$LILBEE"
+
+# 1) Index-level retrieval profile, written BEFORE the sync so the corpus is
+#    embedded + chunked + graphed under these settings (they define the index;
+#    changing them later needs a force-rebuild, so they must be fixed up front).
+mkdir -p "$LILBEE_DATA"
+cat > "$LILBEE_DATA/config.toml" <<TOML
+embedding_model = "$EMBED_REF"
+reranker_model = "$RERANK_REF"
+chunk_size = $CHUNK_SIZE
+concept_graph = true
+TOML
+say "wrote index profile -> $LILBEE_DATA/config.toml"
+
+# 2) Pull the retrieval models (embed is required to ingest; reranker is used at
+#    query time and is pulled now so per-model tuning can lean on it).
+"$LILBEE" model pull "$EMBED_REF"
+"$LILBEE" model pull "$RERANK_REF"
+
+# 3) Ingest the corpus (lilbee's own repo) via the real product path. lilbee add
+#    copies each path under documents/ preserving its subtree, then syncs. A
+#    missing path is logged LOUD, never silently skipped.
+CORPUS=()
+for p in "$LM/src/lilbee" "$LM/docs" "$LM/README.md"; do
+  if [ -e "$p" ]; then CORPUS+=("$p"); else say "WARNING corpus path missing, skipped: $p"; fi
+done
+[ ${#CORPUS[@]} -gt 0 ] || { say "FATAL no corpus paths exist under $LM"; exit 2; }
+say "lilbee add ${CORPUS[*]}"
+"$LILBEE" add "${CORPUS[@]}"
+
+# 4) Start serve (reuse a healthy one) and read the session token. LILBEE_DATA
+#    and LILBEE_MODELS_DIR are inlined into the tmux command because a new tmux
+#    session inherits the tmux SERVER's start-time env, not this script's.
+if ! curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1; then
+  say "starting lilbee serve on :$PORT"
+  tmux kill-session -t lilbeeserve 2>/dev/null || true
+  tmux new-session -d -s lilbeeserve \
+    "cd $LM && LILBEE_DATA=$LILBEE_DATA LILBEE_MODELS_DIR=$LILBEE_MODELS_DIR $LILBEE serve --port $PORT > /tmp/lilbee-serve.log 2>&1"
+  for _ in $(seq 1 60); do
+    curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1 && break; sleep 2
+  done
+fi
+curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1 \
+  || { say "FATAL serve not healthy (see /tmp/lilbee-serve.log)"; exit 3; }
+TOKEN=$(python3 -c "import json;print(json.load(open('$DATA/server.json'))['token'])")
+say "serve healthy; token read"
+
+# 5) Warm the embed engine. The fleet warms the embed role lazily and the first
+#    /api/search can hit a cold engine and 503; poll a real search until it
+#    returns hits so the gate measures a warm index, not a cold-start miss.
+say "warming embed engine via a real search"
+WARM=0
+for _ in $(seq 1 40); do
+  if curl -fsS -m5 -H "Authorization: Bearer $TOKEN" \
+       "http://127.0.0.1:$PORT/api/search?q=dispatch%20chat%20request&top_k=1&chunk_type=raw" 2>/dev/null \
+       | grep -qiE '"source"|\.py'; then WARM=1; break; fi
+  sleep 3
+done
+[ "$WARM" = "1" ] || { say "FATAL embed engine never warmed; search returns no hits"; exit 5; }
+
+# 6) Demo-readiness gate: every probe's expected file must surface, or abort
+#    before spending GPU hours on a corpus that can't ground the demo.
+say "running demo-readiness gate"
+if python3 "$HERE/gate.py" --base-url "http://127.0.0.1:$PORT" --token "$TOKEN" --probes "$HERE/probes.toml"; then
+  say "INGEST COMPLETE: corpus indexed + grounded; data dir ready for launch + tuning."
+else
+  say "GATE FAILED -> corpus not demo-ready; not proceeding"
+  exit 4
+fi

--- a/demos-src/opencode-model-reel/lilbee_http.py
+++ b/demos-src/opencode-model-reel/lilbee_http.py
@@ -1,0 +1,66 @@
+"""Tiny stdlib client for a running ``lilbee serve``.
+
+Hits the real product HTTP surface, the same routes the TUI and the MCP server
+use: ``GET /api/search`` for retrieval and ``PATCH /api/config`` for the
+retrieval knobs (which lands in ``apply_settings_update`` and invalidates the
+in-process caches). Stdlib only (urllib) so it runs under whatever python the pod
+has, with no dependency on the lilbee venv.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+_TIMEOUT_S = 30.0
+
+
+@dataclass
+class LilbeeClient:
+    base_url: str
+    token: str
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"}
+
+    def health(self) -> bool:
+        try:
+            req = urllib.request.Request(f"{self.base_url}/api/health", headers=self._headers())
+            with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:  # noqa: S310
+                return resp.status == 200
+        except (urllib.error.URLError, TimeoutError, ConnectionError):
+            return False
+
+    def search(self, query: str, top_k: int, scope: str = "raw") -> list[dict[str, Any]]:
+        """Return the raw ``/api/search`` document list for *query*.
+
+        ``scope="raw"`` restricts to ingested docs/code (the demo corpus), the
+        same scope the SKILL.md tells agents to use for code lookups.
+        """
+        params = urllib.parse.urlencode({"q": query, "top_k": top_k, "chunk_type": scope})
+        req = urllib.request.Request(f"{self.base_url}/api/search?{params}", headers=self._headers())
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:  # noqa: S310
+            payload = json.loads(resp.read().decode("utf-8"))
+        # The route returns either a bare list or a {"results": [...]} envelope
+        # depending on version; accept both so the harness is not version-brittle.
+        if isinstance(payload, dict):
+            return payload.get("results") or payload.get("documents") or []
+        return payload
+
+    def patch_config(self, updates: dict[str, Any]) -> dict[str, Any]:
+        """Apply retrieval knobs via the real settings boundary; return the response."""
+        body = json.dumps(updates).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.base_url}/api/config", data=body, headers=self._headers(), method="PATCH"
+        )
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))
+
+    def get_config(self) -> dict[str, Any]:
+        req = urllib.request.Request(f"{self.base_url}/api/config", headers=self._headers())
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))

--- a/demos-src/opencode-model-reel/model_demo.sh
+++ b/demos-src/opencode-model-reel/model_demo.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Self-contained, resumable end-to-end opencode demo for ONE model.
+#
+# Generalises run_giant_demo.sh (which was MiniMax-only) into a parameterised
+# driver: it finishes the model download (resumable, retried through connection
+# drops), serves the model, indexes lilbee's source, records the live opencode
+# TUI on a grounding-forcing task, then audits the result into
+# /root/SUMMARY-<family>.txt + /root/audit-<family>.png. Everything logs to
+# /root/run-<family>.log.
+#
+# Used for both the cheap qwen3-coder-30B validation and each giant in the
+# matrix; the only difference is the model spec passed in.
+#
+# Run it DETACHED so it survives an unstable SSH connection:
+#   cd /root/reel && git pull -q origin demo-reel/opencode-model-matrix
+#   FAMILY=qwen3-coder FULL=Qwen3-Coder-30B \
+#     REPO=unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF QUANT='*Q4_K_M*' \
+#     QDIR=/root/models/qwen3-coder MULTIGPU=0 \
+#     tmux new-session -d -s work \
+#       "/root/reel/demos-src/opencode-model-reel/model_demo.sh"
+# Then reconnect any time and read /root/SUMMARY-<family>.txt and the log.
+#
+# HF auth: reads /root/.cache/huggingface/token if present. Never hard-coded.
+set -uo pipefail
+export PATH=$HOME/.local/bin:/usr/local/bin:$PATH
+export HF_HUB_DISABLE_XET=1 HF_HUB_DISABLE_PROGRESS_BARS=1
+# Model weights (an 18GB+ GGUF, or a 240GB giant) MUST live on /workspace (the
+# RunPod network volume) or the download fills the small root overlay and ENOSPCs;
+# the volume also persists across pod restarts. The lilbee index stays on the local
+# root disk (small, fast) via giant_demo.sh's default WS.
+export LILBEE_MODELS_DIR="${LILBEE_MODELS_DIR:-/workspace/models}"
+
+# --- model spec (env-driven; sensible defaults for the qwen3-coder validation) ---
+FAMILY="${FAMILY:-qwen3-coder}"
+FULL="${FULL:-Qwen3-Coder-30B}"
+REPO="${REPO:-unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF}"
+QUANT="${QUANT:-*Q4_K_M*}"
+QDIR="${QDIR:-/workspace/models/$FAMILY}"
+MULTIGPU="${MULTIGPU:-0}"
+STREAM_SLEEP="${STREAM_SLEEP:-150}"   # giants stream slowly; fast-forward in post
+                                      # (>~200s starves VHS's headless-chromium gif capture)
+PROMPT="${PROMPT:-Using ONLY lilbee_search (the code is not on disk here), explain how lilbee turns an incoming chat request into a model call and how it handles tool calls. Name the REAL modules and functions for: (a) dispatching a chat request to the model, (b) parsing or normalizing tool-call arguments, and (c) translating tool calls to the OpenAI wire format. Cite each as path:Lstart-Lend. Then write lilbee_toolcall_walkthrough.py: a short annotated trace that references those exact lilbee functions (not a generic OpenAI tool_calls dict reader), with the path:Lstart-Lend citations inline. If lilbee_search does not surface a piece, say so rather than inventing it.}"
+
+LOG=/root/run-$FAMILY.log
+SUMMARY=/root/SUMMARY-$FAMILY.txt
+ts(){ date -u +%H:%M:%S; }
+say(){ echo "[$(ts)] $*" | tee -a "$LOG"; }
+
+echo "STARTED $(ts)" > "$SUMMARY"
+say "====== MODEL_DEMO START ($FAMILY / $REPO $QUANT, multigpu=$MULTIGPU) ======"
+
+# --- Phase 1: finish the download (resumable; retries through drops) ---
+say "Phase 1: ensure $REPO $QUANT download complete -> $QDIR"
+cd /root/lilbee
+ok=0
+for attempt in $(seq 1 30); do
+  if .venv/bin/python -c "from huggingface_hub import snapshot_download; snapshot_download('$REPO', allow_patterns='$QUANT', local_dir='$QDIR', max_workers=2)" >> /root/dl-$FAMILY.log 2>&1; then
+    say "download complete on attempt $attempt"; ok=1; break
+  fi
+  say "download attempt $attempt dropped ($(du -sh "$QDIR" 2>/dev/null | cut -f1)); resuming"
+  sleep 5
+done
+GGUF=$(find "$QDIR" -ipath '*00001-of-*.gguf' 2>/dev/null | head -1)
+[ -z "$GGUF" ] && GGUF=$(find "$QDIR" -iname '*.gguf' ! -name '*.lock' 2>/dev/null | sort | head -1)
+say "download ok=$ok GGUF=$GGUF size=$(du -sh "$QDIR" 2>/dev/null | cut -f1)"
+if [ -z "$GGUF" ]; then say "FATAL: no GGUF after download"; echo "FAILED: no GGUF" >> "$SUMMARY"; exit 1; fi
+
+# --- Phase 2: serve + index + record the live opencode TUI ---
+say "Phase 2: build_reel (serve + index + record)"
+rm -rf /root/demo-proj; rm -f /root/demos/_raw-$FAMILY.*
+OUT_DIR=/root/demos MULTIGPU=$MULTIGPU /root/reel/demos-src/opencode-model-reel/build_reel.sh \
+  "$FAMILY" "$FULL" "$GGUF" "$PROMPT" "$STREAM_SLEEP" "$MULTIGPU" >> "$LOG" 2>&1
+say "build_reel exit=$?"
+
+# --- Phase 3: audit into SUMMARY + montage ---
+say "Phase 3: audit"
+GIF=/root/demos/opencode-$FULL.gif
+[ -f "$GIF" ] || GIF=/root/demos/_raw-$FAMILY.gif
+mkdir -p /root/frames-$FAMILY; rm -f /root/frames-$FAMILY/*.png
+DUR=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$GIF" 2>/dev/null)
+for i in 0 1 2 3 4 5 6 7; do
+  t=$(awk "BEGIN{printf \"%.2f\", ${DUR:-1}*($i+0.5)/8}")
+  ffmpeg -nostdin -y -loglevel error -ss "$t" -i "$GIF" -frames:v 1 /root/frames-$FAMILY/f$i.png 2>/dev/null
+done
+ffmpeg -nostdin -y -loglevel error -i /root/frames-$FAMILY/f%d.png -vf "scale=640:-1,tile=2x4" /root/audit-$FAMILY.png 2>/dev/null
+{
+  echo "MODEL_DEMO SUMMARY ($FULL)  $(ts)"
+  echo "gguf: $GGUF"
+  echo "gif: $GIF  frames=$(ffprobe -v error -count_frames -select_streams v:0 -show_entries stream=nb_read_frames -of csv=p=0 "$GIF" 2>/dev/null)  dur=${DUR}s"
+  echo "mcp CallToolRequest count: $(grep -ac CallToolRequest /tmp/lilbee-serve.log 2>/dev/null)"
+  echo "agent wrote: $(ls /root/demo-proj/*.py 2>/dev/null || echo NONE)"
+  echo "--- agent output (first 90 lines) ---"
+  cat /root/demo-proj/*.py 2>/dev/null | head -90
+} >> "$SUMMARY" 2>&1
+say "====== MODEL_DEMO DONE -> $SUMMARY + /root/audit-$FAMILY.png ======"

--- a/demos-src/opencode-model-reel/pod_bootstrap.sh
+++ b/demos-src/opencode-model-reel/pod_bootstrap.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Fresh-pod build stage for the opencode model reel (RunPod 2xH200, ephemeral /root).
+#
+# This is the EXACT model-independent bootstrap that runs first on a fresh pod:
+# system deps -> uv -> clone lilbee -> uv sync -> build a CUDA llama-server from
+# source (no prebuilt CUDA Linux binary ships in ggml-org releases). It writes
+# progress to /root/run.log and ends with the BUILD_STAGE_DONE marker.
+#
+# It is launched detached inside the `work` tmux session so it survives SSH drops
+# and so the run can be monitored with `tmux attach -t work` or `tail -F /root/run.log`.
+#
+# After this completes, the per-model serve/index/record pipeline runs:
+#   giant_demo.sh  -> warm a giant on llama-server + index a codebase + lilbee serve /mcp
+#   build_reel.sh  -> record the live opencode TUI tape + cold-start card + review gate
+#
+# Everything runs on the pod, including VHS recording. The "VHS captures 0 frames on
+# the pod" failure was an outdated ttyd (apt ships 1.6.3; VHS needs >=1.7.2) plus the
+# absolute-Output-path parser bug -- both fixed in the VHS step below. No SSH tunnel,
+# no Mac, no public exposure: opencode + VHS record the live TUI locally on the box.
+set -uo pipefail
+LOG=/root/run.log
+exec >>"$LOG" 2>&1
+ts(){ date -u +%H:%M:%S; }
+step(){ echo "[$(ts)] === STEP: $* ==="; }
+fail(){ echo "[$(ts)] !!! FAIL: $* !!!"; echo "BOOTSTRAP_FAILED"; exit 1; }
+export DEBIAN_FRONTEND=noninteractive
+export PATH=$HOME/.local/bin:$PATH
+
+step "apt build deps"
+apt-get update -qq || fail "apt update"
+apt-get install -y -qq cmake build-essential pkg-config ccache tmux >/dev/null || fail "apt install"
+echo "[$(ts)] apt OK"
+
+step "install uv"
+command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh || fail "uv install"
+export PATH=$HOME/.local/bin:$PATH
+command -v uv >/dev/null || fail "uv missing after install"
+echo "[$(ts)] uv $(uv --version)"
+
+step "clone lilbee (public)"
+cd /root
+[ -d /root/lilbee ] || git clone -q https://github.com/tobocop2/lilbee.git || fail "clone lilbee"
+cd /root/lilbee
+git fetch -q origin || true
+git checkout feat/local-model-api || fail "checkout branch"
+echo "[$(ts)] lilbee @ $(git rev-parse --short HEAD)"
+
+step "uv sync lilbee (slow)"
+uv sync || fail "uv sync"
+echo "[$(ts)] uv sync OK"
+
+step "clone + build CUDA llama-server (long pole ~10-20min)"
+cd /root
+[ -d /root/llama.cpp ] || git clone -q --depth 1 https://github.com/ggml-org/llama.cpp || fail "clone llama.cpp"
+cd /root/llama.cpp
+cmake -B build -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=90 -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF || fail "cmake configure"
+echo "[$(ts)] cmake configured, compiling llama-server..."
+cmake --build build -j --target llama-server || fail "cmake build"
+test -f build/bin/llama-server || fail "llama-server binary missing"
+ln -sf /root/llama.cpp/build/bin/llama-server /usr/local/bin/llama-server
+echo "[$(ts)] llama-server: $(command -v llama-server)"
+
+step "install VHS recorder (ffmpeg + ttyd>=1.7.2 + vhs + headless-chromium deps)"
+apt-get install -y -qq ffmpeg >/dev/null || fail "apt ffmpeg"
+# apt's ttyd is 1.6.3 which VHS rejects ("ttyd out of date, VHS requires 1.7.2");
+# install the release binary. This is the fix that makes VHS record on the pod.
+curl -fsSL https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64 -o /usr/local/bin/ttyd \
+  && chmod +x /usr/local/bin/ttyd || fail "ttyd binary"
+hash -r
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://repo.charm.sh/apt/gpg.key | gpg --dearmor -o /etc/apt/keyrings/charm.gpg
+echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" > /etc/apt/sources.list.d/charm.list
+apt-get update -qq && apt-get install -y -qq vhs >/dev/null || fail "apt vhs"
+# go-rod (VHS's headless chromium) runtime libs.
+apt-get install -y -qq libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
+  libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 \
+  libpango-1.0-0 libcairo2 libatspi2.0-0 libxshmfence1 >/dev/null || true
+apt-get install -y -qq libasound2 >/dev/null 2>&1 || apt-get install -y -qq libasound2t64 >/dev/null 2>&1 || true
+echo "[$(ts)] vhs=$(vhs --version 2>&1) ttyd=$(ttyd --version 2>&1)"
+# Smoke-test VHS now so a regression is caught at bootstrap, not at record time.
+# NOTE: the Output path MUST be relative -- an absolute path trips VHS's parser.
+( cd /root && printf 'Output vhscheck.gif\nSet Width 800\nSet Height 400\nType "echo vhs-ok"\nEnter\nSleep 1s\n' > vhscheck.tape \
+  && VHS_NO_SANDBOX=true vhs vhscheck.tape >/dev/null 2>&1 \
+  && [ "$(ffprobe -v error -count_frames -select_streams v:0 -show_entries stream=nb_read_frames -of csv=p=0 vhscheck.gif 2>/dev/null)" -gt 1 ] \
+  && echo "[$(ts)] VHS smoke-test PASS (frames rendered)" \
+  || echo "[$(ts)] VHS smoke-test FAIL -- try: xvfb-run VHS_NO_SANDBOX=true vhs vhscheck.tape" )
+
+step "install opencode CLI (recorded on the pod by build_reel.sh)"
+# Official opencode org is anomalyco/opencode (moved from sst); opencode.ai/install
+# resolves here. Linux CLI ships as a tar.gz, not a zip.
+apt-get install -y -qq unzip >/dev/null 2>&1 || true
+curl -fsSL https://github.com/anomalyco/opencode/releases/latest/download/opencode-linux-x64.tar.gz -o /root/opencode.tar.gz || fail "opencode download"
+tar -xzf /root/opencode.tar.gz -C /usr/local/bin/ || fail "opencode extract"
+chmod +x /usr/local/bin/opencode; hash -r
+echo "[$(ts)] opencode=$(command -v opencode) ver=$(opencode --version 2>&1 | head -1)"
+
+mkdir -p /root/models
+echo "[$(ts)] ====== BUILD_STAGE_DONE ======"

--- a/demos-src/opencode-model-reel/probes.toml
+++ b/demos-src/opencode-model-reel/probes.toml
@@ -1,0 +1,34 @@
+# Probe set for the opencode demo corpus (lilbee's own repo).
+#
+# Each probe is a natural question a coding agent would ask while learning how
+# lilbee turns a chat request into a model call and handles tool calls, paired
+# with the real module(s) that must surface for the answer to be grounded.
+#
+# Single source of truth for two consumers:
+#   - ingest_corpus.sh : verification gate (every probe's expected file must
+#     appear, or the index is not demo-ready and we abort before any GPU hours).
+#   - tune_run.py      : scoring oracle for the per-model retrieval sweep.
+#
+# `expect` entries are path substrings matched against a result's `source`
+# (which preserves the copied subtree, e.g. lilbee/server/chat_dispatch/...),
+# so they stay unambiguous even where basenames collide (two canonical.py).
+
+[[probe]]
+query = "how does lilbee dispatch an incoming chat request to the model"
+expect = ["server/chat_dispatch/dispatch.py"]
+
+[[probe]]
+query = "parsing and normalizing tool call arguments returned by the model"
+expect = ["server/chat_dispatch/tool_args.py"]
+
+[[probe]]
+query = "translate tool calls into the OpenAI chat completions wire format"
+expect = ["server/chat_completions_api/translate.py"]
+
+[[probe]]
+query = "the protocol-neutral canonical chat request and response types"
+expect = ["server/chat_dispatch/canonical.py"]
+
+[[probe]]
+query = "the fleet provider that routes a call to a llama-server for a role"
+expect = ["providers/fleet/provider.py"]

--- a/demos-src/opencode-model-reel/review_demo.py
+++ b/demos-src/opencode-model-reel/review_demo.py
@@ -1,0 +1,127 @@
+"""Timeline review for a recorded demo (gif/webm/mp4).
+
+A demo is NOT done until reviewed across its whole timeline, not just the final
+frame. This extracts frames at evenly spaced timestamps so a reviewer (human or a
+vision model) can confirm the arc: the prompt is on screen, the answer renders, and
+the answer quality is good. It also runs a cheap heuristic to flag the failure mode
+that slipped through before: a recording dominated by a near-static "dead screen"
+(cold-start blinking cursor / generation spinner) with content only in the last frame.
+
+Usage:
+    python review_demo.py <demo-file> [--frames N] [--out DIR]
+
+Exit code 0 = no heuristic red flag; 1 = likely dead-screen-dominated (review the
+extracted frames). The heuristic never replaces looking at the frames; it only stops
+an obviously-broken demo from being called done without a look.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _duration_seconds(path: Path) -> float:
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=duration", "-of", "csv=p=0", str(path)],
+        capture_output=True, text=True, check=False,
+    ).stdout.strip()
+    try:
+        return float(out)
+    except ValueError:
+        # GIFs sometimes report no stream duration; fall back to format duration.
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "csv=p=0", str(path)],
+            capture_output=True, text=True, check=False,
+        ).stdout.strip()
+        return float(out) if out and out != "N/A" else 0.0
+
+
+def _extract_frame(path: Path, t: float, dest: Path) -> int:
+    """Write the frame at *t* seconds to *dest*; return its byte size (0 on failure)."""
+    subprocess.run(
+        ["ffmpeg", "-nostdin", "-y", "-loglevel", "error", "-ss", f"{t:.2f}",
+         "-i", str(path), "-frames:v", "1", str(dest)],
+        check=False,
+    )
+    return dest.stat().st_size if dest.exists() else 0
+
+
+def _motion_ratio(path: Path) -> float:
+    """Fraction of frames that are NOT near-duplicates of the previous one.
+
+    Uses ffmpeg's ``mpdecimate`` (the same near-duplicate detector used to drop
+    static frames). A streaming demo where the screen keeps changing keeps most of
+    its frames; a cold-start/spinner demo that sits on one screen for seconds is
+    mostly duplicates, so the ratio collapses. This is a real motion signal, unlike
+    raw byte size which the static prompt panel keeps high.
+    """
+    total = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0", "-count_packets",
+         "-show_entries", "stream=nb_read_packets", "-of", "csv=p=0", str(path)],
+        capture_output=True, text=True, check=False,
+    ).stdout.strip()
+    proc = subprocess.run(
+        ["ffmpeg", "-nostdin", "-i", str(path), "-vf", "mpdecimate", "-an", "-f", "null", "-"],
+        capture_output=True, text=True, check=False,
+    )
+    # The null muxer's final "frame=" line counts frames that survived mpdecimate.
+    kept = 0
+    for line in proc.stderr.splitlines():
+        if "frame=" in line:
+            try:
+                kept = int(line.split("frame=")[1].split()[0])
+            except (IndexError, ValueError):
+                pass
+    try:
+        n = int(total)
+    except ValueError:
+        return 1.0
+    return kept / n if n else 1.0
+
+
+def review(path: Path, frames: int, out: Path) -> bool:
+    """Extract *frames* evenly-spaced frames for visual review; flag dead screens.
+
+    The frames are the point: a reviewer (human or vision model) must look at them
+    and confirm the prompt is on screen, the answer renders, and the answer quality
+    is good. The motion heuristic is only a tripwire for the cold-start/spinner
+    shape that pays off solely in the final frame; it never replaces looking.
+    """
+    out.mkdir(parents=True, exist_ok=True)
+    dur = _duration_seconds(path)
+    if dur <= 0:
+        print(f"  could not read duration for {path.name}", file=sys.stderr)
+        return False
+    stamps = [dur * (i + 0.5) / frames for i in range(frames)]
+    print(f"{path.name}  ({dur:.1f}s, {frames} frames)")
+    for i, t in enumerate(stamps):
+        dest = out / f"{path.stem}__{i:02d}_{t:05.1f}s.png"
+        size = _extract_frame(path, t, dest)
+        print(f"  {t:5.1f}s  {size/1024:6.1f} KB  {dest}")
+    motion = _motion_ratio(path)
+    # Below ~35% unique frames means the screen sat static for most of the runtime
+    # (cold-start dead screen / generation spinner) -- the broken shape.
+    ok = motion >= 0.35
+    verdict = "LIVE" if ok else "DEAD-SCREEN RISK"
+    print(f"  -> {verdict}: motion={motion:.0%} unique frames. Inspect the frames "
+          f"above to confirm prompt + answer + quality (heuristic is only a tripwire).")
+    return ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("demo", type=Path)
+    ap.add_argument("--frames", type=int, default=8)
+    ap.add_argument("--out", type=Path, default=Path("/tmp/demo_review"))
+    args = ap.parse_args()
+    ok = review(args.demo, args.frames, args.out / args.demo.stem)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos-src/opencode-model-reel/run_giant_demo.sh
+++ b/demos-src/opencode-model-reel/run_giant_demo.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Self-contained, resumable end-to-end giant demo for the pod.
+#
+# Finishes the model download (resumable, retried through connection drops), serves
+# the giant multi-GPU, indexes lilbee's source, records the live opencode TUI on a
+# grounding-forcing task, then audits the result into /root/SUMMARY.txt +
+# /root/audit_montage.png. Everything logs to /root/run.log.
+#
+# Designed to survive an unstable SSH connection: run it DETACHED and walk away.
+#   cd /root/reel && git pull -q origin demo-reel/opencode-model-matrix
+#   tmux new-session -d -s work "/root/reel/demos-src/opencode-model-reel/run_giant_demo.sh"
+# Then reconnect any time and read /root/SUMMARY.txt and /root/run.log.
+#
+# HF auth: reads /root/.cache/huggingface/token if present (set once via
+# `printf %s <token> > /root/.cache/huggingface/token`); falls back to
+# unauthenticated + retries if absent. The token is NEVER hard-coded here.
+set -uo pipefail
+export PATH=$HOME/.local/bin:/usr/local/bin:$PATH
+export HF_HUB_DISABLE_XET=1 HF_HUB_DISABLE_PROGRESS_BARS=1
+export LILBEE_MODELS_DIR=/root/models
+LOG=/root/run.log; SUMMARY=/root/SUMMARY.txt
+ts(){ date -u +%H:%M:%S; }
+say(){ echo "[$(ts)] $*" | tee -a "$LOG"; }
+
+REPO=unsloth/MiniMax-M2-GGUF
+QDIR=/root/models/minimax-q8
+QUANT='Q8_0/*'
+FAMILY=minimax-m2
+FULL=MiniMax-M2
+STREAM_SLEEP=150          # giants generate slowly; fast-forward the slow spans in post
+                          # (>~200s stresses VHS's headless-chromium capture -> empty gif;
+                          #  the 128k context fix lets the giant finish inside 150s)
+MULTIGPU=1               # MiniMax-M2 Q8_0 (~243GB) spans both H200s
+PROMPT='Using ONLY lilbee_search (the code is not on disk here), find lilbee'\''s REAL response parser that extracts tool calls from a model'\''s raw text output. Name the actual module path, the class or function, and which model families it special-cases. Then write tool_call_example.py that mirrors lilbee'\''s real approach (not a generic OpenAI tool_calls dict reader) on a sample raw model-output string, citing the exact lilbee files as path:Lstart-Lend. If lilbee_search does not surface it, say so rather than inventing a generic parser.'
+
+echo "STARTED $(ts)" > "$SUMMARY"
+say "====== RUN_GIANT_DEMO START ($FAMILY) ======"
+
+# --- Phase 1: finish the download (resumable; retries through drops) ---
+say "Phase 1: ensure $REPO $QUANT download complete"
+cd /root/lilbee
+ok=0
+for attempt in $(seq 1 30); do
+  if .venv/bin/python -c "from huggingface_hub import snapshot_download; snapshot_download('$REPO', allow_patterns='$QUANT', local_dir='$QDIR', max_workers=2)" >> /root/dl.log 2>&1; then
+    say "download complete on attempt $attempt"; ok=1; break
+  fi
+  say "download attempt $attempt dropped ($(du -sh "$QDIR" 2>/dev/null | cut -f1)); resuming"
+  sleep 5
+done
+GGUF=$(find "$QDIR" -ipath '*Q8_0*00001-of-*.gguf' 2>/dev/null | head -1)
+[ -z "$GGUF" ] && GGUF=$(find "$QDIR" -ipath '*Q8_0*.gguf' ! -name '*.lock' 2>/dev/null | sort | head -1)
+say "download ok=$ok GGUF=$GGUF size=$(du -sh "$QDIR" 2>/dev/null | cut -f1)"
+if [ -z "$GGUF" ]; then say "FATAL: no GGUF after download"; echo "FAILED: no GGUF" >> "$SUMMARY"; exit 1; fi
+
+# --- Phase 2: serve multi-GPU + index + record the live opencode TUI ---
+say "Phase 2: build_reel (multi-GPU serve + index + record)"
+rm -rf /root/demo-proj; rm -f /root/demos/_raw-$FAMILY.*
+OUT_DIR=/root/demos MULTIGPU=$MULTIGPU /root/reel/demos-src/opencode-model-reel/build_reel.sh \
+  "$FAMILY" "$FULL" "$GGUF" "$PROMPT" "$STREAM_SLEEP" "$MULTIGPU" >> "$LOG" 2>&1
+say "build_reel exit=$?"
+
+# --- Phase 3: audit into SUMMARY + montage ---
+say "Phase 3: audit"
+GIF=/root/demos/_raw-$FAMILY.gif
+mkdir -p /root/frames; rm -f /root/frames/*.png
+DUR=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$GIF" 2>/dev/null)
+for i in 0 1 2 3 4 5 6 7; do
+  t=$(awk "BEGIN{printf \"%.2f\", ${DUR:-1}*($i+0.5)/8}")
+  ffmpeg -nostdin -y -loglevel error -ss "$t" -i "$GIF" -frames:v 1 /root/frames/f$i.png 2>/dev/null
+done
+ffmpeg -nostdin -y -loglevel error -i /root/frames/f%d.png -vf "scale=640:-1,tile=2x4" /root/audit_montage.png 2>/dev/null
+{
+  echo "RUN_GIANT_DEMO SUMMARY ($FULL)  $(ts)"
+  echo "gguf: $GGUF"
+  echo "gif: $GIF  frames=$(ffprobe -v error -count_frames -select_streams v:0 -show_entries stream=nb_read_frames -of csv=p=0 "$GIF" 2>/dev/null)  dur=${DUR}s"
+  echo "mcp CallToolRequest count: $(grep -ac CallToolRequest /tmp/lilbee-serve.log 2>/dev/null)"
+  echo "agent wrote: $(ls /root/demo-proj/*.py 2>/dev/null || echo NONE)"
+  echo "--- agent output (first 90 lines) ---"
+  cat /root/demo-proj/*.py 2>/dev/null | head -90
+} >> "$SUMMARY" 2>&1
+say "====== RUN_GIANT_DEMO DONE -> /root/SUMMARY.txt + /root/audit_montage.png ======"

--- a/demos-src/opencode-model-reel/run_matrix.sh
+++ b/demos-src/opencode-model-reel/run_matrix.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Autonomous pod-side demo matrix.
+#
+# Runs each model end-to-end via model_demo.sh, saves durable results to
+# /workspace/results/<family>/ (the RunPod volume persists when the pod is
+# stopped), gates the giants behind a cheap qwen3-coder canary that must render a
+# real (multi-frame) gif, then POWERS THE POD OFF itself.
+#
+# Built to run unattended while the operator is offline:
+#   cd /root/reel && git pull -q origin demo-reel/opencode-model-matrix
+#   tmux new-session -d -s matrix "/root/reel/demos-src/opencode-model-reel/run_matrix.sh"
+#
+# Resumable: a model whose result dir has a `done` marker is skipped, so on a
+# reconnect you can re-launch this and it continues. Per-model STATUS + the
+# top-level STATE.md record exactly where it got and whether each demo passed.
+set -uo pipefail
+export PATH=$HOME/.local/bin:/usr/local/bin:$PATH
+export HF_HUB_DISABLE_XET=1 HF_HUB_DISABLE_PROGRESS_BARS=1
+
+RES=/workspace/results
+DRIVER=/root/reel/demos-src/opencode-model-reel/model_demo.sh
+MIN_FRAMES=10            # a real demo gif has hundreds of frames; >this rejects the empty-gif failure
+mkdir -p "$RES"
+ts(){ date -u +'%Y-%m-%d %H:%M:%S'; }
+note(){ echo "[$(ts)] $*" | tee -a "$RES/matrix.log"; }
+
+# Pod id for self-power-off. The tmux server may not carry RUNPOD_POD_ID, so fall
+# back to PID 1's environment (the pod's init always has it).
+POD_ID="${RUNPOD_POD_ID:-$(tr '\0' '\n' < /proc/1/environ 2>/dev/null | sed -n 's/^RUNPOD_POD_ID=//p')}"
+
+# family|full|repo|quant|qdir|multigpu   (only verified refs; giants needing ref
+# checks are listed in STATE.md for a supervised pass)
+MODELS=(
+  "qwen3-coder|Qwen3-Coder-30B|unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF|*Q4_K_M*|/workspace/models/qwen3-coder|0"
+  "minimax-m2|MiniMax-M2|unsloth/MiniMax-M2-GGUF|Q8_0/*|/workspace/models/minimax-q8|1"
+)
+
+install_runpodctl(){
+  command -v runpodctl >/dev/null 2>&1 && return 0
+  note "installing runpodctl"
+  wget -qO /usr/local/bin/runpodctl \
+    https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-linux-amd64 2>/dev/null \
+    && chmod +x /usr/local/bin/runpodctl
+  command -v runpodctl >/dev/null 2>&1
+}
+
+poweroff_pod(){
+  note "powering off pod ${POD_ID:-UNKNOWN}"
+  sync
+  if [ -z "$POD_ID" ]; then note "no pod id; cannot self-power-off (stop it manually)"; return; fi
+  if install_runpodctl; then
+    runpodctl stop pod "$POD_ID" || note "runpodctl stop failed; stop it manually"
+  else
+    note "runpodctl unavailable; stop the pod manually"
+  fi
+}
+
+# --- stall watchdog -------------------------------------------------------------
+# Powers the pod off if NOTHING makes progress for STALL_LIMIT: no log file is
+# written, the download dir stops growing, AND the GPUs go idle. A slow-but-real
+# giant download (bytes grow) or inference/load (GPU busy or giant-srv.log ticks)
+# keeps resetting the timer, so only a genuine wedge trips it.
+STALL_LIMIT="${STALL_LIMIT:-1800}"   # 30 min of total silence
+
+gpu_busy(){  # echo 1 if any GPU is doing work, else 0
+  local u
+  u=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits 2>/dev/null \
+        | awk '{s+=$1} END{print s+0}')
+  [ "${u:-0}" -ge 5 ] && echo 1 || echo 0
+}
+
+progress_fp(){  # newest log mtime : total downloaded bytes
+  local newest=0 t f
+  for f in "$RES"/matrix.log "$RES"/*/driver.log /root/dl-*.log \
+           /tmp/lilbee-serve.log /tmp/giant-srv.log; do
+    [ -f "$f" ] || continue
+    t=$(stat -c %Y "$f" 2>/dev/null) || t=0
+    [ "$t" -gt "$newest" ] && newest=$t
+  done
+  local bytes; bytes=$(du -sb /workspace/models 2>/dev/null | cut -f1); bytes=${bytes:-0}
+  echo "$newest:$bytes"
+}
+
+watchdog(){
+  local prev="" last now
+  last=$(date -u +%s)
+  while true; do
+    sleep 60
+    now=$(date -u +%s)
+    if [ "$(progress_fp)" != "$prev" ] || [ "$(gpu_busy)" = "1" ]; then
+      prev=$(progress_fp); last=$now
+    elif [ $((now - last)) -ge "$STALL_LIMIT" ]; then
+      note "WATCHDOG: no progress for ${STALL_LIMIT}s (logs idle, download flat, GPUs idle) -> powering off"
+      printf 'STALLED: no progress for %ss, powered off %s\nLast state was in %s\n' \
+        "$STALL_LIMIT" "$(ts)" "$RES/STATE.md" > "$RES/STALLED.md"
+      poweroff_pod
+      return 0
+    fi
+  done
+}
+
+collect(){  # family full out
+  local family=$1 full=$2 out=$3
+  mkdir -p "$out/agent-output"
+  cp -f "/root/demos/opencode-$full.gif" "$out/" 2>/dev/null
+  cp -f "/root/demos/opencode-$full.mp4" "$out/" 2>/dev/null
+  cp -f "/root/demos/opencode-$full.png" "$out/" 2>/dev/null
+  cp -f "/root/audit-$family.png"        "$out/" 2>/dev/null
+  cp -f "/root/SUMMARY-$family.txt"       "$out/" 2>/dev/null
+  cp -f "/root/run-$family.log"           "$out/" 2>/dev/null
+  cp -f /tmp/lilbee-serve.log             "$out/lilbee-serve.log" 2>/dev/null
+  cp -f /tmp/giant-srv.log                "$out/giant-srv.log" 2>/dev/null
+  cp -f /root/demo-proj/*.py              "$out/agent-output/" 2>/dev/null
+}
+
+frames_of(){  # gif -> integer frame count (0 if missing/non-numeric)
+  local gif=$1 f=0
+  [ -f "$gif" ] && f=$(ffprobe -v error -count_frames -select_streams v:0 \
+    -show_entries stream=nb_read_frames -of csv=p=0 "$gif" 2>/dev/null)
+  case "$f" in (''|*[!0-9]*) f=0 ;; esac
+  echo "$f"
+}
+
+write_status(){  # family full out -> writes STATUS; echoes frame count
+  local family=$1 full=$2 out=$3
+  local frames; frames=$(frames_of "$out/opencode-$full.gif")
+  local grounded=NO
+  grep -rqiE 'response_parser|providers/(worker|llama_cpp|families)|chat_completions_api|retrieval/|[a-z_]+\.py:?L?[0-9]' \
+    "$out/agent-output" "$out/SUMMARY-$family.txt" 2>/dev/null && grounded=YES
+  printf 'family=%s gif_frames=%s grounded=%s\n' "$family" "$frames" "$grounded" > "$out/STATUS"
+  echo "$frames"
+}
+
+note "===== MATRIX START (pod=${POD_ID:-?}; models: qwen3-coder, minimax-m2) ====="
+# Clean slate, but KEEP a warm lilbeeserve if one is up (re-warm is cheap but
+# skipping it is cheaper). model_demo.sh relaunches the per-giant server itself.
+# Use -x (exact process name) NOT -f: this script's path contains "opencode", so
+# pkill -f opencode would kill the matrix runner itself.
+tmux kill-session -t giantsrv 2>/dev/null || true
+pkill -x vhs 2>/dev/null || true
+pkill -x ttyd 2>/dev/null || true
+pkill -x opencode 2>/dev/null || true
+
+# Start the stall watchdog (powers off if everything goes idle for too long).
+watchdog & WD_PID=$!
+
+CANARY_OK=1
+for i in "${!MODELS[@]}"; do
+  IFS='|' read -r family full repo quant qdir mg <<< "${MODELS[$i]}"
+  out="$RES/$family"
+  if [ -f "$out/done" ]; then note "SKIP $family (already done)"; continue; fi
+  if [ "$i" -gt 0 ] && [ "$CANARY_OK" != "1" ]; then
+    note "SKIP $family (canary gif failed; not spending giant GPU hours)"; continue
+  fi
+  mkdir -p "$out"
+  note "RUN $family ($repo $quant mg=$mg)"
+  printf 'RUNNING %s since %s\n' "$family" "$(ts)" > "$RES/STATE.md"
+  FAMILY="$family" FULL="$full" REPO="$repo" QUANT="$quant" QDIR="$qdir" MULTIGPU="$mg" \
+    "$DRIVER" >> "$out/driver.log" 2>&1
+  rc=$?
+  collect "$family" "$full" "$out"
+  frames=$(write_status "$family" "$full" "$out")
+  touch "$out/done"
+  note "RESULT $family rc=$rc gif_frames=$frames ($(cat "$out/STATUS" 2>/dev/null))"
+  # Free the weights before the next model: two 240GB giants will not co-exist on
+  # a 400GB volume. qwen is small but cleaning it keeps headroom for the giant.
+  rm -rf "$qdir" 2>/dev/null && note "freed $qdir"
+  # Canary gate is the PIPELINE mechanic (did a real gif render?), NOT model
+  # grounding quality -- a weaker canary missing a citation says nothing about the
+  # giant. Grounding is recorded per-model for human review, not gated on here.
+  if [ "$family" = "qwen3-coder" ]; then
+    if [ "$frames" -gt "$MIN_FRAMES" ]; then CANARY_OK=1; note "CANARY PASS (gif_frames=$frames)";
+    else CANARY_OK=0; note "CANARY FAIL (gif_frames=$frames <= $MIN_FRAMES) -> giants skipped"; fi
+  fi
+done
+
+{
+  echo "# Matrix finished $(ts)"
+  for s in "$RES"/*/STATUS; do [ -f "$s" ] && echo "- $(cat "$s")"; done
+  [ "$CANARY_OK" = "1" ] || echo "CANARY FAILED: the gif pipeline is broken; debug from /workspace/results/qwen3-coder (driver.log, lilbee-serve.log, the gif)."
+  echo "Pending (need HF-ref verification with operator reachable): Qwen3-235B, GLM-4.6, gpt-oss-120B."
+  echo "Pod powering off now; bring it back up and re-launch run_matrix.sh to resume."
+} > "$RES/STATE.md"
+note "===== MATRIX DONE ====="
+kill "$WD_PID" 2>/dev/null || true   # stop the watchdog; we power off cleanly below
+poweroff_pod

--- a/demos-src/opencode-model-reel/score_retrieval.py
+++ b/demos-src/opencode-model-reel/score_retrieval.py
@@ -1,0 +1,250 @@
+"""Scoring for the opencode-demo retrieval probes.
+
+Pure functions over already-fetched ``/api/search`` results: no I/O, no server,
+no model. ``tune_run.py`` imports these to score each sweep step; the gate in
+``ingest_corpus.sh`` calls the ``--gate`` CLI to fail a non-grounded index before
+any GPU hours are spent.
+
+A probe is "hit" when every one of its expected path substrings appears in the
+returned ``source`` fields. The per-probe token cost is the size of the whole
+search response (all returned chunk contents), because that response is what gets
+injected into the chat as the tool result. ``within_budget`` compares that cost to
+the chat model's retrieval budget, the constraint that turns an over-wide ``top_k``
+into the bb-xdic context overflow.
+
+Run ``python score_retrieval.py --selftest`` to check the scoring logic locally
+without a server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# A chunk of English/code is roughly four characters per token. The sweep only
+# needs the budget comparison to be monotonic, not exact, so a constant divisor
+# is enough to rank settings and to catch a top_k that would overflow the window.
+CHARS_PER_TOKEN = 4
+
+# Fraction of a model's context window we allow a single retrieval tool response
+# to occupy. The rest is reserved for the system prompt, the running conversation,
+# and the model's own generation. Deliberately conservative: an over-budget search
+# response is exactly what produced the bb-xdic "exceeds context window" failure.
+TOOL_BUDGET_FRACTION = 0.35
+
+
+@dataclass(frozen=True)
+class Probe:
+    """One demo question and the real files that must surface to answer it."""
+
+    query: str
+    expect: tuple[str, ...]
+
+
+@dataclass
+class ProbeOutcome:
+    """How one probe fared at a given retrieval setting."""
+
+    query: str
+    hit: bool
+    missed: list[str] = field(default_factory=list)
+    first_rank: int | None = None
+    response_tokens: int = 0
+    within_budget: bool = True
+    citations: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SweepScore:
+    """Aggregate score for a full pass over the probe set."""
+
+    recall: float
+    mrr: float
+    max_response_tokens: int
+    all_within_budget: bool
+    outcomes: list[ProbeOutcome]
+
+    def is_better_than(self, other: SweepScore | None) -> bool:
+        """Greedy comparison: budget-fit first, then recall, then rank quality.
+
+        A setting that pushes any probe response over the model's budget is never
+        an improvement, even if it nominally retrieves more, because the chat turn
+        that follows would overflow. Among budget-safe settings, higher recall
+        wins; ties break on mean reciprocal rank (expected file nearer the top).
+        """
+        if other is None:
+            return True
+        if self.all_within_budget != other.all_within_budget:
+            return self.all_within_budget
+        if self.recall != other.recall:
+            return self.recall > other.recall
+        return self.mrr > other.mrr
+
+
+def load_probes(path: Path) -> list[Probe]:
+    """Parse ``probes.toml`` into ``Probe`` records."""
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    probes = raw.get("probe", [])
+    return [Probe(query=p["query"], expect=tuple(p["expect"])) for p in probes]
+
+
+def estimate_tokens(text: str) -> int:
+    return len(text) // CHARS_PER_TOKEN
+
+
+def budget_for_context(n_ctx: int) -> int:
+    """Token budget a single retrieval response may occupy for an ``n_ctx`` model."""
+    return int(n_ctx * TOOL_BUDGET_FRACTION)
+
+
+def _response_tokens(results: list[dict[str, Any]]) -> int:
+    total = 0
+    for doc in results:
+        for ex in doc.get("excerpts", []):
+            total += estimate_tokens(ex.get("content", ""))
+    return total
+
+
+def _citation(doc: dict[str, Any]) -> str:
+    source = doc.get("source", "?")
+    excerpts = doc.get("excerpts") or []
+    if not excerpts:
+        return source
+    start = excerpts[0].get("line_start")
+    end = excerpts[0].get("line_end")
+    if start and end:
+        return f"{source}:{start}-{end}"
+    return source
+
+
+def score_probe(probe: Probe, results: list[dict[str, Any]], budget: int) -> ProbeOutcome:
+    """Score one probe's search results against its expected files and the budget."""
+    sources = [doc.get("source", "") for doc in results]
+    missed = [
+        needle for needle in probe.expect if not any(needle in src for src in sources)
+    ]
+    first_rank: int | None = None
+    for idx, src in enumerate(sources, start=1):
+        if any(needle in src for needle in probe.expect):
+            first_rank = idx
+            break
+    tokens = _response_tokens(results)
+    hit_docs = [doc for doc in results if any(n in doc.get("source", "") for n in probe.expect)]
+    return ProbeOutcome(
+        query=probe.query,
+        hit=not missed,
+        missed=missed,
+        first_rank=first_rank,
+        response_tokens=tokens,
+        within_budget=tokens <= budget,
+        citations=[_citation(doc) for doc in hit_docs],
+    )
+
+
+def aggregate(outcomes: list[ProbeOutcome]) -> SweepScore:
+    """Combine per-probe outcomes into a single comparable score."""
+    if not outcomes:
+        return SweepScore(0.0, 0.0, 0, True, [])
+    hits = sum(1 for o in outcomes if o.hit)
+    recall = hits / len(outcomes)
+    rr = [1.0 / o.first_rank for o in outcomes if o.first_rank]
+    mrr = sum(rr) / len(outcomes)
+    max_tokens = max(o.response_tokens for o in outcomes)
+    all_safe = all(o.within_budget for o in outcomes)
+    return SweepScore(recall, mrr, max_tokens, all_safe, outcomes)
+
+
+def score_pass(
+    probes: list[Probe], results_by_query: dict[str, list[dict[str, Any]]], budget: int
+) -> SweepScore:
+    """Score a complete pass: one results list per probe query."""
+    outcomes = [
+        score_probe(p, results_by_query.get(p.query, []), budget) for p in probes
+    ]
+    return aggregate(outcomes)
+
+
+def _selftest() -> int:
+    """Exercise the scoring + greedy-comparison logic without a server."""
+    probes = [
+        Probe("a", ("server/chat_dispatch/dispatch.py",)),
+        Probe("b", ("server/chat_completions_api/canonical.py",)),
+    ]
+    big = "x" * (CHARS_PER_TOKEN * 100)
+    thin = {
+        "a": [{"source": "lilbee/server/chat_dispatch/dispatch.py",
+               "excerpts": [{"content": big, "line_start": 10, "line_end": 20}]}],
+        "b": [{"source": "lilbee/server/other.py", "excerpts": [{"content": big}]}],
+    }
+    rich = {
+        "a": thin["a"],
+        "b": [{"source": "lilbee/server/chat_completions_api/canonical.py",
+               "excerpts": [{"content": big, "line_start": 5, "line_end": 9}]}],
+    }
+    budget = 1000
+    thin_score = score_pass(probes, thin, budget)
+    rich_score = score_pass(probes, rich, budget)
+    assert thin_score.recall == 0.5, thin_score.recall
+    assert rich_score.recall == 1.0, rich_score.recall
+    assert rich_score.is_better_than(thin_score)
+    # Budget overflow must lose to a budget-safe, lower-recall pass.
+    overflow = {
+        "a": [{"source": "lilbee/server/chat_dispatch/dispatch.py",
+               "excerpts": [{"content": "y" * (CHARS_PER_TOKEN * 5000)}]}],
+        "b": rich["b"],
+    }
+    over_score = score_pass(probes, overflow, budget)
+    assert over_score.recall == 1.0 and not over_score.all_within_budget
+    assert not over_score.is_better_than(rich_score), "overflow must not beat safe full recall"
+    assert rich_score.outcomes[1].citations == ["lilbee/server/chat_completions_api/canonical.py:5-9"]
+    print("score_retrieval selftest: OK")
+    return 0
+
+
+def _gate(probes_path: Path, results_path: Path, n_ctx: int) -> int:
+    """Fail (exit 1) unless every probe's expected file is present.
+
+    ``results_path`` is a JSON object mapping each probe query to its raw
+    ``/api/search`` result list. Used by ingest_corpus.sh as the demo-readiness
+    gate on the freshly built index.
+    """
+    probes = load_probes(probes_path)
+    results = json.loads(results_path.read_text(encoding="utf-8"))
+    score = score_pass(probes, results, budget_for_context(n_ctx))
+    for o in score.outcomes:
+        mark = "ok " if o.hit else "MISS"
+        where = ", ".join(o.citations) if o.hit else f"missing {', '.join(o.missed)}"
+        print(f"  [{mark}] {o.query}  ->  {where}")
+    print(f"recall={score.recall:.0%}  mrr={score.mrr:.2f}")
+    if score.recall < 1.0:
+        print("GATE FAIL: index does not ground every probe; not demo-ready.", file=sys.stderr)
+        return 1
+    print("GATE PASS: index grounds every probe.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--gate", action="store_true", help="Run the demo-readiness gate.")
+    ap.add_argument("--probes", type=Path, default=Path(__file__).with_name("probes.toml"))
+    ap.add_argument("--results", type=Path, help="JSON: {query: [search results]}")
+    ap.add_argument("--n-ctx", type=int, default=8192)
+    args = ap.parse_args()
+    if args.selftest:
+        return _selftest()
+    if args.gate:
+        if args.results is None:
+            ap.error("--gate requires --results")
+        return _gate(args.probes, args.results, args.n_ctx)
+    ap.error("nothing to do: pass --selftest or --gate")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demos-src/opencode-model-reel/selftune.tape.tmpl
+++ b/demos-src/opencode-model-reel/selftune.tape.tmpl
@@ -1,0 +1,55 @@
+# VHS tape for a SELF-TUNE reel: the chat model tunes lilbee's retrieval itself.
+#
+# Drives the real product end to end: `lilbee launch opencode` (provider + MCP +
+# shipped skill + warm serve) in an EMPTY project dir, so opencode's file tools
+# find nothing and the only way to learn lilbee's code is lilbee_search. The
+# prompt invites SKILL.md workflow #5: when the first search is thin, the model
+# widens retrieval via lilbee_settings_set, searches again, then answers with
+# citations. No disabled tools, no hand-written opencode.json.
+#
+# Substituted per run: __OUT__ (output stem), __PROJ__ (empty cwd), __PROMPT__,
+# __BOOT__ (seconds for the warm TUI to come up), __THINK__ (seconds to let the
+# self-tune + answer play out). Rose-pine to match the rest of the reel.
+
+Set Shell "bash"
+Set Width 1600
+Set Height 1000
+Set FontSize 18
+Set Padding 30
+Set TypingSpeed 28ms
+Set Framerate 60
+Set Theme "rose-pine-moon"
+Set WindowBar Colorful
+
+Output "__OUT__.gif"
+Output "__OUT__.webm"
+
+Hide
+# Use the worktree venv's lilbee (the one with `launch`); the global PATH lilbee
+# is an older install without it. opencode stays resolvable via /opt/homebrew/bin.
+Type "export PATH=__LMBIN__:$PATH && cd __PROJ__ && clear"
+Enter
+Show
+Sleep 600ms
+Type "lilbee launch opencode --yes"
+Sleep 900ms
+Enter
+# Warm serve + pre-warmed model -> the TUI is interactive in a few seconds.
+Sleep __BOOT__
+Type "__PROMPT__"
+Sleep 1200ms
+Enter
+# Let the model search, self-tune, search again, and stream its cited answer.
+Sleep __THINK__
+PageUp
+Sleep 2500ms
+PageUp
+Sleep 2500ms
+PageDown
+Sleep 2000ms
+PageDown
+Sleep 2000ms
+Screenshot "__OUT__.png"
+Sleep 800ms
+Ctrl+C
+Sleep 600ms

--- a/demos-src/opencode-model-reel/selftune_demo.sh
+++ b/demos-src/opencode-model-reel/selftune_demo.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Set 2 reel: the chat model tunes lilbee's retrieval ITSELF, recorded live.
+#
+# Real product path only: an EMPTY project + `lilbee launch opencode` (provider +
+# MCP + shipped skill + warm serve). Retrieval starts deliberately NARROW so the
+# model's first lilbee_search is genuinely thin and it has a real reason to widen
+# via lilbee_settings_set (SKILL.md #5), search again, and answer with citations.
+#
+# Local Mac (Metal via the homebrew llama-server the fleet finds on PATH). Built
+# to verify the HARNESS, not a pod. Produces gif + mp4 + webm + a capture of the
+# knobs the MODEL chose (proof it tuned itself).
+#
+# Usage: selftune_demo.sh <chat_native_ref> <full_display_name> [boot_s] [think_s]
+set -uo pipefail
+
+CHAT_REF="$1"; FULL="$2"; BOOT="${3:-7}"; THINK="${4:-90}"
+# Local Metal inference is slow, so we record the FULL turn (large THINK) and then
+# fast-forward the body in post by SPEED, the way the giant pipeline compresses
+# slow spans. SPEED=1 leaves it real-time (use on a fast GPU pod).
+SPEED="${SPEED:-1}"
+MODEL_PICK="lilbee/$CHAT_REF"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LM="${LM:-/Users/tobias/projects/lilbee-local-model-api}"
+LILBEE="${LILBEE:-$LM/.venv/bin/lilbee}"
+PORT="${PORT:-8080}"
+
+ROOT="${ROOT:-$HOME/lilbee-selftune-demo}"
+export LILBEE_DATA="$ROOT/.lilbee"          # local data dir (models stay global)
+DATA="$LILBEE_DATA/data"
+PROJ="$ROOT/scratch"                          # empty project: forces lilbee_search
+OUT_DIR="${OUT_DIR:-$ROOT/out}"               # artifacts live OUTSIDE the repo
+SERVE_TMUX="lilbeeserve-selftune"
+EMBED_REF="nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q4_K_M.gguf"
+RERANK_REF="gpustack/bge-reranker-v2-m3-GGUF/bge-reranker-v2-m3-Q4_K_M.gguf"
+OPENCODE_CFG="$HOME/.config/opencode/opencode.json"
+
+say(){ echo "[selftune $(date -u +%H:%M:%S)] $*"; }
+mkdir -p "$LILBEE_DATA" "$PROJ" "$OUT_DIR"
+
+# 1) Config: roles + a deliberately NARROW retrieval start so self-tuning matters.
+#    num_ctx kept modest so a Q8 30B + KV cache fits 32 GB unified memory.
+cat > "$LILBEE_DATA/config.toml" <<TOML
+chat_model = "$CHAT_REF"
+embedding_model = "$EMBED_REF"
+reranker_model = "$RERANK_REF"
+num_ctx = 16384
+chunk_size = 320
+concept_graph = true
+top_k = 3
+rerank_candidates = 2
+diversity_max_per_source = 1
+max_distance = 0.6
+TOML
+say "wrote config (narrow start) -> $LILBEE_DATA/config.toml"
+
+# 2) Ensure the chat model is installed (embed + rerank already are).
+if ! "$LILBEE" --json model list 2>/dev/null | grep -q "$CHAT_REF"; then
+  say "chat model not installed: $CHAT_REF -- pull it first (see notes); aborting"
+  exit 2
+fi
+
+# 3) Ingest the corpus subset that grounds the probes (server + providers).
+if ! curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1; then :; fi
+if [ ! -f "$LILBEE_DATA/.selftune_indexed" ]; then
+  say "ingesting corpus subset (src/lilbee/server + providers)"
+  LILBEE_DATA="$LILBEE_DATA" "$LILBEE" add "$LM/src/lilbee/server" "$LM/src/lilbee/providers"
+  touch "$LILBEE_DATA/.selftune_indexed"
+fi
+
+# 4) Start serve so `lilbee launch opencode` reuses it AND we can read the
+#    model-chosen config afterwards. Inline env (tmux server env trap).
+tmux kill-session -t "$SERVE_TMUX" 2>/dev/null || true
+if ! curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1; then
+  say "starting lilbee serve on :$PORT (tmux $SERVE_TMUX)"
+  tmux new-session -d -s "$SERVE_TMUX" \
+    "cd $LM && LILBEE_DATA=$LILBEE_DATA $LILBEE serve --port $PORT > /tmp/selftune-serve.log 2>&1"
+  for _ in $(seq 1 60); do curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1 && break; sleep 2; done
+fi
+curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1 \
+  || { say "FATAL serve not healthy (see /tmp/selftune-serve.log)"; exit 3; }
+TOKEN=$(python3 -c "import json;print(json.load(open('$DATA/server.json'))['token'])")
+
+# 5) Warm embed + chat so the reel doesn't sit on a cold model.
+say "warming embed + chat"
+curl -fsS -m20 -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:$PORT/api/search?q=dispatch%20chat%20request&top_k=1&chunk_type=raw" >/dev/null 2>&1 || true
+curl -fsS -m120 -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "http://127.0.0.1:$PORT/v1/chat/completions" \
+  -d "{\"model\":\"$CHAT_REF\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":8}" \
+  >/tmp/selftune-warm.json 2>&1 || say "warn: chat warm call failed (see /tmp/selftune-warm.json)"
+
+# 6) Pin the model + skip the first-run setup plan, so the reel is clean. The
+#    setup marker makes `lilbee launch opencode` skip its plan print; the model
+#    key in opencode.json selects qwen3-coder. Both are restored afterwards.
+MARKER="$DATA/launchers/opencode-setup.json"
+mkdir -p "$(dirname "$MARKER")"; printf '{"accepted":true}' > "$MARKER"
+mkdir -p "$(dirname "$OPENCODE_CFG")"
+BACKUP=""
+if [ -f "$OPENCODE_CFG" ]; then BACKUP="$OPENCODE_CFG.selftune-bak"; cp -f "$OPENCODE_CFG" "$BACKUP"; fi
+python3 - "$OPENCODE_CFG" "$MODEL_PICK" <<'PY'
+import json, sys
+from pathlib import Path
+path, model = Path(sys.argv[1]), sys.argv[2]
+cfg = {}
+if path.exists():
+    try: cfg = json.loads(path.read_text())
+    except Exception: cfg = {}
+if not isinstance(cfg, dict): cfg = {}
+cfg.setdefault("$schema", "https://opencode.ai/config.json")
+cfg["model"] = model
+path.write_text(json.dumps(cfg, indent=2))
+print("set opencode default model ->", model)
+PY
+
+restore_opencode(){
+  if [ -n "$BACKUP" ]; then mv -f "$BACKUP" "$OPENCODE_CFG"; else rm -f "$OPENCODE_CFG"; fi
+}
+trap restore_opencode EXIT
+
+# 7) Build the prompt (natural dev task that invites self-tuning) and render the tape.
+PROMPT="I'm new to lilbee. Map the FULL path an incoming chat request takes: request dispatch, tool-call argument parsing, OpenAI wire-format translation, fleet routing to a backend, and the canonical request and response types. Cite each real file as path:line. Use the lilbee tools. If a search does not surface every piece, widen retrieval with lilbee_settings_set, then search again before you answer."
+RAW="_selftune-$FULL"
+STEM="$OUT_DIR/$RAW"
+sed -e "s#__OUT__#$RAW#g" \
+    -e "s#__PROJ__#$PROJ#g" \
+    -e "s#__LMBIN__#$LM/.venv/bin#g" \
+    -e "s#__PROMPT__#$PROMPT#g" \
+    -e "s#__BOOT__#${BOOT}s#g" \
+    -e "s#__THINK__#${THINK}s#g" \
+    "$HERE/selftune.tape.tmpl" > "/tmp/selftune-$FULL.tape"
+say "recording reel (boot=${BOOT}s think=${THINK}s)"
+( cd "$OUT_DIR" && VHS_NO_SANDBOX=true vhs "/tmp/selftune-$FULL.tape" )
+# VHS can return before the webm is fully flushed; wait until it stops growing so
+# the transcode never reads a truncated file (the 48-byte mp4 failure mode).
+for _ in $(seq 1 20); do
+  sz1=$(stat -f %z "$STEM.webm" 2>/dev/null || echo 0); sleep 1
+  sz2=$(stat -f %z "$STEM.webm" 2>/dev/null || echo 0)
+  [ "$sz1" = "$sz2" ] && [ "$sz1" -gt 10000 ] && break
+done
+
+# 8) Capture the knobs the MODEL chose (proof it tuned itself), vs the narrow start.
+curl -fsS -m5 -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:$PORT/api/config" \
+  > "$OUT_DIR/selftune-$FULL-chosen-config.json" 2>/dev/null || true
+say "saved model-chosen config -> $OUT_DIR/selftune-$FULL-chosen-config.json"
+
+# 9) Transcode -> mp4 + gif.
+FINAL_MP4="$OUT_DIR/selftune-$FULL.mp4"
+ffmpeg -nostdin -y -loglevel error -i "$STEM.webm" -c:v libx264 -pix_fmt yuv420p -r 60 \
+  -vf "setpts=PTS/${SPEED},scale=1600:1000" -an -movflags +faststart "$FINAL_MP4"
+say "transcoded (speed=${SPEED}x) -> $FINAL_MP4"
+PAL="/tmp/selftune-pal-$FULL.png"
+ffmpeg -nostdin -y -loglevel error -i "$FINAL_MP4" -vf "fps=20,scale=1600:-1:flags=lanczos,palettegen" "$PAL"
+ffmpeg -nostdin -y -loglevel error -i "$FINAL_MP4" -i "$PAL" \
+  -lavfi "fps=20,scale=1600:-1:flags=lanczos[x];[x][1:v]paletteuse" "$OUT_DIR/selftune-$FULL.gif"
+cp -f "$STEM.png" "$OUT_DIR/selftune-$FULL.png" 2>/dev/null || true
+
+# 10) Timeline review gate.
+echo "[review] selftune-$FULL"
+python3 "$HERE/review_demo.py" "$FINAL_MP4" --frames 8 || \
+  echo "[review] selftune-$FULL flagged DEAD-SCREEN RISK -- inspect frames" >&2
+say "DONE -> $OUT_DIR/selftune-$FULL.{gif,mp4,webm,png} + chosen-config.json"

--- a/demos-src/opencode-model-reel/tune_demo.sh
+++ b/demos-src/opencode-model-reel/tune_demo.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Record ONE fine-tuning reel: lilbee tuning retrieval to a chat model on the
+# shared corpus. Also THE precompute step -- it persists the model's tuned knobs
+# to /workspace/results/<family>/query-knobs.toml, which the opencode answer demo
+# later merges into config.toml so it boots already-tuned.
+#
+# Needs ingest_corpus.sh to have built + verified the corpus first. Tuning loads
+# no chat model (embed + rerank + scoring only), so every model's reel is
+# recordable now, before the giant-serving question is solved.
+#
+# Usage: tune_demo.sh <family> <full-name> [n_ctx]
+set -uo pipefail
+export PATH=$HOME/.local/bin:$HOME/.opencode/bin:/usr/local/bin:$PATH
+
+FAMILY="$1"; FULL="$2"; N_CTX="${3:-131072}"
+PACE="${PACE:-1.3}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LM="${LM:-/root/lilbee}"
+export LILBEE_DATA="${LILBEE_DATA:-/workspace/.lilbee}"
+export LILBEE_MODELS_DIR="${LILBEE_MODELS_DIR:-/workspace/models}"
+LILBEE="${LILBEE:-$LM/.venv/bin/lilbee}"
+PORT="${PORT:-8080}"
+OUT_DIR="${OUT_DIR:-/root/demos}"
+RES="/workspace/results/$FAMILY"
+DATA="$LILBEE_DATA/data"
+mkdir -p "$OUT_DIR" "$RES"
+
+say(){ echo "[tune $(date -u +%H:%M:%S)] $*"; }
+
+# 1) Ensure serve is up and read the token (the index must already exist).
+if ! curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1; then
+  say "starting lilbee serve on :$PORT"
+  tmux kill-session -t lilbeeserve 2>/dev/null || true
+  tmux new-session -d -s lilbeeserve \
+    "cd $LM && LILBEE_DATA=$LILBEE_DATA LILBEE_MODELS_DIR=$LILBEE_MODELS_DIR $LILBEE serve --port $PORT > /tmp/lilbee-serve.log 2>&1"
+  for _ in $(seq 1 60); do curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1 && break; sleep 2; done
+fi
+curl -fsS -m2 "http://127.0.0.1:$PORT/api/health" >/dev/null 2>&1 \
+  || { say "FATAL serve not healthy (see /tmp/lilbee-serve.log)"; exit 3; }
+TOKEN=$(python3 -c "import json;print(json.load(open('$DATA/server.json'))['token'])")
+
+# 2) Confirm the corpus is actually indexed; otherwise ingest_corpus.sh wasn't run.
+if ! curl -fsS -m5 -H "Authorization: Bearer $TOKEN" \
+     "http://127.0.0.1:$PORT/api/search?q=dispatch&top_k=1&chunk_type=raw" 2>/dev/null \
+     | grep -qiE '"source"|\.py'; then
+  say "FATAL corpus search returns nothing -- run ingest_corpus.sh first"; exit 5
+fi
+
+OUT="$RES/query-knobs.toml"
+TOKFILE="/tmp/tune-tok-$FAMILY"; umask 077; printf '%s' "$TOKEN" > "$TOKFILE"
+
+# 3) Precompute (authoritative): run the tuner once with no pacing to persist the
+#    tuned knobs and to MEASURE the search wall-time, so the recording's wait is
+#    sized to the real run instead of a guess.
+say "precomputing tuned knobs for $FULL (n_ctx=$N_CTX) -> $OUT"
+T0=$SECONDS
+python3 "$HERE/tune_run.py" --model "$FULL" --n-ctx "$N_CTX" --probes "$HERE/probes.toml" \
+  --out "$OUT" --base-url "http://127.0.0.1:$PORT" --token-file "$TOKFILE" --pace 0 \
+  > "$RES/tune-precompute.log" 2>&1
+PRC=$?
+T_SEARCH=$((SECONDS - T0))
+[ -f "$OUT" ] || { say "FATAL tuner did not write $OUT (see tune-precompute.log)"; exit 6; }
+say "precompute rc=$PRC search_time=${T_SEARCH}s; artifact saved"
+
+# 4) Size the reel: the recording re-runs the searches (~T_SEARCH) plus the narration
+#    pacing, with a buffer so a slow pass never gets cut off mid-climb.
+PACING=$(awk "BEGIN{printf \"%d\", 1.6 + 6*$PACE + 4}")
+WAIT=$((T_SEARCH + PACING + 4))
+say "reel wait=${WAIT}s (search ${T_SEARCH}s + pacing ${PACING}s)"
+
+# 5) Launcher script keeps the token off the recorded command line.
+LAUNCH="/tmp/tune-launch-$FAMILY.sh"
+cat > "$LAUNCH" <<SH
+#!/usr/bin/env bash
+exec python3 "$HERE/tune_run.py" --model "$FULL" --n-ctx $N_CTX \\
+  --probes "$HERE/probes.toml" --out "$OUT" \\
+  --base-url "http://127.0.0.1:$PORT" --token-file "$TOKFILE" --pace $PACE
+SH
+chmod +x "$LAUNCH"
+
+# 6) Render the reel.
+RAW="_tune-$FAMILY"
+STEM="$OUT_DIR/$RAW"
+sed -e "s#__OUT__#$RAW#g" \
+    -e "s#__CMD__#bash $LAUNCH#g" \
+    -e "s#__WAIT__#${WAIT}s#g" \
+    "$HERE/tune_demo.tape.tmpl" > "/tmp/tune-tape-$FAMILY.tape"
+( cd "$OUT_DIR" && VHS_NO_SANDBOX=true vhs "/tmp/tune-tape-$FAMILY.tape" )
+
+# 7) Transcode webm -> mp4 + high-quality gif (same recipe as the opencode reel).
+FINAL_MP4="$OUT_DIR/tune-$FULL.mp4"
+ffmpeg -nostdin -y -loglevel error -i "$STEM.webm" -c:v libx264 -pix_fmt yuv420p -r 60 \
+  -vf scale=1600:1000 -movflags +faststart "$FINAL_MP4"
+PAL="/tmp/tune-pal-$FAMILY.png"
+ffmpeg -nostdin -y -loglevel error -i "$FINAL_MP4" -vf "fps=20,scale=1600:-1:flags=lanczos,palettegen" "$PAL"
+ffmpeg -nostdin -y -loglevel error -i "$FINAL_MP4" -i "$PAL" \
+  -lavfi "fps=20,scale=1600:-1:flags=lanczos[x];[x][1:v]paletteuse" "$OUT_DIR/tune-$FULL.gif"
+cp -f "$STEM.png" "$OUT_DIR/tune-$FULL.png" 2>/dev/null || true
+
+# 8) Timeline review gate + collect durable artifacts.
+echo "[review] tune-$FULL"
+python3 "$HERE/review_demo.py" "$FINAL_MP4" --frames 8 || \
+  echo "[review] tune-$FULL flagged DEAD-SCREEN RISK -- inspect frames before publishing" >&2
+cp -f "$OUT_DIR/tune-$FULL.gif" "$OUT_DIR/tune-$FULL.mp4" "$OUT_DIR/tune-$FULL.png" "$RES/" 2>/dev/null || true
+say "DONE tune-$FULL -> $OUT_DIR + artifacts in $RES"

--- a/demos-src/opencode-model-reel/tune_demo.tape.tmpl
+++ b/demos-src/opencode-model-reel/tune_demo.tape.tmpl
@@ -1,0 +1,38 @@
+# VHS tape for a fine-tuning reel: lilbee tuning retrieval to one chat model on
+# the lilbee corpus. Mirrors the opencode reel look (rose-pine-moon, 1600x1000).
+#
+# The session token never appears on screen: tune_demo.sh writes the real command
+# (with the token) into a launcher script and the tape only types that launcher's
+# name, so the recorded frames carry no secret.
+#
+# Substituted per model: __OUT__ (output stem), __CMD__ (launcher invocation),
+# __WAIT__ (seconds to let the narrated tuning play out, from tune_demo.sh).
+
+Set Shell "bash"
+Set Width 1600
+Set Height 1000
+Set FontSize 18
+Set Padding 30
+Set TypingSpeed 22ms
+Set Framerate 60
+Set Theme "rose-pine-moon"
+Set WindowBar Colorful
+
+Output "__OUT__.gif"
+Output "__OUT__.webm"
+
+Hide
+Type "clear"
+Enter
+Show
+Sleep 800ms
+# Launch the tuner. tune_run paces its own narration, so we just let it play.
+Type "__CMD__"
+Enter
+Sleep __WAIT__
+PageUp
+Sleep 2500ms
+PageDown
+Sleep 1500ms
+Screenshot "__OUT__.png"
+Sleep 800ms

--- a/demos-src/opencode-model-reel/tune_run.py
+++ b/demos-src/opencode-model-reel/tune_run.py
@@ -1,0 +1,291 @@
+"""The recorded fine-tuning session: lilbee tuning retrieval to one chat model.
+
+This is the program VHS records for a fine-tuning reel. It runs a greedy
+forward-selection sweep over lilbee's query-time retrieval knobs against the
+shared corpus, narrating each step: the baseline (some probes miss), each knob it
+tries (recall climbing or "no gain"), the context-budget clamp that keeps the
+retrieved pool inside this model's window, and a before/after of the cited chunks.
+
+It does real work through real product routes (``GET /api/search`` +
+``PATCH /api/config``), and on the way it persists the winning knobs to a per-model
+``query-knobs.toml``. So running the reel IS the precompute: once model serving is
+solved, every opencode demo boots already-tuned.
+
+Tuning needs no chat model loaded, only the embedder + reranker and this model's
+``n_ctx`` for the budget clamp, so every model's reel is recordable up front.
+
+``--fake`` swaps in a deterministic in-process search so the narrative, the clamp,
+and the artifact can be verified locally with no server and no models.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from score_retrieval import (
+    Probe,
+    SweepScore,
+    budget_for_context,
+    load_probes,
+    score_pass,
+)
+
+GREEN = "\033[32m"
+RED = "\033[31m"
+CYAN = "\033[36m"
+YELLOW = "\033[33m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+BAR_WIDTH = 24
+TOP_K_FLOOR = 6  # never clamp below this; fewer chunks stops grounding the answer
+
+# Ordered greedy moves over query-time knobs only (no reindex). Each is tried on
+# top of the accepted-so-far config and kept only if it improves the score.
+MOVES: list[tuple[str, dict[str, Any]]] = [
+    ("wider candidate pool", {"top_k": 16}),
+    ("rerank the top candidates", {"rerank_candidates": 32}),
+    ("allow more chunks per source", {"diversity_max_per_source": 8}),
+    ("accept fuzzier matches", {"max_distance": 0.85}),
+    ("HyDE query expansion", {"hyde": True}),
+]
+
+# Baseline values for the tuned keys when the server can't report them (fake mode).
+BASELINE: dict[str, Any] = {
+    "top_k": 5,
+    "rerank_candidates": 0,
+    "diversity_max_per_source": 3,
+    "max_distance": 0.7,
+    "hyde": False,
+}
+
+SearchFn = Callable[[str, int], list[dict[str, Any]]]
+
+
+@dataclass
+class Tuner:
+    probes: list[Probe]
+    budget: int
+    search: SearchFn
+    apply: Callable[[dict[str, Any]], None]
+    pace: float
+
+    def _pause(self, mult: float = 1.0) -> None:
+        if self.pace:
+            time.sleep(self.pace * mult)
+
+    def _measure(self, knobs: dict[str, Any]) -> SweepScore:
+        self.apply(knobs)
+        results = {p.query: self.search(p.query, knobs["top_k"]) for p in self.probes}
+        return score_pass(self.probes, results, self.budget)
+
+    def run(self, model: str, n_ctx: int) -> tuple[dict[str, Any], SweepScore]:
+        _banner(model, n_ctx, len(self.probes), self.budget)
+        current = dict(BASELINE)
+        best = self._measure(current)
+        _section("BASELINE  (lilbee defaults)")
+        _render_pass(best)
+        _render_bar("recall", best.recall)
+        self._pause(1.6)
+
+        _section("TUNING  (each knob kept only if it helps)")
+        for name, delta in MOVES:
+            trial = {**current, **delta}
+            score = self._measure(trial)
+            if score.is_better_than(best):
+                current, best = trial, score
+                _move_line(name, delta, accepted=True, recall=best.recall, reason="kept")
+            else:
+                self.apply(current)  # revert the rejected trial on the server
+                # Distinguish "wouldn't help" from "would overflow this model's
+                # window" -- the latter is the bb-xdic constraint made visible.
+                over = not score.all_within_budget and score.recall > best.recall
+                reason = "over budget" if over else "no gain"
+                _move_line(name, delta, accepted=False, recall=best.recall, reason=reason)
+            self._pause()
+
+        best = self._clamp_to_budget(current, best, model, n_ctx)
+        return current, best
+
+    def _clamp_to_budget(
+        self, current: dict[str, Any], best: SweepScore, model: str, n_ctx: int
+    ) -> SweepScore:
+        """Shrink top_k until every probe response fits this model's window."""
+        if best.all_within_budget:
+            return best
+        _section(f"CONTEXT CLAMP  (fit {model}'s {n_ctx:,}-token window)")
+        while not best.all_within_budget and current["top_k"] > TOP_K_FLOOR:
+            current["top_k"] = max(TOP_K_FLOOR, current["top_k"] - 2)
+            best = self._measure(current)
+            fit = "fits" if best.all_within_budget else "still over"
+            print(f"  top_k -> {current['top_k']:>2}   "
+                  f"max response {best.max_response_tokens:>5} tok / {self.budget} budget  "
+                  f"{DIM}({fit}){RESET}")
+            self._pause(0.8)
+        return best
+
+
+def _banner(model: str, n_ctx: int, n_probes: int, budget: int) -> None:
+    print(f"{BOLD}{CYAN}lilbee{RESET}  tuning retrieval for "
+          f"{BOLD}{model}{RESET}  ({n_ctx:,}-token context)")
+    print(f"{DIM}corpus: the lilbee repo   probes: {n_probes} grounded code questions   "
+          f"budget: {budget:,} tok/response{RESET}\n")
+
+
+def _section(title: str) -> None:
+    print(f"\n{BOLD}{title}{RESET}")
+
+
+def _short(query: str, width: int = 46) -> str:
+    return query if len(query) <= width else query[: width - 1] + "…"
+
+
+def _render_pass(score: SweepScore) -> None:
+    for o in score.outcomes:
+        if o.hit:
+            cite = o.citations[0] if o.citations else ""
+            over = "" if o.within_budget else f" {RED}[over budget]{RESET}"
+            print(f"  {GREEN}✓{RESET} {_short(o.query):<46} {DIM}{cite}{RESET}{over}")
+        else:
+            miss = ", ".join(o.missed)
+            print(f"  {RED}✗{RESET} {_short(o.query):<46} {DIM}missing {miss}{RESET}")
+
+
+def _render_bar(label: str, frac: float) -> None:
+    filled = round(frac * BAR_WIDTH)
+    bar = "#" * filled + "-" * (BAR_WIDTH - filled)
+    color = GREEN if frac >= 0.999 else (YELLOW if frac >= 0.5 else RED)
+    print(f"  {label:<6} {color}[{bar}]{RESET} {frac:.0%}\n")
+
+
+def _move_line(name: str, delta: dict[str, Any], *, accepted: bool, recall: float, reason: str) -> None:
+    knob = ", ".join(f"{k}={_fmt(v)}" for k, v in delta.items())
+    if accepted:
+        tag = f"{GREEN}+ kept{RESET}"
+    elif reason == "over budget":
+        tag = f"{YELLOW}- over budget{RESET}"
+    else:
+        tag = f"{DIM}- no gain{RESET}"
+    filled = round(recall * BAR_WIDTH)
+    bar = "#" * filled + "-" * (BAR_WIDTH - filled)
+    barcolor = GREEN if recall >= 0.999 else YELLOW
+    print(f"  {tag:<16} {name:<30} {DIM}{knob}{RESET}")
+    print(f"  {'':<16} recall {barcolor}[{bar}]{RESET} {recall:.0%}")
+
+
+def _fmt(v: Any) -> str:
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    return str(v)
+
+
+def _write_artifact(path: Path, knobs: dict[str, Any], model: str, n_ctx: int) -> None:
+    lines = [
+        f"# Tuned retrieval knobs for {model} (n_ctx={n_ctx}) on the lilbee corpus.",
+        "# Produced by tune_run.py; merged into the shared config.toml before launch.",
+        "",
+    ]
+    lines += [f"{k} = {_fmt(v)}" for k, v in knobs.items()]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _fake_search(knobs_holder: dict[str, dict[str, Any]], probes: list[Probe]) -> SearchFn:
+    """Deterministic search whose recall climbs as the right knobs are set.
+
+    Models, loosely, a corpus where each probe needs a different knob to surface
+    its file. Response size scales with top_k so a small-context model triggers
+    the budget clamp. For local verification only; the real reel uses LilbeeClient.
+    """
+    snippet = "x" * 600  # ~150 tokens per returned chunk
+
+    def unlocked(probe_idx: int, k: dict[str, Any]) -> bool:
+        return [
+            True,
+            k["top_k"] >= 16,
+            k["rerank_candidates"] >= 32,
+            k["diversity_max_per_source"] >= 8,
+            k["max_distance"] >= 0.85 or k["hyde"],
+        ][probe_idx]
+
+    by_query = {p.query: i for i, p in enumerate(probes)}
+
+    def search(query: str, top_k: int) -> list[dict[str, Any]]:
+        idx = by_query[query]
+        k = knobs_holder["current"]
+        docs: list[dict[str, Any]] = []
+        if unlocked(idx, k):
+            docs.append({
+                "source": "lilbee/" + probes[idx].expect[0],
+                "excerpts": [{"content": snippet, "line_start": 12, "line_end": 40}],
+            })
+        for d in range(top_k - len(docs)):
+            docs.append({"source": f"lilbee/other/distractor_{d}.py",
+                         "excerpts": [{"content": snippet}]})
+        return docs
+
+    return search
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--n-ctx", type=int, required=True)
+    ap.add_argument("--probes", type=Path, default=Path(__file__).with_name("probes.toml"))
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--base-url", default="http://127.0.0.1:8080")
+    ap.add_argument("--token", default="")
+    ap.add_argument("--token-file", type=Path, help="Read the token from a file (keeps it off "
+                    "the recorded command line).")
+    ap.add_argument("--fake", action="store_true", help="Local verification: no server.")
+    ap.add_argument("--pace", type=float, default=1.3, help="Seconds between narration steps.")
+    args = ap.parse_args()
+
+    probes = load_probes(args.probes)
+    budget = budget_for_context(args.n_ctx)
+
+    if args.fake:
+        holder: dict[str, dict[str, Any]] = {"current": dict(BASELINE)}
+        search = _fake_search(holder, probes)
+
+        def apply(knobs: dict[str, Any]) -> None:
+            holder["current"] = dict(knobs)
+    else:
+        from lilbee_http import LilbeeClient
+
+        token = args.token
+        if args.token_file:
+            token = args.token_file.read_text(encoding="utf-8").strip()
+        client = LilbeeClient(base_url=args.base_url, token=token)
+
+        def apply(knobs: dict[str, Any]) -> None:
+            try:
+                client.patch_config(knobs)
+            except Exception as exc:  # noqa: BLE001 - keep the reel running, note it
+                print(f"  {DIM}(settings note: {exc}){RESET}")
+
+        def search(query: str, top_k: int) -> list[dict[str, Any]]:
+            return client.search(query, top_k=top_k, scope="raw")
+
+    tuner = Tuner(probes=probes, budget=budget, search=search, apply=apply, pace=args.pace)
+    winner, final = tuner.run(args.model, args.n_ctx)
+
+    _section("RESULT")
+    knob_str = "  ".join(f"{k}={_fmt(v)}" for k, v in winner.items())
+    print(f"  {DIM}{knob_str}{RESET}")
+    _render_bar("recall", final.recall)
+    _write_artifact(args.out, winner, args.model, args.n_ctx)
+    print(f"  {GREEN}saved{RESET} {args.out}")
+    print(f"  {DIM}opencode will boot already-tuned for {args.model}.{RESET}")
+
+    _section("AFTER  (grounded, with citations)")
+    _render_pass(final)
+    return 0 if final.recall >= 0.999 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/qa/opencode/matrix.py
+++ b/tools/qa/opencode/matrix.py
@@ -1,0 +1,1061 @@
+"""Local-only QA matrix that drives a real opencode binary against lilbee.
+
+Run before tagging. Not for CI. ``--families <list>`` narrows the matrix;
+``--no-pull`` skips the model download step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import tomllib
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+import httpx
+
+QA_DIR = Path(__file__).resolve().parent
+REPO_ROOT = QA_DIR.parent.parent.parent
+RESULTS_DIR = QA_DIR / "results"
+WORKSPACE_DIR = QA_DIR / "workspace"
+LOG_DIR = QA_DIR / "logs"
+SHARED_WORKSPACE = QA_DIR / "_shared_workspace"
+
+_TMUX_SESSION_PREFIX = "lilbee-qa"
+_TMUX_HISTORY_LINES = 3000
+_TMUX_WINDOW_COLS = 200
+_TMUX_WINDOW_ROWS = 50
+_POST_SEND_SLEEP_S = 0.1
+
+_SERVE_BOOT_TIMEOUT_S = 30.0
+_SERVE_TERMINATE_TIMEOUT_S = 10.0
+_OPENCODE_BOOT_SETTLE_S = 30.0  # boot + first-prompt prefill warmup
+_INDEX_TIMEOUT_S = 120.0
+_MODEL_PULL_TIMEOUT_S = 3600.0  # residential bandwidth, multi-quant repos can run 30+ min
+_POLL_INTERVAL_S = 2.0
+_SCENARIO_TIMEOUT_S = 900.0  # giant MoE (30B) on Apple Silicon Metal: first tool call is slow
+_MULTI_TOOL_TIMEOUT_S = 600.0
+_INTER_SCENARIO_SETTLE_S = 15.0  # let opencode finish the prior turn before queuing the next
+# Fail-fast: declare a scenario dead when the pane stops changing for this long
+# AFTER the model has emitted at least one ``Build · …`` activity marker. Keeps
+# a quiet model from eating the full timeout. Set high enough that a giant MoE on
+# Metal (static "thinking" spinner reads as an idle pane) isn't killed mid-reason
+# before it emits its first tool call.
+_PANE_IDLE_TIMEOUT_S = 240.0
+
+_PANE_EXCERPT_TAIL = 2000
+_OPENCODE_PICKER_STATE = Path.home() / ".local" / "state" / "opencode" / "model.json"
+_OPENCODE_SHARE_DIR = Path.home() / ".local" / "share" / "opencode"
+_OPENCODE_CONFIG = Path.home() / ".config" / "opencode" / "opencode.json"
+# Pre-built Godot 4 class-reference corpus (one-time `lilbee add /root/godot/doc/classes`
+# into LILBEE_DATA=<this>); each cell copies its data/ + documents/ so lilbee_search
+# has the reference without re-embedding. Override with LILBEE_QA_CORPUS.
+_GODOT_CORPUS = Path(os.environ.get("LILBEE_QA_CORPUS", str(Path.home() / "godot_corpus")))
+# opencode's built-in tools that compete with lilbee_search; disabled per cell so
+# the model uses lilbee's MCP search instead of webfetch/read/grep (search mode).
+_TOOLS_OFF = (
+    "webfetch",
+    "read",
+    "write",
+    "edit",
+    "patch",
+    "bash",
+    "glob",
+    "grep",
+    "list",
+    "todowrite",
+    "todoread",
+    "task",
+)
+_LILBEE_PROVIDER_ID = "lilbee"
+
+# Substrings whose appearance in the pane means the cell can't recover --
+# record the scenario as FAIL immediately instead of polling to timeout.
+_FAIL_FAST_MARKERS = (
+    "does not support tool calls",
+    "context_length_exceeded",
+    "exceeds the usable budget",
+    "Internal Server Error",
+)
+_RAW_MARKER_FORBIDDEN = (
+    "<tool_call>",
+    "[TOOL_CALLS]",
+    "functools[",
+    "Error:",
+    "Traceback",
+    # Model emitted the tool call as raw JSON text instead of using opencode's
+    # tool-call channel. lilbee's per-family extractor did not pick the
+    # payload up, so opencode renders the JSON as a chat reply. The cell
+    # cannot be marked "supported" if this happens.
+    '{"name": "lilbee_',
+    '{"name":"lilbee_',
+)
+_SUSPENDED_SUFFIX = ".qa-suspended"
+_CHAT_CTX_TARGET = 131072  # ~24K goes to opencode's system + tools schema; the
+# AGENTS.md plan/search/verify workflow needs the rest. resolve_chat_ctx clamps this
+# to min(model trained ctx, host VRAM), so small-context models are unaffected and
+# giants (qwen3-coder 256K, etc.) get the window the multi-search codegen turn needs.
+_EMBED_REF = "nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q4_K_M.gguf"
+_EMBED_PULL_REF = "nomic-ai/nomic-embed-text-v1.5-GGUF"
+
+
+def _models_manifests_dir() -> Path:
+    """Locate lilbee's chat-manifests directory via cfg."""
+    from lilbee.core.config import cfg
+
+    return Path(cfg.models_dir) / "manifests"
+
+
+def _list_chat_manifests() -> list[Path]:
+    manifests_dir = _models_manifests_dir()
+    if not manifests_dir.exists():
+        return []
+    chats: list[Path] = []
+    for path in manifests_dir.rglob("*.gguf.json"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("task") == "chat":
+            chats.append(path)
+    return chats
+
+
+def _ref_for_manifest(path: Path) -> str:
+    """Convert a manifest path back to its canonical HF ref (subdir-aware)."""
+    rel = path.relative_to(_models_manifests_dir())
+    repo = rel.parts[0].replace("--", "/")
+    rest = "/".join(rel.parts[1:]).removesuffix(".json")
+    return f"{repo}/{rest}"
+
+
+def _installed_ref_for_repo(repo: str) -> str | None:
+    """Return the chat model ref actually installed under *repo*, if any.
+
+    ``lilbee model pull <repo>`` installs the repo's default quant, which need
+    not be the specific file named in models.toml (e.g. legraphista/glm-4-9b
+    installs Q4_K_S, internlm2 installs fp16). Pinning opencode to the
+    models.toml ref then points at an uninstalled file: ``/v1/models`` omits
+    it, opencode never dispatches, and the cell logs zero chat completions.
+    Resolving the installed ref after the pull keeps the cell aligned with
+    whatever quant lilbee actually fetched.
+    """
+    for path in _list_chat_manifests():
+        ref = _ref_for_manifest(path)
+        if _pull_ref_for(ref) == repo:
+            return ref
+    return None
+
+
+def _pull_ref_for(model_ref: str) -> str:
+    """Return the HuggingFace repo id (owner/name) for *model_ref*.
+
+    GGUF refs in models.toml have the shape ``owner/repo[/subdir]/file.gguf``,
+    e.g. ``Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf`` (3 parts, no subdir) or
+    ``unsloth/GLM-4.5-Air-GGUF/Q4_K_M/GLM-4.5-Air-Q4_K_M-00001-of-00002.gguf``
+    (4 parts, with a quant-tier subdir). ``lilbee model pull`` wants exactly
+    ``owner/repo`` regardless, so keep only the first two segments.
+    """
+    return "/".join(model_ref.split("/")[:2])
+
+
+@contextlib.contextmanager
+def suspend_other_chat_manifests(target_ref: str) -> Iterator[None]:
+    """Move every chat manifest except *target_ref* out of the registry.
+
+    The launcher's ``_update_opencode_picker_state`` prepends every entry of
+    ``sorted(installed_chat_model_refs())`` to opencode's recent list, so
+    whichever ref sorts first wins ``recent[0]``. To pin a specific model
+    per cell we suspend the others for the duration of the cell.
+    """
+    suspended: list[tuple[Path, Path]] = []
+    try:
+        for path in _list_chat_manifests():
+            if _ref_for_manifest(path) == target_ref:
+                continue
+            suspended_path = path.with_name(path.name + _SUSPENDED_SUFFIX)
+            path.rename(suspended_path)
+            suspended.append((path, suspended_path))
+        yield
+    finally:
+        for original, suspended_path in suspended:
+            if suspended_path.exists():
+                suspended_path.rename(original)
+
+
+class ScenarioStatus(StrEnum):
+    PASS = "pass"
+    FAIL = "fail"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """One QA cell: send *prompt*, wait for *expected* / *forbidden* in the pane."""
+
+    name: str
+    prompt: str
+    expected: tuple[str, ...]
+    forbidden: tuple[str, ...]
+    timeout_s: float
+
+
+_TOOL_DISPATCH_MARKER = "⚙ lilbee_search"
+"""Glyph opencode renders ONLY when it dispatches a parsed tool call.
+
+opencode draws U+2699 GEAR before the tool name once it has extracted a
+structured ``tool_calls`` payload from lilbee's response and is invoking the
+MCP tool. A model that emits raw ``{"name":"lilbee_search",...}`` JSON, a
+model that never loads, or a serve that 500s never reaches this render path,
+so the glyph cleanly separates real end-to-end dispatch from opencode chrome
+(autocomplete hints, the MCP status panel, the picker badge) that merely
+mentions the tool name. Cross-checked against the launcher-serve.log chat-
+completion count so a stale pane can't carry a prior cell's glyph.
+"""
+
+
+# Tier prompts run against the indexed Godot 4 class reference. One prompt per
+# tier (same yardstick across same-tier models). Natural phrasing -- the model
+# should discover the lilbee_search MCP tool itself; only Smalls get a "look up"
+# nudge. See tools/qa/opencode/README.md for the rationale.
+_TIER_PROMPTS: dict[str, str] = {
+    # Small models answer common Godot API from memory (Node._process etc.), so the
+    # small-tier prompt is explicit ("search the indexed reference") and targets an
+    # obscure class detail the model cannot fabricate, forcing a real lilbee_search.
+    "small": (
+        "Search the indexed Godot 4 class reference for the AStarGrid2D class. "
+        "Then, using only what the search returns, tell me what its get_id_path "
+        "method returns."
+    ),
+    # Mid models discover the tool on their own: natural phrasing, anchored to exact
+    # signatures and flag values they would have to verify against the reference.
+    "mid": (
+        "In Godot 4 I am connecting signals between nodes. What is the exact "
+        "signature of Object.connect, and what do the CONNECT_DEFERRED and "
+        "CONNECT_ONE_SHOT flags do? Include their integer values."
+    ),
+    # Giants get the published level-generator prompt verbatim, from the
+    # godot-level-generator RAG-vs-no-RAG benchmark (docs/benchmarks/
+    # godot-level-generator.md). It only "passes" cleanly when the generated
+    # GDScript uses real Godot 4 API (set_cell, AStarGrid2D.get_point_path, etc.),
+    # verified via lilbee_search rather than hallucinated.
+    "giant": (
+        "make a procedural level generator that places wall and floor tiles and "
+        "scatters collectibles using pathfinding"
+    ),
+}
+
+
+def scenario_for_tier(tier: str) -> Scenario:
+    """The single QA scenario for a model's tier (Godot-reference prompt)."""
+    return Scenario(
+        name=f"{tier} godot",
+        prompt=_TIER_PROMPTS.get(tier, _TIER_PROMPTS["small"]),
+        expected=(_TOOL_DISPATCH_MARKER,),
+        forbidden=_RAW_MARKER_FORBIDDEN,
+        timeout_s=_MULTI_TOOL_TIMEOUT_S,
+    )
+
+
+@dataclass
+class ModelCell:
+    family: str
+    ref: str
+    size_gb: float
+    skip: bool = False
+    tier: str = "small"  # small | mid | giant -> picks the prompt from _TIER_PROMPTS
+
+
+@dataclass
+class ScenarioResult:
+    name: str
+    status: ScenarioStatus
+    detail: str = ""
+    pane_excerpt: str = ""
+    elapsed_s: float = 0.0
+
+
+@dataclass
+class CellResult:
+    family: str
+    ref: str
+    scenarios: list[ScenarioResult] = field(default_factory=list)
+    setup_error: str = ""
+    serve_errors: str = ""
+    """Worker / dispatch errors scraped from the cell's launcher-serve.log.
+    Non-empty means the chat or embed worker raised an exception during the
+    cell, so even an all-green substring check downgrades to FAIL.
+    """
+    chat_completions_ok: int = 0
+    """Count of ``POST /v1/chat/completions ... 200`` lines in launcher-serve.log.
+    Zero means opencode never got a successful chat back (model failed to load,
+    or every turn 500'd), so the cell cannot be a real PASS regardless of pane.
+    """
+
+    @property
+    def passed(self) -> bool:
+        return (
+            not self.setup_error
+            and not self.serve_errors
+            and self.chat_completions_ok >= len(self.scenarios)
+            and bool(self.scenarios)
+            and all(s.status is ScenarioStatus.PASS for s in self.scenarios)
+        )
+
+
+def load_models(path: Path) -> list[ModelCell]:
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return [
+        ModelCell(
+            family=raw["family"],
+            ref=raw["ref"],
+            size_gb=float(raw.get("size_gb", 0.0)),
+            skip=bool(raw.get("skip", False)),
+            tier=str(raw.get("tier", "small")),
+        )
+        for raw in data.get("model", [])
+    ]
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def seed_shared_workspace() -> Path:
+    """Drop three markdown fixtures so lilbee_search returns real results."""
+    SHARED_WORKSPACE.mkdir(parents=True, exist_ok=True)
+    fixtures = {
+        "chat_worker.md": (
+            "# Chat worker\n\n"
+            "The chat worker subprocess in lilbee runs llama-cpp inference. "
+            "It receives ChatRequest payloads over a pipe transport and "
+            "streams tokens back via SSE. Cancellation is enforced through "
+            "an abort flag in shared memory."
+        ),
+        "dispatch.md": (
+            "# Dispatch layer\n\n"
+            "chat_dispatch.dispatch_chat is the canonical entry point that "
+            "the OpenAI-compatible route forwards to. It resolves the model "
+            "through KnownModelCache, enforces tool capability, and routes "
+            "to either the native llama-cpp worker or the SDK backend."
+        ),
+        "tool_extraction.md": (
+            "# Tool extraction\n\n"
+            "Lilbee uses a schema-driven response parser based on the "
+            "HuggingFace transformers chat_parsing_utils.recursive_parse. "
+            "Each supported family ships a JSON schema under "
+            "providers/worker/response_parser/schemas/."
+        ),
+    }
+    for filename, content in fixtures.items():
+        target = SHARED_WORKSPACE / filename
+        if not target.exists() or target.read_text() != content:
+            target.write_text(content)
+    return SHARED_WORKSPACE
+
+
+_AGENTS_MD = """\
+## Instructions
+
+You are working with Godot 4.4. Your training data is outdated -- many classes and
+methods were renamed or replaced in Godot 4.x, so you cannot rely on memory.
+
+**You MUST use the `lilbee_search` MCP tool to look up Godot APIs.** The Godot 4.4
+class reference is indexed locally in lilbee. Do NOT guess or use web search -- call
+`lilbee_search` with the exact class or method name.
+
+### Workflow
+
+1. **Plan** -- list every Godot class and method your answer or code needs.
+2. **Search** -- call `lilbee_search` for each one individually. Do not skip a class
+   even if you are confident; verify every method signature.
+3. **Answer / write** -- use only class names, methods, and properties exactly as
+   confirmed by the search results. If something was not found, do not use it.
+4. **Verify** -- before finishing, re-check every class and method you used against a
+   `lilbee_search` result and fix anything that does not match.
+"""
+
+
+def write_per_cell_workspace(family: str, model_ref: str) -> Path:
+    """Per-cell workspace seeded by copying the pre-built Godot corpus lancedb.
+
+    Wipes any prior ``.lilbee/`` from previous cells, then copies the shared
+    corpus's ``data/`` + ``documents/`` (a fast file copy, no re-embed) so
+    lilbee_search has the Godot class reference. The cell's config.toml pins the
+    target chat model. Requires the one-time corpus build (see README); a missing
+    corpus is a hard error so cells never silently run against an empty index.
+    """
+    if not (_GODOT_CORPUS / "data").is_dir():
+        raise RuntimeError(
+            f"Godot corpus not found at {_GODOT_CORPUS}/data. Build it once: "
+            f"LILBEE_DATA={_GODOT_CORPUS} uv run lilbee add <godot>/doc/classes"
+        )
+    workspace = WORKSPACE_DIR / family
+    workspace.mkdir(parents=True, exist_ok=True)
+    config_dir = workspace / ".lilbee"
+    if config_dir.exists():
+        shutil.rmtree(config_dir)
+    config_dir.mkdir(parents=True)
+    for sub in ("data", "documents"):
+        src = _GODOT_CORPUS / sub
+        if src.is_dir():
+            shutil.copytree(src, config_dir / sub)
+    (config_dir / "config.toml").write_text(
+        f'chat_model = "{model_ref}"\n'
+        f'embedding_model = "{_EMBED_REF}"\n'
+        f"chat_n_ctx_target = {_CHAT_CTX_TARGET}\n"
+    )
+    # opencode reads AGENTS.md from the project dir. This is the published
+    # godot-with-lilbee workflow: it tells the model its Godot knowledge is stale
+    # and it MUST look every class/method up via lilbee_search before using it.
+    # Without it a capable coder model just writes GDScript from memory and never
+    # calls the tool, so the integration looks broken when it is only untriggered.
+    (workspace / "AGENTS.md").write_text(_AGENTS_MD)
+    return workspace
+
+
+def scope_opencode_tools() -> None:
+    """Disable opencode's built-in tools so the model uses lilbee_search.
+
+    Models drift to opencode's built-in webfetch/read/grep over the lilbee MCP
+    search unless those are turned off (search mode). The launcher merges the
+    lilbee provider + MCP into this same config and preserves the tools key.
+    """
+    cfg: dict[str, object] = {}
+    if _OPENCODE_CONFIG.exists():
+        with contextlib.suppress(json.JSONDecodeError):
+            cfg = json.loads(_OPENCODE_CONFIG.read_text(encoding="utf-8"))
+    cfg["tools"] = {tool: False for tool in _TOOLS_OFF}
+    _OPENCODE_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    _OPENCODE_CONFIG.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+
+
+def pin_opencode_default_model(model_ref: str) -> None:
+    """Rewrite opencode's picker state so *model_ref* is recent[0].
+
+    ``lilbee launch opencode`` prepends every installed model to the
+    ``recent`` list. Without this step opencode's default session model
+    is non-deterministic across QA runs; with it the cell loads the
+    intended model.
+    """
+    _OPENCODE_PICKER_STATE.parent.mkdir(parents=True, exist_ok=True)
+    state: dict = {"recent": [], "favorite": [], "variant": {}}
+    if _OPENCODE_PICKER_STATE.exists():
+        with contextlib.suppress(OSError, json.JSONDecodeError):
+            state = json.loads(_OPENCODE_PICKER_STATE.read_text(encoding="utf-8"))
+    recent = [e for e in state.get("recent", []) if isinstance(e, dict)]
+    target_entry = {"providerID": _LILBEE_PROVIDER_ID, "modelID": model_ref}
+    recent = [
+        e
+        for e in recent
+        if not (e.get("modelID") == model_ref and e.get("providerID") == _LILBEE_PROVIDER_ID)
+    ]
+    recent.insert(0, target_entry)
+    state["recent"] = recent
+    _OPENCODE_PICKER_STATE.write_text(json.dumps(state, indent=2))
+
+
+def index_workspace(workspace: Path, log_path: Path) -> None:
+    """Run lilbee add on each fixture so lilbee_search has content.
+
+    Sets ``LILBEE_DATA`` explicitly so the `lilbee add` subprocess writes
+    into the workspace lancedb. matrix.py inherits a polluted ``LILBEE_DATA``
+    pointing at the global data root via ``lilbee.core.config``'s module-import
+    side effect, so without this override the fixtures index into the wrong
+    lancedb and `lilbee_search` calls return empty in opencode.
+    """
+    import os
+
+    env = os.environ.copy()
+    env.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    env["LILBEE_DATA"] = str(workspace / ".lilbee")
+    with log_path.open("a") as log:
+        log.write("=== lilbee add ===\n")
+        log.flush()
+        for fixture in ("chat_worker.md", "dispatch.md", "tool_extraction.md"):
+            subprocess.run(
+                ["uv", "run", "lilbee", "add", str(workspace / fixture)],
+                cwd=workspace,
+                env=env,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                check=False,
+                timeout=_INDEX_TIMEOUT_S,
+            )
+
+
+def boot_serve(workspace: Path, port: int, log_path: Path) -> subprocess.Popen[bytes]:
+    """Spawn lilbee serve on *port* in its own process group and wait for /api/health.
+
+    The process group lets :func:`stop_serve` reap the whole tree (``uv`` plus
+    the lilbee child it forks) rather than orphaning the child python.
+    """
+    log_file = log_path.open("ab")
+    proc = subprocess.Popen(
+        ["uv", "run", "lilbee", "serve", "--port", str(port)],
+        cwd=workspace,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    deadline = time.time() + _SERVE_BOOT_TIMEOUT_S
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"lilbee serve exited before becoming ready (rc={proc.returncode})")
+        try:
+            resp = httpx.get(f"http://127.0.0.1:{port}/api/health", timeout=1.0)
+            if resp.status_code == 200:
+                return proc
+        except (httpx.HTTPError, httpx.RequestError):
+            pass
+        time.sleep(0.5)
+    stop_serve(proc)
+    raise TimeoutError("lilbee serve did not become ready in time")
+
+
+def stop_serve(proc: subprocess.Popen[bytes]) -> None:
+    """Reap the full lilbee-serve process group (uv parent + lilbee python child)."""
+    import os
+    import signal
+
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(proc.pid, signal.SIGTERM)
+    try:
+        proc.wait(timeout=_SERVE_TERMINATE_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=5)
+
+
+def tmux_session_exists(name: str) -> bool:
+    result = subprocess.run(
+        ["tmux", "has-session", "-t", name],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def tmux_kill(name: str) -> None:
+    if tmux_session_exists(name):
+        subprocess.run(["tmux", "kill-session", "-t", name], check=False)
+
+
+def tmux_capture(name: str) -> str:
+    result = subprocess.run(
+        ["tmux", "capture-pane", "-t", name, "-p", "-S", f"-{_TMUX_HISTORY_LINES}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def tmux_send(name: str, keys: str) -> None:
+    subprocess.run(["tmux", "send-keys", "-t", name, keys], check=False)
+    time.sleep(_POST_SEND_SLEEP_S)
+    subprocess.run(["tmux", "send-keys", "-t", name, "Enter"], check=False)
+
+
+def launch_opencode_in_tmux(workspace: Path, session: str) -> None:
+    """Boot opencode in a tmux session pinned to the per-cell lilbee data dir.
+
+    The ``LILBEE_DATA=workspace/.lilbee`` env override is critical: matrix.py
+    imports ``lilbee.core.config``, whose module-import side effect sets
+    ``LILBEE_DATA`` in matrix.py's own env to the GLOBAL data root. Every
+    tmux session and subprocess matrix.py spawns inherits that polluted env,
+    so the launched lilbee serve would read the global config.toml (default
+    chat_model=Qwen3-0.6B) instead of the workspace's. Setting the env
+    explicitly per cell breaks the inheritance: the launched serve resolves
+    workspace/.lilbee/config.toml, picks up chat_model=<cell.ref>, and the
+    worker pool spawns with the right model. See bb-hef0.
+    """
+    import os
+
+    tmux_kill(session)
+    workspace_data = workspace / ".lilbee"
+    env_flags = ["-e", f"LILBEE_DATA={workspace_data}"]
+    # Forward QA diagnostic flags into the launched serve + its worker
+    # subprocesses (multiprocessing-spawn inherits the tmux session env), so
+    # LILBEE_QA_LOG_RAW reaches the chat worker where the raw-output tap lives.
+    if os.environ.get("LILBEE_QA_LOG_RAW"):
+        env_flags += ["-e", "LILBEE_QA_LOG_RAW=1"]
+    subprocess.run(
+        [
+            "tmux",
+            "new-session",
+            "-d",
+            "-s",
+            session,
+            "-x",
+            str(_TMUX_WINDOW_COLS),
+            "-y",
+            str(_TMUX_WINDOW_ROWS),
+            *env_flags,
+            "bash",
+            "-lc",
+            f"cd {workspace} && exec uv run lilbee launch opencode --no-prompt",
+        ],
+        check=True,
+    )
+    time.sleep(_OPENCODE_BOOT_SETTLE_S)
+
+
+_TOOL_TURN_MIN_COMPLETIONS = 2
+"""Chat completions a genuine tool turn drives: the model's tool-call turn plus
+the follow-up answer turn after opencode feeds the tool result back in.
+
+A prose answer -- the model declining to call the tool and replying from
+context -- drives only one completion. The scenarios share one opencode
+session, so an earlier scenario's gear glyph stays visible in the pane; gating
+on the glyph plus a single new completion let a prose turn pass on that stale
+glyph. Requiring the per-scenario completion delta to reach two means the gear
+must be backed by an actual ``opencode -> lilbee -> tool -> answer`` round-trip
+in *this* scenario, not carried over from the previous one.
+"""
+
+
+def run_scenario(session: str, scenario: Scenario, workspace: Path) -> ScenarioResult:
+    """Send the prompt and poll until a FRESH tool dispatch lands or idle/timeout.
+
+    PASS requires the gear-glyph dispatch marker in the pane AND at least
+    ``_TOOL_TURN_MIN_COMPLETIONS`` new ``POST /v1/chat/completions 200`` in the
+    launcher log since this scenario started. The two-completion delta defeats
+    the stale-glyph trap: opencode keeps the prior turn's transcript visible, so
+    a later scenario would otherwise match an earlier scenario's gear off a
+    single prose completion without ever re-dispatching the tool itself.
+    """
+    baseline_calls = _count_ok_chat_completions(workspace)
+    tmux_send(session, scenario.prompt)
+    start = time.time()
+    deadline = start + scenario.timeout_s
+    last_pane = ""
+    last_change_at = start
+    last_pane_len = 0
+    missing: list[str] = list(scenario.expected)
+    while time.time() < deadline:
+        pane = tmux_capture(session)
+        last_pane = pane
+        pane_lower = pane.lower()
+        if pane != "" and len(pane) != last_pane_len:
+            last_pane_len = len(pane)
+            last_change_at = time.time()
+        fail_fast = next((m for m in _FAIL_FAST_MARKERS if m.lower() in pane_lower), None)
+        if fail_fast is not None:
+            return ScenarioResult(
+                name=scenario.name,
+                status=ScenarioStatus.FAIL,
+                detail=f"fail-fast marker hit: {fail_fast!r}",
+                pane_excerpt=pane[-_PANE_EXCERPT_TAIL:],
+                elapsed_s=time.time() - start,
+            )
+        forbidden_hits = [s for s in scenario.forbidden if s.lower() in pane_lower]
+        if forbidden_hits:
+            return ScenarioResult(
+                name=scenario.name,
+                status=ScenarioStatus.FAIL,
+                detail=f"forbidden substring(s) appeared: {forbidden_hits}",
+                pane_excerpt=pane[-_PANE_EXCERPT_TAIL:],
+                elapsed_s=time.time() - start,
+            )
+        missing = [s for s in scenario.expected if s.lower() not in pane_lower]
+        new_calls = _count_ok_chat_completions(workspace) - baseline_calls
+        fresh_call = new_calls >= _TOOL_TURN_MIN_COMPLETIONS
+        if not missing and fresh_call:
+            return ScenarioResult(
+                name=scenario.name,
+                status=ScenarioStatus.PASS,
+                detail="gear dispatch + fresh chat completion",
+                pane_excerpt=pane[-_PANE_EXCERPT_TAIL:],
+                elapsed_s=time.time() - start,
+            )
+        idle_for = time.time() - last_change_at
+        if idle_for > _PANE_IDLE_TIMEOUT_S and time.time() - start > _OPENCODE_BOOT_SETTLE_S:
+            detail = (
+                f"pane idle {idle_for:.0f}s; missing {missing}"
+                if missing
+                else (
+                    f"pane idle {idle_for:.0f}s; gear seen but only {new_calls} new "
+                    f"completion(s), need {_TOOL_TURN_MIN_COMPLETIONS} (prose, no re-dispatch)"
+                )
+            )
+            return ScenarioResult(
+                name=scenario.name,
+                status=ScenarioStatus.TIMEOUT,
+                detail=detail,
+                pane_excerpt=pane[-_PANE_EXCERPT_TAIL:],
+                elapsed_s=time.time() - start,
+            )
+        time.sleep(_POLL_INTERVAL_S)
+    return ScenarioResult(
+        name=scenario.name,
+        status=ScenarioStatus.TIMEOUT,
+        detail=f"missing after {scenario.timeout_s:.0f}s: {missing}",
+        pane_excerpt=last_pane[-_PANE_EXCERPT_TAIL:],
+        elapsed_s=scenario.timeout_s,
+    )
+
+
+def reset_opencode_session_state() -> None:
+    """Wipe opencode's per-user state so the prior cell can't bleed into the new pane.
+
+    Two persistence locations need scrubbing:
+
+    1. ``~/.local/share/opencode/`` -- session DB + storage. Holds the prior
+       cell's conversation transcripts. Without the wipe opencode's recent-
+       sessions panel surfaces tokens from the previous PASS (e.g.
+       ``KnownModelCache``) and the next cell's smoke matches them without
+       its own model ever loading.
+
+    2. ``~/.local/state/opencode/model.json`` -- the picker state. Opencode
+       picks the first installed model in ``recent[]`` as its default. If
+       the previous cell pinned a model that's still installed (e.g.
+       ``Qwen3-8B`` left from the qwen3 cell), opencode silently falls back
+       to it for the next cell whose own ref isn't pulled yet -- and the
+       smoke ends up testing the WRONG model with a fake PASS.
+
+    :func:`pin_opencode_default_model` rewrites the picker after this scrub
+    so the cell's intended model wins the default.
+    """
+    if _OPENCODE_SHARE_DIR.exists():
+        shutil.rmtree(_OPENCODE_SHARE_DIR)
+    if _OPENCODE_PICKER_STATE.exists():
+        _OPENCODE_PICKER_STATE.unlink()
+
+
+def ensure_embedding_model_pulled() -> None:
+    """Idempotent: ensure the shared embedding model is in the registry.
+
+    The matrix's per-cell `lilbee add` step requires the workspace's
+    configured embedding model to be registered, otherwise indexing skips
+    every fixture with "Model not found in registry" and `lilbee_search`
+    comes up empty in opencode. The registry is keyed off ``cfg.models_dir``
+    (global), so one pull at matrix start serves every cell -- no per-cell
+    re-pull needed.
+    """
+    print(f"ensuring embedding model {_EMBED_PULL_REF} is registered")
+    _run_pull_with_group_kill(_EMBED_PULL_REF)
+
+
+def _run_pull_with_group_kill(pull_ref: str) -> None:
+    """Run ``lilbee model pull`` in its own process group so a timeout reaps the
+    full tree (otherwise ``uv``'s child python orphans and keeps the download
+    running, contending for bandwidth with the next cell's pull).
+
+    Progress bars are suppressed so the matrix stdout stays grep-able.
+    """
+    import os
+    import signal
+
+    env = os.environ.copy()
+    env.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    proc = subprocess.Popen(
+        ["uv", "run", "lilbee", "model", "pull", pull_ref],
+        cwd=REPO_ROOT,
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        proc.wait(timeout=_MODEL_PULL_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=10)
+        raise
+
+
+def setup_cell(
+    cell: ModelCell, args: argparse.Namespace, log_path: Path
+) -> tuple[Path, int, subprocess.Popen[bytes] | None]:
+    """Pull, seed, index, pin opencode default.
+
+    ``lilbee launch opencode`` spawns its own lilbee serve internally; we used
+    to also spawn one here for a /api/health smoke-check, but two parallel
+    serves racing for the same workspace ``server.json`` / ``server.port``
+    state caused opencode to land on a stale port whose lilbee serve had a
+    different view of installed models, surfacing as 404 model_not_found at
+    chat time. Letting the launcher own the serve lifecycle eliminates that
+    race; the per-cell log still captures everything via the launcher's stdio.
+    """
+    reset_opencode_session_state()
+    port = free_port()
+    if not args.no_pull:
+        pull_ref = _pull_ref_for(cell.ref)
+        print(f"[{cell.family}] pulling {pull_ref}")
+        _run_pull_with_group_kill(pull_ref)
+        installed = _installed_ref_for_repo(pull_ref)
+        if installed is not None and installed != cell.ref:
+            print(
+                f"[{cell.family}] pull installed {installed}; using it (models.toml had {cell.ref})"
+            )
+            cell.ref = installed
+    workspace = write_per_cell_workspace(cell.family, cell.ref)
+    print(f"[{cell.family}] seeded Godot corpus from {_GODOT_CORPUS}")
+    print(f"[{cell.family}] scoping opencode tools to lilbee_search")
+    scope_opencode_tools()
+    print(f"[{cell.family}] pinning opencode default model")
+    pin_opencode_default_model(cell.ref)
+    return workspace, port, None
+
+
+def run_smoke_scenarios(
+    family: str, tier: str, session: str, workspace: Path
+) -> list[ScenarioResult]:
+    scen = scenario_for_tier(tier)
+    print(f"[{family}] running {scen.name}: {scen.prompt[:60]}...")
+    result = run_scenario(session, scen, workspace)
+    print(f"[{family}]   -> {result.status.value} ({result.elapsed_s:.1f}s) {result.detail}")
+    return [result]
+
+
+def teardown_cell(session: str, serve_proc: subprocess.Popen[bytes] | None, keep: bool) -> None:
+    """Kill the cell's tmux + opencode + lilbee-launch-spawned serve cleanly.
+
+    The serve was spawned by ``lilbee launch opencode`` inside the tmux
+    session, so killing the tmux drops its entire process group. The
+    explicit ``stop_serve`` arm only fires if a separately-tracked
+    ``Popen`` handle was passed (legacy boot_serve path).
+    """
+    if not keep:
+        tmux_kill(session)
+    if serve_proc is not None:
+        stop_serve(serve_proc)
+    # Make sure no orphan ``lilbee serve`` from a previous cell's
+    # launch-opencode survives into the next cell.
+    subprocess.run(["pkill", "-f", "lilbee serve"], check=False)
+
+
+def cleanup_cell_model(cell: ModelCell) -> None:
+    """Delete the cell's chat GGUF from the HF cache + lilbee's manifest.
+
+    Disk pressure on a dev laptop is the real limiter for an exhaustive
+    sweep (qwen3-coder alone is 17 GB). Freeing the blob between cells
+    keeps total disk usage flat at roughly the largest single model
+    instead of the cumulative pull set.
+    """
+    from lilbee.core.config import cfg
+
+    repo = _pull_ref_for(cell.ref)
+    # HF-cache directories ("models--Qwen--Qwen3-4B-GGUF") use the ``models--``
+    # prefix; lilbee's manifests dir ("Qwen--Qwen3-4B-GGUF") does NOT. Cleaning
+    # only the prefixed paths left stale manifests behind, which then convinced
+    # the next pull that the model was cached and convinced lilbee's registry
+    # the install was complete -- both inconsistent with the missing blob,
+    # which surfaced to opencode as a 404 model_not_found at chat time.
+    hf_cache_dir = "models--" + repo.replace("/", "--")
+    manifest_dir = repo.replace("/", "--")
+    models_root = Path(cfg.models_dir)
+    for target in (
+        models_root / hf_cache_dir,
+        models_root / ".locks" / hf_cache_dir,
+        models_root / "manifests" / manifest_dir,
+    ):
+        if target.exists():
+            shutil.rmtree(target, ignore_errors=True)
+
+
+def _scrape_serve_errors(workspace: Path) -> str:
+    """Pull worker/dispatch exceptions out of the cell's launcher-serve.log.
+
+    A cell whose scenarios pass the pane substring check but whose lilbee serve
+    raised a chat-worker exception (e.g., tool-call shape mismatch, context
+    overflow, ProviderError) cannot be marked "supported" -- the model
+    + parser combination is broken, even if opencode happened to render
+    enough text to satisfy the smoke substrings.
+    """
+    log_file = workspace / ".lilbee" / "data" / "logs" / "launcher-serve.log"
+    if not log_file.exists():
+        return ""
+    text = log_file.read_text(encoding="utf-8", errors="replace")
+    needles = ("Traceback (most recent call last)", "ProviderError:", "WorkerError:", "TypeError:")
+    hits = [line for line in text.splitlines() if any(n in line for n in needles)]
+    return "\n".join(hits[-8:]) if hits else ""
+
+
+def _count_ok_chat_completions(workspace: Path) -> int:
+    """Count successful ``POST /v1/chat/completions`` responses in launcher-serve.log.
+
+    uvicorn logs each request as ``... "POST /v1/chat/completions HTTP/1.1" 200 OK``.
+    A cell where opencode never received a 200 chat back (model never loaded,
+    every turn 500'd) has a count of zero and cannot be a real PASS. Paired
+    with :func:`_scrape_serve_errors`, this catches the SSE-200-then-crash case
+    too: the header logs 200 but the mid-stream exception lands in serve_errors.
+    """
+    log_file = workspace / ".lilbee" / "data" / "logs" / "launcher-serve.log"
+    if not log_file.exists():
+        return 0
+    text = log_file.read_text(encoding="utf-8", errors="replace")
+    return sum(1 for line in text.splitlines() if 'POST /v1/chat/completions HTTP/1.1" 200' in line)
+
+
+_ANSWER_SETTLE_TIMEOUT_S = 240.0
+_ANSWER_SETTLE_QUIET_POLLS = 3
+_ANSWER_SETTLE_INTERVAL_S = 4.0
+
+
+def wait_for_answer_settle(session: str) -> None:
+    """Wait for opencode to finish rendering the post-tool answer before capture.
+
+    ``run_scenario`` returns the instant the gear marker plus a fresh chat
+    completion appear, but opencode is still streaming the answer turn then, so a
+    pane captured immediately shows the tool call and no answer. Poll until the
+    pane stops changing for a few consecutive intervals (generation idle), capped
+    by a timeout so a model that streams forever cannot hang the sweep.
+    """
+    deadline = time.monotonic() + _ANSWER_SETTLE_TIMEOUT_S
+    prev = tmux_capture(session)
+    quiet = 0
+    while time.monotonic() < deadline:
+        time.sleep(_ANSWER_SETTLE_INTERVAL_S)
+        cur = tmux_capture(session)
+        if cur == prev:
+            quiet += 1
+            if quiet >= _ANSWER_SETTLE_QUIET_POLLS:
+                return
+        else:
+            quiet = 0
+            prev = cur
+
+
+def run_cell(cell: ModelCell, args: argparse.Namespace) -> CellResult:
+    """Orchestrate one matrix cell: setup, scenarios, teardown, cleanup."""
+    result = CellResult(family=cell.family, ref=cell.ref)
+    session = f"{_TMUX_SESSION_PREFIX}-{cell.family}"
+    log_path = LOG_DIR / f"{cell.family}.log"
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"\n[{cell.family}] starting ({cell.ref})")
+    workspace: Path | None = None
+    try:
+        workspace, _port, serve_proc = setup_cell(cell, args, log_path)
+        try:
+            with suspend_other_chat_manifests(cell.ref):
+                print(f"[{cell.family}] launching opencode in tmux session {session}")
+                launch_opencode_in_tmux(workspace, session)
+                result.scenarios = run_smoke_scenarios(cell.family, cell.tier, session, workspace)
+                if any(s.status == ScenarioStatus.PASS for s in result.scenarios):
+                    print(f"[{cell.family}] tool call seen; waiting for answer to finish rendering")
+                    wait_for_answer_settle(session)
+                pane = tmux_capture(session)
+                RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+                (RESULTS_DIR / f"{cell.family}.pane.txt").write_text(pane, encoding="utf-8")
+                print(
+                    f"[{cell.family}] full pane -> results/{cell.family}.pane.txt "
+                    f"({len(pane)} chars)"
+                )
+        finally:
+            keep = args.keep_on_fail and not result.passed
+            teardown_cell(session, serve_proc, keep)
+    except Exception as exc:
+        result.setup_error = f"{type(exc).__name__}: {exc}"
+        print(f"[{cell.family}] setup error: {result.setup_error}")
+        log_path.write_text(f"setup_error: {result.setup_error}\n")
+    if workspace is not None:
+        result.serve_errors = _scrape_serve_errors(workspace)
+        result.chat_completions_ok = _count_ok_chat_completions(workspace)
+        print(f"[{cell.family}] {result.chat_completions_ok} successful chat completion(s)")
+        if result.serve_errors:
+            print(f"[{cell.family}] serve errors detected, downgrading to FAIL")
+    if not args.keep_models:
+        print(f"[{cell.family}] cleaning up chat GGUF")
+        cleanup_cell_model(cell)
+    return result
+
+
+def render_report(results: list[CellResult]) -> str:
+    lines = [
+        "# QA Matrix Results",
+        "",
+        f"Run at: {time.strftime('%Y-%m-%d %H:%M:%S')}",
+        "",
+        "| Family | Ref | Status | Chat 200s | Scenarios |",
+        "|--------|-----|--------|-----------|-----------|",
+    ]
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        if r.setup_error:
+            cells = f"setup: {r.setup_error}"
+        else:
+            cells = ", ".join(f"{s.name.split()[0]}={s.status.value}" for s in r.scenarios)
+        lines.append(f"| {r.family} | `{r.ref}` | {status} | {r.chat_completions_ok} | {cells} |")
+    lines.append("")
+    for r in results:
+        lines.append(f"## {r.family} ({r.ref})")
+        lines.append("")
+        if r.setup_error:
+            lines.append(f"Setup error: {r.setup_error}")
+        if r.serve_errors:
+            lines.append("### Worker / dispatch errors in launcher-serve.log")
+            lines.append("```")
+            lines.append(r.serve_errors)
+            lines.append("```")
+        for s in r.scenarios:
+            lines.append(f"### {s.name} -> {s.status.value}")
+            lines.append(f"Detail: {s.detail}")
+            lines.append("```")
+            lines.append(s.pane_excerpt or "(no pane captured)")
+            lines.append("```")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--families", help="comma-separated family allowlist")
+    parser.add_argument("--no-pull", action="store_true", help="skip lilbee model pull")
+    parser.add_argument(
+        "--keep-on-fail",
+        action="store_true",
+        default=False,
+        help="leave tmux session up when a cell fails (default: False; opt-in for post-mortem)",
+    )
+    parser.add_argument(
+        "--keep-models",
+        action="store_true",
+        default=False,
+        help="keep the cell's chat GGUF on disk after each cell (default: delete)",
+    )
+    args = parser.parse_args()
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    cells = load_models(QA_DIR / "models.toml")
+    if args.families:
+        wanted = {f.strip() for f in args.families.split(",")}
+        cells = [c for c in cells if c.family in wanted]
+    cells = [c for c in cells if not c.skip]
+
+    if not cells:
+        print("no matching models in models.toml", file=sys.stderr)
+        return 2
+
+    print(f"running QA matrix for {len(cells)} model(s)")
+    if not args.no_pull:
+        ensure_embedding_model_pulled()
+    results = [run_cell(c, args) for c in cells]
+    (RESULTS_DIR / "results.md").write_text(render_report(results))
+    print(f"\nreport: {RESULTS_DIR / 'results.md'}")
+
+    failed = [r for r in results if not r.passed]
+    if failed:
+        print(f"FAIL: {len(failed)}/{len(results)} cell(s) failed")
+        return 1
+    print(f"PASS: all {len(results)} cell(s) passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/qa/opencode/models.toml
+++ b/tools/qa/opencode/models.toml
@@ -1,0 +1,157 @@
+# QA matrix model list. Local-only; not pulled in by CI.
+# Reordered largest-first by tools/qa/reorder-largest-first.py for the
+# cloud GPU sweep. Cleanup-per-cell keeps disk usage flat at the peak
+# single-model size.
+#
+# tier picks the prompt from matrix.py's _TIER_PROMPTS:
+#   giant -> Tier 3 natural codegen (verify API against the indexed reference)
+#   mid   -> Tier 2 natural multi-class question, anchored to exact signatures
+#   small -> Tier 1 explicit single-fact lookup (forces a grounded lilbee_search)
+
+[[model]]
+family = "minimax-m2"
+# ggml-org/MiniMax-M2-GGUF (native mxfp4, ~230GB) was DELETED from HF; the official
+# MiniMaxAI/MiniMax-M2 is safetensors-only (130 shards, no GGUF -> not loadable in
+# llama.cpp). Use ilintar's full-fidelity Q8_0 GGUF (single file, ~245GB) -- the
+# full-size equivalent, splits across the 2xH200 like the original mxfp4 did.
+ref = "ilintar/MiniMax-M2-GGUF/MiniMax-M2-q8_0.gguf"
+size_gb = 245.0
+tier = "giant"
+
+[[model]]
+family = "gpt-oss"
+ref = "ggml-org/gpt-oss-120b-GGUF/gpt-oss-120b-mxfp4-00001-of-00003.gguf"
+size_gb = 63.0
+tier = "giant"
+
+[[model]]
+family = "glm-air"
+ref = "unsloth/GLM-4.5-Air-GGUF/GLM-4.5-Air-Q2_K.gguf"
+size_gb = 60.0
+tier = "giant"
+
+[[model]]
+family = "qwen3-coder"
+ref = "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf"
+size_gb = 17.0
+tier = "giant"
+
+[[model]]
+family = "functionary"
+ref = "meetkai/functionary-small-v3.2-GGUF/functionary-small-v3.2.Q8_0.gguf"
+size_gb = 8.5
+tier = "mid"
+
+[[model]]
+family = "mistral-nemo"
+ref = "bartowski/Mistral-Nemo-Instruct-2407-GGUF/Mistral-Nemo-Instruct-2407-Q4_K_M.gguf"
+size_gb = 7.0
+tier = "mid"
+
+[[model]]
+family = "glm-4-9b"
+ref = "legraphista/glm-4-9b-chat-GGUF/glm-4-9b-chat.Q4_K_S.gguf"
+size_gb = 5.5
+tier = "mid"
+
+# Small DeepSeek R1-Distills. Based on Qwen/Llama, so they dispatch through the
+# qwen3 / llama3 extraction paths (not the deepseek_v31 profile, which is the
+# 671B native format). Reasoning-focused, so whether they reliably tool-call is
+# what the matrix decides.
+[[model]]
+family = "deepseek-r1-llama"
+ref = "bartowski/DeepSeek-R1-Distill-Llama-8B-GGUF/DeepSeek-R1-Distill-Llama-8B-Q4_K_M.gguf"
+size_gb = 4.9
+tier = "mid"
+
+[[model]]
+family = "hermes"
+ref = "bartowski/Hermes-3-Llama-3.1-8B-GGUF/Hermes-3-Llama-3.1-8B-Q4_K_M.gguf"
+size_gb = 4.9
+tier = "mid"
+
+[[model]]
+family = "llama3"
+ref = "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf"
+size_gb = 4.9
+tier = "mid"
+
+[[model]]
+family = "granite"
+ref = "ibm-granite/granite-3.3-8b-instruct-GGUF/granite-3.3-8b-instruct-Q4_K_M.gguf"
+size_gb = 4.8
+tier = "mid"
+
+[[model]]
+family = "olmo3"
+ref = "unsloth/Olmo-3-7B-Instruct-GGUF/Olmo-3-7B-Instruct-Q4_K_M.gguf"
+size_gb = 4.8
+tier = "mid"
+
+[[model]]
+family = "deepseek-r1-qwen"
+ref = "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf"
+size_gb = 4.7
+tier = "mid"
+
+[[model]]
+family = "internlm2"
+ref = "internlm/internlm2_5-7b-chat-gguf/internlm2_5-7b-chat-fp16.gguf"
+size_gb = 4.7
+tier = "mid"
+
+[[model]]
+family = "cohere"
+ref = "bartowski/c4ai-command-r7b-12-2024-GGUF/c4ai-command-r7b-12-2024-Q4_K_M.gguf"
+size_gb = 4.4
+tier = "mid"
+
+[[model]]
+family = "mistral"
+ref = "bartowski/Mistral-7B-Instruct-v0.3-GGUF/Mistral-7B-Instruct-v0.3-Q4_K_M.gguf"
+size_gb = 4.4
+tier = "mid"
+skip = true
+
+[[model]]
+family = "gemma4"
+ref = "unsloth/gemma-4-E2B-it-GGUF/gemma-4-E2B-it-Q4_K_M.gguf"
+size_gb = 3.0
+tier = "small"
+
+[[model]]
+family = "qwen3"
+ref = "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf"
+size_gb = 2.5
+tier = "small"
+
+[[model]]
+family = "phi4mini"
+ref = "bartowski/microsoft_Phi-4-mini-instruct-GGUF/microsoft_Phi-4-mini-instruct-Q4_K_M.gguf"
+size_gb = 2.4
+tier = "small"
+
+[[model]]
+family = "smollm"
+ref = "bartowski/HuggingFaceTB_SmolLM3-3B-GGUF/HuggingFaceTB_SmolLM3-3B-Q4_K_M.gguf"
+size_gb = 2.0
+tier = "small"
+
+[[model]]
+family = "gemma2"
+ref = "bartowski/gemma-2-2b-it-GGUF/gemma-2-2b-it-Q4_K_M.gguf"
+size_gb = 1.6
+tier = "small"
+skip = true
+
+[[model]]
+family = "lfm2"
+ref = "QuantFactory/LFM2-1.2B-Tool-GGUF/LFM2-1.2B-Tool.Q4_K_M.gguf"
+size_gb = 0.9
+tier = "small"
+
+[[model]]
+family = "ernie"
+ref = "unsloth/ERNIE-4.5-0.3B-PT-GGUF/ERNIE-4.5-0.3B-PT-Q4_K_M.gguf"
+size_gb = 0.4
+tier = "small"

--- a/tools/qa/opencode/prevalidate.py
+++ b/tools/qa/opencode/prevalidate.py
@@ -1,0 +1,249 @@
+"""Pre-record QA gate: for EVERY models.toml cell, assert the model actually answers
+the demo prompt well and collect empirical timings -- BEFORE any demo is recorded.
+
+This is prerequisite #1 for the reel: no model gets a demo recorded until it has
+produced a good, complete answer here. It also measures the numbers the demo tape
+needs (cold-start load time + generation time) so the tape is built on real data,
+not guesses.
+
+Per cell it:
+  1. pulls the model (resolves the actually-installed quant) + writes the workspace
+  2. boots ``lilbee serve`` as a subprocess with LILBEE_DATA pinned to that workspace
+     (fresh process => the per-cell chat_model is honored; cfg is import-time)
+  3. WARM-UP completion (max_tokens=1) -> times the cold model load (cold_s)
+  4. runs the tier prompt through the real chat -> tool_calls -> /api/search ->
+     feed-back loop, capturing the FINAL ANSWER TEXT, generation time (gen_s), the
+     number of tool calls, and any error
+  5. tears the serve down; deletes big models to keep disk flat
+  6. writes report.md (full prompt + answer per model, for a human/agent to read and
+     assert quality) and report.json (machine timings the tape build consumes)
+
+A cell auto-FAILS if it errored, never tool-called, or returned an empty answer.
+Auto-PASS only means "produced a non-empty answer via a real tool call" -- the
+quality call (correct, grounded, complete) is made by reading report.md.
+
+Run on the pod (cached models + indexed Godot corpus)::
+
+    LILBEE_MODELS_DIR=/root/models LILBEE_QA_CORPUS=/root/godot_corpus \
+      uv run python tools/qa/opencode/prevalidate.py --out /root/prevalidate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import matrix  # noqa: E402
+
+_SEARCH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "lilbee_search",
+        "description": "Search the indexed Godot 4 class reference; returns cited chunks.",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}, "top_k": {"type": "integer"}},
+            "required": ["query"],
+        },
+    },
+}
+_SYSTEM = (
+    "You are a Godot 4.4 GDScript developer. Your training data is outdated, so you "
+    "MUST call lilbee_search to confirm every class, method, and signature before you "
+    "use it, then answer using only confirmed APIs."
+)
+_HOP_CAP = 6
+_HEALTH_TIMEOUT_S = 240.0
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _boot_serve(workspace: Path, port: int) -> tuple[subprocess.Popen[bytes], str]:
+    """Spawn ``lilbee serve`` on *port* with LILBEE_DATA=*workspace*; return (proc, token)."""
+    env = os.environ.copy()
+    env["LILBEE_DATA"] = str(workspace / ".lilbee")
+    proc = subprocess.Popen(
+        ["uv", "run", "lilbee", "serve", "--port", str(port)],
+        env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    base = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+    while time.monotonic() < deadline:
+        try:
+            if httpx.get(f"{base}/api/health", timeout=5).status_code == 200:
+                break
+        except httpx.HTTPError:
+            time.sleep(1)
+    server_json = workspace / ".lilbee" / "data" / "server.json"
+    token = json.loads(server_json.read_text())["token"] if server_json.exists() else ""
+    return proc, token
+
+
+@dataclass
+class CellReport:
+    family: str
+    ref: str
+    tier: str
+    cold_s: float
+    gen_s: float
+    tool_calls: int
+    answer: str
+    error: str
+    ok: bool
+
+
+def _warmup_cold_s(base: str, headers: dict[str, str], model: str) -> float:
+    """Time a 1-token completion: forces the cold model load. Returns seconds (-1 on error)."""
+    t0 = time.monotonic()
+    try:
+        r = httpx.post(
+            f"{base}/v1/chat/completions", headers=headers,
+            json={"model": model, "messages": [{"role": "user", "content": "hi"}],
+                  "max_tokens": 1, "stream": False},
+            timeout=_HEALTH_TIMEOUT_S,
+        )
+        return time.monotonic() - t0 if r.status_code == 200 else -1.0
+    except httpx.HTTPError:
+        return -1.0
+
+
+def _run_prompt(base: str, headers: dict[str, str], model: str, prompt: str) -> CellReport:
+    msgs = [{"role": "system", "content": _SYSTEM}, {"role": "user", "content": prompt}]
+    tool_calls = 0
+    t0 = time.monotonic()
+    with httpx.Client() as client:
+        for _hop in range(_HOP_CAP):
+            try:
+                r = client.post(
+                    f"{base}/v1/chat/completions", headers=headers,
+                    json={"model": model, "messages": msgs, "max_tokens": 700,
+                          "stream": False, "tools": [_SEARCH_TOOL]},
+                    timeout=300,
+                )
+            except httpx.HTTPError as exc:
+                return CellReport(model, model, "", 0, time.monotonic() - t0, tool_calls,
+                                  "", f"chat exception: {exc}", False)
+            if r.status_code != 200:
+                return CellReport(model, model, "", 0, time.monotonic() - t0, tool_calls,
+                                  "", f"chat {r.status_code}: {r.text[:200]}", False)
+            msg = r.json()["choices"][0]["message"]
+            calls = msg.get("tool_calls") or []
+            if not calls:
+                answer = (msg.get("content") or "").strip()
+                gen_s = time.monotonic() - t0
+                ok = bool(answer) and tool_calls > 0
+                return CellReport(model, model, "", 0, gen_s, tool_calls, answer, "", ok)
+            msgs.append({"role": "assistant", "content": msg.get("content") or "", "tool_calls": calls})
+            for tc in calls:
+                tool_calls += 1
+                try:
+                    qa = json.loads(tc.get("function", {}).get("arguments") or "{}")
+                except (ValueError, TypeError):
+                    qa = {}
+                try:
+                    sr = client.get(f"{base}/api/search", headers=headers,
+                                    params={"q": qa.get("query", "Godot Node"), "top_k": 5}, timeout=90)
+                    items = sr.json() if sr.status_code == 200 else []
+                    result = "\n".join(f"- {it.get('source','?')}: {str(it.get('text', it))[:300]}"
+                                       for it in items[:5]) or "(no results)"
+                except httpx.HTTPError as exc:
+                    result = f"(search error: {exc})"
+                msgs.append({"role": "tool", "tool_call_id": tc.get("id", "0"), "content": result})
+    return CellReport(model, model, "", 0, time.monotonic() - t0, tool_calls,
+                      "(tool loop hit hop cap without a final answer)", "hop_cap", False)
+
+
+def validate_cell(cell, args: argparse.Namespace) -> CellReport:
+    if not args.no_pull:
+        pull_ref = matrix._pull_ref_for(cell.ref)
+        matrix._run_pull_with_group_kill(pull_ref)
+        installed = matrix._installed_ref_for_repo(pull_ref)
+        if installed is not None and installed != cell.ref:
+            cell.ref = installed
+    workspace = matrix.write_per_cell_workspace(cell.family, cell.ref)
+    port = _free_port()
+    subprocess.run(["pkill", "-f", "lilbee serve"], check=False)
+    subprocess.run(["pkill", "-f", "llama-server"], check=False)
+    time.sleep(2)
+    proc, token = _boot_serve(workspace, port)
+    base = f"http://127.0.0.1:{port}"
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        cold_s = _warmup_cold_s(base, headers, cell.ref)
+        rep = _run_prompt(base, headers, cell.ref, matrix._TIER_PROMPTS[cell.tier])
+        rep.family, rep.ref, rep.tier, rep.cold_s = cell.family, cell.ref, cell.tier, cold_s
+        return rep
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        subprocess.run(["pkill", "-f", "lilbee serve"], check=False)
+        subprocess.run(["pkill", "-f", "llama-server"], check=False)
+        if cell.size_gb > 20:
+            matrix.cleanup_cell_model(cell)
+
+
+def _write_reports(reports: list[CellReport], out: Path) -> None:
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "report.json").write_text(json.dumps([asdict(r) for r in reports], indent=2))
+    lines = ["# Pre-record QA matrix: answer quality + timings", "",
+             "Auto-PASS = non-empty answer via a real tool call. Quality (correct, "
+             "grounded, complete) is asserted by READING each answer below.", ""]
+    for r in reports:
+        verdict = "AUTO-PASS" if r.ok else "FAIL"
+        lines += [f"## {r.family} ({r.tier}) -- {verdict}",
+                  f"- ref: `{r.ref}`",
+                  f"- cold_s: {r.cold_s:.1f}  gen_s: {r.gen_s:.1f}  tool_calls: {r.tool_calls}",
+                  (f"- error: {r.error}" if r.error else "- error: none"),
+                  "", "### prompt", matrix._TIER_PROMPTS.get(r.tier, ""), "",
+                  "### answer", "```", r.answer or "(empty)", "```", ""]
+    (out / "report.md").write_text("\n".join(lines))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--families", help="comma-separated allowlist")
+    ap.add_argument("--no-pull", action="store_true")
+    ap.add_argument("--out", type=Path, default=Path("prevalidate_out"))
+    args = ap.parse_args()
+    cells = [c for c in matrix.load_models(matrix.QA_DIR / "models.toml") if not c.skip]
+    if args.families:
+        wanted = {f.strip() for f in args.families.split(",")}
+        cells = [c for c in cells if c.family in wanted]
+    if not args.no_pull:
+        matrix.ensure_embedding_model_pulled()
+    reports: list[CellReport] = []
+    for cell in cells:
+        print(f"[prevalidate] {cell.family} ({cell.tier}) {cell.ref}", flush=True)
+        try:
+            rep = validate_cell(cell, args)
+        except Exception as exc:  # noqa: BLE001
+            rep = CellReport(cell.family, cell.ref, cell.tier, 0, 0, 0, "", f"{type(exc).__name__}: {exc}", False)
+        reports.append(rep)
+        print(f"  -> {'AUTO-PASS' if rep.ok else 'FAIL'} cold_s={rep.cold_s:.1f} "
+              f"gen_s={rep.gen_s:.1f} tools={rep.tool_calls} {rep.error}", flush=True)
+    _write_reports(reports, args.out)
+    n_ok = sum(1 for r in reports if r.ok)
+    print(f"\n{n_ok}/{len(reports)} auto-pass. READ {args.out}/report.md to assert answer quality "
+          f"before recording any demo.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem
The opencode QA harness and the demo reel-generation pipeline were sitting unpushed in local worktrees, so there was nothing reviewable on GitHub.

## Solution
Pushes both for review. `tools/qa/opencode` is the QA harness that drives the real opencode binary against a launched `lilbee serve` and gates on the `lilbee_search` glyph plus a real chat-completion delta; its pane-idle and scenario timeouts are raised so a giant MoE on Apple Metal isn't killed before its first tool call. `demos-src/opencode-model-reel` is the reel pipeline: it builds the corpus index, scores retrieval against grounded probes, and records two demo sets via VHS (harness-tuned configs, and the model tuning lilbee's retrieval itself).

Targeting `gh-pages` as a review vehicle. Output artifacts (gifs, scratch dirs) are intentionally excluded.