### PR TITLE
Honor chat mode on the streaming chat endpoint

### DIFF
--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -460,7 +460,14 @@ class Searcher:
             )
         return format_memory_block(preferences, facts, self._config.memory_token_budget)
 
-    def _direct_messages(
+    def skip_retrieval(self) -> bool:
+        """Whether this turn should bypass RAG: chat-only mode or no embedder."""
+        return (
+            self._config.chat_mode == ChatMode.CHAT.value
+            or not self._embedder.embedding_available()
+        )
+
+    def direct_messages(
         self, question: str, history: list[ChatMessage] | None = None
     ) -> list[ChatMessage]:
         """Build messages for direct LLM chat (no RAG context)."""
@@ -486,7 +493,7 @@ class Searcher:
         options: dict[str, Any] | None,
     ) -> str:
         """Run a no-RAG chat turn and return the cleaned response."""
-        messages = self._direct_messages(question, history)
+        messages = self.direct_messages(question, history)
         provider_messages = self._messages_for_provider(messages)
         opts = options if options is not None else self._config.generation_options()
         raw = str(self._provider.chat(provider_messages, options=opts or None) or "")
@@ -503,10 +510,7 @@ class Searcher:
     ) -> AskResult:
         """Ask a question. Skips retrieval when chat_mode is 'chat' or
         when no embedding model is configured."""
-        if (
-            self._config.chat_mode == ChatMode.CHAT.value
-            or not self._embedder.embedding_available()
-        ):
+        if self.skip_retrieval():
             return AskResult(answer=self._direct_chat(question, history, options), sources=[])
         rag = self.build_rag_context(question, top_k=top_k, history=history, chunk_type=chunk_type)
         if rag is None:
@@ -547,7 +551,7 @@ class Searcher:
         options: dict[str, Any] | None,
     ) -> Generator[StreamToken, None, None]:
         """Streaming branch with the general system prompt (no RAG context)."""
-        messages = self._direct_messages(question, history)
+        messages = self.direct_messages(question, history)
         provider_messages = self._messages_for_provider(messages)
         opts = options if options is not None else self._config.generation_options()
         events = stream_chat_with_cap(
@@ -573,10 +577,7 @@ class Searcher:
         chunk_type: ChunkType | None = None,
     ) -> Generator[StreamToken, None, None]:
         """Stream answer tokens with citations appended at the end."""
-        if (
-            self._config.chat_mode == ChatMode.CHAT.value
-            or not self._embedder.embedding_available()
-        ):
+        if self.skip_retrieval():
             yield from self._stream_direct(question, history, options)
             return
 

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -13,7 +13,7 @@ from lilbee.app.search import clean_result
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
 from lilbee.core.results import DocumentResult, group
