### PR TITLE
Make store writes atomic and lock per-instance

### DIFF
--- a/src/lilbee/data/export.py
+++ b/src/lilbee/data/export.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from lilbee.data.ingest.extract import chunk_and_embed_pages
-from lilbee.data.store import PageTextRecord, SourceType
+from lilbee.data.store import ChunkWrite, PageTextRecord, SourceType
 from lilbee.runtime.progress import DetailedProgressCallback, noop_callback
 
 if TYPE_CHECKING:
@@ -197,10 +197,21 @@ async def import_dataset(
         content_type = source_rows[0]["content_type"] or "text"
         page_texts = [(r["page"], r["text"]) for r in source_rows]
         chunks = await chunk_and_embed_pages(page_texts, name, content_type, on_progress)
-        store.delete_by_source(name)
-        store.add_chunks(cast(list[dict], chunks))
-        store.add_page_texts([dict(r) for r in source_rows])
-        store.upsert_source(name, "", len(chunks), source_type=SourceType.IMPORTED)
+        # One locked transaction (cleanup + chunks + page texts + source row) so a
+        # failure can't leave the source with its old rows deleted and no new ones;
+        # the embedding-dim check inside runs before the cleanup delete.
+        store.write_chunks_batch(
+            [
+                ChunkWrite(
+                    source=name,
+                    file_hash="",
+                    records=cast(list[dict], chunks),
+                    needs_cleanup=True,
+                    page_texts=[dict(r) for r in source_rows],
+                    source_type=SourceType.IMPORTED,
+                )
+            ]
+        )
         imported.append(name)
         total_pages += len(source_rows)
         total_chunks += len(chunks)

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -696,7 +696,7 @@ async def _collect_results(
                 status = _classify_result(result, added, updated, failed, skipped, reasons)
                 if status is BatchStatus.INGESTED:
                     buffered_chunks = await _buffer_and_maybe_flush(
-                        result, buffer, buffered_chunks, added, updated, failed, flush_failed
+                        result, buffer, buffered_chunks, added, updated, failed, skipped, flush_failed
                     )
                 elif status is BatchStatus.SKIPPED and result.needs_cleanup:
                     # Zero-text result is never buffered; collect it for the
@@ -710,7 +710,9 @@ async def _collect_results(
         # The inner finally guarantees the sibling cancel even if the flush
         # itself raises (e.g. a cancellation landing on the to_thread await).
         try:
-            await asyncio.to_thread(_flush_writes, buffer, added, updated, failed, flush_failed)
+            await asyncio.to_thread(
+                _flush_writes, buffer, added, updated, failed, skipped, flush_failed
+            )
             await asyncio.to_thread(_purge_emptied_sources, to_purge)
         finally:
             still_pending = [t for t in in_flight if not t.done()]
@@ -727,6 +729,7 @@ async def _buffer_and_maybe_flush(
     added: dict[str, None],
     updated: dict[str, None],
     failed: dict[str, None],
+    skipped: dict[str, None],
     flush_failed: set[str] | None,
 ) -> int:
     """Buffer one ingested file, flushing at the chunk threshold; returns the new count."""
@@ -734,7 +737,9 @@ async def _buffer_and_maybe_flush(
     # Zero-chunk files count one unit so the buffer stays bounded.
     buffered_chunks += max(result.chunk_count, 1)
     if buffered_chunks >= _WRITE_FLUSH_CHUNKS:
-        await asyncio.to_thread(_flush_writes, buffer, added, updated, failed, flush_failed)
+        await asyncio.to_thread(
+            _flush_writes, buffer, added, updated, failed, skipped, flush_failed
+        )
         buffered_chunks = 0
     return buffered_chunks
 
@@ -886,6 +891,7 @@ def _flush_writes(
     added: dict[str, None],
     updated: dict[str, None],
     failed: dict[str, None],
+    skipped: dict[str, None],
     flush_failed: set[str] | None = None,
 ) -> None:
     """Flush the buffered documents to the store; track a write failure.
@@ -906,6 +912,9 @@ def _flush_writes(
             log.warning("Failed to write %s: %s", r.name, exc)
             added.pop(r.name, None)
             updated.pop(r.name, None)
+            # A page-text-only file was pre-marked skipped at classification; on a
+            # flush failure it belongs in failed only, never both.
+            skipped.pop(r.name, None)
             failed[r.name] = None
             if flush_failed is not None:
                 flush_failed.add(r.name)

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -790,15 +790,21 @@ def _classify_result(
         if reasons is not None:
             reasons[result.name] = f"{type(result.error).__name__}: {result.error}"
         return BatchStatus.FAILED
-    if result.chunk_count == 0 and not result.page_texts:
-        # Nothing extracted: no source row, so the file is retried next sync; a
-        # zero-chunk file WITH page texts stays ingested so it stops replanning.
+    if result.chunk_count == 0:
+        # No searchable chunks: never report it as added/updated. With no page
+        # texts either, nothing is persisted and the file retries next sync. With
+        # page texts, it stays INGESTED so its pages persist (export/recon) and it
+        # stops replanning, but it is reported as skipped since search can't see it.
         added.pop(result.name, None)
         updated.pop(result.name, None)
         skipped[result.name] = None
         if reasons is not None:
-            reasons[result.name] = "no text extracted (0 chunks)"
-        return BatchStatus.SKIPPED
+            reasons[result.name] = (
+                "no text extracted (0 chunks)"
+                if not result.page_texts
+                else "stored page text only (0 searchable chunks)"
+            )
+        return BatchStatus.SKIPPED if not result.page_texts else BatchStatus.INGESTED
     return BatchStatus.INGESTED
 
 

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import math
 from collections.abc import Callable
+from contextlib import AbstractContextManager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -23,7 +24,7 @@ from lilbee.core.config import (
     Config,
 )
 from lilbee.core.security import validate_path_within
-from lilbee.runtime.lock import write_lock
+from lilbee.runtime.lock import LOCK_TIMEOUT, write_lock
 
 from .lance_helpers import (
     _chunk_type_predicate,
@@ -166,6 +167,15 @@ class Store:
         # mutate; callers (temporal filter) hit it per-query.
         self._source_ingested_cache: dict[str, str] | None = None
 
+    def _write_lock(self, timeout: float = LOCK_TIMEOUT) -> AbstractContextManager[None]:
+        """Acquire the write lock keyed on *this* store's data directory.
+
+        A per-instance ``Lilbee`` writes to its own ``lancedb_dir``; locking the
+        global ``cfg`` dir instead would leave those writes uncoordinated across
+        processes.
+        """
+        return write_lock(self._config.lancedb_dir, timeout)
+
     def _invalidate_source_cache(self) -> None:
         """Drop the cached {filename: ingested_at} map."""
         self._source_ingested_cache = None
@@ -264,7 +274,7 @@ class Store:
             return False
         embedding_model = self._config.embedding_model
         embedding_dim = self._config.embedding_dim
-        with write_lock():
+        with self._write_lock():
             # Re-check under the lock so two callers do not both warn-and-write.
             if self.get_meta() is not None:
                 return False
@@ -342,7 +352,7 @@ class Store:
         current_dim = self._config.embedding_dim
         if not self._needs_canonical_meta_rewrite(self.get_meta(), current_model, current_dim):
             return False
-        with write_lock():
+        with self._write_lock():
             meta = self.get_meta()  # re-read under the lock for racing callers
             if not self._needs_canonical_meta_rewrite(meta, current_model, current_dim):
                 return False
@@ -382,7 +392,7 @@ class Store:
         chunk count, so large corpora no longer pay the full
         ``create_fts_index(replace=True)`` rebuild cost on every sync.
         """
-        with write_lock():
+        with self._write_lock():
             table = self.open_table(CHUNKS_TABLE)
             if table is None:
                 return
@@ -407,7 +417,7 @@ class Store:
         Returns True when an index was created or refreshed.
         """
         threshold = self._config.ann_index_threshold
-        with write_lock():
+        with self._write_lock():
             table = self.open_table(CHUNKS_TABLE)
             if table is None:
                 return False
@@ -443,7 +453,7 @@ class Store:
         concurrent ``set_embedding_model`` cannot slip a write in past a stale
         compatibility check.
         """
-        with write_lock():
+        with self._write_lock():
             embedding_model = self._config.embedding_model
             embedding_dim = self._config.embedding_dim
             self._ensure_embedding_compat()
@@ -634,7 +644,7 @@ class Store:
 
     def delete_by_source(self, source: str) -> None:
         """Delete a source's chunks and page texts."""
-        with write_lock():
+        with self._write_lock():
             self._delete_by_source_unlocked(source)
         self._invalidate_source_cache()
 
@@ -642,7 +652,7 @@ class Store:
         """Add per-page text rows (no vectors). Returns count added."""
         if not records:
             return 0
-        with write_lock():
+        with self._write_lock():
             db = self.get_db()
             table = ensure_table(db, PAGE_TEXTS_TABLE, _page_texts_schema())
             table.add(records)
@@ -749,7 +759,7 @@ class Store:
     ) -> None:
         """Add or update a source tracking record."""
         row = self._source_row(filename, file_hash, chunk_count, source_type, stat)
-        with write_lock():
+        with self._write_lock():
             self._replace_source_rows_unlocked([row])
         self._invalidate_source_cache()
 
@@ -767,13 +777,13 @@ class Store:
                 }
                 for bf in backfills[start : start + _SOURCE_STAT_BATCH_ROWS]
             ]
-            with write_lock():
+            with self._write_lock():
                 self._replace_source_rows_unlocked(rows)
         self._invalidate_source_cache()
 
     def optimize_sources(self) -> None:
         """Compact the sources table; per-flush upserts otherwise accrete tiny versions."""
-        with write_lock():
+        with self._write_lock():
             table = self.open_table(SOURCES_TABLE)
             if table is None:
                 return
@@ -796,7 +806,7 @@ class Store:
         """
         if not items:
             return 0
-        with write_lock():
+        with self._write_lock():
             embedding_model = self._config.embedding_model
             embedding_dim = self._config.embedding_dim
             self._ensure_embedding_compat()
@@ -852,7 +862,7 @@ class Store:
 
     def delete_source(self, filename: str) -> None:
         """Remove a source file tracking record."""
-        with write_lock():
+        with self._write_lock():
             self._delete_source_unlocked(filename)
         self._invalidate_source_cache()
 
@@ -890,7 +900,7 @@ class Store:
             if name not in known:
                 not_found.append(name)
                 continue
-            with write_lock():
+            with self._write_lock():
                 self._remove_one_unlocked(name)
             self._invalidate_source_cache()
             removed.append(name)
@@ -907,7 +917,7 @@ class Store:
 
     def clear_table(self, name: str, predicate: str) -> None:
         """Delete rows matching *predicate* from *name*. Acquires write lock."""
-        with write_lock():
+        with self._write_lock():
             table = self.open_table(name)
             if table is not None:
                 _safe_delete_unlocked(table, predicate)
@@ -916,7 +926,7 @@ class Store:
         """Add citation records to the store. Returns count added."""
         if not records:
             return 0
-        with write_lock():
+        with self._write_lock():
             db = self.get_db()
             table = ensure_table(db, CITATIONS_TABLE, _citations_schema())
             table.add(records)
@@ -1002,7 +1012,7 @@ class Store:
                 f"Memory vector dimension mismatch: expected "
                 f"{self._config.embedding_dim}, got {len(record.vector)}"
             )
-        with write_lock():
+        with self._write_lock():
             embedding_model = self._config.embedding_model
             embedding_dim = self._config.embedding_dim
             self._ensure_embedding_compat()
@@ -1064,7 +1074,7 @@ class Store:
         The ``owner`` predicate scopes the mutation to the caller's namespace so an
         agent cannot flip another owner's (or the human's) memory.
         """
-        with write_lock():
+        with self._write_lock():
             table = self.open_table(MEMORIES_TABLE)
             if table is None:
                 return False
@@ -1088,7 +1098,7 @@ class Store:
         The ``owner`` predicate scopes the delete to the caller's namespace so an
         agent cannot destroy another owner's (or the human's) memory.
         """
-        with write_lock():
+        with self._write_lock():
             table = self.open_table(MEMORIES_TABLE)
             if table is None:
                 return False
@@ -1121,7 +1131,7 @@ class Store:
         vectors = embed([m.text for m in memories])
         for memory, vector in zip(memories, vectors, strict=True):
             memory.vector = vector
-        with write_lock():
+        with self._write_lock():
             db = self.get_db()
             db.drop_table(MEMORIES_TABLE)
             new_table = ensure_table(db, MEMORIES_TABLE, self._memories_schema())
@@ -1140,7 +1150,7 @@ class Store:
         documents, so a rebuild preserves it. Only a factory reset (which deletes
         the data directory) clears it.
         """
