### PR TITLE
Reshape tool conversations for strict-alternation chat templates

### DIFF
--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -26,6 +26,7 @@ from lilbee.providers.base import (
     ToolCallDelta,
 )
 from lilbee.providers.fleet.adapters import LLM_RERANK_CONCURRENCY
+from lilbee.providers.fleet.normalize import to_alternating
 from lilbee.providers.roles import RerankMode
 
 _PROVIDER_NAME = "llama-server"
@@ -57,6 +58,10 @@ _EMBED_EST_CHARS_PER_TOKEN = 3
 _UPSTREAM_DIED_MARKER = "exited prematurely"
 # llama-server's 500 body when one input exceeds the physical batch (n_batch).
 _BATCH_OVERFLOW_MARKER = "too large to process"
+# A strict-alternation GGUF chat template (Mistral-Nemo, Cohere command-r) raises
+# this Jinja exception when an OpenAI tool exchange does not alternate plain
+# user/assistant turns; the chat path retries once with normalized messages.
+_ROLE_ALTERNATION_MARKER = "roles must alternate"
 _UPSTREAM_LOG_TAIL_CHARS = 2000
 _UPSTREAM_LOG_TIMEOUT_S = 2.0
 
@@ -137,6 +142,11 @@ def is_connection_failure(exc: Exception) -> bool:
         return True
     # isinstance: only ProviderError carries a kind; other exceptions pass through.
     return isinstance(exc, ProviderError) and exc.kind is ProviderErrorKind.CONNECTION
+
+
+def _is_role_alternation_error(exc: Exception) -> bool:
+    """Whether *exc* is a strict-alternation chat-template rejection (retriable)."""
+    return isinstance(exc, ProviderError) and _ROLE_ALTERNATION_MARKER in str(exc)
 
 
 def _upstream_failure_tail(resp: httpx.Response) -> str:
@@ -380,22 +390,19 @@ class LlamaServerClient:
         The server is launched with ``--jinja`` so it parses the model's native
         tool-call syntax into structured ``message.tool_calls``. When a model
         instead emits a bare-JSON call as content (a native miss), recover it
-        and report ``tool_calls`` as the finish reason.
+        and report ``tool_calls`` as the finish reason. A strict-alternation
+        template that rejects the tool exchange triggers one retry with
+        :func:`to_alternating` messages.
         """
-        payload: dict[str, Any] = {
-            "model": self._model,
-            "messages": messages,
-            "stream": False,
-            **(options or {}),
-        }
-        if tools is not None:
-            payload["tools"] = tools
-        if tool_choice is not None:
-            payload["tool_choice"] = tool_choice
-        with self._track():
-            resp = self._http.post(_CHAT_PATH, json=payload)
-            _raise_for_status(resp)
-            body = resp.json()
+
+        def _post(msgs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+            payload = self._chat_payload(msgs, tools, tool_choice, options, stream=False)
+            with self._track():
+                resp = self._http.post(_CHAT_PATH, json=payload)
+                _raise_for_status(resp)
+                return dict(resp.json())
+
+        body = self._retry_on_role_alternation(_post, messages)
         choice = body["choices"][0]
         usage = _usage_from_body(body) or TokenUsage()
         message = choice["message"]
@@ -432,27 +439,82 @@ class LlamaServerClient:
         Each SSE chunk's ``choices[0].delta`` carries a ``content`` token and/or
         a ``tool_calls`` array; both are surfaced as :data:`ChatStreamItem`
         frames (text strings and :class:`ToolCallDelta`). The dispatch's stream
-        translator accumulates the deltas by ``index``.
+        translator accumulates the deltas by ``index``. The 500 from a
+        strict-alternation template surfaces on the opening request before any
+        frame is yielded, so one retry with :func:`to_alternating` messages
+        recovers it.
         """
-        payload: dict[str, Any] = {
-            "model": self._model,
-            "messages": messages,
-            # include_usage makes llama-server emit a final SSE chunk carrying the
-            # token usage (with an empty choices list) just before [DONE].
-            "stream_options": {"include_usage": True},
-            **(options or {}),
-        }
-        if tools is not None:
-            payload["tools"] = tools
-        if tool_choice is not None:
-            payload["tool_choice"] = tool_choice
+        yielded = False
+        try:
+            for item in self._open_chat_stream(messages, tools, tool_choice, options):
+                yielded = True
+                yield item
+        except ProviderError as exc:
+            # The 500 surfaces at stream-open, before any frame; only then is a
+            # retry safe (re-running mid-stream would duplicate emitted frames).
+            if yielded or not _is_role_alternation_error(exc):
+                raise
+            yield from self._open_chat_stream(
+                to_alternating([dict(m) for m in messages]), tools, tool_choice, options
+            )
+
+    def _open_chat_stream(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        tool_choice: str | dict[str, Any] | None,
+        options: dict[str, Any] | None,
+    ) -> Iterator[str | ToolCallDelta | TokenUsage]:
+        """Open one SSE chat stream and yield its frames; raises before the first frame."""
+        payload = self._chat_payload(messages, tools, tool_choice, options, stream=True)
         with (
             self._track(),
-            self._http.stream("POST", _CHAT_PATH, json={**payload, "stream": True}) as resp,
+            self._http.stream("POST", _CHAT_PATH, json=payload) as resp,
         ):
             _raise_for_status(resp)
             for line in resp.iter_lines():
                 yield from _parse_sse_stream_items(line)
