### PR TITLE
Fail loud when a CUDA build cannot initialize its GPU (bb-3xnx)

### DIFF
--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -14,7 +14,6 @@ can't be a baked rpath because the wheels' location is only known at install tim
 from __future__ import annotations
 
 import importlib.util
-import logging
 import os
 import shutil
 import subprocess
@@ -28,8 +27,6 @@ from lilbee.providers.base import ProviderError
 if TYPE_CHECKING:
     from lilbee.providers.fleet.devices import FleetDevice
 
-log = logging.getLogger(__name__)
-
 # Subpackages the nvidia-*-cu12 wheels install under the ``nvidia`` namespace
 # (the ``cuda12`` extra: nvidia-cuda-runtime-cu12, nvidia-cublas-cu12,
 # nvidia-cuda-nvrtc-cu12).
@@ -41,8 +38,12 @@ _CUDA_WHEEL_IMPORTS: tuple[str, ...] = (
 # The sonames those wheels provide, used to tell from ``ldd`` whether a binary is a
 # CUDA build (it lists the soname whether or not the runtime resolves).
 _CUDA_SONAMES: tuple[str, ...] = ("libcudart.so.12", "libcublas.so.12", "libnvrtc.so.12")
+# Substrings that mark a CUDA init failure in the engine's --list-devices output.
+_CUDA_ERROR_MARKERS: tuple[str, ...] = ("error", "fail", "no cuda")
 _LDD_TIMEOUT_S = 10
 _LIST_DEVICES_TIMEOUT_S = 60
+# How much of the probe output to quote when no specific error line is found.
+_DIAGNOSTIC_TAIL_CHARS = 300
 
 
 def _wheel_lib_dir(import_name: str) -> Path | None:
@@ -121,11 +122,7 @@ def _links_cuda_runtime(binary: Path, env: dict[str, str]) -> bool:
 
 
 def _device_probe_diagnostic(binary: Path, env: dict[str, str]) -> str:
-    """The engine's own ``--list-devices`` error line (or a short tail) for diagnostics.
-
-    Surfacing the engine's real output keeps the failure honest: the cause is what the
-    engine reports (e.g. ``ggml_cuda_init: ... no CUDA-capable device``), not a guess.
-    """
+    """The engine's own ``--list-devices`` CUDA error line, or a short tail of its output."""
     try:
         proc = subprocess.run(  # noqa: S603 - the resolved llama-server binary
             [str(binary), "--list-devices"],
@@ -140,9 +137,9 @@ def _device_probe_diagnostic(binary: Path, env: dict[str, str]) -> str:
     out = f"{proc.stderr}\n{proc.stdout}".strip()
     for line in out.splitlines():
         lowered = line.lower()
-        if "cuda" in lowered and ("error" in lowered or "fail" in lowered or "no cuda" in lowered):
+        if "cuda" in lowered and any(marker in lowered for marker in _CUDA_ERROR_MARKERS):
             return line.strip()
-    return out[-300:] if out else "(the engine's device probe printed nothing)"
+    return out[-_DIAGNOSTIC_TAIL_CHARS:] if out else "(the engine's device probe printed nothing)"
 
 
 def assert_cuda_devices_usable(binary: Path, devices: list[FleetDevice]) -> None:

--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -14,9 +14,21 @@ can't be a baked rpath because the wheels' location is only known at install tim
 from __future__ import annotations
 
 import importlib.util
+import logging
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lilbee.providers import model_cache
+from lilbee.providers.base import ProviderError
+
+if TYPE_CHECKING:
+    from lilbee.providers.fleet.devices import FleetDevice
+
+log = logging.getLogger(__name__)
 
 # Subpackages the nvidia-*-cu12 wheels install under the ``nvidia`` namespace
 # (the ``cuda12`` extra: nvidia-cuda-runtime-cu12, nvidia-cublas-cu12,
@@ -26,6 +38,11 @@ _CUDA_WHEEL_IMPORTS: tuple[str, ...] = (
     "nvidia.cublas",
     "nvidia.cuda_nvrtc",
 )
+# The sonames those wheels provide, used to tell from ``ldd`` whether a binary is a
+# CUDA build (it lists the soname whether or not the runtime resolves).
+_CUDA_SONAMES: tuple[str, ...] = ("libcudart.so.12", "libcublas.so.12", "libnvrtc.so.12")
+_LDD_TIMEOUT_S = 10
+_LIST_DEVICES_TIMEOUT_S = 60
 
 
 def _wheel_lib_dir(import_name: str) -> Path | None:
@@ -63,3 +80,96 @@ def cuda_runtime_env() -> dict[str, str]:
     if existing:
         parts.append(existing)
     return {"LD_LIBRARY_PATH": os.pathsep.join(parts)}
+
+
+def apply_cuda_runtime_env() -> None:
+    """Put the CUDA-runtime wheel libs on this process's ``LD_LIBRARY_PATH``.
+
+    The device probe and the child servers then resolve the same runtime, so a
+    zero-device probe reflects a genuinely unusable GPU rather than a probe that
+    merely ran without the wheel libraries on its search path.
+    """
+    os.environ.update(cuda_runtime_env())
+
+
+def _ldd_output(binary: Path, env: dict[str, str]) -> str | None:
+    """``ldd`` stdout for *binary* under *env*; None when ldd can't run on it."""
+    ldd = shutil.which("ldd")
+    if ldd is None:
+        return None
+    try:
+        proc = subprocess.run(  # noqa: S603 - ldd path and the resolved binary
+            [ldd, str(binary)],
+            capture_output=True,
+            text=True,
+            timeout=_LDD_TIMEOUT_S,
+            env=env,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # Not an ELF, a static binary, or a timeout: nothing to inspect.
+        return None
+    return proc.stdout
+
+
+def _links_cuda_runtime(binary: Path, env: dict[str, str]) -> bool:
+    """True when *binary* lists a CUDA runtime soname (a CUDA build), resolved or not."""
+    out = _ldd_output(binary, env)
+    if out is None:
+        return False
+    return any(soname in out for soname in _CUDA_SONAMES)
+
+
+def _device_probe_diagnostic(binary: Path, env: dict[str, str]) -> str:
+    """The engine's own ``--list-devices`` error line (or a short tail) for diagnostics.
+
+    Surfacing the engine's real output keeps the failure honest: the cause is what the
+    engine reports (e.g. ``ggml_cuda_init: ... no CUDA-capable device``), not a guess.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603 - the resolved llama-server binary
+            [str(binary), "--list-devices"],
+            capture_output=True,
+            text=True,
+            timeout=_LIST_DEVICES_TIMEOUT_S,
+            env=env,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "(the engine's device probe could not be run)"
+    out = f"{proc.stderr}\n{proc.stdout}".strip()
+    for line in out.splitlines():
+        lowered = line.lower()
+        if "cuda" in lowered and ("error" in lowered or "fail" in lowered or "no cuda" in lowered):
+            return line.strip()
+    return out[-300:] if out else "(the engine's device probe printed nothing)"
+
+
+def assert_cuda_devices_usable(binary: Path, devices: list[FleetDevice]) -> None:
+    """Fail loud when a CUDA build links a runtime it cannot initialize a GPU with.
+
+    *devices* is the engine's own ``--list-devices`` result. When it is empty yet
+    *binary* is a CUDA build and the host has an NVIDIA GPU, the runtime loaded but
+    enumerated no device. The engine's own diagnostic is surfaced and the likely causes
+    are listed (rather than asserting one), so placement does not silently fall to CPU.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    if devices:
+        return
+    env = {**os.environ, **cuda_runtime_env()}
+    if not _links_cuda_runtime(binary, env):
+        return
+    if not model_cache.has_nvidia_gpu():
+        return
+    diagnostic = _device_probe_diagnostic(binary, env)
+    raise ProviderError(
+        "The engine links the CUDA runtime and this host has an NVIDIA GPU, but it "
+        "enumerated no CUDA-capable device, so GPU work would silently fall back to CPU.\n"
+        f"The engine reported: {diagnostic}\n"
+        "Likely causes: the installed CUDA runtime is newer than the GPU driver supports "
+        "(check the driver's CUDA version with 'nvidia-smi' and match the "
+        "nvidia-cuda-runtime-cu12 / nvidia-cublas-cu12 / nvidia-cuda-nvrtc-cu12 wheels to "
+        "the engine's CUDA build, e.g. 12.4.x for a cu124 build, or update the driver); a "
+        "restrictive CUDA_VISIBLE_DEVICES; or the runtime libraries missing from the path."
+    )

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -657,9 +657,13 @@ def resolve_devices(binary: Path) -> list[FleetDevice]:
     The binary's ``--list-devices`` is authoritative; when it enumerates nothing,
     fall back to the Vulkan VRAM probe, which reports the same index space.
     """
+    from lilbee.providers.fleet.cuda_runtime import assert_cuda_devices_usable
     from lilbee.providers.fleet.gpu_select import enumerate_gpu_vram
 
     devices = probe_devices(binary)
+    # A CUDA build that links a runtime it cannot init a GPU with must fail loud,
+    # not silently fall back to CPU (the Vulkan VRAM probe below would mask it).
+    assert_cuda_devices_usable(binary, devices)
     if not devices and model_cache.has_nvidia_gpu():
         log.warning(
             "This host has an NVIDIA GPU but the engine's device probe "
@@ -729,10 +733,14 @@ def plan_all_launches() -> list[InstanceLaunch]:
     Disables crash-prone Vulkan layers / dual-vendor ICDs and applies any
     ``cfg.gpu_devices`` pin before the probe and plan (both inherit the env).
     """
+    from lilbee.providers.fleet.cuda_runtime import apply_cuda_runtime_env
     from lilbee.providers.fleet.gpu_env import apply_fleet_gpu_env
 
     apply_fleet_gpu_env()
     binary = resolve_llama_server()
+    # Put the CUDA-runtime wheels on the process path so the device probe sees the
+    # same runtime the servers will, before resolve_devices enumerates GPUs.
+    apply_cuda_runtime_env()
     devices = resolve_devices(binary)
     by_index = {d.index: d for d in devices}
     return plan_launches(None, binary, by_index, devices)

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -204,3 +204,44 @@ def test_cuda_wheel_lib_dirs_collects_only_installed(monkeypatch: pytest.MonkeyP
     }
     monkeypatch.setattr(cuda_runtime, "_wheel_lib_dir", lambda name: found[name])
     assert cuda_runtime._cuda_wheel_lib_dirs() == [Path("/r/lib"), Path("/n/lib")]
+
+
+def test_ldd_output_none_when_subprocess_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _have_ldd(monkeypatch)
+
+    def _raise(*_a: object, **_k: object) -> None:
+        raise OSError("not an ELF binary")
+
+    monkeypatch.setattr(cuda_runtime.subprocess, "run", _raise)
+    assert cuda_runtime._ldd_output(Path("/bin/llama-server"), {}) is None
+
+
+def test_device_probe_diagnostic_returns_tail_when_no_error_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cuda_runtime.subprocess,
+        "run",
+        lambda *_a, **_k: SimpleNamespace(stdout="CUDA0: NVIDIA L40 (45 GiB)\n", stderr=""),
+    )
+    out = cuda_runtime._device_probe_diagnostic(Path("/bin/llama-server"), {})
+    assert "NVIDIA L40" in out  # no error marker -> falls through to the output tail
+
+
+def test_device_probe_diagnostic_when_no_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cuda_runtime.subprocess,
+        "run",
+        lambda *_a, **_k: SimpleNamespace(stdout="", stderr=""),
+    )
+    out = cuda_runtime._device_probe_diagnostic(Path("/bin/llama-server"), {})
+    assert out == "(the engine's device probe printed nothing)"
+
+
+def test_device_probe_diagnostic_when_probe_cannot_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_a: object, **_k: object) -> None:
+        raise OSError("binary not found")
+
+    monkeypatch.setattr(cuda_runtime.subprocess, "run", _raise)
+    out = cuda_runtime._device_probe_diagnostic(Path("/bin/llama-server"), {})
+    assert out == "(the engine's device probe could not be run)"

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -62,9 +62,11 @@ def test_links_cuda_runtime_false_when_ldd_absent(monkeypatch: pytest.MonkeyPatc
 def test_apply_cuda_runtime_env_updates_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
     _force_linux(monkeypatch)
     monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
-    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/wheel/lib")])
+    wheel = Path("/wheel/lib")
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [wheel])
     apply_cuda_runtime_env()
