### PR TITLE
Pass GH_REPO when attaching release binaries (fixes Linux upload in release CI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,5 +384,10 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          # GH_REPO is load-bearing: without it gh resolves the repo from the
+          # git remote, and inside the root-run manylinux container git refuses
+          # the runner-owned checkout ("detected dubious ownership"), so the
+          # Linux upload fails. Passing the repo explicitly skips git entirely.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ inputs.release_tag }}
         run: gh release upload "$TAG" "dist/${{ matrix.asset_name }}" --clobber


### PR DESCRIPTION
## Problem

During a real release the Linux x86_64 binary builds and passes its smoke test, but the `Attach binary to the GH pre-release` step fails with `fatal: detected dubious ownership in repository`. The step runs `gh release upload` without `--repo`, so gh resolves the repository from the git remote; inside the root-run manylinux container git refuses the runner-owned checkout. macOS and Windows builds run outside a container and are unaffected, and the branch validation run skips this step (no `release_tag`), so it never showed up until the binary failed to attach and skipped the entire Docker/Homebrew/AUR/Nix fan-out.

## Solution

Set `GH_REPO` on the step so gh uses the repository directly and never shells out to git.