### PR TITLE
Fix marketing-site install layout and a flaky task-bar test

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -95,7 +95,7 @@
     </section>
 
     <section>
-      <h2 class="label">install</h2>
+      <h2 class="label">see it work</h2>
 
       <div class="tutorial">
         <div class="tutorial-watch"><a class="tutorial-cta" href="tutorial/">▶&nbsp; watch the full tutorial reel</a></div>
@@ -216,6 +216,10 @@
         </div>
 
       </div>
+    </section>
+
+    <section>
+      <h2 class="label">install</h2>
 
       <div class="installtabs" role="tablist" aria-label="Install methods">
         <button type="button" class="tab" role="tab" id="tab-pip" aria-controls="pane-pip" aria-selected="true" tabindex="0">pip</button>
@@ -409,7 +413,7 @@
 
       <div class="installextras">
         <div class="extras-h">optional extras</div>
-        <div class="extras-sub">For a <code>pip</code> / <code>uv</code> install, add the name in brackets, e.g. <code>'lilbee[crawler,litellm]'</code>. The binary, Homebrew, AUR, Nix, and Docker builds bundle all three already. lilbee works without them.</div>
+        <div class="extras-sub">For a <code>pip</code> / <code>uv</code> install, add the name in brackets, e.g. <code>'lilbee[crawler,litellm]'</code>. The binary, Homebrew, AUR, Nix, Docker, Flatpak, and Snap builds bundle all three already. lilbee works without them.</div>
         <div class="extras-grid">
           <div class="extra"><span class="tag">[crawler]</span><span>index websites too: crawl a docs site or wiki to markdown, then search it offline</span></div>
           <div class="extra"><span class="tag">[litellm]</span><span>bridge to popular hosted model providers for chat, vision, or embeddings; you bring the key, the terminal app flags when one's active</span></div>

--- a/tests/test_chat_memory_commands.py
+++ b/tests/test_chat_memory_commands.py
@@ -131,14 +131,27 @@ def _patch_active_tasks(monkeypatch, queue, tasks):
     monkeypatch.setattr(type(queue), "active_tasks", property(lambda _self: tasks))
 
 
-async def test_maybe_extract_skips_while_indexing(mock_svc, monkeypatch):
-    from types import SimpleNamespace
+def _fake_active_task(task_type):
+    """A real Task the TaskBar can render. A bare stub drifts from the render
+    interface (the bar reads name/progress/indeterminate when it repaints
+    mid-test), which made these tests flaky."""
+    from lilbee.cli.tui.task_queue import Task, TaskStatus
 
+    return Task(
+        task_id=f"t-{task_type}",
+        name=task_type,
+        task_type=task_type,
+        fn=lambda: None,
+        status=TaskStatus.ACTIVE,
+    )
+
+
+async def test_maybe_extract_skips_while_indexing(mock_svc, monkeypatch):
     cfg.memory_enabled = True
     cfg.memory_auto_extract = True
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
-        _patch_active_tasks(monkeypatch, app.task_bar.queue, [SimpleNamespace(task_type="sync")])
+        _patch_active_tasks(monkeypatch, app.task_bar.queue, [_fake_active_task("sync")])
         with patch.object(app.screen, "_extract_memories_worker") as worker:
             app.screen._maybe_extract_memories("q", "a")
             await pilot.pause()
@@ -161,11 +174,9 @@ async def test_maybe_extract_runs_when_idle(mock_svc):
 
 
 async def test_indexing_active_reflects_queue(mock_svc, monkeypatch):
-    from types import SimpleNamespace
-
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         _patch_active_tasks(monkeypatch, app.task_bar.queue, [])
         assert app.screen._indexing_active() is False
-        _patch_active_tasks(monkeypatch, app.task_bar.queue, [SimpleNamespace(task_type="add")])
+        _patch_active_tasks(monkeypatch, app.task_bar.queue, [_fake_active_task("add")])
         assert app.screen._indexing_active() is True


### PR DESCRIPTION
## Problem

The marketing site's `install` heading sat directly above the full tutorial-demo reel, so the actual install methods were ~120 lines below the heading. The flatpak/snap install tabs added in #345 also never reached the live site, because the Pages deploy gates on the full test suite and hit a flaky failure in the chat-memory indexing tests.

## Solution

Split the tutorial reel into its own `see it work` section and move the `install` heading directly onto the install tabs (which already carry the flatpak/snap entries from #345). The bundled-extras note now lists flatpak/snap too.

The flaky test stubbed `active_tasks` with a bare `SimpleNamespace`, but the TaskBar repaint reads `name`/`progress`/`indeterminate` off active tasks, so a render landing mid-test raised `AttributeError`. Use a real `Task` so the fake can't drift from the render interface; ran the file repeatedly to confirm it's stable.