### PR TITLE
QA: add a multi-turn tool-calling scenario

### DIFF
--- a/tools/qa/opencode/matrix.py
+++ b/tools/qa/opencode/matrix.py
@@ -38,7 +38,13 @@ from opencode_driver import (
     tmux_kill,
 )
 from report import CellResult, render_report
-from scenarios import ScenarioResult, run_scenario, scenario_for_tier, wait_for_answer_settle
+from scenarios import (
+    ScenarioResult,
+    run_multi_turn_scenario,
+    run_scenario,
+    scenario_for_tier,
+    wait_for_answer_settle,
+)
 from serve import _count_ok_chat_completions, _scrape_serve_errors, stop_serve
 from workspace import free_port, write_per_cell_workspace
 
@@ -82,9 +88,17 @@ def run_smoke_scenarios(
 ) -> list[ScenarioResult]:
     scen = scenario_for_tier(tier)
     print(f"[{family}] running {scen.name}: {scen.prompt[:60]}...")
-    result = run_scenario(session, scen, workspace)
-    print(f"[{family}]   -> {result.status.value} ({result.elapsed_s:.1f}s) {result.detail}")
-    return [result]
+    single = run_scenario(session, scen, workspace)
+    print(f"[{family}]   -> {single.status.value} ({single.elapsed_s:.1f}s) {single.detail}")
+    # Settle the single-call answer before the multi-turn sequence reuses the
+    # session, so its first turn starts from a quiet pane.
+    wait_for_answer_settle(session, workspace)
+    print(f"[{family}] running {tier} multi-turn tool sequence...")
+    multi = run_multi_turn_scenario(session, tier, workspace)
+    print(
+        f"[{family}]   multi-turn -> {multi.status.value} ({multi.elapsed_s:.1f}s) {multi.detail}"
+    )
+    return [single, multi]
 
 
 def teardown_cell(session: str, serve_proc: subprocess.Popen[bytes] | None, keep: bool) -> None:

--- a/tools/qa/opencode/scenarios.py
+++ b/tools/qa/opencode/scenarios.py
@@ -300,3 +300,64 @@ def wait_for_answer_settle(session: str, workspace: Path) -> None:
         else:
             quiet = 0
             prev_pane = cur
+
+
+# Multi-turn tool sequence: each turn is its own user message naming a NEW class
+# detail no single search answers, so the model must call lilbee_search again on
+# every turn. Topics differ from the single-call prompts above so the shared
+# session can't let the model answer a later turn from an earlier search.
+_MULTI_TURN_PROMPTS: dict[str, tuple[str, ...]] = {
+    "small": (
+        "Now search the indexed Godot 4 reference for what the TileMap.set_cell "
+        "method does, and answer using only what that search returns.",
+        "Now search the reference for what Tween.tween_property does and the "
+        "parameters it takes, and answer using only that search.",
+    ),
+    "mid": (
+        "Now look up in the Godot 4 reference what AStarGrid2D.get_point_path "
+        "returns and the parameters it takes, citing only the reference.",
+        "Now look up what the Camera2D limit_left and limit_right properties do, "
+        "citing only the reference.",
+    ),
+    "giant": (
+        "Now look up in the Godot 4 reference how TileMap.set_cell is called and its parameters.",
+        "Now look up AStarGrid2D.get_point_path and how it is used for pathfinding, "
+        "citing only the reference.",
+    ),
+}
+
+
+def run_multi_turn_scenario(session: str, tier: str, workspace: Path) -> ScenarioResult:
+    """Drive a multi-turn conversation; PASS only if EVERY turn lands a fresh dispatch.
+
+    Each turn is its own user message that needs a lilbee_search to answer, sent
+    one after another in the same session. :func:`run_scenario` rebaselines the
+    dispatch count at the start of each call, so a turn passes only on a dispatch
+    beyond the prior turns -- proving sequential tool use, not one lucky call.
+    """
+    prompts = _MULTI_TURN_PROMPTS.get(tier, _MULTI_TURN_PROMPTS["small"])
+    start = time.time()
+    for index, prompt in enumerate(prompts, start=1):
+        turn = Scenario(
+            name=f"{tier} multi-turn t{index}",
+            prompt=prompt,
+            expected=(_TOOL_DISPATCH_MARKER,),
+            forbidden=_RAW_MARKER_FORBIDDEN,
+            timeout_s=_MULTI_TOOL_TIMEOUT_S,
+        )
+        outcome = run_scenario(session, turn, workspace)
+        if outcome.status is not ScenarioStatus.PASS:
+            return ScenarioResult(
+                name=f"{tier} multi-turn",
+                status=outcome.status,
+                detail=f"turn {index}/{len(prompts)} did not dispatch: {outcome.detail}",
+                pane_excerpt=outcome.pane_excerpt,
+                elapsed_s=time.time() - start,
+            )
+        wait_for_answer_settle(session, workspace)
+    return ScenarioResult(
+        name=f"{tier} multi-turn",
+        status=ScenarioStatus.PASS,
+        detail=f"{len(prompts)} sequential tool turns each dispatched",
+        elapsed_s=time.time() - start,
+    )


### PR DESCRIPTION
## Problem

The opencode QA matrix only proved a model could make one `lilbee_search` call. A single dispatch doesn't tell us whether the model can sustain tool use across a conversation, which is the behavior that actually matters for an agent talking to lilbee.

## Solution

Each cell now runs a short follow-up conversation after the single-call check. Every turn names a new class detail that no prior search answered, so a turn only passes when the model dispatches `lilbee_search` again. It reuses the existing per-turn scenario runner, which rebaselines the dispatch count, so a stale answer from earlier in the session can't be mistaken for a fresh call.

This cleanly separates models that ground every turn in a fresh search from models that answer follow-ups from memory. A pod run across the model lineup confirmed the distinction holds: llama3, qwen3, and gemma4 dispatch on every turn, while others answer the second question without searching.

Touches only the QA harness under tools/qa/opencode; no product code.