### PR TITLE
Place large-context tensor-split chat giants instead of rejecting them

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,10 +185,14 @@ flowchart TD
   A model that fits one GPU is a single pinned instance; small models co-locate; a
   model too big for one GPU is tensor-split across the **fewest cards whose per-device
   footprint each fits**, proportionally to each card's free VRAM (so unequal GPUs
-  don't OOM the smaller one). A split chat's context is then sized
-  (`ctx.fit_split_ctx`, a binary search over the gguf-parser estimate) against the
-  **busiest card's** headroom, not the combined pool, so the per-GPU compute buffer
-  can't overflow device 0. On a single CPU/Metal box this
+  don't OOM the smaller one). A tensor-split chat serves **one full-context sequence**
+  (`--parallel 1`): a giant filling several cards has no room to divide its context
+  across batching slots, so the planner reserves and launches it at the single-sequence
+  footprint rather than `ceiling x` the single-GPU slot count (multi-slot batching is
+  for a chat that fits one card). Its context is then sized (`ctx.fit_split_ctx`, a
+  binary search over the gguf-parser estimate) against the **busiest card's** headroom,
+  not the combined pool, so the per-GPU compute buffer can't overflow device 0. On a
+  single CPU/Metal box this
   is a fleet-of-one against one shared pool, where the **search-critical roles
   (embed/rerank) are reserved before the elastic chat model**: chat's slot count and
   context are sized against the budget *minus* the search footprint, and the shared

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
 
 # Fleet-only concurrency: continuous-batching slots (--parallel) per server.
 _CHAT_SLOTS = 4
+# A tensor-split chat fills its cards with one full-context sequence; concurrent
+# slots are for a chat that fits a single GPU, not a multi-card giant.
+_SPLIT_CHAT_SLOTS = 1
 _AUX_SLOTS = 1
 _EMBED_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK)
 # Truncate embed/rerank inputs a few tokens below the per-slot context: the server
@@ -46,9 +49,6 @@ _ALL_LAYER_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK, WorkerRole.VISION)
 _FLASH_ON = "on"
 _FLASH_OFF = "off"
 _DEFAULT_THREADS = 4
-# Nominal context for bootstrapping a tensor-split chat's slot count before its real
-# per-slot context is known; small enough that weights dominate the footprint.
-_SPLIT_BOOTSTRAP_CTX = 512
 # Roles to which flash attention applies; embed/rerank run without it.
 _FLASH_ROLES = (WorkerRole.CHAT, WorkerRole.VISION)
 
