### PR TITLE
Stop llama-swap stdout from leaking into the TUI

### DIFF
--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -18,7 +18,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, BinaryIO
 
 import httpx
 import psutil
@@ -36,6 +36,11 @@ log = logging.getLogger(__name__)
 
 _HOST = "127.0.0.1"
 _CONFIG_FILENAME = "llama-swap.json"
+# llama-swap's own stdout/stderr (its HTTP access log) is captured here instead of
+# inherited from the parent: a TUI or CLI parent owns the terminal, and an inherited
+# fd would bleed llama-swap's request log straight onto the screen and corrupt the
+# render. Per-model upstream logs are unaffected (those go to llama-swap's /logs API).
+_LOG_FILENAME = "llama-swap.log"
 # Cross-run reaping: each owner lilbee writes its own state file (named with its
 # pid) recording its swap's pid/pgid plus the owner's pid and create time, so the
 # next start can kill a dead owner's surviving llama-swap (it holds VRAM
@@ -115,8 +120,10 @@ class SwapManager:
     def __init__(self, data_dir: Path) -> None:
         self._data_dir = data_dir
         self._config_path = data_dir / _CONFIG_FILENAME
+        self._log_path = data_dir / _LOG_FILENAME
         self._state_path = data_dir / _state_filename(os.getpid())
         self._proc: subprocess.Popen[bytes] | None = None
+        self._log_file: BinaryIO | None = None
         self._port: int | None = None
         self._member_ports: list[int] = []
 
@@ -137,6 +144,10 @@ class SwapManager:
         self._config_path.parent.mkdir(parents=True, exist_ok=True)
         self._config_path.write_text(build_swap_config(launches, member_ports))
         self._port = ports[0]
+        # Capture llama-swap's stdout/stderr to a file so its access log never
+        # reaches an inherited terminal (a TUI/CLI parent) and garbles the screen.
+        self._close_log()
+        self._log_file = self._log_path.open("ab")
         self._proc = subprocess.Popen(  # noqa: S603 - argv[0] is the resolved llama-swap
             [
                 str(resolve_llama_swap()),
@@ -145,6 +156,8 @@ class SwapManager:
                 _LISTEN_FLAG,
                 f"{_HOST}:{self._port}",
             ],
+            stdout=self._log_file,
+            stderr=subprocess.STDOUT,
             start_new_session=True,
             creationflags=_CREATE_NEW_PROCESS_GROUP,
         )
@@ -257,6 +270,14 @@ class SwapManager:
             self._state_path.unlink(missing_ok=True)
         self._proc = None
         self._port = None
+        self._close_log()
+
+    def _close_log(self) -> None:
+        """Close the captured llama-swap log handle, if one is open."""
+        if self._log_file is not None:
+            with contextlib.suppress(OSError):
+                self._log_file.close()
+            self._log_file = None
 
     def _await_health(self) -> None:
         """Poll the proxy's /health until it answers, or fail with a clear error."""

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -92,6 +92,37 @@ class TestStart:
         assert len(set(member_ports.values())) == 2
         assert proxy_port not in member_ports.values()
 
+    def test_redirects_llama_swap_stdio_to_a_log_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """llama-swap's stdout/stderr must go to a log file, never an inherited
+        terminal: an inherited fd bleeds its HTTP access log onto a TUI/CLI
+        parent's screen and corrupts the render."""
+        captured: dict[str, object] = {}
+
+        def _capturing_popen(*_args: object, **kwargs: object) -> _FakeProc:
+            captured.update(kwargs)
+            return _FakeProc(poll_result=None)
+
+        monkeypatch.setattr(sm, "resolve_llama_swap", lambda: Path("/fake/llama-swap"))
+        monkeypatch.setattr(sm.subprocess, "Popen", _capturing_popen)
+        monkeypatch.setattr(sm, "_stop_process_tree", lambda p: None)
+        _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
+
+        mgr = SwapManager(tmp_path)
+        mgr.start([_launch(WorkerRole.CHAT)])
+
+        log_path = tmp_path / "llama-swap.log"
+        assert log_path.exists()
+        # stdout is the opened log file (its .name is the path), not None
+        # (inherited terminal) nor a PIPE; stderr merges into the same file.
+        assert getattr(captured["stdout"], "name", None) == str(log_path)
+        assert captured["stdout"] is not subprocess.PIPE
+        assert captured["stderr"] is subprocess.STDOUT
+        # shutdown releases the captured handle.
+        mgr.shutdown()
+        assert mgr._log_file is None
+
     def test_raises_when_process_exits_before_ready(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Problem

llama-swap was spawned with inherited stdout/stderr, so under a TUI or CLI parent its HTTP access log printed straight onto the terminal and corrupted the render. The visible symptom is request lines like `[INFO] Request 127.0.0.1 "POST /upstream/embed-0/tokenize HTTP/1.1" 200 ...` interleaving with the chat pane and shredding the layout while a model is working.

## Solution

Capture llama-swap's stdout/stderr to a per-owner `llama-swap.log` in the data dir instead of letting it inherit the parent's file descriptors, and close that handle on shutdown. The per-model upstream logs are unaffected (those come from llama-swap's `/logs` API, not its stdout).

While here I audited the other engine subprocesses: gguf-parser, the llama-server `--list-devices`/`ldd` probes, nvidia-smi, and the managed `lilbee serve` already redirect or capture their output, and the foreground client inherits the terminal by design. llama-swap was the only leak.

Verified live: with the fix, the TUI pane carries zero access-log lines and every request lands in `llama-swap.log`. Adds a regression test asserting the spawn redirects stdio to the log file and releases the handle on shutdown.