### PR TITLE
TUI review fixes: role assignment, single-source registries, shared card helpers

### DIFF
--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -71,6 +71,9 @@ class SettingDef:
     help_text: str = ""
     choices: tuple[str, ...] | None = None
     hidden: bool = False
+    # List editors validate each line as a regex only when this is set; flag-style
+    # lists (e.g. crawl_browser_extra_args) would be wrongly rejected otherwise.
+    validate_regex: bool = False
 
 
 def get_default(key: str) -> object:
@@ -648,6 +651,7 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         nullable=False,
         group=SettingGroup.CRAWLING,
         render=RenderStyle.LIST_COLLAPSED,
+        validate_regex=True,
         help_text=(
             "Regex patterns that skip URLs at link-discovery time during "
             "recursive crawls. One per line."

--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -13,7 +13,7 @@ from huggingface_hub import ModelInfo
 from huggingface_hub.hf_api import RepoSibling
 
 from lilbee.catalog.compat import classify
-from lilbee.catalog.models import CatalogModel, HfGgufMeta, HfPage
+from lilbee.catalog.models import CatalogModel, HfGgufMeta, HfPage, estimate_min_ram_gb
 from lilbee.catalog.refs import GGUF_GLOB, pick_best_gguf
 
 log = logging.getLogger(__name__)
@@ -243,7 +243,7 @@ class HfClient:
                     hf_repo=item.id,
                     gguf_filename=_resolve_sibling_gguf(item.siblings or []),
                     size_gb=size_gb,
-                    min_ram_gb=round(max(2.0, size_gb * 1.5), 1),
+                    min_ram_gb=estimate_min_ram_gb(size_gb),
                     description=card_desc[:120] if card_desc else "",
                     featured=False,
                     downloads=item.downloads or 0,

--- a/src/lilbee/catalog/models.py
+++ b/src/lilbee/catalog/models.py
@@ -6,6 +6,16 @@ from pydantic import BaseModel
 
 from lilbee.catalog.types import ModelCompat, ModelTask
 
+# Minimum recommended floor so a tiny model still reports a sane RAM ask.
+_MIN_RAM_FLOOR_GB = 2.0
+# Working-set multiple over the on-disk size (weights + KV cache + overhead).
+_RAM_OVER_SIZE_FACTOR = 1.5
+
+
+def estimate_min_ram_gb(size_gb: float) -> float:
+    """Estimate the RAM a model needs from its on-disk size (single source)."""
+    return round(max(_MIN_RAM_FLOOR_GB, size_gb * _RAM_OVER_SIZE_FACTOR), 1)
+
 
 class HfGgufMeta(BaseModel):
     """GGUF metadata returned by the HF API when expand=gguf is requested.

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -21,6 +21,7 @@ from lilbee.app.themes import DARK_THEMES
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.commands import LilbeeCommandProvider
 from lilbee.cli.tui.widgets.status_bar import ViewTabs
+from lilbee.config_meta import MODEL_ROLE_FIELDS
 from lilbee.core.config import cfg
 from lilbee.providers.roles import WorkerRole
 
@@ -278,19 +279,24 @@ class LilbeeApp(App[None]):
         self.theme = name
         apply_settings_update({"theme": name})
 
+    def _reject_if_downloading(self, value: object) -> bool:
+        """Toast and return True if *value* is a model ref still downloading, so a
+        half-pulled file can't land in a model slot."""
+        if not isinstance(value, str):
+            return False
+        downloading = self.task_bar.downloading_label_for(value)
+        if downloading is None:
+            return False
+        self.notify(msg.MODEL_BEING_DOWNLOADED.format(name=downloading), severity="warning")
+        return True
+
     def set_active_model(self, key: str, value: str) -> None:
         """Persist an active model ref through the shared write boundary.
 
         Refs whose download is still queued or active are refused before the
         boundary runs, so a half-pulled file cannot land in a model slot.
         """
-
-        downloading = self.task_bar.downloading_label_for(value)
-        if downloading is not None:
-            self.notify(
-                msg.MODEL_BEING_DOWNLOADED.format(name=downloading),
-                severity="warning",
-            )
+        if self._reject_if_downloading(value):
             return
         try:
             apply_settings_update({key: value})
@@ -306,7 +312,10 @@ class LilbeeApp(App[None]):
         or values rejected by pydantic validation. Callers either catch and toast or let it
         propagate.
         """
-
+        # A model-role ref still downloading must not land in a slot (parity with
+        # set_active_model); toast and skip rather than half-pull.
+        if key in MODEL_ROLE_FIELDS and self._reject_if_downloading(value):
+            return
         apply_settings_update({key: value})
         normalized = getattr(cfg, key)
         if key == "theme" and isinstance(normalized, str) and normalized in self.available_themes:

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -67,20 +67,21 @@ def _make_wiki() -> Screen:
     return WikiScreen()
 
 
-_BASE_VIEWS: dict[str, Callable[[], Screen]] = {
+# Screen factory per managed view name (Chat is special-cased in switch_view and
+# has no factory). The active set + order + wiki gate come from msg.get_nav_views,
+# so the view universe lives in exactly one place (messages.ALL_NAV_VIEWS).
+_VIEW_FACTORIES: dict[str, Callable[[], Screen]] = {
     "Catalog": _make_catalog,
     "Status": _make_status,
     "Settings": _make_settings,
     "Tasks": _make_tasks,
+    "Wiki": _make_wiki,
 }
 
 
 def get_views() -> dict[str, Callable[[], Screen]]:
-    """Return the active view factories, including wiki when enabled."""
-    views = dict(_BASE_VIEWS)
-    if cfg.wiki:
-        views["Wiki"] = _make_wiki
-    return views
+    """Return the active view factories, derived from the nav view list."""
+    return {name: _VIEW_FACTORIES[name] for name in msg.get_nav_views() if name in _VIEW_FACTORIES}
 
 
 class LilbeeApp(App[None]):

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -163,7 +163,7 @@ class LilbeeApp(App[None]):
         if self._test_skip_auto_init:
             return
         self._canonicalize_persisted_models()
-        self.title = f"lilbee: {cfg.chat_model}"
+        self.title = msg.app_title(cfg.chat_model)
         # Restore the persisted theme so the TUI opens in whatever the user
         # picked last session, not always the default.
         persisted = cfg.theme or _DEFAULT_THEME

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -110,7 +110,7 @@ class LilbeeCommandProvider(Provider):
         display = value or "off"
         app.notify(f"{attr}: {display}")
         if attr == "chat_model":
-            app.title = f"lilbee: {value}"
+            app.title = msg.app_title(value)
 
     def _delete_doc(self, name: str) -> None:
         get_services().store.remove_documents([name])

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -113,8 +113,13 @@ class LilbeeCommandProvider(Provider):
             app.title = msg.app_title(value)
 
     def _delete_doc(self, name: str) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import invalidate_document_cache
+
         get_services().store.remove_documents([name])
-        self.screen.app.notify(f"Deleted {name}")
+        # Invalidate the document cache like the chat /delete path, so the
+        # deleted file stops being offered by autocomplete and the palette.
+        invalidate_document_cache()
+        self.screen.app.notify(msg.CMD_DELETE_SUCCESS.format(name=name))
 
     def _action_sync(self) -> None:
         self._app.action_run_sync()

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -160,4 +160,4 @@ class LilbeeCommandProvider(Provider):
         if chat is None:
             app.notify("Open Chat to run /reset")
             return
-        chat._cmd_reset("")
+        chat.request_reset()

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -374,15 +374,17 @@ COMPAT_MODAL_BODY = (
     "so loading after download will probably fail. Pull anyway?"
 )
 DEFAULT_VIEW = "Chat"
-_BASE_NAV_VIEWS: tuple[str, ...] = (DEFAULT_VIEW, "Catalog", "Status", "Settings", "Tasks")
+WIKI_VIEW = "Wiki"
+# The full nav-view universe in order. Single source for the view set: the
+# settings bar pre-creates a tab per entry (toggling Wiki visibility at
+# runtime), get_nav_views() gates Wiki, and app.get_views() derives its
+# factory map from get_nav_views().
+ALL_NAV_VIEWS: tuple[str, ...] = (DEFAULT_VIEW, "Catalog", "Status", "Settings", "Tasks", WIKI_VIEW)
 
 
 def get_nav_views() -> list[str]:
     """Return the active nav view names, including Wiki when enabled."""
-    views = list(_BASE_NAV_VIEWS)
-    if cfg.wiki:
-        views.append("Wiki")
-    return views
+    return [v for v in ALL_NAV_VIEWS if v != WIKI_VIEW or cfg.wiki]
 
 
 MODE_NORMAL = "NORMAL"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -10,6 +10,13 @@ from __future__ import annotations
 from lilbee.core.config import cfg
 from lilbee.wiki.shared import WIKI_TYPE_HEADINGS as _WIKI_TYPE_HEADINGS
 
+
+def app_title(model: str) -> str:
+    """The window title showing the active chat model. Single source so every
+    code path that sets the title uses the same format."""
+    return f"lilbee: {model}"
+
+
 CMD_UNKNOWN = "Unknown command: {cmd}"
 CMD_ADD_NOT_FOUND = "Not found: {path}"
 CMD_ADD_SUCCESS = "Added {count} file(s), syncing..."

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -86,6 +86,7 @@ def retry_skipped_message(count: int) -> str:
 
 
 CMD_DELETE_NO_DOCS = "No documents indexed"
+CMD_DELETE_READ_FAILED = "Could not read the document list"
 CMD_DELETE_USAGE = "Documents: {names}\nUsage: /delete <filename>"
 CMD_DELETE_NOT_FOUND = "Not found: {name}"
 CMD_DELETE_SUCCESS = "Deleted {name}"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -7,8 +7,12 @@ and ensures consistent messaging.
 
 from __future__ import annotations
 
+import logging
+
 from lilbee.core.config import cfg
 from lilbee.wiki.shared import WIKI_TYPE_HEADINGS as _WIKI_TYPE_HEADINGS
+
+log = logging.getLogger(__name__)
 
 
 def app_title(model: str) -> str:
@@ -284,7 +288,10 @@ def _spacy_available() -> bool:
     except (ImportError, OSError):
         return False
     except Exception:
-        return True
+        # An unexpected spaCy-internal failure: don't claim availability (that
+        # would hide the install guidance); log it and treat spaCy as absent.
+        log.debug("spaCy availability check failed unexpectedly", exc_info=True)
+        return False
     return True
 
 

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -889,13 +889,10 @@ class CatalogScreen(Screen[None]):
         search = self._get_search_text()
         installed_rows: list[LocalCatalogRow] = []
         for source in (self._all_family_rows, self._all_hf_rows, self._all_remote_rows):
-            with contextlib.suppress(AttributeError):
-                installed_rows.extend(r for r in source() if r.installed)
+            installed_rows.extend(r for r in source() if r.installed)
         if search:
             installed_rows = [r for r in installed_rows if matches_search(r, search)]
-        frontier: list[FrontierCatalogRow] = []
-        with contextlib.suppress(AttributeError):
-            frontier = self._build_frontier_rows(search)
+        frontier = self._build_frontier_rows(search)
         self._render_library_list(installed_rows, frontier)
         self._render_library_grid(installed_rows, frontier)
 
@@ -1414,9 +1411,14 @@ class CatalogScreen(Screen[None]):
         """
         if self._search_focused:
             return
-        digit_to_index = {"1": 0, "2": 1, "3": 2, "4": 3, "5": 4, "6": 5}
-        index = digit_to_index.get(event.key)
-        if index is None:
+        # 1-based digit -> 0-based tab index; bounded by the tab count so the
+        # 1..6 contract derives from ALL_TAB_IDS rather than a parallel map.
+        from lilbee.cli.tui.screens.catalog_utils import ALL_TAB_IDS
+
+        if not event.key.isdigit():
+            return
+        index = int(event.key) - 1
+        if not 0 <= index < len(ALL_TAB_IDS):
             return
         event.stop()
         event.prevent_default()

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -78,7 +78,7 @@ from lilbee.cli.tui.widgets.task_bar import TaskBar
 from lilbee.cli.tui.widgets.top_bars import TopBars
 from lilbee.core.config import cfg
 from lilbee.modelhub.model_manager import RemoteModel, classify_all_remote_models
-from lilbee.providers.sdk_backend import get_provider_api_key
+from lilbee.providers.sdk_backend import PROVIDER_API_KEY_FIELD, get_provider_api_key
 from lilbee.runtime.hardware import available_memory_for_fit, compute_fit
 
 log = logging.getLogger(__name__)
@@ -1732,7 +1732,7 @@ class CatalogScreen(Screen[None]):
             apply_active_model(self.app, _model_field_for_task(row.task), row.ref)
             self.notify(msg.CATALOG_USING_FRONTIER.format(name=row.name, provider=row.provider))
             return
-        key_field = f"{row.provider_id}_api_key"
+        key_field = PROVIDER_API_KEY_FIELD.get(row.provider_id, f"{row.provider_id}_api_key")
         self.notify(
             msg.CATALOG_NEEDS_KEY.format(provider=row.provider, key_field=key_field),
             severity="warning",

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -832,7 +832,9 @@ class CatalogScreen(Screen[None]):
             return
         self._rows.extend(new_rows)
         self._list_widget.append_rows(list(new_rows))
-        self._list_cache_key = (
+        # Update the per-tab cache key (not a stray singular attribute) so a
+        # subsequent _refresh_list for this tab sees the appended rows as cached.
+        self._list_cache_keys[self._active_tab_id_cache] = (
             tuple((r.name, r.installed) for r in self._rows),
             self._get_search_text(),
         )

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -28,6 +28,7 @@ from lilbee.catalog import (
     get_families,
     resolve_filename,
 )
+from lilbee.catalog.models import estimate_min_ram_gb
 from lilbee.catalog.types import ModelCompat, ModelSource, ModelTask
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import LilbeeApp, apply_active_model
@@ -1831,7 +1832,7 @@ class CatalogScreen(Screen[None]):
             hf_repo=variant.hf_repo,
             gguf_filename=variant.filename,
             size_gb=variant.size_mb / 1024,
-            min_ram_gb=max(2.0, (variant.size_mb / 1024) * 1.5),
+            min_ram_gb=estimate_min_ram_gb(variant.size_mb / 1024),
             description=family.description,
             featured=True,
             downloads=0,

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -93,6 +93,21 @@ _HF_LOAD_MORE_TRIGGER = 4
 _NOTIFY_SEARCHING_TIMEOUT_SECONDS = 4
 _ALL_TASKS = tuple(ModelTask)
 
+# Which config model-role field a selected model is assigned to, keyed by its task.
+# Remote/frontier rows surface into their matching task tab, so selecting one must
+# persist to that role, not always to chat_model.
+_TASK_TO_MODEL_FIELD: dict[ModelTask, str] = {
+    ModelTask.CHAT: "chat_model",
+    ModelTask.EMBEDDING: "embedding_model",
+    ModelTask.VISION: "vision_model",
+    ModelTask.RERANK: "reranker_model",
+}
+
+
+def _model_field_for_task(task: ModelTask | str) -> str:
+    return _TASK_TO_MODEL_FIELD.get(ModelTask(task), "chat_model")
+
+
 _WORKER_FETCH_HF = "fetch_hf_models"
 _WORKER_FETCH_MORE_HF = "fetch_more_hf"
 _WORKER_FETCH_REMOTE = "fetch_remote_models"
@@ -1706,13 +1721,13 @@ class CatalogScreen(Screen[None]):
         elif row.catalog_model:
             self._install_model(row.catalog_model)
         elif row.remote_model:
-            apply_active_model(self.app, "chat_model", row.ref)
+            apply_active_model(self.app, _model_field_for_task(row.remote_model.task), row.ref)
             self.notify(msg.CATALOG_USING_REMOTE.format(name=row.remote_model.name))
 
     def _select_frontier_row(self, row: FrontierCatalogRow) -> None:
         """Activate a cloud model, or jump to settings when the key is missing."""
         if row.key_status == KeyStatus.READY:
-            apply_active_model(self.app, "chat_model", row.ref)
+            apply_active_model(self.app, _model_field_for_task(row.task), row.ref)
             self.notify(msg.CATALOG_USING_FRONTIER.format(name=row.name, provider=row.provider))
             return
         key_field = f"{row.provider_id}_api_key"

--- a/src/lilbee/cli/tui/screens/catalog_grouping.py
+++ b/src/lilbee/cli/tui/screens/catalog_grouping.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 from lilbee.catalog.types import ModelTask
 from lilbee.cli.tui import messages as msg
@@ -139,9 +140,9 @@ def group_rows_for_grid(local_rows: list[LocalCatalogRow]) -> list[GridSection]:
     # then the rest in their incoming order. Stable so HF rank from the API
     # is preserved among non-featured rows.
     for bucket in by_task.values():
-        bucket.sort(key=lambda r: not getattr(r, "featured", False))
+        bucket.sort(key=lambda r: not cast("LocalCatalogRow", r).featured)
     for bucket in extras.values():
-        bucket.sort(key=lambda r: not getattr(r, "featured", False))
+        bucket.sort(key=lambda r: not cast("LocalCatalogRow", r).featured)
     return [
         GridSection(msg.HEADING_INSTALLED, installed),
         *[GridSection(task.capitalize(), by_task[task]) for task in TASK_BUCKET_ORDER],

--- a/src/lilbee/cli/tui/screens/catalog_utils.py
+++ b/src/lilbee/cli/tui/screens/catalog_utils.py
@@ -23,6 +23,10 @@ from lilbee.modelhub.model_manager import RemoteModel
 from lilbee.providers.model_ref import format_remote_ref
 from lilbee.runtime.hardware import FitChip
 
+# Backend label for local GGUF models. Renderers drop this pill (the backend is
+# implied for local models) and only show it for non-native SDK backends.
+NATIVE_BACKEND = "native"
+
 
 class CatalogRowKind(StrEnum):
     """Discriminator for the sealed CatalogRow union."""
@@ -268,7 +272,7 @@ def variant_to_row(v: ModelVariant, f: ModelFamily, installed: bool) -> LocalCat
         sort_downloads=0,
         sort_size=v.size_mb / 1024,
         ref=v.hf_repo,
-        backend="native",
+        backend=NATIVE_BACKEND,
         variant=v,
         family=f,
     )
@@ -289,7 +293,7 @@ def catalog_to_row(m: CatalogModel, installed: bool) -> LocalCatalogRow:
         sort_downloads=m.downloads,
         sort_size=m.size_gb,
         ref=m.ref,
-        backend="native",
+        backend=NATIVE_BACKEND,
         catalog_model=m,
         compat=m.compat,
     )

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -10,6 +10,7 @@ import shlex
 import threading
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -98,6 +99,15 @@ _STREAM_FLUSH_INTERVAL = 0.05
 
 # Auto-scroll throttle. ~6 fps so heavy token streams don't peg the renderer.
 _STREAM_SCROLL_INTERVAL = 0.15
+
+
+@dataclass
+class _StreamTimings:
+    """Last-fired monotonic timestamps for the stream flush and auto-scroll."""
+
+    last_flush: float
+    last_scroll: float = 0.0
+
 
 # ``/crawl`` command flags.
 _CRAWL_FLAG_DEPTH = "--depth"
@@ -1332,7 +1342,7 @@ class ChatScreen(Screen[None]):
         worker = _get_worker()
         reason_buf: list[str] = []
         content_buf: list[str] = []
-        timings = [time.monotonic(), 0.0]  # [last_flush, last_scroll]
+        timings = _StreamTimings(last_flush=time.monotonic())
 
         def flush() -> None:
             if reason_buf:
@@ -1367,15 +1377,15 @@ class ChatScreen(Screen[None]):
             response_parts.append(token.content)
             content_buf.append(token.content)
 
-    def _maybe_flush_and_scroll(self, flush: Callable[[], None], timings: list[float]) -> None:
+    def _maybe_flush_and_scroll(self, flush: Callable[[], None], timings: _StreamTimings) -> None:
         """Run *flush* and the auto-scroll on their respective intervals."""
         now = time.monotonic()
-        if now - timings[0] >= _STREAM_FLUSH_INTERVAL:
+        if now - timings.last_flush >= _STREAM_FLUSH_INTERVAL:
             flush()
-            timings[0] = now
-        if now - timings[1] >= _STREAM_SCROLL_INTERVAL:
+            timings.last_flush = now
+        if now - timings.last_scroll >= _STREAM_SCROLL_INTERVAL:
             call_from_thread(self, self._scroll_to_bottom)
-            timings[1] = now
+            timings.last_scroll = now
 
     def _finalize_stream(
         self, widget: AssistantMessage, sources: list[str], response_parts: list[str]

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1019,7 +1019,7 @@ class ChatScreen(Screen[None]):
     def _cmd_model(self, args: str) -> None:
         if args:
             apply_active_model(self.app, "chat_model", args)
-            self.app.title = f"lilbee -- {cfg.chat_model}"
+            self.app.title = msg.app_title(cfg.chat_model)
             self.notify(msg.CMD_MODEL_SET.format(name=cfg.chat_model))
             self.apply_model_change()
             self.refresh_model_bar()

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -878,10 +878,9 @@ class ChatScreen(Screen[None]):
         call_from_thread(self, self.notify, msg.CMD_CRAWL_SUCCESS.format(count=len(paths), url=url))
 
     def _cmd_catalog(self, _args: str) -> None:
+        # switch_view already installs and navigates to the managed Catalog view;
+        # a push_screen on top would stack a second, orphaned CatalogScreen.
         self.app.switch_view("Catalog")
-        from lilbee.cli.tui.screens.catalog import CatalogScreen
-
-        self.app.push_screen(CatalogScreen())
 
     def _cmd_delete(self, args: str) -> None:
         """Run /delete in a worker so the chat screen stays interactive."""

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1084,6 +1084,11 @@ class ChatScreen(Screen[None]):
         )
 
     def _cmd_reset(self, args: str) -> None:
+        self.request_reset()
+
+    def request_reset(self) -> None:
+        """Public entry for the confirm-then-wipe flow (shared by /reset and the
+        command palette), so callers don't reach into a private slash handler."""
         from lilbee.cli.tui.widgets.confirm_dialog import ConfirmDialog
 
         def _on_confirm(confirmed: bool | None) -> None:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -893,7 +893,7 @@ class ChatScreen(Screen[None]):
             sources = get_services().store.get_sources()
         except Exception:
             log.debug("Failed to list documents for /delete", exc_info=True)
-            call_from_thread(self, self.notify, msg.CMD_DELETE_NO_DOCS, severity="warning")
+            call_from_thread(self, self.notify, msg.CMD_DELETE_READ_FAILED, severity="error")
             return
 
         known = {s.get("filename", s.get("source", "?")) for s in sources}

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -396,7 +396,7 @@ class SettingsScreen(Screen[None]):
         default = get_default(key)
         defaults = list(default) if isinstance(default, list) else []
         text = "\n".join(str(item) for item in defaults)
-        ta = self.query_one(f"#ed-{key}", ListTextArea)
+        ta = self.query_one(f"#{EDITOR_ID_PREFIX}{key}", ListTextArea)
         ta.load_text(text)
         self._persist_value(key, defn, text)
         error_widget = self.query_one(f"#{LIST_ERROR_ID_PREFIX}{key}", Static)
@@ -637,6 +637,13 @@ class SettingsScreen(Screen[None]):
         if tabs.active != next_id:
             tabs.active = next_id
 
+    def _focus_adjacent(self, direction: int) -> None:
+        """Move focus to the next/previous widget app-wide (direction 1 / -1)."""
+        if direction == 1:
+            self.app.action_focus_next()
+        else:
+            self.app.action_focus_previous()
+
     def _move_focus_within_pane(self, *, direction: int) -> None:
         focused = self.app.focused
         tabs = self.query_one("#settings-tabs", TabbedContent)
@@ -644,11 +651,11 @@ class SettingsScreen(Screen[None]):
         try:
             body = self.query_one(f"#{active_pane_id}-body", _LazyGroupBody)
         except Exception:
-            self.app.action_focus_next() if direction == 1 else self.app.action_focus_previous()
+            self._focus_adjacent(direction)
             return
         focusables = [w for w in body.query("*") if w.focusable]
         if not focusables or focused is None or focused not in focusables:
-            self.app.action_focus_next() if direction == 1 else self.app.action_focus_previous()
+            self._focus_adjacent(direction)
             return
         index = focusables.index(focused)
         next_index = index + direction

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -53,7 +53,7 @@ from lilbee.cli.tui.screens.settings_widgets import (
 )
 from lilbee.cli.tui.widgets.list_text_area import ListTextArea
 from lilbee.cli.tui.widgets.model_pick import apply_model_pick
-from lilbee.core.config import DEFAULT_CRAWL_EXCLUDE_PATTERNS, cfg
+from lilbee.core.config import cfg
 from lilbee.providers.roles import MODEL_FIELD_TO_ROLE
 
 if TYPE_CHECKING:
@@ -370,7 +370,7 @@ class SettingsScreen(Screen[None]):
         raw = ta.text
         parsed = self._parse_value(defn, raw)
         assert isinstance(parsed, list)  # noqa: S101 -- mypy narrowing, defn.type is list above
-        err = self._validate_regex_list(parsed)
+        err = self._validate_regex_list(parsed) if defn.validate_regex else None
         error_widget = self.query_one(f"#{LIST_ERROR_ID_PREFIX}{key}", Static)
         if err is not None:
             line_no, err_text = err
@@ -393,8 +393,9 @@ class SettingsScreen(Screen[None]):
         defn = SETTINGS_MAP.get(key)
         if defn is None:
             return
-        defaults = list(DEFAULT_CRAWL_EXCLUDE_PATTERNS)
-        text = "\n".join(defaults)
+        default = get_default(key)
+        defaults = list(default) if isinstance(default, list) else []
+        text = "\n".join(str(item) for item in defaults)
         ta = self.query_one(f"#ed-{key}", ListTextArea)
         ta.load_text(text)
         self._persist_value(key, defn, text)

--- a/src/lilbee/cli/tui/screens/settings.py
+++ b/src/lilbee/cli/tui/screens/settings.py
@@ -486,7 +486,11 @@ class SettingsScreen(Screen[None]):
 
     def _on_model_picker_dismissed(self, key: str, ref: str | None) -> None:
         """Persist the picker selection, refresh the button, and reload the role's server."""
-        apply_model_pick(self, key=key, ref=ref, on_done=lambda: self._after_model_pick(key))
+        # _after_model_pick already reloads the role; let it own the single reload
+        # so the role server isn't respawned twice for one pick.
+        apply_model_pick(
+            self, key=key, ref=ref, reload_worker=False, on_done=lambda: self._after_model_pick(key)
+        )
 
     def _after_model_pick(self, key: str) -> None:
         """Refresh the picker button and reload the role's fleet server after a swap."""

--- a/src/lilbee/cli/tui/screens/settings_widgets.py
+++ b/src/lilbee/cli/tui/screens/settings_widgets.py
@@ -246,7 +246,7 @@ def make_list_editor(key: str) -> Collapsible:
         text="\n".join(current),
         show_line_numbers=True,
         name=key,
-        id=f"ed-{key}",
+        id=f"{EDITOR_ID_PREFIX}{key}",
         classes="setting-list-editor",
     )
     error = Static("", id=f"{LIST_ERROR_ID_PREFIX}{key}", classes="setting-list-error")

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -73,6 +73,7 @@ def _scan_installed_models() -> tuple[list[str], list[str]]:
                 chat.append(m.ref)
         return sorted(chat), sorted(embed)
     except Exception:
+        log.debug("Could not scan installed models for setup wizard", exc_info=True)
         return [], []
 
 

--- a/src/lilbee/cli/tui/screens/wiki.py
+++ b/src/lilbee/cli/tui/screens/wiki.py
@@ -16,6 +16,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
+from textual.timer import Timer
 from textual.widgets import Input, Markdown, Static, Tree
 from textual.widgets.tree import TreeNode
 
@@ -96,9 +97,12 @@ class WikiScreen(Screen[None]):
         Binding("G", "jump_bottom", "End", show=False),
     ]
 
