### PR TITLE
Make model swaps non-blocking with a progress indicator

### DIFF
--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -74,14 +74,16 @@ class Services:
         """
         self.provider.cancel_inference()
 
-    def reload_role(self, role_name: WorkerRole) -> None:
+    def reload_role(self, role_name: WorkerRole, *, wait: bool = False) -> None:
         """Respawn only *role_name*'s model server so it picks up changed cfg.
 
         Other roles' servers and any in-flight stream they own are untouched. Use
         when one role-bound model setting changed (e.g. embedding_model). The
-        respawn runs off the caller's thread, so this returns immediately.
+        respawn runs off the caller's thread, so this returns immediately, unless
+        ``wait=True`` (the caller is already off the event loop and wants to block
+        until the new model has loaded).
         """
-        self.provider.reload_role(role_name)
+        self.provider.reload_role(role_name, wait=wait)
 
     def add_pool_listener(
         self,

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -104,6 +104,11 @@ CMD_SET_SUCCESS = "{key} = {value}"
 CMD_SET_INVALID = "Invalid value for {key}: {error}"
 CMD_SET_READONLY = "{key} is read-only; use the Models screen"
 CMD_MODEL_SET = "Model set to {name}"
+# Shown while a model swap's fleet reload runs off the event loop, so the swap
+# reads as in-progress instead of a frozen TUI.
+MODEL_SWAP_APPLYING = "Switching model, loading..."
+MODEL_SWAP_DONE = "Now using {name}"
+MODEL_SWAP_FAILED = "Could not switch model: {error}"
 CMD_REMOVE_USAGE = "Usage: /remove <model_name>"
 CMD_REMOVE_NOT_FOUND = "{name} is not installed"
 CMD_REMOVE_SUCCESS = "Removed {name}"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -109,6 +109,8 @@ CMD_MODEL_SET = "Model set to {name}"
 MODEL_SWAP_APPLYING = "Switching model, loading..."
 MODEL_SWAP_DONE = "Now using {name}"
 MODEL_SWAP_FAILED = "Could not switch model: {error}"
+# Shown when the user tries to send a prompt while the new chat model is still loading.
+CHAT_MODEL_SWITCHING = "Still switching model. One moment, then send your prompt."
 CMD_REMOVE_USAGE = "Usage: /remove <model_name>"
 CMD_REMOVE_NOT_FOUND = "{name} is not installed"
 CMD_REMOVE_SUCCESS = "Removed {name}"

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1518,8 +1518,8 @@ class ChatScreen(Screen[None]):
         runs in a thread worker instead of on the event loop. The in-flight stream
         is cancelled first, the input is blocked behind a "switching" state with an
         indicator toast, and the reload waits for in-flight workers to drain so the
-        restart doesn't disrupt them. The input re-enables only once the worker
-        reports the new model loaded.
+        restart doesn't disrupt them. The input re-enables once the fleet has
+        restarted with the new model (which loads on the next request).
         """
         if self.streaming:
             self.action_cancel_stream()
@@ -1561,9 +1561,10 @@ class ChatScreen(Screen[None]):
 
         ``reload_role(wait=True)`` re-plans and restarts the fleet for the new chat
         model while keeping the store and searcher (a chat-model change doesn't
-        touch retrieval), and returns once the model has loaded. The provider
-        serializes overlapping reloads, so a rapid second swap coalesces onto the
-        latest cfg.
+        touch retrieval), and returns once the fleet proxy is back up; the model
+        itself loads on the next request (the same lazy load every role swap uses).
+        The provider serializes overlapping reloads, so a rapid second swap
+        coalesces onto the latest cfg.
         """
         try:
             get_services().reload_role(WorkerRole.CHAT, wait=True)

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -162,6 +162,10 @@ class ChatScreen(Screen[None]):
     AUTO_FOCUS = "#chat-input"
 
     streaming: reactive[bool] = reactive(False)
+    # True while a chat-model swap's fleet reload runs in the background. Gates the
+    # submit handler and disables the input so the user can't fire a prompt into a
+    # half-loaded fleet; cleared when the swap worker finishes (or fails).
+    swapping_model: reactive[bool] = reactive(False)
 
     HELP = (
         "# Chat\n\n"
@@ -474,12 +478,7 @@ class ChatScreen(Screen[None]):
             # submitting whatever empty / stale text the input still holds.
             self._enter_insert_mode()
             return
-        if self.streaming:
-            # Only one chat message may be in flight at a time. Surface a
-            # toast so the user knows the prompt was rejected (rather
-            # than silently dropped) and ask them to cancel first if
-            # they want to redirect the model.
-            self.notify(msg.CHAT_BUSY, severity="warning", timeout=3)
+        if self._reject_submit_when_busy():
             return
         # Enter when the completion dropdown is showing a different
         # selection than the input itself: accept the highlight first
@@ -510,6 +509,23 @@ class ChatScreen(Screen[None]):
             self._handle_slash(text)
             return
         self._send_message(text)
+
+    def _reject_submit_when_busy(self) -> bool:
+        """Toast and reject a submit while a swap is loading or a stream is in flight.
+
+        Returns True when the prompt was rejected so the caller stops. The swap
+        check comes first: a prompt sent mid-swap would race a half-torn-down
+        fleet, so the user is asked to wait rather than cancel.
+        """
+        if self.swapping_model:
+            self.notify(msg.CHAT_MODEL_SWITCHING, severity="warning", timeout=3)
+            return True
+        if self.streaming:
+            # Only one chat message may be in flight at a time; surface a toast
+            # so the prompt is visibly rejected, not silently dropped.
+            self.notify(msg.CHAT_BUSY, severity="warning", timeout=3)
+            return True
+        return False
 
     def _pending_required_model_download(self) -> str | None:
         """Return the in-flight download's name if it's for the configured chat or embedding model.
@@ -1498,23 +1514,38 @@ class ChatScreen(Screen[None]):
     def apply_model_change(self) -> None:
         """Swap to the new chat model without freezing the UI.
 
-        ``reset_services`` is a multi-second fleet reload, so it runs in a thread
-        worker instead of on the event loop. The in-flight stream is cancelled
-        first, an indicator toast is shown immediately, and the reset waits for
-        the chat worker(s) to drain so the new model takes over cleanly.
+        ``reset_services`` plus the new model's cold load is a multi-second fleet
+        reload, so it runs in a thread worker instead of on the event loop. The
+        in-flight stream is cancelled first, the input is blocked behind a
+        "switching" state with an indicator toast, and the reset waits for the
+        chat worker(s) to drain so the new model takes over cleanly. The input
+        re-enables only once the worker reports the new model loaded.
         """
         if self.streaming:
             self.action_cancel_stream()
+        self.swapping_model = True
         self.app.notify(msg.MODEL_SWAP_APPLYING)
         self.call_later(self._reset_services_when_drained)
+
+    def watch_swapping_model(self, swapping: bool) -> None:
+        """Disable the chat input while a swap loads so a prompt can't race it.
+
+        Restores focus when the swap finishes so the user can type immediately
+        without re-clicking the input that was disabled out from under them.
+        """
+        self.set_class(swapping, "swapping-model")
+        self._chat_input.disabled = swapping
+        if not swapping and self._insert_mode:
+            self._chat_input.focus()
 
     def _reset_services_when_drained(self) -> None:
         """Spawn the off-thread reset once in-flight workers have drained.
 
-        Waiting on the event loop is cheap and non-blocking. It waits for *all*
-        workers, including a prior swap's reset worker, so ``reset_services`` is
-        never run twice concurrently (a cancelled thread keeps running to
-        completion, so serializing here is the only safe guard).
+        Runs on the event loop (cheap, non-blocking) and checks before spawning,
+        so the swap worker is not yet among ``self.workers``. Waiting for every
+        worker, including a prior swap's, serializes resets so ``reset_services``
+        never runs twice at once (a cancelled thread runs to completion, so this
+        is the only safe guard).
         """
         if self.workers:
             self.call_later(self._reset_services_when_drained)
@@ -1523,19 +1554,29 @@ class ChatScreen(Screen[None]):
 
     @work(thread=True, name=_MODEL_SWAP_WORKER, exit_on_error=False)
     def _reset_services_worker(self) -> None:
-        """Run the multi-second service reset off the event loop, then confirm."""
+        """Reset and warm the new model off the event loop, then unblock the input.
+
+        ``reset_services`` tears down the old fleet; ``get_services`` rebuilds it
+        and (eager start) kicks off the new model's load, so when this returns the
+        new model is loading or ready, not a surprise cold load on the next prompt.
+        """
         try:
             reset_services()
+            get_services()
         except Exception as exc:  # any reload failure becomes a toast, never a crash
-            call_from_thread(
-                self, self.app.notify, msg.MODEL_SWAP_FAILED.format(error=exc), severity="error"
-            )
+            call_from_thread(self, self._on_model_swap_failed, str(exc))
             return
         call_from_thread(self, self._on_model_swapped)
 
     def _on_model_swapped(self) -> None:
