### PR TITLE
Fix post-pull activation for catalog search models

### DIFF
--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -14,6 +14,7 @@ from lilbee.catalog.download_progress import ProgressCallback, _ProgressTracker
 from lilbee.catalog.featured import DEFAULT_MMPROJ_PATTERN, VISION_MMPROJ_FILES
 from lilbee.catalog.hf_client import DEFAULT_TIMEOUT, HF_API_URL, hf_headers, hf_token
 from lilbee.catalog.models import CatalogModel
+from lilbee.catalog.refs import pick_best_gguf
 from lilbee.catalog.types import ModelTask
 from lilbee.core.config.model import cfg
 from lilbee.runtime.cancellation import TaskCancelledError
@@ -227,9 +228,6 @@ def find_mmproj_file(model_ref: str) -> Path | None:
     return None
 
 
-_QUANT_PREFERENCE = ("Q4_K_M", "Q4_K_S", "Q5_K_M", "Q5_K_S", "Q8_0", "Q6_K", "Q3_K_M")
-
-
 def resolve_filename(entry: CatalogModel) -> str:
     """Resolve a GGUF filename pattern to the best concrete filename.
     For exact filenames, return as-is. For wildcards, query the HF API
@@ -262,16 +260,7 @@ def resolve_filename(entry: CatalogModel) -> str:
     if not gguf_files:
         raise RuntimeError(f"No GGUF files found in {entry.hf_repo}")
 
-    return _pick_best_gguf(gguf_files)
-
-
-def _pick_best_gguf(filenames: list[str]) -> str:
-    """Pick the best GGUF file by quantization preference."""
-    for quant in _QUANT_PREFERENCE:
-        for f in filenames:
-            if quant in f:
-                return f
-    return filenames[0]
+    return pick_best_gguf(gguf_files)
 
 
 _SIZE_UNKNOWN = 0
@@ -344,6 +333,6 @@ def fetch_model_file_size(hf_repo: str) -> float:
     if not gguf_files:
         return 0.0
 
-    best_name = _pick_best_gguf([name for name, _ in gguf_files])
+    best_name = pick_best_gguf([name for name, _ in gguf_files])
     size_bytes = next((s for n, s in gguf_files if n == best_name), 0)
     return round(size_bytes / (1024**3), 1) if size_bytes else 0.0

--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -14,6 +14,7 @@ from huggingface_hub.hf_api import RepoSibling
 
 from lilbee.catalog.compat import classify
 from lilbee.catalog.models import CatalogModel, HfGgufMeta, HfPage
+from lilbee.catalog.refs import GGUF_GLOB, pick_best_gguf
 from lilbee.core.config import cfg
 
 log = logging.getLogger(__name__)
@@ -114,6 +115,18 @@ def _hf_search_value(search: str) -> str:
 def _has_gguf_siblings(siblings: list[RepoSibling]) -> bool:
     """Return True if the sibling list contains at least one .gguf file."""
     return any(s.rfilename.endswith(".gguf") for s in siblings)
+
+
+def _resolve_sibling_gguf(siblings: list[RepoSibling]) -> str:
+    """Concrete GGUF filename for a repo's sibling list, or ``GGUF_GLOB``.
+
+    Uses the same quant picker as the pull path so the filename a catalog
+    row carries always names the file a pull of that row produces.
+    """
+    gguf_files = [s.rfilename for s in siblings if s.rfilename.endswith(".gguf")]
+    if not gguf_files:
+        return GGUF_GLOB
+    return pick_best_gguf(gguf_files)
 
 
 def _estimate_size_from_siblings(siblings: list[RepoSibling]) -> float:
@@ -230,7 +243,7 @@ class HfClient:
             models.append(
                 CatalogModel(
                     hf_repo=item.id,
-                    gguf_filename="*.gguf",
+                    gguf_filename=_resolve_sibling_gguf(item.siblings or []),
                     size_gb=size_gb,
                     min_ram_gb=round(max(2.0, size_gb * 1.5), 1),
                     description=card_desc[:120] if card_desc else "",

--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -112,11 +112,6 @@ def _hf_search_value(search: str) -> str:
     return " ".join(tokens)
 
 
-def _has_gguf_siblings(siblings: list[RepoSibling]) -> bool:
-    """Return True if the sibling list contains at least one .gguf file."""
-    return any(s.rfilename.endswith(".gguf") for s in siblings)
-
-
 def _resolve_sibling_gguf(siblings: list[RepoSibling]) -> str:
     """Concrete GGUF filename for a repo's sibling list, or ``GGUF_GLOB``.
 

