### PR TITLE
CLI review fixes: wiki-lint path traversal, launcher leak, search/agent-config parity

### DIFF
--- a/src/lilbee/cli/commands/agent_config.py
+++ b/src/lilbee/cli/commands/agent_config.py
@@ -16,6 +16,8 @@ from lilbee.cli.launchers.server import (
     installed_chat_model_refs,
     running_server_session,
 )
+from lilbee.core.config import cfg
+from lilbee.providers.model_ref import with_configured_remote_chat
 
 agent_config_app = typer.Typer(help="Print a paste-ready config block for an AI client.")
 
@@ -35,7 +37,9 @@ def _emit_block(builder: _JsonBuilder | _TextBuilder, **kwargs: Any) -> None:
     block = builder(
         base_url=f"http://{LOOPBACK}:{port}",
         api_key=token,
-        model_refs=installed_chat_model_refs(),
+        # Include a remote-configured chat model the native registry lacks, so the
+        # emitted config lists the model lilbee serves (matching launch + /v1/models).
+        model_refs=with_configured_remote_chat(installed_chat_model_refs(), cfg.chat_model),
         **kwargs,
     )
     if isinstance(block, str):

--- a/src/lilbee/cli/commands/agent_config.py
+++ b/src/lilbee/cli/commands/agent_config.py
@@ -15,6 +15,7 @@ from lilbee.cli.launchers.server import (
     LOOPBACK,
     installed_chat_model_refs,
     running_server_session,
+    served_chat_ctx,
 )
 from lilbee.core.config import cfg
 from lilbee.providers.model_ref import with_configured_remote_chat
@@ -34,13 +35,20 @@ def _emit_block(builder: _JsonBuilder | _TextBuilder, **kwargs: Any) -> None:
         typer.secho(_SERVE_HINT, err=True, fg=typer.colors.RED)
         raise typer.Exit(1)
     token, port = session
+    extra = dict(kwargs)
+    if builder is opencode.opencode_config:
+        # Match `launch opencode`: pin the served model as default and pass the
+        # context window, so the pasted config opens on a lilbee model and trims
+        # history to the right limit.
+        extra.setdefault("default_ref", str(cfg.chat_model))
+        extra.setdefault("chat_ctx", served_chat_ctx(port))
     block = builder(
         base_url=f"http://{LOOPBACK}:{port}",
         api_key=token,
         # Include a remote-configured chat model the native registry lacks, so the
         # emitted config lists the model lilbee serves (matching launch + /v1/models).
         model_refs=with_configured_remote_chat(installed_chat_model_refs(), cfg.chat_model),
-        **kwargs,
+        **extra,
     )
     if isinstance(block, str):
         # Use typer.echo (no Rich word-wrap) so YAML stays parseable when