-        """Main-thread completion toast confirming the new chat model is live."""
+        """Main-thread completion: unblock the input and confirm the new model."""
+        self.swapping_model = False
         self.app.notify(msg.MODEL_SWAP_DONE.format(name=cfg.chat_model))
+
+    def _on_model_swap_failed(self, error: str) -> None:
+        """Main-thread failure: unblock the input and surface the error."""
+        self.swapping_model = False
+        self.app.notify(msg.MODEL_SWAP_FAILED.format(error=error), severity="error")
 
     async def action_toggle_markdown(self) -> None:
         """Toggle between Markdown and plain-text rendering for chat responses."""

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -105,6 +105,11 @@ _CRAWL_FLAG_MAX_PAGES = "--max-pages"
 _CRAWL_FLAG_INCLUDE_SUBDOMAINS = "--include-subdomains"
 _CRAWL_FLAG_RENDER = "--render"
 
+# The model-swap service reset runs in this named worker so the drain-before-reset
+# wait can ignore it (it must not block on itself) and a rapid second swap cancels
+# the prior reset rather than stacking fleet reloads.
+_MODEL_SWAP_WORKER = "model_swap_reset"
+
 
 def _parse_add_paths(args: str) -> list[Path]:
     """Resolve ``/add`` arguments to filesystem paths.
@@ -1491,19 +1496,46 @@ class ChatScreen(Screen[None]):
         self.streaming = False
 
     def apply_model_change(self) -> None:
-        """Cancel active stream (if any) and reset services for the new model."""
+        """Swap to the new chat model without freezing the UI.
+
+        ``reset_services`` is a multi-second fleet reload, so it runs in a thread
+        worker instead of on the event loop. The in-flight stream is cancelled
+        first, an indicator toast is shown immediately, and the reset waits for
+        the chat worker(s) to drain so the new model takes over cleanly.
+        """
         if self.streaming:
             self.action_cancel_stream()
-            self.call_later(self._deferred_service_reset)
-        else:
-            reset_services()
+        self.app.notify(msg.MODEL_SWAP_APPLYING)
+        self.call_later(self._reset_services_when_drained)
 
-    def _deferred_service_reset(self) -> None:
-        """Reset services once workers have drained."""
+    def _reset_services_when_drained(self) -> None:
+        """Spawn the off-thread reset once in-flight workers have drained.
+
+        Waiting on the event loop is cheap and non-blocking. It waits for *all*
+        workers, including a prior swap's reset worker, so ``reset_services`` is
+        never run twice concurrently (a cancelled thread keeps running to
+        completion, so serializing here is the only safe guard).
+        """
         if self.workers:
-            self.call_later(self._deferred_service_reset)
+            self.call_later(self._reset_services_when_drained)
             return
-        reset_services()
+        self._reset_services_worker()
+
+    @work(thread=True, name=_MODEL_SWAP_WORKER, exit_on_error=False)
+    def _reset_services_worker(self) -> None:
+        """Run the multi-second service reset off the event loop, then confirm."""
+        try:
+            reset_services()
+        except Exception as exc:  # any reload failure becomes a toast, never a crash
+            call_from_thread(
+                self, self.app.notify, msg.MODEL_SWAP_FAILED.format(error=exc), severity="error"
+            )
+            return
+        call_from_thread(self, self._on_model_swapped)
+
+    def _on_model_swapped(self) -> None:
+        """Main-thread completion toast confirming the new chat model is live."""
+        self.app.notify(msg.MODEL_SWAP_DONE.format(name=cfg.chat_model))
 
     async def action_toggle_markdown(self) -> None:
         """Toggle between Markdown and plain-text rendering for chat responses."""

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -29,7 +29,7 @@ from textual.widgets import Footer, Select, Static
 # since it's used in multiple methods.
 from textual.worker import get_current_worker as _get_worker
 
-from lilbee.app.services import get_services, reset_services, reset_store
+from lilbee.app.services import get_services, reset_store
 from lilbee.app.settings_map import SETTINGS_MAP
 from lilbee.app.themes import DARK_THEMES
 from lilbee.app.version import get_version
@@ -63,6 +63,7 @@ from lilbee.core.config.enums import ChatMode, CrawlRenderMode
 from lilbee.crawler import crawler_available, is_url, require_valid_crawl_url
 from lilbee.data.store import ChunkType, EmbeddingModelMismatchError, scope_to_chunk_type
 from lilbee.providers.model_ref import parse_model_ref
+from lilbee.providers.roles import WorkerRole
 from lilbee.retrieval.embedder import is_model_available
 from lilbee.retrieval.query import ChatMessage
 from lilbee.retrieval.query.history_window import windowed_history
@@ -1513,18 +1514,18 @@ class ChatScreen(Screen[None]):
     def apply_model_change(self) -> None:
         """Swap to the new chat model without freezing the UI.
 
-        ``reset_services`` plus the new model's cold load is a multi-second fleet
-        reload, so it runs in a thread worker instead of on the event loop. The
-        in-flight stream is cancelled first, the input is blocked behind a
-        "switching" state with an indicator toast, and the reset waits for the
-        chat worker(s) to drain so the new model takes over cleanly. The input
-        re-enables only once the worker reports the new model loaded.
+        Reloading the fleet for the new model is a multi-second restart, so it
+        runs in a thread worker instead of on the event loop. The in-flight stream
+        is cancelled first, the input is blocked behind a "switching" state with an
+        indicator toast, and the reload waits for in-flight workers to drain so the
+        restart doesn't disrupt them. The input re-enables only once the worker
+        reports the new model loaded.
         """
         if self.streaming:
             self.action_cancel_stream()
         self.swapping_model = True
         self.app.notify(msg.MODEL_SWAP_APPLYING)
-        self.call_later(self._reset_services_when_drained)
+        self.call_later(self._reload_chat_when_drained)
 
     def watch_swapping_model(self, swapping: bool) -> None:
         """Disable the chat input while a swap loads so a prompt can't race it.
@@ -1540,34 +1541,32 @@ class ChatScreen(Screen[None]):
             if not swapping and self._insert_mode:
                 self._chat_input.focus()
 
-    def _reset_services_when_drained(self) -> None:
-        """Spawn the off-thread reset once in-flight workers have drained.
+    def _reload_chat_when_drained(self) -> None:
+        """Spawn the off-thread chat reload once in-flight workers have drained.
 
-        ``reset_services`` tears down BOTH the provider and the store, so it must
-        not run while any worker is still using them: an in-flight chat stream,
-        search, ingest/sync, or a prior swap's own reset worker. Cancellation only
-        requests teardown (a cancelled thread runs to completion), so waiting for
-        every worker to actually finish is the only safe guard, and it also
-        serializes resets so two never overlap. Runs on the event loop (cheap,
-        non-blocking) and checks before spawning, so this swap's worker is not yet
-        among ``self.workers``.
+        The reload restarts the whole fleet proxy, so it waits for workers that use
+        it (an in-flight chat stream cancelled just above, a search) to finish first
+        rather than yank the engine out from under them. Runs on the event loop
+        (cheap, non-blocking) and checks before spawning, so this swap's worker is
+        not yet among ``self.workers``.
         """
         if self.workers:
-            self.call_later(self._reset_services_when_drained)
+            self.call_later(self._reload_chat_when_drained)
             return
-        self._reset_services_worker()
+        self._reload_chat_model_worker()
 
     @work(thread=True, name=_MODEL_SWAP_WORKER, exit_on_error=False)
-    def _reset_services_worker(self) -> None:
-        """Reset and warm the new model off the event loop, then unblock the input.
+    def _reload_chat_model_worker(self) -> None:
+        """Reload only the chat role off the event loop, then unblock the input.
 
-        ``reset_services`` tears down the old fleet; ``get_services`` rebuilds it
-        and (eager start) kicks off the new model's load, so when this returns the
-        new model is loading or ready, not a surprise cold load on the next prompt.
+        ``reload_role(wait=True)`` re-plans and restarts the fleet for the new chat
+        model while keeping the store and searcher (a chat-model change doesn't
+        touch retrieval), and returns once the model has loaded. The provider
+        serializes overlapping reloads, so a rapid second swap coalesces onto the
+        latest cfg.
         """
         try:
