### PR TITLE
Granular launch feedback for lilbee launch (warm progress stream) + QA reel fixes

### DIFF
--- a/src/lilbee/cli/launchers/launcher.py
+++ b/src/lilbee/cli/launchers/launcher.py
@@ -89,6 +89,10 @@ def run_launcher(launcher: Launcher) -> None:
     if native_refs:
         wait_for_chat_warm(port)
     extra_args, env = launcher.prepare(token=token, port=port, model_refs=model_refs)
+    # The client paints its own UI only after its runtime boots, a few silent
+    # seconds; announce the handoff so the warm bar isn't followed by a dead
+    # screen with no explanation.
+    typer.secho(f"Launching {launcher.name}...", fg=typer.colors.GREEN)
     try:
         # binary resolved via the launcher's find_binary on PATH; no shell.
         result = subprocess.run([binary, *extra_args], env=env, check=False)  # noqa: S603

--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -19,6 +19,7 @@ from lilbee.app.services import get_services
 from lilbee.catalog.types import ModelTask
 from lilbee.cli.app import console
 from lilbee.cli.commands.servers import port_file
+from lilbee.cli.launchers.warm_render import render_warm
 from lilbee.core.config import cfg
 from lilbee.modelhub.registry import ModelRegistry
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
@@ -128,19 +129,32 @@ def chat_warm_budget_s() -> float:
 
 
 def wait_for_chat_warm(port: int, timeout_s: float | None = None) -> bool:
-    """Block until the chat model is loaded, showing a warming indicator.
+    """Block until the chat model is loaded, showing granular warm progress.
 
     The server warms the chat role on a background thread at startup, so a client
     launched the instant the HTTP port binds would otherwise hit an
-    apparently-dead stream during the cold model load. Returns True once the
-    chat engine reports ready, or False if the budget (weights-scaled via
-    :func:`chat_warm_budget_s` unless given) elapses first; the caller proceeds
-    either way, so a still-loading model just warms on the first call.
+    apparently-dead stream during the cold model load. Streams ``/api/warm/stream``
+    to render a real read-phase byte bar then an engine-load spinner; falls back
+    to a plain readiness poll when that stream is unavailable (an older server).
+    Returns True once the chat engine reports ready, or False if the budget
+    (weights-scaled via :func:`chat_warm_budget_s` unless given) elapses first;
+    the caller proceeds either way, so a still-loading model just warms on the
+    first call.
     """
     if timeout_s is None:
         timeout_s = chat_warm_budget_s()
     if chat_ready(port):
         return True
+    streamed = render_warm(f"http://{LOOPBACK}:{port}", timeout_s)
+    if streamed is not None:
+        # The stream ran (ready, error, or its own timeout); don't double-spend
+        # the budget on a second poll. The caller proceeds on False regardless.
+        return streamed
+    return _poll_chat_ready(port, timeout_s)
+
+
+def _poll_chat_ready(port: int, timeout_s: float) -> bool:
+    """Fallback warm wait when the progress stream is unavailable: poll readiness."""
     deadline = time.monotonic() + timeout_s
     with console.status("Warming the chat model..."):
         while time.monotonic() < deadline:
@@ -230,9 +244,10 @@ def ensure_server_running() -> tuple[tuple[str, int], subprocess.Popen[bytes] | 
 
 def _spawn_and_wait(port: int) -> subprocess.Popen[bytes] | None:
     """Spawn a server on *port* and wait for health; None when it never comes up."""
-    console.print(f"Starting lilbee server on port {port}...")
     spawned = spawn_server(port)
-    if wait_for_health(port):
+    with console.status(f"Starting lilbee server on port {port}..."):
+        healthy = wait_for_health(port)
+    if healthy:
         return spawned
     stop_spawned_server(spawned)
     return None

--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -135,7 +135,7 @@ def wait_for_chat_warm(port: int, timeout_s: float | None = None) -> bool:
     launched the instant the HTTP port binds would otherwise hit an
     apparently-dead stream during the cold model load. Streams ``/api/warm/stream``
     to render a real read-phase byte bar then an engine-load spinner; falls back
-    to a plain readiness poll when that stream is unavailable (an older server).
+    to a plain readiness poll when that stream can't be opened.
     Returns True once the chat engine reports ready, or False if the budget
     (weights-scaled via :func:`chat_warm_budget_s` unless given) elapses first;
     the caller proceeds either way, so a still-loading model just warms on the

--- a/src/lilbee/cli/launchers/warm_render.py
+++ b/src/lilbee/cli/launchers/warm_render.py
@@ -3,8 +3,8 @@
 A launcher consumes ``/api/warm/stream`` and drives a rich progress display so
 the user sees a real read-phase byte bar, then an engine-load spinner, while a
 large chat model loads, instead of a frozen line. Designed to degrade cleanly:
-when the stream is unavailable (an older server without the endpoint) the caller
-falls back to a plain readiness poll.
+when the stream can't be opened (server still binding, a transient transport
+error, or the endpoint absent) the caller falls back to a plain readiness poll.
 """
 
 from __future__ import annotations
@@ -23,19 +23,19 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 
+from lilbee.catalog.formatting import display_label_for_ref
 from lilbee.cli.app import console
 from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 
 _WARM_STREAM_PATH = "/api/warm/stream"
 _SSE_DATA_PREFIX = "data:"
 _STREAM_CONNECT_TIMEOUT_S = 5.0
+_DEFAULT_MODEL_LABEL = "chat model"
 
 
-def _short_model(ref: str | None) -> str:
-    """A compact model name for the bar (the GGUF filename, sans the repo path)."""
-    if not ref:
-        return "chat model"
-    return ref.rsplit("/", 1)[-1].removesuffix(".gguf")
+def _model_label(ref: str | None) -> str:
+    """The canonical UI label for the warming model, or a generic fallback."""
+    return display_label_for_ref(ref) if ref else _DEFAULT_MODEL_LABEL
 
 
 def _iter_warm_events(base_url: str, timeout_s: float) -> Iterator[WarmProgress]:
