### PR TITLE
Let reranking decide which sources reach the model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -387,6 +387,7 @@ Two query-time effects:
   - Positions 11+: 30% fusion / 70% rerank (reranker has more opportunity to rescue misranked items)
 - **Blending rationale**: derived from learning-to-rank literature (Burges et al. 2005, "[Learning to Rank using Gradient Descent](https://icml.cc/imls/conferences/2005/proceedings/papers/012_Learning_BurgesEtAl.pdf)"). Top positions already have strong signal, so the reranker provides diminishing returns there.
 - **BM25 protection**: if the rank-1 result has a BM25 score above the expansion skip threshold, it is protected from demotion. This prevents the neural reranker from pushing down obvious exact keyword matches.
+- **Context selection**: reranked results carry their blended score (`rerank_score`) and the reranked order decides which chunks become LLM context, taking the top `max_context_sources` directly instead of the set-cover pass below.
 - **Cost**: depends on model and candidate count. ~200-500ms for 20 candidates with a small cross-encoder.
 
 #### Adaptive Distance Threshold
@@ -398,7 +399,7 @@ Two query-time effects:
 - **When it helps**: novel queries or small indexes where strict distance thresholds would return empty results.
 
 #### Adaptive Context Selection
-**On by default.** After search results are ranked, selects which chunks to include as LLM context based on query term coverage rather than just taking the top-k.
+**On by default.** After search results are ranked, selects which chunks to include as LLM context based on query term coverage rather than just taking the top-k. When cross-encoder reranking is active, the reranked order is the more precise signal and replaces this pass.
 
 - **Technique**: greedy set-cover approximation
 - **Algorithm**: tokenize query into terms, greedily select chunks that add the most uncovered terms, stop when coverage reaches 100% or marginal gain drops below 5%