-        with write_lock():
+        with self._write_lock():
             self._fts_ready = False
             db = self.get_db()
             for name in _table_names(db):

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -1141,8 +1141,7 @@ class Store:
         The snapshot, embed, and table rebuild all run under the write lock so a
         concurrent ``add_memory`` cannot commit into the read-then-drop window and
         be erased; it either lands before the snapshot or blocks until the rebuild
-        finishes. (A memory added mid-window would carry the old-dimension vector,
-        so re-reading survivors instead of locking would still need re-embedding.)
+        finishes.
         """
         with self._write_lock():
             table = self.open_table(MEMORIES_TABLE)

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -850,7 +850,7 @@ class Store:
     def _batch_source_rows(self, items: list[ChunkWrite]) -> list[dict]:
         """One ``_sources`` row per batched document."""
         return [
-            self._source_row(it.source, it.file_hash, len(it.records), SourceType.DOCUMENT, it.stat)
+            self._source_row(it.source, it.file_hash, len(it.records), it.source_type, it.stat)
             for it in items
         ]
 

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -922,6 +922,23 @@ class Store:
             if table is not None:
                 _safe_delete_unlocked(table, predicate)
 
+    def clear_and_add(
+        self, name: str, schema: pa.Schema, rows: list[dict], predicate: str
+    ) -> None:
+        """Replace the rows matching *predicate* with *rows* in one locked write.
+
+        Delete and add run under a single write lock, so a reader never observes
+        the table emptied mid-rebuild. The add is skipped when the delete failed,
+        to avoid duplicating rows whose predecessors were not removed.
+        """
+        with self._write_lock():
+            db = self.get_db()
+            table = ensure_table(db, name, schema)
+            if not _safe_delete_unlocked(table, predicate):
+                return
+            if rows:
+                table.add(rows)
+
     def add_citations(self, records: list[CitationRecord]) -> int:
         """Add citation records to the store. Returns count added."""
         if not records:
@@ -1120,18 +1137,24 @@ class Store:
         The vector column dimension is immutable, so a different-dim model needs a
         fresh table; recreating unconditionally also covers the same-dim case. Memory
         text is human-authored and re-embeddable, so no data is lost. Returns the count.
+
+        The snapshot, embed, and table rebuild all run under the write lock so a
+        concurrent ``add_memory`` cannot commit into the read-then-drop window and
+        be erased; it either lands before the snapshot or blocks until the rebuild
+        finishes. (A memory added mid-window would carry the old-dimension vector,
+        so re-reading survivors instead of locking would still need re-embedding.)
         """