@@ -68,7 +68,7 @@ def _apply(progress: Progress, task_id: TaskID, snap: WarmProgress) -> None:
     if snap.phase is WarmPhase.READING_WEIGHTS:
         progress.update(
             task_id,
-            description=f"Reading {_short_model(snap.model_ref)} weights",
+            description=f"Reading {_model_label(snap.model_ref)} weights",
             total=snap.bytes_total or None,
             completed=snap.bytes_done,
             detail=snap.detail or "",

--- a/src/lilbee/cli/launchers/warm_render.py
+++ b/src/lilbee/cli/launchers/warm_render.py
@@ -1,0 +1,122 @@
+"""Render chat-model warm progress from the server's SSE stream.
+
+A launcher consumes ``/api/warm/stream`` and drives a rich progress display so
+the user sees a real read-phase byte bar, then an engine-load spinner, while a
+large chat model loads, instead of a frozen line. Designed to degrade cleanly:
+when the stream is unavailable (an older server without the endpoint) the caller
+falls back to a plain readiness poll.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+
+import httpx
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TextColumn,
+    TimeElapsedColumn,
+)
+
+from lilbee.cli.app import console
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+_WARM_STREAM_PATH = "/api/warm/stream"
+_SSE_DATA_PREFIX = "data:"
+_STREAM_CONNECT_TIMEOUT_S = 5.0
+
+
+def _short_model(ref: str | None) -> str:
+    """A compact model name for the bar (the GGUF filename, sans the repo path)."""
+    if not ref:
+        return "chat model"
+    return ref.rsplit("/", 1)[-1].removesuffix(".gguf")
+
+
+def _iter_warm_events(base_url: str, timeout_s: float) -> Iterator[WarmProgress]:
+    """Yield ``WarmProgress`` snapshots parsed from the SSE warm stream.
+
+    Raises ``httpx.HTTPError`` if the stream cannot be opened (e.g. a server
+    without the endpoint), so the caller can fall back to a plain poll.
+    """
+    timeout = httpx.Timeout(timeout_s, connect=_STREAM_CONNECT_TIMEOUT_S)
+    with httpx.stream("GET", f"{base_url}{_WARM_STREAM_PATH}", timeout=timeout) as resp:
+        resp.raise_for_status()
+        for line in resp.iter_lines():
+            if not line.startswith(_SSE_DATA_PREFIX):
+                continue
+            payload = line[len(_SSE_DATA_PREFIX) :].strip()
+            if not payload:
+                continue
+            try:
+                data = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            # The terminal ``done`` event carries ``{}`` (no phase); only real
+            # snapshots are yielded, so the renderer ignores it naturally.
+            if isinstance(data, dict) and "phase" in data:
+                yield WarmProgress.model_validate(data)
+
+
+def _apply(progress: Progress, task_id: TaskID, snap: WarmProgress) -> None:
+    """Reflect one warm snapshot onto the rich progress task."""
+    if snap.phase is WarmPhase.READING_WEIGHTS:
+        progress.update(
+            task_id,
+            description=f"Reading {_short_model(snap.model_ref)} weights",
+            total=snap.bytes_total or None,
+            completed=snap.bytes_done,
+            detail=snap.detail or "",
+        )
+    elif snap.phase is WarmPhase.LOADING_ENGINE:
+        # No byte signal during the VRAM load: drop to an indeterminate spinner.
+        progress.update(
+            task_id,
+            description="Loading engine",
+            total=None,
+            detail=snap.detail or "",
+        )
+    elif snap.phase is WarmPhase.READY:
+        total = snap.bytes_total or None
+        progress.update(task_id, description="Chat model ready", total=total, completed=total or 0)
+    elif snap.phase is WarmPhase.ERROR:
+        progress.update(task_id, description="Chat model failed to load", detail=snap.error or "")
+    else:  # STARTING
+        progress.update(task_id, description="Preparing chat model", total=None, detail="")
+
+
+def render_warm(base_url: str, timeout_s: float) -> bool | None:
+    """Drive a progress display from the warm stream.
+
+    Returns ``True`` once the chat engine reports ready, ``False`` on an error
+    phase or if the stream ends before ready (the caller proceeds either way),
+    and ``None`` when the stream could not be used at all so the caller falls
+    back to a plain readiness poll.
+    """
+    columns = (
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        DownloadColumn(),
+        TextColumn("{task.fields[detail]}"),
+        TimeElapsedColumn(),
+    )
+    try:
+        with Progress(*columns, console=console, transient=True) as progress:
+            task_id = progress.add_task("Preparing chat model", total=None, detail="")
+            reached_ready = False
+            for snap in _iter_warm_events(base_url, timeout_s):
+                _apply(progress, task_id, snap)
+                if snap.phase is WarmPhase.READY:
+                    reached_ready = True
+                    break
+                if snap.phase is WarmPhase.ERROR:
+                    return False
+            return reached_ready
+    except httpx.HTTPError:
+        return None

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from lilbee.providers.roles import OcrBackend, WorkerRole
+    from lilbee.providers.warm_progress import WarmProgress
     from lilbee.vision import PageText
 
 T_co = TypeVar("T_co", covariant=True)
@@ -411,6 +412,16 @@ class LLMProvider(Protocol):
         A client trims its conversation to this so a long agentic session fits
         the model's actual window instead of overflowing. Default ``None``:
         providers without a managed context (SDK wrappers) advertise nothing.
+        """
+        return None
+
+    def warm_progress(self) -> WarmProgress | None:
+        """Snapshot of the chat model's cold-load progress, or None when idle.
+
+        A launcher streams this to render a real progress bar while a large chat
+        model loads. Default ``None``: providers without a managed load (SDK /
+        routing wrappers) expose nothing, so a launcher falls back to a plain
+        spinner. The fleet returns live read / engine-load state.
         """
         return None
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -20,6 +20,8 @@ from concurrent.futures import TimeoutError as FutureTimeoutError
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
+from lilbee.core.config import cfg
+from lilbee.modelhub.registry import ModelRegistry
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet import planning
 from lilbee.providers.fleet.client import LlamaServerClient, is_connection_failure
@@ -778,12 +780,9 @@ class FleetProvider:
         llama-swap starts an upstream on its first request, so warming sends a
         minimal call to every replica of every role (firing the spawn listeners
         around each role). A per-replica failure is logged and skipped; that replica
-        still loads on its first real use. The chat role also drives the warm
-        tracker (read-phase byte progress, then the engine load) so a launcher can
-        render granular feedback while a large chat model loads.
+        still loads on its first real use. The chat role routes through
+        :meth:`_warm_chat_role` so a launcher gets granular progress.
         """
-        from lilbee.core.config import cfg
-
         with self._lock:
             pools = {role: list(clients) for role, clients in self._clients.items()}
             on_spawning, on_spawned = self._on_spawning, self._on_spawned
@@ -791,21 +790,42 @@ class FleetProvider:
             if on_spawning is not None:
                 on_spawning(role)
             if role is WorkerRole.CHAT:
-                self._warm_tracker.begin(str(cfg.chat_model))
-                self._prewarm_chat_weights()
-                self._warm_tracker.loading_engine()
-            for client in clients:
-                try:
-                    _warm_role(role, client)
-                except Exception:
-                    log.debug("Warm-up request for %s failed.", role.value, exc_info=True)
-            if role is WorkerRole.CHAT:
-                if self.role_ready(WorkerRole.CHAT):
-                    self._warm_tracker.ready()
-                else:
-                    self._warm_tracker.fail("The chat model did not finish loading.")
+                self._warm_chat_role(clients)
+            else:
+                self._warm_role_clients(role, clients)
             if on_spawned is not None:
                 on_spawned(role)
+
+    def _warm_role_clients(self, role: WorkerRole, clients: list[LlamaServerClient]) -> bool:
+        """Warm every replica of *role*; return whether at least one loaded."""
+        warmed = False
+        for client in clients:
+            try:
+                _warm_role(role, client)
+                warmed = True
+            except Exception:
+                log.debug("Warm-up request for %s failed.", role.value, exc_info=True)
+        return warmed
+
+    def _warm_chat_role(self, clients: list[LlamaServerClient]) -> None:
+        """Warm the chat role, driving the tracker through read -> load -> ready/fail.
+
+        Readiness is decided by whether a warm request actually returned, not by
+        re-probing llama-swap (which can transiently report empty right after a
+        successful load). The terminal phase is stamped in ``finally`` so an
+        unexpected error mid-warm still ends the launcher's progress stream.
+        """
+        self._warm_tracker.begin(str(cfg.chat_model))
+        warmed = False
+        try:
+            self._prewarm_chat_weights()
+            self._warm_tracker.loading_engine()
+            warmed = self._warm_role_clients(WorkerRole.CHAT, clients)
+        finally:
+            if warmed:
+                self._warm_tracker.ready()
+            else:
+                self._warm_tracker.fail("The chat model did not finish loading.")
 
     def _prewarm_chat_weights(self) -> None:
         """Page the chat model's GGUF shards into the OS cache, reporting byte progress.
@@ -813,20 +833,15 @@ class FleetProvider:
         Reading the shards before llama-swap loads them does two things: it gives a
         true read-phase percentage for the warm tracker, and it warms the page cache
         so the engine's mmap faults hit memory (a large win on a network filesystem,
-        where random mmap faults stalled cold loads). An unresolvable ref (the model
-        isn't registered yet) is skipped: the tracker just moves to the engine-load
-        phase and the model still loads on the warm request.
+        where random mmap faults stalled cold loads). Best-effort: any failure to
+        resolve or size the shards (unregistered ref, cache miss, I/O error) is
+        skipped, and the model still loads on the warm request.
         """
-        from lilbee.core.config import cfg
-        from lilbee.modelhub.registry import ModelRegistry
-
         try:
             shards = ModelRegistry(cfg.models_dir).shard_paths(str(cfg.chat_model))
-        except (KeyError, ValueError, OSError):
-            return
-        try:
             total = sum(shard.stat().st_size for shard in shards)
-        except OSError:
+        except Exception:
+            log.debug("Prewarm skipped; could not resolve chat shards.", exc_info=True)
             return
         if total <= 0:
             return

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -27,6 +27,7 @@ from lilbee.providers.fleet.swap_config import cold_load_timeout_s
 from lilbee.providers.fleet.swap_manager import SwapManager
 from lilbee.providers.fleet.windowing import window_messages
 from lilbee.providers.roles import WorkerRole, configured_model_message
+from lilbee.providers.warm_progress import WarmProgress, WarmProgressTracker
 
 log = logging.getLogger(__name__)
 
@@ -54,6 +55,9 @@ _CONTEXT_WINDOW_MARGIN = 128
 # starts an upstream on its first request, so warming issues one cheap call).
 _WARM_PROMPT = "warm"
 _WARM_MAX_TOKENS = 1
+# Read size for paging chat shards into the page cache during warm; large enough
+# to keep sequential reads efficient without holding much resident at once.
+_PREWARM_CHUNK_BYTES = 8 * 1024 * 1024
 # Per-role client request budget: the first request covers the lazy cold load plus
 # generation, so the weights-scaled cold-load budget plus the margin raises this floor.
 _REQUEST_TIMEOUT_FLOOR_S = 900.0
@@ -255,6 +259,9 @@ class FleetProvider:
         # so warm-up can report per-role progress as it pre-loads each upstream.
         self._on_spawning: Callable[[WorkerRole], None] | None = None
         self._on_spawned: Callable[[WorkerRole], None] | None = None
+        # Granular cold-load progress for the chat role, streamed to a launcher so
+        # the user sees real read/engine-load progress instead of a frozen spinner.
+        self._warm_tracker = WarmProgressTracker()
         # Single-flight guard for the off-thread warm-up: True from the moment a
         # warm thread is dispatched until it finishes, so a second warm_up_pool
         # never starts a second swap and double-allocates GPU memory.
@@ -371,6 +378,10 @@ class FleetProvider:
         """Per-slot context the chat server runs with, or None if not up."""
         with self._lock:
             return self._chat_ctx if self._swap is not None else None
+
+    def warm_progress(self) -> WarmProgress | None:
+        """Live cold-load progress for the chat role, or None before warm begins."""
+        return self._warm_tracker.snapshot()
 
     def _shutdown_swap(self) -> None:
         # The build lock serializes shutdown against a concurrent reload/build:
@@ -767,21 +778,75 @@ class FleetProvider:
         llama-swap starts an upstream on its first request, so warming sends a
         minimal call to every replica of every role (firing the spawn listeners
         around each role). A per-replica failure is logged and skipped; that replica
-        still loads on its first real use.
+        still loads on its first real use. The chat role also drives the warm
+        tracker (read-phase byte progress, then the engine load) so a launcher can
+        render granular feedback while a large chat model loads.
         """
+        from lilbee.core.config import cfg
+
         with self._lock:
             pools = {role: list(clients) for role, clients in self._clients.items()}
             on_spawning, on_spawned = self._on_spawning, self._on_spawned
         for role, clients in pools.items():
             if on_spawning is not None:
                 on_spawning(role)
+            if role is WorkerRole.CHAT:
+                self._warm_tracker.begin(str(cfg.chat_model))
+                self._prewarm_chat_weights()
+                self._warm_tracker.loading_engine()
             for client in clients:
                 try:
                     _warm_role(role, client)
                 except Exception:
                     log.debug("Warm-up request for %s failed.", role.value, exc_info=True)
+            if role is WorkerRole.CHAT:
+                if self.role_ready(WorkerRole.CHAT):
+                    self._warm_tracker.ready()
+                else:
+                    self._warm_tracker.fail("The chat model did not finish loading.")
             if on_spawned is not None:
                 on_spawned(role)
