### PR TITLE
Data-parallel embed/vision replicas across GPUs (bb-0nw)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,6 +191,15 @@ flowchart TD
   RAM on a unified-memory host drives the OS into a swap-thrash OOM livelock that
   hard-freezes the machine, so refusing is the safe outcome; chat slot count
   (`--parallel`) steps down the same way before refusing.
+- **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
+  vision roles can run as N independent servers, one per GPU, so large-scale ingest
+  fans embedding / OCR across the whole box. The single roles (chat) are placed
+  first; each replica then lands on a distinct card with the most free VRAM (only
+  co-locating a second once every card has one), capped by what fits. The provider
+  holds a client pool per role and round-robins to the least-busy replica. With no
+  discrete GPU the replicas run as co-resident processes against the shared pool.
+  Each replica is its own llama-swap model id (`<role>-<n>`); a role is ready once
+  any replica is.
 - **Loader flags** (`adapters.build_server_argv`): each server's flags derive from
   cfg and the model's GGUF metadata for that role and config. Chat carries
   `--jinja`, `--flash-attn` (on unless `flash_attention` is disabled) and

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -647,6 +647,18 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group=SettingGroup.GENERATION,
         help_text="Fraction of GPU memory the model is allowed to claim (0.1-1.0)",
     ),
+    "embed_replicas": SettingDef(
+        int,
+        nullable=False,
+        group=SettingGroup.GENERATION,
+        help_text="Embedding servers to run in parallel, one per GPU, for large-scale ingest",
+    ),
+    "vision_replicas": SettingDef(
+        int,
+        nullable=False,
+        group=SettingGroup.GENERATION,
+        help_text="Vision OCR servers to run in parallel, one per GPU, for large-scale ingest",
+    ),
     "candidate_multiplier": SettingDef(
         int,
         nullable=False,

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -163,7 +163,7 @@ def _self_check_server(role: WorkerRole, model_path: Path) -> tuple[SwapManager,
     )
     swap = SwapManager(work_dir)
     swap.start([launch])
-    return swap, LlamaServerClient(swap.endpoint(), role.value)
+    return swap, LlamaServerClient(swap.endpoint(), launch.model_id)
 
 
 def _self_check_chat(model_path: Path, max_tokens: int) -> str:

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -268,6 +268,13 @@ class Config(BaseSettings):
     # Fraction of GPU/unified memory reserved for loaded models.
     gpu_memory_fraction: float = ConfigField(default=0.75, ge=0.1, le=1.0, writable=True)
 
+    # Data-parallel replicas of the embed / vision role across GPUs: N independent
+    # servers (one per spare GPU), round-robined, so large-scale ingest fans the
+    # embedding / OCR work across the whole box. 1 = a single server (the default).
+    # Capped at runtime by the GPUs with room after the chat model is placed.
+    embed_replicas: int = ConfigField(default=1, ge=1, writable=True)
+    vision_replicas: int = ConfigField(default=1, ge=1, writable=True)
+
     # Seconds a model stays loaded after last use. 0 = unload immediately.
     model_keep_alive: int = ConfigField(default=300, ge=0, writable=True)
 

--- a/src/lilbee/providers/fleet/launch.py
+++ b/src/lilbee/providers/fleet/launch.py
@@ -7,6 +7,14 @@ from pathlib import Path
 
 from lilbee.providers.roles import WorkerRole
 
+# Separator between a role and its replica index in a llama-swap model id.
+_REPLICA_SEP = "-"
+
+
+def role_model_prefix(role: WorkerRole) -> str:
+    """Prefix shared by every replica model id of *role* (``<role>-``)."""
+    return f"{role.value}{_REPLICA_SEP}"
+
 
 @dataclass
 class InstanceLaunch:
@@ -21,3 +29,9 @@ class InstanceLaunch:
     weights_bytes: int = 0  # model file size on disk; scales the cold-load timeout
     slots: int = 1  # --parallel continuous-batching slots; chat concurrency capacity
     ctx: int = 0  # per-slot context the server runs with; what a client should fit to
+    replica: int = 0  # index within the role's data-parallel pool (0 = single server)
+
+    @property
+    def model_id(self) -> str:
+        """The llama-swap model id for this instance: ``<role>-<replica>``."""
+        return f"{role_model_prefix(self.role)}{self.replica}"

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -25,10 +25,15 @@ _SEARCH_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK)
 
 @dataclass(frozen=True)
 class ModelPlacementInput:
-    """A role's model and its estimated single-instance VRAM footprint."""
+    """A role's model, its estimated single-instance footprint, and replica count.
+
+    ``replicas`` > 1 requests N data-parallel instances (one per GPU) for the role,
+    each charged ``est_vram_bytes``; capped at runtime by the GPUs with room.
+    """
 
     role: WorkerRole
     est_vram_bytes: int
+    replicas: int = 1
 
 
 @dataclass(frozen=True)
@@ -37,12 +42,14 @@ class InstancePlan:
 
     ``devices`` >1 means the model is split across them; ``tensor_split`` is the
     per-device proportion (free VRAM in GiB) so an unequal pair splits by capacity
