### PR TITLE
Fix the Agents footer link on the site

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -506,7 +506,7 @@
         <a href="https://pypi.org/project/lilbee/"><span class="num">[2]</span><span>PyPI</span><span class="dots">·······································</span><span class="desc">package</span></a>
         <a href="api/"><span class="num">[3]</span><span>API docs</span><span class="dots">·······································</span><span class="desc">openapi</span></a>
         <a href="https://github.com/tobocop2/lilbee/blob/main/docs/usage.md"><span class="num">[4]</span><span>Usage guide</span><span class="dots">·······································</span><span class="desc">commands</span></a>
-        <a href="https://github.com/tobocop2/lilbee/blob/main/docs/agent-integration.md"><span class="num">[5]</span><span>Agents</span><span class="dots">·······································</span><span class="desc">mcp / cli</span></a>
+        <a href="https://github.com/tobocop2/lilbee#agent-integration"><span class="num">[5]</span><span>Agents</span><span class="dots">·······································</span><span class="desc">mcp / cli</span></a>
         <a href="coverage/"><span class="num">[6]</span><span>Coverage</span><span class="dots">·······································</span><span class="desc">100%</span></a>
         <a href="https://github.com/tobocop2/lilbee/releases"><span class="num">[7]</span><span>Changelog</span><span class="dots">·······································</span><span class="desc">releases</span></a>
         <a href="https://github.com/tobocop2/lilbee/tree/main/docs/benchmarks"><span class="num">[8]</span><span>Benchmarks</span><span class="dots">·······································</span><span class="desc">godot . ocr</span></a>


### PR DESCRIPTION
## Problem

The site footer's `[5] Agents` link points at `docs/agent-integration.md`, which doesn't exist, so it 404s.

## Solution

Point it at the README's Agent integration section: https://github.com/tobocop2/lilbee#agent-integration