+
+    def _prewarm_chat_weights(self) -> None:
+        """Page the chat model's GGUF shards into the OS cache, reporting byte progress.
+
+        Reading the shards before llama-swap loads them does two things: it gives a
+        true read-phase percentage for the warm tracker, and it warms the page cache
+        so the engine's mmap faults hit memory (a large win on a network filesystem,
+        where random mmap faults stalled cold loads). An unresolvable ref (the model
+        isn't registered yet) is skipped: the tracker just moves to the engine-load
+        phase and the model still loads on the warm request.
+        """
+        from lilbee.core.config import cfg
+        from lilbee.modelhub.registry import ModelRegistry
+
+        try:
+            shards = ModelRegistry(cfg.models_dir).shard_paths(str(cfg.chat_model))
+        except (KeyError, ValueError, OSError):
+            return
+        try:
+            total = sum(shard.stat().st_size for shard in shards)
+        except OSError:
+            return
+        if total <= 0:
+            return
+        done = 0
+        self._warm_tracker.reading(0, total)
+        chunk = bytearray(_PREWARM_CHUNK_BYTES)
+        for index, shard in enumerate(shards):
+            detail = f"shard {index + 1}/{len(shards)}" if len(shards) > 1 else None
+            try:
+                with shard.open("rb", buffering=0) as handle:
+                    while True:
+                        read = handle.readinto(chunk)
+                        if not read:
+                            break
+                        done += read
+                        self._warm_tracker.reading(done, total, detail=detail)
+            except OSError:
+                # A partial/locked shard just shortens the read bar; the engine load
+                # surfaces any real fault as a user-facing error on the warm request.
+                log.debug("Prewarm read of %s stopped early.", shard, exc_info=True)
 
     def cancel_inference(self) -> None:
         """No-op: a llama-server stops generating when its client disconnects.

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -6,7 +6,7 @@ import contextlib
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from lilbee.catalog import is_rerank_ref
 from lilbee.core.config import cfg
@@ -21,6 +21,9 @@ from lilbee.providers.base import (
 from lilbee.providers.litellm_sdk import LitellmSdkBackend
 from lilbee.providers.model_ref import ProviderModelRef, parse_model_ref, routes_to_native_gguf
 from lilbee.providers.roles import OcrBackend, WorkerRole
+
+if TYPE_CHECKING:
+    from lilbee.providers.warm_progress import WarmProgress
 from lilbee.providers.sdk_llm_provider import SdkLLMProvider
 from lilbee.vision import PageText
 
@@ -317,6 +320,12 @@ class RoutingProvider(LLMProvider):
         if self._local is None:
             return None
         return self._local.served_chat_ctx()
+
+    def warm_progress(self) -> WarmProgress | None:
+        """Cold-load progress of the local engine, or None when none exists yet."""
+        if self._local is None:
+            return None
+        return self._local.warm_progress()
 
     def add_spawn_listener(
         self,

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -21,11 +21,11 @@ from lilbee.providers.base import (
 from lilbee.providers.litellm_sdk import LitellmSdkBackend
 from lilbee.providers.model_ref import ProviderModelRef, parse_model_ref, routes_to_native_gguf
 from lilbee.providers.roles import OcrBackend, WorkerRole
+from lilbee.providers.sdk_llm_provider import SdkLLMProvider
+from lilbee.vision import PageText
 
 if TYPE_CHECKING:
     from lilbee.providers.warm_progress import WarmProgress
-from lilbee.providers.sdk_llm_provider import SdkLLMProvider
-from lilbee.vision import PageText
 
 log = logging.getLogger(__name__)
 

--- a/src/lilbee/providers/warm_progress.py
+++ b/src/lilbee/providers/warm_progress.py
@@ -43,19 +43,6 @@ class WarmProgress(BaseModel):
     error: str | None = None
     elapsed_s: float = 0.0
 
-    @property
-    def fraction(self) -> float | None:
-        """Completion in ``0..1`` while reading weights, ``1`` once ready, else None.
-
-        None signals an indeterminate phase (starting / loading the engine) so a
-        renderer shows a spinner instead of a misleading bar.
-        """
-        if self.phase is WarmPhase.READING_WEIGHTS and self.bytes_total > 0:
-            return min(1.0, self.bytes_done / self.bytes_total)
-        if self.phase is WarmPhase.READY:
-            return 1.0
-        return None
-
 
 class WarmProgressTracker:
     """Thread-safe warm-state holder: the warm thread writes, handlers read.

--- a/src/lilbee/providers/warm_progress.py
+++ b/src/lilbee/providers/warm_progress.py
@@ -1,0 +1,127 @@
+"""Server-side view of the chat model's cold load, for granular launch feedback.
+
+A launcher streams this while a chat model loads so the user sees real progress
+(reading weights with a true byte percentage, then the engine load) instead of a
+frozen "Warming..." line. The fleet provider drives the tracker through its warm
+path; providers without a managed load report nothing and a launcher falls back
+to a plain spinner.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class WarmPhase(StrEnum):
+    """The stage a chat-model cold load is in."""
+
+    STARTING = "starting"
+    """Warm thread has begun; the engine has not been touched yet."""
+    READING_WEIGHTS = "reading_weights"
+    """Paging the GGUF shards off disk into the page cache; reports a true byte %."""
+    LOADING_ENGINE = "loading_engine"
+    """The engine is loading the cached weights into VRAM; no byte signal, so
+    surfaces show an indeterminate spinner bounded by readiness."""
+    READY = "ready"
+    """The chat engine is loaded and can serve a first token."""
+    ERROR = "error"
+    """The load failed; ``error`` carries the user-facing reason."""
+
+
+class WarmProgress(BaseModel):
+    """A snapshot of the chat role's warm state, streamed to a launcher."""
+
+    phase: WarmPhase
+    model_ref: str | None = None
+    bytes_done: int = 0
+    bytes_total: int = 0
+    detail: str | None = None
+    error: str | None = None
+    elapsed_s: float = 0.0
+
+    @property
+    def fraction(self) -> float | None:
+        """Completion in ``0..1`` while reading weights, ``1`` once ready, else None.
+
+        None signals an indeterminate phase (starting / loading the engine) so a
+        renderer shows a spinner instead of a misleading bar.
+        """
+        if self.phase is WarmPhase.READING_WEIGHTS and self.bytes_total > 0:
+            return min(1.0, self.bytes_done / self.bytes_total)
+        if self.phase is WarmPhase.READY:
+            return 1.0
+        return None
+
+
+class WarmProgressTracker:
+    """Thread-safe warm-state holder: the warm thread writes, handlers read.
+
+    The fleet warm-up runs on a daemon thread while the health / SSE handlers
+    read concurrently, so every mutation and the snapshot read take the lock.
+    ``elapsed_s`` is stamped at read time from the ``begin`` monotonic mark so
+    callers always see a live elapsed without the writer ticking a clock.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._snapshot: WarmProgress | None = None
+        self._started_at: float | None = None
+
+    def begin(self, model_ref: str | None) -> None:
+        """Mark the start of a cold load; resets elapsed and clears prior state."""
+        with self._lock:
+            self._started_at = time.monotonic()
+            self._snapshot = WarmProgress(phase=WarmPhase.STARTING, model_ref=model_ref)
+
+    def reading(self, bytes_done: int, bytes_total: int, detail: str | None = None) -> None:
+        """Report read-phase progress in bytes."""
+        self._advance(
+            WarmPhase.READING_WEIGHTS,
+            bytes_done=bytes_done,
+            bytes_total=bytes_total,
+            detail=detail,
+        )
+
+    def loading_engine(self, detail: str | None = None) -> None:
+        """Mark the transition into the indeterminate VRAM-load phase."""
+        self._advance(WarmPhase.LOADING_ENGINE, detail=detail)
+
+    def ready(self) -> None:
+        """Mark the chat engine ready to serve."""
+        self._advance(WarmPhase.READY)
+
+    def fail(self, message: str) -> None:
+        """Mark the load as failed with a user-facing reason."""
+        self._advance(WarmPhase.ERROR, error=message)
+
+    def snapshot(self) -> WarmProgress | None:
+        """Return a copy of the current state with live ``elapsed_s``, or None."""
+        with self._lock:
+            if self._snapshot is None:
+                return None
+            elapsed = time.monotonic() - self._started_at if self._started_at is not None else 0.0
+            return self._snapshot.model_copy(update={"elapsed_s": elapsed})
+
+    def _advance(
+        self,
+        phase: WarmPhase,
+        *,
+        bytes_done: int = 0,
+        bytes_total: int = 0,
+        detail: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        with self._lock:
+            model_ref = self._snapshot.model_ref if self._snapshot is not None else None
+            self._snapshot = WarmProgress(
+                phase=phase,
+                model_ref=model_ref,
+                bytes_done=bytes_done,
+                bytes_total=bytes_total,
+                detail=detail,
+                error=error,
+            )

--- a/src/lilbee/runtime/progress/types.py
+++ b/src/lilbee/runtime/progress/types.py
@@ -34,6 +34,7 @@ class SseEvent(StrEnum):
     HEARTBEAT = "heartbeat"
     ALREADY_INGESTING = "already_ingesting"
     WARMING = "warming"
+    WARM = "warm"
     MEMORY_EXTRACTED = "memory_extracted"
 
 

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -34,6 +34,7 @@ from lilbee.server.routes.general import (
     health_route,
     source_content_route,
     status_route,
+    warm_stream_route,
 )
 from lilbee.server.routes.memory import (
     memories_list_route,
@@ -122,6 +123,7 @@ def create_app() -> Litestar:
         route_handlers=[
             mcp_route,
             health_route,
+            warm_stream_route,
             status_route,
             config_route,
             config_defaults_route,

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -10,10 +10,15 @@ API consumed by ``server/routes/*.py``.
 
 from __future__ import annotations
 
+import asyncio
+import time
+from collections.abc import AsyncGenerator
+
 from lilbee.app.services import get_services
 from lilbee.app.status import gather_status
 from lilbee.app.version import get_version
 from lilbee.providers.roles import WorkerRole
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 from lilbee.server.handlers.config import (
     get_config,
     get_config_defaults,
@@ -65,6 +70,16 @@ from lilbee.server.handlers.sse import (
 )
 from lilbee.server.models import HealthResponse, StatusResponse
 
+# SSE event name carrying a WarmProgress snapshot on the warm stream.
+_WARM_EVENT = "warm"
+# How often the warm stream re-snapshots provider state; sub-second so the read
+# bar advances smoothly without busy-spinning.
+_WARM_POLL_INTERVAL_S = 0.25
+# Upper bound on the warm stream; the launcher hands off when this elapses, so a
+# model still loading past it just warms on the client's first call. Generous to
+# cover a cold tensor-split giant off a slow filesystem.
+_WARM_STREAM_TIMEOUT_S = 1800.0
+
 
 async def health() -> HealthResponse:
     """Return service health, version, and whether the chat engine is warm."""
@@ -74,7 +89,35 @@ async def health() -> HealthResponse:
         version=get_version(),
         chat_ready=provider.role_ready(WorkerRole.CHAT),
         chat_ctx=provider.served_chat_ctx(),
+        chat_warm=provider.warm_progress(),
     )
+
+
+async def warm_stream() -> AsyncGenerator[str, None]:
+    """Stream chat-model cold-load progress as SSE until the engine is ready.
+
+    A launcher subscribes to render granular warm feedback. Each ``warm`` event
+    carries a :class:`WarmProgress` snapshot; the stream ends with ``[DONE]`` once
+    the chat role is ready or has failed, or when the budget elapses (the caller
+    proceeds either way, so a still-loading model just warms on its first call).
+    When nothing is loading because the engine is already warm, a single ``ready``
+    snapshot is emitted and the stream closes.
+    """
+    provider = get_services().provider
+    deadline = time.monotonic() + _WARM_STREAM_TIMEOUT_S
+    while time.monotonic() < deadline:
+        snapshot = provider.warm_progress()
+        if snapshot is None:
+            if provider.role_ready(WorkerRole.CHAT):
+                yield sse_event(_WARM_EVENT, WarmProgress(phase=WarmPhase.READY).model_dump())
+                break
+            yield sse_event(_WARM_EVENT, WarmProgress(phase=WarmPhase.STARTING).model_dump())
+        else:
+            yield sse_event(_WARM_EVENT, snapshot.model_dump())
+            if snapshot.phase in (WarmPhase.READY, WarmPhase.ERROR):
+                break
+        await asyncio.sleep(_WARM_POLL_INTERVAL_S)
+    yield sse_done({})
 
 
 async def status() -> StatusResponse:
@@ -123,4 +166,5 @@ __all__ = [
     "sync_stream",
     "update_config",
     "validate_add_paths",
+    "warm_stream",
 ]

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -19,6 +19,7 @@ from lilbee.app.status import gather_status
 from lilbee.app.version import get_version
 from lilbee.providers.roles import WorkerRole
 from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+from lilbee.runtime.progress import SseEvent
 from lilbee.server.handlers.config import (
     get_config,
     get_config_defaults,
@@ -70,8 +71,6 @@ from lilbee.server.handlers.sse import (
 )
 from lilbee.server.models import HealthResponse, StatusResponse
 
-# SSE event name carrying a WarmProgress snapshot on the warm stream.
-_WARM_EVENT = "warm"
 # How often the warm stream re-snapshots provider state; sub-second so the read
 # bar advances smoothly without busy-spinning.
 _WARM_POLL_INTERVAL_S = 0.25
@@ -89,19 +88,18 @@ async def health() -> HealthResponse:
         version=get_version(),
         chat_ready=provider.role_ready(WorkerRole.CHAT),
         chat_ctx=provider.served_chat_ctx(),
-        chat_warm=provider.warm_progress(),
     )
 
 
 async def warm_stream() -> AsyncGenerator[str, None]:
     """Stream chat-model cold-load progress as SSE until the engine is ready.
 