--- a/src/lilbee/catalog/query.py
+++ b/src/lilbee/catalog/query.py
@@ -8,7 +8,7 @@ from huggingface_hub.utils import HFValidationError, validate_repo_id
 from lilbee.app.services import get_services
 from lilbee.catalog.featured import FEATURED_ALL
 from lilbee.catalog.models import CatalogModel, CatalogResult
-from lilbee.catalog.refs import format_native_gguf_ref, hf_repo_from_ref
+from lilbee.catalog.refs import GGUF_GLOB, format_native_gguf_ref, hf_repo_from_ref
 from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
 
 
@@ -227,7 +227,7 @@ def build_adhoc_entry(hf_repo: str, *, task: ModelTask = ModelTask.CHAT) -> Cata
     """Minimal CatalogModel for a non-featured HuggingFace GGUF repo."""
     return CatalogModel(
         hf_repo=hf_repo,
-        gguf_filename="*.gguf",
+        gguf_filename=GGUF_GLOB,
         size_gb=0.0,
         min_ram_gb=2.0,
         description="",

--- a/src/lilbee/catalog/refs.py
+++ b/src/lilbee/catalog/refs.py
@@ -2,6 +2,24 @@
 
 from __future__ import annotations
 
+GGUF_GLOB = "*.gguf"
+
+_QUANT_PREFERENCE = ("Q4_K_M", "Q4_K_S", "Q5_K_M", "Q5_K_S", "Q8_0", "Q6_K", "Q3_K_M")
+
+
+def pick_best_gguf(filenames: list[str]) -> str:
+    """Pick the best GGUF file by quantization preference."""
+    for quant in _QUANT_PREFERENCE:
+        for f in filenames:
+            if quant in f:
+                return f
+    return filenames[0]
+
+
+def is_bare_hf_repo(ref: str) -> bool:
+    """True if *ref* has the bare ``<org>/<repo>`` shape (no filename segment)."""
+    return ref.count("/") == 1 and not ref.endswith(".gguf")
+
 
 def hf_repo_from_ref(ref: str) -> str:
     """Return the ``<org>/<repo>`` portion of a native GGUF ref.

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -399,6 +399,15 @@ class ModelRegistry:
             return None
         return self._read_manifest(hf_repo, gguf_filename)
 
+    def installed_ref_for_repo(self, hf_repo: str) -> str | None:
+        """Full ``<repo>/<file>.gguf`` ref of an installed quant of *hf_repo*, or None.
+
+        Alphabetical-first when several quants are installed, matching
+        ``_resolve_repo_only``'s determinism.
+        """
+        refs = sorted(m.ref for m in self.list_installed() if m.hf_repo == hf_repo)
+        return refs[0] if refs else None
+
     def _manifest_path(self, hf_repo: str, gguf_filename: str) -> Path:
         repo = _validate_hf_repo(hf_repo)
         filename = _validate_gguf_filename(gguf_filename)

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -19,7 +19,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from lilbee.catalog.refs import format_native_gguf_ref
+from lilbee.catalog.refs import format_native_gguf_ref, is_bare_hf_repo
 from lilbee.core.config.model import cfg
 from lilbee.core.security import validate_path_within
 
@@ -148,7 +148,7 @@ class ModelRegistry:
         upgrade keep working without anyone purging their lilbee data dir; it is
         deliberately the exception here, not a pattern to follow elsewhere.
         """
-        if not ref.endswith(".gguf") and ref.count("/") == 1:
+        if is_bare_hf_repo(ref):
             return self._resolve_repo_only(_validate_hf_repo(ref))
         hf_repo, gguf_filename = parse_hf_ref(ref)
         manifest = self._read_manifest(hf_repo, gguf_filename)

--- a/src/lilbee/modelhub/role_validator.py
+++ b/src/lilbee/modelhub/role_validator.py
@@ -5,6 +5,7 @@ import sys
 from typing import Any
 
 from lilbee.catalog import find_catalog_entry
+from lilbee.catalog.refs import is_bare_hf_repo
 from lilbee.catalog.types import ModelTask
 from lilbee.core.config import cfg
 from lilbee.modelhub.model_manager.discovery import reclassify_by_name
@@ -48,9 +49,9 @@ def _model_task_validation_bypassed() -> bool:
     return sys.modules.get("pytest") is not None
 
 
-def _resolve_installed_task(ref: str) -> ModelTask | None:
+def _resolve_installed_task(registry: ModelRegistry, ref: str) -> ModelTask | None:
     """Return the manifest's ``ModelTask`` for *ref*, name-reclassified, or ``None``."""
-    manifest = ModelRegistry(cfg.models_dir).get_manifest(ref)
+    manifest = registry.get_manifest(ref)
     if manifest is None:
         return None
     return ModelTask(reclassify_by_name(ref, manifest.task))
@@ -78,8 +79,15 @@ def _canonical_featured_ref(ref: str, entry: Any, want: ModelTask) -> str:
 
 
 def _validate_installed_ref(ref: str, want: ModelTask) -> str:
-    """Role-check a non-featured ref by consulting the installed registry."""
-    installed_task = _resolve_installed_task(ref)
+    """Role-check a non-featured ref by consulting the installed registry.
+
+    A bare ``<org>/<repo>`` ref canonicalizes to its installed quant's full
+    ref so the persisted value always names the exact GGUF file.
+    """
+    registry = ModelRegistry(cfg.models_dir)
+    if is_bare_hf_repo(ref):
+        ref = registry.installed_ref_for_repo(ref) or ref
+    installed_task = _resolve_installed_task(registry, ref)
     if installed_task is None:
         raise ValueError(
             f"Model '{ref}' is not installed. "

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -23,7 +23,7 @@ from lilbee.catalog import (
     get_catalog,
     get_families,
 )
-from lilbee.catalog.refs import hf_repo_from_ref
+from lilbee.catalog.refs import hf_repo_from_ref, is_bare_hf_repo
 from lilbee.catalog.types import CatalogSize, CatalogSort, KeyStatus, ModelSource, ModelTask
 from lilbee.core.config import cfg
 from lilbee.modelhub.model_manager import classify_all_remote_models, discover_api_models
@@ -168,6 +168,18 @@ def _resolve_via_catalog(model: str, available: set[str]) -> str | None:
     return next((ref for ref in available if ref.startswith(f"{entry.hf_repo}/")), None)
 
 
+def _resolve_via_installed_repo(model: str, available: set[str]) -> str | None:
+    """Resolve a bare ``hf_repo`` to its installed quant, featured or not.
+
+    Only refs the provider also lists are accepted, so remote-only
+    provider modes don't activate a model they can't serve.
+    """
+    if not is_bare_hf_repo(model):
+        return None
+    ref = get_services().registry.installed_ref_for_repo(model)
+    return ref if ref in available else None
+
+
 def _resolve_via_parse(model: str, available: set[str]) -> str | None:
     """Resolve a provider-prefixed ref against *available*.
 
@@ -210,6 +222,7 @@ def _require_model_available(model: str) -> str:
         return model
     hit = (
         _resolve_via_catalog(model, available)
+        or _resolve_via_installed_repo(model, available)
         or _resolve_via_parse(model, available)
         or _resolve_via_provider_key(model)
     )

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -161,11 +161,14 @@ async def _set_model(
 
 
 def _resolve_via_catalog(model: str, available: set[str]) -> str | None:
-    """Resolve a bare ``hf_repo`` to whichever quant of it is in *available*."""
+    """Resolve a bare ``hf_repo`` to whichever quant of it is in *available*.
+
+    Sorted scan so the pick is deterministic when several quants are installed.
+    """
     entry = find_catalog_entry(model)
     if entry is None:
         return None
-    return next((ref for ref in available if ref.startswith(f"{entry.hf_repo}/")), None)
+    return next((ref for ref in sorted(available) if ref.startswith(f"{entry.hf_repo}/")), None)
 
 
 def _resolve_via_installed_repo(model: str, available: set[str]) -> str | None:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -48,6 +48,7 @@ from lilbee.catalog import (
 )
 from lilbee.catalog.hf_client import hf_token
 from lilbee.catalog.models import HfPage
+from lilbee.catalog.refs import GGUF_GLOB, is_bare_hf_repo, pick_best_gguf
 from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
 from lilbee.core.config import cfg
 
@@ -346,6 +347,23 @@ class TestFetchHfModels:
         assert models[0].downloads == 5000
         assert models[0].featured is False
         assert models[0].task == "chat"
+
+    def test_resolves_concrete_gguf_filename_from_siblings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Search rows carry the quant the pull path would pick, not a glob."""
+        mock_resp = httpx.Response(200, json=self._mock_hf_response())
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
+        models = get_services().hf_client.fetch_models().models
+        assert models[0].gguf_filename == "model-7b-Q4_K_M.gguf"
+        assert models[1].gguf_filename == "model-13b-Q4_K_M.gguf"
+
+    def test_no_gguf_siblings_keeps_glob_filename(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        data = [{"id": "user/model", "downloads": 1, "siblings": [{"rfilename": "README.md"}]}]
+        mock_resp = httpx.Response(200, json=data)
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: mock_resp)
+        models = get_services().hf_client.fetch_models().models
+        assert models[0].gguf_filename == GGUF_GLOB
 
     def test_estimates_size_from_gguf_total(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_resp = httpx.Response(200, json=self._mock_hf_response())
@@ -1052,11 +1070,24 @@ class TestResolveFilename:
 
     def test_pick_best_gguf_prefers_q4_k_m(self) -> None:
         files = ["model-Q8_0.gguf", "model-Q4_K_M.gguf", "model-Q5_K_M.gguf"]
-        assert _download._pick_best_gguf(files) == "model-Q4_K_M.gguf"
+        assert pick_best_gguf(files) == "model-Q4_K_M.gguf"
 
     def test_pick_best_gguf_fallback_first(self) -> None:
         files = ["model-weird.gguf"]
-        assert _download._pick_best_gguf(files) == "model-weird.gguf"
+        assert pick_best_gguf(files) == "model-weird.gguf"
+
+
+class TestIsBareHfRepo:
+    @pytest.mark.parametrize("value", ["Qwen/Qwen3-8B-GGUF", "bartowski/SmolLM2-360M-GGUF"])
+    def test_accepts_bare_repos(self, value: str) -> None:
+        assert is_bare_hf_repo(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["Qwen/Qwen3-8B-GGUF/q4.gguf", "Qwen/file.gguf", "qwen3:0.6b", "a/b/c", ""],
+    )
+    def test_rejects_other_shapes(self, value: str) -> None:
+        assert is_bare_hf_repo(value) is False
 
 
 class TestTaskToPipeline:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -277,17 +277,21 @@ class TestIsRerankRef:
         assert is_rerank_ref("bogus/not-real") is False
 
 
-class TestHasGgufSiblings:
-    def test_returns_true_when_gguf_present(self) -> None:
-        siblings = [RepoSibling(rfilename="model-Q4_K_M.gguf"), RepoSibling(rfilename="README.md")]
-        assert _hf_client._has_gguf_siblings(siblings) is True
+class TestResolveSiblingGguf:
+    def test_picks_preferred_quant(self) -> None:
+        siblings = [
+            RepoSibling(rfilename="model-Q8_0.gguf"),
+            RepoSibling(rfilename="model-Q4_K_M.gguf"),
+            RepoSibling(rfilename="README.md"),
+        ]
+        assert _hf_client._resolve_sibling_gguf(siblings) == "model-Q4_K_M.gguf"
 
-    def test_returns_false_when_no_gguf(self) -> None:
+    def test_no_gguf_returns_glob(self) -> None:
         siblings = [RepoSibling(rfilename="model.bin"), RepoSibling(rfilename="config.json")]
-        assert _hf_client._has_gguf_siblings(siblings) is False
+        assert _hf_client._resolve_sibling_gguf(siblings) == GGUF_GLOB
 
-    def test_returns_false_for_empty_list(self) -> None:
-        assert _hf_client._has_gguf_siblings([]) is False
+    def test_empty_list_returns_glob(self) -> None:
+        assert _hf_client._resolve_sibling_gguf([]) == GGUF_GLOB
 
 
 class TestEstimateSizeFromSiblings:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1543,6 +1543,13 @@ class TestValidateModelTaskAssignment:
         )
         assert result == ref
 
+    def test_bare_non_featured_repo_without_install_rejected(self, _task_validation_enabled):
+        """A bare non-featured repo with no installed quant is rejected as not installed."""
+        from lilbee.modelhub.role_validator import validate_model_task_assignment
+
+        with pytest.raises(ValueError, match="not installed"):
+            validate_model_task_assignment("chat_model", "org/Never-Pulled-GGUF")
+
     def test_installed_non_featured_wrong_role_rejected(self, _task_validation_enabled):
         """An installed non-featured chat model in the reranker slot raises TaskMismatchError."""
         from lilbee.catalog.types import ModelTask

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1528,6 +1528,21 @@ class TestValidateModelTaskAssignment:
         )
         assert validate_model_task_assignment("chat_model", ref) == ref
 
+    def test_bare_non_featured_repo_canonicalizes_to_installed_quant(
+        self, _task_validation_enabled
+    ):
+        """A bare non-featured repo persists as the installed quant's full ref."""
+        from lilbee.modelhub.role_validator import validate_model_task_assignment
+        from tests.conftest import install_fake_model
+
+        ref = install_fake_model(
+            "bartowski/SmolLM2-360M-Instruct-GGUF", "SmolLM2-360M-Q4_K_M.gguf", task="chat"
+        )
+        result = validate_model_task_assignment(
+            "chat_model", "bartowski/SmolLM2-360M-Instruct-GGUF"
+        )
+        assert result == ref
+
     def test_installed_non_featured_wrong_role_rejected(self, _task_validation_enabled):
         """An installed non-featured chat model in the reranker slot raises TaskMismatchError."""
         from lilbee.catalog.types import ModelTask

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -653,6 +653,24 @@ class TestModelRegistryWriteManifestErrors:
         assert leftovers == []
 
 
+class TestInstalledRefForRepo:
+    def test_returns_installed_quant_ref(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        registry.install(_REPO, _FILENAME, _write_source(tmp_path), _make_manifest())
+        assert registry.installed_ref_for_repo(_REPO) == _REF
+
+    def test_multiple_quants_picks_alphabetical_first(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        registry.install(_REPO, "z-Q8_0.gguf", _write_source(tmp_path), _make_manifest())
+        registry.install(_REPO, "a-Q4_K_M.gguf", _write_source(tmp_path), _make_manifest())
+        assert registry.installed_ref_for_repo(_REPO) == f"{_REPO}/a-Q4_K_M.gguf"
+
+    def test_unknown_repo_returns_none(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        registry.install(_REPO, _FILENAME, _write_source(tmp_path), _make_manifest())
+        assert registry.installed_ref_for_repo("other/Repo-GGUF") is None
+
+
 class TestModelRegistryGetManifest:
     def test_get_manifest(self, tmp_path: Path) -> None:
         registry = ModelRegistry(tmp_path)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1027,6 +1027,13 @@ class TestSetChatModel:
         assert result.model == _CHAT_REF
         assert cfg.chat_model == _CHAT_REF
 
+    async def test_bare_repo_with_two_quants_resolves_deterministically(self, tmp_path, mock_svc):
+        """With several quants installed, the alphabetically-first ref wins."""
+        other = "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf"
+        mock_svc.provider.list_models.return_value = [_CHAT_REF, other]
+        result = await handlers.set_chat_model("Qwen/Qwen3-0.6B-GGUF")
+        assert result.model == other
+
     async def test_resolves_bare_non_featured_repo_to_installed_quant(self, tmp_path, mock_svc):
         """A bare repo outside the featured catalog resolves via the registry.
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1027,6 +1027,28 @@ class TestSetChatModel:
         assert result.model == _CHAT_REF
         assert cfg.chat_model == _CHAT_REF
 
+    async def test_resolves_bare_non_featured_repo_to_installed_quant(self, tmp_path, mock_svc):
+        """A bare repo outside the featured catalog resolves via the registry.
+
+        This is the post-pull activation path for catalog-search models: the
+        client falls back to the bare repo and the server finds the quant the
+        pull installed.
+        """
+        custom = install_fake_model("org/Search-Hit-GGUF", "search-hit-Q4_K_M.gguf", task="chat")
+        mock_svc.provider.list_models.return_value = [custom]
+        mock_svc.registry.installed_ref_for_repo.return_value = custom
+        result = await handlers.set_chat_model("org/Search-Hit-GGUF")
+        assert result.model == custom
+        assert cfg.chat_model == custom
+
+    async def test_bare_repo_not_routable_stays_rejected(self, tmp_path, mock_svc):
+        """An installed quant the provider doesn't list is not activated."""
+        custom = install_fake_model("org/Search-Hit-GGUF", "search-hit-Q4_K_M.gguf", task="chat")
+        mock_svc.provider.list_models.return_value = []
+        mock_svc.registry.installed_ref_for_repo.return_value = custom
+        with pytest.raises(ValueError, match="not available"):
+            await handlers.set_chat_model("org/Search-Hit-GGUF")
+
     async def test_accepts_installed_out_of_catalog_chat_model(self, tmp_path, mock_svc):
         """A non-featured chat model installed locally IS assignable to chat_model.
 


### PR DESCRIPTION
## Problem
Every catalog row built from HF search carried `gguf_filename='*.gguf'`. The pull resolved the glob to a real quant, but activation never learned which one: the Obsidian plugin falls back to the bare repo for glob filenames, and set-chat-model only resolves bare repos that are featured. Pulling any model found via catalog search succeeded and then immediately toasted 'Failed to set <repo>' (visible in the tour reel with bartowski/SmolLM2-360M-Instruct-GGUF). Featured entries whose filename is a glob (the `*Q8_0.gguf` pins) hit the same fallback.

## Solution
Search rows now resolve a concrete filename from the siblings the HF listing already returns, using the same quant picker as the pull path, so the filename a row shows is the file a pull produces. Activation also accepts a bare repo for any installed model, not just featured ones: the role validator canonicalizes it to the installed quant's full ref at the shared write boundary, so HTTP, MCP, CLI, and TUI all behave the same, and the resolution is deterministic when several quants are installed.

Covered by unit tests across the catalog client, registry, role validator, and the set-model handlers; full suite green at 100% coverage.