### PR TITLE
Record per-file skip reasons (skip_reasons.json sidecar)

### DIFF
--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -30,6 +30,7 @@ from lilbee.data.ingest.skip_marker import (
     clear_skip_markers,
     load_skip_markers,
     write_skip_markers,
+    write_skip_reasons,
 )
 from lilbee.data.ingest.types import (
     ChunkRecord,
@@ -385,6 +386,7 @@ async def sync(
     removed: list[str] = []
     failed: dict[str, None] = {}
     skipped: dict[str, None] = {}
+    reasons: dict[str, str] = {}  # filename → why it was skipped/failed (for reporting)
     flush_failed: set[str] = set()
 
     # Find files to remove (document sources whose file is gone; imports are kept)
@@ -421,6 +423,7 @@ async def sync(
             on_progress=on_progress,
             cancel=cancel,
             flush_failed=flush_failed,
+            reasons=reasons,
         )
 
     # A flush failure is a transient store-side problem, not a verdict on the
@@ -429,6 +432,10 @@ async def sync(
     _persist_skip_markers(
         skip_markers, pending_hashes, succeeded=[*added, *updated], failed=marker_failed
     )
+    # Persist the human-readable reason for each skip-marked file (informational;
+    # the hash markers above drive the resume logic). Only marker_failed files,
+    # so a transient flush failure doesn't leave a stale reason behind.
+    write_skip_reasons(cfg.data_root, {n: reasons[n] for n in marker_failed if n in reasons})
 
     if files_to_process or removed:
         _store.ensure_fts_index()
@@ -504,6 +511,7 @@ async def ingest_batch(
     on_progress: DetailedProgressCallback = noop_callback,
     cancel: threading.Event | None = None,
     flush_failed: set[str] | None = None,
+    reasons: dict[str, str] | None = None,
 ) -> None:
     """Ingest a batch of files, optionally showing a Rich progress bar.
     When *needs_cleanup* is True, old chunks are deleted immediately before
@@ -596,6 +604,7 @@ async def ingest_batch(
             window=window,
             on_progress=on_progress,
             flush_failed=flush_failed,
+            reasons=reasons,
         )
     else:
         with Progress(
@@ -625,6 +634,7 @@ async def ingest_batch(
                 progress=progress,
                 ptask=ptask,
                 flush_failed=flush_failed,
+                reasons=reasons,
             )
 
 
@@ -660,6 +670,7 @@ async def _collect_results(
     progress: Progress | None = None,
     ptask: Any = None,
     flush_failed: set[str] | None = None,
+    reasons: dict[str, str] | None = None,
 ) -> None:
     """Run *pending* through a bounded task window, batching writes and progress.
 
@@ -685,7 +696,7 @@ async def _collect_results(
             for fut in done:
                 result = fut.result()
                 completed_count += 1
-                status = _classify_result(result, added, updated, failed, skipped)
+                status = _classify_result(result, added, updated, failed, skipped, reasons)
                 if status is BatchStatus.INGESTED:
                     buffered_chunks = await _buffer_and_maybe_flush(
                         result, buffer, buffered_chunks, added, updated, failed, flush_failed
@@ -758,12 +769,14 @@ def _classify_result(
     updated: dict[str, None],
     failed: dict[str, None],
     skipped: dict[str, None],
+    reasons: dict[str, str] | None = None,
 ) -> BatchStatus:
     """Record a completed file's outcome and return its batch status.
 
     Failures and zero-chunk files are tracked here; a successful file is reported
     as ``INGESTED`` and its chunks are persisted by the batched flush, so it stays
-    in ``added`` / ``updated`` until then.
+    in ``added`` / ``updated`` until then. When *reasons* is given, the
+    human-readable cause is recorded there (filename → reason) for reporting.
     """
     if result.error is not None:
         # A traceback here would bleed into the TUI chat pane; the full trace stays at DEBUG.
@@ -772,6 +785,8 @@ def _classify_result(
         added.pop(result.name, None)
         updated.pop(result.name, None)
         failed[result.name] = None
+        if reasons is not None:
+            reasons[result.name] = f"{type(result.error).__name__}: {result.error}"
         return BatchStatus.FAILED
     if result.chunk_count == 0 and not result.page_texts:
         # Nothing extracted: no source row, so the file is retried next sync; a
@@ -779,6 +794,8 @@ def _classify_result(
         added.pop(result.name, None)
         updated.pop(result.name, None)
         skipped[result.name] = None
+        if reasons is not None:
+            reasons[result.name] = "no text extracted (0 chunks)"
         return BatchStatus.SKIPPED
     return BatchStatus.INGESTED
 

--- a/src/lilbee/data/ingest/skip_marker.py
+++ b/src/lilbee/data/ingest/skip_marker.py
@@ -1,4 +1,4 @@
-"""Sidecar record of files that produced no chunks, so a sync can skip them.
+"""Sidecar records of files that produced no chunks, so a sync can skip them.
 
 A file that yields zero chunks (Tesseract timeout, decode failure, no usable
 text) gets a marker here keyed by the file hash that failed.
@@ -7,6 +7,11 @@ unchanged, so the per-file extract cost (30-60s for a stubborn scanned PDF) is
 paid once, not on every sync. The marker is a small JSON file in
 ``cfg.data_root``; editing the file changes its hash and re-arms it, and
 ``retry_skipped`` / ``force_rebuild`` drop the file from the marker set.
+
+A second sidecar (``skip_reasons.json``) records filename → human-readable
+reason, so a report can say WHY a file was skipped (the exception message, or
+"no text extracted"), not just that it was. It is informational only -- the
+hash-keyed markers above drive the resume logic -- and is cleared alongside them.
 """
 
 from __future__ import annotations
@@ -20,45 +25,64 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 SKIP_MARKER_FILENAME = "skipped_sources.json"
+SKIP_REASON_FILENAME = "skip_reasons.json"
 
 
-def _marker_path(data_root: Path) -> Path:
-    return data_root / SKIP_MARKER_FILENAME
-
-
-def load_skip_markers(data_root: Path) -> dict[str, str]:
-    """Load the filename → failed-hash map, or empty dict on any read error."""
-    path = _marker_path(data_root)
+def _load_str_map(path: Path) -> dict[str, str]:
+    """Load a ``{str: str}`` JSON file, or empty dict on any read/parse error."""
     if not path.exists():
         return {}
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        log.debug("Skip-marker file unreadable, treating as empty: %s", exc)
+        log.debug("Sidecar %s unreadable, treating as empty: %s", path.name, exc)
         return {}
     if not isinstance(raw, dict):
         return {}
     return {str(k): str(v) for k, v in raw.items() if isinstance(v, str)}
 
 
-def write_skip_markers(data_root: Path, markers: dict[str, str]) -> None:
-    """Replace the marker file atomically. Best-effort: errors are logged, not raised."""
-    path = _marker_path(data_root)
+def _write_str_map(path: Path, data: dict[str, str]) -> None:
+    """Replace *path* atomically with a ``{str: str}`` JSON map. Best-effort."""
     tmp = path.with_suffix(path.suffix + ".tmp")
     try:
-        data_root.mkdir(parents=True, exist_ok=True)
-        tmp.write_text(json.dumps(markers, sort_keys=True), encoding="utf-8")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
         os.replace(tmp, path)
     except OSError as exc:
-        log.warning("Failed to persist skip markers to %s: %s", path, exc)
+        log.warning("Failed to persist %s: %s", path, exc)
         with contextlib.suppress(OSError):
             tmp.unlink()
 
 
-def clear_skip_markers(data_root: Path) -> None:
-    """Delete the marker file. No-op if absent."""
-    path = _marker_path(data_root)
+def _unlink(path: Path) -> None:
     try:
         path.unlink(missing_ok=True)
     except OSError as exc:
-        log.debug("Could not remove skip-marker file %s: %s", path, exc)
+        log.debug("Could not remove %s: %s", path, exc)
+
+
+def load_skip_markers(data_root: Path) -> dict[str, str]:
+    """Load the filename → failed-hash map, or empty dict on any read error."""
+    return _load_str_map(data_root / SKIP_MARKER_FILENAME)
+
+
+def write_skip_markers(data_root: Path, markers: dict[str, str]) -> None:
+    """Replace the marker file atomically. Best-effort: errors are logged, not raised."""
+    _write_str_map(data_root / SKIP_MARKER_FILENAME, markers)
+
+
+def load_skip_reasons(data_root: Path) -> dict[str, str]:
+    """Load the filename → skip-reason map (informational), empty on any read error."""
+    return _load_str_map(data_root / SKIP_REASON_FILENAME)
+
+
+def write_skip_reasons(data_root: Path, reasons: dict[str, str]) -> None:
+    """Replace the reasons sidecar atomically. Best-effort: errors are logged, not raised."""
+    _write_str_map(data_root / SKIP_REASON_FILENAME, reasons)
+
+
+def clear_skip_markers(data_root: Path) -> None:
+    """Delete both the marker file and the reasons sidecar. No-op if absent."""
+    _unlink(data_root / SKIP_MARKER_FILENAME)
+    _unlink(data_root / SKIP_REASON_FILENAME)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1335,6 +1335,32 @@ class TestFileHash:
 
 
 class TestClassifyResult:
+    def test_records_reason_for_failed_and_skipped_files(self):
+        # The optional reasons map captures WHY a file was skipped (the exception
+        # for a failure, "no text" for a zero-chunk file) so a report can show it.
+        from lilbee.data.ingest.pipeline import _classify_result
+        from lilbee.data.ingest.types import _IngestResult
+
+        reasons: dict[str, str] = {}
+        _classify_result(
+            _IngestResult("err.pdf", Path("err.pdf"), 0, error=TimeoutError("OCR timed out")),
+            {},
+            {},
+            {},
+            {},
+            reasons,
+        )
+        _classify_result(
+            _IngestResult("blank.tiff", Path("blank.tiff"), chunk_count=0, error=None),
+            {},
+            {},
+            {},
+            {},
+            reasons,
+        )
+        assert reasons["err.pdf"] == "TimeoutError: OCR timed out"
+        assert reasons["blank.tiff"] == "no text extracted (0 chunks)"
+
     def test_zero_chunks_not_recorded_as_added(self):
         from lilbee.data.ingest.pipeline import _classify_result
         from lilbee.data.ingest.types import _IngestResult

--- a/tests/test_skip_marker.py
+++ b/tests/test_skip_marker.py
@@ -13,9 +13,12 @@ import pytest
 
 from lilbee.data.ingest.skip_marker import (
     SKIP_MARKER_FILENAME,
+    SKIP_REASON_FILENAME,
     clear_skip_markers,
     load_skip_markers,
+    load_skip_reasons,
     write_skip_markers,
+    write_skip_reasons,
 )
 
 
@@ -118,3 +121,42 @@ def test_write_is_atomic_via_tmp_rename(tmp_path: Path, monkeypatch: pytest.Monk
     write_skip_markers(tmp_path, {"k": "v"})
     leftover = list(tmp_path.glob(f"{SKIP_MARKER_FILENAME}.tmp"))
     assert leftover == [], f"tmp file leaked: {leftover}"
+
+
+class TestSkipReasons:
+    """The reasons sidecar records WHY a file was skipped (filename -> error),
+    so a report can show the cause, not just the hash. Separate from the
+    hash-keyed markers, which drive the resume logic."""
+
+    def test_load_empty_when_file_missing(self, tmp_path: Path) -> None:
+        assert load_skip_reasons(tmp_path) == {}
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        reasons = {
+            "a.pdf": "OCR timed out after 120s",
+            "b.tiff": "no text extracted (0 chunks)",
+        }
+        write_skip_reasons(tmp_path, reasons)
+        assert load_skip_reasons(tmp_path) == reasons
+        assert (tmp_path / SKIP_REASON_FILENAME).exists()
+
+    def test_reasons_file_is_separate_from_markers(self, tmp_path: Path) -> None:
+        # The two sidecars are independent files; writing one leaves the other.
+        write_skip_markers(tmp_path, {"a.pdf": "deadbeef"})
+        write_skip_reasons(tmp_path, {"a.pdf": "decode failure"})
+        assert (tmp_path / SKIP_MARKER_FILENAME) != (tmp_path / SKIP_REASON_FILENAME)
+        assert load_skip_markers(tmp_path) == {"a.pdf": "deadbeef"}
+        assert load_skip_reasons(tmp_path) == {"a.pdf": "decode failure"}
+
+    def test_clear_removes_reasons_too(self, tmp_path: Path) -> None:
+        # Clearing skip state (force-rebuild / retry-skipped) must drop the
+        # reasons too, or stale errors linger after a clean re-run.
+        write_skip_markers(tmp_path, {"a.pdf": "deadbeef"})
+        write_skip_reasons(tmp_path, {"a.pdf": "decode failure"})
+        clear_skip_markers(tmp_path)
+        assert not (tmp_path / SKIP_REASON_FILENAME).exists()
+        assert load_skip_reasons(tmp_path) == {}
+
+    def test_load_handles_corrupt_json(self, tmp_path: Path) -> None:
+        (tmp_path / SKIP_REASON_FILENAME).write_text("not json {{{", encoding="utf-8")
+        assert load_skip_reasons(tmp_path) == {}


### PR DESCRIPTION
## Problem

`skipped_sources.json` stores only `{filename -> hash}`. When a file is skipped or fails (OCR timeout, decode failure, no usable text) the reason is logged but not persisted, so there's no way to report WHY a file produced 0 chunks, only that it did. At scale (a large ingest with thousands of skipped files) that makes triage hard.

## Solution

Add a second sidecar, `skip_reasons.json` (`filename -> human-readable reason`). The error is already in hand at `_classify_result`, so the reason is recorded there and persisted from `sync` alongside the hash markers. It's informational only: the hash-keyed markers still drive the resume logic, and only `marker_failed` files get a reason (a transient flush failure leaves none). `load`/`write_skip_markers` were refactored to share read/write/unlink helpers with the new sidecar, and `clear_skip_markers` drops both files so stale reasons don't linger after a force-rebuild / retry-skipped.

`SyncResult` is unchanged, so no existing consumer is affected. This unblocks a per-file error report/CSV for large ingests.

Tracked as bb-kkf. 100% coverage maintained; ruff + smell gate + mypy clean.