### PR TITLE
Fix single-page crawl: treat depth 0 as seed-only

### DIFF
--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -56,18 +56,22 @@ def _get_crawl_semaphore() -> asyncio.Semaphore | None:
     return get_services().crawler_semaphore
 
 
-def _resolve_limit(value: int | None, cfg_ceiling: int | None) -> int | None:
-    """Resolve a caller-provided crawl limit to the number the fetcher consumes.
+def _resolve_depth(value: int | None, cfg_ceiling: int | None) -> int | None:
+    """Resolve a crawl depth to the value the dispatcher consumes.
+
+    Depth has its own contract, distinct from the page-count limit: ``0`` is a
+    valid "seed only / single page" depth, not "unbounded". (Page counts use
+    :func:`_resolve_page_limit`, where ``0`` means "no limit".)
 
     None    -> cfg_ceiling (itself may be None; ``None`` means unbounded)
-    n > 0   -> n (explicit caller intent; cfg is not a ceiling here)
-    n <= 0  -> ValueError (use None for unbounded, not 0)
+    n >= 0  -> n (0 = seed only; explicit caller intent overrides cfg)
+    n < 0   -> ValueError (use None for unbounded)
     """
     effective = value if value is not None else cfg_ceiling
     if effective is None:
         return None
-    if effective <= 0:
-        raise ValueError("crawl limit must be a positive int or None")
+    if effective < 0:
+        raise ValueError("crawl depth must be 0 (seed only) or a positive int")
     return effective
 
 
@@ -188,7 +192,10 @@ async def crawl_recursive(
     disk incrementally and keep partial output across cancellation.
     """
     validate_crawl_url(url)
-    depth = _resolve_limit(max_depth, cfg.crawl_max_depth)
+    # ``_run_crawl`` already resolved the depth ceiling (and routed a seed-only
+    # 0 to the single-page path), so the recursive path takes ``max_depth`` as
+    # given: None = unbounded, a positive int = the cap.
+    depth = max_depth
     pages = _resolve_page_limit(max_pages)
 
     # Fail fast when the ``crawler`` extra wasn't installed so SSE
@@ -363,7 +370,13 @@ async def _run_crawl(
     flush_page: Callable[[Any], Awaitable[Path | None]],
     render_mode: CrawlRenderMode,
 ) -> int:
-    """Run the single-URL or recursive crawl. Returns ``pages_seen``."""
+    """Run the single-URL or recursive crawl. Returns ``pages_seen``.
+
+    Resolves the depth ceiling here (permitting the seed-only ``0``) so a
+    ``cfg.crawl_max_depth`` of 0 routes to the single-page path instead of
+    blowing up inside the recursive resolver.
+    """
+    depth = _resolve_depth(depth, cfg.crawl_max_depth)
     if depth == 0:
         result = await crawl_single(
             url, quiet=quiet, on_progress=on_progress, render_mode=render_mode

--- a/tests/crawler/test_runner.py
+++ b/tests/crawler/test_runner.py
@@ -497,25 +497,29 @@ class TestFetchedToResult:
         assert result.error == "timeout"
 
 
-class TestResolveLimit:
-    """Pure-Python limit resolver: None / positive / zero-negative."""
+class TestResolveDepth:
+    """Pure-Python depth resolver: None / positive / seed-only-zero / negative."""
 
     def test_none_with_no_ceiling_is_none(self):
-        assert runner_mod._resolve_limit(None, None) is None
+        assert runner_mod._resolve_depth(None, None) is None
 
     def test_none_with_ceiling_uses_ceiling(self):
-        assert runner_mod._resolve_limit(None, 25) == 25
+        assert runner_mod._resolve_depth(None, 25) == 25
 
     def test_positive_value_wins_over_ceiling(self):
-        assert runner_mod._resolve_limit(99, 10) == 99
+        assert runner_mod._resolve_depth(99, 10) == 99
 
-    def test_zero_raises(self):
-        with pytest.raises(ValueError, match="positive"):
-            runner_mod._resolve_limit(0, 10)
+    def test_zero_is_seed_only_not_rejected(self):
+        # Depth 0 is the documented "single page / seed only" value.
+        assert runner_mod._resolve_depth(0, 10) == 0
+
+    def test_none_value_with_zero_ceiling_is_seed_only(self):
+        # A cfg ceiling of 0 means "seed only", not an error (bb-4j2p).
+        assert runner_mod._resolve_depth(None, 0) == 0
 
     def test_negative_raises(self):
-        with pytest.raises(ValueError, match="positive"):
-            runner_mod._resolve_limit(-1, None)
+        with pytest.raises(ValueError, match="seed only"):
+            runner_mod._resolve_depth(-1, None)
 
 
 class TestFetcherModuleNotDirectlyImported:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1572,6 +1572,30 @@ class TestCrawlAndSave:
         assert len(paths) == 1
         assert paths[0].exists()
 
+    @patch("lilbee.crawler.runner.crawl_recursive")
+    @patch("lilbee.crawler.runner.crawl_single")
+    async def test_cfg_max_depth_zero_routes_to_single_page(
+        self, mock_crawl_single, mock_crawl_recursive, isolated_env
+    ):
+        """bb-4j2p: a cfg.crawl_max_depth ceiling of 0 means seed-only, not an error.
+
+        depth=None inherits the ceiling; 0 must route to the single-page path
+        instead of raising in the recursive resolver.
+        """
+        cfg.crawl_max_depth = 0
+        mock_crawl_single.return_value = CrawlResult(url="https://example.com", markdown="# Hi")
+        paths = await crawl_and_save("https://example.com", depth=None)
+        assert len(paths) == 1
+        mock_crawl_single.assert_awaited_once()
+        mock_crawl_recursive.assert_not_called()
+
+    @patch("lilbee.crawler.runner.crawl_single")
+    async def test_negative_depth_is_rejected(self, mock_crawl_single, isolated_env):
+        """A negative depth is invalid (use None for unbounded)."""
+        with pytest.raises(ValueError, match="seed only"):
+            await crawl_and_save("https://example.com", depth=-1)
+        mock_crawl_single.assert_not_called()
+
     @patch("lilbee.crawler.runner.crawl_single")
     async def test_triggers_bootstrap_when_chromium_missing(
         self, mock_crawl_single, isolated_env, monkeypatch


### PR DESCRIPTION
## Problem

A single-page crawl failed instead of fetching the seed URL. Unchecking "Recursive" in the crawl dialog (or setting a depth ceiling of 0 via LILBEE_CRAWL_MAX_DEPTH) raised "crawl limit must be a positive int or None" and indexed nothing. Only an unbounded recursive crawl actually worked.

## Solution

Depth is now resolved through a depth-aware path that treats 0 as the documented "seed only / single page" value, while still rejecting negatives. The ceiling resolves once in the dispatcher and a resolved depth of 0 routes to the single-page crawl, so both an explicit depth-0 and a configured ceiling of 0 fetch the seed. Page-count limits keep their own contract (0 means "no limit"), unchanged.

Validated end-to-end in the TUI: unchecking Recursive indexes the single page, and a crawl under LILBEE_CRAWL_MAX_DEPTH=0 fetches the seed without error.