-    assert cuda_runtime.os.environ["LD_LIBRARY_PATH"] == "/wheel/lib"
+    # str(Path) keeps this host-agnostic (/ vs \ between Linux and Windows).
+    assert cuda_runtime.os.environ["LD_LIBRARY_PATH"] == str(wheel)
 
 
 def test_apply_cuda_runtime_env_noop_when_no_wheels(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -8,12 +8,130 @@ from types import SimpleNamespace
 
 import pytest
 
+from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet import cuda_runtime
-from lilbee.providers.fleet.cuda_runtime import cuda_runtime_env
+from lilbee.providers.fleet.cuda_runtime import (
+    apply_cuda_runtime_env,
+    assert_cuda_devices_usable,
+    cuda_runtime_env,
+)
+from lilbee.providers.fleet.devices import FleetDevice
 
 
 def _force_linux(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cuda_runtime.sys, "platform", "linux")
+
+
+def _have_ldd(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.shutil, "which", lambda _name: "/usr/bin/ldd")
+
+
+def _ldd_returns(monkeypatch: pytest.MonkeyPatch, stdout: str) -> None:
+    _have_ldd(monkeypatch)
+    monkeypatch.setattr(
+        cuda_runtime.subprocess,
+        "run",
+        lambda *_a, **_k: SimpleNamespace(stdout=stdout, stderr=""),
+    )
+
+
+_LINKS_CUDA = "\tlibcudart.so.12 => /usr/lib/libcudart.so.12 (0x00007f00)\n"
+_NO_CUDA = "\tlibstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007f00)\n"
+
+
+def test_links_cuda_runtime_true_when_soname_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ldd_returns(monkeypatch, _LINKS_CUDA)
+    assert cuda_runtime._links_cuda_runtime(Path("/bin/llama-server"), {}) is True
+
+
+def test_links_cuda_runtime_true_when_soname_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ldd_returns(monkeypatch, "\tlibcudart.so.12 => not found\n")
+    assert cuda_runtime._links_cuda_runtime(Path("/bin/llama-server"), {}) is True
+
+
+def test_links_cuda_runtime_false_for_non_cuda_build(monkeypatch: pytest.MonkeyPatch) -> None:
+    _ldd_returns(monkeypatch, _NO_CUDA)
+    assert cuda_runtime._links_cuda_runtime(Path("/bin/llama-server"), {}) is False
+
+
+def test_links_cuda_runtime_false_when_ldd_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.shutil, "which", lambda _name: None)
+    assert cuda_runtime._links_cuda_runtime(Path("/bin/llama-server"), {}) is False
+
+
+def test_apply_cuda_runtime_env_updates_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [Path("/wheel/lib")])
+    apply_cuda_runtime_env()
+    assert cuda_runtime.os.environ["LD_LIBRARY_PATH"] == "/wheel/lib"
+
+
+def test_apply_cuda_runtime_env_noop_when_no_wheels(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+    apply_cuda_runtime_env()
+    assert "LD_LIBRARY_PATH" not in cuda_runtime.os.environ
+
+
+def test_assert_devices_noop_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cuda_runtime.sys, "platform", "darwin")
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("must not probe off Linux")
+
+    monkeypatch.setattr(cuda_runtime.subprocess, "run", _boom)
+    assert_cuda_devices_usable(Path("/bin/llama-server"), [])  # no raise
+
+
+def test_assert_devices_passes_when_a_device_enumerated(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    _ldd_returns(monkeypatch, _LINKS_CUDA)
+    monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+    device = FleetDevice("CUDA", 0, "gpu", 1, 1)
+    assert_cuda_devices_usable(Path("/bin/llama-server"), [device])  # no raise
+
+
+def test_assert_devices_passes_for_non_cuda_build(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    _ldd_returns(monkeypatch, _NO_CUDA)
+    monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+    assert_cuda_devices_usable(Path("/bin/llama-server"), [])  # no raise
+
+
+def test_assert_devices_passes_when_no_nvidia_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    _ldd_returns(monkeypatch, _LINKS_CUDA)
+    monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: False)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+    assert_cuda_devices_usable(Path("/bin/llama-server"), [])  # no raise
+
+
+def test_assert_devices_raises_with_engine_diagnostic(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The bb-3xnx failure: a CUDA build + an NVIDIA GPU, but the probe sees nothing.
+    # Must hard-fail, surface the engine's real error, and list causes (not assert one).
+    _force_linux(monkeypatch)
+    _have_ldd(monkeypatch)
+    monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [])
+    cuda_err = "ggml_cuda_init: failed to initialize CUDA: no CUDA-capable device is detected"
+
+    def _run(cmd: list[str], *_a: object, **_k: object) -> SimpleNamespace:
+        if "--list-devices" in cmd:
+            return SimpleNamespace(stdout="", stderr=cuda_err + "\n")
+        return SimpleNamespace(stdout=_LINKS_CUDA, stderr="")  # ldd resolves the soname
+
+    monkeypatch.setattr(cuda_runtime.subprocess, "run", _run)
+    with pytest.raises(ProviderError) as exc:
+        assert_cuda_devices_usable(Path("/bin/llama-server"), [])
+    message = str(exc.value)
+    assert "failed to initialize CUDA" in message  # the engine's own diagnostic, surfaced
+    assert "nvidia-smi" in message
+    assert "12.4" in message
+    assert "CUDA_VISIBLE_DEVICES" in message  # causes listed, not one asserted
 
 
 def test_runtime_env_empty_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1007,6 +1007,19 @@ class TestResolveDevicesProbeFailureWarning:
             assert planning_mod.resolve_devices(Path("/bin/llama-server")) == [device]
         assert not caplog.records
 
+    def test_raises_when_cuda_build_enumerates_no_device(self, monkeypatch) -> None:
+        # The bb-3xnx failure: a CUDA-linked engine + an NVIDIA GPU, but the probe
+        # sees nothing (a runtime the probe can't load). Must hard-fail, not fall back.
+        from lilbee.providers.base import ProviderError
+        from lilbee.providers.fleet import cuda_runtime
+
+        monkeypatch.setattr(cuda_runtime.sys, "platform", "linux")
+        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [])
+        monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
+        monkeypatch.setattr(cuda_runtime, "_links_cuda_runtime", lambda *_a: True)
+        with pytest.raises(ProviderError, match="no CUDA-capable device"):
+            planning_mod.resolve_devices(Path("/bin/llama-server"))
+
 
 def _parse_flags(argv: list[str]) -> dict[str, str | None]:
     """Map each ``--flag`` in *argv* to its value token (None for bare flags)."""


