### PR TITLE
RAG answer quality: grounded refusal, context budgeting, cited subset, surfaced ANN failures

### DIFF
--- a/src/lilbee/cli/commands/search_chat.py
+++ b/src/lilbee/cli/commands/search_chat.py
@@ -188,6 +188,7 @@ def ask(
                     "question": question,
                     "answer": result.answer,
                     "sources": [clean_result(s) for s in result.sources],
+                    "cited_sources": [clean_result(s) for s in result.cited_sources],
                 }
             )
             return

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -377,7 +377,14 @@ class Store:
                 log.info("Vector ANN index created on '%s'", CHUNKS_TABLE)
                 return True
             except Exception:
-                log.debug("Vector index build failed (too few rows?)", exc_info=True)
+                log.warning(
+                    "Vector ANN index build failed on '%s' at %d rows; search falls back "
+                    "to exact flat scan, which is slow at this scale. Free up memory/disk "
+                    "and re-run to rebuild the index.",
+                    CHUNKS_TABLE,
+                    table.count_rows(),
+                    exc_info=True,
+                )
                 return False
 
     def add_chunks(self, records: list[dict]) -> int:

--- a/src/lilbee/retrieval/query/formatting.py
+++ b/src/lilbee/retrieval/query/formatting.py
@@ -95,6 +95,12 @@ def _extract_cited_indices(text: str) -> set[int]:
     return {int(m.group(1)) for m in _CITE_REF_RE.finditer(text)}
 
 
