### PR TITLE
Release streams, clients, subprocesses, and locks on every path

### DIFF
--- a/src/lilbee/app/models.py
+++ b/src/lilbee/app/models.py
@@ -354,6 +354,17 @@ def pull_model_data(
     )
 
 
+def _legacy_disk_size(ref: str, *, fallback: int) -> int:
+    """Sum a split GGUF's shard sizes on disk; *fallback* on any failure/single file."""
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        shards = get_services().registry.shard_paths(ref)
+        if len(shards) > 1:
+            return sum(path.stat().st_size for path in shards)
+    return fallback
+
+
 def remove_model_data(
     ref: str,
     source: ModelSource | None = None,
@@ -363,7 +374,12 @@ def remove_model_data(
     manifests = _native_manifest_index()
     # disk_size_bytes is the full multi-shard total; size_bytes alone would report
     # only the first shard for a split GGUF.
-    size_bytes = manifests[ref].disk_size_bytes if ref in manifests else 0
+    manifest = manifests.get(ref)
+    size_bytes = manifest.disk_size_bytes if manifest is not None else 0
+    if manifest is not None and manifest.total_size_bytes is None:
+        # Legacy manifest without shard accounting: removal still frees every
+        # shard, so recover the true on-disk total from the shards for the report.
+        size_bytes = _legacy_disk_size(ref, fallback=size_bytes)
     removed = manager.remove(ref, source=source)
     return RemoveResult(
         model=ref,

--- a/src/lilbee/app/models.py
+++ b/src/lilbee/app/models.py
@@ -73,7 +73,7 @@ class ModelEntry(BaseModel):
             name=ref,
             source=ModelSource.NATIVE.value,
             task=manifest.task if manifest else None,
-            size_gb=_bytes_to_gb(manifest.size_bytes) if manifest else None,
+            size_gb=_bytes_to_gb(manifest.disk_size_bytes) if manifest else None,
             display_name=clean_display_name(manifest.hf_repo) if manifest else "",
         )
 
@@ -146,8 +146,8 @@ class ManifestData(BaseModel):
             ref=manifest.ref,
             display_name=clean_display_name(manifest.hf_repo),
             task=manifest.task,
-            size_gb=_bytes_to_gb(manifest.size_bytes),
-            size_bytes=manifest.size_bytes,
+            size_gb=_bytes_to_gb(manifest.disk_size_bytes),
+            size_bytes=manifest.disk_size_bytes,
             hf_repo=manifest.hf_repo,
             gguf_filename=manifest.gguf_filename,
             downloaded_at=manifest.downloaded_at,

--- a/src/lilbee/app/models.py
+++ b/src/lilbee/app/models.py
@@ -361,7 +361,9 @@ def remove_model_data(
     """Remove *ref* and return a typed result with freed size."""
     manager = get_services().model_manager
     manifests = _native_manifest_index()
-    size_bytes = manifests[ref].size_bytes if ref in manifests else 0
+    # disk_size_bytes is the full multi-shard total; size_bytes alone would report
+    # only the first shard for a split GGUF.
+    size_bytes = manifests[ref].disk_size_bytes if ref in manifests else 0
     removed = manager.remove(ref, source=source)
     return RemoveResult(
         model=ref,

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -178,7 +178,11 @@ def download_model(
         if len(shards) > 1
         else []
     )
-    grand_total = sum(shard_sizes) if shard_sizes and all(size > 0 for size in shard_sizes) else 0
+    grand_total = (
+        sum(shard_sizes)
+        if shard_sizes and all(size != _SIZE_UNKNOWN for size in shard_sizes)
+        else 0
+    )
     tracker = _ProgressTracker(on_progress, grand_total=grand_total) if on_progress else None
     shard_paths: list[Path] = []
     for shard in shards:

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -170,12 +170,15 @@ def download_model(
         return _finalize_download(entry, dest, on_progress=on_progress, on_complete=on_complete)
 
     # Sum the shard sizes up front so a multi-shard pull reports one monotonic
-    # 0->100% against the real total, not N separate per-shard cycles.
-    grand_total = (
-        sum(fetch_expected_file_size(entry.hf_repo, shard) for shard in shards)
+    # 0->100% against the real total, not N separate per-shard cycles. Only use
+    # the sum when every shard size is known (0 = unresolved/offline); a partial
+    # sum would undercount the total and let progress run past 100%.
+    shard_sizes = (
+        [fetch_expected_file_size(entry.hf_repo, shard) for shard in shards]
         if len(shards) > 1
-        else 0
+        else []
     )
+    grand_total = sum(shard_sizes) if shard_sizes and all(size > 0 for size in shard_sizes) else 0
     tracker = _ProgressTracker(on_progress, grand_total=grand_total) if on_progress else None
     shard_paths: list[Path] = []
     for shard in shards:

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -165,11 +165,18 @@ def download_model(
     ):
         log.info("Model already downloaded: %s", dest)
         if on_progress is not None:
-            size = dest.stat().st_size
-            on_progress(size, size)  # Report 100% immediately
+            size = sum((models_dir / shard).stat().st_size for shard in shards)
+            on_progress(size, size)  # Report 100% immediately (every shard)
         return _finalize_download(entry, dest, on_progress=on_progress, on_complete=on_complete)
 
-    tracker = _ProgressTracker(on_progress) if on_progress else None
+    # Sum the shard sizes up front so a multi-shard pull reports one monotonic
+    # 0->100% against the real total, not N separate per-shard cycles.
+    grand_total = (
+        sum(fetch_expected_file_size(entry.hf_repo, shard) for shard in shards)
+        if len(shards) > 1
+        else 0
+    )
+    tracker = _ProgressTracker(on_progress, grand_total=grand_total) if on_progress else None
     shard_paths: list[Path] = []
     for shard in shards:
         log.info("Downloading %s/%s → %s", entry.hf_repo, shard, models_dir)
@@ -180,14 +187,17 @@ def download_model(
             cache_dir=str(models_dir),
             tqdm_class=tracker.make_tqdm_class() if tracker else None,
         )
-        shard_paths.append(_hf_download_or_translate(entry, config))
+        shard_path = _hf_download_or_translate(entry, config)
+        shard_paths.append(shard_path)
+        if tracker is not None:
+            tracker.shard_done(shard_path.stat().st_size)
     first_shard_path = shard_paths[0]  # the 00001-of-N shard llama.cpp loads from
 
     if on_progress:
-        actual_size = first_shard_path.stat().st_size
+        total_size = sum(path.stat().st_size for path in shard_paths)
         if not tracker or not tracker.was_used:
             log.info("Model found in HuggingFace cache: %s", first_shard_path)
-        on_progress(actual_size, actual_size)
+        on_progress(total_size, total_size)
     return _finalize_download(
         entry, first_shard_path, on_progress=on_progress, on_complete=on_complete
     )

--- a/src/lilbee/catalog/download_progress.py
+++ b/src/lilbee/catalog/download_progress.py
@@ -76,7 +76,9 @@ def make_download_callback(
 
 
 class _CallbackProgressBar(_base_tqdm):
-    """tqdm subclass that forwards progress to a plain callback.
+    """tqdm subclass that suppresses terminal output and tracks cumulative bytes.
+
+    The _ProgressTracker subclass forwards that progress to a callback.
     Fully suppresses terminal output by disabling tqdm rendering and redirecting
     its file handle to a devnull sink: prevents ANSI escape sequences from leaking
     into Textual's managed terminal.
@@ -89,7 +91,6 @@ class _CallbackProgressBar(_base_tqdm):
     """
 
     _lock = threading.RLock()
-    _callback: Any = None
 
     @classmethod
     def get_lock(cls) -> threading.RLock:
@@ -102,10 +103,10 @@ class _CallbackProgressBar(_base_tqdm):
         self._cumulative = 0
 
     def update(self, n: float = 1) -> bool | None:
+        # The base only tracks cumulative bytes and suppresses output; forwarding
+        # to the callback (with split-shard aggregation) lives in the
+        # _ProgressTracker subclass below.
         self._cumulative += int(n)
-        if self._callback is not None:
-            total = self.total if self.total is not None else 0
-            self._callback(int(self._cumulative), int(total))
         return None
 
 

--- a/src/lilbee/catalog/download_progress.py
+++ b/src/lilbee/catalog/download_progress.py
@@ -2,9 +2,10 @@
 
 The TUI runs under Textual which owns the terminal; tqdm output to
 stderr/stdout corrupts the screen. This module provides a tqdm subclass
-(``_CallbackProgressBar``) that suppresses terminal output and forwards
-progress to a plain ``Callable[[int, int], None]`` callback. The
-``_ProgressTracker`` wrapper detects whether progress events actually
+(``_CallbackProgressBar``) that suppresses terminal output and tracks
+cumulative bytes; its ``_ProgressTracker`` subclass forwards progress to a
+plain ``Callable[[int, int], None]`` callback (aggregating across split
+shards) and detects whether progress events actually
 fired so the TUI can detect a cache-hit (no progress events) and render
 ``"already downloaded"`` instead of leaving the bar at 0%.
 

--- a/src/lilbee/catalog/download_progress.py
+++ b/src/lilbee/catalog/download_progress.py
@@ -3,9 +3,9 @@
 The TUI runs under Textual which owns the terminal; tqdm output to
 stderr/stdout corrupts the screen. This module provides a tqdm subclass
 (``_CallbackProgressBar``) that suppresses terminal output and tracks
-cumulative bytes; its ``_ProgressTracker`` subclass forwards progress to a
-plain ``Callable[[int, int], None]`` callback (aggregating across split
-shards) and detects whether progress events actually
+cumulative bytes; the ``_ProgressTracker`` wrapper produces a further subclass
+that forwards progress to a plain ``Callable[[int, int], None]`` callback
+(aggregating across split shards) and detects whether progress events actually
 fired so the TUI can detect a cache-hit (no progress events) and render
 ``"already downloaded"`` instead of leaving the bar at 0%.
 
@@ -79,7 +79,8 @@ def make_download_callback(
 class _CallbackProgressBar(_base_tqdm):
     """tqdm subclass that suppresses terminal output and tracks cumulative bytes.
 
-    The _ProgressTracker subclass forwards that progress to a callback.
+    ``_ProgressTracker`` produces a further subclass of this that forwards the
+    progress to a callback.
     Fully suppresses terminal output by disabling tqdm rendering and redirecting
     its file handle to a devnull sink: prevents ANSI escape sequences from leaking
     into Textual's managed terminal.

--- a/src/lilbee/catalog/download_progress.py
+++ b/src/lilbee/catalog/download_progress.py
@@ -110,20 +110,37 @@ class _CallbackProgressBar(_base_tqdm):
 
 
 class _ProgressTracker:
-    """Wraps a tqdm_class to detect whether progress updates actually fired."""
+    """Wraps a tqdm_class to detect updates and aggregate across split shards.
 
-    def __init__(self, callback: Any) -> None:
+    For a multi-shard GGUF, each shard gets its own tqdm. Reporting each shard's
+    own ``(done, total)`` would show N separate 0->100% cycles against the wrong
+    total; instead the tracker carries ``grand_total`` (all shards) and a
+    ``completed_base`` (bytes from finished shards), so the callback sees one
+    monotonic 0->100% over the whole download. ``grand_total`` of 0 means
+    single-file: fall back to the shard's own tqdm total (unchanged behavior).
+    """
+
+    def __init__(self, callback: Any, grand_total: int = 0) -> None:
         self.was_used = False
         self._callback = callback
+        self.grand_total = grand_total
+        self._completed_base = 0
+
+    def shard_done(self, shard_size: int) -> None:
+        """Roll a finished shard's bytes into the base for the next shard."""
+        self._completed_base += shard_size
 
     def make_tqdm_class(self) -> type[_base_tqdm]:
         tracker = self
 
         class _Cls(_CallbackProgressBar):
-            _callback = staticmethod(tracker._callback)
-
             def update(self, n: float = 1) -> bool | None:
                 tracker.was_used = True
-                return super().update(n)
+                self._cumulative += int(n)
+                done = tracker._completed_base + self._cumulative
+                shard_total = self.total if self.total is not None else 0
+                total = tracker.grand_total or (tracker._completed_base + shard_total)
+                tracker._callback(int(done), int(total))
+                return None
 
         return _Cls

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import re
 import sys
@@ -264,11 +265,16 @@ async def bootstrap_chromium(
     assert proc.stderr is not None  # noqa: S101
 
     stderr_tail: list[str] = []
-    await asyncio.gather(
-        _drain_stdout_to_progress(proc.stdout, on_progress),
-        _drain_stderr(proc.stderr, stderr_tail),
-    )
-    returncode = await proc.wait()
+    try:
+        await asyncio.gather(
+            _drain_stdout_to_progress(proc.stdout, on_progress),
+            _drain_stderr(proc.stderr, stderr_tail),
+        )
+        returncode = await proc.wait()
+    finally:
+        # On cancel (SSE client disconnect) or any error, don't leave the
+        # ~180MB chromium install running orphaned; terminate, then kill.
+        await _terminate_process(proc)
 
     if returncode != 0:
         tail = "\n".join(stderr_tail[-10:]) or f"exit code {returncode}"
@@ -276,3 +282,25 @@ async def bootstrap_chromium(
         raise CrawlerBrowserError(f"Chromium bootstrap failed (exit {returncode}): {tail}")
 
     _emit_setup_done(on_progress, success=True, error=None)
+
+
+_TERMINATE_TIMEOUT_S = 5.0
+
+
+async def _terminate_process(proc: asyncio.subprocess.Process) -> None:
+    """Terminate then kill *proc* if it is still running, and reap it.
+
+    Best-effort and re-cancel-safe: the waits are shielded so a second
+    cancellation while unwinding cannot leave the child orphaned.
+    """
+    if proc.returncode is not None:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        proc.terminate()
+    with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+        await asyncio.wait_for(asyncio.shield(proc.wait()), timeout=_TERMINATE_TIMEOUT_S)
+    if proc.returncode is None:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.shield(proc.wait())

--- a/src/lilbee/crawler/bootstrap.py
+++ b/src/lilbee/crawler/bootstrap.py
@@ -302,5 +302,7 @@ async def _terminate_process(proc: asyncio.subprocess.Process) -> None:
     if proc.returncode is None:
         with contextlib.suppress(ProcessLookupError):
             proc.kill()
-        with contextlib.suppress(asyncio.CancelledError):
-            await asyncio.shield(proc.wait())
+        # SIGKILL is uncatchable so the reap should be near-instant; cap it anyway
+        # so a wedged reap can't hang the cleanup path indefinitely.
+        with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+            await asyncio.wait_for(asyncio.shield(proc.wait()), timeout=_TERMINATE_TIMEOUT_S)

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -595,8 +595,6 @@ def _shard_accounting(first_shard_path: Path) -> tuple[int | None, list[str]]:
     name is its HF blob digest, so the shards are summed and the digests of
     shards 2..N collected for removal-time garbage collection.
     """
-    from lilbee.catalog.download import split_shard_filenames
-
     shard_names = split_shard_filenames(first_shard_path.name)
     if len(shard_names) <= 1:
         return None, []

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -15,7 +15,7 @@ import os
 import re
 import shutil
 import tempfile
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -94,14 +94,24 @@ class ModelManifest:
 
     hf_repo: str
     gguf_filename: str
-    size_bytes: int
+    size_bytes: int  # primary (first-shard) blob size; validated against the blob on disk
     task: ModelTask
     downloaded_at: str  # ISO 8601
     blob: str | None = None  # SHA-256 hex of the blob in the HF cache; None pre-install
+    # A split GGUF has further shard blobs beyond ``blob``. ``total_size_bytes``
+    # is the sum across every shard (None = single file, use ``size_bytes``);
+    # ``shard_blobs`` are the non-primary shard digests, so removal frees them all.
+    total_size_bytes: int | None = None
+    shard_blobs: list[str] = field(default_factory=list)
 
     @property
     def ref(self) -> str:
         return format_native_gguf_ref(self.hf_repo, self.gguf_filename)
+
+    @property
+    def disk_size_bytes(self) -> int:
+        """Total bytes this model occupies on disk, across all shards."""
+        return self.total_size_bytes if self.total_size_bytes is not None else self.size_bytes
 
 
 def _copy_atomic(source_path: Path, blob_path: Path) -> None:
@@ -406,6 +416,10 @@ class ModelRegistry:
             task=manifest.task,
             downloaded_at=manifest.downloaded_at,
             blob=digest,
+            # Carry the split-shard accounting through unchanged (computed by the
+            # caller from the full shard set); install only rewrites the primary.
+            total_size_bytes=manifest.total_size_bytes,
+            shard_blobs=manifest.shard_blobs,
         )
         self._write_manifest(updated)
         return blob_path
@@ -431,8 +445,12 @@ class ModelRegistry:
         repo_dir = manifest_path.parent
         if repo_dir.exists() and not any(repo_dir.iterdir()):
             repo_dir.rmdir()
-        if manifest.blob is not None:
-            self._gc_blob(manifest.hf_repo, manifest.blob)
+        # Free the primary blob and every extra shard blob; a split GGUF has more
+        # than one, and leaving the others orphans them when a sibling quant keeps
+        # the repo cache dir alive.
+        for digest in [manifest.blob, *manifest.shard_blobs]:
+            if digest is not None:
+                self._gc_blob(manifest.hf_repo, digest)
         log.info("Removed model %s", ref)
         return True
 
@@ -457,7 +475,7 @@ class ModelRegistry:
             if cache_path.exists():
                 shutil.rmtree(cache_path)
             return
-        if any(m.blob == digest for m in siblings):
+        if any(digest == m.blob or digest in m.shard_blobs for m in siblings):
             return
         blob_file = cache_path / "blobs" / digest
         if blob_file.exists():
@@ -569,6 +587,31 @@ def _repo_relative_gguf_name(file_path: Path) -> str:
     return "/".join(relative_parts) if relative_parts else file_path.name
 
 
+def _shard_accounting(first_shard_path: Path) -> tuple[int | None, list[str]]:
+    """Total on-disk size and non-primary shard blob digests for a split GGUF.
+
+    ``(None, [])`` for a single-file model. For a split GGUF, the sibling shards
+    live next to the first shard; each snapshot file is a symlink whose target
+    name is its HF blob digest, so the shards are summed and the digests of
+    shards 2..N collected for removal-time garbage collection.
+    """
+    from lilbee.catalog.download import split_shard_filenames
+
+    shard_names = split_shard_filenames(first_shard_path.name)
+    if len(shard_names) <= 1:
+        return None, []
+    total = 0
+    shard_blobs: list[str] = []
+    for index, name in enumerate(shard_names):
+        shard_path = first_shard_path.with_name(name)
+        if not shard_path.exists():
+            continue
+        total += shard_path.stat().st_size
+        if index > 0:  # the primary blob is tracked separately as manifest.blob
+            shard_blobs.append(shard_path.resolve().name)
+    return total, shard_blobs
+
+
 def register_downloaded_model(entry: CatalogModel, file_path: Path) -> None:
     """Write a registry manifest for a freshly downloaded GGUF.
 
@@ -578,12 +621,15 @@ def register_downloaded_model(entry: CatalogModel, file_path: Path) -> None:
     """
     registry = ModelRegistry(cfg.models_dir)
     gguf_filename = _repo_relative_gguf_name(file_path)
+    total_size, shard_blobs = _shard_accounting(file_path)
     manifest = ModelManifest(
         hf_repo=entry.hf_repo,
         gguf_filename=gguf_filename,
         size_bytes=file_path.stat().st_size,
         task=entry.task,
         downloaded_at=datetime.now(UTC).isoformat(),
+        total_size_bytes=total_size,
+        shard_blobs=shard_blobs,
     )
     try:
         registry.install(entry.hf_repo, gguf_filename, file_path, manifest)

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -8,6 +8,7 @@ repo are two distinct installations. Manifests live at
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -249,8 +250,11 @@ class ModelRegistry:
             raise KeyError(f"Model {ref} not installed")
         if self._read_manifest(hf_repo, shards[0]) is None:
             # Same cache recovery as the single-file path; resolve the symlink so
-            # the manifest records the content-hashed blob, not the link.
-            self._reregister_from_cache(hf_repo, shards[0], first_shard.resolve())
+            # the manifest records the content-hashed blob, not the link, and pass
+            # the snapshot path so the shard accounting is recovered too.
+            self._reregister_from_cache(
+                hf_repo, shards[0], first_shard.resolve(), snapshot_path=first_shard
+            )
         return first_shard
 
     def _resolve_repo_only(self, hf_repo: str) -> Path:
@@ -360,8 +364,19 @@ class ModelRegistry:
         )
         return [path for path in candidates if path.exists()]
 
-    def _reregister_from_cache(self, hf_repo: str, gguf_filename: str, blob_path: Path) -> None:
-        """Best-effort manifest write for a cache-recovered model so listings see it."""
+    def _reregister_from_cache(
+        self,
+        hf_repo: str,
+        gguf_filename: str,
+        blob_path: Path,
+        snapshot_path: Path | None = None,
+    ) -> None:
+        """Best-effort manifest write for a cache-recovered model so listings see it.
+
+        *snapshot_path* is the first shard's snapshot path (siblings co-located);
+        when given, the split-shard accounting is recovered too, so a cache-only
+        split GGUF still frees every shard and reports its full size.
+        """
         ref = format_native_gguf_ref(hf_repo, gguf_filename)
         try:
             entry = find_catalog_entry(ref)
@@ -369,6 +384,9 @@ class ModelRegistry:
                 task = entry.task
             else:
                 task = ModelTask(reclassify_by_name(ref, ModelTask.CHAT))
+            total_size, shard_blobs = (
+                _shard_accounting(snapshot_path) if snapshot_path is not None else (None, [])
+            )
             self._write_manifest(
                 ModelManifest(
                     hf_repo=hf_repo,
@@ -377,6 +395,8 @@ class ModelRegistry:
                     task=task,
                     downloaded_at=datetime.now(UTC).isoformat(),
                     blob=blob_path.name,  # the blob's filename is its sha in the HF cache
+                    total_size_bytes=total_size,
+                    shard_blobs=shard_blobs,
                 )
             )
             log.info("Recovered manifest for %s from the model cache", ref)
@@ -440,6 +460,9 @@ class ModelRegistry:
         manifest = self._read_manifest(hf_repo, gguf_filename)
         if manifest is None:
             return False
+        # Manifests written before shard accounting existed have no shard_blobs, so
+        # recover them from the cache *before* unlinking (resolve needs the manifest).
+        shard_blobs = manifest.shard_blobs or self._recover_legacy_shard_blobs(ref)
         manifest_path = self._manifest_path(hf_repo, gguf_filename)
         manifest_path.unlink()
         repo_dir = manifest_path.parent
@@ -448,11 +471,23 @@ class ModelRegistry:
         # Free the primary blob and every extra shard blob; a split GGUF has more
         # than one, and leaving the others orphans them when a sibling quant keeps
         # the repo cache dir alive.
-        for digest in [manifest.blob, *manifest.shard_blobs]:
+        for digest in [manifest.blob, *shard_blobs]:
             if digest is not None:
                 self._gc_blob(manifest.hf_repo, digest)
         log.info("Removed model %s", ref)
         return True
+
+    def _recover_legacy_shard_blobs(self, ref: str) -> list[str]:
+        """Extra shard blob digests for a pre-accounting split GGUF, best-effort.
+
+        Older manifests recorded only the first shard, so removing them would
+        orphan the rest. Derive the sibling shards from the cache; empty on any
+        failure or for a single-file model, so removal never breaks.
+        """
+        with contextlib.suppress(Exception):
+            shards = self.shard_paths(ref)
+            return [_blob_digest(path) for path in shards[1:]]
+        return []
 
     def _gc_blob(self, hf_repo: str, digest: str) -> None:
         """Drop blob bytes and HuggingFace cache cruft now that *digest*
@@ -591,9 +626,10 @@ def _shard_accounting(first_shard_path: Path) -> tuple[int | None, list[str]]:
     """Total on-disk size and non-primary shard blob digests for a split GGUF.
 
     ``(None, [])`` for a single-file model. For a split GGUF, the sibling shards
-    live next to the first shard; each snapshot file is a symlink whose target
-    name is its HF blob digest, so the shards are summed and the digests of
-    shards 2..N collected for removal-time garbage collection.
+    live next to the first shard; ``_blob_digest`` yields each shard's blob digest
+    (the HF cache blob name, or a content hash in copy/non-symlink mode), so the
+    shards are summed and the digests of shards 2..N collected for removal-time
+    garbage collection.
     """
     shard_names = split_shard_filenames(first_shard_path.name)
     if len(shard_names) <= 1:
@@ -606,7 +642,7 @@ def _shard_accounting(first_shard_path: Path) -> tuple[int | None, list[str]]:
             continue
         total += shard_path.stat().st_size
         if index > 0:  # the primary blob is tracked separately as manifest.blob
-            shard_blobs.append(shard_path.resolve().name)
+            shard_blobs.append(_blob_digest(shard_path))
     return total, shard_blobs
 
 

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -1142,8 +1142,11 @@ def _recover_bare_json_stream(
         # Forward close to the source generator: if a consumer closes this
         # wrapper mid-stream, a plain for-loop would not propagate GeneratorExit
         # to *items*, leaking the underlying HTTP stream and its in_flight slot.
+        # Suppress teardown errors (httpx stream close can raise) so they don't
+        # mask the exception that triggered this finally.
         if isinstance(items, Generator):
-            items.close()
+            with contextlib.suppress(Exception):
+                items.close()
 
 
 def _passthrough_text(buffer: str, text: str) -> bool:

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -407,7 +407,7 @@ class LlamaServerClient:
         """
         payload: dict[str, Any] = {"model": self._model, "messages": messages, **(options or {})}
         if stream:
-            return self._chat_stream(payload)
+            return self._stream_tracked(self._chat_stream_body(payload))
         request_timeout = timeout if timeout is not None else httpx.USE_CLIENT_DEFAULT
         with self._track():
             resp = self._http.post(
@@ -416,11 +416,9 @@ class LlamaServerClient:
             _raise_for_status(resp)
             return str(resp.json()["choices"][0]["message"]["content"])
 
-    def _chat_stream(self, payload: dict[str, Any]) -> Iterator[str]:
-        with (
-            self._track(),
-            self._http.stream("POST", _CHAT_PATH, json={**payload, "stream": True}) as resp,
-        ):
+    def _chat_stream_body(self, payload: dict[str, Any]) -> Iterator[str]:
+        # in_flight is reserved by _stream_tracked, which wraps this; see there.
+        with self._http.stream("POST", _CHAT_PATH, json={**payload, "stream": True}) as resp:
             _raise_for_status(resp)
             for line in resp.iter_lines():
                 delta = _parse_sse_delta(line)
@@ -534,22 +532,22 @@ class LlamaServerClient:
         """
         prepared = self._prepare_chat_messages(messages)
         return _recover_bare_json_stream(
-            self._open_chat_stream(prepared, tools, tool_choice, options)
+            self._stream_tracked(self._open_chat_stream_body(prepared, tools, tool_choice, options))
         )
 
-    def _open_chat_stream(
+    def _open_chat_stream_body(
         self,
         messages: Sequence[Mapping[str, Any]],
         tools: list[dict[str, Any]] | None,
         tool_choice: str | dict[str, Any] | None,
         options: dict[str, Any] | None,
     ) -> Iterator[str | ToolCallDelta | TokenUsage]:
-        """Open one SSE chat stream and yield its frames; raises before the first frame."""
+        """Open one SSE chat stream and yield its frames; raises before the first frame.
+
+        in_flight is reserved by _stream_tracked, which wraps this; see there.
+        """
         payload = self._chat_payload(messages, tools, tool_choice, options, stream=True)
-        with (
-            self._track(),
-            self._http.stream("POST", _CHAT_PATH, json=payload) as resp,
-        ):
+        with self._http.stream("POST", _CHAT_PATH, json=payload) as resp:
             _raise_for_status(resp)
             for line in resp.iter_lines():
                 yield from _parse_sse_stream_items(line)
@@ -850,6 +848,35 @@ class LlamaServerClient:
     def _track(self) -> _InFlight:
         return _InFlight(self)
 
+    def _enter_in_flight(self) -> None:
+        """Atomically reserve one in-flight slot (the router balances on this)."""
+        with self._in_flight_lock:
+            self.in_flight += 1
+
+    def _exit_in_flight(self) -> None:
+        """Atomically release one in-flight slot."""
+        with self._in_flight_lock:
+            self.in_flight -= 1
+
+    def _stream_tracked(self, body: Iterator[_T]) -> Iterator[_T]:
+        """Wrap a streaming *body* so its in-flight slot is reserved eagerly.
+
+        Reserves the slot now (at call time), not on the body's first iteration:
+        a stream is often built and handed off before its first frame is pulled,
+        and a concurrent reload's client drain keys on ``in_flight`` to decide a
+        client is idle. Eager reservation keeps a checked-out-but-not-yet-started
+        stream from being closed out from under. The slot is released when the
+        returned generator is exhausted or closed.
+        """
+        self._enter_in_flight()
+        return self._release_in_flight_on_close(body)
+
+    def _release_in_flight_on_close(self, body: Iterator[_T]) -> Iterator[_T]:
+        try:
+            yield from body
+        finally:
+            self._exit_in_flight()
+
 
 class _InFlight:
     """Context manager that atomically bumps the owner's in-flight counter.
@@ -862,12 +889,10 @@ class _InFlight:
         self._client = client
 
     def __enter__(self) -> None:
-        with self._client._in_flight_lock:
-            self._client.in_flight += 1
+        self._client._enter_in_flight()
 
     def __exit__(self, *_exc: object) -> None:
-        with self._client._in_flight_lock:
-            self._client.in_flight -= 1
+        self._client._exit_in_flight()
 
 
 def _rerank_score(item: dict[str, Any]) -> float:

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -8,7 +8,7 @@ import logging
 import math
 import threading
 import time
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Literal, TypedDict, TypeVar, overload
 
@@ -1121,22 +1121,29 @@ def _recover_bare_json_stream(
     """
     buffer = ""  # leading text held back as a potential bare call until resolved
     saw_native = False
-    for item in items:
-        if isinstance(item, ToolCallDelta):
-            yield from _flush_plain(buffer)
-            buffer, saw_native = "", True
-            yield item
-        elif isinstance(item, TokenUsage):
-            yield from _recover_buffer(buffer)
-            buffer = ""
-            yield item
-        elif saw_native or _passthrough_text(buffer, item):
-            yield from _flush_plain(buffer)
-            buffer = ""
-            yield item
-        else:
-            buffer += item
-    yield from _recover_buffer(buffer)
+    try:
+        for item in items:
+            if isinstance(item, ToolCallDelta):
+                yield from _flush_plain(buffer)
+                buffer, saw_native = "", True
+                yield item
+            elif isinstance(item, TokenUsage):
+                yield from _recover_buffer(buffer)
+                buffer = ""
+                yield item
+            elif saw_native or _passthrough_text(buffer, item):
+                yield from _flush_plain(buffer)
+                buffer = ""
+                yield item
+            else:
+                buffer += item
+        yield from _recover_buffer(buffer)
+    finally:
+        # Forward close to the source generator: if a consumer closes this
+        # wrapper mid-stream, a plain for-loop would not propagate GeneratorExit
+        # to *items*, leaking the underlying HTTP stream and its in_flight slot.
+        if isinstance(items, Generator):
+            items.close()
 
 
 def _passthrough_text(buffer: str, text: str) -> bool:

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -407,7 +407,7 @@ class LlamaServerClient:
         """
         payload: dict[str, Any] = {"model": self._model, "messages": messages, **(options or {})}
         if stream:
-            return self._stream_tracked(self._chat_stream_body(payload))
+            return self._chat_stream(payload)
         request_timeout = timeout if timeout is not None else httpx.USE_CLIENT_DEFAULT
         with self._track():
             resp = self._http.post(
@@ -416,9 +416,11 @@ class LlamaServerClient:
             _raise_for_status(resp)
             return str(resp.json()["choices"][0]["message"]["content"])
 
-    def _chat_stream_body(self, payload: dict[str, Any]) -> Iterator[str]:
-        # in_flight is reserved by _stream_tracked, which wraps this; see there.
-        with self._http.stream("POST", _CHAT_PATH, json={**payload, "stream": True}) as resp:
+    def _chat_stream(self, payload: dict[str, Any]) -> Iterator[str]:
+        with (
+            self._track(),
+            self._http.stream("POST", _CHAT_PATH, json={**payload, "stream": True}) as resp,
+        ):
             _raise_for_status(resp)
             for line in resp.iter_lines():
                 delta = _parse_sse_delta(line)
@@ -532,22 +534,22 @@ class LlamaServerClient:
         """
         prepared = self._prepare_chat_messages(messages)
         return _recover_bare_json_stream(
-            self._stream_tracked(self._open_chat_stream_body(prepared, tools, tool_choice, options))
+            self._open_chat_stream(prepared, tools, tool_choice, options)
         )
 
-    def _open_chat_stream_body(
+    def _open_chat_stream(
         self,
         messages: Sequence[Mapping[str, Any]],
         tools: list[dict[str, Any]] | None,
         tool_choice: str | dict[str, Any] | None,
         options: dict[str, Any] | None,
     ) -> Iterator[str | ToolCallDelta | TokenUsage]:
-        """Open one SSE chat stream and yield its frames; raises before the first frame.
-
-        in_flight is reserved by _stream_tracked, which wraps this; see there.
-        """
+        """Open one SSE chat stream and yield its frames; raises before the first frame."""
         payload = self._chat_payload(messages, tools, tool_choice, options, stream=True)
-        with self._http.stream("POST", _CHAT_PATH, json=payload) as resp:
+        with (
+            self._track(),
+            self._http.stream("POST", _CHAT_PATH, json=payload) as resp,
+        ):
             _raise_for_status(resp)
             for line in resp.iter_lines():
                 yield from _parse_sse_stream_items(line)
@@ -848,35 +850,6 @@ class LlamaServerClient:
     def _track(self) -> _InFlight:
         return _InFlight(self)
 
-    def _enter_in_flight(self) -> None:
-        """Atomically reserve one in-flight slot (the router balances on this)."""
-        with self._in_flight_lock:
-            self.in_flight += 1
-
-    def _exit_in_flight(self) -> None:
-        """Atomically release one in-flight slot."""
-        with self._in_flight_lock:
-            self.in_flight -= 1
-
-    def _stream_tracked(self, body: Iterator[_T]) -> Iterator[_T]:
-        """Wrap a streaming *body* so its in-flight slot is reserved eagerly.
-
-        Reserves the slot now (at call time), not on the body's first iteration:
-        a stream is often built and handed off before its first frame is pulled,
-        and a concurrent reload's client drain keys on ``in_flight`` to decide a
-        client is idle. Eager reservation keeps a checked-out-but-not-yet-started
-        stream from being closed out from under. The slot is released when the
-        returned generator is exhausted or closed.
-        """
-        self._enter_in_flight()
-        return self._release_in_flight_on_close(body)
-
-    def _release_in_flight_on_close(self, body: Iterator[_T]) -> Iterator[_T]:
-        try:
-            yield from body
-        finally:
-            self._exit_in_flight()
-
 
 class _InFlight:
     """Context manager that atomically bumps the owner's in-flight counter.
@@ -889,10 +862,12 @@ class _InFlight:
         self._client = client
 
     def __enter__(self) -> None:
-        self._client._enter_in_flight()
+        with self._client._in_flight_lock:
+            self._client.in_flight += 1
 
     def __exit__(self, *_exc: object) -> None:
-        self._client._exit_in_flight()
+        with self._client._in_flight_lock:
+            self._client.in_flight -= 1
 
 
 def _rerank_score(item: dict[str, Any]) -> float:

--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -77,9 +77,12 @@ def cuda_runtime_env() -> dict[str, str]:
     if not dirs:
         return {}
     parts = [str(d) for d in dirs]
+    # Drop existing entries that are already wheel dirs so calling this on every
+    # reload pass (apply_cuda_runtime_env) is idempotent instead of accumulating
+    # duplicate copies that get baked into each spawned server's environment.
+    wheel_dirs = set(parts)
     existing = os.environ.get("LD_LIBRARY_PATH", "")
-    if existing:
-        parts.append(existing)
+    parts.extend(entry for entry in existing.split(os.pathsep) if entry and entry not in wheel_dirs)
     return {"LD_LIBRARY_PATH": os.pathsep.join(parts)}
 
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -70,6 +70,11 @@ _REQUEST_TIMEOUT_GENERATION_MARGIN_S = 120.0
 # under. The deadline is a backstop for a client that never drains.
 _CLIENT_DRAIN_TIMEOUT_S = 600.0
 _CLIENT_DRAIN_POLL_S = 0.1
+# Grace before draining: _require_clients hands out a client under the lock then
+# releases it before the request increments in_flight, so a reader that just
+# checked out an old client has in_flight==0 for that brief handoff. Waiting it
+# out lets the request enter its in_flight window before the drain inspects it.
+_CLIENT_DRAIN_GRACE_S = 0.5
 # Jinja chat templates flag tool support by referencing one of these names as an
 # identifier inside a ``{% ... %}`` / ``{{ ... }}`` block (not free-text prose).
 # The server parses tool calls natively via ``--jinja``; this probe only decides
@@ -454,6 +459,7 @@ class FleetProvider:
             return None
 
         def _drain() -> None:
+            time.sleep(_CLIENT_DRAIN_GRACE_S)  # let just-checked-out requests start
             for client in clients:
                 deadline = time.monotonic() + _CLIENT_DRAIN_TIMEOUT_S
                 while client.in_flight > 0 and time.monotonic() < deadline:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -409,9 +409,9 @@ class FleetProvider:
         keyed by its replica model id; launches carry the chat slots/ctx so the
         capacity and served context come from the launch, not a probe.
         """
-        # A reload re-adopts over an existing pool; close the previous clients'
-        # httpx pools or every reload leaks one pool per replica per role. The
-        # reloaded swap already stopped the old upstreams, so nothing is in flight.
+        # Close the previous clients (a reload re-adopts over an existing pool);
+        # the reloaded swap already stopped their upstreams. Else each reload
+        # leaks an httpx pool per replica per role.
         old_clients = [client for pool in self._clients.values() for client in pool]
         self._swap = swap
         endpoint = swap.endpoint()

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -65,16 +65,6 @@ _PREWARM_CHUNK_BYTES = 8 * 1024 * 1024
 # generation, so the weights-scaled cold-load budget plus the margin raises this floor.
 _REQUEST_TIMEOUT_FLOOR_S = 900.0
 _REQUEST_TIMEOUT_GENERATION_MARGIN_S = 120.0
-# A reload's old clients are closed only after their in-flight requests drain, so
-# a reader still mid-call on an old client snapshot is never closed out from
-# under. The deadline is a backstop for a client that never drains.
-_CLIENT_DRAIN_TIMEOUT_S = 600.0
-_CLIENT_DRAIN_POLL_S = 0.1
-# Grace before draining: _require_clients hands out a client under the lock then
-# releases it before the request increments in_flight, so a reader that just
-# checked out an old client has in_flight==0 for that brief handoff. Waiting it
-# out lets the request enter its in_flight window before the drain inspects it.
-_CLIENT_DRAIN_GRACE_S = 0.5
 # Jinja chat templates flag tool support by referencing one of these names as an
 # identifier inside a ``{% ... %}`` / ``{{ ... }}`` block (not free-text prose).
 # The server parses tool calls natively via ``--jinja``; this probe only decides
@@ -350,6 +340,11 @@ class FleetProvider:
         # all pointed at the llama-swap endpoint and routed by replica model id;
         # rebuilt whenever the swap process (re)starts. Requests round-robin the pool.
         self._clients: dict[WorkerRole, list[LlamaServerClient]] = {}
+        # Clients retired by a reload, awaiting close. A reload's old clients may
+        # still be held by an in-flight reader, so they are closed at the *next*
+        # reload (by when those readers have finished) or at shutdown, never while
+        # potentially in use. See _retire_clients.
+        self._retiring_clients: list[LlamaServerClient] = []
         # Chat batching slots and per-slot context from the chat launch, surfaced to
         # the concurrency gate and clients; defaults until the swap is up.
         self._chat_slots = 1
@@ -419,10 +414,9 @@ class FleetProvider:
         keyed by its replica model id; launches carry the chat slots/ctx so the
         capacity and served context come from the launch, not a probe.
         """
-        # Close the previous clients (a reload re-adopts over an existing pool) once
-        # their in-flight requests drain, off-thread. Closing immediately would
-        # error a reader still mid-call on an old client snapshot; not closing at
-        # all leaks an httpx pool per replica per role on every reload.
+        # Retire the previous clients (a reload re-adopts over an existing pool):
+        # closing them now would error a reader still mid-call on an old client
+        # snapshot, and never closing leaks an httpx pool per replica per role.
         old_clients = [client for pool in self._clients.values() for client in pool]
         self._swap = swap
         endpoint = swap.endpoint()
@@ -443,32 +437,25 @@ class FleetProvider:
         chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
         self._chat_slots = chat.slots if chat is not None else 1
         self._chat_ctx = chat.ctx if chat is not None else None
-        self._close_clients_when_idle(old_clients)
+        self._retire_clients(old_clients)
 
-    def _close_clients_when_idle(
-        self, clients: list[LlamaServerClient]
-    ) -> threading.Thread | None:
-        """Close *clients* once their in-flight requests drain, off the caller's thread.
+    def _retire_clients(self, old_clients: list[LlamaServerClient]) -> None:
+        """Close the previously-retired clients, then retire *old_clients*.
 
-        A reload swaps the pool while reader threads may still hold (and be mid-call
-        on) an old client snapshot, so each client is closed only after its
-        ``in_flight`` reaches zero (bounded by ``_CLIENT_DRAIN_TIMEOUT_S``).
-        Returns the drain thread (or ``None`` when there is nothing to close).
+        Caller holds ``self._lock``. Retired clients are never handed to new
+        readers (they are out of ``self._clients``), so by this reload any reader
+        that held one from a prior reload has finished; an ``in_flight == 0``
+        check confirms it before close, and any still-busy client stays retired
+        for the next reload. This closes idle reloaded-away pools without ever
+        closing one a reader could still use. Shutdown closes whatever remains.
         """
-        if not clients:
-            return None
-
-        def _drain() -> None:
-            time.sleep(_CLIENT_DRAIN_GRACE_S)  # let just-checked-out requests start
-            for client in clients:
-                deadline = time.monotonic() + _CLIENT_DRAIN_TIMEOUT_S
-                while client.in_flight > 0 and time.monotonic() < deadline:
-                    time.sleep(_CLIENT_DRAIN_POLL_S)
+        still_busy: list[LlamaServerClient] = []
+        for client in self._retiring_clients:
+            if client.in_flight == 0:
                 client.close()
-
-        thread = threading.Thread(target=_drain, name="fleet-client-drain", daemon=True)
-        thread.start()
-        return thread
+            else:
+                still_busy.append(client)
+        self._retiring_clients = still_busy + old_clients
 
     def _require_clients(self, role: WorkerRole) -> list[LlamaServerClient]:
         """The client pool for *role*, or a user-facing error when it has no server.
@@ -535,9 +522,12 @@ class FleetProvider:
     def _drop_swap_refs(self) -> None:
         """Clear the swap, its clients, and the chat capacity so the next call rebuilds."""
         with self._lock:
+            # Close the live pool and any clients still awaiting retirement.
             clients = [client for pool in self._clients.values() for client in pool]
+            clients.extend(self._retiring_clients)
             self._swap = None
             self._clients = {}
+            self._retiring_clients = []
             self._chat_slots = 1
             self._chat_ctx = None
         for client in clients:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -409,6 +409,10 @@ class FleetProvider:
         keyed by its replica model id; launches carry the chat slots/ctx so the
         capacity and served context come from the launch, not a probe.
         """
+        # A reload re-adopts over an existing pool; close the previous clients'
+        # httpx pools or every reload leaks one pool per replica per role. The
+        # reloaded swap already stopped the old upstreams, so nothing is in flight.
+        old_clients = [client for pool in self._clients.values() for client in pool]
         self._swap = swap
         endpoint = swap.endpoint()
         # token_cap truncates oversize embed/rerank inputs to the per-slot context
@@ -428,6 +432,8 @@ class FleetProvider:
         chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
         self._chat_slots = chat.slots if chat is not None else 1
         self._chat_ctx = chat.ctx if chat is not None else None
+        for client in old_clients:
+            client.close()
 
     def _require_clients(self, role: WorkerRole) -> list[LlamaServerClient]:
         """The client pool for *role*, or a user-facing error when it has no server.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -65,6 +65,11 @@ _PREWARM_CHUNK_BYTES = 8 * 1024 * 1024
 # generation, so the weights-scaled cold-load budget plus the margin raises this floor.
 _REQUEST_TIMEOUT_FLOOR_S = 900.0
 _REQUEST_TIMEOUT_GENERATION_MARGIN_S = 120.0
+# A reload's old clients are closed only after their in-flight requests drain, so
+# a reader still mid-call on an old client snapshot is never closed out from
+# under. The deadline is a backstop for a client that never drains.
+_CLIENT_DRAIN_TIMEOUT_S = 600.0
+_CLIENT_DRAIN_POLL_S = 0.1
 # Jinja chat templates flag tool support by referencing one of these names as an
 # identifier inside a ``{% ... %}`` / ``{{ ... }}`` block (not free-text prose).
 # The server parses tool calls natively via ``--jinja``; this probe only decides
@@ -409,9 +414,10 @@ class FleetProvider:
         keyed by its replica model id; launches carry the chat slots/ctx so the
         capacity and served context come from the launch, not a probe.
         """
-        # Close the previous clients (a reload re-adopts over an existing pool);
-        # the reloaded swap already stopped their upstreams. Else each reload
-        # leaks an httpx pool per replica per role.
+        # Close the previous clients (a reload re-adopts over an existing pool) once
+        # their in-flight requests drain, off-thread. Closing immediately would
+        # error a reader still mid-call on an old client snapshot; not closing at
+        # all leaks an httpx pool per replica per role on every reload.
         old_clients = [client for pool in self._clients.values() for client in pool]
         self._swap = swap
         endpoint = swap.endpoint()
@@ -432,8 +438,31 @@ class FleetProvider:
         chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
         self._chat_slots = chat.slots if chat is not None else 1
         self._chat_ctx = chat.ctx if chat is not None else None
-        for client in old_clients:
-            client.close()
+        self._close_clients_when_idle(old_clients)
+
+    def _close_clients_when_idle(
+        self, clients: list[LlamaServerClient]
+    ) -> threading.Thread | None:
+        """Close *clients* once their in-flight requests drain, off the caller's thread.
+
+        A reload swaps the pool while reader threads may still hold (and be mid-call
+        on) an old client snapshot, so each client is closed only after its
+        ``in_flight`` reaches zero (bounded by ``_CLIENT_DRAIN_TIMEOUT_S``).
+        Returns the drain thread (or ``None`` when there is nothing to close).
+        """
+        if not clients:
+            return None
+
+        def _drain() -> None:
+            for client in clients:
+                deadline = time.monotonic() + _CLIENT_DRAIN_TIMEOUT_S
+                while client.in_flight > 0 and time.monotonic() < deadline:
+                    time.sleep(_CLIENT_DRAIN_POLL_S)
+                client.close()
+
+        thread = threading.Thread(target=_drain, name="fleet-client-drain", daemon=True)
+        thread.start()
+        return thread
 
     def _require_clients(self, role: WorkerRole) -> list[LlamaServerClient]:
         """The client pool for *role*, or a user-facing error when it has no server.

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -272,8 +272,13 @@ class SwapManager:
         self._fail("The local model engine did not start in time.")
 
     def _ready_models(self) -> set[str]:
-        """Model ids whose upstream is loaded and ready, per llama-swap's /running."""
-        with contextlib.suppress(httpx.HTTPError, ValueError, KeyError, TypeError):
+        """Model ids whose upstream is loaded and ready, per llama-swap's /running.
+
+        A read-only probe: a concurrent shutdown can clear ``_port`` between the
+        caller's check and ``endpoint()``, raising ProviderError, so that is
+        suppressed too and the probe reports "nothing ready" rather than throwing.
+        """
+        with contextlib.suppress(httpx.HTTPError, ValueError, KeyError, TypeError, ProviderError):
             payload = httpx.get(
                 f"{self.endpoint()}{_RUNNING_PATH}", timeout=_PROBE_TIMEOUT_S
             ).json()

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -255,9 +255,15 @@ class SdkLLMProvider(LLMProvider):
         if timeout and timeout > 0:
             from concurrent.futures import ThreadPoolExecutor
 
-            with ThreadPoolExecutor(max_workers=1) as pool:
+            # Don't use the context manager: its __exit__ shutdown(wait=True) would
+            # block until a hung call returns, so the caller would not be freed at
+            # the deadline. Shut down without waiting (matching the fleet OCR path).
+            pool = ThreadPoolExecutor(max_workers=1)
+            try:
                 future = pool.submit(self.chat, messages, stream=False, model=model)
                 result = future.result(timeout=timeout)
+            finally:
+                pool.shutdown(wait=False, cancel_futures=True)
         else:
             result = self.chat(messages, stream=False, model=model)
         if not isinstance(result, ChatResult):

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -257,7 +257,8 @@ class SdkLLMProvider(LLMProvider):
 
             # Don't use the context manager: its __exit__ shutdown(wait=True) would
             # block until a hung call returns, so the caller would not be freed at
-            # the deadline. Shut down without waiting (matching the fleet OCR path).
+            # the deadline. Shut down without waiting (matching the fleet OCR path);
+            # a wedged call's worker thread lives until the backend httpx timeout.
             pool = ThreadPoolExecutor(max_workers=1)
             try:
                 future = pool.submit(self.chat, messages, stream=False, model=model)

--- a/src/lilbee/retrieval/reasoning.py
+++ b/src/lilbee/retrieval/reasoning.py
@@ -231,9 +231,15 @@ def _text_only(stream: Iterator[Any]) -> Iterator[str]:
     frame both ride the same iterator; the RAG / reasoning paths only consume
     text, so any non-str frame is dropped here rather than crashing the chat.
     """
-    for item in stream:
-        if isinstance(item, str):
-            yield item
+    try:
+        for item in stream:
+            if isinstance(item, str):
+                yield item
+    finally:
+        # Forward close to the source: when a consumer (filter_reasoning on
+        # cap-fire) closes this generator, a plain for-loop would not propagate
+        # GeneratorExit to *stream*, leaking its HTTP connection / in_flight slot.
+        _close_iterator(stream)
 
 
 def cap_events_as_stream_tokens(

--- a/src/lilbee/runtime/ingest_lock.py
+++ b/src/lilbee/runtime/ingest_lock.py
@@ -69,10 +69,18 @@ class IngestLockRegistry:
                 acquired.append((name, lock))
         return acquired, busy
 
-    @staticmethod
-    def release(acquired: list[tuple[str, asyncio.Lock]]) -> None:
-        """Release every lock in ``acquired``. Safe to call multiple times."""
+    def release(self, acquired: list[tuple[str, asyncio.Lock]]) -> None:
+        """Release every lock in ``acquired`` and evict its registry entry.
+
+        Runs synchronously (no ``await``), so it is atomic with respect to
+        ``try_acquire`` on the event loop. ``try_acquire`` only ever acquires a
+        free lock, so these per-source locks never accrue waiters; dropping the
+        entry once released keeps the registry from growing one lock per distinct
+        filename for the whole process lifetime. Safe to call multiple times.
+        """
         while acquired:
-            _, lock = acquired.pop()
+            name, lock = acquired.pop()
             if lock.locked():
                 lock.release()
+            if self._locks.get(name) is lock:
+                del self._locks[name]

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -13,7 +13,6 @@ from lilbee.app.ingest import copy_files
 from lilbee.app.services import get_services
 from lilbee.core.config import cfg
 from lilbee.core.security import validate_path_within
-from lilbee.runtime.ingest_lock import IngestLockRegistry
 from lilbee.runtime.progress import SseEvent
 from lilbee.server.handlers.sse import SseStream, sse_done, sse_error, sse_event
 from lilbee.server.models import AddSummary, SyncSummary
@@ -181,7 +180,7 @@ async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await task
     finally:
-        IngestLockRegistry.release(acquired)
+        registry.release(acquired)
 
 
 async def _run_import_with_sentinel(sse: SseStream, data: bytes, fmt: str) -> ImportSummary:

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -589,13 +589,18 @@ async def models_delete(model: str, *, source: str = "native") -> ModelsDeleteRe
     """
     from litestar.exceptions import HTTPException
 
-    manager = get_services().model_manager
+    from lilbee.app.models import remove_model_data
+
     src = _parse_source(source)
     try:
-        deleted = manager.remove(model, src)
+        # Delegate to the shared remove path so REST reports the same freed size
+        # (full multi-shard total) as the CLI and MCP, not a hardcoded 0.
+        result = remove_model_data(model, src)
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return ModelsDeleteResponse(deleted=deleted, model=model, freed_gb=0.0)
+    return ModelsDeleteResponse(
+        deleted=result.deleted, model=result.model, freed_gb=result.freed_gb
+    )
 
 
 _EXTERNAL_MODELS_TTL = 60

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -449,7 +449,7 @@ class TestAddIngestMutex:
         assert IngestLockRegistry.canonical_source_name("doc.txt") == "doc.txt"
 
     async def test_release_evicts_entry_so_registry_does_not_grow(self, isolated_env):
-        """bb-ziks.40: a long-lived daemon must not keep one lock per filename forever."""
+        """A long-lived daemon must not keep one lock per filename forever."""
         from lilbee.runtime.ingest_lock import IngestLockRegistry
 
         registry = IngestLockRegistry()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -466,11 +466,16 @@ class TestAddIngestMutex:
 
         registry = IngestLockRegistry()
         held, _ = await registry.acquire(["doc.txt"])
+        held_lock = held[0][1]
         # A second acquire for the same name is rejected (busy), nothing to evict.
         also, busy = await registry.acquire(["doc.txt"])
         assert also == [] and busy == ["doc.txt"]
-        registry.release(also)  # no-op
-        assert "doc.txt" in registry._locks  # still held by the first batch
+        # Releasing a DIFFERENT batch (other.txt) must not evict doc.txt, and must
+        # not disturb doc.txt's lock identity.
+        other, _ = await registry.acquire(["other.txt"])
+        registry.release(other)
+        assert "other.txt" not in registry._locks  # the released name is evicted
+        assert registry._locks.get("doc.txt") is held_lock  # held entry untouched
         registry.release(held)
         assert registry._locks == {}
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -448,6 +448,32 @@ class TestAddIngestMutex:
         assert IngestLockRegistry.canonical_source_name("/some/path/doc.txt") == "doc.txt"
         assert IngestLockRegistry.canonical_source_name("doc.txt") == "doc.txt"
 
+    async def test_release_evicts_entry_so_registry_does_not_grow(self, isolated_env):
+        """bb-ziks.40: a long-lived daemon must not keep one lock per filename forever."""
+        from lilbee.runtime.ingest_lock import IngestLockRegistry
+
+        registry = IngestLockRegistry()
+        for i in range(50):
+            acquired, busy = await registry.acquire([f"doc{i}.txt"])
+            assert not busy
+            registry.release(acquired)
+        # Every name was released, so no entry should linger.
+        assert registry._locks == {}
+
+    async def test_release_keeps_entry_for_still_held_name(self, isolated_env):
+        """Releasing one batch must not evict a name another batch still holds."""
+        from lilbee.runtime.ingest_lock import IngestLockRegistry
+
+        registry = IngestLockRegistry()
+        held, _ = await registry.acquire(["doc.txt"])
+        # A second acquire for the same name is rejected (busy), nothing to evict.
+        also, busy = await registry.acquire(["doc.txt"])
+        assert also == [] and busy == ["doc.txt"]
+        registry.release(also)  # no-op
+        assert "doc.txt" in registry._locks  # still held by the first batch
+        registry.release(held)
+        assert registry._locks == {}
+
     async def test_acquire_add_locks_dedups_repeated_paths(self, isolated_env):
         """Duplicate paths in one request collapse to a single acquired lock."""
         from lilbee.app.services import get_services

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -186,7 +186,7 @@ class TestModelEntryFactories:
         assert entry.display_name == ""
 
     def test_from_native_reports_full_split_total(self):
-        # bb-ziks.49 follow-up: a split GGUF lists its total on-disk size, not the
+        # A split GGUF lists its total on-disk size, not the
         # first-shard size, so list/show agree with the freed-on-remove total.
         manifest = _manifest(_CHAT_REPO, _CHAT_FILE, size=1 * 1024**3, task="chat")
         manifest.total_size_bytes = 6 * 1024**3  # six-shard total
@@ -222,7 +222,7 @@ class TestModelEntryFactories:
 
 class TestRemoveModelDataFreedSize:
     def test_legacy_split_manifest_reports_full_shard_total(self, tmp_path, monkeypatch):
-        # bb-ziks.49 (review round 6): a pre-accounting split manifest
+        # A pre-accounting split manifest
         # (total_size_bytes None) still frees every shard, so the reported freed
         # size must reflect the on-disk total, not just the first shard.
         from unittest.mock import MagicMock

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -220,6 +220,51 @@ class TestModelEntryFactories:
         assert entry.display_name == ""
 
 
+class TestRemoveModelDataFreedSize:
+    def test_legacy_split_manifest_reports_full_shard_total(self, tmp_path, monkeypatch):
+        # bb-ziks.49 (review round 6): a pre-accounting split manifest
+        # (total_size_bytes None) still frees every shard, so the reported freed
+        # size must reflect the on-disk total, not just the first shard.
+        from unittest.mock import MagicMock
+
+        from lilbee.app.models import _bytes_to_gb, remove_model_data
+
+        manifest = _manifest(_CHAT_REPO, _CHAT_FILE, size=10, task="chat")  # first shard only
+        shards = []
+        for n in (1, 2, 3):
+            path = tmp_path / f"shard{n}.gguf"
+            path.write_bytes(b"x" * 100)  # 100 bytes each -> 300 total
+            shards.append(path)
+        registry = MagicMock()
+        registry.shard_paths.return_value = shards
+        manager = MagicMock()
+        manager.remove.return_value = True
+        services = MagicMock(model_manager=manager, registry=registry)
+        monkeypatch.setattr(model_mod, "get_services", lambda: services)
+        monkeypatch.setattr(model_mod, "_native_manifest_index", lambda: {_CHAT_REF: manifest})
+
+        result = remove_model_data(_CHAT_REF)
+        assert result.freed_gb == _bytes_to_gb(300)  # all 3 shards, not the 10-byte first
+
+    def test_modern_manifest_uses_recorded_total(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from lilbee.app.models import _bytes_to_gb, remove_model_data
+
+        manifest = _manifest(_CHAT_REPO, _CHAT_FILE, size=10, task="chat")
+        manifest.total_size_bytes = 600  # accounted at install; no shard re-stat needed
+        registry = MagicMock()
+        manager = MagicMock()
+        manager.remove.return_value = True
+        services = MagicMock(model_manager=manager, registry=registry)
+        monkeypatch.setattr(model_mod, "get_services", lambda: services)
+        monkeypatch.setattr(model_mod, "_native_manifest_index", lambda: {_CHAT_REF: manifest})
+
+        result = remove_model_data(_CHAT_REF)
+        assert result.freed_gb == _bytes_to_gb(600)
+        registry.shard_paths.assert_not_called()  # recorded total used directly
+
+
 class TestListModelsData:
     def test_default_lists_both_sources(self, fake_manager, native_manifests, with_remote_classify):
         data = model_mod.list_models_data()

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -185,6 +185,21 @@ class TestModelEntryFactories:
         assert entry.size_gb is None
         assert entry.display_name == ""
 
+    def test_from_native_reports_full_split_total(self):
+        # bb-ziks.49 follow-up: a split GGUF lists its total on-disk size, not the
+        # first-shard size, so list/show agree with the freed-on-remove total.
+        manifest = _manifest(_CHAT_REPO, _CHAT_FILE, size=1 * 1024**3, task="chat")
+        manifest.total_size_bytes = 6 * 1024**3  # six-shard total
+        entry = ModelEntry.from_native(_CHAT_REF, manifest)
+        assert entry.size_gb == 6.0
+
+    def test_manifest_data_reports_full_split_total(self):
+        manifest = _manifest(_CHAT_REPO, _CHAT_FILE, size=1 * 1024**3, task="chat")
+        manifest.total_size_bytes = 6 * 1024**3
+        data = ManifestData.from_manifest(manifest)
+        assert data.size_gb == 6.0
+        assert data.size_bytes == 6 * 1024**3
+
     def test_from_backend_with_remote(self):
         remote = _remote(_OLLAMA_REF, task="chat", parameter_size="8B")
         entry = ModelEntry.from_backend(_OLLAMA_REF, remote, ModelSource.OLLAMA)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2945,7 +2945,7 @@ class TestChromiumBootstrapTermination:
         assert proc.killed
 
     async def test_bootstrap_cancel_terminates_install(self, monkeypatch):
-        # bb-ziks.4: cancelling the bootstrap (SSE client disconnect) must not
+        # Cancelling the bootstrap (SSE client disconnect) must not
         # leave the chromium install running orphaned.
         from lilbee.crawler import bootstrap
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2869,3 +2869,95 @@ class TestStreamingFlush:
         evt = done_events[0]
         assert evt.files_written == len(paths)
         assert evt.files_written >= 1
+
+
+class _FakeStream:
+    async def readline(self) -> bytes:
+        return b""  # immediate EOF, so the drains finish
+
+
+class _FakeProc:
+    """Minimal asyncio subprocess stand-in whose wait() can be made to hang."""
+
+    def __init__(self, *, hang_wait: bool = False, returncode: int = 0) -> None:
+        self.stdout = _FakeStream()
+        self.stderr = _FakeStream()
+        self._returncode: int | None = None if hang_wait else returncode
+        self._exit = asyncio.Event()
+        self.terminated = False
+        self.killed = False
+        if not hang_wait:
+            self._exit.set()
+
+    @property
+    def returncode(self) -> int | None:
+        return self._returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self._returncode = 0
+        self._exit.set()
+
+    def kill(self) -> None:
+        self.killed = True
+        self._returncode = -9
+        self._exit.set()
+
+    async def wait(self) -> int | None:
+        await self._exit.wait()
+        return self._returncode
+
+
+class TestChromiumBootstrapTermination:
+    async def test_terminate_process_terminates_running(self):
+        from lilbee.crawler.bootstrap import _terminate_process
+
+        proc = _FakeProc(hang_wait=True)
+        await _terminate_process(proc)
+        assert proc.terminated
+        assert not proc.killed
+
+    async def test_terminate_process_noop_when_already_exited(self):
+        from lilbee.crawler.bootstrap import _terminate_process
+
+        proc = _FakeProc(returncode=0)
+        await _terminate_process(proc)
+        assert not proc.terminated
+
+    async def test_terminate_process_kills_when_terminate_ignored(self, monkeypatch):
+        from lilbee.crawler import bootstrap
+
+        monkeypatch.setattr(bootstrap, "_TERMINATE_TIMEOUT_S", 0.05)
+
+        class _Stubborn(_FakeProc):
+            def terminate(self) -> None:
+                self.terminated = True  # ignores the signal; stays running
+
+        proc = _Stubborn(hang_wait=True)
+        await bootstrap._terminate_process(proc)
+        assert proc.terminated
+        assert proc.killed
+
+    async def test_bootstrap_cancel_terminates_install(self, monkeypatch):
+        # bb-ziks.4: cancelling the bootstrap (SSE client disconnect) must not
+        # leave the chromium install running orphaned.
+        from lilbee.crawler import bootstrap
+
+        monkeypatch.setattr(bootstrap, "chromium_installed", lambda: False)
+        monkeypatch.setattr(bootstrap, "_resolve_playwright_runner", lambda: (["pw"], {}))
+        proc = _FakeProc(hang_wait=True)
+
+        async def _fake_exec(*_args, **_kwargs):
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+        task = asyncio.create_task(bootstrap.bootstrap_chromium())
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if proc.stdout is not None and not proc._exit.is_set():
+                break
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert proc.terminated  # the orphaned install was terminated

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -753,9 +753,11 @@ class TestBootstrapChromium:
             def __init__(self) -> None:
                 self.stdout = _Stream(stdout_lines)
                 self.stderr = _Stream([b""])
+                self.returncode: int | None = None
 
             async def wait(self) -> int:
-                return 0
+                self.returncode = 0
+                return self.returncode
 
         async def _fake_create_subprocess_exec(*_args, **_kwargs):
             return _Proc()
@@ -797,9 +799,11 @@ class TestBootstrapChromium:
                 self.stderr = _Stream(
                     [b"error: network unreachable\n", b"cannot bind socket\n", b""]
                 )
+                self.returncode: int | None = None
 
             async def wait(self) -> int:
-                return 42
+                self.returncode = 42
+                return self.returncode
 
         async def _fake_create_subprocess_exec(*_args, **_kwargs):
             return _Proc()

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -2888,6 +2888,7 @@ class _FakeProc:
         self.stderr = _FakeStream()
         self._returncode: int | None = None if hang_wait else returncode
         self._exit = asyncio.Event()
+        self.wait_entered = asyncio.Event()  # set once wait() is actually awaited
         self.terminated = False
         self.killed = False
         if not hang_wait:
@@ -2908,6 +2909,7 @@ class _FakeProc:
         self._exit.set()
 
     async def wait(self) -> int | None:
+        self.wait_entered.set()
         await self._exit.wait()
         return self._returncode
 
@@ -2957,10 +2959,9 @@ class TestChromiumBootstrapTermination:
         monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
 
         task = asyncio.create_task(bootstrap.bootstrap_chromium())
-        for _ in range(50):
-            await asyncio.sleep(0)
-            if proc.stdout is not None and not proc._exit.is_set():
-                break
+        # Cancel only once the task is genuinely parked inside proc.wait() (the
+        # finally that must terminate it has been entered), not merely scheduled.
+        await asyncio.wait_for(proc.wait_entered.wait(), timeout=2)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -682,6 +682,34 @@ class TestProgressTracker:
         bar.close()
         assert tracker.was_used is True
 
+    def test_single_file_reports_shard_total(self) -> None:
+        # grand_total=0 (single file) falls back to the shard's own total.
+        events: list[tuple[int, int]] = []
+        tracker = _ProgressTracker(lambda d, t: events.append((d, t)))
+        bar = tracker.make_tqdm_class()(total=100)
+        bar.update(40)
+        assert events[-1] == (40, 100)
+
+    def test_split_shards_report_one_monotonic_progression(self) -> None:
+        # bb-7jg1.14: two shards must report one 0->grand_total run, not two
+        # separate 0->100% cycles against the wrong (first-shard) total.
+        events: list[tuple[int, int]] = []
+        tracker = _ProgressTracker(lambda d, t: events.append((d, t)), grand_total=300)
+
+        shard1 = tracker.make_tqdm_class()(total=100)
+        shard1.update(100)
+        assert events[-1] == (100, 300)
+        tracker.shard_done(100)
+
+        shard2 = tracker.make_tqdm_class()(total=200)
+        shard2.update(50)
+        assert events[-1] == (150, 300)  # cumulative across shards, real total
+        shard2.update(150)
+        assert events[-1] == (300, 300)
+
+        # Numerator never goes backwards across the whole download.
+        assert [d for d, _ in events] == sorted(d for d, _ in events)
+
 
 class TestFetchExpectedFileSize:
     """fetch_expected_file_size reads hf_hub file metadata and degrades to unknown."""

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -691,7 +691,7 @@ class TestProgressTracker:
         assert events[-1] == (40, 100)
 
     def test_split_shards_report_one_monotonic_progression(self) -> None:
-        # bb-7jg1.14: two shards must report one 0->grand_total run, not two
+        # Two shards must report one 0->grand_total run, not two
         # separate 0->100% cycles against the wrong (first-shard) total.
         events: list[tuple[int, int]] = []
         tracker = _ProgressTracker(lambda d, t: events.append((d, t)), grand_total=300)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -185,7 +185,7 @@ class TestImportDataset:
             await import_dataset(store, [_page("doc.pdf", 1, "body")])
 
     async def test_import_uses_single_atomic_batch_write(self, services, monkeypatch):
-        # bb-ziks.27: each source must be written via one locked write_chunks_batch
+        # Each source must be written via one locked write_chunks_batch
         # (cleanup + chunks + page texts + source row), not four separate unlocked
         # writes that could destroy the source if one fails mid-way.
         store = services

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -869,6 +869,37 @@ def test_in_flight_resets_after_chat() -> None:
     assert c.in_flight == 0
 
 
+def test_chat_stream_reserves_in_flight_before_first_frame() -> None:
+    # bb-ziks.14 (review round 4): a stream reserves its in-flight slot at creation,
+    # before the first frame is pulled, so a concurrent reload's client drain (which
+    # keys on in_flight) never closes the client during the checkout->first-next gap.
+    body = _content_sse("hi") + "data: [DONE]\n\n"
+    c = _client(_stream_handler(body))
+    stream = c.chat([{"role": "user", "content": "q"}], stream=True)
+    assert c.in_flight == 1  # reserved eagerly, not on first iteration
+    assert list(stream) == ["hi"]
+    assert c.in_flight == 0  # released on exhaustion
+
+
+def test_chat_stream_items_reserves_in_flight_before_first_frame() -> None:
+    body = _content_sse("hi") + "data: [DONE]\n\n"
+    c = _client(_stream_handler(body))
+    stream = c.chat_stream_items([{"role": "user", "content": "q"}], tools=_tools())
+    assert c.in_flight == 1  # reserved eagerly through the recover wrapper too
+    list(stream)
+    assert c.in_flight == 0
+
+
+def test_chat_stream_releases_in_flight_on_close() -> None:
+    body = _content_sse("a") + _content_sse("b") + "data: [DONE]\n\n"
+    c = _client(_stream_handler(body))
+    stream = c.chat([{"role": "user", "content": "q"}], stream=True)
+    assert c.in_flight == 1
+    assert next(stream) == "a"
+    stream.close()  # abandoned mid-stream
+    assert c.in_flight == 0  # released on close, not leaked
+
+
 def test_close_closes_owned_client() -> None:
     c = LlamaServerClient("http://gpu0", "m")  # owns its httpx.Client
     c.close()

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -1197,7 +1197,7 @@ def test_chat_stream_items_recovers_bare_json_tool_call() -> None:
 
 
 def test_recover_bare_json_stream_forwards_close_to_source() -> None:
-    # bb-ziks.17: closing the wrapper must close the source generator, or the
+    # Closing the wrapper must close the source generator, or the
     # underlying HTTP stream and its in_flight slot leak until GC.
     from lilbee.providers.fleet.client import _recover_bare_json_stream
 

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -869,37 +869,6 @@ def test_in_flight_resets_after_chat() -> None:
     assert c.in_flight == 0
 
 
-def test_chat_stream_reserves_in_flight_before_first_frame() -> None:
-    # bb-ziks.14 (review round 4): a stream reserves its in-flight slot at creation,
-    # before the first frame is pulled, so a concurrent reload's client drain (which
-    # keys on in_flight) never closes the client during the checkout->first-next gap.
-    body = _content_sse("hi") + "data: [DONE]\n\n"
-    c = _client(_stream_handler(body))
-    stream = c.chat([{"role": "user", "content": "q"}], stream=True)
-    assert c.in_flight == 1  # reserved eagerly, not on first iteration
-    assert list(stream) == ["hi"]
-    assert c.in_flight == 0  # released on exhaustion
-
-
-def test_chat_stream_items_reserves_in_flight_before_first_frame() -> None:
-    body = _content_sse("hi") + "data: [DONE]\n\n"
-    c = _client(_stream_handler(body))
-    stream = c.chat_stream_items([{"role": "user", "content": "q"}], tools=_tools())
-    assert c.in_flight == 1  # reserved eagerly through the recover wrapper too
-    list(stream)
-    assert c.in_flight == 0
-
-
-def test_chat_stream_releases_in_flight_on_close() -> None:
-    body = _content_sse("a") + _content_sse("b") + "data: [DONE]\n\n"
-    c = _client(_stream_handler(body))
-    stream = c.chat([{"role": "user", "content": "q"}], stream=True)
-    assert c.in_flight == 1
-    assert next(stream) == "a"
-    stream.close()  # abandoned mid-stream
-    assert c.in_flight == 0  # released on close, not leaked
-
-
 def test_close_closes_owned_client() -> None:
     c = LlamaServerClient("http://gpu0", "m")  # owns its httpx.Client
     c.close()

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -1196,6 +1196,26 @@ def test_chat_stream_items_recovers_bare_json_tool_call() -> None:
     assert json.loads(deltas[0].arguments_delta or "") == {"query": "cats"}
 
 
+def test_recover_bare_json_stream_forwards_close_to_source() -> None:
+    # bb-ziks.17: closing the wrapper must close the source generator, or the
+    # underlying HTTP stream and its in_flight slot leak until GC.
+    from lilbee.providers.fleet.client import _recover_bare_json_stream
+
+    source_closed = {"value": False}
+
+    def source():
+        try:
+            yield "hello "
+            yield "world"
+        finally:
+            source_closed["value"] = True
+
+    wrapped = _recover_bare_json_stream(source())
+    assert next(wrapped) == "hello "  # plain text streams straight through
+    wrapped.close()
+    assert source_closed["value"]
+
+
 def test_chat_stream_items_streams_normal_text_incrementally() -> None:
     """Plain text is not buffered to the end; tokens arrive one frame at a time."""
     body = _content_sse("He") + _content_sse("llo") + _content_sse(" there") + "data: [DONE]\n\n"

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -69,6 +69,29 @@ def test_apply_cuda_runtime_env_updates_os_environ(monkeypatch: pytest.MonkeyPat
     assert cuda_runtime.os.environ["LD_LIBRARY_PATH"] == str(wheel)
 
 
+def test_apply_cuda_runtime_env_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    # bb-ziks.15: plan_all_launches re-applies on every reload pass; the wheel
+    # dirs must not accumulate duplicate copies in LD_LIBRARY_PATH.
+    _force_linux(monkeypatch)
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+    wheels = [Path("/wheel/a"), Path("/wheel/b")]
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: wheels)
+    apply_cuda_runtime_env()
+    apply_cuda_runtime_env()
+    apply_cuda_runtime_env()
+    expected = cuda_runtime.os.pathsep.join(str(w) for w in wheels)
+    assert cuda_runtime.os.environ["LD_LIBRARY_PATH"] == expected
+
+
+def test_cuda_runtime_env_keeps_unrelated_existing_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_linux(monkeypatch)
+    wheel = Path("/wheel/lib")
+    monkeypatch.setattr(cuda_runtime, "_cuda_wheel_lib_dirs", lambda: [wheel])
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/usr/local/lib")
+    result = cuda_runtime.cuda_runtime_env()["LD_LIBRARY_PATH"]
+    assert result == cuda_runtime.os.pathsep.join([str(wheel), "/usr/local/lib"])
+
+
 def test_apply_cuda_runtime_env_noop_when_no_wheels(monkeypatch: pytest.MonkeyPatch) -> None:
     _force_linux(monkeypatch)
     monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)

--- a/tests/test_fleet_cuda_runtime.py
+++ b/tests/test_fleet_cuda_runtime.py
@@ -70,7 +70,7 @@ def test_apply_cuda_runtime_env_updates_os_environ(monkeypatch: pytest.MonkeyPat
 
 
 def test_apply_cuda_runtime_env_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
-    # bb-ziks.15: plan_all_launches re-applies on every reload pass; the wheel
+    # plan_all_launches re-applies on every reload pass; the wheel
     # dirs must not accumulate duplicate copies in LD_LIBRARY_PATH.
     _force_linux(monkeypatch)
     monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -159,21 +159,43 @@ def test_adopt_swap_builds_a_client_per_replica(monkeypatch) -> None:
     assert len(p._clients[WorkerRole.EMBED]) == 2  # one client per replica launch
 
 
-def test_adopt_swap_closes_previous_clients(monkeypatch) -> None:
-    # bb-ziks.14: re-adopting over an existing pool (a reload) must close the old
-    # clients' httpx pools, or every reload leaks one pool per replica.
+def test_adopt_swap_schedules_old_client_close(monkeypatch) -> None:
+    # bb-ziks.14: re-adopting over an existing pool (a reload) hands the old
+    # clients to the idle-drain closer, or every reload leaks one pool per replica.
     launch = _fake_launch(WorkerRole.EMBED)
     swap = _install_engine(monkeypatch, launches=[launch])
     p = FleetProvider()
     old = [_fake_client(), _fake_client()]
     p._clients = {WorkerRole.EMBED: old}
+    captured: list = []
+    monkeypatch.setattr(p, "_close_clients_when_idle", lambda clients: captured.extend(clients))
 
     with p._lock:
         p._adopt_swap(swap, [launch])
 
-    for client in old:
-        client.close.assert_called_once_with()
+    assert captured == old  # exactly the previous clients are scheduled for close
     assert p._clients[WorkerRole.EMBED][0] not in old  # fresh client adopted
+
+
+def test_close_clients_when_idle_closes_after_drain() -> None:
+    # bb-ziks.14 (review round 2): an old client mid-request must NOT be closed
+    # out from under; the closer waits for in_flight to drain first.
+    p = FleetProvider()
+    busy = _fake_client(in_flight=1)
+    thread = p._close_clients_when_idle([busy])
+    assert thread is not None
+    thread.join(timeout=0.5)
+    assert thread.is_alive()  # still waiting: in_flight > 0, not closed yet
+    busy.close.assert_not_called()
+
+    busy.in_flight = 0  # request finished
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    busy.close.assert_called_once_with()  # closed only after draining
+
+
+def test_close_clients_when_idle_noop_on_empty() -> None:
+    assert FleetProvider()._close_clients_when_idle([]) is None
 
 
 def test_adopt_swap_threads_rerank_mode(monkeypatch) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -159,45 +159,64 @@ def test_adopt_swap_builds_a_client_per_replica(monkeypatch) -> None:
     assert len(p._clients[WorkerRole.EMBED]) == 2  # one client per replica launch
 
 
-def test_adopt_swap_schedules_old_client_close(monkeypatch) -> None:
-    # bb-ziks.14: re-adopting over an existing pool (a reload) hands the old
-    # clients to the idle-drain closer, or every reload leaks one pool per replica.
+def test_adopt_swap_retires_old_clients_without_closing(monkeypatch) -> None:
+    # bb-ziks.14: re-adopting (a reload) must not close old clients in place (a
+    # reader may still hold one); they are retired for deferred close.
     launch = _fake_launch(WorkerRole.EMBED)
     swap = _install_engine(monkeypatch, launches=[launch])
     p = FleetProvider()
     old = [_fake_client(), _fake_client()]
     p._clients = {WorkerRole.EMBED: old}
-    captured: list = []
-    monkeypatch.setattr(p, "_close_clients_when_idle", lambda clients: captured.extend(clients))
 
     with p._lock:
         p._adopt_swap(swap, [launch])
 
-    assert captured == old  # exactly the previous clients are scheduled for close
+    assert p._retiring_clients == old  # retired, not closed yet
+    for client in old:
+        client.close.assert_not_called()
     assert p._clients[WorkerRole.EMBED][0] not in old  # fresh client adopted
 
 
-def test_close_clients_when_idle_closes_after_drain(monkeypatch) -> None:
-    # bb-ziks.14 (review round 2): an old client mid-request must NOT be closed
-    # out from under; the closer waits for in_flight to drain first.
-    monkeypatch.setattr(prov_mod, "_CLIENT_DRAIN_GRACE_S", 0.0)
-    monkeypatch.setattr(prov_mod, "_CLIENT_DRAIN_POLL_S", 0.01)
+def test_retire_closes_prior_idle_generation_at_next_reload() -> None:
+    # bb-ziks.14 (review round 5): the prior reload's clients are closed at the
+    # next reload, by when their readers (in_flight==0) have finished.
     p = FleetProvider()
-    busy = _fake_client(in_flight=1)
-    thread = p._close_clients_when_idle([busy])
-    assert thread is not None
-    thread.join(timeout=0.5)
-    assert thread.is_alive()  # still waiting: in_flight > 0, not closed yet
-    busy.close.assert_not_called()
+    prior = [_fake_client(in_flight=0), _fake_client(in_flight=0)]
+    p._retiring_clients = list(prior)
+    current_old = [_fake_client(in_flight=0)]
 
-    busy.in_flight = 0  # request finished
-    thread.join(timeout=2)
-    assert not thread.is_alive()
-    busy.close.assert_called_once_with()  # closed only after draining
+    with p._lock:
+        p._retire_clients(current_old)
+
+    for client in prior:
+        client.close.assert_called_once_with()  # prior idle generation closed
+    assert p._retiring_clients == current_old  # this reload's clients now pending
 
 
-def test_close_clients_when_idle_noop_on_empty() -> None:
-    assert FleetProvider()._close_clients_when_idle([]) is None
+def test_retire_keeps_busy_prior_client_for_a_later_reload() -> None:
+    p = FleetProvider()
+    busy = _fake_client(in_flight=1)  # a reader is still mid-request on it
+    p._retiring_clients = [busy]
+
+    with p._lock:
+        p._retire_clients([])
+
+    busy.close.assert_not_called()  # not closed while in flight
+    assert busy in p._retiring_clients  # retained for the next reload
+
+
+def test_drop_swap_refs_closes_retiring_clients() -> None:
+    p = FleetProvider()
+    retiring = _fake_client(in_flight=1)  # even a busy one is closed at shutdown
+    live = _fake_client()
+    p._clients = {WorkerRole.EMBED: [live]}
+    p._retiring_clients = [retiring]
+
+    p._drop_swap_refs()
+
+    live.close.assert_called_once_with()
+    retiring.close.assert_called_once_with()
+    assert p._retiring_clients == []
 
 
 def test_adopt_swap_threads_rerank_mode(monkeypatch) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -177,9 +177,11 @@ def test_adopt_swap_schedules_old_client_close(monkeypatch) -> None:
     assert p._clients[WorkerRole.EMBED][0] not in old  # fresh client adopted
 
 
-def test_close_clients_when_idle_closes_after_drain() -> None:
+def test_close_clients_when_idle_closes_after_drain(monkeypatch) -> None:
     # bb-ziks.14 (review round 2): an old client mid-request must NOT be closed
     # out from under; the closer waits for in_flight to drain first.
+    monkeypatch.setattr(prov_mod, "_CLIENT_DRAIN_GRACE_S", 0.0)
+    monkeypatch.setattr(prov_mod, "_CLIENT_DRAIN_POLL_S", 0.01)
     p = FleetProvider()
     busy = _fake_client(in_flight=1)
     thread = p._close_clients_when_idle([busy])

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -160,7 +160,7 @@ def test_adopt_swap_builds_a_client_per_replica(monkeypatch) -> None:
 
 
 def test_adopt_swap_retires_old_clients_without_closing(monkeypatch) -> None:
-    # bb-ziks.14: re-adopting (a reload) must not close old clients in place (a
+    # Re-adopting (a reload) must not close old clients in place (a
     # reader may still hold one); they are retired for deferred close.
     launch = _fake_launch(WorkerRole.EMBED)
     swap = _install_engine(monkeypatch, launches=[launch])
@@ -178,7 +178,7 @@ def test_adopt_swap_retires_old_clients_without_closing(monkeypatch) -> None:
 
 
 def test_retire_closes_prior_idle_generation_at_next_reload() -> None:
-    # bb-ziks.14 (review round 5): the prior reload's clients are closed at the
+    # The prior reload's clients are closed at the
     # next reload, by when their readers (in_flight==0) have finished.
     p = FleetProvider()
     prior = [_fake_client(in_flight=0), _fake_client(in_flight=0)]
@@ -381,7 +381,7 @@ def test_vision_request_gate_tracks_fleet_capacity(monkeypatch) -> None:
 
 
 def test_vision_gate_resize_deferred_while_in_flight(monkeypatch) -> None:
-    # bb-ziks.30: resizing the gate while a request is in flight would build a
+    # Resizing the gate while a request is in flight would build a
     # fresh full-capacity semaphore beside the old holders and momentarily double
     # the real cap. The resize must wait until the gate drains to idle.
     import threading

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -159,6 +159,23 @@ def test_adopt_swap_builds_a_client_per_replica(monkeypatch) -> None:
     assert len(p._clients[WorkerRole.EMBED]) == 2  # one client per replica launch
 
 
+def test_adopt_swap_closes_previous_clients(monkeypatch) -> None:
+    # bb-ziks.14: re-adopting over an existing pool (a reload) must close the old
+    # clients' httpx pools, or every reload leaks one pool per replica.
+    launch = _fake_launch(WorkerRole.EMBED)
+    swap = _install_engine(monkeypatch, launches=[launch])
+    p = FleetProvider()
+    old = [_fake_client(), _fake_client()]
+    p._clients = {WorkerRole.EMBED: old}
+
+    with p._lock:
+        p._adopt_swap(swap, [launch])
+
+    for client in old:
+        client.close.assert_called_once_with()
+    assert p._clients[WorkerRole.EMBED][0] not in old  # fresh client adopted
+
+
 def test_adopt_swap_threads_rerank_mode(monkeypatch) -> None:
     launch = _fake_launch(WorkerRole.RERANK)
     launch.rerank_mode = RerankMode.LLM

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -166,6 +166,12 @@ class TestRoleReady:
         mgr = self._started(tmp_path, monkeypatch, _refuse)
         assert mgr.role_ready(WorkerRole.CHAT) is False
 
+    def test_false_when_shutdown_clears_port_mid_probe(self, tmp_path: Path) -> None:
+        # bb-ziks.16: a concurrent shutdown clears _port, so endpoint() raises
+        # ProviderError; the read-only probe must report False, not throw.
+        mgr = SwapManager(tmp_path)  # never started -> _port is None
+        assert mgr.role_ready(WorkerRole.CHAT) is False
+
 
 class TestLifecycle:
     def test_shutdown_is_noop_when_not_started(self, tmp_path: Path) -> None:

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -167,7 +167,7 @@ class TestRoleReady:
         assert mgr.role_ready(WorkerRole.CHAT) is False
 
     def test_false_when_shutdown_clears_port_mid_probe(self, tmp_path: Path) -> None:
-        # bb-ziks.16: a concurrent shutdown clears _port, so endpoint() raises
+        # A concurrent shutdown clears _port, so endpoint() raises
         # ProviderError; the read-only probe must report False, not throw.
         mgr = SwapManager(tmp_path)  # never started -> _port is None
         assert mgr.role_ready(WorkerRole.CHAT) is False

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -958,7 +958,7 @@ class TestZeroChunkPageTextPersistence:
             "lilbee.data.ingest.pipeline._produce_records", side_effect=self._pages_no_chunks
         ):
             first = await sync(quiet=True)
-            # 0 searchable chunks: reported as skipped, not added (bb-7jg1.11) ...
+            # 0 searchable chunks: reported as skipped, not added ...
             assert "blank.pdf" not in first.added
             assert "blank.pdf" in first.skipped
             # ... but its page text and source row still persist (one atomic write).
@@ -1427,7 +1427,7 @@ class TestClassifyResult:
 
     def test_zero_chunks_with_page_texts_persists_but_counts_skipped(self):
         # Whitespace-only OCR: no searchable chunks, so it is reported as skipped
-        # (bb-7jg1.11), but the pages and source row must still persist (it stops
+        # , but the pages and source row must still persist (it stops
         # replanning), so the status stays INGESTED for the batched flush.
         from lilbee.data.ingest.pipeline import _classify_result
         from lilbee.data.ingest.types import _IngestResult
@@ -1574,7 +1574,7 @@ class TestCollectResultsSkipped:
 
     async def test_zero_text_update_purges_prior_index_entry(self, mock_svc):
         # An already-indexed file edited to extract to nothing must have its old
-        # chunks/source row removed, not left orphaned in search (bb-ziks.74).
+        # Chunks/source row removed, not left orphaned in search.
         from lilbee.data.ingest.pipeline import _collect_results
         from lilbee.data.ingest.types import _IngestResult
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1156,7 +1156,7 @@ class TestSettingsMcp:
 
     def test_settings_set_validates_string_chunk_overlap(self, isolated_env):
         # MCP forwards raw JSON, so an agent can send a numeric as a string. The
-        # chunk_overlap < chunk_size guard must still fire (bb-ziks.71).
+        # chunk_overlap < chunk_size guard must still fire.
         cfg.data_root = isolated_env
         cfg.chunk_size = 512
         result = settings_set({"chunk_overlap": "1024"})

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3141,6 +3141,29 @@ class TestSdkLLMProviderVisionOcr:
         ):
             provider.vision_ocr(b"\x89PNG", "ollama/llava:7b", "p", timeout=0.01)
 
+    def test_timeout_frees_caller_without_waiting_for_hung_call(self) -> None:
+        # bb-7jg1.22: on timeout the caller must be freed at the deadline, not
+        # blocked by the pool's shutdown(wait=True) until the hung call returns.
+        import threading
+        import time
+
+        provider = self._make_provider()
+        release = threading.Event()
+
+        def hung_chat(*_args, **_kwargs):
+            release.wait(timeout=10)
+            return "too late"
+
+        start = time.monotonic()
+        with (
+            mock.patch.object(provider, "chat", side_effect=hung_chat),
+            pytest.raises(TimeoutError),
+        ):
+            provider.vision_ocr(b"\x89PNG", "ollama/llava:7b", "p", timeout=0.1)
+        elapsed = time.monotonic() - start
+        release.set()  # let the orphaned worker finish
+        assert elapsed < 2.0  # freed at the deadline, not blocked on the 10s call
+
     def test_zero_timeout_returns_chat_result(self) -> None:
         """``timeout=0`` skips the thread pool and returns chat's result."""
         from lilbee.providers.base import ChatResult, FinishReason

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3142,7 +3142,7 @@ class TestSdkLLMProviderVisionOcr:
             provider.vision_ocr(b"\x89PNG", "ollama/llava:7b", "p", timeout=0.01)
 
     def test_timeout_frees_caller_without_waiting_for_hung_call(self) -> None:
-        # bb-7jg1.22: on timeout the caller must be freed at the deadline, not
+        # On timeout the caller must be freed at the deadline, not
         # blocked by the pool's shutdown(wait=True) until the hung call returns.
         import threading
         import time

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -350,7 +350,7 @@ class TestStreamChatWithCap:
         assert provider.chat.call_count == 2
 
     def test_cap_fire_closes_the_first_stream_through_text_only(self):
-        # bb-ziks.17: on cap-fire the first stream is closed via _text_only's
+        # On cap-fire the first stream is closed via _text_only's
         # forwarded close, or its HTTP connection / in_flight slot leaks until GC.
         class ClosableStream:
             def __init__(self, tokens) -> None:

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -349,6 +349,38 @@ class TestStreamChatWithCap:
         assert "final " in response and "answer." in response
         assert provider.chat.call_count == 2
 
+    def test_cap_fire_closes_the_first_stream_through_text_only(self):
+        # bb-ziks.17: on cap-fire the first stream is closed via _text_only's
+        # forwarded close, or its HTTP connection / in_flight slot leaks until GC.
+        class ClosableStream:
+            def __init__(self, tokens) -> None:
+                self._tokens = iter(tokens)
+                self.closed = False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                return next(self._tokens)
+
+            def close(self) -> None:
+                self.closed = True
+
+        first = ClosableStream(["<think>" + ("x " * 400) + "</think>not reached"])
+        provider = MagicMock()
+        provider.chat.side_effect = [first, iter(["answer"])]
+        list(
+            stream_chat_with_cap(
+                provider,
+                [{"role": "user", "content": "q"}],
+                options=None,
+                model="test-model",
+                show_reasoning=True,
+                cap_chars=512,
+            )
+        )
+        assert first.closed  # the capped first stream was closed, not leaked
+
     def test_continuation_call_appends_user_nudge(self):
         long_think = "<think>" + ("x " * 400) + "</think>"
         provider = self._make_provider([long_think], ["done"])

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -889,13 +889,15 @@ class TestModelRegistryRemove:
         registry.install(_REPO, _FILENAME, src, _make_manifest())
         blobs = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs"
         (blobs / "shared").write_bytes(b"x" * 10)
+        (blobs / "unique").write_bytes(b"y" * 10)
         manifest = registry._read_manifest(_REPO, _FILENAME)
         assert manifest is not None
-        manifest.shard_blobs = ["shared"]
+        manifest.shard_blobs = ["shared", "unique"]  # remove() must iterate both
         registry._write_manifest(manifest)
 
         registry.remove(_REF)
         assert (blobs / "shared").exists()  # still referenced by the sibling
+        assert not (blobs / "unique").exists()  # removed: proves remove() gc's shard_blobs
 
     def test_disk_size_bytes_uses_total_for_split(self, tmp_path: Path) -> None:
         manifest = _make_manifest()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from unittest import mock
 
@@ -23,6 +24,7 @@ from lilbee.modelhub.registry import (
 _REPO = "Qwen/Qwen3-0.6B-GGUF"
 _FILENAME = "Qwen3-0.6B-Q4_K_M.gguf"
 _REF = f"{_REPO}/{_FILENAME}"
+_SHA256_HEX_RE = re.compile(r"[0-9a-f]{64}")
 
 
 def _make_manifest(
@@ -449,6 +451,45 @@ class TestModelRegistryResolve:
         registry = ModelRegistry(tmp_path)
         with pytest.raises(KeyError, match="not installed"):
             registry.shard_paths(_REF)
+
+    def _seed_split(self, tmp_path: Path, repo: str) -> str:
+        for n in (1, 2, 3):
+            _seed_hf_cache(
+                tmp_path,
+                repo=repo,
+                filename=f"m-mxfp4-0000{n}-of-00003.gguf",
+                content=f"shard-{n}".encode(),
+            )
+        return f"{repo}/m-mxfp4-00001-of-00003.gguf"
+
+    def test_cache_recovered_split_records_shard_accounting(self, tmp_path: Path) -> None:
+        # bb-ziks.49 (review round 2): a cache-only split GGUF (no manifest yet)
+        # must recover its total size and every shard digest, not just the first.
+        registry = ModelRegistry(tmp_path)
+        repo = "ggml-org/gpt-oss-120b-GGUF"
+        ref = self._seed_split(tmp_path, repo)
+        registry.resolve(ref)  # triggers _reregister_from_cache
+        manifest = registry._read_manifest(repo, "m-mxfp4-00001-of-00003.gguf")
+        assert manifest is not None
+        assert manifest.total_size_bytes == sum(len(f"shard-{n}".encode()) for n in (1, 2, 3))
+        assert len(manifest.shard_blobs) == 2  # shards 2 and 3
+        assert all(_SHA256_HEX_RE.fullmatch(d) for d in manifest.shard_blobs)
+
+    def test_recover_legacy_shard_blobs_finds_extra_shards(self, tmp_path: Path) -> None:
+        # bb-ziks.49 (review round 2): a pre-accounting manifest (empty shard_blobs)
+        # still frees every shard because removal recovers them from the cache.
+        registry = ModelRegistry(tmp_path)
+        repo = "ggml-org/gpt-oss-120b-GGUF"
+        ref = self._seed_split(tmp_path, repo)
+        registry.resolve(ref)
+        blobs = registry._recover_legacy_shard_blobs(ref)
+        assert len(blobs) == 2  # shards 2 and 3 (primary excluded)
+        assert all(_SHA256_HEX_RE.fullmatch(d) for d in blobs)
+
+    def test_recover_legacy_shard_blobs_empty_for_single_file(self, tmp_path: Path) -> None:
+        registry = ModelRegistry(tmp_path)
+        _seed_hf_cache(tmp_path)
+        assert registry._recover_legacy_shard_blobs(_REF) == []
 
     def test_split_gguf_shards_present_but_snapshot_missing_raises_not_installed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1132,6 +1173,8 @@ class TestShardAccounting:
         total, shard_blobs = _shard_accounting(tmp_path / names[0])
         assert total == 30  # all three shards summed
         assert len(shard_blobs) == 2  # shards 2 and 3 (primary tracked separately)
+        # Copy/non-symlink mode: digests are content hashes, never snapshot names.
+        assert all(_SHA256_HEX_RE.fullmatch(d) for d in shard_blobs)
 
     def test_multi_shard_skips_missing_shard(self, tmp_path: Path) -> None:
         from lilbee.modelhub.registry import _shard_accounting

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -491,6 +491,11 @@ class TestModelRegistryResolve:
         _seed_hf_cache(tmp_path)
         assert registry._recover_legacy_shard_blobs(_REF) == []
 
+    def test_recover_legacy_shard_blobs_empty_when_unresolvable(self, tmp_path: Path) -> None:
+        # Uninstalled ref: shard_paths raises, suppressed so removal never breaks.
+        registry = ModelRegistry(tmp_path)
+        assert registry._recover_legacy_shard_blobs(_REF) == []
+
     def test_split_gguf_shards_present_but_snapshot_missing_raises_not_installed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -809,6 +809,60 @@ class TestModelRegistryRemove:
         registry.remove(f"{_REPO}/Q4.gguf")
         assert registry.is_installed(f"{_REPO}/Q8.gguf")
 
+    def test_remove_gcs_all_split_shard_blobs(self, tmp_path: Path) -> None:
+        """bb-ziks.49: a split GGUF's extra shard blobs are freed on remove.
+
+        A sibling quant keeps the repo cache dir alive, so removal must gc each
+        shard blob individually rather than relying on wiping the whole repo dir.
+        """
+        registry = ModelRegistry(tmp_path)
+        sib = tmp_path / "sib.gguf"
+        sib.write_bytes(b"GGUF" + b"\x09" * 30)
+        registry.install(_REPO, "Sibling.gguf", sib, _make_manifest(gguf_filename="Sibling.gguf"))
+        src = _write_source(tmp_path)
+        registry.install(_REPO, _FILENAME, src, _make_manifest())
+        blobs = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs"
+        (blobs / "shard2digest").write_bytes(b"x" * 10)
+        (blobs / "shard3digest").write_bytes(b"x" * 10)
+        manifest = registry._read_manifest(_REPO, _FILENAME)
+        assert manifest is not None
+        manifest.shard_blobs = ["shard2digest", "shard3digest"]
+        registry._write_manifest(manifest)
+
+        registry.remove(_REF)
+        assert not (blobs / "shard2digest").exists()
+        assert not (blobs / "shard3digest").exists()
+        assert registry.is_installed(f"{_REPO}/Sibling.gguf")
+
+    def test_remove_keeps_shard_blob_referenced_by_sibling(self, tmp_path: Path) -> None:
+        """A shard digest still referenced by a sibling's shard_blobs survives."""
+        registry = ModelRegistry(tmp_path)
+        sib = tmp_path / "sib.gguf"
+        sib.write_bytes(b"GGUF" + b"\x09" * 30)
+        registry.install(_REPO, "Sibling.gguf", sib, _make_manifest(gguf_filename="Sibling.gguf"))
+        sibling = registry._read_manifest(_REPO, "Sibling.gguf")
+        assert sibling is not None
+        sibling.shard_blobs = ["shared"]
+        registry._write_manifest(sibling)
+        src = _write_source(tmp_path)
+        registry.install(_REPO, _FILENAME, src, _make_manifest())
+        blobs = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs"
+        (blobs / "shared").write_bytes(b"x" * 10)
+        manifest = registry._read_manifest(_REPO, _FILENAME)
+        assert manifest is not None
+        manifest.shard_blobs = ["shared"]
+        registry._write_manifest(manifest)
+
+        registry.remove(_REF)
+        assert (blobs / "shared").exists()  # still referenced by the sibling
+
+    def test_disk_size_bytes_uses_total_for_split(self, tmp_path: Path) -> None:
+        manifest = _make_manifest()
+        manifest.size_bytes = 100  # first shard only
+        assert manifest.disk_size_bytes == 100  # single-file: falls back to size_bytes
+        manifest.total_size_bytes = 600  # six-shard total
+        assert manifest.disk_size_bytes == 600
+
     def test_remove_missing(self, tmp_path: Path) -> None:
         registry = ModelRegistry(tmp_path)
         removed = registry.remove(_REF)
@@ -1055,3 +1109,26 @@ class TestModelRegistryGCBlobPathGuard:
         assert any(
             "Refusing to remove cache outside models_dir" in r.message for r in caplog.records
         )
+
+
+class TestShardAccounting:
+    def test_single_file_returns_none_and_empty(self, tmp_path: Path) -> None:
+        from lilbee.modelhub.registry import _shard_accounting
+
+        f = tmp_path / "model-Q4_K_M.gguf"
+        f.write_bytes(b"x" * 10)
+        assert _shard_accounting(f) == (None, [])
+
+    def test_multi_shard_sums_size_and_collects_extra_blobs(self, tmp_path: Path) -> None:
+        from lilbee.modelhub.registry import _shard_accounting
+
+        names = [
+            "m-00001-of-00003.gguf",
+            "m-00002-of-00003.gguf",
+            "m-00003-of-00003.gguf",
+        ]
+        for name in names:
+            (tmp_path / name).write_bytes(b"x" * 10)
+        total, shard_blobs = _shard_accounting(tmp_path / names[0])
+        assert total == 30  # all three shards summed
+        assert len(shard_blobs) == 2  # shards 2 and 3 (primary tracked separately)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1132,3 +1132,13 @@ class TestShardAccounting:
         total, shard_blobs = _shard_accounting(tmp_path / names[0])
         assert total == 30  # all three shards summed
         assert len(shard_blobs) == 2  # shards 2 and 3 (primary tracked separately)
+
+    def test_multi_shard_skips_missing_shard(self, tmp_path: Path) -> None:
+        from lilbee.modelhub.registry import _shard_accounting
+
+        # Only shards 1 and 3 are on disk (2 is missing); the missing one is skipped.
+        for name in ("m-00001-of-00003.gguf", "m-00003-of-00003.gguf"):
+            (tmp_path / name).write_bytes(b"x" * 10)
+        total, shard_blobs = _shard_accounting(tmp_path / "m-00001-of-00003.gguf")
+        assert total == 20  # only the two present shards
+        assert len(shard_blobs) == 1  # only shard 3 (primary is shard 1)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -463,7 +463,7 @@ class TestModelRegistryResolve:
         return f"{repo}/m-mxfp4-00001-of-00003.gguf"
 
     def test_cache_recovered_split_records_shard_accounting(self, tmp_path: Path) -> None:
-        # bb-ziks.49 (review round 2): a cache-only split GGUF (no manifest yet)
+        # A cache-only split GGUF (no manifest yet)
         # must recover its total size and every shard digest, not just the first.
         registry = ModelRegistry(tmp_path)
         repo = "ggml-org/gpt-oss-120b-GGUF"
@@ -476,7 +476,7 @@ class TestModelRegistryResolve:
         assert all(_SHA256_HEX_RE.fullmatch(d) for d in manifest.shard_blobs)
 
     def test_recover_legacy_shard_blobs_finds_extra_shards(self, tmp_path: Path) -> None:
-        # bb-ziks.49 (review round 2): a pre-accounting manifest (empty shard_blobs)
+        # A pre-accounting manifest (empty shard_blobs)
         # still frees every shard because removal recovers them from the cache.
         registry = ModelRegistry(tmp_path)
         repo = "ggml-org/gpt-oss-120b-GGUF"
@@ -856,7 +856,7 @@ class TestModelRegistryRemove:
         assert registry.is_installed(f"{_REPO}/Q8.gguf")
 
     def test_remove_gcs_all_split_shard_blobs(self, tmp_path: Path) -> None:
-        """bb-ziks.49: a split GGUF's extra shard blobs are freed on remove.
+        """A split GGUF's extra shard blobs are freed on remove.
 
         A sibling quant keeps the repo cache dir alive, so removal must gc each
         shard blob individually rather than relying on wiping the whole repo dir.

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2496,22 +2496,34 @@ class TestModelsPull:
 
 class TestModelsDelete:
     async def test_returns_deleted_true(self):
-        mock_manager = MagicMock()
-        mock_manager.remove.return_value = True
+        from lilbee.app.models import RemoveResult
+
         with patch(
-            "lilbee.server.handlers.models.get_services",
-            return_value=MagicMock(model_manager=mock_manager),
+            "lilbee.app.models.remove_model_data",
+            return_value=RemoveResult(model="test", deleted=True, freed_gb=4.0),
         ):
             result = await handlers.models_delete("test", source="native")
         assert result.deleted is True
         assert result.model == "test"
 
-    async def test_returns_deleted_false(self):
-        mock_manager = MagicMock()
-        mock_manager.remove.return_value = False
+    async def test_reports_freed_size_from_shared_remove(self):
+        # bb-ziks.49 (review round 3): REST reports the real freed size (full
+        # multi-shard total), not a hardcoded 0, matching CLI and MCP.
+        from lilbee.app.models import RemoveResult
+
         with patch(
-            "lilbee.server.handlers.models.get_services",
-            return_value=MagicMock(model_manager=mock_manager),
+            "lilbee.app.models.remove_model_data",
+            return_value=RemoveResult(model="m", deleted=True, freed_gb=40.0),
+        ):
+            result = await handlers.models_delete("m", source="native")
+        assert result.freed_gb == 40.0
+
+    async def test_returns_deleted_false(self):
+        from lilbee.app.models import RemoveResult
+
+        with patch(
+            "lilbee.app.models.remove_model_data",
+            return_value=RemoveResult(model="missing", deleted=False, freed_gb=0.0),
         ):
             result = await handlers.models_delete("missing", source="native")
         assert result.deleted is False
@@ -2521,14 +2533,13 @@ class TestModelsDelete:
         """Refusing to remove a read-only local-server model surfaces as a 409."""
         from litestar.exceptions import HTTPException
 
-        mock_manager = MagicMock()
-        mock_manager.remove.side_effect = ValueError(
-            "lilbee runs Ollama models but doesn't remove them. Manage them in Ollama instead."
-        )
         with (
             patch(
-                "lilbee.server.handlers.models.get_services",
-                return_value=MagicMock(model_manager=mock_manager),
+                "lilbee.app.models.remove_model_data",
+                side_effect=ValueError(
+                    "lilbee runs Ollama models but doesn't remove them. "
+                    "Manage them in Ollama instead."
+                ),
             ),
             pytest.raises(HTTPException) as exc_info,
         ):

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1094,7 +1094,7 @@ class TestSyncStreamDoneDelivery:
     async def test_put_threadsafe_defers_enqueue_to_loop(self):
         """put_threadsafe schedules the enqueue on the loop instead of mutating
         the asyncio.Queue inline; even called from the loop thread the item is
-        not present until a loop iteration runs (bb-ziks.76)."""
+        not present until a loop iteration runs."""
         from lilbee.server.handlers import SseStream
 
         sse = SseStream()
@@ -2507,7 +2507,7 @@ class TestModelsDelete:
         assert result.model == "test"
 
     async def test_reports_freed_size_from_shared_remove(self):
-        # bb-ziks.49 (review round 3): REST reports the real freed size (full
+        # REST reports the real freed size (full
         # multi-shard total), not a hardcoded 0, matching CLI and MCP.
         from lilbee.app.models import RemoveResult
 

--- a/tests/test_store_memory.py
+++ b/tests/test_store_memory.py
@@ -361,7 +361,7 @@ class TestRebuildEmbeddings:
         assert got.vector[3] == 1.0
 
     def test_snapshot_and_embed_run_under_write_lock(self, store):
-        # bb-ziks.7: the read+embed must hold the lock, or a concurrent add_memory
+        # The read+embed must hold the lock, or a concurrent add_memory
         # committing in the embed window is erased by the unconditional drop_table.
         from lilbee.runtime.lock import _write_mutex
 

--- a/tests/test_wiki_lint.py
+++ b/tests/test_wiki_lint.py
@@ -278,7 +278,7 @@ class TestOrphanDetection:
         assert orphan_issues == []
 
     def test_link_only_from_draft_does_not_exempt_orphan(self, tmp_path: Path):
-        # bb-ziks.78: a [[slug]] living only in a draft must not keep the live
+        # A [[slug]] living only in a draft must not keep the live
         # concept page off the orphan list (no published page links it).
         write_wiki_page(tmp_path, "concepts", "braking", "# Braking\n\nText.\n")
         write_wiki_page(tmp_path, "drafts", "wip", "Mentions [[braking]] but unpublished.\n")


### PR DESCRIPTION
## Problem

Several runtime resources were not released on the non-happy path, so a long-lived server slowly leaked them:

- The per-source ingest-lock registry kept one lock per filename forever; a daemon ingesting many files grew without bound.
- Reloading a role (a model or setting change) abandoned the old llama-server HTTP client pools without closing them, leaking sockets on every reload.
- The reasoning cap-fire path and the bare-JSON stream wrapper did not forward close to the underlying chat stream, leaking its connection until garbage collection.
- The crawler's chromium bootstrap left the ~180MB install subprocess running orphaned when the request was cancelled.
- The SDK vision-OCR timeout blocked the caller until the hung call returned instead of freeing it at the deadline.
- A split GGUF was tracked by only its first shard, so removal freed one shard's blob (orphaning the rest) and reported a fraction of the space actually freed; multi-shard downloads showed several separate 0-100% cycles against the wrong total.
- A couple of smaller issues: the readiness probe could throw mid-shutdown, and the CUDA library path grew a duplicate entry on every reload.

## Solution

The ingest-lock registry evicts a lock when it is released. Old client pools from a reload are retired and closed at the next reload (by which point their requests have finished) or at shutdown, never while a request might still hold one. The reasoning and bare-JSON stream wrappers forward close to their source. The chromium install is terminated on cancel. The SDK OCR caller is freed at the deadline. A split GGUF records its total size and every shard, so removal frees them all and reports the real total, and a multi-shard download shows one smooth 0-100%. The readiness probe stays read-only, and the CUDA path is composed idempotently.

All changed paths keep full test coverage, including the leak and lifecycle behaviors.
