### PR TITLE
Size the multi-GPU chat fleet against per-device VRAM

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,14 +174,21 @@ flowchart TD
   subprocess and memoized on the GGUF's path + mtime + sizing. It reports both a
   discrete-GPU footprint (`nonuma`, what lands in device VRAM) and a unified-memory
   footprint (`uma`, total resident on an Apple Silicon / shared-RAM host); the
-  planner charges whichever matches the host. This replaced a hand-rolled
+  planner charges whichever matches the host. For a multi-GPU tensor-split it passes
+  `--tensor-split`, so gguf-parser returns the **per-device** breakdown; the planner
+  fits and charges the busiest card (`peak_footprint`), because a split OOMs on
+  whichever GPU is fullest, not on the summed total. This replaced a hand-rolled
   weights + KV-cache estimate that used discrete-GPU accounting and over-estimated
   ~3x on unified memory, which was crowding the co-resident embed/rerank servers out
   of the budget and 503-ing every search.
 - **Placement** (`placement.py`): first-fit-decreasing bin-pack with 90% headroom.
   A model that fits one GPU is a single pinned instance; small models co-locate; a
-  model too big for one GPU is tensor-split **proportionally to each card's free
-  VRAM** (so unequal GPUs don't OOM the smaller one). On a single CPU/Metal box this
+  model too big for one GPU is tensor-split across the **fewest cards whose per-device
+  footprint each fits**, proportionally to each card's free VRAM (so unequal GPUs
+  don't OOM the smaller one). A split chat's context is then sized
+  (`ctx.fit_split_ctx`, a binary search over the gguf-parser estimate) against the
+  **busiest card's** headroom, not the combined pool, so the per-GPU compute buffer
+  can't overflow device 0. On a single CPU/Metal box this
   is a fleet-of-one against one shared pool, where the **search-critical roles
   (embed/rerank) are reserved before the elastic chat model**: chat's slot count and
   context are sized against the budget *minus* the search footprint, and the shared

--- a/src/lilbee/providers/engine_params.py
+++ b/src/lilbee/providers/engine_params.py
@@ -113,25 +113,21 @@ def _kv_elem_bytes_for_cfg() -> int:
     return KV_CACHE_TYPE_BYTES[cfg.kv_cache_type]
 
 
-def resolve_chat_ctx(
-    model_path: Path,
-    meta: dict[str, str] | None,
-    available_bytes: int | None = None,
-    slots: int = 1,
-) -> int:
-    """Pick n_ctx aiming for ``cfg.chat_n_ctx_target``, clamped to model + host.
+def chat_ctx_ceiling(meta: dict[str, str] | None, model_path: Path) -> int:
+    """Hard upper bound on a chat per-slot n_ctx: trained context, capped by ``cfg.num_ctx_max``."""
+    training_ctx = train_ctx_from_meta(meta, fallback=DEFAULT_NUM_CTX, model_path=model_path)
+    if cfg.num_ctx_max is not None:
+        return min(training_ctx, cfg.num_ctx_max)
+    return training_ctx
+
+
+def resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
+    """Pick a single-GPU n_ctx aiming for ``cfg.chat_n_ctx_target``, clamped to model + host.
 
     When ``cfg.num_ctx_max`` is ``None`` the model's training_ctx is the only
     ceiling, so a long-context model can grow past the target if the host has
-    the RAM to back it. Setting ``num_ctx_max`` explicitly caps below
-    training_ctx for per-host policy reasons.
-
-    *available_bytes* / *slots* are set by the fleet for a model tensor-split
-    across multiple GPUs: *available_bytes* is the combined free VRAM of those
-    GPUs and *slots* is ``--parallel``. A single-GPU read (the default) under-
-    budgets a split giant and collapses its context to the floor; and because the
-    fleet serves ``--ctx-size = per_slot x slots``, the per-slot value must be the
-    total KV budget divided by *slots*. See :func:`split_chat_ctx`.
+    the RAM to back it. A multi-GPU tensor-split chat is sized separately by the
+    fleet against its per-device headroom (see :func:`lilbee.providers.fleet.ctx.fit_split_ctx`).
     """
     training_ctx = train_ctx_from_meta(meta, fallback=DEFAULT_NUM_CTX, model_path=model_path)
     ceiling = cfg.num_ctx_max if cfg.num_ctx_max is not None else training_ctx
@@ -139,14 +135,6 @@ def resolve_chat_ctx(
     try:
         model_bytes = model_path.stat().st_size
         kv_per_tok = kv_bytes_per_token(meta, _kv_elem_bytes_for_cfg())
-        if available_bytes is not None:
-            return split_chat_ctx(
-                combined_free_bytes=available_bytes,
-                model_bytes=model_bytes,
-                kv_bytes_per_tok=kv_per_tok,
-                slots=slots,
-                upper=min(training_ctx, ceiling),
-            )
         return compute_dynamic_ctx(
             model_bytes=model_bytes,
             available_bytes=get_available_memory(cfg.gpu_memory_fraction),
@@ -158,39 +146,6 @@ def resolve_chat_ctx(
     except (OSError, ValueError):
         log.debug("dynamic ctx sizing failed for %s, using static cap", model_path, exc_info=True)
         return min(training_ctx, cfg.chat_n_ctx_target)
-
-
-def split_chat_ctx(
-    *,
-    combined_free_bytes: int,
-    model_bytes: int,
-    kv_bytes_per_tok: int,
-    slots: int,
-    upper: int,
-) -> int:
-    """Per-slot n_ctx for a chat model tensor-split across GPUs.
-
-    Sizes the per-slot context so the total KV cache (``per_slot x slots``) fits
-    the same budget the placement planner reserves: the usable fraction of the
-    combined free VRAM, minus the weights and the flat per-instance overhead.
-    Staying inside the planner's budget keeps the launched context placeable, and
-    dividing by *slots* accounts for ``--ctx-size`` being shared across the
-    continuous-batching slots. A dedicated giant therefore uses its real
-    headroom instead of the conservative single-GPU target.
-    """
-    from lilbee.providers.fleet.placement import _MODEL_OVERHEAD_BYTES, _VRAM_USABLE_FRACTION
-    from lilbee.providers.model_cache import _DYNAMIC_CTX_FLOOR, _DYNAMIC_CTX_QUANTUM
-
-    if kv_bytes_per_tok <= 0:
-        return max(_DYNAMIC_CTX_FLOOR, upper)
-    kv_budget = (
-        int(combined_free_bytes * _VRAM_USABLE_FRACTION) - model_bytes - _MODEL_OVERHEAD_BYTES
-    )
-    if kv_budget <= 0:
-        return _DYNAMIC_CTX_FLOOR
-    per_slot = kv_budget // (max(1, slots) * kv_bytes_per_tok)
-    bounded = max(_DYNAMIC_CTX_FLOOR, min(per_slot, upper))
-    return max(_DYNAMIC_CTX_FLOOR, (bounded // _DYNAMIC_CTX_QUANTUM) * _DYNAMIC_CTX_QUANTUM)
 
 
 def resolve_n_gpu_layers(*, embedding: bool) -> int:

--- a/src/lilbee/providers/fleet/ctx.py
+++ b/src/lilbee/providers/fleet/ctx.py
@@ -1,0 +1,73 @@
+"""Per-device context sizing for a tensor-split chat model in the fleet.
+
+Single-GPU chat ctx lives in ``engine_params.resolve_chat_ctx``; this is its
+multi-GPU counterpart, sizing the per-slot context against the busiest card's
+headroom rather than the summed pool. See docs/architecture.md (VRAM estimation).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from lilbee.core.config.enums import KvCacheType
+from lilbee.providers.engine_params import chat_ctx_ceiling
+from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION, estimate_instance_footprint
+from lilbee.providers.model_cache import _DYNAMIC_CTX_FLOOR, _DYNAMIC_CTX_QUANTUM
+
+# Extra VRAM held back on the busiest card on top of the gguf-parser estimate.
+# In --split-mode layer, gguf-parser ignores --main-gpu and so under-models the
+# compute graph + logits that real llama.cpp concentrates on the main device.
+# Default 0 (trust the estimate); raise once measured on a multi-GPU pod (bb-ds8).
+_MAIN_GPU_SKEW_RESERVE_BYTES = 0
+
+
+def fit_split_ctx(
+    model_path: Path,
+    *,
+    meta: dict[str, str] | None,
+    slots: int,
+    ratio: tuple[int, ...],
+    per_device_free_bytes: Sequence[int],
+    gpu_layers: int,
+    flash_attn: bool,
+    kv_cache_type: KvCacheType,
+) -> int:
+    """Largest quantized per-slot n_ctx whose per-device peak fits the busiest card.
+
+    Binary-searches the gguf-parser estimate at the launch tensor-split *ratio*:
+    the server serves ``--ctx-size = per_slot x slots``, so each probe estimates
+    that total and accepts the per-slot value when the peak device's footprint
+    stays under its usable headroom. Falls to the floor when even that overflows.
+    """
+    bottleneck = (
+        min(int(free * USABLE_VRAM_FRACTION) for free in per_device_free_bytes)
+        - _MAIN_GPU_SKEW_RESERVE_BYTES
+    )
+    if bottleneck <= 0:
+        return _DYNAMIC_CTX_FLOOR
+    upper = chat_ctx_ceiling(meta, model_path)
+
+    def _peak_fits(per_slot: int) -> bool:
+        est = estimate_instance_footprint(
+            model_path,
+            ctx=per_slot * slots,
+            slots=slots,
+            gpu_layers=gpu_layers,
+            flash_attn=flash_attn,
+            kv_cache_type=kv_cache_type,
+            tensor_split=ratio,
+        )
+        return est.peak_footprint(unified=False) <= bottleneck
+
+    if not _peak_fits(_DYNAMIC_CTX_FLOOR):
+        return _DYNAMIC_CTX_FLOOR
+    steps = max(0, (upper - _DYNAMIC_CTX_FLOOR) // _DYNAMIC_CTX_QUANTUM)
+    lo, hi, best = 0, steps, 0
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if _peak_fits(_DYNAMIC_CTX_FLOOR + mid * _DYNAMIC_CTX_QUANTUM):
+            best, lo = mid, mid + 1
+        else:
+            hi = mid - 1
+    return _DYNAMIC_CTX_FLOOR + best * _DYNAMIC_CTX_QUANTUM

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -9,18 +9,20 @@ that fits nowhere gets no server (its calls error). See docs/architecture.md.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
+from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION
 from lilbee.providers.roles import WorkerRole
 
-# Mirrors vLLM's gpu_memory_utilization default: never pack a GPU past 90%.
-_VRAM_USABLE_FRACTION = 0.9
-# Flat per-instance overhead (CUDA context, compute buffers) reserved on top of
-# weights when sizing a tensor-split chat's per-slot context (see split_chat_ctx).
-_MODEL_OVERHEAD_BYTES = 1024**3
 # Search-critical roles reserved ahead of the elastic chat model in a shared pool,
 # so a large chat can never crowd embed/rerank out (which would 503 every search).
 _SEARCH_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK)
+
+# (role, per-device tensor-split ratio) -> the instance's per-device VRAM footprint
+# vector aligned to that ratio. A split is accepted only when every card's entry
+# fits its own headroom, and each card is charged its own entry, not the sum.
+PeakEstimator = Callable[[WorkerRole, tuple[int, ...]], tuple[int, ...]]
 
 
 @dataclass(frozen=True)
@@ -68,14 +70,15 @@ def plan_placement(
     models: list[ModelPlacementInput],
     devices: list[tuple[int, int]],
     *,
+    estimate_peak: PeakEstimator,
     unified_budget: int | None = None,
 ) -> Placement:
     """Bin-pack *models* onto *devices* (``[(index, vram_bytes), ...]``).
 
     First-fit-decreasing by footprint with a 90% headroom per GPU. A model that
     fits one GPU takes a single instance; one too big for any single GPU is
-    tensor-split across the fewest GPUs whose combined headroom fits; a model that
-    fits nowhere is returned as an unplaceable role (it gets no server).
+    tensor-split across the fewest GPUs whose per-device share (from
+    *estimate_peak*) each fits; a model that fits nowhere is an unplaceable role.
 
     No GPU devices is the CPU/unified-memory case (a GPU-less host, or an Apple
     Silicon box where the probe found nothing): roles run as single un-pinned
@@ -94,7 +97,7 @@ def plan_placement(
                 unplaceable_roles=(),
             )
         return _place_shared_memory(models, unified_budget)
-    remaining: dict[int, float] = {idx: vram * _VRAM_USABLE_FRACTION for idx, vram in devices}
+    remaining: dict[int, float] = {idx: vram * USABLE_VRAM_FRACTION for idx, vram in devices}
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
 
@@ -103,7 +106,7 @@ def plan_placement(
     singles = [m for m in models if m.replicas <= 1]
     replicated = [m for m in models if m.replicas > 1]
     for model in sorted(singles, key=lambda m: m.est_vram_bytes, reverse=True):
-        plan = _place_single(model, remaining)
+        plan = _place_single(model, remaining, estimate_peak)
         if plan is None:
             unplaceable.append(model.role)
         else:
@@ -118,17 +121,40 @@ def plan_placement(
     return Placement(instances=tuple(instances), unplaceable_roles=tuple(unplaceable))
 
 
-def _place_single(model: ModelPlacementInput, remaining: dict[int, float]) -> InstancePlan | None:
+def _place_single(
+    model: ModelPlacementInput,
+    remaining: dict[int, float],
+    estimate_peak: PeakEstimator,
+) -> InstancePlan | None:
     """Place one instance: a single GPU when it fits, else a tensor-split, else None."""
     single = _best_single_device(model.est_vram_bytes, remaining)
     if single is not None:
         remaining[single] -= model.est_vram_bytes
         return InstancePlan(role=model.role, devices=(single,))
-    split = _devices_for_split(model.est_vram_bytes, remaining)
-    if split is not None:
-        ratio = tuple(max(1, int(remaining[idx] / 1024**3)) for idx in split)
-        _charge_split(model.est_vram_bytes, split, remaining)
-        return InstancePlan(role=model.role, devices=tuple(split), tensor_split=ratio)
+    return _place_split(model, remaining, estimate_peak)
+
+
+def _place_split(
+    model: ModelPlacementInput,
+    remaining: dict[int, float],
+    estimate_peak: PeakEstimator,
+) -> InstancePlan | None:
+    """Tensor-split across the fewest most-free GPUs whose per-device share each fits.
+
+    Charges each chosen card its own entry from *estimate_peak*'s vector, so the
+    busiest card (which OOMs first) is what gates the split, not the summed pool.
+    """
+    by_free = sorted(remaining, key=lambda idx: remaining[idx], reverse=True)
+    for count in range(2, len(by_free) + 1):
+        chosen = by_free[:count]
+        ratio = tuple(max(1, int(remaining[idx] / 1024**3)) for idx in chosen)
+        per_device = estimate_peak(model.role, ratio)
+        if len(per_device) == count and all(
+            peak <= remaining[idx] for idx, peak in zip(chosen, per_device, strict=True)
+        ):
+            for idx, peak in zip(chosen, per_device, strict=True):
+                remaining[idx] -= peak
+            return InstancePlan(role=model.role, devices=tuple(chosen), tensor_split=ratio)
     return None
 
 
@@ -191,23 +217,3 @@ def _best_single_device(need: int, remaining: dict[int, float]) -> int | None:
     if not candidates:
         return None
     return max(candidates, key=lambda idx: remaining[idx])
-
-
-def _devices_for_split(need: int, remaining: dict[int, float]) -> list[int] | None:
-    """Fewest devices (most-free first) whose combined headroom fits *need*."""
-    by_free = sorted(remaining, key=lambda idx: remaining[idx], reverse=True)
-    chosen: list[int] = []
-    total = 0.0
-    for idx in by_free:
-        chosen.append(idx)
-        total += remaining[idx]
-        if total >= need:
-            return chosen
-    return None
-
-
-def _charge_split(need: int, split: list[int], remaining: dict[int, float]) -> None:
-    """Debit *need* across *split* in proportion to each device's free VRAM."""
-    total_free = sum(remaining[idx] for idx in split)
-    for idx in split:
-        remaining[idx] -= need * (remaining[idx] / total_free)

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -18,7 +18,12 @@ from lilbee.providers.fleet.adapters import (
 from lilbee.providers.fleet.binary import llama_server_runtime_env, resolve_llama_server
 from lilbee.providers.fleet.devices import FleetDevice, probe_devices, visible_env
 from lilbee.providers.fleet.launch import InstanceLaunch
-from lilbee.providers.fleet.placement import InstancePlan, ModelPlacementInput, plan_placement
+from lilbee.providers.fleet.placement import (
+    InstancePlan,
+    ModelPlacementInput,
+    PeakEstimator,
+    plan_placement,
+)
 from lilbee.providers.fleet.vram import estimate_instance_footprint
 from lilbee.providers.roles import RerankMode, WorkerRole
 
@@ -222,21 +227,13 @@ def _fit_slots(
     return 1
 
 
-def _role_ctx(
-    role: WorkerRole,
-    model_path: Path,
-    meta: dict[str, str] | None,
-    chat_available_bytes: int | None = None,
-    chat_slots: int = 1,
-) -> int:
+def _role_ctx(role: WorkerRole, model_path: Path, meta: dict[str, str] | None) -> int:
     """Per-slot context for a role, derived as the in-process loader does.
 
     Embed/rerank use the embedding model's training context; vision uses the
     vision loader's training-context picker; chat honors ``cfg.num_ctx`` then
-    falls back to the dynamic chat-ctx picker. *chat_available_bytes* / *chat_slots*
-    (set by the launch path for a tensor-split chat model) are the combined free
-    VRAM of its devices and its ``--parallel`` count, so its per-slot context is
-    sized against the whole split, divided across the batching slots.
+    falls back to the single-GPU dynamic chat-ctx picker. A tensor-split chat is
+    sized against its per-device headroom instead (see :func:`fit_split_ctx`).
     """
     from lilbee.core.config import cfg
     from lilbee.providers.engine_params import (
@@ -256,7 +253,7 @@ def _role_ctx(
         return resolve_vision_ctx(model_path)
     if cfg.num_ctx is not None:
         return cfg.num_ctx
-    return resolve_chat_ctx(model_path, meta, chat_available_bytes, chat_slots)
+    return resolve_chat_ctx(model_path, meta)
 
 
 def _rerank_mode_for(meta: dict[str, str] | None) -> RerankMode:
@@ -379,6 +376,68 @@ def _estimate_role(
     )
 
 
+def _placement_estimate_ctx(role: WorkerRole, model_path: Path, meta: dict[str, str] | None) -> int:
+    """Per-slot ctx ceiling for the placement estimate: the most a launch can use.
+
+    fit_split_ctx caps the launched per-slot ctx at this same ceiling, so estimating
+    here keeps the per-device reservation an upper bound on the launched footprint.
+    """
+    from lilbee.core.config import cfg
+    from lilbee.providers.engine_params import chat_ctx_ceiling
+
+    if role is WorkerRole.CHAT:
+        return cfg.num_ctx if cfg.num_ctx is not None else chat_ctx_ceiling(meta, model_path)
+    return _role_ctx(role, model_path, meta)
+
+
+def _placement_estimate_slots(role: WorkerRole, meta: dict[str, str] | None) -> int:
+    """The launch ceiling on a role's batching slots, for a conservative estimate.
+
+    Returning the maximum (_slots_for never launches more) keeps the reservation an
+    upper bound: estimated total ctx (per-slot ceiling x these slots) is the most a
+    launch can hold, so the launched per-device footprint cannot exceed it.
+    """
+    from lilbee.core.config import cfg
+
+    if role is WorkerRole.CHAT:
+        return _CHAT_SLOTS
+    if role is WorkerRole.VISION:
+        return max(1, cfg.vision_ocr_concurrency)
+    if role is WorkerRole.RERANK and _rerank_mode_for(meta) is RerankMode.LLM:
+        return LLM_RERANK_CONCURRENCY
+    return _AUX_SLOTS
+
+
+def _peak_estimator(model_refs: dict[WorkerRole, str]) -> PeakEstimator:
+    """Per-device VRAM-vector estimator for the planner, bound to the configured models.
+
+    Estimates each role at its launch ceiling (ctx x slots) with the candidate
+    tensor-split ratio, so the planner reserves enough cards for the busiest one.
+    """
+    from lilbee.providers.engine_params import resolve_model_path
+    from lilbee.providers.gguf_meta import read_gguf_metadata
+
+    def estimate_peak(role: WorkerRole, ratio: tuple[int, ...]) -> tuple[int, ...]:
+        path = resolve_model_path(model_refs[role])
+        meta = read_gguf_metadata(path)
+        mmproj = _vision_mmproj(model_refs[role]) if role is WorkerRole.VISION else None
+        slots = _placement_estimate_slots(role, meta)
+        ctx = _placement_estimate_ctx(role, path, meta)
+        est = estimate_instance_footprint(
+            path,
+            ctx=ctx * slots,
+            slots=slots,
+            gpu_layers=_role_gpu_layers(role),
+            flash_attn=_role_flash(role),
+            kv_cache_type=_role_kv_cache_type(role),
+            mmproj_path=mmproj,
+            tensor_split=ratio,
+        )
+        return est.per_device_vram
+
+    return estimate_peak
+
+
 def _search_reservation(inputs: dict[WorkerRole, ModelPlacementInput]) -> int:
     """Total footprint of the placed search roles (all replicas), held back ahead
     of chat."""
@@ -461,23 +520,35 @@ def _launch_for(
     model_path = resolve_model_path(model_ref)
     weights_bytes = model_path.stat().st_size
     meta = read_gguf_metadata(model_path)
+    from lilbee.core.config import cfg
+
     chosen = tuple(by_index[i] for i in plan.devices)
     is_chat = plan.role is WorkerRole.CHAT
     is_vision = plan.role is WorkerRole.VISION
     mmproj = _vision_mmproj(model_ref) if is_vision else None
-    # A tensor-split chat model's KV budget spans every device it occupies; sizing
-    # its context against one GPU collapses it to the floor (see resolve_chat_ctx).
-    # The slots count divides the shared --ctx-size, so bootstrap it first.
-    split_chat = is_chat and len(chosen) > 1
-    chat_available = sum(d.free_bytes for d in chosen) if split_chat else None
-    chat_slots = (
-        _slots_for(
+    # A tensor-split chat's context is sized against the busiest card's headroom,
+    # not one GPU's; the slot count divides the shared --ctx-size, so bootstrap it
+    # first. A cfg.num_ctx pin overrides the fit (handled by _role_ctx).
+    split_chat = is_chat and len(chosen) > 1 and cfg.num_ctx is None
+    if split_chat:
+        # circular: fleet.ctx -> engine_params -> app.services
+        from lilbee.providers.fleet.ctx import fit_split_ctx
+
+        chat_slots = _slots_for(
             WorkerRole.CHAT, model_path, _SPLIT_BOOTSTRAP_CTX, chat_reservation=chat_reservation
         )
-        if split_chat
-        else 1
-    )
-    ctx = _role_ctx(plan.role, model_path, meta, chat_available, chat_slots)
+        ctx = fit_split_ctx(
+            model_path,
+            meta=meta,
+            slots=chat_slots,
+            ratio=plan.tensor_split,
+            per_device_free_bytes=[d.free_bytes for d in chosen],
+            gpu_layers=_role_gpu_layers(WorkerRole.CHAT),
+            flash_attn=_role_flash(WorkerRole.CHAT),
+            kv_cache_type=_role_kv_cache_type(WorkerRole.CHAT),
+        )
+    else:
+        ctx = _role_ctx(plan.role, model_path, meta)
     rerank_mode = _rerank_mode_for(meta) if plan.role is WorkerRole.RERANK else None
     is_llm_rerank = rerank_mode is RerankMode.LLM
     # Size slots the same way the estimator did so the launched --parallel matches
@@ -576,6 +647,7 @@ def plan_launches(
     placement = plan_placement(
         inputs,
         [(d.index, d.free_bytes) for d in devices],
+        estimate_peak=_peak_estimator(model_refs),
         unified_budget=unified_budget,
     )
     for role in placement.unplaceable_roles:

--- a/src/lilbee/providers/fleet/vram.py
+++ b/src/lilbee/providers/fleet/vram.py
@@ -26,6 +26,9 @@ _FLAG_CACHE_V = "--cache-type-v"
 _FLAG_MMPROJ = "--mmproj-path"
 _FLAG_FLASH = "--flash-attention"
 _FLAG_NO_FLASH = "--no-flash-attention"
+_FLAG_TENSOR_SPLIT = "--tensor-split"
+_FLAG_SPLIT_MODE = "--split-mode"
+_SPLIT_MODE_LAYER = "layer"
 _FLAG_JSON = "--json"
 
 # gguf-parser JSON keys (estimate.items[0] carries the per-instance footprint).
@@ -40,10 +43,19 @@ _PROVIDER = "llama-server"
 _PARSE_TIMEOUT_S = 60
 _CACHE_SIZE = 64
 
+# Mirrors vLLM's gpu_memory_utilization default: never charge a GPU past 90% of
+# its free VRAM, leaving headroom for allocator fragmentation and driver overhead.
+USABLE_VRAM_FRACTION = 0.9
+
 
 @dataclass(frozen=True)
 class GgufVramEstimate:
-    """One instance's footprint from gguf-parser, for both memory models."""
+    """One instance's footprint from gguf-parser, for both memory models.
+
+    ``per_device_*`` carry the per-GPU breakdown gguf-parser returns once a
+    ``tensor_split`` is supplied. A tensor-split instance OOMs on its busiest card,
+    so the planner fits/charges ``peak_footprint`` (the max device), never the sum.
+    """
 
     vram_bytes: int
     """Discrete-GPU model: bytes resident in device VRAM (summed over devices)."""
@@ -51,10 +63,23 @@ class GgufVramEstimate:
     """Discrete-GPU model: host RAM bytes (mmap pages, compute buffers)."""
     unified_bytes: int
     """Unified-memory model: total resident footprint (RAM + would-be VRAM)."""
+    per_device_vram: tuple[int, ...] = ()
+    """Discrete-GPU VRAM per device (gguf-parser ``vrams[].nonuma``)."""
+    per_device_unified: tuple[int, ...] = ()
+    """Unified-memory footprint per device (``vrams[].uma``)."""
 
     def footprint(self, *, unified: bool) -> int:
-        """Bytes to charge against the budget for this host's memory model."""
+        """Total bytes to charge against a shared budget for this memory model."""
         return self.unified_bytes if unified else self.vram_bytes
+
+    def peak_footprint(self, *, unified: bool) -> int:
+        """The busiest single device's bytes -- what must fit on one GPU.
+
+        Falls back to the total when there is no per-device breakdown (a
+        single-device estimate, or an estimate run without a tensor split).
+        """
+        per_device = self.per_device_unified if unified else self.per_device_vram
+        return max(per_device) if per_device else self.footprint(unified=unified)
 
 
 def estimate_instance_footprint(
@@ -66,8 +91,14 @@ def estimate_instance_footprint(
     flash_attn: bool,
     kv_cache_type: KvCacheType,
     mmproj_path: Path | None = None,
+    tensor_split: tuple[int, ...] = (),
 ) -> GgufVramEstimate:
-    """gguf-parser's UMA-aware footprint for one llama-server instance."""
+    """gguf-parser's UMA-aware footprint for one llama-server instance.
+
+    Pass *tensor_split* (the per-device proportions a multi-GPU instance launches
+    with) so gguf-parser reports the real per-device breakdown; without it the
+    estimate is single-device and the per-GPU peak that actually OOMs is invisible.
+    """
     mmproj = str(mmproj_path) if mmproj_path is not None else None
     mmproj_mtime = mmproj_path.stat().st_mtime_ns if mmproj_path is not None else 0
     return _cached_footprint(
@@ -80,6 +111,7 @@ def estimate_instance_footprint(
         kv_cache_type.value,
         mmproj,
         mmproj_mtime,
+        tensor_split,
     )
 
 
@@ -94,6 +126,7 @@ def _cached_footprint(
     kv_cache_type: str,
     mmproj: str | None,
     _mmproj_mtime_ns: int,
+    tensor_split: tuple[int, ...],
 ) -> GgufVramEstimate:
     """Memoised gguf-parser run keyed on path + mtime + sizing.
 
@@ -117,6 +150,15 @@ def _cached_footprint(
         _FLAG_FLASH if flash_attn else _FLAG_NO_FLASH,
         _FLAG_JSON,
     ]
+    if tensor_split:
+        # The split proportions are gguf-parser's only signal for the device count,
+        # so it returns one ``vrams[]`` entry per GPU instead of a single total.
+        argv += [
+            _FLAG_TENSOR_SPLIT,
+            ",".join(str(p) for p in tensor_split),
+            _FLAG_SPLIT_MODE,
+            _SPLIT_MODE_LAYER,
+        ]
     if mmproj is not None:
         argv += [_FLAG_MMPROJ, mmproj]
     return _parse_estimate(_run_parser(argv, path_str), path_str)
@@ -143,12 +185,14 @@ def _parse_estimate(stdout: str, path_str: str) -> GgufVramEstimate:
         item = json.loads(stdout)[_KEY_ESTIMATE][_KEY_ITEMS][0]
         ram = item[_KEY_RAM]
         vrams = item[_KEY_VRAMS]
-        vram_nonuma = sum(int(v[_KEY_NONUMA]) for v in vrams)
-        vram_uma = sum(int(v[_KEY_UMA]) for v in vrams)
+        per_device_vram = tuple(int(v[_KEY_NONUMA]) for v in vrams)
+        per_device_unified = tuple(int(v[_KEY_UMA]) for v in vrams)
         return GgufVramEstimate(
-            vram_bytes=vram_nonuma,
+            vram_bytes=sum(per_device_vram),
             ram_bytes=int(ram[_KEY_NONUMA]),
-            unified_bytes=int(ram[_KEY_UMA]) + vram_uma,
+            unified_bytes=int(ram[_KEY_UMA]) + sum(per_device_unified),
+            per_device_vram=per_device_vram,
+            per_device_unified=per_device_unified,
         )
     except (ValueError, KeyError, IndexError, TypeError) as exc:
         raise ProviderError(

--- a/tests/test_engine_params.py
+++ b/tests/test_engine_params.py
@@ -117,57 +117,17 @@ class TestResolveChatCtx:
         # A nonexistent path makes .stat() raise OSError -> static min(training, target).
         assert ep.resolve_chat_ctx(Path("/nonexistent/x.gguf"), None) == 4096
 
-    def test_uses_split_sizing_when_available_bytes_given(self, tmp_path, monkeypatch) -> None:
-        # The fleet passes combined free VRAM + slots for a tensor-split giant, so
-        # resolve routes to split_chat_ctx instead of the single-GPU dynamic path.
-        model = tmp_path / "m.gguf"
-        model.write_bytes(b"x" * 100)
+
+class TestChatCtxCeiling:
+    def test_returns_training_ctx_without_num_ctx_max(self, monkeypatch) -> None:
         monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 8192)
-        monkeypatch.setattr(ep, "kv_bytes_per_token", lambda _meta, _b: 1000)
         monkeypatch.setattr(cfg, "num_ctx_max", None)
-        seen: dict = {}
+        assert ep.chat_ctx_ceiling({"arch": "x"}, Path("/m.gguf")) == 8192
 
-        def _capture(**kwargs):
-            seen.update(kwargs)
-            return 7777
-
-        monkeypatch.setattr(ep, "split_chat_ctx", _capture)
-        result = ep.resolve_chat_ctx(model, {"arch": "x"}, available_bytes=10**11, slots=4)
-        assert result == 7777
-        assert seen["slots"] == 4 and seen["combined_free_bytes"] == 10**11
-
-
-class TestSplitChatCtx:
-    def test_zero_kv_per_token_returns_upper(self) -> None:
-        # No KV cost (degenerate metadata) -> the upper bound, floored.
-        assert ep.split_chat_ctx(
-            combined_free_bytes=10**11, model_bytes=0, kv_bytes_per_tok=0, slots=1, upper=8192
-        ) == max(8192, 0)
-
-    def test_negative_budget_returns_floor(self) -> None:
-        from lilbee.providers.model_cache import _DYNAMIC_CTX_FLOOR
-
-        # Weights alone exceed the usable VRAM, so there is no KV budget.
-        assert (
-            ep.split_chat_ctx(
-                combined_free_bytes=1, model_bytes=10**12, kv_bytes_per_tok=100, slots=1, upper=8192
-            )
-            == _DYNAMIC_CTX_FLOOR
-        )
-
-    def test_divides_budget_across_slots_and_quantizes(self) -> None:
-        from lilbee.providers.model_cache import _DYNAMIC_CTX_FLOOR, _DYNAMIC_CTX_QUANTUM
-
-        result = ep.split_chat_ctx(
-            combined_free_bytes=10**11,
-            model_bytes=0,
-            kv_bytes_per_tok=1000,
-            slots=4,
-            upper=32768,
-        )
-        assert result >= _DYNAMIC_CTX_FLOOR
-        assert result % _DYNAMIC_CTX_QUANTUM == 0
-        assert result <= 32768
+    def test_caps_at_num_ctx_max_when_lower(self, monkeypatch) -> None:
+        monkeypatch.setattr(ep, "train_ctx_from_meta", lambda *a, **k: 8192)
+        monkeypatch.setattr(cfg, "num_ctx_max", 4096)
+        assert ep.chat_ctx_ceiling({"arch": "x"}, Path("/m.gguf")) == 4096
 
 
 class TestResolveNGpuLayers:

--- a/tests/test_fleet_ctx.py
+++ b/tests/test_fleet_ctx.py
@@ -1,0 +1,76 @@
+"""Tests for fleet per-device context sizing (fit_split_ctx)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from lilbee.core.config.enums import KvCacheType
+from lilbee.providers.fleet import ctx as ctx_mod
+from lilbee.providers.fleet.ctx import fit_split_ctx
+from lilbee.providers.fleet.vram import GgufVramEstimate
+from lilbee.providers.model_cache import _DYNAMIC_CTX_FLOOR, _DYNAMIC_CTX_QUANTUM
+
+_GB = 1024**3
+
+
+def _peak_estimator(peak_for: Callable[[int], int]):
+    """Fake estimate_instance_footprint whose per-device peak is a function of total ctx."""
+
+    def fake(_model_path: Path, **kw: object) -> GgufVramEstimate:
+        peak = peak_for(int(kw["ctx"]))  # type: ignore[arg-type]
+        return GgufVramEstimate(
+            vram_bytes=peak, ram_bytes=0, unified_bytes=0, per_device_vram=(peak,)
+        )
+
+    return fake
+
+
+def _fit(model_path: Path, **overrides: object) -> int:
+    kwargs: dict[str, object] = {
+        "meta": {"arch": "x"},
+        "slots": 4,
+        "ratio": (1, 1, 1),
+        "per_device_free_bytes": [80 * _GB, 80 * _GB, 80 * _GB],
+        "gpu_layers": -1,
+        "flash_attn": True,
+        "kv_cache_type": KvCacheType.F16,
+    }
+    kwargs.update(overrides)
+    return fit_split_ctx(model_path, **kwargs)  # type: ignore[arg-type]
+
+
+class TestFitSplitCtx:
+    def test_returns_floor_when_bottleneck_nonpositive(self, monkeypatch) -> None:
+        # No usable headroom on the busiest card -> the floor, without estimating.
+        monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", _peak_estimator(lambda _c: 1))
+        assert _fit(Path("/m.gguf"), per_device_free_bytes=[0, 0]) == _DYNAMIC_CTX_FLOOR
+
+    def test_returns_floor_when_even_floor_overflows(self, monkeypatch) -> None:
+        # The smallest context already exceeds the budget -> launch at the floor anyway.
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 131072)
+        monkeypatch.setattr(
+            ctx_mod, "estimate_instance_footprint", _peak_estimator(lambda _c: 999 * _GB)
+        )
+        assert _fit(Path("/m.gguf")) == _DYNAMIC_CTX_FLOOR
+
+    def test_returns_quantized_ceiling_when_everything_fits(self, monkeypatch) -> None:
+        # Every probe fits -> the largest grid point at or below the ceiling.
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 32768)
+        monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", _peak_estimator(lambda _c: 1))
+        result = _fit(Path("/m.gguf"))
+        assert (result - _DYNAMIC_CTX_FLOOR) % _DYNAMIC_CTX_QUANTUM == 0
+        assert 32768 - _DYNAMIC_CTX_QUANTUM < result <= 32768
+
+    def test_searches_largest_per_slot_within_bottleneck(self, monkeypatch) -> None:
+        # peak == total ctx, so the per-slot value is gated at bottleneck / slots.
+        bottleneck_free = 36000  # *0.9 usable -> 32400 budget; slots=4 -> per_slot <= 8100
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 131072)
+        monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", _peak_estimator(lambda c: c))
+        result = _fit(
+            Path("/m.gguf"), slots=4, per_device_free_bytes=[bottleneck_free, bottleneck_free]
+        )
+        budget = int(bottleneck_free * 0.9)
+        assert (result - _DYNAMIC_CTX_FLOOR) % _DYNAMIC_CTX_QUANTUM == 0
+        assert result * 4 <= budget
+        assert (result + _DYNAMIC_CTX_QUANTUM) * 4 > budget

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from lilbee.providers.fleet.placement import (
     InstancePlan,
     ModelPlacementInput,
+    PeakEstimator,
     Placement,
     plan_placement,
 )
@@ -13,11 +14,29 @@ from lilbee.providers.roles import WorkerRole
 _GB = 1024**3
 
 
+def _never(_role: WorkerRole, _ratio: tuple[int, ...]) -> tuple[int, ...]:
+    """Estimator that fails if invoked: a placement that fits single cards never splits."""
+    raise AssertionError(
+        "estimate_peak called unexpectedly; this placement should not tensor-split"
+    )
+
+
+def _even(*models: ModelPlacementInput) -> PeakEstimator:
+    """Fake estimator: each model's footprint split evenly across the cards, no overhead."""
+    by_role = {m.role: m.est_vram_bytes for m in models}
+
+    def estimate_peak(role: WorkerRole, ratio: tuple[int, ...]) -> tuple[int, ...]:
+        return tuple(by_role[role] // len(ratio) for _ in ratio)
+
+    return estimate_peak
+
+
 class TestPlanPlacement:
     def test_single_model_fits_one_gpu(self) -> None:
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.CHAT, 10 * _GB)],
             [(0, 24 * _GB)],
+            estimate_peak=_never,
         )
         assert plan == Placement(
             instances=(InstancePlan(WorkerRole.CHAT, (0,)),),
@@ -31,16 +50,19 @@ class TestPlanPlacement:
                 ModelPlacementInput(WorkerRole.RERANK, 1 * _GB),
             ],
             [(0, 24 * _GB)],
+            estimate_peak=_never,
         )
         assert plan.unplaceable_roles == ()
         assert {i.role for i in plan.instances} == {WorkerRole.EMBED, WorkerRole.RERANK}
         assert all(i.devices == (0,) for i in plan.instances)
 
     def test_tensor_splits_model_too_big_for_one_gpu(self) -> None:
-        # 30 GB > 24*0.9 per GPU, but < combined headroom -> split across both.
+        # 30 GB > 24*0.9 per GPU, but each card's even share fits -> split across both.
+        model = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
         plan = plan_placement(
-            [ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)],
+            [model],
             [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=_even(model),
         )
         # Equal cards -> equal proportion (int(24*0.9 GiB) = 21 each).
         assert plan.instances == (InstancePlan(WorkerRole.CHAT, (0, 1), (21, 21)),)
@@ -49,17 +71,21 @@ class TestPlanPlacement:
     def test_tensor_split_is_proportional_on_unequal_gpus(self) -> None:
         # 28 GB splits across a 24 GB + 16 GB pair; the ratio must follow free VRAM
         # (int(24*0.9)=21, int(16*0.9)=14), not an even 1:1 that would OOM the small card.
+        model = ModelPlacementInput(WorkerRole.CHAT, 28 * _GB)
         plan = plan_placement(
-            [ModelPlacementInput(WorkerRole.CHAT, 28 * _GB)],
+            [model],
             [(0, 24 * _GB), (1, 16 * _GB)],
+            estimate_peak=_even(model),
         )
         assert plan.instances[0].devices == (0, 1)
         assert plan.instances[0].tensor_split == (21, 14)
 
     def test_unplaceable_when_model_fits_nowhere(self) -> None:
+        model = ModelPlacementInput(WorkerRole.CHAT, 100 * _GB)
         plan = plan_placement(
-            [ModelPlacementInput(WorkerRole.CHAT, 100 * _GB)],
+            [model],
             [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=_even(model),
         )
         assert plan.instances == ()
         assert plan.unplaceable_roles == (WorkerRole.CHAT,)
@@ -73,6 +99,7 @@ class TestPlanPlacement:
                 ModelPlacementInput(WorkerRole.EMBED, 1 * _GB),
             ],
             [],
+            estimate_peak=_never,
         )
         assert {i.role for i in plan.instances} == {WorkerRole.CHAT, WorkerRole.EMBED}
         assert all(i.devices == () and i.tensor_split == () for i in plan.instances)
@@ -87,6 +114,7 @@ class TestPlanPlacement:
                 ModelPlacementInput(WorkerRole.EMBED, 1 * _GB),
             ],
             [],
+            estimate_peak=_never,
             unified_budget=12 * _GB,
         )
         assert {i.role for i in plan.instances} == {WorkerRole.CHAT, WorkerRole.EMBED}
@@ -99,6 +127,7 @@ class TestPlanPlacement:
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.CHAT, 20 * _GB)],
             [],
