### PR TITLE
Mirror CI models to a GitHub Release to stop HuggingFace 429 flakes

### DIFF
--- a/.github/actions/restore-ci-models/action.yml
+++ b/.github/actions/restore-ci-models/action.yml
@@ -43,6 +43,10 @@ runs:
           echo "restored=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        tar -xzf "$tmp/$asset" -C "$models_dir"
+        if ! tar -xzf "$tmp/$asset" -C "$models_dir"; then
+          echo "Failed to extract $asset; caller falls back to HuggingFace." >&2
+          echo "restored=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
         echo "Restored CI models into $models_dir"
         echo "restored=true" >> "$GITHUB_OUTPUT"

--- a/.github/actions/restore-ci-models/action.yml
+++ b/.github/actions/restore-ci-models/action.yml
@@ -1,0 +1,48 @@
+name: Restore CI model mirror
+description: "Download the fixed CI GGUF model set from the ci-models GitHub Release and extract it into the lilbee models directory. No HuggingFace contact; sets restored=true on success."
+
+inputs:
+  models-dir:
+    description: "Directory to extract the models into. Defaults to the canonical platform models dir. A leading ~/ is expanded."
+    required: false
+    default: ""
+  release-tag:
+    description: "Release tag holding the per-OS model tarballs."
+    required: false
+    default: "ci-models"
+
+outputs:
+  restored:
+    description: "true when the mirror was restored, false when the asset was missing (caller should fall back to HuggingFace)."
+    value: ${{ steps.restore.outputs.restored }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download and extract model mirror
+      id: restore
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        INPUT_MODELS_DIR: ${{ inputs.models-dir }}
+        RELEASE_TAG: ${{ inputs.release-tag }}
+      run: |
+        set -uo pipefail
+        case "$RUNNER_OS" in
+          Linux)   default_dir="$HOME/.local/share/lilbee/models";            asset="ci-models-linux.tar.gz" ;;
+          macOS)   default_dir="$HOME/Library/Application Support/lilbee/models"; asset="ci-models-macos.tar.gz" ;;
+          Windows) default_dir="$HOME/AppData/Local/lilbee/models";            asset="ci-models-windows.tar.gz" ;;
+          *) echo "Unsupported runner OS: $RUNNER_OS" >&2; echo "restored=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
+        esac
+        models_dir="${INPUT_MODELS_DIR:-$default_dir}"
+        models_dir="${models_dir/#\~\//$HOME/}"
+        mkdir -p "$models_dir"
+        tmp="$(mktemp -d)"
+        if ! gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "$asset" --dir "$tmp"; then
+          echo "Mirror asset $asset not in release $RELEASE_TAG; caller falls back to HuggingFace." >&2
+          echo "restored=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        tar -xzf "$tmp/$asset" -C "$models_dir"
+        echo "Restored CI models into $models_dir"
+        echo "restored=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,27 +254,6 @@ jobs:
           path: ${{ github.workspace }}/.playwright-browsers
           key: playwright-${{ runner.os }}-${{ hashFiles('uv.lock') }}
 
-      - name: Cache GGUF models (Linux)
-        if: runner.os == 'Linux'
-        uses: actions/cache@v5
-        with:
-          path: ~/.local/share/lilbee/models
-          key: gguf-models-Linux-v4
-
-      - name: Cache GGUF models (macOS)
-        if: runner.os == 'macOS'
-        uses: actions/cache@v5
-        with:
-          path: ~/Library/Application Support/lilbee/models
-          key: gguf-models-macOS-v4
-
-      - name: Cache GGUF models (Windows)
-        if: runner.os == 'Windows'
-        uses: actions/cache@v5
-        with:
-          path: ~\AppData\Local\lilbee\models
-          key: gguf-models-Windows-v4
-
       - name: Cache HuggingFace models
         uses: actions/cache@v5
         with:
@@ -331,8 +310,16 @@ jobs:
           & C:\ollama\ollama.exe pull qwen3:0.6b
           & C:\ollama\ollama.exe pull nomic-embed-text
 
-      - name: Pre-download GGUF models
+      - name: Restore GGUF models from release mirror
+        id: ci-models
+        uses: ./.github/actions/restore-ci-models
+
+      # Only runs if the mirror asset is missing; HF_TOKEN lifts the anon rate limit.
+      - name: Pre-download GGUF models from HuggingFace (fallback)
+        if: steps.ci-models.outputs.restored != 'true'
         shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           for i in 1 2 3; do
             uv run lilbee model pull nomic-ai/nomic-embed-text-v1.5-GGUF && \
@@ -348,3 +335,4 @@ jobs:
           LILBEE_LLM_PROVIDER: llama-cpp
           OLLAMA_HOST: http://127.0.0.1:11434
           PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/qa-matrix.yml
