### PR TITLE
Ingestion & chunking integrity: non-ASCII code, OCR, embeddings, cancel-safety

### DIFF
--- a/src/lilbee/data/code_chunker.py
+++ b/src/lilbee/data/code_chunker.py
@@ -105,6 +105,23 @@ def _chunk_header(source_name: str, symbols: list[str], line_start: int, line_en
     return header
 
 
+def _line_span(start_line_zero_based: int, content: str) -> tuple[int, int]:
+    """1-based inclusive ``(line_start, line_end)`` the chunk's content covers.
+
+    ``line_end`` is derived from the content's own line count rather than the
+    parser's ``end_line``: tree-sitter reports ``end_line`` as the count of
+    newline-terminated lines, so a chunk whose final line has no trailing newline
+    (the last chunk of a file that does not end in one, or a sub-line split) would
+    otherwise under-report its last line by one.
+    """
+    line_start = start_line_zero_based + 1
+    # count("\n") plus one for a final line without a trailing newline; empty
+    # content yields a single (degenerate) line so line_end never precedes start.
+    spanned = content.count("\n") + (0 if content.endswith("\n") else 1)
+    line_end = line_start + max(spanned, 1) - 1
+    return line_start, line_end
+
+
 def _chunks_from_result(result: Any, source_name: str) -> list[CodeChunk]:
     """Build :class:`CodeChunk` records from tree-sitter's size-bounded ``result.chunks``.
 
@@ -117,8 +134,7 @@ def _chunks_from_result(result: Any, source_name: str) -> list[CodeChunk]:
     chunks: list[CodeChunk] = []
     for i, tc in enumerate(result.chunks):
         symbols = list(tc.metadata.symbols_defined) if tc.metadata is not None else []
-        line_start = tc.start_line + 1
-        line_end = tc.end_line
+        line_start, line_end = _line_span(tc.start_line, tc.content)
         header = _chunk_header(source_name, symbols, line_start, line_end)
         chunks.append(
             CodeChunk(

--- a/src/lilbee/data/code_chunker.py
+++ b/src/lilbee/data/code_chunker.py
@@ -25,17 +25,6 @@ log = logging.getLogger(__name__)
 
 
 @dataclass
-class SymbolInfo:
-    """Extracted symbol metadata from tree-sitter process()."""
-
-    name: str
-    kind: str
-    line_start: int
-    line_end: int
-    text: str
-
-
-@dataclass
 class CodeChunk:
     """A chunk of source code with line location metadata."""
 
@@ -101,32 +90,62 @@ def _fallback_chunks(text: str) -> list[CodeChunk]:
     return results
 
 
-def _extract_symbols(result: Any, source_text: str) -> list[SymbolInfo]:
-    """Parse process() result into typed SymbolInfo objects."""
-    symbols: list[SymbolInfo] = []
-    for entry in result.structure:
-        span = entry.span
-        symbols.append(
-            SymbolInfo(
-                name=str(entry.name),
-                kind=str(entry.kind).lower(),
-                line_start=span.start_line + 1,
-                line_end=span.end_line + 1,
-                text=source_text[span.start_byte : span.end_byte],
+def _chunk_header(source_name: str, symbols: list[str], line_start: int, line_end: int) -> str:
+    """Build the metadata header prepended to a code chunk.
+
+    ``source_name`` is the relative source path, never the host's absolute path,
+    so an exported/shared corpus does not leak the operator's disk layout.
+    ``symbols`` are the names defined in the chunk (empty for an anonymous or
+    symbol-free span, in which case the name segment is omitted entirely).
+    """
+    header = f"# File: {source_name}"
+    if symbols:
+        header += f" | {', '.join(symbols)}"
+    header += f" (lines {line_start}-{line_end})"
+    return header
+
+
+def _chunks_from_result(result: Any, source_name: str) -> list[CodeChunk]:
+    """Build :class:`CodeChunk` records from tree-sitter's size-bounded ``result.chunks``.
+
+    ``result.chunks`` is the ``chunk_max_size``-aware output: each entry's
+    ``content`` is the already-extracted UTF-8 text (so there is no manual
+    byte-offset slicing, which corrupts non-ASCII source) and its size honors
+    the configured budget. ``metadata.symbols_defined`` lists the symbols in the
+    chunk, including methods of a class, so nested symbols are not folded away.
+    """
+    chunks: list[CodeChunk] = []
+    for i, tc in enumerate(result.chunks):
+        symbols = list(tc.metadata.symbols_defined) if tc.metadata is not None else []
+        line_start = tc.start_line + 1
+        line_end = tc.end_line
+        header = _chunk_header(source_name, symbols, line_start, line_end)
+        chunks.append(
+            CodeChunk(
+                chunk=f"{header}\n\n{tc.content}",
+                line_start=line_start,
+                line_end=line_end,
+                chunk_index=i,
             )
         )
-    return symbols
+    return chunks
 
 
-def chunk_code(file_path: Path) -> list[CodeChunk]:
+def chunk_code(file_path: Path, source_name: str | None = None) -> list[CodeChunk]:
     """Chunk a source file using tree-sitter-language-pack's process() API.
-    Extracts structural symbols (functions, classes) and builds enriched
-    chunks with metadata headers. Falls back to token-based chunking
-    if the language isn't supported or parsing fails.
+
+    Emits the parser's size-bounded chunks (``chunk_max_size``-aware) with a
+    metadata header naming the relative ``source_name`` and the symbols defined
+    in each chunk. Falls back to token-based chunking when the language is
+    unsupported, the parser is unavailable, parsing fails, or it produces no
+    chunks. ``source_name`` defaults to the file's basename so the header never
+    carries the absolute path.
     """
     source_text = file_path.read_text(encoding="utf-8", errors="replace")
     if not source_text.strip():
         return []
+
+    label = source_name if source_name is not None else file_path.name
 
     lang = _detect_language(file_path)
     if not lang:
@@ -147,26 +166,9 @@ def chunk_code(file_path: Path) -> list[CodeChunk]:
         log.debug("tree-sitter process() failed for %s", file_path, exc_info=True)
         return _fallback_chunks(source_text)
 
-    symbols = _extract_symbols(result, source_text)
-    if not symbols:
+    chunks = _chunks_from_result(result, label)
+    if not chunks:
         return _fallback_chunks(source_text)
-
-    chunks: list[CodeChunk] = []
-    for i, sym in enumerate(symbols):
-        header = f"# File: {file_path}"
-        if sym.name and sym.kind:
-            header += f" | {sym.kind}: {sym.name}"
-        header += f" (lines {sym.line_start}-{sym.line_end})"
-
-        chunks.append(
-            CodeChunk(
-                chunk=f"{header}\n\n{sym.text}",
-                line_start=sym.line_start,
-                line_end=sym.line_end,
-                chunk_index=i,
-            )
-        )
-
     return chunks
 
 

--- a/src/lilbee/data/code_chunker.py
+++ b/src/lilbee/data/code_chunker.py
@@ -1,7 +1,8 @@
-"""Code chunking via tree-sitter AST analysis.
+"""Code chunking via tree-sitter.
 
-Extracts structured symbol information (functions, classes, imports)
-and builds enriched chunk headers with symbol metadata.
+Consumes the parser's size-bounded chunks and prepends a header naming the
+relative source and the symbols each chunk defines. Falls back to plain text
+chunking when the language is unsupported or parsing fails.
 """
 
 import logging

--- a/src/lilbee/data/ingest/code.py
+++ b/src/lilbee/data/ingest/code.py
@@ -17,7 +17,7 @@ def ingest_code_sync(
     on_progress: DetailedProgressCallback = noop_callback,
 ) -> list[ChunkRecord]:
     """Parse code with tree-sitter, chunk, embed, and return store-ready records."""
-    code_chunks: list[CodeChunk] = chunk_code(path)
+    code_chunks: list[CodeChunk] = chunk_code(path, source_name=source_name)
     if not code_chunks:
         return []
 

--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -11,7 +11,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from PIL import Image
+from PIL import Image, ImageSequence
 
 if TYPE_CHECKING:
     from kreuzberg import ExtractionConfig, ExtractionResult
@@ -187,11 +187,14 @@ async def _vision_ocr_cached(
     loop or a single image). Output is cached by file content + model, so a retry
     after a downstream failure (chunk/embed/store) reuses the pages, not re-OCR-ing.
     """
+    # The per-page timeout bounds completeness: a page that exhausts the budget
+    # yields empty text. Key on it so raising the timeout re-OCRs the file rather
+    # than serving the earlier, partially-empty cached result for the same content.
     key = ocr_cache_key(
         file_hash(path),
         backend="vision",
         model=cfg.vision_model,
-        extra=str(cfg.vision_ocr_max_tokens),
+        extra=f"{cfg.vision_ocr_max_tokens}:{_effective_ocr_timeout()}",
     )
     cached = load_ocr_pages(key)
     if cached is not None:
@@ -253,11 +256,19 @@ async def _vision_image_ocr(
     on_progress: DetailedProgressCallback,
     page_texts_out: list[PageTextRecord] | None = None,
 ) -> list[ChunkRecord]:
-    """Vision OCR a single image (one page) through the worker pool."""
+    """Vision OCR an image through the worker pool, one page per frame.
+
+    A multi-frame TIFF/GIF yields one OCR page per frame instead of silently
+    dropping every frame after the first.
+    """
 
     async def _ocr() -> list[tuple[int, str]]:
-        text = await asyncio.to_thread(_image_ocr_text, path)
-        return [(1, text)]
+        page_pngs = await asyncio.to_thread(_image_page_pngs, path)
+        pages: list[tuple[int, str]] = []
+        for page_num, png in enumerate(page_pngs, start=1):
+            text = await asyncio.to_thread(_ocr_image_png, png)
+            pages.append((page_num, text))
+        return pages
 
     return await _vision_ocr_cached(
         path,
@@ -269,19 +280,26 @@ async def _vision_image_ocr(
     )
 
 
-def _image_ocr_text(path: Path) -> str:
-    """OCR one image through the vision server (a single chat-completions call)."""
+def _ocr_image_png(png: bytes) -> str:
+    """OCR one rendered image page through the vision server."""
     return get_services().provider.vision_ocr(
-        _image_to_png_bytes(path), cfg.vision_model, timeout=_effective_ocr_timeout()
+        png, cfg.vision_model, timeout=_effective_ocr_timeout()
     )
 
 
-def _image_to_png_bytes(path: Path) -> bytes:
-    """Load any mapped image extension and re-encode as PNG for the projector."""
+def _image_page_pngs(path: Path) -> list[bytes]:
+    """Each frame of a (possibly multi-frame) image, re-encoded as PNG.
+
+    A single-frame image yields one entry; a multipage TIFF/GIF yields one per
+    frame so every page reaches the projector instead of just the first.
+    """
+    pages: list[bytes] = []
     with Image.open(path) as img:
-        buf = BytesIO()
-        img.convert("RGB").save(buf, format="PNG")
-        return buf.getvalue()
+        for frame in ImageSequence.Iterator(img):
+            buf = BytesIO()
+            frame.convert("RGB").save(buf, format="PNG")
+            pages.append(buf.getvalue())
+    return pages
 
 
 def _run_tesseract_sync(path: Path) -> Any:
@@ -347,6 +365,16 @@ async def _tesseract_ocr_fallback(
     return await chunk_and_embed_pages(page_texts, source_name, content_type, on_progress)
 
 
+def _chunk_pages(page_texts: Sequence[tuple[int, str]]) -> list[tuple[int, str]]:
+    """Chunk each OCR page's text. Semantic chunking is off: a single OCR page
+    rarely spans multiple topics, so the semantic round-trip is not worth it."""
+    return [
+        (page_num, chunk)
+        for page_num, text in page_texts
+        for chunk in chunk_text(text, use_semantic=False)
+    ]
+
+
 async def chunk_and_embed_pages(
     page_texts: Sequence[tuple[int, str]],
     source_name: str,
@@ -357,12 +385,9 @@ async def chunk_and_embed_pages(
     if not page_texts:
         return []
 
-    # Single OCR page rarely spans multiple topics; skip the semantic round-trip.
-    all_chunks = [
-        (page_num, chunk)
-        for page_num, text in page_texts
-        for chunk in chunk_text(text, use_semantic=False)
-    ]
+    # chunk_text runs kreuzberg's synchronous extractor; offload it so a long OCR
+    # document does not stall sibling files sharing this event loop.
+    all_chunks = await asyncio.to_thread(_chunk_pages, page_texts)
     if not all_chunks:
         return []
     texts = [c for _, c in all_chunks]
@@ -427,6 +452,11 @@ async def _handle_scanned_pdf_fallback(
     file.
     """
     del result  # Both backends re-extract; the kreuzberg result is not reused.
+    if _effective_enable_ocr() is False:
+        # OCR explicitly disabled: skip entirely (vision and Tesseract) rather
+        # than paying the full Tesseract cost the config says is turned off.
+        log.info("OCR disabled; skipping scanned-PDF OCR for %s", source_name)
+        return []
     use_ocr = _should_run_ocr()
     if use_ocr and cfg.vision_model:
         log.info(
@@ -474,6 +504,11 @@ async def _handle_image(
     An image has no text layer to extract first, so it routes straight to OCR --
     the same downstream call a PDF page hits after it is rasterized to an image.
     """
+    if _effective_enable_ocr() is False:
+        # OCR explicitly disabled: an image has no text layer, so skip it rather
+        # than paying the full Tesseract cost the config says is turned off.
+        log.info("OCR disabled; skipping image OCR for %s", source_name)
+        return []
     if _should_run_ocr() and cfg.vision_model:
         log.info("Image: using vision OCR for %s (model=%s)", source_name, cfg.vision_model)
         return await _vision_image_ocr(
@@ -584,7 +619,11 @@ async def ingest_markdown(
     if not raw_text.strip():
         return []
 
-    texts = chunk_text(raw_text, mime_type="text/markdown", heading_context=True)
+    # chunk_text runs kreuzberg's synchronous extractor; offload it so a large
+    # markdown doc does not stall sibling files sharing this event loop.
+    texts = await asyncio.to_thread(
+        chunk_text, raw_text, mime_type="text/markdown", heading_context=True
+    )
     if not texts:
         return []
 

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -690,8 +690,19 @@ async def _collect_results(
         while in_flight:
             done, still_running = await asyncio.wait(in_flight, return_when=asyncio.FIRST_COMPLETED)
             in_flight = set(still_running)
+            saw_cancel = False
             for fut in done:
-                result = fut.result()
+                try:
+                    result = fut.result()
+                except asyncio.CancelledError:
+                    # A user cancel completes several futures together. Flag it but
+                    # keep draining `done` so a sibling that genuinely finished in
+                    # the same batch is still buffered and flushed (the
+                    # cancel-persists contract), then propagate after the loop. A
+                    # non-cancel exception still propagates immediately, as before,
+                    # so a genuine ingest bug surfaces and cancels the siblings.
+                    saw_cancel = True
+                    continue
                 completed_count += 1
                 status = _classify_result(result, added, updated, failed, skipped, reasons)
                 if status is BatchStatus.INGESTED:
@@ -712,6 +723,10 @@ async def _collect_results(
                 _report_file_progress(
                     result, status, completed_count, total, on_progress, progress, ptask
                 )
+            if saw_cancel:
+                # Completed siblings in this batch are now buffered; propagate the
+                # cancel so the finally flushes them and cancels still-running work.
+                raise asyncio.CancelledError
             _refill_window(in_flight, pending, window)
     finally:
         # The inner finally guarantees the sibling cancel even if the flush

--- a/src/lilbee/data/store/lance_helpers.py
+++ b/src/lilbee/data/store/lance_helpers.py
@@ -85,8 +85,14 @@ def safe_delete(
 
 
 def escape_sql_string(value: str) -> str:
-    """Escape single quotes for SQL predicates."""
-    return value.replace("\\", "\\\\").replace("'", "''")
+    """Escape a value for a single-quoted SQL string literal in a LanceDB predicate.
+
+    LanceDB's Datafusion engine follows standard SQL: the only escape inside a
+    ``'...'`` literal is doubling the single quote. Backslash is an ordinary
+    character, so escaping it (``\\`` -> ``\\\\``) corrupts the literal and makes a
+    value containing a backslash (e.g. a Windows path) never match.
+    """
+    return value.replace("'", "''")
 
 
 def local_owner_predicate() -> str:

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -533,8 +533,8 @@ class LitellmSdkBackend:
         # Order by the response's ``index`` rather than arrival order: a proxy or
         # gateway may return the batch out of order, and the consumer zips vectors
         # to inputs positionally, so a reorder would silently mis-pair every chunk
-        # with the wrong vector. Falls back to arrival position when an item omits
-        # index. Mirrors the rerank path's index handling.
+        # with the wrong vector. ``index`` is required (always present in a
+        # spec-conforming response), mirroring the rerank path's direct read.
         vectors = [_embedding_vector(item) for item in sorted(data, key=_embedding_index)]
         if isinstance(response, dict):
             model = response.get("model")

--- a/src/lilbee/providers/litellm_sdk.py
+++ b/src/lilbee/providers/litellm_sdk.py
@@ -15,7 +15,7 @@ import base64
 import functools
 import logging
 from collections.abc import Callable, Iterator
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -324,6 +324,23 @@ _KIND_MESSAGES: dict[ProviderErrorKind, str] = {
     ),
 }
 
+
+def _embedding_index(item: Any) -> int:
+    """Return an embedding item's ``index`` across the dict and object response shapes.
+
+    The OpenAI embeddings response always carries ``index``; mirrors the rerank
+    path's direct read rather than a defaulted lookup.
+    """
+    idx = item["index"] if isinstance(item, dict) else item.index
+    return int(idx)
+
+
+def _embedding_vector(item: Any) -> list[float]:
+    """Return an embedding item's vector across the dict and object response shapes."""
+    vector = item["embedding"] if isinstance(item, dict) else item.embedding
+    return cast("list[float]", vector)
+
+
 # Operation labels prefixed onto the fallback message for an unrecognised error.
 _CHAT_FAILED = "Chat failed"
 _EMBED_FAILED = "Embedding failed"
@@ -513,7 +530,12 @@ class LitellmSdkBackend:
         except Exception as exc:
             raise _provider_error(_EMBED_FAILED, exc, request.ref.for_display()) from exc
         data = response["data"] if isinstance(response, dict) else response.data
-        vectors = [item["embedding"] for item in data]
+        # Order by the response's ``index`` rather than arrival order: a proxy or
+        # gateway may return the batch out of order, and the consumer zips vectors
+        # to inputs positionally, so a reorder would silently mis-pair every chunk
+        # with the wrong vector. Falls back to arrival position when an item omits
+        # index. Mirrors the rerank path's index handling.
+        vectors = [_embedding_vector(item) for item in sorted(data, key=_embedding_index)]
         if isinstance(response, dict):
             model = response.get("model")
         else:

--- a/tests/providers/test_sdk_backend_contract.py
+++ b/tests/providers/test_sdk_backend_contract.py
@@ -256,7 +256,7 @@ class TestCompletionKwargs:
 
     def test_api_key_forwarded_to_embed(self, backend: LlmSdkBackend) -> None:
         fake = mock.MagicMock()
-        fake.embedding.return_value = {"data": [{"embedding": [0.1]}], "model": "x"}
+        fake.embedding.return_value = {"data": [{"embedding": [0.1], "index": 0}], "model": "x"}
         req = EmbeddingRequest(
             ref=parse_model_ref("openai/text-embedding-3-small"),
             inputs=["hi"],
@@ -271,10 +271,28 @@ class TestCompletionKwargs:
 class TestEmbedReturnsEmbeddingResult:
     def test_vectors_returned(self, backend: LlmSdkBackend) -> None:
         fake = mock.MagicMock()
-        fake.embedding.return_value = {"data": [{"embedding": [0.1, 0.2]}], "model": "fake"}
+        fake.embedding.return_value = {
+            "data": [{"embedding": [0.1, 0.2], "index": 0}],
+            "model": "fake",
+        }
         with mock.patch.dict(sys.modules, {"litellm": fake}):
             result = backend.embed(_embedding_request())
         assert result.vectors == [[0.1, 0.2]]
+
+    def test_embeddings_reordered_by_index(self, backend: LlmSdkBackend) -> None:
+        """A gateway returning the batch out of order is corrected by the response's
+        index, since the consumer zips vectors to inputs positionally."""
+        fake = mock.MagicMock()
+        fake.embedding.return_value = {
+            "data": [
+                {"embedding": [1.0], "index": 1},
+                {"embedding": [0.0], "index": 0},
+            ],
+            "model": "x",
+        }
+        with mock.patch.dict(sys.modules, {"litellm": fake}):
+            result = backend.embed(_embedding_request())
+        assert result.vectors == [[0.0], [1.0]]
 
     def test_embed_error_is_wrapped(self, backend: LlmSdkBackend) -> None:
         fake = mock.MagicMock()
@@ -288,7 +306,7 @@ class TestEmbedReturnsEmbeddingResult:
     def test_object_response_model_attribute(self, backend: LlmSdkBackend) -> None:
         # Some SDKs return a response object rather than a dict.
         resp = mock.MagicMock()
-        resp.data = [{"embedding": [0.3]}]
+        resp.data = [{"embedding": [0.3], "index": 0}]
         resp.model = "obj-model"
         fake = mock.MagicMock()
         fake.embedding.return_value = resp

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -495,9 +495,64 @@ class Greeter:
         finally:
             path.unlink()
         joined = "\n".join(c.chunk for c in chunks)
-        assert "náme" in joined
-        assert "Wörker" in joined
-        assert "résumé" in joined
+        # Assert the exact multi-byte spans, not bare identifiers: byte-offset
+        # slicing of a str shifts after the first multibyte char, so the full
+        # declarations would be mangled even though a stray identifier might survive.
+        assert "def greet(náme):" in joined
+        assert 'return f"Hallo {náme}"' in joined
+        assert "class Wörker:" in joined
+        assert "def café(self):" in joined
+        assert 'return "résumé"' in joined
+
+    def test_line_end_derived_from_content_not_parser_end_line(self):
+        """A chunk whose final line has no trailing newline must report that line as
+        line_end. tree-sitter's end_line counts newline-terminated lines, so it
+        under-reports here; line_end is derived from the content instead."""
+        from unittest.mock import patch
+
+        from lilbee.data.code_chunker import chunk_code
+
+        # Content spans two physical lines but ends without a trailing newline;
+        # the fake's end_line=1 mirrors the real parser's under-count.
+        result = _FakeResult(
+            [_FakeTSChunk("def a():\n    return 1", start_line=0, end_line=1, symbols=["a"])]
+        )
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("def a():\n    return 1")
+            f.flush()
+            path = Path(f.name)
+        try:
+            with (
+                patch("lilbee.data.code_chunker._ensure_language", return_value=True),
+                patch("lilbee.data.code_chunker.process", return_value=result),
+            ):
+                chunks = chunk_code(path, source_name="m.py")
+        finally:
+            path.unlink()
+        assert chunks[0].line_start == 1
+        assert chunks[0].line_end == 2
+        assert "lines 1-2" in chunks[0].chunk
+
+    def test_real_parser_line_range_spans_no_trailing_newline_file(self):
+        """Against the real parser, the chunk line range reaches the file's final
+        line even when the file has no trailing newline."""
+        from lilbee.data.code_chunker import chunk_code
+
+        # 5 physical lines (L1..L5), no trailing newline on the last.
+        code = "def alpha():\n    return 1\n\ndef beta():\n    return 2"
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", mode="w", encoding="utf-8", delete=False
+        ) as f:
+            f.write(code)
+            f.flush()
+            path = Path(f.name)
+        try:
+            chunks = chunk_code(path)
+        finally:
+            path.unlink()
+        assert chunks
+        assert min(c.line_start for c in chunks) == 1
+        assert max(c.line_end for c in chunks) == 5
 
 
 class TestHeadingContextNoDuplicate:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -5,11 +5,40 @@ implementation.
 """
 
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 
 from lilbee.data.chunk import chunk_text
+
+
+@dataclass
+class _FakeMeta:
+    """Stand-in for tree-sitter ChunkContext.metadata in chunk_code tests."""
+
+    symbols_defined: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _FakeTSChunk:
+    """Stand-in for a tree-sitter result.chunks entry (size-bounded CodeChunk)."""
+
+    content: str
+    start_line: int
+    end_line: int
+    symbols: list[str] = field(default_factory=list)
+
+    @property
+    def metadata(self) -> _FakeMeta:
+        return _FakeMeta(symbols_defined=self.symbols)
+
+
+@dataclass
+class _FakeResult:
+    """Stand-in for tree-sitter ProcessResult exposing only .chunks."""
+
+    chunks: list[_FakeTSChunk]
 
 
 class TestChunkText:
@@ -296,7 +325,7 @@ class Greeter:
         finally:
             path.unlink()
 
-    def test_empty_symbols_triggers_fallback(self):
+    def test_empty_chunks_triggers_fallback(self):
         from unittest.mock import patch
 
         from lilbee.data.code_chunker import chunk_code
@@ -307,16 +336,15 @@ class Greeter:
             path = Path(f.name)
 
         try:
-            # Stub out _ensure_language and process so we land on the
-            # no-symbols branch deterministically, regardless of whether
-            # tree-sitter Python is installed on the host.
+            # process() yielding no size-bounded chunks must fall back to text
+            # chunking rather than returning nothing.
             with (
                 patch("lilbee.data.code_chunker._ensure_language", return_value=True),
-                patch("lilbee.data.code_chunker.process", return_value={}),
-                patch("lilbee.data.code_chunker._extract_symbols", return_value=[]),
+                patch("lilbee.data.code_chunker.process", return_value=_FakeResult([])),
             ):
                 chunks = chunk_code(path)
                 assert isinstance(chunks, list)
+                assert chunks  # fell back to non-empty text chunks
         finally:
             path.unlink()
 
@@ -360,22 +388,22 @@ class Greeter:
         finally:
             path.unlink()
 
-    def test_chunk_code_emits_symbol_chunks(self):
-        """Cover the structured-chunk emission path when _extract_symbols
-        returns at least one symbol. Mocked so the test is independent of
-        whether tree-sitter actually parses on this CI host."""
+    def test_chunk_code_emits_chunks_from_result(self):
+        """chunk_code consumes the parser's size-bounded result.chunks (not the
+        unbounded structure tree): the header names the relative source and the
+        chunk's symbols, and the content is passed through verbatim. Mocked so the
+        test is independent of whether tree-sitter parses on this CI host."""
         from unittest.mock import patch
 
-        from lilbee.data.code_chunker import SymbolInfo, chunk_code
+        from lilbee.data.code_chunker import chunk_code
 
-        symbol = SymbolInfo(
-            name="hello",
-            kind="function",
-            line_start=1,
-            line_end=3,
-            text="def hello():\n    return 1\n",
+        result = _FakeResult(
+            [
+                _FakeTSChunk(
+                    "def hello():\n    return 1\n", start_line=0, end_line=2, symbols=["hello"]
+                )
+            ]
         )
-
         with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
             f.write("def hello():\n    return 1\n")
             f.flush()
@@ -384,19 +412,92 @@ class Greeter:
         try:
             with (
                 patch("lilbee.data.code_chunker._ensure_language", return_value=True),
-                patch("lilbee.data.code_chunker.process", return_value={}),
-                patch("lilbee.data.code_chunker._extract_symbols", return_value=[symbol]),
+                patch("lilbee.data.code_chunker.process", return_value=result),
             ):
-                chunks = chunk_code(path)
+                chunks = chunk_code(path, source_name="pkg/mod.py")
         finally:
             path.unlink()
 
         assert len(chunks) == 1
         first = chunks[0]
-        assert "function: hello" in first.chunk
+        assert "# File: pkg/mod.py | hello (lines 1-2)" in first.chunk
+        assert "def hello" in first.chunk
         assert first.line_start == 1
-        assert first.line_end == 3
+        assert first.line_end == 2
         assert first.chunk_index == 0
+
+    def test_chunk_header_omits_symbols_and_never_says_none(self):
+        """A symbol-free (anonymous) chunk omits the symbol segment entirely
+        rather than rendering the literal string 'None' (bb-ziks.62)."""
+        from unittest.mock import patch
+
+        from lilbee.data.code_chunker import chunk_code
+
+        result = _FakeResult([_FakeTSChunk("x = 1\n", start_line=0, end_line=1, symbols=[])])
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("x = 1\n")
+            f.flush()
+            path = Path(f.name)
+        try:
+            with (
+                patch("lilbee.data.code_chunker._ensure_language", return_value=True),
+                patch("lilbee.data.code_chunker.process", return_value=result),
+            ):
+                chunks = chunk_code(path, source_name="m.py")
+        finally:
+            path.unlink()
+        assert chunks[0].chunk.startswith("# File: m.py (lines 1-1)")
+        assert "None" not in chunks[0].chunk
+        assert "|" not in chunks[0].chunk
+
+    def test_header_uses_relative_source_name_not_absolute_path(self):
+        """The header carries the relative source name, never the host's absolute
+        path, so an exported corpus does not leak the operator's disk layout
+        (bb-ziks.19)."""
+        from unittest.mock import patch
+
+        from lilbee.data.code_chunker import chunk_code
+
+        result = _FakeResult([_FakeTSChunk("code\n", start_line=0, end_line=1, symbols=["s"])])
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("code\n")
+            f.flush()
+            path = Path(f.name)
+        try:
+            with (
+                patch("lilbee.data.code_chunker._ensure_language", return_value=True),
+                patch("lilbee.data.code_chunker.process", return_value=result),
+            ):
+                chunks = chunk_code(path, source_name="src/x.py")
+        finally:
+            path.unlink()
+        assert "src/x.py" in chunks[0].chunk
+        assert str(path) not in chunks[0].chunk
+
+    def test_non_ascii_code_not_corrupted(self):
+        """Non-ASCII identifiers/strings survive chunking: the prior code sliced a
+        str with tree-sitter UTF-8 byte offsets, mis-slicing every symbol after
+        the first multibyte char (bb-7jg1.4)."""
+        from lilbee.data.code_chunker import chunk_code
+
+        code = (
+            'def greet(náme):\n    return f"Hallo {náme}"\n\n'
+            'class Wörker:\n    def café(self):\n        return "résumé"\n'
+        )
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", mode="w", encoding="utf-8", delete=False
+        ) as f:
+            f.write(code)
+            f.flush()
+            path = Path(f.name)
+        try:
+            chunks = chunk_code(path)
+        finally:
+            path.unlink()
+        joined = "\n".join(c.chunk for c in chunks)
+        assert "náme" in joined
+        assert "Wörker" in joined
+        assert "résumé" in joined
 
 
 class TestHeadingContextNoDuplicate:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -744,7 +744,24 @@ class TestSyncCancellation:
         def _record_flush(buffer, _added, _updated, _failed, _skipped, _flush_failed):
             flushed.extend(r.name for r in buffer)
 
+        # `done` is a set, so the order the loop sees the two completed futures is
+        # not guaranteed. Force the cancelled future to be processed FIRST so the
+        # test deterministically fails on the old code (its CancelledError aborted
+        # the loop before the completed sibling) and passes only with the fix.
+        real_wait = pipeline.asyncio.wait
+
+        async def _cancel_first_wait(fs, **kwargs):
+            done, pending = await real_wait(fs, **kwargs)
+
+            def _is_cancel(fut):
+                return fut.cancelled() or isinstance(
+                    fut.exception() if not fut.cancelled() else None, asyncio.CancelledError
+                )
+
+            return sorted(done, key=lambda f: 0 if _is_cancel(f) else 1), pending
+
         with (
+            mock.patch.object(pipeline.asyncio, "wait", _cancel_first_wait),
             mock.patch.object(pipeline, "_flush_writes", side_effect=_record_flush),
             mock.patch.object(pipeline, "_purge_emptied_sources"),
             pytest.raises(asyncio.CancelledError),
@@ -829,6 +846,38 @@ class TestIngestHelpers:
         with patch("lilbee.data.code_chunker.chunk_code", return_value=[]):
             result = ingest_code_sync(f, "empty.py")
             assert result == []
+
+    async def test_ingest_code_header_uses_relative_source_name(self, isolated_env, mock_svc):
+        """ingest_code_sync threads the relative source_name into the chunk header so
+        the indexed content never carries the host's absolute path (bb-ziks.19).
+        Reverting to chunk_code(path) would emit the file's basename instead."""
+        from unittest.mock import patch
+
+        from lilbee.data.ingest import ingest_code_sync
+
+        class _FakeMeta:
+            symbols_defined = ("alpha",)
+
+        class _FakeChunk:
+            content = "def alpha():\n    return 1\n"
+            start_line = 0
+            end_line = 2
+            metadata = _FakeMeta()
+
+        class _FakeResult:
+            chunks = (_FakeChunk(),)
+
+        f = isolated_env / "abs_module.py"
+        f.write_text("def alpha():\n    return 1\n")
+        with (
+            patch("lilbee.data.code_chunker._ensure_language", return_value=True),
+            patch("lilbee.data.code_chunker.process", return_value=_FakeResult()),
+        ):
+            records = ingest_code_sync(f, "pkg/mod.py")
+        assert records
+        joined = "\n".join(r["chunk"] for r in records)
+        assert "# File: pkg/mod.py" in joined
+        assert str(f) not in joined  # absolute path must never leak into content
 
     @mock.patch("kreuzberg.extract_file_sync", new_callable=Mock)
     async def testingest_document_pdf_with_pages(self, mock_kf, isolated_env):
@@ -2363,6 +2412,24 @@ class TestImageOcr:
         with mock.patch("lilbee.data.ingest.extract._run_tesseract_sync") as mock_tess:
             mock_tess.return_value = _make_empty_result()
             assert await ingest_document(f, "scan.png", "image") == []
+
+    async def test_multipage_image_ocrs_every_frame_end_to_end(self, isolated_env, mock_svc):
+        """A multi-frame TIFF routed to vision OCR yields one OCR call and one page
+        record per frame (bb-7jg1.10), not just the first frame."""
+        cfg.enable_ocr = True
+        cfg.vision_model = "org/Test-Vision-GGUF/test-vision-Q4_K_M.gguf"
+        mock_svc.provider.vision_ocr.return_value = "frame text " * 5
+        from PIL import Image
+
+        f = isolated_env / "multi.tiff"
+        frames = [Image.new("RGB", (4, 4), color=c) for c in [(1, 2, 3), (4, 5, 6), (7, 8, 9)]]
+        frames[0].save(f, format="TIFF", save_all=True, append_images=frames[1:])
+
+        from lilbee.data.ingest import ingest_document
+
+        records = await ingest_document(f, "multi.tiff", "image")
+        assert mock_svc.provider.vision_ocr.call_count == 3
+        assert sorted({r["page_start"] for r in records}) == [1, 2, 3]
 
     def test_image_page_pngs_single_frame_reencodes(self, isolated_env):
         from lilbee.data.ingest.extract import _image_page_pngs

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -2076,13 +2076,11 @@ class TestVisionFallback:
         )
 
     @mock.patch("kreuzberg.extract_file_sync", new_callable=Mock)
-    async def test_vision_pool_not_called_when_ocr_disabled(self, mock_kf, isolated_env, mock_svc):
-        """``cfg.enable_ocr=False`` skips the vision pool path entirely.
-
-        Tesseract OCR runs inline (via the patched ``extract_file_sync``)
-        rather than through ``provider.pdf_ocr``, so the assertion is
-        that the pool was never reached.
-        """
+    async def test_ocr_disabled_skips_both_backends(self, mock_kf, isolated_env, mock_svc):
+        """``cfg.enable_ocr=False`` disables OCR entirely (bb-ziks.20): neither the
+        vision pool nor the Tesseract fallback runs. Only the initial text-layer
+        extract is attempted; finding none, the file is skipped without paying the
+        Tesseract cost the config says is turned off."""
         mock_kf.return_value = _make_empty_result()
         cfg.enable_ocr = False
         f = isolated_env / "scanned.pdf"
@@ -2090,8 +2088,12 @@ class TestVisionFallback:
 
         from lilbee.data.ingest import ingest_document
 
-        result = await ingest_document(f, "scanned.pdf", "pdf")
+        with mock.patch("lilbee.data.ingest.extract._run_tesseract_sync") as mock_tess:
+            result = await ingest_document(f, "scanned.pdf", "pdf")
         mock_svc.provider.pdf_ocr.assert_not_called()
+        mock_tess.assert_not_called()
+        # Only the initial text-layer extract ran; no Tesseract re-extract.
+        assert mock_kf.call_count == 1
         assert result == []
 
     @mock.patch("kreuzberg.extract_file_sync", new_callable=Mock)
@@ -2272,6 +2274,48 @@ class TestImageOcr:
 
         assert await ingest_document(f, "scan.png", "image") == []
 
+    async def test_image_ocr_disabled_skips_both_backends(self, isolated_env, mock_svc):
+        """enable_ocr=False disables OCR entirely for images (bb-ziks.20): neither
+        the vision pool nor the Tesseract fallback runs."""
+        cfg.enable_ocr = False
+        cfg.vision_model = "org/Test-Vision-GGUF/test-vision-Q4_K_M.gguf"
+        f = isolated_env / "scan.png"
+        _write_png(f)
+
+        from lilbee.data.ingest import ingest_document
+
+        with mock.patch("lilbee.data.ingest.extract._run_tesseract_sync") as mock_tess:
+            result = await ingest_document(f, "scan.png", "image")
+        assert result == []
+        mock_svc.provider.vision_ocr.assert_not_called()
+        mock_tess.assert_not_called()
+
+    async def test_vision_ocr_cache_key_includes_timeout(self, isolated_env, mock_svc, monkeypatch):
+        """The vision OCR cache key carries the per-page timeout so raising it
+        re-OCRs rather than serving an earlier partially-empty result for the same
+        content (bb-ziks.39). Also exercises the cache-hit reuse path."""
+        from lilbee.data.ingest import extract
+        from lilbee.runtime.progress import noop_callback
+
+        cfg.enable_ocr = True
+        cfg.vision_model = "org/Test-Vision-GGUF/test-vision-Q4_K_M.gguf"
+        cfg.ocr_timeout = 77.0
+        captured: dict[str, str] = {}
+
+        def fake_key(file_h, *, backend, model, extra):
+            captured["extra"] = extra
+            return "cache-key"
+
+        monkeypatch.setattr(extract, "ocr_cache_key", fake_key)
+        monkeypatch.setattr(extract, "load_ocr_pages", lambda key: [(1, "cached page text")])
+        f = isolated_env / "scan.png"
+        _write_png(f)
+
+        result = await extract._vision_image_ocr(f, "scan.png", "image", on_progress=noop_callback)
+        assert "77" in captured["extra"]
+        assert result  # cache hit produced chunks from the cached page, no re-OCR
+        mock_svc.provider.vision_ocr.assert_not_called()
+
     async def test_image_tesseract_empty_skips_file(self, isolated_env, mock_svc):
         cfg.vision_model = ""
         cfg.enable_ocr = None
@@ -2284,15 +2328,32 @@ class TestImageOcr:
             mock_tess.return_value = _make_empty_result()
             assert await ingest_document(f, "scan.png", "image") == []
 
-    def test_image_to_png_bytes_reencodes(self, isolated_env):
-        from lilbee.data.ingest.extract import _image_to_png_bytes
+    def test_image_page_pngs_single_frame_reencodes(self, isolated_env):
+        from lilbee.data.ingest.extract import _image_page_pngs
 
         f = isolated_env / "x.bmp"
         from PIL import Image
 
         Image.new("RGB", (4, 4), color=(1, 2, 3)).save(f, format="BMP")
-        png = _image_to_png_bytes(f)
-        assert png.startswith(b"\x89PNG\r\n")
+        pages = _image_page_pngs(f)
+        assert len(pages) == 1
+        assert pages[0].startswith(b"\x89PNG\r\n")
+
+    def test_image_page_pngs_multipage_tiff_yields_all_frames(self, isolated_env):
+        """A multi-frame TIFF produces one PNG page per frame; the prior code
+        dropped every frame after the first (bb-7jg1.10)."""
+        from lilbee.data.ingest.extract import _image_page_pngs
+
+        f = isolated_env / "multi.tiff"
+        from PIL import Image
+
+        frame0 = Image.new("RGB", (4, 4), color=(1, 2, 3))
+        frame1 = Image.new("RGB", (4, 4), color=(4, 5, 6))
+        frame2 = Image.new("RGB", (4, 4), color=(7, 8, 9))
+        frame0.save(f, format="TIFF", save_all=True, append_images=[frame1, frame2])
+        pages = _image_page_pngs(f)
+        assert len(pages) == 3
+        assert all(p.startswith(b"\x89PNG\r\n") for p in pages)
 
 
 class TestShouldRunOcrAutoDetect:
@@ -2467,7 +2528,7 @@ class TestOcrFallbackBackendDispatch:
         self, mock_kf, isolated_env, mock_svc, caplog
     ):
         """Tesseract returning no pages produces a user-facing skip warning."""