+            estimate_peak=_never,
             unified_budget=11 * _GB,
         )
         assert plan.instances == ()
@@ -114,6 +143,7 @@ class TestPlanPlacement:
                 ModelPlacementInput(WorkerRole.EMBED, 4 * _GB),
             ],
             [],
+            estimate_peak=_never,
             unified_budget=12 * _GB,
         )
         assert {i.role for i in plan.instances} == {WorkerRole.EMBED}
@@ -126,12 +156,83 @@ class TestPlanPlacement:
                 ModelPlacementInput(WorkerRole.CHAT, 20 * _GB),
             ],
             [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=_never,
         )
         by_role = {i.role: i.devices for i in plan.instances}
         # Largest (chat) placed first on device 0; embed then lands on the
         # now-emptier device 1. Each is a single-GPU instance.
         assert by_role == {WorkerRole.CHAT: (0,), WorkerRole.EMBED: (1,)}
         assert plan.unplaceable_roles == ()
+
+
+class TestPerDeviceSplit:
+    """The split decision fits and charges each card on its own share, not the summed pool."""
+
+    def test_reserves_more_cards_when_per_device_peak_exceeds_combined_fit(self) -> None:
+        # Two cards' combined 90% headroom (43.2 GiB) "fits" the 32 GB single-device
+        # estimate, so a combined-scalar planner would cram onto 2 and OOM device 0.
+        # The replicated compute buffer makes each card's real share overflow at 2;
+        # only a 3-way split fits -> the per-device planner must reserve 3 cards.
+        model = ModelPlacementInput(WorkerRole.CHAT, 32 * _GB)
+
+        def peak(_role: WorkerRole, ratio: tuple[int, ...]) -> tuple[int, ...]:
+            return tuple(18 * _GB // len(ratio) + 14 * _GB for _ in ratio)
+
+        plan = plan_placement(
+            [model],
+            [(0, 24 * _GB), (1, 24 * _GB), (2, 24 * _GB)],
+            estimate_peak=peak,
+        )
+        assert plan.unplaceable_roles == ()
+        assert plan.instances[0].devices == (0, 1, 2)
+
+    def test_charges_each_card_its_own_share(self) -> None:
+        # Chat splits with an uneven per-device charge (10 GiB, 5 GiB). A following
+        # embed that fits only the less-charged card proves the debit is per-device,
+        # not the proportional/summed charge the old planner applied.
+        chat = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
+        embed = ModelPlacementInput(WorkerRole.EMBED, 12 * _GB)
+
+        def peak(_role: WorkerRole, _ratio: tuple[int, ...]) -> tuple[int, ...]:
+            return (10 * _GB, 5 * _GB)
+
+        plan = plan_placement(
+            [chat, embed],
+            [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=peak,
+        )
+        embed_inst = next(i for i in plan.instances if i.role is WorkerRole.EMBED)
+        assert embed_inst.devices == (
+            1,
+        )  # card 1 (charged 5) has room; card 0 (charged 10) does not
+
+    def test_unplaceable_when_per_device_never_fits(self) -> None:
+        model = ModelPlacementInput(WorkerRole.CHAT, 40 * _GB)
+
+        def peak(_role: WorkerRole, ratio: tuple[int, ...]) -> tuple[int, ...]:
+            return tuple(30 * _GB for _ in ratio)  # 30 > 24*0.9 at any card count
+
+        plan = plan_placement(
+            [model],
+            [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=peak,
+        )
+        assert plan.instances == ()
+        assert plan.unplaceable_roles == (WorkerRole.CHAT,)
+
+    def test_skips_count_when_estimator_returns_wrong_cardinality(self) -> None:
+        # A malformed estimate (cardinality != device count) is skipped, not crashed.
+        model = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
+
+        def peak(_role: WorkerRole, _ratio: tuple[int, ...]) -> tuple[int, ...]:
+            return (5 * _GB,)  # always one entry, never matching a 2-card split
+
+        plan = plan_placement(
+            [model],
+            [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=peak,
+        )
+        assert plan.unplaceable_roles == (WorkerRole.CHAT,)
 
 
 class TestReplicas:
@@ -144,6 +245,7 @@ class TestReplicas:
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=3)],
             [(0, 24 * _GB), (1, 24 * _GB), (2, 24 * _GB)],
+            estimate_peak=_never,
         )
         embeds = self._embeds(plan)
         assert len(embeds) == 3
@@ -156,6 +258,7 @@ class TestReplicas:
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.EMBED, 10 * _GB, replicas=8)],
             [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=_never,
         )
         embeds = self._embeds(plan)
         assert len(embeds) == 4  # two per card, then no room
