### PR TITLE
Fix Nuitka frozen detection so the binary stops printing "No such command" on exit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,6 +273,28 @@ jobs:
             exit 1
           fi
 
+          # Frozen multiprocessing reinvocations must be intercepted before typer.
+          # Two real reinvocation shapes the running binary spawns into itself:
+          #   1. the splash subprocess: [exe, -m, lilbee.runtime._splash_runner, <fd>]
+          #   2. the resource tracker:  [exe, -c, "from multiprocessing... main(<fd>)"]
+          # Nuitka never sets sys.frozen, so a build that mis-detects frozen state
+          # leaks these into typer ("No such command '<fd>'", "No such option: -c"),
+          # which is what users see on TUI exit. Drive both shapes directly; fd 999
+          # is unopened so the splash runner sees a dead pipe and exits immediately.
+          MP=$(mktemp)
+          "$EXE" -m lilbee.runtime._splash_runner 999 > "$MP" 2>&1 || true
+          if grep -qE "No such command|No such option" "$MP"; then
+            echo "FAIL: splash -m reinvocation leaked into typer (frozen detection broken)"
+            cat "$MP"
+            exit 1
+          fi
+          "$EXE" -c "import multiprocessing" > "$MP" 2>&1 || true
+          if grep -qE "No such command|No such option" "$MP"; then
+            echo "FAIL: resource-tracker -c reinvocation leaked into typer (frozen detection broken)"
+            cat "$MP"
+            exit 1
+          fi
+
           # Boot server, scan stderr for the spawn-loop pattern, verify /api/health version.
           export LILBEE_DATA="${{ runner.temp }}/lilbee-smoke"
           mkdir -p "$LILBEE_DATA"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lilbee"
-version = "0.6.66b501"
+version = "0.6.66b502"
 description = "Run and manage local AI models, then search your files, code, and the web pages you crawl, with answers that cite the source. Everything runs on your machine in one process: per-project libraries, semantic and hybrid search, vision OCR, an auto-built wiki, CLI, TUI, MCP server, REST API, and Python library. No model server, no database server. Works with your own Ollama or LM Studio models too."
 readme = "README.md"
 license = "Elastic-2.0"

--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -48,12 +48,19 @@ def _prestart_mp_resource_tracker() -> None:
     (Nuitka onefile), where ``sys.executable`` is the lilbee exe itself
     and the tracker's spawn would re-enter typer with ``-B -s -E`` as
     CLI args (``__main__._dispatch_frozen_child`` handles that case).
+
+    Detecting the frozen build via :func:`lilbee._frozen.is_frozen` is
+    load-bearing: Nuitka never sets ``sys.frozen``, so a check on that
+    attribute alone would let the tracker spawn fire inside the onefile
+    binary and surface the typer error.
     """
     import sys as _sys
 
+    from lilbee._frozen import is_frozen
+
     if _sys.platform == "win32":
         return
-    if getattr(_sys, "frozen", False):
+    if is_frozen():
         return
     try:
         from multiprocessing import resource_tracker

--- a/src/lilbee/__main__.py
+++ b/src/lilbee/__main__.py
@@ -30,6 +30,20 @@ def _isolate_vendored_openssl() -> None:
     os.environ.setdefault("OPENSSL_CONF", os.devnull)
 
 
+def _is_frozen() -> bool:
+    """True when running from a frozen build.
+
+    A deliberate local copy of :func:`lilbee._frozen.is_frozen`: the dispatch
+    path below must import nothing from the ``lilbee`` package (the splash
+    subprocess this intercepts is stdlib-only and must stay light), so it
+    cannot import the shared helper. PyInstaller/cx_Freeze set ``sys.frozen``;
+    Nuitka never does, but injects a ``__compiled__`` global into every module
+    it compiles. Both must be checked so the dispatchers fire in the shipped
+    Nuitka onefile binary, not just under PyInstaller.
+    """
+    return bool(sys.__dict__.get("frozen")) or "__compiled__" in globals()
+
+
 def _multiprocessing_child_code(argv: list[str]) -> str | None:
     """Return the ``-c`` payload if *argv* is a multiprocessing child reinvocation.
 
