### PR TITLE
Attach executables to the release as they build; keep release ccache warm

### DIFF
--- a/.github/workflows/build-cuda-executables.yml
+++ b/.github/workflows/build-cuda-executables.yml
@@ -27,6 +27,10 @@ on:
         description: "Build even if the smoke step fails."
         type: boolean
         default: false
+      release_tag:
+        description: "GH release tag to eagerly attach each built executable to (empty = artifacts only)."
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -112,6 +116,8 @@ jobs:
         if: runner.os == 'Linux'
         uses: hendrikmuhs/ccache-action@v1
         with:
+          # Tag-scoped cache saves are unrestorable by future runs; don't evict useful ones.
+          save: ${{ github.ref_type != 'tag' }}
           key: nuitka-${{ matrix.os }}-${{ matrix.backend }}
           max-size: '2G'
 
@@ -181,9 +187,17 @@ jobs:
           name: ${{ matrix.asset_name }}
           path: dist/${{ matrix.asset_name }}
 
+      # workflow_call eager attach: the caller created the pre-release shell,
+      # so each cell's exe appears on the release as soon as it builds.
+      - name: Attach binary to the GH pre-release (call mode)
+        if: inputs.release_tag != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.release_tag }}
+        run: gh release upload "$TAG" "dist/${{ matrix.asset_name }}" --clobber
+
       # Standalone-dispatch mode: attach to the named release tag directly.
-      # workflow_call mode skips this because the caller's attach-prerelease
-      # picks up the run artifact via the lilbee-* glob.
       - name: Attach binary to release (dispatch mode)
         if: inputs.tag != ''
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/flatpak-validate.yml
+++ b/.github/workflows/flatpak-validate.yml
@@ -2,6 +2,8 @@ name: Flatpak validate
 
 # Builds the Linux executable like release.yml, then proves it boots inside a
 # real Flatpak sandbox (the freedesktop runtime segfault regression, #342).
+# The weekly run doubles as the main-branch ccache primer: tag-scoped release
+# builds can only restore caches saved on main, so this keeps them warm.
 on:
   workflow_dispatch:
     inputs:
@@ -9,8 +11,8 @@ on:
         description: "Branch/tag/SHA to build"
         required: false
         type: string
-  push:
-    branches: [fix/flatpak-openssl-conf]
+  schedule:
+    - cron: '0 7 * * 1'  # Mondays 07:00 UTC
 
 jobs:
   build:

--- a/.github/workflows/flatpak-validate.yml
+++ b/.github/workflows/flatpak-validate.yml
@@ -2,8 +2,11 @@ name: Flatpak validate
 
 # Builds the Linux executable like release.yml, then proves it boots inside a
 # real Flatpak sandbox (the freedesktop runtime segfault regression, #342).
-# The weekly run doubles as the main-branch ccache primer: tag-scoped release
-# builds can only restore caches saved on main, so this keeps them warm.
+# Two clocks, two triggers: the cron catches freedesktop runtime drift (their
+# schedule, not our commits) and keeps the main-branch ccache alive past
+# GitHub's 7-day eviction; the push trigger re-primes and re-validates the
+# moment compile inputs change (dep bumps are exactly when the vendored-lib
+# crash class can regress). Release builds can only restore main-saved caches.
 on:
   workflow_dispatch:
     inputs:
@@ -13,6 +16,17 @@ on:
         type: string
   schedule:
     - cron: '0 7 * * 1'  # Mondays 07:00 UTC
