### PR TITLE
Fetch the target branch explicitly in the QA pod bootstrap

### DIFF
--- a/tools/qa/opencode/pod_bootstrap.sh
+++ b/tools/qa/opencode/pod_bootstrap.sh
@@ -62,9 +62,10 @@ if [ ! -d "$REPO_DIR/.git" ]; then
   git clone --depth 1 --branch "$BRANCH" https://github.com/tobocop2/lilbee.git "$REPO_DIR"
 else
   log "updating lilbee ($BRANCH)"
-  git -C "$REPO_DIR" fetch origin -q
-  git -C "$REPO_DIR" checkout -q "$BRANCH"
-  git -C "$REPO_DIR" reset --hard "origin/$BRANCH"
+  # The cached clone is shallow + single-branch, so a bare `fetch origin` won't
+  # pull a branch it wasn't cloned with; fetch the target branch explicitly.
+  git -C "$REPO_DIR" fetch --depth 1 origin "$BRANCH" -q
+  git -C "$REPO_DIR" checkout -q -B "$BRANCH" FETCH_HEAD
 fi
 cd "$REPO_DIR"
 


### PR DESCRIPTION
## Problem

The opencode QA pod reuses a cached, shallow single-branch clone on its volume.
Its fetch refspec is restricted to the branch it was cloned with, so a bare
`git fetch origin` never pulls a different branch, and checking out a fresh
branch fails with "pathspec did not match any file(s) known to git" — the setup
dies before the matrix runs.

## Solution

Fetch the target branch explicitly and check out `FETCH_HEAD`, so the bootstrap
can switch the cached clone to any branch regardless of what it was cloned with.
