### PR TITLE
Cleanup: native TOML lists, atomic opencode marker, query-safe crawl filenames, seeded Leiden

### DIFF
--- a/src/lilbee/cli/launchers/opencode.py
+++ b/src/lilbee/cli/launchers/opencode.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import sys
+import tempfile
 from importlib import resources
 from pathlib import Path
 
@@ -36,10 +37,19 @@ def _setup_recorded() -> bool:
 
 
 def _record_setup() -> None:
-    """Persist that the user accepted opencode setup; idempotent."""
+    """Persist that the user accepted opencode setup; idempotent (atomic write)."""
     path = _setup_marker_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"accepted": True}), encoding="utf-8")
+    tmp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=path.parent, suffix=".tmp", delete=False) as tmp:
+            tmp_name = tmp.name
+            tmp.write(json.dumps({"accepted": True}).encode("utf-8"))
+        os.replace(tmp_name, path)
+    except BaseException:
+        if tmp_name is not None:
+            Path(tmp_name).unlink(missing_ok=True)
+        raise
 
 
 def _print_setup_plan() -> None:

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -992,8 +992,10 @@ class _TomlSource:
         # Empty strings represent "no persisted value" for nullable scalar
         # fields (legacy from set_setting writing "" for None). Pydantic
         # can't coerce "" to int|None, so dropping them here lets the field
-        # default apply rather than crashing the whole Config load.
-        return {k: str(v) for k, v in data.items() if str(v) != ""}
+        # default apply rather than crashing the whole Config load. TOML's
+        # native types (lists, ints, bools) pass through untouched: stringifying
+        # turned a list field's ["a", "b"] into the literal "['a', 'b']".
+        return {k: v for k, v in data.items() if v != ""}
 
 
 def _build_cfg() -> tuple[Config, Exception | None]:

--- a/src/lilbee/crawler/save.py
+++ b/src/lilbee/crawler/save.py
@@ -23,6 +23,10 @@ _MAX_FILENAME_LEN = 200
 # Sentinel for index pages (trailing slash or empty path)
 _INDEX_FILENAME = "index.md"
 
+# Length of the query-string hash folded into a filename to keep distinct
+# queries on the same path from mapping to (and overwriting) the same file.
+_QUERY_HASH_LEN = 8
+
 # How often the crawl metadata JSON is rewritten during a streaming crawl.
 # Markdown files are durable per-page; metadata batches to keep write volume
 # bounded. Worst-case loss on crash is N-1 entries, recoverable from the files.
@@ -34,34 +38,36 @@ def url_to_filename(url: str) -> str:
 
     Examples:
         https://docs.python.org/3/tutorial/ → docs.python.org/3/tutorial/index.md
-        https://example.com/page?q=1#frag   → example.com/page.md
+        https://example.com/page?q=1        → example.com/page/index_q<hash>.md
         https://example.com/                → example.com/index.md
