### PR TITLE
Cap vision OCR concurrency at the fleet's real slot count (429 storm)

### DIFF
--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -179,6 +179,33 @@ def _supports_tools_cached(path_str: str, _mtime_ns: int) -> bool:
     return _TOOL_TEMPLATE_PATTERN.search(template) is not None
 
 
+class _VisionRequestGate:
+    """Process-wide cap on concurrent vision-server requests at the fleet's OCR slots.
+
+    The ingest file fan-out runs many files at once and each file's ``pdf_ocr`` opens
+    its own ``vision_ocr_concurrency`` page pool, so without a shared cap the aggregate
+    over-subscribes a single-replica vision server into a 429 storm. The semaphore is
+    rebuilt when the configured capacity (``vision_replicas * vision_ocr_concurrency``)
+    changes.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._capacity = 0
+        self._semaphore: threading.BoundedSemaphore | None = None
+
+    def semaphore(self) -> threading.BoundedSemaphore:
+        capacity = max(1, cfg.vision_replicas * cfg.vision_ocr_concurrency)
+        with self._lock:
+            if self._semaphore is None or self._capacity != capacity:
+                self._capacity = capacity
+                self._semaphore = threading.BoundedSemaphore(capacity)
+            return self._semaphore
+
+
+_VISION_GATE = _VisionRequestGate()
+
+
 def _vision_call(
     client: LlamaServerClient, messages: Sequence[Mapping[str, Any]], timeout: float | None
 ) -> str:
@@ -188,6 +215,7 @@ def _vision_call(
     on one page (seen looping to tens of thousands of chars) can't dominate a
     scan's OCR time; a real page stays well under the cap. A timeout surfaces as
     a ``ProviderError`` so the page-level OCR caller can fail just that page.
+    Callers hold ``_VISION_GATE`` so queue time isn't billed against the timeout.
     """
     from lilbee.core.config import cfg
 
@@ -220,6 +248,46 @@ def _bounded_vision_chat(
         ) from None
     finally:
         pool.shutdown(wait=False, cancel_futures=True)
+
+
+def _ocr_pdf_page(
+    idx: int,
+    png: bytes,
+    *,
+    clients: list[LlamaServerClient],
+    ocr_prompt: str,
+    deadline: float | None,
+    page_path: Path,
+) -> tuple[int, str]:
+    """OCR one rasterized page through the gated vision server; empty text on failure.
+
+    Acquires the gate before reading the clock so queue time isn't billed against the
+    page's share of the document-wide deadline; an exhausted budget skips the page
+    rather than running it un-timed.
+    """
+    from lilbee.vision import build_vision_messages
+
+    messages = build_vision_messages(ocr_prompt, png)
+    with _VISION_GATE.semaphore():
+        remaining = max(0.0, deadline - time.monotonic()) if deadline is not None else None
+        if remaining == 0.0:
+            log.warning(
+                "Vision OCR budget exhausted before page %d of %s; skipping.",
+                idx + 1,
+                page_path.name,
+            )
+            return idx, ""
+        try:
+            return idx, _vision_call(_least_in_flight(clients), messages, remaining)
+        except ProviderError:
+            # One failed/timed-out page yields empty text; siblings continue.
+            log.warning(
+                "Vision OCR failed for page %d of %s; skipping that page.",
+                idx + 1,
+                page_path.name,
+                exc_info=True,
+            )
+            return idx, ""
 
 
 def _pdf_drain_budget(total_pages: int, per_page_timeout_s: float | None) -> float | None:
@@ -563,7 +631,8 @@ class FleetProvider:
         clients = self._require_clients(WorkerRole.VISION)
         effective = model or str(cfg.vision_model)
         messages = build_vision_messages(prompt or resolve_ocr_prompt(effective), png_bytes)