-        table = self.open_table(MEMORIES_TABLE)
-        if table is None:
-            return 0
-        rows = table.search().limit(None).to_list()
-        if not rows:
-            return 0
-        memories = [MemoryRow(**r) for r in rows]
-        vectors = embed([m.text for m in memories])
-        for memory, vector in zip(memories, vectors, strict=True):
-            memory.vector = vector
         with self._write_lock():
+            table = self.open_table(MEMORIES_TABLE)
+            if table is None:
+                return 0
+            rows = table.search().limit(None).to_list()
+            if not rows:
+                return 0
+            memories = [MemoryRow(**r) for r in rows]
+            vectors = embed([m.text for m in memories])
+            for memory, vector in zip(memories, vectors, strict=True):
+                memory.vector = vector
             db = self.get_db()
             db.drop_table(MEMORIES_TABLE)
             new_table = ensure_table(db, MEMORIES_TABLE, self._memories_schema())

--- a/src/lilbee/data/store/lance_helpers.py
+++ b/src/lilbee/data/store/lance_helpers.py
@@ -12,6 +12,8 @@ from lilbee.runtime.lock import write_lock
 from .types import LOCAL_OWNER, ChunkType
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import lancedb
     import lancedb.table
     import pyarrow as pa
@@ -70,9 +72,15 @@ def _safe_delete_unlocked(table: lancedb.table.Table, predicate: str) -> bool:
         return False
 
 
-def safe_delete(table: lancedb.table.Table, predicate: str) -> bool:
-    """Delete rows matching predicate, logging on failure. Returns success."""
-    with write_lock():
+def safe_delete(
+    table: lancedb.table.Table, predicate: str, lancedb_dir: Path | None = None
+) -> bool:
+    """Delete rows matching predicate, logging on failure. Returns success.
+
+    Pass the store's ``lancedb_dir`` so the write lock coordinates on that
+    instance's data dir; ``None`` falls back to the global config dir.
+    """
+    with write_lock(lancedb_dir):
         return _safe_delete_unlocked(table, predicate)
 
 

--- a/src/lilbee/data/store/types.py
+++ b/src/lilbee/data/store/types.py
@@ -33,13 +33,26 @@ class ConceptRecords:
         )
 
 
+class SourceType(StrEnum):
+    """Values for the ``_sources.source_type`` column.
+
+    ``DOCUMENT`` mirrors a file under ``documents/`` and is managed by the
+    file-driven sync. ``IMPORTED`` is detached: it came from ``lilbee import``
+    and has no backing file, so sync must not treat it as a missing document.
+    """
+
+    DOCUMENT = "document"
+    IMPORTED = "imported"
+
+
 class ChunkWrite(NamedTuple):
     """One document's chunks plus its source-table update, for a batched write.
 
     ``Store.write_chunks_batch`` folds many of these into a single locked
     transaction so bulk ingest doesn't pay a write-lock acquisition per document.
     ``page_texts`` rows land in the same transaction, after the cleanup delete
-    and before the source row.
+    and before the source row. ``source_type`` lets the detached import path
+    reuse the same atomic write while still tagging its rows ``IMPORTED``.
     """
 
     source: str
@@ -48,6 +61,7 @@ class ChunkWrite(NamedTuple):
     needs_cleanup: bool
     stat: SourceStat | None = None
     page_texts: list[dict] | None = None
+    source_type: SourceType = SourceType.DOCUMENT
 
 
 class ChunkType(StrEnum):