-    rather than evenly. Empty for a single-device instance.
+    rather than evenly. Empty for a single-device instance. ``replica`` is the
+    instance's index within its role's data-parallel pool (0 for a single server).
     """
 
     role: WorkerRole
     devices: tuple[int, ...]
     tensor_split: tuple[int, ...] = ()
+    replica: int = 0
 
 
 @dataclass(frozen=True)
@@ -79,7 +86,11 @@ def plan_placement(
     if not devices:
         if unified_budget is None:
             return Placement(
-                instances=tuple(InstancePlan(role=m.role, devices=()) for m in models),
+                instances=tuple(
+                    InstancePlan(role=m.role, devices=(), replica=r)
+                    for m in models
+                    for r in range(m.replicas)
+                ),
                 unplaceable_roles=(),
             )
         return _place_shared_memory(models, unified_budget)
@@ -87,40 +98,83 @@ def plan_placement(
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
 
-    for model in sorted(models, key=lambda m: m.est_vram_bytes, reverse=True):
-        single = _best_single_device(model.est_vram_bytes, remaining)
-        if single is not None:
-            remaining[single] -= model.est_vram_bytes
-            instances.append(InstancePlan(role=model.role, devices=(single,)))
-            continue
-        split = _devices_for_split(model.est_vram_bytes, remaining)
-        if split is not None:
-            ratio = tuple(max(1, int(remaining[idx] / 1024**3)) for idx in split)
-            _charge_split(model.est_vram_bytes, split, remaining)
-            instances.append(
-                InstancePlan(role=model.role, devices=tuple(split), tensor_split=ratio)
-            )
-            continue
-        unplaceable.append(model.role)
+    # Single-instance roles first (chat tensor-splits here, claiming its cards),
+    # largest-first; then data-parallel replicas fill the remaining headroom.
+    singles = [m for m in models if m.replicas <= 1]
+    replicated = [m for m in models if m.replicas > 1]
+    for model in sorted(singles, key=lambda m: m.est_vram_bytes, reverse=True):
+        plan = _place_single(model, remaining)
+        if plan is None:
+            unplaceable.append(model.role)
+        else:
+            instances.append(plan)
+    for model in replicated:
+        replica_plans = _place_replicas(model, remaining)
+        if replica_plans:
+            instances.extend(replica_plans)
+        else:
+            unplaceable.append(model.role)
 
     return Placement(instances=tuple(instances), unplaceable_roles=tuple(unplaceable))
+
+
+def _place_single(model: ModelPlacementInput, remaining: dict[int, float]) -> InstancePlan | None:
+    """Place one instance: a single GPU when it fits, else a tensor-split, else None."""
+    single = _best_single_device(model.est_vram_bytes, remaining)
+    if single is not None:
+        remaining[single] -= model.est_vram_bytes
+        return InstancePlan(role=model.role, devices=(single,))
+    split = _devices_for_split(model.est_vram_bytes, remaining)
+    if split is not None:
+        ratio = tuple(max(1, int(remaining[idx] / 1024**3)) for idx in split)
+        _charge_split(model.est_vram_bytes, split, remaining)
+        return InstancePlan(role=model.role, devices=tuple(split), tensor_split=ratio)
+    return None
+
+
+def _place_replicas(model: ModelPlacementInput, remaining: dict[int, float]) -> list[InstancePlan]:
+    """Place up to ``model.replicas`` instances, one per distinct GPU (most-free first).
+
+    Spreads for throughput: each replica lands on a card not yet hosting one of this
+    role's replicas, only co-locating a second round once every card has one. Stops
+    early when no card has room, so the pool shrinks to what fits.
+    """
+    plans: list[InstancePlan] = []
+    used: set[int] = set()
+    for replica in range(model.replicas):
+        candidates = [idx for idx, free in remaining.items() if free >= model.est_vram_bytes]
+        if not candidates:
+            break
+        fresh = [idx for idx in candidates if idx not in used]
+        pick = max(fresh or candidates, key=lambda idx: remaining[idx])
+        remaining[pick] -= model.est_vram_bytes
+        used.add(pick)
+        if len(used) == len(remaining):
+            used = set()
+        plans.append(InstancePlan(role=model.role, devices=(pick,), replica=replica))
+    return plans
 
 
 def _place_shared_memory(models: list[ModelPlacementInput], budget: int) -> Placement:
     """Fit un-pinned roles into one shared RAM *budget*.
 
     Search-critical roles (embed/rerank) are reserved first so the elastic chat
