### PR TITLE
Fix opencode launch spawning a second llama-swap

### DIFF
--- a/src/lilbee/cli/launchers/launcher.py
+++ b/src/lilbee/cli/launchers/launcher.py
@@ -13,6 +13,7 @@ from lilbee.cli.launchers.server import (
     stop_spawned_server,
     wait_for_chat_warm,
 )
+from lilbee.core.config import cfg
 
 
 class Launcher(Protocol):
@@ -46,6 +47,11 @@ def run_launcher(launcher: Launcher) -> None:
     if binary is None:
         typer.secho(launcher.install_hint, err=True, fg=typer.colors.RED)
         raise typer.Exit(1)
+    # The launcher only reads the registry and talks to the spawned `lilbee serve`
+    # over HTTP; it runs no inference itself. Skip the eager warm so get_services()
+    # here doesn't start a second llama-swap that races the server's for the model
+    # port (the loser gets connection-refused). The spawned serve warms its own.
+    cfg.worker_pool_eager_start = False
     (token, port), spawned = ensure_server_running()
     model_refs = installed_chat_model_refs()
     if not model_refs:

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -804,3 +804,37 @@ def test_launch_opencode_propagates_opencode_exit_code():
     ):
         result = runner.invoke(app, ["launch", "opencode"])
     assert result.exit_code == 42
+
+
+def test_run_launcher_disables_eager_warm_in_launcher_process():
+    """The launcher delegates inference to the spawned `lilbee serve`, so it must
+    turn off the eager fleet warm in its own process. Otherwise get_services()
+    starts a second llama-swap that races the server's for the model's port and the
+    loser gets connection-refused. Regression for the opencode double-spawn."""
+    import typer
+
+    from lilbee.cli.launchers.launcher import run_launcher
+    from lilbee.core.config import cfg
+
+    launcher = MagicMock()
+    launcher.find_binary.return_value = "/usr/local/bin/client"
+    launcher.prepare.return_value = ([], {})
+    old = cfg.worker_pool_eager_start
+    cfg.worker_pool_eager_start = True
+    try:
+        with (
+            patch(
+                "lilbee.cli.launchers.launcher.ensure_server_running",
+                return_value=(("tok", 1234), None),
+            ),
+            patch("lilbee.cli.launchers.launcher.installed_chat_model_refs", return_value=[]),
+            patch(
+                "lilbee.cli.launchers.launcher.subprocess.run",
+                return_value=MagicMock(returncode=0),
+            ),
+            pytest.raises(typer.Exit),
+        ):
+            run_launcher(launcher)
+        assert cfg.worker_pool_eager_start is False
+    finally:
+        cfg.worker_pool_eager_start = old


### PR DESCRIPTION
## Problem

`lilbee launch opencode` started two llama-swap processes instead of one. The launcher process calls `get_services()` to read the model registry, which eager-warms its own fleet by default, while it *also* spawns a `lilbee serve` that warms its own fleet. The two llama-swap instances raced for the chat model's port and the loser's upstream came up refusing connections. That surfaced as the transient "connection refused" / "upstream restarted on two different ports" noise the opencode QA matrix kept flagging (bb-76o), and as a cold-start error for real users.

The earlier theory (concurrent boot probes hitting a single loading upstream) was reproduced on the Mac and disproved: a single llama-swap holds concurrent cold requests fine. The real cause was the double spawn, also Mac-reproducible (`launch opencode` -> 2 llama-swap; plain `serve` -> 1).

## Solution

The launcher runs no inference itself; it only reads the registry and talks to the spawned serve over HTTP. It now skips the eager warm in its own process (`cfg.worker_pool_eager_start = False`), so only the spawned serve's llama-swap exists. This mirrors the existing one-shot pattern in `ingest_sync.py`. The spawned serve still warms from its own config, so the launched client opens onto a warm engine.

Validated on the Mac: launch now yields a single llama-swap and opencode boots clean. Adds a regression test asserting the launcher disables its eager warm. Full local gate green (100% coverage).