+++ b/.github/workflows/qa-matrix.yml
@@ -49,8 +49,6 @@ permissions:
 env:
   # Ollama-registry analogue of conftest's _DEFAULT_CHAT_MODEL; keep param count aligned.
   OLLAMA_TINY_MODEL: qwen3:0.6b
-  # Bump alongside conftest _DEFAULT_*_MODEL so model changes invalidate the cache.
-  QA_MODELS_CACHE_KEY: lilbee-qa-models-v2-qwen3-0.6b-nomic-embed-v1.5-bge-rerank-v2-m3
 
 concurrency:
   group: qa-matrix-${{ github.ref }}
@@ -89,11 +87,10 @@ jobs:
           rc_version: ${{ inputs.version }}
           lilbee_version: ${{ inputs.lilbee_version || 'latest' }}
 
-      - name: Restore QA models cache
-        uses: actions/cache@v5
+      - name: Restore QA models from release mirror
+        uses: ./.github/actions/restore-ci-models
         with:
-          path: ~/.lilbee-qa-models
-          key: ${{ env.QA_MODELS_CACHE_KEY }}
+          models-dir: ~/.lilbee-qa-models
 
       - name: Download wheel artifacts from sibling run (lane=pypi, RC mode)
         if: matrix.lane == 'pypi' && inputs.wheel_run_id != ''
@@ -167,6 +164,7 @@ jobs:
           LILBEE_QA_LANE: ${{ matrix.lane == 'pypi' && 'l1-pypi' || 'l2-binary' }}
           LILBEE_QA_MODELS_DIR: ${{ github.workspace }}/.lilbee-qa-models
           PYTHONUNBUFFERED: "1"
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         shell: bash
         run: |
           echo "Lane: $LILBEE_QA_LANE"
@@ -234,11 +232,10 @@ jobs:
           rc_version: ${{ inputs.version }}
           lilbee_version: ${{ inputs.lilbee_version || 'latest' }}
 
-      - name: Restore QA models cache
-        uses: actions/cache@v5
+      - name: Restore QA models from release mirror
+        uses: ./.github/actions/restore-ci-models
         with:
-          path: ~/.lilbee-qa-models
-          key: ${{ env.QA_MODELS_CACHE_KEY }}
+          models-dir: ~/.lilbee-qa-models
 
       - name: Download wheel artifacts from sibling run (lane=pypi, RC mode)
         if: matrix.lane == 'pypi' && inputs.wheel_run_id != ''
@@ -298,6 +295,7 @@ jobs:
           LILBEE_QA_LANE: ${{ matrix.lane == 'pypi' && 'l1-pypi' || 'l2-binary' }}
           LILBEE_QA_MODELS_DIR: ${{ github.workspace }}/.lilbee-qa-models
           PYTHONUNBUFFERED: "1"
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           echo "Lane: $LILBEE_QA_LANE"
           echo "Binary: $LILBEE_QA_BIN"
@@ -342,11 +340,10 @@ jobs:
           rc_version: ${{ inputs.version }}
           lilbee_version: ${{ inputs.lilbee_version || 'latest' }}
 
-      - name: Restore QA models cache
-        uses: actions/cache@v5
+      - name: Restore QA models from release mirror
+        uses: ./.github/actions/restore-ci-models
         with:
-          path: ~/.lilbee-qa-models
-          key: ${{ env.QA_MODELS_CACHE_KEY }}
+          models-dir: ~/.lilbee-qa-models
 
       - name: Download wheel artifacts from sibling run (RC mode)
         if: inputs.wheel_run_id != ''
@@ -380,6 +377,7 @@ jobs:
           LILBEE_QA_LANE: l1-pypi
           LILBEE_QA_MODELS_DIR: ${{ github.workspace }}/.lilbee-qa-models
           PYTHONUNBUFFERED: "1"
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           mkdir -p "$LILBEE_QA_MODELS_DIR"
           if [ -d "$HOME/.lilbee-qa-models" ]; then
@@ -422,11 +420,10 @@ jobs:
           rc_version: ${{ inputs.version }}
           lilbee_version: ${{ inputs.lilbee_version || 'latest' }}
 
-      - name: Restore QA models cache
-        uses: actions/cache@v5
+      - name: Restore QA models from release mirror
+        uses: ./.github/actions/restore-ci-models
         with:
-          path: ~/.lilbee-qa-models
-          key: ${{ env.QA_MODELS_CACHE_KEY }}
+          models-dir: ~/.lilbee-qa-models
 
       - name: Download wheel artifacts from sibling run (RC mode)
         if: inputs.wheel_run_id != ''
@@ -455,6 +452,7 @@ jobs:
           LILBEE_QA_LANE: l1-pypi
           LILBEE_QA_MODELS_DIR: ${{ github.workspace }}/.lilbee-qa-models
           PYTHONUNBUFFERED: "1"
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           mkdir -p "$LILBEE_QA_MODELS_DIR"
           if [ -d "$HOME/.lilbee-qa-models" ]; then

