### PR TITLE
Bundle the splash runner in the frozen binary; let Esc close a focus-raced catalog filter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,6 +288,12 @@ jobs:
             cat "$MP"
             exit 1
           fi
+          # The runner ships only via --include-module; catch a missing module here too.
+          if grep -qE "No module named|ModuleNotFoundError" "$MP"; then
+            echo "FAIL: splash runner module is not bundled in the frozen binary"
+            cat "$MP"
+            exit 1
+          fi
           "$EXE" -c "import multiprocessing" > "$MP" 2>&1 || true
           if grep -qE "No such command|No such option" "$MP"; then
             echo "FAIL: resource-tracker -c reinvocation leaked into typer (frozen detection broken)"

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -107,6 +107,9 @@ _LIST_PAGE_ROWS = 10
 _GRID_ID_PREFIX = "grid-"
 _LIST_ID_PREFIX = "list-"
 
+# Toggles the filter Input between revealed and `display: none` (catalog.tcss).
+_HIDDEN_CLASS = "-hidden"
+
 _SORT_CYCLE: tuple[str, ...] = ("Name", "Downloads", "Size", "Params")
 
 # Braille spinner frames for the catalog pagination/search loading
@@ -336,6 +339,11 @@ class CatalogScreen(Screen[None]):
         """
         return isinstance(self.focused, Input)
 
+    @property
+    def _filter_open(self) -> bool:
+        """True while the filter Input is revealed, independent of focus."""
+        return not self._search_input.has_class(_HIDDEN_CLASS)
+
     def compose(self) -> ComposeResult:
         from lilbee.cli.tui.widgets.grid_list_toggle import GridListToggle
 
@@ -344,7 +352,7 @@ class CatalogScreen(Screen[None]):
             yield Input(
                 placeholder=msg.CATALOG_FILTER_PLACEHOLDER,
                 id="catalog-search",
-                classes="-hidden",
+                classes=_HIDDEN_CLASS,
             )
         with Horizontal(id="catalog-toolbar"):
             yield GridListToggle()
@@ -588,7 +596,7 @@ class CatalogScreen(Screen[None]):
 
     def action_focus_search(self) -> None:
         """Reveal and focus the filter input. Bound to / key."""
-        self._search_input.remove_class("-hidden")
+        self._search_input.remove_class(_HIDDEN_CLASS)
         self._search_input.focus()
 
     _SEARCH_FILTER_DEBOUNCE_SECONDS = 0.08
@@ -1855,12 +1863,11 @@ class CatalogScreen(Screen[None]):
         self.notify(msg.CATALOG_QUEUED_DOWNLOAD.format(name=model.display_name))
 
     def action_go_back(self) -> None:
-        # Escape from a focused filter input collapses the input back to
-        # hidden and restores focus to the grid/list, so screen-level
-        # keys (s / v) reach the screen instead of the (now-hidden) input.
-        if self._search_focused:
+        # An open filter collapses to hidden (restoring grid/list focus);
+        # otherwise q leaves for Chat.
+        if self._filter_open:
             self._search_input.value = ""
-            self._search_input.add_class("-hidden")
+            self._search_input.add_class(_HIDDEN_CLASS)
             self._focus_list_or_grid()
             return
         self.app.switch_view("Chat")
@@ -1874,9 +1881,9 @@ class CatalogScreen(Screen[None]):
         Input on the next screen. Esc now only handles the filter; the
         dismiss path is `q` (action_go_back) which still does both.
         """
-        if self._search_focused:
+        if self._filter_open:
             self._search_input.value = ""
-            self._search_input.add_class("-hidden")
+            self._search_input.add_class(_HIDDEN_CLASS)
             self._focus_list_or_grid()
 
     def _focus_list_or_grid(self) -> None:

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -185,6 +185,49 @@ async def test_action_toggle_drawer_flips_collapsed_class() -> None:
         assert drawer.has_class("-collapsed")
 
 
+async def test_dismiss_filter_closes_revealed_bar_when_unfocused() -> None:
+    """Esc closes an open filter even when focus has raced off the Input."""
+    async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = pilot.app.query_one(CatalogScreen)
+        screen._activation_settled = True
+        inp = screen.query_one("#catalog-search", Input)
+
+        await pilot.press("slash")  # reveal the filter as `/` does
+        await pilot.pause()
+        assert screen._filter_open
+        inp.value = "qwen"
+        screen.set_focus(None)  # model the reveal-time focus race
+        await pilot.pause()
+        assert not screen._search_focused
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert inp.has_class("-hidden")
+        assert inp.value == ""
+
+
+async def test_go_back_closes_revealed_bar_when_unfocused() -> None:
+    """`q` collapses an open filter (even unfocused) instead of leaving the screen."""
+    async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = pilot.app.query_one(CatalogScreen)
+        screen._activation_settled = True
+        inp = screen.query_one("#catalog-search", Input)
+
+        await pilot.press("slash")
+        await pilot.pause()
+        assert screen._filter_open
+        screen.set_focus(None)
+        await pilot.pause()
+        assert not screen._search_focused
+
+        await pilot.press("q")
+        await pilot.pause()
+        assert inp.has_class("-hidden")
+        assert pilot.app.query_one(CatalogScreen) is screen
+
+
 async def test_action_dismiss_filter_no_op_outside_input() -> None:
     """Esc outside the filter Input must not dismiss; the screen stays put."""
     async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