-    A launcher subscribes to render granular warm feedback. Each ``warm`` event
-    carries a :class:`WarmProgress` snapshot; the stream ends with ``[DONE]`` once
-    the chat role is ready or has failed, or when the budget elapses (the caller
-    proceeds either way, so a still-loading model just warms on its first call).
-    When nothing is loading because the engine is already warm, a single ``ready``
-    snapshot is emitted and the stream closes.
+    A launcher subscribes to render granular warm feedback. Each
+    :data:`SseEvent.WARM` event carries a :class:`WarmProgress` snapshot; a
+    terminal :data:`SseEvent.DONE` closes the stream once the chat role is ready
+    or has failed, or when the budget elapses (the caller proceeds either way, so
+    a still-loading model just warms on its first call). When nothing is loading
+    because the engine is already warm, a single ready snapshot is emitted.
     """
     provider = get_services().provider
     deadline = time.monotonic() + _WARM_STREAM_TIMEOUT_S
@@ -109,11 +107,11 @@ async def warm_stream() -> AsyncGenerator[str, None]:
         snapshot = provider.warm_progress()
         if snapshot is None:
             if provider.role_ready(WorkerRole.CHAT):
-                yield sse_event(_WARM_EVENT, WarmProgress(phase=WarmPhase.READY).model_dump())
+                yield sse_event(SseEvent.WARM, WarmProgress(phase=WarmPhase.READY).model_dump())
                 break
-            yield sse_event(_WARM_EVENT, WarmProgress(phase=WarmPhase.STARTING).model_dump())
+            yield sse_event(SseEvent.WARM, WarmProgress(phase=WarmPhase.STARTING).model_dump())
         else:
-            yield sse_event(_WARM_EVENT, snapshot.model_dump())
+            yield sse_event(SseEvent.WARM, snapshot.model_dump())
             if snapshot.phase in (WarmPhase.READY, WarmPhase.ERROR):
                 break
         await asyncio.sleep(_WARM_POLL_INTERVAL_S)

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel, Field, field_validator
 
 from lilbee.catalog.types import KeyStatus, ModelCompat, ModelSource, ModelTask
 from lilbee.data.store import ChunkType, MemoryKind, SearchScope
-from lilbee.providers.warm_progress import WarmProgress
 from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 
 
@@ -177,10 +176,6 @@ class HealthResponse(BaseModel):
     chat_ctx: int | None = None
     """Per-slot context the chat engine serves, so a launcher can tell the client
     its window and the client trims history to fit. None until the engine is up."""
-    chat_warm: WarmProgress | None = None
-    """Cold-load progress for the chat role, or None when nothing is loading. A
-    non-streaming client reads a single snapshot here; a launcher prefers the
-    push-based ``/api/warm/stream`` for live updates."""
 
 
 class AskResponse(BaseModel):

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from lilbee.catalog.types import KeyStatus, ModelCompat, ModelSource, ModelTask
 from lilbee.data.store import ChunkType, MemoryKind, SearchScope
+from lilbee.providers.warm_progress import WarmProgress
 from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 
 
@@ -176,6 +177,10 @@ class HealthResponse(BaseModel):
     chat_ctx: int | None = None
     """Per-slot context the chat engine serves, so a launcher can tell the client
     its window and the client trims history to fit. None until the engine is up."""
+    chat_warm: WarmProgress | None = None
+    """Cold-load progress for the chat role, or None when nothing is loading. A
+    non-streaming client reads a single snapshot here; a launcher prefers the
+    push-based ``/api/warm/stream`` for live updates."""
 
 
 class AskResponse(BaseModel):

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from litestar import Response, get, patch
+from litestar.response import Stream
 from pydantic import ValidationError
 
 from lilbee.server import handlers
@@ -24,6 +25,13 @@ from lilbee.server.models import (
 async def health_route() -> HealthResponse:
     """Service health check returning server version and uptime status."""
     return await handlers.health()
+
+
+@get("/api/warm/stream")
+@read_only
+async def warm_stream_route() -> Stream:
+    """Stream chat-model cold-load progress as SSE for a launcher's warm indicator."""
+    return Stream(handlers.warm_stream(), media_type="text/event-stream")
 
 
 @get("/api/status")

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -244,6 +244,37 @@ def test_wait_for_chat_warm_returns_false_on_timeout(monkeypatch):
 
 
 @pytest.mark.no_warm_default
+def test_wait_for_chat_warm_returns_streamed_result(monkeypatch):
+    # When the progress stream runs, its verdict is returned directly without a
+    # second readiness poll (don't double-spend the budget).
+    from lilbee.cli.launchers import server as launch_mod
+
+    monkeypatch.setattr(launch_mod, "chat_ready", lambda _port: False)
+    monkeypatch.setattr(launch_mod, "render_warm", lambda _url, _timeout: True)
+    assert launch_mod.wait_for_chat_warm(8765, timeout_s=5.0) is True
+
+    monkeypatch.setattr(launch_mod, "render_warm", lambda _url, _timeout: False)
+    assert launch_mod.wait_for_chat_warm(8765, timeout_s=5.0) is False
+
+
+@pytest.mark.no_warm_default
+def test_wait_for_chat_warm_falls_back_to_poll_when_stream_unavailable(monkeypatch):
+    from lilbee.cli.launchers import server as launch_mod
+
+    calls = {"n": 0}
+
+    def _ready(_port):
+        calls["n"] += 1
+        return calls["n"] >= 2  # cold past the early check, warm on the poll
+
+    monkeypatch.setattr(launch_mod, "render_warm", lambda _url, _timeout: None)
+    monkeypatch.setattr(launch_mod, "chat_ready", _ready)
+    monkeypatch.setattr(launch_mod.time, "sleep", lambda _s: None)
+    assert launch_mod.wait_for_chat_warm(8765, timeout_s=5.0) is True
+    assert calls["n"] >= 2  # confirms the poll fallback actually ran
+
+
+@pytest.mark.no_warm_default
 def test_served_chat_ctx_reads_health_window(monkeypatch):
     from lilbee.cli.launchers import server as launch_mod
 

--- a/tests/cli/test_warm_render.py
+++ b/tests/cli/test_warm_render.py
@@ -42,15 +42,23 @@ def _patch_stream(stream: _FakeStream):
     return mock.patch.object(warm_render.httpx, "stream", return_value=stream)
 
 
-def test_short_model_strips_repo_and_suffix() -> None:
+def test_model_label_uses_canonical_label_with_fallback() -> None:
     ref = "unsloth/GLM-4.5-Air-GGUF/GLM-4.5-Air-Q2_K.gguf"
-    assert warm_render._short_model(ref) == "GLM-4.5-Air-Q2_K"
-    assert warm_render._short_model(None) == "chat model"
+    # Reuses the project's canonical ref-to-label helper, so it matches the rest
+    # of the UI (cleaned repo name) rather than a bespoke filename.
+    assert warm_render._model_label(ref) == warm_render.display_label_for_ref(ref)
+    assert warm_render._model_label(None) == "chat model"
 
 
-def test_render_returns_true_when_stream_reaches_ready() -> None:
+def test_render_walks_all_phases_to_ready() -> None:
+    # Includes STARTING so the indeterminate-preparing branch of _apply is covered.
     lines = [
-        _sse(WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=5, bytes_total=10)),
+        _sse(WarmProgress(phase=WarmPhase.STARTING)),
+        _sse(
+            WarmProgress(
+                phase=WarmPhase.READING_WEIGHTS, bytes_done=5, bytes_total=10, detail="shard 1/2"
+            )
+        ),
         _sse(WarmProgress(phase=WarmPhase.LOADING_ENGINE)),
         _sse(WarmProgress(phase=WarmPhase.READY, bytes_total=10)),
         "data: [DONE]",

