### PR TITLE
Surface real engine failure cause instead of 'exited prematurely'

### DIFF
--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -103,10 +103,13 @@ def _raise_for_status(resp: httpx.Response) -> None:
             kind=ProviderErrorKind.RATE_LIMIT,
         )
     detail = f": {body[:600]}" if body else ""
-    # llama-swap reports a dead server only as "exited prematurely"; log the
-    # server's own captured output so the actual exit reason is diagnosable.
+    # llama-swap masks a dead server as "exited prematurely"; surface the server's
+    # own captured output (a missing CUDA runtime, a model load failure, a bind
+    # error) so the real exit reason reaches the caller, not only the log.
     if _UPSTREAM_DIED_MARKER in body:
-        _log_upstream_tail(resp)
+        tail = _upstream_failure_tail(resp)
+        if tail:
+            detail = f"{detail}\nupstream server output:\n{tail}"
     raise ProviderError(
         f"llama-server returned HTTP {resp.status_code}{detail}",
         provider=_PROVIDER_NAME,
@@ -136,14 +139,16 @@ def is_connection_failure(exc: Exception) -> bool:
     return isinstance(exc, ProviderError) and exc.kind is ProviderErrorKind.CONNECTION
 
 
-def _log_upstream_tail(resp: httpx.Response) -> None:
-    """Log the dead upstream's recent output from llama-swap's log stream."""
+def _upstream_failure_tail(resp: httpx.Response) -> str:
+    """Return (and log) the dead upstream's recent output, or empty when unreadable."""
     with contextlib.suppress(httpx.HTTPError, json.JSONDecodeError, KeyError, TypeError):
         base = str(resp.request.url).split("/v1/")[0]
         model = json.loads(resp.request.content)["model"]
         tail = _fetch_log_tail(f"{base}/logs/stream/{model}")
         if tail:
             log.warning("%s exited prematurely; recent server output:\n%s", model, tail)
+            return tail
+    return ""
 
 
 def _fetch_log_tail(url: str) -> str:

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -516,9 +516,10 @@ def _premature_exit_response() -> httpx.Response:
     )
 
 
-def test_raise_for_status_logs_upstream_tail_on_premature_exit(monkeypatch, caplog) -> None:
-    # llama-swap masks the dead server's stderr behind "exited prematurely";
-    # the client fetches the upstream's captured output and logs it.
+def test_raise_for_status_surfaces_upstream_tail_on_premature_exit(monkeypatch, caplog) -> None:
+    # llama-swap masks the dead server's stderr behind "exited prematurely"; the
+    # client fetches the upstream's captured output, logs it, AND surfaces it in
+    # the raised error so the real exit reason reaches the caller.
     import lilbee.providers.fleet.client as client_mod
     from lilbee.providers.fleet.client import _raise_for_status
 
@@ -542,10 +543,13 @@ def test_raise_for_status_logs_upstream_tail_on_premature_exit(monkeypatch, capl
         return _FakeStream()
 
     monkeypatch.setattr(client_mod.httpx, "stream", _fake_stream)
-    with caplog.at_level("WARNING"), pytest.raises(ProviderError, match="exited prematurely"):
+    with caplog.at_level("WARNING"), pytest.raises(ProviderError) as excinfo:
         _raise_for_status(_premature_exit_response())
     assert seen["url"] == "http://127.0.0.1:9100/logs/stream/embed-0"
+    # The captured server output is both logged and surfaced in the error message.
     assert "couldn't bind HTTP server socket" in caplog.text
+    assert "couldn't bind HTTP server socket" in str(excinfo.value)
+    assert "exited prematurely" in str(excinfo.value)
 
 
 def test_raise_for_status_premature_exit_survives_log_fetch_failure(monkeypatch) -> None:
@@ -557,8 +561,11 @@ def test_raise_for_status_premature_exit_survives_log_fetch_failure(monkeypatch)
         raise httpx.ConnectError("refused")
 
     monkeypatch.setattr(client_mod.httpx, "stream", _refuse)
-    with pytest.raises(ProviderError, match="exited prematurely"):
+    with pytest.raises(ProviderError) as excinfo:
         _raise_for_status(_premature_exit_response())
+    # An unreadable tail appends nothing; the original error still propagates.
+    assert "exited prematurely" in str(excinfo.value)
+    assert "upstream server output:" not in str(excinfo.value)
 
 
 def test_chat_stream_surfaces_server_error_body() -> None:
@@ -1068,7 +1075,7 @@ def test_raise_for_status_tags_premature_exit_as_connection(monkeypatch) -> None
     from lilbee.providers.base import ProviderErrorKind
     from lilbee.providers.fleet.client import _raise_for_status
 
-    monkeypatch.setattr(client_mod, "_log_upstream_tail", lambda _resp: None)
+    monkeypatch.setattr(client_mod, "_upstream_failure_tail", lambda _resp: "")
     with pytest.raises(ProviderError) as excinfo:
         _raise_for_status(_premature_exit_response())
     assert excinfo.value.kind is ProviderErrorKind.CONNECTION


### PR DESCRIPTION
## Problem

When a fleet llama-server replica dies, the orchestrator reports it only as "upstream command exited prematurely." The client already fetches the server's own captured output, which carries the real cause (a missing CUDA runtime, a model that failed to load, a port that couldn't bind), but it only writes that to the log. Callers, and therefore the API response and opencode, see just the opaque marker. During the QA run this hid a real startup failure behind a generic error for a long time.

## Solution

Surface the captured output instead of only logging it. The helper that fetches the dead upstream's recent output now returns it, and the error path appends it to the raised error so the actual exit reason travels with the failure. When the log stream can't be read, behavior is unchanged and the original error still propagates.

Tests cover that the captured output is both logged and present in the raised error.