### PR TITLE
Derive embedding_dim from the embedder GGUF on config-file load

### DIFF
--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -127,6 +127,7 @@ def get_services() -> Services:
     if _svc is not None:
         return _svc
 
+    from lilbee.app.settings import reconcile_embedding_dim
     from lilbee.catalog.hf_client import HfClient
     from lilbee.core.config import cfg
     from lilbee.data.store import Store
@@ -142,12 +143,16 @@ def get_services() -> Services:
     from lilbee.runtime.ingest_lock import IngestLockRegistry
 
     provider = create_provider(cfg)
+    registry = ModelRegistry(cfg.models_dir)
+    # A config-file embedding_model with no embedding_dim would otherwise build the
+    # store at the stale 768 default; pin the width to the embedder before Store().
+    # Pass the registry so resolution doesn't re-enter this half-built get_services.
+    reconcile_embedding_dim(registry)
     store = Store(cfg)
     embedder = Embedder(cfg, provider)
     reranker = Reranker(cfg)
     concepts = ConceptGraph(cfg, store)
     clusterer = Clusterer(cfg, store)
-    registry = ModelRegistry(cfg.models_dir)
     searcher = Searcher(cfg, provider, store, embedder, reranker, concepts)
     hf_client = HfClient()
     ingest_lock_registry = IngestLockRegistry()

--- a/src/lilbee/app/settings.py
+++ b/src/lilbee/app/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import types
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
 
 from pydantic_core import PydanticUndefined
 
@@ -22,6 +22,9 @@ from lilbee.core.config.keys import (
     PROVIDER_API_KEYS,
     PROVIDER_SWITCHING_KEYS,
 )
+
+if TYPE_CHECKING:
+    from lilbee.modelhub.registry import ModelRegistry
 
 _MIN_CHUNK_SIZE = 64
 
@@ -342,14 +345,12 @@ def _pin_legacy_store_meta() -> None:
     get_services().store.initialize_meta_if_legacy()
 
 
-def _embedder_dim_from_gguf(ref: str) -> int | None:
+def _embedder_dim_from_gguf(ref: str, registry: ModelRegistry | None = None) -> int | None:
     """The embedder's output width from its GGUF header (``<arch>.embedding_length``).
 
-    Keeps ``embedding_dim`` in step with ``embedding_model`` so a fresh index is
-    built at the right vector width: without it a non-768 embedder (e.g.
-    Qwen3-Embedding's 4096) fails every ingest with a dimension mismatch against
-    the 768 default. None when the model can't be resolved or the header lacks the
-    field, leaving the existing dim untouched. Cheap: a cached header read, no load.
+    None when the model can't be resolved or the header lacks the field. Cheap: a
+    cached header read, no load. *registry* is forwarded to resolve the GGUF without
+    ``get_services()`` (callers running inside its construction).
     """
     from lilbee.providers.base import ProviderError
     from lilbee.providers.engine_params import resolve_model_path
@@ -358,7 +359,7 @@ def _embedder_dim_from_gguf(ref: str) -> int | None:
     try:
         # resolve_model_path raises ProviderError for a non-native (ollama/SDK) ref,
         # which has no local GGUF -- those embedders carry no width to derive here.
-        meta = read_gguf_metadata(resolve_model_path(ref))
+        meta = read_gguf_metadata(resolve_model_path(ref, registry))
     except (ProviderError, ValueError, OSError, RuntimeError, TypeError):
         return None
     raw = meta.get("embedding_length") if meta else None
@@ -369,6 +370,14 @@ def _embedder_dim_from_gguf(ref: str) -> int | None:
     except (TypeError, ValueError):
         return None
     return dim if dim > 0 else None
+
+
+def reconcile_embedding_dim(registry: ModelRegistry | None = None) -> None:
+    """Pin ``cfg.embedding_dim`` to the native embedder's GGUF width before the store
+    is built; no-op for non-native embedders or an already-matching dim."""
+    dim = _embedder_dim_from_gguf(cfg.embedding_model, registry)
+    if dim is not None and dim != cfg.embedding_dim:
+        cfg.embedding_dim = dim
 
 
 def _embed_reindex_required(new_ref: str) -> bool:

