### PR TITLE
Persist server logs so crash reports carry evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ lilbee stands on a stack of established open-source projects, all bundled into o
 
 ## Support
 
+Having trouble? See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for log locations and common failures.
+
 lilbee is built and maintained by one person. If it is useful to you, you can chip in via [PayPal](https://paypal.me/lilbeedotsh). Bug reports and pull requests help just as much.
 
 ## License

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,60 @@
+# Troubleshooting
+
+When something goes wrong, the logs almost always say why. This page covers where they are, how to make them more verbose, and what to send when you [open an issue](https://github.com/tobocop2/lilbee/issues).
+
+## Where the logs live
+
+Everything lands in `logs/` under your data root:
+
+| File | What's in it |
+| --- | --- |
+| `server.log` | Everything `lilbee serve` does at INFO and above: startup, requests, indexing, errors. Rotates at 2 MiB; the previous files are kept as `server.log.1` through `server.log.3`. |
+| `server-fault.log` | Native crash tracebacks from `faulthandler`. Usually empty. If the server died without a Python traceback (a segfault in llama.cpp, for instance), this is where the evidence is. |
+| `worker-<role>.log` | One file per model worker subprocess: `worker-chat.log`, `worker-embed.log`, `worker-rerank.log`, `worker-vision.log`. Model load output and per-request activity for that role. |
+| `tui.log` | Logs from the full-screen terminal app, routed here so they don't draw over the screen. |
+
+**The data root is resolved in this order**, highest precedence first:
+
+1. `--global` forces the platform default below, ignoring any local `.lilbee/`.
+2. `--data-dir <path>` uses exactly that path.
+3. `LILBEE_DATA` environment variable, if set.
+4. A `.lilbee/` directory found by walking up from the current directory (per-project libraries).
+5. The platform default: `~/Library/Application Support/lilbee` on macOS, `$XDG_DATA_HOME/lilbee` (default `~/.local/share/lilbee`) on Linux, `%LOCALAPPDATA%\lilbee` on Windows.
+
+Not sure which one you're on? `lilbee status` prints the active data directory.
+
+## Turning up verbosity
+
+The log level is controlled by the `LILBEE_LOG_LEVEL` environment variable (`DEBUG`, `INFO`, `WARNING`, `ERROR`; default `WARNING`) or the `--log-level` flag, which overrides the variable:
+
+```bash
+LILBEE_LOG_LEVEL=DEBUG lilbee serve
+# or
+lilbee --log-level DEBUG serve
+```
+
+`WARNING` keeps the console to problems only. `INFO` adds the normal lifecycle: startup, requests, indexing progress. `DEBUG` adds everything underneath, which is what you want when reproducing a bug.
+
+**The file log is more verbose than the console.** `server.log` captures INFO and above even at the default level, so the console staying quiet doesn't mean the file is empty. Check `server.log` first; raise the level only when you need DEBUG detail.
+
+## Worker crashes
+
+lilbee runs each model in its own subprocess. When one dies mid-request you get a `WorkerCrashError` naming the role, for example:
+
+```
+WorkerCrashError: Worker 'embed' subprocess exited unexpectedly. See <data root>/logs/worker-embed.log for details.
+```
+
+The error already includes the last few log lines, but the full story is in the worker's own file: `worker-chat.log`, `worker-embed.log`, `worker-rerank.log`, or `worker-vision.log`. The usual causes are a model that doesn't fit in memory, an unsupported GGUF architecture, or a GPU driver issue, and the log tail names which.
+
+When reporting a worker crash, attach the last ~100 lines of the worker log plus `server-fault.log` if it's non-empty:
+
+```bash
+tail -n 100 "<data root>/logs/worker-embed.log"
+```
+
+## Using with the Obsidian plugin
+
+The [Obsidian plugin](https://github.com/tobocop2/obsidian-lilbee) in managed mode runs this server for you, with each vault's data root under the plugin's shared install at `vaults/<id>/`. The same `logs/` layout applies inside that directory.
+
+You don't have to dig those paths out by hand: the plugin's **Export diagnostics** command bundles these logs (plus plugin-side state) into a single file you can attach to an issue. See the plugin's own [TROUBLESHOOTING.md](https://github.com/tobocop2/obsidian-lilbee/blob/main/TROUBLESHOOTING.md) for that side of the setup.

--- a/src/lilbee/cli/commands/serve_logging.py
+++ b/src/lilbee/cli/commands/serve_logging.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import faulthandler
 import logging
+import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from types import TracebackType
+from typing import IO
 
 from lilbee.core.config import cfg
 
+logger = logging.getLogger(__name__)
+
 _LOG_DIR_NAME = "logs"
 _SERVER_LOG_FILE_NAME = "server.log"
+_FAULT_LOG_FILE_NAME = "server-fault.log"
 _MAX_BYTES = 2_097_152  # 2 MiB
 _BACKUP_COUNT = 3
 _LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
@@ -37,3 +44,39 @@ def setup_server_log_file() -> Path:
                 handler.setLevel(root.level)
         root.setLevel(logging.INFO)
     return log_path
+
+
+class _FaultLog:
+    """Holds the fault-log handle alive; faulthandler writes to the raw fd."""
+
+    def __init__(self) -> None:
+        self._handle: IO[str] | None = None
+
+    def enable(self) -> Path:
+        """Open the fault log if needed and point faulthandler at it."""
+        log_dir = cfg.data_root / _LOG_DIR_NAME
+        log_dir.mkdir(parents=True, exist_ok=True)
+        fault_path = log_dir / _FAULT_LOG_FILE_NAME
+        if self._handle is None or self._handle.closed:
+            self._handle = fault_path.open("a")
+            faulthandler.enable(file=self._handle)
+        return fault_path
+
+
+_fault_log = _FaultLog()
+
+
+def enable_fault_log() -> Path:
+    """Point ``faulthandler`` at ``cfg.data_root/logs/server-fault.log``. Idempotent."""
+    return _fault_log.enable()
+
+
+def install_excepthook() -> None:
+    """Log unhandled exceptions before the previous hook runs."""
+    previous = sys.excepthook
+
+    def _hook(exc_type: type[BaseException], exc: BaseException, tb: TracebackType | None) -> None:
+        logger.critical("unhandled exception", exc_info=(exc_type, exc, tb))
+        previous(exc_type, exc, tb)
+
+    sys.excepthook = _hook

--- a/src/lilbee/cli/commands/serve_logging.py
+++ b/src/lilbee/cli/commands/serve_logging.py
@@ -1,0 +1,39 @@
+"""Server log-file routing for ``lilbee serve``: rotating file under the data root."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from lilbee.core.config import cfg
+
+_LOG_DIR_NAME = "logs"
+_SERVER_LOG_FILE_NAME = "server.log"
+_MAX_BYTES = 2_097_152  # 2 MiB
+_BACKUP_COUNT = 3
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+
+def setup_server_log_file() -> Path:
+    """Install a RotatingFileHandler at ``cfg.data_root/logs/server.log``. Idempotent."""
+    log_dir = cfg.data_root / _LOG_DIR_NAME
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / _SERVER_LOG_FILE_NAME
+
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if isinstance(handler, RotatingFileHandler) and Path(handler.baseFilename) == log_path:
+            return log_path
+
+    file_handler = RotatingFileHandler(log_path, maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT)
+    file_handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+    file_handler.setLevel(logging.INFO)
+    root.addHandler(file_handler)
+    if root.level > logging.INFO:
+        # NOTSET stream handlers delegate to root; pin them so stderr verbosity is unchanged.
+        for handler in root.handlers:
+            if handler is not file_handler and handler.level == logging.NOTSET:
+                handler.setLevel(root.level)
+        root.setLevel(logging.INFO)
+    return log_path

--- a/src/lilbee/cli/commands/serve_logging.py
+++ b/src/lilbee/cli/commands/serve_logging.py
@@ -71,15 +71,34 @@ def enable_fault_log() -> Path:
     return _fault_log.enable()
 
 
+class _ExceptHook:
+    """Tracks whether the logging excepthook is installed."""
+
+    def __init__(self) -> None:
+        self.installed = False
+
+    def install(self) -> None:
+        """Install the logging excepthook once, chaining to the previous hook."""
+        if self.installed:
+            return
+        previous = sys.excepthook
+
+        def _hook(
+            exc_type: type[BaseException], exc: BaseException, tb: TracebackType | None
+        ) -> None:
+            logger.critical("unhandled exception", exc_info=(exc_type, exc, tb))
+            previous(exc_type, exc, tb)
+
+        sys.excepthook = _hook
+        self.installed = True
+
+
+_except_hook = _ExceptHook()
+
+
 def install_excepthook() -> None:
-    """Log unhandled exceptions before the previous hook runs."""
-    previous = sys.excepthook
-
-    def _hook(exc_type: type[BaseException], exc: BaseException, tb: TracebackType | None) -> None:
-        logger.critical("unhandled exception", exc_info=(exc_type, exc, tb))
-        previous(exc_type, exc, tb)
-
-    sys.excepthook = _hook
+    """Log unhandled exceptions before the previous hook runs. Idempotent."""
+    _except_hook.install()
 
 
 def setup_server_logging() -> None:

--- a/src/lilbee/cli/commands/serve_logging.py
+++ b/src/lilbee/cli/commands/serve_logging.py
@@ -80,3 +80,10 @@ def install_excepthook() -> None:
         previous(exc_type, exc, tb)
 
     sys.excepthook = _hook
+
+
+def setup_server_logging() -> None:
+    """File log, fault log, and excepthook for a ``serve`` process."""
+    setup_server_log_file()
+    enable_fault_log()
+    install_excepthook()

--- a/src/lilbee/cli/commands/servers.py
+++ b/src/lilbee/cli/commands/servers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,7 @@ from lilbee.cli.app import (
     data_dir_option,
     global_option,
 )
+from lilbee.cli.commands.serve_logging import setup_server_logging
 from lilbee.core.config import cfg
 
 if TYPE_CHECKING:
@@ -25,11 +27,23 @@ def _port_file() -> Path:
     return cfg.data_dir / "server.port"
 
 
+def _log_loop_exception(_loop: asyncio.AbstractEventLoop, context: dict[str, object]) -> None:
+    exc = context.get("exception")
+    # isinstance: asyncio's context dict is untyped; "exception" may be absent
+    if isinstance(exc, BaseException):
+        logging.getLogger(__name__).error("asyncio task error", exc_info=exc)
+    else:
+        logging.getLogger(__name__).error("asyncio task error: %s", context.get("message"))
+
+
 async def _run_server(server: uvicorn.Server, config: uvicorn.Config, host: str) -> None:
     """Start uvicorn, write port file, and clean up on shutdown."""
     import atexit
 
     from lilbee.parent_monitor import parse_parent_pid, watch_parent_async
+
+    loop = asyncio.get_running_loop()
+    loop.set_exception_handler(_log_loop_exception)
 
     port_path = _port_file()
 
@@ -89,7 +103,7 @@ def serve(
     if port is not None:
         cfg.server_port = port
 
-    import logging
+    setup_server_logging()
 
     import uvicorn
 

--- a/src/lilbee/cli/commands/servers.py
+++ b/src/lilbee/cli/commands/servers.py
@@ -16,7 +16,7 @@ from lilbee.cli.app import (
     data_dir_option,
     global_option,
 )
-from lilbee.cli.commands.serve_logging import setup_server_logging
+from lilbee.cli.commands.serve_logging import setup_server_log_file, setup_server_logging
 from lilbee.core.config import cfg
 
 if TYPE_CHECKING:
@@ -111,7 +111,10 @@ def serve(
 
     logging.getLogger("asyncio").setLevel(logging.ERROR)
 
-    config = uvicorn.Config(create_app(), host=cfg.server_host, port=cfg.server_port)
+    app = create_app()
+    # Litestar's app construction reconfigures root logging; re-install the file handler.
+    setup_server_log_file()
+    config = uvicorn.Config(app, host=cfg.server_host, port=cfg.server_port)
     server = uvicorn.Server(config)
     asyncio.run(_run_server(server, config, cfg.server_host))
 

--- a/tests/cli/test_serve_logging.py
+++ b/tests/cli/test_serve_logging.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import faulthandler
 import logging
+import sys
 from collections.abc import Iterator
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import pytest
 
+from lilbee.cli.commands import serve_logging
 from lilbee.cli.commands.serve_logging import (
     _BACKUP_COUNT,
     _MAX_BYTES,
+    enable_fault_log,
+    install_excepthook,
     setup_server_log_file,
 )
 from lilbee.core.config import cfg
@@ -89,3 +94,67 @@ def test_pins_notset_stream_handler_to_old_root_level(data_root: Path) -> None:
         handler.flush()
     assert "file only" in log_path.read_text()
     assert stream_handler.level == logging.WARNING
+
+
+@pytest.fixture(autouse=True)
+def _reset_fault_log() -> Iterator[None]:
+    yield
+    handle = serve_logging._fault_log._handle
+    if handle is not None and not handle.closed:
+        faulthandler.disable()
+        handle.close()
+        # Restore pytest's stderr fault dumping.
+        faulthandler.enable()
+    serve_logging._fault_log._handle = None
+
+
+@pytest.fixture(autouse=True)
+def _restore_excepthook() -> Iterator[None]:
+    before = sys.excepthook
+    yield
+    sys.excepthook = before
+
+
+def test_fault_log_enabled(data_root: Path) -> None:
+    fault_path = enable_fault_log()
+    assert fault_path == data_root / "logs" / "server-fault.log"
+    assert fault_path.exists()
+    assert faulthandler.is_enabled()
+    # pytest enables faulthandler itself, so also assert our handle is live.
+    handle = serve_logging._fault_log._handle
+    assert handle is not None
+    assert not handle.closed
+    assert Path(handle.name) == fault_path
+
+
+def test_fault_log_idempotent(data_root: Path) -> None:
+    first = enable_fault_log()
+    handle = serve_logging._fault_log._handle
+    second = enable_fault_log()
+    assert first == second
+    assert serve_logging._fault_log._handle is handle
+
+
+def test_fault_log_reopens_closed_handle(data_root: Path) -> None:
+    first = enable_fault_log()
+    handle = serve_logging._fault_log._handle
+    assert handle is not None
+    faulthandler.disable()
+    handle.close()
+    second = enable_fault_log()
+    assert second == first
+    reopened = serve_logging._fault_log._handle
+    assert reopened is not None
+    assert not reopened.closed
+    assert faulthandler.is_enabled()
+
+
+def test_excepthook_logs_and_chains(data_root: Path, caplog: pytest.LogCaptureFixture) -> None:
+    called: list[type[BaseException]] = []
+    sys.excepthook = lambda tp, val, tb: called.append(tp)
+    install_excepthook()
+    err = RuntimeError("kaboom")
+    with caplog.at_level(logging.CRITICAL):
+        sys.excepthook(RuntimeError, err, None)
+    assert "kaboom" in caplog.text
+    assert called == [RuntimeError]

--- a/tests/cli/test_serve_logging.py
+++ b/tests/cli/test_serve_logging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import faulthandler
 import logging
+import logging.config
 import sys
 from collections.abc import Iterator
 from logging.handlers import RotatingFileHandler
@@ -95,6 +96,32 @@ def test_pins_notset_stream_handler_to_old_root_level(data_root: Path) -> None:
         handler.flush()
     assert "file only" in log_path.read_text()
     assert stream_handler.level == logging.WARNING
+
+
+def test_reinstalls_after_dictconfig_root_reset(data_root: Path) -> None:
+    log_path = setup_server_log_file()
+    logging.config.dictConfig(
+        {"version": 1, "disable_existing_loggers": False, "root": {"handlers": [], "level": "INFO"}}
+    )
+    assert not _server_log_handlers(log_path)
+    setup_server_log_file()
+    assert len(_server_log_handlers(log_path)) == 1
+    logging.getLogger("lilbee.test").info("after reset")
+    for handler in _server_log_handlers(log_path):
+        handler.flush()
+    assert "after reset" in log_path.read_text()
+
+
+def test_create_app_wipes_root_handlers_and_recall_restores(data_root: Path) -> None:
+    from lilbee.server import create_app
+
+    log_path = setup_server_log_file()
+    # Pins the litestar behavior serve() works around: app construction
+    # applies a dictConfig that replaces root's handlers.
+    create_app()
+    assert not _server_log_handlers(log_path)
+    setup_server_log_file()
+    assert len(_server_log_handlers(log_path)) == 1
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/test_serve_logging.py
+++ b/tests/cli/test_serve_logging.py
@@ -114,6 +114,7 @@ def _restore_excepthook() -> Iterator[None]:
     before = sys.excepthook
     yield
     sys.excepthook = before
+    serve_logging._except_hook.installed = False
 
 
 def test_fault_log_enabled(data_root: Path) -> None:
@@ -165,4 +166,15 @@ def test_excepthook_logs_and_chains(data_root: Path, caplog: pytest.LogCaptureFi
     with caplog.at_level(logging.CRITICAL):
         sys.excepthook(RuntimeError, err, None)
     assert "kaboom" in caplog.text
+    assert called == [RuntimeError]
+
+
+def test_excepthook_install_idempotent(data_root: Path, caplog: pytest.LogCaptureFixture) -> None:
+    called: list[type[BaseException]] = []
+    sys.excepthook = lambda tp, val, tb: called.append(tp)
+    install_excepthook()
+    install_excepthook()
+    with caplog.at_level(logging.CRITICAL):
+        sys.excepthook(RuntimeError, RuntimeError("once"), None)
+    assert caplog.text.count("unhandled exception") == 1
     assert called == [RuntimeError]

--- a/tests/cli/test_serve_logging.py
+++ b/tests/cli/test_serve_logging.py
@@ -18,6 +18,7 @@ from lilbee.cli.commands.serve_logging import (
     enable_fault_log,
     install_excepthook,
     setup_server_log_file,
+    setup_server_logging,
 )
 from lilbee.core.config import cfg
 
@@ -146,6 +147,13 @@ def test_fault_log_reopens_closed_handle(data_root: Path) -> None:
     reopened = serve_logging._fault_log._handle
     assert reopened is not None
     assert not reopened.closed
+    assert faulthandler.is_enabled()
+
+
+def test_setup_server_logging_installs_everything(data_root: Path) -> None:
+    setup_server_logging()
+    assert _server_log_handlers(data_root / "logs" / "server.log")
+    assert (data_root / "logs" / "server-fault.log").exists()
     assert faulthandler.is_enabled()
 
 

--- a/tests/cli/test_serve_logging.py
+++ b/tests/cli/test_serve_logging.py
@@ -1,0 +1,91 @@
+"""Tests for the serve log-file routing."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+import pytest
+
+from lilbee.cli.commands.serve_logging import (
+    _BACKUP_COUNT,
+    _MAX_BYTES,
+    setup_server_log_file,
+)
+from lilbee.core.config import cfg
+
+
+@pytest.fixture()
+def data_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(cfg, "data_root", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _clean_root_logger() -> Iterator[None]:
+    root = logging.getLogger()
+    before_handlers = list(root.handlers)
+    before_level = root.level
+    yield
+    for handler in root.handlers:
+        if handler not in before_handlers:
+            root.removeHandler(handler)
+            handler.close()
+    root.setLevel(before_level)
+
+
+def _server_log_handlers(log_path: Path) -> list[RotatingFileHandler]:
+    return [
+        h
+        for h in logging.getLogger().handlers
+        if isinstance(h, RotatingFileHandler) and Path(h.baseFilename) == log_path
+    ]
+
+
+def test_installs_rotating_handler(data_root: Path) -> None:
+    log_path = setup_server_log_file()
+    assert log_path == data_root / "logs" / "server.log"
+    handlers = _server_log_handlers(log_path)
+    assert len(handlers) == 1
+    assert handlers[0].maxBytes == _MAX_BYTES
+    assert handlers[0].backupCount == _BACKUP_COUNT
+    assert handlers[0].level == logging.INFO
+
+
+def test_idempotent(data_root: Path) -> None:
+    first = setup_server_log_file()
+    second = setup_server_log_file()
+    assert first == second
+    assert len(_server_log_handlers(first)) == 1
+
+
+def test_info_reaches_file_when_root_was_warning(data_root: Path) -> None:
+    logging.getLogger().setLevel(logging.WARNING)
+    log_path = setup_server_log_file()
+    logging.getLogger("lilbee.test").info("hello file")
+    for handler in _server_log_handlers(log_path):
+        handler.flush()
+    assert "hello file" in log_path.read_text()
+
+
+def test_does_not_lower_a_more_verbose_root(data_root: Path) -> None:
+    logging.getLogger().setLevel(logging.DEBUG)
+    setup_server_log_file()
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_pins_notset_stream_handler_to_old_root_level(data_root: Path) -> None:
+    root = logging.getLogger()
+    root.setLevel(logging.WARNING)
+    stream_handler = logging.StreamHandler()
+    root.addHandler(stream_handler)
+    assert stream_handler.level == logging.NOTSET
+
+    log_path = setup_server_log_file()
+    logging.getLogger("lilbee.test").info("file only")
+    for handler in _server_log_handlers(log_path):
+        handler.flush()
+    assert "file only" in log_path.read_text()
+    assert stream_handler.level == logging.WARNING

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -90,25 +90,29 @@ class TestTokenCommand:
 
 
 class TestServeCommand:
+    @mock.patch("lilbee.cli.commands.servers.setup_server_logging")
     @mock.patch("lilbee.cli.commands.servers.asyncio.run", side_effect=_close_coro)
     @mock.patch("lilbee.server.create_app")
-    def test_default_host_port(self, mock_create_app, mock_asyncio_run):
+    def test_default_host_port(self, mock_create_app, mock_asyncio_run, mock_setup_logging):
         mock_create_app.return_value = "fake_app"
         result = runner.invoke(app, ["serve"])
         assert result.exit_code == 0
         mock_asyncio_run.assert_called_once()
+        mock_setup_logging.assert_called_once()
 
+    @mock.patch("lilbee.cli.commands.servers.setup_server_logging")
     @mock.patch("lilbee.cli.commands.servers.asyncio.run", side_effect=_close_coro)
     @mock.patch("lilbee.server.create_app")
-    def test_custom_host_port(self, mock_create_app, mock_asyncio_run):
+    def test_custom_host_port(self, mock_create_app, mock_asyncio_run, mock_setup_logging):
         mock_create_app.return_value = "fake_app"
         result = runner.invoke(app, ["serve", "--host", "0.0.0.0", "--port", "8080"])
         assert result.exit_code == 0
         mock_asyncio_run.assert_called_once()
 
+    @mock.patch("lilbee.cli.commands.servers.setup_server_logging")
     @mock.patch("lilbee.cli.commands.servers.asyncio.run", side_effect=_close_coro)
     @mock.patch("lilbee.server.create_app")
-    def test_short_flags(self, mock_create_app, mock_asyncio_run):
+    def test_short_flags(self, mock_create_app, mock_asyncio_run, mock_setup_logging):
         mock_create_app.return_value = "fake_app"
         result = runner.invoke(app, ["serve", "-H", "0.0.0.0", "-p", "9000"])
         assert result.exit_code == 0
@@ -120,6 +124,28 @@ class TestPortFile:
         from lilbee.cli.commands.servers import _port_file
 
         assert _port_file() == cfg.data_dir / "server.port"
+
+
+class TestLogLoopException:
+    def test_logs_exception_from_context(self, caplog):
+        import logging
+
+        from lilbee.cli.commands.servers import _log_loop_exception
+
+        err = RuntimeError("task blew up")
+        with caplog.at_level(logging.ERROR, logger="lilbee.cli.commands.servers"):
+            _log_loop_exception(mock.MagicMock(), {"exception": err})
+        assert "asyncio task error" in caplog.text
+        assert "task blew up" in caplog.text
+
+    def test_logs_message_when_no_exception(self, caplog):
+        import logging
+
+        from lilbee.cli.commands.servers import _log_loop_exception
+
+        with caplog.at_level(logging.ERROR, logger="lilbee.cli.commands.servers"):
+            _log_loop_exception(mock.MagicMock(), {"message": "task was destroyed"})
+        assert "asyncio task error: task was destroyed" in caplog.text
 
 
 class TestRunServer:
@@ -269,6 +295,27 @@ class TestRunServer:
         port_path.write_text("11111")
         cleanup_fn()
         assert not port_path.exists()
+
+    def test_installs_loop_exception_handler(self):
+        from lilbee.cli.commands.servers import _log_loop_exception, _run_server
+
+        fake_server_obj = mock.MagicMock()
+        fake_server_obj.servers = []
+        fake_server_obj.startup = mock.AsyncMock()
+        fake_server_obj.shutdown = mock.AsyncMock()
+
+        seen_handler = None
+
+        async def capture_handler() -> None:
+            nonlocal seen_handler
+            seen_handler = asyncio.get_running_loop().get_exception_handler()
+
+        fake_server_obj.main_loop = capture_handler
+        fake_config = mock.MagicMock()
+
+        asyncio.run(_run_server(fake_server_obj, fake_config, "127.0.0.1"))
+
+        assert seen_handler is _log_loop_exception
 
     def test_does_not_call_shutdown_when_startup_fails(self):
         """If `startup()` raises, `server.servers` was never assigned. Calling

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -90,29 +90,39 @@ class TestTokenCommand:
 
 
 class TestServeCommand:
+    @mock.patch("lilbee.cli.commands.servers.setup_server_log_file")
     @mock.patch("lilbee.cli.commands.servers.setup_server_logging")
     @mock.patch("lilbee.cli.commands.servers.asyncio.run", side_effect=_close_coro)
     @mock.patch("lilbee.server.create_app")
-    def test_default_host_port(self, mock_create_app, mock_asyncio_run, mock_setup_logging):
+    def test_default_host_port(
+        self, mock_create_app, mock_asyncio_run, mock_setup_logging, mock_setup_log_file
+    ):
         mock_create_app.return_value = "fake_app"
         result = runner.invoke(app, ["serve"])
         assert result.exit_code == 0
         mock_asyncio_run.assert_called_once()
         mock_setup_logging.assert_called_once()
+        mock_setup_log_file.assert_called_once()
 
+    @mock.patch("lilbee.cli.commands.servers.setup_server_log_file")
     @mock.patch("lilbee.cli.commands.servers.setup_server_logging")
     @mock.patch("lilbee.cli.commands.servers.asyncio.run", side_effect=_close_coro)
     @mock.patch("lilbee.server.create_app")
-    def test_custom_host_port(self, mock_create_app, mock_asyncio_run, mock_setup_logging):
+    def test_custom_host_port(
+        self, mock_create_app, mock_asyncio_run, mock_setup_logging, mock_setup_log_file
+    ):
         mock_create_app.return_value = "fake_app"
         result = runner.invoke(app, ["serve", "--host", "0.0.0.0", "--port", "8080"])
         assert result.exit_code == 0
         mock_asyncio_run.assert_called_once()
 
+    @mock.patch("lilbee.cli.commands.servers.setup_server_log_file")
     @mock.patch("lilbee.cli.commands.servers.setup_server_logging")
     @mock.patch("lilbee.cli.commands.servers.asyncio.run", side_effect=_close_coro)
     @mock.patch("lilbee.server.create_app")
-    def test_short_flags(self, mock_create_app, mock_asyncio_run, mock_setup_logging):
+    def test_short_flags(
+        self, mock_create_app, mock_asyncio_run, mock_setup_logging, mock_setup_log_file
+    ):
         mock_create_app.return_value = "fake_app"
         result = runner.invoke(app, ["serve", "-H", "0.0.0.0", "-p", "9000"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Problem

`lilbee serve` writes no log file. The only handler streams to stderr, and when the Obsidian plugin runs the server in managed mode it keeps just the last 20 stderr lines in memory. A server that crashes, or never comes up, leaves nothing on disk to attach to a bug report: native segfaults vanish without a trace, and asyncio background-task errors disappear with the process.

## Solution

`serve` now sets up persistent logging in its data root before starting uvicorn:

- `logs/server.log`, a rotating file (2 MiB, 3 backups) that captures INFO and above even when the console stays at the default WARNING. Existing stderr verbosity is unchanged: handlers that delegated to the root logger get pinned to the old level before the root is lowered.
- `logs/server-fault.log`, a faulthandler target, so a segfault in native code leaves a traceback instead of nothing.
- A last-gasp excepthook that logs unhandled exceptions before the previous hook runs, and an asyncio loop exception handler that routes background-task errors into the log.

All three installs are idempotent. Worker subprocesses already had their own `logs/worker-<role>.log` files; this fills in the main process.

## Docs

New TROUBLESHOOTING.md covers where the logs live, how the data root is resolved, turning up verbosity, and what to send when reporting a worker crash. Linked from the README's support section.