### PR TITLE
Log eager worker-pool start failures instead of suppressing them

### DIFF
--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import logging
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from lilbee.providers.worker.pool import shutdown_pool_runtime
+
+log = logging.getLogger(__name__)
 
 _RELOAD_CLOSE_TIMEOUT_S = 5.0
 """Wall-clock budget for closing a detached worker channel during reload_role.
@@ -209,12 +212,15 @@ def get_services() -> Services:
     # vision. Set ``cfg.worker_pool_eager_start = false`` for headless
     # scripts where mount time matters more than first-call latency.
     if cfg.worker_pool_eager_start:
-        from contextlib import suppress
-
-        with suppress(Exception):
+        try:
             provider.warm_up_pool()
             pool_runtime.start()
             pool_runtime.run_sync(worker_pool.start_eager(), timeout=30.0)
+        except Exception:
+            log.warning(
+                "Eager worker-pool start failed; workers will retry on first use",
+                exc_info=True,
+            )
     return _svc
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -205,8 +206,8 @@ class TestEagerStartBranch:
         assert "start" in called
         assert "run_sync" in called
 
-    def test_eager_start_swallows_runtime_failure(self, monkeypatch):
-        """Suppress(Exception) keeps get_services() resilient if eager start raises."""
+    def test_eager_start_swallows_runtime_failure(self, monkeypatch, caplog):
+        """An eager-start failure is logged but keeps get_services() resilient."""
         cfg.worker_pool_eager_start = True
 
         from lilbee.app import services as services_mod
@@ -232,8 +233,10 @@ class TestEagerStartBranch:
 
         try:
             # Must not raise even though start() blew up.
-            svc = services_mod.get_services()
+            with caplog.at_level(logging.WARNING, logger="lilbee.app.services"):
+                svc = services_mod.get_services()
             assert svc is not None
+            assert any("Eager worker-pool start failed" in r.message for r in caplog.records)
         finally:
             services_mod.set_services(None)
 


### PR DESCRIPTION
When the worker pool fails to warm up at startup (a missing Vulkan loader is the typical case on bare Linux), get_services() suppressed the exception entirely. The server came up looking healthy and the first chat or embed call failed later, with nothing in server.log to connect the two.

The warm-up stays best-effort: a failure still doesn't crash startup, but it now leaves a warning with the full traceback in the log, so a diagnostics bundle shows why the workers were cold.