--- a/tests/cli/test_warm_render.py
+++ b/tests/cli/test_warm_render.py
@@ -1,0 +1,91 @@
+"""Tests for the launcher-side warm progress renderer and its SSE parsing."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from unittest import mock
+
+import httpx
+
+from lilbee.cli.launchers import warm_render
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+
+def _sse(progress: WarmProgress) -> str:
+    return f"data: {json.dumps(progress.model_dump())}"
+
+
+class _FakeStream:
+    """Stand-in for ``httpx.stream(...)`` as a context manager over SSE lines."""
+
+    def __init__(self, lines: list[str], *, raise_on_enter: Exception | None = None) -> None:
+        self._lines = lines
+        self._raise = raise_on_enter
+
+    def __enter__(self) -> _FakeStream:
+        if self._raise is not None:
+            raise self._raise
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_lines(self) -> Iterator[str]:
+        yield from self._lines
+
+
+def _patch_stream(stream: _FakeStream):
+    return mock.patch.object(warm_render.httpx, "stream", return_value=stream)
+
+
+def test_short_model_strips_repo_and_suffix() -> None:
+    ref = "unsloth/GLM-4.5-Air-GGUF/GLM-4.5-Air-Q2_K.gguf"
+    assert warm_render._short_model(ref) == "GLM-4.5-Air-Q2_K"
+    assert warm_render._short_model(None) == "chat model"
+
+
+def test_render_returns_true_when_stream_reaches_ready() -> None:
+    lines = [
+        _sse(WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=5, bytes_total=10)),
+        _sse(WarmProgress(phase=WarmPhase.LOADING_ENGINE)),
+        _sse(WarmProgress(phase=WarmPhase.READY, bytes_total=10)),
+        "data: [DONE]",
+    ]
+    with _patch_stream(_FakeStream(lines)):
+        assert warm_render.render_warm("http://x", 5.0) is True
+
+
+def test_render_returns_false_on_error_phase() -> None:
+    lines = [_sse(WarmProgress(phase=WarmPhase.ERROR, error="no vram"))]
+    with _patch_stream(_FakeStream(lines)):
+        assert warm_render.render_warm("http://x", 5.0) is False
+
+
+def test_render_returns_false_when_stream_ends_without_ready() -> None:
+    lines = [_sse(WarmProgress(phase=WarmPhase.LOADING_ENGINE)), "data: [DONE]"]
+    with _patch_stream(_FakeStream(lines)):
+        assert warm_render.render_warm("http://x", 5.0) is False
+
+
+def test_render_returns_none_when_stream_unavailable() -> None:
+    # An older server without the endpoint -> connection error -> caller falls back.
+    stream = _FakeStream([], raise_on_enter=httpx.ConnectError("refused"))
+    with _patch_stream(stream):
+        assert warm_render.render_warm("http://x", 5.0) is None
+
+
+def test_iter_skips_non_data_and_malformed_lines() -> None:
+    lines = [
+        "event: warm",
+        "",
+        "data: not-json",
+        'data: {"no_phase": 1}',
+        _sse(WarmProgress(phase=WarmPhase.READY)),
+    ]
+    with _patch_stream(_FakeStream(lines)):
+        events = list(warm_render._iter_warm_events("http://x", 5.0))
+    assert [e.phase for e in events] == [WarmPhase.READY]

--- a/tests/cli/test_warm_render.py
+++ b/tests/cli/test_warm_render.py
@@ -90,6 +90,7 @@ def test_iter_skips_non_data_and_malformed_lines() -> None:
     lines = [
         "event: warm",
         "",
+        "data:",  # a data line with an empty payload (e.g. a keep-alive)
         "data: not-json",
         'data: {"no_phase": 1}',
         _sse(WarmProgress(phase=WarmPhase.READY)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,6 +271,9 @@ def _default_provider_mock():
     # with an unknown window so the gate and the /v1/models shape stay valid.
     provider.max_concurrent_chats.return_value = 1
     provider.served_chat_ctx.return_value = None
+    # warm_progress feeds HealthResponse.chat_warm (WarmProgress | None); default
+    # to None (idle) so the mock validates. Warm-stream tests override this.
+    provider.warm_progress.return_value = None
     return provider
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,8 +271,8 @@ def _default_provider_mock():
     # with an unknown window so the gate and the /v1/models shape stay valid.
     provider.max_concurrent_chats.return_value = 1
     provider.served_chat_ctx.return_value = None
-    # warm_progress feeds HealthResponse.chat_warm (WarmProgress | None); default
-    # to None (idle) so the mock validates. Warm-stream tests override this.
+    # warm_progress feeds the /api/warm/stream handler (WarmProgress | None);
+    # default to None (idle). Warm-stream tests override this.
     provider.warm_progress.return_value = None
     return provider
 

--- a/tests/providers/test_warm_progress.py
+++ b/tests/providers/test_warm_progress.py
@@ -1,4 +1,4 @@
-"""Tests for the chat-model warm-progress tracker and its fraction logic."""
+"""Tests for the chat-model warm-progress tracker."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ def test_snapshot_is_none_before_begin() -> None:
     assert WarmProgressTracker().snapshot() is None
 
 
-def test_reading_reports_true_byte_fraction() -> None:
+def test_reading_reports_byte_progress() -> None:
     tracker = WarmProgressTracker()
     tracker.begin("repo/Model-Q4.gguf")
     tracker.reading(25, 100, detail="shard 1/3")
@@ -17,20 +17,20 @@ def test_reading_reports_true_byte_fraction() -> None:
     assert snap is not None
     assert snap.phase is WarmPhase.READING_WEIGHTS
     assert snap.model_ref == "repo/Model-Q4.gguf"
+    assert snap.bytes_done == 25
+    assert snap.bytes_total == 100
     assert snap.detail == "shard 1/3"
-    assert snap.fraction == 0.25
     assert snap.elapsed_s >= 0.0
 
 
-def test_fraction_is_capped_and_indeterminate_off_read_phase() -> None:
+def test_phase_transitions_carry_model_ref() -> None:
     tracker = WarmProgressTracker()
     tracker.begin("m")
-    tracker.reading(150, 100)  # over-count clamps to a full bar, never > 1
-    assert tracker.snapshot().fraction == 1.0
+    tracker.reading(150, 100)
     tracker.loading_engine("on 3 GPUs")
     engine = tracker.snapshot()
     assert engine.phase is WarmPhase.LOADING_ENGINE
-    assert engine.fraction is None  # no byte signal -> indeterminate
+    assert engine.detail == "on 3 GPUs"
     assert engine.model_ref == "m"  # model carried across phases
 
 
@@ -39,21 +39,15 @@ def test_ready_and_error_phases() -> None:
     tracker.begin("m")
     tracker.ready()
     assert tracker.snapshot().phase is WarmPhase.READY
-    assert tracker.snapshot().fraction == 1.0
     tracker.fail("out of memory")
     failed = tracker.snapshot()
     assert failed.phase is WarmPhase.ERROR
     assert failed.error == "out of memory"
-    assert failed.fraction is None
 
 
-def test_starting_phase_has_no_fraction() -> None:
+def test_progress_model_defaults() -> None:
     snap = WarmProgress(phase=WarmPhase.STARTING)
-    assert snap.fraction is None
-
-
-def test_zero_total_read_is_indeterminate() -> None:
-    # A registry that can't size the shards yields total 0; the bar must not
-    # divide by zero and must stay indeterminate.
-    snap = WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=0, bytes_total=0)
-    assert snap.fraction is None
+    assert snap.model_ref is None
+    assert snap.bytes_done == 0
+    assert snap.bytes_total == 0
+    assert snap.error is None

--- a/tests/providers/test_warm_progress.py
+++ b/tests/providers/test_warm_progress.py
@@ -1,0 +1,59 @@
+"""Tests for the chat-model warm-progress tracker and its fraction logic."""
+
+from __future__ import annotations
+
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress, WarmProgressTracker
+
+
+def test_snapshot_is_none_before_begin() -> None:
+    assert WarmProgressTracker().snapshot() is None
+
+
+def test_reading_reports_true_byte_fraction() -> None:
+    tracker = WarmProgressTracker()
+    tracker.begin("repo/Model-Q4.gguf")
+    tracker.reading(25, 100, detail="shard 1/3")
+    snap = tracker.snapshot()
+    assert snap is not None
+    assert snap.phase is WarmPhase.READING_WEIGHTS
+    assert snap.model_ref == "repo/Model-Q4.gguf"
+    assert snap.detail == "shard 1/3"
+    assert snap.fraction == 0.25
+    assert snap.elapsed_s >= 0.0
+
+
+def test_fraction_is_capped_and_indeterminate_off_read_phase() -> None:
+    tracker = WarmProgressTracker()
+    tracker.begin("m")
+    tracker.reading(150, 100)  # over-count clamps to a full bar, never > 1
+    assert tracker.snapshot().fraction == 1.0
+    tracker.loading_engine("on 3 GPUs")
+    engine = tracker.snapshot()
+    assert engine.phase is WarmPhase.LOADING_ENGINE
+    assert engine.fraction is None  # no byte signal -> indeterminate
+    assert engine.model_ref == "m"  # model carried across phases
+
+
+def test_ready_and_error_phases() -> None:
+    tracker = WarmProgressTracker()
+    tracker.begin("m")
+    tracker.ready()
+    assert tracker.snapshot().phase is WarmPhase.READY
+    assert tracker.snapshot().fraction == 1.0
+    tracker.fail("out of memory")
+    failed = tracker.snapshot()
+    assert failed.phase is WarmPhase.ERROR
+    assert failed.error == "out of memory"
+    assert failed.fraction is None
+
+
+def test_starting_phase_has_no_fraction() -> None:
+    snap = WarmProgress(phase=WarmPhase.STARTING)
+    assert snap.fraction is None
+
+
+def test_zero_total_read_is_indeterminate() -> None:
+    # A registry that can't size the shards yields total 0; the bar must not
+    # divide by zero and must stay indeterminate.
+    snap = WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=0, bytes_total=0)
+    assert snap.fraction is None

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -866,6 +866,9 @@ def test_preload_roles_warms_each_role_and_fires_listeners(monkeypatch) -> None:
     chat, embed = _fake_client(), _fake_client()
     embed.embed.return_value = [[0.1]]
     p = _provider_with_clients({WorkerRole.CHAT: [chat], WorkerRole.EMBED: [embed]})