@@ -59,18 +73,6 @@ class ChunkType(StrEnum):
 
     RAW = "raw"
     WIKI = "wiki"
-
-
-class SourceType(StrEnum):
-    """Values for the ``_sources.source_type`` column.
-
-    ``DOCUMENT`` mirrors a file under ``documents/`` and is managed by the
-    file-driven sync. ``IMPORTED`` is detached: it came from ``lilbee import``
-    and has no backing file, so sync must not treat it as a missing document.
-    """
-
-    DOCUMENT = "document"
-    IMPORTED = "imported"
 
 
 # ``schema_version`` is an integer for forward-compat. Bump only if we ever need to

--- a/src/lilbee/retrieval/concepts/graph.py
+++ b/src/lilbee/retrieval/concepts/graph.py
@@ -130,7 +130,7 @@ class ConceptGraph:
 
     def write_concept_records(self, records: ConceptRecords) -> None:
         """Write batched concept rows: one lock acquisition, at most one add per table."""
-        with lock.write_lock():
+        with lock.write_lock(self._config.lancedb_dir):
             db = self._store.get_db()
             # Always create tables so get_graph() returns True even when
             # concept extraction yields no results for the current corpus.
@@ -300,7 +300,7 @@ class ConceptGraph:
 
         self._store.clear_table(CONCEPT_NODES_TABLE, "concept IS NOT NULL")
         if node_records:
-            with lock.write_lock():
+            with lock.write_lock(self._config.lancedb_dir):
                 db = self._store.get_db()
                 nodes_table = data_store.ensure_table(
                     db, CONCEPT_NODES_TABLE, _concept_nodes_schema()
@@ -310,7 +310,7 @@ class ConceptGraph:
 
     def compact_tables(self) -> None:
         """Compact the concept tables; per-file adds otherwise accrete tiny versions."""
-        with lock.write_lock():
+        with lock.write_lock(self._config.lancedb_dir):
             for name in _CONCEPT_TABLES:
                 table = self._store.open_table(name)
                 if table is None:

--- a/src/lilbee/retrieval/concepts/graph.py
+++ b/src/lilbee/retrieval/concepts/graph.py
@@ -298,14 +298,12 @@ class ConceptGraph:
             for node, cluster_id in partition.items()
         ]
 
-        self._store.clear_table(CONCEPT_NODES_TABLE, "concept IS NOT NULL")
-        if node_records:
-            with lock.write_lock(self._config.lancedb_dir):
-                db = self._store.get_db()
-                nodes_table = data_store.ensure_table(
-                    db, CONCEPT_NODES_TABLE, _concept_nodes_schema()
-                )
-                nodes_table.add(node_records)
+        # Delete the old nodes and add the new ones under one lock so a reader
+        # never sees the nodes table emptied while get_graph() still reports it
+        # present (which would blank top_communities / cluster labels).
+        self._store.clear_and_add(
+            CONCEPT_NODES_TABLE, _concept_nodes_schema(), node_records, "concept IS NOT NULL"
+        )
         self.compact_tables()
 
     def compact_tables(self) -> None:

