### PR TITLE
Fix fleet servers dying on shared hosts, small machines, and Windows

### DIFF
--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import math
@@ -52,6 +53,12 @@ _EMBED_N_SEQ_MAX = 64
 # query</s></s>candidate pairs are token-dense (the separator is several tokens
 # in a few chars), so char estimation would under-count and over-pack.
 _EMBED_EST_CHARS_PER_TOKEN = 3
+# llama-swap's error body when the spawned llama-server exited before serving.
+_UPSTREAM_DIED_MARKER = "exited prematurely"
+# llama-server's 500 body when one input exceeds the physical batch (n_batch).
+_BATCH_OVERFLOW_MARKER = "too large to process"
+_UPSTREAM_LOG_TAIL_CHARS = 2000
+_UPSTREAM_LOG_TIMEOUT_S = 2.0
 
 log = logging.getLogger(__name__)
 
@@ -96,10 +103,50 @@ def _raise_for_status(resp: httpx.Response) -> None:
             kind=ProviderErrorKind.RATE_LIMIT,
         )
     detail = f": {body[:600]}" if body else ""
+    # llama-swap reports a dead server only as "exited prematurely"; log the
+    # server's own captured output so the actual exit reason is diagnosable.
+    if _UPSTREAM_DIED_MARKER in body:
+        _log_upstream_tail(resp)
+    # An input past the server's n_batch is a 500 whose body says "too large to
+    # process"; tagged CONTEXT_OVERFLOW so the embed path re-truncates exactly.
+    kind = (
+        ProviderErrorKind.CONTEXT_OVERFLOW
+        if _BATCH_OVERFLOW_MARKER in body
+        else ProviderErrorKind.UNKNOWN
+    )
     raise ProviderError(
         f"llama-server returned HTTP {resp.status_code}{detail}",
         provider=_PROVIDER_NAME,
+        kind=kind,
     )
+
+
+def _log_upstream_tail(resp: httpx.Response) -> None:
+    """Log the dead upstream's recent output from llama-swap's log stream."""
+    with contextlib.suppress(httpx.HTTPError, json.JSONDecodeError, KeyError, TypeError):
+        base = str(resp.request.url).split("/v1/")[0]
+        model = json.loads(resp.request.content)["model"]
+        tail = _fetch_log_tail(f"{base}/logs/stream/{model}")
+        if tail:
+            log.warning("%s exited prematurely; recent server output:\n%s", model, tail)
+
+
+def _fetch_log_tail(url: str) -> str:
+    """The last ``_UPSTREAM_LOG_TAIL_CHARS`` of llama-swap's log stream for one model.
+
+    The stream replays the upstream's buffered output then stays open; the read
+    timeout is the cutoff once the replay is drained.
+    """
+    chunks: list[str] = []
+    with (
+        contextlib.suppress(httpx.HTTPError),
+        httpx.stream("GET", url, timeout=_UPSTREAM_LOG_TIMEOUT_S) as stream,
+    ):
+        for chunk in stream.iter_text():
+            chunks.append(chunk)
+            if sum(len(piece) for piece in chunks) > _UPSTREAM_LOG_TAIL_CHARS:
+                break
+    return "".join(chunks)[-_UPSTREAM_LOG_TAIL_CHARS:]
 
 
 # Match the in-process embedder: llama-cpp-python's create_embedding does not

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -72,8 +72,11 @@ _CHAT_VRAM_FRACTION = 0.8
 # small one steps down toward 1.
 _LLM_RERANK_VRAM_FRACTION = 0.5
 