--- a/.github/workflows/warm-ci-models.yml
+++ b/.github/workflows/warm-ci-models.yml
@@ -1,0 +1,100 @@
+name: Warm CI model mirror
+
+# Pulls the fixed CI model set once (authenticated) and uploads per-OS tarballs
+# to the ci-models release so integration tests and qa-matrix never hit
+# HuggingFace rate limits. The models don't change, so run on demand or monthly.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 1 * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: warm-ci-models
+  cancel-in-progress: false
+
+env:
+  # Keep aligned with tests/integration/conftest.py and tools/qa/conftest.py.
+  CI_MODELS: >-
+    Qwen/Qwen3-0.6B-GGUF
+    nomic-ai/nomic-embed-text-v1.5-GGUF
+    gpustack/bge-reranker-v2-m3-GGUF
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Ensure ci-models release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view ci-models --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create ci-models \
+              --repo "$GITHUB_REPOSITORY" \
+              --target main \
+              --title "CI model mirror" \
+              --notes "Fixed GGUF model set mirrored for CI so integration tests and qa-matrix don't hit HuggingFace rate limits. Refreshed by the warm-ci-models workflow." \
+              --latest=false
+          fi
+
+  warm:
+    needs: prepare
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      # Mirror ci.yml's baseline build flags so the wheel builds on every runner.
+      - name: Install lilbee
+        run: uv sync --locked --all-extras
+        env:
+          CMAKE_ARGS: >-
+            -DGGML_METAL=OFF
+            -DGGML_NATIVE=OFF
+            -DGGML_CUDA=OFF
+            ${{ runner.os == 'macOS' && '-DGGML_BLAS=ON' || '-DGGML_BLAS=OFF' }}
+            ${{ runner.arch == 'X64' && '-DGGML_AVX=ON -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_AVX_VNNI=OFF -DGGML_AVX512=OFF' || '' }}
+
+      - name: Pull models (authenticated)
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+          for ref in $CI_MODELS; do
+            for i in 1 2 3 4 5; do
+              if uv run lilbee model pull "$ref"; then break; fi
+              echo "pull $ref attempt $i failed; retrying in $((i * 10))s"
+              sleep $((i * 10))
+            done
+          done
+
+      - name: Pack and upload mirror
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "$RUNNER_OS" in
+            Linux)   models_dir="$HOME/.local/share/lilbee/models";            asset="ci-models-linux.tar.gz" ;;
+            macOS)   models_dir="$HOME/Library/Application Support/lilbee/models"; asset="ci-models-macos.tar.gz" ;;
+            Windows) models_dir="$HOME/AppData/Local/lilbee/models";            asset="ci-models-windows.tar.gz" ;;
+          esac
+          tar -czf "$asset" -C "$models_dir" .
+          gh release upload ci-models "$asset" --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/warm-ci-models.yml
+++ b/.github/workflows/warm-ci-models.yml
@@ -38,6 +38,7 @@ jobs:
               --target main \
               --title "CI model mirror" \
               --notes "Fixed GGUF model set mirrored for CI so integration tests and qa-matrix don't hit HuggingFace rate limits. Refreshed by the warm-ci-models workflow." \
+              --prerelease \
               --latest=false
           fi
 


### PR DESCRIPTION
## Problem

Integration tests (`ci.yml`) and the QA matrix pull the same fixed GGUF model set on every run: Qwen3-0.6B, nomic-embed-v1.5, and bge-reranker-v2-m3. The source is HuggingFace, which rate-limits anonymous requests, so runs intermittently fail with 429.

The existing `actions/cache` for these models doesn't reliably prevent it: GitHub caches are branch-isolated, evicted after 7 days, and share a 10GB repo cap, so fresh feature branches usually cold-start and fall straight through to HuggingFace. CI also ran unauthenticated, and two of the three models use a wildcard quant pattern (`*Q8_0.gguf`) that triggers a small HF API call to resolve the filename on every run regardless of the byte cache.

## Solution

The models never change, so mirror them to a stable, GitHub-native source instead of re-fetching from HuggingFace:

- A new `warm-ci-models` workflow pulls the set once (authenticated with `HF_TOKEN`, retried) and uploads per-OS tarballs to a `ci-models` release. Run on demand or monthly.
- A `restore-ci-models` composite action restores from that release via `gh` (GitHub to GitHub, no rate limit). The HuggingFace pull stays only as a fallback for when the mirror asset is missing.
- `HF_TOKEN` is now passed to the integration and QA test runs so the residual metadata calls (wildcard quant resolution, etag checks) are authenticated rather than anonymous.

After this lands, run the `warm-ci-models` workflow once to populate the `ci-models` release.

Validated with actionlint and shellcheck (no new findings; the two pre-existing PowerShell shellcheck notes are unchanged). YAML-only change, no Python touched.