### PR TITLE
Drop functionary from the opencode QA matrix

### DIFF
--- a/tools/qa/opencode/models.toml
+++ b/tools/qa/opencode/models.toml
@@ -33,11 +33,16 @@ ref = "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/Qwen3-Coder-30B-A3B-Instruct-Q4
 size_gb = 17.0
 tier = "giant"
 
+# Dropped: functionary emits its own >>>recipient tool syntax, not standard
+# tool-call JSON, so llama-server's --jinja parser never surfaces a tool call
+# and opencode never dispatches. Old (Llama-3.1 era) and superseded by the
+# native tool-callers already covered here.
 [[model]]
 family = "functionary"
 ref = "meetkai/functionary-small-v3.2-GGUF/functionary-small-v3.2.Q8_0.gguf"
 size_gb = 8.5
 tier = "mid"
+skip = true
 
 [[model]]
 family = "mistral-nemo"


### PR DESCRIPTION
## Problem

functionary fails every scenario in the opencode QA matrix: both the single-call and multi-turn runs time out with no `lilbee_search` dispatch, even though the model serves chat completions fine. The cause is its tool format. functionary emits its own `>>>recipient` function-call syntax rather than standard tool-call JSON, so llama-server's `--jinja` parser never surfaces a tool call and opencode never dispatches.

## Solution

Mark functionary `skip = true` in the QA matrix model list, alongside mistral and gemma2. It is an old Llama-3.1-era dedicated function-caller with a nonstandard format, superseded by the native tool-callers the matrix already covers (llama3, qwen3, gemma4, mistral-nemo). There is no per-family chat-template override hook today, and building one just for functionary is not worth it.

Verified against the latest 1-GPU matrix run on feat/local-model-api: functionary timed out on both scenarios while the working tool-callers (llama3, gemma4, qwen3) passed.