+    # Keep the unit hermetic: the chat warm path's shard prewarm reads cfg.chat_model
+    # off disk, which this test isn't exercising.
+    monkeypatch.setattr(p, "_prewarm_chat_weights", lambda: None)
     spawning: list[WorkerRole] = []
     spawned: list[WorkerRole] = []
     p.add_spawn_listener(on_spawning=spawning.append, on_spawned=spawned.append)
@@ -1468,18 +1471,23 @@ class TestReloadSingleFlight:
 class TestWarmProgressTracking:
     """The chat-role warm path drives the WarmProgress tracker for launchers."""
 
+    @staticmethod
+    def _patch_registry(monkeypatch, registry: MagicMock) -> None:
+        # ModelRegistry is imported at the fleet module top, so patch it there.
+        monkeypatch.setattr(prov_mod, "ModelRegistry", lambda _dir: registry)
+
     def test_prewarm_reads_shards_and_reports_full_byte_progress(
         self, monkeypatch, tmp_path: Path
     ) -> None:
-        from lilbee.providers import warm_progress as wp_mod
+        from lilbee.providers.warm_progress import WarmPhase
 
         shard_a = tmp_path / "model-00001.gguf"
         shard_b = tmp_path / "model-00002.gguf"
         shard_a.write_bytes(b"a" * 4096)
         shard_b.write_bytes(b"b" * 2048)
-        fake_registry = MagicMock()
-        fake_registry.shard_paths.return_value = [shard_a, shard_b]
-        monkeypatch.setattr("lilbee.modelhub.registry.ModelRegistry", lambda _dir: fake_registry)
+        registry = MagicMock()
+        registry.shard_paths.return_value = [shard_a, shard_b]
+        self._patch_registry(monkeypatch, registry)
         monkeypatch.setattr(cfg, "chat_model", "repo/model-00001.gguf")
 
         p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
@@ -1487,39 +1495,102 @@ class TestWarmProgressTracking:
         p._prewarm_chat_weights()
 
         snap = p._warm_tracker.snapshot()
-        assert snap.phase is wp_mod.WarmPhase.READING_WEIGHTS
+        assert snap.phase is WarmPhase.READING_WEIGHTS
         assert snap.bytes_done == 4096 + 2048
         assert snap.bytes_total == 4096 + 2048
-        assert snap.fraction == 1.0
+        assert snap.detail == "shard 2/2"  # multi-shard detail string
+
+    def test_prewarm_single_shard_omits_detail(self, monkeypatch, tmp_path: Path) -> None:
+        from lilbee.providers.warm_progress import WarmPhase
+
+        shard = tmp_path / "solo.gguf"
+        shard.write_bytes(b"x" * 1024)
+        registry = MagicMock()
+        registry.shard_paths.return_value = [shard]
+        self._patch_registry(monkeypatch, registry)
+        monkeypatch.setattr(cfg, "chat_model", "repo/solo.gguf")
+
+        p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
+        p._warm_tracker.begin("repo/solo.gguf")
+        p._prewarm_chat_weights()
+        snap = p._warm_tracker.snapshot()
+        assert snap.phase is WarmPhase.READING_WEIGHTS
+        assert snap.bytes_done == 1024
+        assert snap.detail is None  # single shard: no "shard N/M" label
 
     def test_prewarm_skips_unresolvable_ref(self, monkeypatch) -> None:
-        fake_registry = MagicMock()
-        fake_registry.shard_paths.side_effect = KeyError("not registered")
-        monkeypatch.setattr("lilbee.modelhub.registry.ModelRegistry", lambda _dir: fake_registry)
+        from lilbee.providers.warm_progress import WarmPhase
+
+        registry = MagicMock()
+        registry.shard_paths.side_effect = KeyError("not registered")
+        self._patch_registry(monkeypatch, registry)
         p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
         p._warm_tracker.begin("ghost/model.gguf")
-        # Must not raise; the tracker simply stays in its pre-read phase.
         p._prewarm_chat_weights()
-        assert p._warm_tracker.snapshot().phase is not None
+        # Returned before the read phase: the tracker stays at STARTING.
+        assert p._warm_tracker.snapshot().phase is WarmPhase.STARTING
 
-    def test_preload_marks_chat_ready_on_success(self, monkeypatch) -> None:
+    def test_prewarm_skips_when_shards_are_empty(self, monkeypatch) -> None:
+        from lilbee.providers.warm_progress import WarmPhase
+
+        registry = MagicMock()
+        registry.shard_paths.return_value = []  # nothing to size -> total 0
+        self._patch_registry(monkeypatch, registry)
+        p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
+        p._warm_tracker.begin("repo/m.gguf")
+        p._prewarm_chat_weights()
+        assert p._warm_tracker.snapshot().phase is WarmPhase.STARTING
+
+    def test_prewarm_tolerates_an_unreadable_shard_mid_read(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        from lilbee.providers.warm_progress import WarmPhase
+
+        good = tmp_path / "good.gguf"
+        good.write_bytes(b"a" * 2048)
+        # A directory stats fine (so sizing succeeds) but open('rb') raises
+        # IsADirectoryError (an OSError), exercising the inner read guard.
+        unreadable = tmp_path / "broken.gguf"
+        unreadable.mkdir()
+        registry = MagicMock()
+        registry.shard_paths.return_value = [good, unreadable]
+        self._patch_registry(monkeypatch, registry)
+        monkeypatch.setattr(cfg, "chat_model", "repo/m.gguf")
+
+        p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
+        p._warm_tracker.begin("repo/m.gguf")
+        p._prewarm_chat_weights()  # must not raise
+        snap = p._warm_tracker.snapshot()
+        assert snap.phase is WarmPhase.READING_WEIGHTS
+        assert snap.bytes_done == 2048  # only the readable shard counted
+
+    def test_preload_marks_chat_ready_when_a_warm_request_returns(self, monkeypatch) -> None:
         from lilbee.providers.warm_progress import WarmPhase
 
         p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
         monkeypatch.setattr(p, "_prewarm_chat_weights", lambda: None)
-        monkeypatch.setattr(p, "role_ready", lambda role: True)
         monkeypatch.setattr(cfg, "chat_model", "repo/m.gguf")
-        p._preload_roles()
+        p._preload_roles()  # the fake client's warm request returns -> ready
         assert p._warm_tracker.snapshot().phase is WarmPhase.READY
 
-    def test_preload_marks_chat_failed_when_not_ready(self, monkeypatch) -> None:
+    def test_preload_marks_chat_failed_when_every_warm_request_raises(self, monkeypatch) -> None:
         from lilbee.providers.warm_progress import WarmPhase
 
-        p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
+        client = _fake_client()
+        client.chat.side_effect = RuntimeError("engine never came up")
+        p = _provider_with_clients({WorkerRole.CHAT: [client]})
         monkeypatch.setattr(p, "_prewarm_chat_weights", lambda: None)
-        monkeypatch.setattr(p, "role_ready", lambda role: False)
         monkeypatch.setattr(cfg, "chat_model", "repo/m.gguf")
         p._preload_roles()
         snap = p._warm_tracker.snapshot()
         assert snap.phase is WarmPhase.ERROR
         assert snap.error
+
+    def test_warm_progress_snapshot_exposed(self, monkeypatch) -> None:
+        from lilbee.providers.warm_progress import WarmPhase
+
+        p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
+        assert p.warm_progress() is None  # nothing warming yet
+        p._warm_tracker.begin("repo/m.gguf")
+        p._warm_tracker.ready()
+        assert p.warm_progress().phase is WarmPhase.READY

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -1463,3 +1463,63 @@ class TestReloadSingleFlight:
         shutter.join(timeout=5.0)
         assert order == ["reload", "shutdown"]  # serialized, no interleaving
         assert p._swap is None  # the shutdown's state cleanup still landed
+
+
+class TestWarmProgressTracking:
+    """The chat-role warm path drives the WarmProgress tracker for launchers."""
+
+    def test_prewarm_reads_shards_and_reports_full_byte_progress(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        from lilbee.providers import warm_progress as wp_mod
+
+        shard_a = tmp_path / "model-00001.gguf"
+        shard_b = tmp_path / "model-00002.gguf"
+        shard_a.write_bytes(b"a" * 4096)
+        shard_b.write_bytes(b"b" * 2048)
+        fake_registry = MagicMock()
+        fake_registry.shard_paths.return_value = [shard_a, shard_b]
+        monkeypatch.setattr("lilbee.modelhub.registry.ModelRegistry", lambda _dir: fake_registry)
+        monkeypatch.setattr(cfg, "chat_model", "repo/model-00001.gguf")
+
+        p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
+        p._warm_tracker.begin("repo/model-00001.gguf")
+        p._prewarm_chat_weights()
+
+        snap = p._warm_tracker.snapshot()
+        assert snap.phase is wp_mod.WarmPhase.READING_WEIGHTS
+        assert snap.bytes_done == 4096 + 2048
+        assert snap.bytes_total == 4096 + 2048
+        assert snap.fraction == 1.0
+
+    def test_prewarm_skips_unresolvable_ref(self, monkeypatch) -> None:
+        fake_registry = MagicMock()
+        fake_registry.shard_paths.side_effect = KeyError("not registered")
+        monkeypatch.setattr("lilbee.modelhub.registry.ModelRegistry", lambda _dir: fake_registry)
+        p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
+        p._warm_tracker.begin("ghost/model.gguf")
+        # Must not raise; the tracker simply stays in its pre-read phase.
+        p._prewarm_chat_weights()
+        assert p._warm_tracker.snapshot().phase is not None
+
+    def test_preload_marks_chat_ready_on_success(self, monkeypatch) -> None:
+        from lilbee.providers.warm_progress import WarmPhase
+
+        p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
+        monkeypatch.setattr(p, "_prewarm_chat_weights", lambda: None)
+        monkeypatch.setattr(p, "role_ready", lambda role: True)
+        monkeypatch.setattr(cfg, "chat_model", "repo/m.gguf")
+        p._preload_roles()
+        assert p._warm_tracker.snapshot().phase is WarmPhase.READY
+
+    def test_preload_marks_chat_failed_when_not_ready(self, monkeypatch) -> None:
+        from lilbee.providers.warm_progress import WarmPhase
+
+        p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
+        monkeypatch.setattr(p, "_prewarm_chat_weights", lambda: None)
+        monkeypatch.setattr(p, "role_ready", lambda role: False)
+        monkeypatch.setattr(cfg, "chat_model", "repo/m.gguf")
+        p._preload_roles()
+        snap = p._warm_tracker.snapshot()
+        assert snap.phase is WarmPhase.ERROR
+        assert snap.error

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -268,6 +268,22 @@ class TestRoutingProvider:
         assert rp.supports_tools(ref) is False
         mock_local.supports_tools.assert_called_once_with(ref)
 
+    def test_warm_progress_is_none_without_a_local_engine(self) -> None:
+        rp = self._make_provider()
+        rp._local = None
+        assert rp.warm_progress() is None
+
+    def test_warm_progress_delegates_to_local_engine(self) -> None:
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        rp = self._make_provider()
+        mock_local = mock.MagicMock()
+        snapshot = WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=1, bytes_total=2)
+        mock_local.warm_progress.return_value = snapshot
+        rp._local = mock_local
+        assert rp.warm_progress() is snapshot
+        mock_local.warm_progress.assert_called_once_with()
+
     def test_routes_chat_to_litellm_for_ollama_model(self) -> None:
         rp = self._make_provider()
         mock_litellm = mock.MagicMock()

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -114,16 +114,6 @@ class TestHealth:
         mock_svc.provider.role_ready.return_value = True
         assert (await handlers.health()).chat_ready is True
 
-    async def test_health_carries_warm_snapshot(self, mock_svc):
-        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
-
-        snap = WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=3, bytes_total=4)
-        mock_svc.provider.warm_progress.return_value = snap
-        result = await handlers.health()
-        assert result.chat_warm is not None
-        assert result.chat_warm.phase is WarmPhase.READING_WEIGHTS
-        assert result.chat_warm.fraction == 0.75
-
 
 def _parse_warm_events(chunks: list[str]) -> list[dict]:
     """Pull the JSON payloads off ``warm`` SSE chunks, ignoring the [DONE] tail."""
