### PR TITLE
Fleet & catalog integrity: arch-compat guard, GGUF parse, vision failover, placement

### DIFF
--- a/src/lilbee/catalog/compat.py
+++ b/src/lilbee/catalog/compat.py
@@ -9,6 +9,11 @@ from huggingface_hub import hf_hub_url
 from huggingface_hub.utils import HFValidationError
 
 from lilbee.catalog.header_probe import probe_architecture
+from lilbee.catalog.refs import (
+    NATIVE_GGUF_REF_MIN_SLASHES,
+    gguf_filename_from_ref,
+    hf_repo_from_ref,
+)
 from lilbee.catalog.types import ModelCompat
 
 if TYPE_CHECKING:
@@ -38,8 +43,15 @@ def resolve_arch_for_pull(ref: str, hf_client: HfClient) -> str:
 
 
 def _resolve_blob_url(ref: str) -> str:
-    """Return a probable .gguf blob URL for *ref*, or empty string if unresolvable."""
-    if ":" in ref:
+    """Return a probable .gguf blob URL for *ref*, or empty string if unresolvable.
+
+    lilbee's canonical native refs are slash-delimited ``<org>/<repo>/<file>.gguf``
+    (the filename may add subdirs for a quant), so the repo and filename are split
+    on that shape; an ollama-style ``repo:tag`` ref is split on the colon.
+    """
+    if ref.endswith(".gguf") and ref.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
+        repo, filename = hf_repo_from_ref(ref), gguf_filename_from_ref(ref)
+    elif ":" in ref:
         repo, filename = ref.split(":", 1)
     else:
         repo, filename = ref, ""

--- a/src/lilbee/catalog/header_probe.py
+++ b/src/lilbee/catalog/header_probe.py
@@ -1,16 +1,19 @@
-"""Range-GET a GGUF blob's header and extract general.architecture via gguf-py."""
+"""Range-GET a GGUF blob's header and extract general.architecture.
+
+The architecture is read by walking the metadata KV table directly (see
+``_parse_arch``) rather than via gguf-py's ``GGUFReader``, which needs the whole
+KV table -- including a model's multi-megabyte tokenizer arrays -- present, and
+so chokes on a Range-GET-truncated header.
+"""
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import struct
-import tempfile
 from http import HTTPStatus
-from pathlib import Path
 
 import httpx
-from gguf import GGUFReader, GGUFValueType, ReaderField
+from gguf import GGUFValueType, ReaderField
 
 log = logging.getLogger(__name__)
 
@@ -18,8 +21,6 @@ GGUF_HEADER_PROBE_BYTES = 65536
 GGUF_MAGIC = b"GGUF"
 GGUF_ARCH_KEY = "general.architecture"
 _PROBE_TIMEOUT_S = 10.0
-_TENSOR_COUNT_OFFSET = 8
-_TENSOR_COUNT_SIZE = 8
 
 
 def probe_architecture(blob_url: str) -> str:
@@ -39,32 +40,98 @@ def probe_architecture(blob_url: str) -> str:
         return ""
 
 
+# GGUF metadata value-type tags (gguf spec) and the fixed byte sizes of the
+# scalar ones. ARRAY/STRING carry their own length prefixes.
+_GGUF_TYPE_STRING = 8
+_GGUF_TYPE_ARRAY = 9
+_GGUF_SCALAR_SIZES = {0: 1, 1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 1, 10: 8, 11: 8, 12: 8}
+# magic(4) + version(4) + tensor_count(8) + kv_count(8)
+_GGUF_HEADER_FIXED = 24
+
+
+class _TruncatedHeaderError(Exception):
+    """The probe window ended before the bytes a parse step needed."""
+
+
+class _HeaderCursor:
+    """Little-endian reader over the probed GGUF header bytes."""
+
+    def __init__(self, blob: bytes) -> None:
+        self._blob = blob
+        self._pos = 0
+
+    def take(self, n: int) -> bytes:
+        end = self._pos + n
+        if n < 0 or end > len(self._blob):
+            raise _TruncatedHeaderError
+        chunk = self._blob[self._pos : end]
+        self._pos = end
+        return chunk
+
+    def u32(self) -> int:
+        return int(struct.unpack_from("<I", self.take(4))[0])
+
+    def u64(self) -> int:
+        return int(struct.unpack_from("<Q", self.take(8))[0])
+
+    def gguf_string(self) -> bytes:
+        return self.take(self.u64())
+
+
+def _skip_value(cur: _HeaderCursor, value_type: int) -> None:
+    """Advance *cur* past one metadata value of *value_type*."""
+    size = _GGUF_SCALAR_SIZES.get(value_type)
+    if size is not None:
+        cur.take(size)
+        return
+    if value_type == _GGUF_TYPE_STRING:
+        cur.gguf_string()
+        return
+    if value_type == _GGUF_TYPE_ARRAY:
+        elem_type = cur.u32()
+        count = cur.u64()
+        elem_size = _GGUF_SCALAR_SIZES.get(elem_type)
+        if elem_size is not None:
+            cur.take(elem_size * count)
+        elif elem_type == _GGUF_TYPE_STRING:
+            for _ in range(count):
+                cur.gguf_string()
+        else:
+            raise _TruncatedHeaderError  # nested/unknown array element: stop parsing
+        return
+    raise _TruncatedHeaderError  # unknown value type: stop parsing
+
+
 def _parse_arch(blob: bytes) -> str:
     """Extract general.architecture from a (possibly truncated) GGUF header.
 
-    Patches the tensor_count field to zero so ``gguf-py``'s ``GGUFReader``
-    skips the tensor info table that would otherwise require the full
-    file. Only the KV table needs to be intact for architecture lookup.
+    Walks the metadata KV table directly and returns as soon as it reaches
+    ``general.architecture``, which GGUF writers emit among the first entries.
+    This deliberately avoids gguf-py's ``GGUFReader``, which parses the entire KV
+    table up front: a real model's multi-megabyte tokenizer arrays run past the
+    Range-GET probe window, so ``GGUFReader`` raises on the truncation before any
+    field can be read. Returns empty string on a malformed or too-short header.
     """
