### PR TITLE
Force UTF-8 stdio at startup so crawling can't crash under a C locale

### DIFF
--- a/src/lilbee/runtime/launcher.py
+++ b/src/lilbee/runtime/launcher.py
@@ -7,6 +7,8 @@ launches the animation process, then performs the heavy
 
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import sys
 
@@ -22,8 +24,19 @@ def _shell_completion_active() -> bool:
     )
 
 
+def _force_utf8_stdio() -> None:
+    """Make stdio UTF-8 so a no-locale (GUI-spawned) launch can't crash on non-ASCII output."""
+    for stream in (sys.stdout, sys.stderr):
+        if isinstance(stream, io.TextIOWrapper):
+            # Swallow on an already-detached stream; non-TextIOWrapper streams
+            # (StringIO redirects, capture shims) need no reconfiguration.
+            with contextlib.suppress(ValueError, OSError):
+                stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+
 def main() -> None:
     """Entry point for the ``lilbee`` console script."""
+    _force_utf8_stdio()
     args = sys.argv[1:]
     is_interactive = (not args or args[0] in ("chat", "")) and not _shell_completion_active()
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import os
 import sys
 from unittest.mock import Mock
@@ -111,3 +112,29 @@ def test_keyboard_interrupt_restores_cursor_and_exits_130(
         launcher.main()
 
     assert exc.value.code == 130
+
+
+class TestForceUtf8Stdio:
+    """``_force_utf8_stdio`` makes stdio UTF-8 without crashing on odd streams."""
+
+    def test_reconfigures_both_streams_to_utf8(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        out = Mock(spec=io.TextIOWrapper)
+        err = Mock(spec=io.TextIOWrapper)
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr(sys, "stderr", err)
+        launcher._force_utf8_stdio()
+        for stream in (out, err):
+            stream.reconfigure.assert_called_once_with(encoding="utf-8", errors="backslashreplace")
+
+    def test_non_textiowrapper_stream_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A StringIO redirect / capture shim isn't a TextIOWrapper; must be a no-op.
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        monkeypatch.setattr(sys, "stderr", io.StringIO())
+        launcher._force_utf8_stdio()
+
+    def test_reconfigure_error_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        bad = Mock(spec=io.TextIOWrapper)
+        bad.reconfigure.side_effect = ValueError("stream detached")
+        monkeypatch.setattr(sys, "stdout", bad)
+        monkeypatch.setattr(sys, "stderr", Mock(spec=io.TextIOWrapper))
+        launcher._force_utf8_stdio()


### PR DESCRIPTION
## Problem

When a GUI host (e.g. the Obsidian plugin) spawns the server, the child process inherits no locale, so Python defaults to ASCII for stdout/stderr. Crawling a page whose console output contains a non-ASCII character (a crawler progress glyph like "→") then raises UnicodeEncodeError — the crawl reports done but indexes nothing.

## Solution

Reconfigure stdout/stderr to UTF-8 (errors=backslashreplace) at the launcher entry point, before anything else runs, so non-ASCII output never aborts regardless of the launch locale. Both entry paths (console script and `python -m lilbee`) go through `main()`, so the bundled binary is covered. Defense-in-depth behind the plugin's UTF-8 spawn env; helps any caller running under a C locale.

Verified on the shipped binary: under a C locale the crawl indexes nothing; with UTF-8 stdio it saves the page.