--- a/src/lilbee/providers/engine_params.py
+++ b/src/lilbee/providers/engine_params.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lilbee.app.services import get_services
+
+if TYPE_CHECKING:
+    from lilbee.modelhub.registry import ModelRegistry
 from lilbee.core.config import DEFAULT_NUM_CTX, cfg
 from lilbee.core.config.enums import KV_CACHE_TYPE_BYTES
 from lilbee.providers.base import ProviderError, ProviderErrorKind, filter_options
@@ -74,13 +77,15 @@ def chat_options_to_kwargs(options: dict[str, Any] | None) -> dict[str, Any]:
     return filtered
 
 
-def resolve_model_path(model: str) -> Path:
+def resolve_model_path(model: str, registry: ModelRegistry | None = None) -> Path:
     """Resolve a model name to a .gguf file path.
 
     Resolution order: (1) registry (canonical source for installed models),
-    (2) an absolute path to an existing file.
+    (2) an absolute path to an existing file. Pass *registry* to resolve without
+    reaching for ``get_services()`` (callers running inside its construction).
     """
-    registry = get_services().registry
+    if registry is None:
+        registry = get_services().registry
     try:
         return registry.resolve(model)
     except (KeyError, ValueError):

--- a/tests/test_dynamic_settings_eviction.py
+++ b/tests/test_dynamic_settings_eviction.py
@@ -164,7 +164,8 @@ def test_embedder_dim_from_gguf_reads_embedding_length(monkeypatch):
     from lilbee.app.settings import _embedder_dim_from_gguf
 
     monkeypatch.setattr(
-        "lilbee.providers.engine_params.resolve_model_path", lambda _ref: Path("/x.gguf")
+        "lilbee.providers.engine_params.resolve_model_path",
+        lambda _ref, _registry=None: Path("/x.gguf"),
     )
     monkeypatch.setattr(
         "lilbee.providers.gguf_meta.read_gguf_metadata",
@@ -178,14 +179,15 @@ def test_embedder_dim_from_gguf_handles_unresolvable_and_missing(monkeypatch):
 
     from lilbee.app.settings import _embedder_dim_from_gguf
 
-    def boom(_ref):
+    def boom(_ref, _registry=None):
         raise OSError("not installed")
 
     monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", boom)
     assert _embedder_dim_from_gguf("ref") is None
 
     monkeypatch.setattr(
-        "lilbee.providers.engine_params.resolve_model_path", lambda _ref: Path("/x.gguf")
+        "lilbee.providers.engine_params.resolve_model_path",
+        lambda _ref, _registry=None: Path("/x.gguf"),
     )
     monkeypatch.setattr(
         "lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {"architecture": "bert"}
@@ -202,6 +204,72 @@ def test_embedder_dim_from_gguf_handles_unresolvable_and_missing(monkeypatch):
         "lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {"embedding_length": "0"}
     )
     assert _embedder_dim_from_gguf("ref") is None
+
+
+def test_resolve_model_path_with_registry_skips_get_services(monkeypatch):
+    """A passed registry resolves WITHOUT reaching for get_services -- the re-entrancy
+    break that lets reconcile_embedding_dim run inside get_services' own construction."""
+    from pathlib import Path
+
+    from lilbee.providers import engine_params
+
+    def explode():
+        raise AssertionError("get_services must not be called when a registry is passed")
+
+    monkeypatch.setattr(engine_params, "get_services", explode)
+    fake_registry = mock.MagicMock()
+    fake_registry.resolve.return_value = Path("/m/embed.gguf")
+    assert engine_params.resolve_model_path("ref", fake_registry) == Path("/m/embed.gguf")
+    fake_registry.resolve.assert_called_once_with("ref")
+
+
+def test_embedder_dim_from_gguf_forwards_registry(monkeypatch):
+    """_embedder_dim_from_gguf forwards the registry to resolve_model_path so the
+    config-load reconcile never re-enters get_services."""
+    from pathlib import Path
+
+    from lilbee.app.settings import _embedder_dim_from_gguf
+
+    seen: dict[str, object] = {}
+
+    def fake_resolve(_ref, registry=None):
+        seen["registry"] = registry
+        return Path("/x.gguf")
+
+    monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", fake_resolve)
+    monkeypatch.setattr(
+        "lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {"embedding_length": "1024"}
+    )
+    sentinel = mock.MagicMock()
+    assert _embedder_dim_from_gguf("ref", sentinel) == 1024
+    assert seen["registry"] is sentinel
+
+
+def test_reconcile_embedding_dim_pins_native_width(monkeypatch):
+    """A config-loaded embedding_model with no embedding_dim gets the store width pinned
+    from the embedder GGUF, where the 768 default would build the index at the wrong width."""
+    from lilbee.app import settings as settings_mod
+
+    cfg.embedding_model = "Qwen/Qwen3-Embedding-8B-GGUF/x.gguf"
+    cfg.embedding_dim = 768
+    monkeypatch.setattr(settings_mod, "_embedder_dim_from_gguf", lambda _ref, _reg=None: 4096)
+    settings_mod.reconcile_embedding_dim()
+    assert cfg.embedding_dim == 4096
+
+
+def test_reconcile_embedding_dim_leaves_dim_when_unreadable_or_matching(monkeypatch):
+    """A non-native embedder (no GGUF width) or an already-correct dim is left as-is."""
+    from lilbee.app import settings as settings_mod
+
+    cfg.embedding_model = "ollama/test-embed-model:v1"
+    cfg.embedding_dim = 768
+    monkeypatch.setattr(settings_mod, "_embedder_dim_from_gguf", lambda _ref, _reg=None: None)
+    settings_mod.reconcile_embedding_dim()
+    assert cfg.embedding_dim == 768  # unreadable -> untouched
+
+    monkeypatch.setattr(settings_mod, "_embedder_dim_from_gguf", lambda _ref, _reg=None: 768)
+    settings_mod.reconcile_embedding_dim()
+    assert cfg.embedding_dim == 768  # already matches -> untouched
 
 
 def test_chat_and_vision_model_change_reloads_those_roles():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4563,6 +4563,21 @@ async def test_catalog_load_more_noop_when_exhausted():
                 assert screen._hf_offset_by_task[ModelTask.CHAT] == old_offset
 
 
+def test_catalog_load_more_short_circuits_without_more_pages():
+    """_load_more's guard returns without fetching or arming the loading flag when
+    the active task has no more pages. Constructed without a pilot so coverage of the
+    guard is deterministic across platforms, not subject to TUI mount timing."""
+    from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+    screen = CatalogScreen()
+    screen._active_tab_id_cache = "chat"
+    screen._hf_has_more_by_task[ModelTask.CHAT] = False
+    with patch.object(screen, "_fetch_more_hf_for_task") as fetch:
+        screen._load_more()
+    assert not fetch.called
+    assert screen._loading_more is False
+
+
 async def test_catalog_append_more_hf_to_list_extends_rows_and_options():
     """Newly-arrived HF rows mount to the list view via append_rows."""
     from lilbee.cli.tui.screens.catalog import CatalogScreen


### PR DESCRIPTION
## Problem

If a config file set an embedding model but not its dimension, the search index got built at the wrong width and every document failed to index with a dimension mismatch. This showed up indexing the Godot QA corpus with a 4096-wide embedder against the old 768 default. The earlier fix only handled switching the embedder at runtime, not loading one from config at startup.

## Solution

On startup, lilbee now reads the embedder's real dimension from its model file and builds the index to match, so a config-set embedder just works. Covered by tests.