### PR TITLE
Fix Windows /add path completion stripping the directory

### DIFF
--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -47,6 +47,7 @@ from lilbee.cli.tui.widgets.autocomplete import (
     CompletionOverlay,
     get_completions,
     longest_common_prefix,
+    path_completion_prefix,
 )
 from lilbee.cli.tui.widgets.chat_input import ChatInput
 from lilbee.cli.tui.widgets.help_hint import HelpHint
@@ -1468,7 +1469,7 @@ class ChatScreen(Screen[None]):
             return display
         cmd, _, partial = text.partition(" ")
         if cmd.lower() == "/add":
-            head = partial[: partial.rfind("/") + 1]
+            head = path_completion_prefix(partial)
             return f"{cmd} {head}{display}"
         return f"{cmd} {display}"
 

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -144,6 +144,21 @@ def _path_options(partial: str = "") -> list[str]:
         return []
 
 
+_PATH_SEPARATORS = ("/", "\\")
+
+
+def path_completion_prefix(partial: str) -> str:
+    """Directory prefix of *partial* up to and including the last path separator.
+
+    Splits on both ``/`` and ``\\`` so accepting an /add path completion keeps
+    the directory the user typed instead of collapsing to the basename. On
+    Windows the typed path uses backslashes, so a ``/``-only split would drop
+    the whole directory and turn ``C:\\dir\\file.md`` into ``file.md``.
+    """
+    cut = max(partial.rfind(sep) for sep in _PATH_SEPARATORS)
+    return partial[: cut + 1]
+
+
 def longest_common_prefix(values: list[str]) -> str:
     """Return the longest string that prefixes every value (``""`` if none)."""
     if not values:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3454,6 +3454,51 @@ async def test_chat_accept_on_enter_with_no_highlight_hides():
         assert not overlay.is_visible
 
 
+async def test_chat_completion_value_preserves_windows_directory():
+    """Accepting an /add path completion keeps the typed Windows directory.
+
+    Regression for the windows-latest integration failure: a backslash path
+    must rebuild to the same full path so Enter falls through to submit
+    instead of being consumed as a completion-accept.
+    """
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        app.screen._completion_origin = r"/add C:\Users\me\docs\quantum_test.md"
+        assert (
+            app.screen._completion_value("quantum_test.md")
+            == r"/add C:\Users\me\docs\quantum_test.md"
+        )
+
+
+async def test_chat_completion_value_preserves_posix_directory():
+    """Accepting an /add path completion keeps the typed POSIX directory."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        app.screen._completion_origin = "/add /var/tmp/docs/quantum_test.md"
+        assert (
+            app.screen._completion_value("quantum_test.md") == "/add /var/tmp/docs/quantum_test.md"
+        )
+
+
+async def test_chat_accept_on_enter_falls_through_for_full_windows_path():
+    """A fully-typed backslash /add path must not be consumed by the overlay.
+
+    The highlighted completion (basename) rebuilds to the same full path, so
+    Enter falls through to submit the command rather than re-filling the input.
+    """
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        full_path = r"/add C:\Users\me\docs\quantum_test.md"
+        app.screen._set_input(full_path)
+        overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
+        app.screen._completion_origin = full_path
+        overlay.show_completions(["quantum_test.md"])
+        consumed = app.screen._accept_overlay_selection_on_enter()
+        assert consumed is False
+
+
 async def test_chat_send_message():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2436,6 +2436,28 @@ class TestGetCompletions:
         assert any("beta.txt" in x for x in r)
 
 
+class TestPathCompletionPrefix:
+    def test_posix_path_keeps_directory(self) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import path_completion_prefix
+
+        assert path_completion_prefix("/var/tmp/docs/file.md") == "/var/tmp/docs/"
+
+    def test_windows_path_keeps_directory(self) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import path_completion_prefix
+
+        assert path_completion_prefix(r"C:\Users\me\docs\file.md") == "C:\\Users\\me\\docs\\"
+
+    def test_bare_basename_has_no_prefix(self) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import path_completion_prefix
+
+        assert path_completion_prefix("file.md") == ""
+
+    def test_mixed_separators_use_rightmost(self) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import path_completion_prefix
+
+        assert path_completion_prefix(r"C:/Users\me/docs\file.md") == "C:/Users\\me/docs\\"
+
+
 class TestLongestCommonPrefix:
     def test_empty_list(self) -> None:
         from lilbee.cli.tui.widgets.autocomplete import longest_common_prefix


### PR DESCRIPTION
## Problem

On Windows, accepting an `/add` path completion ran `partial.rfind("/")`, which returns -1 for a backslash path and collapsed `C:\dir\file.md` to `file.md`. That made Enter accept the completion instead of submitting `/add`, so the file was never indexed. This was the consistent `test_add_file_becomes_searchable` failure on windows-latest.

## Solution

Split the path on both `/` and `\` so the typed directory is kept on every platform. Added unit and screen-level regression tests.