@@ -166,6 +269,7 @@ class TestReplicas:
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.EMBED, 100 * _GB, replicas=2)],
             [(0, 24 * _GB)],
+            estimate_peak=_never,
         )
         assert plan.instances == ()
         assert plan.unplaceable_roles == (WorkerRole.EMBED,)
@@ -177,6 +281,7 @@ class TestReplicas:
                 ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=2),
             ],
             [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=_never,
         )
         assert len([i for i in plan.instances if i.role is WorkerRole.CHAT]) == 1
         assert len(self._embeds(plan)) == 2
@@ -186,6 +291,7 @@ class TestReplicas:
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.EMBED, 2 * _GB, replicas=3)],
             [],
+            estimate_peak=_never,
             unified_budget=10 * _GB,
         )
         embeds = self._embeds(plan)
@@ -197,6 +303,7 @@ class TestReplicas:
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.EMBED, 4 * _GB, replicas=5)],
             [],
+            estimate_peak=_never,
             unified_budget=10 * _GB,
         )
         assert len(self._embeds(plan)) == 2  # 2x4=8<=10; a third (12) overruns
@@ -206,6 +313,7 @@ class TestReplicas:
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=2)],
             [],
+            estimate_peak=_never,
         )
         embeds = self._embeds(plan)
         assert len(embeds) == 2

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -426,6 +426,81 @@ def test_search_reservation_scales_with_replicas() -> None:
     assert planning_mod._search_reservation(inputs) == 3 * 2 * _GB + 1 * _GB
 
 
