### PR TITLE
QA harness: fail ungrounded answers, let reels write their artifact

### DIFF
--- a/tools/qa/opencode/matrix.py
+++ b/tools/qa/opencode/matrix.py
@@ -40,6 +40,7 @@ from opencode_driver import (
 from report import CellResult, render_report
 from scenarios import (
     ScenarioResult,
+    downgrade_if_ungrounded,
     run_multi_turn_scenario,
     run_scenario,
     scenario_for_tier,
@@ -89,10 +90,13 @@ def run_smoke_scenarios(
     scen = scenario_for_tier(tier)
     print(f"[{family}] running {scen.name}: {scen.prompt[:60]}...")
     single = run_scenario(session, scen, workspace)
-    print(f"[{family}]   -> {single.status.value} ({single.elapsed_s:.1f}s) {single.detail}")
-    # Settle the single-call answer before the multi-turn sequence reuses the
-    # session, so its first turn starts from a quiet pane.
+    # Settle the single-call answer before grading it (and before the multi-turn
+    # sequence reuses the session): the verdict trips at dispatch + completion
+    # while the answer is still streaming, so answer-grounding can only be judged
+    # once it has rendered on the pane.
     wait_for_answer_settle(session, workspace)
+    single = downgrade_if_ungrounded(single, tmux_capture(session))
+    print(f"[{family}]   -> {single.status.value} ({single.elapsed_s:.1f}s) {single.detail}")
     print(f"[{family}] running {tier} multi-turn tool sequence...")
     multi = run_multi_turn_scenario(session, tier, workspace)
     print(

--- a/tools/qa/opencode/reelrun.sh
+++ b/tools/qa/opencode/reelrun.sh
@@ -42,6 +42,11 @@ ws = write_per_cell_workspace("$FAMILY", "$REF")
 import json
 cfg = {"\$schema": "https://opencode.ai/config.json",
        "tools": {"webfetch": False, "bash": False, "question": False},
+       # Auto-approve edits so the coder/giant reels can write the artifact: an
+       # automated VHS reel has no human to satisfy opencode's default "ask" edit
+       # permission, so writes silently never happen and the model narrates the
+       # code instead of creating the file.
+       "permission": {"edit": "allow"},
        "autoupdate": False}
 (ws / "opencode.json").write_text(json.dumps(cfg, indent=2))
 from lilbee.core.config import cfg as lilbee_cfg

--- a/tools/qa/opencode/scenarios.py
+++ b/tools/qa/opencode/scenarios.py
@@ -51,6 +51,25 @@ completion count so a stale pane can't carry a prior cell's glyph.
 """
 
 
+# Phrases a model emits when its lilbee_search returned nothing usable, so it
+# answers "I couldn't find it" instead of grounding the answer in the reference.
+# A fresh dispatch plus a chat completion is NOT a pass when the answer is
+# ungrounded: the tier prompts target content the indexed Godot reference does
+# contain (AStarGrid2D.get_id_path, Object.connect), so an ungrounded answer is a
+# real failure (retrieval gap or the model not using the results), not a correct
+# "absent" response. Without this gate a model that dispatches and then answers
+# "not found" passes, which greenlights demos in which lilbee appears to find
+# nothing.
+_UNGROUNDED_ANSWER_MARKERS: tuple[str, ...] = (
+    "not found in the indexed",
+    "not found in the knowledge base",
+    "no documentation exists",
+    "did not find any information",
+    "not found in the provided",
+    "no documentation found",
+)
+
+
 # Tier prompts run against the indexed Godot 4 class reference. One prompt per
 # tier (same yardstick across same-tier models). Natural phrasing -- the model
 # should discover the lilbee_search MCP tool itself; only Smalls get a "look up"
@@ -157,6 +176,12 @@ def _poll_verdict(
     forbidden_hits = [s for s in scenario.forbidden if s.lower() in pane_lower]
     if forbidden_hits:
         return result(ScenarioStatus.FAIL, f"forbidden substring(s) appeared: {forbidden_hits}")
+    ungrounded = next((m for m in _UNGROUNDED_ANSWER_MARKERS if m in pane_lower), None)
+    if ungrounded is not None:
+        return result(
+            ScenarioStatus.FAIL,
+            f"ungrounded answer (lilbee_search returned nothing usable): {ungrounded!r}",
+        )
     events = read_events(workspace)
     if has_session_error(events):
         return result(ScenarioStatus.FAIL, "session.error event from opencode")

--- a/tools/qa/opencode/scenarios.py
+++ b/tools/qa/opencode/scenarios.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from events import count_session_idles, count_tool_dispatches, has_session_error, read_events
@@ -56,8 +56,8 @@ completion count so a stale pane can't carry a prior cell's glyph.
 # the indexed reference had nothing: the tier prompts target content the
 # reference does contain (AStarGrid2D.get_id_path, Object.connect), so that is a
 # retrieval/answer failure, not a correct "absent" response. Kept narrow and
-# scanned only on the would-be-PASS answer tail (see _poll_verdict) so transient
-# mid-search reasoning or an incidental negative does not false-fail.
+# scanned only on the settled answer tail (see downgrade_if_ungrounded) so
+# transient mid-search reasoning or an incidental negative does not false-fail.
 _UNGROUNDED_ANSWER_MARKERS: tuple[str, ...] = (
     "not found in the indexed",
     "not found in the knowledge base",
@@ -180,23 +180,9 @@ def _poll_verdict(
     fresh_dispatches = count_tool_dispatches(events, _SEARCH_TOOL_SUBSTR) - baseline_dispatches
     fresh_call = _count_ok_chat_completions(workspace) - baseline_calls
     missing = [s for s in scenario.expected if s.lower() not in pane_lower]
-    verdict = _dispatch_verdict(
+    return _dispatch_verdict(
         result, fresh_dispatches, fresh_call, has_events=bool(events), missing=missing
     )
-    # Downgrade only a would-be-PASS: the answer turn has completed (a fresh
-    # dispatch AND chat completion), so the final answer is rendered. Scan just
-    # the answer tail so an earlier transient "not found" from mid-search
-    # reasoning cannot false-fail a recovered, grounded final answer.
-    if verdict is not None and verdict.status is ScenarioStatus.PASS:
-        tail = pane_lower[-_UNGROUNDED_SCAN_TAIL:]
-        ungrounded = next((m for m in _UNGROUNDED_ANSWER_MARKERS if m.lower() in tail), None)
-        if ungrounded is not None:
-            return result(
-                ScenarioStatus.FAIL,
-                f"dispatched + completed but the answer is ungrounded "
-                f"(search found nothing in the reference): {ungrounded!r}",
-            )
-    return verdict
 
 
 def _dispatch_verdict(
@@ -282,6 +268,29 @@ def run_scenario(session: str, scenario: Scenario, workspace: Path) -> ScenarioR
         detail=f"no {_SEARCH_TOOL_SUBSTR} dispatch within {scenario.timeout_s:.0f}s",
         pane_excerpt=last_pane[-_PANE_EXCERPT_TAIL:],
         elapsed_s=scenario.timeout_s,
+    )
+
+
+def downgrade_if_ungrounded(result: ScenarioResult, settled_pane: str) -> ScenarioResult:
+    """Downgrade a PASS to FAIL when the settled answer is ungrounded.
+
+    Must run on the SETTLED pane (after :func:`wait_for_answer_settle`): the
+    verdict trips at dispatch + completion, before opencode finishes streaming
+    the answer, so grounding can only be judged once the answer is rendered.
+    Scans the answer tail for a marker that the search returned nothing usable.
+    Non-PASS results and grounded answers pass through unchanged.
+    """
+    if result.status is not ScenarioStatus.PASS:
+        return result
+    tail = settled_pane.lower()[-_UNGROUNDED_SCAN_TAIL:]
+    ungrounded = next((m for m in _UNGROUNDED_ANSWER_MARKERS if m.lower() in tail), None)
+    if ungrounded is None:
+        return result
+    return replace(
+        result,
+        status=ScenarioStatus.FAIL,
+        detail=f"dispatched + completed but the answer is ungrounded "
+        f"(search found nothing in the reference): {ungrounded!r}",
     )
 
 

--- a/tools/qa/opencode/scenarios.py
+++ b/tools/qa/opencode/scenarios.py
@@ -51,23 +51,21 @@ completion count so a stale pane can't carry a prior cell's glyph.
 """
 
 
-# Phrases a model emits when its lilbee_search returned nothing usable, so it
-# answers "I couldn't find it" instead of grounding the answer in the reference.
-# A fresh dispatch plus a chat completion is NOT a pass when the answer is
-# ungrounded: the tier prompts target content the indexed Godot reference does
-# contain (AStarGrid2D.get_id_path, Object.connect), so an ungrounded answer is a
-# real failure (retrieval gap or the model not using the results), not a correct
-# "absent" response. Without this gate a model that dispatches and then answers
-# "not found" passes, which greenlights demos in which lilbee appears to find
-# nothing.
+# Phrases that mark a final answer the search could not ground in the reference.
+# A fresh dispatch + chat completion is not a PASS when the settled answer says
+# the indexed reference had nothing: the tier prompts target content the
+# reference does contain (AStarGrid2D.get_id_path, Object.connect), so that is a
+# retrieval/answer failure, not a correct "absent" response. Kept narrow and
+# scanned only on the would-be-PASS answer tail (see _poll_verdict) so transient
+# mid-search reasoning or an incidental negative does not false-fail.
 _UNGROUNDED_ANSWER_MARKERS: tuple[str, ...] = (
     "not found in the indexed",
     "not found in the knowledge base",
     "no documentation exists",
-    "did not find any information",
-    "not found in the provided",
-    "no documentation found",
 )
+# Pane-tail window scanned for ungrounded markers: large enough for the settled
+# final answer, small enough to exclude earlier mid-search reasoning.
+_UNGROUNDED_SCAN_TAIL = 2000
 
 
 # Tier prompts run against the indexed Godot 4 class reference. One prompt per
@@ -176,21 +174,29 @@ def _poll_verdict(
     forbidden_hits = [s for s in scenario.forbidden if s.lower() in pane_lower]
     if forbidden_hits:
         return result(ScenarioStatus.FAIL, f"forbidden substring(s) appeared: {forbidden_hits}")
-    ungrounded = next((m for m in _UNGROUNDED_ANSWER_MARKERS if m in pane_lower), None)
-    if ungrounded is not None:
-        return result(
-            ScenarioStatus.FAIL,
-            f"ungrounded answer (lilbee_search returned nothing usable): {ungrounded!r}",
-        )
     events = read_events(workspace)
     if has_session_error(events):
         return result(ScenarioStatus.FAIL, "session.error event from opencode")
     fresh_dispatches = count_tool_dispatches(events, _SEARCH_TOOL_SUBSTR) - baseline_dispatches
     fresh_call = _count_ok_chat_completions(workspace) - baseline_calls
     missing = [s for s in scenario.expected if s.lower() not in pane_lower]
-    return _dispatch_verdict(
+    verdict = _dispatch_verdict(
         result, fresh_dispatches, fresh_call, has_events=bool(events), missing=missing
     )
+    # Downgrade only a would-be-PASS: the answer turn has completed (a fresh
+    # dispatch AND chat completion), so the final answer is rendered. Scan just
+    # the answer tail so an earlier transient "not found" from mid-search
+    # reasoning cannot false-fail a recovered, grounded final answer.
+    if verdict is not None and verdict.status is ScenarioStatus.PASS:
+        tail = pane_lower[-_UNGROUNDED_SCAN_TAIL:]
+        ungrounded = next((m for m in _UNGROUNDED_ANSWER_MARKERS if m.lower() in tail), None)
+        if ungrounded is not None:
+            return result(
+                ScenarioStatus.FAIL,
+                f"dispatched + completed but the answer is ungrounded "
+                f"(search found nothing in the reference): {ungrounded!r}",
+            )
+    return verdict
 
 
 def _dispatch_verdict(

--- a/tools/qa/opencode/test_scenarios_verdict.py
+++ b/tools/qa/opencode/test_scenarios_verdict.py
@@ -75,3 +75,42 @@ def test_dispatch_without_lilbee_chat_completion_fails_as_zen_fallback(tmp_path:
 def test_no_dispatch_keeps_waiting(tmp_path: Path) -> None:
     _write_chat_completions(tmp_path, 1)  # chat but no search dispatch yet
     assert _verdict(tmp_path) is None
+
+
+def _verdict_with_pane(workspace: Path, pane: str):
+    return _poll_verdict(
+        _scenario(),
+        workspace,
+        pane=pane,
+        baseline_calls=0,
+        baseline_dispatches=0,
+        start=0.0,
+    )
+
+
+def test_ungrounded_not_found_answer_fails_despite_dispatch(tmp_path: Path) -> None:
+    # A fresh dispatch + a lilbee chat completion is NOT a pass when the answer
+    # says the search found nothing: the tier prompts target content the indexed
+    # reference does contain, so "not found" is a real failure, not a clean pass.
+    _write_dispatch_event(tmp_path)
+    _write_chat_completions(tmp_path, 1)
+    pane = (
+        "The AStarGrid2D class and its get_id_path method are not found in the indexed reference."
+    )
+    verdict = _verdict_with_pane(tmp_path, pane)
+    assert verdict is not None
+    assert verdict.status is ScenarioStatus.FAIL
+    assert "ungrounded" in verdict.detail
+
+
+def test_grounded_answer_still_passes(tmp_path: Path) -> None:
+    # A real answer (no ungrounded markers) with dispatch + completion passes:
+    # the gate must not over-fire on substantive responses.
+    _write_dispatch_event(tmp_path)
+    _write_chat_completions(tmp_path, 1)
+    pane = (
+        "Object.connect signature: func connect(signal, callable, flags=0). CONNECT_DEFERRED is 1."
+    )
+    verdict = _verdict_with_pane(tmp_path, pane)
+    assert verdict is not None
+    assert verdict.status is ScenarioStatus.PASS

--- a/tools/qa/opencode/test_scenarios_verdict.py
+++ b/tools/qa/opencode/test_scenarios_verdict.py
@@ -114,3 +114,13 @@ def test_grounded_answer_still_passes(tmp_path: Path) -> None:
     verdict = _verdict_with_pane(tmp_path, pane)
     assert verdict is not None
     assert verdict.status is ScenarioStatus.PASS
+
+
+def test_ungrounded_answer_without_dispatch_keeps_waiting(tmp_path: Path) -> None:
+    # The ungrounded gate only downgrades a would-be-PASS. A model that answers
+    # "not found" from memory without ever dispatching must NOT be mislabeled as
+    # an ungrounded-search failure; it keeps waiting (and later times out on the
+    # accurate no-dispatch detail).
+    _write_chat_completions(tmp_path, 1)  # completion but no search dispatch
+    pane = "AStarGrid2D get_id_path is not found in the indexed reference."
+    assert _verdict_with_pane(tmp_path, pane) is None

--- a/tools/qa/opencode/test_scenarios_verdict.py
+++ b/tools/qa/opencode/test_scenarios_verdict.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from scenarios import Scenario, ScenarioStatus, _poll_verdict
+from scenarios import (
+    Scenario,
+    ScenarioResult,
+    ScenarioStatus,
+    _poll_verdict,
+    downgrade_if_ungrounded,
+)
 
 
 def _scenario() -> Scenario:
@@ -77,50 +83,42 @@ def test_no_dispatch_keeps_waiting(tmp_path: Path) -> None:
     assert _verdict(tmp_path) is None
 
 
-def _verdict_with_pane(workspace: Path, pane: str):
-    return _poll_verdict(
-        _scenario(),
-        workspace,
-        pane=pane,
-        baseline_calls=0,
-        baseline_dispatches=0,
-        start=0.0,
-    )
+# downgrade_if_ungrounded runs on the SETTLED pane (after wait_for_answer_settle),
+# so these inject a settled pane directly, which is exactly how the harness calls it.
+def _passing() -> ScenarioResult:
+    return ScenarioResult(name="x", status=ScenarioStatus.PASS, detail="1 dispatch + completion")
 
 
-def test_ungrounded_not_found_answer_fails_despite_dispatch(tmp_path: Path) -> None:
-    # A fresh dispatch + a lilbee chat completion is NOT a pass when the answer
-    # says the search found nothing: the tier prompts target content the indexed
-    # reference does contain, so "not found" is a real failure, not a clean pass.
-    _write_dispatch_event(tmp_path)
-    _write_chat_completions(tmp_path, 1)
+def test_downgrade_ungrounded_pass_becomes_fail() -> None:
     pane = (
         "The AStarGrid2D class and its get_id_path method are not found in the indexed reference."
     )
-    verdict = _verdict_with_pane(tmp_path, pane)
-    assert verdict is not None
-    assert verdict.status is ScenarioStatus.FAIL
-    assert "ungrounded" in verdict.detail
+    out = downgrade_if_ungrounded(_passing(), pane)
+    assert out.status is ScenarioStatus.FAIL
+    assert "ungrounded" in out.detail
 
 
-def test_grounded_answer_still_passes(tmp_path: Path) -> None:
-    # A real answer (no ungrounded markers) with dispatch + completion passes:
-    # the gate must not over-fire on substantive responses.
-    _write_dispatch_event(tmp_path)
-    _write_chat_completions(tmp_path, 1)
+def test_downgrade_keeps_grounded_pass() -> None:
+    # A substantive grounded answer is left untouched (no over-fire).
     pane = (
         "Object.connect signature: func connect(signal, callable, flags=0). CONNECT_DEFERRED is 1."
     )
-    verdict = _verdict_with_pane(tmp_path, pane)
-    assert verdict is not None
-    assert verdict.status is ScenarioStatus.PASS
+    assert downgrade_if_ungrounded(_passing(), pane).status is ScenarioStatus.PASS
 
 
-def test_ungrounded_answer_without_dispatch_keeps_waiting(tmp_path: Path) -> None:
-    # The ungrounded gate only downgrades a would-be-PASS. A model that answers
-    # "not found" from memory without ever dispatching must NOT be mislabeled as
-    # an ungrounded-search failure; it keeps waiting (and later times out on the
-    # accurate no-dispatch detail).
-    _write_chat_completions(tmp_path, 1)  # completion but no search dispatch
+def test_downgrade_noop_on_non_pass() -> None:
+    # The gate only downgrades a PASS; a FAIL (e.g. no dispatch) keeps its
+    # accurate detail rather than being relabeled "ungrounded".
+    fail = ScenarioResult(name="x", status=ScenarioStatus.FAIL, detail="no dispatch")
     pane = "AStarGrid2D get_id_path is not found in the indexed reference."
-    assert _verdict_with_pane(tmp_path, pane) is None
+    out = downgrade_if_ungrounded(fail, pane)
+    assert out.status is ScenarioStatus.FAIL
+    assert out.detail == "no dispatch"
+
+
+def test_downgrade_scans_only_the_tail() -> None:
+    # An ungrounded phrase from earlier mid-search reasoning, pushed out of the
+    # tail by a long grounded final answer, must not false-fail.
+    early = "search 1: not found in the indexed set; retrying. "
+    grounded = "get_id_path returns a PackedInt64Array of point ids. " * 80
+    assert downgrade_if_ungrounded(_passing(), early + grounded).status is ScenarioStatus.PASS


### PR DESCRIPTION
## Problem

Frame-by-frame review of the full-matrix demo reels surfaced two QA-harness issues the matrix pass-gate had masked:

- **The pass-gate accepted ungrounded answers.** A scenario passed on a fresh `lilbee_search` dispatch plus a chat completion, with no check that the answer was grounded. Several recorded reels showed models dispatch a search and then answer "not found in the indexed reference" / "no documentation exists" for real Godot classes, yet all were PASS. The tier prompts target content the indexed reference does contain, so that is a real failure, not a clean pass.
- **The coder/giant reels never wrote their artifact.** An automated VHS reel has no human to satisfy opencode's default `ask` edit permission, so file writes silently never happened and the model narrated the code instead of creating the file.

## Solution

- Add `downgrade_if_ungrounded(result, settled_pane)` and apply it in the single-call scenario right after `wait_for_answer_settle`, so a dispatched-and-completed answer that says the search found nothing is downgraded to FAIL. It runs on the settled answer (the verdict trips while the answer is still streaming, so grounding can only be judged once it renders), scans only the answer tail, and uses a narrow set of markers so a grounded answer scoping a negative is not flagged.
- Add `permission.edit = allow` to the reel's `opencode.json` so the coder/giant reels auto-approve writes.

A related retrieval gap (some real classes like AStarGrid2D return "not found" while others resolve) is intentionally not addressed here: the content is present, so it is a product-side retrieval issue that needs a pod to reproduce and diagnose. The new gate now surfaces it (those scenarios correctly fail) rather than masking it.

Tests cover the gate's downgrade, the grounded-answer no-op, the non-PASS no-op, and the tail-scan. The change was reviewed for blast radius and convention across several passes; an earlier in-verdict placement that mis-timed against the answer stream was reworked to the settled-pane approach above.