--- a/src/lilbee/runtime/lock.py
+++ b/src/lilbee/runtime/lock.py
@@ -52,7 +52,11 @@ def write_lock(
     cannot stall ~60s.
     """
     deadline = time.monotonic() + timeout
-    flock = FileLock(_lock_path(lancedb_dir))
+    lock_path = _lock_path(lancedb_dir)
+    # The first write to a per-instance store can run before its data dir exists;
+    # the file lock cannot be created in a missing directory.
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    flock = FileLock(lock_path)
     try:
         flock.acquire(timeout=timeout)
     except FileLockTimeout:

--- a/src/lilbee/runtime/lock.py
+++ b/src/lilbee/runtime/lock.py
@@ -50,9 +50,9 @@ def write_lock(
     store's ``lancedb_dir`` (a per-instance ``Lilbee`` uses its own dir).
     ``None`` falls back to the global ``cfg.lancedb_dir``.
 
-    ``timeout`` is the total budget for both stages: the time spent waiting on
-    the file lock is deducted before waiting on the mutex, so a 30s request
-    cannot stall ~60s.
+    The two stages share one budget: the time spent waiting on the file lock is
+    deducted before waiting on the mutex (plus a small ``_MUTEX_MIN_WAIT`` floor),
+    so a 30s request cannot stall for roughly twice that.
     """
     deadline = time.monotonic() + timeout
     lock_path = _lock_path(lancedb_dir)

--- a/src/lilbee/runtime/lock.py
+++ b/src/lilbee/runtime/lock.py
@@ -8,6 +8,7 @@ by LanceDB's built-in MVCC via ``read_consistency_interval`` in
 
 import logging
 import threading
+import time
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -31,20 +32,34 @@ class LockTimeoutError(TimeoutError):
 _write_mutex = threading.Lock()
 
 
-def _lock_path() -> Path:
-    return cfg.lancedb_dir / ".lock"
+def _lock_path(lancedb_dir: Path | None) -> Path:
+    return (lancedb_dir if lancedb_dir is not None else cfg.lancedb_dir) / ".lock"
 
 
 @contextmanager
-def write_lock(timeout: float = LOCK_TIMEOUT) -> Generator[None, None, None]:
-    """Context manager: acquire exclusive file lock then in-process mutex."""
-    flock = FileLock(_lock_path())
+def write_lock(
+    lancedb_dir: Path | None = None, timeout: float = LOCK_TIMEOUT
+) -> Generator[None, None, None]:
+    """Acquire the cross-process file lock then the in-process mutex.
+
+    The file lock lives next to the store's data, so cross-process writers
+    coordinate only when they lock the *same* directory: callers pass their
+    store's ``lancedb_dir`` (a per-instance ``Lilbee`` uses its own dir).
+    ``None`` falls back to the global ``cfg.lancedb_dir``.
+
+    ``timeout`` is the total budget for both stages: the time spent waiting on
+    the file lock is deducted before waiting on the mutex, so a 30s request
+    cannot stall ~60s.
+    """
+    deadline = time.monotonic() + timeout
+    flock = FileLock(_lock_path(lancedb_dir))
     try:
         flock.acquire(timeout=timeout)
     except FileLockTimeout:
         raise LockTimeoutError("Timed out waiting for exclusive file lock") from None
     try:
-        acquired = _write_mutex.acquire(timeout=timeout)
+        remaining = max(0.0, deadline - time.monotonic())
+        acquired = _write_mutex.acquire(timeout=remaining)
         if not acquired:
             raise LockTimeoutError("Timed out waiting for write lock")
         try:

--- a/src/lilbee/runtime/lock.py
+++ b/src/lilbee/runtime/lock.py
@@ -22,6 +22,9 @@ log = logging.getLogger(__name__)
 
 # Default timeout (seconds) for acquiring the write lock
 LOCK_TIMEOUT = 30.0
+# Minimum blocking wait granted to the in-process mutex even when the file lock
+# consumed the whole budget, so a deadline-edge acquire still gets a real attempt.
+_MUTEX_MIN_WAIT = 0.1
 
 
 class LockTimeoutError(TimeoutError):
@@ -62,7 +65,10 @@ def write_lock(
     except FileLockTimeout:
         raise LockTimeoutError("Timed out waiting for exclusive file lock") from None
     try:
-        remaining = max(0.0, deadline - time.monotonic())
+        # Floor the mutex budget so a file lock that wins right at the deadline
+        # still gets a brief blocking attempt instead of a zero-timeout poll that
+        # spuriously fails when another thread holds the mutex for an instant.
+        remaining = max(_MUTEX_MIN_WAIT, deadline - time.monotonic())
         acquired = _write_mutex.acquire(timeout=remaining)
         if not acquired:
             raise LockTimeoutError("Timed out waiting for write lock")

--- a/src/lilbee/wiki/lint.py
+++ b/src/lilbee/wiki/lint.py
@@ -32,6 +32,11 @@ from lilbee.wiki.shared import (
 
 _ORPHAN_CANDIDATE_SUBDIRS: tuple[str, ...] = (WikiSubdir.CONCEPTS, WikiSubdir.ENTITIES)
 
+# Subdirs whose links don't count as "published" backlinks for orphan detection:
+# a [[slug]] living only in a draft or an archived page must not exempt a live
+# concept/entity page from the orphan flag.
+_UNPUBLISHED_SUBDIRS: tuple[str, ...] = (WikiSubdir.DRAFTS, WikiSubdir.ARCHIVE)
+
 log = logging.getLogger(__name__)
 
 
@@ -277,12 +282,16 @@ def _lint_orphans(wiki_root: Path, config: Config) -> list[LintIssue]:
     referenced: set[str] = set()
     candidates: list[Path] = []
     candidate_roots = {wiki_root / sub for sub in _ORPHAN_CANDIDATE_SUBDIRS}
+    unpublished_roots = {wiki_root / sub for sub in _UNPUBLISHED_SUBDIRS}
     for md_path in wiki_root.rglob("*.md"):
-        text = md_path.read_text(encoding="utf-8", errors="replace")
-        for match in WIKI_LINK_RE.finditer(text):
-            slug = match.group(1).split("|", 1)[0].strip().lower()
-            if slug:
-                referenced.add(slug)
+        # Only published pages contribute backlinks; a link from a draft or an
+        # archived page must not keep a live concept/entity page off the orphan list.
+        if not any(root in md_path.parents for root in unpublished_roots):
+            text = md_path.read_text(encoding="utf-8", errors="replace")
+            for match in WIKI_LINK_RE.finditer(text):
+                slug = match.group(1).split("|", 1)[0].strip().lower()
+                if slug:
+                    referenced.add(slug)
         if any(root in md_path.parents for root in candidate_roots):
             candidates.append(md_path)
 

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -718,14 +718,10 @@ class TestRebuildClusters:
         mock_svc.store.open_table.return_value = mock_table
         cg.rebuild_clusters()
 
-    @patch("lilbee.runtime.lock.write_lock")
-    @patch("lilbee.data.store.ensure_table")
     @patch("lilbee.retrieval.concepts.graph._leiden_partition")
-    def test_rebuild_with_edges(self, mock_leiden, mock_ensure, mock_lock, cg, mock_svc):
+    def test_rebuild_with_edges(self, mock_leiden, cg, mock_svc):
         import pyarrow as pa
 
-        mock_lock.return_value.__enter__ = MagicMock()
-        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
         mock_table = MagicMock()
         edge_rows = [
             {"source": "python", "target": "ml", "weight": 2.0},
@@ -739,17 +735,17 @@ class TestRebuildClusters:
             }
         )
         mock_svc.store.open_table.return_value = mock_table
-        mock_svc.store.get_db.return_value = MagicMock()
         mock_leiden.return_value = (
             {"python": 0, "ml": 0, "deep learning": 1},
             {"python": 1, "ml": 2, "deep learning": 1},
         )
-        mock_nodes_table = MagicMock()
-        mock_ensure.return_value = mock_nodes_table
 
         cg.rebuild_clusters()
         mock_leiden.assert_called_once_with(edge_rows)
-        mock_nodes_table.add.assert_called_once()
+        # Nodes are replaced atomically (delete+add under one lock), not a bare add.
+        mock_svc.store.clear_and_add.assert_called_once()
+        node_records = mock_svc.store.clear_and_add.call_args.args[2]
+        assert {r["concept"] for r in node_records} == {"python", "ml", "deep learning"}
 
     @patch("lilbee.runtime.lock.write_lock")
     @patch("lilbee.data.store.ensure_table")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -183,3 +183,30 @@ class TestImportDataset:
         test_config.embedding_model = "ollama/other-model:v1"
         with pytest.raises(EmbeddingModelMismatchError):
             await import_dataset(store, [_page("doc.pdf", 1, "body")])
+
+    async def test_import_uses_single_atomic_batch_write(self, services, monkeypatch):
+        # bb-ziks.27: each source must be written via one locked write_chunks_batch
+        # (cleanup + chunks + page texts + source row), not four separate unlocked
+        # writes that could destroy the source if one fails mid-way.
+        store = services
+        batch_calls = 0
+        real_batch = store.write_chunks_batch
+
+        def counting_batch(items):
+            nonlocal batch_calls
+            batch_calls += 1
+            return real_batch(items)
+
+        legacy: list[str] = []
+        monkeypatch.setattr(store, "write_chunks_batch", counting_batch)
+        monkeypatch.setattr(store, "delete_by_source", lambda *a, **k: legacy.append("delete"))
+        monkeypatch.setattr(store, "add_chunks", lambda *a, **k: legacy.append("add_chunks"))
+        monkeypatch.setattr(store, "add_page_texts", lambda *a, **k: legacy.append("page_texts"))
+        monkeypatch.setattr(store, "upsert_source", lambda *a, **k: legacy.append("upsert"))
+
+        await import_dataset(store, [_page("doc.pdf", 1, "body")])
+
+        assert batch_calls == 1
+        assert legacy == []  # none of the old per-op unlocked writes were used
+        # The atomic write still landed the source as IMPORTED.
+        assert store.get_sources()[0]["source_type"] == SourceType.IMPORTED

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -399,12 +399,37 @@ class TestSync:
         updated: dict[str, None] = {}
         failed: dict[str, None] = {}
         flush_failed: set[str] = set()
-        pipeline._flush_writes(buffer, added, updated, failed, flush_failed)
+        pipeline._flush_writes(buffer, added, updated, failed, {}, flush_failed)
 
         assert added == {}
         assert list(failed) == ["a.txt"]
         assert flush_failed == {"a.txt"}
         assert buffer == []
+
+    def test_flush_failure_drops_page_text_only_file_from_skipped(self, _mock_extract_file):
+        # A page-text-only file is pre-marked skipped at classification but still
+        # buffered; if the flush fails it must end up in failed only, never both.
+        from lilbee.app.services import get_services
+        from lilbee.data.ingest import pipeline
+        from lilbee.data.ingest.types import _IngestResult
+
+        get_services().store.write_chunks_batch.side_effect = RuntimeError("disk full")
+        result = _IngestResult(
+            name="blank.pdf",
+            path=Path("blank.pdf"),
+            chunk_count=0,
+            error=None,
+            file_hash="h",
+            records=[],
+            needs_cleanup=True,
+            page_texts=[{"source": "blank.pdf", "page": 1, "text": " ", "content_type": "pdf"}],
+        )
+        skipped: dict[str, None] = {"blank.pdf": None}
+        failed: dict[str, None] = {}
+        pipeline._flush_writes([result], {}, {}, failed, skipped, set())
+
+        assert list(failed) == ["blank.pdf"]
+        assert "blank.pdf" not in skipped  # not double-listed
 
     def test_flush_writes_retries_once_on_lock_timeout(self, _mock_extract_file, monkeypatch):
         # A LockTimeoutError on the first write is retried after a short backoff;
@@ -431,7 +456,7 @@ class TestSync:
         added: dict[str, None] = {"a.txt": None}
         failed: dict[str, None] = {}
         flush_failed: set[str] = set()
-        pipeline._flush_writes([result], added, {}, failed, flush_failed)
+        pipeline._flush_writes([result], added, {}, failed, {}, flush_failed)
 
         assert store.write_chunks_batch.call_count == 2
         assert sleeps == [pipeline._FLUSH_RETRY_DELAY_SECONDS]
@@ -464,7 +489,7 @@ class TestSync:
         added: dict[str, None] = {"a.txt": None}
         failed: dict[str, None] = {}
         flush_failed: set[str] = set()
-        pipeline._flush_writes([result], added, {}, failed, flush_failed)
+        pipeline._flush_writes([result], added, {}, failed, {}, flush_failed)
 
         assert list(failed) == ["a.txt"]
         assert flush_failed == {"a.txt"}
@@ -497,11 +522,11 @@ class TestSync:
 
         store = _install_real_store()
         result = _real_ingest_result("a.pdf", file_hash="h1")
-        pipeline._flush_writes([result], {"a.pdf": None}, {}, {}, set())
+        pipeline._flush_writes([result], {"a.pdf": None}, {}, {}, {}, set())
         assert [row["text"] for row in store.get_page_texts("a.pdf")] == ["page one of a.pdf"]
 
         replanned = _real_ingest_result("a.pdf", file_hash="h2", page_text="page one, edited")
-        pipeline._flush_writes([replanned], {"a.pdf": None}, {}, {}, set())
+        pipeline._flush_writes([replanned], {"a.pdf": None}, {}, {}, {}, set())
         assert [row["text"] for row in store.get_page_texts("a.pdf")] == ["page one, edited"]
         sources = {s["filename"]: s for s in store.get_sources()}
         assert sources["a.pdf"]["file_hash"] == "h2"
@@ -519,7 +544,7 @@ class TestSync:
         store = _install_real_store()
         old_stat = SourceStat(11, 22, 33)
         first = _real_ingest_result("a.pdf", file_hash="h1", stat=old_stat)
-        pipeline._flush_writes([first], {"a.pdf": None}, {}, {}, set())
+        pipeline._flush_writes([first], {"a.pdf": None}, {}, {}, {}, set())
 
         real_ensure = core_mod.ensure_table
 
@@ -535,7 +560,7 @@ class TestSync:
         failed: dict[str, None] = {}
         flush_failed: set[str] = set()
         with mock.patch.object(core_mod, "ensure_table", _failing_ensure):
-            pipeline._flush_writes([replanned], added, {}, failed, flush_failed)
+            pipeline._flush_writes([replanned], added, {}, failed, {}, flush_failed)
 
         assert added == {}
         assert list(failed) == ["a.pdf"]
@@ -1173,7 +1198,7 @@ class TestStatShortCircuit:
             needs_cleanup=True,
         )
         failed: dict[str, None] = {}
-        pipeline._flush_writes([result], {"a.txt": None}, {}, failed)
+        pipeline._flush_writes([result], {"a.txt": None}, {}, failed, {})
         assert list(failed) == ["a.txt"]
 
     def test_changed_content_reprocessed_with_stat(self, isolated_env):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1400,9 +1400,10 @@ class TestClassifyResult:
         assert "scanned.pdf" not in failed
         assert "scanned.pdf" in skipped
 
-    def test_zero_chunks_with_page_texts_stays_for_flush(self):
-        # Whitespace-only OCR: no chunks, but the pages and source row must
-        # persist so the file stops replanning, so the result stays INGESTED.
+    def test_zero_chunks_with_page_texts_persists_but_counts_skipped(self):
+        # Whitespace-only OCR: no searchable chunks, so it is reported as skipped
+        # (bb-7jg1.11), but the pages and source row must still persist (it stops
+        # replanning), so the status stays INGESTED for the batched flush.
         from lilbee.data.ingest.pipeline import _classify_result
         from lilbee.data.ingest.types import _IngestResult
         from lilbee.runtime.progress import BatchStatus
@@ -1417,8 +1418,8 @@ class TestClassifyResult:
             page_texts=[{"source": "blank.pdf", "page": 1, "text": " ", "content_type": "pdf"}],
         )
         assert _classify_result(result, added, {}, {}, skipped) is BatchStatus.INGESTED
