### PR TITLE
QA harness autonomy: derive embedding_dim on embedder switch + complete pod env file

### DIFF
--- a/src/lilbee/app/settings.py
+++ b/src/lilbee/app/settings.py
@@ -301,6 +301,8 @@ def apply_settings_update(
             )
     _validate(updates)
     embed_in_batch = "embedding_model" in updates
+    # Derived (not user-writable) fields applied alongside the validated batch.
+    effective_updates = dict(updates)
     if embed_in_batch:
         # Pin the OLD ref into store meta before mutation, otherwise the
         # next read lazy-initializes meta from the NEW cfg and silently
@@ -308,7 +310,12 @@ def apply_settings_update(
         # so a legacy meta row is always canonicalized on the first swap
         # attempt.
         _pin_legacy_store_meta()
-    to_persist, to_delete, snapshot = _apply_with_rollback(updates)
+        # Track the new embedder's output width so a fresh index is built at
+        # the right dimension (embedding_dim is derived, not in SETTINGS_MAP).
+        dim = _embedder_dim_from_gguf(updates["embedding_model"])
+        if dim is not None:
+            effective_updates["embedding_dim"] = dim
+    to_persist, to_delete, snapshot = _apply_with_rollback(effective_updates)
     try:
         if to_persist:
             persistent_settings.update_values(cfg.data_root, to_persist)
@@ -317,7 +324,7 @@ def apply_settings_update(
     except OSError:
         _restore_snapshot(snapshot)
         raise
-    _invalidate_caches(set(updates))
+    _invalidate_caches(set(effective_updates))
     reindex_required = bool(REINDEX_FIELDS & set(updates))
     if embed_in_batch:
         reindex_required = reindex_required or _embed_reindex_required(updates["embedding_model"])
@@ -333,6 +340,35 @@ def _pin_legacy_store_meta() -> None:
     from lilbee.app.services import get_services
 
     get_services().store.initialize_meta_if_legacy()
+
+
+def _embedder_dim_from_gguf(ref: str) -> int | None:
+    """The embedder's output width from its GGUF header (``<arch>.embedding_length``).
+
+    Keeps ``embedding_dim`` in step with ``embedding_model`` so a fresh index is
+    built at the right vector width: without it a non-768 embedder (e.g.
+    Qwen3-Embedding's 4096) fails every ingest with a dimension mismatch against
+    the 768 default. None when the model can't be resolved or the header lacks the
+    field, leaving the existing dim untouched. Cheap: a cached header read, no load.
+    """
+    from lilbee.providers.base import ProviderError
+    from lilbee.providers.engine_params import resolve_model_path
+    from lilbee.providers.gguf_meta import read_gguf_metadata
+
+    try:
+        # resolve_model_path raises ProviderError for a non-native (ollama/SDK) ref,
+        # which has no local GGUF -- those embedders carry no width to derive here.
+        meta = read_gguf_metadata(resolve_model_path(ref))
+    except (ProviderError, ValueError, OSError, RuntimeError, TypeError):
+        return None
+    raw = meta.get("embedding_length") if meta else None
+    if not raw:
+        return None
+    try:
+        dim = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return dim if dim > 0 else None
 
 
 def _embed_reindex_required(new_ref: str) -> bool:

--- a/tests/test_dynamic_settings_eviction.py
+++ b/tests/test_dynamic_settings_eviction.py
@@ -129,6 +129,81 @@ def test_embed_and_rerank_model_change_reloads_only_those_roles():
         _restore_services()
 
 
+def test_embedding_model_change_derives_embedding_dim(monkeypatch):
+    """Switching embedding_model also persists the model's output width (from its
+    GGUF header), so a fresh index is built at the right dimension instead of the
+    768 default -- the gap that broke a Qwen3-Embedding (4096) corpus build."""
+    from lilbee.app import settings as settings_mod
+
+    _install_recording_provider()
+    try:
+        monkeypatch.setattr(settings_mod, "_embedder_dim_from_gguf", lambda _ref: 4096)
+        apply_settings_update({"embedding_model": "Qwen/Qwen3-Embedding-8B-GGUF/x.gguf"})
+        assert cfg.embedding_dim == 4096
+    finally:
+        _restore_services()
+
+
+def test_embedding_model_change_leaves_dim_when_unreadable(monkeypatch):
+    """An unresolvable/headerless embedder leaves embedding_dim untouched (no crash)."""
+    from lilbee.app import settings as settings_mod
+
+    _install_recording_provider()
+    cfg.embedding_dim = 768
+    try:
+        monkeypatch.setattr(settings_mod, "_embedder_dim_from_gguf", lambda _ref: None)
+        apply_settings_update({"embedding_model": "some/unreadable.gguf"})
+        assert cfg.embedding_dim == 768
+    finally:
+        _restore_services()
+
+
+def test_embedder_dim_from_gguf_reads_embedding_length(monkeypatch):
+    from pathlib import Path
+
+    from lilbee.app.settings import _embedder_dim_from_gguf
+
+    monkeypatch.setattr(
+        "lilbee.providers.engine_params.resolve_model_path", lambda _ref: Path("/x.gguf")
+    )
+    monkeypatch.setattr(
+        "lilbee.providers.gguf_meta.read_gguf_metadata",
+        lambda _p: {"architecture": "bert", "embedding_length": "384"},
+    )
+    assert _embedder_dim_from_gguf("ref") == 384
+
+
+def test_embedder_dim_from_gguf_handles_unresolvable_and_missing(monkeypatch):
+    from pathlib import Path
+
+    from lilbee.app.settings import _embedder_dim_from_gguf
+
+    def boom(_ref):
+        raise OSError("not installed")
+
+    monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", boom)
+    assert _embedder_dim_from_gguf("ref") is None
+
+    monkeypatch.setattr(
+        "lilbee.providers.engine_params.resolve_model_path", lambda _ref: Path("/x.gguf")
+    )
+    monkeypatch.setattr(
+        "lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {"architecture": "bert"}
+    )
+    assert _embedder_dim_from_gguf("ref") is None
+
+    # Non-integer or non-positive embedding_length is junk -> leave dim untouched.
+    monkeypatch.setattr(
+        "lilbee.providers.gguf_meta.read_gguf_metadata",
+        lambda _p: {"embedding_length": "notanint"},
+    )
+    assert _embedder_dim_from_gguf("ref") is None
+    monkeypatch.setattr(
+        "lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {"embedding_length": "0"}
+    )
+    assert _embedder_dim_from_gguf("ref") is None
+
+
 def test_chat_and_vision_model_change_reloads_those_roles():
     """A chat_model / vision_model swap reloads that role's server so the next
     request uses the new model. The fleet serves the configured model per role

--- a/tools/qa/opencode/README.md
+++ b/tools/qa/opencode/README.md
@@ -21,9 +21,8 @@ engine isn't recompiled). VHS records on the pod (ttyd 1.7.7 + `VHS_NO_SANDBOX`
 
 ```bash
 bash tools/qa/opencode/pod_bootstrap.sh        # BACKEND=cu124 by default
-source /root/lilbee_venv/bin/activate
-export PATH=/usr/local/go/bin:$HOME/.local/bin:$HOME/.opencode/bin:$PATH
-export LILBEE_MODELS_DIR=/workspace/models HF_HOME=/workspace/hf
+source /workspace/qa_env.sh                     # complete env the bootstrap wrote
+export HF_TOKEN=...                              # for model pulls
 ```
 
 Then the corpus:

--- a/tools/qa/opencode/pod_bootstrap.sh
+++ b/tools/qa/opencode/pod_bootstrap.sh
@@ -133,12 +133,30 @@ for f in (resolve_llama_server, resolve_llama_swap, resolve_gguf_parser):
     print('  engine:', f())
 "
 
+# 10. Write a complete, sourceable env file. Printing partial exports left every
+#     shell to re-derive the environment and rediscover the non-obvious bits --
+#     UV_PROJECT_ENVIRONMENT/UV_NO_SYNC (without which the matrix's `uv run lilbee`
+#     re-syncs and the engine-wheel rebuild fails), the persistent models/HF dirs,
+#     and the corpus path. One `source` now sets all of it.
+log "writing $WORKSPACE/qa_env.sh"
+cat > "$WORKSPACE/qa_env.sh" <<EOF
+source $UV_PROJECT_ENVIRONMENT/bin/activate
+export PATH=/usr/local/go/bin:\$HOME/.local/bin:\$HOME/.opencode/bin:\$PATH
+export UV_PROJECT_ENVIRONMENT=$UV_PROJECT_ENVIRONMENT
+export UV_CACHE_DIR=$UV_CACHE_DIR
+export UV_LINK_MODE=copy
+export UV_NO_SYNC=1
+export LILBEE_MODELS_DIR=$LILBEE_MODELS_DIR
+export HF_HOME=$HF_HOME
+export LILBEE_QA_CORPUS=\${LILBEE_QA_CORPUS:-$WORKSPACE/godot_corpus}
+# export HF_TOKEN=...   # set per shell for model pulls; never commit it
+EOF
+
 cat <<EOF
-[bootstrap] ready. For each shell:
-  source $UV_PROJECT_ENVIRONMENT/bin/activate
-  export PATH=/usr/local/go/bin:\$HOME/.local/bin:\$HOME/.opencode/bin:\$PATH
-  export LILBEE_MODELS_DIR=$LILBEE_MODELS_DIR HF_HOME=$HF_HOME
-Then: lilbee model pull <ref>; python tools/qa/opencode/matrix.py --families <fam>
+[bootstrap] ready. Source the generated env, then run the matrix:
+  source $WORKSPACE/qa_env.sh
+  export HF_TOKEN=...                       # for model pulls
+  python tools/qa/opencode/matrix.py --families <fam>
 Recording reels: run VHS as 'VHS_NO_SANDBOX=true vhs <tape>' with a RELATIVE Output
 path, from the output dir (an absolute Output trips VHS's parser).
 EOF


### PR DESCRIPTION
## Problem

Two things made the opencode QA matrix need hand-holding on a fresh pod, neither requiring a GPU to fix:

- `embedding_dim` was never updated when the embedding model changed, so building a fresh index with a non-768-dim embedder (Qwen3-Embedding is 4096) failed every ingest with a dimension mismatch against the 768 default. The corpus build had to set `embedding_dim` by hand.
- `pod_bootstrap.sh` only printed partial export instructions, so every shell re-derived the environment and rediscovered the non-obvious vars — `UV_NO_SYNC` especially, without which the matrix's `uv run lilbee` re-syncs and the engine-wheel rebuild fails.

## Solution

- The settings boundary now derives `embedding_dim` from the new embedder's GGUF `embedding_length` whenever `embedding_model` is set (a cheap cached header read, no model load; skipped for non-native refs that have no local GGUF). `use-embedder` persists the right width automatically.
- `pod_bootstrap.sh` now writes a complete sourceable `/workspace/qa_env.sh` (venv, `UV_NO_SYNC`, `UV_PROJECT_ENVIRONMENT`, the persistent models/HF dirs, the corpus path) and prints `source` it.

Validated on a Mac (no pod): `use-embedder` with All-MiniLM (384) now writes `embedding_dim = 384` instead of the 768 default. Under the existing 100% coverage gate.
