### PR TITLE
Use a present GPU when the orchestrator leaves CUDA_VISIBLE_DEVICES empty

### DIFF
--- a/src/lilbee/providers/fleet/gpu_env.py
+++ b/src/lilbee/providers/fleet/gpu_env.py
@@ -86,6 +86,24 @@ def _apply_gpu_devices_pin() -> bool:
     return True
 
 
+def _clear_empty_visible_device_vars() -> None:
+    """Drop an empty backend visible-devices var when a GPU is physically present.
+
+    An orchestrator (SkyPilot, some Docker/Kubernetes GPU setups) can export an empty
+    ``CUDA_VISIBLE_DEVICES`` while exposing the GPU via ``NVIDIA_VISIBLE_DEVICES``; the
+    empty value reads as "no devices" and hides a real GPU. A non-empty value is left
+    untouched, so an explicit pin and the conventional ``-1`` CPU opt-out both survive.
+    """
+    from lilbee.providers import model_cache
+
+    if not model_cache.has_nvidia_gpu():
+        return
+    for name in _GPU_VISIBLE_ENV_VARS:
+        if name in os.environ and not os.environ[name].strip():
+            del os.environ[name]
+            log.info("Cleared empty %s so the present GPU is visible to the engine", name)
+
+
 def apply_fleet_gpu_env() -> None:
     """Fleet engine bootstrap: loader safety plus the ``cfg.gpu_devices`` pin only.
 
@@ -93,6 +111,9 @@ def apply_fleet_gpu_env() -> None:
     its own placement, and autodetect would pin ``GGML_VK_VISIBLE_DEVICES`` to one
     adapter before ``probe_devices`` runs and hide every other GPU. A
     ``cfg.gpu_devices`` pin is still honored (the probe inherits this environment).
+    An empty backend visible-devices var from the orchestrator is cleared first so it
+    does not hide a present GPU, and so a pin can replace it rather than be blocked.
     """
     _apply_vulkan_loader_safety()
+    _clear_empty_visible_device_vars()
     _apply_gpu_devices_pin()

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -1025,6 +1025,81 @@ def test_apply_fleet_gpu_env_honors_gpu_devices_pin(monkeypatch) -> None:
         assert os.environ[name] == "0"
 
 
+def test_apply_fleet_gpu_env_clears_empty_cuda_visible_devices(monkeypatch) -> None:
+    # SkyPilot / Docker GPU setups expose the GPU via NVIDIA_VISIBLE_DEVICES but export an
+    # empty CUDA_VISIBLE_DEVICES, which hides the GPU from CUDA ("no CUDA-capable device").
+    # With a GPU present, the empty var must be cleared so the engine can enumerate it.
+    from lilbee.providers.fleet import gpu_env
+    from lilbee.providers.fleet.gpu_env import _GPU_VISIBLE_ENV_VARS
+
+    for name in _GPU_VISIBLE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(cfg, "gpu_devices", None)
+    monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    gpu_env.apply_fleet_gpu_env()
+    assert "CUDA_VISIBLE_DEVICES" not in os.environ
+
+
+def test_apply_fleet_gpu_env_clears_empty_non_cuda_visible_devices(monkeypatch) -> None:
+    # The clear covers every backend visible-devices var, not just CUDA: an empty
+    # GGML_VK_VISIBLE_DEVICES would otherwise hide adapters from the Vulkan VRAM fallback.
+    from lilbee.providers.fleet import gpu_env
+    from lilbee.providers.fleet.gpu_env import _GPU_VISIBLE_ENV_VARS
+
+    for name in _GPU_VISIBLE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(cfg, "gpu_devices", None)
+    monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
+    monkeypatch.setenv("GGML_VK_VISIBLE_DEVICES", "")
+    gpu_env.apply_fleet_gpu_env()
+    assert "GGML_VK_VISIBLE_DEVICES" not in os.environ
+
+
+def test_apply_fleet_gpu_env_keeps_nonempty_cuda_visible_devices(monkeypatch) -> None:
+    # An explicit index pin (and the conventional "-1" CPU opt-out) is user intent, not an
+    # orchestration artifact: leave it alone.
+    from lilbee.providers.fleet import gpu_env
+    from lilbee.providers.fleet.gpu_env import _GPU_VISIBLE_ENV_VARS
+
+    for name in _GPU_VISIBLE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(cfg, "gpu_devices", None)
+    monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+    gpu_env.apply_fleet_gpu_env()
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "1"
+
+
+def test_apply_fleet_gpu_env_pin_replaces_empty_cuda_visible_devices(monkeypatch) -> None:
+    # Clearing the empty var before the pin runs is what lets a cfg.gpu_devices pin take
+    # effect: setdefault would otherwise treat the present-but-empty value as already set.
+    from lilbee.providers.fleet import gpu_env
+    from lilbee.providers.fleet.gpu_env import _GPU_VISIBLE_ENV_VARS
+
+    for name in _GPU_VISIBLE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(cfg, "gpu_devices", "0")
+    monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: True)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    gpu_env.apply_fleet_gpu_env()
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
+
+
+def test_apply_fleet_gpu_env_keeps_empty_cuda_visible_devices_without_gpu(monkeypatch) -> None:
+    # With no GPU present, an empty CUDA_VISIBLE_DEVICES is honored as genuine CPU intent.
+    from lilbee.providers.fleet import gpu_env
+    from lilbee.providers.fleet.gpu_env import _GPU_VISIBLE_ENV_VARS
+
+    for name in _GPU_VISIBLE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(cfg, "gpu_devices", None)
+    monkeypatch.setattr("lilbee.providers.model_cache.has_nvidia_gpu", lambda: False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    gpu_env.apply_fleet_gpu_env()
+    assert os.environ.get("CUDA_VISIBLE_DEVICES") == ""
+
+
 def test_routing_provider_local_engine_is_fleet() -> None:
     # The fleet is the sole local engine now: AUTO routes local refs through
     # RoutingProvider, whose local engine is a FleetProvider (a single machine


### PR DESCRIPTION
## Problem

On a GPU host, a container orchestrator (SkyPilot, some Docker/Kubernetes GPU setups) can export an empty `CUDA_VISIBLE_DEVICES` while exposing the GPU through `NVIDIA_VISIBLE_DEVICES`. An empty value reads as "no devices", so `llama-server --list-devices` reports `ggml_cuda_init: no CUDA-capable device`, the fleet device probe enumerates nothing, and `assert_cuda_devices_usable` fails the ingest, on a host that has a perfectly good GPU.

This surfaced on a RunPod ingest where every page failed. The engine saw the GPU when `--list-devices` was run by hand (env with the var unset) but not inside the sync, whose environment carried the empty var.

## Solution

During fleet GPU bootstrap, clear an empty backend visible-devices var when a GPU is physically present (detected via nvidia-smi/NVML, which is independent of `CUDA_VISIBLE_DEVICES`). The clear runs before the `cfg.gpu_devices` pin so a pin can replace the empty value instead of being blocked by `setdefault`.

A non-empty value is left untouched, so an explicit pin and the conventional `-1` CPU opt-out both survive; with no GPU present, an empty value is honored as CPU intent.

Validated end-to-end on a RunPod A6000 in the failing environment: the probe went from 0 devices to the real card, GPU utilization 0% to 100%, embeddings from empty to real, and the ingest from Failed:3 to Added:3.