-        assert "blank.pdf" in added
-        assert "blank.pdf" not in skipped
+        assert "blank.pdf" not in added  # not counted as added: search can't see it
+        assert "blank.pdf" in skipped
 
     def test_nonzero_chunks_stay_for_flush(self):
         # A successful file is reported INGESTED and left in added; persistence

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -933,8 +933,10 @@ class TestZeroChunkPageTextPersistence:
             "lilbee.data.ingest.pipeline._produce_records", side_effect=self._pages_no_chunks
         ):
             first = await sync(quiet=True)
-            assert "blank.pdf" in first.added
-            assert "blank.pdf" not in first.skipped
+            # 0 searchable chunks: reported as skipped, not added (bb-7jg1.11) ...
+            assert "blank.pdf" not in first.added
+            assert "blank.pdf" in first.skipped
+            # ... but its page text and source row still persist (one atomic write).
             items = mock_svc.store.write_chunks_batch.call_args.args[0]
             item = next(it for it in items if it.source == "blank.pdf")
             assert item.records == []
@@ -966,7 +968,9 @@ class TestZeroChunkPageTextPersistence:
             ) as flush_spy,
         ):
             result = await sync(quiet=True)
-        assert len(result.added) == 3
+        # Zero searchable chunks -> reported skipped, but still buffered/flushed.
+        assert len(result.skipped) == 3
+        assert not result.added
         assert flush_spy.call_count >= 2
 
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -104,6 +104,62 @@ class TestWriteLock:
 
     def test_lock_file_created(self):
         """Lock file is created at the expected path."""