-from lilbee.data.store import ChunkType, EmbeddingModelMismatchError
+from lilbee.data.store import ChunkType, EmbeddingModelMismatchError, SearchChunk
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.retrieval.reasoning import (
     CAP_NOTICE_TEMPLATE,
@@ -159,24 +159,35 @@ async def _stream_rag_response(
     top_k: int = 0,
     options: dict[str, Any] | None = None,
     chunk_type: ChunkType | None = None,
+    *,
+    honor_chat_mode: bool = False,
 ) -> AsyncGenerator[str, None]:
-    """Shared SSE streaming for ask_stream and chat_stream."""
+    """Shared SSE streaming for ask_stream and chat_stream.
+
+    With ``honor_chat_mode`` (chat_stream), a chat-only mode or a missing embedder
+    streams a direct answer with no retrieval and no sources.
+    """
     yield ""  # force generator
 
-    try:
-        rag = get_services().searcher.build_rag_context(
-            question, top_k=top_k, history=history, chunk_type=chunk_type
-        )
-    except EmbeddingModelMismatchError as exc:
-        # detail carries the index's embedder so the client can offer to adopt it.
-        detail = exc.persisted_model if exc.dims_match else None
-        yield sse_error(str(exc), code=SseErrorCode.INDEX_EMBEDDER_MISMATCH, detail=detail)
-        return
-    if rag is None:
-        yield sse_error("No relevant documents found.")
-        return
+    searcher = get_services().searcher
+    results: list[SearchChunk] = []
+    if honor_chat_mode and searcher.skip_retrieval():
+        messages = searcher.direct_messages(question, history)
+    else:
+        try:
+            rag = searcher.build_rag_context(
+                question, top_k=top_k, history=history, chunk_type=chunk_type
+            )
+        except EmbeddingModelMismatchError as exc:
+            # detail carries the index's embedder so the client can offer to adopt it.
+            detail = exc.persisted_model if exc.dims_match else None
+            yield sse_error(str(exc), code=SseErrorCode.INDEX_EMBEDDER_MISMATCH, detail=detail)
+            return
+        if rag is None:
+            yield sse_error("No relevant documents found.")
+            return
+        results, messages = rag
 
-    results, messages = rag
     opts = _resolve_generation_options(options) or cfg.generation_options()
 
     sse = SseStream()
@@ -244,5 +255,10 @@ def chat_stream(
 ) -> AsyncGenerator[str, None]:
     """Yield SSE events with chat history support."""
     return _stream_rag_response(
-        question, history=history, top_k=top_k, options=options, chunk_type=chunk_type
+        question,
+        history=history,
+        top_k=top_k,
+        options=options,
+        chunk_type=chunk_type,
+        honor_chat_mode=True,
     )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1540,20 +1540,20 @@ class TestStructuredQueryWikiRaw:
 
 class TestDirectMessagesNoEmbed:
     def test_builds_system_history_user(self, mock_svc):
-        """_direct_messages builds [system, ...history, user] when no embedding."""
+        """direct_messages builds [system, ...history, user] when no embedding."""
         searcher = get_services().searcher
         history = [
             {"role": "user", "content": "prev"},
             {"role": "assistant", "content": "prev answer"},
         ]
-        msgs = searcher._direct_messages("new question", history=history)
+        msgs = searcher.direct_messages("new question", history=history)
         assert msgs[0]["role"] == "system"
         assert msgs[1]["content"] == "prev"
         assert msgs[2]["content"] == "prev answer"
         assert msgs[3]["content"] == "new question"
 
     def test_no_history(self, mock_svc):
-        msgs = get_services().searcher._direct_messages("q")
+        msgs = get_services().searcher.direct_messages("q")
         assert len(msgs) == 2
         assert msgs[0]["role"] == "system"
         assert msgs[1]["role"] == "user"

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -69,6 +69,8 @@ def mock_svc():
     searcher.search.return_value = []
     searcher.ask_raw.return_value = MagicMock(answer="", sources=[])
     searcher.build_rag_context.return_value = None
+    # Default to the retrieval path; chat-mode tests flip this explicitly.
+    searcher.skip_retrieval.return_value = False
     services = make_mock_services(searcher=searcher)
     svc_mod.set_services(services)
     yield services
@@ -248,6 +250,16 @@ class TestAskStream:
         async for _ in handlers.ask_stream("q", chunk_type="wiki"):
             pass
         assert mock_svc.searcher.build_rag_context.call_args.kwargs.get("chunk_type") == "wiki"
+
+    async def test_always_retrieves_ignoring_chat_mode(self, mock_svc):
+        """ask is an explicit document query: it retrieves even when the searcher
+        would skip retrieval in chat-only mode."""
+        mock_svc.searcher.skip_retrieval.return_value = True
+        mock_svc.searcher.build_rag_context.return_value = None
+        events = [e async for e in handlers.ask_stream("q")]
+        mock_svc.searcher.build_rag_context.assert_called_once()
+        mock_svc.searcher.direct_messages.assert_not_called()
+        assert any(e.startswith("event: error") for e in events if e)
 
     async def test_unknown_error_yields_internal_error(self, mock_svc):
         mock_svc.searcher.build_rag_context.return_value = _rag_return()
@@ -500,6 +512,26 @@ class TestChatStream:
         token_events = [e for e in non_empty if e.startswith("event: token")]
         assert len(token_events) == 1
         assert "reply" in token_events[0]
+
+    async def test_chat_mode_streams_direct_without_retrieval(self, mock_svc):
+        """When the searcher would skip retrieval (chat-only mode or no embedder),
+        chat_stream answers directly with no RAG context and empty sources."""
+        mock_svc.searcher.skip_retrieval.return_value = True
+        mock_svc.searcher.direct_messages.return_value = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "q"},
+        ]
+        mock_svc.provider.chat.return_value = iter(["hello"])
+        events = [e async for e in handlers.chat_stream("q", [])]
+
+        mock_svc.searcher.build_rag_context.assert_not_called()
+        mock_svc.searcher.direct_messages.assert_called_once()
+        types = _event_types(events)
+        assert "token" in types
+        assert "done" in types
+        sources_events = [e for e in events if e and e.startswith("event: sources")]
+        assert len(sources_events) == 1
+        assert _parse_data(sources_events[0]) == []
 
 
 def _event_types(events: list[str]) -> list[str]:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -441,7 +441,10 @@ class TestEmbeddingMismatchSurfacing:
 
         async def _collect():
             with mock.patch.object(rag, "get_services") as mock_services:
-                mock_services.return_value.searcher.build_rag_context.side_effect = self._mismatch()
+                searcher = mock_services.return_value.searcher
+                # A mismatch only surfaces while retrieving, i.e. in search mode.
+                searcher.skip_retrieval.return_value = False
+                searcher.build_rag_context.side_effect = self._mismatch()
                 return [event async for event in rag.chat_stream(question="q", history=[])]
 
         events = asyncio.run(_collect())


### PR DESCRIPTION
## Problem

The chat sidebar's Search/Chat toggle persists `chat_mode` to the server, but Chat mode behaves identically to Search: both still retrieve from the index. The streaming endpoint `/api/chat/stream` routes through `_stream_rag_response`, which always calls `build_rag_context` and never consults `chat_mode`. The method that does honor it (`Searcher.ask_stream`, with its no-retrieval direct branch) was never wired to the HTTP streaming path. The one-shot `/api/chat` route goes through `ask_raw` and does skip retrieval in chat mode, so the two paths disagreed.

## Solution

The streaming chat handler now skips retrieval when the searcher would skip it, matching the non-streaming path. `_stream_rag_response` takes a `honor_chat_mode` flag (set only by `chat_stream`); when chat-only mode is active or no embedder is configured, it streams a direct answer with no RAG context and an empty sources event. `ask_stream` is unchanged and always retrieves, since asking is an explicit document query.

The duplicated "skip retrieval?" condition that lived in both `ask_raw` and `ask_stream` is now a single `Searcher.skip_retrieval()` predicate, reused by the handler.