### PR TITLE
Open opencode on the configured chat model

### DIFF
--- a/src/lilbee/cli/launchers/opencode.py
+++ b/src/lilbee/cli/launchers/opencode.py
@@ -119,20 +119,29 @@ def _install_lilbee_skill() -> Path | None:
     return dest
 
 
-def _update_opencode_picker_state(model_refs: list[str]) -> Path | None:
-    """Make lilbee models appear in opencode's model picker on first run.
+def _update_opencode_picker_state(model_refs: list[str], default_ref: str) -> Path | None:
+    """Put lilbee models in opencode's picker, the configured chat model first.
 
-    opencode uses the same XDG-style state path on every platform, so this runs
-    everywhere; a no-op when there are no installed models.
+    opencode opens on ``recent[0]``; leading with *default_ref* makes it select the
+    chat model lilbee actually serves instead of the alphabetically-first installed
+    one (which otherwise leaves opencode on its own fallback provider). No-op when no
+    models are installed; same XDG-style state path on every platform.
     """
     if not model_refs:
         return None
     path = _opencode_state_file()
     state = _read_opencode_state(path)
-    state["recent"] = _merge_recent(state.get("recent"), model_refs)
+    state["recent"] = _merge_recent(state.get("recent"), _default_first(model_refs, default_ref))
     path.parent.mkdir(parents=True, exist_ok=True)
     _atomic_write_json(path, state)
     return path
+
+
+def _default_first(model_refs: list[str], default_ref: str) -> list[str]:
+    """Order so *default_ref* leads, leaving the rest in their existing order."""
+    if default_ref not in model_refs:
+        return model_refs
+    return [default_ref, *(ref for ref in model_refs if ref != default_ref)]
 
 
 def _read_opencode_state(path: Path) -> PickerState:
@@ -230,7 +239,7 @@ class OpencodeLauncher:
         if not _confirm_setup(self._assume_yes):
             raise typer.Exit(0)
         _install_lilbee_skill()
-        _update_opencode_picker_state(model_refs)
+        _update_opencode_picker_state(model_refs, str(cfg.chat_model))
         block = opencode_config(
             base_url=f"http://{LOOPBACK}:{port}",
             api_key=token,

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -357,6 +357,26 @@ def test_launch_opencode_updates_picker_state_on_unix(tmp_path):
     assert state["recent"][0] == {"providerID": "lilbee", "modelID": _CHAT_REF}
 
 
+def test_default_first_leads_with_configured_model():
+    from lilbee.cli.launchers.opencode import _default_first
+
+    refs = ["aaa/x.gguf", "zzz/y.gguf", "mmm/z.gguf"]
+    assert _default_first(refs, "mmm/z.gguf") == ["mmm/z.gguf", "aaa/x.gguf", "zzz/y.gguf"]
+    # A default that isn't installed leaves the order untouched.
+    assert _default_first(refs, "not/installed.gguf") == refs
+
+
+def test_picker_state_leads_with_configured_default_not_alphabetically_first(tmp_path):
+    from lilbee.cli.launchers.opencode import _update_opencode_picker_state
+
+    # "zzz" sorts last but is the configured chat model -> it must be recent[0],
+    # otherwise opencode opens on "aaa" and ignores the model lilbee serves.
+    _update_opencode_picker_state(["aaa/x.gguf", "zzz/y.gguf"], "zzz/y.gguf")
+    state = json.loads((tmp_path / ".local" / "state" / "opencode" / "model.json").read_text())
+    assert state["recent"][0] == {"providerID": "lilbee", "modelID": "zzz/y.gguf"}
+    assert {e["modelID"] for e in state["recent"]} == {"aaa/x.gguf", "zzz/y.gguf"}
+
+
 def test_launch_opencode_picker_state_dedupes_prior_lilbee_entries(tmp_path):
     _write_server_session()
     fake_opencode = "/usr/local/bin/opencode"

--- a/tools/qa/opencode/harness_config.py
+++ b/tools/qa/opencode/harness_config.py
@@ -62,7 +62,6 @@ _TOOLS_OFF = (
     "todoread",
     "task",
 )
-_LILBEE_PROVIDER_ID = "lilbee"
 
 # Substrings whose appearance in the pane means the cell can't recover --
 # record the scenario as FAIL immediately instead of polling to timeout.

--- a/tools/qa/opencode/matrix.py
+++ b/tools/qa/opencode/matrix.py
@@ -31,7 +31,6 @@ from models import (
 )
 from opencode_driver import (
     launch_opencode_in_tmux,
-    pin_opencode_default_model,
     reset_opencode_session_state,
     scope_opencode_tools,
     tmux_capture,
@@ -72,8 +71,6 @@ def setup_cell(
     print(f"[{cell.family}] seeded Godot corpus from {_GODOT_CORPUS}")
     print(f"[{cell.family}] scoping opencode tools to lilbee_search")
     scope_opencode_tools()
-    print(f"[{cell.family}] pinning opencode default model")
-    pin_opencode_default_model(cell.ref)
     return workspace, port, None
 
 

--- a/tools/qa/opencode/opencode_driver.py
+++ b/tools/qa/opencode/opencode_driver.py
@@ -10,7 +10,6 @@ import time
 from pathlib import Path
 
 from harness_config import (
-    _LILBEE_PROVIDER_ID,
     _OPENCODE_BOOT_SETTLE_S,
     _OPENCODE_CONFIG,
     _OPENCODE_PICKER_STATE,
@@ -37,31 +36,6 @@ def scope_opencode_tools() -> None:
     cfg["tools"] = {tool: False for tool in _TOOLS_OFF}
     _OPENCODE_CONFIG.parent.mkdir(parents=True, exist_ok=True)
     _OPENCODE_CONFIG.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
-
-
-def pin_opencode_default_model(model_ref: str) -> None:
-    """Rewrite opencode's picker state so *model_ref* is recent[0].
-
-    ``lilbee launch opencode`` prepends every installed model to the
-    ``recent`` list. Without this step opencode's default session model
-    is non-deterministic across QA runs; with it the cell loads the
-    intended model.
-    """
-    _OPENCODE_PICKER_STATE.parent.mkdir(parents=True, exist_ok=True)
-    state: dict = {"recent": [], "favorite": [], "variant": {}}
-    if _OPENCODE_PICKER_STATE.exists():
-        with contextlib.suppress(OSError, json.JSONDecodeError):
-            state = json.loads(_OPENCODE_PICKER_STATE.read_text(encoding="utf-8"))
-    recent = [e for e in state.get("recent", []) if isinstance(e, dict)]
-    target_entry = {"providerID": _LILBEE_PROVIDER_ID, "modelID": model_ref}
-    recent = [
-        e
-        for e in recent
-        if not (e.get("modelID") == model_ref and e.get("providerID") == _LILBEE_PROVIDER_ID)
-    ]
-    recent.insert(0, target_entry)
-    state["recent"] = recent
-    _OPENCODE_PICKER_STATE.write_text(json.dumps(state, indent=2))
 
 
 def tmux_session_exists(name: str) -> bool:
@@ -163,8 +137,8 @@ def reset_opencode_session_state() -> None:
        to it for the next cell whose own ref isn't pulled yet -- and the
        smoke ends up testing the WRONG model with a fake PASS.
 
-    :func:`pin_opencode_default_model` rewrites the picker after this scrub
-    so the cell's intended model wins the default.
+    ``lilbee launch opencode`` rewrites the picker on the next boot with the
+    cell's configured chat model as the default, so the scrub is safe.
     """
     if _OPENCODE_SHARE_DIR.exists():
         shutil.rmtree(_OPENCODE_SHARE_DIR)


### PR DESCRIPTION
## Problem

`lilbee launch opencode` adds every installed model to opencode's picker but marks none as the default, so opencode opens on whichever model sorts first alphabetically. When that isn't the model lilbee is serving, opencode silently falls back to its own built-in provider. A giant-model cell, for example, ended up running GLM-5.1 over Hugging Face instead of the MiniMax-M2 that lilbee had loaded.

## Solution

The launcher now leads opencode's picker with the configured chat model, so opencode opens on the model lilbee actually serves. The opencode QA harness no longer needs its own pin-the-default workaround, so that's removed.