-        expected = _lock_path()
+        expected = _lock_path(None)
         with write_lock(timeout=2):
             assert expected.exists()
+
+    def test_lock_path_uses_passed_dir(self, tmp_path):
+        """A passed lancedb_dir keys the lock file; None falls back to cfg."""
+        other = tmp_path / "other_db"
+        assert _lock_path(other) == other / ".lock"
+        assert _lock_path(None) == cfg.lancedb_dir / ".lock"
+
+    def test_write_lock_targets_passed_dir(self, tmp_path):
+        """write_lock(dir) creates the lock file under that dir, not cfg's.
+
+        A per-instance store writes to its own lancedb_dir; the file lock must
+        live there or cross-process writers never coordinate.
+        """
+        other = tmp_path / "other_db"
+        other.mkdir()
+        with write_lock(other, timeout=2):
+            assert (other / ".lock").exists()
+        assert not (cfg.lancedb_dir / ".lock").exists()
+
+    def test_timeout_budget_is_split_across_stages(self, monkeypatch, tmp_path):
+        """The file-lock wait is deducted from the mutex wait (single budget).
+
+        Previously each stage got the full timeout, so a 30s request could stall
+        ~60s. The mutex must receive only the budget the file lock left.
+        """
+        from filelock import FileLock
+
+        import lilbee.runtime.lock as lockmod
+
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(lockmod.time, "monotonic", lambda: clock["t"])
+
+        class FakeMutex:
+            def __init__(self) -> None:
+                self.captured: float | None = None
+
+            def acquire(self, timeout: float = -1) -> bool:
+                self.captured = timeout
+                return True
+
+            def release(self) -> None: ...
+
+        fake = FakeMutex()
+        monkeypatch.setattr(lockmod, "_write_mutex", fake)
+
+        real_flock_acquire = FileLock.acquire
+
+        def slow_flock_acquire(self, timeout=None, **kw):
+            clock["t"] += 22.0  # the file lock consumed 22s of the budget
+            return real_flock_acquire(self, timeout=timeout, **kw)
+
+        monkeypatch.setattr(FileLock, "acquire", slow_flock_acquire)
+
+        with write_lock(tmp_path, timeout=30.0):
+            pass
+        assert fake.captured == pytest.approx(8.0, abs=0.5)  # 30 - 22 remaining

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -53,6 +53,17 @@ def _make_records(n=3, dim=None, chunk_type="raw"):
     ]
 
 
+class TestWriteLockDir:
+    def test_write_lock_keys_on_store_config_dir(self, store, test_config):
+        """A per-instance store locks its own lancedb_dir, not the global cfg dir."""
+        from lilbee.core.config import cfg as global_cfg
+
+        assert test_config.lancedb_dir != global_cfg.lancedb_dir
+        test_config.lancedb_dir.mkdir(parents=True, exist_ok=True)
+        with store._write_lock(timeout=2):
+            assert (test_config.lancedb_dir / ".lock").exists()
+
+
 class TestEnsureFtsIndex:
     def test_noop_when_no_table(self, store):
         store.ensure_fts_index()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -64,6 +64,38 @@ class TestWriteLockDir:
             assert (test_config.lancedb_dir / ".lock").exists()
 
 
+class TestClearAndAdd:
+    def test_replaces_rows_atomically(self, store):
+        import pyarrow as pa
+
+        schema = pa.schema([pa.field("concept", pa.utf8()), pa.field("n", pa.int64())])
+        store.clear_and_add("t_demo", schema, [{"concept": "a", "n": 1}], "concept IS NOT NULL")
+        store.clear_and_add("t_demo", schema, [{"concept": "b", "n": 2}], "concept IS NOT NULL")
+        rows = store.open_table("t_demo").search().to_list()
+        assert {r["concept"] for r in rows} == {"b"}  # old row replaced, not appended
+
+    def test_holds_lock_across_delete_and_add(self, store, monkeypatch):
+        import pyarrow as pa
+
+        from lilbee.runtime.lock import _write_mutex
+
+        schema = pa.schema([pa.field("concept", pa.utf8())])
+        store.clear_and_add("t_lock", schema, [{"concept": "seed"}], "concept IS NOT NULL")
+
+        locked_during: list[bool] = []
+        import lilbee.data.store.core as core_mod
+
+        real = core_mod._safe_delete_unlocked
+
+        def spy_delete(table, predicate):
+            locked_during.append(_write_mutex.locked())
+            return real(table, predicate)
+
+        monkeypatch.setattr(core_mod, "_safe_delete_unlocked", spy_delete)
+        store.clear_and_add("t_lock", schema, [{"concept": "next"}], "concept IS NOT NULL")
+        assert locked_during == [True]  # delete ran under the write lock
+
+
 class TestEnsureFtsIndex:
     def test_noop_when_no_table(self, store):
         store.ensure_fts_index()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -95,6 +95,19 @@ class TestClearAndAdd:
         store.clear_and_add("t_lock", schema, [{"concept": "next"}], "concept IS NOT NULL")
         assert locked_during == [True]  # delete ran under the write lock
 