-    model can never crowd them out; the rest pack largest-first. A role that no
-    longer fits is unplaceable (gets no server, its calls error).
+    model can never crowd them out; the rest pack largest-first. Replicas run as N
+    co-resident processes against the shared pool (no per-GPU spread without GPUs).
+    A role with no instance placed is unplaceable (gets no server, its calls error).
     """
     remaining = budget
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
     for model in sorted(models, key=_shared_pool_order):
-        if model.est_vram_bytes <= remaining:
+        placed = 0
+        for _ in range(model.replicas):
+            if model.est_vram_bytes > remaining:
+                break
             remaining -= model.est_vram_bytes
-            instances.append(InstancePlan(role=model.role, devices=()))
-        else:
+            instances.append(InstancePlan(role=model.role, devices=(), replica=placed))
+            placed += 1
+        if placed == 0:
             unplaceable.append(model.role)
     return Placement(instances=tuple(instances), unplaceable_roles=tuple(unplaceable))
 

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -246,6 +246,18 @@ def _role_kv_cache_type(role: WorkerRole) -> KvCacheType:
     return cfg.kv_cache_type if role is WorkerRole.CHAT else KvCacheType.F16
 
 
+def _replica_count(role: WorkerRole) -> int:
+    """Requested data-parallel instances for *role*: embed/vision honor their
+    ``*_replicas`` knob (capped by available GPUs at placement); others run one."""
+    from lilbee.core.config import cfg
+
+    if role is WorkerRole.EMBED:
+        return max(1, cfg.embed_replicas)
+    if role is WorkerRole.VISION:
+        return max(1, cfg.vision_replicas)
+    return 1
+
+
 def _cache_type_flag() -> str | None:
     """KV cache type for chat, or ``None`` to leave llama-server's f16 default."""
     from lilbee.core.config import cfg
@@ -308,13 +320,20 @@ def _estimate_role(
         mmproj_path=mmproj,
     )
     return ModelPlacementInput(
-        role=role, est_vram_bytes=est.footprint(unified=unified_budget is not None)
+        role=role,
+        est_vram_bytes=est.footprint(unified=unified_budget is not None),
+        replicas=_replica_count(role),
     )
 
 
 def _search_reservation(inputs: dict[WorkerRole, ModelPlacementInput]) -> int:
-    """Total footprint of the placed search roles, held back ahead of chat."""
-    return sum(inputs[role].est_vram_bytes for role in _EMBED_ROLES if role in inputs)
+    """Total footprint of the placed search roles (all replicas), held back ahead
+    of chat."""
+    return sum(
+        inputs[role].est_vram_bytes * inputs[role].replicas
+        for role in _EMBED_ROLES
+        if role in inputs
+    )
 
 
 def _server_model_inputs(
@@ -436,9 +455,9 @@ def _launch_for(
         argv=argv,
         env_overrides={**visible_env(chosen), **llama_server_runtime_env()},
         model=model_ref,
-        # Stamp the owning lilbee pid so a concurrent instance's reaper won't
-        # touch this server (only a dead parent's orphans get reaped).
-        port_file=data_dir / f"llama-server-{plan.role.value}-{os.getpid()}.port",
+        # Unique per role + replica + owning pid so a concurrent instance's reaper
+        # won't touch this server (only a dead parent's orphans get reaped).
+        port_file=data_dir / f"llama-server-{plan.role.value}-{plan.replica}-{os.getpid()}.port",
         # Embed/rerank truncate oversize inputs to the per-slot context.
         token_cap=ctx if plan.role in _EMBED_ROLES else None,
         # Weights size scales the cold-load ready timeout (larger model = longer).
@@ -446,6 +465,7 @@ def _launch_for(
         # Slots is the chat concurrency the gate admits; ctx is what a client fits to.
         slots=slots,
         ctx=ctx,
+        replica=plan.replica,
     )
 
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -148,9 +148,10 @@ class FleetProvider:
 
     def __init__(self) -> None:
         self._swap: SwapManager | None = None
-        # One OpenAI client per placed role, all pointed at the llama-swap endpoint
-        # and routed by model id; rebuilt whenever the swap process (re)starts.
-        self._clients: dict[WorkerRole, LlamaServerClient] = {}
+        # A pool of OpenAI clients per placed role (one per data-parallel replica),
+        # all pointed at the llama-swap endpoint and routed by replica model id;
+        # rebuilt whenever the swap process (re)starts. Requests round-robin the pool.
+        self._clients: dict[WorkerRole, list[LlamaServerClient]] = {}
         # Chat batching slots and per-slot context from the chat launch, surfaced to
         # the concurrency gate and clients; defaults until the swap is up.
         self._chat_slots = 1
@@ -201,48 +202,51 @@ class FleetProvider:
             return swap
 
     def _adopt_swap(self, swap: SwapManager, launches: list[InstanceLaunch]) -> None:
-        """Record a freshly started swap and build a client per placed role.
+        """Record a freshly started swap and build a client pool per placed role.
 
-        Caller holds ``self._lock``. ``launches`` carries each role's slots/ctx so
-        the chat capacity and served context come from the launch, not a probe.
+        Caller holds ``self._lock``. Each launch (one per replica) becomes a client
+        keyed by its replica model id; launches carry the chat slots/ctx so the
+        capacity and served context come from the launch, not a probe.
         """
         self._swap = swap
         endpoint = swap.endpoint()
         # token_cap truncates oversize embed/rerank inputs to the per-slot context
         # (the in-process backstop); the longer timeout covers a cold upstream load.
-        self._clients = {
-            launch.role: LlamaServerClient(
-                endpoint,
-                launch.role.value,
-                token_cap=launch.token_cap,
-                timeout=_REQUEST_TIMEOUT_S,
+        clients: dict[WorkerRole, list[LlamaServerClient]] = {}
+        for launch in launches:
+            clients.setdefault(launch.role, []).append(
+                LlamaServerClient(
+                    endpoint,
+                    launch.model_id,
+                    token_cap=launch.token_cap,
+                    timeout=_REQUEST_TIMEOUT_S,
+                )
             )
-            for launch in launches
-        }
+        self._clients = clients
         chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
         self._chat_slots = chat.slots if chat is not None else 1
         self._chat_ctx = chat.ctx if chat is not None else None
 
     def _require_clients(self, role: WorkerRole) -> list[LlamaServerClient]:
-        """The client for *role*, or a user-facing error when it has no server.
+        """The client pool for *role*, or a user-facing error when it has no server.
 
-        A configured, placeable role gets a client; its absence means the role is
-        unconfigured or did not fit memory. llama-swap loads the upstream on the
-        first request, so a returned client may still be cold. No in-process
-        fallback, so a missing client is a hard error.
+        A configured, placeable role gets one or more replica clients; their absence
+        means the role is unconfigured or did not fit memory. llama-swap loads each
+        upstream on its first request, so a returned client may still be cold. No
+        in-process fallback, so a missing pool is a hard error.
         """
         from lilbee.providers.base import ProviderError
 
         self._ensure_swap()
         with self._lock:
-            client = self._clients.get(role)
-        if client is None:
+            clients = self._clients.get(role)
+        if not clients:
             raise ProviderError(
                 f"No {role.value} model server is running. Make sure a {role.value} "
                 "model is installed and configured, then try again.",
                 provider=_PROVIDER_NAME,
             )
-        return [client]
+        return list(clients)
 
     def role_ready(self, role: WorkerRole) -> bool:
         """Whether *role*'s upstream is loaded and ready, without starting the swap.
@@ -275,7 +279,7 @@ class FleetProvider:
     def _shutdown_swap(self) -> None:
         with self._lock:
             swap = self._swap
-            clients = list(self._clients.values())
+            clients = [client for pool in self._clients.values() for client in pool]
             self._swap = None
             self._clients = {}
             self._chat_slots = 1
@@ -601,22 +605,24 @@ class FleetProvider:
                 self._warming = False
 
     def _preload_roles(self) -> None:
-        """Issue one cheap request per role so llama-swap loads its upstream now.
+        """Issue a cheap request per replica so llama-swap loads each upstream now.
 
         llama-swap starts an upstream on its first request, so warming sends a
-        minimal call per role (firing the spawn listeners around each). A per-role
-        failure is logged and skipped; the role still loads on its first real use.
+        minimal call to every replica of every role (firing the spawn listeners
+        around each role). A per-replica failure is logged and skipped; that replica
+        still loads on its first real use.
         """
         with self._lock:
-            clients = dict(self._clients)
+            pools = {role: list(clients) for role, clients in self._clients.items()}
             on_spawning, on_spawned = self._on_spawning, self._on_spawned
-        for role, client in clients.items():
+        for role, clients in pools.items():
             if on_spawning is not None:
                 on_spawning(role)
-            try:
-                _warm_role(role, client)
-            except Exception:
-                log.debug("Warm-up request for %s failed.", role.value, exc_info=True)
+            for client in clients:
+                try:
+                    _warm_role(role, client)
+                except Exception:
+                    log.debug("Warm-up request for %s failed.", role.value, exc_info=True)
             if on_spawned is not None:
                 on_spawned(role)
 

--- a/src/lilbee/providers/fleet/swap_config.py
+++ b/src/lilbee/providers/fleet/swap_config.py
@@ -57,7 +57,7 @@ def build_swap_config(launches: list[InstanceLaunch]) -> str:
         }
         if launch.env_overrides:
             entry[_KEY_ENV] = [f"{key}={value}" for key, value in launch.env_overrides.items()]
-        models[launch.role.value] = entry
+        models[launch.model_id] = entry
     config: dict[str, object] = {
         _KEY_START_PORT: _START_PORT,
         _KEY_HEALTH_TIMEOUT: _HEALTH_CHECK_TIMEOUT_S,
@@ -68,7 +68,7 @@ def build_swap_config(launches: list[InstanceLaunch]) -> str:
                 _KEY_SWAP: False,
                 _KEY_EXCLUSIVE: False,
                 _KEY_PERSISTENT: True,
-                _KEY_MEMBERS: [launch.role.value for launch in launches],
+                _KEY_MEMBERS: [launch.model_id for launch in launches],
             }
         },
     }

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -19,6 +19,7 @@ import httpx
 
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet.binary import resolve_llama_swap
+from lilbee.providers.fleet.launch import role_model_prefix
 from lilbee.providers.fleet.swap_config import build_swap_config
 
 if TYPE_CHECKING:
@@ -86,8 +87,9 @@ class SwapManager:
         return f"http://{_HOST}:{self._port}"
 
     def role_ready(self, role: WorkerRole) -> bool:
-        """Whether *role*'s upstream server is loaded and ready behind llama-swap."""
-        return role.value in self._ready_models()
+        """Whether at least one of *role*'s replica servers is loaded and ready."""
+        prefix = role_model_prefix(role)
+        return any(model.startswith(prefix) for model in self._ready_models())
 
     def reload(self, launches: list[InstanceLaunch]) -> None:
         """Apply a changed model set by restarting llama-swap with a fresh config."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,23 @@ def _reset_services_after_test():
 
 
 @pytest.fixture(autouse=True)
+def _join_fleet_background_threads():
+    """Join lingering fleet warm-up / reload daemon threads after each test.
+
+    ``warm_up_pool`` / ``reload_role`` dispatch fire-and-forget daemon threads; on a
+    host without the engine binary they fail fast and log a warning. Joining them
+    here keeps that warning inside the test that started the thread instead of
+    leaking it into a later test's log capture.
+    """
+    yield
+    import threading
+
+    for thread in threading.enumerate():
+        if thread.name.startswith("fleet-") and thread.is_alive():
+            thread.join(timeout=5.0)
+
+
+@pytest.fixture(autouse=True)
 def _ignore_user_global_config(monkeypatch):
     """Skip the platform-default config.toml for unit tests.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3834,6 +3834,24 @@ class TestSelfCheckHelpers:
             setup._self_check_embed(tmp_path / "embed.gguf")
         swap.shutdown.assert_called_once()
 
+    def test_self_check_client_addresses_the_replica_model_id(self, monkeypatch, tmp_path) -> None:
+        # The client must address the model by its llama-swap id (role-0), matching
+        # the generated config, or the request would not route.
+        from unittest import mock
+
+        from lilbee.cli.commands import setup
+        from lilbee.providers.roles import WorkerRole
+
+        swap = mock.MagicMock()
+        self._patch_fleet_primitives(monkeypatch, swap=swap, client=mock.MagicMock())
+        seen: dict[str, str] = {}
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.client.LlamaServerClient",
+            lambda _endpoint, model: seen.update(model=model) or mock.MagicMock(),
+        )
+        setup._self_check_server(WorkerRole.CHAT, tmp_path / "chat.gguf")
+        assert seen["model"] == "chat-0"
+
 
 class TestSelfCheckExtras:
     """`lilbee self-check-extras` probes the optional extras for the frozen-binary smoke test."""

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2001,8 +2001,13 @@ class TestCrawlCancel:
 
         # No synthetic failure entry on the cancel path
         assert results == []
-        # The teardown error is at DEBUG, not WARNING
-        warnings = [r for r in caplog.records if r.levelno == _logging.WARNING]
+        # The teardown error is at DEBUG, not WARNING. Scope to the crawler logger:
+        # an unrelated background warm-up thread can otherwise leak a warning here.
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == _logging.WARNING and r.name.startswith("lilbee.crawler")
+        ]
         assert not warnings
 
     async def test_safe_strategy_cancel_missing_method(self):

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -132,3 +132,81 @@ class TestPlanPlacement:
         # now-emptier device 1. Each is a single-GPU instance.
         assert by_role == {WorkerRole.CHAT: (0,), WorkerRole.EMBED: (1,)}
         assert plan.unplaceable_roles == ()