@@ -174,6 +164,23 @@ class TestWarmStream:
         events = _parse_warm_events(chunks)
         assert events[-1]["phase"] == WarmPhase.ERROR
         assert events[-1]["error"] == "no vram"
+
+    async def test_emits_starting_then_exits_on_deadline(self, mock_svc):
+        # Nothing loading and the engine not yet ready: emit STARTING placeholders
+        # and end the stream when the budget elapses (the caller proceeds anyway).
+        from lilbee.providers.warm_progress import WarmPhase
+
+        mock_svc.provider.warm_progress.return_value = None
+        mock_svc.provider.role_ready.return_value = False
+        with (
+            patch("lilbee.server.handlers._WARM_POLL_INTERVAL_S", 0),
+            patch("lilbee.server.handlers._WARM_STREAM_TIMEOUT_S", 0.05),
+        ):
+            chunks = [chunk async for chunk in handlers.warm_stream()]
+        events = _parse_warm_events(chunks)
+        assert events  # at least one STARTING placeholder was emitted
+        assert all(e["phase"] == WarmPhase.STARTING for e in events)
+        assert "event: done" in chunks[-1]
 
 
 class TestStatus:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -114,6 +114,67 @@ class TestHealth:
         mock_svc.provider.role_ready.return_value = True
         assert (await handlers.health()).chat_ready is True
 
+    async def test_health_carries_warm_snapshot(self, mock_svc):
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        snap = WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=3, bytes_total=4)
+        mock_svc.provider.warm_progress.return_value = snap
+        result = await handlers.health()
+        assert result.chat_warm is not None
+        assert result.chat_warm.phase is WarmPhase.READING_WEIGHTS
+        assert result.chat_warm.fraction == 0.75
+
+
+def _parse_warm_events(chunks: list[str]) -> list[dict]:
+    """Pull the JSON payloads off ``warm`` SSE chunks, ignoring the [DONE] tail."""
+    import json
+
+    events = []
+    for chunk in chunks:
+        for line in chunk.splitlines():
+            if line.startswith("data:"):
+                payload = line[len("data:") :].strip()
+                if not payload:
+                    continue
+                data = json.loads(payload)
+                if "phase" in data:  # skip the terminal done event ({})
+                    events.append(data)
+    return events
+
+
+class TestWarmStream:
+    async def test_idle_engine_emits_single_ready(self, mock_svc):
+        from lilbee.providers.warm_progress import WarmPhase
+
+        mock_svc.provider.warm_progress.return_value = None
+        mock_svc.provider.role_ready.return_value = True
+        chunks = [chunk async for chunk in handlers.warm_stream()]
+        events = _parse_warm_events(chunks)
+        assert [e["phase"] for e in events] == [WarmPhase.READY]
+        assert "event: done" in chunks[-1]
+
+    async def test_streams_until_ready(self, mock_svc):
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        reading = WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=1, bytes_total=2)
+        ready = WarmProgress(phase=WarmPhase.READY, bytes_total=2)
+        mock_svc.provider.warm_progress.side_effect = [reading, ready]
+        with patch("lilbee.server.handlers._WARM_POLL_INTERVAL_S", 0):
+            chunks = [chunk async for chunk in handlers.warm_stream()]
+        phases = [e["phase"] for e in _parse_warm_events(chunks)]
+        assert phases == [WarmPhase.READING_WEIGHTS, WarmPhase.READY]
+
+    async def test_stops_on_error_phase(self, mock_svc):
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        mock_svc.provider.warm_progress.return_value = WarmProgress(
+            phase=WarmPhase.ERROR, error="no vram"
+        )
+        chunks = [chunk async for chunk in handlers.warm_stream()]
+        events = _parse_warm_events(chunks)
+        assert events[-1]["phase"] == WarmPhase.ERROR
+        assert events[-1]["error"] == "no vram"
+
 
 class TestStatus:
     async def test_returns_config_and_sources(self):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -168,17 +168,30 @@ class TestWarmStream:
     async def test_emits_starting_then_exits_on_deadline(self, mock_svc):
         # Nothing loading and the engine not yet ready: emit STARTING placeholders
         # and end the stream when the budget elapses (the caller proceeds anyway).
+        # The clock is driven by hand so the loop runs a fixed number of iterations
+        # instead of busy-looping against a wall-clock deadline.
         from lilbee.providers.warm_progress import WarmPhase
 
         mock_svc.provider.warm_progress.return_value = None
         mock_svc.provider.role_ready.return_value = False
+        # Drive the clock by hand: the first two reads are inside the budget (the
+        # deadline calc plus one loop check), then it jumps past the deadline so
+        # the loop exits. Counter-based so extra monotonic() calls (asyncio) don't
+        # break it; one STARTING placeholder is emitted before the deadline.
+        calls = {"n": 0}
+
+        def _fake_monotonic() -> float:
+            calls["n"] += 1
+            return 0.0 if calls["n"] <= 2 else 99.0
+
         with (
             patch("lilbee.server.handlers._WARM_POLL_INTERVAL_S", 0),
-            patch("lilbee.server.handlers._WARM_STREAM_TIMEOUT_S", 0.05),
+            patch("lilbee.server.handlers._WARM_STREAM_TIMEOUT_S", 5.0),
+            patch("lilbee.server.handlers.time.monotonic", _fake_monotonic),
         ):
             chunks = [chunk async for chunk in handlers.warm_stream()]
         events = _parse_warm_events(chunks)
-        assert events  # at least one STARTING placeholder was emitted
+        assert events  # at least one STARTING placeholder before the deadline
         assert all(e["phase"] == WarmPhase.STARTING for e in events)
         assert "event: done" in chunks[-1]
 

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -78,6 +78,19 @@ class TestStatusRoute:
         assert resp.json()["total_chunks"] == 0
 
 
+class TestWarmStreamRoute:
+    def test_streams_warm_events(self, client):
+        async def _fake_warm():
+            yield 'event: warm\ndata: {"phase": "ready"}\n\n'
+            yield "event: done\ndata: {}\n\n"
+
+        with mock.patch("lilbee.server.handlers.warm_stream", return_value=_fake_warm()):
+            resp = client.get("/api/warm/stream")
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+        assert '"phase": "ready"' in resp.text
+
+
 class TestSearchRoute:
     @mock.patch("lilbee.server.handlers.search", new_callable=AsyncMock, return_value=[])
     def test_empty_results(self, mock_search, client):

--- a/tools/qa/opencode/reelrun.sh
+++ b/tools/qa/opencode/reelrun.sh
@@ -18,8 +18,8 @@ mkdir -p "$OUT"
 case "$TIER" in
   small) GEN_SLEEP=90;  PROMPT="Search the indexed Godot 4 class reference for the AStarGrid2D class and tell me, citing what the search returns, exactly what its get_id_path method returns." ;;
   mid)   GEN_SLEEP=120; PROMPT="In Godot 4 I am connecting signals between nodes. What is the exact signature of Object.connect, and what do the CONNECT_DEFERRED and CONNECT_ONE_SHOT flags do? Verify against my indexed reference and include their integer values." ;;
-  coder) GEN_SLEEP=200; PROMPT="write level_generator.gd: a procedural level generator that places wall and floor tiles and scatters collectibles using pathfinding. Verify every Godot API you use against my indexed reference. Pick sensible defaults yourself and never ask me questions." ;;
-  giant) GEN_SLEEP=280; PROMPT="write level_generator.gd: a procedural level generator that places wall and floor tiles and scatters collectibles using pathfinding. Verify every Godot API you use against my indexed reference. Pick sensible defaults yourself and never ask me questions." ;;
+  coder) GEN_SLEEP=200; PROMPT="write ./level_generator.gd here in the project root: a procedural level generator that places wall and floor tiles and scatters collectibles using pathfinding. Verify every Godot API you use against my indexed reference. Pick sensible defaults yourself and never ask me questions." ;;
+  giant) GEN_SLEEP=280; PROMPT="write ./level_generator.gd here in the project root: a procedural level generator that places wall and floor tiles and scatters collectibles using pathfinding. Verify every Godot API you use against my indexed reference. Pick sensible defaults yourself and never ask me questions." ;;
   *) echo "bad tier"; exit 2 ;;
 esac
 
@@ -28,7 +28,8 @@ lilbee model pull "$REF" >/dev/null 2>&1 || lilbee model pull "$REF"
 
 echo "[reelrun] rebuilding workspace"
 python3 - <<PYEOF