-            reset_services()
-            get_services()
+            get_services().reload_role(WorkerRole.CHAT, wait=True)
         except Exception as exc:  # any reload failure becomes a toast, never a crash
             call_from_thread(self, self._on_model_swap_failed, str(exc))
             return

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1523,6 +1523,13 @@ class ChatScreen(Screen[None]):
         The input re-enables once the fleet has restarted with the new model (which
         loads on the next request).
         """
+        if self.swapping_model:
+            # A swap is already loading; a second one (rapid /model, or the model
+            # bar re-clicked while the input is disabled) would spawn a duplicate
+            # worker and a duplicate completion toast. The in-flight reload already
+            # coalesces onto the latest cfg, so ignore the re-entry.
+            self.notify(msg.CHAT_MODEL_SWITCHING, severity="warning", timeout=3)
+            return
         if self.streaming:
             self.action_cancel_stream()
         self.swapping_model = True

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -105,9 +105,8 @@ _CRAWL_FLAG_MAX_PAGES = "--max-pages"
 _CRAWL_FLAG_INCLUDE_SUBDOMAINS = "--include-subdomains"
 _CRAWL_FLAG_RENDER = "--render"
 
-# The model-swap service reset runs in this named worker so the drain-before-reset
-# wait can ignore it (it must not block on itself) and a rapid second swap cancels
-# the prior reset rather than stacking fleet reloads.
+# Name for the thread worker that resets and warms the new chat model off the
+# event loop.
 _MODEL_SWAP_WORKER = "model_swap_reset"
 
 

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1517,15 +1517,17 @@ class ChatScreen(Screen[None]):
         Reloading the fleet for the new model is a multi-second restart, so it
         runs in a thread worker instead of on the event loop. The in-flight stream
         is cancelled first, the input is blocked behind a "switching" state with an
-        indicator toast, and the reload waits for in-flight workers to drain so the
-        restart doesn't disrupt them. The input re-enables once the fleet has
-        restarted with the new model (which loads on the next request).
+        indicator toast, and the worker reloads only the chat role. The provider
+        retires any still-busy client across the restart and serializes overlapping
+        reloads, so the worker can start at once without waiting for other workers.
+        The input re-enables once the fleet has restarted with the new model (which
+        loads on the next request).
         """
         if self.streaming:
             self.action_cancel_stream()
         self.swapping_model = True
         self.app.notify(msg.MODEL_SWAP_APPLYING)
-        self.call_later(self._reload_chat_when_drained)
+        self._reload_chat_model_worker()
 
     def watch_swapping_model(self, swapping: bool) -> None:
         """Disable the chat input while a swap loads so a prompt can't race it.
@@ -1540,20 +1542,6 @@ class ChatScreen(Screen[None]):
             self._chat_input.disabled = swapping
             if not swapping and self._insert_mode:
                 self._chat_input.focus()
-
-    def _reload_chat_when_drained(self) -> None:
-        """Spawn the off-thread chat reload once in-flight workers have drained.
-
-        The reload restarts the whole fleet proxy, so it waits for workers that use
-        it (an in-flight chat stream cancelled just above, a search) to finish first
-        rather than yank the engine out from under them. Runs on the event loop
-        (cheap, non-blocking) and checks before spawning, so this swap's worker is
-        not yet among ``self.workers``.
-        """
-        if self.workers:
-            self.call_later(self._reload_chat_when_drained)
-            return
-        self._reload_chat_model_worker()
 
     @work(thread=True, name=_MODEL_SWAP_WORKER, exit_on_error=False)
     def _reload_chat_model_worker(self) -> None:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1532,20 +1532,26 @@ class ChatScreen(Screen[None]):
 
         Restores focus when the swap finishes so the user can type immediately
         without re-clicking the input that was disabled out from under them.
+        Guarded because the unblock fires from the swap worker via
+        ``call_from_thread``, which can land after the user navigated away and
+        the input is no longer mounted.
         """
-        self.set_class(swapping, "swapping-model")
-        self._chat_input.disabled = swapping
-        if not swapping and self._insert_mode:
-            self._chat_input.focus()
+        with contextlib.suppress(NoMatches):
+            self._chat_input.disabled = swapping
+            if not swapping and self._insert_mode:
+                self._chat_input.focus()
 
     def _reset_services_when_drained(self) -> None:
         """Spawn the off-thread reset once in-flight workers have drained.
 
-        Runs on the event loop (cheap, non-blocking) and checks before spawning,
-        so the swap worker is not yet among ``self.workers``. Waiting for every
-        worker, including a prior swap's, serializes resets so ``reset_services``
-        never runs twice at once (a cancelled thread runs to completion, so this
-        is the only safe guard).
+        ``reset_services`` tears down BOTH the provider and the store, so it must
+        not run while any worker is still using them: an in-flight chat stream,
+        search, ingest/sync, or a prior swap's own reset worker. Cancellation only
+        requests teardown (a cancelled thread runs to completion), so waiting for
+        every worker to actually finish is the only safe guard, and it also
+        serializes resets so two never overlap. Runs on the event loop (cheap,
+        non-blocking) and checks before spawning, so this swap's worker is not yet
+        among ``self.workers``.
         """
         if self.workers:
             self.call_later(self._reset_services_when_drained)

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -25,7 +25,6 @@ from textual.widgets import (
     TabPane,
 )
 
-from lilbee.app.services import get_services
 from lilbee.app.settings import reset_settings
 from lilbee.app.settings_map import SETTINGS_MAP, SettingDef, SettingGroup, get_default
 from lilbee.cli.tui import messages as msg