+
+    A distinct query string folds a short hash of the query into the filename so
+    two URLs differing only in their query do not map to the same file and
+    overwrite each other. The fragment is client-side and intentionally ignored.
     """
     parsed = urlparse(url)
     host = parsed.hostname or "unknown"
-    path = parsed.path.rstrip("/")
+    path = parsed.path.strip("/")
 
-    if not path or path == "/":
-        return f"{host}/{_INDEX_FILENAME}"
-
-    # Strip leading slash
-    path = path.lstrip("/")
-
-    # Neutralize path traversal segments
-    path = re.sub(r"\.\.+", "_", path)
-
-    # Replace unsafe filesystem characters
-    path = re.sub(r'[<>:"|?*]', "_", path)
-
-    # If the last segment has no extension, treat as directory
-    last_segment = path.rsplit("/", 1)[-1]
-    if "." not in last_segment:
-        path = f"{path}/{_INDEX_FILENAME}"
+    if not path:
+        rel = _INDEX_FILENAME
     else:
-        # Replace existing extension with .md
-        path = re.sub(r"\.[^./]+$", ".md", path)
+        # Neutralize path traversal segments and unsafe filesystem characters.
+        path = re.sub(r"\.\.+", "_", path)
+        path = re.sub(r'[<>:"|?*]', "_", path)
+        last_segment = path.rsplit("/", 1)[-1]
+        if re.search(r"\.[^./]+$", last_segment):
+            rel = re.sub(r"\.[^./]+$", ".md", path)  # real extension: swap it for .md
+        else:
+            # No real extension (incl. a bare "." segment) -> treat as a directory.
+            # This guarantees rel ends in .md so the query suffix below always applies.
+            rel = f"{path}/{_INDEX_FILENAME}"
 
-    full = f"{host}/{path}"
+    if parsed.query:
+        query_hash = hashlib.sha256(parsed.query.encode()).hexdigest()[:_QUERY_HASH_LEN]
+        rel = re.sub(r"\.md$", f"_q{query_hash}.md", rel)
+
+    full = f"{host}/{rel}"
 
     # Truncate if too long, preserving .md extension
     if len(full) > _MAX_FILENAME_LEN:

--- a/src/lilbee/retrieval/concepts/community.py
+++ b/src/lilbee/retrieval/concepts/community.py
@@ -8,6 +8,9 @@ from dataclasses import dataclass
 from typing import Any
 
 _MIN_LEIDEN_WEIGHT = 0.01
+# Fixed seed so Leiden returns the same communities for the same edge set;
+# the algorithm is randomized and would otherwise drift between runs.
+_LEIDEN_SEED = 42
 
 
 @dataclass
@@ -53,7 +56,7 @@ def _leiden_partition(
     edges: list[tuple[str, str, float]] = [
         (row["source"], row["target"], max(_MIN_LEIDEN_WEIGHT, row["weight"])) for row in edge_rows
     ]
-    _modularity, partition = leiden(edges=edges)  # type: ignore[call-arg]
+    _modularity, partition = leiden(edges=edges, seed=_LEIDEN_SEED)  # type: ignore[call-arg]
 
     degree_map: dict[str, int] = Counter()
     for row in edge_rows:

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -659,6 +659,34 @@ def test_launch_opencode_first_run_records_setup_marker(tmp_path):
     assert "First-time opencode setup will write" in result.stdout
 
 
+def test_record_setup_writes_marker_atomically(tmp_path, monkeypatch):
+    from lilbee.cli.launchers import opencode
+
+    marker = tmp_path / "opencode-setup.json"
+    monkeypatch.setattr(opencode, "_setup_marker_path", lambda: marker)
+    opencode._record_setup()
+    assert json.loads(marker.read_text()) == {"accepted": True}
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_record_setup_leaves_existing_marker_intact_on_failure(tmp_path, monkeypatch):
+    """A failed rewrite must not truncate or litter: the prior marker survives."""
+    from lilbee.cli.launchers import opencode
+
+    marker = tmp_path / "opencode-setup.json"
+    marker.write_text(json.dumps({"accepted": True}))
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(opencode, "_setup_marker_path", lambda: marker)
+    monkeypatch.setattr(opencode.os, "replace", _boom)
+    with pytest.raises(OSError):
+        opencode._record_setup()
+    assert json.loads(marker.read_text()) == {"accepted": True}
+    assert not list(tmp_path.glob("*.tmp"))
+
+
 def test_launch_opencode_skips_prompt_when_marker_present(tmp_path):
     # A recorded marker means later launches do not re-print the setup plan.
     _write_server_session()

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -903,6 +903,17 @@ class TestLeidenPartition:
             edges_passed = call_args[1]["edges"]
             assert edges_passed[0][2] == _MIN_LEIDEN_WEIGHT
 
+    def test_passes_deterministic_seed(self):
+        """Leiden is randomized; the call must pin a seed so the same edge set
+        always yields the same communities."""
+        mock_graspologic = MagicMock()
+        mock_graspologic.leiden.return_value = (0.5, {"a": 0, "b": 0})
+        with patch.dict("sys.modules", {"graspologic_native": mock_graspologic}):
+            from lilbee.retrieval.concepts.community import _LEIDEN_SEED, _leiden_partition
+
+            _leiden_partition([{"source": "a", "target": "b", "weight": 1.0}])
+            assert mock_graspologic.leiden.call_args[1]["seed"] == _LEIDEN_SEED
+
 
 class TestCommunityDataclass:
     def test_community_fields(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -320,6 +320,33 @@ class TestTomlConfigFile:
             c = Config()
             assert c.enable_ocr is True
 
+    def test_list_field_from_toml_stays_a_list(self, tmp_path):
+        """A TOML array maps to a native list, not its stringified repr."""
+        toml_path = tmp_path / "config.toml"
+        toml_path.write_text(
+            'cors_origins = ["https://a.example", "https://b.example"]\n'
+            'crawl_exclude_patterns = [".*/private/.*"]\n'
+            'crawl_browser_extra_args = ["--disable-gpu", "--no-sandbox"]\n'
+        )
+        env = _clean_env()
+        env["LILBEE_DATA"] = str(tmp_path)
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.cors_origins == ["https://a.example", "https://b.example"]
+            assert c.crawl_exclude_patterns == [".*/private/.*"]
+            # No before-validator splitter, so the old str(v) coercion hard-failed here.
+            assert c.crawl_browser_extra_args == ["--disable-gpu", "--no-sandbox"]
+
+    def test_empty_string_scalar_in_toml_falls_back_to_default(self, tmp_path):
+        """Legacy '' sentinel (set_setting wrote it for None) is dropped, not coerced."""
+        toml_path = tmp_path / "config.toml"
+        toml_path.write_text('chat_model = ""\n')
+        env = _clean_env()
+        env["LILBEE_DATA"] = str(tmp_path)
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.chat_model == _DEFAULT_CHAT_REF
+
     def test_top_p_from_toml(self, tmp_path):
         toml_path = tmp_path / "config.toml"
         toml_path.write_text("top_p = 0.9\n")

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -108,13 +108,39 @@ class TestUrlToFilename:
         result = url_to_filename("https://example.com/docs/guide.html")
         assert result == "example.com/docs/guide.md"
 
-    def test_query_params_stripped(self):
-        result = url_to_filename("https://example.com/page?q=1&foo=bar")
-        assert result == "example.com/page/index.md"
+    def test_distinct_queries_map_to_distinct_files(self):
+        # ?q=1 and ?q=2 are different resources; they must not clobber each other.
+        a = url_to_filename("https://example.com/page?q=1")
+        b = url_to_filename("https://example.com/page?q=2")
+        assert a != b
+        assert a.startswith("example.com/page/") and a.endswith(".md")
+        assert b.startswith("example.com/page/") and b.endswith(".md")
+
+    def test_same_query_is_stable(self):
+        url = "https://example.com/page?q=1&foo=bar"
+        assert url_to_filename(url) == url_to_filename(url)
+
+    def test_query_with_file_extension_disambiguated(self):
+        a = url_to_filename("https://example.com/docs/guide.html?v=1")
+        b = url_to_filename("https://example.com/docs/guide.html?v=2")
+        assert a != b
+        assert a.startswith("example.com/docs/guide") and a.endswith(".md")
+
+    def test_dotted_non_extension_segment_still_disambiguates_query(self):
+        # A path segment that is a bare "." has no real extension; it must still
+        # route to .md so distinct queries don't collide on it.
+        a = url_to_filename("https://example.com/.?a=1")
+        b = url_to_filename("https://example.com/.?a=2")
+        assert a != b
+        assert a.endswith(".md") and b.endswith(".md")
 
     def test_fragment_stripped(self):
-        result = url_to_filename("https://example.com/page#section")
-        assert result == "example.com/page/index.md"
+        # Fragments are client-side; same resource -> same file (and no query suffix).
+        assert (
+            url_to_filename("https://example.com/page#section")
+            == url_to_filename("https://example.com/page")
+            == "example.com/page/index.md"
+        )
 
     def test_unsafe_chars_replaced(self):
         result = url_to_filename("https://example.com/a<b>c")


### PR DESCRIPTION
## Problem

Four unrelated cleanups surfaced during review:

- `config.toml` list-typed fields (`cors_origins`, `crawl_exclude_patterns`, `crawl_browser_extra_args`) were stringified on load, so a TOML array `["a", "b"]` became the literal string `"['a', 'b']"`. Fields with a before-validator degraded to a garbage one-element list; `crawl_browser_extra_args` (no splitter) failed outright.
- The opencode setup marker was written with a direct `write_text`, so a crash mid-write could leave a truncated marker.
- The crawler mapped two URLs that differ only by query string to the same filename, so one crawled page silently overwrote the other.
- Leiden community detection ran without a seed, giving non-deterministic concept clusters between runs.

## Solution

- `_TomlSource` no longer stringifies values: TOML's native types pass through, so list fields load as lists. The legacy empty-string sentinel for nullable scalars is still dropped.
- The opencode marker is written to a temp file and `os.replace`d into place, cleaning up the temp file on failure.
- `url_to_filename` folds a short hash of the query string into the filename so distinct queries map to distinct files; the fragment stays ignored.
- Leiden runs with a fixed seed for reproducible clusters.

Each fix has unit tests (native-list load including the no-splitter field, atomic write surviving a mid-write failure, distinct-query/stable/fragment-ignored filenames, and the seed being passed).
