### PR TITLE
Add 'crawl a whole site' demo to README + tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ Install the `[crawler]` extra, point lilbee at a docs site, a wiki, or a vendor'
 
 ![/crawl a Wikipedia page, then ask a cited question against it](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl.gif)
 
-Or crawl a whole site, not just one page. With recursive crawling on, lilbee follows the links and indexes the lot; watch the page count climb in the Task Center.
+Or crawl a whole site, not just one page. With recursive crawling on, lilbee follows the links and indexes the lot; watch the page count climb in the Task Center, then ask one question that synthesizes across the whole site.
 
-![crawl a whole site at depth 1: hundreds of pages indexed, with live progress in the Task Center](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.gif)
+![crawl a whole site at depth 1, then ask a multipart question that spans it: a cited answer drawn from across the pages, with Qwen3-8B and a reranker](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.gif)
 
 ### Documents, code, and scanned images
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Install the `[crawler]` extra, point lilbee at a docs site, a wiki, or a vendor'
 
 ![/crawl a Wikipedia page, then ask a cited question against it](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl.gif)
 
+Or crawl a whole site, not just one page. With recursive crawling on, lilbee follows the links and indexes the lot; watch the page count climb in the Task Center.
+
+![crawl a whole site at depth 1: hundreds of pages indexed, with live progress in the Task Center](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.gif)
+
 ### Documents, code, and scanned images
 
 lilbee splits indexing by what's being read:

--- a/site/index.html
+++ b/site/index.html
@@ -165,7 +165,7 @@
           <div class="tutorial-clip">
             <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption">Recursive crawl (depth 1) of a whole site: hundreds of Wikipedia pages indexed, with the count climbing live in the Task Center (fast-forwarded).</p>
+          <p class="tutorial-caption">Recursive crawl (depth 1) of a whole site: hundreds of Wikipedia pages indexed (fast-forwarded), then one multipart question synthesized across them, cited, with Qwen3-8B and a reranker.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-catalog" aria-labelledby="tutorial-tab-catalog" hidden>

--- a/site/index.html
+++ b/site/index.html
@@ -106,6 +106,7 @@
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-chat"     aria-controls="tutorial-pane-chat"     aria-selected="false" tabindex="-1">chat</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-add"      aria-controls="tutorial-pane-add"      aria-selected="false" tabindex="-1">add files</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-crawl"    aria-controls="tutorial-pane-crawl"    aria-selected="false" tabindex="-1">crawl</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-crawlsite" aria-controls="tutorial-pane-crawlsite" aria-selected="false" tabindex="-1">crawl a site</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-catalog"  aria-controls="tutorial-pane-catalog"  aria-selected="false" tabindex="-1">catalog</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-ollama"   aria-controls="tutorial-pane-ollama"   aria-selected="false" tabindex="-1">ollama</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-lmstudio" aria-controls="tutorial-pane-lmstudio" aria-selected="false" tabindex="-1">lm studio</button>
@@ -158,6 +159,13 @@
             <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
           <p class="tutorial-caption"><code>/crawl &lt;url&gt;</code> fetches a page into your library, then answers against it with a page citation.</p>
+        </div>
+
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-crawlsite" aria-labelledby="tutorial-tab-crawlsite" hidden>
+          <div class="tutorial-clip">
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+          </div>
+          <p class="tutorial-caption">Recursive crawl (depth 1) of a whole site: hundreds of Wikipedia pages indexed, with the count climbing live in the Task Center (fast-forwarded).</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-catalog" aria-labelledby="tutorial-tab-catalog" hidden>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -61,6 +61,7 @@
           <li><a href="#chat">Chat with cited answers</a></li>
           <li><a href="#add">Add files</a></li>
           <li><a href="#crawl">Crawl a URL</a></li>
+          <li><a href="#crawl-site">Crawl a whole site</a></li>
           <li class="toc-group"><a href="#tui-models">Models &amp; providers</a></li>
           <li><a href="#catalog">Model catalog</a></li>
           <li><a href="#ollama">Use a model from Ollama</a></li>
@@ -165,6 +166,17 @@
           <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl.png">
             <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl.mp4" type="video/mp4">
             <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl.mp4">crawl (MP4)</a>
+          </video>
+        </div>
+      </section>
+
+      <section class="tutorial-section" id="crawl-site">
+        <h4><a href="#crawl-site">Crawl a whole site</a></h4>
+        <p>Leave recursive crawling on and <code>/crawl</code> follows the links at depth 1 and indexes the whole site. Here it crawls hundreds of Wikipedia pages, with the count climbing live in the Task Center (fast-forwarded).</p>
+        <div class="tutorial-clip">
+          <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.png">
+            <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.mp4" type="video/mp4">
+            <a href="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.mp4">crawl a whole site (MP4)</a>
           </video>
         </div>
       </section>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -172,7 +172,7 @@
 
       <section class="tutorial-section" id="crawl-site">
         <h4><a href="#crawl-site">Crawl a whole site</a></h4>
-        <p>Leave recursive crawling on and <code>/crawl</code> follows the links at depth 1 and indexes the whole site. Here it crawls hundreds of Wikipedia pages, with the count climbing live in the Task Center (fast-forwarded).</p>
+        <p>Leave recursive crawling on and <code>/crawl</code> follows the links at depth 1 and indexes the whole site. Here it crawls hundreds of Wikipedia pages (fast-forwarded), then asks one multipart question that synthesizes across them, cited, with Qwen3-8B and a reranker.</p>
         <div class="tutorial-clip">
           <video controls muted playsinline preload="metadata" poster="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.png">
             <source src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-crawl-site.mp4" type="video/mp4">


### PR DESCRIPTION
## Problem
The crawl docs only show a single-page crawl.

## Solution
Adds the whole-site crawl demo (recursive depth-1 of Full-size_car) next to the single-page one: README 'Offline copies of websites' section, a 'crawl a site' tab on lilbee.sh, and a tutorial section + TOC entry. Asset lands in #380.