### PR TITLE
Polish the site meta description and sitemap

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,7 @@
 </script>
 
 <title>lilbee: run local AI models and search your files, code, and the web</title>
-<meta name="description" content="Run local AI models and search your files, code, and the web, with answers that cite the source — local RAG, meaning it reads your own files and answers with citations. Works with your own models or your existing Ollama or LM Studio setup. Local-first, one install: CLI, TUI, and an MCP server.">
+<meta name="description" content="Run local AI models and search your files, code, and the web, with answers that cite the source, using local RAG to read your own files and answer with citations. Works with your own models or your existing Ollama or LM Studio setup. Local-first, one install: CLI, TUI, and an MCP server.">
 <link rel="canonical" href="https://lilbee.sh/">
 
 <!-- Open Graph: rich link previews for any client that reads the protocol. -->

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://lilbee.sh/</loc>
-    <lastmod>2026-05-31</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://lilbee.sh/tutorial</loc>
-    <lastmod>2026-05-31</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Problem

The homepage meta description used an em dash, and the sitemap `lastmod` dates were stale.

## Solution

Reword the description clause so it reads cleanly without the em dash, and bump both sitemap `lastmod` entries to today. The single keyword-rich h1 and the crawl coverage across the title, Open Graph, and JSON-LD were already in good shape, so nothing else needed changing here.