--- a/src/lilbee/data/store/types.py
+++ b/src/lilbee/data/store/types.py
@@ -79,6 +79,7 @@ class SearchChunk(BaseModel):
     """A search result from LanceDB.
     Hybrid results have ``relevance_score`` set (higher = better).
     Vector-only results have ``distance`` set (lower = better).
+    Reranked results have ``rerank_score`` set (higher = better).
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -102,6 +103,7 @@ class SearchChunk(BaseModel):
     vector: list[float] = Field(repr=False)
     distance: float | None = Field(None, alias="_distance")
     relevance_score: float | None = Field(None, alias="_relevance_score")
+    rerank_score: float | None = None
 
 
 class SourceRecord(TypedDict):

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -285,11 +285,17 @@ class Searcher:
     def select_context(
         self, results: list[SearchChunk], question: str, max_sources: int | None = None
     ) -> list[SearchChunk]:
-        """Pick ``max_sources`` chunks by greedy IDF-weighted set cover."""
+        """Pick ``max_sources`` chunks.
+
+        Results carrying ``rerank_score`` keep the cross-encoder order (top
+        ``max_sources``); otherwise greedy IDF-weighted set cover.
+        """
         if max_sources is None:
             max_sources = self._config.max_context_sources
         if len(results) <= max_sources:
             return results
+        if any(r.rerank_score is not None for r in results):
+            return results[:max_sources]
 
         question_terms = set(_tokenize(question))
         if not question_terms:

--- a/src/lilbee/retrieval/reranker.py
+++ b/src/lilbee/retrieval/reranker.py
@@ -51,7 +51,11 @@ def _normalize_scores(scores: list[float]) -> list[float]:
 
 
 def _blend_scores(to_rerank: list[SearchChunk], norm_scores: list[float]) -> list[ScoredChunk]:
-    """Blend fusion scores with reranker scores using position-aware weights."""
+    """Blend fusion scores with reranker scores using position-aware weights.
+
+    Each chunk is copied with ``rerank_score`` set to its blended score;
+    the input chunks are left untouched.
+    """
     blended: list[ScoredChunk] = []
     for i, (chunk, rerank_score) in enumerate(zip(to_rerank, norm_scores, strict=True)):
         fusion_score = chunk.relevance_score or (1.0 - (chunk.distance or 0.5))
@@ -65,24 +69,23 @@ def _blend_scores(to_rerank: list[SearchChunk], norm_scores: list[float]) -> lis
             fw, rw = _BLEND_SCHEDULE["bottom"]
 
         final_score = fw * fusion_norm + rw * rerank_score
-        blended.append(ScoredChunk(final_score, chunk))
+        scored = chunk.model_copy(update={"rerank_score": final_score})
+        blended.append(ScoredChunk(final_score, scored))
     return blended
 
 
 def _pin_original_top(
     blended: list[ScoredChunk],
-    to_rerank: list[SearchChunk],
     skip_threshold: float,
 ) -> list[ScoredChunk]:
     """Pin the original top result if its relevance exceeds the skip threshold."""
-    top_score = to_rerank[0].relevance_score or 0 if to_rerank else 0
+    original_top = blended[0].chunk
+    top_score = original_top.relevance_score or 0
     blended_sorted = sorted(blended, key=lambda x: x.score, reverse=True)
-    if top_score >= skip_threshold:
-        original_top = to_rerank[0]
-        if blended_sorted[0].chunk is not original_top:
-            blended_sorted = [ScoredChunk(999.0, original_top)] + [
-                ScoredChunk(s, c) for s, c in blended_sorted if c is not original_top
-            ]
+    if top_score >= skip_threshold and blended_sorted[0].chunk is not original_top:
+        blended_sorted = [ScoredChunk(999.0, original_top)] + [
+            ScoredChunk(s, c) for s, c in blended_sorted if c is not original_top
+        ]
     return blended_sorted
 
 
@@ -120,9 +123,7 @@ class Reranker:
 
         norm_scores = _normalize_scores(scores)
         blended = _blend_scores(to_rerank, norm_scores)
-        blended_sorted = _pin_original_top(
-            blended, to_rerank, self._config.expansion_skip_threshold
-        )
+        blended_sorted = _pin_original_top(blended, self._config.expansion_skip_threshold)
 
         reranked = [chunk for _, chunk in blended_sorted]
         return reranked + remainder

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -115,6 +115,7 @@ class CleanedChunk(BaseModel):
     chunk: str
     distance: float | None = None
     relevance_score: float | None = None
+    rerank_score: float | None = None
     page_start: int = 0
     page_end: int = 0
     line_start: int = 0

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -81,6 +81,7 @@ def _make_result(
     chunk_index=0,
     distance=0.5,
     relevance_score=None,
+    rerank_score=None,
     vector=None,
 ) -> SearchChunk:
     return SearchChunk(
@@ -95,6 +96,7 @@ def _make_result(
         chunk_index=chunk_index,
         distance=distance,
         relevance_score=relevance_score,
+        rerank_score=rerank_score,
         vector=vector or [0.1],
     )
 
@@ -900,6 +902,29 @@ class TestSelectContext:
         sources = [r.source for r in result]
         assert "b.md" in sources  # cover pick
         assert sources == sorted(sources)
+
+    def test_rerank_scores_make_reranked_order_authoritative(self, mock_svc):
+        # The top reranked chunk shares no query terms; set cover would drop it.
+        chunks = [
+            _make_result(chunk="grounding upgrade big three", source="fix.md", rerank_score=0.9),
+            _make_result(chunk="radio resets at idle", source="radio.md", rerank_score=0.5),
+            _make_result(chunk="headlights dim at idle", source="lights.md", rerank_score=0.4),
+            _make_result(chunk="battery health log", source="battery.md", rerank_score=0.2),
+        ]
+        result = get_services().searcher.select_context(
+            chunks, "radio resets headlights dim", max_sources=2
+        )
+        assert [r.source for r in result] == ["fix.md", "radio.md"]
+
+    def test_partially_scored_results_keep_reranked_order(self, mock_svc):
+        # Remainder chunks beyond the rerank candidate cap carry no score.
+        chunks = [
+            _make_result(chunk="alpha", source="a.md", rerank_score=0.9),
+            _make_result(chunk="beta", source="b.md", rerank_score=0.8),
+            _make_result(chunk="gamma", source="c.md"),
+        ]
+        result = get_services().searcher.select_context(chunks, "alpha beta gamma", max_sources=2)
+        assert [r.source for r in result] == ["a.md", "b.md"]
 
     def test_hyphenated_phrase_splits_into_tokens(self, mock_svc):
         # Regression: the old tokenizer would strip the hyphens and

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -9,6 +9,8 @@ from lilbee.data.store import SearchChunk
 from lilbee.retrieval.query.searcher import Searcher
 from lilbee.retrieval.reranker import _BLEND_SCHEDULE, Reranker
 
+_RERANKER_MODEL = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+
 
 @pytest.fixture(autouse=True)
 def _reset():
@@ -62,7 +64,7 @@ class TestRerank:
         assert reranker.rerank("query", results) == results
 
     def test_reranks_with_provider_scores(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         results = [
             _chunk("a.md", "chunk A", relevance=0.3),
             _chunk("b.md", "chunk B", relevance=0.8),
@@ -73,7 +75,7 @@ class TestRerank:
         assert [c.chunk for c in reranked] == ["chunk B", "chunk A", "chunk C"]
 
     def test_bm25_protection(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         cfg.expansion_skip_threshold = 0.8
         results = [
             _chunk("a.md", "exact match", distance=0.9, relevance=0.9),
@@ -85,7 +87,7 @@ class TestRerank:
         assert reranked[0].chunk == "exact match"
 
     def test_handles_remainder(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         cfg.rerank_candidates = 2
         results = [
             _chunk("a.md", "chunk A"),
@@ -98,11 +100,11 @@ class TestRerank:
         assert reranked[-1].chunk == "chunk C"
 
     def test_empty_results(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         assert reranker.rerank("query", []) == []
 
     def test_equal_scores(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         results = [_chunk("a.md", "A"), _chunk("b.md", "B")]
         with _patch_provider(lambda query, cands: [0.5, 0.5]):
             reranked = reranker.rerank("test", results)
@@ -111,7 +113,7 @@ class TestRerank:
         assert chunks == {"A", "B"}
 
     def test_provider_error_preserves_results(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         results = [_chunk("a.md", "A"), _chunk("b.md", "B")]
 
         def explode(query: str, cands: list[str]) -> list[float]:
@@ -123,7 +125,7 @@ class TestRerank:
         assert all(r.rerank_score is None for r in out)
 
     def test_stamps_rerank_score_on_candidates_only(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         results = [
             _chunk("a.md", "chunk A"),
             _chunk("b.md", "chunk B"),
@@ -138,7 +140,7 @@ class TestRerank:
         assert all(r.rerank_score is None for r in results)  # inputs stay untouched
 
     def test_pinned_top_keeps_blended_rerank_score(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         cfg.expansion_skip_threshold = 0.8
         results = [
             _chunk("a.md", "exact match", relevance=0.9),
@@ -152,7 +154,7 @@ class TestRerank:
         assert all(r.rerank_score is not None and r.rerank_score <= 1.0 for r in reranked)
 
     def test_sends_chunk_text_to_provider(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         results = [_chunk("a.md", "alpha"), _chunk("b.md", "beta")]
         captured: dict[str, list[str] | str] = {}
 
@@ -175,7 +177,7 @@ class TestBlendSchedule:
 
 class TestRerankerBlendPositions:
     def test_mid_and_bottom_positions(self):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         r = Reranker(cfg)
         scores = [0.9 - i * 0.05 for i in range(12)]
 
@@ -185,7 +187,7 @@ class TestRerankerBlendPositions:
         assert len(reranked) == 12
 
     def test_no_bm25_protection_when_below_threshold(self):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         cfg.expansion_skip_threshold = 0.8
         r = Reranker(cfg)
         results = [
@@ -205,7 +207,7 @@ class TestGoldenOrdering:
     """
 
     def test_higher_rerank_score_sorts_first(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         results = [
             _chunk("a.md", "least", relevance=0.5),
             _chunk("b.md", "most", relevance=0.5),
@@ -217,7 +219,7 @@ class TestGoldenOrdering:
         assert [c.chunk for c in reranked] == ["most", "middle", "least"]
 
     def test_all_equal_scores_preserve_input_order(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         cfg.expansion_skip_threshold = 0.6  # above chunk relevance: no BM25 pin
         results = [_chunk(f"{i}.md", f"chunk {i}", relevance=0.5) for i in range(5)]
         with _patch_provider(lambda query, cands: [0.5] * len(cands)):
@@ -226,7 +228,7 @@ class TestGoldenOrdering:
         assert [c.chunk for c in reranked] == [f"chunk {i}" for i in range(5)]
 
     def test_both_scores_none_uses_fusion_default(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         cfg.expansion_skip_threshold = 0.6  # top relevance is None->0: no pin
 
         def _bare(source: str, chunk: str) -> SearchChunk:
@@ -268,7 +270,7 @@ class TestRerankChangesContext:
         ]
 
     def test_reranking_changes_selected_context_set(self):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         cfg.expansion_skip_threshold = 0.95  # top fusion hit stays below: no pin
         reranker = Reranker(cfg)
         searcher = Searcher(
@@ -314,7 +316,7 @@ class TestMixedPoolBias:
         )
 
     def test_ambiguous_scores_keep_both_sides(self, reranker):
-        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.reranker_model = _RERANKER_MODEL
         results = [
             self._wiki_chunk("wiki/summaries/a.md", "wiki a", relevance=0.5),
             _chunk("a.md", "raw a", relevance=0.5),

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -6,6 +6,7 @@ import pytest
 
 from lilbee.core.config import cfg
 from lilbee.data.store import SearchChunk
+from lilbee.retrieval.query.searcher import Searcher
 from lilbee.retrieval.reranker import _BLEND_SCHEDULE, Reranker
 
 
@@ -119,6 +120,36 @@ class TestRerank:
         with _patch_provider(explode):
             out = reranker.rerank("test", results)
         assert [c.chunk for c in out] == ["A", "B"]
+        assert all(r.rerank_score is None for r in out)
+
+    def test_stamps_rerank_score_on_candidates_only(self, reranker):
+        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        results = [
+            _chunk("a.md", "chunk A"),
+            _chunk("b.md", "chunk B"),
+            _chunk("c.md", "chunk C"),
+        ]
+        with _patch_provider(lambda query, cands: [0.9, 0.1]):
+            reranked = reranker.rerank("test", results, candidates=2)
+        scored = [r.chunk for r in reranked if r.rerank_score is not None]
+        unscored = [r.chunk for r in reranked if r.rerank_score is None]
+        assert sorted(scored) == ["chunk A", "chunk B"]
+        assert unscored == ["chunk C"]
+        assert all(r.rerank_score is None for r in results)  # inputs stay untouched
+
+    def test_pinned_top_keeps_blended_rerank_score(self, reranker):
+        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.expansion_skip_threshold = 0.8
+        results = [
+            _chunk("a.md", "exact match", relevance=0.9),
+            _chunk("b.md", "reranker favorite", relevance=0.5),
+        ]
+        with _patch_provider(lambda query, cands: [0.0, 1.0]):
+            reranked = reranker.rerank("test", results)
+        assert [c.chunk for c in reranked] == ["exact match", "reranker favorite"]
+        assert len(reranked) == 2  # the pin must not duplicate the top chunk
+        # The pin sentinel orders the list; the stamped score stays the real blend.
+        assert all(r.rerank_score is not None and r.rerank_score <= 1.0 for r in reranked)
 
     def test_sends_chunk_text_to_provider(self, reranker):
         cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
@@ -217,6 +248,47 @@ class TestGoldenOrdering:
         with _patch_provider(lambda query, cands: [0.1, 0.9]):
             reranked = reranker.rerank("test", results)
         assert [c.chunk for c in reranked] == ["B", "A"]
+
+
+class TestRerankChangesContext:
+    """Empirical gate: reranking changes WHICH chunks reach the model.
+
+    The cross-encoder favorite shares no surface terms with the question,
+    so term-coverage set cover alone can never select it.
+    """
+
+    _QUESTION = "radio resets and headlights dim at idle"
+
+    def _candidates(self) -> list[SearchChunk]:
+        return [
+            _chunk("dock.md", "radio resets when the laptop dock is plugged", relevance=0.9),
+            _chunk("lightbar.md", "headlights dim with the light bar load", relevance=0.8),
+            _chunk("battery.md", "battery log shows the radio and headlights draw", relevance=0.7),
+            _chunk("grounding.md", "grounding upgrade with one zero gauge cable", relevance=0.6),
+        ]
+
+    def test_reranking_changes_selected_context_set(self):
+        cfg.reranker_model = "gpustack/bge-reranker-v2-m3-GGUF/bge-Q4_K_M.gguf"
+        cfg.expansion_skip_threshold = 0.95  # top fusion hit stays below: no pin
+        reranker = Reranker(cfg)
+        searcher = Searcher(
+            cfg,
+            mock.MagicMock(),
+            mock.MagicMock(),
+            mock.MagicMock(),
+            reranker,
+            mock.MagicMock(),
+        )
+
+        baseline = searcher.select_context(self._candidates(), self._QUESTION, max_sources=3)
+        assert "grounding.md" not in {r.source for r in baseline}
+
+        with _patch_provider(lambda query, cands: [0.1, 0.2, 0.1, 1.0]):
+            reranked = reranker.rerank(self._QUESTION, self._candidates())
+        selected = searcher.select_context(reranked, self._QUESTION, max_sources=3)
+        sources = {r.source for r in selected}
+        assert "grounding.md" in sources
+        assert sources != {r.source for r in baseline}
 
 
 class TestMixedPoolBias:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -188,6 +188,7 @@ class TestAsk:
                     chunk="c",
                     chunk_index=0,
                     distance=0.1,
+                    rerank_score=0.8,
                     vector=[0.1],
                 )
             ],
@@ -196,6 +197,7 @@ class TestAsk:
         assert result.answer == "42"
         assert len(result.sources) == 1
         assert result.sources[0].distance == 0.1
+        assert result.sources[0].rerank_score == 0.8
 
     async def test_no_sources(self, mock_svc):
         from lilbee.retrieval.query import AskResult


### PR DESCRIPTION
## Problem

Enabling the cross-encoder reranker barely changed answers. The reranker reordered the candidates, but the final context chunks were then re-picked by a term-coverage pass that ignores rerank scores entirely. A note the reranker ranked first was dropped from context whenever it didn't share surface terms with the question, which is exactly the case reranking exists for.

## Solution

The rerank pass now stamps its blended score onto each scored result, and context selection treats the reranked order as authoritative when those scores are present, taking the top sources directly. With reranking off, or when the rerank pass fails, the term-coverage selection runs unchanged. Chat sources expose the score in the API, so stream and non-stream responses carry the same shape.

A new empirical gate test asserts that reranking changes the selected context set even when the reranker's top note shares no surface terms with the question.