### PR TITLE
Force last-token pooling for decoder-only embedders

### DIFF
--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -121,7 +121,7 @@ def _self_check_server(role: WorkerRole, model_path: Path) -> tuple[SwapManager,
         resolve_embed_ctx,
         resolve_n_gpu_layers,
     )
-    from lilbee.providers.fleet.adapters import ROLE_SPECS, build_server_argv
+    from lilbee.providers.fleet.adapters import ROLE_SPECS, build_server_argv, embed_spec
     from lilbee.providers.fleet.binary import (
         llama_server_runtime_env,
         resolve_llama_server,
@@ -137,9 +137,10 @@ def _self_check_server(role: WorkerRole, model_path: Path) -> tuple[SwapManager,
         ctx = resolve_embed_ctx(meta, model_path)
     else:
         ctx = cfg.num_ctx or resolve_chat_ctx(model_path, meta)
+    spec = embed_spec(meta) if is_embed else ROLE_SPECS[role]
     argv = build_server_argv(
         binary=resolve_llama_server(),
-        spec=ROLE_SPECS[role],
+        spec=spec,
         model_path=model_path,
         devices=(),
         n_gpu_layers=resolve_n_gpu_layers(embedding=is_embed),

--- a/src/lilbee/providers/fleet/adapters.py
+++ b/src/lilbee/providers/fleet/adapters.py
@@ -8,7 +8,8 @@ to assemble one llama-server command line.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from enum import StrEnum
 from pathlib import Path
 
 from lilbee.core.config.enums import RerankerType
@@ -64,8 +65,10 @@ ROLE_SPECS: dict[WorkerRole, RoleServerSpec] = {
     ),
 }
 
-# Decoder-arch rerankers (Qwen3-Reranker, mxbai-rerank-v2) are served generatively.
-_DECODER_RERANK_ARCHS: frozenset[str] = frozenset(
+# Decoder-only architectures. Served generatively as rerankers (Qwen3-Reranker,
+# mxbai-rerank-v2), and their embeddings use last-token (EOS) pooling, not the
+# encoder default of mean/cls.
+_DECODER_ARCHS: frozenset[str] = frozenset(
     {"qwen2", "qwen3", "llama", "mistral", "gemma", "gemma2", "gemma3", "phi3"}
 )
 
@@ -97,7 +100,7 @@ def resolve_rerank_mode(reranker_type: RerankerType, arch: str | None) -> Rerank
         return RerankMode.LLM
     if reranker_type is RerankerType.CROSS_ENCODER:
         return RerankMode.CROSS_ENCODER
-    if arch in _DECODER_RERANK_ARCHS:
+    if arch in _DECODER_ARCHS:
         return RerankMode.LLM
     return RerankMode.CROSS_ENCODER
 
@@ -105,6 +108,42 @@ def resolve_rerank_mode(reranker_type: RerankerType, arch: str | None) -> Rerank
 def rerank_spec(mode: RerankMode) -> RoleServerSpec:
     """The server spec for a RERANK launch given its resolved mode."""
     return _RERANK_MODE_SPECS[mode]
+
+
+class PoolingType(StrEnum):
+    """A llama-server ``--pooling`` value (also the GGUF pooling_type enum names)."""
+
+    NONE = "none"
+    MEAN = "mean"
+    CLS = "cls"
+    LAST = "last"
+    RANK = "rank"
+
+
+# GGUF <arch>.pooling_type integer (as read_gguf_metadata returns it, a string) ->
+# the --pooling value. NONE (0) is omitted: a 0 on an embedder is the unset default,
+# so it falls through to the arch-based choice rather than per-token (non-)pooling.
+_GGUF_POOLING: dict[str, PoolingType] = {
+    "1": PoolingType.MEAN,
+    "2": PoolingType.CLS,
+    "3": PoolingType.LAST,
+    "4": PoolingType.RANK,
+}
+
+
+def embed_spec(meta: dict[str, str] | None) -> RoleServerSpec:
+    """The EMBED server spec with the model's pooling resolved for llama-server."""
+    # The GGUF's declared pooling wins; else a decoder-only embedder pools on its
+    # last/EOS token (llama-server would otherwise default to mean, which is wrong).
+    arch = meta.get("architecture") if meta else None
+    pooling_type = meta.get("pooling_type") if meta else None
+    pooling = _GGUF_POOLING.get(pooling_type or "")
+    if pooling is None and arch in _DECODER_ARCHS:
+        pooling = PoolingType.LAST
+    base = ROLE_SPECS[WorkerRole.EMBED]
+    if pooling is None:
+        return base
+    return replace(base, extra_args=(*base.extra_args, "--pooling", pooling.value))
 
 
 def build_server_argv(

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -13,7 +13,9 @@ from lilbee.providers import model_cache
 from lilbee.providers.fleet.adapters import (
     LLM_RERANK_CONCURRENCY,
     ROLE_SPECS,
+    RoleServerSpec,
     build_server_argv,
+    embed_spec,
     rerank_spec,
     resolve_rerank_mode,
 )
@@ -294,6 +296,18 @@ def _rerank_mode_for(meta: dict[str, str] | None) -> RerankMode:
 def _role_rerank_mode(role: WorkerRole, meta: dict[str, str] | None) -> RerankMode | None:
     """The RERANK serving mode for *role*, or ``None`` for every other role."""
     return _rerank_mode_for(meta) if role is WorkerRole.RERANK else None
+
+
+def _server_spec(
+    role: WorkerRole, rerank_mode: RerankMode | None, meta: dict[str, str] | None
+) -> RoleServerSpec:
+    """The llama-server spec for a launch: rerank mode, decoder-aware embed pooling,
+    or the role default. EMBED forces ``--pooling last`` for decoder-only archs."""
+    if rerank_mode is not None:
+        return rerank_spec(rerank_mode)
+    if role is WorkerRole.EMBED:
+        return embed_spec(meta)
+    return ROLE_SPECS[role]
 
 
 def _pooled_batch_size(role: WorkerRole, rerank_mode: RerankMode | None, ctx: int) -> int | None:
@@ -600,7 +614,7 @@ def _launch_for(
             rerank_mode=rerank_mode,
         )
     )
-    spec = rerank_spec(rerank_mode) if rerank_mode is not None else ROLE_SPECS[plan.role]
+    spec = _server_spec(plan.role, rerank_mode, meta)
     # Cross-encoder embed/rerank pools the whole input in one batch; an LLM reranker
     # is generative and uses the default batching plus flash attention.
     cross_encoder_pooled = plan.role in _EMBED_ROLES and not is_llm_rerank

--- a/src/lilbee/providers/gguf_meta.py
+++ b/src/lilbee/providers/gguf_meta.py
@@ -35,6 +35,8 @@ _ARCH_FIELD_SUFFIXES: dict[str, str] = {
     "attention.head_count": "head_count",
     "attention.key_length": "key_length",
     "attention.value_length": "value_length",
+    # Embedding pooling the model was trained for; absent on most non-embedders.
+    "pooling_type": "pooling_type",
 }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3988,6 +3988,26 @@ class TestSelfCheckHelpers:
         setup._self_check_server(WorkerRole.CHAT, tmp_path / "chat.gguf")
         assert seen["model"] == "chat-0"
 
+    def test_self_check_embed_applies_decoder_pooling(self, monkeypatch, tmp_path) -> None:
+        # The embed self-check must launch with the same pooling a real ingest uses,
+        # so a decoder embedder is exercised with --pooling last (bb-872r).
+        from unittest import mock
+
+        from lilbee.cli.commands import setup
+        from lilbee.providers.roles import WorkerRole
+
+        self._patch_fleet_primitives(monkeypatch, swap=mock.MagicMock(), client=mock.MagicMock())
+        monkeypatch.setattr(
+            "lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {"architecture": "qwen3"}
+        )
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.adapters.build_server_argv",
+            lambda **kw: seen.update(kw) or ["/bin/llama-server"],
+        )
+        setup._self_check_server(WorkerRole.EMBED, tmp_path / "embed.gguf")
+        assert seen["spec"].extra_args == ("--embeddings", "--pooling", "last")
+
 
 class TestSelfCheckExtras:
     """`lilbee self-check-extras` probes the optional extras for the frozen-binary smoke test."""

--- a/tests/test_fleet_adapters.py
+++ b/tests/test_fleet_adapters.py
@@ -11,6 +11,7 @@ from lilbee.providers.fleet.adapters import (
     LLM_RERANK_SPEC,
     ROLE_SPECS,
     build_server_argv,
+    embed_spec,
     rerank_spec,
     resolve_rerank_mode,
 )
@@ -224,4 +225,39 @@ def test_llm_rerank_spec_is_generative_chat() -> None:
     assert LLM_RERANK_SPEC.role is WorkerRole.RERANK
     assert LLM_RERANK_SPEC.endpoint_path == "/v1/chat/completions"
     assert LLM_RERANK_SPEC.extra_args == ("--jinja",)
+
+
+def test_embed_spec_encoder_arch_uses_plain_spec() -> None:
+    # No declared pooling + a non-decoder arch keeps the GGUF's own mean/cls (no flag).
+    assert embed_spec({"architecture": "bert"}) is ROLE_SPECS[WorkerRole.EMBED]
+
+
+def test_embed_spec_without_metadata_is_plain() -> None:
+    assert embed_spec(None) is ROLE_SPECS[WorkerRole.EMBED]
+
+
+def test_embed_spec_decoder_arch_forces_last_token_pooling() -> None:
+    spec = embed_spec({"architecture": "qwen3"})
+    assert spec.extra_args == ("--embeddings", "--pooling", "last")
+
+
+@pytest.mark.parametrize(
+    ("pooling_type", "expected"),
+    [("1", "mean"), ("2", "cls"), ("3", "last"), ("4", "rank")],
+)
+def test_embed_spec_honors_declared_pooling_type(pooling_type, expected) -> None:
+    # A declared GGUF pooling_type wins, even over a decoder arch's default.
+    meta = {"architecture": "qwen3", "pooling_type": pooling_type}
+    assert embed_spec(meta).extra_args == ("--embeddings", "--pooling", expected)
+
+
+def test_embed_spec_declared_none_falls_through_to_arch() -> None:
+    # pooling_type 0 (NONE) is the unset default: a decoder arch still gets last,
+    assert embed_spec({"architecture": "qwen3", "pooling_type": "0"}).extra_args == (
+        "--embeddings",
+        "--pooling",
+        "last",
+    )
+    # and an encoder arch keeps the plain spec.
+    assert embed_spec({"architecture": "bert", "pooling_type": "0"}) is ROLE_SPECS[WorkerRole.EMBED]
     assert LLM_RERANK_SPEC.server_capable is True

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1153,3 +1153,36 @@ class TestWeightsBytes:
         plan = InstancePlan(role=WorkerRole.CHAT, devices=(0,))
         launch = planning_mod._launch_for(plan, "ref", Path("/bin/llama-server"), {0: device})
         assert launch.weights_bytes == 2048  # both shards, not just the served file
+
+
+def test_server_spec_embed_decoder_forces_last_pooling() -> None:
+    spec = planning_mod._server_spec(WorkerRole.EMBED, None, {"architecture": "qwen3"})
+    assert spec.extra_args == ("--embeddings", "--pooling", "last")
+
+
+def test_server_spec_embed_honors_declared_pooling() -> None:
+    spec = planning_mod._server_spec(
+        WorkerRole.EMBED, None, {"architecture": "qwen3", "pooling_type": "1"}
+    )
+    assert spec.extra_args == ("--embeddings", "--pooling", "mean")
+
+
+def test_server_spec_embed_without_meta_is_plain() -> None:
+    from lilbee.providers.fleet.adapters import ROLE_SPECS
+
+    spec = planning_mod._server_spec(WorkerRole.EMBED, None, None)
+    assert spec is ROLE_SPECS[WorkerRole.EMBED]
+
+
+def test_server_spec_rerank_uses_rerank_spec() -> None:
+    from lilbee.providers.fleet.adapters import ROLE_SPECS
+
+    spec = planning_mod._server_spec(WorkerRole.RERANK, RerankMode.CROSS_ENCODER, None)
+    assert spec is ROLE_SPECS[WorkerRole.RERANK]
+
+
+def test_server_spec_other_role_uses_role_default() -> None:
+    from lilbee.providers.fleet.adapters import ROLE_SPECS
+
+    spec = planning_mod._server_spec(WorkerRole.CHAT, None, None)
+    assert spec is ROLE_SPECS[WorkerRole.CHAT]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2493,6 +2493,18 @@ class TestReadGgufMetadata:
             "name": "Test Model",
         }
 
+    def test_exposes_declared_pooling_type(self, tmp_path: Path) -> None:
+        """An embedder's <arch>.pooling_type is surfaced for the embed-pooling choice."""
+        from lilbee.providers.gguf_meta import read_gguf_metadata
+
+        path = write_test_gguf(
+            tmp_path / "model.gguf",
+            arch="qwen3",
+            fields={"qwen3.pooling_type": 3},
+        )
+
+        assert read_gguf_metadata(path) == {"architecture": "qwen3", "pooling_type": "3"}
+
     def test_returns_none_for_empty_metadata(self, tmp_path: Path) -> None:
         """read_gguf_metadata returns None when the header carries no fields."""
         from lilbee.providers.gguf_meta import read_gguf_metadata


### PR DESCRIPTION
## Problem

The fleet EMBED role launched llama-server with only `--embeddings` and no `--pooling`, so a decoder-only embedder like Qwen3-Embedding got llama-server's default mean pooling. These models derive their sentence vector from the last/EOS token, so mean pooling produces wrong embeddings and silently degrades retrieval.

## Solution

`embed_spec(meta)` resolves the embed pooling from the GGUF: a model's declared `pooling_type` wins, otherwise a decoder-only architecture falls back to `--pooling last`; encoder embedders (bge-m3, nomic) keep their mean/cls default unchanged. Both the ingest launch and the CLI embed self-check route through it, so the self-check exercises the same pooling a real ingest uses. `read_gguf_metadata` now surfaces `pooling_type`.

Resolves bb-872r.