+def test_placement_estimate_ctx_chat_uses_ceiling(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr("lilbee.providers.engine_params.chat_ctx_ceiling", lambda _m, _p: 131072)
+    assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 131072
+
+
+def test_placement_estimate_ctx_chat_honors_num_ctx_pin(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "num_ctx", 16384)
+    assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 16384
+
+
+def test_placement_estimate_ctx_non_chat_delegates_to_role_ctx(monkeypatch) -> None:
+    monkeypatch.setattr(planning_mod, "_role_ctx", lambda _r, _p, _m: 512)
+    assert planning_mod._placement_estimate_ctx(WorkerRole.EMBED, Path("/m.gguf"), {}) == 512
+
+
+def test_placement_estimate_slots_per_role(monkeypatch) -> None:
+    assert planning_mod._placement_estimate_slots(WorkerRole.CHAT, {}) == planning_mod._CHAT_SLOTS
+    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 3)
+    assert planning_mod._placement_estimate_slots(WorkerRole.VISION, {}) == 3
+    assert planning_mod._placement_estimate_slots(WorkerRole.EMBED, {}) == planning_mod._AUX_SLOTS
+
+
+def test_placement_estimate_slots_rerank_modes(monkeypatch) -> None:
+    from lilbee.providers.fleet.adapters import LLM_RERANK_CONCURRENCY
+
+    monkeypatch.setattr(planning_mod, "_rerank_mode_for", lambda _m: RerankMode.LLM)
+    assert planning_mod._placement_estimate_slots(WorkerRole.RERANK, {}) == LLM_RERANK_CONCURRENCY
+    monkeypatch.setattr(planning_mod, "_rerank_mode_for", lambda _m: RerankMode.CROSS_ENCODER)
+    assert planning_mod._placement_estimate_slots(WorkerRole.RERANK, {}) == planning_mod._AUX_SLOTS
+
+
+def test_peak_estimator_returns_per_device_vector(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "lilbee.providers.engine_params.resolve_model_path", lambda _r: Path("/m/c.gguf")
+    )
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+    monkeypatch.setattr(planning_mod, "_placement_estimate_slots", lambda _r, _m: 2)
+    monkeypatch.setattr(planning_mod, "_placement_estimate_ctx", lambda _r, _p, _m: 1000)
+    seen: dict = {}
+
+    def _est(_path, *, ctx, slots, tensor_split, mmproj_path=None, **_k) -> GgufVramEstimate:
+        seen.update(ctx=ctx, slots=slots, ratio=tensor_split, mmproj=mmproj_path)
+        return GgufVramEstimate(
+            vram_bytes=0, ram_bytes=0, unified_bytes=0, per_device_vram=(11, 22)
+        )
+
+    monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _est)
+    estimate = planning_mod._peak_estimator({WorkerRole.CHAT: "ref"})
+    assert estimate(WorkerRole.CHAT, (1, 1)) == (11, 22)
+    # --ctx-size is per-slot x slots, so the estimate is run at that total.
+    assert seen["ctx"] == 2000 and seen["slots"] == 2 and seen["ratio"] == (1, 1)
+    assert seen["mmproj"] is None  # chat carries no projector
+
+
+def test_peak_estimator_vision_passes_mmproj(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "lilbee.providers.engine_params.resolve_model_path", lambda _r: Path("/m/v.gguf")
+    )
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+    monkeypatch.setattr(planning_mod, "_vision_mmproj", lambda _r: Path("/m/mmproj.gguf"))
+    monkeypatch.setattr(planning_mod, "_placement_estimate_slots", lambda _r, _m: 1)
+    monkeypatch.setattr(planning_mod, "_placement_estimate_ctx", lambda _r, _p, _m: 100)
+    seen: dict = {}
+
+    def _est(_path, *, mmproj_path=None, **_k) -> GgufVramEstimate:
+        seen["mmproj"] = mmproj_path
+        return GgufVramEstimate(vram_bytes=0, ram_bytes=0, unified_bytes=0, per_device_vram=(5, 5))
+
+    monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _est)
+    estimate = planning_mod._peak_estimator({WorkerRole.VISION: "ref"})
+    assert estimate(WorkerRole.VISION, (1, 1)) == (5, 5)
+    assert seen["mmproj"] == Path("/m/mmproj.gguf")
+
+
 class TestBuildFleetWiring:
     def test_server_model_inputs_skips_unconfigured_optional_roles(self, monkeypatch) -> None:
         monkeypatch.setattr(
@@ -608,6 +683,54 @@ class TestBuildFleetWiring:
         assert "--model" in launch.argv
         assert "--port" not in launch.argv  # claimed at spawn, not here
         assert launch.weights_bytes == 2048  # model file size scales the ready timeout
+
+    def test_launch_for_split_chat_sizes_ctx_against_per_device_headroom(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        model = tmp_path / "chat.gguf"
+        model.write_bytes(b"x" * 2048)
+        monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
+        monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+        monkeypatch.setattr(cfg, "num_ctx", None)
+        monkeypatch.setattr(planning_mod, "_slots_for", lambda *a, **k: 2)
+        seen: dict = {}
+
+        def _fit(_model_path, *, slots, ratio, per_device_free_bytes, **_k) -> int:
+            seen.update(slots=slots, ratio=ratio, free=per_device_free_bytes)
+            return 5000
+
+        monkeypatch.setattr("lilbee.providers.fleet.ctx.fit_split_ctx", _fit)
+        d0 = FleetDevice("CUDA", 0, "gpu", 80 * _GB, 70 * _GB)
+        d1 = FleetDevice("CUDA", 1, "gpu", 80 * _GB, 60 * _GB)
+        plan = InstancePlan(role=WorkerRole.CHAT, devices=(0, 1), tensor_split=(1, 1))
+        launch = planning_mod._launch_for(
+            plan, "ref", Path("/bin/llama-server"), Path("/data"), {0: d0, 1: d1}
+        )
+        assert launch.ctx == 5000
+        assert seen["slots"] == 2 and seen["ratio"] == (1, 1)
+        assert seen["free"] == [70 * _GB, 60 * _GB]  # per-device free, not the summed pool
+        assert launch.argv[launch.argv.index("--ctx-size") + 1] == str(5000 * 2)
+
+    def test_launch_for_split_chat_honors_num_ctx_pin(self, tmp_path, monkeypatch) -> None:
+        # A cfg.num_ctx pin overrides the per-device fit even across multiple GPUs.
+        model = tmp_path / "chat.gguf"
+        model.write_bytes(b"x" * 2048)
+        monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
+        monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+        monkeypatch.setattr(cfg, "num_ctx", 8192)
+        monkeypatch.setattr(planning_mod, "_slots_for", lambda *a, **k: 2)
+
+        def _fail(*_a, **_k) -> int:
+            raise AssertionError("fit_split_ctx must not run when cfg.num_ctx pins the context")
+
+        monkeypatch.setattr("lilbee.providers.fleet.ctx.fit_split_ctx", _fail)
+        d0 = FleetDevice("CUDA", 0, "gpu", 80 * _GB, 70 * _GB)
+        d1 = FleetDevice("CUDA", 1, "gpu", 80 * _GB, 60 * _GB)
+        plan = InstancePlan(role=WorkerRole.CHAT, devices=(0, 1), tensor_split=(1, 1))
+        launch = planning_mod._launch_for(
+            plan, "ref", Path("/bin/llama-server"), Path("/data"), {0: d0, 1: d1}
+        )
+        assert launch.ctx == 8192
 
     def _launch_role(self, tmp_path, monkeypatch, role: WorkerRole, ctx: int = 4096) -> list[str]:
         return self._launch_for_role(tmp_path, monkeypatch, role, ctx).argv
@@ -807,7 +930,7 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(
             planning_mod,
             "plan_placement",
-            lambda inputs, devices, *, unified_budget=None: Placement(
+            lambda inputs, devices, *, estimate_peak, unified_budget=None: Placement(
                 instances=(InstancePlan(WorkerRole.CHAT, (0,)),), unplaceable_roles=()
             ),
         )
@@ -833,7 +956,7 @@ class TestBuildFleetWiring:
             ),
         )
 
-        def _capture(inputs, devices, *, unified_budget=None):
+        def _capture(inputs, devices, *, estimate_peak, unified_budget=None):
             seen["devices"] = devices
             return Placement(instances=(), unplaceable_roles=(WorkerRole.CHAT,))
 

--- a/tests/test_fleet_vram.py
+++ b/tests/test_fleet_vram.py
@@ -131,6 +131,33 @@ class TestEstimateInstanceFootprint:
         assert "--flash-attention" in argv
         assert "--mmproj-path" not in argv
 
+    def test_tensor_split_passes_ratio_and_returns_per_device(
+        self, model_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A multi-GPU split sends the ratio so gguf-parser breaks the estimate out
+        # per card; the peak (busiest card) gates placement, not the summed total.
+        calls: list[list[str]] = []
+        _patch_parser(
+            monkeypatch,
+            stdout=_sample_json(ram_uma=1, ram_nonuma=2, vrams=[(10, 100), (10, 110), (10, 120)]),
+            recorder=calls,
+        )
+        est = estimate_instance_footprint(
+            model_file,
+            ctx=131072,
+            slots=4,
+            gpu_layers=-1,
+            flash_attn=True,
+            kv_cache_type=KvCacheType.F16,
+            tensor_split=(1, 1, 1),
+        )
+        argv = calls[0]
+        assert argv[argv.index("--tensor-split") + 1] == "1,1,1"
+        assert argv[argv.index("--split-mode") + 1] == "layer"
+        assert est.per_device_vram == (100, 110, 120)
+        assert est.peak_footprint(unified=False) == 120
+        assert est.vram_bytes == 100 + 110 + 120
+
     def test_disabled_flash_passes_no_flash_flag(
         self, model_file: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Problem

On a multi-GPU box, loading a large chat model could OOM at startup with `failed to allocate compute pp buffers`, even when the model comfortably fit across the cards. The planner placed each model using a single combined-VRAM number, so it split the chat model across too few GPUs, and the chat context was sized against the summed free VRAM. Both ignored that a tensor-split instance runs out of memory on its busiest single card, not on the combined total.

## Solution

The VRAM estimator now asks gguf-parser for a per-device breakdown. The planner splits a too-big model across the fewest cards whose per-device share each fits, and a split chat's context is sized against the busiest card's headroom rather than the combined pool. Single-GPU and CPU/Metal hosts are unchanged.