-        cfg.enable_ocr = False
+        cfg.enable_ocr = None  # auto: no vision model -> Tesseract fallback runs
         cfg.vision_model = ""
         # Both pre-extract and tesseract fallback return empty.
         mock_kf.side_effect = [_make_empty_result(), _make_empty_result()]
@@ -2501,7 +2562,7 @@ class TestOcrFallbackBackendDispatch:
     @mock.patch("kreuzberg.extract_file_sync", new_callable=Mock)
     async def test_tesseract_no_timeout_runs_uncapped(self, mock_kf, isolated_env, mock_svc):
         """``cfg.tesseract_timeout == 0`` skips ``asyncio.wait_for`` and runs uncapped."""
-        cfg.enable_ocr = False
+        cfg.enable_ocr = None  # auto: no vision model -> Tesseract fallback runs
         cfg.vision_model = ""
         cfg.tesseract_timeout = 0
         mock_kf.side_effect = [
@@ -2523,7 +2584,7 @@ class TestOcrFallbackBackendDispatch:
         self, mock_kf, isolated_env, mock_svc, caplog
     ):
         """Tesseract exceeding the wall-clock cap logs a warning and skips the file."""
-        cfg.enable_ocr = False
+        cfg.enable_ocr = None  # auto: no vision model -> Tesseract fallback runs
         cfg.vision_model = ""
         cfg.tesseract_timeout = 30.0
         # Pre-extract returns empty; tesseract fallback's wait_for fires.