-    if len(blob) < _TENSOR_COUNT_OFFSET + _TENSOR_COUNT_SIZE or blob[:4] != GGUF_MAGIC:
+    if len(blob) < _GGUF_HEADER_FIXED or blob[:4] != GGUF_MAGIC:
         return ""
-    patched = bytearray(blob)
-    patched[_TENSOR_COUNT_OFFSET : _TENSOR_COUNT_OFFSET + _TENSOR_COUNT_SIZE] = struct.pack("<Q", 0)
-    with tempfile.NamedTemporaryFile(suffix=".gguf", delete=False) as f:
-        f.write(bytes(patched))
-        tmp = Path(f.name)
+    cur = _HeaderCursor(blob)
+    arch_key = GGUF_ARCH_KEY.encode("utf-8")
     try:
-        return _read_architecture(tmp)
-    except (ValueError, struct.error, IndexError, OSError, UnicodeDecodeError) as exc:
-        log.debug("GGUFReader parse failed: %s", exc)
+        cur.take(4)  # magic
+        cur.u32()  # version
+        cur.u64()  # tensor_count (the tensor-info table is never read)
+        kv_count = cur.u64()
+        for _ in range(kv_count):
+            key = cur.gguf_string()
+            value_type = cur.u32()
+            if key == arch_key:
+                if value_type != _GGUF_TYPE_STRING:
+                    return ""
+                return cur.gguf_string().decode("utf-8", errors="replace")
+            _skip_value(cur, value_type)
+    except _TruncatedHeaderError:
         return ""
-    finally:
-        # GGUFReader memory-maps the file; on Windows the mapping must be released
-        # before the file can be deleted (a held mapping raises PermissionError /
-        # WinError 32, which missing_ok does not cover). _read_architecture scopes
-        # the reader so it is freed on return; suppress is a best-effort backstop.
-        with contextlib.suppress(OSError):
-            tmp.unlink()
+    return ""
 
 
 def gguf_scalar_str(field: ReaderField | None) -> str | None:
@@ -88,19 +155,3 @@ def gguf_scalar_str(field: ReaderField | None) -> str | None:
     if isinstance(scalar, (list, tuple)):
         scalar = scalar[0] if scalar else None
     return None if scalar is None else str(scalar)
-
-
-def _read_architecture(path: Path) -> str:
-    """Return general.architecture from the GGUF file at *path*, or empty string.
-
-    Kept separate so the ``GGUFReader`` (and its memory map of *path*) is released
-    when this returns, letting the caller delete the temp file on Windows.
-
-    Architecture is a string by spec; a field present under a non-STRING type is
-    malformed, so it yields an empty string rather than a stringified number.
-    """
-    reader = GGUFReader(str(path))
-    field = reader.fields.get(GGUF_ARCH_KEY)
-    if field is None or not field.types or field.types[-1] != GGUFValueType.STRING:
-        return ""
-    return gguf_scalar_str(field) or ""

--- a/src/lilbee/catalog/header_probe.py
+++ b/src/lilbee/catalog/header_probe.py
@@ -26,7 +26,11 @@ def probe_architecture(blob_url: str) -> str:
     """Return general.architecture from the GGUF header, or empty string on any failure."""
     try:
         headers = {"Range": f"bytes=0-{GGUF_HEADER_PROBE_BYTES - 1}"}
-        resp = httpx.get(blob_url, headers=headers, timeout=_PROBE_TIMEOUT_S)
+        # follow_redirects: a HuggingFace ``/resolve/`` URL for an LFS-backed GGUF
+        # 302-redirects to the CDN; without following it the probe reads the tiny
+        # redirect body, the GGUF magic check fails, and every arch verdict is
+        # silently UNKNOWN (so the unsupported-arch guard never fires).
+        resp = httpx.get(blob_url, headers=headers, timeout=_PROBE_TIMEOUT_S, follow_redirects=True)
         if resp.status_code >= HTTPStatus.BAD_REQUEST:
             return ""
         return _parse_arch(resp.content)

--- a/src/lilbee/catalog/refs.py
+++ b/src/lilbee/catalog/refs.py
@@ -39,6 +39,18 @@ def hf_repo_from_ref(ref: str) -> str:
     return ref
 
 
+def gguf_filename_from_ref(ref: str) -> str:
+    """Return the filename portion of a native GGUF ref (after ``<org>/<repo>/``).
+
+    The filename may include repo subdirectories (a quant stored under e.g.
+    ``Q4_K_M/...gguf``), so everything past the first two segments is kept.
+    Returns empty string for non-native refs (bare repos, provider-prefixed).
+    """
+    if ref.endswith(".gguf") and ref.count("/") >= NATIVE_GGUF_REF_MIN_SLASHES:
+        return "/".join(ref.split("/")[NATIVE_GGUF_REF_MIN_SLASHES:])
+    return ""
+
+
 def format_native_gguf_ref(hf_repo: str, gguf_filename: str) -> str:
     """Render the canonical ``<hf_repo>/<gguf_filename>`` native GGUF ref."""
     return f"{hf_repo}/{gguf_filename}"

--- a/src/lilbee/providers/fleet/devices.py
+++ b/src/lilbee/providers/fleet/devices.py
@@ -115,7 +115,20 @@ def _compose_visible(indices: list[int], parent_value: str | None) -> str:
     if parent_value is None:
         return ",".join(str(i) for i in indices)
     entries = [entry.strip() for entry in parent_value.split(",") if entry.strip()]
