### PR TITLE
Fix frozen-binary chat and splash crashes (regressed by #387)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,9 +294,22 @@ jobs:
             cat "$MP"
             exit 1
           fi
+          # Any traceback means the dispatch crashed running the module. runpy.run_module
+          # raised AttributeError ("nuitka_module_loader has no attribute 'get_code'") in
+          # the onefile binary; fd 999 is dead, so the runner must exit silently.
+          if grep -qE "Traceback|Error:|get_code" "$MP"; then
+            echo "FAIL: splash -m reinvocation raised an exception in the frozen binary"
+            cat "$MP"
+            exit 1
+          fi
           "$EXE" -c "import multiprocessing" > "$MP" 2>&1 || true
           if grep -qE "No such command|No such option" "$MP"; then
             echo "FAIL: resource-tracker -c reinvocation leaked into typer (frozen detection broken)"
+            cat "$MP"
+            exit 1
+          fi
+          if grep -qE "Traceback|Error:|get_code" "$MP"; then
+            echo "FAIL: resource-tracker -c reinvocation raised an exception in the frozen binary"
             cat "$MP"
             exit 1
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lilbee"
-version = "0.6.66b503"
+version = "0.6.66b504"
 description = "Run and manage local AI models, then search your files, code, and the web pages you crawl, with answers that cite the source. Everything runs on your machine in one process: per-project libraries, semantic and hybrid search, vision OCR, an auto-built wiki, CLI, TUI, MCP server, REST API, and Python library. No model server, no database server. Works with your own Ollama or LM Studio models too."
 readme = "README.md"
 license = "Elastic-2.0"

--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -42,25 +42,23 @@ def _install_thread_only_tqdm_lock() -> None:
 def _prestart_mp_resource_tracker() -> None:
     """Start the multiprocessing resource tracker before Textual swaps stderr.
 
-    Later ``Process.start()`` calls reuse the cached tracker fd and
-    never hit the fork_exec with a bad fd. No-op on Windows, which
-    doesn't use ``_posixsubprocess``, and no-op under a frozen build
-    (Nuitka onefile), where ``sys.executable`` is the lilbee exe itself
-    and the tracker's spawn would re-enter typer with ``-B -s -E`` as
-    CLI args (``__main__._dispatch_frozen_child`` handles that case).
+    The tracker launches lazily on the first semaphore creation, which in
+    the TUI is a worker's ``Value(lock=True)`` abort flag, spawned after
+    Textual has replaced ``sys.stderr`` with a stream whose ``fileno()``
+    returns -1. The tracker's launch passes that -1 into
+    ``_posixsubprocess.fork_exec`` and crashes with ``bad value(s) in
+    fds_to_keep``. Launching it here, at import time with a real stderr,
+    caches a valid tracker fd that every later ``Process.start()`` reuses.
 
-    Detecting the frozen build via :func:`lilbee._frozen.is_frozen` is
-    load-bearing: Nuitka never sets ``sys.frozen``, so a check on that
-    attribute alone would let the tracker spawn fire inside the onefile
-    binary and surface the typer error.
+    Runs in frozen builds too (Nuitka onefile): the tracker re-executes
+    ``sys.executable`` with ``-c "from multiprocessing.resource_tracker
+    import main;main(N)"``, which ``__main__._dispatch_frozen_child``
+    intercepts and execs before typer sees it. No-op on Windows, which
+    does not use ``_posixsubprocess``.
     """
     import sys as _sys
 
-    from lilbee._frozen import is_frozen
-
     if _sys.platform == "win32":
-        return
-    if is_frozen():
         return
     try:
         from multiprocessing import resource_tracker

--- a/src/lilbee/__main__.py
+++ b/src/lilbee/__main__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
 import os
-import runpy
 import sys
 from pathlib import Path
 
@@ -92,10 +92,16 @@ def _dispatch_module_invocation() -> bool:
     """Run a `python -m lilbee.<module>` reinvocation and return True when handled.
 
     Internal subprocesses spawned via ``[sys.executable, "-m", "lilbee.X", ...]``
-    (e.g. ``splash._splash_runner``) hit typer's `--model -m` short-form parser
-    in a frozen build. Detect the pattern, route to runpy, never reach typer.
-    Restricted to the ``lilbee.*`` namespace so a stray ``lilbee -m foo`` typed
-    by a user can't reach exec.
+    (e.g. ``splash.start`` launching ``lilbee.runtime._splash_runner``) hit
+    typer's `--model -m` short-form parser in a frozen build. Detect the
+    pattern, run the target module's ``main()`` directly, never reach typer.
+
+    Imports the module and calls ``main()`` rather than ``runpy.run_module``:
+    Nuitka's module loader does not implement ``get_code``, so ``runpy`` raises
+    ``AttributeError: ... has no attribute 'get_code'`` inside the onefile
+    binary. Every ``lilbee.*`` module reinvoked this way exposes a ``main()``
+    entry point. Restricted to the ``lilbee.*`` namespace so a stray
+    ``lilbee -m foo`` typed by a user can't reach exec.
     """
     if not _is_frozen():
         return False
@@ -105,7 +111,8 @@ def _dispatch_module_invocation() -> bool:
     if not module_name.startswith("lilbee."):
         return False
     sys.argv = [module_name, *sys.argv[3:]]
-    runpy.run_module(module_name, run_name="__main__", alter_sys=True)
+    module = importlib.import_module(module_name)
+    module.main()
     return True
 
 

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -311,12 +311,13 @@ class TestInitDefensiveBranches:
             _prestart_mp_resource_tracker()
         called.assert_not_called()
 
-    def test_prestart_resource_tracker_noop_when_frozen(
+    def test_prestart_resource_tracker_runs_when_frozen(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """In a PyInstaller frozen bundle sys.executable is the lilbee exe,
-        so spawning the tracker re-enters typer with '-B -s -E' and the CLI
-        rejects the unknown options. Short-circuit to avoid that.
+        """The prestart must run in frozen builds too. Disabling it there let the
+        tracker launch lazily under Textual's swapped stderr (fileno -1), crashing
+        chat with "bad value(s) in fds_to_keep". The tracker's -c reinvocation is
+        handled by __main__._dispatch_frozen_child, so launching it here is safe.
         """
         import sys
 
@@ -326,10 +327,9 @@ class TestInitDefensiveBranches:
         monkeypatch.setattr(sys, "frozen", True, raising=False)
         with mock.patch(
             "multiprocessing.resource_tracker.ensure_running",
-            side_effect=AssertionError("must not be called when frozen"),
         ) as called:
             _prestart_mp_resource_tracker()
-        called.assert_not_called()
+        called.assert_called_once_with()
 
 
 class TestDownloadModelProgressChain:

--- a/tests/test_main_dispatch.py
+++ b/tests/test_main_dispatch.py
@@ -184,7 +184,7 @@ class TestDispatchFrozenChild:
 
 
 class TestDispatchModuleInvocation:
-    """Route `[bin, -m, lilbee.<module>, ...]` to runpy before typer sees it."""
+    """Route `[bin, -m, lilbee.<module>, ...]` to the module's main() before typer."""
 
     def test_returns_false_when_not_frozen(self) -> None:
         with (
@@ -217,48 +217,47 @@ class TestDispatchModuleInvocation:
     def test_routes_under_nuitka_without_sys_frozen(self) -> None:
         # Regression: same Nuitka frozen-detection gap as the mp-child dispatcher.
         argv_in = ["bin", "-m", "lilbee.core.system", "extra"]
+        module = mock.Mock()
         with (
             mock.patch.object(main_mod.sys, "frozen", False, create=True),
             mock.patch.object(main_mod, "__compiled__", object(), create=True),
             mock.patch.object(main_mod.sys, "argv", argv_in),
-            mock.patch("runpy.run_module") as run_module,
+            mock.patch.object(main_mod.importlib, "import_module", return_value=module) as imp,
         ):
             assert main_mod._dispatch_module_invocation() is True
-        run_module.assert_called_once_with(
-            "lilbee.core.system", run_name="__main__", alter_sys=True
-        )
+        imp.assert_called_once_with("lilbee.core.system")
+        module.main.assert_called_once_with()
 
-    def test_routes_lilbee_module_through_runpy(self) -> None:
-        argv_in = ["bin", "-m", "lilbee.core.system", "extra"]
+    def test_runs_module_main_with_rewritten_argv(self) -> None:
+        # The reinvocation calls the module's main() (never runpy, which fails
+        # under Nuitka: its loader has no get_code). argv is stripped to the
+        # module name plus the original trailing args so main() reads its fd.
+        argv_in = ["bin", "-m", "lilbee.runtime._splash_runner", "999"]
         captured: dict[str, object] = {}
-
-        def fake_run_module(name: str, *, run_name: str, alter_sys: bool) -> None:
-            captured["name"] = name
-            captured["run_name"] = run_name
-            captured["alter_sys"] = alter_sys
-            captured["argv_at_call"] = list(main_mod.sys.argv)
+        module = mock.Mock()
+        module.main.side_effect = lambda: captured.update(argv_at_call=list(main_mod.sys.argv))
 
         with (
             mock.patch.object(main_mod.sys, "frozen", True, create=True),
             mock.patch.object(main_mod.sys, "argv", argv_in),
-            mock.patch("runpy.run_module", side_effect=fake_run_module),
+            mock.patch.object(main_mod.importlib, "import_module", return_value=module) as imp,
         ):
             assert main_mod._dispatch_module_invocation() is True
 
-        assert captured["name"] == "lilbee.core.system"
-        assert captured["run_name"] == "__main__"
-        assert captured["alter_sys"] is True
-        assert captured["argv_at_call"] == ["lilbee.core.system", "extra"]
+        imp.assert_called_once_with("lilbee.runtime._splash_runner")
+        module.main.assert_called_once_with()
+        assert captured["argv_at_call"] == ["lilbee.runtime._splash_runner", "999"]
 
 
 class TestPrestartMpResourceTracker:
-    """The package-import prestart must skip frozen builds, including Nuitka."""
+    """The package-import prestart must run on POSIX, including frozen Nuitka builds."""
 
-    def test_skips_under_nuitka_without_sys_frozen(self) -> None:
-        # Regression: under the bug this prestart spawned the resource_tracker
-        # child inside the onefile binary, surfacing "No such command '<fd>'".
-        # The guard delegates to lilbee._frozen.is_frozen, which reads its own
-        # __compiled__ marker.
+    def test_prestarts_under_nuitka_without_sys_frozen(self) -> None:
+        # Regression (the chat "bad value(s) in fds_to_keep" crash): the prestart
+        # was disabled in frozen builds, so the resource tracker launched lazily
+        # at worker-spawn time after Textual swapped stderr (fileno -1). It must
+        # run in frozen builds too; the tracker's -c reinvocation is intercepted
+        # by __main__._dispatch_frozen_child.
         from multiprocessing import resource_tracker
 
         import lilbee
@@ -272,7 +271,7 @@ class TestPrestartMpResourceTracker:
             mock.patch.object(resource_tracker, "ensure_running", lambda: called.append(1)),
         ):
             lilbee._prestart_mp_resource_tracker()
-        assert called == []
+        assert called == [1]
 
     def test_prestarts_on_posix_when_not_frozen(self) -> None:
         from multiprocessing import resource_tracker
@@ -287,3 +286,16 @@ class TestPrestartMpResourceTracker:
         ):
             lilbee._prestart_mp_resource_tracker()
         assert called == [1]
+
+    def test_skips_on_windows(self) -> None:
+        from multiprocessing import resource_tracker
+
+        import lilbee
+
+        called: list[int] = []
+        with (
+            mock.patch.object(main_mod.sys, "platform", "win32"),
+            mock.patch.object(resource_tracker, "ensure_running", lambda: called.append(1)),
+        ):
+            lilbee._prestart_mp_resource_tracker()
+        assert called == []

--- a/uv.lock
+++ b/uv.lock
@@ -1625,7 +1625,7 @@ wheels = [
 
 [[package]]
 name = "lilbee"
-version = "0.6.66b503"
+version = "0.6.66b504"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
## Problem

The shipped Nuitka onefile binary (b502, b503) has two crashes that don't reproduce in dev installs, so they slipped through.

Chat: typing a question crashes with `Error: bad value(s) in fds_to_keep`. The multiprocessing resource tracker launches lazily on the first semaphore creation, which in the TUI is a worker's `Value(lock=True)` abort flag, spawned after Textual has replaced `sys.stderr` with a stream whose `fileno()` returns -1. The tracker's launch passes that -1 into `_posixsubprocess.fork_exec` and raises. `_prestart_mp_resource_tracker()` exists to launch the tracker early with a real stderr, but #387 disabled it in frozen builds; its stated reason (the tracker's `-c` reinvocation would leak into typer) is already handled by `__main__._dispatch_frozen_child`, so the guard only broke chat.

Splash: the startup animation crashes with `AttributeError: type object 'nuitka_module_loader' has no attribute 'get_code'`. `_dispatch_module_invocation` routed the `[exe, -m, lilbee.runtime._splash_runner, <fd>]` reinvocation through `runpy.run_module`, which calls `loader.get_code()` - a method Nuitka's loader does not implement.

The release smoke test missed both: it grepped only for typer leaks and missing modules, not for tracebacks.

## Solution

Re-enable the resource-tracker prestart on every POSIX build. Replace `runpy.run_module` with `importlib.import_module` + `main()` for the `-m` reinvocation. Add a traceback guard to both reinvocation checks in the smoke test.

Verified by building the onefile binary locally off this branch and driving the TUI: the splash renders, chat spawns every worker and streams a full answer with sources, and the binary exits with no leak. Bumps to 0.6.66b504.