### PR TITLE
Lead with the 'what is lilbee' hero demo (README + site)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 A batteries-included local search engine you can talk to: it runs the AI models, indexes your files and code, crawls the web, and plugs into your coding agent, so there's nothing else to install or set up. Ask in plain English; every answer cites the file and line.
 
-![lilbee chat with cited answers from an indexed PDF manual](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.gif)
+![ask lilbee "what is lilbee in one sentence?" and get a cited answer drawn from its own README](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/what_is_lilbee.gif)
 
 It's all one program: you never stand up a separate model server, a [vector database](#built-on), or a container. lilbee runs the models and keeps the index itself. Reach it as a full-screen terminal app, a command-line tool, a Model Context Protocol server, an HTTP API, or a Python library. Close it and it's gone, or run it as a service if you'd rather keep it warm. It runs on your computer; lilbee uses a cloud model only when you pick one.
 
@@ -119,6 +119,8 @@ lilbee does all of it, in one install: it finds and runs the models for you, pro
 Point lilbee at a folder of PDFs, notes, ebooks, or code and it builds a searchable library, with citations that click back to the source line. The pattern works for anything you have a lot of text about: a shelf of appliance manuals, a field's research papers, a car's service manuals, your company's internal wiki. Whatever you give it becomes searchable, and you can talk to it.
 
 ![/add a PDF, watch the Task Center, ask a cited question](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-add.gif)
+
+![chat with an indexed PDF manual: a cited markdown table extracted from the source](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-chat.gif)
 
 ### Already using an MCP-aware agent? Hand setup to it.
 

--- a/site/index.html
+++ b/site/index.html
@@ -100,7 +100,8 @@
       <div class="tutorial">
         <div class="tutorial-watch"><a class="tutorial-cta" href="tutorial/">▶&nbsp; watch the full tutorial reel</a></div>
         <div class="tutorialtabs" role="tablist" aria-label="Tutorial reel">
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-setup"    aria-controls="tutorial-pane-setup"    aria-selected="true"  tabindex="0">first run</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-whatis"   aria-controls="tutorial-pane-whatis"   aria-selected="true"  tabindex="0">what is lilbee</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-setup"    aria-controls="tutorial-pane-setup"    aria-selected="false" tabindex="-1">first run</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-tour"     aria-controls="tutorial-pane-tour"     aria-selected="false" tabindex="-1">tui-tour</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-chat"     aria-controls="tutorial-pane-chat"     aria-selected="false" tabindex="-1">chat</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-add"      aria-controls="tutorial-pane-add"      aria-selected="false" tabindex="-1">add files</button>
@@ -117,7 +118,14 @@
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-godot"    aria-controls="tutorial-pane-godot"    aria-selected="false" tabindex="-1">agent: godot</button>
         </div>
 
-        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-setup" aria-labelledby="tutorial-tab-setup">
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-whatis" aria-labelledby="tutorial-tab-whatis">
+          <div class="tutorial-clip">
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/what_is_lilbee.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+          </div>
+          <p class="tutorial-caption">Index lilbee's own README, ask "what is lilbee in one sentence?", and get a cited answer drawn straight from the source.</p>
+        </div>
+
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-setup" aria-labelledby="tutorial-tab-setup" hidden>
           <div class="tutorial-clip">
             <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-setup.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -53,6 +53,7 @@
         <a class="tutorial-toc-title" href="#tui">Drive it yourself <span>· full terminal app</span></a>
         <ul>
           <li class="toc-group"><a href="#tui-getting-started">Getting started</a></li>
+          <li><a href="#what-is-lilbee">What is lilbee?</a></li>
           <li><a href="#first-run">First run</a></li>
           <li><a href="#tui-tour">TUI tour</a></li>
           <li><a href="#command-surface">Command surface</a></li>
@@ -88,6 +89,17 @@
       <h2 class="tutorial-track-head"><a href="#tui">Drive it yourself <span class="track-sub">· full terminal app</span></a></h2>
 
       <h3 class="tutorial-group" id="tui-getting-started"><a href="#tui-getting-started">Getting started</a></h3>
+
+      <section class="tutorial-section" id="what-is-lilbee">
+        <h4><a href="#what-is-lilbee">What is lilbee?</a></h4>
+        <p>Index lilbee's own README, then ask <em>what is lilbee in one sentence?</em> and get a cited answer drawn straight from the source.</p>
+        <div class="tutorial-clip">
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/what_is_lilbee.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/what_is_lilbee.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/what_is_lilbee.mp4">what is lilbee (MP4)</a>
+          </video>
+        </div>
+      </section>
 
       <section class="tutorial-section" id="first-run">
         <h4><a href="#first-run">First run</a></h4>


### PR DESCRIPTION
## Problem
Neither the README nor the marketing site opens with a demo that says what lilbee *is*.

## Solution
Makes `what_is_lilbee` the lead demo everywhere: a TUI clip where lilbee's own README is indexed and you ask it "what is lilbee in one sentence?", getting a cited answer from the README.

- **README**: what_is_lilbee.gif becomes the hero; tui-add stays as the next demo; tui-chat moves into the 'library of your own files' section (nothing dropped).
- **Site (lilbee.sh)**: what_is_lilbee is the first tutorial tab; first-run moves to second.
- **Tutorial page**: added as the first section + TOC entry.

Needs the gif/mp4 on gh-pages (#374).