-    return ",".join(entries[i] if i < len(entries) else str(i) for i in indices)
+    out: list[str] = []
+    for i in indices:
+        if i >= len(entries):
+            # The probe enumerates devices under the parent restriction, so every
+            # index must map into it. An out-of-range index is an invariant
+            # violation; emitting a bare ``str(i)`` would pin an absolute integer
+            # into a possibly UUID-namespaced list, silently selecting the wrong
+            # GPU. Fail loudly instead.
+            raise ValueError(
+                f"device index {i} is outside the parent visible-devices list "
+                f"{parent_value!r}; cannot compose a child pin without selecting the wrong GPU"
+            )
+        out.append(entries[i])
+    return ",".join(out)
 
 
 def visible_env(devices: tuple[FleetDevice, ...]) -> dict[str, str]:

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -101,11 +101,14 @@ def plan_placement(
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
 
-    # Single-instance roles first (chat tensor-splits here, claiming its cards),
-    # largest-first; then data-parallel replicas fill the remaining headroom.
+    # Single-instance roles first; then data-parallel replicas fill the remaining
+    # headroom. Within the singles, place the search-critical roles (embed/rerank)
+    # before chat: chat tensor-splits across cards and, placed first, can claim
+    # them all and leave an essential search role unplaceable. Search-first here
+    # mirrors the shared-memory path's reservation.
     singles = [m for m in models if m.replicas <= 1]
     replicated = [m for m in models if m.replicas > 1]
-    for model in sorted(singles, key=lambda m: m.est_vram_bytes, reverse=True):
+    for model in sorted(singles, key=_shared_pool_order):
         plan = _place_single(model, remaining, estimate_peak)
         if plan is None:
             unplaceable.append(model.role)

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -305,7 +305,9 @@ def _ocr_pdf_page(
             )
             return idx, ""
         try:
-            return idx, _vision_call(_least_in_flight(clients), messages, remaining)
+            return idx, _call_with_failover(
+                clients, lambda client: _vision_call(client, messages, remaining)
+            )
         except ProviderError:
             # One failed/timed-out page yields empty text; siblings continue.
             log.warning(
@@ -690,7 +692,9 @@ class FleetProvider:
         effective = model or str(cfg.vision_model)
         messages = build_vision_messages(prompt or resolve_ocr_prompt(effective), png_bytes)
         with _VISION_GATE.slot():
-            return _vision_call(_least_in_flight(clients), messages, timeout)
+            return _call_with_failover(
+                clients, lambda client: _vision_call(client, messages, timeout)
+            )
 
     def pdf_ocr(
         self,

--- a/src/lilbee/providers/gguf_meta.py
+++ b/src/lilbee/providers/gguf_meta.py
@@ -7,6 +7,7 @@ metadata is available to any provider without loading a model into the engine.
 from __future__ import annotations
 
 import logging
+import struct
 import threading
 from pathlib import Path
 
@@ -111,8 +112,15 @@ def read_gguf_metadata(model_path: Path) -> dict[str, str] | None:
 
 
 def _read_gguf_metadata_uncached(model_path: Path) -> dict[str, str] | None:
-    reader = GGUFReader(str(model_path))
-    fields = reader.fields
+    try:
+        reader = GGUFReader(str(model_path))
+        fields = reader.fields
+    except (ValueError, KeyError, IndexError, struct.error, OSError, UnicodeDecodeError) as exc:
+        # A truncated or corrupt GGUF header surfaces as a parser error. Report
+        # "no readable metadata" (None, an outcome callers already handle) rather
+        # than letting a raw parse error abort the whole fleet build.
+        log.warning("Could not parse GGUF metadata from %s: %s", model_path, exc)
+        return None
     result: dict[str, str] = {}
 
     arch = gguf_scalar_str(fields.get(GGUF_ARCH_KEY))

--- a/src/lilbee/providers/gguf_meta.py
+++ b/src/lilbee/providers/gguf_meta.py
@@ -115,7 +115,7 @@ def _read_gguf_metadata_uncached(model_path: Path) -> dict[str, str] | None:
     try:
         reader = GGUFReader(str(model_path))
         fields = reader.fields
-    except (ValueError, struct.error, IndexError, OSError, UnicodeDecodeError) as exc:
+    except (ValueError, KeyError, IndexError, struct.error, OSError, UnicodeDecodeError) as exc:
         # A truncated or corrupt GGUF header surfaces as a parser error. Report
         # "no readable metadata" (None, an outcome callers already handle) rather
         # than letting a raw parse error abort the whole fleet build.

--- a/src/lilbee/providers/gguf_meta.py
+++ b/src/lilbee/providers/gguf_meta.py
@@ -115,7 +115,7 @@ def _read_gguf_metadata_uncached(model_path: Path) -> dict[str, str] | None:
     try:
         reader = GGUFReader(str(model_path))
         fields = reader.fields
-    except (ValueError, KeyError, IndexError, struct.error, OSError, UnicodeDecodeError) as exc:
+    except (ValueError, struct.error, IndexError, OSError, UnicodeDecodeError) as exc:
         # A truncated or corrupt GGUF header surfaces as a parser error. Report
         # "no readable metadata" (None, an outcome callers already handle) rather
         # than letting a raw parse error abort the whole fleet build.

--- a/src/lilbee/server/wiki.py
+++ b/src/lilbee/server/wiki.py
@@ -126,7 +126,9 @@ async def wiki_draft_accept_route(slug: str) -> WikiDraftAcceptResponse:
     slug = slug.lstrip("/")
     store = svc_mod.get_services().store
     try:
-        result = accept_draft(slug, _wiki_root(), store)
+        # accept_draft re-chunks and embeds the page; offload so it doesn't block
+        # the event loop (and every other REST/MCP request on it).
+        result = await asyncio.to_thread(accept_draft, slug, _wiki_root(), store)
     except FileNotFoundError as exc:
         raise NotFoundException(detail=f"draft not found: {slug}") from exc
     except PathTraversalError as exc:
@@ -194,7 +196,8 @@ def _citations_for_slug(slug: str) -> WikiCitationsResult:
 async def wiki_lint_route() -> WikiLintResult:
     """Trigger a full wiki lint."""
     _require_wiki()
-    report = lint_mod.lint_all(svc_mod.get_services().store)
+    # lint_all scans every page and embeds; offload so it doesn't block the loop.
+    report = await asyncio.to_thread(lint_mod.lint_all, svc_mod.get_services().store)
     return WikiLintResult(
         issues=[WikiLintIssueItem(**i.to_dict()) for i in report.issues],
         errors=report.error_count,
@@ -206,7 +209,8 @@ async def wiki_lint_route() -> WikiLintResult:
 async def wiki_prune_route() -> WikiPruneResult:
     """Trigger pruning of stale/orphaned wiki pages."""
     _require_wiki()
-    report = prune_mod.prune_wiki(svc_mod.get_services().store)
+    # prune_wiki walks the whole wiki tree and store; offload off the loop.
+    report = await asyncio.to_thread(prune_mod.prune_wiki, svc_mod.get_services().store)
     return WikiPruneResult(
         records=[WikiPruneRecordResponse(**r.to_dict()) for r in report.records],
         archived=report.archived_count,
@@ -287,7 +291,7 @@ async def wiki_status_route() -> WikiStatusResult:
     summaries = list(summaries_dir.rglob("*.md")) if summaries_dir.exists() else []
     drafts = list(drafts_dir.rglob("*.md")) if drafts_dir.exists() else []
 
-    report = lint_mod.lint_all(svc_mod.get_services().store)
+    report = await asyncio.to_thread(lint_mod.lint_all, svc_mod.get_services().store)
     return WikiStatusResult(
         wiki_enabled=cfg.wiki,
         summaries=len(summaries),

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -355,6 +355,52 @@ class TestWikiEnabled:
         assert body["archived"] == 0
         assert body["flagged"] == 0
 
+    async def test_prune_runs_off_the_event_loop(self, monkeypatch: pytest.MonkeyPatch):
+        """prune_wiki walks the whole tree + store; it runs in a worker thread, not
+        on the event loop (bb-ziks.44)."""
+        import threading
+
+        from conftest import make_mock_services
+        from lilbee.wiki import prune as prune_mod
+
+        monkeypatch.setattr("lilbee.app.services.get_services", make_mock_services)
+        loop_tid = threading.get_ident()
+        seen: list[int] = []
+
+        def fake_prune(store):
+            seen.append(threading.get_ident())
+            return prune_mod.PruneReport()
+
+        monkeypatch.setattr(prune_mod, "prune_wiki", fake_prune)
+        async with AsyncTestClient(_create_app()) as client:
+            resp = await client.post("/api/wiki/prune", headers=_h())
+        assert resp.status_code == 201
+        assert seen and seen[0] != loop_tid
+
+    async def test_status_runs_lint_off_the_event_loop(
+        self, isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The status route's lint pass embeds; it runs off the event loop (bb-ziks.44)."""
+        import threading
+
+        from conftest import make_mock_services
+        from lilbee.wiki import lint as lint_mod
+
+        monkeypatch.setattr("lilbee.app.services.get_services", make_mock_services)
+        _make_wiki_page(isolated_env / "wiki", "summaries", "s1")  # so status reaches lint
+        loop_tid = threading.get_ident()
+        seen: list[int] = []
+
+        def fake_lint(store, config=None):
+            seen.append(threading.get_ident())
+            return lint_mod.LintReport()
+
+        monkeypatch.setattr(lint_mod, "lint_all", fake_lint)
+        async with AsyncTestClient(_create_app()) as client:
+            resp = await client.get("/api/wiki/status", headers=_h())
+        assert resp.status_code == 200
+        assert seen and seen[0] != loop_tid
+
     async def test_build_returns_summary(self, monkeypatch):
         monkeypatch.setattr(
             "lilbee.server.wiki.run_full_build",
@@ -646,6 +692,36 @@ class TestWikiDraftsEndpoints:
         assert body["reindexed_chunks"] == 3
         assert body["moved_to"].endswith("summaries/cv-manual.md")
         assert captured["slug"] == "cv-manual"
+
+    async def test_accept_runs_off_the_event_loop(
+        self, isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """accept_draft re-chunks + embeds; it runs in a worker thread, not on the
+        event loop that serves every other request (bb-ziks.44)."""
+        import threading
+
+        from lilbee.server import wiki as server_wiki_mod
+        from lilbee.wiki.drafts import AcceptResult
+
+        wiki_root = isolated_env / "wiki"
+        _make_draft(wiki_root, "cv-manual", drift_pct=20)
+        loop_tid = threading.get_ident()
+        seen: list[int] = []
+
+        def _fake_accept(slug: str, root: Path, store: object) -> AcceptResult:
+            seen.append(threading.get_ident())
+            return AcceptResult(
+                slug=slug,
+                requested_slug=slug,
+                moved_to=root / "summaries" / f"{slug}.md",
+                reindexed_chunks=1,
+            )
+
+        monkeypatch.setattr(server_wiki_mod, "accept_draft", _fake_accept)
+        async with AsyncTestClient(_create_app()) as client:
+            resp = await client.post("/api/wiki/drafts/accept/cv-manual", headers=_h())
+        assert resp.status_code == 201
+        assert seen and seen[0] != loop_tid
 
     async def test_accept_missing_404(self, monkeypatch: pytest.MonkeyPatch):
         from lilbee.server import wiki as server_wiki_mod

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -317,6 +317,30 @@ class TestWikiEnabled:
         assert body["warnings"] == 0
         assert body["issues"] == []
 
+    async def test_lint_runs_off_the_event_loop(
+        self, isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """lint_all scans every page and embeds, so it runs in a worker thread, not
+        on the event loop that serves every other REST/MCP request (bb-ziks.44)."""
+        import threading
+
+        from conftest import make_mock_services
+        from lilbee.wiki import lint as lint_mod
+
+        monkeypatch.setattr("lilbee.app.services.get_services", make_mock_services)
+        loop_tid = threading.get_ident()
+        seen: list[int] = []
+
+        def fake_lint(store, config=None):
+            seen.append(threading.get_ident())
+            return lint_mod.LintReport()
+
+        monkeypatch.setattr(lint_mod, "lint_all", fake_lint)
+        async with AsyncTestClient(_create_app()) as client:
+            resp = await client.post("/api/wiki/lint", headers=_h())
+        assert resp.status_code == 201
+        assert seen and seen[0] != loop_tid
+
     async def test_lint_status_route_removed(self):
         async with AsyncTestClient(_create_app()) as client:
             resp = await client.get("/api/wiki/lint/task-abc", headers=_h())

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -810,6 +810,30 @@ class TestHfRepoFromRef:
         assert hf_repo_from_ref("ollama/llama3:8b") == "ollama/llama3:8b"
 
 
+class TestGgufFilenameFromRef:
+    def test_flat_ref_yields_filename(self) -> None:
+        from lilbee.catalog.refs import gguf_filename_from_ref
+
+        ref = "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf"
+        assert gguf_filename_from_ref(ref) == "Qwen3-8B-Q4_K_M.gguf"
+
+    def test_subdir_ref_keeps_quant_subdir(self) -> None:
+        from lilbee.catalog.refs import gguf_filename_from_ref
+
+        ref = "unsloth/MiniMax-M2-GGUF/Q4_K_M/MiniMax-M2-Q4_K_M-00001-of-00003.gguf"
+        assert gguf_filename_from_ref(ref) == "Q4_K_M/MiniMax-M2-Q4_K_M-00001-of-00003.gguf"
+
+    def test_bare_repo_yields_empty(self) -> None:
+        from lilbee.catalog.refs import gguf_filename_from_ref
+
+        assert gguf_filename_from_ref("Qwen/Qwen3-8B-GGUF") == ""
+
+    def test_provider_prefixed_ref_yields_empty(self) -> None:
+        from lilbee.catalog.refs import gguf_filename_from_ref
+
+        assert gguf_filename_from_ref("ollama/llama3:8b") == ""
+
+
 class TestBuildAdhocEntry:
     def test_valid_repo_derives_defaults(self) -> None:
         entry = build_adhoc_entry("bartowski/gemma-2-2b-it-GGUF")

--- a/tests/test_catalog_header_probe.py
+++ b/tests/test_catalog_header_probe.py
@@ -18,18 +18,94 @@ def test_probe_reads_architecture(monkeypatch: pytest.MonkeyPatch) -> None:
     assert probe_architecture("https://example.test/model.gguf") == "llama"
 
 
-def test_probe_survives_tempfile_cleanup_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    # On Windows the GGUFReader memory-map can keep the temp file locked, so the
-    # unlink raises PermissionError (WinError 32). The probe must still return the
-    # parsed architecture rather than propagating the cleanup error.
-    blob = make_minimal_gguf("llama")
+def _gguf_arch_then_truncated_tokenizer(arch: str) -> bytes:
+    """A header with general.architecture first, then a tokenizer string-array whose
+    declared count is huge but whose bytes are cut off (as a real model's tokenizer
+    arrays are by the Range-GET probe window)."""
+
+    def gstr(s: bytes) -> bytes:
+        return struct.pack("<Q", len(s)) + s
+
+    blob = b"GGUF" + struct.pack("<I", 3)  # magic + version
+    blob += struct.pack("<Q", 0)  # tensor_count
+    blob += struct.pack("<Q", 2)  # kv_count
+    # KV0: general.architecture = <arch> (value type 8 = STRING)
+    blob += gstr(b"general.architecture") + struct.pack("<I", 8) + gstr(arch.encode())
+    # KV1: tokenizer.ggml.tokens = ARRAY(STRING) declaring 151936 entries, then cut off.
+    blob += gstr(b"tokenizer.ggml.tokens") + struct.pack("<I", 9)
+    blob += struct.pack("<I", 8) + struct.pack("<Q", 151936)
+    blob += gstr(b"only-one-token-then-truncated")
+    return blob
+
+
+def _kv(key: bytes, vtype: int, value: bytes) -> bytes:
+    return struct.pack("<Q", len(key)) + key + struct.pack("<I", vtype) + value
+
+
+def _gstr(s: bytes) -> bytes:
+    return struct.pack("<Q", len(s)) + s
+
+
+def _hdr(entries: list[bytes], kv_count: int | None = None) -> bytes:
+    count = kv_count if kv_count is not None else len(entries)
+    head = b"GGUF" + struct.pack("<I", 3) + struct.pack("<Q", 0) + struct.pack("<Q", count)
+    return head + b"".join(entries)
+
+
+class TestParseArchWalker:
+    """The KV walker behind probe_architecture, exercised at the byte level."""
+
+    def test_skips_scalar_string_and_array_values_before_arch(self) -> None:
+        blob = _hdr(
+            [
+                _kv(b"general.quantization_version", 4, struct.pack("<I", 2)),  # uint32 scalar
+                _kv(b"general.name", 8, _gstr(b"m")),  # string
+                _kv(
+                    b"x.list",
+                    9,
+                    struct.pack("<I", 4) + struct.pack("<Q", 2) + struct.pack("<II", 1, 2),
+                ),
+                _kv(b"general.architecture", 8, _gstr(b"qwen3")),
+            ]
+        )
+        assert header_probe._parse_arch(blob) == "qwen3"
+
+    def test_skips_string_array_before_arch(self) -> None:
+        arr = struct.pack("<I", 8) + struct.pack("<Q", 2) + _gstr(b"a") + _gstr(b"bb")
+        blob = _hdr(
+            [
+                _kv(b"x.strs", 9, arr),
+                _kv(b"general.architecture", 8, _gstr(b"llama")),
+            ]
+        )
+        assert header_probe._parse_arch(blob) == "llama"
+
+    def test_truncated_mid_kv_returns_empty(self) -> None:
+        blob = _hdr([_kv(b"general.name", 8, _gstr(b"m"))], kv_count=5)  # claims 5, only 1 present
+        assert header_probe._parse_arch(blob) == ""
+
+    def test_unknown_value_type_returns_empty(self) -> None:
+        blob = _hdr([_kv(b"weird", 99, b"")], kv_count=1)  # arch never reached
+        assert header_probe._parse_arch(blob) == ""
+
+    def test_unknown_array_element_type_returns_empty(self) -> None:
+        bad_arr = struct.pack("<I", 99) + struct.pack("<Q", 1)
+        blob = _hdr([_kv(b"weird", 9, bad_arr)], kv_count=1)
+        assert header_probe._parse_arch(blob) == ""
+
+    def test_non_string_arch_returns_empty(self) -> None:
+        blob = _hdr([_kv(b"general.architecture", 4, struct.pack("<I", 1))])
+        assert header_probe._parse_arch(blob) == ""
+
+
+def test_probe_reads_arch_before_truncated_tokenizer_array(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real GGUF emits general.architecture first, then multi-megabyte tokenizer
+    arrays that run past the probe window. The KV walker returns the arch without
+    parsing those arrays, where gguf-py's GGUFReader chokes on the truncation and
+    the arch-compat guard never fired (bb-ziks.43 end-to-end)."""
+    blob = _gguf_arch_then_truncated_tokenizer("qwen3")
     monkeypatch.setattr(httpx, "get", lambda *a, **kw: httpx.Response(200, content=blob))
-
-    def _raise_unlink(self: object, *_a: object, **_k: object) -> None:
-        raise PermissionError("WinError 32 simulated")
-
-    monkeypatch.setattr(header_probe.Path, "unlink", _raise_unlink)
-    assert probe_architecture("https://example.test/model.gguf") == "llama"
+    assert probe_architecture("https://example.test/model.gguf") == "qwen3"
 
 
 def test_probe_handles_truncated_header(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_catalog_header_probe.py
+++ b/tests/test_catalog_header_probe.py
@@ -54,13 +54,19 @@ def test_probe_sends_range_header(monkeypatch: pytest.MonkeyPatch) -> None:
     blob = make_minimal_gguf("llama")
     captured: dict[str, object] = {}
 
-    def _capture(url: str, headers: dict[str, str], timeout: float) -> httpx.Response:
+    def _capture(
+        url: str, headers: dict[str, str], timeout: float, follow_redirects: bool = False
+    ) -> httpx.Response:
         captured["headers"] = headers
+        captured["follow_redirects"] = follow_redirects
         return httpx.Response(200, content=blob)
 
     monkeypatch.setattr(header_probe.httpx, "get", _capture)
     probe_architecture("https://example.test/model.gguf")
     assert captured["headers"]["Range"] == f"bytes=0-{GGUF_HEADER_PROBE_BYTES - 1}"
+    # HF /resolve/ URLs 302 to the CDN; the probe must follow the redirect or it
+    # reads the redirect notice instead of the GGUF header (bb-ziks.43).
+    assert captured["follow_redirects"] is True
 
 
 def test_probe_returns_empty_on_missing_arch_key(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_catalog_resolve_arch.py
+++ b/tests/test_catalog_resolve_arch.py
@@ -54,3 +54,19 @@ def test_resolve_blob_url_returns_url_for_concrete_filename() -> None:
     url = compat._resolve_blob_url("acme/foo-GGUF:model-q4.gguf")
     assert "acme/foo-GGUF" in url
     assert url.endswith("model-q4.gguf")
+
+
+def test_resolve_blob_url_resolves_native_slash_ref() -> None:
+    """A canonical native ref ``<org>/<repo>/<file>.gguf`` resolves to its blob URL.
+    The prior split-on-colon left every native ref with an empty filename, so the
+    arch-compat guard never probed (bb-ziks.72)."""
+    url = compat._resolve_blob_url("Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf")
+    assert "Qwen/Qwen3-0.6B-GGUF" in url
+    assert url.endswith("Qwen3-0.6B-Q4_K_M.gguf")
+
+
+def test_resolve_blob_url_native_ref_keeps_quant_subdir() -> None:
+    """A quant stored under a repo subdir keeps the subdir in the resolved filename."""
+    url = compat._resolve_blob_url("unsloth/M-GGUF/Q4_K_M/model.gguf")
+    assert "unsloth/M-GGUF" in url
+    assert url.endswith("Q4_K_M/model.gguf")

--- a/tests/test_fleet_devices.py
+++ b/tests/test_fleet_devices.py
@@ -137,12 +137,13 @@ class TestPresetVisibleDeviceComposition:
         env = visible_env((FleetDevice("CUDA", 1, "", 0, 0),))
         assert env["CUDA_VISIBLE_DEVICES"] == "GPU-bbb"
 
-    def test_cuda_index_past_parent_list_falls_back_to_relative(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_cuda_index_past_parent_list_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An index outside the parent restriction is an invariant violation; pinning
+        a bare absolute index into a (possibly UUID) parent list would select the
+        wrong GPU, so composition fails loudly instead (bb-7jg1.13)."""
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2")
-        env = visible_env((FleetDevice("CUDA", 0, "", 0, 0), FleetDevice("CUDA", 1, "", 0, 0)))
-        assert env["CUDA_VISIBLE_DEVICES"] == "2,1"
+        with pytest.raises(ValueError, match="outside the parent visible-devices list"):
+            visible_env((FleetDevice("CUDA", 0, "", 0, 0), FleetDevice("CUDA", 1, "", 0, 0)))
 
     def test_cuda_clean_env_emits_relative_ids(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -43,6 +43,18 @@ class TestPlanPlacement:
             unplaceable_roles=(),
         )
 
+    def test_search_role_placed_before_chat_on_constrained_host(self) -> None:
+        """When chat and an essential search role can't both fit, the search role
+        wins its placement instead of being starved by the larger chat model
+        placed first (bb-7jg1.6)."""
+        chat = ModelPlacementInput(WorkerRole.CHAT, 20 * _GB)
+        embed = ModelPlacementInput(WorkerRole.EMBED, 18 * _GB)
+        # One 24 GB card (21.6 GB usable): either model fits alone, not both.
+        plan = plan_placement([chat, embed], [(0, 24 * _GB)], estimate_peak=_even(chat, embed))
+        placed = {i.role for i in plan.instances}
+        assert WorkerRole.EMBED in placed
+        assert WorkerRole.CHAT in plan.unplaceable_roles
+
     def test_colocates_small_models_on_one_gpu(self) -> None:
         plan = plan_placement(
             [
@@ -149,7 +161,7 @@ class TestPlanPlacement:
         assert {i.role for i in plan.instances} == {WorkerRole.EMBED}
         assert plan.unplaceable_roles == (WorkerRole.CHAT,)
 
-    def test_first_fit_decreasing_places_largest_first(self) -> None:
+    def test_search_role_placed_first_then_chat(self) -> None:
         plan = plan_placement(
             [
                 ModelPlacementInput(WorkerRole.EMBED, 5 * _GB),
@@ -159,9 +171,9 @@ class TestPlanPlacement:
             estimate_peak=_never,
         )
         by_role = {i.role: i.devices for i in plan.instances}
-        # Largest (chat) placed first on device 0; embed then lands on the
-        # now-emptier device 1. Each is a single-GPU instance.
-        assert by_role == {WorkerRole.CHAT: (0,), WorkerRole.EMBED: (1,)}
+        # Search-first: embed claims device 0, then chat lands on the emptier
+        # device 1. Each is a single-GPU instance (bb-7jg1.6).
+        assert by_role == {WorkerRole.EMBED: (0,), WorkerRole.CHAT: (1,)}
         assert plan.unplaceable_roles == ()
 
 
@@ -188,21 +200,23 @@ class TestPerDeviceSplit:
 
     def test_charges_each_card_its_own_share(self) -> None:
         # Chat splits with an uneven per-device charge (10 GiB, 5 GiB). A following
-        # embed that fits only the less-charged card proves the debit is per-device,
-        # not the proportional/summed charge the old planner applied.
+        # single role that fits only the less-charged card proves the debit is
+        # per-device, not the proportional/summed charge the old planner applied.
+        # Vision (a non-search single) is placed after chat, so it exercises the
+        # post-chat fit; a search role would be placed first (bb-7jg1.6).
         chat = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
-        embed = ModelPlacementInput(WorkerRole.EMBED, 12 * _GB)
+        vision = ModelPlacementInput(WorkerRole.VISION, 12 * _GB)
 
         def peak(_role: WorkerRole, _ratio: tuple[int, ...]) -> tuple[int, ...]:
             return (10 * _GB, 5 * _GB)
 
         plan = plan_placement(
-            [chat, embed],
+            [chat, vision],
             [(0, 24 * _GB), (1, 24 * _GB)],
             estimate_peak=peak,
         )
-        embed_inst = next(i for i in plan.instances if i.role is WorkerRole.EMBED)
-        assert embed_inst.devices == (
+        vision_inst = next(i for i in plan.instances if i.role is WorkerRole.VISION)
+        assert vision_inst.devices == (
             1,
         )  # card 1 (charged 5) has room; card 0 (charged 10) does not
 

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -1389,6 +1389,14 @@ class _FakeReplica:
             raise self.fail
         return [0.5] * len(candidates)
 
+    def chat(
+        self, messages: object, options: object = None, stream: bool = False, **_kw: object
+    ) -> str:
+        self.calls += 1
+        if self.fail is not None:
+            raise self.fail
+        return "ocr text"
+
 
 class TestReplicaHealthRouting:
     def test_least_in_flight_skips_unhealthy_clients(self) -> None:
@@ -1431,6 +1439,41 @@ class TestReplicaHealthRouting:
         p = _provider_with_clients({WorkerRole.EMBED: [only]})
         with pytest.raises(ProviderError, match="no healthy replica"):
             p.embed(["a"])
+
+    def test_vision_ocr_fails_over_to_healthy_replica(self, monkeypatch) -> None:
+        """Vision OCR uses the failover path like embed/rerank: a dead replica is
+        marked unhealthy and the call retries on a live one, instead of the dead
+        replica being re-picked and the error swallowed to empty text (bb-7jg1.5)."""
+        import httpx as _httpx
+
+        dead = _FakeReplica(fail=_httpx.ConnectError("refused"))
+        alive = _FakeReplica(in_flight=5)  # busier, picked only after failover
+        monkeypatch.setattr(cfg, "vision_model", "org/vis/model.gguf")
+        p = _provider_with_clients({WorkerRole.VISION: [dead, alive]})
+        assert p.vision_ocr(b"\x89PNG", "") == "ocr text"
+        assert dead.healthy is False
+        assert alive.calls == 1
+
+    def test_vision_pdf_page_fails_over_to_healthy_replica(self, monkeypatch) -> None:
+        """The per-page PDF OCR path fails a dead replica over too, so a page is
+        OCR'd by a live replica rather than skipped to empty text (bb-7jg1.5)."""
+        import httpx as _httpx
+
+        from lilbee.providers.fleet import provider as prov
+
+        dead = _FakeReplica(fail=_httpx.ConnectError("refused"))
+        alive = _FakeReplica(in_flight=5)
+        idx, text = prov._ocr_pdf_page(
+            0,
+            b"\x89PNG",
+            clients=[dead, alive],
+            ocr_prompt="read it",
+            deadline=None,
+            page_path=Path("doc.pdf"),
+        )
+        assert (idx, text) == (0, "ocr text")
+        assert dead.healthy is False
+        assert alive.calls == 1
 
     def test_successful_call_restores_an_unhealthy_replica(self) -> None:
         only = _FakeReplica()

--- a/tests/test_gguf_meta.py
+++ b/tests/test_gguf_meta.py
@@ -1,0 +1,25 @@
+"""read_gguf_metadata robustness against corrupt/truncated GGUF headers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lilbee.providers.gguf_meta import read_gguf_metadata
+from tests._gguf_fixture import make_minimal_gguf
+
+
+def test_returns_metadata_for_valid_gguf(tmp_path: Path) -> None:
+    f = tmp_path / "ok.gguf"
+    f.write_bytes(make_minimal_gguf("llama"))
+    meta = read_gguf_metadata(f)
+    assert meta is not None
+    assert meta.get("architecture") == "llama"
+
+
+def test_returns_none_for_truncated_header(tmp_path: Path) -> None:
+    """A truncated/corrupt GGUF must yield None, not a raw parser error that would
+    abort the whole fleet build (bb-7jg1.15)."""
+    f = tmp_path / "bad.gguf"
+    # GGUF magic + version, then the tensor/kv count fields cut off mid-read.
+    f.write_bytes(b"GGUF" + b"\x03\x00\x00\x00" + b"\x01\x00")
+    assert read_gguf_metadata(f) is None

--- a/tests/test_gguf_meta.py
+++ b/tests/test_gguf_meta.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import struct
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,19 @@ def test_returns_metadata_for_valid_gguf(tmp_path: Path) -> None:
     assert meta.get("architecture") == "llama"
 
 
+def _gguf_with_duplicate_key() -> bytes:
+    """A parseable GGUF header carrying the same metadata key twice; GGUFReader
+    raises KeyError ('Duplicate ... already in list') on the second one."""
+
+    def gstr(s: bytes) -> bytes:
+        return struct.pack("<Q", len(s)) + s
+
+    blob = b"GGUF" + struct.pack("<I", 3) + struct.pack("<Q", 0) + struct.pack("<Q", 2)
+    for _ in range(2):
+        blob += gstr(b"general.name") + struct.pack("<I", 8) + gstr(b"x")
+    return blob
+
+
 @pytest.mark.parametrize(
     ("label", "data"),
     [
@@ -27,12 +41,14 @@ def test_returns_metadata_for_valid_gguf(tmp_path: Path) -> None:
         ("bad_magic", b"XXXX" + b"\x00" * 40),
         # magic only, no count/field table -> IndexError from the gguf reader.
         ("magic_only", b"GGUF"),
+        # duplicate metadata key -> KeyError from GGUFReader._push_field.
+        ("duplicate_key", _gguf_with_duplicate_key()),
     ],
 )
 def test_returns_none_for_corrupt_header(tmp_path: Path, label: str, data: bytes) -> None:
-    """A truncated/corrupt GGUF must yield None across the parser's failure modes
-    (ValueError and IndexError are both observed), not a raw error that would abort
-    the whole fleet build (bb-7jg1.15)."""
+    """A corrupt-but-parseable GGUF must yield None across the parser's failure
+    modes (ValueError, IndexError, and the duplicate-key KeyError are all
+    observed), not a raw error that would abort the whole fleet build (bb-7jg1.15)."""
     f = tmp_path / f"{label}.gguf"
     f.write_bytes(data)
     assert read_gguf_metadata(f) is None

--- a/tests/test_gguf_meta.py
+++ b/tests/test_gguf_meta.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from lilbee.providers.gguf_meta import read_gguf_metadata
 from tests._gguf_fixture import make_minimal_gguf
 
@@ -16,10 +18,21 @@ def test_returns_metadata_for_valid_gguf(tmp_path: Path) -> None:
     assert meta.get("architecture") == "llama"
 
 
-def test_returns_none_for_truncated_header(tmp_path: Path) -> None:
-    """A truncated/corrupt GGUF must yield None, not a raw parser error that would
-    abort the whole fleet build (bb-7jg1.15)."""
-    f = tmp_path / "bad.gguf"
-    # GGUF magic + version, then the tensor/kv count fields cut off mid-read.
-    f.write_bytes(b"GGUF" + b"\x03\x00\x00\x00" + b"\x01\x00")
+@pytest.mark.parametrize(
+    ("label", "data"),
+    [
+        # version + counts cut off mid-read -> ValueError from the gguf reader.
+        ("truncated", b"GGUF" + b"\x03\x00\x00\x00" + b"\x01\x00"),
+        # bad magic -> ValueError.
+        ("bad_magic", b"XXXX" + b"\x00" * 40),
+        # magic only, no count/field table -> IndexError from the gguf reader.
+        ("magic_only", b"GGUF"),
+    ],
+)
+def test_returns_none_for_corrupt_header(tmp_path: Path, label: str, data: bytes) -> None:
+    """A truncated/corrupt GGUF must yield None across the parser's failure modes
+    (ValueError and IndexError are both observed), not a raw error that would abort
+    the whole fleet build (bb-7jg1.15)."""
+    f = tmp_path / f"{label}.gguf"
+    f.write_bytes(data)
     assert read_gguf_metadata(f) is None


### PR DESCRIPTION
## Problem

A handful of fleet and catalog paths failed silently or in the wrong direction:

- The unsupported-architecture pull guard never fired end to end. Native slash-style GGUF refs were never resolved to a blob filename, the HuggingFace `/resolve/` redirect to the CDN wasn't followed, and the header parse leaned on gguf-py's `GGUFReader`, which needs the whole metadata table (including a model's multi-megabyte tokenizer arrays) and so raised on a Range-GET-truncated header. The net effect: every architecture verdict came back UNKNOWN and the guard was dead.
- `read_gguf_metadata` could let a raw parser error (including the duplicate-key `KeyError` `GGUFReader` raises) abort an entire fleet build.
- Vision OCR calls hit a single replica with no failover.
- Discrete single-model GPU placement ordered by VRAM instead of role, so search could land behind chat on a shared card.
- An out-of-range device index silently pinned the wrong GPU instead of failing.
- Several wiki routes ran heavy synchronous work directly on the event loop.

## Solution

- Resolve native slash refs to their blob filename, follow redirects on the header probe, and read `general.architecture` by walking the GGUF KV table directly so the arch-compat guard fires without parsing tokenizer arrays. Validated byte-for-byte against gguf-py across every value type, scalar size, array skip, UTF-8 arch, and a real-shaped header truncated to the 64KB probe window.
- Catch the parser's failure modes (`ValueError`/`KeyError`/`IndexError`/`struct.error`/`OSError`/`UnicodeDecodeError`) in `read_gguf_metadata` and return `None` so a corrupt GGUF can't abort the build.
- Route vision OCR through the replica failover helper.
- Order discrete single-model placement search-first.
- Raise on an out-of-range device index instead of pinning the wrong card.
- Offload the heavy wiki route work with `asyncio.to_thread`.

Unit tests cover the KV walker at the byte level (including truncated tokenizer arrays), the duplicate-key parse, vision failover, search-first placement, the out-of-range pin, and the off-event-loop wiki routes.