+
+
+class TestReplicas:
+    """Data-parallel replicas: N instances of a role spread one-per-GPU for throughput."""
+
+    def _embeds(self, plan: Placement) -> list[InstancePlan]:
+        return [i for i in plan.instances if i.role is WorkerRole.EMBED]
+
+    def test_replicas_spread_one_per_distinct_gpu(self) -> None:
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=3)],
+            [(0, 24 * _GB), (1, 24 * _GB), (2, 24 * _GB)],
+        )
+        embeds = self._embeds(plan)
+        assert len(embeds) == 3
+        assert {i.devices[0] for i in embeds} == {0, 1, 2}  # one per distinct card
+        assert {i.replica for i in embeds} == {0, 1, 2}  # distinct replica indices
+        assert plan.unplaceable_roles == ()
+
+    def test_replicas_wrap_to_colocate_when_more_than_gpus(self) -> None:
+        # embed ~10GB, 2x24GB (21.6 usable) fits 2 per card -> 4 of 8 requested place.
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 10 * _GB, replicas=8)],
+            [(0, 24 * _GB), (1, 24 * _GB)],
+        )
+        embeds = self._embeds(plan)
+        assert len(embeds) == 4  # two per card, then no room
+        assert sorted(i.devices[0] for i in embeds) == [0, 0, 1, 1]
+        assert {i.replica for i in embeds} == {0, 1, 2, 3}
+
+    def test_replicated_role_unplaceable_when_no_gpu_fits_one(self) -> None:
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 100 * _GB, replicas=2)],
+            [(0, 24 * _GB)],
+        )
+        assert plan.instances == ()
+        assert plan.unplaceable_roles == (WorkerRole.EMBED,)
+
+    def test_chat_placed_before_replicas_then_replicas_fill_remaining(self) -> None:
+        plan = plan_placement(
+            [
+                ModelPlacementInput(WorkerRole.CHAT, 20 * _GB),  # single, claims a card first
+                ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=2),
+            ],
+            [(0, 24 * _GB), (1, 24 * _GB)],
+        )
+        assert len([i for i in plan.instances if i.role is WorkerRole.CHAT]) == 1
+        assert len(self._embeds(plan)) == 2
+        assert plan.unplaceable_roles == ()
+
+    def test_unified_budget_runs_replicas_as_coresident_processes(self) -> None:
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 2 * _GB, replicas=3)],
+            [],
+            unified_budget=10 * _GB,
+        )
+        embeds = self._embeds(plan)
+        assert len(embeds) == 3  # 3x2GB <= 10GB
+        assert all(i.devices == () for i in embeds)
+        assert {i.replica for i in embeds} == {0, 1, 2}
+
+    def test_unified_budget_caps_replicas_to_what_fits(self) -> None:
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 4 * _GB, replicas=5)],
+            [],
+            unified_budget=10 * _GB,
+        )
+        assert len(self._embeds(plan)) == 2  # 2x4=8<=10; a third (12) overruns
+
+    def test_no_gpu_no_budget_expands_every_replica(self) -> None:
+        # GPU-less + ungated legacy path: each replica becomes an un-pinned instance.
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=2)],
+            [],
+        )
+        embeds = self._embeds(plan)
+        assert len(embeds) == 2
+        assert {i.replica for i in embeds} == {0, 1}

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -335,6 +335,36 @@ def test_server_model_inputs_no_reservation_on_discrete_gpu(monkeypatch) -> None
     assert seen["chat_reservation"] == 0
 
 