+  push:
+    branches: [main]
+    paths:
+      - uv.lock
+      - pyproject.toml
+      - tools/wheel-build/**
+      - .github/workflows/flatpak-validate.yml
+
+concurrency:
+  group: flatpak-validate-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -90,20 +90,43 @@ jobs:
       ref: ${{ needs.resolve.outputs.ref }}
     secrets: inherit
 
-  build-binaries:
+  # Pre-release shell created up front so executable build jobs can attach
+  # their asset the moment it builds instead of waiting for the slowest cell.
+  create-prerelease:
     needs: [resolve]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1 \
+            || gh release create "$TAG" --repo "$REPO" --prerelease \
+                 --notes "Release candidate building; executables attach here as each one finishes."
+
+  build-binaries:
+    needs: [resolve, create-prerelease]
+    # create-prerelease is skipped on workflow_dispatch; only a real failure blocks.
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.create-prerelease.result != 'failure' }}
     uses: ./.github/workflows/release.yml
     with:
       ref: ${{ needs.resolve.outputs.ref }}
       skip_tests: ${{ inputs.skip_tests || false }}
+      release_tag: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) && needs.resolve.outputs.tag || '' }}
     secrets: inherit
 
   build-cuda:
-    needs: [resolve]
+    needs: [resolve, create-prerelease]
+    if: ${{ !cancelled() && needs.resolve.result == 'success' && needs.create-prerelease.result != 'failure' }}
     uses: ./.github/workflows/build-cuda-executables.yml
     with:
       ref: ${{ needs.resolve.outputs.ref }}
       skip_tests: ${{ inputs.skip_tests || false }}
+      release_tag: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) && needs.resolve.outputs.tag || '' }}
     secrets: inherit
 
   # Attach this run's executables AND every wheel to a GH pre-release. The

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,13 @@ on:
         description: "Build the executables even if the test job fails (re-run past a known-flaky test)."
         type: boolean
         default: false
+      release_tag:
+        description: "GH release tag to eagerly attach each built executable to (empty = artifacts only)."
+        type: string
+        default: ""
 
 permissions:
-  contents: read
+  contents: write  # eager release_tag attach; otherwise read-only behavior is unchanged
   actions: read   # gate job: look up the CI workflow's conclusion for this commit
 
 jobs:
@@ -207,6 +211,8 @@ jobs:
         with:
           key: nuitka-${{ matrix.os }}-${{ matrix.backend }}
           max-size: '2G'
+          # Tag-scoped cache saves are unrestorable by future runs; don't evict useful ones.
+          save: ${{ github.ref_type != 'tag' }}
 
       - name: Install dependencies
         # `pip` is required by build_llama_cpp.sh's `pip wheel` invocation.
@@ -334,3 +340,13 @@ jobs:
         with:
           name: ${{ matrix.asset_name }}
           path: dist/${{ matrix.asset_name }}
+
+      # Eager attach: release-candidate creates the pre-release shell before
+      # calling, so the asset shows up as soon as this cell finishes.
+      - name: Attach binary to the GH pre-release
+        if: inputs.release_tag != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.release_tag }}
+        run: gh release upload "$TAG" "dist/${{ matrix.asset_name }}" --clobber


### PR DESCRIPTION
## Problem

Release artifacts only land on the GitHub release after the entire build matrix finishes, so the slowest Windows executable gates everything (the dispatchable attach workflow from #341 exists purely to work around this). Separately, every release build compiles completely cold: the v0.6.66b495 linux job logged ccache 0/662 hits. Caches saved on tag refs are unrestorable by any later run, and nothing on main ever saves one, so each release pays the full multi-hour llama.cpp plus Nuitka compile.

## Solution

The release-candidate workflow creates the pre-release shell right after resolve and passes a `release_tag` input into the executable build workflows; each matrix cell now uploads its asset with `gh release upload --clobber` the moment it finishes. The final attach-prerelease job is unchanged and still adds the wheels and finalizes the notes, so nothing downstream moves.

For the cache: tag runs stop saving ccache (those saves were pure cache-cap pollution), and flatpak-validate gains a weekly Monday schedule whose build job keeps the linux vulkan ccache warm on main while doubling as a regression check for the Flatpak sandbox fix. Dispatching flatpak-validate once after merge does the first prime. CUDA, macOS, and Windows cache priming are follow-ups on the tracking issue.

actionlint and YAML-validation pass; the eager-attach path gets its first end-to-end exercise on the next tag.