-import sys
+import os, sys
+os.environ["LILBEE_DATA"] = "$WS/.lilbee"
 sys.path.insert(0, "$QA")
 from workspace import write_per_cell_workspace
 ws = write_per_cell_workspace("$FAMILY", "$REF")
@@ -37,7 +38,12 @@ cfg = {"\$schema": "https://opencode.ai/config.json",
        "tools": {"webfetch": False, "bash": False, "question": False},
        "autoupdate": False}
 (ws / "opencode.json").write_text(json.dumps(cfg, indent=2))
+from lilbee.core.config import cfg as lilbee_cfg
+marker = lilbee_cfg.data_dir / "launchers" / "opencode-setup.json"
+marker.parent.mkdir(parents=True, exist_ok=True)
+marker.write_text('{"accepted": true}')
 print("workspace ready:", ws)
+print("setup marker:", marker)
 PYEOF
 
 echo "[reelrun] warming serve"
@@ -64,6 +70,7 @@ Set Width 1600
 Set Height 900
 Set FontSize 14
 Set PlaybackSpeed 1.0
+Set Theme { "name": "rose-pine", "background": "#191724", "foreground": "#e0def4", "cursor": "#e0def4", "selection": "#403d52", "black": "#26233a", "red": "#eb6f92", "green": "#9ccfd8", "yellow": "#f6c177", "blue": "#31748f", "magenta": "#c4a7e7", "cyan": "#ebbcba", "white": "#e0def4", "brightBlack": "#6e6a86", "brightRed": "#eb6f92", "brightGreen": "#9ccfd8", "brightYellow": "#f6c177", "brightBlue": "#31748f", "brightMagenta": "#c4a7e7", "brightCyan": "#ebbcba", "brightWhite": "#e0def4" }
 
 Env PATH "/root/lilbee_venv/bin:/root/.opencode/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Env LILBEE_DATA "$WS/.lilbee"
@@ -75,7 +82,10 @@ Sleep 2s
 Type "lilbee launch opencode"
 Sleep 500ms
 Enter
-Sleep 25s
+# Launch arc: the warm bar + "Launching opencode..." line cover this wait now;
+# the serve is pre-warmed so opencode paints within seconds. Tune per-tier on
+# the pod against the frame review if a model boots slower.
+Sleep 12s
 
 Type "$PROMPT"
 Sleep 1s

--- a/tools/qa/opencode/scenarios.py
+++ b/tools/qa/opencode/scenarios.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -128,9 +129,16 @@ def _poll_verdict(
     """One poll iteration's verdict, or ``None`` to keep waiting.
 
     PASS gate: a fresh ``lilbee_search`` dispatch event past this scenario's
-    baseline, else (tap never loaded) the pane gear marker plus
-    ``_TOOL_TURN_MIN_COMPLETIONS`` fresh completions; forbidden-marker checks
-    always run on the rendered pane.
+    baseline AND a fresh successful chat completion on lilbee's own serve, else
+    (tap never loaded) the pane gear marker plus ``_TOOL_TURN_MIN_COMPLETIONS``
+    fresh completions; forbidden-marker checks always run on the rendered pane.
+
+    The chat-completion requirement closes the Zen-fallback hole: if opencode's
+    model pin fails to resolve, opencode silently serves the chat from its own
+    hosted provider while still calling lilbee's MCP search tool, so the dispatch
+    event fires but lilbee serves no chat completion. Counting lilbee's own
+    ``POST /v1/chat/completions`` 200s proves lilbee served the chat, not just the
+    search.
     """
 
     def result(status: ScenarioStatus, detail: str) -> ScenarioResult:
@@ -153,13 +161,41 @@ def _poll_verdict(
     if has_session_error(events):
         return result(ScenarioStatus.FAIL, "session.error event from opencode")
     fresh_dispatches = count_tool_dispatches(events, _SEARCH_TOOL_SUBSTR) - baseline_dispatches
-    if fresh_dispatches >= 1:
-        return result(
-            ScenarioStatus.PASS, f"{fresh_dispatches} {_SEARCH_TOOL_SUBSTR} dispatch event(s)"
-        )
-    missing = [s for s in scenario.expected if s.lower() not in pane_lower]
     fresh_call = _count_ok_chat_completions(workspace) - baseline_calls
-    if not events and not missing and fresh_call >= _TOOL_TURN_MIN_COMPLETIONS:
+    missing = [s for s in scenario.expected if s.lower() not in pane_lower]
+    return _dispatch_verdict(
+        result, fresh_dispatches, fresh_call, has_events=bool(events), missing=missing
+    )
+
+
+def _dispatch_verdict(
+    result: Callable[[ScenarioStatus, str], ScenarioResult],
+    fresh_dispatches: int,
+    fresh_call: int,
+    *,
+    has_events: bool,
+    missing: list[str],
+) -> ScenarioResult | None:
+    """Resolve the tool-dispatch PASS gate (event tap first, then pane fallback).
+
+    A fresh dispatch without a fresh lilbee chat completion is the Zen-fallback
+    signature (the model pin fell back to opencode's own hosted provider, which
+    still calls the MCP search tool), so it FAILs rather than passing on the
+    search alone.
+    """
+    if fresh_dispatches >= 1:
+        if fresh_call < 1:
+            return result(
+                ScenarioStatus.FAIL,
+                f"{fresh_dispatches} {_SEARCH_TOOL_SUBSTR} dispatch(es) but lilbee "
+                "served no chat completion: the model pin fell back to opencode's "
+                "own hosted provider, so lilbee served the search tool, not the chat",
+            )
+        return result(
+            ScenarioStatus.PASS,
+            f"{fresh_dispatches} {_SEARCH_TOOL_SUBSTR} dispatch(es) + lilbee chat completion",
+        )
+    if not has_events and not missing and fresh_call >= _TOOL_TURN_MIN_COMPLETIONS:
         return result(
             ScenarioStatus.PASS, "gear dispatch + fresh chat completion (pane fallback; no tap)"
         )

--- a/tools/qa/opencode/test_scenarios_verdict.py
+++ b/tools/qa/opencode/test_scenarios_verdict.py
@@ -1,8 +1,9 @@
 """Verdict tests for the opencode QA scenario gate (run on the pod harness).
 
 Flat-module imports match the harness's own layout, so run from this directory:
-``cd tools/qa/opencode && python -m pytest test_scenarios_verdict.py``. The main
-suite (``testpaths = ["tests"]``) does not collect these.
+``cd tools/qa/opencode && python -m pytest --noconftest test_scenarios_verdict.py``
+(``--noconftest`` skips the parent ``tools/qa/conftest.py``, which pulls pod-only
+deps). The main suite (``testpaths = ["tests"]``) does not collect these.
 """
 
 from __future__ import annotations

--- a/tools/qa/opencode/test_scenarios_verdict.py
+++ b/tools/qa/opencode/test_scenarios_verdict.py
@@ -1,0 +1,76 @@
+"""Verdict tests for the opencode QA scenario gate (run on the pod harness).
+
+Flat-module imports match the harness's own layout, so run from this directory:
+``cd tools/qa/opencode && python -m pytest test_scenarios_verdict.py``. The main
+suite (``testpaths = ["tests"]``) does not collect these.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scenarios import Scenario, ScenarioStatus, _poll_verdict
+
+
+def _scenario() -> Scenario:
+    return Scenario(
+        name="tool-turn",
+        prompt="search the indexed reference",
+        expected=(),
+        forbidden=(),
+        timeout_s=60.0,
+    )
+
+
+def _write_dispatch_event(workspace: Path) -> None:
+    events = workspace / ".lilbee" / "qa-events.jsonl"
+    events.parent.mkdir(parents=True, exist_ok=True)
+    events.write_text(
+        json.dumps({"type": "qa.tool.after", "tool": "lilbee_search"}) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_chat_completions(workspace: Path, count: int) -> None:
+    log = workspace / ".lilbee" / "data" / "logs" / "launcher-serve.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    line = '127.0.0.1 - "POST /v1/chat/completions HTTP/1.1" 200 OK\n'
+    log.write_text(line * count, encoding="utf-8")
+
+
+def _verdict(workspace: Path):
+    return _poll_verdict(
+        _scenario(),
+        workspace,
+        pane="opencode pane text",
+        baseline_calls=0,
+        baseline_dispatches=0,
+        start=0.0,
+    )
+
+
+def test_dispatch_with_lilbee_chat_completion_passes(tmp_path: Path) -> None:
+    _write_dispatch_event(tmp_path)
+    _write_chat_completions(tmp_path, 1)
+    verdict = _verdict(tmp_path)
+    assert verdict is not None
+    assert verdict.status is ScenarioStatus.PASS
+    assert "lilbee chat completion" in verdict.detail
+
+
+def test_dispatch_without_lilbee_chat_completion_fails_as_zen_fallback(tmp_path: Path) -> None:
+    # The Zen-fallback signature: lilbee_search fired (MCP) but lilbee served no
+    # chat completion because opencode's pin fell back to its own hosted model.
+    _write_dispatch_event(tmp_path)
+    _write_chat_completions(tmp_path, 0)
+    verdict = _verdict(tmp_path)
+    assert verdict is not None
+    assert verdict.status is ScenarioStatus.FAIL
+    assert "no chat completion" in verdict.detail
+    assert "hosted provider" in verdict.detail
+
+
+def test_no_dispatch_keeps_waiting(tmp_path: Path) -> None:
+    _write_chat_completions(tmp_path, 1)  # chat but no search dispatch yet
+    assert _verdict(tmp_path) is None


### PR DESCRIPTION
## Problem

`lilbee launch opencode` gave almost no feedback during a cold start. The model load showed one static "Warming the chat model..." line with no model, size, or progress, the server-boot wait was silent, and opencode's own startup added a few more dead seconds. For a large model that's minutes of apparent deadness with no way to tell what's happening or how long it'll take.

## Solution

The launcher now shows real progress while a model loads: a byte progress bar as the weights are read, then an engine-load spinner, then a clear handoff to opencode. The server boot gets a spinner too. Repeat launches are fast when a server is already running (`lilbee serve` once, reused by every later launch).

Also fixes the demo QA so the reels can be recreated correctly: the pass gate now confirms lilbee actually served the chat (not just the search tool, which masked a silent fallback to opencode's own hosted model), and the reel tapes use a rose-pine theme.

Tests cover the progress tracking, the launcher rendering, and the QA gate. Lint, typecheck, and the affected suites are green.
