### PR TITLE
Register quant-subdir model refs (missing from model list / v1/models)

### DIFF
--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -254,7 +254,10 @@ class ModelRegistry:
         """
         manifest_dir = self._manifests_dir / repo_to_dir(hf_repo)
         if manifest_dir.is_dir():
-            for mf in sorted(manifest_dir.glob("*.gguf.json")):
+            # rglob, like list_installed: a quant-subdir ref writes its manifest one
+            # directory deeper, so a non-recursive scan would miss it and fall through
+            # to the slower huggingface_hub cache recovery.
+            for mf in sorted(manifest_dir.rglob("*.gguf.json")):
                 manifest = self._load_manifest_file(mf)
                 if manifest is None or manifest.blob is None:
                     continue
@@ -474,7 +477,11 @@ class ModelRegistry:
         for repo_dir in sorted(self._manifests_dir.iterdir()):
             if not repo_dir.is_dir():
                 continue
-            for tag_file in sorted(repo_dir.glob("*.gguf.json")):
+            # rglob, not glob: a quant-subdir ref (unsloth stores quants under e.g.
+            # Q4_K_S/<model>.gguf) writes its manifest one level deeper, so a
+            # non-recursive scan omitted it from `model list` and /v1/models, and
+            # opencode silently fell back to its own provider.
+            for tag_file in sorted(repo_dir.rglob("*.gguf.json")):
                 manifest = self._load_manifest_file(tag_file)
                 if manifest is not None and self._blob_present(manifest):
                     manifests.append(manifest)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -296,8 +296,62 @@ class TestModelRegistryInstall:
         listed = registry.list_installed()
         assert listed[0].blob == hashlib.sha256(content).hexdigest()
 
+    def test_list_installed_includes_quant_subdir_ref(self, tmp_path: Path) -> None:
+        # unsloth stores quants under a subdirectory (Q4_K_S/<model>.gguf), so the
+        # manifest is written one level deeper than a flat ref. A non-recursive scan
+        # dropped it from `model list` + /v1/models, silently sending opencode to
+        # its fallback provider, so the recursive scan must surface it.
+        repo = "unsloth/MiniMax-M2-GGUF"
+        subdir_ref = "Q4_K_S/MiniMax-M2-Q4_K_S-00001-of-00003.gguf"
+        registry = ModelRegistry(tmp_path)
+        content = b"GGUF" + b"\x00" * 256
+        src = tmp_path / "source.gguf"
+        src.write_bytes(content)
+        manifest = _make_manifest(hf_repo=repo, gguf_filename=subdir_ref, size_bytes=len(content))
+        registry.install(repo, subdir_ref, src, manifest)
+        assert f"{repo}/{subdir_ref}" in [m.ref for m in registry.list_installed()]
+
+    def test_list_installed_includes_flat_and_subdir_quants_in_one_repo(
+        self, tmp_path: Path
+    ) -> None:
+        # A flat quant and a quant-subdir quant of the same repo both register and
+        # surface as distinct refs (the recursive scan must not drop or merge them).
+        repo = "unsloth/Some-GGUF"
+        registry = ModelRegistry(tmp_path)
+        flat = "Some-Q8_0.gguf"
+        subdir = "Q4_K_M/Some-Q4_K_M.gguf"
+        for filename, byte in ((flat, b"\x01"), (subdir, b"\x02")):
+            content = b"GGUF" + byte * 256
+            src = tmp_path / f"{byte!r}.gguf"
+            src.write_bytes(content)
+            registry.install(
+                repo,
+                filename,
+                src,
+                _make_manifest(hf_repo=repo, gguf_filename=filename, size_bytes=len(content)),
+            )
+        refs = {m.ref for m in registry.list_installed()}
+        assert refs == {f"{repo}/{flat}", f"{repo}/{subdir}"}
+
 
 class TestModelRegistryResolve:
+    def test_resolve_repo_only_finds_quant_subdir_manifest(self, tmp_path: Path) -> None:
+        # A bare org/repo ref must resolve through the fast manifest path even when
+        # the installed quant lives in a subdir, not fall through to cache recovery.
+        repo = "unsloth/Some-GGUF"
+        subdir_ref = "Q4_K_M/Some-Q4_K_M.gguf"
+        registry = ModelRegistry(tmp_path)
+        content = b"GGUF" + b"\x00" * 256
+        src = tmp_path / "source.gguf"
+        src.write_bytes(content)
+        registry.install(
+            repo,
+            subdir_ref,
+            src,
+            _make_manifest(hf_repo=repo, gguf_filename=subdir_ref, size_bytes=len(content)),
+        )
+        assert registry.resolve(repo) == registry.resolve(f"{repo}/{subdir_ref}")
+
     def test_resolve_not_installed(self, tmp_path: Path) -> None:
         registry = ModelRegistry(tmp_path)
         with pytest.raises(KeyError, match="not installed"):


### PR DESCRIPTION
## Problem

A model reference whose path carries a quantization subdirectory, like `unsloth/MiniMax-M2-GGUF/Q4_K_S/MiniMax-M2-Q4_K_S-00001-of-00003.gguf`, downloads fully and can be served by path, but never shows up in `lilbee model list` or `GET /v1/models`. Flat references (the shard suffix is in the filename, like gpt-oss) list fine. The consequence is that opencode pins the lilbee model id, fetches the model list, can't find it, and silently serves the chat from its own fallback provider instead of lilbee. MiniMax-M2 was the only such reference in the QA set, and this is why its opencode cell failed.

## Solution

Make the installed-model scan recursive. The registry already parses, validates, and resolves subdirectory refs correctly; the one gap was enumeration. Each pulled model writes a small manifest next to the ref it represents, so a quant-subdir ref lands one directory deeper than a flat one. The scan walked each repo with a non-recursive glob and missed the nested manifests, so switching it to a recursive walk surfaces them like any flat ref.

Includes a test that a quant-subdir reference appears in the installed list after install.