### PR TITLE
Detect NVIDIA GPUs without initializing NVML in-process

### DIFF
--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 import platform
+import subprocess
+import sys
 from enum import StrEnum
 from pathlib import Path
 
@@ -164,42 +167,60 @@ def has_nvidia_gpu() -> bool:
     return _try_nvidia_memory() is not None
 
 
+# A pynvml probe that runs in its OWN process: prints the minimum device total in
+# bytes, or nothing. Run as a subprocess so NVML init never touches THIS process.
+_PYNVML_MIN_TOTAL_SNIPPET = (
+    "import pynvml; pynvml.nvmlInit();"
+    "t=[pynvml.nvmlDeviceGetMemoryInfo(pynvml.nvmlDeviceGetHandleByIndex(i)).total"
+    " for i in range(pynvml.nvmlDeviceGetCount())];"
+    "pynvml.nvmlShutdown();"
+    "print(min(t)) if t else None"
+)
+_NVIDIA_PROBE_TIMEOUT_S = 10
+
+
+@functools.cache
 def _try_nvidia_memory() -> int | None:
-    """NVIDIA GPU total memory via pynvml, then nvidia-smi.
+    """Minimum NVIDIA GPU total memory (bytes), detected WITHOUT touching NVML/CUDA here.
 
-    Takes the MINIMUM total across visible devices: sizing against the smallest
-    card is conservative on a heterogeneous-GPU host.
+    Initializing NVML in this process (``pynvml.nvmlInit``) leaves NVIDIA driver state
+    that breaks a later ``llama-server --list-devices`` CUDA probe on newer drivers, so
+    detection runs only as subprocesses: ``nvidia-smi`` (ships with the driver), then an
+    isolated python+pynvml process. The minimum across visible devices is conservative on
+    a heterogeneous-GPU host. Cached: the subprocess runs once per process.
     """
+    return _nvidia_smi_min_total() or _pynvml_min_total_isolated()
+
+
+def _nvidia_smi_min_total() -> int | None:
+    """Minimum GPU total memory (bytes) via ``nvidia-smi``, or None."""
     try:
-        import pynvml  # type: ignore[import-untyped]
-
-        pynvml.nvmlInit()
-        totals = [
-            int(pynvml.nvmlDeviceGetMemoryInfo(pynvml.nvmlDeviceGetHandleByIndex(i)).total)
-            for i in range(pynvml.nvmlDeviceGetCount())
-        ]
-        pynvml.nvmlShutdown()
-        if totals:
-            return min(totals)
-    except Exception:  # noqa: S110 -- optional GPU detect; absence is expected on non-NVIDIA hosts
-        pass
-
-    try:
-        import subprocess
-
-        # nvidia-smi ships with the NVIDIA driver and is always on PATH when
-        # present; fully-qualifying it would break on every install layout.
+        # nvidia-smi ships with the NVIDIA driver and is always on PATH when present;
+        # fully-qualifying it would break on every install layout.
         result = subprocess.run(
             ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],  # noqa: S607
             capture_output=True,
             text=True,
             timeout=5,
         )
-        if result.returncode == 0:
-            mibs = [int(line) for line in result.stdout.strip().splitlines() if line.strip()]
-            if mibs:
-                return min(mibs) * 1024 * 1024
-    except Exception:  # noqa: S110 -- optional GPU detect; same rationale as above
-        pass
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    mibs = [int(line) for line in result.stdout.strip().splitlines() if line.strip()]
+    return min(mibs) * 1024 * 1024 if mibs else None
 
-    return None
+
+def _pynvml_min_total_isolated() -> int | None:
+    """Minimum GPU total memory (bytes) via pynvml run in an isolated subprocess, or None."""
+    try:
+        proc = subprocess.run(  # noqa: S603 - this interpreter + a fixed in-repo snippet
+            [sys.executable, "-c", _PYNVML_MIN_TOTAL_SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=_NVIDIA_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    out = proc.stdout.strip()
+    return int(out) if out.isdigit() else None

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import platform
+import sys
 from pathlib import Path
 from unittest import mock
 
@@ -221,88 +222,82 @@ class TestTotalSystemMemory:
         assert total_system_memory() == 8_000_000_000
 
 
+def _fake_nvidia_run(smi=None, pynvml_out=""):
+    """subprocess.run fake: nvidia-smi returns *smi* (stdout str, or an Exception to
+    raise, or None for a nonzero exit); the isolated python+pynvml subprocess returns
+    *pynvml_out* on stdout."""
+
+    def run(cmd, *_a, **_k):
+        if cmd and cmd[0] == "nvidia-smi":
+            if isinstance(smi, Exception):
+                raise smi
+            return mock.MagicMock(returncode=0 if smi is not None else 1, stdout=smi or "")
+        return mock.MagicMock(returncode=0, stdout=pynvml_out)
+
+    return run
+
+
 class TestTryNvidiaMemory:
-    def test_returns_total_from_pynvml_when_available(self, monkeypatch) -> None:
-        """pynvml success path returns the GPU total in bytes."""
-        fake_pynvml = mock.MagicMock()
-        fake_info = mock.MagicMock()
-        fake_info.total = 16 * 1024 * 1024 * 1024
-        fake_pynvml.nvmlDeviceGetMemoryInfo.return_value = fake_info
-        monkeypatch.setitem(__import__("sys").modules, "pynvml", fake_pynvml)
-        assert _try_nvidia_memory() == 16 * 1024 * 1024 * 1024
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        _try_nvidia_memory.cache_clear()
+        yield
+        _try_nvidia_memory.cache_clear()
 
-    def test_returns_none_when_pynvml_and_nvidia_smi_fail(self, monkeypatch) -> None:
-        # Force pynvml import to fail (no module installed by default in CI).
-        original_import = __import__("builtins").__import__
+    def test_nvidia_smi_is_primary(self, monkeypatch) -> None:
+        monkeypatch.setattr("subprocess.run", _fake_nvidia_run(smi="8192\n"))
+        assert _try_nvidia_memory() == 8192 * 1024 * 1024
 
-        def _no_pynvml(name, *args, **kwargs):
+    def test_nvidia_smi_takes_minimum_across_lines(self, monkeypatch) -> None:
+        monkeypatch.setattr("subprocess.run", _fake_nvidia_run(smi="24576\n8192\n"))
+        assert _try_nvidia_memory() == 8192 * 1024 * 1024
+
+    def test_falls_back_to_isolated_pynvml_subprocess(self, monkeypatch) -> None:
+        # nvidia-smi missing -> the total comes from the isolated python+pynvml subprocess.
+        monkeypatch.setattr(
+            "subprocess.run",
+            _fake_nvidia_run(smi=FileNotFoundError(), pynvml_out=str(8 * 1024**3) + "\n"),
+        )
+        assert _try_nvidia_memory() == 8 * 1024**3
+
+    def test_never_initializes_nvml_in_process(self, monkeypatch) -> None:
+        # The fix: NVML must never be imported/initialized in THIS process -- the pynvml
+        # fallback runs as a fresh subprocess, so it cannot poison a later CUDA probe.
+        calls: list[list[str]] = []
+
+        def run(cmd, *_a, **_k):
+            calls.append(cmd)
+            if cmd[0] == "nvidia-smi":
+                raise FileNotFoundError
+            return mock.MagicMock(returncode=0, stdout="123\n")
+
+        monkeypatch.setattr("subprocess.run", run)
+        real_import = __import__("builtins").__import__
+
+        def _no_inprocess_pynvml(name, *a, **k):
             if name == "pynvml":
-                raise ImportError("not installed")
-            return original_import(name, *args, **kwargs)
+                raise AssertionError("pynvml must not be imported in this process")
+            return real_import(name, *a, **k)
 
-        monkeypatch.setattr("builtins.__import__", _no_pynvml)
+        monkeypatch.setattr("builtins.__import__", _no_inprocess_pynvml)
+        assert _try_nvidia_memory() == 123
+        assert any(c[0] == sys.executable for c in calls)  # used the isolated subprocess
+
+    def test_returns_none_when_both_fail(self, monkeypatch) -> None:
         monkeypatch.setattr("subprocess.run", mock.MagicMock(side_effect=FileNotFoundError))
         assert _try_nvidia_memory() is None
 
-    def test_returns_total_from_nvidia_smi_when_pynvml_unavailable(self, monkeypatch) -> None:
-        original_import = __import__("builtins").__import__
-
-        def _no_pynvml(name, *args, **kwargs):
-            if name == "pynvml":
-                raise ImportError("not installed")
-            return original_import(name, *args, **kwargs)
-
-        monkeypatch.setattr("builtins.__import__", _no_pynvml)
-        result = mock.MagicMock(returncode=0, stdout="8192\n")
-        monkeypatch.setattr("subprocess.run", mock.MagicMock(return_value=result))
-        assert _try_nvidia_memory() == 8192 * 1024 * 1024
-
     @pytest.mark.parametrize("returncode", [1, 2])
-    def test_returns_none_when_nvidia_smi_nonzero_exit(self, monkeypatch, returncode: int) -> None:
-        original_import = __import__("builtins").__import__
+    def test_returns_none_when_nvidia_smi_nonzero_and_no_pynvml(
+        self, monkeypatch, returncode: int
+    ) -> None:
+        def run(cmd, *_a, **_k):
+            if cmd[0] == "nvidia-smi":
+                return mock.MagicMock(returncode=returncode, stdout="")
+            return mock.MagicMock(returncode=0, stdout="")  # pynvml subprocess: no output
 
-        def _no_pynvml(name, *args, **kwargs):
-            if name == "pynvml":
-                raise ImportError("not installed")
-            return original_import(name, *args, **kwargs)
-
-        monkeypatch.setattr("builtins.__import__", _no_pynvml)
-        result = mock.MagicMock(returncode=returncode, stdout="")
-        monkeypatch.setattr("subprocess.run", mock.MagicMock(return_value=result))
+        monkeypatch.setattr("subprocess.run", run)
         assert _try_nvidia_memory() is None
-
-
-class TestHeterogeneousGpuSizing:
-    def test_pynvml_takes_minimum_total_across_devices(self, monkeypatch) -> None:
-        # Heterogeneous GPUs: sizing against the smallest card is conservative.
-        fake_pynvml = mock.MagicMock()
-        fake_pynvml.nvmlDeviceGetCount.return_value = 2
-        infos = {0: mock.MagicMock(total=24 * 1024**3), 1: mock.MagicMock(total=8 * 1024**3)}
-        fake_pynvml.nvmlDeviceGetHandleByIndex.side_effect = lambda i: i
-        fake_pynvml.nvmlDeviceGetMemoryInfo.side_effect = lambda handle: infos[handle]
-        monkeypatch.setitem(__import__("sys").modules, "pynvml", fake_pynvml)
-        assert _try_nvidia_memory() == 8 * 1024**3
-
-    def test_pynvml_zero_devices_falls_through_to_nvidia_smi(self, monkeypatch) -> None:
-        fake_pynvml = mock.MagicMock()
-        fake_pynvml.nvmlDeviceGetCount.return_value = 0
-        monkeypatch.setitem(__import__("sys").modules, "pynvml", fake_pynvml)
-        result = mock.MagicMock(returncode=0, stdout="4096\n")
-        monkeypatch.setattr("subprocess.run", mock.MagicMock(return_value=result))
-        assert _try_nvidia_memory() == 4096 * 1024 * 1024
-
-    def test_nvidia_smi_takes_minimum_total_across_lines(self, monkeypatch) -> None:
-        original_import = __import__("builtins").__import__
-
-        def _no_pynvml(name, *args, **kwargs):
-            if name == "pynvml":
-                raise ImportError("not installed")
-            return original_import(name, *args, **kwargs)
-
-        monkeypatch.setattr("builtins.__import__", _no_pynvml)
-        result = mock.MagicMock(returncode=0, stdout="24576\n8192\n")
-        monkeypatch.setattr("subprocess.run", mock.MagicMock(return_value=result))
-        assert _try_nvidia_memory() == 8192 * 1024 * 1024
 
 
 class TestHasNvidiaGpu:


### PR DESCRIPTION
## What this does

`has_nvidia_gpu()` / `_try_nvidia_memory()` could call `pynvml.nvmlInit()` **in the main process**. Initializing NVML (or CUDA) in the process that later spawns the `llama-server --list-devices` probe risks leaving driver state that makes the probe enumerate no device — a latent foot-gun on hosts where `pynvml` is installed.

This makes GPU detection run **only as subprocesses** — `nvidia-smi` first (ships with the driver), then an isolated `python -c` + `pynvml` fallback — and caches the result. With no in-process NVML/CUDA init, GPU detection can never poison the device probe.

## Honest scope

This is a **defensive robustness fix**, not the root cause of the Phase-2 ingest failures we hit (on those pods `pynvml` wasn't installed, so detection already used the nvidia-smi subprocess; the actual fix there was #389's `apply_cuda_runtime_env`, now merged). It removes a real latent failure mode for setups that do have `pynvml`, and keeps GPU detection from ever interfering with the engine probe.

Unit tests cover nvidia-smi primary, the isolated-pynvml fallback, and an explicit assertion that NVML is never imported in-process. Full lint + typecheck green.