### PR TITLE
Resolve the OCR prompt per vision model

### DIFF
--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -557,11 +557,12 @@ class FleetProvider:
         self, png_bytes: bytes, model: str, prompt: str = "", *, timeout: float | None = None
     ) -> str:
         from lilbee.core.config import cfg
-        from lilbee.vision import OCR_PROMPT, build_vision_messages
+        from lilbee.vision import build_vision_messages, resolve_ocr_prompt
 
         self._require_configured_model(model, str(cfg.vision_model), WorkerRole.VISION)
         clients = self._require_clients(WorkerRole.VISION)
-        messages = build_vision_messages(prompt or OCR_PROMPT, png_bytes)
+        effective = model or str(cfg.vision_model)
+        messages = build_vision_messages(prompt or resolve_ocr_prompt(effective), png_bytes)
         return _vision_call(_least_in_flight(clients), messages, timeout)
 
     def pdf_ocr(
@@ -585,16 +586,19 @@ class FleetProvider:
         from lilbee.core.config import cfg
         from lilbee.runtime.progress import EventType, ExtractEvent
         from lilbee.vision import (
-            OCR_PROMPT,
             PageText,
             build_vision_messages,
             pdf_page_count,
             rasterize_pdf,
+            resolve_ocr_prompt,
         )
 
         del quiet  # protocol parity; no server-side Rich progress to suppress.
         self._require_configured_model(model, str(cfg.vision_model), WorkerRole.VISION)
         clients = self._require_clients(WorkerRole.VISION)
+        # The model is fixed for the whole document, so resolve its prompt once.
+        ocr_prompt = resolve_ocr_prompt(model or str(cfg.vision_model))
+        log.debug("OCR prompt for %s -> %r", model or cfg.vision_model, ocr_prompt)
         total = pdf_page_count(path)
         # One document-wide deadline (pages*per_page + load grace), not a per-page
         # cap: each page gets whatever budget remains, so a slow page borrows from
@@ -603,7 +607,7 @@ class FleetProvider:
         deadline = (time.monotonic() + budget) if budget is not None else None
 
         def _ocr(idx: int, png: bytes) -> tuple[int, str]:
-            messages = build_vision_messages(OCR_PROMPT, png)
+            messages = build_vision_messages(ocr_prompt, png)
             remaining = max(0.0, deadline - time.monotonic()) if deadline is not None else None
             try:
                 return idx, _vision_call(_least_in_flight(clients), messages, remaining)

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -249,9 +249,9 @@ class SdkLLMProvider(LLMProvider):
         timeout: float | None = None,
     ) -> str:
         """OCR via a multipart chat completion; ``timeout`` enforced via thread pool."""
-        from lilbee.vision import OCR_PROMPT, build_vision_messages
+        from lilbee.vision import build_vision_messages, resolve_ocr_prompt
 
-        messages = build_vision_messages(prompt or OCR_PROMPT, png_bytes)
+        messages = build_vision_messages(prompt or resolve_ocr_prompt(model), png_bytes)
         if timeout and timeout > 0:
             from concurrent.futures import ThreadPoolExecutor
 

--- a/src/lilbee/vision.py
+++ b/src/lilbee/vision.py
@@ -36,6 +36,23 @@ OCR_PROMPT = (
     "Include all rows, columns, headers, and page text exactly as shown."
 )
 
+# Lowercase family token (as in the model ref or GGUF path) -> the model's
+# documented OCR prompt. Unlisted models fall back to OCR_PROMPT.
+_NATIVE_OCR_PROMPTS: tuple[tuple[str, str], ...] = (
+    ("deepseek-ocr", "<|grounding|>Convert the document to markdown."),
+    ("glm-ocr", "OCR"),
+)
+
+
+def resolve_ocr_prompt(model_ref: str) -> str:
+    """Return *model_ref*'s native OCR prompt, or the generic one if it has none."""
+    needle = model_ref.lower()
+    for family, prompt in _NATIVE_OCR_PROMPTS:
+        if family in needle:
+            return prompt
+    return OCR_PROMPT
+
+
 _RASTER_DPI = 150
 
 

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -159,3 +159,29 @@ class TestBuildVisionMessages:
         assert content[0]["image_url"]["url"].startswith("data:image/png;base64,")
         assert content[1]["type"] == "text"
         assert content[1]["text"] == "describe this"
+
+
+class TestResolveOcrPrompt:
+    """The OCR prompt is resolved per model: native for specialists, generic fallback otherwise."""
+
+    def test_deepseek_gets_its_grounding_prompt(self):
+        from lilbee.vision import resolve_ocr_prompt
+
+        prompt = resolve_ocr_prompt("ggml-org/DeepSeek-OCR-GGUF")
+        assert prompt == "<|grounding|>Convert the document to markdown."
+
+    def test_glm_ocr_gets_terse_prompt(self):
+        from lilbee.vision import resolve_ocr_prompt
+
+        assert resolve_ocr_prompt("ggml-org/GLM-OCR-GGUF") == "OCR"
+
+    def test_match_is_case_insensitive_and_works_on_a_gguf_path(self):
+        from lilbee.vision import resolve_ocr_prompt
+
+        path = "/models/ggml-org/GLM-OCR-GGUF/glm-ocr-Q8_0.gguf"
+        assert resolve_ocr_prompt(path) == "OCR"
+
+    def test_unknown_model_falls_back_to_generic_prompt(self):
+        from lilbee.vision import OCR_PROMPT, resolve_ocr_prompt
+
+        assert resolve_ocr_prompt("unsloth/Qwen3-VL-8B-Instruct-GGUF") == OCR_PROMPT


### PR DESCRIPTION
## Problem

Vision OCR sends one fixed prompt to every model. `OCR_PROMPT` is a generic "extract as clean markdown" instruction, but OCR-specialist models are trained on their own prompt (GLM-OCR expects `"OCR"`, DeepSeek-OCR a `<|grounding|>` instruction). Sending the generic prompt to those models quietly handicaps exactly the models that should be strongest on scanned pages, which skews any comparison between vision models toward the instruction-following general VLMs.

## Solution

`resolve_ocr_prompt(model)` picks a model's native OCR prompt by family token and falls back to the generic `OCR_PROMPT` for anything unlisted, so no existing model regresses. Only prompts verified from the model's own docs are listed (GLM-OCR, DeepSeek-OCR today); the map is trivial to extend. Wired through the fleet provider (`vision_ocr` + `pdf_ocr`) and the sdk provider; an explicit caller prompt still wins. `pdf_ocr` logs the resolved prompt once per document so a run can confirm each model got the right one.

Covered by unit tests for the resolver (native prompts, case-insensitive path match, generic fallback); existing vision and fleet-provider tests pass unchanged.