### PR TITLE
Fix concurrency and shared-state races for the always-on server

### DIFF
--- a/src/lilbee/app/ingest.py
+++ b/src/lilbee/app/ingest.py
@@ -53,14 +53,12 @@ def temporary_ocr_config(
     enable_ocr: bool | None = None,
     ocr_timeout: float | None = None,
 ) -> Generator[None, None, None]:
-    """Temporarily override OCR config for the duration of the block."""
-    old_ocr, old_timeout = cfg.enable_ocr, cfg.ocr_timeout
-    try:
-        if enable_ocr is not None:
-            cfg.enable_ocr = enable_ocr
-        if ocr_timeout is not None:
-            cfg.ocr_timeout = ocr_timeout
+    """Override OCR config for the duration of the block, per request.
+
+    Backed by a ContextVar rather than a global ``cfg`` mutation, so concurrent
+    ingests on the shared HTTP daemon do not clobber one another's OCR settings.
+    """
+    from lilbee.data.ingest.extract import ocr_override
+
+    with ocr_override(enable_ocr, ocr_timeout):
         yield
-    finally:
-        cfg.enable_ocr = old_ocr
-        cfg.ocr_timeout = old_timeout

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -207,12 +207,19 @@ def peek_services() -> Services | None:
 
 
 def reset_services() -> None:
-    """Shut down and discard all cached instances."""
+    """Shut down and discard all cached instances.
+
+    Swap the module reference to ``None`` *before* tearing the old instances
+    down, so a new caller never observes a half-closed container. Concurrent
+    runtime resets are confined to stdio (one serialized client); the shared
+    HTTP daemon refuses the tools (init/reset) that would call this mid-flight.
+    """
     global _svc
-    if _svc is not None:
-        _svc.provider.shutdown()
-        _svc.store.close()
+    old = _svc
     _svc = None
+    if old is not None:
+        old.provider.shutdown()
+        old.store.close()
 
 
 def reset_store() -> None:
@@ -233,7 +240,9 @@ def reset_store() -> None:
     from lilbee.retrieval.concepts import ConceptGraph
     from lilbee.retrieval.query import Searcher
 
-    _svc.store.close()
+    # Build the replacement, swap the reference, then close the old store last so
+    # a new caller never observes a closed handle mid-swap.
+    old_store = _svc.store
     store = Store(cfg)
     concepts = ConceptGraph(cfg, store)
     clusterer = Clusterer(cfg, store)
@@ -245,6 +254,7 @@ def reset_store() -> None:
         clusterer=clusterer,
         searcher=searcher,
     )
+    old_store.close()
 
 
 atexit.register(reset_services)

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -210,9 +210,10 @@ def reset_services() -> None:
     """Shut down and discard all cached instances.
 
     Swap the module reference to ``None`` *before* tearing the old instances
-    down, so a new caller never observes a half-closed container. Concurrent
-    runtime resets are confined to stdio (one serialized client); the shared
-    HTTP daemon refuses the tools (init/reset) that would call this mid-flight.
+    down, so a new caller never observes a half-closed container. On the shared
+    HTTP daemon every entry point that would call this mid-flight is refused: the
+    init/reset MCP tools, and a provider switch via MCP settings_set or the REST
+    config handler. Outside the daemon (CLI, TUI, stdio) it runs single-client.
     """
     global _svc
     old = _svc

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -211,9 +211,8 @@ def reset_services() -> None:
 
     Swap the module reference to ``None`` *before* tearing the old instances
     down, so a new caller never observes a half-closed container. On the shared
-    HTTP daemon every entry point that would call this mid-flight is refused: the
-    init/reset MCP tools, and a provider switch via MCP settings_set or the REST
-    config handler. Outside the daemon (CLI, TUI, stdio) it runs single-client.
+    HTTP daemon every entry point that would call this mid-flight is refused, so
+    it only ever runs single-client (CLI, TUI, stdio MCP).
     """
     global _svc
     old = _svc

--- a/src/lilbee/app/settings.py
+++ b/src/lilbee/app/settings.py
@@ -284,6 +284,19 @@ def requires_services_reset(updates: dict[str, Any]) -> bool:
     return bool(set(updates) & PROVIDER_SWITCHING_KEYS)
 
 
+def provider_reset_refused_message(action: str) -> str:
+    """Shared user-facing refusal for a provider *action* on the HTTP server.
+
+    *action* is the verb shown to the user, e.g. ``"Switching"`` or
+    ``"Resetting"``. Kept in one place so the daemon entry points (MCP
+    settings_set / settings_reset, REST config) cannot drift apart.
+    """
+    return (
+        f"{action} the model provider is unavailable on the HTTP server: it rebuilds "
+        "the shared engine for every connected client. Change it from the CLI."
+    )
+
+
 def _invalidate_caches(changed_keys: set[str]) -> None:
     """Drop every read-side cache whose freshness depends on a changed setting."""
     if not changed_keys:

--- a/src/lilbee/app/settings.py
+++ b/src/lilbee/app/settings.py
@@ -273,6 +273,17 @@ def _reload_changed_roles(changed_keys: set[str]) -> None:
         services.provider.drop_loaded_models_async()
 
 
+def requires_services_reset(updates: dict[str, Any]) -> bool:
+    """True if applying *updates* would tear down and rebuild the Services singleton.
+
+    A provider switch reconstructs the provider via ``create_provider``, which
+    only runs at services init, so it forces a full ``reset_services()``. Callers
+    on the shared HTTP daemon use this to refuse the swap rather than tear the
+    singleton down under concurrent in-flight handlers.
+    """
+    return bool(set(updates) & PROVIDER_SWITCHING_KEYS)
+
+
 def _invalidate_caches(changed_keys: set[str]) -> None:
     """Drop every read-side cache whose freshness depends on a changed setting."""
     if not changed_keys:

--- a/src/lilbee/app/settings.py
+++ b/src/lilbee/app/settings.py
@@ -170,6 +170,27 @@ def _is_nullable(key: str) -> bool:
     return False
 
 
+def _as_int_setting(value: Any) -> int | None:
+    """Coerce a settings value to int the way pydantic will, or None if not numeric.
+
+    MCP settings_set forwards raw JSON, so a numeric setting can arrive as a
+    string (``{"chunk_overlap": "1000"}``). The cross-field guards must compare
+    the coerced int, not skip on the string and let pydantic accept an
+    unvalidated value downstream. ``bool`` is excluded (it is not a meaningful
+    chunk size) and non-numeric strings fall through to pydantic's type error.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
 def _validate(updates: dict[str, Any]) -> None:
     """Reject unknown keys, null on non-nullable, and out-of-range chunk sizes."""
     for key, value in updates.items():
@@ -177,12 +198,12 @@ def _validate(updates: dict[str, Any]) -> None:
             raise ValueError(f"Unknown or read-only setting: {key}")
         if value is None and not _is_nullable(key):
             raise ValueError(f"Setting '{key}' does not accept null")
-    new_chunk_size = updates.get("chunk_size")
-    if isinstance(new_chunk_size, int) and new_chunk_size < _MIN_CHUNK_SIZE:
+    new_chunk_size = _as_int_setting(updates.get("chunk_size"))
+    if new_chunk_size is not None and new_chunk_size < _MIN_CHUNK_SIZE:
         raise ValueError(f"chunk_size must be >= {_MIN_CHUNK_SIZE}")
-    effective_chunk_size = new_chunk_size if isinstance(new_chunk_size, int) else cfg.chunk_size
-    new_overlap = updates.get("chunk_overlap")
-    if isinstance(new_overlap, int) and new_overlap >= effective_chunk_size:
+    effective_chunk_size = new_chunk_size if new_chunk_size is not None else cfg.chunk_size
+    new_overlap = _as_int_setting(updates.get("chunk_overlap"))
+    if new_overlap is not None and new_overlap >= effective_chunk_size:
         raise ValueError(
             f"chunk_overlap ({new_overlap}) must be < chunk_size ({effective_chunk_size})"
         )

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -3,6 +3,7 @@
 import fnmatch
 import logging
 import re
+import threading
 from collections.abc import Callable
 from http import HTTPStatus
 from pathlib import Path
@@ -45,6 +46,15 @@ class DownloadConfig(BaseModel):
 
 _HTTP_TOO_LARGE_MARKER = "too large to be downloaded using the regular download method"
 
+_xet_flip_lock = threading.Lock()
+"""Serializes the global ``HF_HUB_DISABLE_XET`` flip in ``_download_with_xet``.
+
+The flag is a huggingface_hub module global with no per-call override, so two
+overlapping xet downloads would otherwise nest their save/restore and leave xet
+permanently toggled. Holding the lock for the whole download keeps the window
+exclusive; over-cap xet downloads are rare large files, so serializing them is
+an acceptable cost for a correct restore."""
+
 
 def _download_with_xet(config: DownloadConfig) -> Path:
     """Re-run the download with xet enabled, for files past the HTTP size cap.
@@ -52,18 +62,20 @@ def _download_with_xet(config: DownloadConfig) -> Path:
     lilbee disables xet by default (``HF_HUB_DISABLE_XET``) so download progress
     bars stay smooth, but huggingface_hub refuses files over its HTTP size cap on
     the regular path and only xet can fetch them. ``is_xet_available()`` reads the
-    constant live, so flip it for this one download and restore it after. hf_xet
-    is a hard dependency, so the xet path is always available.
+    constant live, so flip it for this one download (under ``_xet_flip_lock`` so
+    concurrent xet downloads cannot corrupt the restore) and restore it after.
+    hf_xet is a hard dependency, so the xet path is always available.
     """
     from huggingface_hub import constants, hf_hub_download
 
-    original = constants.HF_HUB_DISABLE_XET
-    constants.HF_HUB_DISABLE_XET = False
-    try:
-        log.info("File exceeds the HTTP download cap; retrying %s via xet.", config.repo_id)
-        return Path(hf_hub_download(**config.model_dump(exclude_none=True)))
-    finally:
-        constants.HF_HUB_DISABLE_XET = original
+    with _xet_flip_lock:
+        original = constants.HF_HUB_DISABLE_XET
+        constants.HF_HUB_DISABLE_XET = False
+        try:
+            log.info("File exceeds the HTTP download cap; retrying %s via xet.", config.repo_id)
+            return Path(hf_hub_download(**config.model_dump(exclude_none=True)))
+        finally:
+            constants.HF_HUB_DISABLE_XET = original
 
 
 def _hf_download_or_translate(entry: CatalogModel, config: DownloadConfig) -> Path:

--- a/src/lilbee/cli/commands/ingest_sync.py
+++ b/src/lilbee/cli/commands/ingest_sync.py
@@ -47,7 +47,13 @@ _ocr_timeout_option = typer.Option(
 
 
 def _apply_ocr_overrides(ocr: bool | None, ocr_timeout: float | None) -> None:
-    """Apply --ocr/--no-ocr and --ocr-timeout CLI overrides to config."""
+    """Apply --ocr/--no-ocr and --ocr-timeout CLI overrides to config.
+
+    The CLI is a single-shot, single-process invocation, so mutating the global
+    cfg here is safe (it mirrors ``apply_overrides`` for the data dir). The
+    daemon-shared per-request OCR override uses a ContextVar instead; see
+    ``temporary_ocr_config``.
+    """
     if ocr is not None:
         cfg.enable_ocr = ocr
     if ocr_timeout is not None:

--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Generator, Sequence
+from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -89,18 +91,68 @@ def extraction_config(mode: ExtractMode) -> ExtractionConfig:
     return builders[mode]()
 
 
+_ocr_enable_override: contextvars.ContextVar[bool | None] = contextvars.ContextVar(
+    "lilbee_ocr_enable_override", default=None
+)
+_ocr_timeout_override: contextvars.ContextVar[float | None] = contextvars.ContextVar(
+    "lilbee_ocr_timeout_override", default=None
+)
+
+
+def _effective_enable_ocr() -> bool | None:
+    """``cfg.enable_ocr`` unless a per-request OCR override is active.
+
+    The override is a ContextVar, not a global cfg mutation, so concurrent
+    ingests on the shared HTTP daemon each see their own setting. It reaches the
+    ``asyncio.to_thread`` extract workers because ``to_thread`` copies the
+    calling task's context into the worker thread.
+    """
+    override = _ocr_enable_override.get()
+    return cfg.enable_ocr if override is None else override
+
+
+def _effective_ocr_timeout() -> float:
+    """``cfg.ocr_timeout`` unless a per-request OCR timeout override is active."""
+    override = _ocr_timeout_override.get()
+    return cfg.ocr_timeout if override is None else override
+
+
+@contextmanager
+def ocr_override(
+    enable_ocr: bool | None = None, ocr_timeout: float | None = None
+) -> Generator[None, None, None]:
+    """Scope per-request OCR settings without mutating the global cfg.
+
+    A ``None`` argument leaves that setting at its cfg default. Each override is
+    isolated to the entering context (and any ``to_thread`` work it spawns), so
+    overlapping ingests never clobber one another's OCR config.
+    """
+    tokens: list[tuple[contextvars.ContextVar[Any], contextvars.Token[Any]]] = []
+    try:
+        if enable_ocr is not None:
+            tokens.append((_ocr_enable_override, _ocr_enable_override.set(enable_ocr)))
+        if ocr_timeout is not None:
+            tokens.append((_ocr_timeout_override, _ocr_timeout_override.set(ocr_timeout)))
+        yield
+    finally:
+        for var, token in reversed(tokens):
+            var.reset(token)
+
+
 def _should_run_ocr() -> bool:
     """Decide whether to attempt vision-based OCR on scanned PDFs.
 
-    Uses ``cfg.enable_ocr`` and ``cfg.vision_model``:
+    Uses the effective OCR setting (``cfg.enable_ocr`` or a per-request
+    override) and ``cfg.vision_model``:
     True = force on (requires ``cfg.vision_model`` to be set for a real
     vision run; otherwise the caller falls back to Tesseract).
     False = force off.
     None = auto-detect: run vision OCR when ``cfg.vision_model`` is set.
     """
-    if cfg.enable_ocr is True:
+    enable_ocr = _effective_enable_ocr()
+    if enable_ocr is True:
         return True
-    if cfg.enable_ocr is False:
+    if enable_ocr is False:
         return False
     return bool(cfg.vision_model)
 
@@ -177,7 +229,7 @@ async def _vision_ocr_fallback(
             path,
             backend="vision",
             model=cfg.vision_model,
-            per_page_timeout_s=cfg.ocr_timeout,
+            per_page_timeout_s=_effective_ocr_timeout(),
             quiet=quiet,
             on_progress=on_progress,
         )
@@ -220,7 +272,7 @@ async def _vision_image_ocr(
 def _image_ocr_text(path: Path) -> str:
     """OCR one image through the vision server (a single chat-completions call)."""
     return get_services().provider.vision_ocr(
-        _image_to_png_bytes(path), cfg.vision_model, timeout=cfg.ocr_timeout
+        _image_to_png_bytes(path), cfg.vision_model, timeout=_effective_ocr_timeout()
     )
 
 

--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -103,9 +103,9 @@ def _effective_enable_ocr() -> bool | None:
     """``cfg.enable_ocr`` unless a per-request OCR override is active.
 
     The override is a ContextVar, not a global cfg mutation, so concurrent
-    ingests on the shared HTTP daemon each see their own setting. It reaches the
-    ``asyncio.to_thread`` extract workers because ``to_thread`` copies the
-    calling task's context into the worker thread.
+    ingests on the shared HTTP daemon each see their own setting. The override
+    also propagates into ``asyncio.to_thread`` workers (``to_thread`` copies the
+    calling task's context), which is how the timeout reaches the image-OCR call.
     """
     override = _ocr_enable_override.get()
     return cfg.enable_ocr if override is None else override

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -703,9 +703,8 @@ async def _collect_results(
                         result, buffer, buffered_chunks, added, updated, failed, flush_failed
                     )
                 elif status is BatchStatus.SKIPPED and result.needs_cleanup:
-                    # An already-indexed file edited to yield zero chunks and zero
-                    # page texts is never buffered, so the flush's cleanup never
-                    # runs; purge its stale chunks/source row so it stops surfacing.
+                    # Zero-text result is never buffered; collect it for the
+                    # purge pass (see _purge_emptied_sources).
                     to_purge.append(result.name)
                 _report_file_progress(
                     result, status, completed_count, total, on_progress, progress, ptask

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -687,6 +687,7 @@ async def _collect_results(
     buffer: list[_IngestResult] = []
     buffered_chunks = 0
     completed_count = 0
+    to_purge: list[str] = []
     in_flight: set[asyncio.Task[_IngestResult]] = set()
     try:
         _refill_window(in_flight, pending, window)
@@ -701,6 +702,11 @@ async def _collect_results(
                     buffered_chunks = await _buffer_and_maybe_flush(
                         result, buffer, buffered_chunks, added, updated, failed, flush_failed
                     )
+                elif status is BatchStatus.SKIPPED and result.needs_cleanup:
+                    # An already-indexed file edited to yield zero chunks and zero
+                    # page texts is never buffered, so the flush's cleanup never
+                    # runs; purge its stale chunks/source row so it stops surfacing.
+                    to_purge.append(result.name)
                 _report_file_progress(
                     result, status, completed_count, total, on_progress, progress, ptask
                 )
@@ -710,6 +716,7 @@ async def _collect_results(
         # itself raises (e.g. a cancellation landing on the to_thread await).
         try:
             await asyncio.to_thread(_flush_writes, buffer, added, updated, failed, flush_failed)
+            await asyncio.to_thread(_purge_emptied_sources, to_purge)
         finally:
             still_pending = [t for t in in_flight if not t.done()]
             for task in still_pending:
@@ -857,6 +864,20 @@ def _flush_concept_records(buffer: list[_IngestResult]) -> None:
         get_services().concepts.write_concept_records(ConceptRecords.merged(batches))
     except Exception:
         log.warning("Concept indexing failed for %d-file batch", len(batches), exc_info=True)
+
+
+def _purge_emptied_sources(names: list[str]) -> None:
+    """Remove the prior index entry for files that now extract to nothing.
+
+    An already-indexed file edited to yield zero chunks and zero page texts is
+    classified SKIPPED and never buffered, so the batched cleanup delete never
+    runs and its old chunks and source row would linger in search results. Full
+    removal here keeps the index consistent; ``remove_documents`` is a no-op for
+    never-indexed (brand-new empty) files, so unindexed inputs cost nothing.
+    """
+    if not names:
+        return
+    get_services().store.remove_documents(names)
 
 
 def _flush_writes(

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -35,6 +35,7 @@ from lilbee.app.settings import (
     apply_settings_update,
     get_setting,
     list_settings,
+    requires_services_reset,
     reset_settings,
 )
 from lilbee.catalog.types import ModelSource
@@ -76,8 +77,7 @@ class _TransportState:
     agents share one process and one global cfg/Services singleton, so
     vault-switching (init) and factory reset are refused: switching or tearing
     down the store under concurrent in-flight handlers is a use-after-close /
-    identity race. stdio (one agent per process) keeps both. Encapsulated on an
-    instance rather than a bare module global so it carries no reassigned global.
+    identity race. stdio (one agent per process) keeps both.
     """
 
     http_mounted: bool = False
@@ -89,6 +89,16 @@ _transport = _TransportState()
 def set_http_mounted(value: bool) -> None:
     """Mark whether this process serves MCP over the shared HTTP daemon."""
     _transport.http_mounted = value
+
+
+def is_http_mounted() -> bool:
+    """True when this process serves over the shared HTTP daemon.
+
+    True only inside the running HTTP server (REST + MCP-over-http share one
+    process and one Services singleton); False under the CLI, the TUI, and the
+    stdio MCP server, which are single-client.
+    """
+    return _transport.http_mounted
 
 
 _F = TypeVar("_F", bound=Callable[..., Any])
@@ -649,7 +659,12 @@ def settings_set(updates: dict[str, Any]) -> dict[str, Any]:
     ``{updated, reindex_required}``; ``reindex_required=true`` means run
     ``sync(force_rebuild=true)`` to refresh the index.
     """
-
+    if _transport.http_mounted and requires_services_reset(updates):
+        return _error(
+            "Switching the model provider is unavailable on the HTTP server: it "
+            "rebuilds the shared engine for every connected client. Change it from "
+            "the CLI or the stdio MCP server."
+        )
     try:
         result = apply_settings_update(updates)
     except (ValueError, TypeError) as exc:

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -67,6 +67,30 @@ mcp = FastMCP(
     "those cannot see the indexed corpus.",
 )
 
+
+class _TransportState:
+    """Process-level MCP transport facts.
+
+    ``http_mounted`` is True only when MCP is exposed over the shared
+    streamable-http daemon (set by build_mcp_mount). On that transport multiple
+    agents share one process and one global cfg/Services singleton, so
+    vault-switching (init) and factory reset are refused: switching or tearing
+    down the store under concurrent in-flight handlers is a use-after-close /
+    identity race. stdio (one agent per process) keeps both. Encapsulated on an
+    instance rather than a bare module global so it carries no reassigned global.
+    """
+
+    http_mounted: bool = False
+
+
+_transport = _TransportState()
+
+
+def set_http_mounted(value: bool) -> None:
+    """Mark whether this process serves MCP over the shared HTTP daemon."""
+    _transport.http_mounted = value
+
+
 _F = TypeVar("_F", bound=Callable[..., Any])
 
 
@@ -319,6 +343,11 @@ def init(path: str = "") -> dict[str, Any]:
 
     Switches the MCP session to use it for subsequent calls.
     """
+    if _transport.http_mounted:
+        return _error(
+            "init is unavailable on the HTTP server: it is bound to one vault and "
+            "shared by every connected client. Start a separate server for another vault."
+        )
     base = Path(path) if path else Path.cwd()
     root = base / LOCAL_ROOT_DIRNAME
 
@@ -413,6 +442,11 @@ async def import_dataset(dataset: str, fmt: str = "", ctx: Context | None = None
 @_tool
 def reset(confirm: bool = False) -> dict[str, Any]:
     """Factory reset: delete all documents and indexed data. Requires ``confirm=true``."""
+    if _transport.http_mounted:
+        return _error(
+            "reset is unavailable on the HTTP server: it would wipe the shared index for "
+            "every connected client. Run it from the CLI or the stdio MCP server."
+        )
     if not confirm:
         return _error("pass confirm=true to confirm deletion")
     from lilbee.app.reset import perform_reset

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -91,16 +91,6 @@ def set_http_mounted(value: bool) -> None:
     _transport.http_mounted = value
 
 
-def is_http_mounted() -> bool:
-    """True when this process serves over the shared HTTP daemon.
-
-    True only inside the running HTTP server (REST + MCP-over-http share one
-    process and one Services singleton); False under the CLI, the TUI, and the
-    stdio MCP server, which are single-client.
-    """
-    return _transport.http_mounted
-
-
 _F = TypeVar("_F", bound=Callable[..., Any])
 
 

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -35,6 +35,7 @@ from lilbee.app.settings import (
     apply_settings_update,
     get_setting,
     list_settings,
+    provider_reset_refused_message,
     requires_services_reset,
     reset_settings,
 )
@@ -650,11 +651,7 @@ def settings_set(updates: dict[str, Any]) -> dict[str, Any]:
     ``sync(force_rebuild=true)`` to refresh the index.
     """
     if _transport.http_mounted and requires_services_reset(updates):
-        return _error(
-            "Switching the model provider is unavailable on the HTTP server: it "
-            "rebuilds the shared engine for every connected client. Change it from "
-            "the CLI or the stdio MCP server."
-        )
+        return _error(provider_reset_refused_message("Switching"))
     try:
         result = apply_settings_update(updates)
     except (ValueError, TypeError) as exc:
@@ -669,7 +666,8 @@ def settings_set(updates: dict[str, Any]) -> dict[str, Any]:
 @_tool
 def settings_reset(keys: list[str]) -> dict[str, Any]:
     """Reset writable settings to their built-in defaults."""
-
+    if _transport.http_mounted and requires_services_reset(dict.fromkeys(keys)):
+        return _error(provider_reset_refused_message("Resetting"))
     try:
         result = reset_settings(keys)
     except (ValueError, TypeError) as exc:

--- a/src/lilbee/providers/fleet/devices.py
+++ b/src/lilbee/providers/fleet/devices.py
@@ -135,15 +135,31 @@ def visible_env(devices: tuple[FleetDevice, ...]) -> dict[str, str]:
             _CUDA_ORDER_VAR: os.environ.get(_CUDA_ORDER_VAR, _PCI_BUS_ID_ORDER),
         }
     if backend in ("ROCm", "HIP"):
-        return {
-            _ROCR_VISIBLE_VAR: _compose_visible(indices, os.environ.get(_ROCR_VISIBLE_VAR)),
-            _HIP_VISIBLE_VAR: _compose_visible(indices, os.environ.get(_HIP_VISIBLE_VAR)),
-        }
+        return _amd_visible_env(indices)
     if backend == "Vulkan":
         return {_VK_VISIBLE_VAR: _compose_visible(indices, os.environ.get(_VK_VISIBLE_VAR))}
     if backend == "SYCL":
         return {_ONEAPI_SELECTOR_VAR: _compose_sycl(indices, os.environ.get(_ONEAPI_SELECTOR_VAR))}
     return {}
+
+
+def _amd_visible_env(indices: list[int]) -> dict[str, str]:
+    """Pin an AMD ROCm/HIP child to the probe's *indices* with one visibility var.
+
+    ``ROCR_VISIBLE_DEVICES`` and ``HIP_VISIBLE_DEVICES`` are applied sequentially
+    by the runtime: ROCR filters first, then HIP re-indexes within the survivors.
+    The probe enumerated a single index space already filtered by whichever var
+    the parent set, so emitting BOTH (each composed against its own parent) would
+    double-filter and select the wrong cards. Emit only the var the parent used,
+    composed against that parent value, and leave the other inherited untouched;
+    default to HIP when the parent restricted neither. The child inherits the
+    parent env, so an unset override keeps any inherited sibling var in force.
+    """
+    parent_rocr = os.environ.get(_ROCR_VISIBLE_VAR)
+    parent_hip = os.environ.get(_HIP_VISIBLE_VAR)
+    if parent_rocr is not None and parent_hip is None:
+        return {_ROCR_VISIBLE_VAR: _compose_visible(indices, parent_rocr)}
+    return {_HIP_VISIBLE_VAR: _compose_visible(indices, parent_hip)}
 
 
 def _compose_sycl(indices: list[int], parent_value: str | None) -> str:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -204,10 +204,9 @@ class _VisionRequestGate:
         concurrent capacity change cannot release the wrong object.
         """
         sem = self._checkout()
-        # _checkout already incremented _in_flight, so the decrement must run on
-        # every exit path -- including one where acquire() itself raises (e.g. an
-        # interrupted blocking acquire). Otherwise a leaked count would pin the
-        # gate non-idle and defer every later capacity resize forever.
+        # _checkout incremented _in_flight; decrement on every exit path,
+        # including one where acquire() raises, or a leaked count pins the gate
+        # non-idle and defers every later capacity resize forever.
         try:
             sem.acquire()
             try:
@@ -221,10 +220,9 @@ class _VisionRequestGate:
     def _checkout(self) -> threading.BoundedSemaphore:
         capacity = max(1, cfg.vision_replicas * cfg.vision_ocr_concurrency)
         with self._lock:
-            # Only resize when the gate is idle. Swapping in a fresh full-capacity
-            # semaphore while holders of the old one are still in flight would
-            # momentarily double the real cap and undo the 429 protection, so a
-            # capacity change waits for the current batch to drain.
+            # Resize only when idle: rebuilding while old-semaphore holders are
+            # in flight would briefly double the real cap, so a capacity change
+            # waits for the current batch to drain.
             if self._semaphore is None or (self._capacity != capacity and self._in_flight == 0):
                 self._capacity = capacity
                 self._semaphore = threading.BoundedSemaphore(capacity)

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -204,11 +204,17 @@ class _VisionRequestGate:
         concurrent capacity change cannot release the wrong object.
         """
         sem = self._checkout()
-        sem.acquire()
+        # _checkout already incremented _in_flight, so the decrement must run on
+        # every exit path -- including one where acquire() itself raises (e.g. an
+        # interrupted blocking acquire). Otherwise a leaked count would pin the
+        # gate non-idle and defer every later capacity resize forever.
         try:
-            yield
+            sem.acquire()
+            try:
+                yield
+            finally:
+                sem.release()
         finally:
-            sem.release()
             with self._lock:
                 self._in_flight -= 1
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -17,6 +17,7 @@ import threading
 import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from concurrent.futures import TimeoutError as FutureTimeoutError
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
@@ -34,7 +35,7 @@ from lilbee.providers.warm_progress import WarmProgress, WarmProgressTracker
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Iterator, Mapping, Sequence
 
     from lilbee.providers.base import (
         ChatMessage,
@@ -185,21 +186,43 @@ class _VisionRequestGate:
     The ingest file fan-out runs many files at once and each file's ``pdf_ocr`` opens
     its own ``vision_ocr_concurrency`` page pool, so without a shared cap the aggregate
     over-subscribes a single-replica vision server into a 429 storm. The semaphore is
-    rebuilt when the configured capacity (``vision_replicas * vision_ocr_concurrency``)
-    changes.
+    rebuilt to the configured capacity (``vision_replicas * vision_ocr_concurrency``)
+    only while the gate is idle, so a capacity change never doubles the live cap.
     """
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._capacity = 0
+        self._in_flight = 0
         self._semaphore: threading.BoundedSemaphore | None = None
 
-    def semaphore(self) -> threading.BoundedSemaphore:
+    @contextmanager
+    def slot(self) -> Iterator[None]:
+        """Hold one vision-request slot for the duration of the block.
+
+        The acquired semaphore is captured and released by this same call, so a
+        concurrent capacity change cannot release the wrong object.
+        """
+        sem = self._checkout()
+        sem.acquire()
+        try:
+            yield
+        finally:
+            sem.release()
+            with self._lock:
+                self._in_flight -= 1
+
+    def _checkout(self) -> threading.BoundedSemaphore:
         capacity = max(1, cfg.vision_replicas * cfg.vision_ocr_concurrency)
         with self._lock:
-            if self._semaphore is None or self._capacity != capacity:
+            # Only resize when the gate is idle. Swapping in a fresh full-capacity
+            # semaphore while holders of the old one are still in flight would
+            # momentarily double the real cap and undo the 429 protection, so a
+            # capacity change waits for the current batch to drain.
+            if self._semaphore is None or (self._capacity != capacity and self._in_flight == 0):
                 self._capacity = capacity
                 self._semaphore = threading.BoundedSemaphore(capacity)
+            self._in_flight += 1
             return self._semaphore
 
 
@@ -268,7 +291,7 @@ def _ocr_pdf_page(
     from lilbee.vision import build_vision_messages
 
     messages = build_vision_messages(ocr_prompt, png)
-    with _VISION_GATE.semaphore():
+    with _VISION_GATE.slot():
         remaining = max(0.0, deadline - time.monotonic()) if deadline is not None else None
         if remaining == 0.0:
             log.warning(
@@ -631,7 +654,7 @@ class FleetProvider:
         clients = self._require_clients(WorkerRole.VISION)
         effective = model or str(cfg.vision_model)
         messages = build_vision_messages(prompt or resolve_ocr_prompt(effective), png_bytes)
-        with _VISION_GATE.semaphore():
+        with _VISION_GATE.slot():
             return _vision_call(_least_in_flight(clients), messages, timeout)
 
     def pdf_ocr(

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -44,16 +44,18 @@ class RoutingProvider(LLMProvider):
     def __init__(self) -> None:
         self._local: LLMProvider | None = None
         self._sdk_provider: SdkLLMProvider | None = None
-        # Guards both lazy inits: building a FleetProvider spawns role servers,
-        # so two concurrent first-callers on the shared daemon must not each
-        # construct one (duplicate GPU servers, a leaked instance).
+        # Guards both lazy inits so two concurrent first-callers on the shared
+        # daemon don't each build a backend and leak the loser. (Construction is
+        # cheap field init; FleetProvider defers the role-server spawn to first
+        # use and single-flights it internally, so this lock is the singleton
+        # guard, not the spawn guard.)
         self._init_lock = threading.Lock()
 
     def _get_local(self) -> LLMProvider:
         if self._local is None:
-            # heavy: FleetProvider composes the llama-server stack and spawns
-            # the role servers on first use. Double-checked under _init_lock so
-            # only the first concurrent caller builds it.
+            # FleetProvider composes the llama-server stack; its role servers
+            # spawn lazily on first use, not here. Double-checked under
+            # _init_lock so only the first concurrent caller builds it.
             with self._init_lock:
                 if self._local is None:
                     from lilbee.providers.fleet.provider import FleetProvider

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import threading
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -43,22 +44,31 @@ class RoutingProvider(LLMProvider):
     def __init__(self) -> None:
         self._local: LLMProvider | None = None
         self._sdk_provider: SdkLLMProvider | None = None
+        # Guards both lazy inits: building a FleetProvider spawns role servers,
+        # so two concurrent first-callers on the shared daemon must not each
+        # construct one (duplicate GPU servers, a leaked instance).
+        self._init_lock = threading.Lock()
 
     def _get_local(self) -> LLMProvider:
         if self._local is None:
             # heavy: FleetProvider composes the llama-server stack and spawns
-            # the role servers on first use.
-            from lilbee.providers.fleet.provider import FleetProvider
+            # the role servers on first use. Double-checked under _init_lock so
+            # only the first concurrent caller builds it.
+            with self._init_lock:
+                if self._local is None:
+                    from lilbee.providers.fleet.provider import FleetProvider
 
-            self._local = FleetProvider()
+                    self._local = FleetProvider()
         return self._local
 
     def _get_sdk_provider(self) -> SdkLLMProvider:
         if self._sdk_provider is None:
-            self._sdk_provider = SdkLLMProvider(
-                LitellmSdkBackend(),
-                api_key=cfg.llm_api_key,
-            )
+            with self._init_lock:
+                if self._sdk_provider is None:
+                    self._sdk_provider = SdkLLMProvider(
+                        LitellmSdkBackend(),
+                        api_key=cfg.llm_api_key,
+                    )
         return self._sdk_provider
 
     def _pick_backend(self, ref: ProviderModelRef) -> LLMProvider:

--- a/src/lilbee/retrieval/concepts/graph.py
+++ b/src/lilbee/retrieval/concepts/graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from collections import Counter
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
@@ -53,6 +54,10 @@ class ConceptGraph:
         self._store = store
         self._nlp: Any = None
         self._nlp_unavailable: bool = False
+        # A spaCy Language is not safe for concurrent processing (shared Vocab /
+        # StringStore). ConceptGraph is a Services singleton, so serialize every
+        # nlp() / nlp.pipe() call on the shared daemon behind this lock.
+        self._nlp_lock = threading.Lock()
 
     def _ensure_nlp(self) -> Any | None:
         """Lazy-load and cache the spaCy model. Returns None if unavailable."""
@@ -76,8 +81,9 @@ class ConceptGraph:
         nlp = self._ensure_nlp()
         if nlp is None:
             return []
-        doc = nlp(text)
-        return _filter_noun_chunks(doc, max_concepts)
+        with self._nlp_lock:
+            doc = nlp(text)
+            return _filter_noun_chunks(doc, max_concepts)
 
     def extract_concepts_batch(self, texts: list[str]) -> list[list[str]]:
         """Batch-extract concepts from multiple texts."""
@@ -87,7 +93,10 @@ class ConceptGraph:
         if nlp is None:
             return [[] for _ in texts]
         max_concepts = self._config.concept_max_per_chunk
-        return [_filter_noun_chunks(doc, max_concepts) for doc in nlp.pipe(texts)]
+        # Hold the lock across the full pipe iteration: nlp.pipe is lazy, so the
+        # actual parsing happens as the comprehension consumes it.
+        with self._nlp_lock:
+            return [_filter_noun_chunks(doc, max_concepts) for doc in nlp.pipe(texts)]
 
     def build_concept_records(
         self, chunk_ids: list[tuple[str, int]], concept_lists: list[list[str]]

--- a/src/lilbee/retrieval/concepts/graph.py
+++ b/src/lilbee/retrieval/concepts/graph.py
@@ -61,15 +61,16 @@ class ConceptGraph:
 
     def _ensure_nlp(self) -> Any | None:
         """Lazy-load and cache the spaCy model. Returns None if unavailable."""
-        if self._nlp_unavailable:
-            return None
-        if self._nlp is None:
-            try:
-                self._nlp = _ensure_spacy_model()
-            except ImportError:
-                log.warning("Concept graph disabled: spaCy model unavailable")
-                self._nlp_unavailable = True
-                return None
+        if self._nlp is None and not self._nlp_unavailable:
+            # Double-checked under _nlp_lock so two concurrent first-callers don't
+            # each load en_core_web_sm (the loser would just be discarded).
+            with self._nlp_lock:
+                if self._nlp is None and not self._nlp_unavailable:
+                    try:
+                        self._nlp = _ensure_spacy_model()
+                    except ImportError:
+                        log.warning("Concept graph disabled: spaCy model unavailable")
+                        self._nlp_unavailable = True
         return self._nlp
 
     def extract_concepts(self, text: str, max_concepts: int | None = None) -> list[str]:

--- a/src/lilbee/server/handlers/config.py
+++ b/src/lilbee/server/handlers/config.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from pydantic_core import PydanticUndefined
 
-from lilbee.app.settings import apply_settings_update
+from lilbee.app.settings import apply_settings_update, requires_services_reset
 from lilbee.config_meta import (
     MODEL_ROLE_FIELDS as _MODEL_ROLE_FIELDS,
 )
@@ -30,7 +30,16 @@ async def update_config(updates: dict[str, Any]) -> ConfigUpdateResponse:
     CLI, and the TUI share one write boundary. Model role writes are
     refused at this surface because PUT /api/models/<role> already
     handles them with an install-availability check.
+
+    A provider switch rebuilds the shared Services singleton, unsafe while other
+    clients have in-flight requests, so it is refused on the always-concurrent
+    HTTP server; do it from the CLI instead.
     """
+    if requires_services_reset(updates):
+        raise ValueError(
+            "Switching the model provider is unavailable on the HTTP server: it "
+            "rebuilds the shared engine for every connected client. Change it from the CLI."
+        )
     result = apply_settings_update(updates, allow_model_roles=False)
     return ConfigUpdateResponse(updated=result.updated, reindex_required=result.reindex_required)
 

--- a/src/lilbee/server/handlers/config.py
+++ b/src/lilbee/server/handlers/config.py
@@ -8,7 +8,11 @@ from typing import Any
 
 from pydantic_core import PydanticUndefined
 
-from lilbee.app.settings import apply_settings_update, requires_services_reset
+from lilbee.app.settings import (
+    apply_settings_update,
+    provider_reset_refused_message,
+    requires_services_reset,
+)
 from lilbee.config_meta import (
     MODEL_ROLE_FIELDS as _MODEL_ROLE_FIELDS,
 )
@@ -36,10 +40,7 @@ async def update_config(updates: dict[str, Any]) -> ConfigUpdateResponse:
     HTTP server; do it from the CLI instead.
     """
     if requires_services_reset(updates):
-        raise ValueError(
-            "Switching the model provider is unavailable on the HTTP server: it "
-            "rebuilds the shared engine for every connected client. Change it from the CLI."
-        )
+        raise ValueError(provider_reset_refused_message("Switching"))
     result = apply_settings_update(updates, allow_model_roles=False)
     return ConfigUpdateResponse(updated=result.updated, reindex_required=result.reindex_required)
 

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -7,7 +7,7 @@ import contextlib
 import dataclasses
 import logging
 import threading
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from lilbee.app.memory import auto_extract, auto_extract_enabled
@@ -141,7 +141,7 @@ def _chat_warming_events() -> list[str]:
 def _run_llm_stream(
     messages: list[ChatMessage],
     opts: dict[str, Any] | None,
-    queue: asyncio.Queue[str | None],
+    put: Callable[[str | None], None],
     cancel: threading.Event,
     error_holder: list[BaseException],
     answer_parts: list[str],
@@ -165,7 +165,7 @@ def _run_llm_stream(
                 events.close()
                 break
             if isinstance(event, CapNotice):
-                queue.put_nowait(
+                put(
                     sse_event(
                         SseEvent.REASONING,
                         {"token": CAP_NOTICE_TEMPLATE.format(chars=event.cap_chars)},
@@ -175,11 +175,11 @@ def _run_llm_stream(
                 kind = SseEvent.REASONING if event.is_reasoning else SseEvent.TOKEN
                 if kind is SseEvent.TOKEN:
                     answer_parts.append(event.content)
-                queue.put_nowait(sse_event(kind, {"token": event.content}))
+                put(sse_event(kind, {"token": event.content}))
     except Exception as exc:
         error_holder.append(exc)
     finally:
-        queue.put_nowait(None)
+        put(None)
 
 
 async def _emit_extracted_memories(question: str, answer: str) -> AsyncGenerator[str, None]:
@@ -235,7 +235,14 @@ async def _stream_rag_response(
     answer_parts: list[str] = []
 
     executor_fut = sse.loop.run_in_executor(
-        None, _run_llm_stream, messages, opts, sse.queue, sse.cancel, error_holder, answer_parts
+        None,
+        _run_llm_stream,
+        messages,
+        opts,
+        sse.put_threadsafe,
+        sse.cancel,
+        error_holder,
+        answer_parts,
     )
     task = asyncio.ensure_future(executor_fut)
     async for event in sse.drain(task, "RAG stream"):

--- a/src/lilbee/server/handlers/sse.py
+++ b/src/lilbee/server/handlers/sse.py
@@ -183,6 +183,16 @@ class SseStream:
         self.loop = asyncio.get_running_loop()
         self.callback: DetailedProgressCallback = self._build_callback()
 
+    def put_threadsafe(self, item: str | None) -> None:
+        """Enqueue an always-delivered event from a worker thread.
+
+        ``asyncio.Queue.put_nowait`` is not thread-safe: it wakes a pending
+        getter via ``Future.set_result``, which must run on the loop thread. A
+        producer running under ``run_in_executor`` therefore hands the put back
+        to the loop instead of mutating the queue directly.
+        """
+        self.loop.call_soon_threadsafe(self.queue.put_nowait, item)
+
     def _build_callback(self) -> DetailedProgressCallback:
         """Create a progress callback that serializes events into the queue.
         Safe to call from both the event-loop thread and worker threads.

--- a/src/lilbee/server/mcp_mount.py
+++ b/src/lilbee/server/mcp_mount.py
@@ -11,7 +11,7 @@ from litestar.types import ASGIApp, Receive, Scope, Send
 from mcp.server.transport_security import TransportSecuritySettings
 
 from lilbee.core.config import cfg
-from lilbee.mcp_server import mcp
+from lilbee.mcp_server import mcp, set_http_mounted
 
 if TYPE_CHECKING:
     from litestar import Litestar
@@ -62,6 +62,10 @@ def build_mcp_mount() -> tuple[ASGIRouteHandler, _Lifespan]:
     only be entered once per instance, and the app factory runs once per
     process in production but repeatedly across tests.
     """
+    # Mark MCP as served over the shared HTTP daemon so single-vault-only tools
+    # (init, reset) refuse runtime vault-switch / teardown that would race
+    # concurrent in-flight handlers on the process-global Services singleton.
+    set_http_mounted(True)
     # FastMCP caches the session manager; clear it so each app owns its own,
     # since run() is single-use per instance.
     mcp._session_manager = None

--- a/src/lilbee/wiki/entity_extractor/ner_concepts.py
+++ b/src/lilbee/wiki/entity_extractor/ner_concepts.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import functools
 import logging
 import re
+import threading
 from typing import TYPE_CHECKING, Any
 
 from lilbee.core.text import is_valid_label, make_slug
@@ -93,11 +94,15 @@ class NerConceptsExtractor:
             "kept_entity_surfaces": 0,
         }
         cleaned_texts = (pre_clean_for_ner(c.chunk) for c in chunks)
-        for chunk, doc in zip(chunks, nlp.pipe(cleaned_texts), strict=True):
-            ref = ChunkRef(source=chunk.source, chunk_index=chunk.chunk_index)
-            _accumulate_doc_entities(
-                doc, ref, entity_records, allowed_ent_types, funnel, debug_enabled
-            )
+        # _load_spacy returns a process-global Language shared by every extractor
+        # instance; a spaCy Language is not safe for concurrent processing, so
+        # serialize the whole lazy nlp.pipe iteration behind the module lock.
+        with _NLP_LOCK:
+            for chunk, doc in zip(chunks, nlp.pipe(cleaned_texts), strict=True):
+                ref = ChunkRef(source=chunk.source, chunk_index=chunk.chunk_index)
+                _accumulate_doc_entities(
+                    doc, ref, entity_records, allowed_ent_types, funnel, debug_enabled
+                )
 
         if debug_enabled:
             log.debug(
@@ -179,6 +184,13 @@ def _make_record(agg: _Aggregate, kind: EntityKind, min_mentions: int) -> Extrac
         type_hint=agg.type_hint,
         chunk_refs=_sorted_refs(agg.refs),
     )
+
+
+_NLP_LOCK = threading.Lock()
+"""Serializes use of the shared (``@functools.cache``d) spaCy Language.
+
+A spaCy Language is not safe for concurrent processing; every extract() call
+runs ``nlp.pipe`` on the same cached instance, so the daemon serializes them."""
 
 
 @functools.cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,12 +145,16 @@ def _reset_services_after_test():
     from contextlib import suppress
 
     from lilbee.app.services import peek_services, set_services
+    from lilbee.mcp_server import set_http_mounted
 
     svc = peek_services()
     if svc is not None:
         with suppress(Exception):
             svc.provider.shutdown()
     set_services(None)
+    # build_mcp_mount() flips this process-global True; clear it so a mount test
+    # never leaves init/reset gated for an unrelated later test.
+    set_http_mounted(False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1010,6 +1010,53 @@ class TestSplitShardDownload:
         assert disable_during_retry == [False]  # xet was on for the retry
         assert hc.HF_HUB_DISABLE_XET is True  # flag restored afterwards
 
+    def test_xet_flip_holds_lock_during_download(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The global XET flip stays under _xet_flip_lock for the whole download.
+
+        Two overlapping xet downloads would otherwise nest their save/restore and
+        leave xet permanently toggled; the lock makes the flip window exclusive.
+        """
+        import huggingface_hub.constants as hc
+
+        from lilbee.catalog.download import DownloadConfig, _download_with_xet, _xet_flip_lock
+
+        monkeypatch.setattr(hc, "HF_HUB_DISABLE_XET", True)
+        locked_during: list[bool] = []
+
+        def fake(**kwargs: Any) -> str:
+            locked_during.append(_xet_flip_lock.locked())
+            return str(tmp_path / "x.gguf")
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake)
+        config = DownloadConfig(repo_id="r/r", filename="x.gguf", token=None)
+        _download_with_xet(config)
+
+        assert locked_during == [True]  # lock held across the flipped window
+        assert hc.HF_HUB_DISABLE_XET is True  # restored, lock released
+
+    def test_xet_flip_restores_and_releases_on_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed xet download still restores the flag and releases the lock."""
+        import huggingface_hub.constants as hc
+
+        from lilbee.catalog.download import DownloadConfig, _download_with_xet, _xet_flip_lock
+
+        monkeypatch.setattr(hc, "HF_HUB_DISABLE_XET", True)
+
+        def fake(**kwargs: Any) -> str:
+            raise ValueError("boom")
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake)
+        config = DownloadConfig(repo_id="r/r", filename="x.gguf", token=None)
+        with pytest.raises(ValueError, match="boom"):
+            _download_with_xet(config)
+
+        assert hc.HF_HUB_DISABLE_XET is True  # restored even on failure
+        assert not _xet_flip_lock.locked()  # lock released
+
 
 class TestDownloadModel:
     def test_returns_existing_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3495,13 +3495,15 @@ class TestChatSyncCallback:
 
 class TestTemporaryOcrConfig:
     def test_ocr_timeout_override(self):
-        """temporary_ocr_config overrides ocr_timeout and restores it."""
+        """temporary_ocr_config overrides the effective timeout without mutating cfg."""
         from lilbee.app.ingest import temporary_ocr_config
+        from lilbee.data.ingest.extract import _effective_ocr_timeout
 
         original = cfg.ocr_timeout
         with temporary_ocr_config(ocr_timeout=99.0):
-            assert cfg.ocr_timeout == 99.0
-        assert cfg.ocr_timeout == original
+            assert _effective_ocr_timeout() == 99.0
+            assert cfg.ocr_timeout == original  # global cfg is never mutated
+        assert _effective_ocr_timeout() == original
 
 
 class TestSyncResultToJson:

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -188,6 +188,23 @@ class TestExtractConcepts:
         assert "158 vehicle" not in result
         assert "chevrolet caprice" in result
 
+    @patch("lilbee.retrieval.concepts.graph._ensure_spacy_model")
+    def test_holds_nlp_lock_during_processing(self, mock_spacy, cg):
+        """The shared (non-thread-safe) spaCy Language is used under _nlp_lock."""
+        locked_during: list[bool] = []
+        nlp = MagicMock()
+
+        def call_fn(text):
+            locked_during.append(cg._nlp_lock.locked())
+            return _make_mock_doc(["good concept"])
+
+        nlp.side_effect = call_fn
+        mock_spacy.return_value = nlp
+
+        cg.extract_concepts("text")
+        assert locked_during == [True]  # lock held while nlp() runs
+        assert not cg._nlp_lock.locked()  # released afterwards
+
 
 class TestExtractConceptsBatch:
     @patch("lilbee.retrieval.concepts.graph._ensure_spacy_model")
@@ -224,6 +241,24 @@ class TestExtractConceptsBatch:
         mock_spacy.return_value = _make_mock_nlp({"text": ["alpha", "beta", "gamma", "delta"]})
         result = cg.extract_concepts_batch(["text"])
         assert len(result[0]) == 2
+
+    @patch("lilbee.retrieval.concepts.graph._ensure_spacy_model")
+    def test_holds_nlp_lock_across_pipe(self, mock_spacy, cg):
+        """nlp.pipe is lazy, so the lock is held across the whole iteration."""
+        locked_during: list[bool] = []
+        nlp = MagicMock()
+        nlp.side_effect = lambda text: _make_mock_doc([])
+
+        def pipe_fn(texts):
+            locked_during.append(cg._nlp_lock.locked())
+            return [_make_mock_doc(["good concept"]) for _ in texts]
+
+        nlp.pipe = pipe_fn
+        mock_spacy.return_value = nlp
+
+        cg.extract_concepts_batch(["text"])
+        assert locked_during == [True]
+        assert not cg._nlp_lock.locked()
 
 
 class TestGetNlp:

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -244,20 +244,24 @@ class TestExtractConceptsBatch:
 
     @patch("lilbee.retrieval.concepts.graph._ensure_spacy_model")
     def test_holds_nlp_lock_across_pipe(self, mock_spacy, cg):
-        """nlp.pipe is lazy, so the lock is held across the whole iteration."""
+        """nlp.pipe is lazy, so the lock must stay held across the iteration."""
         locked_during: list[bool] = []
         nlp = MagicMock()
         nlp.side_effect = lambda text: _make_mock_doc([])
 
+        # A generator (like real spaCy nlp.pipe): each doc is produced during
+        # iteration, so the lock must still be held as the comprehension pulls
+        # items -- not merely when pipe() is first called.
         def pipe_fn(texts):
-            locked_during.append(cg._nlp_lock.locked())
-            return [_make_mock_doc(["good concept"]) for _ in texts]
+            for _ in texts:
+                locked_during.append(cg._nlp_lock.locked())
+                yield _make_mock_doc(["good concept"])
 
         nlp.pipe = pipe_fn
         mock_spacy.return_value = nlp
 
-        cg.extract_concepts_batch(["text"])
-        assert locked_during == [True]
+        cg.extract_concepts_batch(["a", "b", "c"])
+        assert locked_during == [True, True, True]  # held for every yielded doc
         assert not cg._nlp_lock.locked()
 
 

--- a/tests/test_fleet_devices.py
+++ b/tests/test_fleet_devices.py
@@ -90,9 +90,15 @@ def test_visible_env_cuda_pins_by_index_and_pins_order() -> None:
     assert env == {"CUDA_VISIBLE_DEVICES": "2,3", "CUDA_DEVICE_ORDER": "PCI_BUS_ID"}
 
 
-def test_visible_env_rocm_uses_rocr_and_hip() -> None:
+def test_visible_env_rocm_emits_single_var_on_clean_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ROCR and HIP filter sequentially, so the child pins with one var only;
+    # with neither parent var set it defaults to HIP at the absolute index.
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
     env = visible_env((FleetDevice("ROCm", 1, "", 0, 0),))
-    assert env == {"ROCR_VISIBLE_DEVICES": "1", "HIP_VISIBLE_DEVICES": "1"}
+    assert env == {"HIP_VISIBLE_DEVICES": "1"}
 
 
 def test_visible_env_vulkan_uses_ggml_var() -> None:
@@ -154,17 +160,29 @@ class TestPresetVisibleDeviceComposition:
         monkeypatch.delenv("CUDA_DEVICE_ORDER", raising=False)
         assert dev_mod._probe_env()["CUDA_DEVICE_ORDER"] == "PCI_BUS_ID"
 
-    def test_rocm_parent_lists_compose_per_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rocm_rocr_only_parent_emits_rocr_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Parent restricted via ROCR only: emit ROCR composed against it, and do
+        # NOT also emit HIP (which would re-index within the ROCR survivors).
         monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "4,5")
         monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
         env = visible_env((FleetDevice("ROCm", 1, "", 0, 0),))
-        assert env == {"ROCR_VISIBLE_DEVICES": "5", "HIP_VISIBLE_DEVICES": "1"}
+        assert env == {"ROCR_VISIBLE_DEVICES": "5"}  # relative 1 -> physical 5
 
-    def test_hip_parent_list_composes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rocm_hip_only_parent_emits_hip_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The finding's scenario: HIP-only parent. Emitting an absolute ROCR here
+        # would select the wrong physical card, so only HIP is composed/emitted.
         monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
-        monkeypatch.setenv("HIP_VISIBLE_DEVICES", "6,7")
+        monkeypatch.setenv("HIP_VISIBLE_DEVICES", "1,3")
         env = visible_env((FleetDevice("HIP", 0, "", 0, 0),))
-        assert env == {"ROCR_VISIBLE_DEVICES": "0", "HIP_VISIBLE_DEVICES": "6"}
+        assert env == {"HIP_VISIBLE_DEVICES": "1"}  # relative 0 -> physical 1, no ROCR
+
+    def test_rocm_both_parents_set_emits_hip_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # When both are set, the inherited ROCR stays in force and only HIP is
+        # re-pinned (within the ROCR survivors), so the cap is never doubled.
+        monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "0,1,2")
+        monkeypatch.setenv("HIP_VISIBLE_DEVICES", "6,7")
+        env = visible_env((FleetDevice("ROCm", 1, "", 0, 0),))
+        assert env == {"HIP_VISIBLE_DEVICES": "7"}  # relative 1 -> physical 7
 
     def test_vulkan_parent_list_composes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("GGML_VK_VISIBLE_DEVICES", "1,2")

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -305,16 +305,64 @@ def test_vision_call_caps_output_tokens(monkeypatch) -> None:
 
 def test_vision_request_gate_tracks_fleet_capacity(monkeypatch) -> None:
     # The gate must cap in-flight vision requests at the fleet's real OCR capacity
-    # (replicas x per-server slots) and rebuild when that capacity changes.
+    # (replicas x per-server slots) and rebuild to a new capacity while idle.
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
     monkeypatch.setattr(cfg, "vision_replicas", 3)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
-    gate = prov_mod._VISION_GATE.semaphore()
+    with prov_mod._VISION_GATE.slot():
+        first = prov_mod._VISION_GATE._semaphore
     assert prov_mod._VISION_GATE._capacity == 12
     monkeypatch.setattr(cfg, "vision_replicas", 1)
-    assert prov_mod._VISION_GATE.semaphore() is not gate
+    with prov_mod._VISION_GATE.slot():
+        assert prov_mod._VISION_GATE._semaphore is not first  # rebuilt while idle
     assert prov_mod._VISION_GATE._capacity == 4
+
+
+def test_vision_gate_resize_deferred_while_in_flight(monkeypatch) -> None:
+    # bb-ziks.30: resizing the gate while a request is in flight would build a
+    # fresh full-capacity semaphore beside the old holders and momentarily double
+    # the real cap. The resize must wait until the gate drains to idle.
+    import threading
+
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 1)
+    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
+
+    entered = threading.Event()
+    release = threading.Event()
+    held: list[object] = []
+
+    def _hold() -> None:
+        with prov_mod._VISION_GATE.slot():
+            held.append(prov_mod._VISION_GATE._semaphore)
+            entered.set()
+            release.wait(timeout=5)
+
+    worker = threading.Thread(target=_hold)
+    worker.start()
+    try:
+        assert entered.wait(timeout=5)
+        # Capacity change arrives mid-flight; a checkout must reuse the live
+        # semaphore rather than swap, so the cap is never doubled.
+        monkeypatch.setattr(cfg, "vision_replicas", 4)
+        reused = prov_mod._VISION_GATE._checkout()
+        try:
+            assert reused is held[0]
+            assert prov_mod._VISION_GATE._capacity == 2
+        finally:
+            with prov_mod._VISION_GATE._lock:  # balance the raw _checkout increment
+                prov_mod._VISION_GATE._in_flight -= 1
+    finally:
+        release.set()
+        worker.join()
+
+    # Once idle again, the next checkout applies the deferred capacity.
+    with prov_mod._VISION_GATE.slot():
+        assert prov_mod._VISION_GATE._capacity == 8
 
 
 def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
@@ -327,6 +375,7 @@ def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
 
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
     monkeypatch.setattr(cfg, "vision_replicas", 1)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 
@@ -337,7 +386,7 @@ def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
 
     def _hold() -> None:
         nonlocal live, peak, ran
-        with prov_mod._VISION_GATE.semaphore():
+        with prov_mod._VISION_GATE.slot():
             with lock:
                 live += 1
                 peak = max(peak, live)

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -365,6 +365,34 @@ def test_vision_gate_resize_deferred_while_in_flight(monkeypatch) -> None:
         assert prov_mod._VISION_GATE._capacity == 8
 
 
+def test_vision_gate_slot_decrements_in_flight_when_acquire_raises(monkeypatch) -> None:
+    # If acquire() raises (e.g. an interrupted blocking acquire), the in-flight
+    # counter must still be decremented, or a leaked count would pin the gate
+    # non-idle and defer every later capacity resize forever.
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 1)
+    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
+
+    real_checkout = prov_mod._VISION_GATE._checkout
+
+    class _BoomSemaphore:
+        def acquire(self) -> None:
+            raise KeyboardInterrupt
+
+    def _checkout_returning_boom():
+        real_checkout()  # increments _in_flight like the real path
+        return _BoomSemaphore()
+
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_checkout", _checkout_returning_boom)
+
+    with pytest.raises(KeyboardInterrupt), prov_mod._VISION_GATE.slot():
+        pass  # pragma: no cover - acquire raises before the body
+
+    assert prov_mod._VISION_GATE._in_flight == 0  # counter not leaked
+
+
 def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
     # The ingest file fan-out can launch far more concurrent OCR requests than the
     # vision server has slots; the gate (held by every vision entry point) caps

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2371,6 +2371,19 @@ class TestOcrOverrideContextVar:
             assert cfg.ocr_timeout == 8.0
         assert _effective_ocr_timeout() == 8.0
 
+    async def test_override_propagates_into_to_thread_worker(self, isolated_env):
+        # The fix relies on asyncio.to_thread copying the calling context, which
+        # is how the override reaches the extract worker that actually OCRs.
+        import asyncio
+
+        from lilbee.data.ingest.extract import _effective_ocr_timeout, ocr_override
+
+        cfg.ocr_timeout = 5.0
+        with ocr_override(ocr_timeout=88.0):
+            seen = await asyncio.to_thread(_effective_ocr_timeout)
+        assert seen == 88.0
+        assert await asyncio.to_thread(_effective_ocr_timeout) == 5.0
+
 
 class TestOcrFallbackBackendDispatch:
     """``_handle_scanned_pdf_fallback`` routes to the right backend on the pool."""

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -71,6 +71,11 @@ def mock_svc():
     store.write_chunks_batch.side_effect = _write_batch
     store.delete_source.side_effect = lambda fn: _sources.pop(fn, None)
     store.delete_by_source.return_value = None
+
+    def _remove_documents(names, **_kw):
+        return [_sources.pop(n, None) for n in names]
+
+    store.remove_documents.side_effect = _remove_documents
     store.drop_all.side_effect = lambda: _sources.clear()
     store.ensure_fts_index.return_value = None
     embedder = MagicMock()
@@ -1536,6 +1541,38 @@ class TestCollectResultsSkipped:
         assert len(captured) == 1
         assert captured[0][1].status == "skipped"
         assert "scan.pdf" in skipped
+
+    async def test_zero_text_update_purges_prior_index_entry(self, mock_svc):
+        # An already-indexed file edited to extract to nothing must have its old
+        # chunks/source row removed, not left orphaned in search (bb-ziks.74).
+        from lilbee.data.ingest.pipeline import _collect_results
+        from lilbee.data.ingest.types import _IngestResult
+
+        async def _emptied() -> _IngestResult:
+            return _IngestResult(
+                "notes.md", Path("notes.md"), chunk_count=0, error=None, needs_cleanup=True
+            )
+
+        await _collect_results(iter([_emptied()]), 1, {}, {}, {}, {}, window=2)
+        mock_svc.store.remove_documents.assert_called_once_with(["notes.md"])
+
+    async def test_zero_text_without_cleanup_does_not_purge(self, mock_svc):
+        from lilbee.data.ingest.pipeline import _collect_results
+        from lilbee.data.ingest.types import _IngestResult
+
+        async def _emptied() -> _IngestResult:
+            return _IngestResult(
+                "fresh.md", Path("fresh.md"), chunk_count=0, error=None, needs_cleanup=False
+            )
+
+        await _collect_results(iter([_emptied()]), 1, {}, {}, {}, {}, window=2)
+        mock_svc.store.remove_documents.assert_not_called()
+
+    def test_purge_emptied_sources_noop_on_empty(self, mock_svc):
+        from lilbee.data.ingest.pipeline import _purge_emptied_sources
+
+        _purge_emptied_sources([])
+        mock_svc.store.remove_documents.assert_not_called()
 
     async def test_error_cancels_still_running_siblings(self):
         """When one task raises, _collect_results' finally cancels the in-flight ones."""

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2262,6 +2262,79 @@ class TestShouldRunOcrAutoDetect:
         assert _should_run_ocr() is False
 
 
+class TestOcrOverrideContextVar:
+    """Per-request OCR overrides use a ContextVar, never a global cfg mutation."""
+
+    def test_override_does_not_mutate_global_cfg(self, isolated_env):
+        from lilbee.data.ingest.extract import ocr_override
+
+        cfg.enable_ocr = False
+        cfg.ocr_timeout = 11.0
+        with ocr_override(enable_ocr=True, ocr_timeout=99.0):
+            pass
+        assert cfg.enable_ocr is False
+        assert cfg.ocr_timeout == 11.0
+
+    def test_effective_values_reflect_override_then_revert(self, isolated_env):
+        from lilbee.data.ingest.extract import (
+            _effective_enable_ocr,
+            _effective_ocr_timeout,
+            ocr_override,
+        )
+
+        cfg.enable_ocr = False
+        cfg.ocr_timeout = 11.0
+        with ocr_override(enable_ocr=True, ocr_timeout=99.0):
+            assert _effective_enable_ocr() is True
+            assert _effective_ocr_timeout() == 99.0
+        assert _effective_enable_ocr() is False
+        assert _effective_ocr_timeout() == 11.0
+
+    def test_none_arguments_keep_cfg_defaults(self, isolated_env):
+        from lilbee.data.ingest.extract import _effective_enable_ocr, ocr_override
+
+        cfg.enable_ocr = True
+        with ocr_override(enable_ocr=None, ocr_timeout=None):
+            assert _effective_enable_ocr() is True
+
+    def test_should_run_ocr_honors_override(self, isolated_env):
+        from lilbee.data.ingest.extract import _should_run_ocr, ocr_override
+
+        cfg.enable_ocr = True
+        cfg.vision_model = ""
+        with ocr_override(enable_ocr=False):
+            assert _should_run_ocr() is False
+
+    def test_overrides_isolated_across_contexts(self, isolated_env):
+        # Two copied contexts must each see only their own override; this is the
+        # concurrency guarantee that a global cfg mutation could not give.
+        import contextvars
+
+        from lilbee.data.ingest.extract import _effective_ocr_timeout, ocr_override
+
+        cfg.ocr_timeout = 5.0
+        seen: dict[str, float] = {}
+
+        def run_with(value: float, key: str) -> None:
+            with ocr_override(ocr_timeout=value):
+                seen[key] = _effective_ocr_timeout()
+
+        contextvars.copy_context().run(run_with, 30.0, "a")
+        contextvars.copy_context().run(run_with, 70.0, "b")
+        assert seen == {"a": 30.0, "b": 70.0}
+        assert _effective_ocr_timeout() == 5.0  # parent context untouched
+
+    def test_temporary_ocr_config_delegates_without_global_mutation(self, isolated_env):
+        from lilbee.app.ingest import temporary_ocr_config
+        from lilbee.data.ingest.extract import _effective_ocr_timeout
+
+        cfg.ocr_timeout = 8.0
+        with temporary_ocr_config(ocr_timeout=42.0):
+            assert _effective_ocr_timeout() == 42.0
+            assert cfg.ocr_timeout == 8.0
+        assert _effective_ocr_timeout() == 8.0
+
+
 class TestOcrFallbackBackendDispatch:
     """``_handle_scanned_pdf_fallback`` routes to the right backend on the pool."""
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1103,6 +1103,29 @@ class TestSettingsMcp:
         assert "error" in result
         assert cfg.top_k == 5
 
+    def test_settings_set_validates_string_chunk_overlap(self, isolated_env):
+        # MCP forwards raw JSON, so an agent can send a numeric as a string. The
+        # chunk_overlap < chunk_size guard must still fire (bb-ziks.71).
+        cfg.data_root = isolated_env
+        cfg.chunk_size = 512
+        result = settings_set({"chunk_overlap": "1024"})
+        assert "error" in result
+        assert "chunk_overlap" in result["error"]
+        assert cfg.chunk_overlap != 1024
+
+    def test_settings_set_validates_string_chunk_size_minimum(self, isolated_env):
+        cfg.data_root = isolated_env
+        result = settings_set({"chunk_size": "1"})
+        assert "error" in result
+        assert "chunk_size must be >=" in result["error"]
+
+    def test_settings_set_accepts_valid_string_numeric(self, isolated_env):
+        cfg.data_root = isolated_env
+        cfg.chunk_size = 512
+        result = settings_set({"chunk_overlap": "64"})
+        assert result["command"] == "settings_set"
+        assert cfg.chunk_overlap == 64
+
     def test_settings_set_rolls_back_when_pydantic_rejects_second_field(self, isolated_env):
         cfg.data_root = isolated_env
         cfg.top_k = 5

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -25,6 +25,7 @@ from lilbee.mcp_server import (
     remove,
     reset,
     search,
+    set_http_mounted,
     settings_get,
     settings_list,
     settings_reset,
@@ -493,6 +494,36 @@ class TestInit:
 
         assert cfg.chat_model == "ollama/qwen3:4b"
         assert cfg.embedding_model == "ollama/nomic-embed-text:v1.5"
+
+
+class TestHttpDaemonGate:
+    """init/reset refuse to run on the shared HTTP daemon (teardown-race guard)."""
+
+    def test_init_refused_on_http_daemon_without_mutating_cfg(self, tmp_path):
+        before = cfg.data_root
+        set_http_mounted(True)
+        try:
+            result = init(str(tmp_path / "proj"))
+        finally:
+            set_http_mounted(False)
+        assert "error" in result
+        assert "HTTP server" in result["error"]
+        assert not (tmp_path / "proj" / ".lilbee").exists()  # no side effects
+        assert cfg.data_root == before  # cfg untouched
+
+    def test_reset_refused_on_http_daemon(self):
+        set_http_mounted(True)
+        try:
+            result = reset(confirm=True)
+        finally:
+            set_http_mounted(False)
+        assert "error" in result
+        assert "HTTP server" in result["error"]
+
+    def test_init_allowed_on_stdio(self, tmp_path):
+        set_http_mounted(False)  # stdio default
+        result = init(str(tmp_path / "proj"))
+        assert result.get("command") == "init"
 
 
 class TestAdd:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -525,6 +525,30 @@ class TestHttpDaemonGate:
         result = init(str(tmp_path / "proj"))
         assert result.get("command") == "init"
 
+    def test_provider_switch_refused_on_http_daemon(self, isolated_env):
+        # settings_set('llm_provider') triggers reset_services(); refuse it on the
+        # daemon for the same teardown-race reason init/reset are refused.
+        cfg.data_root = isolated_env
+        before = cfg.llm_provider
+        set_http_mounted(True)
+        try:
+            result = settings_set({"llm_provider": "remote"})
+        finally:
+            set_http_mounted(False)
+        assert "error" in result
+        assert "HTTP server" in result["error"]
+        assert cfg.llm_provider == before  # no teardown, cfg untouched
+
+    def test_non_provider_settings_allowed_on_http_daemon(self, isolated_env):
+        cfg.data_root = isolated_env
+        set_http_mounted(True)
+        try:
+            result = settings_set({"top_k": 7})
+        finally:
+            set_http_mounted(False)
+        assert result["command"] == "settings_set"
+        assert cfg.top_k == 7
+
 
 class TestAdd:
     @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -549,6 +549,30 @@ class TestHttpDaemonGate:
         assert result["command"] == "settings_set"
         assert cfg.top_k == 7
 
+    def test_provider_reset_refused_on_http_daemon(self, isolated_env):
+        # settings_reset(['llm_provider']) also triggers reset_services(); the
+        # daemon must refuse it just like settings_set and init/reset.
+        cfg.data_root = isolated_env
+        before = cfg.llm_provider
+        set_http_mounted(True)
+        try:
+            result = settings_reset(["llm_provider"])
+        finally:
+            set_http_mounted(False)
+        assert "error" in result
+        assert "HTTP server" in result["error"]
+        assert cfg.llm_provider == before
+
+    def test_non_provider_reset_allowed_on_http_daemon(self, isolated_env):
+        cfg.data_root = isolated_env
+        cfg.top_k = 99
+        set_http_mounted(True)
+        try:
+            result = settings_reset(["top_k"])
+        finally:
+            set_http_mounted(False)
+        assert result["command"] == "settings_reset"
+
 
 class TestAdd:
     @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -564,6 +564,8 @@ class TestHttpDaemonGate:
         assert cfg.llm_provider == before
 
     def test_non_provider_reset_allowed_on_http_daemon(self, isolated_env):
+        from lilbee.core.config import Config
+
         cfg.data_root = isolated_env
         cfg.top_k = 99
         set_http_mounted(True)
@@ -572,6 +574,7 @@ class TestHttpDaemonGate:
         finally:
             set_http_mounted(False)
         assert result["command"] == "settings_reset"
+        assert cfg.top_k == Config.model_fields["top_k"].default  # actually reset
 
 
 class TestAdd:

--- a/tests/test_ner_concepts_extractor.py
+++ b/tests/test_ner_concepts_extractor.py
@@ -412,3 +412,28 @@ class TestFunnelLogging:
         with _patch_pipeline({"t": doc}):
             extractor.extract([_chunk("s.txt", 0, "t")])
         assert not any("ner funnel" in r.message for r in caplog.records)
+
+
+class TestNlpLockSerialization:
+    def test_extract_holds_nlp_lock_during_pipe(self) -> None:
+        """The shared cached spaCy Language is iterated under _NLP_LOCK.
+
+        The Language is not safe for concurrent processing, so extract() must
+        hold the module lock across the lazy nlp.pipe iteration.
+        """
+        from lilbee.wiki.entity_extractor import ner_concepts
+
+        locked_during: list[bool] = []
+
+        class _LockProbePipeline:
+            def pipe(self, texts: Any) -> Any:
+                for _text in texts:
+                    locked_during.append(ner_concepts._NLP_LOCK.locked())
+                    yield _FakeDoc(ents=[_FakeSpan(text="Acme", label_="ORG")])
+
+        extractor = NerConceptsExtractor(MagicMock(), cfg)
+        with patch.object(ner_concepts, "_load_spacy", return_value=_LockProbePipeline()):
+            extractor.extract([_chunk("a.txt", 0, "Acme makes things")])
+
+        assert locked_during == [True]  # lock held during pipe iteration
+        assert not ner_concepts._NLP_LOCK.locked()  # released afterwards

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -513,6 +513,7 @@ class TestRoutingProvider:
         FleetProvider (duplicate role servers) and all but one leak.
         """
         import threading
+        import time
 
         from lilbee.providers.routing_provider import RoutingProvider
 
@@ -523,6 +524,10 @@ class TestRoutingProvider:
             def __init__(self) -> None:
                 with count_lock:
                     construct_count["n"] += 1
+                # Widen the check-then-set window: without it the cheap __init__
+                # runs to completion before the GIL yields, so a racing caller
+                # never observes None and the test passes even on unlocked code.
+                time.sleep(0.05)
 
             def shutdown(self) -> None: ...
 
@@ -555,6 +560,7 @@ class TestRoutingProvider:
         constructions instead.
         """
         import threading
+        import time
 
         from lilbee.providers.routing_provider import RoutingProvider
 
@@ -565,6 +571,10 @@ class TestRoutingProvider:
             def __init__(self, *args, **kwargs) -> None:
                 with count_lock:
                     construct_count["n"] += 1
+                # Widen the check-then-set window so a racing caller observes the
+                # uninitialized slot; otherwise the test is false-green on
+                # unlocked code (see test_get_local_single_init_under_concurrency).
+                time.sleep(0.05)
 
             def shutdown(self) -> None: ...
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -506,6 +506,66 @@ class TestRoutingProvider:
         second = rp._get_sdk_provider()
         assert first is second
 
+    def test_get_local_single_init_under_concurrency(self, monkeypatch) -> None:
+        """Concurrent first-callers build the FleetProvider exactly once.
+
+        Without the double-checked _init_lock, simultaneous callers each spawn a
+        FleetProvider (duplicate role servers) and all but one leak.
+        """
+        import threading
+
+        from lilbee.providers.routing_provider import RoutingProvider
+
+        construct_count = {"n": 0}
+        count_lock = threading.Lock()
+
+        class FakeFleet:
+            def __init__(self) -> None:
+                with count_lock:
+                    construct_count["n"] += 1
+
+            def shutdown(self) -> None: ...
+
+        monkeypatch.setattr("lilbee.providers.fleet.provider.FleetProvider", FakeFleet)
+
+        rp = RoutingProvider()
+        self._to_shutdown.append(rp)
+        barrier = threading.Barrier(8)
+        results: list = []
+
+        def worker() -> None:
+            barrier.wait()
+            results.append(rp._get_local())
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert construct_count["n"] == 1
+        assert len({id(r) for r in results}) == 1
+
+    def test_get_sdk_provider_single_init_under_concurrency(self) -> None:
+        """Concurrent first-callers share one SdkLLMProvider (double-checked lock)."""
+        import threading
+
+        rp = self._make_provider()
+        barrier = threading.Barrier(8)
+        results: list = []
+
+        def worker() -> None:
+            barrier.wait()
+            results.append(rp._get_sdk_provider())
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len({id(r) for r in results}) == 1
+
     def test_list_chat_models_empty_when_sdk_unavailable(self) -> None:
         # list_chat_models must skip the SDK backend entirely when the SDK
         # is not installed; native llama-cpp never has a frontier catalog.

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -546,11 +546,32 @@ class TestRoutingProvider:
         assert construct_count["n"] == 1
         assert len({id(r) for r in results}) == 1
 
-    def test_get_sdk_provider_single_init_under_concurrency(self) -> None:
-        """Concurrent first-callers share one SdkLLMProvider (double-checked lock)."""
+    def test_get_sdk_provider_single_init_under_concurrency(self, monkeypatch) -> None:
+        """Concurrent first-callers construct exactly one SdkLLMProvider.
+
+        Asserting on the returned identity alone is false-green: without the
+        lock, racing callers each construct an instance and the last write wins,
+        so every late reader still sees the same final attribute. Count actual
+        constructions instead.
+        """
         import threading
 
-        rp = self._make_provider()
+        from lilbee.providers.routing_provider import RoutingProvider
+
+        construct_count = {"n": 0}
+        count_lock = threading.Lock()
+
+        class FakeSdk:
+            def __init__(self, *args, **kwargs) -> None:
+                with count_lock:
+                    construct_count["n"] += 1
+
+            def shutdown(self) -> None: ...
+
+        monkeypatch.setattr("lilbee.providers.routing_provider.SdkLLMProvider", FakeSdk)
+
+        rp = RoutingProvider()
+        self._to_shutdown.append(rp)
         barrier = threading.Barrier(8)
         results: list = []
 
@@ -564,6 +585,7 @@ class TestRoutingProvider:
         for t in threads:
             t.join()
 
+        assert construct_count["n"] == 1
         assert len({id(r) for r in results}) == 1
 
     def test_list_chat_models_empty_when_sdk_unavailable(self) -> None:

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2628,6 +2628,16 @@ class TestUpdateConfig:
         with pytest.raises(ValueError, match="chunk_overlap"):
             await handlers.update_config({"chunk_overlap": 1024})
 
+    def test_as_int_setting_coerces_strings_excludes_bool(self):
+        """The chunk guards coerce string numerics but never treat a bool as a size."""
+        from lilbee.app.settings import _as_int_setting
+
+        assert _as_int_setting("1000") == 1000
+        assert _as_int_setting(256) == 256
+        assert _as_int_setting("not_numeric") is None
+        assert _as_int_setting(True) is None
+        assert _as_int_setting(None) is None
+
     async def test_llm_api_key_write_only(self, tmp_path):
         """llm_api_key can be written via PATCH but is excluded from GET."""
         result = await handlers.update_config({"llm_api_key": "sk-test123"})

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2652,6 +2652,24 @@ class TestUpdateConfig:
         assert _as_int_setting(True) is None
         assert _as_int_setting(None) is None
 
+    async def test_provider_switch_refused_on_http_server(self):
+        """A provider switch rebuilds the shared singleton, so REST refuses it.
+
+        The REST handler only ever runs inside the always-concurrent HTTP server,
+        so a provider switch (which forces reset_services) is refused here.
+        """
+        before = cfg.llm_provider
+        with pytest.raises(ValueError, match="HTTP server"):
+            await handlers.update_config({"llm_provider": "remote"})
+        assert cfg.llm_provider == before  # no teardown triggered
+
+    def test_requires_services_reset_detects_provider_switch(self):
+        from lilbee.app.settings import requires_services_reset
+
+        assert requires_services_reset({"llm_provider": "remote"}) is True
+        assert requires_services_reset({"top_k": 5}) is False
+        assert requires_services_reset({}) is False
+
     async def test_llm_api_key_write_only(self, tmp_path):
         """llm_api_key can be written via PATCH but is excluded from GET."""
         result = await handlers.update_config({"llm_api_key": "sk-test123"})

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1091,6 +1091,27 @@ class TestSyncStreamDoneDelivery:
         counts = json.loads(done_events[0].split("data: ")[1].strip())
         assert counts == {"added": 0, "updated": 0, "removed": 0, "failed": 0, "skipped": 0}
 
+    async def test_put_threadsafe_enqueues_from_worker_thread(self):
+        """put_threadsafe hands the enqueue back to the loop, so a producer on a
+        worker thread never mutates the asyncio.Queue directly (bb-ziks.76)."""
+        from lilbee.server.handlers import SseStream
+
+        sse = SseStream()
+
+        def producer() -> None:
+            sse.put_threadsafe("hello")
+            sse.put_threadsafe(None)
+
+        await asyncio.to_thread(producer)
+
+        received: list[str] = []
+        while True:
+            item = await sse.queue.get()
+            if item is None:
+                break
+            received.append(item)
+        assert received == ["hello"]
+
     async def test_drain_exits_cleanly_when_producer_raises(self):
         """A raising producer still enqueues the sentinel via finally so drain closes."""
         from lilbee.server.handlers import SseStream
@@ -3520,7 +3541,7 @@ class TestRunLlmStreamCancel:
             _rag_h._run_llm_stream(
                 [{"role": "user", "content": "hi"}],
                 None,
-                queue,
+                queue.put_nowait,
                 cancel,
                 error_holder,
                 [],
@@ -3569,7 +3590,7 @@ class TestReasoningCapHandling:
                 _rag_h._run_llm_stream(
                     [{"role": "user", "content": "explain quantum tunneling"}],
                     None,
-                    queue,
+                    queue.put_nowait,
                     cancel,
                     error_holder,
                     [],
@@ -3605,7 +3626,7 @@ class TestReasoningCapHandling:
                 _rag_h._run_llm_stream(
                     [{"role": "user", "content": "hi"}],
                     None,
-                    queue,
+                    queue.put_nowait,
                     cancel,
                     error_holder,
                     [],
@@ -3646,7 +3667,7 @@ class TestReasoningCapHandling:
                 _rag_h._run_llm_stream(
                     [{"role": "user", "content": "hi"}],
                     None,
-                    queue,
+                    queue.put_nowait,
                     cancel,
                     error_holder,
                     [],
@@ -3681,7 +3702,7 @@ class TestReasoningCapHandling:
                 _rag_h._run_llm_stream(
                     [{"role": "user", "content": "long question"}],
                     None,
-                    queue,
+                    queue.put_nowait,
                     cancel,
                     error_holder,
                     [],

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1091,9 +1091,23 @@ class TestSyncStreamDoneDelivery:
         counts = json.loads(done_events[0].split("data: ")[1].strip())
         assert counts == {"added": 0, "updated": 0, "removed": 0, "failed": 0, "skipped": 0}
 
+    async def test_put_threadsafe_defers_enqueue_to_loop(self):
+        """put_threadsafe schedules the enqueue on the loop instead of mutating
+        the asyncio.Queue inline; even called from the loop thread the item is
+        not present until a loop iteration runs (bb-ziks.76)."""
+        from lilbee.server.handlers import SseStream
+
+        sse = SseStream()
+        sse.put_threadsafe("hello")
+        # call_soon_threadsafe defers to a later iteration: a direct put_nowait
+        # would have enqueued synchronously here.
+        assert sse.queue.empty()
+        await asyncio.sleep(0)
+        assert sse.queue.get_nowait() == "hello"
+
     async def test_put_threadsafe_enqueues_from_worker_thread(self):
-        """put_threadsafe hands the enqueue back to the loop, so a producer on a
-        worker thread never mutates the asyncio.Queue directly (bb-ziks.76)."""
+        """A producer on a worker thread reaches the loop's queue via the
+        threadsafe handoff."""
         from lilbee.server.handlers import SseStream
 
         sse = SseStream()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -130,6 +130,31 @@ class TestEagerStartBranch:
         provider.warm_up_pool.assert_not_called()
 
 
+class TestResetServicesSwapBeforeClose:
+    """reset_services clears the singleton before tearing the old one down."""
+
+    def test_reference_cleared_before_teardown(self):
+        from lilbee.app import services as services_mod
+        from tests.conftest import make_mock_services
+
+        observed: list[bool] = []
+        store = MagicMock()
+        provider = MagicMock()
+        # When teardown runs, the module singleton must already be None so a
+        # concurrent get_services() never hands out a closing container.
+        store.close.side_effect = lambda: observed.append(services_mod.peek_services() is None)
+
+        services_mod.set_services(make_mock_services(store=store, provider=provider))
+        try:
+            services_mod.reset_services()
+            assert services_mod.peek_services() is None
+            provider.shutdown.assert_called_once()
+            store.close.assert_called_once()
+            assert observed == [True]  # cleared before close
+        finally:
+            services_mod.set_services(None)
+
+
 class TestResetStore:
     def test_keeps_provider_and_embedder_replaces_store(self, tmp_path):
         """``reset_store`` rebuilds Store-bound services without unloading the provider."""


### PR DESCRIPTION
## Problem

lilbee began as a single-process, single-vault tool, but it now runs as an always-on server that many clients (the TUI, agents over MCP, REST callers) hit at once. A batch of state that was safe to mutate in place when one caller owned the process becomes a race when several do. This branch fixes that class of bug:

- Vault-switch and factory-reset, and a model-provider switch, all tear down and rebuild the shared engine. On the HTTP server that can happen while other clients have requests in flight, leaving them holding a closed handle.
- OCR settings, the HuggingFace xet flag, and the lazy provider/spaCy singletons were all mutated through process globals, so concurrent ingests and first-callers clobbered each other.
- The vision-request cap could be momentarily doubled when its size was changed mid-run, reopening the rate-limit storm it exists to prevent.
- The streaming answer endpoint pushed tokens onto the event loop's queue from a worker thread, which is not safe.
- A file edited down to no extractable text kept its old chunks in the index, so stale content still showed up in search.
- A couple of settings guards were skipped when a value arrived as a string (as it does over MCP).

## Solution

Per-request settings (OCR) move to a context variable that each request and its worker threads see in isolation. The provider, spaCy, and xet globals are guarded so only one caller initializes or flips them. On the HTTP server, the operations that rebuild the shared engine are refused with a clear message pointing the user at the CLI, while the TUI, CLI, and stdio MCP keep them. The vision cap only resizes once it is idle, the streaming endpoint hands its tokens back to the loop safely, an emptied file is removed from the index on the next sync, and the string-valued settings are coerced before validation.

All paths keep full test coverage, including the concurrency behaviors.