+def test_replica_count_reads_per_role_knobs(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 3)
+    monkeypatch.setattr(cfg, "vision_replicas", 2)
+    assert planning_mod._replica_count(WorkerRole.EMBED) == 3
+    assert planning_mod._replica_count(WorkerRole.VISION) == 2
+    assert planning_mod._replica_count(WorkerRole.CHAT) == 1  # chat never replicates
+    assert planning_mod._replica_count(WorkerRole.RERANK) == 1  # rerank never replicates
+
+
+def test_estimate_role_carries_replica_count(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 4)
+    model = tmp_path / "e.gguf"
+    model.write_bytes(b"x" * 1000)
+    monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+    monkeypatch.setattr(planning_mod, "_role_ctx", lambda _r, _p, _m, *_a: 16)
+    monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=10))
+    inp = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1)
+    assert inp.replicas == 4
+
+
+def test_search_reservation_scales_with_replicas() -> None:
+    inputs = {
+        WorkerRole.EMBED: ModelPlacementInput(WorkerRole.EMBED, 2 * _GB, replicas=3),
+        WorkerRole.RERANK: ModelPlacementInput(WorkerRole.RERANK, 1 * _GB),
+    }
+    # 3 embed replicas + 1 rerank are all reserved ahead of chat.
+    assert planning_mod._search_reservation(inputs) == 3 * 2 * _GB + 1 * _GB
+
+
 class TestBuildFleetWiring:
     def test_server_model_inputs_skips_unconfigured_optional_roles(self, monkeypatch) -> None:
         monkeypatch.setattr(
@@ -513,7 +543,7 @@ class TestBuildFleetWiring:
         assert launch.role == WorkerRole.CHAT
         assert launch.env_overrides == visible_env((device,))
         # port file is stamped with the owning pid so reaping is instance-safe
-        assert launch.port_file == Path(f"/data/llama-server-chat-{os.getpid()}.port")
+        assert launch.port_file == Path(f"/data/llama-server-chat-0-{os.getpid()}.port")
         assert "--model" in launch.argv
         assert "--port" not in launch.argv  # claimed at spawn, not here
         assert launch.weights_bytes == 2048  # model file size scales the ready timeout

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -71,10 +71,10 @@ def _install_engine(monkeypatch, *, launches: list, swap: _FakeSwap | None = Non
 
 
 def _provider_with_clients(clients: dict[WorkerRole, list[MagicMock]]) -> FleetProvider:
-    """A provider with a fake swap already up and one client per role (no real start)."""
+    """A provider with a fake swap already up and a client pool per role (no real start)."""
     p = FleetProvider()
     p._swap = _FakeSwap()  # non-None so _ensure_swap short-circuits
-    p._clients = {role: cs[0] for role, cs in clients.items() if cs}
+    p._clients = {role: list(cs) for role, cs in clients.items() if cs}
     return p
 
 
@@ -129,6 +129,24 @@ def test_embed_routes_to_server_when_present() -> None:
     client.embed.return_value = [[0.1]]
     p = _provider_with_clients({WorkerRole.EMBED: [client]})
     assert p.embed(["a"]) == [[0.1]]
+
+
+def test_embed_routes_to_least_busy_replica() -> None:
+    # Data-parallel replicas: a request goes to the idlest replica in the pool.
+    busy, idle = _fake_client(5), _fake_client(1)
+    idle.embed.return_value = [[0.2]]
+    p = _provider_with_clients({WorkerRole.EMBED: [busy, idle]})
+    assert p.embed(["a"]) == [[0.2]]
+    idle.embed.assert_called_once()
+    busy.embed.assert_not_called()
+
+
+def test_adopt_swap_builds_a_client_per_replica(monkeypatch) -> None:
+    launches = [_fake_launch(WorkerRole.EMBED), _fake_launch(WorkerRole.EMBED)]
+    _install_engine(monkeypatch, launches=launches)
+    p = FleetProvider()
+    p._ensure_swap()
+    assert len(p._clients[WorkerRole.EMBED]) == 2  # one client per replica launch
 
 
 def test_embed_without_server_raises() -> None:

--- a/tests/test_fleet_swap_config.py
+++ b/tests/test_fleet_swap_config.py
@@ -10,9 +10,17 @@ from lilbee.providers.fleet.swap_config import build_swap_config
 from lilbee.providers.roles import WorkerRole
 
 
-def _launch(role: WorkerRole, argv: list[str], env: dict[str, str] | None = None) -> InstanceLaunch:
+def _mid(role: WorkerRole, replica: int = 0) -> str:
+    """The llama-swap model id for a role's replica (matches InstanceLaunch.model_id)."""
+    return f"{role.value}-{replica}"
+
+
+def _launch(
+    role: WorkerRole, argv: list[str], env: dict[str, str] | None = None, replica: int = 0
+) -> InstanceLaunch:
     return InstanceLaunch(
         role=role,
+        replica=replica,
         argv=argv,
         env_overrides=env or {},
         model=f"{role.value}-model",
@@ -31,14 +39,32 @@ class TestBuildSwapConfig:
         assert cfg["healthCheckTimeout"] >= 1
         assert "logLevel" in cfg
 
-    def test_one_model_per_role_keyed_by_role_name(self) -> None:
+    def test_one_model_per_launch_keyed_by_model_id(self) -> None:
         cfg = _config(
             [
                 _launch(WorkerRole.CHAT, ["/bin/llama-server", "--jinja"]),
                 _launch(WorkerRole.EMBED, ["/bin/llama-server", "--embeddings"]),
             ]
         )
-        assert set(cfg["models"]) == {WorkerRole.CHAT.value, WorkerRole.EMBED.value}
+        assert set(cfg["models"]) == {_mid(WorkerRole.CHAT), _mid(WorkerRole.EMBED)}
+
+    def test_replicas_get_distinct_model_entries_all_co_resident(self) -> None:
+        # Each embed replica is its own llama-swap model id, all held in the group.
+        cfg = _config(
+            [
+                _launch(WorkerRole.CHAT, ["/bin/llama-server"]),
+                _launch(WorkerRole.EMBED, ["/bin/llama-server", "--embeddings"], replica=0),
+                _launch(WorkerRole.EMBED, ["/bin/llama-server", "--embeddings"], replica=1),
+            ]
+        )
+        assert set(cfg["models"]) == {
+            _mid(WorkerRole.CHAT),
+            _mid(WorkerRole.EMBED, 0),
+            _mid(WorkerRole.EMBED, 1),
+        }
+        (group,) = cfg["groups"].values()
+        assert _mid(WorkerRole.EMBED, 0) in group["members"]
+        assert _mid(WorkerRole.EMBED, 1) in group["members"]
 
     def test_group_holds_all_roles_co_resident(self) -> None:
         cfg = _config(
@@ -52,38 +78,38 @@ class TestBuildSwapConfig:
         assert group["swap"] is False  # never evict a member to load another
         assert group["persistent"] is True
         assert set(group["members"]) == {
-            WorkerRole.CHAT.value,
-            WorkerRole.EMBED.value,
-            WorkerRole.RERANK.value,
+            _mid(WorkerRole.CHAT),
+            _mid(WorkerRole.EMBED),
+            _mid(WorkerRole.RERANK),
         }
 
     def test_command_carries_port_macro_and_role_argv(self) -> None:
         cfg = _config([_launch(WorkerRole.CHAT, ["/bin/llama-server", "--jinja"])])
-        cmd = cfg["models"][WorkerRole.CHAT.value]["cmd"]
+        cmd = cfg["models"][_mid(WorkerRole.CHAT)]["cmd"]
         assert "--jinja" in cmd
         assert cmd.endswith("--port ${PORT}")
-        assert cfg["models"][WorkerRole.CHAT.value]["proxy"] == "http://localhost:${PORT}"
+        assert cfg["models"][_mid(WorkerRole.CHAT)]["proxy"] == "http://localhost:${PORT}"
 
     def test_embed_command_keeps_embeddings_flag(self) -> None:
         cfg = _config([_launch(WorkerRole.EMBED, ["/bin/llama-server", "--embeddings"])])
-        assert "--embeddings" in cfg["models"][WorkerRole.EMBED.value]["cmd"]
+        assert "--embeddings" in cfg["models"][_mid(WorkerRole.EMBED)]["cmd"]
 
     def test_spaced_model_path_is_quoted(self) -> None:
         argv = ["/bin/llama-server", "--model", "/Application Support/lilbee/m.gguf"]
         cfg = _config([_launch(WorkerRole.CHAT, argv)])
-        cmd = cfg["models"][WorkerRole.CHAT.value]["cmd"]
+        cmd = cfg["models"][_mid(WorkerRole.CHAT)]["cmd"]
         assert "'/Application Support/lilbee/m.gguf'" in cmd  # shell-quoted, survives the space
 
     def test_env_overrides_become_env_list_when_present(self) -> None:
         cfg = _config(
             [_launch(WorkerRole.CHAT, ["/bin/llama-server"], env={"CUDA_VISIBLE_DEVICES": "0"})]
         )
-        assert cfg["models"][WorkerRole.CHAT.value]["env"] == ["CUDA_VISIBLE_DEVICES=0"]
+        assert cfg["models"][_mid(WorkerRole.CHAT)]["env"] == ["CUDA_VISIBLE_DEVICES=0"]
 
     def test_env_key_absent_when_no_overrides(self) -> None:
         cfg = _config([_launch(WorkerRole.CHAT, ["/bin/llama-server"])])
-        assert "env" not in cfg["models"][WorkerRole.CHAT.value]
+        assert "env" not in cfg["models"][_mid(WorkerRole.CHAT)]
 
     def test_member_never_times_out(self) -> None:
         cfg = _config([_launch(WorkerRole.CHAT, ["/bin/llama-server"])])
-        assert cfg["models"][WorkerRole.CHAT.value]["ttl"] == 0
+        assert cfg["models"][_mid(WorkerRole.CHAT)]["ttl"] == 0

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -122,15 +122,23 @@ class TestRoleReady:
     def test_true_when_role_loaded_and_ready(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        running = {"running": [{"model": "chat", "state": "ready"}]}
+        running = {"running": [{"model": "chat-0", "state": "ready"}]}
         mgr = self._started(tmp_path, monkeypatch, lambda _url: _fake_response(payload=running))
         assert mgr.role_ready(WorkerRole.CHAT) is True
         assert mgr.role_ready(WorkerRole.EMBED) is False
 
+    def test_true_when_any_replica_ready(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A role is ready as soon as one of its data-parallel replicas is up.
+        running = {"running": [{"model": "embed-1", "state": "ready"}]}
+        mgr = self._started(tmp_path, monkeypatch, lambda _url: _fake_response(payload=running))
+        assert mgr.role_ready(WorkerRole.EMBED) is True
+
     def test_false_when_role_still_loading(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        running = {"running": [{"model": "chat", "state": "starting"}]}
+        running = {"running": [{"model": "chat-0", "state": "starting"}]}
         mgr = self._started(tmp_path, monkeypatch, lambda _url: _fake_response(payload=running))
         assert mgr.role_ready(WorkerRole.CHAT) is False
 

--- a/tools/qa/opencode/models.toml
+++ b/tools/qa/opencode/models.toml
@@ -10,8 +10,7 @@
 
 [[model]]
 family = "minimax-m2"
-# Q4_K_S (3 shards, ~130GB) splits across 7 of 8x24GB cards, freeing one for the
-# embedder; Q8_0 (~245GB) is the 2xH200 config.
+# Q4_K_S (3 shards, ~130GB) spans 2 of 3x80GB cards, leaving the third for the embedder.
 ref = "unsloth/MiniMax-M2-GGUF/Q4_K_S/MiniMax-M2-Q4_K_S-00001-of-00003.gguf"
 size_gb = 130.0
 tier = "giant"


### PR DESCRIPTION
## Problem

Multi-GPU today means tensor-splitting one model to make it fit, not running it many ways for throughput. Embedding and OCR are single-instance, so ingesting a large corpus (millions of pages) can't fan the work across the GPUs and has to fall back to manual per-GPU process sharding.

## Solution

Add data-parallel replicas for the embed and vision roles. `embed_replicas` / `vision_replicas` run N independent servers, one per GPU. Placement places the single roles first (chat keeps its tensor-split), then spreads each replica onto a distinct card with the most free VRAM, capping at what fits. Each replica is its own llama-swap model, co-resident in the group; the provider keeps a client pool per role and round-robins to the least-busy replica. Without a discrete GPU the replicas run as co-resident processes against the shared pool.

Validated against the real binary: two embed replicas spawn co-resident behind one endpoint and both serve embeddings. The multi-GPU spread and throughput is pending validation on the pod.

Stacks on #318 (the llama-swap engine) and targets that branch.