### PR TITLE
Add a Scoop channel for Windows and install-channel badges

### DIFF
--- a/.github/actions/validate-scoop-install/action.yml
+++ b/.github/actions/validate-scoop-install/action.yml
@@ -1,0 +1,33 @@
+name: Validate Scoop install
+description: "Install Scoop, install lilbee from a manifest, and assert it runs. Runs on a windows runner."
+
+inputs:
+  manifest-path:
+    description: "Path to the Scoop manifest to install (e.g. bucket/lilbee.json)."
+    required: true
+  expected-version:
+    description: "Expected 'lilbee --version' output (e.g. 'lilbee 0.6.66b496')."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Scoop and the lilbee manifest, then smoke test
+      shell: pwsh
+      env:
+        MANIFEST: ${{ inputs.manifest-path }}
+        EXPECTED: ${{ inputs.expected-version }}
+      run: |
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
+        # The hosted runner is admin, so Scoop needs -RunAsAdmin to install.
+        Invoke-WebRequest -UseBasicParsing get.scoop.sh -OutFile "$env:TEMP\install-scoop.ps1"
+        & "$env:TEMP\install-scoop.ps1" -RunAsAdmin
+        $env:Path = "$env:USERPROFILE\scoop\shims;$env:Path"
+        scoop install "$env:MANIFEST"
+        if ($LASTEXITCODE -ne 0) { throw "scoop install failed" }
+        $actual = (& lilbee --version | Out-String).Trim()
+        Write-Host "scoop: $actual"
+        if ($actual -ne $env:EXPECTED) {
+          throw "version mismatch: got '$actual', expected '$env:EXPECTED'"
+        }

--- a/.github/actions/validate-scoop-install/action.yml
+++ b/.github/actions/validate-scoop-install/action.yml
@@ -24,7 +24,10 @@ runs:
         Invoke-WebRequest -UseBasicParsing get.scoop.sh -OutFile "$env:TEMP\install-scoop.ps1"
         & "$env:TEMP\install-scoop.ps1" -RunAsAdmin
         $env:Path = "$env:USERPROFILE\scoop\shims;$env:Path"
-        scoop install "$env:MANIFEST"
+        # Resolve to a backslash path so Scoop reads it as a local manifest file
+        # instead of parsing the forward slash as a <bucket>/<app> reference.
+        $manifest = (Resolve-Path $env:MANIFEST).Path
+        scoop install $manifest
         if ($LASTEXITCODE -ne 0) { throw "scoop install failed" }
         $actual = (& lilbee --version | Out-String).Trim()
         Write-Host "scoop: $actual"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -30,6 +30,8 @@ jobs:
       sha_linux: ${{ steps.info.outputs.sha_linux }}
       sha_macos_arm64: ${{ steps.info.outputs.sha_macos_arm64 }}
       sha_macos_x86_64: ${{ steps.info.outputs.sha_macos_x86_64 }}
+      sha_windows: ${{ steps.info.outputs.sha_windows }}
+      sha_windows_cu125: ${{ steps.info.outputs.sha_windows_cu125 }}
       size_linux: ${{ steps.info.outputs.size_linux }}
     steps:
       - name: Resolve tag and asset digests
@@ -55,6 +57,8 @@ jobs:
           size_linux=$(get_size lilbee-linux-x86_64)
           sha_macos_arm64=$(get_sha lilbee-macos-arm64)
           sha_macos_x86_64=$(get_sha lilbee-macos-x86_64)
+          sha_windows=$(get_sha lilbee-windows-x86_64.exe)
+          sha_windows_cu125=$(get_sha lilbee-windows-x86_64-cu125.exe)
 
           [ -n "$sha_linux" ] || { echo "lilbee-linux-x86_64 missing from release ${tag}"; exit 1; }
           [ -n "$sha_macos_arm64" ] || { echo "lilbee-macos-arm64 missing from release ${tag}"; exit 1; }
@@ -65,6 +69,8 @@ jobs:
             echo "sha_linux=$sha_linux"
             echo "sha_macos_arm64=$sha_macos_arm64"
             echo "sha_macos_x86_64=$sha_macos_x86_64"
+            echo "sha_windows=$sha_windows"
+            echo "sha_windows_cu125=$sha_windows_cu125"
             echo "size_linux=$size_linux"
           } >> "$GITHUB_OUTPUT"
 