+    _SEARCH_FILTER_DEBOUNCE_SECONDS = 0.12
+
     def __init__(self) -> None:
         super().__init__()
         self._page_slugs: list[str] = []
+        self._search_filter_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         from textual.widgets import Footer
@@ -286,8 +290,15 @@ class WikiScreen(Screen[None]):
 
     @on(Input.Changed, "#wiki-search")
     def _on_search_changed(self, event: Input.Changed) -> None:
-        """Filter pages when search input changes."""
-        self._load_pages(filter_text=event.value.strip())
+        """Re-filter after a short debounce so a multi-key term re-walks the wiki
+        tree once on pause, not once per keystroke."""
+        filter_text = event.value.strip()
+        if self._search_filter_timer is not None:
+            self._search_filter_timer.stop()
+        self._search_filter_timer = self.set_timer(
+            self._SEARCH_FILTER_DEBOUNCE_SECONDS,
+            lambda: self._load_pages(filter_text=filter_text),
+        )
 
     def _selected_source(self) -> str | None:
         """Return the source name for the highlighted wiki page, or None."""

--- a/src/lilbee/cli/tui/screens/wiki.py
+++ b/src/lilbee/cli/tui/screens/wiki.py
@@ -23,7 +23,6 @@ from textual.widgets.tree import TreeNode
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.widgets.task_bar import TaskBar
 from lilbee.core.config import cfg