@@ -331,26 +374,16 @@ async def test_action_select_tab_idempotent_when_already_active() -> None:
 
 
 async def test_action_dismiss_filter_clears_input_value() -> None:
-    """Esc with focus inside the filter Input clears it and hides the box.
-
-    Uses a focus-state property override rather than driving real focus
-    so the test passes on CI runners where set_focus doesn't pin reliably.
-    """
-    from unittest.mock import PropertyMock, patch
-
-    from textual.screen import Screen
-
+    """Esc on an open filter clears its value and hides the box."""
     async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         screen = pilot.app.query_one(CatalogScreen)
         screen._activation_settled = True
         inp = screen.query_one("#catalog-search", Input)
+        await pilot.press("slash")
+        await pilot.pause()
         inp.value = "qwen"
-        # Stub Screen.focused to point at the Input regardless of CI focus
-        # quirks. The action's isinstance(self.focused, Input) gate fires
-        # the filter-clear branch we want to exercise.
-        with patch.object(Screen, "focused", new_callable=PropertyMock, return_value=inp):
-            screen.action_dismiss_filter()
+        await pilot.press("escape")
         await pilot.pause()
         assert inp.value == ""
         assert inp.has_class("-hidden")

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -406,8 +406,9 @@ class TestCatalogScreenAsync:
             app.push_screen(catalog)
             for _ in range(8):
                 await pilot.pause()
-            # Focus the filter input explicitly to match the scenario.
-            catalog.query_one("#catalog-search", Input).focus()
+            # Open the filter via `/` (reveal + focus); a hidden input is
+            # never focused in production.
+            await pilot.press("slash")
             await pilot.pause()
             assert isinstance(catalog.focused, Input)
             catalog.action_go_back()
@@ -435,7 +436,8 @@ class TestCatalogScreenAsync:
             await pilot.pause()
             catalog.action_toggle_view()  # switch to list view
             await pilot.pause()
-            catalog.query_one("#catalog-search", Input).focus()
+            # Open the filter via `/`, not a bare focus on a hidden input.
+            await pilot.press("slash")
             await pilot.pause()
             assert isinstance(catalog.focused, Input)
             catalog.action_go_back()

--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -42,6 +42,10 @@ for f in "$SITE_PKG"/*__mypyc*.so; do
     MYPYC_FLAGS+=("--include-data-files=$f=$(basename "$f")")
 done
 
+# Spawned via `python -m`, never statically imported, so Nuitka's import
+# following misses it; include it explicitly or the splash subprocess dies.
+SPLASH_FLAGS=(--include-module=lilbee.runtime._splash_runner)
+
 uv run --no-sync python -m nuitka \
     --mode=onefile \
     --user-plugin=tools/wheel-build/playwright_node_verbatim.py \
@@ -83,5 +87,6 @@ uv run --no-sync python -m nuitka \
     --include-distribution-metadata=catalogue \
     --include-data-dir=src/lilbee/cli/tui=lilbee/cli/tui \
     --include-data-files=src/lilbee/featured_models.toml=lilbee/featured_models.toml \
+    "${SPLASH_FLAGS[@]}" \
     "${MYPYC_FLAGS[@]}" \
     src/lilbee/__main__.py


### PR DESCRIPTION
## Problem

Two bugs visible on the released (brew) binary.

The frozen binary crashed at startup with `ImportError: No module named lilbee.runtime._splash_runner`. The splash animator runs as a `python -m lilbee.runtime._splash_runner` subprocess and is never statically imported, so Nuitka's import following never bundled it. The release smoke test already reinvoked the module, but only checked for typer-leak output, so a missing module passed as a false green and shipped.

In the model catalog, pressing `/` opened the filter bar but Esc could not close it, so it stayed superimposed. Revealing the bar focuses the filter Input, but focus can race away from it; dismissal was gated on the Input being focused, so an open-but-unfocused bar had no key to close it.

## Solution

Add `--include-module=lilbee.runtime._splash_runner` to the Nuitka build, and extend the release smoke test to also fail on `No module named`/`ImportError` from the splash reinvocation so this can't regress silently.

Gate the catalog filter's Esc/`q` dismissal on whether the bar is open (the `-hidden` class) rather than whether the Input is focused, so a focus-raced bar still closes. Esc still no-ops when the filter is closed, preserving the deliberate "Esc never leaves the catalog" behavior.

New tests cover dismissing an open-but-unfocused filter via Esc and `q`; the fix was also verified in a real terminal.