@@ -59,7 +73,7 @@ def _multiprocessing_child_code(argv: list[str]) -> str | None:
 
 def _dispatch_frozen_child() -> bool:
     """Exec a multiprocessing child payload and return True when handled."""
-    if not getattr(sys, "frozen", False):
+    if not _is_frozen():
         return False
     code = _multiprocessing_child_code(sys.argv)
     if code is None:
@@ -83,7 +97,7 @@ def _dispatch_module_invocation() -> bool:
     Restricted to the ``lilbee.*`` namespace so a stray ``lilbee -m foo`` typed
     by a user can't reach exec.
     """
-    if not getattr(sys, "frozen", False):
+    if not _is_frozen():
         return False
     if len(sys.argv) < _DASH_M_MIN_ARGV or sys.argv[1] != "-m":
         return False

--- a/src/lilbee/_frozen.py
+++ b/src/lilbee/_frozen.py
@@ -1,0 +1,22 @@
+"""Frozen-build detection shared by package-level code.
+
+``__main__`` keeps its own copy of this predicate on purpose: the
+multiprocessing/-m child dispatch path there must import nothing from the
+``lilbee`` package (the splash subprocess is deliberately stdlib-only), so it
+cannot import this module. Every other caller imports :func:`is_frozen`.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def is_frozen() -> bool:
+    """True when running from a frozen build.
+
+    PyInstaller/cx_Freeze set ``sys.frozen``; Nuitka never does but injects a
+    ``__compiled__`` global into every module it compiles. Both must be checked
+    so detection works in the shipped Nuitka onefile binary, not just under
+    PyInstaller.
+    """
+    return bool(sys.__dict__.get("frozen")) or "__compiled__" in globals()

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -8,6 +8,7 @@ import re
 import sys
 from pathlib import Path
 