### PR DESCRIPTION
## Problem

On a GPU pod, the fleet's device probe runs `llama-server --list-devices` *without* the CUDA-runtime wheels on `LD_LIBRARY_PATH`. When the runtime lives in those wheels (driver-only images, or a reused engine built without the system CUDA toolkit), the probe enumerates zero devices, so placement silently falls back to shared-memory/CPU and OCR + embedding crawl with only a warning.

This hit live on a Phase-1 ingest pod (2x L40): a reused engine binary had no `libcudart` on the fresh pod, and even after installing the runtime wheels the probe still reported no GPU because it ran without them on its path. Every page failed until the runtime was wired by hand.

## Solution

- `apply_cuda_runtime_env()` puts the CUDA-runtime wheels on the process `LD_LIBRARY_PATH` before the probe, so the probe resolves the same runtime the spawned servers will.
- `assert_cuda_devices_usable()` hard-fails when a CUDA-linked build enumerates no device on a host with an NVIDIA GPU. It surfaces the engine's own `--list-devices` diagnostic and lists the likely causes (runtime/driver mismatch, restrictive `CUDA_VISIBLE_DEVICES`, missing libs) rather than asserting one, and replaces the silent CPU fallback for CUDA builds.

Targeted unit tests cover the device self-check (raise/pass paths, the surfaced diagnostic) and the wiring; full lint + typecheck green.