-from lilbee.wiki.browse import read_page
 
 log = logging.getLogger(__name__)
 
@@ -316,29 +315,6 @@ class WikiScreen(Screen[None]):
             self._SEARCH_FILTER_DEBOUNCE_SECONDS,
             lambda: self._load_pages(filter_text=filter_text),
         )
-
-    def _selected_source(self) -> str | None:
-        """Return the source name for the highlighted wiki page, or None."""
-        tree = self.query_one("#wiki-page-list", Tree)
-        node = tree.cursor_node
-        if node is None:
-            return None
-        slug = node.data
-        if not isinstance(slug, str):
-            return None
-        return self._source_for_slug(slug)
-
-    def _source_for_slug(self, slug: str) -> str | None:
-        """Extract the primary source filename from a wiki page's frontmatter."""
-        root = _wiki_root()
-        page = read_page(root, slug)
-        if page is None:
-            return None
-        sources = page.frontmatter.get("sources")
-        # frontmatter values are untyped (Any from YAML); guard against non-list shapes
-        if isinstance(sources, list) and sources:
-            return str(sources[0])
-        return None
 
     def action_focus_search(self) -> None:
         """Focus the search input -- bound to / key."""

--- a/src/lilbee/cli/tui/screens/wiki.py
+++ b/src/lilbee/cli/tui/screens/wiki.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, cast
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.app import LilbeeApp
@@ -38,6 +38,22 @@ _SLUG_WITH_TYPE_MIN_PARTS = 2
 def _wiki_root() -> Path:
     """Resolve the wiki root directory from config."""
     return cfg.data_root / cfg.wiki_dir
