### PR TITLE
Fix the compiled binary segfault inside Flatpak sandboxes

### DIFF
--- a/.github/workflows/flatpak-validate.yml
+++ b/.github/workflows/flatpak-validate.yml
@@ -1,0 +1,142 @@
+name: Flatpak validate
+
+# Builds the Linux executable like release.yml, then proves it boots inside a
+# real Flatpak sandbox (the freedesktop runtime segfault regression, #342).
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch/tag/SHA to build"
+        required: false
+        type: string
+  push:
+    branches: [fix/flatpak-openssl-conf]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_34_x86_64
+    timeout-minutes: 300
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(awk -F'"' '/^version *= */ { print $2; exit }' pyproject.toml)
+          NUITKA_VERSION=$(echo "$VERSION" | tr -cs '0-9' ' ' | awk '{ printf "%s.%s.%s.%s", $1, $2, $3, $4 }')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "LILBEE_NUITKA_VERSION=$NUITKA_VERSION" >> "$GITHUB_ENV"
+
+      - name: Install Vulkan SDK
+        shell: bash
+        run: |
+          set -euxo pipefail
+          dnf install -y libxkbcommon-devel libX11-devel libXrandr-devel libXcursor-devel libXi-devel libXinerama-devel mesa-libGL-devel
+          VULKAN_VERSION="1.3.296.0"
+          curl -L -o /tmp/vulkan-sdk.tar.xz \
+            "https://sdk.lunarg.com/sdk/download/${VULKAN_VERSION}/linux/vulkansdk-linux-x86_64-${VULKAN_VERSION}.tar.xz"
+          mkdir -p /opt/vulkan
+          tar -xf /tmp/vulkan-sdk.tar.xz -C /opt/vulkan --strip-components=1
+          {
+            echo "VULKAN_SDK=/opt/vulkan/x86_64"
+            echo "LD_LIBRARY_PATH=/opt/vulkan/x86_64/lib:${LD_LIBRARY_PATH:-}"
+          } >> "$GITHUB_ENV"
+          echo "/opt/vulkan/x86_64/bin" >> "$GITHUB_PATH"
+
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: nuitka-ubuntu-latest-vulkan
+          max-size: '2G'
+
+      - name: Install dependencies
+        run: uv sync --extra release && uv pip install 'nuitka[onefile]>=4.0,<5' pip
+
+      - name: Build llama-cpp-python from source
+        shell: bash
+        env:
+          BACKEND: vulkan
+          LLAMA_BUILD_DIR: "/tmp/llama-build"
+        run: bash tools/wheel-build/build_llama_cpp.sh
+
+      - name: Install the freshly-built llama-cpp-python
+        shell: bash
+        run: uv pip install --reinstall --no-deps /tmp/llama-build/llama_cpp_python-*.whl
+
+      - name: Build executable
+        shell: bash
+        env:
+          ASSET_NAME: lilbee-linux-x86_64
+          PRODUCT_VERSION: ${{ env.LILBEE_NUITKA_VERSION }}
+        run: bash tools/wheel-build/build_lilbee_binary.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lilbee-linux-x86_64
+          path: dist/lilbee-linux-x86_64
+          if-no-files-found: error
+
+  sandbox:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      APPDATA: /home/runner/.var/app/md.obsidian.Obsidian
+      EXPECTED: lilbee ${{ needs.build.outputs.version }}
+    steps:
+      - name: Install flatpak and Obsidian
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq flatpak
+          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y --noninteractive flathub md.obsidian.Obsidian
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: lilbee-linux-x86_64
+          path: /tmp/dist
+
+      - name: Baseline outside the sandbox
+        run: |
+          chmod +x /tmp/dist/lilbee-linux-x86_64
+          ACTUAL=$(/tmp/dist/lilbee-linux-x86_64 --version)
+          echo "outside: $ACTUAL"
+          test "$ACTUAL" = "$EXPECTED"
+
+      - name: Validate inside the Obsidian Flatpak sandbox
+        run: |
+          mkdir -p "$APPDATA/data/lilbee/bin"
+          cp /tmp/dist/lilbee-linux-x86_64 "$APPDATA/data/lilbee/bin/lilbee"
+          cat > "$APPDATA/data/lilbee/validate.sh" <<EOF
+          #!/bin/sh
+          set -u
+          EXPECTED="$EXPECTED"
+          EOF
+          cat >> "$APPDATA/data/lilbee/validate.sh" <<'EOF'
+          BIN="$HOME/.var/app/md.obsidian.Obsidian/data/lilbee/bin/lilbee"
+          echo "=== onefile, default env ==="
+          ACTUAL=$("$BIN" --version); RC=$?
+          echo "stdout: $ACTUAL (exit=$RC)"
+          [ $RC -eq 0 ] && [ "$ACTUAL" = "$EXPECTED" ] || { echo "FAIL: onefile"; exit 1; }
+          MAIN=$(echo "$XDG_CACHE_HOME"/lilbee/*/lilbee-linux-x86_64.bin)
+          echo "=== unpacked main, default env: $MAIN ==="
+          ACTUAL=$("$MAIN" --version); RC=$?
+          echo "stdout: $ACTUAL (exit=$RC)"
+          [ $RC -eq 0 ] && [ "$ACTUAL" = "$EXPECTED" ] || { echo "FAIL: unpacked"; exit 1; }
+          echo "PASS: binary boots inside the Flatpak sandbox"
+          EOF
+          flatpak run --command=sh md.obsidian.Obsidian "$APPDATA/data/lilbee/validate.sh"

--- a/src/lilbee/__main__.py
+++ b/src/lilbee/__main__.py
@@ -11,7 +11,7 @@ _FLATPAK_INFO = Path("/.flatpak-info")  # present in every Flatpak sandbox
 
 
 def _isolate_vendored_openssl() -> None:
-    """Default ``OPENSSL_CONF`` to the empty config in frozen Flatpak runs.
+    """Default ``OPENSSL_CONF`` to the empty config inside Flatpak sandboxes.
 
     Flatpak's freedesktop runtime ships an openssl.cnf whose engine section
     dlopens engine modules built against the runtime's own OpenSSL. Bundled
@@ -21,9 +21,10 @@ def _isolate_vendored_openssl() -> None:
     vendored OpenSSL self-contained; certificate paths are unaffected.
     Scoped to Flatpak sandboxes so every other install keeps reading the
     host config, and an explicitly set ``OPENSSL_CONF`` always wins.
+    Deliberately not gated on a frozen-binary check: Nuitka does not set
+    ``sys.frozen``, and a pip install run inside a sandbox crashes the same
+    way.
     """
-    if not hasattr(sys, "frozen"):
-        return
     if sys.platform != "linux" or not _FLATPAK_INFO.exists():
         return
     os.environ.setdefault("OPENSSL_CONF", os.devnull)

--- a/src/lilbee/__main__.py
+++ b/src/lilbee/__main__.py
@@ -2,8 +2,31 @@
 
 from __future__ import annotations
 
+import os
 import runpy
 import sys
+from pathlib import Path
+
+_FLATPAK_INFO = Path("/.flatpak-info")  # present in every Flatpak sandbox
+
+
+def _isolate_vendored_openssl() -> None:
+    """Default ``OPENSSL_CONF`` to the empty config in frozen Flatpak runs.
+
+    Flatpak's freedesktop runtime ships an openssl.cnf whose engine section
+    dlopens engine modules built against the runtime's own OpenSSL. Bundled
+    wheels that vendor a static OpenSSL (pyarrow's libarrow) honor that
+    config during import-time init, load the ABI-incompatible engine, and
+    segfault before any lilbee code runs. An empty config keeps every
+    vendored OpenSSL self-contained; certificate paths are unaffected.
+    Scoped to Flatpak sandboxes so every other install keeps reading the
+    host config, and an explicitly set ``OPENSSL_CONF`` always wins.
+    """
+    if not hasattr(sys, "frozen"):
+        return
+    if sys.platform != "linux" or not _FLATPAK_INFO.exists():
+        return
+    os.environ.setdefault("OPENSSL_CONF", os.devnull)
 
 
 def _multiprocessing_child_code(argv: list[str]) -> str | None:
@@ -72,6 +95,10 @@ def _dispatch_module_invocation() -> bool:
 
 
 if __name__ == "__main__":  # pragma: no cover - process entry glue; logic is unit-tested above
+    # Must run before anything that can initialize OpenSSL (pyarrow import,
+    # ssl), including the multiprocessing child payloads dispatched below.
+    _isolate_vendored_openssl()
+
     # Make the frozen exe a valid subprocess target for multiprocessing's
     # sys.executable reinvocations, BEFORE any import that could pull typer.
     if _dispatch_module_invocation():

--- a/tests/test_main_dispatch.py
+++ b/tests/test_main_dispatch.py
@@ -10,13 +10,12 @@ from lilbee import __main__ as main_mod
 
 
 class TestIsolateVendoredOpenssl:
-    """Default OPENSSL_CONF to the empty config only in frozen Flatpak runs."""
+    """Default OPENSSL_CONF to the empty config only inside Flatpak sandboxes."""
 
-    def test_sets_devnull_when_frozen_in_flatpak(self, tmp_path: Path) -> None:
+    def test_sets_devnull_inside_flatpak(self, tmp_path: Path) -> None:
         marker = tmp_path / ".flatpak-info"
         marker.touch()
         with (
-            mock.patch.object(main_mod.sys, "frozen", True, create=True),
             mock.patch.object(main_mod.sys, "platform", "linux"),
             mock.patch.object(main_mod, "_FLATPAK_INFO", marker),
             mock.patch.dict(os.environ, clear=True),
@@ -28,7 +27,6 @@ class TestIsolateVendoredOpenssl:
         marker = tmp_path / ".flatpak-info"
         marker.touch()
         with (
-            mock.patch.object(main_mod.sys, "frozen", True, create=True),
             mock.patch.object(main_mod.sys, "platform", "linux"),
             mock.patch.object(main_mod, "_FLATPAK_INFO", marker),
             mock.patch.dict(os.environ, {"OPENSSL_CONF": "/etc/custom.cnf"}, clear=True),
@@ -38,21 +36,8 @@ class TestIsolateVendoredOpenssl:
 
     def test_noop_outside_flatpak(self, tmp_path: Path) -> None:
         with (
-            mock.patch.object(main_mod.sys, "frozen", True, create=True),
             mock.patch.object(main_mod.sys, "platform", "linux"),
             mock.patch.object(main_mod, "_FLATPAK_INFO", tmp_path / "absent"),
-            mock.patch.dict(os.environ, clear=True),
-        ):
-            main_mod._isolate_vendored_openssl()
-            assert "OPENSSL_CONF" not in os.environ
-
-    def test_noop_when_not_frozen(self, tmp_path: Path) -> None:
-        marker = tmp_path / ".flatpak-info"
-        marker.touch()
-        # sys.frozen does not exist in a regular interpreter; no patching needed.
-        with (
-            mock.patch.object(main_mod.sys, "platform", "linux"),
-            mock.patch.object(main_mod, "_FLATPAK_INFO", marker),
             mock.patch.dict(os.environ, clear=True),
         ):
             main_mod._isolate_vendored_openssl()
@@ -62,7 +47,6 @@ class TestIsolateVendoredOpenssl:
         marker = tmp_path / ".flatpak-info"
         marker.touch()
         with (
-            mock.patch.object(main_mod.sys, "frozen", True, create=True),
             mock.patch.object(main_mod.sys, "platform", "darwin"),
             mock.patch.object(main_mod, "_FLATPAK_INFO", marker),
             mock.patch.dict(os.environ, clear=True),

--- a/tests/test_main_dispatch.py
+++ b/tests/test_main_dispatch.py
@@ -2,10 +2,73 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest import mock
 
 from lilbee import __main__ as main_mod
+
+
+class TestIsolateVendoredOpenssl:
+    """Default OPENSSL_CONF to the empty config only in frozen Flatpak runs."""
+
+    def test_sets_devnull_when_frozen_in_flatpak(self, tmp_path: Path) -> None:
+        marker = tmp_path / ".flatpak-info"
+        marker.touch()
+        with (
+            mock.patch.object(main_mod.sys, "frozen", True, create=True),
+            mock.patch.object(main_mod.sys, "platform", "linux"),
+            mock.patch.object(main_mod, "_FLATPAK_INFO", marker),
+            mock.patch.dict(os.environ, clear=True),
+        ):
+            main_mod._isolate_vendored_openssl()
+            assert os.environ["OPENSSL_CONF"] == os.devnull
+
+    def test_preserves_explicit_openssl_conf(self, tmp_path: Path) -> None:
+        marker = tmp_path / ".flatpak-info"
+        marker.touch()
+        with (
+            mock.patch.object(main_mod.sys, "frozen", True, create=True),
+            mock.patch.object(main_mod.sys, "platform", "linux"),
+            mock.patch.object(main_mod, "_FLATPAK_INFO", marker),
+            mock.patch.dict(os.environ, {"OPENSSL_CONF": "/etc/custom.cnf"}, clear=True),
+        ):
+            main_mod._isolate_vendored_openssl()
+            assert os.environ["OPENSSL_CONF"] == "/etc/custom.cnf"
+
+    def test_noop_outside_flatpak(self, tmp_path: Path) -> None:
+        with (
+            mock.patch.object(main_mod.sys, "frozen", True, create=True),
+            mock.patch.object(main_mod.sys, "platform", "linux"),
+            mock.patch.object(main_mod, "_FLATPAK_INFO", tmp_path / "absent"),
+            mock.patch.dict(os.environ, clear=True),
+        ):
+            main_mod._isolate_vendored_openssl()
+            assert "OPENSSL_CONF" not in os.environ
+
+    def test_noop_when_not_frozen(self, tmp_path: Path) -> None:
+        marker = tmp_path / ".flatpak-info"
+        marker.touch()
+        # sys.frozen does not exist in a regular interpreter; no patching needed.
+        with (
+            mock.patch.object(main_mod.sys, "platform", "linux"),
+            mock.patch.object(main_mod, "_FLATPAK_INFO", marker),
+            mock.patch.dict(os.environ, clear=True),
+        ):
+            main_mod._isolate_vendored_openssl()
+            assert "OPENSSL_CONF" not in os.environ
+
+    def test_noop_on_other_platforms(self, tmp_path: Path) -> None:
+        marker = tmp_path / ".flatpak-info"
+        marker.touch()
+        with (
+            mock.patch.object(main_mod.sys, "frozen", True, create=True),
+            mock.patch.object(main_mod.sys, "platform", "darwin"),
+            mock.patch.object(main_mod, "_FLATPAK_INFO", marker),
+            mock.patch.dict(os.environ, clear=True),
+        ):
+            main_mod._isolate_vendored_openssl()
+            assert "OPENSSL_CONF" not in os.environ
 
 
 class TestMultiprocessingChildCode:


### PR DESCRIPTION
## Problem

Inside a Flatpak sandbox the Linux binary dies before printing anything: the compiled binary segfaults and the onefile wrapper swallows the crash as a silent exit 0, so anything spawning lilbee (the Obsidian plugin's managed mode, for one) just sees the server die instantly with no logs. The gdb backtrace from a real sandbox pinned it down: the freedesktop runtime's openssl.cnf tells OpenSSL to load the runtime's pkcs11 engine, and the vendored OpenSSL inside pyarrow's libarrow honors that config during import-time init, dlopens the ABI-incompatible engine, and crashes on a null deref. Outside the sandbox no engine is configured, so the binary runs fine.

Fixes #342.

## Solution

Default `OPENSSL_CONF` to `/dev/null` at the entry point when running on Linux inside a Flatpak sandbox (detected via `/.flatpak-info`). The vendored OpenSSL falls back to its built-in defaults instead of loading host engines; certificate paths are unaffected. Installs outside Flatpak are completely untouched, and an explicitly set `OPENSSL_CONF` always wins.

Unit tests cover the gating. The new `flatpak-validate` workflow builds the real executable from this branch and proves it boots inside the actual Obsidian Flatpak sandbox (both the onefile wrapper and the unpacked binary), which is exactly the failing signature before this change. Validating against the first build also surfaced that Nuitka never sets `sys.frozen` (an early revision gated on it and stayed dead in the binary); that affects the existing frozen dispatchers too and is tracked separately.