@@ -377,11 +377,7 @@ def _estimate_role(
 
 
 def _placement_estimate_ctx(role: WorkerRole, model_path: Path, meta: dict[str, str] | None) -> int:
-    """Per-slot ctx ceiling for the placement estimate: the most a launch can use.
-
-    fit_split_ctx caps the launched per-slot ctx at this same ceiling, so estimating
-    here keeps the per-device reservation an upper bound on the launched footprint.
-    """
+    """Per-slot context the placement estimate sizes a role against (the launch ceiling)."""
     from lilbee.core.config import cfg
     from lilbee.providers.engine_params import chat_ctx_ceiling
 
@@ -391,16 +387,15 @@ def _placement_estimate_ctx(role: WorkerRole, model_path: Path, meta: dict[str, 
 
 
 def _placement_estimate_slots(role: WorkerRole, meta: dict[str, str] | None) -> int:
-    """The launch ceiling on a role's batching slots, for a conservative estimate.
+    """The slot count a role launches with, so the estimate's total ctx matches the launch.
 
-    Returning the maximum (_slots_for never launches more) keeps the reservation an
-    upper bound: estimated total ctx (per-slot ceiling x these slots) is the most a
-    launch can hold, so the launched per-device footprint cannot exceed it.
+    A tensor-split chat serves a single full-context sequence, so the placement total
+    is the per-sequence ceiling, not ``ceiling x _CHAT_SLOTS`` (KV no launch allocates).
     """
     from lilbee.core.config import cfg
 
     if role is WorkerRole.CHAT:
-        return _CHAT_SLOTS
+        return _SPLIT_CHAT_SLOTS
     if role is WorkerRole.VISION:
         return max(1, cfg.vision_ocr_concurrency)
     if role is WorkerRole.RERANK and _rerank_mode_for(meta) is RerankMode.LLM:
@@ -526,21 +521,18 @@ def _launch_for(
     is_chat = plan.role is WorkerRole.CHAT
     is_vision = plan.role is WorkerRole.VISION
     mmproj = _vision_mmproj(model_ref) if is_vision else None
-    # A tensor-split chat's context is sized against the busiest card's headroom,
-    # not one GPU's; the slot count divides the shared --ctx-size, so bootstrap it
-    # first. A cfg.num_ctx pin overrides the fit (handled by _role_ctx).
-    split_chat = is_chat and len(chosen) > 1 and cfg.num_ctx is None
+    # A tensor-split chat serves one full-context sequence sized against the busiest
+    # card's headroom. A cfg.num_ctx pin overrides the fit (handled by _role_ctx).
+    multi_card_chat = is_chat and len(chosen) > 1
+    split_chat = multi_card_chat and cfg.num_ctx is None
     if split_chat:
         # circular: fleet.ctx -> engine_params -> app.services
         from lilbee.providers.fleet.ctx import fit_split_ctx
 
-        chat_slots = _slots_for(
-            WorkerRole.CHAT, model_path, _SPLIT_BOOTSTRAP_CTX, chat_reservation=chat_reservation
-        )
         ctx = fit_split_ctx(
             model_path,
             meta=meta,
-            slots=chat_slots,
+            slots=_SPLIT_CHAT_SLOTS,
             ratio=plan.tensor_split,
             per_device_free_bytes=[d.free_bytes for d in chosen],
             gpu_layers=_role_gpu_layers(WorkerRole.CHAT),
@@ -551,16 +543,20 @@ def _launch_for(
         ctx = _role_ctx(plan.role, model_path, meta)
     rerank_mode = _rerank_mode_for(meta) if plan.role is WorkerRole.RERANK else None
     is_llm_rerank = rerank_mode is RerankMode.LLM
-    # Size slots the same way the estimator did so the launched --parallel matches
-    # the placement estimate (chat honors the search reservation; mmproj via gguf-parser).
-    slots = _slots_for(
-        plan.role,
-        model_path,
-        ctx,
-        mmproj_path=mmproj,
-        unified_budget=unified_budget,
-        chat_reservation=chat_reservation,
-        rerank_mode=rerank_mode,
+    # A multi-card chat runs one slot; other roles size --parallel against the budget
+    # the same way the estimator did so the launch matches the placement reservation.
+    slots = (
+        _SPLIT_CHAT_SLOTS
+        if multi_card_chat
+        else _slots_for(
+            plan.role,
+            model_path,
+            ctx,
+            mmproj_path=mmproj,
+            unified_budget=unified_budget,
+            chat_reservation=chat_reservation,
+            rerank_mode=rerank_mode,
+        )
     )
     spec = rerank_spec(rerank_mode) if rerank_mode is not None else ROLE_SPECS[plan.role]
     # Cross-encoder embed/rerank pools the whole input in one batch; an LLM reranker

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -443,7 +443,11 @@ def test_placement_estimate_ctx_non_chat_delegates_to_role_ctx(monkeypatch) -> N
 
 
 def test_placement_estimate_slots_per_role(monkeypatch) -> None:
-    assert planning_mod._placement_estimate_slots(WorkerRole.CHAT, {}) == planning_mod._CHAT_SLOTS
+    # A tensor-split chat reserves for one full-context sequence, not _CHAT_SLOTS.
+    assert (
+        planning_mod._placement_estimate_slots(WorkerRole.CHAT, {})
+        == planning_mod._SPLIT_CHAT_SLOTS
+    )
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 3)
     assert planning_mod._placement_estimate_slots(WorkerRole.VISION, {}) == 3
     assert planning_mod._placement_estimate_slots(WorkerRole.EMBED, {}) == planning_mod._AUX_SLOTS
@@ -499,6 +503,29 @@ def test_peak_estimator_vision_passes_mmproj(monkeypatch) -> None:
     estimate = planning_mod._peak_estimator({WorkerRole.VISION: "ref"})
     assert estimate(WorkerRole.VISION, (1, 1)) == (5, 5)
     assert seen["mmproj"] == Path("/m/mmproj.gguf")
+
+
+def test_peak_estimator_reserves_single_sequence_total_for_split_chat(monkeypatch) -> None:
+    # Regression (bb-xly): a tensor-split chat reserves the per-sequence ceiling as the
+    # total --ctx-size (slots=1), not ceiling x _CHAT_SLOTS, which would over-reserve KV
+    # no launch allocates and wrongly mark a large-context giant unplaceable.
+    monkeypatch.setattr(
+        "lilbee.providers.engine_params.resolve_model_path", lambda _r: Path("/m/c.gguf")
+    )
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+    monkeypatch.setattr(planning_mod, "_placement_estimate_ctx", lambda _r, _p, _m: 196608)
+    seen: dict = {}
+
+    def _est(_path, *, ctx, slots, tensor_split, **_k) -> GgufVramEstimate:
+        seen.update(ctx=ctx, slots=slots)
+        return GgufVramEstimate(
+            vram_bytes=0, ram_bytes=0, unified_bytes=0, per_device_vram=(5, 5, 5)
+        )
+
+    monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _est)
+    planning_mod._peak_estimator({WorkerRole.CHAT: "ref"})(WorkerRole.CHAT, (1, 1, 1))
+    assert seen["slots"] == planning_mod._SPLIT_CHAT_SLOTS
+    assert seen["ctx"] == 196608  # ceiling x 1, not ceiling x _CHAT_SLOTS
 
 
 class TestBuildFleetWiring:
@@ -692,7 +719,6 @@ class TestBuildFleetWiring:
         monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
         monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
         monkeypatch.setattr(cfg, "num_ctx", None)
-        monkeypatch.setattr(planning_mod, "_slots_for", lambda *a, **k: 2)
         seen: dict = {}
 
         def _fit(_model_path, *, slots, ratio, per_device_free_bytes, **_k) -> int:
@@ -707,18 +733,21 @@ class TestBuildFleetWiring:
             plan, "ref", Path("/bin/llama-server"), Path("/data"), {0: d0, 1: d1}
         )
         assert launch.ctx == 5000
-        assert seen["slots"] == 2 and seen["ratio"] == (1, 1)
+        # A multi-card chat serves one full-context slot, fit against per-device free.
+        assert seen["slots"] == planning_mod._SPLIT_CHAT_SLOTS and seen["ratio"] == (1, 1)
         assert seen["free"] == [70 * _GB, 60 * _GB]  # per-device free, not the summed pool
-        assert launch.argv[launch.argv.index("--ctx-size") + 1] == str(5000 * 2)
+        assert launch.slots == planning_mod._SPLIT_CHAT_SLOTS
+        ctx_total = 5000 * planning_mod._SPLIT_CHAT_SLOTS
+        assert launch.argv[launch.argv.index("--ctx-size") + 1] == str(ctx_total)
 
-    def test_launch_for_split_chat_honors_num_ctx_pin(self, tmp_path, monkeypatch) -> None:
-        # A cfg.num_ctx pin overrides the per-device fit even across multiple GPUs.
+    def test_launch_for_pinned_multi_card_chat_runs_one_slot(self, tmp_path, monkeypatch) -> None:
+        # A cfg.num_ctx pin skips the fit, but a multi-card chat still serves one slot
+        # so --ctx-size matches the single-sequence footprint the planner reserved.
         model = tmp_path / "chat.gguf"
         model.write_bytes(b"x" * 2048)
         monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
         monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
         monkeypatch.setattr(cfg, "num_ctx", 8192)
-        monkeypatch.setattr(planning_mod, "_slots_for", lambda *a, **k: 2)
 
         def _fail(*_a, **_k) -> int:
             raise AssertionError("fit_split_ctx must not run when cfg.num_ctx pins the context")
@@ -731,6 +760,7 @@ class TestBuildFleetWiring:
             plan, "ref", Path("/bin/llama-server"), Path("/data"), {0: d0, 1: d1}
         )
         assert launch.ctx == 8192
+        assert launch.slots == planning_mod._SPLIT_CHAT_SLOTS
 
     def _launch_role(self, tmp_path, monkeypatch, role: WorkerRole, ctx: int = 4096) -> list[str]:
         return self._launch_for_role(tmp_path, monkeypatch, role, ctx).argv


### PR DESCRIPTION
## Problem

On a multi-GPU box, a large-context model that has to be tensor-split (for example minimax-m2, 196K training context, ~129GB) was reported as not fitting available memory and got no server, even though it loads comfortably across the cards. The planner reserved each card for four batching slots, each at the model's full context, which is KV that no launch ever allocates, so a giant looked far larger per card than it really is.

## Solution

A tensor-split chat serves one full-context sequence (a single `--parallel` slot): a model that fills several cards has no room to divide its context across batching slots. The planner now reserves and launches a multi-card chat at that single-sequence footprint, so a giant places across the cards it actually fits on. This also removes a fragile slot-count probe that sized against host RAM instead of GPU memory whenever GPU detection fell through.

Verified on 3xA100: minimax-m2 loads at full 196K context across the three cards (~61 GiB each, no out-of-memory), and the planner now produces that exact configuration.