### PR TITLE
App/core/runtime review fixes: config round-trip, reset symlinks, chunk invariant

### DIFF
--- a/src/lilbee/app/models.py
+++ b/src/lilbee/app/models.py
@@ -207,8 +207,9 @@ def adopt_embedder(ref: str) -> AdoptResult:
     from lilbee.catalog.types import ModelSource
 
     manager = get_services().model_manager
-    already_active = cfg.embedding_model == ref and manager.is_installed(ref, ModelSource.NATIVE)
-    if not manager.is_installed(ref, ModelSource.NATIVE):
+    installed = manager.is_installed(ref, ModelSource.NATIVE)
+    already_active = cfg.embedding_model == ref and installed
+    if not installed:
         pull_model_data(ref, ModelSource.NATIVE)
     result = apply_settings_update({"embedding_model": ref})
     return AdoptResult(

--- a/src/lilbee/app/reset.py
+++ b/src/lilbee/app/reset.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from pydantic import BaseModel
 
 from lilbee.core.config import cfg
-from lilbee.core.security import validate_path_within
 
 
 class ResetResult(BaseModel):
@@ -30,9 +29,14 @@ def _clear_dir(base_dir: Path, skipped: list[str]) -> int:
     if not base_dir.exists():
         return deleted
     for item in list(base_dir.iterdir()):
-        validate_path_within(item, base_dir)
         try:
-            if item.is_dir():
+            # iterdir yields direct children only, so the entry is within
+            # base_dir by construction. Remove a symlink as the link itself
+            # (never follow it) -- resolving it would both escape base_dir and
+            # risk deleting the target, neither of which reset intends.
+            if item.is_symlink():
+                item.unlink()
+            elif item.is_dir():
                 shutil.rmtree(item)
             else:
                 item.unlink()

--- a/src/lilbee/app/settings.py
+++ b/src/lilbee/app/settings.py
@@ -203,9 +203,13 @@ def _validate(updates: dict[str, Any]) -> None:
         raise ValueError(f"chunk_size must be >= {_MIN_CHUNK_SIZE}")
     effective_chunk_size = new_chunk_size if new_chunk_size is not None else cfg.chunk_size
     new_overlap = _as_int_setting(updates.get("chunk_overlap"))
-    if new_overlap is not None and new_overlap >= effective_chunk_size:
+    # Compare the effective overlap against the effective chunk_size so that
+    # lowering chunk_size alone (below the already-persisted overlap) is caught,
+    # not just an explicit new overlap.
+    effective_overlap = new_overlap if new_overlap is not None else cfg.chunk_overlap
+    if effective_overlap >= effective_chunk_size:
         raise ValueError(
-            f"chunk_overlap ({new_overlap}) must be < chunk_size ({effective_chunk_size})"
+            f"chunk_overlap ({effective_overlap}) must be < chunk_size ({effective_chunk_size})"
         )
 
 
@@ -330,9 +334,10 @@ def apply_settings_update(
     """Validate, apply, persist, and invalidate caches for a batch of updates.
 
     Atomic on validation: a rejection rolls every field back and writes
-    nothing. Atomic on disk failure: an ``OSError`` from the TOML write
-    also restores the in-memory snapshot before re-raising. Cache
-    invalidation runs only after a successful persist.
+    nothing. Atomic on disk failure: an ``OSError`` from the TOML write, or a
+    parse error reloading a corrupt config.toml, restores the in-memory
+    snapshot before re-raising. Cache invalidation runs only after a
+    successful persist.
 
     Pass ``allow_model_roles=False`` to reject ``chat_model`` /
     ``embedding_model`` / ``vision_model`` / ``reranker_model`` at the
@@ -364,12 +369,18 @@ def apply_settings_update(
         if dim is not None:
             effective_updates["embedding_dim"] = dim
     to_persist, to_delete, snapshot = _apply_with_rollback(effective_updates)
+    # embedding_dim is derived and applied to cfg in-memory, but the overlay
+    # loader ignores it on reload (it is re-derived), so don't write it to disk.
+    to_persist.pop("embedding_dim", None)
     try:
         if to_persist:
             persistent_settings.update_values(cfg.data_root, to_persist)
         if to_delete:
             persistent_settings.delete_values(cfg.data_root, to_delete)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError from the write, or a TOMLDecodeError (ValueError) when
+        # update/delete reloads a corrupt on-disk config.toml: either way the
+        # in-memory snapshot must be restored so cfg matches what was persisted.
         _restore_snapshot(snapshot)
         raise
     _invalidate_caches(set(effective_updates))

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -687,6 +687,7 @@ class Config(BaseSettings):
             try:
                 return parse_bool(v)
             except ValueError:
+                log.warning("Invalid flash_attention=%r, using auto", v)
                 return None
         return bool(v)
 
@@ -785,6 +786,20 @@ class Config(BaseSettings):
     def _split_cors_origins(cls, v: Any) -> Any:
         if isinstance(v, str):
             return [o.strip() for o in v.split(",") if o.strip()]
+        return v
+
+    @field_validator("crawl_browser_extra_args", mode="before")
+    @classmethod
+    def _split_crawl_browser_extra_args(cls, v: Any) -> Any:
+        """Accept a newline-separated string, matching how the field is persisted.
+
+        ``app.settings`` joins list values with newlines before writing them to
+        ``config.toml`` as a scalar string. Without this inverse, reload cannot
+        coerce that string to ``list[str]`` and the whole config.toml is dropped.
+        TOML lists and JSON arrays pass through unchanged.
+        """
+        if isinstance(v, str):
+            return [a.strip() for a in v.splitlines() if a.strip()]
         return v
 
     @field_validator("crawl_exclude_patterns", mode="before")

--- a/src/lilbee/runtime/_splash_runner.py
+++ b/src/lilbee/runtime/_splash_runner.py
@@ -68,7 +68,7 @@ def build_logo_frames() -> list[list[str]]:
 
 
 def build_knight_rider_frames() -> list[str]:
-    """Build 22-frame Knight Rider bar spanning the full logo width."""
+    """Build a Knight Rider bar sweeping the full logo width and back."""
     frames: list[str] = []
     sweep_range = LOGO_WIDTH - 1
     total_frames = sweep_range * 2

--- a/src/lilbee/runtime/temporal.py
+++ b/src/lilbee/runtime/temporal.py
@@ -20,8 +20,8 @@ class DateRange(NamedTuple):
     end: datetime
 
 
-# Temporal keywords mapped to date range generators.
-# Each value is a callable taking "now" and returning a DateRange.
+# Temporal keyword -> resolver-key string; the resolver callables live in
+# _RANGE_RESOLVERS, keyed by these strings.
 _TEMPORAL_KEYWORDS: dict[str, str] = {
     "today": "today",
     "yesterday": "yesterday",

--- a/tests/test_app_reset.py
+++ b/tests/test_app_reset.py
@@ -1,0 +1,39 @@
+"""Unit tests for app.reset._clear_dir."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lilbee.app.reset import _clear_dir
+
+
+def test_clears_files_and_dirs(tmp_path: Path) -> None:
+    (tmp_path / "a.md").write_text("x")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.md").write_text("y")
+    skipped: list[str] = []
+    deleted = _clear_dir(tmp_path, skipped)
+    assert deleted == 2
+    assert skipped == []
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_symlink_pointing_outside_is_removed_not_followed(tmp_path: Path) -> None:
+    """A stray symlink whose target is outside must be unlinked (the link only),
+    not abort the reset and not delete the target."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "keep.md"
+    target.write_text("precious")
+    base = tmp_path / "base"
+    base.mkdir()
+    link = base / "link.md"
+    link.symlink_to(target)
+
+    skipped: list[str] = []
+    deleted = _clear_dir(base, skipped)
+
+    assert skipped == []
+    assert not link.exists()  # the link is gone
+    assert target.read_text() == "precious"  # the target is untouched
+    assert deleted == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1411,6 +1411,34 @@ class TestCrawlExcludePatternsValidator:
         assert Config._split_crawl_exclude_patterns("\n\n  \n") == []
 
 
+class TestCrawlBrowserExtraArgsValidator:
+    def test_newline_separated_string_splits(self):
+        """The persist path joins list values with newlines; reload must split them."""
+        from lilbee.core.config import Config
+
+        result = Config._split_crawl_browser_extra_args("--flag-a\n--flag-b")
+        assert result == ["--flag-a", "--flag-b"]
+
+    def test_list_passes_through_unchanged(self):
+        from lilbee.core.config import Config
+
+        assert Config._split_crawl_browser_extra_args(["--a", "--b"]) == ["--a", "--b"]
+
+    def test_persisted_newline_string_round_trips(self, tmp_path):
+        """A value persisted as a newline-joined string must not crash the whole
+        config load (which would silently discard every other setting)."""
+        toml_path = tmp_path / "config.toml"
+        toml_path.write_text(
+            'crawl_browser_extra_args = "--flag-a\\n--flag-b"\nchat_model = "ollama/keep:latest"\n'
+        )
+        env = _clean_env()
+        env["LILBEE_DATA"] = str(tmp_path)
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = Config()
+            assert c.crawl_browser_extra_args == ["--flag-a", "--flag-b"]
+            assert c.chat_model == "ollama/keep:latest"  # other settings survive
+
+
 class TestPlainEnvSourceSkipsEmpty:
     def test_empty_chat_model_uses_default(self, tmp_path):
         env = _clean_env(tmp_path)

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2716,8 +2716,9 @@ class TestUpdateConfig:
             await handlers.update_config({"chunk_size": 5})
 
     async def test_chunk_size_at_minimum_accepted(self, tmp_path):
-        result = await handlers.update_config({"chunk_size": 64})
-        assert result.updated == ["chunk_size"]
+        # Lower the overlap alongside it so the overlap < chunk_size invariant holds.
+        result = await handlers.update_config({"chunk_size": 64, "chunk_overlap": 32})
+        assert set(result.updated) == {"chunk_size", "chunk_overlap"}
         assert cfg.chunk_size == 64
 
     async def test_chunk_overlap_at_or_above_chunk_size_rejected(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,7 +2,43 @@
 
 from unittest import mock
 
+import pytest
+
 from lilbee.core import settings
+
+
+class TestChunkSizeOverlapInvariant:
+    def test_lowering_chunk_size_below_existing_overlap_is_rejected(self, monkeypatch):
+        from lilbee.app import settings as appset
+
+        monkeypatch.setattr(appset.cfg, "chunk_size", 512)
+        monkeypatch.setattr(appset.cfg, "chunk_overlap", 100)
+        with pytest.raises(ValueError, match="chunk_overlap"):
+            appset._validate({"chunk_size": 64})
+
+    def test_lowering_chunk_size_above_existing_overlap_is_allowed(self, monkeypatch):
+        from lilbee.app import settings as appset
+
+        monkeypatch.setattr(appset.cfg, "chunk_size", 512)
+        monkeypatch.setattr(appset.cfg, "chunk_overlap", 50)
+        appset._validate({"chunk_size": 256})  # 50 < 256, no raise
+
+
+class TestApplySettingsRollback:
+    def test_parse_error_during_persist_restores_snapshot(self, monkeypatch):
+        """A non-OSError (e.g. corrupt-toml parse) during persist must roll the
+        in-memory snapshot back, not leave cfg holding unpersisted values."""
+        from lilbee.app import settings as appset
+
+        original = appset.cfg.chunk_size
+
+        def _boom(*_a, **_k):
+            raise ValueError("corrupt config.toml")
+
+        monkeypatch.setattr(appset.persistent_settings, "update_values", _boom)
+        with pytest.raises(ValueError):
+            appset.apply_settings_update({"chunk_size": original + 64})
+        assert appset.cfg.chunk_size == original
 
 
 class TestLoad:


### PR DESCRIPTION
## Problem

Review of the app/core/runtime layer surfaced a config-integrity blocking bug plus several smaller correctness and consistency issues:

- `crawl_browser_extra_args` (a writable `list[str]`) had no string-splitting validator. The settings layer persists list values as newline-joined strings, so on the next launch the value failed to coerce to a list and the entire `config.toml` was silently discarded, losing every other persisted setting.
- Reset aborted entirely when it hit a symlink whose target resolved outside the directory (the path-traversal guard rejected a safe operation).
- Settings validation let you lower `chunk_size` below the existing `chunk_overlap`, leaving an invalid state the chunker rejects.
- Smaller: `flash_attention` swallowed invalid values without the warning its sibling parsers log; derived `embedding_dim` was written to `config.toml` but ignored on reload; settings rollback only covered `OSError`, not a parse error while persisting; `adopt_embedder` checked `is_installed` twice; stale temporal/splash docstrings.

## Solution

- Add a newline-splitting before-validator for `crawl_browser_extra_args` mirroring `crawl_exclude_patterns`, so the persist/reload round-trip works.
- Reset now removes a symlink as the link itself (never follows it) instead of validating-and-aborting.
- Validation compares the effective overlap (new or existing) against the effective chunk_size.
- Warn on invalid `flash_attention`; stop persisting derived `embedding_dim`; widen the settings rollback to parse errors; compute `is_installed` once; correct the docstrings.

Tested: config round-trip (no whole-file discard), reset symlink handling, the chunk invariant, and the settings rollback.