+
+    def _chat_payload(
+        self,
+        messages: Sequence[Mapping[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        tool_choice: str | dict[str, Any] | None,
+        options: dict[str, Any] | None,
+        *,
+        stream: bool,
+    ) -> dict[str, Any]:
+        """Build the chat-completions request body shared by the stream and non-stream paths."""
+        payload: dict[str, Any] = {"model": self._model, "messages": messages, "stream": stream}
+        if stream:
+            # include_usage makes llama-server emit a final SSE chunk carrying the
+            # token usage (with an empty choices list) just before [DONE].
+            payload["stream_options"] = {"include_usage": True}
+        if tools is not None:
+            payload["tools"] = tools
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+        payload.update(options or {})
+        return payload
+
+    def _retry_on_role_alternation(
+        self,
+        call: Callable[[Sequence[Mapping[str, Any]]], _T],
+        messages: Sequence[Mapping[str, Any]],
+    ) -> _T:
+        """Run *call*, retrying once with normalized messages on an alternation error.
+
+        A strict-alternation chat template (Mistral-Nemo, Cohere command-r) rejects
+        the OpenAI tool exchange with a Jinja exception. The single retry reshapes
+        the messages into strict user/assistant alternation; a second failure (or
+        any non-alternation error) propagates unchanged.
+        """
+        try:
+            return call(messages)
+        except ProviderError as exc:
+            if not _is_role_alternation_error(exc):
+                raise
+            return call(to_alternating([dict(m) for m in messages]))
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed a batch via ``/v1/embeddings``."""

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -10,7 +10,7 @@ import threading
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Literal, TypeVar, overload
+from typing import Any, Literal, TypedDict, TypeVar, overload
 
 import httpx
 
@@ -26,7 +26,7 @@ from lilbee.providers.base import (
     ToolCallDelta,
 )
 from lilbee.providers.fleet.adapters import LLM_RERANK_CONCURRENCY
-from lilbee.providers.fleet.normalize import to_alternating
+from lilbee.providers.fleet.normalize import ChatMessage, to_alternating
 from lilbee.providers.roles import RerankMode
 
 _PROVIDER_NAME = "llama-server"
@@ -58,6 +58,23 @@ _EMBED_EST_CHARS_PER_TOKEN = 3
 _UPSTREAM_DIED_MARKER = "exited prematurely"
 # llama-server's 500 body when one input exceeds the physical batch (n_batch).
 _BATCH_OVERFLOW_MARKER = "too large to process"
+
+
+class _ChatToolSpecFunction(TypedDict, total=False):
+    """The ``function`` payload of an OpenAI tool definition (wire shape)."""
+
+    name: str
+    description: str
+    parameters: dict[str, Any]
+
+
+class ChatTool(TypedDict, total=False):
+    """One OpenAI tool definition sent in a chat request (wire shape)."""
+
+    type: str
+    function: _ChatToolSpecFunction
+
+
 # Some GGUF chat templates (Mistral-Nemo, Cohere command-r) reject a standard
 # OpenAI tool exchange: they require plain user/assistant turns to alternate and
 # raise a Jinja exception on the tool role or two same-role turns in a row. Rather
@@ -67,7 +84,7 @@ _BATCH_OVERFLOW_MARKER = "too large to process"
 # flagged so every later request is reshaped up front. Two assistant tool-call
 # turns separated by tool results is the minimal shape that trips strict
 # alternation; max_tokens=1 keeps the probe to template rendering, not generation.
-_ALTERNATION_PROBE_TOOLS = [
+_ALTERNATION_PROBE_TOOLS: list[ChatTool] = [
     {
         "type": "function",
         "function": {
@@ -83,7 +100,7 @@ _ALTERNATION_PROBE_TOOLS = [
         },
     }
 ]
-_ALTERNATION_PROBE_MESSAGES: list[dict[str, Any]] = [
+_ALTERNATION_PROBE_MESSAGES: list[ChatMessage] = [
     {"role": "system", "content": "You are a helpful assistant."},
     {"role": "user", "content": "Look something up."},
     {
@@ -535,7 +552,7 @@ class LlamaServerClient:
     def _chat_payload(
         self,
         messages: Sequence[Mapping[str, Any]],
-        tools: list[dict[str, Any]] | None,
+        tools: Sequence[Mapping[str, Any]] | None,
         tool_choice: str | dict[str, Any] | None,
         options: dict[str, Any] | None,
         *,

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -58,10 +58,65 @@ _EMBED_EST_CHARS_PER_TOKEN = 3
 _UPSTREAM_DIED_MARKER = "exited prematurely"
 # llama-server's 500 body when one input exceeds the physical batch (n_batch).
 _BATCH_OVERFLOW_MARKER = "too large to process"
-# A strict-alternation GGUF chat template (Mistral-Nemo, Cohere command-r) raises
-# this Jinja exception when an OpenAI tool exchange does not alternate plain
-# user/assistant turns; the chat path retries once with normalized messages.
-_ROLE_ALTERNATION_MARKER = "roles must alternate"
+# Some GGUF chat templates (Mistral-Nemo, Cohere command-r) reject a standard
+# OpenAI tool exchange: they require plain user/assistant turns to alternate and
+# raise a Jinja exception on the tool role or two same-role turns in a row. Rather
+# than fail a real request and parse the engine's error text, the client probes
+# the live template once per server with this representative tool exchange: if the
+# server rejects it as sent but renders the to_alternating() form, the model is
+# flagged so every later request is reshaped up front. Two assistant tool-call
+# turns separated by tool results is the minimal shape that trips strict
+# alternation; max_tokens=1 keeps the probe to template rendering, not generation.
+_ALTERNATION_PROBE_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "probe",
+            "description": "Probe whether the chat template renders a tool exchange.",
+            # A single declared property (rather than an empty object) so a grammar
+            # that requires at least one parameter still renders the probe call.
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+]
+_ALTERNATION_PROBE_MESSAGES: list[dict[str, Any]] = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Look something up."},
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "probe-1",
+                "type": "function",
+                "function": {"name": "probe", "arguments": '{"query": "x"}'},
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "probe-1", "content": "first result"},
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "probe-2",
+                "type": "function",
+                "function": {"name": "probe", "arguments": '{"query": "x"}'},
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "probe-2", "content": "second result"},
+    {"role": "user", "content": "Summarize."},
+]
+_ALTERNATION_PROBE_OPTIONS = {"max_tokens": 1}
+# The probe holds _alternation_lock across its request, so it uses a short, bounded
+# timeout rather than the chat default: a slow/wedged replica yields an inconclusive
+# (transient) result and a re-probe instead of blocking every first chat on the lock.
+_ALTERNATION_PROBE_TIMEOUT_S = 30.0
 _UPSTREAM_LOG_TAIL_CHARS = 2000
 _UPSTREAM_LOG_TIMEOUT_S = 2.0
 
@@ -144,9 +199,13 @@ def is_connection_failure(exc: Exception) -> bool:
     return isinstance(exc, ProviderError) and exc.kind is ProviderErrorKind.CONNECTION
 
 
-def _is_role_alternation_error(exc: Exception) -> bool:
-    """Whether *exc* is a strict-alternation chat-template rejection (retriable)."""
-    return isinstance(exc, ProviderError) and _ROLE_ALTERNATION_MARKER in str(exc)
+def _is_transient_probe_failure(exc: Exception) -> bool:
+    """Whether a probe failure is transient (dead replica or a busy 429), not a
+    template verdict. A cold replica 429s its first traffic, so a busy response
+    must not be read as the template rejecting the exchange."""
+    if is_connection_failure(exc):
+        return True
+    return isinstance(exc, ProviderError) and exc.kind is ProviderErrorKind.RATE_LIMIT
 
 
 def _upstream_failure_tail(resp: httpx.Response) -> str:
@@ -245,6 +304,13 @@ class LlamaServerClient:
         self._rerank_mode = rerank_mode
         self.in_flight = 0
         self._in_flight_lock = threading.Lock()
+        # Whether this server's chat template needs OpenAI tool exchanges reshaped
+        # into strict user/assistant alternation. Determined lazily by a one-time
+        # probe of the live template (see _prepare_chat_messages); None until then.
+        # A client is bound to one model for its lifetime, so the template (hence
+        # the verdict) is fixed once determined.
+        self._needs_alternation: bool | None = None
+        self._alternation_lock = threading.Lock()
         # Routing health: cleared on a connection-level failure (see _UNHEALTHY_RETRY_S).
         self._healthy = True
         # Monotonic stamp of the last mark_unhealthy; consulted only while unhealthy.
@@ -360,7 +426,7 @@ class LlamaServerClient:
         """
         payload: dict[str, Any] = {
             "model": self._model,
-            "messages": messages,
+            "messages": self._prepare_chat_messages(messages),
             "tools": tools,
             "stream": False,
             **(options or {}),
@@ -390,19 +456,17 @@ class LlamaServerClient:
         The server is launched with ``--jinja`` so it parses the model's native
         tool-call syntax into structured ``message.tool_calls``. When a model
         instead emits a bare-JSON call as content (a native miss), recover it
-        and report ``tool_calls`` as the finish reason. A strict-alternation
-        template that rejects the tool exchange triggers one retry with
-        :func:`to_alternating` messages.
+        and report ``tool_calls`` as the finish reason. Messages are reshaped to
+        strict alternation up front when this server's template needs it (see
+        :meth:`_prepare_chat_messages`).
         """
-
-        def _post(msgs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
-            payload = self._chat_payload(msgs, tools, tool_choice, options, stream=False)
-            with self._track():
-                resp = self._http.post(_CHAT_PATH, json=payload)
-                _raise_for_status(resp)
-                return dict(resp.json())
-
-        body = self._retry_on_role_alternation(_post, messages)
+        payload = self._chat_payload(
+            self._prepare_chat_messages(messages), tools, tool_choice, options, stream=False
+        )
+        with self._track():
+            resp = self._http.post(_CHAT_PATH, json=payload)
+            _raise_for_status(resp)
+            body = dict(resp.json())
         choice = body["choices"][0]
         usage = _usage_from_body(body) or TokenUsage()
         message = choice["message"]
@@ -439,24 +503,17 @@ class LlamaServerClient:
         Each SSE chunk's ``choices[0].delta`` carries a ``content`` token and/or
         a ``tool_calls`` array; both are surfaced as :data:`ChatStreamItem`
         frames (text strings and :class:`ToolCallDelta`). The dispatch's stream
-        translator accumulates the deltas by ``index``. The 500 from a
-        strict-alternation template surfaces on the opening request before any
-        frame is yielded, so one retry with :func:`to_alternating` messages
-        recovers it.
+        translator accumulates the deltas by ``index``. Messages are reshaped to
+        strict alternation up front when this server's template needs it (see
+        :meth:`_prepare_chat_messages`), so the open never fails on a template
+        that rejects the raw tool exchange.
+
+        Not a generator: the up-front probe runs when this is called, not deferred
+        to the first iteration, matching the eager non-stream paths.
         """
-        yielded = False
-        try:
-            for item in self._open_chat_stream(messages, tools, tool_choice, options):
-                yielded = True
-                yield item
-        except ProviderError as exc:
-            # The 500 surfaces at stream-open, before any frame; only then is a
-            # retry safe (re-running mid-stream would duplicate emitted frames).
-            if yielded or not _is_role_alternation_error(exc):
-                raise
-            yield from self._open_chat_stream(
-                to_alternating([dict(m) for m in messages]), tools, tool_choice, options
-            )
+        return self._open_chat_stream(
+            self._prepare_chat_messages(messages), tools, tool_choice, options
+        )
 
     def _open_chat_stream(
         self,
@@ -497,24 +554,76 @@ class LlamaServerClient:
         payload.update(options or {})
         return payload
 
-    def _retry_on_role_alternation(
-        self,
-        call: Callable[[Sequence[Mapping[str, Any]]], _T],
-        messages: Sequence[Mapping[str, Any]],
-    ) -> _T:
-        """Run *call*, retrying once with normalized messages on an alternation error.
+    def _prepare_chat_messages(
+        self, messages: Sequence[Mapping[str, Any]]
+    ) -> Sequence[Mapping[str, Any]]:
+        """Reshape *messages* to strict alternation when this server's template needs it.
 
-        A strict-alternation chat template (Mistral-Nemo, Cohere command-r) rejects
-        the OpenAI tool exchange with a Jinja exception. The single retry reshapes
-        the messages into strict user/assistant alternation; a second failure (or
-        any non-alternation error) propagates unchanged.
+        The need is detected once per server by :meth:`_ensure_alternation_probed`
+        (a binary accept/reject of a representative tool exchange against the live
+        template), then cached, so real requests are normalized up front rather
+        than failing and retrying.
         """
+        self._ensure_alternation_probed()
+        if self._needs_alternation:
+            return to_alternating([dict(m) for m in messages])
+        return messages
+
+    def _ensure_alternation_probed(self) -> None:
+        """Probe the live template once to learn whether it needs alternation.
+
+        Caches only a conclusive verdict: a transient unreachable server leaves
+        the flag unset so the next request re-probes rather than locking in a
+        wrong answer.
+        """
+        if self._needs_alternation is not None:
+            return
+        with self._alternation_lock:
+            if self._needs_alternation is not None:
+                return
+            verdict = self._probe_alternation()
+            if verdict is not None:
+                self._needs_alternation = verdict
+
+    def _probe_alternation(self) -> bool | None:
+        """Whether the template needs normalization: ``None`` when undetermined.
+
+        Renders the probe exchange as sent; if the template accepts it, no
+        normalization is needed. If it rejects it, normalization is needed only
+        when the reshaped exchange is accepted. A transient failure on either
+        render is inconclusive (``None``) so no verdict is cached; a genuine
+        rejection of both forms is a conclusive ``False`` (the template fault is
+        unrelated to alternation, so reshaping would not help).
+        """
+        raw = self._chat_probe(_ALTERNATION_PROBE_MESSAGES)
+        if raw is None:
+            return None  # transient; stay undetermined so the next request re-probes
+        if raw:
+            return False  # the template renders the raw OpenAI exchange as sent
+        reshaped = self._chat_probe(to_alternating([dict(m) for m in _ALTERNATION_PROBE_MESSAGES]))
+        if reshaped is None:
+            return None  # transient on the reshape probe; stay undetermined
+        return reshaped
+
+    def _chat_probe(self, messages: Sequence[Mapping[str, Any]]) -> bool | None:
+        """Post the probe exchange: ``True`` rendered, ``False`` rejected, ``None`` undetermined.
+
+        A connection failure or a server-busy (HTTP 429) response is transient and
+        unrelated to the template, so it is undetermined: only a clean render or a
+        genuine rejection is a verdict the caller may cache.
+        """
+        payload = self._chat_payload(
+            messages, _ALTERNATION_PROBE_TOOLS, None, _ALTERNATION_PROBE_OPTIONS, stream=False
+        )
         try:
-            return call(messages)
-        except ProviderError as exc:
-            if not _is_role_alternation_error(exc):
-                raise
-            return call(to_alternating([dict(m) for m in messages]))
+            with self._track():
+                resp = self._http.post(
+                    _CHAT_PATH, json=payload, timeout=_ALTERNATION_PROBE_TIMEOUT_S
+                )
+                _raise_for_status(resp)
+        except (ProviderError, httpx.TransportError) as exc:
+            return None if _is_transient_probe_failure(exc) else False
+        return True
 
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Embed a batch via ``/v1/embeddings``."""

--- a/src/lilbee/providers/fleet/normalize.py
+++ b/src/lilbee/providers/fleet/normalize.py
@@ -11,18 +11,48 @@ template once, then applies it proactively before every such request.
 from __future__ import annotations
 
 import json
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import Any, Final, Literal, TypedDict
 
-_SYSTEM_ROLE = "system"
-_USER_ROLE = "user"
-_ASSISTANT_ROLE = "assistant"
-_TOOL_ROLE = "tool"
+# Roles this reshaper understands; an unrecognized role falls through to a plain
+# user turn, so the Literal documents the set without rejecting foreign input.
+ChatRole = Literal["system", "user", "assistant", "tool"]
+_SYSTEM_ROLE: Final = "system"
+_USER_ROLE: Final = "user"
+_ASSISTANT_ROLE: Final = "assistant"
+_TOOL_ROLE: Final = "tool"
 # A tool result carried as a user turn is labelled so the model reads it as a
 # result rather than a fresh user instruction.
 _TOOL_RESULT_PREFIX = "Tool result:"
 # An assistant turn whose only payload was tool_calls becomes a short text note
 # so the turn is non-empty (the templates reject empty content).
 _TOOL_CALL_NOTE_PREFIX = "Calling tool"
+
+
+class ChatToolCallFunction(TypedDict, total=False):
+    """The ``function`` payload of an OpenAI tool call (wire shape)."""
+
+    name: str
+    arguments: str
+
+
+class ChatToolCall(TypedDict, total=False):
+    """One entry of an assistant message's ``tool_calls`` (wire shape)."""
+
+    id: str
+    type: str
+    function: ChatToolCallFunction
+
+
+class ChatMessage(TypedDict, total=False):
+    """One OpenAI chat message in transit. Keys are partial: which are present
+    depends on the role (a tool result carries ``tool_call_id``, an assistant
+    tool call carries ``tool_calls``)."""
+
+    role: ChatRole
+    content: Any
+    tool_calls: list[ChatToolCall]
+    tool_call_id: str
 
 
 def _content_text(content: Any) -> str:
@@ -61,13 +91,13 @@ def _tool_calls_note(tool_calls: Any) -> str:
     return "\n".join(note for call in tool_calls if (note := _one_tool_call_note(call)))
 
 
-def _assistant_text(message: dict[str, Any]) -> str:
+def _assistant_text(message: Mapping[str, Any]) -> str:
     """Assistant turn text: its content plus a note for any tool_calls it made."""
     pieces = [_content_text(message.get("content")), _tool_calls_note(message.get("tool_calls"))]
     return "\n".join(piece for piece in pieces if piece)
 
 
-def _to_turn(message: dict[str, Any]) -> tuple[str, str]:
+def _to_turn(message: Mapping[str, Any]) -> tuple[ChatRole, str]:
     """Map one OpenAI message to a ``(user|assistant, text)`` pair.
 
     An assistant turn keeps its content and gains a note for any tool calls; a
@@ -84,7 +114,7 @@ def _to_turn(message: dict[str, Any]) -> tuple[str, str]:
     return _USER_ROLE, _content_text(message.get("content"))
 
 
-def _append_or_merge(turns: list[dict[str, Any]], turn: dict[str, Any]) -> None:
+def _append_or_merge(turns: list[ChatMessage], turn: ChatMessage) -> None:
     """Append a turn, or fold it into the previous turn when the role repeats."""
     if turns and turns[-1]["role"] == turn["role"]:
         turns[-1]["content"] = f"{turns[-1]['content']}\n{turn['content']}"
@@ -92,7 +122,7 @@ def _append_or_merge(turns: list[dict[str, Any]], turn: dict[str, Any]) -> None:
         turns.append(turn)
 
 
-def to_alternating(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def to_alternating(messages: Sequence[Mapping[str, Any]]) -> list[ChatMessage]:
     """Rewrite an OpenAI tool conversation into strict user/assistant alternation.
 
     Keeps any leading system messages verbatim, maps each remaining message to a
@@ -102,7 +132,7 @@ def to_alternating(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     emitted turn has non-empty content, so a strict-alternation template accepts
     it.
     """
-    leading_system: list[dict[str, Any]] = []
+    leading_system: list[ChatMessage] = []
     index = 0
     while index < len(messages) and messages[index].get("role") == _SYSTEM_ROLE:
         leading_system.append(
@@ -110,7 +140,7 @@ def to_alternating(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         )
         index += 1
 
-    turns: list[dict[str, Any]] = []
+    turns: list[ChatMessage] = []
     for message in messages[index:]:
         role, text = _to_turn(message)
         if text:

--- a/src/lilbee/providers/fleet/normalize.py
+++ b/src/lilbee/providers/fleet/normalize.py
@@ -4,7 +4,8 @@ Some GGUF chat templates (Mistral-Nemo, Cohere command-r) reject a standard
 OpenAI tool exchange: they require plain user/assistant turns to alternate and
 raise a Jinja exception on the ``tool`` role or on two same-role turns in a row.
 :func:`to_alternating` rewrites the conversation into the shape those templates
-accept, used only as a retry after such a template rejects the request.
+accept. The fleet client learns which models need this by probing the live
+template once, then applies it proactively before every such request.
 """
 
 from __future__ import annotations

--- a/src/lilbee/providers/fleet/normalize.py
+++ b/src/lilbee/providers/fleet/normalize.py
@@ -1,0 +1,117 @@
+"""Reshape an OpenAI tool conversation into strict user/assistant alternation.
+
+Some GGUF chat templates (Mistral-Nemo, Cohere command-r) reject a standard
+OpenAI tool exchange: they require plain user/assistant turns to alternate and
+raise a Jinja exception on the ``tool`` role or on two same-role turns in a row.
+:func:`to_alternating` rewrites the conversation into the shape those templates
+accept, used only as a retry after such a template rejects the request.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_SYSTEM_ROLE = "system"
+_USER_ROLE = "user"
+_ASSISTANT_ROLE = "assistant"
+_TOOL_ROLE = "tool"
+# A tool result carried as a user turn is labelled so the model reads it as a
+# result rather than a fresh user instruction.
+_TOOL_RESULT_PREFIX = "Tool result:"
+# An assistant turn whose only payload was tool_calls becomes a short text note
+# so the turn is non-empty (the templates reject empty content).
+_TOOL_CALL_NOTE_PREFIX = "Calling tool"
+
+
+def _content_text(content: Any) -> str:
+    """Flatten a message ``content`` (string or OpenAI multipart list) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            str(part.get("text", ""))
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        return "\n".join(p for p in parts if p)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _one_tool_call_note(call: Any) -> str:
+    """Render one tool call as ``Calling name(args)``; empty when malformed."""
+    fn = call.get("function") if isinstance(call, dict) else None
+    if not isinstance(fn, dict):
+        return ""
+    name = fn.get("name")
+    if not isinstance(name, str) or not name:
+        return ""
+    arguments = fn.get("arguments")
+    rendered_args = arguments if isinstance(arguments, str) else json.dumps(arguments)
+    return f"{_TOOL_CALL_NOTE_PREFIX} {name}({rendered_args})"
+
+
+def _tool_calls_note(tool_calls: Any) -> str:
+    """Render an assistant message's ``tool_calls`` as a short text note."""
+    if not isinstance(tool_calls, list):
+        return ""
+    return "\n".join(note for call in tool_calls if (note := _one_tool_call_note(call)))
+
+
+def _assistant_text(message: dict[str, Any]) -> str:
+    """Assistant turn text: its content plus a note for any tool_calls it made."""
+    pieces = [_content_text(message.get("content")), _tool_calls_note(message.get("tool_calls"))]
+    return "\n".join(piece for piece in pieces if piece)
+
+
+def _to_turn(message: dict[str, Any]) -> tuple[str, str]:
+    """Map one OpenAI message to a ``(user|assistant, text)`` pair.
+
+    An assistant turn keeps its content and gains a note for any tool calls; a
+    ``tool`` result becomes a labelled user turn; everything else, including a
+    stray non-leading ``system`` message, becomes a plain user turn (so it can't
+    re-open a system block or break alternation mid-conversation).
+    """
+    role = message.get("role")
+    if role == _ASSISTANT_ROLE:
+        return _ASSISTANT_ROLE, _assistant_text(message)
+    if role == _TOOL_ROLE:
+        result = _content_text(message.get("content"))
+        return _USER_ROLE, f"{_TOOL_RESULT_PREFIX} {result}".strip()
+    return _USER_ROLE, _content_text(message.get("content"))
+
+
+def _append_or_merge(turns: list[dict[str, Any]], turn: dict[str, Any]) -> None:
+    """Append a turn, or fold it into the previous turn when the role repeats."""
+    if turns and turns[-1]["role"] == turn["role"]:
+        turns[-1]["content"] = f"{turns[-1]['content']}\n{turn['content']}"
+    else:
+        turns.append(turn)
+
+
+def to_alternating(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Rewrite an OpenAI tool conversation into strict user/assistant alternation.
+
+    Keeps any leading system messages verbatim, maps each remaining message to a
+    plain user or assistant turn (``tool`` results become labelled user turns;
+    assistant tool calls become a text note), then merges consecutive same-role
+    turns so the result alternates user/assistant after the system block. Every
+    emitted turn has non-empty content, so a strict-alternation template accepts
+    it.
+    """
+    leading_system: list[dict[str, Any]] = []
+    index = 0
+    while index < len(messages) and messages[index].get("role") == _SYSTEM_ROLE:
+        leading_system.append(
+            {"role": _SYSTEM_ROLE, "content": _content_text(messages[index].get("content"))}
+        )
+        index += 1
+
+    turns: list[dict[str, Any]] = []
+    for message in messages[index:]:
+        role, text = _to_turn(message)
+        if text:
+            _append_or_merge(turns, {"role": role, "content": text})
+    return leading_system + turns

--- a/src/lilbee/server/chat_dispatch/dispatch.py
+++ b/src/lilbee/server/chat_dispatch/dispatch.py
@@ -142,11 +142,14 @@ async def dispatch_chat_stream(
     req: CanonicalChatRequest,
 ) -> AsyncIterator[CanonicalStreamEvent]:
     """Stream a canonical event sequence by translating provider frames on the fly."""
-    # The preflight can do blocking HTTP model discovery when its TTL lapses;
-    # run it in a thread so the event loop stays responsive.
+    # The preflight can do blocking HTTP model discovery when its TTL lapses, and
+    # opening the stream can issue a one-time template probe; run both in a thread
+    # so the event loop stays responsive.
     canonical_model = await asyncio.to_thread(preflight_chat_request, req)
-    stream = get_services().provider.chat(
-        stream=True, **_provider_chat_kwargs(req, canonical_model)
+    stream = await asyncio.to_thread(
+        lambda: get_services().provider.chat(
+            stream=True, **_provider_chat_kwargs(req, canonical_model)
+        )
     )
     try:
         yield MessageStart(id=_new_message_id(), model=canonical_model)

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -38,9 +38,19 @@ def _handler(request: httpx.Request) -> httpx.Response:
     return httpx.Response(404)
 
 
-def _client(handler=_handler) -> LlamaServerClient:
+def _unprobed_client(handler=_handler) -> LlamaServerClient:
+    """A client whose template has not yet been probed for strict alternation."""
     http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://gpu0")
     return LlamaServerClient("http://gpu0", "test-model", http=http)
+
+
+def _client(handler=_handler) -> LlamaServerClient:
+    # Most chat tests are orthogonal to alternation detection; treat the template
+    # as already probed-lenient so the one-time probe adds no request. The probe
+    # itself is exercised by the dedicated alternation tests below.
+    client = _unprobed_client(handler)
+    client._needs_alternation = False
+    return client
 
 
 def test_rerank_scores_pairs_via_rank_pooling() -> None:
@@ -596,107 +606,196 @@ _TOOL_LOOP_MESSAGES = [
 ]
 
 
-def test_chat_result_retries_with_normalized_messages_on_alternation_error() -> None:
-    # A strict-alternation template 500s the OpenAI tool exchange; the client must
-    # retry once with normalized (strictly alternating) messages and return.
-    seen: list[list[dict]] = []
+def _strict_alternation_handler(request: httpx.Request) -> httpx.Response:
+    """Model a strict-alternation template: reject the tool role or two same-role
+    turns in a row after the system block, render anything else."""
+    if request.url.path == "/health":
+        return httpx.Response(200)
+    body = json.loads(request.content)
+    convo = [m["role"] for m in body["messages"] if m["role"] != "system"]
+    if "tool" in convo or any(earlier == later for earlier, later in pairwise(convo)):
+        return httpx.Response(500, text=_ALTERNATION_BODY)
+    if body.get("stream"):
+        return httpx.Response(
+            200, text='data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n'
+        )
+    return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+
+def _is_probe(request: httpx.Request) -> bool:
+    """Whether *request* is the alternation probe (its tool is named ``probe``)."""
+    tools = json.loads(request.content).get("tools") or []
+    return bool(tools) and tools[0]["function"]["name"] == "probe"
+
+
+def test_chat_result_normalizes_when_template_requires_alternation() -> None:
+    # The probe finds the template rejects the raw tool exchange but renders the
+    # normalized one, so the real (non-probe) request is reshaped before sending.
+    sent: list[list[dict]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        body = json.loads(request.content)
-        seen.append(body["messages"])
-        if len(seen) == 1:
-            return httpx.Response(500, text=_ALTERNATION_BODY)
-        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+        if request.url.path == "/v1/chat/completions" and not _is_probe(request):
+            sent.append(json.loads(request.content)["messages"])
+        return _strict_alternation_handler(request)
 
-    result = _client(handler).chat_result(_TOOL_LOOP_MESSAGES)
+    client = _unprobed_client(handler)
+    result = client.chat_result(_TOOL_LOOP_MESSAGES)
+
     assert result.text == "ok"
-    assert len(seen) == 2
-    # The retry's messages strictly alternate user/assistant after the system, with
-    # no tool role remaining.
-    retried = seen[1]
-    convo_roles = [m["role"] for m in retried if m["role"] != "system"]
+    assert client._needs_alternation is True
+    convo_roles = [m["role"] for m in sent[-1] if m["role"] != "system"]
     assert "tool" not in convo_roles
     for earlier, later in pairwise(convo_roles):
         assert earlier != later
 
 
-def test_chat_result_does_not_retry_non_alternation_error() -> None:
-    # A different 500 must surface immediately, with exactly one request made.
-    seen: list[object] = []
-
-    def handler(_request: httpx.Request) -> httpx.Response:
-        seen.append(1)
-        return httpx.Response(500, text="decode failure")
-
-    with pytest.raises(ProviderError, match="decode failure"):
-        _client(handler).chat_result(_TOOL_LOOP_MESSAGES)
-    assert len(seen) == 1
-
-
-def test_chat_result_propagates_alternation_error_when_retry_also_fails() -> None:
-    # If the normalized retry also hits the alternation error, the original error
-    # propagates rather than looping.
-    seen: list[object] = []
-
-    def handler(_request: httpx.Request) -> httpx.Response:
-        seen.append(1)
-        return httpx.Response(500, text=_ALTERNATION_BODY)
-
-    with pytest.raises(ProviderError, match="roles must alternate"):
-        _client(handler).chat_result(_TOOL_LOOP_MESSAGES)
-    assert len(seen) == 2  # one original attempt + exactly one retry
-
-
-def test_chat_stream_items_retries_with_normalized_messages_on_alternation_error() -> None:
-    # The 500 surfaces at stream-open before any frame, so the stream path also
-    # retries once with normalized messages and then streams normally.
-    seen: list[list[dict]] = []
+def test_chat_result_keeps_raw_messages_when_template_accepts_tool_exchange() -> None:
+    # A lenient template renders the raw exchange, so the probe leaves messages
+    # untouched and the tool role survives into the real request.
+    sent: list[list[dict]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        body = json.loads(request.content)
-        seen.append(body["messages"])
-        if len(seen) == 1:
-            return httpx.Response(500, text=_ALTERNATION_BODY)
-        return httpx.Response(
-            200, text='data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n'
-        )
+        if request.url.path == "/v1/chat/completions" and not _is_probe(request):
+            sent.append(json.loads(request.content)["messages"])
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
 
-    frames = list(_client(handler).chat_stream_items(_TOOL_LOOP_MESSAGES))
+    client = _unprobed_client(handler)
+    result = client.chat_result(_TOOL_LOOP_MESSAGES)
+
+    assert result.text == "ok"
+    assert client._needs_alternation is False
+    assert any(m["role"] == "tool" for m in sent[-1])
+
+
+def test_chat_stream_items_normalizes_when_template_requires_alternation() -> None:
+    # The stream path reshapes up front too, so the open never hits the rejection.
+    sent: list[list[dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/chat/completions" and not _is_probe(request):
+            sent.append(json.loads(request.content)["messages"])
+        return _strict_alternation_handler(request)
+
+    frames = list(_unprobed_client(handler).chat_stream_items(_TOOL_LOOP_MESSAGES))
+
     assert frames == ["hi"]
-    assert len(seen) == 2
-    convo_roles = [m["role"] for m in seen[1] if m["role"] != "system"]
+    convo_roles = [m["role"] for m in sent[-1] if m["role"] != "system"]
     assert "tool" not in convo_roles
 
 
-def test_chat_stream_items_does_not_retry_non_alternation_error() -> None:
-    seen: list[object] = []
+def test_alternation_probe_runs_once_and_is_cached() -> None:
+    # The probe (raw + normalized) fires once; a second chat reuses the verdict.
+    probes: list[int] = []
 
-    def handler(_request: httpx.Request) -> httpx.Response:
-        seen.append(1)
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/chat/completions" and _is_probe(request):
+            probes.append(1)
+        return _strict_alternation_handler(request)
+
+    client = _unprobed_client(handler)
+    client.chat_result(_TOOL_LOOP_MESSAGES)
+    client.chat_result(_TOOL_LOOP_MESSAGES)
+
+    assert client._needs_alternation is True
+    assert len(probes) == 2  # one raw + one normalized, from the single probe round
+
+
+def test_alternation_probe_skips_when_another_thread_resolved_it() -> None:
+    # Double-checked locking: if another caller resolves the verdict between the
+    # outer check and the lock, the inner re-check returns without re-probing.
+    client = _unprobed_client()
+
+    class _ResolvingLock:
+        def __enter__(self) -> object:
+            client._needs_alternation = False
+            return self
+
+        def __exit__(self, *_exc: object) -> bool:
+            return False
+
+    client._alternation_lock = _ResolvingLock()  # type: ignore[assignment]
+    client._ensure_alternation_probed()
+    assert client._needs_alternation is False
+
+
+def test_alternation_probe_inconclusive_when_server_unreachable() -> None:
+    # A connection failure during the probe must not cache a verdict; once the
+    # server recovers, the next probe re-runs and resolves it.
+    state = {"up": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if not state["up"]:
+            raise httpx.ConnectError("replica down")
+        return _strict_alternation_handler(request)
+
+    client = _unprobed_client(handler)
+    client._ensure_alternation_probed()
+    assert client._needs_alternation is None
+
+    state["up"] = True
+    client._ensure_alternation_probed()
+    assert client._needs_alternation is True
+
+
+def test_alternation_probe_inconclusive_when_server_busy() -> None:
+    # A 429 (cold replica, slots warming) during the probe is transient, not a
+    # template verdict: it must not be cached, and the next probe resolves it.
+    state = {"busy": True}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200)
+        if state["busy"]:
+            return httpx.Response(429)
+        return _strict_alternation_handler(request)
+
+    client = _unprobed_client(handler)
+    client._ensure_alternation_probed()
+    assert client._needs_alternation is None
+
+    state["busy"] = False
+    client._ensure_alternation_probed()
+    assert client._needs_alternation is True
+
+
+def test_alternation_probe_inconclusive_when_reshape_probe_is_busy() -> None:
+    # The raw exchange is rejected but the reshaped probe hits a transient 429;
+    # the verdict stays undetermined rather than caching a wrong False.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200)
+        convo = [m["role"] for m in json.loads(request.content)["messages"]]
+        if "tool" in convo:
+            return httpx.Response(500, text=_ALTERNATION_BODY)
+        return httpx.Response(429)
+
+    client = _unprobed_client(handler)
+    client._ensure_alternation_probed()
+    assert client._needs_alternation is None
+
+
+def test_alternation_probe_skips_normalization_when_reshape_also_rejected() -> None:
+    # If even the normalized exchange is rejected (an unrelated template fault),
+    # the probe leaves the model un-normalized rather than guessing.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200)
+        return httpx.Response(500, text="decode failure")
+
+    client = _unprobed_client(handler)
+    client._ensure_alternation_probed()
+    assert client._needs_alternation is False
+
+
+def test_chat_result_propagates_server_error_after_probe() -> None:
+    # With no normalization flagged, the real request's error surfaces unchanged.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200)
         return httpx.Response(500, text="decode failure")
 
     with pytest.raises(ProviderError, match="decode failure"):
-        list(_client(handler).chat_stream_items(_TOOL_LOOP_MESSAGES))
-    assert len(seen) == 1
-
-
-def test_chat_stream_items_does_not_retry_after_a_frame_is_yielded(monkeypatch) -> None:
-    # A mid-stream failure (after frames were emitted) must not retry, or the
-    # caller would see duplicated content; the error propagates after the frame.
-    client = _client()
-    calls: list[int] = []
-
-    def fake_open(messages, tools, tool_choice, options):
-        calls.append(1)
-        yield "partial"
-        raise ProviderError(_ALTERNATION_BODY)
-
-    monkeypatch.setattr(client, "_open_chat_stream", fake_open)
-    stream = client.chat_stream_items(_TOOL_LOOP_MESSAGES)
-    assert next(stream) == "partial"
-    with pytest.raises(ProviderError, match="roles must alternate"):
-        next(stream)
-    assert calls == [1]  # the failure raised, no second (retry) stream opened
+        _unprobed_client(handler).chat_result(_TOOL_LOOP_MESSAGES)
 
 
 def test_embed_subbatches_when_token_budget_exceeded() -> None:

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from itertools import pairwise
 
 import httpx
 import pytest
@@ -576,6 +577,126 @@ def test_chat_stream_surfaces_server_error_body() -> None:
 
     with pytest.raises(ProviderError, match="model is still loading"):
         list(_client(handler).chat([{"role": "user", "content": "hi"}], stream=True))
+
+
+_ALTERNATION_BODY = (
+    "Jinja Exception: After the optional system message, conversation roles "
+    "must alternate user/assistant/user/assistant/..."
+)
+_TOOL_LOOP_MESSAGES = [
+    {"role": "system", "content": "sys"},
+    {"role": "user", "content": "find foo"},
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"function": {"name": "grep", "arguments": "{}"}}],
+    },
+    {"role": "tool", "content": "a.py:1", "tool_call_id": "c1"},
+    {"role": "assistant", "content": "It is in a.py."},
+]
+
+
+def test_chat_result_retries_with_normalized_messages_on_alternation_error() -> None:
+    # A strict-alternation template 500s the OpenAI tool exchange; the client must
+    # retry once with normalized (strictly alternating) messages and return.
+    seen: list[list[dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        seen.append(body["messages"])
+        if len(seen) == 1:
+            return httpx.Response(500, text=_ALTERNATION_BODY)
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    result = _client(handler).chat_result(_TOOL_LOOP_MESSAGES)
+    assert result.text == "ok"
+    assert len(seen) == 2
+    # The retry's messages strictly alternate user/assistant after the system, with
+    # no tool role remaining.
+    retried = seen[1]
+    convo_roles = [m["role"] for m in retried if m["role"] != "system"]
+    assert "tool" not in convo_roles
+    for earlier, later in pairwise(convo_roles):
+        assert earlier != later
+
+
+def test_chat_result_does_not_retry_non_alternation_error() -> None:
+    # A different 500 must surface immediately, with exactly one request made.
+    seen: list[object] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        seen.append(1)
+        return httpx.Response(500, text="decode failure")
+
+    with pytest.raises(ProviderError, match="decode failure"):
+        _client(handler).chat_result(_TOOL_LOOP_MESSAGES)
+    assert len(seen) == 1
+
+
+def test_chat_result_propagates_alternation_error_when_retry_also_fails() -> None:
+    # If the normalized retry also hits the alternation error, the original error
+    # propagates rather than looping.
+    seen: list[object] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        seen.append(1)
+        return httpx.Response(500, text=_ALTERNATION_BODY)
+
+    with pytest.raises(ProviderError, match="roles must alternate"):
+        _client(handler).chat_result(_TOOL_LOOP_MESSAGES)
+    assert len(seen) == 2  # one original attempt + exactly one retry
+
+
+def test_chat_stream_items_retries_with_normalized_messages_on_alternation_error() -> None:
+    # The 500 surfaces at stream-open before any frame, so the stream path also
+    # retries once with normalized messages and then streams normally.
+    seen: list[list[dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        seen.append(body["messages"])
+        if len(seen) == 1:
+            return httpx.Response(500, text=_ALTERNATION_BODY)
+        return httpx.Response(
+            200, text='data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n'
+        )
+
+    frames = list(_client(handler).chat_stream_items(_TOOL_LOOP_MESSAGES))
+    assert frames == ["hi"]
+    assert len(seen) == 2
+    convo_roles = [m["role"] for m in seen[1] if m["role"] != "system"]
+    assert "tool" not in convo_roles
+
+
+def test_chat_stream_items_does_not_retry_non_alternation_error() -> None:
+    seen: list[object] = []
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        seen.append(1)
+        return httpx.Response(500, text="decode failure")
+
+    with pytest.raises(ProviderError, match="decode failure"):
+        list(_client(handler).chat_stream_items(_TOOL_LOOP_MESSAGES))
+    assert len(seen) == 1
+
+
+def test_chat_stream_items_does_not_retry_after_a_frame_is_yielded(monkeypatch) -> None:
+    # A mid-stream failure (after frames were emitted) must not retry, or the
+    # caller would see duplicated content; the error propagates after the frame.
+    client = _client()
+    calls: list[int] = []
+
+    def fake_open(messages, tools, tool_choice, options):
+        calls.append(1)
+        yield "partial"
+        raise ProviderError(_ALTERNATION_BODY)
+
+    monkeypatch.setattr(client, "_open_chat_stream", fake_open)
+    stream = client.chat_stream_items(_TOOL_LOOP_MESSAGES)
+    assert next(stream) == "partial"
+    with pytest.raises(ProviderError, match="roles must alternate"):
+        next(stream)
+    assert calls == [1]  # the failure raised, no second (retry) stream opened
 
 
 def test_embed_subbatches_when_token_budget_exceeded() -> None:

--- a/tests/test_fleet_normalize.py
+++ b/tests/test_fleet_normalize.py
@@ -1,0 +1,232 @@
+"""Tests for reshaping an OpenAI tool conversation into strict alternation."""
+
+from __future__ import annotations
+
+from itertools import pairwise
+from typing import Any
+
+from lilbee.providers.fleet.normalize import to_alternating
+
+_SYSTEM = "system"
+_USER = "user"
+_ASSISTANT = "assistant"
+
+
+def _roles_after_system(messages: list[dict[str, Any]]) -> list[str]:
+    return [m["role"] for m in messages if m["role"] != _SYSTEM]
+
+
+def _assert_strict_alternation(messages: list[dict[str, Any]]) -> None:
+    """Output has no tool role, no empty turns, and alternates after the system block."""
+    roles = [m["role"] for m in messages]
+    assert "tool" not in roles
+    assert all(m["content"] for m in messages)
+    convo = _roles_after_system(messages)
+    assert all(role in (_USER, _ASSISTANT) for role in convo)
+    for earlier, later in pairwise(convo):
+        assert earlier != later
+
+
+def test_tool_role_becomes_labelled_user_turn() -> None:
+    out = to_alternating(
+        [
+            {"role": _USER, "content": "search"},
+            {"role": _ASSISTANT, "content": "looking"},
+            {"role": "tool", "content": "found it", "tool_call_id": "abc"},
+            {"role": _ASSISTANT, "content": "done"},
+        ]
+    )
+    _assert_strict_alternation(out)
+    assert _roles_after_system(out) == [_USER, _ASSISTANT, _USER, _ASSISTANT]
+    assert out[2]["content"] == "Tool result: found it"
+
+
+def test_assistant_tool_calls_render_as_text_note() -> None:
+    out = to_alternating(
+        [
+            {"role": _USER, "content": "go"},
+            {
+                "role": _ASSISTANT,
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "grep", "arguments": '{"q":"x"}'}},
+                ],
+            },
+            {"role": "tool", "content": "match", "tool_call_id": "id"},
+            {"role": _ASSISTANT, "content": "answer"},
+        ]
+    )
+    _assert_strict_alternation(out)
+    # The empty assistant content is replaced by a note for the tool call, so the
+    # turn is non-empty and the templates accept it.
+    assert "Calling tool grep" in out[1]["content"]
+    assert '{"q":"x"}' in out[1]["content"]
+
+
+def test_consecutive_assistant_turns_merge() -> None:
+    out = to_alternating(
+        [
+            {"role": _USER, "content": "q"},
+            {"role": _ASSISTANT, "content": "a1"},
+            {"role": _ASSISTANT, "content": "a2"},
+        ]
+    )
+    _assert_strict_alternation(out)
+    assert _roles_after_system(out) == [_USER, _ASSISTANT]
+    assert out[-1]["content"] == "a1\na2"
+
+
+def test_leading_system_messages_kept_verbatim() -> None:
+    out = to_alternating(
+        [
+            {"role": _SYSTEM, "content": "sys A"},
+            {"role": _SYSTEM, "content": "sys B"},
+            {"role": _USER, "content": "hi"},
+        ]
+    )
+    assert out[0] == {"role": _SYSTEM, "content": "sys A"}
+    assert out[1] == {"role": _SYSTEM, "content": "sys B"}
+    _assert_strict_alternation(out)
+
+
+def test_full_opencode_tool_loop_alternates() -> None:
+    # The exact shape the opencode tool loop emits: system, user, then repeated
+    # assistant(tool_calls) / tool(result) pairs ending in a plain assistant.
+    out = to_alternating(
+        [
+            {"role": _SYSTEM, "content": "you are a coding agent"},
+            {"role": _USER, "content": "find foo"},
+            {
+                "role": _ASSISTANT,
+                "content": "",
+                "tool_calls": [{"function": {"name": "grep", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "a.py:1", "tool_call_id": "c1"},
+            {
+                "role": _ASSISTANT,
+                "content": "",
+                "tool_calls": [{"function": {"name": "read", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "def foo", "tool_call_id": "c2"},
+            {"role": _ASSISTANT, "content": "It is in a.py."},
+        ]
+    )
+    _assert_strict_alternation(out)
+    # System stays first; the rest alternates user/assistant with no empty turns.
+    assert out[0]["role"] == _SYSTEM
+    assert _roles_after_system(out)[0] == _USER
+
+
+def test_late_system_message_folds_into_user_turn() -> None:
+    out = to_alternating(
+        [
+            {"role": _USER, "content": "q"},
+            {"role": _SYSTEM, "content": "mid-conversation system"},
+        ]
+    )
+    _assert_strict_alternation(out)
+    # The late system message must not re-open a system block mid-conversation.
+    assert out[0]["role"] == _USER
+    assert "mid-conversation system" in out[0]["content"]
+
+
+def test_multipart_content_flattens_to_text() -> None:
+    out = to_alternating(
+        [
+            {
+                "role": _USER,
+                "content": [
+                    {"type": "text", "text": "part one"},
+                    {"type": "text", "text": "part two"},
+                ],
+            },
+        ]
+    )
+    assert out == [{"role": _USER, "content": "part one\npart two"}]
+
+
+def test_empty_turns_are_dropped() -> None:
+    out = to_alternating(
+        [
+            {"role": _USER, "content": "q"},
+            {"role": _ASSISTANT, "content": ""},  # no content, no tool_calls -> dropped
+            {"role": _USER, "content": "still here"},
+        ]
+    )
+    _assert_strict_alternation(out)
+    # Both user turns survive and merge (the empty assistant between them vanished).
+    assert _roles_after_system(out) == [_USER]
+    assert out[0]["content"] == "q\nstill here"
+
+
+def test_malformed_tool_call_entries_skipped() -> None:
+    out = to_alternating(
+        [
+            {"role": _USER, "content": "q"},
+            {
+                "role": _ASSISTANT,
+                "content": "thinking",
+                "tool_calls": [
+                    "not-a-dict",
+                    {"function": {"arguments": "{}"}},  # no name
+                    {"function": {"name": "ok", "arguments": "{}"}},
+                ],
+            },
+        ]
+    )
+    _assert_strict_alternation(out)
+    assert "Calling tool ok" in out[-1]["content"]
+    assert out[-1]["content"].startswith("thinking")
+
+
+def test_none_content_assistant_keeps_only_tool_note() -> None:
+    # An assistant turn with content=None (OpenAI's shape for a pure tool call)
+    # still produces a non-empty turn from its tool-call note.
+    out = to_alternating(
+        [
+            {"role": _USER, "content": "q"},
+            {
+                "role": _ASSISTANT,
+                "content": None,
+                "tool_calls": [{"function": {"name": "f", "arguments": "{}"}}],
+            },
+        ]
+    )
+    _assert_strict_alternation(out)
+    assert out[-1]["content"].startswith("Calling tool f")
+
+
+def test_non_text_multipart_parts_are_dropped() -> None:
+    # Image parts carry no text and must not leak into the flattened content.
+    out = to_alternating(
+        [
+            {
+                "role": _USER,
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:..."}},
+                    {"type": "text", "text": "describe"},
+                ],
+            },
+        ]
+    )
+    assert out == [{"role": _USER, "content": "describe"}]
+
+
+def test_non_string_non_list_content_stringified() -> None:
+    # A non-standard scalar content (number) is coerced to text rather than dropped.
+    out = to_alternating([{"role": _USER, "content": 42}])
+    assert out == [{"role": _USER, "content": "42"}]
+
+
+def test_non_string_tool_arguments_serialized() -> None:
+    out = to_alternating(
+        [
+            {"role": _USER, "content": "q"},
+            {
+                "role": _ASSISTANT,
+                "content": "",
+                "tool_calls": [{"function": {"name": "f", "arguments": {"k": "v"}}}],
+            },
+        ]
+    )
+    assert '{"k": "v"}' in out[-1]["content"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -322,7 +322,9 @@ class TestModelRegistryInstall:
         subdir = "Q4_K_M/Some-Q4_K_M.gguf"
         for filename, byte in ((flat, b"\x01"), (subdir, b"\x02")):
             content = b"GGUF" + byte * 256
-            src = tmp_path / f"{byte!r}.gguf"
+            # Name the temp source by the byte's hex, not repr(): repr(b"\x01") is
+            # "b'\\x01'", whose backslash is a path separator on Windows.
+            src = tmp_path / f"src-{byte.hex()}.gguf"
             src.write_bytes(content)
             registry.install(
                 repo,


### PR DESCRIPTION
## Problem

A few local chat templates (Mistral-Nemo, Cohere command-r, and similar) refuse a
normal tool conversation. They insist that user and assistant turns strictly
alternate, so an agent's tool calls make them error out. Detecting that case
relied on matching the engine's error text, which is brittle and breaks whenever
the wording changes between builds.

## Solution

Work it out ahead of time instead. The first time a model is used, lilbee sends it
one small tool exchange and sees whether the template accepts it. If the model
only accepts the strictly alternating form, lilbee remembers that and reshapes
those conversations automatically from then on. No guessing from error strings,
and a model that is still warming up won't get misjudged.