@@ -2549,7 +2610,7 @@ class TestOcrFallbackBackendDispatch:
         self, mock_kf, isolated_env, mock_svc, caplog
     ):
         """A kreuzberg backend crash logs a warning and returns no chunks."""
-        cfg.enable_ocr = False
+        cfg.enable_ocr = None  # auto: no vision model -> Tesseract fallback runs
         cfg.vision_model = ""
         cfg.tesseract_timeout = 30.0
         # Pre-extract OK; tesseract fallback raises.

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -725,6 +725,42 @@ class TestSyncCancellation:
         with pytest.raises(asyncio.CancelledError):
             await ingest_batch(files, added, {}, {}, {}, quiet=True, cancel=cancel)
 
+    async def test_cancel_in_batch_still_flushes_completed_sibling(self, isolated_env, mock_svc):
+        """A cancel landing in the same done-batch as a genuinely completed file must
+        not drop that file: it is buffered and flushed before the cancel propagates
+        (bb-ziks.21). Prior code re-raised the first CancelledError from fut.result()
+        and abandoned the sibling."""
+        from lilbee.data.ingest import pipeline
+
+        async def _ok():
+            return _real_ingest_result("good.pdf", file_hash="h-good")
+
+        async def _cancelled():
+            raise asyncio.CancelledError
+
+        added: dict[str, None] = {}
+        flushed: list[str] = []
+
+        def _record_flush(buffer, _added, _updated, _failed, _skipped, _flush_failed):
+            flushed.extend(r.name for r in buffer)
+
+        with (
+            mock.patch.object(pipeline, "_flush_writes", side_effect=_record_flush),
+            mock.patch.object(pipeline, "_purge_emptied_sources"),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await pipeline._collect_results(
+                iter([_ok(), _cancelled()]),
+                total=2,
+                added=added,
+                updated={},
+                failed={},
+                skipped={},
+                window=2,
+            )
+
+        assert "good.pdf" in flushed
+
     async def test_atomic_delete_for_modified_file(self, mock_extract_file, isolated_env, mock_svc):
         """Modified file: its old chunks are cleaned up in the same batched write."""
         from lilbee.data.ingest import sync

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3294,7 +3294,7 @@ class TestEmbedApiBaseRouting:
         provider = SdkLLMProvider(LitellmSdkBackend())
         cfg.embedding_model = "ollama/nomic-embed-text:latest"
         fake = mock.MagicMock()
-        fake.embedding.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
+        fake.embedding.return_value = {"data": [{"embedding": [0.1, 0.2], "index": 0}]}
 
         with mock.patch.dict("sys.modules", {"litellm": fake}):
             provider.embed(["hello"])
@@ -3309,7 +3309,7 @@ class TestEmbedApiBaseRouting:
         provider = SdkLLMProvider(LitellmSdkBackend())
         cfg.embedding_model = "openai/text-embedding-3-small"
         fake = mock.MagicMock()
-        fake.embedding.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
+        fake.embedding.return_value = {"data": [{"embedding": [0.1, 0.2], "index": 0}]}
 
         with mock.patch.dict("sys.modules", {"litellm": fake}):
             provider.embed(["hello"])

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1015,8 +1015,11 @@ class TestEscapeSqlString:
     def test_escapes_single_quotes(self):
         assert escape_sql_string("it's") == "it''s"
 
-    def test_escapes_backslashes(self):
-        assert escape_sql_string("path\\file") == "path\\\\file"
+    def test_backslash_is_not_escaped(self):
+        # LanceDB's Datafusion treats backslash literally inside a '...' literal,
+        # so doubling it corrupts the value and a backslash-bearing name never
+        # matches its predicate (bb-7jg1).
+        assert escape_sql_string("path\\file") == "path\\file"
 
     def test_injection_payload(self):
         escaped = escape_sql_string("' OR 1=1 --")
@@ -1025,6 +1028,24 @@ class TestEscapeSqlString:
         # No lone single quote remains (all are doubled)
         stripped = escaped.replace("''", "")
         assert "'" not in stripped
+
+    def test_delete_by_source_matches_backslash_source(self, store):
+        """A source name with a backslash must match its predicate end-to-end; the
+        prior backslash-doubling made it never match, leaking the source's chunks."""
+        backslash_src = r"win\dir\doc.md"
+        backslash = _make_records(n=1)
+        backslash[0]["source"] = backslash_src
+        plain = _make_records(n=1)
+        plain[0]["source"] = "plain.md"
+        plain[0]["chunk_index"] = 1
+        store.add_chunks(backslash + plain)
+
+        store.delete_by_source(backslash_src)
+
+        rows = store.open_table("chunks").search().to_list()
+        sources = {r["source"] for r in rows}
+        assert backslash_src not in sources
+        assert "plain.md" in sources
 
 
 class TestChunkTypeField:


### PR DESCRIPTION
## Problem

Several ingestion paths corrupted or dropped data. The code chunker sliced source text with tree-sitter's UTF-8 byte offsets, so every symbol after the first non-ASCII character was mis-sliced and the corrupted text was embedded and stored. It also ignored the parser's size-bounded output (so oversized symbols were silently truncated by the embedder), folded a class's methods into one chunk, rendered anonymous symbols as the literal "None", and embedded the host's absolute file path into indexed content. Turning OCR off still ran Tesseract on every scanned PDF and image. Multi-frame TIFF/GIF images OCR'd only the first frame. Large markdown/OCR documents chunked synchronously on the event loop, freezing sibling files and the TUI. The OCR cache key ignored the per-page timeout, so raising it served an earlier partially-empty result. A user cancel mid-batch dropped a file that had genuinely finished in the same batch. Remote embeddings were paired to inputs by arrival order, so an out-of-order gateway batch silently mismatched every vector. SQL predicates doubled backslashes, which LanceDB's Datafusion treats literally, so any source/owner/wiki path containing a backslash never matched.

## Solution

The chunker now consumes tree-sitter's size-bounded chunks: the content is the already-extracted UTF-8 text (no manual slicing), honors the size budget, lists nested symbols, and carries only the relative source name. Line ranges are derived from each chunk's own line count so they stay correct whether or not the final line ends in a newline. Disabling OCR now skips both vision and Tesseract; multi-frame images OCR every frame; chunking is offloaded off the event loop; the OCR cache key includes the timeout. The ingest pipeline keeps draining a cancel batch so a completed sibling still flushes before the cancel propagates. Remote embeddings are ordered by the response index, and SQL escaping only doubles the single quote.

Covers bb-7jg1.4, bb-7jg1.10, and bb-ziks.18/.19/.20/.21/.22/.39/.60/.61/.62. Review converged over two rounds. 100% coverage on changed lines.