### PR TITLE
Fix web crawling on Linux (bundled node segfault)

### DIFF
--- a/.github/workflows/flatpak-validate.yml
+++ b/.github/workflows/flatpak-validate.yml
@@ -154,5 +154,14 @@ jobs:
           echo "stdout: $ACTUAL (exit=$RC)"
           [ $RC -eq 0 ] && [ "$ACTUAL" = "$EXPECTED" ] || { echo "FAIL: unpacked"; exit 1; }
           echo "PASS: binary boots inside the Flatpak sandbox"
+          NODE=$(echo "$XDG_CACHE_HOME"/lilbee/*/playwright/driver/node)
+          echo "=== crawler: bundled Playwright node must not segfault: $NODE ==="
+          [ -x "$NODE" ] || { echo "FAIL: bundled node missing"; exit 1; }
+          "$NODE" --version; RC=$?
+          [ $RC -eq 0 ] || { echo "FAIL: bundled node segfaults (exit=$RC)"; exit 1; }
+          echo "=== crawler: setup crawler must install Chromium ==="
+          "$BIN" setup crawler; RC=$?
+          [ $RC -eq 0 ] || { echo "FAIL: setup crawler (exit=$RC)"; exit 1; }
+          echo "PASS: crawler installs inside the Flatpak sandbox"
           EOF
           flatpak run --command=sh md.obsidian.Obsidian "$APPDATA/data/lilbee/validate.sh"

--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -42,6 +42,23 @@ for f in "$SITE_PKG"/*__mypyc*.so; do
     MYPYC_FLAGS+=("--include-data-files=$f=$(basename "$f")")
 done
 
+# Nuitka shells out to `patchelf` to rewrite bundled binaries' RPATHs. The
+# patchelf 0.17.2 in the manylinux build image corrupts large binaries with many
+# notes, which silently breaks Playwright's ~121MB `node` driver: it segfaults at
+# startup, so `lilbee setup crawler` dies with SIGSEGV. Pin a known-good patchelf
+# ahead of it on PATH. Linux only; macOS relocates with install_name_tool.
+if [ "$(uname -s)" = "Linux" ]; then
+    PATCHELF_VERSION=0.14.5
+    PATCHELF_SHA256=514bb05d8f0e41ea0a6cb999041acb6aa386662e9ccdbdfbbfca469fb22d44fa
+    PATCHELF_DIR=$(mktemp -d)
+    curl -fsSL -o "$PATCHELF_DIR/patchelf.tar.gz" \
+        "https://github.com/NixOS/patchelf/releases/download/${PATCHELF_VERSION}/patchelf-${PATCHELF_VERSION}-x86_64.tar.gz"
+    echo "${PATCHELF_SHA256}  ${PATCHELF_DIR}/patchelf.tar.gz" | sha256sum -c -
+    tar -xf "$PATCHELF_DIR/patchelf.tar.gz" -C "$PATCHELF_DIR"
+    export PATH="$PATCHELF_DIR/bin:$PATH"
+    patchelf --version
+fi
+
 uv run --no-sync python -m nuitka \
     --mode=onefile \
     --no-deployment-flag=self-execution \


### PR DESCRIPTION
## Problem

Web crawling is broken on Linux. `lilbee setup crawler` (and the first crawl) fails with `Chromium bootstrap failed (exit -11)`: the Playwright `node` driver bundled in the release binary segfaults at startup, before it can download Chromium. It hits every Linux user of the standalone binary (direct download, AUR, Snap, Flatpak, and the Obsidian plugin, which downloads the same binary), and only surfaced now because it was first tried through Obsidian's Flatpak.

Root cause: the `patchelf` 0.17.2 in the manylinux build image corrupts large binaries with many notes when Nuitka rewrites their RPATH. The ~121MB `node` driver is exactly such a binary, so it ships byte-corrupted and segfaults on launch (even `node --version`, on a bare host, outside any sandbox). Removing the injected RPATH afterward doesn't repair it; patchelf 0.14.5 and 0.18.0 don't corrupt it at all. Fixes #353.

## Solution

Pin a known-good `patchelf` (0.14.5, checksum-verified) ahead of the image's on PATH for the Nuitka build, so `node` is no longer corrupted. The existing Flatpak sandbox check only ran `--version`, which is why this slipped through; it now also asserts the bundled `node` runs and that `setup crawler` installs Chromium inside the sandbox, so the crawler can't regress silently.

Verified by the extended `flatpak-validate` run: boots, `node --version`, and `setup crawler` all green inside the Obsidian sandbox.

A follow-up will ship the driver verbatim so `node` is never patched in the first place, removing the dependency on the build image's patchelf version.
