### PR TITLE
Render the README logo on PyPI via an absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://lilbee.sh/">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="docs/lilbee-logo-dark.svg">
-      <img alt="lilbee" src="docs/lilbee-logo-light.svg" width="340">
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tobocop2/lilbee/main/docs/lilbee-logo-dark.svg">
+      <img alt="lilbee" src="https://raw.githubusercontent.com/tobocop2/lilbee/main/docs/lilbee-logo-light.svg" width="340">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
## Problem

The header logo uses a repo-relative path (`docs/lilbee-logo-*.svg`). GitHub resolves it, but PyPI can't, so the logo shows broken on the project page.

## Solution

Point the logo `<source>`/`<img>` at the raw GitHub URL, the same absolute-reference pattern the demo GIFs already use. Raw GitHub serves the SVGs as `image/svg+xml`, so they render on PyPI like the existing SVG badges.