### PR TITLE
Bump crawl4ai to >=0.8.9 to clear six CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
 [project.optional-dependencies]
 litellm = ["litellm>=1.50"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
-crawler = ["crawl4ai>=0.8.6"]
+crawler = ["crawl4ai>=0.8.9"]
 release = ["lilbee[crawler,litellm,graph]"]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -669,7 +669,7 @@ toml = [
 
 [[package]]
 name = "crawl4ai"
-version = "0.8.6"
+version = "0.8.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -706,9 +706,9 @@ dependencies = [
     { name = "unclecode-litellm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/96/7525bd2e1f8f2f2924f350b0432481d673c3fb43e4d60f7d151e4137b8a6/crawl4ai-0.8.6.tar.gz", hash = "sha256:2a2afab05ae021435fe025cfc5732f5dcebcefd7ff9a529e41050642ee954316", size = 578962 }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2b/9e2b376ec8d4b803cc7b47b428a0ac762c59ce1215d0ab5a4aa9e7afc4a3/crawl4ai-0.8.9.tar.gz", hash = "sha256:00a3c97b9492a694f24fa66bc80b9f1533e5637745dc0e30914c88aac52763e3", size = 608119 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/e2/aa851e2f0248f0b19c63b0fe11f6bdc2ca64900924d399af368dc28f2a20/crawl4ai-0.8.6-py3-none-any.whl", hash = "sha256:57e127e8113640d8358705b231111d3cd9cc4ab05d44705e724cebc4a383e09c", size = 501931 },
+    { url = "https://files.pythonhosted.org/packages/c3/97/6443bf99add1c16b16d992b8d0816a3ce7adecde37323d368bed36dd0aff/crawl4ai-0.8.9-py3-none-any.whl", hash = "sha256:7836cfc9d81ed7fc646d614e984402c336e5a682462f3d92ff37de121a4244d6", size = 516731 },
 ]
 
 [[package]]
@@ -1660,7 +1660,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "crawl4ai", marker = "extra == 'crawler'", specifier = ">=0.8.6" },
+    { name = "crawl4ai", marker = "extra == 'crawler'", specifier = ">=0.8.9" },
     { name = "diskcache", specifier = ">=5.6.1" },
     { name = "filelock" },
     { name = "gguf", specifier = ">=0.18" },


### PR DESCRIPTION
## Problem

Code scanning flags `crawl4ai@0.8.6` with six advisories (two critical, four high): AST sandbox-escape pre-auth RCE, multiple Docker-API vulnerabilities, LLM credential exfiltration, arbitrary file write via symlink/TOCTOU, and two SSRF bypasses. All live in crawl4ai's Docker server/API.

## Solution

Bump the `crawler` extra floor to `crawl4ai>=0.8.9` and relock. 0.8.9 is the latest release and patches all six. lilbee uses crawl4ai as a library (not its Docker server), so it wasn't exploitable, but the upgrade closes the alerts cleanly. Verified every public symbol lilbee imports (`AsyncWebCrawler`, `BrowserConfig`, `CrawlerRunConfig`, the dispatchers, deep-crawl filters/strategy) is unchanged in 0.8.9, so the crawler integration is unaffected.

The lock diff is just crawl4ai 0.8.6 -> 0.8.9 with no transitive churn. Lint passes locally.