### PR TITLE
Emit a proper SSE error event when a chat stream fails

### DIFF
--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncGenerator
 
 from litestar import get, post
@@ -15,6 +16,7 @@ from lilbee.data.store import EmbeddingModelMismatchError, scope_to_chunk_type
 from lilbee.retrieval.query import ChatMessage as ChatMessageDict
 from lilbee.server import handlers
 from lilbee.server.auth import read_only
+from lilbee.server.handlers.sse import sse_error
 from lilbee.server.models import (
     AskRequest,
     AskResponse,
@@ -27,6 +29,8 @@ from lilbee.server.models import (
 # stream blocks the client for many seconds with no feedback. Returning
 # 429 + Retry-After fast lets clients surface a real error and decide.
 # The lock binds to the worker's running event loop on first acquire.
+log = logging.getLogger(__name__)
+
 _chat_inflight_lock = asyncio.Lock()
 
 
@@ -68,11 +72,16 @@ async def _gated_stream(
 
     The lock must already be held when this is called. Release happens on
     natural completion, exception, and client-disconnect (GeneratorExit
-    fires the ``finally`` block).
+    fires the ``finally`` block). A failure inside the generator becomes an
+    SSE error event; raising after the 201 headers would drop the connection
+    with no body for the client to read.
     """
     try:
         async for chunk in generator:
             yield chunk
+    except Exception as exc:
+        log.exception("streaming chat handler failed")
+        yield sse_error(str(exc))
     finally:
         _chat_inflight_lock.release()
 
@@ -151,6 +160,10 @@ async def chat_route(data: ChatRequest) -> AskResponse:
         )
     except EmbeddingModelMismatchError as exc:
         raise _embedding_mismatch_http(exc) from exc
+    except ValueError as exc:
+        raise ValidationException(str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @post("/api/chat/stream")

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -46,6 +46,12 @@ async def mock_async_gen(*events):
         yield e
 
 
+async def mock_failing_gen(*events, exc):
+    for e in events:
+        yield e
+    raise exc
+
+
 class TestHealthRoute:
     @mock.patch(
         "lilbee.server.handlers.health",
@@ -240,6 +246,65 @@ class TestChatStreamRoute:
         )
         assert resp.status_code == 201
         assert mock_stream.call_args.kwargs.get("chunk_type") == "raw"
+
+
+class TestStreamErrorEvents:
+    """A failure inside a streaming handler surfaces as an SSE error event."""
+
+    @mock.patch("lilbee.server.handlers.chat_stream")
+    def test_chat_stream_failure_yields_sse_error(self, mock_stream, client):
+        mock_stream.return_value = mock_failing_gen(
+            exc=ValueError("Embedding dimension mismatch: expected 768, got 384")
+        )
+        resp = client.post("/api/chat/stream", json={"question": "hi", "history": []})
+        assert resp.status_code == 201
+        assert b"event: error" in resp.content
+        assert b"Embedding dimension mismatch" in resp.content
+
+    @mock.patch("lilbee.server.handlers.chat_stream")
+    def test_chat_stream_failure_mid_stream_yields_sse_error(self, mock_stream, client):
+        mock_stream.return_value = mock_failing_gen(
+            "event: token\ndata: {}\n\n", exc=RuntimeError("worker died")
+        )
+        resp = client.post("/api/chat/stream", json={"question": "hi", "history": []})
+        assert b"event: token" in resp.content
+        assert b"event: error" in resp.content
+        assert b"worker died" in resp.content
+
+    @mock.patch("lilbee.server.handlers.ask_stream")
+    def test_ask_stream_failure_yields_sse_error(self, mock_stream, client):
+        mock_stream.return_value = mock_failing_gen(exc=RuntimeError("boom"))
+        resp = client.post("/api/ask/stream", json={"question": "hi"})
+        assert resp.status_code == 201
+        assert b"event: error" in resp.content
+        assert b"boom" in resp.content
+
+    @mock.patch("lilbee.server.handlers.chat_stream")
+    def test_lock_released_after_stream_failure(self, mock_stream, client):
+        mock_stream.return_value = mock_failing_gen(exc=RuntimeError("boom"))
+        client.post("/api/chat/stream", json={"question": "hi", "history": []})
+        mock_stream.return_value = mock_async_gen("event: done\ndata: {}\n\n")
+        resp = client.post("/api/chat/stream", json={"question": "hi", "history": []})
+        assert resp.status_code == 201
+        assert b"event: done" in resp.content
+
+
+class TestChatRouteErrorMapping:
+    """chat_route maps errors like ask_route: ValueError 400, others 503."""
+
+    @mock.patch("lilbee.server.handlers.chat", new_callable=AsyncMock)
+    def test_value_error_maps_to_400(self, mock_chat, client):
+        mock_chat.side_effect = ValueError("Embedding dimension mismatch: expected 768, got 384")
+        resp = client.post("/api/chat", json={"question": "q", "history": []})
+        assert resp.status_code == 400
+        assert "Embedding dimension mismatch" in resp.json()["detail"]
+
+    @mock.patch("lilbee.server.handlers.chat", new_callable=AsyncMock)
+    def test_unexpected_error_maps_to_503(self, mock_chat, client):
+        mock_chat.side_effect = RuntimeError("worker died")
+        resp = client.post("/api/chat", json={"question": "q", "history": []})
+        assert resp.status_code == 503
+        assert "worker died" in resp.json()["detail"]
 
 
 class TestStreamSingleFlightGate:


### PR DESCRIPTION
## Problem
A failure inside a streaming chat handler after the 201 headers have gone out kills the connection with no body. Clients see a bare network error with no indication of what went wrong. A vault whose index dimension no longer matches the active embedder reproduced this on every chat: the `ValueError` from `validate_vector` escaped `_stream_rag_response`'s targeted catch and dropped the stream. The non-streaming `/api/chat` had the same gap and returned a blank 500, while `/api/ask` and `/api/search` already map these errors.

## Solution
`_gated_stream` now converts any failure from the wrapped generator into an SSE `error` event carrying the exception message, logs the traceback, and still releases the in-flight lock. This covers both `/api/ask/stream` and `/api/chat/stream` for anything the handlers' own error handling misses. `chat_route` gains the same `ValueError` → 400 and catch-all → 503 mapping `ask_route` already has.