### PR TITLE
Make GPU ingest work on driver-only images by wiring the CUDA runtime

### DIFF
--- a/src/lilbee/providers/fleet/binary.py
+++ b/src/lilbee/providers/fleet/binary.py
@@ -84,11 +84,14 @@ def resolve_gguf_parser() -> Path:
 
 
 def llama_server_runtime_env() -> dict[str, str]:
-    """Extra environment for a spawned ``llama-server`` (empty on every platform).
+    """Extra environment for a spawned ``llama-server``.
 
     The bundled wheel ships its own ggml/llama/mtmd next to the binary with a baked
-    rpath (``@loader_path`` on macOS, ``$ORIGIN`` on Linux), and a bring-your-own
-    binary carries its own libraries, so the fleet never injects a library search
-    path. Kept as the single hook for any future per-spawn environment.
+    rpath (``@loader_path`` on macOS, ``$ORIGIN`` on Linux), but a CUDA build also
+    links the CUDA 12 runtime, which driver-only GPU images omit. On Linux this
+    adds any installed CUDA-runtime wheel libs to ``LD_LIBRARY_PATH``; elsewhere it
+    is empty.
     """
-    return {}
+    from lilbee.providers.fleet.cuda_runtime import cuda_runtime_env
+
+    return cuda_runtime_env()

--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -1,0 +1,123 @@
+"""Make a CUDA-linked llama-server start on driver-only GPU images.
+
+Driver-only GPU images (common on RunPod) ship ``libcuda.so`` from the kernel
+driver but not the CUDA 12 runtime the engine links: ``libcudart.so.12``,
+``libcublas.so.12``, ``libnvrtc.so.12``. Without them llama-server exits before
+binding its port and llama-swap reports only an opaque "exited prematurely".
+
+The pip wheels ``nvidia-cuda-runtime-cu12`` / ``nvidia-cublas-cu12`` /
+``nvidia-cuda-nvrtc-cu12`` carry those libraries under ``site-packages/nvidia``.
+When they are installed, :func:`cuda_runtime_env` puts their ``lib`` directories
+on the spawned server's ``LD_LIBRARY_PATH`` so GPU ingest works out of the box;
+when the libraries are still unresolved, :func:`preflight_cuda_runtime` turns the
+opaque failure into an install hint that names the exact packages.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from lilbee.providers.base import ProviderError
+
+log = logging.getLogger(__name__)
+
+# (import name, pip package, the soname the wheel provides). The import names are
+# the subpackages the nvidia-*-cu12 wheels install under the ``nvidia`` namespace.
+_CUDA_WHEEL_PACKAGES: tuple[tuple[str, str, str], ...] = (
+    ("nvidia.cuda_runtime", "nvidia-cuda-runtime-cu12", "libcudart.so.12"),
+    ("nvidia.cublas", "nvidia-cublas-cu12", "libcublas.so.12"),
+    ("nvidia.cuda_nvrtc", "nvidia-cuda-nvrtc-cu12", "libnvrtc.so.12"),
+)
+_SONAME_TO_PACKAGE = {soname: pkg for _imp, pkg, soname in _CUDA_WHEEL_PACKAGES}
+
+_LDD_TIMEOUT_S = 10
+
+
+def _wheel_lib_dir(import_name: str) -> Path | None:
+    """The ``lib/`` directory of an installed nvidia CUDA wheel subpackage, or None."""
+    try:
+        spec = importlib.util.find_spec(import_name)
+    except ModuleNotFoundError:
+        # The ``nvidia`` namespace parent is not installed at all.
+        return None
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    lib = Path(next(iter(spec.submodule_search_locations))) / "lib"
+    return lib if lib.is_dir() else None
+
+
+def _cuda_wheel_lib_dirs() -> list[Path]:
+    """Lib directories of every installed CUDA-runtime wheel, in link order."""
+    dirs = []
+    for import_name, _pkg, _soname in _CUDA_WHEEL_PACKAGES:
+        lib = _wheel_lib_dir(import_name)
+        if lib is not None:
+            dirs.append(lib)
+    return dirs
+
+
+def cuda_runtime_env() -> dict[str, str]:
+    """``LD_LIBRARY_PATH`` carrying the CUDA-runtime wheel libs, or empty.
+
+    Empty off Linux (where the wheels and ``LD_LIBRARY_PATH`` do not apply) and
+    when no wheel is installed. Wheel directories are prepended so they win over
+    any stale system copy, with the caller's existing path preserved behind them.
+    """
+    if not sys.platform.startswith("linux"):
+        return {}
+    dirs = _cuda_wheel_lib_dirs()
+    if not dirs:
+        return {}
+    parts = [str(d) for d in dirs]
+    existing = os.environ.get("LD_LIBRARY_PATH", "")
+    if existing:
+        parts.append(existing)
+    return {"LD_LIBRARY_PATH": os.pathsep.join(parts)}
+
+
+def _missing_cuda_libs(binary: Path, env: dict[str, str]) -> list[str]:
+    """CUDA runtime sonames *binary* links but ``ldd`` cannot resolve under *env*."""
+    ldd = shutil.which("ldd")
+    if ldd is None:
+        return []
+    try:
+        proc = subprocess.run(  # noqa: S603 - ldd path and the resolved binary
+            [ldd, str(binary)],
+            capture_output=True,
+            text=True,
+            timeout=_LDD_TIMEOUT_S,
+            env=env,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # Not an ELF, a static binary, or a timeout: nothing to preflight.
+        return []
+    return [soname for soname in _SONAME_TO_PACKAGE if f"{soname} => not found" in proc.stdout]
+
+
+def preflight_cuda_runtime(binary: Path) -> None:
+    """Raise an actionable error if *binary* links CUDA libs that won't load.
+
+    Runs after the wheel directories are on ``LD_LIBRARY_PATH`` so it only fires
+    when the runtime is genuinely absent. A CPU/Vulkan-only build does not link
+    the CUDA runtime, so ``ldd`` reports nothing missing and this is a no-op.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    env = {**os.environ, **cuda_runtime_env()}
+    missing = _missing_cuda_libs(binary, env)
+    if not missing:
+        return
+    packages = " ".join(_SONAME_TO_PACKAGE[soname] for soname in missing)
+    raise ProviderError(
+        f"llama-server needs the CUDA 12 runtime but {', '.join(missing)} could not be "
+        "found on this host (common on driver-only GPU images). Install the runtime with: "
+        f"pip install {packages} -- lilbee adds their libraries to the engine's search path "
+        "automatically. Or set LD_LIBRARY_PATH to a directory that contains them."
+    )

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -714,11 +714,15 @@ def plan_all_launches() -> list[InstanceLaunch]:
 
     Disables crash-prone Vulkan layers / dual-vendor ICDs and applies any
     ``cfg.gpu_devices`` pin before the probe and plan (both inherit the env).
+    Preflights the CUDA runtime before the device probe so a driver-only image
+    fails with an install hint instead of an opaque probe error.
     """
+    from lilbee.providers.fleet.cuda_runtime import preflight_cuda_runtime
     from lilbee.providers.fleet.gpu_env import apply_fleet_gpu_env
 
     apply_fleet_gpu_env()
     binary = resolve_llama_server()
+    preflight_cuda_runtime(binary)
     devices = resolve_devices(binary)
     by_index = {d.index: d for d in devices}
     return plan_launches(None, binary, by_index, devices)

--- a/tests/test_fleet_binary.py
+++ b/tests/test_fleet_binary.py
@@ -140,7 +140,11 @@ def test_aux_tool_raises_when_not_found(monkeypatch: pytest.MonkeyPatch) -> None
         resolve_gguf_parser()
 
 
-def test_runtime_env_is_empty() -> None:
-    # The self-contained wheel (rpath-baked) and a BYO binary both carry their own
-    # libs, so the fleet injects no library search path.
-    assert llama_server_runtime_env() == {}
+def test_runtime_env_delegates_to_cuda_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The self-contained wheel and a BYO binary carry their own libs; the only
+    # per-spawn env is the CUDA-runtime wheel path that driver-only images need.
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.cuda_runtime.cuda_runtime_env",
+        lambda: {"LD_LIBRARY_PATH": "/wheel/lib"},
+    )
+    assert llama_server_runtime_env() == {"LD_LIBRARY_PATH": "/wheel/lib"}

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -1,0 +1,156 @@
+"""Tests for CUDA-runtime wiring that lets the engine start on driver-only images."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from lilbee.providers.base import ProviderError
+from lilbee.providers.fleet import cuda_runtime
+from lilbee.providers.fleet.cuda_runtime import (
+    cuda_runtime_env,
+    preflight_cuda_runtime,
+)
+
+
+def _force_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.sys, "platform", "linux")
+
+
+def test_runtime_env_empty_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.sys, "platform", "darwin")
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/wheel/lib")])
+    assert cuda_runtime_env() == {}
+
+
+def test_runtime_env_empty_when_no_wheels(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+    assert cuda_runtime_env() == {}
+
+
+def test_runtime_env_sets_wheel_dirs_without_existing_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+    monkeypatch.setattr(
+        cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/a/lib"), Path("/b/lib")]
+    )
+    assert cuda_runtime_env() == {"LD_LIBRARY_PATH": "/a/lib:/b/lib"}
+
+
+def test_runtime_env_prepends_wheel_dirs_before_existing_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/usr/lib")
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/a/lib")])
+    assert cuda_runtime_env() == {"LD_LIBRARY_PATH": "/a/lib:/usr/lib"}
+
+
+def test_wheel_lib_dir_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    spec = SimpleNamespace(submodule_search_locations=[str(tmp_path)])
+    monkeypatch.setattr(cuda_runtime.importlib.util, "find_spec", lambda _name: spec)
+    assert cuda_runtime._wheel_lib_dir("nvidia.cuda_runtime") == lib
+
+
+def test_wheel_lib_dir_none_when_spec_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.importlib.util, "find_spec", lambda _name: None)
+    assert cuda_runtime._wheel_lib_dir("nvidia.cuda_runtime") is None
+
+
+def test_wheel_lib_dir_none_when_lib_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec = SimpleNamespace(submodule_search_locations=[str(tmp_path)])
+    monkeypatch.setattr(cuda_runtime.importlib.util, "find_spec", lambda _name: spec)
+    assert cuda_runtime._wheel_lib_dir("nvidia.cuda_runtime") is None
+
+
+def test_wheel_lib_dir_handles_uninstalled_parent(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(_name: str) -> None:
+        raise ModuleNotFoundError("No module named 'nvidia'")
+
+    monkeypatch.setattr(cuda_runtime.importlib.util, "find_spec", _raise)
+    assert cuda_runtime._wheel_lib_dir("nvidia.cuda_runtime") is None
+
+
+def test_preflight_noop_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.sys, "platform", "darwin")
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("ldd must not run off Linux")
+
+    monkeypatch.setattr(cuda_runtime.subprocess, "run", _boom)
+    preflight_cuda_runtime(Path("/bin/llama-server"))  # no raise
+
+
+def _have_ldd(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.shutil, "which", lambda _name: "/usr/bin/ldd")
+
+
+def test_preflight_passes_when_libs_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    _have_ldd(monkeypatch)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+    clean = "\tlibcudart.so.12 => /usr/lib/libcudart.so.12 (0x00007f00)\n"
+    monkeypatch.setattr(
+        cuda_runtime.subprocess,
+        "run",
+        lambda *_a, **_k: SimpleNamespace(stdout=clean, stderr=""),
+    )
+    preflight_cuda_runtime(Path("/bin/llama-server"))  # no raise
+
+
+def test_preflight_silent_when_ldd_not_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.setattr(cuda_runtime.shutil, "which", lambda _name: None)
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("ldd must not run when absent from PATH")
+
+    monkeypatch.setattr(cuda_runtime.subprocess, "run", _boom)
+    preflight_cuda_runtime(Path("/bin/llama-server"))  # no raise
+
+
+def test_preflight_raises_actionable_error_when_libs_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_linux(monkeypatch)
+    _have_ldd(monkeypatch)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+    missing = (
+        "\tlibcudart.so.12 => not found\n"
+        "\tlibcublas.so.12 => not found\n"
+        "\tlibnvrtc.so.12 => not found\n"
+    )
+    monkeypatch.setattr(
+        cuda_runtime.subprocess,
+        "run",
+        lambda *_a, **_k: SimpleNamespace(stdout=missing, stderr=""),
+    )
+    with pytest.raises(ProviderError) as exc:
+        preflight_cuda_runtime(Path("/bin/llama-server"))
+    message = str(exc.value)
+    assert "libcudart.so.12" in message
+    assert "nvidia-cuda-runtime-cu12" in message
+    assert "nvidia-cublas-cu12" in message
+    assert "nvidia-cuda-nvrtc-cu12" in message
+    assert "LD_LIBRARY_PATH" in message
+
+
+def test_preflight_silent_when_ldd_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    _have_ldd(monkeypatch)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+
+    def _raise(*_a: object, **_k: object) -> None:
+        raise OSError("ldd failed on a static binary")
+
+    monkeypatch.setattr(cuda_runtime.subprocess, "run", _raise)
+    preflight_cuda_runtime(Path("/bin/llama-server"))  # no raise

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -953,6 +953,35 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(planning_mod, "_launch_for", lambda *a, **kw: sentinel)
         assert planning_mod.plan_all_launches() == [sentinel]
 
+    def test_plan_all_launches_preflights_cuda_before_probing(self, monkeypatch) -> None:
+        # A missing CUDA runtime must surface before the device probe, which would
+        # otherwise fail opaquely on the same absent libraries.
+        seen: list[str] = []
+        monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.cuda_runtime.preflight_cuda_runtime",
+            lambda _binary: seen.append("preflight"),
+        )
+        monkeypatch.setattr(
+            planning_mod,
+            "probe_devices",
+            lambda _binary: seen.append("probe") or [],
+        )
+        monkeypatch.setattr("lilbee.providers.fleet.gpu_select.enumerate_gpu_vram", lambda: [])
+        monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: False)
+        monkeypatch.setattr(
+            planning_mod,
+            "_server_model_inputs",
+            lambda *_roles, **_kw: ([], {}, 0),
+        )
+        monkeypatch.setattr(
+            planning_mod,
+            "plan_placement",
+            lambda *a, **kw: Placement(instances=(), unplaceable_roles=()),
+        )
+        planning_mod.plan_all_launches()
+        assert seen == ["preflight", "probe"]
+
     def test_plan_all_launches_falls_back_to_vulkan_probe(self, monkeypatch) -> None:
         monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))
         monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [])  # can't enumerate


### PR DESCRIPTION
## Problem

The fleet llama-server links the CUDA 12 runtime (`libcudart.so.12`, `libcublas.so.12`, `libnvrtc.so.12`), but driver-only GPU images (common on RunPod) ship only `libcuda.so` from the kernel driver. The runtime libraries are missing, so llama-server exits before binding its port and llama-swap surfaces only an opaque "exited prematurely" — every vision/embed call then returns nothing. The benchmark has been working around this by hand: pip-installing the CUDA runtime wheels and putting them on `LD_LIBRARY_PATH`.

## Solution

New `fleet/cuda_runtime.py`. On Linux, `llama_server_runtime_env()` now prepends the lib directories of any installed `nvidia-cuda-runtime-cu12` / `nvidia-cublas-cu12` / `nvidia-cuda-nvrtc-cu12` wheels to the spawned server's `LD_LIBRARY_PATH`, so GPU ingest works out of the box once those wheels are present. `plan_all_launches()` preflights the runtime with `ldd` before the device probe; when the libraries are still unresolved it raises an actionable error naming the exact pip packages to install, instead of letting the probe fail opaquely. A CPU/Vulkan build does not link the CUDA runtime, so the preflight is a no-op there, and it does nothing off Linux.

Unit tests cover the env wiring, the wheel-dir discovery, and the preflight (missing libs, clean libs, no ldd), plus the planning preflight-before-probe ordering. Full lint, format-check, mypy, and imports-check pass.

Closes bb-b5lr.