### PR TITLE
Ingest format parity with kreuzberg: gif/jp2 family, legacy Office, email, htm, dbf

### DIFF
--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -225,7 +225,7 @@ def _image_ocr_text(path: Path) -> str:
 
 
 def _image_to_png_bytes(path: Path) -> bytes:
-    """Load a supported image (png/jpg/tiff/bmp/webp) and re-encode as PNG for the projector."""
+    """Load any mapped image extension (Pillow decodes them all) and re-encode as PNG for the projector."""
     with Image.open(path) as img:
         buf = BytesIO()
         img.convert("RGB").save(buf, format="PNG")

--- a/src/lilbee/data/ingest/types.py
+++ b/src/lilbee/data/ingest/types.py
@@ -119,17 +119,48 @@ class _IngestResult:
     page_texts: list[PageTextRecord] | None = None
 
 
-# Extension → content_type string for document formats handled by kreuzberg
+# Extension → content_type string for document formats handled by kreuzberg.
+# Container formats (.zip/.tar/.7z/.pst) are deliberately absent: kreuzberg can
+# extract them, but one file fans out to many inner documents, which the
+# source/citation model can't express yet.
 DOCUMENT_EXTENSION_MAP: dict[str, str] = {
-    **{ext: "text" for ext in (".md", ".txt", ".html", ".rst", ".yaml", ".yml")},
+    **{ext: "text" for ext in (".md", ".txt", ".html", ".htm", ".rst", ".yaml", ".yml")},
     ".pdf": PDF_CONTENT_TYPE,
-    **{ext: ext.lstrip(".") for ext in (".docx", ".xlsx", ".pptx")},
+    **{
+        ext: ext.lstrip(".")
+        for ext in (
+            ".docx",
+            ".xlsx",
+            ".pptx",
+            ".doc",
+            ".xls",
+            ".ppt",
+            ".rtf",
+            ".odt",
+            ".ods",
+            ".eml",
+            ".msg",
+        )
+    },
     ".epub": "epub",
     **{
         ext: IMAGE_CONTENT_TYPE
-        for ext in (".png", ".jpg", ".jpeg", ".tiff", ".tif", ".bmp", ".webp")
+        for ext in (
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".tiff",
+            ".tif",
+            ".bmp",
+            ".webp",
+            ".gif",
+            ".jp2",
+            ".j2k",
+            ".j2c",
+            ".jpx",
+        )
     },
-    **{ext: "data" for ext in (".csv", ".tsv")},
+    **{ext: "data" for ext in (".csv", ".tsv", ".dbf")},
     ".xml": "xml",
     **{ext: "json" for ext in (".json", ".jsonl")},
 }

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1171,6 +1171,39 @@ class TestExtractionConfig:
             assert config.chunking.topic_threshold == pytest.approx(0.42, abs=1e-5)
 
 
+class TestClassifyKreuzbergParityFormats:
+    """Formats kreuzberg extracts that the map must not silently drop."""
+
+    @pytest.mark.parametrize(
+        "filename, expected",
+        [
+            ("anim.gif", "image"),
+            ("scan.jp2", "image"),
+            ("scan.j2k", "image"),
+            ("scan.j2c", "image"),
+            ("scan.jpx", "image"),
+            ("page.htm", "text"),
+            ("memo.doc", "doc"),
+            ("deck.ppt", "ppt"),
+            ("ledger.xls", "xls"),
+            ("letter.rtf", "rtf"),
+            ("memo.odt", "odt"),
+            ("ledger.ods", "ods"),
+            ("mail.eml", "eml"),
+            ("mail.msg", "msg"),
+            ("table.dbf", "data"),
+            # Containers stay unsupported on purpose: one file fans out to many
+            # inner documents, which the source/citation model can't express yet.
+            ("archive.pst", None),
+            ("archive.7z", None),
+        ],
+    )
+    def test_classify(self, filename, expected):
+        from lilbee.data.ingest import classify_file
+
+        assert classify_file(Path(filename)) == expected
+
+
 class TestClassifyStructuredFormats:
     @pytest.mark.parametrize(
         "filename, expected",


### PR DESCRIPTION
## Problem

`classify_file` returns `None` for a set of extensions kreuzberg 4.9.x already extracts, so the files are silently invisible: no log line, no `skipped_sources.json` entry. The gap covers the jp2 scan family (common in government/archival scan pipelines), gif, `.htm` (only `.html` was mapped), legacy Office (doc/xls/ppt/rtf/odt/ods), email (eml/msg), and dbf.

## Solution

Add the missing extensions to `DOCUMENT_EXTENSION_MAP`. Images route to the existing vision-OCR path (Pillow decodes all of them; verified with a transcode round-trip), everything else goes to kreuzberg extraction, which detects MIME from file content, so map entries are all that's needed. Container formats (zip/tar/7z/pst) stay out on purpose: one file fans out to many inner documents, which the source/citation model can't express yet; tests pin them to `None`.