### PR TITLE
Suppress unfixable nltk path-traversal CVE in security scans

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -88,7 +88,7 @@ jobs:
           #   (py.path.svnwc). Pulled in transitively by pytest-forked>=1.6.0.
           #   Not reachable from lilbee or pytest-forked. No upstream fix.
           # - GHSA-vfmq-68hx-4jfw: XXE in lxml <6.1 default iterparse config.
-          #   Transitively pinned to 5.x by crawl4ai 0.8.6 (`lxml~=5.3`);
+          #   Transitively pinned to 5.x by crawl4ai 0.8.9 (`lxml~=5.3`);
           #   only installed with the `crawler` extra. Revisit when crawl4ai
           #   allows lxml 6.x.
           # - GHSA-xqmj-j6mv-4862: SSTI in the LiteLLM Proxy server's
@@ -118,6 +118,12 @@ jobs:
           #   (CVE-2024-34997). NumpyArrayWrapper only reads joblib-produced
           #   cache files (trusted content). joblib is transitive via nltk via
           #   crawl4ai (`crawler` extra); lilbee never imports it.
+          # - GHSA-p4gq-832x-fm9v: path traversal in nltk.data.load()
+          #   (CVE-2026-54293). No fixed nltk on PyPI (3.9.4 is latest).
+          #   Transitive via crawl4ai (`crawler` extra); lilbee never imports
+          #   nltk and crawl4ai only loads hardcoded resource names, so the
+          #   attacker-controlled-path vector is unreachable. bb-m851 tracks
+          #   the bump to nltk >= 3.10 once it ships.
           ignore-vulns: |
             CVE-2025-69872
             PYSEC-2022-42969
@@ -128,6 +134,7 @@ jobs:
             GHSA-wxxx-gvqv-xp7p
             PYSEC-2025-183
             PYSEC-2024-277
+            GHSA-p4gq-832x-fm9v
 
   osv-scan:
     name: OSV-Scanner (multi-ecosystem CVEs)

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -14,7 +14,7 @@ reason = "py 1.11.0 (unmaintained) pulled in transitively by pytest-forked>=1.6.
 
 [[IgnoredVulns]]
 id = "GHSA-vfmq-68hx-4jfw"
-reason = "lxml 5.4.0 pinned transitively by crawl4ai 0.8.6 (latest release), which requires `lxml~=5.3`. The fix lands in lxml 6.1.0 (defaults `resolve_entities` to 'internal' for iterparse/ETCompatXMLParser). lxml is only installed when users opt into the `crawler` extra, and crawl4ai uses lxml primarily for HTML scraping, not untrusted XML parsing with iterparse. Revisit when crawl4ai loosens its lxml pin."
+reason = "lxml 5.4.0 pinned transitively by crawl4ai 0.8.9 (latest release), which requires `lxml~=5.3`. The fix lands in lxml 6.1.0 (defaults `resolve_entities` to 'internal' for iterparse/ETCompatXMLParser). lxml is only installed when users opt into the `crawler` extra, and crawl4ai uses lxml primarily for HTML scraping, not untrusted XML parsing with iterparse. Revisit when crawl4ai loosens its lxml pin."
 
 [[IgnoredVulns]]
 id = "GHSA-xqmj-j6mv-4862"
@@ -57,3 +57,7 @@ reason = "DISPUTED deserialization finding in joblib.numpy_pickle.NumpyArrayWrap
 [[IgnoredVulns]]
 id = "GHSA-h8wq-7xc4-p3qx"
 reason = "False positive against nltk 3.9.4. OSV advisory CVE-2026-0846 fixes the issue in nltk 3.9.3 (affected versions enumerate up to 3.9.2 only); uv.lock pins 3.9.4, which is already past the fix. osv-scanner's range comparison still flags it; suppression is a guard until the scanner refreshes. nltk is pulled in transitively by crawl4ai under the `crawler` extra and lilbee never imports it. Remove this entry once osv-scanner stops emitting the alert."
+
+[[IgnoredVulns]]
+id = "GHSA-p4gq-832x-fm9v"
+reason = "Path traversal in nltk.data.load() via URL-encoded path separators (CVE-2026-54293). All nltk <= 3.9.4 are affected and no fixed version has been published to PyPI (3.9.4 is the latest release; 3.10.0 is still a pre-release). nltk is pulled in transitively by crawl4ai under the `crawler` extra; lilbee never imports nltk, and crawl4ai only calls it with hardcoded resource names (e.g. `tokenizers/punkt`) while crawled text is passed to sent_tokenize/word_tokenize as data, never as a resource path, so the attacker-controlled-path vector is unreachable. The Dependabot alert is dismissed as tolerable risk; bb-m851 tracks the bump to nltk >= 3.10 once it ships."


### PR DESCRIPTION
## Problem

The Security Scan workflow is red on main: OSV-Scanner (and pip-audit) flag `nltk@3.9.4` for GHSA-p4gq-832x-fm9v (CVE-2026-54293), a path traversal in `nltk.data.load()`. No fixed nltk exists on PyPI — 3.9.4 is the latest release and the whole `<= 3.9.4` range is affected — so there is nothing to bump to. This was already failing before the crawl4ai bump.

## Solution

Add GHSA-p4gq-832x-fm9v to the existing suppression lists (`osv-scanner.toml` and the mirrored pip-audit `ignore-vulns`), following the repo's established pattern for no-fix / not-reachable CVEs. nltk is transitive via the optional `crawler` extra; lilbee never imports it and crawl4ai only calls it with hardcoded resource names (crawled text goes to the tokenizers as data, never as a resource path), so the attacker-controlled-path vector is unreachable. The matching Dependabot alert is already dismissed as tolerable risk and bb-m851 tracks the bump to nltk >=3.10 once it ships.

Also refreshes the lxml suppression note to reference crawl4ai 0.8.9 (still pins `lxml~=5.3`) after the recent bump.