### PR TITLE
Bound OCR ingest concurrency to vision slot capacity on a single GPU

### DIFF
--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -75,23 +75,19 @@ def _max_concurrent() -> int:
     """Files allowed in their compute phase at once.
 
     ``cpu_quota()`` (cpu_count // 2) keeps worker storms from starving the TUI's asyncio
-    main thread. But with a data-parallel fleet (N vision/embed servers, one per GPU), a
-    few-core box would cap file concurrency below the GPU count and starve the extra
-    cards, so the bottleneck role's total slots set the floor: vision OCR (replicas x
-    per-server pages) when a vision model is configured, else the embed replicas.
+    main thread, and is the cap for text/code ingest. Vision OCR is different: every file
+    in compute holds a continuous-batching slot on a vision server, which returns 429 when
+    oversubscribed, so an OCR run is bounded by the vision slot capacity (replicas x
+    per-server pages) -- a single vision server included. Otherwise a many-core box fans
+    ``cpu_quota()`` requests (dozens) at one server's few slots and 429-drops files, while a
+    few-core box with several GPUs would starve the extra cards.
     """
     from lilbee.core.config import cfg
 
-    # Only a multi-replica (multi-GPU) fleet scales above cpu_quota; with one replica per
-    # role the cpu_quota cap is untouched, so single-GPU/CPU hosts and the macOS TUI see
-    # exactly the previous behavior.
-    vision_slots = (
-        cfg.vision_replicas * cfg.vision_ocr_concurrency
-        if cfg.vision_model and cfg.vision_replicas > 1
-        else 0
-    )
+    if cfg.vision_model:
+        return max(1, cfg.vision_replicas * cfg.vision_ocr_concurrency)
     embed_slots = cfg.embed_replicas if cfg.embed_replicas > 1 else 0
-    return max(cpu_quota(), vision_slots, embed_slots)
+    return max(cpu_quota(), embed_slots)
 
 
 async def _rebuild_concept_clusters() -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -297,15 +297,27 @@ class TestMaxConcurrent:
         monkeypatch.setattr(cfg, "embed_replicas", 1)
         assert pipeline._max_concurrent() == 32
 
-    def test_single_replica_does_not_scale_above_cpu_quota(self, monkeypatch) -> None:
-        # A single vision replica (default) must leave cpu_quota untouched so weaker
-        # single-GPU/CPU hosts and the macOS TUI see no regression.
+    def test_single_replica_caps_at_vision_slots(self, monkeypatch) -> None:
+        # A single vision server has vision_ocr_concurrency continuous-batching slots;
+        # file-concurrency tracks that capacity so all slots stay fed.
         from lilbee.data.ingest import pipeline
 
         monkeypatch.setattr(pipeline, "cpu_quota", lambda: 4)
         monkeypatch.setattr(cfg, "vision_model", "org/repo/model.gguf")
         monkeypatch.setattr(cfg, "vision_replicas", 1)
         monkeypatch.setattr(cfg, "vision_ocr_concurrency", 8)
+        monkeypatch.setattr(cfg, "embed_replicas", 1)
+        assert pipeline._max_concurrent() == 8
+
+    def test_single_vision_server_not_flooded_by_cpu_quota(self, monkeypatch) -> None:
+        # The 429-storm bug: a many-core box must NOT fan cpu_quota (dozens) of OCR
+        # requests at one vision server's few slots; the cap is the vision capacity.
+        from lilbee.data.ingest import pipeline
+
+        monkeypatch.setattr(pipeline, "cpu_quota", lambda: 32)
+        monkeypatch.setattr(cfg, "vision_model", "org/repo/model.gguf")
+        monkeypatch.setattr(cfg, "vision_replicas", 1)
+        monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
         monkeypatch.setattr(cfg, "embed_replicas", 1)
         assert pipeline._max_concurrent() == 4
 


### PR DESCRIPTION
## Problem

On a single-GPU fleet, vision-OCR ingest drops files with `HTTP 429 "llama-server is busy"`. `_max_concurrent()` only raised file-concurrency to the vision OCR capacity (`vision_replicas * vision_ocr_concurrency`) when `vision_replicas > 1`. With one vision server it fell back to `cpu_quota()` (`cpu_count // 2`), so a many-core host fans dozens of concurrent OCR requests at one vision server that has only `vision_ocr_concurrency` continuous-batching slots. The server 429s the overflow; the bounded `RATE_LIMIT` retries exhaust under the sustained oversubscription, and the file is dropped.

Observed live on a 1x A100 ingest: 643 files dropped to 429 while the GPU sat at 97% utilization.

## Solution

Bound file-concurrency by the vision slot capacity whenever a vision model is configured (single server included), instead of falling back to `cpu_quota()`. This also fixes a latent multi-GPU case where `cpu_quota()` exceeded the total slots and would flood them.

Unit-tested, including a regression test for the exact flood (cpu_quota 32 vs vision capacity 4 -> caps at 4).

## Validation

Diagnosed from the live 1x A100 bench above. A single-GPU pod re-bench to confirm the 429 storm is gone end-to-end is pending US-KS-2 GPU capacity; this should not merge until that passes.
