### PR TITLE
Fix 8 dependency security findings (crawl4ai, pydantic-settings)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,14 +53,14 @@ dependencies = [
     "gguf>=0.18",
     "huggingface_hub>=1.11.0",
     "psutil>=5.9",
-    "pydantic-settings>=2.13.1",
+    "pydantic-settings>=2.14.2",
     "numpy",
 ]
 
 [project.optional-dependencies]
 litellm = ["litellm>=1.84.0"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
-crawler = ["crawl4ai>=0.8.9"]
+crawler = ["crawl4ai>=0.9.0"]
 release = ["lilbee[crawler,litellm,graph]"]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -669,7 +669,7 @@ toml = [
 
 [[package]]
 name = "crawl4ai"
-version = "0.8.9"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -706,9 +706,9 @@ dependencies = [
     { name = "unclecode-litellm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2b/9e2b376ec8d4b803cc7b47b428a0ac762c59ce1215d0ab5a4aa9e7afc4a3/crawl4ai-0.8.9.tar.gz", hash = "sha256:00a3c97b9492a694f24fa66bc80b9f1533e5637745dc0e30914c88aac52763e3", size = 608119 }
+sdist = { url = "https://files.pythonhosted.org/packages/52/37/9b288598bb0049b918eeb00f029592c748465c8a3e819461e95d8b5f9dab/crawl4ai-0.9.0.tar.gz", hash = "sha256:00c1c3516d9ca24a9b5004523ae67974ace8a5baadc6e92e295afca73f077153", size = 591734 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/97/6443bf99add1c16b16d992b8d0816a3ce7adecde37323d368bed36dd0aff/crawl4ai-0.8.9-py3-none-any.whl", hash = "sha256:7836cfc9d81ed7fc646d614e984402c336e5a682462f3d92ff37de121a4244d6", size = 516731 },
+    { url = "https://files.pythonhosted.org/packages/c9/19/2d634f26d9ad1281874c503c1043174042fef9af631dc10798f4f22c1544/crawl4ai-0.9.0-py3-none-any.whl", hash = "sha256:1296072d9cd92e79144c6823ed6f27ab3966f16ce44e79fcbe86943b3435c366", size = 499084 },
 ]
 
 [[package]]
@@ -1660,7 +1660,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "crawl4ai", marker = "extra == 'crawler'", specifier = ">=0.8.9" },
+    { name = "crawl4ai", marker = "extra == 'crawler'", specifier = ">=0.9.0" },
     { name = "diskcache", specifier = ">=5.6.1" },
     { name = "filelock" },
     { name = "gguf", specifier = ">=0.18" },
@@ -1678,7 +1678,7 @@ requires-dist = [
     { name = "numpy" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "psutil", specifier = ">=5.9" },
-    { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "spacy", marker = "extra == 'graph'", specifier = ">=3.8" },
     { name = "textual", specifier = ">=0.75" },
     { name = "tiktoken" },
@@ -2937,16 +2937,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826 }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929 },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

GitHub flagged 8 open security findings (4 advisories, each surfaced on both the Dependabot and Code scanning tabs):

| Advisory | Package | Severity |
|---|---|---|
| GHSA-2jq4-q6vv-4cp3 | crawl4ai | critical (path-traversal write -> RCE) |
| GHSA-r253-r9jw-qg44 | crawl4ai | critical (launch-arg injection -> RCE) |
| GHSA-wm69-2pc3-rmmf | crawl4ai | high (SSRF on /crawl/stream) |
| GHSA-4xgf-cpjx-pc3j | pydantic-settings | medium (symlink read outside secrets_dir) |

crawl4ai accounts for 6 findings (3 advisories x Dependabot + Code scanning), pydantic-settings for 2.

## Solution

Bump the constraints past the patched versions and relock: crawl4ai `>=0.9.0` (was `>=0.8.9`) and pydantic-settings `>=2.14.2` (was `>=2.13.1`). The lockfile updates only those two packages and their hashes, no transitive churn. `uv lock --check` is clean.