### PR TITLE
Recover bare-JSON tool calls on the streaming chat path

### DIFF
--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -527,9 +527,14 @@ class LlamaServerClient:
 
         Not a generator: the up-front probe runs when this is called, not deferred
         to the first iteration, matching the eager non-stream paths.
+
+        A model that emits a tool call as bare-JSON text instead of native
+        ``tool_calls`` (a native miss, as on the non-stream paths) is recovered by
+        wrapping the raw frames; see :func:`_recover_bare_json_stream`.
         """
-        return self._open_chat_stream(
-            self._prepare_chat_messages(messages), tools, tool_choice, options
+        prepared = self._prepare_chat_messages(messages)
+        return _recover_bare_json_stream(
+            self._open_chat_stream(prepared, tools, tool_choice, options)
         )
 
     def _open_chat_stream(
@@ -1078,3 +1083,93 @@ def _recover_bare_json_tool_calls(content: str) -> ChatToolResult:
     if not calls:
         return ChatToolResult(content=content, tool_calls=[])
     return ChatToolResult(content="", tool_calls=calls)
+
+
+# Leading non-whitespace characters that mark streamed text as a potential bare
+# JSON tool call (an object or an array of them); any other first char is plain
+# text and streams through untouched.
+_BARE_CALL_OPENERS = "{["
+
+
+def _tool_call_delta_from_recovered(call: ToolCall, index: int) -> ToolCallDelta:
+    """Shape a recovered bare-JSON :class:`ToolCall` as a single streaming delta.
+
+    Mirrors :func:`_tool_call_delta_from_chunk`: id and name ride the opener (the
+    only frame for a recovered call), the arguments JSON is the lone
+    ``arguments_delta``, and the position is the index.
+    """
+    return ToolCallDelta(
+        index=index,
+        id=call.id or None,
+        name=call.name or None,
+        arguments_delta=call.arguments or None,
+    )
+
+
+def _recover_bare_json_stream(
+    items: Iterator[str | ToolCallDelta | TokenUsage],
+) -> Iterator[str | ToolCallDelta | TokenUsage]:
+    """Wrap a raw chat stream to recover a tool call emitted as bare-JSON text.
+
+    Some small models print ``{"name": ..., "arguments": {...}}`` as content
+    instead of native ``tool_calls``; the non-stream paths recover this via
+    :func:`_recover_bare_json_tool_calls`. This applies the same recovery to the
+    stream, but only when the model emitted no native :class:`ToolCallDelta` and
+    the streamed text looks like a bare call from its first character. Normal text
+    still streams token by token: once the buffered head proves not to be a bare
+    call it is flushed and all later text passes straight through.
+    """
+    buffer = ""  # leading text held back as a potential bare call until resolved
+    saw_native = False
+    for item in items:
+        if isinstance(item, ToolCallDelta):
+            yield from _flush_plain(buffer)
+            buffer, saw_native = "", True
+            yield item
+        elif isinstance(item, TokenUsage):
+            yield from _recover_buffer(buffer)
+            buffer = ""
+            yield item
+        elif saw_native or _passthrough_text(buffer, item):
+            yield from _flush_plain(buffer)
+            buffer = ""
+            yield item
+        else:
+            buffer += item
+    yield from _recover_buffer(buffer)
+
+
+def _passthrough_text(buffer: str, text: str) -> bool:
+    """Whether *text* should stream through directly rather than buffer.
+
+    True once the accumulated head's first non-whitespace char is known and is not
+    a bare-call opener (plain text): the buffer is empty in that case, so the
+    caller yields *text* as is. While the head is all whitespace, or once it opens
+    with ``{``/``[``, the text is buffered (False) pending recovery.
+    """
+    head = (buffer + text).lstrip()
+    return bool(head) and head[0] not in _BARE_CALL_OPENERS
+
+
+def _flush_plain(buffer: str) -> Iterator[str]:
+    """Yield buffered leading text verbatim (it was not a bare call after all)."""
+    if buffer:
+        yield buffer
+
+
+def _recover_buffer(buffer: str) -> Iterator[str | ToolCallDelta]:
+    """Resolve the buffered leading text at a terminator or end of stream.
+
+    The buffer reaching here was held as a potential bare call (text starting with
+    ``{``/``[`` and no native call seen). Run :func:`_recover_bare_json_tool_calls`:
+    emit one delta per recovered call, or yield the text unchanged when it only
+    happened to start with ``{``/``[`` but is not a call.
+    """
+    if not buffer:
+        return
+    recovered = _recover_bare_json_tool_calls(buffer)
+    if not recovered.tool_calls:
+        yield buffer
+        return
+    for index, call in enumerate(recovered.tool_calls):
+        yield _tool_call_delta_from_recovered(call, index)

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -1157,6 +1157,135 @@ def test_chat_stream_items_text_only() -> None:
     assert items == ["He", "llo"]
 
 
+def _content_sse(content: str) -> str:
+    """One OpenAI SSE chunk carrying *content* as a text delta."""
+    return f"data: {json.dumps({'choices': [{'delta': {'content': content}}]})}\n\n"
+
+
+def _stream_handler(stream_body: str):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(200, text=stream_body)
+        return httpx.Response(404)
+
+    return handler
+
+
+def test_chat_stream_items_recovers_bare_json_tool_call() -> None:
+    """A model that streams a bare-JSON call as text yields recovered deltas, no
+    raw JSON leaking to the client."""
+    from lilbee.providers.base import ToolCallDelta
+
+    # Split the bare-JSON call across chunks so the buffer must reassemble the
+    # full call before parsing.
+    # A leading whitespace-only token (common from small models) must not resolve
+    # the buffer as plain text: it stays buffered until the '{' arrives.
+    head = '{"name": "lilbee_search", '
+    tail = '"arguments": {"query": "cats"}}'
+    body = _content_sse("  ") + _content_sse(head) + _content_sse(tail) + "data: [DONE]\n\n"
+    items = list(
+        _client(_stream_handler(body)).chat_stream_items(
+            [{"role": "user", "content": "find cats"}], tools=_tools()
+        )
+    )
+    assert not any(isinstance(i, str) for i in items), "raw JSON text must not leak"
+    deltas = [i for i in items if isinstance(i, ToolCallDelta)]
+    assert len(deltas) == 1
+    assert deltas[0].index == 0
+    assert deltas[0].name == "lilbee_search"
+    assert json.loads(deltas[0].arguments_delta or "") == {"query": "cats"}
+
+
+def test_chat_stream_items_streams_normal_text_incrementally() -> None:
+    """Plain text is not buffered to the end; tokens arrive one frame at a time."""
+    body = _content_sse("He") + _content_sse("llo") + _content_sse(" there") + "data: [DONE]\n\n"
+    items = list(
+        _client(_stream_handler(body)).chat_stream_items([{"role": "user", "content": "hi"}])
+    )
+    # Each content token is its own frame (incremental), not one coalesced blob.
+    assert items == ["He", "llo", " there"]
+
+
+def test_chat_stream_items_leading_whitespace_then_text_keeps_order() -> None:
+    """A whitespace-only first token is buffered (its first non-ws char is unknown),
+    then flushed in order once plain text resolves it -- not reordered to the end."""
+    body = _content_sse("  ") + _content_sse("Hello") + _content_sse(" world") + "data: [DONE]\n\n"
+    items = list(
+        _client(_stream_handler(body)).chat_stream_items([{"role": "user", "content": "hi"}])
+    )
+    # The leading whitespace stays first; subsequent tokens stream through in order.
+    assert items == ["  ", "Hello", " world"]
+    assert "".join(i for i in items if isinstance(i, str)) == "  Hello world"
+
+
+def test_chat_stream_items_text_starting_with_brace_is_not_recovered() -> None:
+    """Text that opens with '{' but is not a tool call streams through as text."""
+    body = _content_sse("{not really") + _content_sse(" a call}") + "data: [DONE]\n\n"
+    items = list(
+        _client(_stream_handler(body)).chat_stream_items(
+            [{"role": "user", "content": "x"}], tools=_tools()
+        )
+    )
+    from lilbee.providers.base import ToolCallDelta
+
+    assert not any(isinstance(i, ToolCallDelta) for i in items)
+    assert "".join(i for i in items if isinstance(i, str)) == "{not really a call}"
+
+
+def test_chat_stream_items_native_tool_calls_pass_through_untouched() -> None:
+    """Native tool_calls deltas are forwarded as is with no double-recovery. The
+    leading text opens with '{' so it is buffered as a candidate, then flushed
+    verbatim when the native delta proves it was just text."""
+    from lilbee.providers.base import ToolCallDelta
+
+    native_delta = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "c1",
+                            "function": {"name": "get_weather", "arguments": '{"city":"SF"}'},
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    body = (
+        _content_sse("{thinking} ") + f"data: {json.dumps(native_delta)}\n\n" + "data: [DONE]\n\n"
+    )
+    items = list(
+        _client(_stream_handler(body)).chat_stream_items(
+            [{"role": "user", "content": "weather?"}], tools=_tools()
+        )
+    )
+    # The buffered '{...}' lead is flushed as text; exactly one native delta, not recovered.
+    assert items[0] == "{thinking} "
+    deltas = [i for i in items if isinstance(i, ToolCallDelta)]
+    assert len(deltas) == 1
+    assert deltas[0].id == "c1"
+    assert deltas[0].name == "get_weather"
+
+
+def test_chat_stream_items_recovery_still_emits_usage_terminator_last() -> None:
+    """The usage terminator is emitted after a recovered bare-JSON call."""
+    from lilbee.providers.base import TokenUsage, ToolCallDelta
+
+    call_text = '{"name": "lilbee_search", "arguments": {"query": "x"}}'
+    usage_chunk = '{"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2}}'
+    body = _content_sse(call_text) + f"data: {usage_chunk}\n\n" + "data: [DONE]\n\n"
+    items = list(
+        _client(_stream_handler(body)).chat_stream_items(
+            [{"role": "user", "content": "x"}], tools=_tools()
+        )
+    )
+    assert isinstance(items[0], ToolCallDelta)
+    assert items[0].name == "lilbee_search"
+    assert items[-1] == TokenUsage(prompt_tokens=5, completion_tokens=2)
+
+
 def test_chat_result_forwards_tool_choice() -> None:
     seen: dict = {}
 


### PR DESCRIPTION
## Problem

When a model emits a tool call as bare JSON text in its content (instead of
structured `tool_calls`), lilbee recovers it on the non-streaming chat path but
not on the streaming path that coding agents use. So on a streamed response the
JSON leaks to the client as plain text and the tool never fires. The two paths
should behave the same.

## Solution

Apply the same recovery to the streaming path. `chat_stream_items` now wraps the
raw stream: it holds back leading content that looks like a bare call from its
first character, and if the buffered text parses as a bare-JSON tool call (the
same check the non-stream path already uses), it emits structured tool-call
deltas instead of text. Normal text still streams token by token, and native
tool calls pass through untouched.

This covers clean top-level `{"name", "arguments"}` calls, matching the
non-stream behavior. Models that wrap calls in preamble text, use a `parameters`
key, or emit custom end-tokens are a separate, engine-level concern.