+from lilbee._frozen import is_frozen
 from lilbee.runtime.progress import (
     DetailedProgressCallback,
     EventType,
@@ -212,7 +213,8 @@ def _resolve_playwright_runner() -> tuple[list[str], dict[str, str]]:
     Spawns Playwright's bundled Node driver directly so the call works under a
     pip install, ``uv tool install``, or a frozen (Nuitka onefile) binary. Falls
     back to ``[sys.executable, '-m', 'playwright']`` for unfrozen builds when the
-    driver lookup fails; re-raises for frozen builds.
+    driver lookup fails; re-raises for frozen builds, where ``sys.executable``
+    is the lilbee exe and ``-m playwright`` would leak into typer.
     """
     try:
         from playwright._impl._driver import compute_driver_executable, get_driver_env
@@ -221,7 +223,7 @@ def _resolve_playwright_runner() -> tuple[list[str], dict[str, str]]:
     try:
         driver_exe, driver_cli = compute_driver_executable()
     except Exception:
-        if not getattr(sys, "frozen", False):
+        if not is_frozen():
             return [sys.executable, "-m", "playwright"], dict(os.environ)
         raise
     return [str(driver_exe), str(driver_cli)], dict(get_driver_env())

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -917,6 +917,21 @@ class TestResolvePlaywrightRunner:
         with pytest.raises(RuntimeError, match="API drift"):
             bootstrap_mod._resolve_playwright_runner()
 
+    def test_compute_driver_failure_under_nuitka_propagates(self, monkeypatch):
+        """Nuitka sets __compiled__ but never sys.frozen; still propagate (no -m fallback)."""
+        from lilbee import _frozen
+
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.setattr(_frozen, "__compiled__", object(), raising=False)
+
+        def _boom() -> tuple[str, str]:
+            raise RuntimeError("playwright API drift")
+
+        self._install_fake_driver_module(monkeypatch, compute=_boom, env={})
+
+        with pytest.raises(RuntimeError, match="API drift"):
+            bootstrap_mod._resolve_playwright_runner()
+
     def test_playwright_missing_raises_actionable_error(self, monkeypatch):
         """ImportError on playwright raises CrawlerBrowserError with install hint."""
         import builtins

--- a/tests/test_main_dispatch.py
+++ b/tests/test_main_dispatch.py
@@ -90,6 +90,51 @@ class TestMultiprocessingChildCode:
         assert main_mod._multiprocessing_child_code(["bin", "-c", "print('hi')"]) is None
 
 
+class TestIsFrozen:
+    """Detect frozen builds via sys.frozen (PyInstaller) or __compiled__ (Nuitka)."""
+
+    def test_true_when_sys_frozen_set(self) -> None:
+        with mock.patch.object(main_mod.sys, "frozen", True, create=True):
+            assert main_mod._is_frozen() is True
+
+    def test_true_when_nuitka_compiled_marker_present(self) -> None:
+        # Nuitka injects __compiled__ into every module but never sets sys.frozen.
+        with (
+            mock.patch.object(main_mod.sys, "frozen", False, create=True),
+            mock.patch.object(main_mod, "__compiled__", object(), create=True),
+        ):
+            assert main_mod._is_frozen() is True
+
+    def test_false_in_plain_interpreter(self) -> None:
+        with mock.patch.object(main_mod.sys, "frozen", False, create=True):
+            assert main_mod._is_frozen() is False
+
+
+class TestSharedIsFrozen:
+    """lilbee._frozen.is_frozen is the canonical helper for package-level code."""
+
+    def test_true_when_sys_frozen_set(self) -> None:
+        from lilbee import _frozen
+
+        with mock.patch.object(_frozen.sys, "frozen", True, create=True):
+            assert _frozen.is_frozen() is True
+
+    def test_true_when_nuitka_compiled_marker_present(self) -> None:
+        from lilbee import _frozen
+
+        with (
+            mock.patch.object(_frozen.sys, "frozen", False, create=True),
+            mock.patch.object(_frozen, "__compiled__", object(), create=True),
+        ):
+            assert _frozen.is_frozen() is True
+
+    def test_false_in_plain_interpreter(self) -> None:
+        from lilbee import _frozen
+
+        with mock.patch.object(_frozen.sys, "frozen", False, create=True):
+            assert _frozen.is_frozen() is False
+
+
 class TestDispatchFrozenChild:
     """Run multiprocessing `-c` payloads inside the frozen exe."""
 
@@ -100,6 +145,23 @@ class TestDispatchFrozenChild:
             mock.patch.object(main_mod.sys, "argv", argv),
         ):
             assert main_mod._dispatch_frozen_child() is False
+
+    def test_execs_payload_under_nuitka_without_sys_frozen(self, tmp_path: Path) -> None:
+        # Regression: Nuitka onefile never sets sys.frozen, so gating the
+        # dispatcher on it leaks the resource_tracker reinvocation into typer
+        # ("No such command '3'"). __compiled__ is the Nuitka frozen marker.
+        marker = tmp_path / "marker.txt"
+        payload = (
+            f"from multiprocessing.resource_tracker import main\n"
+            f"open({str(marker)!r}, 'w').write('ran')"
+        )
+        with (
+            mock.patch.object(main_mod.sys, "frozen", False, create=True),
+            mock.patch.object(main_mod, "__compiled__", object(), create=True),
+            mock.patch.object(main_mod.sys, "argv", ["bin", "-c", payload]),
+        ):
+            assert main_mod._dispatch_frozen_child() is True
+        assert marker.read_text() == "ran"
 
     def test_returns_false_when_no_payload(self) -> None:
         with (
@@ -152,6 +214,20 @@ class TestDispatchModuleInvocation:
         ):
             assert main_mod._dispatch_module_invocation() is False
 
+    def test_routes_under_nuitka_without_sys_frozen(self) -> None:
+        # Regression: same Nuitka frozen-detection gap as the mp-child dispatcher.
+        argv_in = ["bin", "-m", "lilbee.core.system", "extra"]
+        with (
+            mock.patch.object(main_mod.sys, "frozen", False, create=True),
+            mock.patch.object(main_mod, "__compiled__", object(), create=True),
+            mock.patch.object(main_mod.sys, "argv", argv_in),
+            mock.patch("runpy.run_module") as run_module,
+        ):
+            assert main_mod._dispatch_module_invocation() is True
+        run_module.assert_called_once_with(
+            "lilbee.core.system", run_name="__main__", alter_sys=True
+        )
+
     def test_routes_lilbee_module_through_runpy(self) -> None:
         argv_in = ["bin", "-m", "lilbee.core.system", "extra"]
         captured: dict[str, object] = {}
@@ -173,3 +249,41 @@ class TestDispatchModuleInvocation:
         assert captured["run_name"] == "__main__"
         assert captured["alter_sys"] is True
         assert captured["argv_at_call"] == ["lilbee.core.system", "extra"]
+
+
+class TestPrestartMpResourceTracker:
+    """The package-import prestart must skip frozen builds, including Nuitka."""
+
+    def test_skips_under_nuitka_without_sys_frozen(self) -> None:
+        # Regression: under the bug this prestart spawned the resource_tracker
+        # child inside the onefile binary, surfacing "No such command '<fd>'".
+        # The guard delegates to lilbee._frozen.is_frozen, which reads its own
+        # __compiled__ marker.
+        from multiprocessing import resource_tracker
+
+        import lilbee
+        from lilbee import _frozen
+
+        called: list[int] = []
+        with (
+            mock.patch.object(main_mod.sys, "frozen", False, create=True),
+            mock.patch.object(_frozen, "__compiled__", object(), create=True),
+            mock.patch.object(main_mod.sys, "platform", "linux"),
+            mock.patch.object(resource_tracker, "ensure_running", lambda: called.append(1)),
+        ):
+            lilbee._prestart_mp_resource_tracker()
+        assert called == []
+
+    def test_prestarts_on_posix_when_not_frozen(self) -> None:
+        from multiprocessing import resource_tracker
+
+        import lilbee
+
+        called: list[int] = []
+        with (
+            mock.patch.object(main_mod.sys, "frozen", False, create=True),
+            mock.patch.object(main_mod.sys, "platform", "linux"),
+            mock.patch.object(resource_tracker, "ensure_running", lambda: called.append(1)),
+        ):
+            lilbee._prestart_mp_resource_tracker()
+        assert called == [1]

--- a/uv.lock
+++ b/uv.lock
@@ -1598,7 +1598,7 @@ wheels = [
 
 [[package]]
 name = "lilbee"
-version = "0.6.66b501"
+version = "0.6.66b502"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
## Problem

Running the release binary and exiting prints an error like `No such command '3'` to the terminal. Nuitka onefile builds never set `sys.frozen`, but three places that need to know they're running inside the frozen binary gated on `getattr(sys, "frozen", False)`. In the shipped binary those guards were dead, so the multiprocessing reinvocations the program makes into itself leaked into the typer CLI parser:

- the splash subprocess runs `[exe, -m, lilbee.runtime._splash_runner, <fd>]` into itself, and typer reads `-m` as `--model`, leaving the pipe fd (e.g. `3`) as a bogus command;
- the resource-tracker prestart spawned `[exe, -c, "...resource_tracker..."]`, which typer also rejected.

The error is hidden behind the TUI's alternate screen, so it only surfaces on exit. It was invisible to CI because `sys.frozen` was mocked true in the unit tests and the existing smoke checks don't drive these reinvocation shapes.

## Solution

Add `lilbee._frozen.is_frozen()`, which also checks Nuitka's `__compiled__` marker, and route the package-level detection sites (the resource-tracker prestart and the crawler Playwright-runner fallback) through it. `__main__` keeps a small local copy on purpose: its dispatch path must not import the `lilbee` package, because the splash subprocess it intercepts is stdlib-only and has to stay light.

The release smoke test now drives both reinvocation shapes through the real binary and fails if either leaks into typer, so a future regression is caught at build time rather than by users.

Tests cover every detection site (PyInstaller `sys.frozen` and Nuitka `__compiled__` paths). Full unit suite green.