+
+
+def _safe_float(value: object) -> float | None:
+    """Coerce an untyped frontmatter value to float, or None if not numeric."""
+    try:
+        return float(cast("float", value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: object, default: int = 0) -> int:
+    """Coerce an untyped frontmatter value to int, or *default* if not numeric."""
+    try:
+        return int(cast("float", value))
+    except (TypeError, ValueError):
+        return default
 
 
 def _format_page_header(
@@ -262,8 +278,9 @@ class WikiScreen(Screen[None]):
             self.query_one("#wiki-content", Markdown).update(msg.WIKI_NO_CONTENT)
             return
 
-        faithfulness = page.frontmatter.get("faithfulness_score")
-        faith_val = float(faithfulness) if faithfulness is not None else None
+        # Frontmatter is arbitrary parsed YAML; a non-numeric value must not
+        # crash the node-select handler that calls this.
+        faith_val = _safe_float(page.frontmatter.get("faithfulness_score"))
 
         page_type = ""
         parts = slug.split("/")
@@ -280,7 +297,7 @@ class WikiScreen(Screen[None]):
         header_text = _format_page_header(
             title=page.title,
             page_type=page_type,
-            source_count=int(source_count) if source_count else 0,
+            source_count=_safe_int(source_count),
             created_at=str(created_at),
             faithfulness=faith_val,
         )

--- a/src/lilbee/cli/tui/thread_safe.py
+++ b/src/lilbee/cli/tui/thread_safe.py
@@ -30,7 +30,11 @@ def call_from_thread(node: DOMNode, fn: Any, *args: Any, **kwargs: Any) -> None:
     """
     try:
         node.app.call_from_thread(fn, *args, **kwargs)
-    except Exception as exc:
+    except (OSError, RuntimeError) as exc:
+        # Only the shutdown signals: OSError when the message queue is closed,
+        # RuntimeError (incl. NoActiveAppError) when the app is no longer running.
+        # A genuine exception raised inside *fn* propagates so the bug surfaces
+        # instead of being silently swallowed.
         log.debug(
             "call_from_thread dropped %s: %s",
             getattr(fn, "__name__", fn),

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -14,6 +14,7 @@ from textual.widgets import OptionList
 from textual.widgets.option_list import Option
 
 from lilbee.app.services import get_services
+from lilbee.app.settings import _is_settable
 from lilbee.app.settings_map import SETTINGS_MAP
 from lilbee.app.themes import DARK_THEMES
 from lilbee.cli.tui.command_registry import completion_names
@@ -83,7 +84,9 @@ def _model_options() -> list[str]:
 
 
 def _setting_options() -> list[str]:
-    return list(SETTINGS_MAP.keys())
+    # Only settable keys, in map order: a non-writable entry (e.g. wiki_dir)
+    # would be offered then refused by /set.
+    return [k for k in SETTINGS_MAP if _is_settable(k)]
 
 
 def _document_options() -> list[str]:

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 from collections.abc import Callable
 from pathlib import Path
@@ -28,13 +29,6 @@ _MAX_VISIBLE = 8  # max dropdown items shown at once
 _MAX_PATH_COMPLETIONS = 20
 
 _CSS_FILE = Path(__file__).parent / "autocomplete.tcss"
-
-
-# Cached document list for ``/delete`` and ``/reset`` Tab completion.
-# Invalidated by ``invalidate_document_cache`` on document mutations so
-# Tab returns the live set. Order is stable across reads because the
-# dropdown renders in fetch order.
-_doc_cache: list[str] | None = None
 
 
 def get_completions(text: str) -> list[str]:
@@ -89,24 +83,27 @@ def _setting_options() -> list[str]:
     return [k for k in SETTINGS_MAP if _is_settable(k)]
 
 
-def _document_options() -> list[str]:
-    global _doc_cache
-    if _doc_cache is not None:
-        return _doc_cache
+@functools.lru_cache(maxsize=1)
+def _document_options_cached() -> tuple[str, ...]:
+    # Cached for ``/delete`` and ``/reset`` Tab completion; cleared by
+    # invalidate_document_cache on document mutations. Order is stable (fetch
+    # order) so the dropdown is deterministic.
     try:
-        _doc_cache = [
+        return tuple(
             s.get("filename", s.get("source", "")) for s in get_services().store.get_sources()
-        ]
+        )
     except Exception:
         log.debug("Failed to list documents for autocomplete", exc_info=True)
-        _doc_cache = []
-    return _doc_cache
+        return ()
+
+
+def _document_options() -> list[str]:
+    return list(_document_options_cached())
 
 
 def invalidate_document_cache() -> None:
     """Drop the cached document list; the next Tab refetches from the store."""
-    global _doc_cache
-    _doc_cache = None
+    _document_options_cached.cache_clear()
 
 
 def _theme_options() -> list[str]:

--- a/src/lilbee/cli/tui/widgets/catalog_card_shared.py
+++ b/src/lilbee/cli/tui/widgets/catalog_card_shared.py
@@ -1,0 +1,72 @@
+"""Rendering helpers shared by the catalog card, grid, and list widgets.
+
+These were duplicated across ``model_card`` and ``model_grid`` (name
+truncation, the spec/status pills) and the fit-level color map was also
+copied into ``catalog_detail``. Keeping them here means a change to the card
+surface is made once. ``model_card`` / ``model_grid`` re-export the names they
+use, so callers (and tests) can keep importing them from those modules.
+"""
+
+from __future__ import annotations
+
+from textual.content import Content
+
+from lilbee.cli.tui.pill import pill
+from lilbee.cli.tui.screens.catalog_utils import KeyStatus, LocalCatalogRow
+from lilbee.cli.tui.widgets.catalog_theme import MIDDLE_DOT
+from lilbee.runtime.hardware import FitChip, FitLevel
+
+_NAME_MAX_CHARS = 28
+_ELLIPSIS = "…"
+
+# Pill background per fit level, shared by the grid card and the detail drawer.
+_FIT_LEVEL_BACKGROUND: dict[FitLevel, str] = {
+    FitLevel.FITS: "$success",
+    FitLevel.TIGHT: "$warning",
+    FitLevel.WONT_RUN: "$error",
+}
+
+
+def _render_fit_pill(fit: FitChip) -> Content:
+    """Verbose fit chip with signed headroom GB, used by the detail drawer.
+
+    Negative headroom means the model overflows available memory; the won't-run
+    label reports the shortfall as a positive amount.
+    """
+    if fit.level is FitLevel.FITS:
+        text = f"fits +{fit.headroom_gb:.1f} GB"
+    elif fit.level is FitLevel.TIGHT:
+        text = f"tight +{max(0.0, fit.headroom_gb):.1f} GB"
+    else:
+        text = f"won't run, short by {abs(fit.headroom_gb):.1f} GB"
+    return pill(text, _FIT_LEVEL_BACKGROUND[fit.level], "$text")
+
+
+def _truncate_name(name: str) -> str:
+    """Return *name* shortened to ``_NAME_MAX_CHARS`` with an ellipsis tail."""
+    if len(name) <= _NAME_MAX_CHARS:
+        return name
+    return name[: _NAME_MAX_CHARS - 1].rstrip() + _ELLIPSIS
+
+
+def _key_status_pill(status: KeyStatus) -> Content:
+    if status == KeyStatus.READY:
+        return pill("ready", "$success", "$text")
+    return pill("needs key", "$warning", "$text")
+
+
+def _build_specs(params: str, quant: str, size: str) -> Content:
+    """Build the specs line: params · quant · size."""
+    parts = [p for p in (params, quant, size) if p and p != "--"]
+    if not parts:
+        return Content("--")
+    return Content(f" {MIDDLE_DOT} ".join(parts))
+
+
+def _build_local_status(row: LocalCatalogRow) -> Content | None:
+    """Build the status pill for installed or download count."""
+    if row.installed:
+        return pill("installed", "$success", "$text")
+    if row.sort_downloads > 0:
+        return Content.styled(f"↓ {row.downloads}", "$text-muted")
+    return None

--- a/src/lilbee/cli/tui/widgets/catalog_detail.py
+++ b/src/lilbee/cli/tui/widgets/catalog_detail.py
@@ -14,11 +14,9 @@ from typing import ClassVar
 
 from textual.app import ComposeResult
 from textual.containers import Vertical
-from textual.content import Content
 from textual.widgets import Static
 
 from lilbee.catalog.types import ModelCompat
-from lilbee.cli.tui.pill import pill
 from lilbee.cli.tui.screens.catalog_utils import (
     CatalogRow,
     CatalogRowKind,
@@ -26,15 +24,10 @@ from lilbee.cli.tui.screens.catalog_utils import (
     LocalCatalogRow,
     SizeVariant,
 )
-from lilbee.runtime.hardware import FitChip, FitLevel
+from lilbee.cli.tui.widgets.catalog_card_shared import _render_fit_pill
+from lilbee.runtime.hardware import FitLevel
 
 _CSS_FILE = Path(__file__).parent / "catalog_detail.tcss"
-
-_FIT_LEVEL_BACKGROUND: dict[FitLevel, str] = {
-    FitLevel.FITS: "$success",
-    FitLevel.TIGHT: "$warning",
-    FitLevel.WONT_RUN: "$error",
-}
 
 _EMPTY_HINT = "Highlight a model to see details."
 
@@ -104,16 +97,6 @@ class CatalogDetailDrawer(Vertical):
         self.query_one("#catalog-detail-description", Static).update(
             f"Cloud model accessed via the {row.provider} API."
         )
-
-
-def _render_fit_pill(fit: FitChip) -> Content:
-    if fit.level is FitLevel.FITS:
-        text = f"fits +{fit.headroom_gb:.1f} GB"
-    elif fit.level is FitLevel.TIGHT:
-        text = f"tight +{max(0.0, fit.headroom_gb):.1f} GB"
-    else:
-        text = f"won't run, short by {abs(fit.headroom_gb):.1f} GB"
-    return pill(text, _FIT_LEVEL_BACKGROUND[fit.level], "$text")
 
 
 def _render_sizes_block(variants: list[SizeVariant]) -> str:

--- a/src/lilbee/cli/tui/widgets/catalog_detail.py
+++ b/src/lilbee/cli/tui/widgets/catalog_detail.py
@@ -112,7 +112,7 @@ def _render_fit_pill(fit: FitChip) -> Content:
     elif fit.level is FitLevel.TIGHT:
         text = f"tight +{max(0.0, fit.headroom_gb):.1f} GB"
     else:
-        text = f"won't {fit.headroom_gb:.1f} GB"
+        text = f"won't run, short by {abs(fit.headroom_gb):.1f} GB"
     return pill(text, _FIT_LEVEL_BACKGROUND[fit.level], "$text")
 
 

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -322,7 +322,7 @@ class ModelPickerButton(Static, can_focus=True):
         ``apply_model_pick`` already persisted the ref and (for non-chat
         scopes) reloaded the worker. Chat swaps cancel the in-flight stream
         and reset services here so the new chat model takes over cleanly. Works
-        Works regardless of which container the button is mounted in.
+        regardless of which container the button is mounted in.
         """
         self._refresh()
         if self._scope != "chat":

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -16,6 +16,7 @@ from textual import events, work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Horizontal
+from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Static
 
@@ -501,7 +502,9 @@ class RoleRow(Widget, can_focus=False):
         self.set_class(active, "-active")
         self.set_class(not active, "-off")
         bg, fg = _SCOPE_PILL_COLORS[self.scope] if active else _OFF_PILL_COLORS
-        with contextlib.suppress(Exception):
+        # Tolerate "children not mounted yet" only; a real pill/repaint failure
+        # should surface rather than be silently swallowed.
+        with contextlib.suppress(NoMatches):
             self.query_one(".model-bar-pill", Static).update(
                 pill(_SCOPE_TO_LABEL[self.scope], bg, fg)
             )

--- a/src/lilbee/cli/tui/widgets/model_card.py
+++ b/src/lilbee/cli/tui/widgets/model_card.py
@@ -25,6 +25,7 @@ from textual.reactive import reactive
 from lilbee.catalog.types import ModelCompat
 from lilbee.cli.tui.pill import pill
 from lilbee.cli.tui.screens.catalog_utils import (
+    NATIVE_BACKEND,
     CatalogRow,
     CatalogRowKind,
     FrontierCatalogRow,
@@ -103,7 +104,8 @@ def _render_local(row: LocalCatalogRow, *, selected: bool) -> Content:
     if row.featured:
         primary_pills.append(pill("pick", "$warning", "$text"))
     primary_pills.append(pill(row.task, bg, "$text"))
-    if row.backend:
+    # Drop the implied 'native' backend pill (parity with ModelGrid / ModelList).
+    if row.backend and row.backend != NATIVE_BACKEND:
         primary_pills.append(pill(row.backend, "$accent", "$text"))
     primary_line = Content(" ").join(primary_pills)
 

--- a/src/lilbee/cli/tui/widgets/model_card.py
+++ b/src/lilbee/cli/tui/widgets/model_card.py
@@ -29,27 +29,20 @@ from lilbee.cli.tui.screens.catalog_utils import (
     CatalogRow,
     CatalogRowKind,
     FrontierCatalogRow,
-    KeyStatus,
     LocalCatalogRow,
 )
-from lilbee.cli.tui.widgets.catalog_theme import MIDDLE_DOT, TASK_COLORS
+from lilbee.cli.tui.widgets.catalog_card_shared import (
+    _build_local_status,
+    _build_specs,
+    _key_status_pill,
+    _truncate_name,
+)
+from lilbee.cli.tui.widgets.catalog_theme import TASK_COLORS
 
 if TYPE_CHECKING:
     pass
 
 _CSS_FILE = Path(__file__).parent / "model_card.tcss"
-
-_NAME_MAX_CHARS = 28
-"""Maximum displayed model-name length; longer names are ellipsis-truncated."""
-
-_ELLIPSIS = "…"
-
-
-def _truncate_name(name: str) -> str:
-    """Return *name* shortened to ``_NAME_MAX_CHARS`` with an ellipsis tail."""
-    if len(name) <= _NAME_MAX_CHARS:
-        return name
-    return name[: _NAME_MAX_CHARS - 1].rstrip() + _ELLIPSIS
 
 
 class ModelCard(containers.VerticalGroup):
@@ -147,24 +140,5 @@ def _compat_pill(compat: ModelCompat) -> Content | None:
     return pill(msg.COMPAT_PILL_UNKNOWN, "$panel", "$text-muted")
 
 
-def _key_status_pill(status: KeyStatus) -> Content:
-    if status == KeyStatus.READY:
-        return pill("ready", "$success", "$text")
-    return pill("needs key", "$warning", "$text")
-
-
-def _build_specs(params: str, quant: str, size: str) -> Content:
-    """Build the specs line: params · quant · size."""
-    parts = [p for p in (params, quant, size) if p and p != "--"]
-    if not parts:
-        return Content("--")
-    return Content(f" {MIDDLE_DOT} ".join(parts))
-
-
-def _build_local_status(row: LocalCatalogRow) -> Content | None:
-    """Build the status pill for installed or download count."""
-    if row.installed:
-        return pill("installed", "$success", "$text")
-    if row.sort_downloads > 0:
-        return Content.styled(f"↓ {row.downloads}", "$text-muted")
-    return None
+# _key_status_pill / _build_specs / _build_local_status live in
+# catalog_card_shared and are re-imported above.

--- a/src/lilbee/cli/tui/widgets/model_grid.py
+++ b/src/lilbee/cli/tui/widgets/model_grid.py
@@ -29,6 +29,7 @@ from lilbee.cli.tui.screens.catalog_utils import (
     FrontierCatalogRow,
     KeyStatus,
     LocalCatalogRow,
+    SizeVariant,
 )
 from lilbee.cli.tui.widgets.catalog_theme import MIDDLE_DOT, TASK_COLORS
 from lilbee.runtime.hardware import FitChip, FitLevel
@@ -460,7 +461,7 @@ def _local_lines(row: LocalCatalogRow, *, selected: bool) -> list[Content]:
     return lines
 
 
-def _build_size_variant_strip(variants: list) -> Content:
+def _build_size_variant_strip(variants: list[SizeVariant]) -> Content:
     """Inline chip strip showing every quant for a family-aggregated card.
 
     Renders compact 'Q4 · Q5 · F16' style chips so the eye reads the

--- a/src/lilbee/cli/tui/widgets/model_grid.py
+++ b/src/lilbee/cli/tui/widgets/model_grid.py
@@ -28,9 +28,16 @@ from lilbee.cli.tui.screens.catalog_utils import (
     CatalogRow,
     CatalogRowKind,
     FrontierCatalogRow,
-    KeyStatus,
     LocalCatalogRow,
     SizeVariant,
+)
+from lilbee.cli.tui.widgets.catalog_card_shared import (
+    _FIT_LEVEL_BACKGROUND,
+    _build_local_status,
+    _build_specs,
+    _key_status_pill,
+    _render_fit_pill,
+    _truncate_name,
 )
 from lilbee.cli.tui.widgets.catalog_theme import MIDDLE_DOT, TASK_COLORS
 from lilbee.runtime.hardware import FitChip, FitLevel
@@ -344,18 +351,6 @@ class ModelGrid(Widget, can_focus=True):
         return Strip(joined.render_segments(Style.null())).simplify()
 
 
-_NAME_MAX_CHARS = 28
-"""Cap displayed model names so long refs don't blow up the grid layout."""
-
-_ELLIPSIS = "…"
-
-
-def _truncate_name(name: str) -> str:
-    if len(name) <= _NAME_MAX_CHARS:
-        return name
-    return name[: _NAME_MAX_CHARS - 1].rstrip() + _ELLIPSIS
-
-
 def _render_card_strip(
     row: CatalogRow, *, selected: bool, width: int, border_style: str
 ) -> _CardLines:
@@ -485,38 +480,14 @@ def _frontier_lines(row: FrontierCatalogRow) -> list[Content]:
     return [name, pill_line, Content(""), info, Content(""), Content("")]
 
 
-_FIT_LEVEL_BACKGROUND: dict[FitLevel, str] = {
-    FitLevel.FITS: "$success",
-    FitLevel.TIGHT: "$warning",
-    FitLevel.WONT_RUN: "$error",
-}
-
-
 _FIT_LEVEL_LABEL_COMPACT: dict[FitLevel, str] = {
     FitLevel.FITS: "fits",
     FitLevel.TIGHT: "tight",
     FitLevel.WONT_RUN: "won't run",
 }
 
-
-def _fit_pill(fit: FitChip) -> Content:
-    """Verbose fit chip with headroom GB, used by the detail drawer.
-
-    Headroom is signed; negative values mean the model overflows the host's
-    available memory by that much. The chip's background tracks the level so
-    colour-blind users still get the qualitative signal from the label itself.
-    Cards render the compact form (``fits`` / ``tight`` / ``won't run``)
-    via :func:`_fit_pill_compact` so the pill row fits the card width; the
-    headroom GB belongs in the wider drawer where it has room to breathe.
-    """
-    headroom_gb = fit.headroom_gb
-    if fit.level is FitLevel.FITS:
-        text = f"fits +{headroom_gb:.1f} GB"
-    elif fit.level is FitLevel.TIGHT:
-        text = f"tight +{max(0.0, headroom_gb):.1f} GB"
-    else:
-        text = f"won't {headroom_gb:.1f} GB"
-    return pill(text, _FIT_LEVEL_BACKGROUND[fit.level], "$text")
+# The verbose drawer fit pill is the shared renderer.
+_fit_pill = _render_fit_pill
 
 
 def _fit_pill_compact(fit: FitChip) -> Content:
@@ -524,22 +495,5 @@ def _fit_pill_compact(fit: FitChip) -> Content:
     return pill(_FIT_LEVEL_LABEL_COMPACT[fit.level], _FIT_LEVEL_BACKGROUND[fit.level], "$text")
 
 
-def _key_status_pill(status: KeyStatus) -> Content:
-    if status == KeyStatus.READY:
-        return pill("ready", "$success", "$text")
-    return pill("needs key", "$warning", "$text")
-
-
-def _build_specs(params: str, quant: str, size: str) -> Content:
-    parts = [p for p in (params, quant, size) if p and p != "--"]
-    if not parts:
-        return Content("--")
-    return Content(f" {MIDDLE_DOT} ".join(parts))
-
-
-def _build_local_status(row: LocalCatalogRow) -> Content | None:
-    if row.installed:
-        return pill("installed", "$success", "$text")
-    if row.sort_downloads > 0:
-        return Content.styled(f"↓ {row.downloads}", "$text-muted")
-    return None
+# _key_status_pill / _build_specs / _build_local_status live in
+# catalog_card_shared and are re-imported above.

--- a/src/lilbee/cli/tui/widgets/model_grid.py
+++ b/src/lilbee/cli/tui/widgets/model_grid.py
@@ -24,6 +24,7 @@ from textual.widget import Widget
 
 from lilbee.cli.tui.pill import pill
 from lilbee.cli.tui.screens.catalog_utils import (
+    NATIVE_BACKEND,
     CatalogRow,
     CatalogRowKind,
     FrontierCatalogRow,
@@ -428,7 +429,7 @@ def _local_lines(row: LocalCatalogRow, *, selected: bool) -> list[Content]:
     # Drop the 'native' backend pill on cards to free horizontal space; the
     # backend is implied for local models. Remote backends (ollama, etc.)
     # still surface their pill since that's a meaningful distinction.
-    if row.backend and row.backend != "native":
+    if row.backend and row.backend != NATIVE_BACKEND:
         primary_pills.append(pill(row.backend, "$accent", "$text"))
     primary_line = Content(" ").join(primary_pills)
 

--- a/src/lilbee/cli/tui/widgets/model_grid.py
+++ b/src/lilbee/cli/tui/widgets/model_grid.py
@@ -149,7 +149,9 @@ class ModelGrid(Widget, can_focus=True):
         self._last_click_at: float = 0.0
         # render_line is called once per terminal row, so each card is asked for
         # _CARD_HEIGHT times per repaint; cache the built lines so a card renders
-        # once. Cleared whenever the dataset, highlight, or width changes.
+        # once. Flushed on set_rows and highlight changes, and on a resize that
+        # shifts the column count; col_width is part of the key, so a width change
+        # at the same column count is served fresh without an explicit flush.
         self._card_cache: dict[tuple[int, int, bool, str], _CardLines] = {}
 
     @property

--- a/src/lilbee/cli/tui/widgets/model_grid.py
+++ b/src/lilbee/cli/tui/widgets/model_grid.py
@@ -147,6 +147,10 @@ class ModelGrid(Widget, can_focus=True):
         self._cards_per_row: int = _DEFAULT_COLUMNS
         self._last_click_index: int | None = None
         self._last_click_at: float = 0.0
+        # render_line is called once per terminal row, so each card is asked for
+        # _CARD_HEIGHT times per repaint; cache the built lines so a card renders
+        # once. Cleared whenever the dataset, highlight, or width changes.
+        self._card_cache: dict[tuple[int, int, bool, str], _CardLines] = {}
 
     @property
     def rows(self) -> list[CatalogRow]:
@@ -161,6 +165,7 @@ class ModelGrid(Widget, can_focus=True):
     def set_rows(self, rows: list[CatalogRow]) -> None:
         """Replace the dataset and reset the highlight."""
         self._rows = list(rows)
+        self._card_cache.clear()
         self.highlighted = None
         self.refresh(layout=True)
 
@@ -168,6 +173,7 @@ class ModelGrid(Widget, can_focus=True):
         new_cols = self._columns_for_width(self.size.width)
         if new_cols != self._cards_per_row:
             self._cards_per_row = new_cols
+            self._card_cache.clear()
             self.refresh(layout=True)
 
     @staticmethod
@@ -200,6 +206,9 @@ class ModelGrid(Widget, can_focus=True):
         and ask the parent to scroll. The Highlighted message lets the
         catalog screen run keyboard-driven prefetch on every cursor move.
         """
+        # The two cards whose selected state flipped must re-render; clearing
+        # also bounds the cache to one repaint's worth of cards.
+        self._card_cache.clear()
         self.refresh()
         if new is None or self._cards_per_row <= 0 or self.size.width <= 0:
             return
@@ -325,6 +334,19 @@ class ModelGrid(Widget, can_focus=True):
         self.highlighted = index
         self.focus()
 
+    def _card_lines(
+        self, index: int, col_width: int, selected: bool, border_style: str
+    ) -> _CardLines:
+        """Build (and cache for this repaint) the card lines for one cell."""
+        key = (index, col_width, selected, border_style)
+        cached = self._card_cache.get(key)
+        if cached is None:
+            cached = _render_card_strip(
+                self._rows[index], selected=selected, width=col_width, border_style=border_style
+            )
+            self._card_cache[key] = cached
+        return cached
+
     def render_line(self, y: int) -> Strip:
         """Compose one terminal line by stitching the per-column card slices."""
         if y < 0:
@@ -341,11 +363,8 @@ class ModelGrid(Widget, can_focus=True):
                 # Empty slot in a partial last row -> match screen surface.
                 segments.append(Content.styled(" " * col_width, _GAP_STYLE))
                 continue
-            row = self._rows[index]
             selected = index == self.highlighted
-            card = _render_card_strip(
-                row, selected=selected, width=col_width, border_style=border_style
-            )
+            card = self._card_lines(index, col_width, selected, border_style)
             segments.append(card.lines[line_within])
         joined = Content("").join(segments)
         return Strip(joined.render_segments(Style.null())).simplify()

--- a/src/lilbee/cli/tui/widgets/model_list.py
+++ b/src/lilbee/cli/tui/widgets/model_list.py
@@ -20,6 +20,7 @@ from textual.widgets.option_list import Option
 
 from lilbee.catalog.types import ModelCompat
 from lilbee.cli.tui.screens.catalog_utils import (
+    NATIVE_BACKEND,
     CatalogRow,
     CatalogRowKind,
     FrontierCatalogRow,
@@ -199,7 +200,7 @@ def _render_local_meta(row: LocalCatalogRow) -> list[Content]:
 
 def _local_meta_strip(row: LocalCatalogRow) -> list[str]:
     rest: list[str] = []
-    if row.backend and row.backend != "native":
+    if row.backend and row.backend != NATIVE_BACKEND:
         rest.append(row.backend)
     specs = _format_specs(row)
     if specs:

--- a/src/lilbee/cli/tui/widgets/model_pick.py
+++ b/src/lilbee/cli/tui/widgets/model_pick.py
@@ -10,7 +10,7 @@ from lilbee.app.services import get_services
 from lilbee.app.settings_map import SETTINGS_MAP
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import apply_active_model
-from lilbee.providers.roles import WorkerRole
+from lilbee.providers.roles import MODEL_FIELD_TO_ROLE
 
 if TYPE_CHECKING:
     from textual.app import App
@@ -19,16 +19,6 @@ if TYPE_CHECKING:
     from lilbee.cli.tui.screens.model_picker import PickerScope
 
 log = logging.getLogger(__name__)
-
-# Single source of truth for "after a model-key write, which worker pool role
-# needs to respawn so the next call picks up the new ref?". Used by both the
-# Settings picker dismiss path and the chat-screen model rail's button.
-_MODEL_KEY_TO_WORKER_ROLE: dict[str, WorkerRole] = {
-    "chat_model": WorkerRole.CHAT,
-    "embedding_model": WorkerRole.EMBED,
-    "reranker_model": WorkerRole.RERANK,
-    "vision_model": WorkerRole.VISION,
-}
 
 
 def config_key_for_scope(scope: PickerScope) -> str:
@@ -128,7 +118,7 @@ def _persist(
     app: App, key: str, ref: str, on_done: Callable[[], None], reload_worker: bool
 ) -> None:
     apply_active_model(app, key, ref)
-    role = _MODEL_KEY_TO_WORKER_ROLE.get(key)
+    role = MODEL_FIELD_TO_ROLE.get(key)
     if reload_worker and role is not None:
         get_services().reload_role(role)
     on_done()

--- a/src/lilbee/cli/tui/widgets/status_bar.py
+++ b/src/lilbee/cli/tui/widgets/status_bar.py
@@ -90,7 +90,7 @@ class ViewTabs(Widget):
         # Compose every nav view including Wiki; visibility is toggled at
         # runtime via _apply_wiki_visibility so the user can flip the wiki
         # setting without restarting.
-        all_views = [*msg._BASE_NAV_VIEWS, "Wiki"]
+        all_views = list(msg.ALL_NAV_VIEWS)
         with Horizontal(id="view-tabs-row"):
             for i, name in enumerate(all_views):
                 if i > 0:

--- a/src/lilbee/cli/tui/widgets/suggester.py
+++ b/src/lilbee/cli/tui/widgets/suggester.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import logging
+
 from textual.suggester import Suggester
 
 from lilbee.app.services import get_services
+from lilbee.app.settings import _is_settable
 from lilbee.app.settings_map import SETTINGS_MAP
 from lilbee.app.themes import DARK_THEMES
 from lilbee.cli.tui.command_registry import completion_names
+
+log = logging.getLogger(__name__)
 
 _SLASH_COMMANDS = completion_names()
 
@@ -62,16 +67,20 @@ class SlashSuggester(Suggester):
 
             return list_installed_models()
         except Exception:
+            log.debug("Failed to list models for suggester", exc_info=True)
             return []
 
     def _get_setting_names(self) -> list[str]:
-        return list(SETTINGS_MAP.keys())
+        # Only settable keys, in map order: a non-writable entry (e.g. wiki_dir)
+        # would be offered then refused by /set.
+        return [k for k in SETTINGS_MAP if _is_settable(k)]
 
     def _get_document_names(self) -> list[str]:
         try:
             sources = get_services().store.get_sources()
             return [s.get("filename", s.get("source", "")) for s in sources]
         except Exception:
+            log.debug("Failed to list documents for suggester", exc_info=True)
             return []
 
     def _get_theme_names(self) -> list[str]:

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -57,6 +57,8 @@ class TaskBar(Static):
         # flash holds the coloured dot + summary past queue drain.
         self._flash_until_tick: int | None = None
         self._flash_outcome: TaskStatus | None = None
+        # Failures among the just-finished batch (not all of persistent history).
+        self._flash_failed_count: int = 0
         # Task ids we've already flashed on. Task Center rows linger in
         # history after DONE/FAILED/CANCELLED so the user can review
         # recent work; without this gate the bar would re-flash the same
@@ -183,16 +185,24 @@ class TaskBar(Static):
             # Center until cleared), so we must gate by task_id instead
             # of "history is non-empty".
             if not active and not queued and history:
-                last = history[-1]
-                if last.task_id not in self._flashed_ids and last.status in (
-                    TaskStatus.DONE,
-                    TaskStatus.FAILED,
-                ):
-                    self._flashed_ids.add(last.task_id)
+                new_done = [
+                    t
+                    for t in history
+                    if t.task_id not in self._flashed_ids
+                    and t.status in (TaskStatus.DONE, TaskStatus.FAILED)
+                ]
+                if new_done:
+                    for t in new_done:
+                        self._flashed_ids.add(t.task_id)
                     self._flash_until_tick = self._tick_count + int(
                         _DONE_FLASH_SECONDS / _POLL_INTERVAL_ACTIVE_S
                     )
-                    self._flash_outcome = last.status
+                    self._flash_failed_count = sum(
+                        1 for t in new_done if t.status == TaskStatus.FAILED
+                    )
+                    self._flash_outcome = (
+                        TaskStatus.FAILED if self._flash_failed_count else TaskStatus.DONE
+                    )
 
         idle = not active and not queued and not in_flash and self._flash_outcome is None
         pending = self._controller.pending_sync_count if idle else 0
@@ -292,7 +302,7 @@ class TaskBar(Static):
         if self._flash_outcome == TaskStatus.DONE:
             return "$success", msg.TASKBAR_ALL_DONE
         if self._flash_outcome == TaskStatus.FAILED:
-            count = sum(1 for t in self.queue.history if t.status == TaskStatus.FAILED)
+            count = self._flash_failed_count
             key = msg.TASKBAR_FAILED if count == 1 else msg.TASKBAR_FAILED_PLURAL
             return "$error", key.format(count=count)
 

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -1088,3 +1088,18 @@ async def test_populate_library_renders_with_empty_frontier_when_attr_missing() 
 
         ml = screen.query_one("#list-library", ModelList)
         assert ml.option_count > 0
+
+
+class TestModelFieldForTask:
+    def test_each_task_maps_to_its_role_field(self):
+        from lilbee.cli.tui.screens.catalog import _model_field_for_task
+
+        assert _model_field_for_task(ModelTask.CHAT) == "chat_model"
+        assert _model_field_for_task(ModelTask.EMBEDDING) == "embedding_model"
+        assert _model_field_for_task(ModelTask.VISION) == "vision_model"
+        assert _model_field_for_task(ModelTask.RERANK) == "reranker_model"
+
+    def test_accepts_str_task_from_frontier_rows(self):
+        from lilbee.cli.tui.screens.catalog import _model_field_for_task
+
+        assert _model_field_for_task("vision") == "vision_model"

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -122,6 +122,20 @@ async def test_on_key_non_digit_is_passthrough() -> None:
         screen.on_key(event)
 
 
+async def test_on_key_out_of_range_digit_is_passthrough() -> None:
+    """A digit past the tab count is ignored, not clamped, and does not switch tabs."""
+    async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = pilot.app.query_one(CatalogScreen)
+        screen._activation_settled = True
+        tabs = screen.query_one("#catalog-tabs", TabbedContent)
+        before = tabs.active
+        event = Key(key="9", character="9")
+        screen.on_key(event)
+        await pilot.pause()
+        assert tabs.active == before
+
+
 async def test_on_key_digit_swallowed_when_input_focused() -> None:
     async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
         await pilot.pause()

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -1068,28 +1068,6 @@ async def test_activate_initial_tab_switches_to_chat() -> None:
         assert tabs.active == "chat"
 
 
-async def test_populate_library_renders_with_empty_frontier_when_attr_missing() -> None:
-    """_populate_library_list still renders installed rows when frontier source is gone."""
-    async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = pilot.app.query_one(CatalogScreen)
-        installed = _row("Llama 3 8B", installed=True)
-        screen._all_family_rows = lambda: [installed]  # type: ignore[method-assign]
-        screen._all_hf_rows = lambda: []  # type: ignore[method-assign]
-        screen._all_remote_rows = lambda: []  # type: ignore[method-assign]
-
-        def boom(_search: str) -> list[FrontierCatalogRow]:
-            raise AttributeError("frontier_rows missing")
-
-        screen._build_frontier_rows = boom  # type: ignore[method-assign]
-        screen._populate_library_list()
-        await pilot.pause()
-        from lilbee.cli.tui.widgets.model_list import ModelList
-
-        ml = screen.query_one("#list-library", ModelList)
-        assert ml.option_count > 0
-
-
 class TestModelFieldForTask:
     def test_each_task_maps_to_its_role_field(self):
         from lilbee.cli.tui.screens.catalog import _model_field_for_task

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -1103,3 +1103,12 @@ class TestModelFieldForTask:
         from lilbee.cli.tui.screens.catalog import _model_field_for_task
 
         assert _model_field_for_task("vision") == "vision_model"
+
+
+class TestEstimateMinRamGb:
+    def test_applies_floor_and_factor_rounded(self):
+        from lilbee.catalog.models import estimate_min_ram_gb
+
+        assert estimate_min_ram_gb(0.1) == 2.0  # floor
+        assert estimate_min_ram_gb(4.0) == 6.0  # 4 * 1.5
+        assert estimate_min_ram_gb(3.0) == 4.5  # rounded to 1 dp

--- a/tests/test_catalog_detail_drawer.py
+++ b/tests/test_catalog_detail_drawer.py
@@ -140,8 +140,8 @@ async def test_render_fit_pill_handles_wont_run_branch() -> None:
 
     chip = FitChip(level=FitLevel.WONT_RUN, headroom_gb=-2.0)
     rendered = _render_fit_pill(chip)
-    assert "won't" in rendered.plain
-    assert "-2.0 GB" in rendered.plain
+    # Grammatical, with a positive shortfall (not the bare "won't -2.0 GB").
+    assert "won't run, short by 2.0 GB" in rendered.plain
 
 
 async def test_render_sizes_block_marks_each_fit_level() -> None:

--- a/tests/test_catalog_fit_chip.py
+++ b/tests/test_catalog_fit_chip.py
@@ -36,5 +36,4 @@ def test_tight_pill_clamps_headroom_at_zero_for_display() -> None:
 def test_wont_run_pill_shows_negative_headroom() -> None:
     chip = FitChip(level=FitLevel.WONT_RUN, headroom_gb=-2.0)
     pill_content = _fit_pill(chip)
-    assert "won't" in pill_content.plain
-    assert "-2.0 GB" in pill_content.plain
+    assert "won't run, short by 2.0 GB" in pill_content.plain

--- a/tests/test_catalog_frontier.py
+++ b/tests/test_catalog_frontier.py
@@ -280,13 +280,6 @@ class TestFrontierTabBehavior:
             assert "2" in text  # 2 cloud models
             assert "providers" in text
 
-    async def test_populate_library_list_silently_returns_when_widget_missing(self) -> None:
-        from lilbee.cli.tui.screens.catalog import CatalogScreen
-
-        screen = CatalogScreen.__new__(CatalogScreen)
-        screen._frontier_rows = []
-        screen._populate_library_list()
-
     async def test_action_load_more_is_noop_on_frontier_tab(self) -> None:
         from textual.app import ComposeResult
         from textual.widgets import TabbedContent
@@ -310,14 +303,6 @@ class TestFrontierTabBehavior:
             with mock.patch.object(screen, "_load_more") as mock_load:
                 screen.action_load_more()
                 mock_load.assert_not_called()
-
-    async def test_populate_library_list_swallows_lookup_failure(self) -> None:
-        """_populate_library_list returns silently if catalog-tabs is gone."""
-        from lilbee.cli.tui.screens.catalog import CatalogScreen
-
-        screen = CatalogScreen.__new__(CatalogScreen)
-        screen._frontier_rows = [_frontier("x")]
-        screen._populate_library_list()
 
     async def test_populate_library_list_repopulates_when_tab_already_present(self) -> None:
         from textual.app import ComposeResult

--- a/tests/test_chat_wiki_controller_integration.py
+++ b/tests/test_chat_wiki_controller_integration.py
@@ -270,8 +270,13 @@ def test_do_crawl_reports_setup_progress() -> None:
 
     def _worker() -> None:
         try:
-            screen.notify = lambda *a, **kw: None  # type: ignore[assignment]
-            with patch("lilbee.crawler.crawl_and_save", side_effect=fake_crawl):
+            # The screen is unmounted (__new__ without __init__), so the trailing
+            # success notify cannot reach a live app; patch the dispatch so the
+            # test isolates _do_crawl's progress wiring.
+            with (
+                patch("lilbee.cli.tui.screens.chat.call_from_thread"),
+                patch("lilbee.crawler.crawl_and_save", side_effect=fake_crawl),
+            ):
                 screen._do_crawl("https://x", 0, 2, reporter)
         except Exception as e:  # pragma: no cover - re-raised
             exc.append(e)
@@ -313,8 +318,13 @@ def test_do_crawl_reports_page_progress() -> None:
 
     def _worker() -> None:
         try:
-            screen.notify = lambda *a, **kw: None  # type: ignore[assignment]
-            with patch("lilbee.crawler.crawl_and_save", side_effect=fake_crawl):
+            # The screen is unmounted (__new__ without __init__), so the trailing
+            # success notify cannot reach a live app; patch the dispatch so the
+            # test isolates _do_crawl's progress wiring.
+            with (
+                patch("lilbee.cli.tui.screens.chat.call_from_thread"),
+                patch("lilbee.crawler.crawl_and_save", side_effect=fake_crawl),
+            ):
                 screen._do_crawl("https://x", 0, 2, reporter)
         except Exception as e:  # pragma: no cover - re-raised
             exc.append(e)

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -1515,7 +1515,7 @@ class TestModelCardTruncate:
     """`_truncate_name` shortens names longer than the visible budget."""
 
     def test_long_name_is_truncated(self) -> None:
-        from lilbee.cli.tui.widgets.model_card import _NAME_MAX_CHARS, _truncate_name
+        from lilbee.cli.tui.widgets.catalog_card_shared import _NAME_MAX_CHARS, _truncate_name
 
         long_name = "x" * (_NAME_MAX_CHARS + 5)
         out = _truncate_name(long_name)
@@ -1526,7 +1526,7 @@ class TestModelGridTruncateAndPad:
     """The model_grid module has its own _truncate_name + render padding."""
 
     def test_grid_truncate_name_long(self) -> None:
-        from lilbee.cli.tui.widgets.model_grid import _NAME_MAX_CHARS, _truncate_name
+        from lilbee.cli.tui.widgets.catalog_card_shared import _NAME_MAX_CHARS, _truncate_name
 
         long_name = "x" * (_NAME_MAX_CHARS + 5)
         out = _truncate_name(long_name)

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -2356,6 +2356,14 @@ class TestAppSetActiveModelDownloadGuard:
         finally:
             cfg.chat_model = chat_default
 
+    async def test_reject_if_downloading_passes_non_string_value(self) -> None:
+        """A non-string setting value cannot be a model ref, so the guard lets it through."""
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        assert app._reject_if_downloading(True) is False
+        assert app._reject_if_downloading(7) is False
+
 
 class TestModelInfoExceptionBranches:
     """``_read_chat_arch`` / ``_read_embed_arch`` swallow read errors and return the info object."""

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -2293,6 +2293,33 @@ class TestAppSetActiveModelDownloadGuard:
         finally:
             cfg.chat_model = chat_default
 
+    async def test_set_setting_blocks_model_role_while_downloading(self) -> None:
+        """set_setting applies the same download guard for model-role keys."""
+        from lilbee.cli.tui.app import LilbeeApp
+        from lilbee.cli.tui.task_queue import TaskType
+        from lilbee.core.config import cfg
+
+        chat_default = cfg.chat_model
+        ref = "Qwen/Qwen2.5-0.5B-Instruct-GGUF"
+        notify_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        app = LilbeeApp()
+        try:
+            app.task_bar.queue.enqueue(lambda: None, "Qwen2.5 0.5B", TaskType.DOWNLOAD.value)
+            with (
+                mock.patch.object(
+                    app, "notify", side_effect=lambda *a, **kw: notify_calls.append((a, kw))
+                ),
+                mock.patch(
+                    "lilbee.app.settings.persistent_settings.update_values"
+                ) as mock_update_values,
+            ):
+                app.set_setting("chat_model", ref)
+            assert cfg.chat_model == chat_default
+            mock_update_values.assert_not_called()
+            assert len(notify_calls) == 1
+        finally:
+            cfg.chat_model = chat_default
+
     async def test_unrelated_download_does_not_block_assignment(self) -> None:
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.task_queue import TaskType

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -1552,6 +1552,26 @@ class TestModelGridTruncateAndPad:
             out = mg._render_card_strip(row, selected=False, width=20, border_style="dim")
         assert out.lines, "expected card lines"
 
+    def test_card_lines_builds_each_card_once_per_repaint(self) -> None:
+        """The per-cell cache means a card builds once, not _CARD_HEIGHT times."""
+        from lilbee.cli.tui.screens.catalog_utils import FrontierCatalogRow, KeyStatus
+        from lilbee.cli.tui.widgets import model_grid as mg
+
+        row = FrontierCatalogRow(
+            name="api",
+            ref="acme/api",
+            task="chat",
+            provider="Acme",
+            provider_id="acme",
+            key_status=KeyStatus.READY,
+        )
+        grid = mg.ModelGrid(rows=[row])
+        with mock.patch.object(mg, "_render_card_strip", wraps=mg._render_card_strip) as spy:
+            first = grid._card_lines(0, 20, False, "dim")
+            again = grid._card_lines(0, 20, False, "dim")
+        assert first is again
+        assert spy.call_count == 1
+
     def test_cell_at_returns_none_in_gutter_row(self) -> None:
         from lilbee.cli.tui.screens.catalog_utils import LocalCatalogRow
         from lilbee.cli.tui.widgets import model_grid as mg

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -1455,14 +1455,16 @@ class TestWikiEmptyStateSpacyBranches:
         ):
             assert _spacy_available() is False
 
-    def test_spacy_available_returns_true_on_other_exception(self) -> None:
+    def test_spacy_available_returns_false_on_unexpected_exception(self) -> None:
+        """An unexpected spaCy error must not fail open to 'available' (which
+        would hide the install guidance)."""
         from lilbee.cli.tui.messages import _spacy_available
 
         with mock.patch(
             "lilbee.retrieval.concepts.nlp.load_spacy_pipeline",
             side_effect=RuntimeError,
         ):
-            assert _spacy_available() is True
+            assert _spacy_available() is False
 
     def test_spacy_available_returns_true_on_success(self) -> None:
         from lilbee.cli.tui.messages import _spacy_available

--- a/tests/test_model_card_compat_pill.py
+++ b/tests/test_model_card_compat_pill.py
@@ -87,3 +87,16 @@ def test_grid_card_lines_omit_compat_pill_for_supported() -> None:
     joined = "\n".join(line.plain for line in lines)
     assert COMPAT_PILL_UNSUPPORTED not in joined
     assert COMPAT_PILL_UNKNOWN not in joined
+
+
+def test_native_backend_pill_is_dropped() -> None:
+    """The implied 'native' backend pill is not rendered (parity with grid/list)."""
+    out = _render_local(_row(ModelCompat.SUPPORTED), selected=False)
+    assert "native" not in out.plain
+
+
+def test_non_native_backend_pill_is_shown() -> None:
+    row = _row(ModelCompat.SUPPORTED)
+    row.backend = "Ollama"
+    out = _render_local(row, selected=False)
+    assert "Ollama" in out.plain

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -308,3 +308,12 @@ class TestOverlayPersistedSettings:
             assert cfg.chat_model == original
         finally:
             cfg.chat_model = original
+
+
+class TestListSettingRegexMarker:
+    def test_only_regex_list_validates_as_regex(self):
+        from lilbee.app.settings_map import SETTINGS_MAP
+
+        assert SETTINGS_MAP["crawl_exclude_patterns"].validate_regex is True
+        # Chromium flag list must not be regex-validated.
+        assert SETTINGS_MAP["crawl_browser_extra_args"].validate_regex is False

--- a/tests/test_taskbar_pulsing_dot.py
+++ b/tests/test_taskbar_pulsing_dot.py
@@ -248,6 +248,27 @@ async def test_taskbar_failure_flash_shows_count() -> None:
         assert "failed" in text.lower()
 
 
+async def test_taskbar_failure_flash_counts_only_new_batch() -> None:
+    """A later failure flashes count=1, not the cumulative persistent-history total."""
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        bar = app.query_one(TaskBar)
+        t1 = app.task_bar.queue.enqueue(lambda: None, "a", TaskType.SYNC.value)
+        app.task_bar.queue.advance(TaskType.SYNC.value)
+        app.task_bar.queue.fail_task(t1, "err1")
+        bar._refresh_display()
+        assert bar._flash_failed_count == 1
+        # End the flash, then fail a second task; history now holds two failures.
+        bar._flash_until_tick = None
+        bar._flash_outcome = None
+        t2 = app.task_bar.queue.enqueue(lambda: None, "b", TaskType.SYNC.value)
+        app.task_bar.queue.advance(TaskType.SYNC.value)
+        app.task_bar.queue.fail_task(t2, "err2")
+        bar._refresh_display()
+        assert bar._flash_failed_count == 1  # only the new failure, not 2
+
+
 @pytest.mark.asyncio
 async def test_taskbar_starts_in_idle_mode_when_queue_empty() -> None:
     """First mount with no work keeps the timer at the idle cadence."""

--- a/tests/test_thread_safe.py
+++ b/tests/test_thread_safe.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from lilbee.cli.tui.thread_safe import call_from_thread
 
 
@@ -21,3 +23,18 @@ def test_call_from_thread_swallows_shutdown_error():
     node.app.call_from_thread.side_effect = OSError("[Errno 9] Bad file descriptor")
     fn = MagicMock()
     call_from_thread(node, fn, "arg")  # should not raise
+
+
+def test_call_from_thread_swallows_app_not_running():
+    """RuntimeError (incl. NoActiveAppError) during shutdown is dropped, not raised."""
+    node = MagicMock()
+    node.app.call_from_thread.side_effect = RuntimeError("App is not running")
+    call_from_thread(node, MagicMock(), "arg")  # should not raise
+
+
+def test_call_from_thread_propagates_genuine_callback_error():
+    """A real bug in the callback (e.g. KeyError) must surface, not be swallowed."""
+    node = MagicMock()
+    node.app.call_from_thread.side_effect = KeyError("missing")
+    with pytest.raises(KeyError):
+        call_from_thread(node, MagicMock(), "arg")

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -3430,6 +3430,8 @@ class TestStreamFlushCoalescing:
 
         from lilbee.cli.tui.screens.chat import ChatScreen
 
+        from lilbee.cli.tui.screens.chat import _StreamTimings
+
         screen = MagicMock(spec=ChatScreen)
         flush_calls: list[None] = []
 
@@ -3437,11 +3439,11 @@ class TestStreamFlushCoalescing:
             flush_calls.append(None)
 
         # Past timings: long enough ago that both the flush and the scroll fire.
-        timings = [0.0, 0.0]
+        timings = _StreamTimings(last_flush=0.0, last_scroll=0.0)
         with mock.patch("lilbee.cli.tui.screens.chat.call_from_thread"):
             ChatScreen._maybe_flush_and_scroll(screen, fake_flush, timings)
         assert len(flush_calls) == 1
-        assert timings[0] > 0  # last_flush bumped
+        assert timings.last_flush > 0  # last_flush bumped
 
     def test_maybe_flush_skips_flush_within_interval(self):
         """Inside the flush window, flush() is not called and timings stay unchanged."""
@@ -3449,6 +3451,8 @@ class TestStreamFlushCoalescing:
         from unittest.mock import MagicMock
 
         from lilbee.cli.tui.screens.chat import ChatScreen
+
+        from lilbee.cli.tui.screens.chat import _StreamTimings
 
         screen = MagicMock(spec=ChatScreen)
         flush_calls: list[None] = []
@@ -3458,8 +3462,8 @@ class TestStreamFlushCoalescing:
 
         # Set timings to 'right now' so the interval check fails.
         now = time.monotonic()
-        timings = [now, now]
+        timings = _StreamTimings(last_flush=now, last_scroll=now)
         with mock.patch("lilbee.cli.tui.screens.chat.call_from_thread"):
             ChatScreen._maybe_flush_and_scroll(screen, fake_flush, timings)
         assert flush_calls == []
-        assert timings == [now, now]
+        assert timings.last_flush == now and timings.last_scroll == now

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -3428,9 +3428,7 @@ class TestStreamFlushCoalescing:
         """When the elapsed time crosses the threshold, flush() runs and timing advances."""
         from unittest.mock import MagicMock
 
-        from lilbee.cli.tui.screens.chat import ChatScreen
-
-        from lilbee.cli.tui.screens.chat import _StreamTimings
+        from lilbee.cli.tui.screens.chat import ChatScreen, _StreamTimings
 
         screen = MagicMock(spec=ChatScreen)
         flush_calls: list[None] = []
@@ -3450,9 +3448,7 @@ class TestStreamFlushCoalescing:
         import time
         from unittest.mock import MagicMock
 
-        from lilbee.cli.tui.screens.chat import ChatScreen
-
-        from lilbee.cli.tui.screens.chat import _StreamTimings
+        from lilbee.cli.tui.screens.chat import ChatScreen, _StreamTimings
 
         screen = MagicMock(spec=ChatScreen)
         flush_calls: list[None] = []

--- a/tests/test_tui_model_bar.py
+++ b/tests/test_tui_model_bar.py
@@ -7,11 +7,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from lilbee.cli.tui.widgets.model_pick import (
-    _MODEL_KEY_TO_WORKER_ROLE,
     apply_model_pick,
     config_key_for_scope,
 )
-from lilbee.providers.roles import WorkerRole
+from lilbee.providers.roles import MODEL_FIELD_TO_ROLE, WorkerRole
 from tests._lilbee_app_test_host import LilbeeAppHost
 
 
@@ -46,7 +45,8 @@ async def test_apply_model_pick_browse_unknown_key_is_noop() -> None:
     ],
 )
 def test_model_key_to_worker_role_covers_all_four(key: str, expected: WorkerRole) -> None:
-    assert _MODEL_KEY_TO_WORKER_ROLE[key] is expected
+    # model_pick reuses the canonical roles map rather than a private copy.
+    assert MODEL_FIELD_TO_ROLE[key] is expected
 
 
 async def test_apply_model_pick_persists_and_reloads_vision() -> None:

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8237,9 +8237,33 @@ class TestWikiScreenSearch:
             assert isinstance(screen, WikiScreen)
             search = app.screen.query_one("#wiki-search", TextualInput)
             search.value = "Alpha"
-            await pilot.pause()
+            # Wait out the search debounce so the filter pass runs.
+            await pilot.pause(0.25)
             assert "summaries/alpha-doc" in screen._page_slugs
             assert "summaries/beta-doc" not in screen._page_slugs
+
+    async def test_search_debounce_collapses_rapid_keystrokes(self, tmp_path):
+        """Two rapid edits trigger a single filter pass, not one per keystroke."""
+        cfg.wiki = True
+        cfg.data_root = tmp_path
+        wiki_root = cfg.data_root / cfg.wiki_dir
+        _create_wiki_page(wiki_root, "summaries", "alpha-doc", "Alpha Document")
+
+        app = WikiTestApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            from textual.widgets import Input as TextualInput
+
+            from lilbee.cli.tui.screens.wiki import WikiScreen
+
+            screen = app.screen
+            assert isinstance(screen, WikiScreen)
+            search = app.screen.query_one("#wiki-search", TextualInput)
+            with patch.object(screen, "_load_pages") as mock_load:
+                search.value = "A"
+                await pilot.pause()
+                search.value = "Al"
+                await pilot.pause(0.25)
+            assert mock_load.call_count == 1
 
     async def test_escape_clears_search(self, tmp_path):
         """Escape clears search text when search has a value."""

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8201,7 +8201,15 @@ class TestWikiScreenSearch:
             assert "summaries/beta-doc" not in screen._page_slugs
 
     async def test_search_debounce_collapses_rapid_keystrokes(self, tmp_path):
-        """Two rapid edits trigger a single filter pass, not one per keystroke."""
+        """Two rapid edits schedule a single filter pass, not one per keystroke.
+
+        Driven through the handler with a fake ``set_timer`` so the assertion is on
+        the debounce bookkeeping, not on a real timer firing within a wall-clock
+        window (that timing race starved and flaked under parallel CI load).
+        """
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
         cfg.wiki = True
         cfg.data_root = tmp_path
         wiki_root = cfg.data_root / cfg.wiki_dir
@@ -8209,21 +8217,33 @@ class TestWikiScreenSearch:
 
         app = WikiTestApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            from textual.widgets import Input as TextualInput
-
             from lilbee.cli.tui.screens.wiki import WikiScreen
 
             screen = app.screen
             assert isinstance(screen, WikiScreen)
-            search = app.screen.query_one("#wiki-search", TextualInput)
-            # Both edits land before any pause so the first debounce timer cannot
-            # expire in the gap (that race made this flaky on slow CI runners);
-            # the second Changed resets the timer, so exactly one pass fires.
-            with patch.object(screen, "_load_pages") as mock_load:
-                search.value = "A"
-                search.value = "Al"
-                await pilot.pause(0.25)
-            assert mock_load.call_count == 1
+
+            scheduled: list[tuple[object, MagicMock]] = []
+
+            def _fake_set_timer(_delay, callback):
+                timer = MagicMock()
+                scheduled.append((callback, timer))
+                return timer
+
+            with (
+                patch.object(screen, "_load_pages") as mock_load,
+                patch.object(screen, "set_timer", side_effect=_fake_set_timer),
+            ):
+                screen._on_search_changed(SimpleNamespace(value="A"))
+                screen._on_search_changed(SimpleNamespace(value="Al"))
+                # The second edit cancels the first pending timer; both scheduled.
+                assert len(scheduled) == 2
+                _, first_timer = scheduled[0]
+                first_timer.stop.assert_called_once()
+                # Firing only the surviving (latest) debounce runs one filter pass.
+                latest_callback, _ = scheduled[-1]
+                latest_callback()
+                await pilot.pause()
+            mock_load.assert_called_once_with(filter_text="Al")
 
     async def test_escape_clears_search(self, tmp_path):
         """Escape clears search text when search has a value."""

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3897,8 +3897,13 @@ async def test_command_provider_delete_doc(mock_svc):
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
-        provider._delete_doc("notes.md")
+        with patch(
+            "lilbee.cli.tui.widgets.autocomplete.invalidate_document_cache"
+        ) as mock_invalidate:
+            provider._delete_doc("notes.md")
         mock_svc.store.remove_documents.assert_called_once_with(["notes.md"])
+        # Palette delete invalidates the doc cache like the chat /delete path.
+        mock_invalidate.assert_called_once()
 
 
 async def test_command_provider_action_sync():
@@ -12922,3 +12927,19 @@ async def test_catalog_mount_remaining_grid_sections_iterates_remaining():
             await _pilot.pause()
             after = len(list(screen._grid_container.query(".section-heading")))
             assert after > before, "expected an additional section heading"
+
+
+class TestWikiSafeCoerce:
+    def test_safe_float_handles_non_numeric(self):
+        from lilbee.cli.tui.screens.wiki import _safe_float
+
+        assert _safe_float("0.8") == 0.8
+        assert _safe_float(None) is None
+        assert _safe_float("high") is None  # non-numeric frontmatter must not crash
+
+    def test_safe_int_handles_non_numeric(self):
+        from lilbee.cli.tui.screens.wiki import _safe_int
+
+        assert _safe_int(3) == 3
+        assert _safe_int(None) == 0
+        assert _safe_int("lots", default=0) == 0

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -12418,6 +12418,12 @@ async def test_settings_model_picker_dismissed_reloads_worker_for_role():
                 "lilbee.cli.tui.widgets.model_pick.get_services",
                 return_value=services_mock,
             ),
+            # The single reload now runs in _after_model_pick (settings module);
+            # apply_model_pick is called with reload_worker=False to avoid a double.
+            patch(
+                "lilbee.cli.tui.screens.settings.get_services",
+                return_value=services_mock,
+            ),
         ):
             screen._on_model_picker_dismissed("vision_model", "fake/vision.gguf")
         services_mock.reload_role.assert_called_once_with(WorkerRole.VISION)

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2776,7 +2776,8 @@ async def test_chat_slash_delete_store_error(mock_svc):
             await app.screen.workers.wait_for_complete()
             await _pilot.pause()
             mock_notify.assert_called_once()
-            assert "No documents" in mock_notify.call_args[0][0]
+            # A read failure is distinct from the genuinely-empty case.
+            assert "Could not read" in mock_notify.call_args[0][0]
 
 
 async def test_chat_slash_delete_empty_sources(mock_svc):

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8176,54 +8176,6 @@ class TestWikiRootShortcuts:
             assert "Log" not in top_labels
 
 
-class TestWikiSelectedSource:
-    """_selected_source covers all three branches: no-cursor, group-node, leaf.
-
-    Patches ``query_one`` to swap in a faked Tree whose ``cursor_node``
-    is set explicitly per branch. Directly invoking the real widget
-    cursor is flaky because setting ``cursor_line = -1`` doesn't always
-    nullify ``cursor_node`` in the Textual version in use.
-    """
-
-    async def test_all_branches(self, tmp_path):
-        from unittest.mock import MagicMock
-
-        from textual.widgets import Tree
-
-        from lilbee.cli.tui.screens.wiki import WikiScreen
-
-        cfg.wiki = True
-        cfg.data_root = tmp_path
-        wiki_root = cfg.data_root / cfg.wiki_dir
-        _create_wiki_page(wiki_root, "summaries", "my-doc", "My Doc")
-
-        app = WikiTestApp()
-        async with app.run_test(size=(120, 40)) as _pilot:
-            screen = app.screen
-            assert isinstance(screen, WikiScreen)
-            real_tree = screen.query_one("#wiki-page-list", Tree)
-            fake_tree = MagicMock(spec=Tree)
-
-            # Branch 1: cursor_node is None → returns None (line 284).
-            fake_tree.cursor_node = None
-            with patch.object(screen, "query_one", return_value=fake_tree):
-                assert screen._selected_source() is None
-
-            # Branch 2: group node carries data=None, not a slug string.
-            group_node = real_tree.root.children[0]
-            fake_tree.cursor_node = group_node
-            with patch.object(screen, "query_one", return_value=fake_tree):
-                assert screen._selected_source() is None
-
-            # Branch 3: leaf with a real slug reaches line 288 and delegates
-            # to _source_for_slug. The return value may be None when the
-            # frontmatter omits a source; the point is line 288 is executed.
-            leaf_node = group_node.children[0]
-            fake_tree.cursor_node = leaf_node
-            with patch.object(screen, "query_one", return_value=fake_tree):
-                screen._selected_source()
-
-
 class TestWikiScreenSearch:
     async def test_search_filters_pages(self, tmp_path):
         """Search input filters the page list."""
@@ -11974,58 +11926,6 @@ async def test_chat_crawl_dialog_callback_none_noop():
             app.screen.dismiss(None)
             await _pilot.pause()
         mock_start.assert_not_called()
-
-
-async def test_wiki_source_for_slug_returns_source():
-    """_source_for_slug extracts source from page frontmatter."""
-    app = _make_wiki_app()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        mock_page = MagicMock()
-        mock_page.frontmatter = {"sources": ["doc.txt", "other.txt"]}
-        with patch("lilbee.cli.tui.screens.wiki.read_page", return_value=mock_page):
-            result = app.screen._source_for_slug("summaries/doc")
-        assert result == "doc.txt"
-
-
-async def test_wiki_source_for_slug_returns_none_for_missing():
-    """_source_for_slug returns None when page not found."""
-    app = _make_wiki_app()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        with patch("lilbee.cli.tui.screens.wiki.read_page", return_value=None):
-            result = app.screen._source_for_slug("summaries/missing")
-        assert result is None
-
-
-async def test_wiki_source_for_slug_returns_none_for_empty_sources():
-    """_source_for_slug returns None when sources list is empty."""
-    app = _make_wiki_app()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        mock_page = MagicMock()
-        mock_page.frontmatter = {"sources": []}
-        with patch("lilbee.cli.tui.screens.wiki.read_page", return_value=mock_page):
-            result = app.screen._source_for_slug("summaries/doc")
-        assert result is None
-
-
-async def test_wiki_selected_source_returns_none_for_branch_without_slug():
-    """_selected_source returns None when the highlighted tree node is a branch (no slug)."""
-    from textual.widgets import Tree
-
-    app = _make_wiki_app()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        tree = app.screen.query_one("#wiki-page-list", Tree)
-        tree.reset("Wiki")
-        tree.root.add("Branch")  # branch with no data=slug
-        tree.focus()
-        await pilot.pause()
-        await pilot.press("down")
-        await pilot.pause()
-        result = app.screen._selected_source()
-        assert result is None
 
 
 # =============================================================================

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -8216,9 +8216,11 @@ class TestWikiScreenSearch:
             screen = app.screen
             assert isinstance(screen, WikiScreen)
             search = app.screen.query_one("#wiki-search", TextualInput)
+            # Both edits land before any pause so the first debounce timer cannot
+            # expire in the gap (that race made this flaky on slow CI runners);
+            # the second Changed resets the timer, so exactly one pass fires.
             with patch.object(screen, "_load_pages") as mock_load:
                 search.value = "A"
-                await pilot.pause()
                 search.value = "Al"
                 await pilot.pause(0.25)
             assert mock_load.call_count == 1

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -3939,7 +3939,7 @@ async def test_command_provider_action_version():
 
 
 async def test_command_provider_action_reset_pushes_confirm():
-    """Palette 'Reset knowledge base' invokes ChatScreen._cmd_reset to push the ConfirmDialog."""
+    """Palette 'Reset knowledge base' invokes ChatScreen.request_reset (the public entry)."""
     from lilbee.cli.tui.app import LilbeeApp
     from lilbee.cli.tui.screens.chat import ChatScreen
 
@@ -3948,11 +3948,11 @@ async def test_command_provider_action_reset_pushes_confirm():
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         chat = next(s for s in app.screen_stack if isinstance(s, ChatScreen))
-        with patch.object(chat, "_cmd_reset") as mock_reset:
+        with patch.object(chat, "request_reset") as mock_reset:
             provider = LilbeeCommandProvider(app.screen, match_style=None)
             provider._action_reset()
             await pilot.pause()
-            mock_reset.assert_called_once_with("")
+            mock_reset.assert_called_once_with()
 
 
 async def test_command_provider_action_reset_no_chat_screen():

--- a/tests/test_tui_slash_discoverability.py
+++ b/tests/test_tui_slash_discoverability.py
@@ -1110,3 +1110,12 @@ class TestCompletionOpenAndAcceptAsync:
             # the next path segment.
             assert inp.value == "/add mydir/"
             assert not overlay.is_visible
+
+
+def test_setting_options_exclude_non_settable_keys():
+    """Autocomplete offers only settable keys (wiki_dir is read-only)."""
+    from lilbee.cli.tui.widgets.autocomplete import _setting_options
+
+    opts = _setting_options()
+    assert "wiki_dir" not in opts
+    assert "chat_model" in opts

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2221,6 +2221,26 @@ class TestSlashSuggester:
         s = SlashSuggester(use_cache=False)
         assert await s.get_suggestion("") is None
 
+    def test_setting_names_exclude_non_settable(self) -> None:
+        from lilbee.cli.tui.widgets.suggester import SlashSuggester
+
+        names = SlashSuggester(use_cache=False)._get_setting_names()
+        assert "wiki_dir" not in names  # read-only: would be refused by /set
+        assert "chat_model" in names
+
+    def test_model_and_document_lookups_log_and_return_empty_on_error(self) -> None:
+        from unittest.mock import patch
+
+        from lilbee.cli.tui.widgets.suggester import SlashSuggester
+
+        s = SlashSuggester(use_cache=False)
+        with patch(
+            "lilbee.modelhub.models.list_installed_models", side_effect=RuntimeError("boom")
+        ):
+            assert s._get_model_names() == []
+        with patch("lilbee.cli.tui.widgets.suggester.get_services", side_effect=RuntimeError):
+            assert s._get_document_names() == []
+
     async def test_slash_prefix_suggests_command(self) -> None:
         from lilbee.cli.tui.widgets.suggester import SlashSuggester
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -6578,3 +6578,10 @@ class TestCatalogFocusEdgeGuards:
         assert screen.load_more_called is True
         assert screen.focus_next_called is False
         assert scroll_end_calls, "last-grid LeaveDown must scroll to end to reveal hint"
+
+
+class TestAppTitleSingleSource:
+    def test_app_title_format(self):
+        from lilbee.cli.tui import messages as msg
+
+        assert msg.app_title("owner/Model-GGUF/m.gguf") == "lilbee: owner/Model-GGUF/m.gguf"


### PR DESCRIPTION
## Problem

Review of the TUI surface found a range of correctness, consistency, and DRY issues across the catalog, settings, chat, wiki, and shared widgets.

## Solution

Correctness: a selected remote/frontier model is assigned to its task's role (not always chat_model); the per-tab list cache key is updated after pagination; `/catalog` navigates once instead of stacking a second screen; a settings model-pick reloads the role server once; list-setting "Restore defaults" writes each key's own default and regex validation runs only for regex lists; frontmatter coercion can't crash the wiki node-select handler; the TaskBar failure flash counts only the just-finished batch; `set_setting` refuses a still-downloading model ref like `set_active_model`.

Consistency / single-source: the nav-view universe (`messages.ALL_NAV_VIEWS`), the app window title (`msg.app_title`), the `NATIVE_BACKEND` constant, `PROVIDER_API_KEY_FIELD`, `MODEL_FIELD_TO_ROLE`, `estimate_min_ram_gb`, and the digit→tab map are each defined once. Catalog card/grid/detail share their helpers (name truncation, spec/status pills, fit-level colors, fit pill) via a new `catalog_card_shared` module. The `/set` autocomplete offers only settable keys; the palette delete invalidates the doc cache; `ChatScreen.request_reset` is a public entry the palette uses instead of a private handler.

Robustness / perf: `call_from_thread` and several blanket `except` blocks are narrowed so real bugs surface; the spaCy availability check fails closed; the document-completion cache uses `lru_cache` instead of a module global; the wiki search input is debounced; and `ModelGrid` caches each card's rendered lines so a card builds once per repaint instead of once per line.

A small follow-up (moving WikiScreen's file reads off the UI thread) is tracked separately.