+    def test_skips_add_when_delete_fails(self, store, monkeypatch):
+        import pyarrow as pa
+
+        import lilbee.data.store.core as core_mod
+
+        schema = pa.schema([pa.field("concept", pa.utf8())])
+        store.clear_and_add("t_fail", schema, [{"concept": "old"}], "concept IS NOT NULL")
+        # A failed delete must not add the new rows (would duplicate the stale ones).
+        monkeypatch.setattr(core_mod, "_safe_delete_unlocked", lambda table, predicate: False)
+        store.clear_and_add("t_fail", schema, [{"concept": "new"}], "concept IS NOT NULL")
+        rows = store.open_table("t_fail").search().to_list()
+        assert {r["concept"] for r in rows} == {"old"}  # unchanged; new rows not added
+
 
 class TestEnsureFtsIndex:
     def test_noop_when_no_table(self, store):

--- a/tests/test_store_memory.py
+++ b/tests/test_store_memory.py
@@ -360,6 +360,22 @@ class TestRebuildEmbeddings:
         got = store.get_memories(owner_predicate=LOCAL_PREDICATE)[0]
         assert got.vector[3] == 1.0
 
+    def test_snapshot_and_embed_run_under_write_lock(self, store):
+        # bb-ziks.7: the read+embed must hold the lock, or a concurrent add_memory
+        # committing in the embed window is erased by the unconditional drop_table.
+        from lilbee.runtime.lock import _write_mutex
+
+        store.add_memory(_memory(store, text="x", axis=0))
+        dim = store._config.embedding_dim
+        locked_during: list[bool] = []
+
+        def embed(texts: list[str]) -> list[list[float]]:
+            locked_during.append(_write_mutex.locked())
+            return [_unit_vector(dim, 3) for _ in texts]
+
+        store.rebuild_memory_embeddings(embed)
+        assert locked_during == [True]  # embed ran while the write lock was held
+
 
 class TestEmbeddingCompat:
     def test_add_after_model_change_raises(self, store):

--- a/tests/test_wiki_lint.py
+++ b/tests/test_wiki_lint.py
@@ -277,6 +277,34 @@ class TestOrphanDetection:
         ]
         assert orphan_issues == []
 
+    def test_link_only_from_draft_does_not_exempt_orphan(self, tmp_path: Path):
+        # bb-ziks.78: a [[slug]] living only in a draft must not keep the live
+        # concept page off the orphan list (no published page links it).
+        write_wiki_page(tmp_path, "concepts", "braking", "# Braking\n\nText.\n")
+        write_wiki_page(tmp_path, "drafts", "wip", "Mentions [[braking]] but unpublished.\n")
+        store = MagicMock(spec=Store)
+        store.get_citations_for_wiki.return_value = []
+        report = lint_all(store)
+        orphan_slugs = {
+            i.wiki_source
+            for i in report.issues
+            if i.issue_type is not None and i.issue_type.value == "orphan"
+        }
+        assert "wiki/concepts/braking.md" in orphan_slugs
+
+    def test_link_only_from_archive_does_not_exempt_orphan(self, tmp_path: Path):
+        write_wiki_page(tmp_path, "concepts", "braking", "# Braking\n\nText.\n")
+        write_wiki_page(tmp_path, "archive", "old", "Mentions [[braking]].\n")
+        store = MagicMock(spec=Store)
+        store.get_citations_for_wiki.return_value = []
+        report = lint_all(store)
+        orphan_slugs = {
+            i.wiki_source
+            for i in report.issues
+            if i.issue_type is not None and i.issue_type.value == "orphan"
+        }
+        assert "wiki/concepts/braking.md" in orphan_slugs
+
     def test_entity_page_with_incoming_link_is_not_orphan(self, tmp_path: Path):
         write_wiki_page(tmp_path, "entities", "henry-ford", "# Henry Ford\n\nText.\n")
         write_wiki_page(


### PR DESCRIPTION
## Problem

The store has no multi-statement transactions, and several write paths read, computed, and wrote in separate locked steps. Under the always-on server that opens a window where a failure or a concurrent client leaves the index half-updated:

- Importing a dataset deleted a source's old rows, then added the new chunks, page texts, and source row as four separate locked writes. A failure after the delete (or a reader mid-sequence) saw the source's data gone.
- Re-embedding memories read and embedded the rows before taking the lock, then dropped and recreated the table. A memory added in that window was silently erased.
- Rebuilding concept clusters cleared the nodes table in one locked step and re-added in another, so readers briefly saw no clusters while the graph still reported present.
- The write lock was always built from the global config directory, so a per-instance engine pointed at its own data directory locked the wrong file and got no cross-process coordination. The single lock timeout was also applied twice in sequence, so a request could stall for roughly double.

Two smaller reporting issues rode along: a file that extracts page text but no searchable chunks was counted as added even though search can't see it, and the wiki orphan linter treated links inside drafts and archived pages as real backlinks.

## Solution

Import now writes each source through the same single-locked transaction the ingest path uses, with the embedding checks running before the delete. Memory re-embedding snapshots, embeds, and rebuilds entirely under the lock. Cluster rebuild replaces the nodes table via a new delete-and-add-under-one-lock helper. The write lock is keyed on each store's own data directory and shares one timeout budget across its two stages. The search-invisible file is reported as skipped while still persisting its page text, and the orphan linter only counts backlinks from published pages.

All changed paths keep full test coverage, including the atomicity and locking behaviors.
