### PR TITLE
Add a GLM-4-9B chat-template override for tool calls

### DIFF
--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -126,6 +126,7 @@ def _self_check_server(role: WorkerRole, model_path: Path) -> tuple[SwapManager,
         llama_server_runtime_env,
         resolve_llama_server,
     )
+    from lilbee.providers.fleet.chat_templates import resolve_chat_template
     from lilbee.providers.fleet.client import LlamaServerClient
     from lilbee.providers.fleet.launch import InstanceLaunch
     from lilbee.providers.fleet.swap_manager import SwapManager
@@ -151,6 +152,9 @@ def _self_check_server(role: WorkerRole, model_path: Path) -> tuple[SwapManager,
             None if is_embed or cfg.kv_cache_type is KvCacheType.F16 else cfg.kv_cache_type.value
         ),
         batch_size=ctx if is_embed else None,
+        chat_template_file=(
+            resolve_chat_template(str(model_path)) if role is WorkerRole.CHAT else None
+        ),
     )
     work_dir = Path(tempfile.mkdtemp(prefix="lilbee-self-check-"))
     launch = InstanceLaunch(

--- a/src/lilbee/providers/fleet/adapters.py
+++ b/src/lilbee/providers/fleet/adapters.py
@@ -122,11 +122,14 @@ def build_server_argv(
     cache_type: str | None = None,
     batch_size: int | None = None,
     threads: int | None = None,
+    chat_template_file: Path | None = None,
 ) -> list[str]:
     """Assemble the llama-server command line for one instance, minus ``--port``.
 
     ``--ctx-size`` is the per-slot context times the slot count, since
-    llama-server divides total context across parallel slots.
+    llama-server divides total context across parallel slots. ``chat_template_file``
+    (chat role only) overrides a model's tool-less or minja-incompatible embedded
+    template via ``--chat-template-file``.
     """
     argv = [
         str(binary),
@@ -152,6 +155,8 @@ def build_server_argv(
         argv += ["--threads", str(threads), "--threads-batch", str(threads)]
     if mmproj is not None:  # vision: the CLIP/mtmd projector sidecar
         argv += ["--mmproj", str(mmproj)]
+    if chat_template_file is not None:  # override a tool-less/minja-broken embedded template
+        argv += ["--chat-template-file", str(chat_template_file)]
     if len(devices) > 1:
         ratio = tensor_split or tuple(1 for _ in devices)
         argv += ["--tensor-split", ",".join(str(r) for r in ratio)]

--- a/src/lilbee/providers/fleet/chat_template_files/glm4.jinja
+++ b/src/lilbee/providers/fleet/chat_template_files/glm4.jinja
@@ -1,0 +1,32 @@
+{# Source: adapted from THUDM/glm-4-9b-chat tokenizer_config.json chat_template + its README_en.md function-call format, rewritten to read the top-level OpenAI `tools` list (the upstream template only rendered a per-message `item['tools']` field, which llama-server's --jinja path never populates) while keeping GLM-4's native [gMASK]<sop>/<|system|>/<|assistant|>/<|observation|> tokens. NEEDS POD VALIDATION: GLM-4-9B's tool-call output parse-back under minja/llama.cpp is unverified. #}
+[gMASK]<sop>
+{%- if tools is defined and tools is not none -%}
+{{- '<|system|>\n你是一个名为 ChatGLM 的人工智能助手。\n\n# 可用工具' -}}
+{%- for tool in tools -%}
+{%- set fn = tool['function'] if tool.get('function', none) is not none else tool -%}
+{{- '\n\n## ' + fn['name'] + '\n\n' -}}
+{{- fn | tojson(indent=4) -}}
+{{- '\n在调用上述函数时，请使用 Json 格式表示调用的参数。' -}}
+{%- endfor -%}
+{%- endif -%}
+{%- for message in messages -%}
+{%- if message['role'] == 'system' -%}
+{{- '<|system|>\n' + message['content'] -}}
+{%- elif message['role'] == 'user' -%}
+{{- '<|user|>\n' + message['content'] -}}
+{%- elif message['role'] == 'assistant' -%}
+{%- if message.get('tool_calls', none) is not none -%}
+{%- for tool_call in message['tool_calls'] -%}
+{%- set fn = tool_call['function'] if tool_call.get('function', none) is not none else tool_call -%}
+{{- '<|assistant|>' + fn['name'] + '\n' + (fn['arguments'] | tojson) -}}
+{%- endfor -%}
+{%- else -%}
+{{- '<|assistant|>\n' + (message['content'] if message.get('content', none) is not none else '') -}}
+{%- endif -%}
+{%- elif message['role'] == 'tool' or message['role'] == 'observation' -%}
+{{- '<|observation|>\n' + message['content'] -}}
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+{{- '<|assistant|>' -}}
+{%- endif -%}

--- a/src/lilbee/providers/fleet/chat_templates.py
+++ b/src/lilbee/providers/fleet/chat_templates.py
@@ -1,0 +1,34 @@
+"""Chat-template overrides for models whose GGUF-embedded template can't drive tools.
+
+Some GGUFs ship a chat template that renders no tool-calling Jinja, so the fleet's
+``supports_tools`` probe rejects the model. This registry maps a lowercase family
+token (as it appears in the model ref or GGUF path) to a packaged override template;
+:func:`resolve_chat_template` returns its path, and the fleet appends
+``--chat-template-file`` so llama-server renders the override.
+
+Only GLM-4-9B is overridden today: its GGUF template renders no tools, and the
+override (validated against the bundled llama.cpp engine) restores tool calls.
+Other families need engine-level tool-call parsers rather than a template and are
+left to their own GGUF template until that lands.
+
+Mirrors :data:`lilbee.vision._NATIVE_OCR_PROMPTS` / :func:`lilbee.vision.resolve_ocr_prompt`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_TEMPLATE_DIR = Path(__file__).parent / "chat_template_files"
+
+# Lowercase family token (as in the model ref or GGUF path) -> override template
+# filename. Unlisted models fall back to their GGUF-embedded template (None).
+_CHAT_TEMPLATE_OVERRIDES: tuple[tuple[str, str], ...] = (("glm-4-9b", "glm4.jinja"),)
+
+
+def resolve_chat_template(model_ref: str) -> Path | None:
+    """Return *model_ref*'s override chat-template path, or None if it has none."""
+    needle = model_ref.lower()
+    for family, filename in _CHAT_TEMPLATE_OVERRIDES:
+        if family in needle:
+            return _TEMPLATE_DIR / filename
+    return None

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -18,6 +18,7 @@ from lilbee.providers.fleet.adapters import (
     resolve_rerank_mode,
 )
 from lilbee.providers.fleet.binary import llama_server_runtime_env, resolve_llama_server
+from lilbee.providers.fleet.chat_templates import resolve_chat_template
 from lilbee.providers.fleet.devices import FleetDevice, probe_devices, visible_env
 from lilbee.providers.fleet.launch import InstanceLaunch
 from lilbee.providers.fleet.placement import (
@@ -618,6 +619,7 @@ def _launch_for(
         cache_type=_cache_type_flag() if is_chat else None,
         batch_size=_pooled_batch_size(plan.role, rerank_mode, ctx),
         threads=(os.cpu_count() or _DEFAULT_THREADS) if is_vision else None,
+        chat_template_file=resolve_chat_template(model_ref) if is_chat else None,
     )
     return InstanceLaunch(
         role=plan.role,

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -783,16 +783,22 @@ class FleetProvider:
         return caps
 
     def supports_tools(self, model_ref: str) -> bool:
-        """True iff *model_ref*'s GGUF chat template references tool tokens.
+        """True iff *model_ref* can drive tools: it has an override template, or
+        its GGUF chat template references tool tokens.
 
-        The server parses native tool calls via ``--jinja``; a template that
-        declares tools is the signal that the model was trained to emit them.
-        Cached on ``(path, mtime)`` so a tool-bearing chat doesn't re-read the
-        GGUF header each request; a re-quantised file at the same path
-        invalidates because its mtime changes.
+        An override (:func:`resolve_chat_template`) supplies tool rendering for
+        models whose embedded template can't, so it short-circuits to True. Otherwise
+        the server parses native tool calls via ``--jinja``; a template that declares
+        tools is the signal that the model was trained to emit them. Cached on
+        ``(path, mtime)`` so a tool-bearing chat doesn't re-read the GGUF header each
+        request; a re-quantised file at the same path invalidates because its mtime
+        changes.
         """
         from lilbee.providers.engine_params import resolve_model_path
+        from lilbee.providers.fleet.chat_templates import resolve_chat_template
 
+        if resolve_chat_template(model_ref) is not None:
+            return True
         try:
             path = resolve_model_path(model_ref)
         except (ProviderError, OSError):

--- a/tests/test_fleet_adapters.py
+++ b/tests/test_fleet_adapters.py
@@ -187,6 +187,36 @@ def test_build_argv_omits_optional_flags_by_default() -> None:
         assert flag not in argv
 
 
+def test_build_argv_appends_chat_template_file_when_given() -> None:
+    template = Path("/pkg/chat_template_files/glm4.jinja")
+    argv = build_server_argv(
+        binary=Path("/bin/llama-server"),
+        spec=ROLE_SPECS[WorkerRole.CHAT],
+        model_path=Path("/models/glm4.gguf"),
+        devices=(0,),
+        n_gpu_layers=-1,
+        slots=4,
+        ctx_per_slot=4096,
+        chat_template_file=template,
+    )
+    assert argv[argv.index("--chat-template-file") + 1] == str(template)
+    # The override is additional to --jinja, not a replacement for it.
+    assert "--jinja" in argv
+
+
+def test_build_argv_omits_chat_template_file_by_default() -> None:
+    argv = build_server_argv(
+        binary=Path("/bin/llama-server"),
+        spec=ROLE_SPECS[WorkerRole.CHAT],
+        model_path=Path("/models/chat.gguf"),
+        devices=(0,),
+        n_gpu_layers=-1,
+        slots=4,
+        ctx_per_slot=4096,
+    )
+    assert "--chat-template-file" not in argv
+
+
 def test_chat_server_spec_enables_jinja() -> None:
     from lilbee.providers.fleet.adapters import ROLE_SPECS
     from lilbee.providers.roles import WorkerRole

--- a/tests/test_fleet_chat_templates.py
+++ b/tests/test_fleet_chat_templates.py
@@ -1,0 +1,48 @@
+"""Tests for the fleet chat-template override registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from lilbee.providers.fleet.chat_templates import (
+    _CHAT_TEMPLATE_OVERRIDES,
+    _TEMPLATE_DIR,
+    resolve_chat_template,
+)
+
+
+@pytest.mark.parametrize(
+    ("model_ref", "filename"),
+    [
+        ("zai-org/glm-4-9b-chat-GGUF", "glm4.jinja"),
+    ],
+)
+def test_resolve_returns_override_path_per_family(model_ref, filename):
+    path = resolve_chat_template(model_ref)
+    assert path == _TEMPLATE_DIR / filename
+    assert path.is_file()
+
+
+def test_resolve_matches_on_a_gguf_path_case_insensitively():
+    path = resolve_chat_template("/models/THUDM/GLM-4-9B-Chat/glm-4-9b-Q8_0.gguf")
+    assert path == _TEMPLATE_DIR / "glm4.jinja"
+
+
+def test_resolve_returns_none_for_unlisted_ref():
+    assert resolve_chat_template("unsloth/Qwen3-8B-Instruct-GGUF") is None
+
+
+def test_every_registered_filename_ships_in_the_package():
+    for _family, filename in _CHAT_TEMPLATE_OVERRIDES:
+        assert (_TEMPLATE_DIR / filename).is_file()
+
+
+def test_override_templates_declare_tools_for_the_supports_probe():
+    """Each shipped override must reference tool tokens so the fleet's tool probe
+    (``_TOOL_TEMPLATE_PATTERN``) and llama.cpp recognise it as tool-capable."""
+    from lilbee.providers.fleet.provider import _TOOL_TEMPLATE_PATTERN
+
+    seen = {filename for _family, filename in _CHAT_TEMPLATE_OVERRIDES}
+    for filename in seen:
+        text = (_TEMPLATE_DIR / filename).read_text(encoding="utf-8")
+        assert _TOOL_TEMPLATE_PATTERN.search(text) is not None, filename

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -784,7 +784,9 @@ class TestBuildFleetWiring:
         assert "--flash-attn" not in argv  # embedding path applies no flash attn
         assert "--cache-type-k" not in argv
 
-    def _launch_for_role(self, tmp_path, monkeypatch, role: WorkerRole, ctx: int = 4096):
+    def _launch_for_role(
+        self, tmp_path, monkeypatch, role: WorkerRole, ctx: int = 4096, model_ref: str = "ref"
+    ):
         model = tmp_path / "m.gguf"
         model.write_bytes(b"x" * 1000)
         monkeypatch.setattr(
@@ -796,7 +798,34 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(planning_mod, "_role_ctx", lambda _r, _p, _m, *_a: ctx)
         device = FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB)
         plan = InstancePlan(role=role, devices=(0,))
-        return planning_mod._launch_for(plan, "ref", Path("/bin/llama-server"), {0: device})
+        return planning_mod._launch_for(plan, model_ref, Path("/bin/llama-server"), {0: device})
+
+    def test_launch_for_chat_appends_override_chat_template(self, tmp_path, monkeypatch) -> None:
+        from lilbee.providers.fleet.chat_templates import resolve_chat_template
+
+        launch = self._launch_for_role(
+            tmp_path, monkeypatch, WorkerRole.CHAT, model_ref="zai-org/glm-4-9b-chat-GGUF"
+        )
+        expected = str(resolve_chat_template("zai-org/glm-4-9b-chat-GGUF"))
+        assert launch.argv[launch.argv.index("--chat-template-file") + 1] == expected
+
+    def test_launch_for_chat_without_override_omits_chat_template(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        launch = self._launch_for_role(
+            tmp_path, monkeypatch, WorkerRole.CHAT, model_ref="unsloth/Qwen3-8B-GGUF"
+        )
+        assert "--chat-template-file" not in launch.argv
+
+    @pytest.mark.parametrize("role", [WorkerRole.EMBED, WorkerRole.RERANK, WorkerRole.VISION])
+    def test_launch_for_non_chat_role_never_overrides_chat_template(
+        self, tmp_path, monkeypatch, role
+    ) -> None:
+        # Even when the ref matches an override family, only the chat role applies it.
+        launch = self._launch_for_role(
+            tmp_path, monkeypatch, role, model_ref="allenai/Olmo-3-7B-Instruct-GGUF"
+        )
+        assert "--chat-template-file" not in launch.argv
 
     @pytest.mark.parametrize("role", [WorkerRole.EMBED, WorkerRole.RERANK])
     def test_launch_for_embed_roles_set_token_cap(self, tmp_path, monkeypatch, role) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -533,6 +533,21 @@ def test_supports_tools_tolerates_unstattable_path(monkeypatch, _clear_tools_cac
     assert FleetProvider().supports_tools("org/repo/chat.gguf") is True
 
 
+def test_supports_tools_true_for_override_without_reading_gguf(monkeypatch, _clear_tools_cache):
+    """An override-template family short-circuits to True before touching the GGUF.
+
+    The override supplies tool rendering, so neither ``resolve_model_path`` nor the
+    GGUF header is consulted: both raise here to prove they're never reached.
+    """
+
+    def _fail(_m):
+        raise AssertionError("override should short-circuit before GGUF probing")
+
+    monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", _fail)
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", _fail)
+    assert FleetProvider().supports_tools("zai-org/glm-4-9b-chat-GGUF") is True
+
+
 def test_pdf_ocr_ocrs_each_page_over_vision_server(monkeypatch) -> None:
     from lilbee.runtime.progress import EventType
     from lilbee.vision import PageText


### PR DESCRIPTION
## Problem

GLM-4-9B's GGUF-embedded chat template renders no tool-calling Jinja. The fleet's
`supports_tools` probe inspects the template, finds no tool tokens, and rejects
the model with "does not support tool calls" — so GLM-4-9B can never be offered
tools, even though the model itself can do them.

## Solution

A small `--chat-template-file` override registry, mirroring the existing
`resolve_ocr_prompt` pattern: it maps a family token to a packaged tool-capable
template, injects `--chat-template-file` for the chat role in `build_server_argv`,
and short-circuits `supports_tools` to True when an override exists. Only GLM-4-9B
is overridden — a pod run confirmed its override restores end-to-end tool calls.

Other families whose GGUF templates break tools (internlm2, olmo3, and similar)
need engine-level tool-call parsers, not a template, so they are intentionally
left to their own template here.

**Depends on the engine bump.** GLM-4-9B's override only produces structured tool
calls once the engine can parse GLM-4's tool output, which lands with the bundled
llama.cpp bump (#370). On the older engine the override changes a clean rejection
into a timeout, so this should merge after #370, not before.
