### PR TITLE
Wire the CUDA 12 runtime via a cuda12 extra (driver-only GPU images)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ dependencies = [
 remote = ["litellm>=1.50"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
 crawler = ["crawl4ai>=0.8.6"]
+# The CUDA 12 runtime the bundled llama-server links, from NVIDIA's official PyPI
+# wheels. Markers keep it a no-op off Linux x86_64 (no wheel exists elsewhere);
+# fleet.cuda_runtime adds their lib dirs to the engine's LD_LIBRARY_PATH.
+cuda12 = [
+    "nvidia-cuda-runtime-cu12; platform_system=='Linux' and platform_machine=='x86_64'",
+    "nvidia-cublas-cu12; platform_system=='Linux' and platform_machine=='x86_64'",
+    "nvidia-cuda-nvrtc-cu12; platform_system=='Linux' and platform_machine=='x86_64'",
+]
 release = ["lilbee[crawler,remote,graph]"]
 
 [project.urls]

--- a/src/lilbee/providers/fleet/binary.py
+++ b/src/lilbee/providers/fleet/binary.py
@@ -84,11 +84,14 @@ def resolve_gguf_parser() -> Path:
 
 
 def llama_server_runtime_env() -> dict[str, str]:
-    """Extra environment for a spawned ``llama-server`` (empty on every platform).
+    """Extra environment for a spawned ``llama-server``.
 
     The bundled wheel ships its own ggml/llama/mtmd next to the binary with a baked
-    rpath (``@loader_path`` on macOS, ``$ORIGIN`` on Linux), and a bring-your-own
-    binary carries its own libraries, so the fleet never injects a library search
-    path. Kept as the single hook for any future per-spawn environment.
+    rpath (``@loader_path`` on macOS, ``$ORIGIN`` on Linux), but a CUDA build also
+    links the CUDA 12 runtime, which driver-only GPU images omit. On Linux this
+    adds any installed CUDA-runtime wheel libs to ``LD_LIBRARY_PATH``; elsewhere it
+    is empty.
     """
-    return {}
+    from lilbee.providers.fleet.cuda_runtime import cuda_runtime_env
+
+    return cuda_runtime_env()

--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -1,0 +1,65 @@
+"""Put the CUDA 12 runtime wheels on the engine's library search path.
+
+Driver-only GPU images (common on RunPod) ship ``libcuda.so`` from the kernel
+driver but not the CUDA 12 runtime that llama-server links (``libcudart.so.12``,
+``libcublas.so.12``, ``libnvrtc.so.12``); without them llama-server exits before
+binding its port. Installing lilbee with the ``cuda12`` extra pulls the
+``nvidia-cuda-runtime-cu12`` / ``nvidia-cublas-cu12`` / ``nvidia-cuda-nvrtc-cu12``
+wheels, which carry those libraries under ``site-packages/nvidia``.
+:func:`cuda_runtime_env` adds their ``lib`` directories to the spawned server's
+``LD_LIBRARY_PATH`` so GPU ingest works without a system CUDA toolkit -- the path
+can't be a baked rpath because the wheels' location is only known at install time.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+# Subpackages the nvidia-*-cu12 wheels install under the ``nvidia`` namespace
+# (the ``cuda12`` extra: nvidia-cuda-runtime-cu12, nvidia-cublas-cu12,
+# nvidia-cuda-nvrtc-cu12).
+_CUDA_WHEEL_IMPORTS: tuple[str, ...] = (
+    "nvidia.cuda_runtime",
+    "nvidia.cublas",
+    "nvidia.cuda_nvrtc",
+)
+
+
+def _wheel_lib_dir(import_name: str) -> Path | None:
+    """The ``lib/`` directory of an installed nvidia CUDA wheel subpackage, or None."""
+    try:
+        spec = importlib.util.find_spec(import_name)
+    except ModuleNotFoundError:
+        # The ``nvidia`` namespace parent is not installed at all.
+        return None
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    lib = Path(next(iter(spec.submodule_search_locations))) / "lib"
+    return lib if lib.is_dir() else None
+
+
+def _cuda_wheel_lib_dirs() -> list[Path]:
+    """Lib directories of every installed CUDA-runtime wheel, in link order."""
+    return [lib for name in _CUDA_WHEEL_IMPORTS if (lib := _wheel_lib_dir(name)) is not None]
+
+
+def cuda_runtime_env() -> dict[str, str]:
+    """``LD_LIBRARY_PATH`` carrying the CUDA-runtime wheel libs, or empty.
+
+    Empty off Linux (where the wheels and ``LD_LIBRARY_PATH`` do not apply) and
+    when no wheel is installed. Wheel directories are prepended so they win over
+    any stale system copy, with the caller's existing path preserved behind them.
+    """
+    if not sys.platform.startswith("linux"):
+        return {}
+    dirs = _cuda_wheel_lib_dirs()
+    if not dirs:
+        return {}
+    parts = [str(d) for d in dirs]
+    existing = os.environ.get("LD_LIBRARY_PATH", "")
+    if existing:
+        parts.append(existing)
+    return {"LD_LIBRARY_PATH": os.pathsep.join(parts)}

--- a/tests/test_fleet_binary.py
+++ b/tests/test_fleet_binary.py
@@ -140,7 +140,11 @@ def test_aux_tool_raises_when_not_found(monkeypatch: pytest.MonkeyPatch) -> None
         resolve_gguf_parser()
 
 
-def test_runtime_env_is_empty() -> None:
-    # The self-contained wheel (rpath-baked) and a BYO binary both carry their own
-    # libs, so the fleet injects no library search path.
-    assert llama_server_runtime_env() == {}
+def test_runtime_env_delegates_to_cuda_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The self-contained wheel and a BYO binary carry their own libs; the only
+    # per-spawn env is the CUDA-runtime wheel path that driver-only images need.
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.cuda_runtime.cuda_runtime_env",
+        lambda: {"LD_LIBRARY_PATH": "/wheel/lib"},
+    )
+    assert llama_server_runtime_env() == {"LD_LIBRARY_PATH": "/wheel/lib"}

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -1,0 +1,86 @@
+"""Tests for CUDA-runtime wiring that lets the engine start on driver-only images."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from lilbee.providers.fleet import cuda_runtime
+from lilbee.providers.fleet.cuda_runtime import cuda_runtime_env
+
+
+def _force_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.sys, "platform", "linux")
+
+
+def test_runtime_env_empty_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.sys, "platform", "darwin")
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/wheel/lib")])
+    assert cuda_runtime_env() == {}
+
+
+def test_runtime_env_empty_when_no_wheels(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+    assert cuda_runtime_env() == {}
+
+
+def test_runtime_env_sets_wheel_dirs_without_existing_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+    monkeypatch.setattr(
+        cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/a/lib"), Path("/b/lib")]
+    )
+    assert cuda_runtime_env() == {"LD_LIBRARY_PATH": "/a/lib:/b/lib"}
+
+
+def test_runtime_env_prepends_wheel_dirs_before_existing_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/usr/lib")
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/a/lib")])
+    assert cuda_runtime_env() == {"LD_LIBRARY_PATH": "/a/lib:/usr/lib"}
+
+
+def test_wheel_lib_dir_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    spec = SimpleNamespace(submodule_search_locations=[str(tmp_path)])
+    monkeypatch.setattr(cuda_runtime.importlib.util, "find_spec", lambda _name: spec)
+    assert cuda_runtime._wheel_lib_dir("nvidia.cuda_runtime") == lib
+
+
+def test_wheel_lib_dir_none_when_spec_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.importlib.util, "find_spec", lambda _name: None)
+    assert cuda_runtime._wheel_lib_dir("nvidia.cuda_runtime") is None
+
+
+def test_wheel_lib_dir_none_when_lib_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec = SimpleNamespace(submodule_search_locations=[str(tmp_path)])
+    monkeypatch.setattr(cuda_runtime.importlib.util, "find_spec", lambda _name: spec)
+    assert cuda_runtime._wheel_lib_dir("nvidia.cuda_runtime") is None
+
+
+def test_wheel_lib_dir_handles_uninstalled_parent(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(_name: str) -> None:
+        raise ModuleNotFoundError("No module named 'nvidia'")
+
+    monkeypatch.setattr(cuda_runtime.importlib.util, "find_spec", _raise)
+    assert cuda_runtime._wheel_lib_dir("nvidia.cuda_runtime") is None
+
+
+def test_cuda_wheel_lib_dirs_collects_only_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    found = {
+        "nvidia.cuda_runtime": Path("/r/lib"),
+        "nvidia.cublas": None,
+        "nvidia.cuda_nvrtc": Path("/n/lib"),
+    }
+    monkeypatch.setattr(cuda_runtime, "_wheel_lib_dir", lambda name: found[name])
+    assert cuda_runtime._cuda_wheel_lib_dirs() == [Path("/r/lib"), Path("/n/lib")]

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -32,10 +33,10 @@ def test_runtime_env_sets_wheel_dirs_without_existing_path(
 ) -> None:
     _force_linux(monkeypatch)
     monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
-    monkeypatch.setattr(
-        cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/a/lib"), Path("/b/lib")]
-    )
-    assert cuda_runtime_env() == {"LD_LIBRARY_PATH": "/a/lib:/b/lib"}
+    dirs = [Path("/a/lib"), Path("/b/lib")]
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: dirs)
+    # os.pathsep / str(Path) keep this host-agnostic (':' vs ';', / vs \).
+    assert cuda_runtime_env() == {"LD_LIBRARY_PATH": os.pathsep.join(str(d) for d in dirs)}
 
 
 def test_runtime_env_prepends_wheel_dirs_before_existing_path(
@@ -43,8 +44,9 @@ def test_runtime_env_prepends_wheel_dirs_before_existing_path(
 ) -> None:
     _force_linux(monkeypatch)
     monkeypatch.setenv("LD_LIBRARY_PATH", "/usr/lib")
-    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/a/lib")])
-    assert cuda_runtime_env() == {"LD_LIBRARY_PATH": "/a/lib:/usr/lib"}
+    lib = Path("/a/lib")
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [lib])
+    assert cuda_runtime_env() == {"LD_LIBRARY_PATH": os.pathsep.join([str(lib), "/usr/lib"])}
 
 
 def test_wheel_lib_dir_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1631,6 +1631,11 @@ dependencies = [
 crawler = [
     { name = "crawl4ai" },
 ]
+cuda12 = [
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
 graph = [
     { name = "graspologic-native" },
     { name = "spacy" },
@@ -1679,6 +1684,9 @@ requires-dist = [
     { name = "litestar", specifier = ">=2.0" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "numpy" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'cuda12'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'cuda12'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'cuda12'" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "psutil", specifier = ">=5.9" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
@@ -1690,7 +1698,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.5.0" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
-provides-extras = ["remote", "graph", "crawler", "release"]
+provides-extras = ["remote", "graph", "crawler", "cuda12", "release"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2356,6 +2364,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/58/ad/1100d7229bb248394939a12a8074d485b655e8ed44207d328fdd7fcebc7b/numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e58765ad74dcebd3ef0208a5078fba32dc8ec3578fe84a604432950cd043d79", size = 15800434 },
     { url = "https://files.pythonhosted.org/packages/0c/fd/16d710c085d28ba4feaf29ac60c936c9d662e390344f94a6beaa2ac9899b/numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e236dbda4e1d319d681afcbb136c0c4a8e0f1a5c58ceec2adebb547357fe857", size = 16729409 },
     { url = "https://files.pythonhosted.org/packages/57/a7/b35835e278c18b85206834b3aa3abe68e77a98769c59233d1f6300284781/numpy-2.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4b42639cdde6d24e732ff823a3fa5b701d8acad89c4142bc1d0bd6dc85200ba5", size = 12504685 },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.9.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110 },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129 },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The fleet's `llama-server` links the CUDA 12 runtime (`libcudart.so.12`,
`libcublas.so.12`, `libnvrtc.so.12`). Driver-only GPU images (common on RunPod)
ship only `libcuda.so` from the kernel driver, so the runtime is missing and
llama-server exits before binding its port — every GPU vision/embed call then
returns nothing. Nothing in lilbee installs that runtime today, so a plain
`pip install lilbee` on a GPU box hits this.

## Solution

Install the runtime the standard way and point the engine at it:
- A `cuda12` optional-dependency extra pulling NVIDIA's official PyPI wheels
  (`nvidia-cuda-runtime-cu12`, `nvidia-cublas-cu12`, `nvidia-cuda-nvrtc-cu12`),
  gated by environment markers so it's a no-op off Linux x86_64.
- A small `cuda_runtime_env()` shim that adds those wheels' `lib/` dirs to the
  spawned server's `LD_LIBRARY_PATH`. An rpath can't be baked because the wheel
  location is only known at install time.

`pip install lilbee[cuda12]` then runs the GPU engine out of the box, no system
CUDA toolkit required.

This replaces #373, which solved the same problem with ~120 lines including a
runtime `ldd`-subprocess preflight to diagnose the missing dependency. Declaring
the dependency and adding a tiny shim handles it at the right layer, so the
preflight machinery is gone.