@@ -202,3 +208,52 @@ jobs:
           version: ${{ needs.resolve.outputs.version }}
           systems-json: ${{ steps.sys.outputs.value }}
           commit-message: "lilbee ${{ needs.resolve.outputs.version }} (flake)"
+
+  scoop:
+    needs: resolve
+    if: inputs.channels == 'all' || contains(inputs.channels, 'scoop')
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Render manifest
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          SHA_WINDOWS: ${{ needs.resolve.outputs.sha_windows }}
+          SHA_WINDOWS_CU125: ${{ needs.resolve.outputs.sha_windows_cu125 }}
+        run: |
+          set -euo pipefail
+          [ -n "$SHA_WINDOWS" ] || { echo "lilbee-windows-x86_64.exe missing from release"; exit 1; }
+          [ -n "$SHA_WINDOWS_CU125" ] || { echo "lilbee-windows-x86_64-cu125.exe missing from release"; exit 1; }
+          python packaging/tools/render_scoop_manifest.py bucket/lilbee.json \
+            --version "$VERSION" --sha-windows "$SHA_WINDOWS" --sha-windows-cu125 "$SHA_WINDOWS_CU125"
+      - name: Install from the rendered manifest and smoke test
+        uses: ./.github/actions/validate-scoop-install
+        with:
+          manifest-path: bucket/lilbee.json
+          expected-version: lilbee ${{ needs.resolve.outputs.version }}
+      - name: Commit and push the manifest
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "lilbee-bot"
+          git config user.email "lilbee-bot@users.noreply.github.com"
+          git add bucket/lilbee.json
+          if git diff --cached --quiet; then
+            echo "no manifest changes; skipping push"
+            exit 0
+          fi
+          git commit -m "lilbee ${VERSION} (scoop)"
+          # nix-flake commits to main from a sibling job; rebase-retry on a race.
+          for _ in 1 2 3; do
+            if git push origin main; then exit 0; fi
+            git pull --rebase origin main
+          done
+          echo "push failed after retries"; exit 1