-        return _vision_call(_least_in_flight(clients), messages, timeout)
+        with _VISION_GATE.semaphore():
+            return _vision_call(_least_in_flight(clients), messages, timeout)
 
     def pdf_ocr(
         self,
@@ -587,7 +656,6 @@ class FleetProvider:
         from lilbee.runtime.progress import EventType, ExtractEvent
         from lilbee.vision import (
             PageText,
-            build_vision_messages,
             pdf_page_count,
             rasterize_pdf,
             resolve_ocr_prompt,
@@ -606,20 +674,13 @@ class FleetProvider:
         budget = _pdf_drain_budget(total, per_page_timeout_s)
         deadline = (time.monotonic() + budget) if budget is not None else None
 
-        def _ocr(idx: int, png: bytes) -> tuple[int, str]:
-            messages = build_vision_messages(ocr_prompt, png)
-            remaining = max(0.0, deadline - time.monotonic()) if deadline is not None else None
-            try:
-                return idx, _vision_call(_least_in_flight(clients), messages, remaining)
-            except ProviderError:
-                # One failed/timed-out page yields empty text; siblings continue.
-                log.warning(
-                    "Vision OCR failed for page %d of %s; skipping that page.",
-                    idx + 1,
-                    path.name,
-                    exc_info=True,
-                )
-                return idx, ""
+        _ocr = functools.partial(
+            _ocr_pdf_page,
+            clients=clients,
+            ocr_prompt=ocr_prompt,
+            deadline=deadline,
+            page_path=path,
+        )
 
         # OCR pages concurrently (a single-page decode underuses the GPU; the vision
         # server runs cfg.vision_ocr_concurrency batching slots). A bounded sliding

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -303,6 +303,78 @@ def test_vision_call_caps_output_tokens(monkeypatch) -> None:
     assert client.chat.call_args.kwargs["options"] == {"max_tokens": 4096}
 
 
+def test_vision_request_gate_tracks_fleet_capacity(monkeypatch) -> None:
+    # The gate must cap in-flight vision requests at the fleet's real OCR capacity
+    # (replicas x per-server slots) and rebuild when that capacity changes.
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 3)
+    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
+    gate = prov_mod._VISION_GATE.semaphore()
+    assert prov_mod._VISION_GATE._capacity == 12
+    monkeypatch.setattr(cfg, "vision_replicas", 1)
+    assert prov_mod._VISION_GATE.semaphore() is not gate
+    assert prov_mod._VISION_GATE._capacity == 4
+
+
+def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
+    # The ingest file fan-out can launch far more concurrent OCR requests than the
+    # vision server has slots; the gate (held by every vision entry point) caps
+    # concurrent holders at vision_replicas * vision_ocr_concurrency so a
+    # single-replica server isn't 429-stormed. All callers still run.
+    import threading
+    import time
+
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 1)
+    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
+
+    lock = threading.Lock()
+    live = 0
+    peak = 0
+    ran = 0
+
+    def _hold() -> None:
+        nonlocal live, peak, ran
+        with prov_mod._VISION_GATE.semaphore():
+            with lock:
+                live += 1
+                peak = max(peak, live)
+            time.sleep(0.02)
+            with lock:
+                live -= 1
+                ran += 1
+
+    threads = [threading.Thread(target=_hold) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert peak == 2  # the cap is both reached and never exceeded
+    assert ran == 8  # every caller ran, just serialized through the gate
+
+
+def test_ocr_pdf_page_skips_when_budget_exhausted(monkeypatch) -> None:
+    # A page that waited out the document deadline while queued is skipped (empty
+    # text), not run un-timed -- a 0 timeout would disable the per-page cap.
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
+    monkeypatch.setattr("lilbee.vision.build_vision_messages", lambda *_a, **_k: [])
+    called: list[object] = []
+    monkeypatch.setattr(prov_mod, "_vision_call", lambda *a, **_k: called.append(a) or "ocr")
+    idx, text = prov_mod._ocr_pdf_page(
+        3,
+        b"\x89PNG",
+        clients=[_fake_client()],
+        ocr_prompt="describe",
+        deadline=time.monotonic() - 1.0,  # already past
+        page_path=Path("doc.pdf"),
+    )
+    assert (idx, text) == (3, "")
+    assert called == []  # _vision_call never ran
+
+
 def test_chat_streams_from_server() -> None:
     client = _fake_client(0)
     client.chat_stream_items.return_value = iter(["a", "b"])


### PR DESCRIPTION
## Problem

On a single-GPU host, ingesting many scanned or image files floods the vision server with HTTP 429s and most pages silently fail. The ingest pipeline processes a batch of files concurrently, and each file's PDF OCR already opens its own page-level worker pool sized to the per-server OCR slot count. Those two layers multiply: the total in-flight vision requests become (files in flight) times (per-file page workers), while a single-replica vision server only has the one server's worth of slots. The overflow comes back as 429 and the client drops those pages.

## Solution

Add a process-wide gate around the single vision-request choke point, shared by both image and PDF OCR, sized to the fleet's real OCR capacity (replicas times per-server slots). Total in-flight requests now stay at the server's capacity no matter how many files OCR at once; every page still runs, just serialized through the gate. The gate is a small class holding a bounded semaphore that it rebuilds if the configured capacity changes.

Tests cover the gate tracking the configured capacity and that concurrent calls never exceed the cap while all still complete.