-# RAM kept free for the OS when placing against system memory (no discrete GPU).
-_SYSTEM_MEMORY_FLOOR_BYTES = 4 * 1024**3
+# RAM kept free for the OS when placing against system memory (no discrete GPU):
+# a quarter of total RAM, capped at 4 GiB. A fixed 4 GiB floor leaves a small
+# host (7-8 GB) with no budget at all, refusing to serve even tiny models.
+_SYSTEM_MEMORY_FLOOR_CAP_BYTES = 4 * 1024**3
+_SYSTEM_MEMORY_FLOOR_DIVISOR = 4
 
 
 def _slots_for(
@@ -550,9 +553,13 @@ def _unified_memory_budget(devices: list[FleetDevice]) -> int | None:
     RAM is not the constraint there."""
     if devices:
         return None
-    from lilbee.providers.model_cache import free_system_memory
+    from lilbee.providers.model_cache import free_system_memory, total_system_memory
 
-    return max(0, free_system_memory() - _SYSTEM_MEMORY_FLOOR_BYTES)
+    floor = min(
+        _SYSTEM_MEMORY_FLOOR_CAP_BYTES,
+        total_system_memory() // _SYSTEM_MEMORY_FLOOR_DIVISOR,
+    )
+    return max(0, free_system_memory() - floor)
 
 
 def plan_launches(

--- a/src/lilbee/providers/fleet/swap_config.py
+++ b/src/lilbee/providers/fleet/swap_config.py
@@ -7,26 +7,28 @@ from __future__ import annotations
 
 import json
 import shlex
+import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from lilbee.providers.fleet.launch import InstanceLaunch
 
 # One group holds every role with swap disabled, so llama-swap brings them all up
 # and never evicts one to load another (the co-residency the fleet needs).
 _GROUP_NAME = "lilbee"
-_START_PORT = 5800
 # Generous cold-load ceiling: a multi-hundred-GB giant can take minutes to map.
 _HEALTH_CHECK_TIMEOUT_S = 600
 _LOG_LEVEL = "info"
-# llama-swap substitutes ${PORT} per member before running the command.
-_PORT_MACRO = "${PORT}"
-_PROXY_URL = "http://localhost:${PORT}"
+# Matches the --host every server argv binds (adapters); "localhost" would have
+# llama-swap dial [::1] first, where another process could hold the same port.
+_PROXY_URL_TEMPLATE = "http://127.0.0.1:{port}"
 _PORT_FLAG = "--port"
 _TTL_KEEP = 0  # never time a member out; the group keeps it resident
 
 # llama-swap config keys.
-_KEY_START_PORT = "startPort"
 _KEY_HEALTH_TIMEOUT = "healthCheckTimeout"
 _KEY_LOG_LEVEL = "logLevel"
 _KEY_MODELS = "models"
@@ -41,25 +43,28 @@ _KEY_PERSISTENT = "persistent"
 _KEY_MEMBERS = "members"
 
 
-def build_swap_config(launches: list[InstanceLaunch]) -> str:
+def build_swap_config(launches: list[InstanceLaunch], member_ports: Mapping[str, int]) -> str:
     """Render a llama-swap config (JSON, which is valid YAML) for *launches*.
 
     Each role becomes a model whose id is the role name and whose command is the
-    role's llama-server argv plus llama-swap's ${PORT} macro; one ``swap: false``
-    group holds them all co-resident behind the single OpenAI endpoint.
+    role's llama-server argv plus the explicit port from *member_ports*; one
+    ``swap: false`` group holds them all co-resident behind the single OpenAI
+    endpoint. Ports are allocated fresh per start (never llama-swap's fixed
+    ``startPort`` range) so a previous instance's lingering server can't collide
+    with the new fleet's bind.
     """
     models: dict[str, object] = {}
     for launch in launches:
+        port = member_ports[launch.model_id]
         entry: dict[str, object] = {
-            _KEY_CMD: _command_line(launch.argv),
-            _KEY_PROXY: _PROXY_URL,
+            _KEY_CMD: _command_line(launch.argv, port),
+            _KEY_PROXY: _PROXY_URL_TEMPLATE.format(port=port),
             _KEY_TTL: _TTL_KEEP,
         }
         if launch.env_overrides:
             entry[_KEY_ENV] = [f"{key}={value}" for key, value in launch.env_overrides.items()]
         models[launch.model_id] = entry
     config: dict[str, object] = {
-        _KEY_START_PORT: _START_PORT,
         _KEY_HEALTH_TIMEOUT: _HEALTH_CHECK_TIMEOUT_S,
         _KEY_LOG_LEVEL: _LOG_LEVEL,
         _KEY_MODELS: models,
@@ -75,10 +80,15 @@ def build_swap_config(launches: list[InstanceLaunch]) -> str:
     return json.dumps(config, indent=2)
 
 
-def _command_line(argv: list[str]) -> str:
-    """Shell command for a member: the role argv plus the ${PORT} macro.
+def _command_line(argv: list[str], port: int) -> str:
+    """Shell command for a member: the role argv plus its explicit port.
 
-    Argv is shell-quoted so a spaced model path survives; the macro is appended
-    literally so llama-swap substitutes the claimed port.
+    Quoting must match how llama-swap splits the command back into argv: MS
+    rules on Windows (POSIX single quotes would stay literal in the paths and
+    the spawn fails with "file does not exist"), POSIX everywhere else.
     """
-    return f"{shlex.join(argv)} {_PORT_FLAG} {_PORT_MACRO}"
+    if sys.platform == "win32":
+        rendered = subprocess.list2cmdline(argv)
+    else:
+        rendered = shlex.join(argv)
+    return f"{rendered} {_PORT_FLAG} {port}"

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -16,6 +16,7 @@ import time
 from typing import TYPE_CHECKING
 
 import httpx
+import psutil
 
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet.binary import resolve_llama_swap
@@ -39,6 +40,8 @@ _RUNNING_PATH = "/running"
 _BOOT_TIMEOUT_S = 30.0
 _BOOT_POLL_S = 0.25
 _STOP_TIMEOUT_S = 10.0
+# Grace for a llama-server that outlived llama-swap before it is force-killed.
+_ORPHAN_STOP_TIMEOUT_S = 5.0
 _PROBE_TIMEOUT_S = 5.0
 _PROVIDER = "llama-server"
 # /running JSON shape: {"running": [{"model": <id>, "state": "ready", ...}, ...]}.
@@ -66,10 +69,18 @@ class SwapManager:
         self._port: int | None = None
 
     def start(self, launches: list[InstanceLaunch]) -> None:
-        """Write the config and spawn llama-swap, waiting for its proxy to answer."""
+        """Write the config and spawn llama-swap, waiting for its proxy to answer.
+
+        The proxy and every member get a freshly allocated free port; a fixed
+        member port range would collide with a previous instance's server that
+        is still shutting down (the new llama-server then fails its bind and
+        llama-swap reports it only as "exited prematurely").
+        """
+        ports = _pick_free_ports(1 + len(launches))
+        member_ports = dict(zip([launch.model_id for launch in launches], ports[1:], strict=True))
         self._config_path.parent.mkdir(parents=True, exist_ok=True)
-        self._config_path.write_text(build_swap_config(launches))
-        self._port = _pick_free_port()
+        self._config_path.write_text(build_swap_config(launches, member_ports))
+        self._port = ports[0]
         self._proc = subprocess.Popen(  # noqa: S603 - argv[0] is the resolved llama-swap
             [
                 str(resolve_llama_swap()),
@@ -104,10 +115,10 @@ class SwapManager:
         self.start(launches)
 
     def shutdown(self) -> None:
-        """Stop the llama-swap process group (a no-op when not running)."""
+        """Stop llama-swap and every server it spawned (a no-op when not running)."""
         proc = self._proc
         if proc is not None:
-            _terminate_group(proc)
+            _stop_process_tree(proc)
         self._proc = None
         self._port = None
 
@@ -143,21 +154,61 @@ class SwapManager:
         raise ProviderError(message, provider=_PROVIDER, kind=ProviderErrorKind.SERVER)
 
 
-def _pick_free_port() -> int:
-    """Bind an ephemeral localhost port and return it (closed before reuse)."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind((_HOST, 0))
-        return int(sock.getsockname()[1])
+def _pick_free_ports(count: int) -> list[int]:
+    """Bind *count* ephemeral localhost ports at once and return them.
+
+    All sockets stay open until every port is claimed so the OS cannot hand the
+    same port out twice within one allocation.
+    """
+    sockets = [socket.socket(socket.AF_INET, socket.SOCK_STREAM) for _ in range(count)]
+    try:
+        for sock in sockets:
+            sock.bind((_HOST, 0))
+        return [int(sock.getsockname()[1]) for sock in sockets]
+    finally:
+        for sock in sockets:
+            sock.close()
+
+
+def _stop_process_tree(proc: subprocess.Popen[bytes]) -> None:
+    """Stop llama-swap and reap any llama-server that outlives it.
+
+    llama-swap starts each server in its own process group (its Setpgid), so
+    signalling llama-swap's group never reaches the servers; a survivor keeps
+    its port bound and that port's next bind fails. The children are captured
+    while llama-swap is still alive, then swept after it stops.
+    """
+    children = _live_children(proc.pid)
+    if sys.platform == "win32":
+        _hard_stop(proc)
+    else:
+        _terminate_group(proc)
+    _reap_survivors(children)
+
+
+def _live_children(pid: int) -> list[psutil.Process]:
+    """The process's current descendants, or none when it already exited."""
+    try:
+        children: list[psutil.Process] = psutil.Process(pid).children(recursive=True)
+    except psutil.NoSuchProcess:
+        return []
+    return children
+
+
+def _reap_survivors(children: list[psutil.Process]) -> None:
+    """Terminate then kill any captured child that is still running."""
+    survivors = [child for child in children if child.is_running()]
+    for child in survivors:
+        with contextlib.suppress(psutil.NoSuchProcess):
+            child.terminate()
+    _, alive = psutil.wait_procs(survivors, timeout=_ORPHAN_STOP_TIMEOUT_S)
+    for child in alive:
+        with contextlib.suppress(psutil.NoSuchProcess):
+            child.kill()
 
 
 def _terminate_group(proc: subprocess.Popen[bytes]) -> None:
-    """SIGTERM the process group, escalating to SIGKILL on timeout.
-
-    Windows has no process groups via this path, so it hard-stops the process.
-    """
-    if sys.platform == "win32":
-        _hard_stop(proc)
-        return
+    """SIGTERM the process group, escalating to SIGKILL on timeout."""
     try:
         pgid = os.getpgid(proc.pid)
     except ProcessLookupError:  # pragma: no cover - process exited between checks

--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -152,6 +152,13 @@ def free_system_memory() -> int:
     return int(psutil.virtual_memory().available)
 
 
+def total_system_memory() -> int:
+    """Total installed system RAM in bytes."""
+    import psutil
+
+    return int(psutil.virtual_memory().total)
+
+
 def _try_nvidia_memory() -> int | None:
     """Try to get NVIDIA GPU total memory via pynvml, then nvidia-smi."""
     try:

--- a/tests/integration/test_fleet_integration.py
+++ b/tests/integration/test_fleet_integration.py
@@ -18,7 +18,7 @@ import httpx
 import pytest
 
 from lilbee.providers.fleet.client import LlamaServerClient
-from lilbee.providers.fleet.swap_manager import _pick_free_port
+from lilbee.providers.fleet.swap_manager import _pick_free_ports
 
 _STUB = Path(__file__).parent / "_llama_server_stub.py"
 
@@ -26,7 +26,7 @@ _STUB = Path(__file__).parent / "_llama_server_stub.py"
 @pytest.fixture
 def stub_client() -> Iterator[LlamaServerClient]:
     """A LlamaServerClient pointed at a freshly spawned stub llama-server."""
-    port = _pick_free_port()
+    (port,) = _pick_free_ports(1)
     proc = subprocess.Popen([sys.executable, str(_STUB), "--port", str(port)])
     base = f"http://127.0.0.1:{port}"
     try:

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -461,6 +461,63 @@ def test_raise_for_status_tags_context_overflow_400() -> None:
     assert "context window" in str(excinfo.value).lower()
 
 
+def _premature_exit_response() -> httpx.Response:
+    request = httpx.Request(
+        "POST", "http://127.0.0.1:9100/v1/embeddings", json={"model": "embed-0"}
+    )
+    return httpx.Response(
+        500,
+        text='{"src":"llama-swap", "error": "unspecific error: upstream command'
+        ' exited prematurely"}',
+        request=request,
+    )
+
+
+def test_raise_for_status_logs_upstream_tail_on_premature_exit(monkeypatch, caplog) -> None:
+    # llama-swap masks the dead server's stderr behind "exited prematurely";
+    # the client fetches the upstream's captured output and logs it.
+    import lilbee.providers.fleet.client as client_mod
+    from lilbee.providers.fleet.client import _raise_for_status
+
+    seen: dict[str, str] = {}
+
+    class _FakeStream:
+        def __enter__(self) -> _FakeStream:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def iter_text(self):
+            # Padded past the tail cap so the read stops at the size limit
+            # instead of waiting out the stream timeout.
+            yield "x" * 2500 + "E srv start: couldn't bind HTTP server socket, port: 5801\n"
+            raise AssertionError("must stop reading once the tail cap is reached")
+
+    def _fake_stream(method: str, url: str, timeout: float) -> _FakeStream:
+        seen["url"] = url
+        return _FakeStream()
+
+    monkeypatch.setattr(client_mod.httpx, "stream", _fake_stream)
+    with caplog.at_level("WARNING"), pytest.raises(ProviderError, match="exited prematurely"):
+        _raise_for_status(_premature_exit_response())
+    assert seen["url"] == "http://127.0.0.1:9100/logs/stream/embed-0"
+    assert "couldn't bind HTTP server socket" in caplog.text
+
+
+def test_raise_for_status_premature_exit_survives_log_fetch_failure(monkeypatch) -> None:
+    # A dead log stream must not mask the original ProviderError.
+    import lilbee.providers.fleet.client as client_mod
+    from lilbee.providers.fleet.client import _raise_for_status
+
+    def _refuse(method: str, url: str, timeout: float) -> object:
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(client_mod.httpx, "stream", _refuse)
+    with pytest.raises(ProviderError, match="exited prematurely"):
+        _raise_for_status(_premature_exit_response())
+
+
 def test_chat_stream_surfaces_server_error_body() -> None:
     # On a streaming request the response body isn't read yet, so the error path
     # must read it before extracting the message (the ResponseNotRead branch).
@@ -923,6 +980,32 @@ def test_embed_retries_with_exact_tokenize_on_context_overflow() -> None:
     assert out == [[0.5]]
     assert calls["embed"] == 2  # first overflowed, retry succeeded
     assert calls["tokenize"] >= 1  # retry used exact tokenization
+
+
+def test_embed_retries_exact_on_batch_overflow_500() -> None:
+    """An input past the server's n_batch is a 500 saying "too large to process"
+    (not the 400 context shape); it must take the same exact-tokenize retry."""
+    calls = {"embed": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/tokenize"):
+            return httpx.Response(200, json={"tokens": list(range(20))})
+        if path.endswith("/detokenize"):
+            return httpx.Response(200, json={"content": "t"})
+        if path == "/v1/embeddings":
+            calls["embed"] += 1
+            if calls["embed"] == 1:
+                return httpx.Response(
+                    500,
+                    text='{"error":{"code":500,"message":"input (136 tokens) is too large'
+                    ' to process. increase the physical batch size","type":"server_error"}}',
+                )
+            return httpx.Response(200, json={"data": [{"embedding": [0.5]}]})
+        return httpx.Response(404)
+
+    assert _capped_client(handler, 10).embed(["dense"]) == [[0.5]]
+    assert calls["embed"] == 2
 
 
 def test_embed_does_not_retry_on_non_overflow_error() -> None:

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -275,15 +275,26 @@ def test_unified_memory_budget_none_when_discrete_gpu_present() -> None:
 def test_unified_memory_budget_subtracts_os_floor_when_no_gpu(monkeypatch) -> None:
     # No enumerated GPU (Apple Silicon / CPU): budget = free RAM minus the OS floor.
     monkeypatch.setattr("lilbee.providers.model_cache.free_system_memory", lambda: 20 * 10**9)
+    monkeypatch.setattr("lilbee.providers.model_cache.total_system_memory", lambda: 64 * 10**9)
     assert (
         planning_mod._unified_memory_budget([])
-        == 20 * 10**9 - planning_mod._SYSTEM_MEMORY_FLOOR_BYTES
+        == 20 * 10**9 - planning_mod._SYSTEM_MEMORY_FLOOR_CAP_BYTES
     )
+
+
+def test_unified_memory_budget_scales_floor_down_on_small_hosts(monkeypatch) -> None:
+    # An 8 GB host keeps a quarter of RAM for the OS, not the full 4 GiB cap;
+    # otherwise a CI-runner-sized machine refuses to serve even an 80 MB model.
+    total = 8 * 10**9
+    monkeypatch.setattr("lilbee.providers.model_cache.free_system_memory", lambda: 4 * 10**9)
+    monkeypatch.setattr("lilbee.providers.model_cache.total_system_memory", lambda: total)
+    assert planning_mod._unified_memory_budget([]) == 4 * 10**9 - total // 4
 
 
 def test_unified_memory_budget_floors_at_zero_under_pressure(monkeypatch) -> None:
     # Less free than the floor -> budget 0 -> every model unplaceable (no freeze).
     monkeypatch.setattr("lilbee.providers.model_cache.free_system_memory", lambda: 1 * 10**9)
+    monkeypatch.setattr("lilbee.providers.model_cache.total_system_memory", lambda: 64 * 10**9)
     assert planning_mod._unified_memory_budget([]) == 0
 
 

--- a/tests/test_fleet_swap_config.py
+++ b/tests/test_fleet_swap_config.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+from lilbee.providers.fleet import swap_config as swap_config_mod
 from lilbee.providers.fleet.launch import InstanceLaunch
 from lilbee.providers.fleet.swap_config import build_swap_config
 from lilbee.providers.roles import WorkerRole
@@ -28,8 +31,12 @@ def _launch(
     )
 
 
+_BASE_PORT = 5900
+
+
 def _config(launches: list[InstanceLaunch]) -> dict:
-    return json.loads(build_swap_config(launches))
+    ports = {launch.model_id: _BASE_PORT + i for i, launch in enumerate(launches)}
+    return json.loads(build_swap_config(launches, ports))
 
 
 def test_instance_launch_rerank_mode_defaults_none() -> None:
@@ -39,7 +46,7 @@ def test_instance_launch_rerank_mode_defaults_none() -> None:
 class TestBuildSwapConfig:
     def test_emits_valid_json_with_top_level_keys(self) -> None:
         cfg = _config([_launch(WorkerRole.CHAT, ["/bin/llama-server", "--model", "/m/c.gguf"])])
-        assert cfg["startPort"] == 5800
+        assert "startPort" not in cfg  # members carry explicit ports, never a fixed range
         assert cfg["healthCheckTimeout"] >= 1
         assert "logLevel" in cfg
 
@@ -87,22 +94,46 @@ class TestBuildSwapConfig:
             _mid(WorkerRole.RERANK),
         }
 
-    def test_command_carries_port_macro_and_role_argv(self) -> None:
+    def test_command_carries_explicit_port_and_role_argv(self) -> None:
         cfg = _config([_launch(WorkerRole.CHAT, ["/bin/llama-server", "--jinja"])])
         cmd = cfg["models"][_mid(WorkerRole.CHAT)]["cmd"]
         assert "--jinja" in cmd
-        assert cmd.endswith("--port ${PORT}")
-        assert cfg["models"][_mid(WorkerRole.CHAT)]["proxy"] == "http://localhost:${PORT}"
+        assert cmd.endswith(f"--port {_BASE_PORT}")
+        assert cfg["models"][_mid(WorkerRole.CHAT)]["proxy"] == f"http://127.0.0.1:{_BASE_PORT}"
+
+    def test_each_member_gets_its_own_port(self) -> None:
+        cfg = _config(
+            [
+                _launch(WorkerRole.CHAT, ["/bin/llama-server"]),
+                _launch(WorkerRole.EMBED, ["/bin/llama-server", "--embeddings"]),
+            ]
+        )
+        chat = cfg["models"][_mid(WorkerRole.CHAT)]
+        embed = cfg["models"][_mid(WorkerRole.EMBED)]
+        assert chat["cmd"].endswith(f"--port {_BASE_PORT}")
+        assert embed["cmd"].endswith(f"--port {_BASE_PORT + 1}")
+        assert embed["proxy"] == f"http://127.0.0.1:{_BASE_PORT + 1}"
 
     def test_embed_command_keeps_embeddings_flag(self) -> None:
         cfg = _config([_launch(WorkerRole.EMBED, ["/bin/llama-server", "--embeddings"])])
         assert "--embeddings" in cfg["models"][_mid(WorkerRole.EMBED)]["cmd"]
 
-    def test_spaced_model_path_is_quoted(self) -> None:
+    def test_spaced_model_path_is_quoted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(swap_config_mod.sys, "platform", "linux")
         argv = ["/bin/llama-server", "--model", "/Application Support/lilbee/m.gguf"]
         cfg = _config([_launch(WorkerRole.CHAT, argv)])
         cmd = cfg["models"][_mid(WorkerRole.CHAT)]["cmd"]
         assert "'/Application Support/lilbee/m.gguf'" in cmd  # shell-quoted, survives the space
+
+    def test_windows_uses_ms_quoting(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # llama-swap splits cmd with MS rules on Windows; POSIX single quotes
+        # would stay literal in the paths and the server spawn fails.
+        monkeypatch.setattr(swap_config_mod.sys, "platform", "win32")
+        argv = ["C:\\llama\\llama-server.exe", "--model", "C:\\Program Files\\lilbee\\m.gguf"]
+        cmd = _config([_launch(WorkerRole.CHAT, argv)])["models"][_mid(WorkerRole.CHAT)]["cmd"]
+        assert "'" not in cmd
+        assert '"C:\\Program Files\\lilbee\\m.gguf"' in cmd
+        assert cmd.startswith("C:\\llama\\llama-server.exe")
 
     def test_env_overrides_become_env_list_when_present(self) -> None:
         cfg = _config(

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import httpx
@@ -50,8 +53,8 @@ def _fake_response(*, status: int = 200, payload: object = None) -> object:
 def _patch_spawn(monkeypatch: pytest.MonkeyPatch, proc: _FakeProc) -> None:
     monkeypatch.setattr(sm, "resolve_llama_swap", lambda: Path("/fake/llama-swap"))
     monkeypatch.setattr(sm.subprocess, "Popen", lambda *a, **k: proc)
-    # Isolate lifecycle tests from the real process-group teardown.
-    monkeypatch.setattr(sm, "_terminate_group", lambda p: None)
+    # Isolate lifecycle tests from the real process-tree teardown.
+    monkeypatch.setattr(sm, "_stop_process_tree", lambda p: None)
 
 
 def _patch_http(monkeypatch: pytest.MonkeyPatch, responder) -> None:
@@ -77,8 +80,16 @@ class TestStart:
         mgr = SwapManager(tmp_path)
         mgr.start([_launch(WorkerRole.CHAT), _launch(WorkerRole.EMBED)])
         # Config was written and the endpoint is live.
-        assert (tmp_path / "llama-swap.json").exists()
+        config = json.loads((tmp_path / "llama-swap.json").read_text())
         assert mgr.endpoint().startswith("http://127.0.0.1:")
+        # Each member got its own freshly allocated port, distinct from the proxy's.
+        member_ports = {
+            model_id: int(entry["cmd"].rsplit(" ", 1)[-1])
+            for model_id, entry in config["models"].items()
+        }
+        proxy_port = int(mgr.endpoint().rsplit(":", 1)[-1])
+        assert len(set(member_ports.values())) == 2
+        assert proxy_port not in member_ports.values()
 
     def test_raises_when_process_exits_before_ready(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -162,11 +173,11 @@ class TestLifecycle:
         terminated: list[object] = []
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        monkeypatch.setattr(sm, "_terminate_group", lambda p: terminated.append(p))
+        monkeypatch.setattr(sm, "_stop_process_tree", lambda p: terminated.append(p))
         mgr = SwapManager(tmp_path)
         mgr.start([_launch(WorkerRole.CHAT)])
         mgr.shutdown()
-        assert terminated  # the process group was torn down
+        assert terminated  # the process tree was torn down
         with pytest.raises(ProviderError):
             mgr.endpoint()  # port cleared after shutdown
 
@@ -185,12 +196,31 @@ class TestLifecycle:
         assert starts == [2]  # restarted with the new launch set
 
 
+class _FakeChild:
+    """A stand-in psutil.Process that records the signals it receives."""
+
+    def __init__(self, *, running: bool = True) -> None:
+        self.running = running
+        self.terminated = False
+        self.killed = False
+
+    def is_running(self) -> bool:
+        return self.running
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+
 class TestProcessTeardown:
-    def test_pick_free_port_returns_bound_port(self) -> None:
-        assert 1024 < sm._pick_free_port() <= 65535
+    def test_pick_free_ports_returns_distinct_bound_ports(self) -> None:
+        ports = sm._pick_free_ports(3)
+        assert len(set(ports)) == 3
+        assert all(1024 < port <= 65535 for port in ports)
 
     def test_terminate_group_posix_sigterm(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sm.sys, "platform", "linux")
         monkeypatch.setattr(sm.os, "getpgid", lambda _pid: 99, raising=False)
         signals: list[int] = []
         monkeypatch.setattr(
@@ -202,7 +232,6 @@ class TestProcessTeardown:
     def test_terminate_group_escalates_to_sigkill_on_timeout(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(sm.sys, "platform", "linux")
         monkeypatch.setattr(sm.os, "getpgid", lambda _pid: 99, raising=False)
         signals: list[int] = []
         monkeypatch.setattr(
@@ -216,11 +245,63 @@ class TestProcessTeardown:
         sm._terminate_group(_Stuck(poll_result=None))
         assert signals == [sm.signal.SIGTERM, sm._SIGKILL]
 
-    def test_terminate_group_windows_hard_stops(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_stop_process_tree_windows_hard_stops(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sm.sys, "platform", "win32")
+        monkeypatch.setattr(sm, "_live_children", lambda _pid: [])
         proc = _FakeProc(poll_result=None)
-        sm._terminate_group(proc)
+        sm._stop_process_tree(proc)
         assert proc.terminated is True
+
+    def test_stop_process_tree_posix_terminates_group(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sm.sys, "platform", "linux")
+        monkeypatch.setattr(sm, "_live_children", lambda _pid: [])
+        groups: list[object] = []
+        monkeypatch.setattr(sm, "_terminate_group", lambda p: groups.append(p))
+        sm._stop_process_tree(_FakeProc(poll_result=None))
+        assert groups
+
+    def test_stop_process_tree_reaps_surviving_children(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # llama-swap puts each server in its own process group, so the group
+        # kill misses them; a survivor must be swept or it keeps its port.
+        survivor = _FakeChild(running=True)
+        monkeypatch.setattr(sm.sys, "platform", "linux")
+        monkeypatch.setattr(sm, "_live_children", lambda _pid: [survivor])
+        monkeypatch.setattr(sm, "_terminate_group", lambda p: None)
+        monkeypatch.setattr(sm.psutil, "wait_procs", lambda procs, timeout: ([], []))
+        sm._stop_process_tree(_FakeProc(poll_result=None))
+        assert survivor.terminated is True
+
+    def test_reap_survivors_kills_after_grace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stubborn = _FakeChild(running=True)
+        monkeypatch.setattr(sm.psutil, "wait_procs", lambda procs, timeout: ([], [stubborn]))
+        sm._reap_survivors([stubborn])
+        assert stubborn.terminated is True
+        assert stubborn.killed is True
+
+    def test_reap_survivors_skips_already_dead(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dead = _FakeChild(running=False)
+        monkeypatch.setattr(sm.psutil, "wait_procs", lambda procs, timeout: ([], []))
+        sm._reap_survivors([dead])
+        assert dead.terminated is False
+
+    def test_live_children_empty_when_process_gone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _gone(_pid: int) -> object:
+            raise sm.psutil.NoSuchProcess(_pid)
+
+        monkeypatch.setattr(sm.psutil, "Process", _gone)
+        assert sm._live_children(12345) == []
+
+    def test_live_children_finds_spawned_child(self) -> None:
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        try:
+            assert proc.pid in [child.pid for child in sm._live_children(os.getpid())]
+        finally:
+            proc.kill()
+            proc.wait()
 
     def test_hard_stop_kills_on_timeout(self) -> None:
         class _Stuck(_FakeProc):

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -18,6 +18,7 @@ from lilbee.providers.model_cache import (
     free_system_memory,
     get_available_memory,
     kv_bytes_per_token,
+    total_system_memory,
 )
 
 
@@ -209,6 +210,14 @@ class TestFreeSystemMemory:
         fake_psutil.virtual_memory.return_value.available = 7_000_000_000
         monkeypatch.setitem(__import__("sys").modules, "psutil", fake_psutil)
         assert free_system_memory() == 7_000_000_000
+
+
+class TestTotalSystemMemory:
+    def test_returns_psutil_total(self, monkeypatch) -> None:
+        fake_psutil = mock.MagicMock()
+        fake_psutil.virtual_memory.return_value.total = 8_000_000_000
+        monkeypatch.setitem(__import__("sys").modules, "psutil", fake_psutil)
+        assert total_system_memory() == 8_000_000_000
 
 
 class TestTryNvidiaMemory:


### PR DESCRIPTION
## Problem

Integration CI on this branch was red on every platform: each embed and chat call returned HTTP 500, with llama-swap reporting only "upstream command exited prematurely". The servers were dying for four unrelated reasons that the masked error hid.

Every fleet wrote the same fixed port range (5800+) into its llama-swap config, so a server from a previous fleet that was still shutting down, or had leaked, held the port and the next fleet's llama-server failed its bind and exited. One stuck process poisoned every start after it. And leaking was easy: llama-swap puts each server in its own process group, so shutting down llama-swap's group never signalled the servers, and a shutdown that escalated to SIGKILL left them running forever (one dev machine had dozens accumulated).

On machines without a discrete GPU, placement held back a fixed 4 GiB of RAM for the OS. A 7 GB host, like the CI runners or a base spec laptop, ended up with no budget at all and refused to serve even an 80 MB embedding model.

On Windows two more: the server command was quoted POSIX-style but llama-swap splits it with Windows rules, so the quoted binary path never resolved and no server ever started. And an input past the server's physical batch comes back as a 500 the embed path didn't recognize as overflow, so its truncation retry never ran (CRLF-inflated code chunks hit this).

## Solution

Each fleet start now allocates fresh free ports for the proxy and every member, and shutdown reaps any server that outlives llama-swap, so nothing can squat on a port a future fleet needs. The OS memory reserve scales to a quarter of total RAM, capped at the old 4 GiB, so small machines keep a proportionate reserve instead of nothing. The member command renders with native quoting on Windows, and the batch-overflow 500 now takes the same exact-tokenize truncation retry as the context-overflow 400. When a server does die at startup, the client logs the server's own captured output, so the real reason lands in the log instead of an opaque 500.

Unit tests cover the new paths under the existing 100% gate; the integration matrix is green on all three platforms.