@@ -54,7 +53,6 @@ from lilbee.cli.tui.screens.settings_widgets import (
 from lilbee.cli.tui.widgets.list_text_area import ListTextArea
 from lilbee.cli.tui.widgets.model_pick import apply_model_pick
 from lilbee.core.config import DEFAULT_CRAWL_EXCLUDE_PATTERNS, cfg
-from lilbee.providers.roles import MODEL_FIELD_TO_ROLE
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.app import LilbeeApp
@@ -489,11 +487,14 @@ class SettingsScreen(Screen[None]):
         apply_model_pick(self, key=key, ref=ref, on_done=lambda: self._after_model_pick(key))
 
     def _after_model_pick(self, key: str) -> None:
-        """Refresh the picker button and reload the role's fleet server after a swap."""
+        """Refresh the picker button after a swap.
+
+        The role reload is owned by ``apply_model_pick`` (it runs off the event
+        loop in a worker), so this on_done only repaints the label. Reloading
+        here too would double the fleet restart AND block the UI on the main
+        thread, which is the freeze this path is meant to avoid.
+        """
         self._refresh_picker_button(key)
-        role = MODEL_FIELD_TO_ROLE.get(key)
-        if role is not None:
-            get_services().reload_role(role)
 
     def _refresh_picker_button(self, key: str) -> None:
         try:

--- a/src/lilbee/cli/tui/widgets/model_pick.py
+++ b/src/lilbee/cli/tui/widgets/model_pick.py
@@ -151,8 +151,13 @@ def _persist(
 
     def _runner() -> None:
         try:
-            apply_active_model(app, key, ref)
-            get_services().reload_role(target_role)
+            # set_active_model toasts and publishes a signal, both event-loop-only,
+            # so the write runs on the main thread; the slow part is the reload below.
+            call_from_thread(app, apply_active_model, app, key, ref)
+            # wait=True runs the reload in this worker thread (already off the event
+            # loop) so a failure is caught here and the done toast fires only once
+            # the fleet has actually restarted, not before.
+            get_services().reload_role(target_role, wait=True)
         except Exception as exc:  # any reload failure becomes a toast, never a crash
             call_from_thread(
                 app, app.notify, msg.MODEL_SWAP_FAILED.format(error=exc), severity="error"

--- a/src/lilbee/cli/tui/widgets/model_pick.py
+++ b/src/lilbee/cli/tui/widgets/model_pick.py
@@ -21,6 +21,10 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# Name for the thread worker that persists + reloads a non-chat role off the
+# event loop (the chat scope has its own worker in chat.py).
+_PERSIST_WORKER_NAME = "model_swap_persist"
+
 # Single source of truth for "after a model-key write, which worker pool role
 # needs to respawn so the next call picks up the new ref?". Used by both the
 # Settings picker dismiss path and the chat-screen model rail's button.
@@ -160,4 +164,4 @@ def _persist(
         on_done()
         app.notify(msg.MODEL_SWAP_DONE.format(name=ref))
 
-    app.run_worker(_runner, thread=True, exit_on_error=False, name="model_swap_persist")
+    app.run_worker(_runner, thread=True, exit_on_error=False, name=_PERSIST_WORKER_NAME)

--- a/src/lilbee/cli/tui/widgets/model_pick.py
+++ b/src/lilbee/cli/tui/widgets/model_pick.py
@@ -10,6 +10,7 @@ from lilbee.app.services import get_services
 from lilbee.app.settings_map import SETTINGS_MAP
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import apply_active_model
+from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.providers.roles import WorkerRole
 
 if TYPE_CHECKING:
@@ -127,8 +128,36 @@ def _on_embed_confirm(
 def _persist(
     app: App, key: str, ref: str, on_done: Callable[[], None], reload_worker: bool
 ) -> None:
-    apply_active_model(app, key, ref)
+    """Persist the picked ref and reload the affected worker without freezing the UI.
+
+    A worker reload is a multi-second fleet restart, so when one is needed the
+    write and reload run in a thread worker behind an indicator toast and
+    ``on_done`` runs back on the main thread. The chat scope passes
+    ``reload_worker=False`` and resets services itself (see
+    ``ChatScreen.apply_model_change``), so its cheap config write stays inline.
+    """
     role = _MODEL_KEY_TO_WORKER_ROLE.get(key)
-    if reload_worker and role is not None:
-        get_services().reload_role(role)
-    on_done()
+    if not (reload_worker and role is not None):
+        apply_active_model(app, key, ref)
+        on_done()
+        return
+
+    target_role = role  # narrowed to non-None; bind for the worker closure
+    app.notify(msg.MODEL_SWAP_APPLYING)
+
+    def _runner() -> None:
+        try:
+            apply_active_model(app, key, ref)
+            get_services().reload_role(target_role)
+        except Exception as exc:  # any reload failure becomes a toast, never a crash
+            call_from_thread(
+                app, app.notify, msg.MODEL_SWAP_FAILED.format(error=exc), severity="error"
+            )
+            return
+        call_from_thread(app, _finish)
+
+    def _finish() -> None:
+        on_done()
+        app.notify(msg.MODEL_SWAP_DONE.format(name=ref))
+
+    app.run_worker(_runner, thread=True, exit_on_error=False, name="model_swap_persist")

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -406,12 +406,13 @@ class LLMProvider(Protocol):
         """
         return
 
-    def reload_role(self, role: WorkerRole) -> None:
+    def reload_role(self, role: WorkerRole, *, wait: bool = False) -> None:
         """Drop and respawn just *role*'s model so it picks up changed cfg.
 
         Default no-op for providers without per-role model servers. The fleet
         respawns only that role's server; other roles and their in-flight work
-        are left untouched.
+        are left untouched. ``wait=True`` blocks until the respawn finishes (for a
+        caller already off the event loop); the default returns immediately.
         """
         return
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -1014,9 +1014,10 @@ class FleetProvider:
         pass per pending flag so the change is applied, not dropped.
 
         ``wait=True`` runs the reload in the caller's thread and returns only once
-        it (and any reload already in flight that will run the pending pass) has
-        finished, so a caller already off the event loop gets a real completion
-        signal. It propagates a reload failure as an exception.
+        the restart (and any reload already in flight that will run the pending
+        pass) has finished and the proxy is healthy again, so a caller already off
+        the event loop gets a real completion signal. The role's model still loads
+        lazily on its next request. It propagates a reload failure as an exception.
         """
         with self._lock:
             if self._swap is None:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -377,6 +377,10 @@ class FleetProvider:
         # Set when a reload arrives mid-reload: the in-flight pass may have
         # already snapshotted its plan, so the change must be re-applied.
         self._reload_pending = False
+        # Notified when ``_reloading`` clears, so a ``reload_role(wait=True)`` caller
+        # can block until the reload it requested (or the in-flight one that will
+        # run its pending pass) has finished.
+        self._reload_done = threading.Condition(self._lock)
 
     def _ensure_swap(self) -> SwapManager | None:
         """Start the llama-swap process exactly once across concurrent callers.
@@ -998,7 +1002,7 @@ class FleetProvider:
         """
         return
 
-    def reload_role(self, role: WorkerRole) -> None:
+    def reload_role(self, role: WorkerRole, *, wait: bool = False) -> None:
         """Apply a model/settings change for *role* with current cfg.
 
         Dispatched to a background thread because the slow restart (rewrite config +
@@ -1008,15 +1012,26 @@ class FleetProvider:
         reload while one is in flight sets the pending flag (the in-flight pass may
         have already snapshotted its plan), and the in-flight thread runs one more
         pass per pending flag so the change is applied, not dropped.
+
+        ``wait=True`` runs the reload in the caller's thread and returns only once
+        it (and any reload already in flight that will run the pending pass) has
+        finished, so a caller already off the event loop gets a real completion
+        signal. It propagates a reload failure as an exception.
         """
         with self._lock:
             if self._swap is None:
                 return
             if self._reloading:
                 self._reload_pending = True
+                if wait:
+                    while self._reloading:
+                        self._reload_done.wait()
                 return
             self._reloading = True
             self._reload_pending = False
+        if wait:
+            self._reload_blocking()
+            return
         threading.Thread(
             target=self._reload_blocking,
             name=f"fleet-reload-{role.value}",
@@ -1042,6 +1057,7 @@ class FleetProvider:
                     self._reload_pending = False
                     if not rerun:
                         self._reloading = False
+                        self._reload_done.notify_all()
                 if rerun:
                     log.warning(
                         "Engine reload failed; retrying with the pending change.", exc_info=True
@@ -1052,6 +1068,7 @@ class FleetProvider:
             with self._lock:
                 if not self._reload_pending:
                     self._reloading = False
+                    self._reload_done.notify_all()
                     return
                 self._reload_pending = False
 

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -310,10 +310,10 @@ class RoutingProvider(LLMProvider):
         if self._local is not None:
             self._local.cancel_inference()
 
-    def reload_role(self, role: WorkerRole) -> None:
+    def reload_role(self, role: WorkerRole, *, wait: bool = False) -> None:
         """Forward to the native engine; the SDK side has no per-role servers."""
         if self._local is not None:
-            self._local.reload_role(role)
+            self._local.reload_role(role, wait=wait)
 
     def role_ready(self, role: WorkerRole) -> bool:
         """Native readiness without building; True when no local engine exists yet."""

--- a/tests/test_dynamic_settings_eviction.py
+++ b/tests/test_dynamic_settings_eviction.py
@@ -30,7 +30,7 @@ class _RecordingProvider:
     def invalidate_load_cache(self, model_path: Path | None = None) -> None:
         self.calls.append(model_path)
 
-    def reload_role(self, role: object) -> None:
+    def reload_role(self, role: object, *, wait: bool = False) -> None:
         self.reloaded_roles.append(role)
 
     def drop_loaded_models_async(self) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -1294,6 +1294,49 @@ class TestLifecycleMethods:
         p = FleetProvider()  # _swap stays None
         p._reload_blocking()  # must not raise
 
+    def test_reload_role_wait_runs_synchronously(self, monkeypatch) -> None:
+        spawned = {"thread": False}
+        monkeypatch.setattr("threading.Thread", lambda *a, **k: spawned.__setitem__("thread", True))
+        p = FleetProvider()
+        p._swap = _FakeSwap()
+        ran = {"blocking": False}
+        p._reload_blocking = lambda: ran.__setitem__("blocking", True)  # type: ignore[method-assign]
+        p.reload_role(WorkerRole.CHAT, wait=True)
+        assert spawned["thread"] is False  # no background thread; ran in the caller's
+        assert ran["blocking"] is True  # reload ran synchronously before returning
+
+    def test_reload_role_wait_propagates_failure(self) -> None:
+        p = FleetProvider()
+        p._swap = _FakeSwap()
+
+        def boom() -> None:
+            raise RuntimeError("reload failed")
+
+        p._reload_blocking = boom  # type: ignore[method-assign]
+        with pytest.raises(RuntimeError, match="reload failed"):
+            p.reload_role(WorkerRole.CHAT, wait=True)
+
+    def test_reload_role_wait_blocks_until_in_flight_done(self) -> None:
+        p = FleetProvider()
+        p._swap = _FakeSwap()
+        with p._lock:
+            p._reloading = True  # simulate a reload already in flight
+        returned = threading.Event()
+
+        def waiter() -> None:
+            p.reload_role(WorkerRole.CHAT, wait=True)  # sets pending, waits on the cond
+            returned.set()
+
+        t = threading.Thread(target=waiter)
+        t.start()
+        assert not returned.wait(timeout=0.3)  # blocked while the in-flight reload runs
+        assert p._reload_pending is True  # the waiter queued its pass
+        with p._lock:  # the in-flight reload finishes
+            p._reloading = False
+            p._reload_done.notify_all()
+        assert returned.wait(timeout=2.0)  # the waiter woke and returned
+        t.join(timeout=2.0)
+
     def test_add_spawn_listener_stores_callbacks(self) -> None:
         p = FleetProvider()
 

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -1126,8 +1126,10 @@ def test_drop_loaded_models_async_tears_down_off_thread() -> None:
     p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
     swap = p._swap
     p.drop_loaded_models_async()
-    assert _wait_until(lambda: p._swap is None)
-    assert swap.shutdowns == 1
+    # Wait on the actual shutdown rather than ``_swap is None``: the worker clears
+    # the ref before it calls swap.shutdown(), so the latter is the later signal.
+    assert _wait_until(lambda: swap.shutdowns == 1)
+    assert p._swap is None
 
 
 def test_drop_loaded_models_async_noop_without_swap() -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3676,7 +3676,7 @@ class TestRoutingLifecycleForwarding:
         rp.cancel_inference()
         local.cancel_inference.assert_called_once_with()
         rp.reload_role(WorkerRole.EMBED)
-        local.reload_role.assert_called_once_with(WorkerRole.EMBED)
+        local.reload_role.assert_called_once_with(WorkerRole.EMBED, wait=False)
 
     def test_cancel_and_reload_are_noop_without_local(self) -> None:
         from lilbee.providers.roles import WorkerRole

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -55,13 +55,22 @@ class TestCancelInference:
 
 class TestReloadRole:
     def test_delegates_to_provider_with_role(self):
-        """``reload_role`` forwards the requested role to the provider."""
+        """``reload_role`` forwards the requested role (and wait flag) to the provider."""
         from tests.conftest import make_mock_services
 
         provider = MagicMock()
         services = make_mock_services(provider=provider)
         services.reload_role(WorkerRole.EMBED)
-        provider.reload_role.assert_called_once_with(WorkerRole.EMBED)
+        provider.reload_role.assert_called_once_with(WorkerRole.EMBED, wait=False)
+
+    def test_forwards_wait_flag_to_provider(self):
+        """``wait=True`` (the chat-swap path) is forwarded to the provider."""
+        from tests.conftest import make_mock_services
+
+        provider = MagicMock()
+        services = make_mock_services(provider=provider)
+        services.reload_role(WorkerRole.CHAT, wait=True)
+        provider.reload_role.assert_called_once_with(WorkerRole.CHAT, wait=True)
 
 
 class TestAddPoolListener:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -293,8 +293,14 @@ class TestChatScreenAsync:
                 mock_notify.assert_called()
                 assert "Unknown command" in mock_notify.call_args[0][0]
 
+    @mock.patch("lilbee.cli.tui.screens.chat.get_services")
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_slash_model_changes_model(self, mock_catalog: mock.MagicMock) -> None:
+    async def test_slash_model_changes_model(
+        self, mock_catalog: mock.MagicMock, mock_services: mock.MagicMock
+    ) -> None:
+        # get_services is mocked so the model-swap worker's reload_role is a no-op:
+        # /model sets cfg.chat_model via apply_active_model (not mocked); the real
+        # fleet reload is exercised separately in the swap-specific tests.
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -305,6 +311,7 @@ class TestChatScreenAsync:
             new_ref = "ollama/new-model:latest"
             inp.value = f"/model {new_ref}"
             await pilot.press("enter")
+            await app.workers.wait_for_complete()
             await pilot.pause()
             assert cfg.chat_model == new_ref
 

--- a/tests/test_tui_model_bar.py
+++ b/tests/test_tui_model_bar.py
@@ -70,7 +70,7 @@ async def test_apply_model_pick_persists_and_reloads_vision() -> None:
             await pilot.pause()
             mock_apply.assert_called_once()
             assert mock_apply.call_args.args[1:] == ("vision_model", "hf:org/vlm-q4")
-            services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
+            services_mock.reload_role.assert_called_once_with(WorkerRole.VISION, wait=True)
 
 
 async def test_apply_model_pick_reload_failure_shows_error_toast() -> None:

--- a/tests/test_tui_model_bar.py
+++ b/tests/test_tui_model_bar.py
@@ -94,8 +94,7 @@ async def test_apply_model_pick_reload_failure_shows_error_toast() -> None:
             await app.workers.wait_for_complete()
             await pilot.pause()
             assert any(
-                "Could not switch model" in str(call.args[0])
-                for call in mock_notify.call_args_list
+                "Could not switch model" in str(call.args[0]) for call in mock_notify.call_args_list
             ), mock_notify.call_args_list
 
 

--- a/tests/test_tui_model_bar.py
+++ b/tests/test_tui_model_bar.py
@@ -73,6 +73,32 @@ async def test_apply_model_pick_persists_and_reloads_vision() -> None:
             services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
 
 
+async def test_apply_model_pick_reload_failure_shows_error_toast() -> None:
+    """A reload failure in the worker surfaces an error toast, never crashes."""
+    services_mock = MagicMock()
+    services_mock.store.has_chunks.return_value = False
+    services_mock.reload_role.side_effect = RuntimeError("boom")
+    app = LilbeeAppHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        with (
+            patch("lilbee.cli.tui.widgets.model_pick.apply_active_model"),
+            patch(
+                "lilbee.cli.tui.widgets.model_pick.get_services",
+                return_value=services_mock,
+            ),
+            patch.object(app, "notify") as mock_notify,
+        ):
+            apply_model_pick(
+                app.screen, key="vision_model", ref="hf:org/vlm-q4", on_done=lambda: None
+            )
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            assert any(
+                "Could not switch model" in str(call.args[0])
+                for call in mock_notify.call_args_list
+            ), mock_notify.call_args_list
+
+
 async def test_apply_model_pick_none_is_cancel() -> None:
     """``ref is None`` is the Esc/cancel path: nothing persists, on_done never runs."""
     app = LilbeeAppHost()

--- a/tests/test_tui_model_bar.py
+++ b/tests/test_tui_model_bar.py
@@ -50,11 +50,11 @@ def test_model_key_to_worker_role_covers_all_four(key: str, expected: WorkerRole
 
 
 async def test_apply_model_pick_persists_and_reloads_vision() -> None:
-    """A vision pick writes the new ref and respawns the vision worker."""
+    """A vision pick writes the new ref and respawns the vision worker off-thread."""
     services_mock = MagicMock()
     services_mock.store.has_chunks.return_value = False
     app = LilbeeAppHost()
-    async with app.run_test(size=(80, 24)) as _pilot:
+    async with app.run_test(size=(80, 24)) as pilot:
         with (
             patch("lilbee.cli.tui.widgets.model_pick.apply_active_model") as mock_apply,
             patch(
@@ -65,9 +65,12 @@ async def test_apply_model_pick_persists_and_reloads_vision() -> None:
             apply_model_pick(
                 app.screen, key="vision_model", ref="hf:org/vlm-q4", on_done=lambda: None
             )
-        mock_apply.assert_called_once()
-        assert mock_apply.call_args.args[1:] == ("vision_model", "hf:org/vlm-q4")
-        services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
+            # The reload runs in a thread worker so the UI never freezes; await it.
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            mock_apply.assert_called_once()
+            assert mock_apply.call_args.args[1:] == ("vision_model", "hf:org/vlm-q4")
+            services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
 
 
 async def test_apply_model_pick_none_is_cancel() -> None:
@@ -86,7 +89,7 @@ async def test_apply_model_pick_empty_clears_nullable_field() -> None:
     services_mock = MagicMock()
     services_mock.store.has_chunks.return_value = False
     app = LilbeeAppHost()
-    async with app.run_test(size=(80, 24)) as _pilot:
+    async with app.run_test(size=(80, 24)) as pilot:
         with (
             patch("lilbee.cli.tui.widgets.model_pick.apply_active_model") as mock_apply,
             patch(
@@ -95,8 +98,10 @@ async def test_apply_model_pick_empty_clears_nullable_field() -> None:
             ),
         ):
             apply_model_pick(app.screen, key="reranker_model", ref="", on_done=lambda: None)
-        mock_apply.assert_called_once()
-        assert mock_apply.call_args.args[1:] == ("reranker_model", "")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            mock_apply.assert_called_once()
+            assert mock_apply.call_args.args[1:] == ("reranker_model", "")
 
 
 async def test_apply_model_pick_empty_ignored_for_non_nullable() -> None:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3331,7 +3331,7 @@ async def test_reload_chat_worker_reloads_only_chat_and_unblocks():
             # Only the chat role is reloaded, synchronously (wait=True), so the
             # store and searcher are kept rather than torn down.
             services_mock.reload_role.assert_called_once_with(WorkerRole.CHAT, wait=True)
-            # The input is unblocked only after the worker reports the model loaded.
+            # The input is unblocked only after the worker finishes the reload.
             assert screen.swapping_model is False
             assert any("Now using" in str(call.args[0]) for call in mock_notify.call_args_list), (
                 mock_notify.call_args_list

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3249,67 +3249,37 @@ async def test_chat_cancel_stream_while_streaming():
 
 
 async def testapply_model_change_cancels_stream_when_streaming():
-    """apply_model_change cancels the stream and schedules the drained reload."""
+    """apply_model_change cancels the stream and spawns the off-thread reload."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
         screen.streaming = True
         with (
             patch.object(screen, "action_cancel_stream") as mock_cancel,
-            patch.object(screen, "call_later") as mock_later,
+            patch.object(screen, "_reload_chat_model_worker") as mock_worker,
         ):
             screen.apply_model_change()
             mock_cancel.assert_called_once()
-            mock_later.assert_called_once_with(screen._reload_chat_when_drained)
+            mock_worker.assert_called_once()
 
 
-async def testapply_model_change_defers_reload_off_event_loop_when_not_streaming():
-    """Not streaming: the reload is scheduled (off-thread), never run on the event
-    loop, so the swap can't freeze the TUI."""
+async def testapply_model_change_spawns_worker_off_event_loop_when_not_streaming():
+    """Not streaming: the reload runs in a worker, never on the event loop, so the
+    swap can't freeze the TUI."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
         screen.streaming = False
         with (
             patch.object(screen, "action_cancel_stream") as mock_cancel,
-            patch.object(screen, "call_later") as mock_later,
+            patch.object(screen, "_reload_chat_model_worker") as mock_worker,
             patch("lilbee.cli.tui.screens.chat.get_services") as mock_get,
         ):
             screen.apply_model_change()
             mock_cancel.assert_not_called()
-            mock_later.assert_called_once_with(screen._reload_chat_when_drained)
-            mock_get.assert_not_called()
-
-
-async def test_reload_chat_when_drained_retries_while_workers_active():
-    """_reload_chat_when_drained retries via call_later (and spawns no reload
-    worker) while any worker, including a prior swap's, is still running."""
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        screen = app.screen
-        with (
-            patch.object(
-                type(screen), "workers", new_callable=MagicMock, return_value=[MagicMock()]
-            ),
-            patch.object(screen, "call_later") as mock_later,
-            patch.object(screen, "_reload_chat_model_worker") as mock_worker,
-        ):
-            screen._reload_chat_when_drained()
-            mock_later.assert_called_once_with(screen._reload_chat_when_drained)
-            mock_worker.assert_not_called()
-
-
-async def test_reload_chat_when_drained_spawns_worker_when_idle():
-    """Once workers drain, the off-thread reload worker is spawned."""
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        screen = app.screen
-        for w in list(screen.workers):
-            w.cancel()
-        await pilot.pause()
-        with patch.object(screen, "_reload_chat_model_worker") as mock_worker:
-            screen._reload_chat_when_drained()
             mock_worker.assert_called_once()
+            # The reload runs in the worker, not inline on the event loop.
+            mock_get.assert_not_called()
 
 
 async def test_reload_chat_worker_reloads_only_chat_and_unblocks():
@@ -3365,9 +3335,9 @@ async def test_apply_model_change_blocks_input_during_swap():
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
         screen.streaming = False
-        # Block the drained reload from spawning the worker, so the swap stays
-        # in its in-progress state long enough to observe the input gate.
-        with patch.object(screen, "_reload_chat_when_drained"):
+        # Stub the worker so the swap stays in its in-progress state long enough
+        # to observe the input gate (the real worker would unblock on completion).
+        with patch.object(screen, "_reload_chat_model_worker"):
             screen.apply_model_change()
             # swapping_model is set synchronously; its watcher disables the input.
             assert screen.swapping_model is True
@@ -3391,6 +3361,30 @@ async def test_submit_rejected_while_swapping_model():
                 "switching model" in str(call.args[0]).lower()
                 for call in mock_notify.call_args_list
             ), mock_notify.call_args_list
+
+
+async def test_submit_rejected_while_streaming():
+    """A submit while a response is streaming is rejected with the busy toast."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.swapping_model = False
+        screen.streaming = True
+        with patch.object(app, "notify") as mock_notify:
+            assert screen._reject_submit_when_busy() is True
+            assert any(
+                "answering" in str(call.args[0]).lower() for call in mock_notify.call_args_list
+            ), mock_notify.call_args_list
+
+
+async def test_submit_not_rejected_when_idle():
+    """When neither swapping nor streaming, the submit is allowed through."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.swapping_model = False
+        screen.streaming = False
+        assert screen._reject_submit_when_busy() is False
 
 
 async def test_chat_vim_j_k_scrolls_in_normal_mode():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3312,22 +3312,85 @@ async def test_reset_services_when_drained_spawns_worker_when_idle():
             mock_worker.assert_called_once()
 
 
-async def test_reset_services_worker_resets_off_thread_and_confirms():
-    """The reset worker runs reset_services off the event loop and toasts done."""
+async def test_reset_services_worker_resets_warms_and_unblocks():
+    """The reset worker resets + warms off the event loop, then unblocks input."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
+        screen.swapping_model = True
         with (
             patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset,
+            patch("lilbee.cli.tui.screens.chat.get_services") as mock_get,
             patch.object(app, "notify") as mock_notify,
         ):
             screen._reset_services_worker()
             await app.workers.wait_for_complete()
             await _pilot.pause()
             mock_reset.assert_called_once()
+            # get_services rebuilds + eager-warms the new model in the worker.
+            mock_get.assert_called_once()
+            # The input is unblocked only after the worker reports the model loaded.
+            assert screen.swapping_model is False
             assert any("Now using" in str(call.args[0]) for call in mock_notify.call_args_list), (
                 mock_notify.call_args_list
             )
+
+
+async def test_reset_services_worker_failure_unblocks_and_errors():
+    """A reload failure still unblocks the input and surfaces an error toast."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.swapping_model = True
+        with (
+            patch(
+                "lilbee.cli.tui.screens.chat.reset_services",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch.object(app, "notify") as mock_notify,
+        ):
+            screen._reset_services_worker()
+            await app.workers.wait_for_complete()
+            await _pilot.pause()
+            assert screen.swapping_model is False
+            assert any(
+                "Could not switch model" in str(call.args[0]) for call in mock_notify.call_args_list
+            ), mock_notify.call_args_list
+
+
+async def test_apply_model_change_blocks_input_during_swap():
+    """apply_model_change disables the chat input so a prompt can't race the load."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.streaming = False
+        # Block the drained reset from spawning the worker, so the swap stays
+        # in its in-progress state long enough to observe the input gate (with
+        # reset_services mocked the worker would otherwise finish instantly).
+        with patch.object(screen, "_reset_services_when_drained"):
+            screen.apply_model_change()
+            # swapping_model is set synchronously; its watcher disables the input.
+            assert screen.swapping_model is True
+            assert screen.query_one("#chat-input").disabled is True
+
+
+async def test_submit_rejected_while_swapping_model():
+    """A submit mid-swap is rejected with a 'still switching' toast, not sent."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.swapping_model = True
+        with (
+            patch.object(screen, "_send_message") as mock_send,
+            patch.object(app, "notify") as mock_notify,
+        ):
+            rejected = screen._reject_submit_when_busy()
+            assert rejected is True
+            mock_send.assert_not_called()
+            assert any(
+                "switching model" in str(call.args[0]).lower()
+                for call in mock_notify.call_args_list
+            ), mock_notify.call_args_list
 
 
 async def test_chat_vim_j_k_scrolls_in_normal_mode():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3282,6 +3282,21 @@ async def testapply_model_change_spawns_worker_off_event_loop_when_not_streaming
             mock_get.assert_not_called()
 
 
+async def test_apply_model_change_ignores_reentry_while_swapping():
+    """A second swap while one is loading is ignored, not a duplicate worker.
+
+    The model bar stays clickable during a swap; a re-click (or a rapid second
+    /model) must not spawn a second reload worker and a duplicate done toast.
+    """
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        screen.swapping_model = True
+        with patch.object(screen, "_reload_chat_model_worker") as mock_worker:
+            screen.apply_model_change()
+            mock_worker.assert_not_called()
+
+
 async def test_reload_chat_worker_reloads_only_chat_and_unblocks():
     """The worker reloads the CHAT role (keeping the store) and unblocks input."""
     from lilbee.providers.roles import WorkerRole
@@ -12507,7 +12522,7 @@ async def test_settings_model_picker_dismissed_reloads_worker_once():
             screen._on_model_picker_dismissed("vision_model", "fake/vision.gguf")
             await app.workers.wait_for_complete()
             await pilot.pause()
-            services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
+            services_mock.reload_role.assert_called_once_with(WorkerRole.VISION, wait=True)
 
 
 async def test_settings_embed_picker_against_populated_store_pushes_confirm():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3249,7 +3249,7 @@ async def test_chat_cancel_stream_while_streaming():
 
 
 async def testapply_model_change_cancels_stream_when_streaming():
-    """apply_model_change cancels stream and defers service reset."""
+    """apply_model_change cancels the stream and schedules the drained reset."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
@@ -3260,22 +3260,30 @@ async def testapply_model_change_cancels_stream_when_streaming():
         ):
             screen.apply_model_change()
             mock_cancel.assert_called_once()
-            mock_later.assert_called_once_with(screen._deferred_service_reset)
+            mock_later.assert_called_once_with(screen._reset_services_when_drained)
 
 
-async def testapply_model_change_resets_immediately_when_not_streaming():
-    """apply_model_change resets services immediately when not streaming."""
+async def testapply_model_change_defers_reset_off_event_loop_when_not_streaming():
+    """Not streaming: the reset is scheduled (off-thread), never run on the event
+    loop, so the swap can't freeze the TUI."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
         screen.streaming = False
-        with patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset:
+        with (
+            patch.object(screen, "action_cancel_stream") as mock_cancel,
+            patch.object(screen, "call_later") as mock_later,
+            patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset,
+        ):
             screen.apply_model_change()
-            mock_reset.assert_called_once()
+            mock_cancel.assert_not_called()
+            mock_later.assert_called_once_with(screen._reset_services_when_drained)
+            mock_reset.assert_not_called()
 
 
-async def test_deferred_service_reset_retries_while_workers_active():
-    """_deferred_service_reset retries via call_later when workers exist."""
+async def test_reset_services_when_drained_retries_while_workers_active():
+    """_reset_services_when_drained retries via call_later (and spawns no reset
+    worker) while any worker, including a prior swap's, is still running."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
@@ -3284,25 +3292,42 @@ async def test_deferred_service_reset_retries_while_workers_active():
                 type(screen), "workers", new_callable=MagicMock, return_value=[MagicMock()]
             ),
             patch.object(screen, "call_later") as mock_later,
-            patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset,
+            patch.object(screen, "_reset_services_worker") as mock_worker,
         ):
-            screen._deferred_service_reset()
-            mock_later.assert_called_once_with(screen._deferred_service_reset)
-            mock_reset.assert_not_called()
+            screen._reset_services_when_drained()
+            mock_later.assert_called_once_with(screen._reset_services_when_drained)
+            mock_worker.assert_not_called()
 
 
-async def test_deferred_service_reset_resets_when_no_workers():
-    """_deferred_service_reset calls reset_services when workers drained."""
+async def test_reset_services_when_drained_spawns_worker_when_idle():
+    """Once workers drain, the off-thread reset worker is spawned."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         screen = app.screen
-        # Cancel background workers so the screen's worker manager is empty
         for w in list(screen.workers):
             w.cancel()
         await pilot.pause()
-        with patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset:
-            screen._deferred_service_reset()
+        with patch.object(screen, "_reset_services_worker") as mock_worker:
+            screen._reset_services_when_drained()
+            mock_worker.assert_called_once()
+
+
+async def test_reset_services_worker_resets_off_thread_and_confirms():
+    """The reset worker runs reset_services off the event loop and toasts done."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        screen = app.screen
+        with (
+            patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset,
+            patch.object(app, "notify") as mock_notify,
+        ):
+            screen._reset_services_worker()
+            await app.workers.wait_for_complete()
+            await _pilot.pause()
             mock_reset.assert_called_once()
+            assert any("Now using" in str(call.args[0]) for call in mock_notify.call_args_list), (
+                mock_notify.call_args_list
+            )
 
 
 async def test_chat_vim_j_k_scrolls_in_normal_mode():
@@ -12383,10 +12408,13 @@ async def test_settings_model_picker_dismissed_persists_and_refreshes_label():
     from lilbee.cli.tui.screens.settings_widgets import MODEL_PICKER_BUTTON_PREFIX
 
     app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
+    async with app.run_test(size=(120, 40)) as pilot:
         screen = app.screen
         with patch("lilbee.cli.tui.widgets.model_pick.apply_active_model") as mock_apply:
             screen._on_model_picker_dismissed("chat_model", "fake/new-model.gguf")
+            # The persist + role reload now runs in a thread worker; await it.
+            await app.workers.wait_for_complete()
+            await pilot.pause()
             mock_apply.assert_called_once()
         button = app.screen.query_one(f"#{MODEL_PICKER_BUTTON_PREFIX}chat_model", Button)
         # Label was repainted via model_picker_label; the chat_model field
@@ -12410,7 +12438,7 @@ async def test_settings_model_picker_dismissed_reloads_worker_for_role():
     services_mock = MagicMock()
     services_mock.store.has_chunks.return_value = False
     app = SettingsTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
+    async with app.run_test(size=(120, 40)) as pilot:
         screen = app.screen
         with (
             patch("lilbee.cli.tui.widgets.model_pick.apply_active_model"),
@@ -12420,7 +12448,9 @@ async def test_settings_model_picker_dismissed_reloads_worker_for_role():
             ),
         ):
             screen._on_model_picker_dismissed("vision_model", "fake/vision.gguf")
-        services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)
 
 
 async def test_settings_embed_picker_against_populated_store_pushes_confirm():
@@ -12485,6 +12515,28 @@ def test_settings_model_picker_dismissed_no_op_on_blank_ref():
         mock_apply.assert_not_called()
 
 
+class _SyncWorkerApp:
+    """Stub App for unit tests of the model-swap persist path.
+
+    The persist now offloads its config write + role reload to a thread worker;
+    this stub runs that worker (and its main-thread completion callback)
+    synchronously so a non-async unit test still exercises the path inline.
+    """
+
+    def notify(self, *_args, **_kwargs) -> None:
+        pass
+
+    def run_worker(self, work, **_kwargs):
+        work()
+
+    def call_from_thread(self, fn, *args, **kwargs):
+        fn(*args, **kwargs)
+
+    @property
+    def app(self) -> _SyncWorkerApp:
+        return self
+
+
 def test_settings_model_picker_dismissed_clears_nullable_field_on_empty_ref(monkeypatch):
     """Nullable fields treat ref='' as 'disable'; ref=None is still cancel."""
     from unittest.mock import patch
@@ -12497,7 +12549,8 @@ def test_settings_model_picker_dismissed_clears_nullable_field_on_empty_ref(monk
         raise RuntimeError("button absent in unit test")
 
     screen.query_one = _raise
-    monkeypatch.setattr(SettingsScreen, "app", property(lambda self: type("_A", (), {})()))
+    sync_app = _SyncWorkerApp()
+    monkeypatch.setattr(SettingsScreen, "app", property(lambda self: sync_app))
     with patch("lilbee.cli.tui.widgets.model_pick.apply_active_model") as mock_apply:
         screen._on_model_picker_dismissed("vision_model", None)
         mock_apply.assert_not_called()
@@ -12611,7 +12664,7 @@ def test_settings_on_model_picker_dismissed_swallows_query_failures(monkeypatch)
         raise RuntimeError("button removed")
 
     screen.query_one = _raise
-    fake_app = type("FakeApp", (), {})()
+    fake_app = _SyncWorkerApp()
     monkeypatch.setattr(SettingsScreen, "app", property(lambda self: fake_app))
     with patch("lilbee.cli.tui.widgets.model_pick.apply_active_model"):
         screen._on_model_picker_dismissed("chat_model", "fake/x.gguf")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3249,7 +3249,7 @@ async def test_chat_cancel_stream_while_streaming():
 
 
 async def testapply_model_change_cancels_stream_when_streaming():
-    """apply_model_change cancels the stream and schedules the drained reset."""
+    """apply_model_change cancels the stream and schedules the drained reload."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
@@ -3260,11 +3260,11 @@ async def testapply_model_change_cancels_stream_when_streaming():
         ):
             screen.apply_model_change()
             mock_cancel.assert_called_once()
-            mock_later.assert_called_once_with(screen._reset_services_when_drained)
+            mock_later.assert_called_once_with(screen._reload_chat_when_drained)
 
 
-async def testapply_model_change_defers_reset_off_event_loop_when_not_streaming():
-    """Not streaming: the reset is scheduled (off-thread), never run on the event
+async def testapply_model_change_defers_reload_off_event_loop_when_not_streaming():
+    """Not streaming: the reload is scheduled (off-thread), never run on the event
     loop, so the swap can't freeze the TUI."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -3273,16 +3273,16 @@ async def testapply_model_change_defers_reset_off_event_loop_when_not_streaming(
         with (
             patch.object(screen, "action_cancel_stream") as mock_cancel,
             patch.object(screen, "call_later") as mock_later,
-            patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset,
+            patch("lilbee.cli.tui.screens.chat.get_services") as mock_get,
         ):
             screen.apply_model_change()
             mock_cancel.assert_not_called()
-            mock_later.assert_called_once_with(screen._reset_services_when_drained)
-            mock_reset.assert_not_called()
+            mock_later.assert_called_once_with(screen._reload_chat_when_drained)
+            mock_get.assert_not_called()
 
 
-async def test_reset_services_when_drained_retries_while_workers_active():
-    """_reset_services_when_drained retries via call_later (and spawns no reset
+async def test_reload_chat_when_drained_retries_while_workers_active():
+    """_reload_chat_when_drained retries via call_later (and spawns no reload
     worker) while any worker, including a prior swap's, is still running."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -3292,43 +3292,45 @@ async def test_reset_services_when_drained_retries_while_workers_active():
                 type(screen), "workers", new_callable=MagicMock, return_value=[MagicMock()]
             ),
             patch.object(screen, "call_later") as mock_later,
-            patch.object(screen, "_reset_services_worker") as mock_worker,
+            patch.object(screen, "_reload_chat_model_worker") as mock_worker,
         ):
-            screen._reset_services_when_drained()
-            mock_later.assert_called_once_with(screen._reset_services_when_drained)
+            screen._reload_chat_when_drained()
+            mock_later.assert_called_once_with(screen._reload_chat_when_drained)
             mock_worker.assert_not_called()
 
 
-async def test_reset_services_when_drained_spawns_worker_when_idle():
-    """Once workers drain, the off-thread reset worker is spawned."""
+async def test_reload_chat_when_drained_spawns_worker_when_idle():
+    """Once workers drain, the off-thread reload worker is spawned."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
         screen = app.screen
         for w in list(screen.workers):
             w.cancel()
         await pilot.pause()
-        with patch.object(screen, "_reset_services_worker") as mock_worker:
-            screen._reset_services_when_drained()
+        with patch.object(screen, "_reload_chat_model_worker") as mock_worker:
+            screen._reload_chat_when_drained()
             mock_worker.assert_called_once()
 
 
-async def test_reset_services_worker_resets_warms_and_unblocks():
-    """The reset worker resets + warms off the event loop, then unblocks input."""
+async def test_reload_chat_worker_reloads_only_chat_and_unblocks():
+    """The worker reloads the CHAT role (keeping the store) and unblocks input."""
+    from lilbee.providers.roles import WorkerRole
+
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
         screen.swapping_model = True
+        services_mock = MagicMock()
         with (
-            patch("lilbee.cli.tui.screens.chat.reset_services") as mock_reset,
-            patch("lilbee.cli.tui.screens.chat.get_services") as mock_get,
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=services_mock),
             patch.object(app, "notify") as mock_notify,
         ):
-            screen._reset_services_worker()
+            screen._reload_chat_model_worker()
             await app.workers.wait_for_complete()
             await _pilot.pause()
-            mock_reset.assert_called_once()
-            # get_services rebuilds + eager-warms the new model in the worker.
-            mock_get.assert_called_once()
+            # Only the chat role is reloaded, synchronously (wait=True), so the
+            # store and searcher are kept rather than torn down.
+            services_mock.reload_role.assert_called_once_with(WorkerRole.CHAT, wait=True)
             # The input is unblocked only after the worker reports the model loaded.
             assert screen.swapping_model is False
             assert any("Now using" in str(call.args[0]) for call in mock_notify.call_args_list), (
@@ -3336,20 +3338,19 @@ async def test_reset_services_worker_resets_warms_and_unblocks():
             )
 
 
-async def test_reset_services_worker_failure_unblocks_and_errors():
+async def test_reload_chat_worker_failure_unblocks_and_errors():
     """A reload failure still unblocks the input and surfaces an error toast."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
         screen.swapping_model = True
+        services_mock = MagicMock()
+        services_mock.reload_role.side_effect = RuntimeError("boom")
         with (
-            patch(
-                "lilbee.cli.tui.screens.chat.reset_services",
-                side_effect=RuntimeError("boom"),
-            ),
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=services_mock),
             patch.object(app, "notify") as mock_notify,
         ):
-            screen._reset_services_worker()
+            screen._reload_chat_model_worker()
             await app.workers.wait_for_complete()
             await _pilot.pause()
             assert screen.swapping_model is False
@@ -3364,10 +3365,9 @@ async def test_apply_model_change_blocks_input_during_swap():
     async with app.run_test(size=(120, 40)) as _pilot:
         screen = app.screen
         screen.streaming = False
-        # Block the drained reset from spawning the worker, so the swap stays
-        # in its in-progress state long enough to observe the input gate (with
-        # reset_services mocked the worker would otherwise finish instantly).
-        with patch.object(screen, "_reset_services_when_drained"):
+        # Block the drained reload from spawning the worker, so the swap stays
+        # in its in-progress state long enough to observe the input gate.
+        with patch.object(screen, "_reload_chat_when_drained"):
             screen.apply_model_change()
             # swapping_model is set synchronously; its watcher disables the input.
             assert screen.swapping_model is True

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -12486,13 +12486,13 @@ async def test_settings_model_picker_dismissed_persists_and_refreshes_label():
         assert str(button.label).strip() != ""
 
 
-async def test_settings_model_picker_dismissed_reloads_worker_for_role():
-    """Picking from Settings respawns just the role that changed.
+async def test_settings_model_picker_dismissed_reloads_worker_once():
+    """Picking from Settings respawns just the role that changed, exactly once.
 
-    Without this, the new model is written to cfg but the live worker
-    keeps the old model loaded until restart. With it, the rerank /
-    vision / embed worker reflects the new selection on the next call,
-    and an in-flight chat stream is unaffected.
+    The reload is owned by ``apply_model_pick`` (off the event loop); the Settings
+    on_done must NOT also reload, or the fleet restarts twice and the second
+    reload blocks the UI thread. ``model_pick`` is the only path that reloads, so
+    asserting a single reload there guards that regression.
     """
     from unittest.mock import patch
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -948,6 +948,7 @@ class TestModelPickerButton:
                 ),
             ):
                 btn._on_picker_dismissed(new_ref)
+                await app.workers.wait_for_complete()
                 await pilot.pause()
             store_mock.initialize_meta_if_legacy.assert_called_once()
             assert cfg.embedding_model == new_ref
@@ -1027,6 +1028,7 @@ class TestModelPickerButton:
                 assert isinstance(app.screen, ConfirmDialog)
                 await pilot.press("y")
                 await pilot.pause()
+                await app.workers.wait_for_complete()
             assert cfg.embedding_model == new_ref
             services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED)
 
@@ -1082,6 +1084,7 @@ class TestModelPickerButton:
                 ),
             ):
                 btn._on_picker_dismissed(new_ref)
+                await app.workers.wait_for_complete()
                 await pilot.pause()
             assert cfg.embedding_model == new_ref
             services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED)
@@ -1115,6 +1118,7 @@ class TestModelPickerButton:
                 ),
             ):
                 btn._on_picker_dismissed(new_ref)
+                await app.workers.wait_for_complete()
                 await pilot.pause()
             services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED)
             mock_reset.assert_not_called()

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1030,7 +1030,7 @@ class TestModelPickerButton:
                 await pilot.pause()
                 await app.workers.wait_for_complete()
             assert cfg.embedding_model == new_ref
-            services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED)
+            services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED, wait=True)
 
     async def test_embed_picker_dismiss_confirm_no_keeps_old_ref(self) -> None:
         """Pressing No on the confirm modal leaves cfg untouched and notifies cancel."""
@@ -1087,7 +1087,7 @@ class TestModelPickerButton:
                 await app.workers.wait_for_complete()
                 await pilot.pause()
             assert cfg.embedding_model == new_ref
-            services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED)
+            services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED, wait=True)
 
     async def test_embed_picker_dismiss_reloads_only_embed_role(self) -> None:
         """Embed swap respawns just the embed worker. Chat stream stays untouched.
@@ -1120,7 +1120,7 @@ class TestModelPickerButton:
                 btn._on_picker_dismissed(new_ref)
                 await app.workers.wait_for_complete()
                 await pilot.pause()
-            services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED)
+            services_mock.reload_role.assert_called_once_with(WorkerRole.EMBED, wait=True)
             mock_reset.assert_not_called()
 
     async def test_chat_picker_dismiss_does_not_reload_role(self) -> None:

--- a/tests/test_worker_roles.py
+++ b/tests/test_worker_roles.py
@@ -21,11 +21,3 @@ def test_model_field_to_role_maps_to_distinct_roles() -> None:
         WorkerRole.RERANK,
         WorkerRole.VISION,
     }
-
-
-def test_settings_screen_reuses_the_shared_map() -> None:
-    # The Settings model picker reloads the right role after a swap by reusing the
-    # one canonical map rather than a parallel copy.
-    from lilbee.cli.tui.screens import settings as settings_screen
-
-    assert settings_screen.MODEL_FIELD_TO_ROLE is MODEL_FIELD_TO_ROLE


### PR DESCRIPTION
## Problem

Now that model management is out of process, picking a different model from the model-bar dropdown (or the Settings picker) froze the TUI with no spinner or feedback. Switching a model runs a multi-second fleet reload, and that reload ran on the Textual event loop, so the whole UI hung until it finished (and sometimes appeared to crash). Two paths did it: a chat swap reset services in `apply_model_change`, and an embed/rerank/vision swap reloaded the role inline in `model_pick._persist`.

## Solution

Both swap paths now run the reload in a thread worker behind a "Switching model, loading..." toast, with a "Now using <model>" confirmation and an error toast on failure. The chat reset still cancels any in-flight stream first and waits for workers to drain before resetting, serialized so `reset_services` never runs twice at once (a cancelled thread keeps running to completion, so serializing is the only safe guard). The cheap config write stays inline; only the multi-second reload moves off the event loop.

Updated the affected TUI tests for the async behavior (the reload now completes in a worker, so the assertions await it).