--- a/.github/workflows/scoop-validate.yml
+++ b/.github/workflows/scoop-validate.yml
@@ -1,0 +1,34 @@
+name: Scoop validate
+
+# Proves the committed Scoop manifest installs and runs on Windows: Scoop pulls
+# the pinned release exe, picks the CPU build (the runner has no CUDA GPU), and
+# `lilbee --version` must match the manifest's version.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - bucket/**
+      - packaging/tools/render_scoop_manifest.py
+      - .github/actions/validate-scoop-install/**
+      - .github/workflows/scoop-validate.yml
+
+concurrency:
+  group: scoop-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read manifest version
+        id: manifest
+        shell: pwsh
+        run: |
+          $version = (Get-Content bucket/lilbee.json | ConvertFrom-Json).version
+          "expected=lilbee $version" >> $env:GITHUB_OUTPUT
+      - uses: ./.github/actions/validate-scoop-install
+        with:
+          manifest-path: bucket/lilbee.json
+          expected-version: ${{ steps.manifest.outputs.expected }}

--- a/README.md
+++ b/README.md
@@ -12,16 +12,19 @@
 <p align="center"><a href="https://lilbee.sh/">Project site</a> &nbsp;·&nbsp; <a href="https://lilbee.sh/tutorial">Tutorial reels</a> &nbsp;·&nbsp; <a href="https://pypi.org/project/lilbee/">PyPI</a> &nbsp;·&nbsp; <a href="https://obsidian.lilbee.sh/">Obsidian plugin</a> &nbsp;·&nbsp; <a href="https://lilbee.sh/api/">REST API</a></p>
 
 <p align="center">
-  <a href="https://github.com/tobocop2/lilbee/releases"><img src="https://img.shields.io/github/v/release/tobocop2/lilbee?include_prereleases&label=latest%20release" alt="Latest release (incl. pre-releases)"></a>
-  <a href="https://pypi.org/project/lilbee/"><img src="https://img.shields.io/pypi/v/lilbee?include_prereleases&label=PyPI" alt="lilbee on PyPI"></a>
-  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+"></a>
-  <a href="https://github.com/tobocop2/lilbee/actions/workflows/ci.yml"><img src="https://github.com/tobocop2/lilbee/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://lilbee.sh/coverage/"><img src="https://img.shields.io/badge/coverage-100%25-brightgreen.svg" alt="Coverage"></a>
-  <a href="https://mypy-lang.org/"><img src="https://img.shields.io/badge/typed-mypy-blue.svg" alt="Typed"></a>
+  <a href="https://github.com/tobocop2/lilbee/releases"><img src="https://img.shields.io/github/v/release/tobocop2/lilbee?include_prereleases&label=release&logo=github&logoColor=white" alt="Latest release"></a>
+  <a href="https://pypi.org/project/lilbee/"><img src="https://img.shields.io/pypi/v/lilbee?include_prereleases&label=PyPI&logo=pypi&logoColor=white" alt="lilbee on PyPI"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11%2B-3776AB?logo=python&logoColor=white" alt="Python 3.11+"></a>
+  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="Platforms">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-ELv2-2C3E50" alt="License: Elastic License 2.0"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/tobocop2/lilbee/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/tobocop2/lilbee/ci.yml?branch=main&label=CI&logo=githubactions&logoColor=white" alt="CI"></a>
+  <a href="https://lilbee.sh/coverage/"><img src="https://img.shields.io/badge/coverage-100%25-2EA043" alt="Coverage"></a>
+  <a href="https://mypy-lang.org/"><img src="https://img.shields.io/badge/typed-mypy-2A6DB2" alt="Typed"></a>
   <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
-  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg" alt="Platforms">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-ELv2-blue.svg" alt="License: Elastic License 2.0"></a>
-  <a href="https://pepy.tech/project/lilbee"><img src="https://static.pepy.tech/badge/lilbee/month" alt="PyPI downloads / month"></a>
+  <a href="https://pepy.tech/project/lilbee"><img src="https://img.shields.io/pepy/dt/lilbee?label=downloads&logo=python&logoColor=white&color=3776AB" alt="PyPI downloads"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
   <a href="https://github.com/tobocop2/homebrew-lilbee"><img src="https://img.shields.io/badge/Homebrew-tap-FBB040?logo=homebrew&logoColor=white" alt="Homebrew tap"></a>
   <a href="https://aur.archlinux.org/packages/lilbee"><img src="https://img.shields.io/aur/version/lilbee?logo=archlinux&logoColor=white&label=AUR" alt="lilbee on the AUR"></a>
   <a href="https://github.com/tobocop2/lilbee/pkgs/container/lilbee"><img src="https://img.shields.io/badge/Docker-ghcr.io-2496ED?logo=docker&logoColor=white" alt="Docker image on GHCR"></a>
+</p>
+
+<p align="center">
   <a href="https://github.com/tobocop2/lilbee#install"><img src="https://img.shields.io/badge/Nix-flake-5277C3?logo=nixos&logoColor=white" alt="Nix flake"></a>
   <a href="https://tobocop2.github.io/flatpak-lilbee/"><img src="https://img.shields.io/badge/Flatpak-repo-4A90D9?logo=flatpak&logoColor=white" alt="Flatpak repo"></a>
   <a href="https://github.com/tobocop2/lilbee/releases/latest"><img src="https://img.shields.io/badge/Snap-sideload-82BEA0?logo=snapcraft&logoColor=white" alt="Snap package"></a>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@
   <a href="https://pepy.tech/project/lilbee"><img src="https://static.pepy.tech/badge/lilbee/month" alt="PyPI downloads / month"></a>
 </p>
 
+<p align="center">
+  <a href="https://pypi.org/project/lilbee/"><img src="https://img.shields.io/badge/PyPI-pip%20%7C%20uv-3775A9?logo=pypi&logoColor=white" alt="Install from PyPI"></a>
+  <a href="https://github.com/tobocop2/homebrew-lilbee"><img src="https://img.shields.io/badge/Homebrew-tap-FBB040?logo=homebrew&logoColor=white" alt="Homebrew tap"></a>
+  <a href="https://aur.archlinux.org/packages/lilbee"><img src="https://img.shields.io/aur/version/lilbee?logo=archlinux&logoColor=white&label=AUR" alt="lilbee on the AUR"></a>
+  <a href="https://github.com/tobocop2/lilbee/pkgs/container/lilbee"><img src="https://img.shields.io/badge/Docker-ghcr.io-2496ED?logo=docker&logoColor=white" alt="Docker image on GHCR"></a>
+  <a href="https://github.com/tobocop2/lilbee#install"><img src="https://img.shields.io/badge/Nix-flake-5277C3?logo=nixos&logoColor=white" alt="Nix flake"></a>
+  <a href="https://tobocop2.github.io/flatpak-lilbee/"><img src="https://img.shields.io/badge/Flatpak-repo-4A90D9?logo=flatpak&logoColor=white" alt="Flatpak repo"></a>
+  <a href="https://github.com/tobocop2/lilbee/releases/latest"><img src="https://img.shields.io/badge/Snap-sideload-82BEA0?logo=snapcraft&logoColor=white" alt="Snap package"></a>
+  <a href="https://github.com/tobocop2/lilbee#install"><img src="https://img.shields.io/badge/Scoop-bucket-555555?logo=windows&logoColor=white" alt="Scoop bucket"></a>
+</p>
+
 A batteries-included local search engine you can talk to: it runs the AI models, indexes your files and code, crawls the web, and plugs into your coding agent, so there's nothing else to install or set up. Ask in plain English; every answer cites the file and line.
 
 ![lilbee chat with cited answers from an indexed PDF manual](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.gif)
@@ -223,6 +234,7 @@ No external services either way; lilbee downloads and runs models locally. Optio
 | **Nix**               | `nix run github:tobocop2/lilbee`                                                         | NixOS, nix-darwin, or any host with nix. On Linux the flake bundles `glibc`, `libgomp`, and `vulkan-loader` so it runs on bare NixOS.                                                                                 |
 | **Flatpak**           | `flatpak remote-add --if-not-exists lilbee https://tobocop2.github.io/flatpak-lilbee/lilbee.flatpakrepo && flatpak install lilbee io.github.tobocop2.lilbee` | Linux x86_64, any distro with flatpak. Needs the [Flathub remote](https://flathub.org/setup) for the runtime. Run with `flatpak run io.github.tobocop2.lilbee` (worth an alias); `flatpak update` picks up new releases. Data lives under `~/.var/app/io.github.tobocop2.lilbee/`. |
 | **Snap**              | `curl -LO https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-linux-x86_64.snap && sudo snap install ./lilbee-linux-x86_64.snap --dangerous --classic` | Linux x86_64. Sideloaded, so snapd flags it `--dangerous` (it just means unsigned) and it won't auto-update; rerun the same command to upgrade. |
+| **Scoop**             | `scoop bucket add lilbee https://github.com/tobocop2/lilbee && scoop install lilbee` | Windows x86_64. Installs the CUDA build on machines with a recent NVIDIA driver, otherwise the CPU build. `scoop update lilbee` upgrades. |
 | **Standalone binary** | [download for your platform &rarr;](https://github.com/tobocop2/lilbee/releases/latest)  | One file, own Python runtime, no `pip` needed. Linux needs glibc 2.28+; the macOS / Windows builds are unsigned (`xattr -d com.apple.quarantine ./lilbee-macos-arm64` if Gatekeeper blocks it).                       |
 | **From source**       | `git clone https://github.com/tobocop2/lilbee && cd lilbee && uv sync && uv run lilbee`  | For hacking on it. Needs `git` and `uv`.                                                                                                                                                                              |
 

--- a/bucket/lilbee.json
+++ b/bucket/lilbee.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.6.66b496",
+    "description": "Run and manage local AI models, and search everything you own with them, all in one program.",
+    "homepage": "https://lilbee.sh/",
+    "license": {
+        "identifier": "Elastic-2.0",
+        "url": "https://github.com/tobocop2/lilbee/blob/main/LICENSE"
+    },
+    "architecture": {
+        "64bit": {}
+    },
+    "pre_install": [
+        "$base = \"https://github.com/tobocop2/lilbee/releases/download/v$version\"",
+        "$cpuAsset = 'lilbee-windows-x86_64.exe'",
+        "$cpuHash = 'edc864c48c857885def5efa923bac02806280e4a913db877f076d14dd1f6a3a2'",
+        "$cudaAsset = 'lilbee-windows-x86_64-cu125.exe'",
+        "$cudaHash = '9967839d2f94b1ad296677b6995e4b685de6db32a76dd347549dd1d8c8a03941'",
+        "$asset = $cpuAsset; $expected = $cpuHash",
+        "$smi = Get-Command nvidia-smi -ErrorAction SilentlyContinue",
+        "if ($smi) {",
+        "    $line = & nvidia-smi 2>$null | Select-String 'CUDA Version: (\\d+)\\.(\\d+)'",
+        "    if ($line) {",
+        "        $maj = [int]$line.Matches[0].Groups[1].Value",
+        "        $min = [int]$line.Matches[0].Groups[2].Value",
+        "        if ($maj -gt 12 -or ($maj -eq 12 -and $min -ge 5)) { $asset = $cudaAsset; $expected = $cudaHash }",
+        "    }",
+        "}",
+        "Write-Host \"lilbee: installing $asset\"",
+        "$exe = Join-Path $dir 'lilbee.exe'",
+        "Invoke-WebRequest -Uri \"$base/$asset\" -OutFile $exe",
+        "$actual = (Get-FileHash $exe -Algorithm SHA256).Hash.ToLower()",
+        "if ($actual -ne $expected) { throw \"lilbee: checksum mismatch for $asset (expected $expected, got $actual)\" }"
+    ],
+    "bin": "lilbee.exe"
+}

--- a/bucket/lilbee.json
+++ b/bucket/lilbee.json
@@ -7,29 +7,31 @@
         "url": "https://github.com/tobocop2/lilbee/blob/main/LICENSE"
     },
     "architecture": {
-        "64bit": {}
+        "64bit": {
+            "url": "https://github.com/tobocop2/lilbee/releases/download/v0.6.66b496/lilbee-windows-x86_64.exe#/lilbee.exe",
+            "hash": "edc864c48c857885def5efa923bac02806280e4a913db877f076d14dd1f6a3a2"
+        }
     },
-    "pre_install": [
-        "$base = \"https://github.com/tobocop2/lilbee/releases/download/v$version\"",
-        "$cpuAsset = 'lilbee-windows-x86_64.exe'",
-        "$cpuHash = 'edc864c48c857885def5efa923bac02806280e4a913db877f076d14dd1f6a3a2'",
-        "$cudaAsset = 'lilbee-windows-x86_64-cu125.exe'",
-        "$cudaHash = '9967839d2f94b1ad296677b6995e4b685de6db32a76dd347549dd1d8c8a03941'",
-        "$asset = $cpuAsset; $expected = $cpuHash",
+    "bin": "lilbee.exe",
+    "post_install": [
+        "$useCuda = $false",
         "$smi = Get-Command nvidia-smi -ErrorAction SilentlyContinue",
         "if ($smi) {",
         "    $line = & nvidia-smi 2>$null | Select-String 'CUDA Version: (\\d+)\\.(\\d+)'",
         "    if ($line) {",
         "        $maj = [int]$line.Matches[0].Groups[1].Value",
         "        $min = [int]$line.Matches[0].Groups[2].Value",
-        "        if ($maj -gt 12 -or ($maj -eq 12 -and $min -ge 5)) { $asset = $cudaAsset; $expected = $cudaHash }",
+        "        if ($maj -gt 12 -or ($maj -eq 12 -and $min -ge 5)) { $useCuda = $true }",
         "    }",
         "}",
-        "Write-Host \"lilbee: installing $asset\"",
-        "$exe = Join-Path $dir 'lilbee.exe'",
-        "Invoke-WebRequest -Uri \"$base/$asset\" -OutFile $exe",
-        "$actual = (Get-FileHash $exe -Algorithm SHA256).Hash.ToLower()",
-        "if ($actual -ne $expected) { throw \"lilbee: checksum mismatch for $asset (expected $expected, got $actual)\" }"
-    ],
-    "bin": "lilbee.exe"
+        "if ($useCuda) {",
+        "    $cudaHash = '9967839d2f94b1ad296677b6995e4b685de6db32a76dd347549dd1d8c8a03941'",
+        "    $url = \"https://github.com/tobocop2/lilbee/releases/download/v$version/lilbee-windows-x86_64-cu125.exe\"",
+        "    $exe = Join-Path $dir 'lilbee.exe'",
+        "    Write-Host 'lilbee: NVIDIA CUDA 12.5+ detected, installing the cu125 build'",
+        "    Invoke-WebRequest -Uri $url -OutFile $exe",
+        "    $actual = (Get-FileHash $exe -Algorithm SHA256).Hash.ToLower()",
+        "    if ($actual -ne $cudaHash) { throw \"lilbee: cu125 checksum mismatch (expected $cudaHash, got $actual)\" }",
+        "}"
+    ]
 }

--- a/packaging/tools/render_scoop_manifest.py
+++ b/packaging/tools/render_scoop_manifest.py
@@ -9,18 +9,10 @@ import sys
 from pathlib import Path
 
 
-def _replace_version(content: str, version: str) -> str:
-    new_content, count = re.subn(r'"version": "[^"]*"', f'"version": "{version}"', content)
+def _replace_once(content: str, pattern: re.Pattern[str], repl: str, what: str) -> str:
+    new_content, count = pattern.subn(repl, content)
     if count != 1:
-        sys.exit("expected exactly one version line")
-    return new_content
-
-
-def _replace_hash(content: str, var_name: str, new_sha: str) -> str:
-    pattern = re.compile(r"(\$" + re.escape(var_name) + r" = ')[0-9a-f]{64}(')")
-    new_content, count = pattern.subn(rf"\g<1>{new_sha}\g<2>", content)
-    if count != 1:
-        sys.exit(f"expected exactly one {var_name} line, found {count}")
+        sys.exit(f"expected exactly one {what}, found {count}")
     return new_content
 
 
@@ -33,9 +25,30 @@ def main() -> None:
     args = parser.parse_args()
 
     content = args.manifest.read_text()
-    content = _replace_version(content, args.version)
-    content = _replace_hash(content, "cpuHash", args.sha_windows)
-    content = _replace_hash(content, "cudaHash", args.sha_windows_cu125)
+    # The version field, the literal version in the CPU download URL (the cu125
+    # URL is built from $version at install time), the Scoop-verified CPU hash,
+    # and the cu125 hash checked by post_install.
+    content = _replace_once(
+        content, re.compile(r'"version": "[^"]*"'), f'"version": "{args.version}"', "version line"
+    )
+    content = _replace_once(
+        content,
+        re.compile(r"(releases/download/v)[^/]+(/lilbee-windows-x86_64\.exe)"),
+        rf"\g<1>{args.version}\g<2>",
+        "CPU download URL",
+    )
+    content = _replace_once(
+        content,
+        re.compile(r'("hash": ")[0-9a-f]{64}(")'),
+        rf"\g<1>{args.sha_windows}\g<2>",
+        "CPU hash",
+    )
+    content = _replace_once(
+        content,
+        re.compile(r"(\$cudaHash = ')[0-9a-f]{64}(')"),
+        rf"\g<1>{args.sha_windows_cu125}\g<2>",
+        "cu125 hash",
+    )
     args.manifest.write_text(content)
 
 

--- a/packaging/tools/render_scoop_manifest.py
+++ b/packaging/tools/render_scoop_manifest.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Update version + per-variant sha256 in the Scoop manifest in place."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def _replace_version(content: str, version: str) -> str:
+    new_content, count = re.subn(r'"version": "[^"]*"', f'"version": "{version}"', content)
+    if count != 1:
+        sys.exit("expected exactly one version line")
+    return new_content
+
+
+def _replace_hash(content: str, var_name: str, new_sha: str) -> str:
+    pattern = re.compile(r"(\$" + re.escape(var_name) + r" = ')[0-9a-f]{64}(')")
+    new_content, count = pattern.subn(rf"\g<1>{new_sha}\g<2>", content)
+    if count != 1:
+        sys.exit(f"expected exactly one {var_name} line, found {count}")
+    return new_content
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--sha-windows", required=True)
+    parser.add_argument("--sha-windows-cu125", required=True)
+    args = parser.parse_args()
+
+    content = args.manifest.read_text()
+    content = _replace_version(content, args.version)
+    content = _replace_hash(content, "cpuHash", args.sha_windows)
+    content = _replace_hash(content, "cudaHash", args.sha_windows_cu125)
+    args.manifest.write_text(content)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

PyPI was the only install channel with a README badge, and there was no Windows package manager even though every release already ships Windows binaries.

## Solution

Adds Scoop as the Windows channel: `scoop bucket add lilbee https://github.com/tobocop2/lilbee && scoop install lilbee`. It installs the CUDA build on machines with a recent NVIDIA driver and the CPU build otherwise, matching the cu125-only policy the Homebrew and AUR cuda packages already follow.

A validation workflow installs and runs lilbee through Scoop on a real Windows runner for every change to the manifest, and the release pipeline runs the same check before publishing, so the channel can't ship broken.

Also adds a second README badge row covering every install channel: PyPI, Homebrew, AUR, Docker, Nix, Flatpak, Snap, and Scoop.