--- a/src/lilbee/cli/commands/ingest_sync.py
+++ b/src/lilbee/cli/commands/ingest_sync.py
@@ -450,6 +450,9 @@ def _add_json_mode(file_paths: list[Path], crawled_paths: list[Path], *, force: 
     copy_result = CopyResult()
     if file_paths:
         copy_result = copy_files(file_paths, force=force)
+    # Headless one-shot ingest: only the embed server is needed, so suppress eager
+    # start (matching the interactive path) instead of warming every role's VRAM.
+    cfg.worker_pool_eager_start = False
     result = asyncio.run(sync(quiet=True))
     json_output(
         {

--- a/src/lilbee/cli/commands/memory.py
+++ b/src/lilbee/cli/commands/memory.py
@@ -132,5 +132,10 @@ def memory_remove(
     deleted = forget(memory_id)
     if cfg.json_mode:
         json_output({"id": memory_id, "deleted": deleted})
+        if not deleted:
+            raise typer.Exit(1)
         return
     console.print(f"Removed {memory_id}." if deleted else f"No memory {memory_id} found.")
+    # Exit non-zero on not-found, matching `model remove` / `remove`.
+    if not deleted:
+        raise typer.Exit(1)

--- a/src/lilbee/cli/commands/search_chat.py
+++ b/src/lilbee/cli/commands/search_chat.py
@@ -39,6 +39,8 @@ from lilbee.providers.roles import WorkerRole
 
 # How many top concepts to show inline before truncating with a ``+N more`` tail.
 _TOPIC_PREVIEW_LIMIT = 5
+# Upper bound on retrieved results, matching the REST search route's le=100 cap.
+_MAX_TOP_K = 100
 
 _EMBED_MISMATCH_ADOPT_HINT = (
     "Run `lilbee use-embedder {model}` to search this index with its embedder."
@@ -77,6 +79,18 @@ _scope_option = typer.Option(
 )
 
 
+def _reject_if_empty(value: str, label: str) -> None:
+    """Exit with a uniform error if *value* is empty/whitespace (matches REST)."""
+    if value and value.strip():
+        return
+    msg = f"{label} must not be empty"
+    if cfg.json_mode:
+        json_output({"error": msg})
+        raise SystemExit(1)
+    console.print(f"[{theme.ERROR}]Error:[/{theme.ERROR}] {msg}")
+    raise SystemExit(1)
+
+
 def _display_score(result: dict[str, Any]) -> float:
     """Relevance score, else distance, else 0.0. Explicit None checks keep a
     legitimate 0.0 from falling through a truthy ``or`` chain."""
@@ -96,18 +110,13 @@ def search(
     """Search the knowledge base for relevant chunks."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
 
-    if not query or not query.strip():
-        if cfg.json_mode:
-            json_output({"error": "query must not be empty"})
-            raise SystemExit(1)
-        console.print(f"[{theme.ERROR}]Error:[/{theme.ERROR}] query must not be empty")
-        raise SystemExit(1)
+    _reject_if_empty(query, "query")
 
     err = announce_cold_start(WorkerRole.EMBED, str(cfg.embedding_model))
     try:
         results = get_services().searcher.search(
             query,
-            top_k=top_k or cfg.top_k,
+            top_k=min(top_k or cfg.top_k, _MAX_TOP_K),
             chunk_type=scope_to_chunk_type(scope),
         )
         announce_ready(err, WorkerRole.EMBED)
@@ -173,6 +182,7 @@ def ask(
         num_ctx=num_ctx,
         seed=seed,
     )
+    _reject_if_empty(question, "question")
 
     try:
         from lilbee.app.settings import apply_settings_update

--- a/src/lilbee/cli/commands/search_chat.py
+++ b/src/lilbee/cli/commands/search_chat.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import NoReturn
+from typing import Any, NoReturn
 
 import typer
 from rich.table import Table
@@ -77,6 +77,15 @@ _scope_option = typer.Option(
 )
 
 
+def _display_score(result: dict[str, Any]) -> float:
+    """Relevance score, else distance, else 0.0. Explicit None checks keep a
+    legitimate 0.0 from falling through a truthy ``or`` chain."""
+    score = result.get("relevance_score")
+    if score is None:
+        score = result.get("distance")
+    return 0.0 if score is None else score
+
+
 def search(
     query: str = typer.Argument(..., help="Search query"),
     top_k: int = typer.Option(None, "--top-k", "-k", help="Number of results"),
@@ -110,6 +119,9 @@ def search(
             raise SystemExit(1) from None
         console.print(f"[{theme.ERROR}]Error:[/{theme.ERROR}] {exc}")
         raise SystemExit(1) from None
+    # Apply the same relevance cutoff the REST and MCP search paths use, so the
+    # CLI doesn't surface lower-relevance chunks the API would suppress.
+    results = [r for r in results if r.distance is None or r.distance <= cfg.max_distance]
     cleaned = [clean_result(r) for r in results]
 
     if cfg.json_mode:
@@ -132,8 +144,7 @@ def search(
         preview = chunk_text[:CHUNK_PREVIEW_LEN]
         if len(chunk_text) > CHUNK_PREVIEW_LEN:
             preview += "..."
-        score = r.get("relevance_score") or r.get("distance") or 0
-        table.add_row(r["source"], preview, f"{score:.4f}")
+        table.add_row(r["source"], preview, f"{_display_score(r):.4f}")
     console.print(table)
 
 

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import asyncio
 import importlib
 import json
+import shutil
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import typer
 
@@ -28,6 +30,8 @@ from lilbee.runtime.progress import EventType, SetupProgressEvent
 if TYPE_CHECKING:
     from lilbee.providers.fleet.client import LlamaServerClient
     from lilbee.providers.fleet.swap_manager import SwapManager
+
+_LegResultT = TypeVar("_LegResultT")
 
 _SELF_CHECK_CHAT_REPO = "Qwen/Qwen3-0.6B-GGUF"
 _SELF_CHECK_CHAT_FILE = "Qwen3-0.6B-Q8_0.gguf"
@@ -51,14 +55,20 @@ def _download_self_check_model(repo: str, filename: str) -> Path:
     dest = dest_dir / filename
     console.print(f"Downloading {url}")
     last_exc: BaseException | None = None
-    for attempt in range(3):
-        try:
-            with urllib.request.urlopen(url, timeout=120) as response:  # noqa: S310  literal https url
-                dest.write_bytes(response.read())
-            return dest
-        except (OSError, urllib.error.URLError) as exc:
-            last_exc = exc
-            console.print(f"download attempt {attempt + 1} failed: {exc!r}")
+    try:
+        for attempt in range(3):
+            try:
+                with urllib.request.urlopen(url, timeout=120) as response:  # noqa: S310  literal https url
+                    dest.write_bytes(response.read())
+                return dest
+            except (OSError, urllib.error.URLError) as exc:
+                last_exc = exc
+                console.print(f"download attempt {attempt + 1} failed: {exc!r}")
+    except BaseException:
+        shutil.rmtree(dest_dir, ignore_errors=True)
+        raise
+    # All attempts failed: drop the empty temp dir before raising.
+    shutil.rmtree(dest_dir, ignore_errors=True)
     raise RuntimeError(f"GGUF download failed after 3 attempts: {last_exc!r}")
 
 
@@ -106,7 +116,9 @@ def _resolved_provider_kwargs() -> dict[str, Any]:
     }
 
 
-def _self_check_server(role: WorkerRole, model_path: Path) -> tuple[SwapManager, LlamaServerClient]:
+def _self_check_server(
+    role: WorkerRole, model_path: Path
+) -> tuple[SwapManager, LlamaServerClient, Path]:
     """Start a one-model llama-swap for *model_path* in *role* and return its
     manager plus an OpenAI client.
 
@@ -163,12 +175,12 @@ def _self_check_server(role: WorkerRole, model_path: Path) -> tuple[SwapManager,
     )
     swap = SwapManager(work_dir)
     swap.start([launch])
-    return swap, LlamaServerClient(swap.endpoint(), launch.model_id)
+    return swap, LlamaServerClient(swap.endpoint(), launch.model_id), work_dir
 
 
 def _self_check_chat(model_path: Path, max_tokens: int) -> str:
     """Run a chat model through a one-off llama-swap, request a tiny completion, tear down."""
-    swap, client = _self_check_server(WorkerRole.CHAT, model_path)
+    swap, client, work_dir = _self_check_server(WorkerRole.CHAT, model_path)
     try:
         result = client.chat(
             [{"role": "user", "content": "2+2="}],
@@ -178,16 +190,46 @@ def _self_check_chat(model_path: Path, max_tokens: int) -> str:
         return str(result)
     finally:
         swap.shutdown()
+        shutil.rmtree(work_dir, ignore_errors=True)
 
 
 def _self_check_embed(model_path: Path) -> int:
     """Run an embedding model through a one-off llama-swap, return one vector's dim."""
-    swap, client = _self_check_server(WorkerRole.EMBED, model_path)
+    swap, client, work_dir = _self_check_server(WorkerRole.EMBED, model_path)
     try:
         vectors = client.embed(["test"])
         return len(vectors[0]) if vectors else 0
     finally:
         swap.shutdown()
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+def _self_check_leg(
+    model_path: Path | None,
+    repo: str,
+    filename: str,
+    label: str,
+    check: Callable[[Path], _LegResultT],
+) -> tuple[_LegResultT, Path]:
+    """Resolve a model (user path or download), run *check*, and clean any download.
+
+    On any failure emits the structured failure and exits 1, matching the
+    per-leg error handling the self-check command used inline.
+    """
+    download_dir: Path | None = None
+    try:
+        if model_path is None:
+            model_path = _download_self_check_model(repo, filename)
+            download_dir = model_path.parent
+        console.print(f"Loading {label} model {model_path}")
+        result = check(model_path)
+    except Exception as exc:
+        _self_check_emit_failure(repr(exc))
+        raise typer.Exit(1) from exc
+    finally:
+        if download_dir is not None:
+            shutil.rmtree(download_dir, ignore_errors=True)
+    return result, model_path
 
 
 def self_check_cmd(
@@ -215,15 +257,13 @@ def self_check_cmd(
     Exits 0 on success, 1 on any failure. Intended for post-install
     verification and as the end-to-end gate in release CI.
     """
-    try:
-        chat_path = chat_model_path or _download_self_check_model(
-            _SELF_CHECK_CHAT_REPO, _SELF_CHECK_CHAT_FILE
-        )
-        console.print(f"Loading chat model {chat_path}")
-        text = _self_check_chat(chat_path, max_tokens)
-    except Exception as exc:
-        _self_check_emit_failure(repr(exc))
-        raise typer.Exit(1) from exc
+    text, chat_path = _self_check_leg(
+        chat_model_path,
+        _SELF_CHECK_CHAT_REPO,
+        _SELF_CHECK_CHAT_FILE,
+        "chat",
+        lambda p: _self_check_chat(p, max_tokens),
+    )
 
     if not text.strip():
         _self_check_emit_failure("empty inference response")
@@ -231,15 +271,13 @@ def self_check_cmd(
 
     embedding_dims: int | None = None
     if not skip_embedding:
-        try:
-            embed_path = embed_model_path or _download_self_check_model(
-                _SELF_CHECK_EMBED_REPO, _SELF_CHECK_EMBED_FILE
-            )
-            console.print(f"Loading embedding model {embed_path}")
-            embedding_dims = _self_check_embed(embed_path)
-        except Exception as exc:
-            _self_check_emit_failure(repr(exc))
-            raise typer.Exit(1) from exc
+        embedding_dims, _ = _self_check_leg(
+            embed_model_path,
+            _SELF_CHECK_EMBED_REPO,
+            _SELF_CHECK_EMBED_FILE,
+            "embedding",
+            _self_check_embed,
+        )
 
         if not embedding_dims:
             _self_check_emit_failure("empty embedding vector")

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -174,7 +174,14 @@ def _self_check_server(
         token_cap=ctx if is_embed else None,
     )
     swap = SwapManager(work_dir)
-    swap.start([launch])
+    try:
+        swap.start([launch])
+    except BaseException:
+        # start() raises on engine-load failure (the case self-check exists to
+        # catch); work_dir is never returned, so clean it here rather than orphan it.
+        swap.shutdown()
+        shutil.rmtree(work_dir, ignore_errors=True)
+        raise
     return swap, LlamaServerClient(swap.endpoint(), launch.model_id), work_dir
 
 

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -55,6 +55,8 @@ def _download_self_check_model(repo: str, filename: str) -> Path:
     dest = dest_dir / filename
     console.print(f"Downloading {url}")
     last_exc: BaseException | None = None
+    # Any exit other than a successful return drops the temp dir, so a failed
+    # download never leaves an empty/partial dir behind.
     try:
         for attempt in range(3):
             try:
@@ -64,12 +66,10 @@ def _download_self_check_model(repo: str, filename: str) -> Path:
             except (OSError, urllib.error.URLError) as exc:
                 last_exc = exc
                 console.print(f"download attempt {attempt + 1} failed: {exc!r}")
+        raise RuntimeError(f"GGUF download failed after 3 attempts: {last_exc!r}")
     except BaseException:
         shutil.rmtree(dest_dir, ignore_errors=True)
         raise
-    # All attempts failed: drop the empty temp dir before raising.
-    shutil.rmtree(dest_dir, ignore_errors=True)
-    raise RuntimeError(f"GGUF download failed after 3 attempts: {last_exc!r}")
 
 
 _self_check_chat_path_option = typer.Option(

--- a/src/lilbee/cli/commands/wiki.py
+++ b/src/lilbee/cli/commands/wiki.py
@@ -178,7 +178,7 @@ def wiki_status(
         )
         return
 
-    color = "green" if cfg.wiki else "red"
+    color = theme.SUCCESS if cfg.wiki else theme.ERROR
     label = "enabled" if cfg.wiki else "disabled"
     console.print(f"Wiki: [{color}]{label}[/{color}]")
     console.print(f"  Summaries: [{theme.LABEL}]{summaries}[/{theme.LABEL}]")

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -169,6 +169,7 @@ def auto_sync(con: Console, *, background: bool = False) -> None:
         run_sync_background(con)
         return
 
+    from lilbee.cli.sync import _format_sync_summary
     from lilbee.data.ingest import sync
 
     try:
@@ -176,18 +177,12 @@ def auto_sync(con: Console, *, background: bool = False) -> None:
     except RuntimeError as exc:
         con.print(f"[{theme.ERROR}]Error:[/{theme.ERROR}] {exc}")
         raise SystemExit(1) from None
-    total = (
-        len(result.added)
-        + len(result.updated)
-        + len(result.removed)
-        + len(result.failed)
-        + len(result.skipped)
+    summary = _format_sync_summary(
+        len(result.added),
+        len(result.updated),
+        len(result.removed),
+        len(result.failed),
+        len(result.skipped),
     )
-    if total:
-        con.print(
-            f"[{theme.MUTED}]Synced: {len(result.added)} added, "
-            f"{len(result.updated)} updated, "
-            f"{len(result.removed)} removed, "
-            f"{len(result.skipped)} skipped, "
-            f"{len(result.failed)} failed[/{theme.MUTED}]"
-        )
+    if summary:
+        con.print(f"[{theme.MUTED}]Synced: {summary}[/{theme.MUTED}]")

--- a/src/lilbee/cli/launchers/launcher.py
+++ b/src/lilbee/cli/launchers/launcher.py
@@ -79,21 +79,24 @@ def run_launcher(launcher: Launcher) -> None:
     # port (the loser gets connection-refused). The spawned serve warms its own.
     cfg.worker_pool_eager_start = False
     (token, port), spawned = ensure_server_running()
-    native_refs = installed_chat_model_refs()
-    model_refs = with_configured_remote_chat(native_refs, cfg.chat_model)
-    _warn_on_model_pin_gaps(model_refs)
-    # Wait out the cold model load before handing off, so the client opens onto a
-    # warm engine instead of an apparently-dead stream. Only meaningful when a
-    # native chat model is installed to warm; a remote-configured model has no
-    # local load to wait for.
-    if native_refs:
-        wait_for_chat_warm(port)
-    extra_args, env = launcher.prepare(token=token, port=port, model_refs=model_refs)
-    # The client paints its own UI only after its runtime boots, a few silent
-    # seconds; announce the handoff so the warm bar isn't followed by a dead
-    # screen with no explanation.
-    typer.secho(f"Launching {launcher.name}...", fg=typer.colors.GREEN)
+    # Everything after the spawn runs under the finally so a raise from prepare()
+    # (e.g. the user declining opencode setup) or the warm wait can't leak the
+    # spawned `lilbee serve` process.
     try:
+        native_refs = installed_chat_model_refs()
+        model_refs = with_configured_remote_chat(native_refs, cfg.chat_model)
+        _warn_on_model_pin_gaps(model_refs)
+        # Wait out the cold model load before handing off, so the client opens onto a
+        # warm engine instead of an apparently-dead stream. Only meaningful when a
+        # native chat model is installed to warm; a remote-configured model has no
+        # local load to wait for.
+        if native_refs:
+            wait_for_chat_warm(port)
+        extra_args, env = launcher.prepare(token=token, port=port, model_refs=model_refs)
+        # The client paints its own UI only after its runtime boots, a few silent
+        # seconds; announce the handoff so the warm bar isn't followed by a dead
+        # screen with no explanation.
+        typer.secho(f"Launching {launcher.name}...", fg=typer.colors.GREEN)
         # binary resolved via the launcher's find_binary on PATH; no shell.
         result = subprocess.run([binary, *extra_args], env=env, check=False)  # noqa: S603
     finally:

--- a/src/lilbee/cli/launchers/opencode.py
+++ b/src/lilbee/cli/launchers/opencode.py
@@ -97,11 +97,19 @@ def _install_lilbee_skill() -> Path | None:
     dest = _opencode_skill_dest()
     if dest.exists():
         return None
-    dest.mkdir(parents=True)
     source = resources.files(_SKILL_PACKAGE)
-    for entry in source.iterdir():
-        if entry.is_file() and not entry.name.startswith("__"):
-            (dest / entry.name).write_bytes(entry.read_bytes())
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Build in a temp dir and atomically rename, so a failed/partial copy never
+    # leaves a half-written skill dir that exists() would then skip forever.
+    staging = Path(tempfile.mkdtemp(dir=dest.parent, prefix=".lilbee-mcp-"))
+    try:
+        for entry in source.iterdir():
+            if entry.is_file() and not entry.name.startswith("__"):
+                (staging / entry.name).write_bytes(entry.read_bytes())
+        os.replace(staging, dest)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
     return dest
 
 

--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -36,6 +36,7 @@ _SERVER_POLL_INTERVAL_S = 0.5
 _WARM_TIMEOUT_S = 600.0
 _HEALTH_PROBE_TIMEOUT_S = 2.0
 _HTTP_OK = 200
+_HEALTH_PATH = "/api/health"
 _TERMINATE_GRACE_S = 10
 _KILL_GRACE_S = 5
 # Spawn attempts; free_port()'s released probe port can be stolen before the server binds.
@@ -72,13 +73,28 @@ def free_port() -> int:
         return int(s.getsockname()[1])
 
 
+def _probe_health(port: int) -> dict[str, object] | None:
+    """GET ``/api/health`` once; return the parsed body on 200, else None.
+
+    The single place the probe URL, timeout, error handling, and status check
+    live, so the three public probes below stay consistent.
+    """
+    try:
+        resp = httpx.get(f"http://{LOOPBACK}:{port}{_HEALTH_PATH}", timeout=_HEALTH_PROBE_TIMEOUT_S)
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != _HTTP_OK:
+        return None
+    try:
+        body = resp.json()
+    except ValueError:
+        return {}
+    return body if isinstance(body, dict) else {}
+
+
 def health_ok(port: int) -> bool:
     """Single-shot ``/api/health`` probe; True iff a 200 comes back fast."""
-    try:
-        resp = httpx.get(f"http://{LOOPBACK}:{port}/api/health", timeout=_HEALTH_PROBE_TIMEOUT_S)
-    except httpx.HTTPError:
-        return False
-    return resp.status_code == _HTTP_OK
+    return _probe_health(port) is not None
 
 
 def wait_for_health(port: int, timeout_s: float = _SERVER_BOOT_TIMEOUT_S) -> bool:
@@ -93,13 +109,8 @@ def wait_for_health(port: int, timeout_s: float = _SERVER_BOOT_TIMEOUT_S) -> boo
 
 def chat_ready(port: int) -> bool:
     """Single-shot probe: True iff ``/api/health`` reports the chat engine warm."""
-    try:
-        resp = httpx.get(f"http://{LOOPBACK}:{port}/api/health", timeout=_HEALTH_PROBE_TIMEOUT_S)
-    except httpx.HTTPError:
-        return False
-    if resp.status_code != _HTTP_OK:
-        return False
-    return bool(resp.json().get("chat_ready", False))
+    body = _probe_health(port)
+    return bool(body and body.get("chat_ready", False))
 
 
 def served_chat_ctx(port: int) -> int | None:
@@ -108,13 +119,10 @@ def served_chat_ctx(port: int) -> int | None:
     A launcher passes this to the client so it trims history to the model's
     actual window instead of overflowing on a long agentic session.
     """
-    try:
-        resp = httpx.get(f"http://{LOOPBACK}:{port}/api/health", timeout=_HEALTH_PROBE_TIMEOUT_S)
-    except httpx.HTTPError:
+    body = _probe_health(port)
+    if body is None:
         return None
-    if resp.status_code != _HTTP_OK:
-        return None
-    ctx = resp.json().get("chat_ctx")
+    ctx = body.get("chat_ctx")
     return ctx if isinstance(ctx, int) and ctx > 0 else None
 
 
@@ -182,6 +190,7 @@ def spawn_server(port: int) -> subprocess.Popen[bytes]:
         else [sys.executable, "-m", "lilbee", "serve", "--port", str(port)]
     )
 
+    log_file: IO[bytes] | None = None
     if os.environ.get("LILBEE_LAUNCHER_SERVE_QUIET"):
         stdout: int | IO[bytes] = subprocess.DEVNULL
         stderr: int | IO[bytes] = subprocess.DEVNULL
@@ -197,12 +206,18 @@ def spawn_server(port: int) -> subprocess.Popen[bytes]:
         stdout = log_file
         stderr = subprocess.STDOUT
 
-    # Only caller-controlled value is the validated integer port; no shell.
-    return subprocess.Popen(  # noqa: S603
-        cmd,
-        stdout=stdout,
-        stderr=stderr,
-    )
+    try:
+        # Only caller-controlled value is the validated integer port; no shell.
+        return subprocess.Popen(  # noqa: S603
+            cmd,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    finally:
+        # Popen dups the fd into the child; the parent's handle is no longer
+        # needed and would otherwise leak for the launcher's whole lifetime.
+        if log_file is not None:
+            log_file.close()
 
 
 def stop_spawned_server(proc: subprocess.Popen[bytes]) -> None:

--- a/src/lilbee/cli/launchers/warm_render.py
+++ b/src/lilbee/cli/launchers/warm_render.py
@@ -106,11 +106,13 @@ def render_warm(base_url: str, timeout_s: float) -> bool | None:
         TextColumn("{task.fields[detail]}"),
         TimeElapsedColumn(),
     )
+    saw_event = False
     try:
         with Progress(*columns, console=console, transient=True) as progress:
             task_id = progress.add_task("Preparing chat model", total=None, detail="")
             reached_ready = False
             for snap in _iter_warm_events(base_url, timeout_s):
+                saw_event = True
                 _apply(progress, task_id, snap)
                 if snap.phase is WarmPhase.READY:
                     reached_ready = True
@@ -119,4 +121,7 @@ def render_warm(base_url: str, timeout_s: float) -> bool | None:
                     return False
             return reached_ready
     except httpx.HTTPError:
-        return None
+        # Only None means "stream never ran, poll instead". If it opened and
+        # yielded events before dropping, report not-ready so the caller does not
+        # double-spend the full warm budget on a second poll.
+        return None if not saw_event else False

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -7,6 +7,7 @@ the Rich renderers below adapt them for human-readable terminal output.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -332,8 +333,6 @@ def _is_interactive_terminal() -> bool:
     CliRunner replaces ``sys.stdin`` during invoke which makes direct
     monkey-patching of ``sys.stdin.isatty`` unreliable.
     """
-    import sys
-
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 

--- a/src/lilbee/cli/model.py
+++ b/src/lilbee/cli/model.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from lilbee.catalog import DownloadProgress
-    from lilbee.catalog.types import ModelSource
+    from lilbee.catalog.types import ModelSource, ModelTask
 
 
 def _render_list(data: ListModelsResult) -> Table:
@@ -118,6 +118,27 @@ def _parse_source_or_bad_param(value: str | None) -> ModelSource | None:
         raise typer.BadParameter(str(exc)) from exc
 
 
+def _parse_task_or_bad_param(value: str | None) -> ModelTask | None:
+    """Parse a CLI --task value, mirroring --source's JSON-envelope + friendly error.
+
+    Without this, an invalid --task leaked Python's "'x' is not a valid ModelTask"
+    and broke --json by emitting Typer usage text instead of the error envelope.
+    """
+    from lilbee.catalog.types import ModelTask
+
+    if not value:
+        return None
+    try:
+        return ModelTask(value)
+    except ValueError:
+        allowed = ", ".join(t.value for t in ModelTask)
+        msg = f"invalid task {value!r}; expected one of: {allowed}"
+        if cfg.json_mode:
+            json_output({"error": msg})
+            raise SystemExit(1) from None
+        raise typer.BadParameter(msg) from None
+
+
 @model_app.command("list")
 def list_cmd(
     source: str | None = _source_option,
@@ -126,13 +147,8 @@ def list_cmd(
     use_global: bool = global_option,
 ) -> None:
     """List installed models across all sources."""
-    from lilbee.catalog.types import ModelTask
-
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    try:
-        parsed_task = ModelTask(task) if task else None
-    except ValueError as exc:
-        raise typer.BadParameter(str(exc)) from exc
+    parsed_task = _parse_task_or_bad_param(task)
     data = list_models_data(source=_parse_source_or_bad_param(source), task=parsed_task)
     if cfg.json_mode:
         json_output(data.model_dump())

--- a/src/lilbee/cli/sync.py
+++ b/src/lilbee/cli/sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING
@@ -119,9 +120,15 @@ class SyncStatus:
     def __init__(self) -> None:
         self.text: str = ""
         self.pending: int = 0
+        self._pending_lock = threading.Lock()
 
     def clear(self) -> None:
         self.text = ""
+
+    def adjust_pending(self, delta: int) -> None:
+        """Atomically change the queued-sync counter (mutated from two threads)."""
+        with self._pending_lock:
+            self.pending += delta
 
 
 def _chat_sync_callback(status: SyncStatus) -> DetailedProgressCallback:
@@ -172,11 +179,11 @@ def run_sync_background(
 
     def _run() -> object:
         if chat_mode:
-            status.pending -= 1
+            status.adjust_pending(-1)
         return asyncio.run(sync(quiet=True, on_progress=callback))
 
     if chat_mode:
-        status.pending += 1
+        status.adjust_pending(1)
 
     future = _get_executor().submit(_run)
     future.add_done_callback(lambda f: _on_sync_done(con, f, chat_mode=chat_mode))

--- a/src/lilbee/cli/theme.py
+++ b/src/lilbee/cli/theme.py
@@ -3,6 +3,7 @@
 # Rich markup colors: used in [tag]...[/tag] strings
 ERROR = "red"
 ERROR_BOLD = "bold red"
+SUCCESS = "green"
 WARNING = "yellow"
 ACCENT = "cyan"
 MUTED = "dim"

--- a/src/lilbee/wiki/lint.py
+++ b/src/lilbee/wiki/lint.py
@@ -13,7 +13,7 @@ from enum import Enum
 from pathlib import Path
 
 from lilbee.core.config import Config, cfg
-from lilbee.core.security import validate_path_within
+from lilbee.core.security import PathTraversalError, validate_path_within
 from lilbee.data.ingest import file_hash
 from lilbee.data.store import CitationRecord, Store
 from lilbee.wiki.citation import (
@@ -194,6 +194,12 @@ def lint_wiki_page(
     # wiki_source is like "wiki/summaries/doc.md": strip the wiki_dir prefix
     relative = str(wiki_source).removeprefix(str(config.wiki_dir) + "/")
     wiki_path = wiki_root / relative
+    # wiki_source reaches here straight from the CLI/MCP, so a traversal source
+    # ("../../etc/passwd") would otherwise read and disclose an arbitrary file.
+    try:
+        validate_path_within(wiki_path, wiki_root)
+    except PathTraversalError:
+        return issues
     if wiki_path.exists():
         text = wiki_path.read_text(encoding="utf-8", errors="replace")
         issues.extend(_lint_unmarked(wiki_source, text))

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -867,3 +867,21 @@ def test_chat_warm_budget_scales_with_split_giant_weights(tmp_path):
 
     budget = launch_mod.chat_warm_budget_s()
     assert budget == max(launch_mod._WARM_TIMEOUT_S, float(cold_load_timeout_s(total)))
+
+
+def test_install_skill_is_atomic_on_failure(tmp_path, monkeypatch):
+    """A failed copy must not leave a half-written skill dir (which exists()
+    would skip forever) or any staging litter."""
+    from lilbee.cli.launchers import opencode
+
+    dest = tmp_path / "skills" / "lilbee-mcp"
+    monkeypatch.setattr(opencode, "_opencode_skill_dest", lambda: dest)
+
+    def _boom(*_a, **_k):
+        raise OSError("rename failed")
+
+    monkeypatch.setattr(opencode.os, "replace", _boom)
+    with pytest.raises(OSError):
+        opencode._install_lilbee_skill()
+    assert not dest.exists()
+    assert not list((tmp_path / "skills").glob(".lilbee-mcp-*"))

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -515,6 +515,31 @@ def test_run_launcher_serves_remote_configured_chat_model():
     warm.assert_not_called()
 
 
+def test_run_launcher_stops_spawned_server_when_prepare_raises():
+    """A raise from prepare() (e.g. declining setup) must still stop a freshly
+    spawned server, not leak it."""
+    import typer
+
+    from lilbee.cli.launchers.launcher import run_launcher
+
+    launcher = MagicMock()
+    launcher.find_binary.return_value = "/usr/local/bin/client"
+    launcher.prepare.side_effect = typer.Exit(0)
+    fake_proc = MagicMock()
+    with (
+        patch.object(cfg, "chat_model", "ollama/qwen3:8b"),
+        patch(
+            "lilbee.cli.launchers.launcher.ensure_server_running",
+            return_value=(("tok", 1234), fake_proc),
+        ),
+        patch("lilbee.cli.launchers.launcher.installed_chat_model_refs", return_value=[]),
+        patch("lilbee.cli.launchers.launcher.stop_spawned_server") as stop,
+        pytest.raises(typer.Exit),
+    ):
+        run_launcher(launcher)
+    stop.assert_called_once_with(fake_proc)
+
+
 def test_run_launcher_warns_and_skips_warm_when_no_models_at_all(capsys):
     """No native models and a native-configured ref: warn, don't warm."""
     import typer

--- a/tests/cli/test_launcher_spawn_server.py
+++ b/tests/cli/test_launcher_spawn_server.py
@@ -80,6 +80,14 @@ class TestHealthProbes:
         )
         assert server_mod.chat_ready(8080) is False
 
+    def test_health_ok_true_on_non_json_200_body(self, monkeypatch) -> None:
+        """A 200 with a non-JSON body still counts as healthy (empty parsed body)."""
+        monkeypatch.setattr(
+            server_mod.httpx, "get", lambda *_a, **_k: httpx.Response(200, text="OK")
+        )
+        assert server_mod.health_ok(8080) is True
+        assert server_mod.chat_ready(8080) is False  # no chat_ready field in body
+
     def test_served_chat_ctx_none_on_transport_error(self, monkeypatch) -> None:
         def _boom(*_a, **_k):
             raise httpx.ConnectError("refused")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1173,6 +1173,20 @@ class TestSearch:
         data = json.loads(result.output.strip())
         assert data["results"] == []
 
+    def test_search_applies_max_distance_filter(self, mock_svc, monkeypatch):
+        """CLI search drops chunks beyond cfg.max_distance, like REST and MCP."""
+        from lilbee.core.config import cfg
+
+        monkeypatch.setattr(cfg, "max_distance", 0.5)
+        near = _MOCK_SEARCH_RESULTS[0]  # distance 0.25
+        far = _MOCK_SEARCH_RESULTS[0].model_copy(update={"source": "far.pdf", "distance": 0.9})
+        mock_svc.searcher.search.return_value = [near, far]
+        result = runner.invoke(app, ["--json", "search", "q"])
+        assert result.exit_code == 0
+        sources = [r["source"] for r in json.loads(result.output.strip())["results"]]
+        assert "manual.pdf" in sources
+        assert "far.pdf" not in sources
+
     def test_search_human_output(self, mock_svc):
         mock_svc.searcher.search.return_value = _MOCK_SEARCH_RESULTS
         result = runner.invoke(app, ["search", "engine oil"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3748,6 +3748,11 @@ class TestSelfCheck:
         d = tmp_path / "wd"
         d.mkdir()
         monkeypatch.setattr("tempfile.mkdtemp", lambda *a, **k: str(d))
+        # The llama-server binary isn't present in CI; stub the resolver so the
+        # function reaches the swap.start cleanup path under test.
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.binary.resolve_llama_server", lambda: "/fake/llama-server"
+        )
         fake_swap = mock.MagicMock()
         fake_swap.start.side_effect = RuntimeError("engine died")
         monkeypatch.setattr(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3721,6 +3721,43 @@ class TestSelfCheck:
             ),
         )
 
+    def test_download_failure_cleans_temp_dir(self, tmp_path: Path, monkeypatch) -> None:
+        import urllib.error
+        import urllib.request
+
+        from lilbee.cli.commands import setup
+
+        d = tmp_path / "dl"
+        d.mkdir()
+        monkeypatch.setattr("tempfile.mkdtemp", lambda *a, **k: str(d))
+
+        def _down(*_a, **_k):
+            raise urllib.error.URLError("offline")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _down)
+        with pytest.raises(RuntimeError):
+            setup._download_self_check_model("repo/x", "f.gguf")
+        assert not d.exists()
+
+    def test_self_check_server_cleans_work_dir_on_start_failure(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from lilbee.cli.commands import setup
+        from lilbee.providers.roles import WorkerRole
+
+        d = tmp_path / "wd"
+        d.mkdir()
+        monkeypatch.setattr("tempfile.mkdtemp", lambda *a, **k: str(d))
+        fake_swap = mock.MagicMock()
+        fake_swap.start.side_effect = RuntimeError("engine died")
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.swap_manager.SwapManager", lambda *a, **k: fake_swap
+        )
+        with pytest.raises(RuntimeError):
+            setup._self_check_server(WorkerRole.CHAT, tmp_path / "model.gguf")
+        assert not d.exists()
+        fake_swap.shutdown.assert_called_once()
+
     def test_skips_download_when_model_paths_given(self, tmp_path: Path) -> None:
         chat = tmp_path / "chat.gguf"
         chat.write_bytes(b"chat")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1880,6 +1880,16 @@ class TestRebuildJson:
 
 class TestAddJson:
     @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_add_json_suppresses_eager_start(self, mock_sync, isolated_env, tmp_path):
+        """Headless json add only needs embed; it must not eager-warm every role."""
+        src = tmp_path / "source" / "m.txt"
+        src.parent.mkdir()
+        src.write_text("x")
+        cfg.worker_pool_eager_start = True
+        runner.invoke(app, ["--json", "add", str(src)])
+        assert cfg.worker_pool_eager_start is False
+
+    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_add_json(self, mock_sync, isolated_env, tmp_path):
         src = tmp_path / "source" / "manual.txt"
         src.parent.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -277,6 +277,12 @@ class TestAsk:
         result = runner.invoke(app, ["ask", "test question"])
         assert result.exit_code == 0
 
+    def test_ask_rejects_empty_question(self, mock_svc):
+        result = runner.invoke(app, ["ask", "   "])
+        assert result.exit_code != 0
+        assert "must not be empty" in result.output
+        mock_svc.searcher.ask_stream.assert_not_called()
+
     @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_with_model_flag(self, mock_sync, mock_svc):
         mock_svc.searcher.ask_stream.return_value = _mock_stream("answer")
@@ -1172,6 +1178,17 @@ class TestSearch:
         assert result.exit_code == 0
         data = json.loads(result.output.strip())
         assert data["results"] == []
+
+    def test_search_caps_top_k(self, mock_svc):
+        mock_svc.searcher.search.return_value = []
+        result = runner.invoke(app, ["search", "q", "--top-k", "500"])
+        assert result.exit_code == 0
+        assert mock_svc.searcher.search.call_args.kwargs["top_k"] == 100
+
+    def test_search_rejects_empty_query(self, mock_svc):
+        result = runner.invoke(app, ["search", "   "])
+        assert result.exit_code != 0
+        assert "must not be empty" in result.output
 
     def test_search_applies_max_distance_filter(self, mock_svc, monkeypatch):
         """CLI search drops chunks beyond cfg.max_distance, like REST and MCP."""

--- a/tests/test_cli_memory.py
+++ b/tests/test_cli_memory.py
@@ -165,3 +165,11 @@ class TestRemove:
         mock_svc.store.delete_memory.return_value = False
         result = runner.invoke(app, ["memory", "remove", "ghost"])
         assert "No memory ghost found." in result.output
+        assert result.exit_code == 1  # not-found exits non-zero, like `model remove`
+
+    def test_remove_unknown_id_json_exits_nonzero(self, mock_svc):
+        cfg.memory_enabled = True
+        mock_svc.store.delete_memory.return_value = False
+        result = runner.invoke(app, ["--json", "memory", "remove", "ghost"])
+        assert json.loads(result.output) == {"id": "ghost", "deleted": False}
+        assert result.exit_code == 1

--- a/tests/test_cli_model.py
+++ b/tests/test_cli_model.py
@@ -350,7 +350,17 @@ class TestListCmd:
     def test_invalid_task_raises_bad_param(self, fake_manager):
         result = runner.invoke(app, ["model", "list", "--task", "bogus"])
         assert result.exit_code != 0
-        assert "ModelTask" in result.output
+        # Friendly message listing valid tasks; never leaks the internal enum name.
+        assert "ModelTask" not in result.output
+        assert "chat" in result.output
+
+    def test_invalid_task_json_mode_emits_error_envelope(self, fake_manager):
+        result = runner.invoke(app, ["--json", "model", "list", "--task", "bogus"])
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert "error" in data
+        assert "bogus" in data["error"]
+        assert "ModelTask" not in data["error"]
 
 
 class TestShowModelData:

--- a/tests/test_wiki_lint.py
+++ b/tests/test_wiki_lint.py
@@ -351,6 +351,16 @@ class TestPathTraversalDefense:
         error_issues = [i for i in issues if i.severity == IssueSeverity.ERROR]
         assert any("escapes documents dir" in i.message for i in error_issues)
 
+    def test_wiki_source_traversal_does_not_read_outside_wiki_root(self, tmp_path: Path):
+        """A traversal wiki_source must not read/disclose a file outside wiki_root."""
+        secret = cfg.data_root.parent / "secret.md"
+        secret.write_text("UNMARKEDSECRET disclosed claim line\n")
+        store = MagicMock(spec=Store)
+        store.get_citations_for_wiki.return_value = []
+        issues = lint_wiki_page("../../secret.md", store)
+        assert issues == []
+        assert all("UNMARKEDSECRET" not in i.message for i in issues)
+
 
 class TestParseFrontmatter:
     def test_extracts_field(self):


### PR DESCRIPTION
## Problem

Review of the CLI command layer found a security blocking bug plus several entry-point parity gaps:

- `lilbee wiki lint <wiki_source>` joined the user-supplied source onto the wiki root with no containment check, so a traversal source (`../../../../etc/passwd`) read an arbitrary file and echoed its lines back as "unmarked claim" issues.
- `run_launcher` ran `prepare()` and the warm wait outside the cleanup `finally`, leaking the spawned `lilbee serve` process when prepare raised (e.g. declining opencode setup).
- CLI `search` skipped the `cfg.max_distance` relevance cutoff that REST and MCP both apply, returning lower-relevance chunks than the API for the same query.
- `model list --task` validated differently from `--source`: it leaked the internal `ModelTask` enum name and, in `--json` mode, emitted Typer usage text instead of the JSON error envelope.
- `agent-config` emitted a config omitting a remote-configured chat model that `launch opencode` and `/v1/models` both include.
- The opencode MCP skill install wasn't atomic: a partial copy left a half-written dir that was then skipped forever.

## Solution

- Validate the resolved wiki path within the wiki root before reading (mirrors `browse.find_page` and the drafts path).
- Wrap the post-spawn launcher work in the `finally` so the serve process is always stopped.
- Apply the `max_distance` filter in CLI search; select the display score with explicit None checks so a real 0.0 survives.
- Add `_parse_task_or_bad_param` mirroring the source parser (JSON envelope + friendly message).
- Include a remote-configured chat model in `agent-config`.
- Install the skill into a temp dir then `os.replace`, cleaning up staging on failure.

Tested: the traversal is rejected without disclosure, the launcher cleanup, the max_distance filter, the `--task` envelope, and the atomic skill install.
