### PR TITLE
Ship the Playwright node driver verbatim (drop the patchelf pin)

### DIFF
--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -42,25 +42,9 @@ for f in "$SITE_PKG"/*__mypyc*.so; do
     MYPYC_FLAGS+=("--include-data-files=$f=$(basename "$f")")
 done
 
-# Nuitka shells out to `patchelf` to rewrite bundled binaries' RPATHs. The
-# patchelf 0.17.2 in the manylinux build image corrupts large binaries with many
-# notes, which silently breaks Playwright's ~121MB `node` driver: it segfaults at
-# startup, so `lilbee setup crawler` dies with SIGSEGV. Pin a known-good patchelf
-# ahead of it on PATH. Linux only; macOS relocates with install_name_tool.
-if [ "$(uname -s)" = "Linux" ]; then
-    PATCHELF_VERSION=0.14.5
-    PATCHELF_SHA256=514bb05d8f0e41ea0a6cb999041acb6aa386662e9ccdbdfbbfca469fb22d44fa
-    PATCHELF_DIR=$(mktemp -d)
-    curl -fsSL -o "$PATCHELF_DIR/patchelf.tar.gz" \
-        "https://github.com/NixOS/patchelf/releases/download/${PATCHELF_VERSION}/patchelf-${PATCHELF_VERSION}-x86_64.tar.gz"
-    echo "${PATCHELF_SHA256}  ${PATCHELF_DIR}/patchelf.tar.gz" | sha256sum -c -
-    tar -xf "$PATCHELF_DIR/patchelf.tar.gz" -C "$PATCHELF_DIR"
-    export PATH="$PATCHELF_DIR/bin:$PATH"
-    patchelf --version
-fi
-
 uv run --no-sync python -m nuitka \
     --mode=onefile \
+    --user-plugin=tools/wheel-build/playwright_node_verbatim.py \
     --no-deployment-flag=self-execution \
     --onefile-cache-mode=cached \
     --onefile-tempdir-spec='{CACHE_DIR}/lilbee/{VERSION}' \

--- a/tools/wheel-build/playwright_node_verbatim.py
+++ b/tools/wheel-build/playwright_node_verbatim.py
@@ -1,0 +1,48 @@
+"""Nuitka plugin: ship Playwright's `node` driver byte-for-byte.
+
+Nuitka treats ``playwright/driver/node`` as a relocatable binary and rewrites
+its RPATH with ``patchelf``. patchelf corrupts that ~121 MB binary (it has many
+ELF notes), so the bundled node segfaults at startup and ``lilbee setup
+crawler`` dies with SIGSEGV. node needs no RPATH -- it resolves its libraries
+from the system loader -- so the rewrite is both unnecessary and harmful.
+
+This restores the pristine node bytes after Nuitka has copied and patched it,
+keeping node's executable entry-point handling (permissions, onefile packaging)
+untouched. It removes the dependency on the build image's patchelf version.
+"""
+
+import os
+import shutil
+
+from nuitka.plugins.PluginBase import NuitkaPluginBase
+
+_NODE_REL_PATH = "playwright/driver/node"
+
+
+class NuitkaPluginPlaywrightNodeVerbatim(NuitkaPluginBase):
+    plugin_name = "playwright-node-verbatim"
+    plugin_desc = "Restore Playwright's node driver to its pristine, unpatched bytes."
+
+    @staticmethod
+    def isAlwaysEnabled():
+        return True
+
+    def _pristine_node(self):
+        playwright_path = self.locateModule("playwright")
+        if not playwright_path:
+            return None
+        if os.path.isfile(playwright_path):  # __init__.py rather than the package dir
+            playwright_path = os.path.dirname(playwright_path)
+        node = os.path.join(playwright_path, "driver", "node")
+        return node if os.path.isfile(node) else None
+
+    def onCopiedDLL(self, dll_filename):
+        if not dll_filename.replace(os.sep, "/").endswith(_NODE_REL_PATH):
+            return
+        pristine = self._pristine_node()
+        if pristine is None:
+            self.sysexit("playwright-node-verbatim: could not locate the pristine node driver")
+        mode = os.stat(dll_filename).st_mode
+        shutil.copyfile(pristine, dll_filename)
+        os.chmod(dll_filename, mode)
+        self.info("Restored Playwright node driver verbatim: %s" % dll_filename)


### PR DESCRIPTION
## Problem

b497 fixed the Linux crawler segfault by pinning patchelf 0.14.5 in the build, to dodge the manylinux image's patchelf 0.17.2 corrupting Playwright's ~121MB `node` driver. That works, but it's a version pin: it depends on the build image shipping a specific patchelf, and it still leaves `node` modified (it gets an RPATH it never needed).

## Solution

Ship the `node` driver verbatim. A small Nuitka user-plugin restores the pristine `node` bytes right after Nuitka copies and RPATH-patches it, so the bundled binary is byte-identical to the upstream Playwright driver no matter which patchelf the build image ships. `node` resolves its libraries from the system loader, so it never needed an RPATH; removing the rewrite is both correct and harmless. The patchelf pin is dropped entirely.

Verified: the plugin's `onCopiedDLL` hook fires and the built `node`'s sha256 matches the pip-installed Playwright `node`, and it runs. The Flatpak sandbox crawler check added in b497 still gates this end to end (boots, `node --version`, `setup crawler` installs Chromium).
