### PR TITLE
Stop release CI from sharing CPU-native llama wheels across runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,15 @@ jobs:
           version: "latest"
       - run: uv python install 3.12
       - run: uv sync
+        env:
+          # AVX-baseline llama-cpp-python build; see the test job below.
+          CMAKE_ARGS: >-
+            -DGGML_METAL=OFF
+            -DGGML_NATIVE=OFF
+            -DGGML_BLAS=OFF
+            -DGGML_CUDA=OFF
+            -DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF
+            -DGGML_BMI2=OFF -DGGML_AVX_VNNI=OFF -DGGML_AVX512=OFF
       - run: make lint
       - run: make format-check
       - run: make typecheck
@@ -88,6 +97,18 @@ jobs:
           version: "latest"
       - run: uv python install 3.12
       - run: uv sync
+        env:
+          # llama-cpp-python is sdist-only; an unflagged build compiles ggml
+          # with -march=native, and the built wheel is shared across runners
+          # with different CPUs via the setup-uv cache, SIGILLing the test
+          # job. Cap at AVX baseline like ci.yml's test matrix.
+          CMAKE_ARGS: >-
+            -DGGML_METAL=OFF
+            -DGGML_NATIVE=OFF
+            -DGGML_BLAS=OFF
+            -DGGML_CUDA=OFF
+            -DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF
+            -DGGML_BMI2=OFF -DGGML_AVX_VNNI=OFF -DGGML_AVX512=OFF
       - run: make test-ci
         env:
           LILBEE_DATA: ${{ runner.temp }}/lilbee

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -63,7 +63,16 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --all-extras
         env:
-          CMAKE_ARGS: "-DGGML_METAL=OFF -DGGML_NATIVE=OFF"
+          # GGML_NATIVE=OFF alone still auto-enables AVX2/FMA/BMI2 from the
+          # build host; pin the AVX baseline so the cached wheel runs on any
+          # runner (matches ci.yml).
+          CMAKE_ARGS: >-
+            -DGGML_METAL=OFF
+            -DGGML_NATIVE=OFF
+            -DGGML_BLAS=OFF
+            -DGGML_CUDA=OFF
+            -DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF
+            -DGGML_BMI2=OFF -DGGML_AVX_VNNI=OFF -DGGML_AVX512=OFF
 
       - name: Run pip-audit
         uses: pypa/gh-action-pip-audit@v1.1.0


### PR DESCRIPTION
The release workflow's lint and test jobs run uv sync with no CMAKE_ARGS. llama-cpp-python is sdist-only, so whichever job builds it first compiles ggml with -march=native and the setup-uv cache hands that wheel to sibling jobs on different runners. Every release bumps uv.lock, which rotates the cache key, so each release run rebuilds the wheel and then plays runner-CPU roulette: if the test job lands on a CPU older than the lint job's, the first real Llama() call dies with an illegal instruction. That is what killed five xdist workers in run 27081428734 and blocked 0.6.66b492.

ci.yml already pins an AVX-baseline build for exactly this reason, so this mirrors those flags onto the release workflow's uv sync steps. security-scan.yml had GGML_NATIVE=OFF but not the AVX pinning, and ggml auto-enables AVX2/FMA/BMI2 from the build host even with NATIVE off, so it gets the same baseline.