### PR TITLE
Bump the bundled llama.cpp engine to 0.3.30

### DIFF
--- a/.github/workflows/build-cuda-executables.yml
+++ b/.github/workflows/build-cuda-executables.yml
@@ -54,7 +54,7 @@ jobs:
             backend: cu121
             cuda: "12.1.0"
             asset_name: lilbee-linux-x86_64-cu121
-            llama-cpp-version: "0.3.20"
+            llama-cpp-version: "0.3.30"
           - os: ubuntu-22.04
             backend: cu124
             cuda: "12.4.0"

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -18,7 +18,7 @@ set -euxo pipefail
 # llama.cpp commit we build the server from. Bump deliberately (and re-run the
 # Metal/CPU/GPU self-check matrix) rather than tracking latest. llama-cpp-python
 # is only a BUILD-TIME source here -- lilbee no longer depends on it at runtime.
-_DEFAULT_LLAMA_CPP_VERSION="0.3.23"
+_DEFAULT_LLAMA_CPP_VERSION="0.3.30"
 
 # Pinned source tags for the two Go engine helpers bundled alongside llama-server.
 # Built from source (deterministic, no release-asset-name guessing); the wheel-build


### PR DESCRIPTION
## Problem

The bundled llama.cpp engine is pinned to llama-cpp-python `0.3.23`, with an
inconsistent `0.3.20` in the CUDA-executables build. Newer llama.cpp carries
additional native tool-call format parsers and fixes that several local chat
models need before they can return structured tool calls instead of leaking the
call as text.

## Solution

Bump both pins to `0.3.30` (current release) and unify them. The engine is built
from source at the llama.cpp commit this release vendors, so this is a deliberate
bump gated by the engine self-check matrix and the opencode tool-call validation.
