### PR TITLE
Fix max_pages=1 crawl indexing nothing

### DIFF
--- a/src/lilbee/crawler/runner.py
+++ b/src/lilbee/crawler/runner.py
@@ -375,9 +375,14 @@ async def _run_crawl(
     Resolves the depth ceiling here (permitting the seed-only ``0``) so a
     ``cfg.crawl_max_depth`` of 0 routes to the single-page path instead of
     blowing up inside the recursive resolver.
+
+    A resolved page limit of 1 is also a single-page crawl: crawl4ai's BFS
+    under-counts tiny ``max_pages`` (``max_pages=1`` yields 0 pages), so route
+    the "at most one page" request to the reliable single-URL fetch.
     """
     depth = _resolve_depth(depth, cfg.crawl_max_depth)
-    if depth == 0:
+    pages = _resolve_page_limit(max_pages)
+    if depth == 0 or pages == 1:
         result = await crawl_single(
             url, quiet=quiet, on_progress=on_progress, render_mode=render_mode
         )

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1596,6 +1596,23 @@ class TestCrawlAndSave:
             await crawl_and_save("https://example.com", depth=-1)
         mock_crawl_single.assert_not_called()
 
+    @patch("lilbee.crawler.runner.crawl_recursive")
+    @patch("lilbee.crawler.runner.crawl_single")
+    async def test_max_pages_one_routes_to_single_page(
+        self, mock_crawl_single, mock_crawl_recursive, isolated_env
+    ):
+        """bb-7oh9: max_pages=1 is a single-page crawl.
+
+        crawl4ai's BFS under-counts tiny max_pages (max_pages=1 yields 0), so a
+        one-page request must route to the reliable single-URL fetch and index
+        the seed rather than nothing.
+        """
+        mock_crawl_single.return_value = CrawlResult(url="https://example.com", markdown="# Hi")
+        paths = await crawl_and_save("https://example.com", max_pages=1)
+        assert len(paths) == 1
+        mock_crawl_single.assert_awaited_once()
+        mock_crawl_recursive.assert_not_called()
+
     @patch("lilbee.crawler.runner.crawl_single")
     async def test_triggers_bootstrap_when_chromium_missing(
         self, mock_crawl_single, isolated_env, monkeypatch


### PR DESCRIPTION
## Problem

A crawl capped at one page (max_pages=1) returned "Crawled 0 page(s)" and indexed nothing. crawl4ai's BFS under-counts tiny page limits — asking for one page yielded zero — so a one-page crawl produced no content.

## Solution

A page limit of 1 is semantically a single-page crawl, so it now routes to the reliable single-URL fetch (the same path depth 0 uses) and indexes the seed. Larger limits are unchanged.

Validated end-to-end in the TUI: a crawl with max_pages=1 indexes the seed page with no error.