### PR TITLE
Make crawl browser memory knobs configurable; name the /crawl flags

### DIFF
--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -520,6 +520,25 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         ),
         choices=tuple(m.value for m in CrawlRenderMode),
     ),
+    "crawl_browser_recycle_pages": SettingDef(
+        int,
+        nullable=False,
+        group=SettingGroup.CRAWLING,
+        help_text=(
+            "Browser mode: recycle the Chromium process every N pages to cap memory "
+            "growth on long crawls (0 = never recycle)."
+        ),
+    ),
+    "crawl_browser_extra_args": SettingDef(
+        list,
+        nullable=False,
+        group=SettingGroup.CRAWLING,
+        render=RenderStyle.LIST_COLLAPSED,
+        help_text=(
+            "Browser mode: extra Chromium launch flags, one per line. "
+            "Defaults trim shared-memory and GPU use."
+        ),
+    ),
     "crawl_max_pages": SettingDef(
         int,
         nullable=True,

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -99,6 +99,12 @@ _STREAM_FLUSH_INTERVAL = 0.05
 # Auto-scroll throttle. ~6 fps so heavy token streams don't peg the renderer.
 _STREAM_SCROLL_INTERVAL = 0.15
 
+# ``/crawl`` command flags.
+_CRAWL_FLAG_DEPTH = "--depth"
+_CRAWL_FLAG_MAX_PAGES = "--max-pages"
+_CRAWL_FLAG_INCLUDE_SUBDOMAINS = "--include-subdomains"
+_CRAWL_FLAG_RENDER = "--render"
+
 
 class ChatWelcome(Static):
     """Empty-state welcome posted into the chat log; removed on first message."""
@@ -771,17 +777,17 @@ class ChatScreen(Screen[None]):
         ``--render http|browser`` returns None when absent so the caller
         inherits ``cfg.crawl_render_mode``; an unrecognized value is ignored.
         """
-        flag_map = {"--depth": "depth", "--max-pages": "max_pages"}
+        flag_map = {_CRAWL_FLAG_DEPTH: "depth", _CRAWL_FLAG_MAX_PAGES: "max_pages"}
         parsed: dict[str, int | None] = {"depth": None, "max_pages": None}
         include_subdomains = False
         render_mode: CrawlRenderMode | None = None
         i = 0
         while i < len(tokens):
-            if tokens[i] == "--include-subdomains":
+            if tokens[i] == _CRAWL_FLAG_INCLUDE_SUBDOMAINS:
                 include_subdomains = True
                 i += 1
                 continue
-            if tokens[i] == "--render" and i + 1 < len(tokens):
+            if tokens[i] == _CRAWL_FLAG_RENDER and i + 1 < len(tokens):
                 with contextlib.suppress(ValueError):
                     render_mode = CrawlRenderMode(tokens[i + 1])
                 i += 2

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -255,6 +255,19 @@ class Config(BaseSettings):
     # that render content client-side, at a much higher memory cost.
     crawl_render_mode: CrawlRenderMode = ConfigField(default=CrawlRenderMode.HTTP, writable=True)
 
+    # Browser-mode memory levers (only used when crawl_render_mode is browser).
+    # Recycle the Chromium process every N fetched pages to cap RSS growth on a
+    # long recursive crawl; 0 disables recycling. Raise on a roomy machine for
+    # fewer restarts, lower it if memory is tight.
+    crawl_browser_recycle_pages: int = ConfigField(default=50, ge=0, writable=True)
+
+    # Extra Chromium launch flags for browser-mode crawls. Defaults trim shared
+    # memory and GPU use; override to pass site- or environment-specific flags.
+    crawl_browser_extra_args: list[str] = ConfigField(
+        default_factory=lambda: ["--disable-dev-shm-usage", "--disable-gpu"],
+        writable=True,
+    )
+
     # Optional global ceilings. None = no ceiling.
     crawl_max_depth: int | None = ConfigField(default=None, ge=0, writable=True)
     crawl_max_pages: int | None = ConfigField(default=None, ge=1, writable=True)

--- a/src/lilbee/crawler/crawl4ai_fetcher.py
+++ b/src/lilbee/crawler/crawl4ai_fetcher.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncGenerator, AsyncIterator
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+from lilbee.core.config import cfg
 from lilbee.core.config.enums import CrawlRenderMode
 from lilbee.crawler import bootstrap
 from lilbee.crawler.bootstrap import CrawlerBrowserError
@@ -28,18 +29,13 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-# Browser-mode memory levers. Constants, not config: there is no per-user knob
-# worth exposing, and they only apply on the heavy Chromium path. Recycling the
-# browser process every N pages caps the RSS growth of a long recursive crawl.
-_BROWSER_RECYCLE_PAGES = 50
-_BROWSER_EXTRA_ARGS = ("--disable-dev-shm-usage", "--disable-gpu")
-
 
 def _build_inner_crawler(*, verbose: bool, render_mode: CrawlRenderMode) -> Any:
     """Construct a crawl4ai ``AsyncWebCrawler`` for the requested render mode.
 
     HTTP mode swaps in the browserless HTTP strategy; browser mode tunes
-    Chromium for memory (light/text/memory-saving + periodic process recycle).
+    Chromium for memory (light/text/memory-saving + periodic process recycle),
+    reading the recycle threshold and launch flags from config.
     """
     from crawl4ai import AsyncWebCrawler
 
@@ -54,8 +50,8 @@ def _build_inner_crawler(*, verbose: bool, render_mode: CrawlRenderMode) -> Any:
         light_mode=True,
         text_mode=True,
         memory_saving_mode=True,
-        max_pages_before_recycle=_BROWSER_RECYCLE_PAGES,
-        extra_args=list(_BROWSER_EXTRA_ARGS),
+        max_pages_before_recycle=cfg.crawl_browser_recycle_pages,
+        extra_args=list(cfg.crawl_browser_extra_args),
         verbose=verbose,
     )
     return AsyncWebCrawler(config=config, verbose=verbose)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2228,6 +2228,21 @@ class TestCrawlDispatcher:
         assert mad_kwargs["max_session_permit"] == 4
         assert mad_kwargs["rate_limiter"] is mock_rl.return_value
 
+    def test_browser_config_reads_memory_levers_from_cfg(self, monkeypatch):
+        """Browser-mode BrowserConfig is built from the configurable memory levers."""
+        from lilbee.crawler import crawl4ai_fetcher
+
+        monkeypatch.setattr(cfg, "crawl_browser_recycle_pages", 7)
+        monkeypatch.setattr(cfg, "crawl_browser_extra_args", ["--flag-a", "--flag-b"])
+        mock_mod = MagicMock()
+        with patch.dict("sys.modules", {"crawl4ai": mock_mod}):
+            crawl4ai_fetcher._build_inner_crawler(
+                verbose=False, render_mode=CrawlRenderMode.BROWSER
+            )
+        bc_kwargs = mock_mod.BrowserConfig.call_args.kwargs
+        assert bc_kwargs["max_pages_before_recycle"] == 7
+        assert bc_kwargs["extra_args"] == ["--flag-a", "--flag-b"]
+
     async def test_rate_limiter_disabled_when_flag_off(self):
         """crawl_retry_on_rate_limit=False skips the dispatcher entirely."""
         mock_instance = AsyncMock()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -190,6 +190,22 @@ class TestMemoryTuningSettingsMap:
         # field must be writable through the HTTP / MCP / programmatic contract.
         assert "crawl_render_mode" in WRITABLE_CONFIG_FIELDS
 
+    def test_browser_memory_levers_in_settings_map(self):
+        from lilbee.app.settings_map import SETTINGS_MAP, get_default
+
+        recycle = SETTINGS_MAP["crawl_browser_recycle_pages"]
+        assert recycle.writable is True
+        assert recycle.type is int
+        assert get_default("crawl_browser_recycle_pages") == 50
+
+        extra = SETTINGS_MAP["crawl_browser_extra_args"]
+        assert extra.writable is True
+        assert extra.type is list
+        assert get_default("crawl_browser_extra_args") == [
+            "--disable-dev-shm-usage",
+            "--disable-gpu",
+        ]
+
 
 class TestCrawlRenderModeConfig:
     def test_default_is_http(self):
@@ -214,6 +230,13 @@ class TestCrawlRenderModeConfig:
         monkeypatch.setenv("LILBEE_CRAWL_RENDER_MODE", "bogus")
         with pytest.raises(ValidationError):
             Config()
+
+    def test_browser_memory_lever_defaults(self):
+        from lilbee.core.config.model import Config
+
+        c = Config()
+        assert c.crawl_browser_recycle_pages == 50
+        assert c.crawl_browser_extra_args == ["--disable-dev-shm-usage", "--disable-gpu"]
 
 
 class TestOverlayPersistedSettings:


### PR DESCRIPTION
## Problem

Two convention slips landed with the crawl render-mode work: the browser-mode memory levers (process-recycle threshold and Chromium launch flags) were frozen module constants rather than tunable settings, and the `/crawl` command parsed its flags against inline string literals instead of named constants.

## Solution

The recycle threshold and launch flags are now `crawl_browser_recycle_pages` and `crawl_browser_extra_args` config fields with the same defaults, writable and visible in the settings screen so they can be tuned without code changes. The `/crawl` flag names are named constants used at both the parse and lookup sites. Behavior and defaults are unchanged.