+def cited_subset(answer: str, sources: list[SearchChunk]) -> list[SearchChunk]:
+    """The sources the answer actually cited via [n] markers, in order (empty if none)."""
+    cited = _extract_cited_indices(answer)
+    return [sources[i - 1] for i in sorted(cited) if 1 <= i <= len(sources)]
+
+
 def strip_llm_citations(text: str) -> str:
     """Remove LLM-generated trailing citation blocks from answer text."""
     return _LLM_CITATION_BLOCK_RE.sub("", text).rstrip()

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -7,7 +7,7 @@ from collections.abc import Generator
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from lilbee.core.config import Config
@@ -33,10 +33,11 @@ from lilbee.retrieval.query.dedup import (
 from lilbee.retrieval.query.expansion import EXPANSION_MAX_TOKENS, EXPANSION_PROMPT
 from lilbee.retrieval.query.formatting import (
     CONTEXT_TEMPLATE,
-    _extract_cited_indices,
     build_context,
+    cited_subset,
     strip_llm_citations,
 )
+from lilbee.retrieval.query.history_window import estimate_text_tokens
 from lilbee.retrieval.query.memory import format_memory_block
 from lilbee.retrieval.query.tokenize import _idf_weights, _tokenize
 from lilbee.retrieval.reasoning import (
@@ -57,6 +58,18 @@ log = logging.getLogger(__name__)
 # scores for the expansion-skip heuristic.
 _MIN_BM25_PROBE_RESULTS = 2
 
+# RAG mode answer when retrieval finds no usable sources: a grounded refusal
+# instead of free-wheeling on the model's parametric knowledge. Users who want
+# off-corpus answers can switch to chat mode.
+_GROUNDED_REFUSAL = "I couldn't find anything in the indexed documents that answers that."
+
+# Token reserve for the generated answer when budgeting RAG context to num_ctx.
+_ANSWER_RESERVE_TOKENS = 1024
+# Approximate token cost of the Context/Question template wrapper.
+_CONTEXT_TEMPLATE_TOKENS = 16
+# Approximate per-source overhead: the "[i] " marker plus blank-line separator.
+_PER_SOURCE_TOKENS = 8
+
 
 class ChatMessage(TypedDict):
     """A single chat message with role and content."""
@@ -66,10 +79,16 @@ class ChatMessage(TypedDict):
 
 
 class AskResult(BaseModel):
-    """Structured result from ask_raw -- answer text + raw search results."""
+    """Structured result from ask_raw: answer text, retrieved sources, and the cited subset.
+
+    ``sources`` is the full retrieved/reranked set; ``cited_sources`` is the subset the
+    answer actually referenced via [n] markers (empty when it cited nothing), so a JSON
+    consumer can tell whether the answer was grounded without re-parsing the text.
+    """
 
     answer: str
     sources: list[SearchChunk]
+    cited_sources: list[SearchChunk] = Field(default_factory=list)
 
 
 class Searcher:
@@ -417,18 +436,53 @@ class Searcher:
             results = self._reranker.rerank(question, results)
         results = self._apply_temporal_filter(results, question)
         results = self.select_context(results, question)
+        system = self._system_with_memory(self._config.rag_system_prompt, question)
+        results = self._fit_context_budget(results, system, question, history)
         context = build_context(results)
         prompt = CONTEXT_TEMPLATE.format(context=context, question=question)
-        messages: list[ChatMessage] = [
-            {
-                "role": "system",
-                "content": self._system_with_memory(self._config.rag_system_prompt, question),
-            }
-        ]
+        messages: list[ChatMessage] = [{"role": "system", "content": system}]
         if history:
             messages.extend(history)
         messages.append({"role": "user", "content": prompt})
         return results, messages
+
+    def _fit_context_budget(
+        self,
+        results: list[SearchChunk],
+        system: str,
+        question: str,
+        history: list[ChatMessage] | None,
+    ) -> list[SearchChunk]:
+        """Drop the lowest-ranked sources until the assembled prompt fits num_ctx.
+
+        ``max_context_sources`` caps by count; this caps by tokens so a
+        retrieval-heavy query degrades gracefully instead of erroring with
+        CONTEXT_OVERFLOW. The top-ranked source is always kept.
+        """
+        ctx = self._config.num_ctx or self._config.chat_n_ctx_target
+        reserve = (
+            estimate_text_tokens(system)
+            + estimate_text_tokens(question)
+            + sum(estimate_text_tokens(m["content"]) for m in history or [])
+            + _ANSWER_RESERVE_TOKENS
+            + _CONTEXT_TEMPLATE_TOKENS
+        )
+        budget = ctx - reserve
+        kept: list[SearchChunk] = []
+        used = 0
+        for r in results:
+            cost = estimate_text_tokens(r.chunk) + _PER_SOURCE_TOKENS
+            if kept and used + cost > budget:
+                break
+            kept.append(r)
+            used += cost
+        if len(kept) < len(results):
+            log.info(
+                "Kept %d of %d sources to fit the model context window.",
+                len(kept),
+                len(results),
+            )
+        return kept
 
     def _system_with_memory(self, base_prompt: str, question: str) -> str:
         """Append the local-owner memory block to *base_prompt* when memory is enabled."""
@@ -511,14 +565,14 @@ class Searcher:
             return AskResult(answer=self._direct_chat(question, history, options), sources=[])
         rag = self.build_rag_context(question, top_k=top_k, history=history, chunk_type=chunk_type)
         if rag is None:
-            return AskResult(answer=self._direct_chat(question, history, options), sources=[])
+            return AskResult(answer=_GROUNDED_REFUSAL, sources=[])
         results, messages = rag
         provider_messages = self._messages_for_provider(messages)
         opts = options if options is not None else self._config.generation_options()
         result = self._provider.chat(provider_messages, options=opts or None)
         raw = result.text
         clean = raw if self._config.show_reasoning else strip_reasoning(raw)
-        return AskResult(answer=clean, sources=results)
+        return AskResult(answer=clean, sources=results, cited_sources=cited_subset(clean, results))
 
     def ask(
         self,
@@ -535,10 +589,8 @@ class Searcher:
         )
         if not result.sources:
             return result.answer
-        cited = _extract_cited_indices(result.answer)
-        used = [result.sources[i - 1] for i in sorted(cited) if 1 <= i <= len(result.sources)]
         answer = strip_llm_citations(result.answer)
-        source_list = used if used else result.sources
+        source_list = result.cited_sources if result.cited_sources else result.sources
         citations = deduplicate_sources(source_list)
         return f"{answer}\n\nSources:\n" + "\n".join(citations)
 
@@ -584,7 +636,7 @@ class Searcher:
 
         rag = self.build_rag_context(question, top_k=top_k, history=history, chunk_type=chunk_type)
         if rag is None:
-            yield from self._stream_direct(question, history, options)
+            yield StreamToken(content=_GROUNDED_REFUSAL, is_reasoning=False)
             return
         results, messages = rag
         provider_messages = self._messages_for_provider(messages)
@@ -609,8 +661,7 @@ class Searcher:
         # retroactively stripped. The system prompt discourages them; this
         # only filters the code-appended Sources block to cited chunks.
         full_answer = "".join(answer_parts)
-        cited = _extract_cited_indices(full_answer)
-        used = [results[i - 1] for i in sorted(cited) if 1 <= i <= len(results)]
+        used = cited_subset(full_answer, results)
         source_list = used if used else results
         citations = deduplicate_sources(source_list)
         yield StreamToken(content="\n\nSources:\n" + "\n".join(citations), is_reasoning=False)

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -19,6 +19,7 @@ from lilbee.core.results import DocumentResult, group
 from lilbee.data.store import ChunkType, EmbeddingModelMismatchError
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.roles import WorkerRole
+from lilbee.retrieval.query.formatting import cited_subset
 from lilbee.retrieval.reasoning import (
     CAP_CONTINUATION_PROMPT,
     CAP_NOTICE_TEMPLATE,
@@ -106,6 +107,7 @@ async def ask(
     return AskResponse(
         answer=result.answer,
         sources=[CleanedChunk(**clean_result(s)) for s in result.sources],
+        cited_sources=[CleanedChunk(**clean_result(s)) for s in result.cited_sources],
     )
 
 
@@ -271,6 +273,7 @@ async def chat(
     return AskResponse(
         answer=answer,
         sources=[CleanedChunk(**clean_result(s)) for s in sources],
+        cited_sources=[CleanedChunk(**clean_result(s)) for s in cited_subset(answer, sources)],
     )
 
 

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -179,10 +179,15 @@ class HealthResponse(BaseModel):
 
 
 class AskResponse(BaseModel):
-    """Response for /api/ask and /api/chat."""
+    """Response for /api/ask and /api/chat.
+
+    ``sources`` is the full retrieved set; ``cited_sources`` is the subset the answer
+    actually cited, so a client can tell a grounded answer from an off-corpus one.
+    """
 
     answer: str
     sources: list[CleanedChunk]
+    cited_sources: list[CleanedChunk] = Field(default_factory=list)
 
 
 class SetModelResponse(BaseModel):

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -505,6 +505,7 @@ async def test_action_select_tab_swallows_missing_tabs(monkeypatch) -> None:
         screen.action_select_tab(2)
 
 
+@pytest.mark.xdist_group("tui_pilot")
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="ModelList population race on Windows Textual; passes on Linux/macOS",

--- a/tests/test_chat_memory_commands.py
+++ b/tests/test_chat_memory_commands.py
@@ -133,13 +133,16 @@ def _patch_active_tasks(monkeypatch, queue, tasks):
 
 
 async def test_maybe_extract_skips_while_indexing(mock_svc, monkeypatch):
-    from types import SimpleNamespace
+    from lilbee.cli.tui.task_queue import Task, TaskType
 
     cfg.memory_enabled = True
     cfg.memory_auto_extract = True
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
-        _patch_active_tasks(monkeypatch, app.task_bar.queue, [SimpleNamespace(task_type="sync")])
+        # A real Task carries every field the task-bar timer reads when a tick
+        # lands mid-test; a bare SimpleNamespace stub raced the timer (bb-5ze).
+        task = Task(task_id="t1", name="Indexing", task_type=TaskType.SYNC.value, fn=lambda: None)
+        _patch_active_tasks(monkeypatch, app.task_bar.queue, [task])
         with patch.object(app.screen, "_extract_memories_worker") as worker:
             app.screen._maybe_extract_memories("q", "a")
             await pilot.pause()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1912,6 +1912,9 @@ class TestAskJson:
         assert len(data["sources"]) == 1
         assert "vector" not in data["sources"][0]
         assert "distance" in data["sources"][0]
+        # bb-ky3: cited_sources is present and empty when the answer cited nothing,
+        # so a JSON consumer can tell a grounded answer from an off-corpus one.
+        assert data["cited_sources"] == []
 
     @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_json_no_results(self, mock_sync, mock_svc):
@@ -1925,6 +1928,32 @@ class TestAskJson:
         data = json.loads(result.output.strip())
         assert data["sources"] == []
         assert "No relevant" in data["answer"]
+
+    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_json_reports_cited_subset(self, mock_sync, mock_svc):
+        """bb-ky3: cited_sources carries only the source the answer actually cited."""
+        from lilbee.retrieval.query import AskResult
+
+        cited = SearchChunk(
+            source="manual.pdf",
+            content_type="pdf",
+            page_start=1,
+            page_end=1,
+            line_start=0,
+            line_end=0,
+            chunk="oil",
+            chunk_index=0,
+            distance=0.3,
+            vector=[0.1],
+        )
+        mock_svc.searcher.ask_raw.return_value = AskResult(
+            answer="5 quarts [1]", sources=[cited], cited_sources=[cited]
+        )
+        result = runner.invoke(app, ["--json", "ask", "oil capacity?"])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert [s["source"] for s in data["cited_sources"]] == ["manual.pdf"]
+        assert "vector" not in data["cited_sources"][0]
 
 
 class TestAskModelNotFound:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -16,7 +16,12 @@ from lilbee.retrieval.query import (
     strip_llm_citations,
 )
 from lilbee.retrieval.query.dedup import _relevance_weight
-from lilbee.retrieval.query.formatting import _extract_cited_indices, _format_citation
+from lilbee.retrieval.query.formatting import (
+    _extract_cited_indices,
+    _format_citation,
+    cited_subset,
+)
+from lilbee.retrieval.query.searcher import _GROUNDED_REFUSAL
 from tests.conftest import make_citation
 
 
@@ -516,6 +521,93 @@ class TestExpandQuery:
         assert concept_batch == ["kubernetes", "scheduling"]
 
 
+class TestFormattingHelpers:
+    def test_cited_subset_maps_markers_in_order(self):
+        sources = [_make_result(source="a.pdf"), _make_result(source="b.pdf")]
+        assert [s.source for s in cited_subset("see [2], then [2] again", sources)] == ["b.pdf"]
+
+    def test_cited_subset_empty_when_no_markers(self):
+        assert cited_subset("no markers here", [_make_result()]) == []
+
+    def test_cited_subset_ignores_out_of_range_markers(self):
+        assert cited_subset("[5] does not exist", [_make_result()]) == []
+
+
+class TestCitedSources:
+    """bb-ky3: ask_raw exposes the answer's cited subset so JSON consumers get
+    the same citation truth the string method computes."""
+
+    def test_ask_raw_cited_sources_is_the_cited_subset(self, mock_svc):
+        mock_svc.store.search.return_value = [
+            _make_result(source="a.pdf", chunk="alpha", distance=0.1),
+            _make_result(source="b.pdf", chunk="beta", distance=0.2),
+        ]
+        mock_svc.provider.chat.return_value = _text_result("As shown in [2].")
+        result = get_services().searcher.ask_raw("q")
+        assert len(result.sources) == 2
+        assert [s.source for s in result.cited_sources] == ["b.pdf"]
+
+    def test_ask_raw_cited_sources_empty_when_uncited(self, mock_svc):
+        mock_svc.store.search.return_value = [_make_result(chunk="alpha")]
+        mock_svc.provider.chat.return_value = _text_result("No markers in this answer.")
+        result = get_services().searcher.ask_raw("q")
+        assert result.sources
+        assert result.cited_sources == []
+
+    def test_ask_lists_only_the_cited_source(self, mock_svc):
+        mock_svc.store.search.return_value = [
+            _make_result(source="a.pdf", chunk="alpha", distance=0.1),
+            _make_result(source="b.pdf", chunk="beta", distance=0.2),
+        ]
+        mock_svc.provider.chat.return_value = _text_result("From [1] we learn the answer.")
+        answer = get_services().searcher.ask("q")
+        assert "a.pdf" in answer
+        assert "b.pdf" not in answer
+
+
+class TestContextBudget:
+    """bb-6kt: RAG sources are trimmed to fit num_ctx instead of overflow-erroring."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_ctx(self):
+        old = (cfg.num_ctx, cfg.chat_n_ctx_target)
+        yield
+        cfg.num_ctx, cfg.chat_n_ctx_target = old
+
+    def test_trims_lowest_ranked_sources_to_fit(self, mock_svc):
+        cfg.num_ctx = 1400
+        results = [_make_result(source=f"{i}.pdf", chunk="x" * 300) for i in range(5)]
+        kept = get_services().searcher._fit_context_budget(results, "sys", "q", None)
+        assert 0 < len(kept) < len(results)
+        assert kept == results[: len(kept)]  # keeps the top-ranked prefix
+
+    def test_keeps_all_when_budget_ample(self, mock_svc):
+        cfg.num_ctx = 100_000
+        results = [_make_result(source=f"{i}.pdf", chunk="short") for i in range(5)]
+        assert get_services().searcher._fit_context_budget(results, "sys", "q", None) == results
+
+    def test_keeps_top_source_even_if_alone_over_budget(self, mock_svc):
+        cfg.num_ctx = 1
+        results = [_make_result(source="big.pdf", chunk="x" * 9000), _make_result(source="b.pdf")]
+        kept = get_services().searcher._fit_context_budget(results, "sys", "q", None)
+        assert len(kept) == 1
+
+    def test_history_counts_against_the_budget(self, mock_svc):
+        cfg.num_ctx = 1400
+        results = [_make_result(source=f"{i}.pdf", chunk="x" * 300) for i in range(5)]
+        history = [{"role": "user", "content": "h" * 600}]
+        no_hist = get_services().searcher._fit_context_budget(results, "sys", "q", None)
+        with_hist = get_services().searcher._fit_context_budget(results, "sys", "q", history)
+        assert len(with_hist) < len(no_hist)
+
+    def test_logs_when_trimming(self, mock_svc, caplog):
+        cfg.num_ctx = 1400
+        results = [_make_result(source=f"{i}.pdf", chunk="x" * 300) for i in range(5)]
+        with caplog.at_level("INFO"):
+            get_services().searcher._fit_context_budget(results, "sys", "q", None)
+        assert "to fit the model context window" in caplog.text
+
+
 class TestAskRaw:
     def test_returns_structured_result(self, mock_svc):
         mock_svc.store.search.return_value = [_make_result(chunk="oil is 5 quarts")]
@@ -525,18 +617,16 @@ class TestAskRaw:
         assert len(result.sources) == 1
         assert result.sources[0].source == "test.pdf"
 
-    def test_no_results_falls_through_to_general_chat(self, mock_svc):
-        """Zero RAG hits route through the general system prompt (no canned
-        message, no citation grammar). Sources stay empty so callers can tell
-        the response was not grounded."""
+    def test_no_results_returns_grounded_refusal(self, mock_svc):
+        """Zero RAG hits in RAG mode return a grounded refusal instead of
+        free-wheeling on the model's parametric knowledge (bb-0i0). The model is
+        never called, and sources stay empty."""
         mock_svc.store.search.return_value = []
-        mock_svc.provider.chat.return_value = _text_result("general answer")
         result = get_services().searcher.ask_raw("anything")
-        assert result.answer == "general answer"
+        assert result.answer == _GROUNDED_REFUSAL
         assert result.sources == []
-        sent = mock_svc.provider.chat.call_args[0][0]
-        assert sent[0]["role"] == "system"
-        assert sent[0]["content"] == cfg.general_system_prompt
+        assert result.cited_sources == []
+        mock_svc.provider.chat.assert_not_called()
 
     def test_ask_raw_with_history(self, mock_svc):
         mock_svc.store.search.return_value = [_make_result()]
@@ -578,14 +668,13 @@ class TestAsk:
         assert "Sources:" in answer
         assert "test.pdf" in answer
 
-    def test_no_results_falls_through_to_general_chat(self, mock_svc):
-        """ask() also falls through to general chat when retrieval is empty."""
+    def test_no_results_returns_grounded_refusal(self, mock_svc):
+        """ask() surfaces the grounded refusal verbatim, with no Sources block (bb-0i0)."""
         mock_svc.store.search.return_value = []
-        mock_svc.provider.chat.return_value = _text_result("general answer")
         answer = get_services().searcher.ask("anything")
-        assert "general answer" in answer
-        # No citations are appended for an ungrounded answer.
+        assert answer == _GROUNDED_REFUSAL
         assert "Sources:" not in answer
+        mock_svc.provider.chat.assert_not_called()
 
     def test_ask_with_history(self, mock_svc):
         mock_svc.store.search.return_value = [_make_result()]
@@ -609,15 +698,15 @@ class TestAskStream:
         assert "Hello world" in combined
         assert "Sources:" in combined
 
-    def test_empty_results_falls_through_to_general_chat(self, mock_svc):
-        """Zero RAG hits stream a general-prompt response, no canned message."""
+    def test_empty_results_streams_grounded_refusal(self, mock_svc):
+        """Zero RAG hits stream a single grounded-refusal token, no Sources block,
+        and never call the model (bb-0i0)."""
         mock_svc.store.search.return_value = []
-        mock_svc.provider.chat.return_value = iter(["general", " answer"])
         stream_tokens = list(get_services().searcher.ask_stream("anything"))
         combined = "".join(st.content for st in stream_tokens)
-        assert "general answer" in combined
-        # No Sources block when there are no grounding chunks.
+        assert combined == _GROUNDED_REFUSAL
         assert "Sources:" not in combined
+        mock_svc.provider.chat.assert_not_called()
 
     def test_ask_stream_with_history(self, mock_svc):
         mock_svc.store.search.return_value = [_make_result()]
@@ -1643,15 +1732,16 @@ class TestAskRawChatMode:
         finally:
             cfg.chat_mode = old
 
-    def test_search_mode_empty_results_falls_through(self, mock_svc):
+    def test_search_mode_empty_results_returns_grounded_refusal(self, mock_svc):
+        """Search mode is a RAG path, so zero hits refuse rather than free-wheel (bb-0i0)."""
         old = cfg.chat_mode
         cfg.chat_mode = "search"
         try:
             mock_svc.store.search.return_value = []
-            mock_svc.provider.chat.return_value = _text_result("general answer")
             result = get_services().searcher.ask_raw("question")
-            assert result.answer == "general answer"
+            assert result.answer == _GROUNDED_REFUSAL
             assert result.sources == []
+            mock_svc.provider.chat.assert_not_called()
         finally:
             cfg.chat_mode = old
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -193,29 +193,29 @@ class TestAsk:
     async def test_returns_answer_and_sources(self, mock_svc):
         from lilbee.retrieval.query import AskResult
 
+        chunk = SearchChunk(
+            source="doc.pdf",
+            content_type="pdf",
+            page_start=1,
+            page_end=1,
+            line_start=0,
+            line_end=0,
+            chunk="c",
+            chunk_index=0,
+            distance=0.1,
+            rerank_score=0.8,
+            vector=[0.1],
+        )
         mock_svc.searcher.ask_raw.return_value = AskResult(
-            answer="42",
-            sources=[
-                SearchChunk(
-                    source="doc.pdf",
-                    content_type="pdf",
-                    page_start=1,
-                    page_end=1,
-                    line_start=0,
-                    line_end=0,
-                    chunk="c",
-                    chunk_index=0,
-                    distance=0.1,
-                    rerank_score=0.8,
-                    vector=[0.1],
-                )
-            ],
+            answer="42 [1]", sources=[chunk], cited_sources=[chunk]
         )
         result = await handlers.ask("what?")
-        assert result.answer == "42"
+        assert result.answer == "42 [1]"
         assert len(result.sources) == 1
         assert result.sources[0].distance == 0.1
         assert result.sources[0].rerank_score == 0.8
+        # bb-ky3: the HTTP response mirrors the cited subset too.
+        assert [s.source for s in result.cited_sources] == ["doc.pdf"]
 
     async def test_no_sources(self, mock_svc):
         from lilbee.retrieval.query import AskResult
@@ -490,6 +490,31 @@ class TestChat:
         mock_svc.searcher.build_rag_context.return_value = _rag_return()
         await handlers.chat("q", [], chunk_type="raw")
         assert mock_svc.searcher.build_rag_context.call_args.kwargs.get("chunk_type") == "raw"
+
+    async def test_populates_cited_sources(self, mock_svc, monkeypatch):
+        """bb-ky3: /chat mirrors /ask and carries the answer's cited subset."""
+        from lilbee.server.chat_dispatch.canonical import (
+            CanonicalResponse,
+            CanonicalUsage,
+            StopReason,
+            TextBlock,
+        )
+
+        def _fake_dispatch(req):
+            return CanonicalResponse(
+                id="msg_test",
+                model=req.model,
+                content=[TextBlock(text="The answer is in [1].")],
+                stop_reason=StopReason.END_TURN,
+                usage=CanonicalUsage(input_tokens=0, output_tokens=0),
+            )
+
+        monkeypatch.setattr(_rag_h, "dispatch_chat", _fake_dispatch)
+        monkeypatch.setattr(cfg, "chat_mode", ChatMode.SEARCH.value)
+        mock_svc.searcher.build_rag_context.return_value = _rag_return()
+        result = await handlers.chat("q", [])
+        assert len(result.sources) == 1
+        assert [s.source for s in result.cited_sources] == [result.sources[0].source]
 
     async def test_retrieval_ran_but_no_context_falls_back_to_direct_chat(
         self, mock_svc, monkeypatch

--- a/tests/test_splash_runner.py
+++ b/tests/test_splash_runner.py
@@ -306,3 +306,22 @@ def test_main_valid_fd():
 
     with patch("sys.argv", ["_splash_runner", str(r)]):
         main()
+
+
+def test_animation_loop_sleeps_during_startup_then_exits(monkeypatch):
+    """The startup poll loop sleeps while the pipe is open, then returns once it
+    closes. Covers the poll/sleep path deterministically; before this the line
+    was hit only by the timing-dependent e2e subprocess test."""
+    import lilbee.runtime._splash_runner as sr
+
+    sleeps: list[float] = []
+    polls = {"n": 0}
+
+    def fake_closed(_fd: int) -> bool:
+        polls["n"] += 1
+        return polls["n"] > 1  # open on the first poll, closed afterward
+
+    monkeypatch.setattr(sr.time, "sleep", lambda interval: sleeps.append(interval))
+    monkeypatch.setattr(sr, "pipe_closed", fake_closed)
+    sr.animation_loop(0)
+    assert sleeps == [sr.POLL_INTERVAL]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -201,13 +201,18 @@ class TestEnsureVectorIndex:
             assert store.ensure_vector_index() is True
         optimize_spy.assert_called_once()
 
-    def test_build_failure_returns_false(self, store, test_config):
+    def test_build_failure_warns_and_returns_false(self, store, test_config, caplog):
+        """bb-con: a real ANN build failure at scale is surfaced as a warning with
+        the flat-search impact, not swallowed at debug."""
         store.add_chunks(_make_records())
         table = store.open_table("chunks")
-        with mock.patch.object(
-            type(table), "create_index", side_effect=RuntimeError("too few rows")
+        with (
+            mock.patch.object(type(table), "create_index", side_effect=RuntimeError("boom")),
+            caplog.at_level("WARNING"),
         ):
             assert store.ensure_vector_index(force=True) is False
+        assert "ANN index build failed" in caplog.text
+        assert "flat scan" in caplog.text
 
     def test_has_vector_index_swallows_list_indices_errors(self, store):
         from lilbee.data.store.lance_helpers import _has_vector_index

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2956,6 +2956,7 @@ class TestCatalogGridFocus:
                     "Tab focus on a ModelGrid must auto-highlight the first card"
                 )
 
+    @pytest.mark.xdist_group("tui_pilot")
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="Textual highlighted-row update timing is flaky on Windows runners",

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -7845,6 +7845,7 @@ async def test_chat_tab_in_input_inserts_literal_tab():
         assert inp.has_focus
 
 
+@pytest.mark.xdist_group("tui_pilot")
 async def test_chat_tab_cycles_through_all_four_model_buttons():
     """Tab walks all four role buttons in order: chat -> embed -> vision -> rerank."""
     from lilbee.cli.tui.widgets.model_bar import ModelPickerButton
@@ -9834,6 +9835,7 @@ async def test_catalog_grid_leave_down_at_last_grid_with_no_more_keeps_focus():
             assert screen.focused is last
 
 
+@pytest.mark.xdist_group("tui_pilot")
 async def test_catalog_grid_leave_up_focuses_previous():
     """LeaveUp on a NON-first grid moves focus to the previous grid."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen


### PR DESCRIPTION
## Problem

A pass over the RAG answer path during the demo review turned up four quality gaps, plus two CI test flakes:

- A question that retrieves nothing usable still got answered from the model's own knowledge, with no sources and no signal that the answer was ungrounded. For a "grounded, cites or declines" product that's a hallucination surface.
- The RAG prompt was assembled with no token budget. Raising the source count or hitting long chunks could push the prompt past the model's context window, so a normal question failed with a context-overflow error instead of degrading.
- `ask --json` (and the HTTP `/ask` and `/chat` responses) returned the full retrieved set as `sources`, never the subset the answer actually cited. A consumer checking "did the answer cite anything" got a false green.
- A vector index build failure on a large corpus was swallowed at debug level, leaving the store silently on slow exact search with no signal to the operator.
- Two Textual tests flaked on loaded CI runners, and one task-bar test used a stub that a mid-test timer tick could trip over.

## Solution

- **Grounded refusal:** in RAG mode, zero usable sources now returns a short grounded refusal and does not call the model. Chat mode still answers from general knowledge, so the existing mode toggle is the escape hatch rather than a new setting.
- **Context budgeting:** sources are packed in rank order until the token budget (the model's `num_ctx` minus a reserve for the system prompt, question, history, and answer) is reached; the lowest-ranked overflow is dropped and the top source is always kept. Retrieval-heavy queries degrade instead of erroring. Reuses the existing history-window token estimator.
- **Cited subset:** the answer's `[n]` markers are resolved to the cited sources once and exposed as `cited_sources` on `ask_raw` and the `/ask` and `/chat` responses (empty when nothing was cited). The human answer path reuses the same subset.
- **Surfaced index failures:** a failed ANN build is now a warning that names the flat-search fallback and its cost at scale.
- **Test flakes:** the load-sensitive Textual tests are serialized onto one xdist worker via the existing `xdist_group` convention, and the task-bar test uses a real `Task`.
