### PR TITLE
Server/MCP review fixes: catalog parity, error mapping, decoder unification, behavioral parity, event-loop offloads

### DIFF
--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -43,6 +43,7 @@ class LLMOptions(BaseModel):
     num_predict: int | None = None
     repeat_penalty: float | None = None
     num_ctx: int | None = None
+    stop: list[str] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return only non-None values as a dict."""

--- a/src/lilbee/server/chat_completions_api/routes.py
+++ b/src/lilbee/server/chat_completions_api/routes.py
@@ -60,6 +60,14 @@ async def list_models_endpoint(request: Request) -> Response:
     if auth_error is not None:
         return auth_error
 
+    # list_installed walks the model filesystem and served_chat_ctx may probe the
+    # engine; run both off the event loop like the sibling chat-completions route.
+    payload = await asyncio.to_thread(_build_models_list_payload)
+    return Response(payload.model_dump(), media_type="application/json")
+
+
+def _build_models_list_payload() -> ModelsListResponse:
+    """Synchronous /v1/models body: blocking registry walk + engine ctx probe."""
     services = get_services()
     # The served window applies to the active chat model; advertise it so a
     # client trims history to fit instead of overflowing on a long session.
@@ -72,7 +80,7 @@ async def list_models_endpoint(request: Request) -> Response:
     # A ref without a registry entry carries the newest native timestamp so a
     # client sorting by created desc does not bury the model lilbee serves.
     fallback_created = max((_parse_created(m.downloaded_at) for m in installed.values()), default=0)
-    payload = ModelsListResponse(
+    return ModelsListResponse(
         data=[
             ModelEntry(
                 id=ref,
@@ -84,7 +92,6 @@ async def list_models_endpoint(request: Request) -> Response:
             for ref in refs
         ]
     )
-    return Response(payload.model_dump(), media_type="application/json")
 
 
 @post("/v1/chat/completions", status_code=200)
@@ -104,9 +111,10 @@ async def chat_completions_endpoint(
         # (e.g. image content). Surface as 400 instead of a generic 500.
         return _error_response(400, CompletionsErrorCode.INVALID_REQUEST, str(exc))
 
-    preflush_error = await _preflush_or_none(req)
-    if preflush_error is not None:
-        return preflush_error
+    preflight = await _preflight_resolved_model(req)
+    if isinstance(preflight, Response):
+        return preflight
+    resolved_model = preflight
 
     try:
         await acquire_chat_slot_or_busy(get_services().provider.max_concurrent_chats())
@@ -124,31 +132,35 @@ async def chat_completions_endpoint(
         # The after-send hook frees the slot when a disconnect lands before the
         # generator's first iteration (its finally never runs in that case).
         return Stream(
-            _gated_completions_stream(req, guard, include_usage=include_usage),
+            _gated_completions_stream(
+                req, guard, model=resolved_model, include_usage=include_usage
+            ),
             media_type="text/event-stream",
             background=BackgroundTask(guard.release),
         )
     return await _run_non_stream(req, guard)
 
 
-async def _preflush_or_none(req: CanonicalChatRequest) -> Response | None:
-    """Validate *req* before any streaming response starts.
+async def _preflight_resolved_model(req: CanonicalChatRequest) -> str | Response:
+    """Validate *req* before any streaming response starts, returning the resolved model.
 
     A 4xx body here is reachable by any OpenAI-compatible client; once a
     Stream is returned the headers are flushed at 200 and downstream errors
     can only travel via SSE frames which not every client surfaces cleanly.
     Runs the preflight in a thread: a lapsed model-discovery TTL makes it do
-    blocking HTTP probes that must not stall the event loop.
-    Returns ``None`` when *req* is fit to dispatch.
+    blocking HTTP probes that must not stall the event loop. Returns the
+    canonical resolved model string when *req* is fit to dispatch, so the
+    streaming response echoes the same model the non-streaming path does.
     """
     try:
-        await asyncio.to_thread(preflight_chat_request, req)
-    except Exception as exc:  # typed dispatch errors only; classify or re-raise
+        return await asyncio.to_thread(preflight_chat_request, req)
+    except Exception as exc:
         classified = classify_provider_error(exc)
         if classified is None:
-            raise
+            # Mirror _run_non_stream: an unclassified failure still rides the
+            # OpenAI error envelope, not a bare framework 500.
+            return _internal_error_response()
         return _error_response(classified.http_status, classified.code, classified.message)
-    return None
 
 
 _INTERNAL_ERROR_MESSAGE = "Internal server error. Check the server logs for details."
@@ -181,6 +193,7 @@ async def _gated_completions_stream(
     req: CanonicalChatRequest,
     guard: ChatSlotGuard,
     *,
+    model: str,
     include_usage: bool = False,
 ) -> AsyncGenerator[bytes, None]:
     """Drive ``dispatch_chat_stream`` -> translate -> SSE-encode, freeing the slot on exit.
@@ -196,7 +209,7 @@ async def _gated_completions_stream(
         try:
             events = dispatch_chat_stream(req)
             chunks = canonical_stream_to_completions_chunks(
-                events, model=req.model, response_id=_response_id(), include_usage=include_usage
+                events, model=model, response_id=_response_id(), include_usage=include_usage
             )
             async for frame in encode_completions_sse(chunks):
                 yield frame

--- a/src/lilbee/server/chat_dispatch/dispatch.py
+++ b/src/lilbee/server/chat_dispatch/dispatch.py
@@ -163,7 +163,9 @@ async def dispatch_chat_stream(
             yield event
         yield MessageStop()
     finally:
-        stream.close()
+        # close() tears down the provider HTTP connection and can block; offload
+        # it like the open and per-frame reads so the event loop stays responsive.
+        await asyncio.to_thread(stream.close)
 
 
 async def _async_iter_provider_stream(

--- a/src/lilbee/server/handlers/documents.py
+++ b/src/lilbee/server/handlers/documents.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import mimetypes
 
 from lilbee.app.services import get_services
@@ -106,7 +107,14 @@ async def get_source_content(
     """Return a stored source file: JSON with markdown text for text types, or
     ``(bytes, content_type)`` when *raw* is True. Binary types return empty
     markdown so clients know to re-request with ``raw=1``.
+
+    Reads the file off the event loop so a large source doesn't stall it.
     """
+    return await asyncio.to_thread(_get_source_content_sync, source, raw)
+
+
+def _get_source_content_sync(source: str, raw: bool) -> SourceContentResponse | tuple[bytes, str]:
+    """Blocking body of :func:`get_source_content`: path validation + file read."""
     from lilbee.wiki.index import parse_title
 
     if not source or not source.strip():

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -142,16 +142,20 @@ def _parse_ocr_params(data: dict[str, Any]) -> tuple[bool | None, float | None]:
     return enable_ocr, ocr_timeout
 
 
-async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
+async def add_files_stream(
+    paths: list[str],
+    *,
+    force: bool = False,
+    enable_ocr: bool | None = None,
+    ocr_timeout: float | None = None,
+) -> AsyncGenerator[str, None]:
     """Copy files, sync, and yield SSE progress events.
 
-    Contended sources emit ``already_ingesting`` and the stream closes
-    without a ``done`` event, signalling the client to wait rather than retry.
+    Takes the already-validated/parsed values from ``validate_add_paths`` so the
+    request dict is decoded once. Contended sources emit ``already_ingesting``
+    and the stream closes without a ``done`` event, signalling the client to
+    wait rather than retry.
     """
-    paths = data.get("paths", [])
-    force = bool(data.get("force", False))
-    enable_ocr, ocr_timeout = _parse_ocr_params(data)
-
     registry = get_services().ingest_lock_registry
     acquired, busy = await registry.acquire(paths)
     try:
@@ -162,8 +166,14 @@ async def add_files_stream(data: dict[str, Any]) -> AsyncGenerator[str, None]:
         if not acquired:
             return
 
+        # Ingest only the paths this request actually locked; contended ones
+        # already got an ``already_ingesting`` event and must not be re-ingested
+        # under the holder's lock. ``acquired`` keys are canonical source names,
+        # so select the original path strings whose name was acquired.
+        acquired_names = {name for name, _lock in acquired}
+        locked_paths = [p for p in paths if registry.canonical_source_name(p) in acquired_names]
         sse = SseStream()
-        task = asyncio.create_task(_run_add(paths, force, enable_ocr, ocr_timeout, sse))
+        task = asyncio.create_task(_run_add(locked_paths, force, enable_ocr, ocr_timeout, sse))
         try:
             async for event in sse.drain(task, "Add files stream"):
                 yield event

--- a/src/lilbee/server/handlers/models.py
+++ b/src/lilbee/server/handlers/models.py
@@ -141,7 +141,8 @@ async def list_models() -> ModelsResponse:
     Uses the unfiltered installed set so a single ref lights up in every
     catalog section it legitimately matches.
     """
-    installed = set(get_services().model_manager.list_installed())
+    # list_installed walks the model filesystem; offload it like list_external_models.
+    installed = set(await asyncio.to_thread(get_services().model_manager.list_installed))
 
     return ModelsResponse(
         chat=_catalog_section(FEATURED_CHAT, cfg.chat_model, installed),
@@ -481,6 +482,7 @@ async def models_catalog(
         sort=parsed_sort,
         limit=limit,
         offset=offset,
+        model_manager=get_services().model_manager,
     )
 
     registry = get_services().registry

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -96,7 +96,11 @@ async def search(
     """Search and return grouped DocumentResults."""
     if not q or not q.strip():
         raise ValueError("query must not be empty")
-    results = get_services().searcher.search(q, top_k=top_k, chunk_type=chunk_type)
+    # search() blocks on retrieval; run it off the event loop so other admitted
+    # requests stay responsive, matching the sibling ask() handler.
+    results = await asyncio.to_thread(
+        get_services().searcher.search, q, top_k=top_k, chunk_type=chunk_type
+    )
     results = [r for r in results if r.distance is None or r.distance <= cfg.max_distance]
     return group(results)
 
@@ -111,15 +115,20 @@ async def ask(
     if not question or not question.strip():
         raise ValueError("question must not be empty")
     opts = _resolve_generation_options(options)
+    searcher = get_services().searcher
     # ask_raw blocks for retrieval plus the whole generation; run it off the
     # event loop so other admitted requests stay responsive.
     result = await asyncio.to_thread(
-        get_services().searcher.ask_raw,
+        searcher.ask_raw,
         question,
         top_k=top_k,
         options=opts,
         chunk_type=chunk_type,
     )
+    # Mirror the streaming ask path: auto-extract memories from a real answer,
+    # but never from the search-needs-embedder refusal ask_raw returns.
+    if not searcher.search_unavailable():
+        await _store_extracted_memories(question, result.answer)
     return AskResponse(
         answer=result.answer,
         sources=[CleanedChunk(**clean_result(s)) for s in result.sources],
@@ -183,16 +192,24 @@ def _run_llm_stream(
         put(None)
 
 
+async def _store_extracted_memories(question: str, answer: str) -> list[Any]:
+    """Run the auto-extraction LLM pass off the event loop and return stored memories.
+
+    Returns an empty list (no-op) when the answer is empty or auto-extraction is
+    off, so one-shot and streaming callers share one extraction path.
+    """
+    if not answer or not auto_extract_enabled():
+        return []
+    return await asyncio.to_thread(auto_extract, question, answer)
+
+
 async def _emit_extracted_memories(question: str, answer: str) -> AsyncGenerator[str, None]:
     """Yield a ``memory_extracted`` SSE event if the turn auto-saved any memories.
 
-    Runs the extraction LLM pass off the event loop. Silent (yields nothing)
-    when the answer is empty, auto-extraction is off, or nothing was extracted,
-    so existing consumers are unaffected.
+    Silent (yields nothing) when the answer is empty, auto-extraction is off, or
+    nothing was extracted, so existing consumers are unaffected.
     """
-    if not answer or not auto_extract_enabled():
-        return
-    stored = await asyncio.to_thread(auto_extract, question, answer)
+    stored = await _store_extracted_memories(question, answer)
     if not stored:
         return
     event = MemoryExtractedEvent(
@@ -312,11 +329,17 @@ async def chat(
     chunk_type: ChunkType | None = None,
 ) -> AskResponse:
     """Chat with history. Returns answer and sources via canonical dispatch."""
+    searcher = get_services().searcher
+    if searcher.search_unavailable():
+        # Search mode with no embedder can't ground; refuse cleanly with the same
+        # message ask returns instead of silently answering off-corpus.
+        return AskResponse(answer=SEARCH_NEEDS_EMBEDDER, sources=[], cited_sources=[])
     sources, messages = _build_chat_messages(question, history, top_k, chunk_type)
     req = _build_canonical_request(messages, options)
     response = await asyncio.to_thread(dispatch_chat, req)
     text = _join_text_blocks(response.content)
     answer = text if cfg.show_reasoning else strip_reasoning(text)
+    await _store_extracted_memories(question, answer)
     return AskResponse(
         answer=answer,
         sources=[CleanedChunk(**clean_result(s)) for s in sources],
@@ -349,6 +372,13 @@ async def _stream_chat_response(
         yield warming
 
     searcher = get_services().searcher
+    if searcher.search_unavailable():
+        # Search mode with no embedder can't ground; refuse cleanly with the same
+        # token the ask stream emits instead of silently answering off-corpus.
+        yield sse_event(SseEvent.TOKEN, {"token": SEARCH_NEEDS_EMBEDDER})
+        yield sse_event(SseEvent.SOURCES, [])
+        yield sse_done({})
+        return
     if searcher.skip_retrieval():
         # Chat-only mode (or no embedder): answer directly with no RAG context.
         sources: list[SearchChunk] = []

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -11,21 +11,21 @@ from pydantic import BaseModel, Field, field_validator
 
 from lilbee.catalog.types import KeyStatus, ModelCompat, ModelSource, ModelTask
 from lilbee.core.config.enums import CrawlRenderMode
-from lilbee.data.store import ChunkType, MemoryKind, SearchScope
+from lilbee.data.store import ChunkType, MemoryKind, scope_to_chunk_type
 from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 
 
-def _validate_chunk_type(value: str | None) -> ChunkType | None:
+def decode_chunk_type(value: str | None) -> ChunkType | None:
     """Decode a ``chunk_type`` string into a ``ChunkType`` at the HTTP boundary.
 
-    Matches the CLI/MCP behaviour: only ``"raw"`` or ``"wiki"`` filter the
-    pool; everything else (including ``None`` and the UI-side ``"both"``)
-    means no filter. Any other string raises ``ValueError``.
+    Delegates to the canonical :func:`scope_to_chunk_type` so query-param and
+    request-body routes share one decoder: only ``"raw"`` or ``"wiki"`` filter
+    the pool; everything else (including ``None`` and the UI-side ``"both"``)
+    means no filter. Any other string raises ``ValueError`` with boundary-
+    friendly guidance.
     """
-    if value is None or value == SearchScope.BOTH.value:
-        return None
     try:
-        return ChunkType(value)
+        return scope_to_chunk_type(value)
     except ValueError as exc:
         raise ValueError(
             f"chunk_type must be one of 'raw', 'wiki', 'both', or omitted; got {value!r}"
@@ -43,7 +43,7 @@ class AskRequest(BaseModel):
     @field_validator("chunk_type", mode="before")
     @classmethod
     def _check_chunk_type(cls, v: str | None) -> ChunkType | None:
-        return _validate_chunk_type(v)
+        return decode_chunk_type(v)
 
 
 class ChatRequest(BaseModel):
@@ -58,7 +58,7 @@ class ChatRequest(BaseModel):
     @field_validator("chunk_type", mode="before")
     @classmethod
     def _check_chunk_type(cls, v: str | None) -> ChunkType | None:
-        return _validate_chunk_type(v)
+        return decode_chunk_type(v)
 
 
 class SyncRequest(BaseModel):
@@ -215,14 +215,16 @@ class CrawlRequest(BaseModel):
     """Request body for /api/crawl.
 
     depth: null / omitted = whole-site unbounded recursion. 0 = single URL
-    only. Positive int = max depth. max_pages: null / omitted = no cap.
-    Positive int = explicit page cap. render_mode: null / omitted = configured
-    default; "http" is browserless, "browser" runs Chromium with JavaScript.
+    only. Positive int = max depth. max_pages: null / omitted = the protective
+    safety cap. 0 = explicitly unlimited (the CRAWL_PAGES_UNLIMITED sentinel the
+    TUI and crawler honor). Positive int = explicit page cap. render_mode: null /
+    omitted = configured default; "http" is browserless, "browser" runs Chromium
+    with JavaScript.
     """
 
     url: str
     depth: int | None = Field(default=None, ge=0)
-    max_pages: int | None = Field(default=None, ge=1)
+    max_pages: int | None = Field(default=None, ge=0)
     render_mode: CrawlRenderMode | None = Field(default=None)
 
 
@@ -351,16 +353,6 @@ class AddSummary(BaseModel):
     skipped: list[str]
     errors: list[str]
     sync: SyncSummary | None = None
-
-
-class WikiPageSummary(BaseModel):
-    """Summary of a wiki page for list endpoints."""
-
-    slug: str
-    title: str = ""
-    page_type: str = "unknown"
-    source_count: int = 0
-    created_at: str = ""
 
 
 class WikiCitationRecord(BaseModel):

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -50,11 +50,13 @@ async def sync_route(data: SyncRequest | None = None) -> Stream:
 async def add_route(data: AddRequest) -> Stream:
     """Add files to the knowledge base with streaming SSE progress."""
     try:
-        handlers.validate_add_paths(data.model_dump())
+        paths, force, enable_ocr, ocr_timeout = handlers.validate_add_paths(data.model_dump())
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
     return Stream(
-        handlers.add_files_stream(data.model_dump()),
+        handlers.add_files_stream(
+            paths, force=force, enable_ocr=enable_ocr, ocr_timeout=ocr_timeout
+        ),
         media_type="text/event-stream",
         status_code=201,
     )

--- a/src/lilbee/server/routes/general.py
+++ b/src/lilbee/server/routes/general.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from litestar import Response, get, patch
+from litestar.exceptions import NotFoundException, ValidationException
 from litestar.response import Stream
 from pydantic import ValidationError
 
@@ -61,8 +62,6 @@ async def config_update_route(data: dict[str, Any]) -> ConfigUpdateResponse:
     try:
         return await handlers.update_config(data)
     except (ValueError, ValidationError) as exc:
-        from litestar.exceptions import ValidationException
-
         raise ValidationException(str(exc)) from exc
 
 
@@ -72,15 +71,11 @@ async def source_content_route(
     source: str, raw: bool = False
 ) -> SourceContentResponse | Response[bytes]:
     """Return stored source file as JSON (``raw=0``) or raw bytes (``raw=1``)."""
-    from litestar.exceptions import NotFoundException
-
     try:
         result = await handlers.get_source_content(source, raw=raw)
     except FileNotFoundError as exc:
         raise NotFoundException(f"source not found: {source}") from exc
     except ValueError as exc:
-        from litestar.exceptions import ValidationException
-
         raise ValidationException(str(exc)) from exc
 
     # ``raw=True`` returns ``(bytes, content_type)``; narrow via ``isinstance``

--- a/src/lilbee/server/routes/models.py
+++ b/src/lilbee/server/routes/models.py
@@ -8,6 +8,7 @@ from litestar.params import Parameter
 from litestar.response import Stream
 from pydantic import BaseModel
 
+from lilbee.catalog.types import ModelSource
 from lilbee.modelhub.role_validator import TaskMismatchError
 from lilbee.server import handlers
 from lilbee.server.auth import read_only
@@ -34,7 +35,7 @@ class PullRequest(BaseModel):
     """Request body for /api/models/pull."""
 
     model: str
-    source: str = "native"
+    source: str = ModelSource.NATIVE.value
     allow_unsupported: bool = False
 
 
@@ -94,6 +95,7 @@ async def models_catalog_route(
     task: str | None = Parameter(query="task", default=None),
     search: str = Parameter(query="search", default=""),
     size: str | None = Parameter(query="size", default=None),
+    installed: bool | None = Parameter(query="installed", default=None),
     featured: bool | None = Parameter(query="featured", default=None),
     sort: str = Parameter(query="sort", default="featured"),
     limit: int = Parameter(query="limit", default=20, le=1000),
@@ -105,6 +107,7 @@ async def models_catalog_route(
             task=task,
             search=search,
             size=size,
+            installed=installed,
             featured=featured,
             sort=sort,
             limit=limit,
@@ -125,10 +128,14 @@ async def models_installed_route() -> ModelsInstalledResponse:
 async def models_pull_route(data: PullRequest) -> Stream:
     """Pull a model with streaming SSE progress events."""
     # Validate before opening the stream so an unsupported arch is a real 409, not
-    # an in-stream abort after the 200 SSE headers have flushed.
-    await handlers.enforce_pull_arch_compat(
-        data.model, source=data.source, allow_unsupported=data.allow_unsupported
-    )
+    # an in-stream abort after the 200 SSE headers have flushed. An unknown source
+    # is a client error (422), mirroring the catalog route, not a 500.
+    try:
+        await handlers.enforce_pull_arch_compat(
+            data.model, source=data.source, allow_unsupported=data.allow_unsupported
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     return Stream(
         handlers.models_pull(
             data.model, source=data.source, allow_unsupported=data.allow_unsupported
@@ -144,6 +151,11 @@ async def models_show_route(data: SetModelRequest) -> ModelsShowResponse:
 
 
 @delete("/api/models/{model:str}", status_code=200)
-async def models_delete_route(model: str, source: str = "native") -> ModelsDeleteResponse:
+async def models_delete_route(
+    model: str, source: str = ModelSource.NATIVE.value
+) -> ModelsDeleteResponse:
     """Delete a model from the specified source."""
-    return await handlers.models_delete(model, source=source)
+    try:
+        return await handlers.models_delete(model, source=source)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/src/lilbee/server/routes/search.py
+++ b/src/lilbee/server/routes/search.py
@@ -13,7 +13,7 @@ from litestar.params import Parameter
 from litestar.response import Stream
 
 from lilbee.core.results import DocumentResult
-from lilbee.data.store import EmbeddingModelMismatchError, scope_to_chunk_type
+from lilbee.data.store import EmbeddingModelMismatchError
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.retrieval.query import ChatMessage as ChatMessageDict
 from lilbee.server import handlers
@@ -33,6 +33,7 @@ from lilbee.server.models import (
     AskRequest,
     AskResponse,
     ChatRequest,
+    decode_chunk_type,
 )
 
 _BAD_REQUEST_STATUS = 400
@@ -142,11 +143,11 @@ async def search_route(
 ) -> list[DocumentResult]:
     """Search indexed documents by semantic similarity. No LLM call required."""
     try:
-        chunk_type = scope_to_chunk_type(chunk_type)
+        parsed_chunk_type = decode_chunk_type(chunk_type)
     except ValueError as exc:
         raise ValidationException(str(exc)) from exc
     try:
-        return await handlers.search(q, top_k=top_k, chunk_type=chunk_type)
+        return await handlers.search(q, top_k=top_k, chunk_type=parsed_chunk_type)
     except EmbeddingModelMismatchError as exc:
         raise _embedding_mismatch_http(exc) from exc
     except ValueError as exc:

--- a/src/lilbee/server/routes/setup.py
+++ b/src/lilbee/server/routes/setup.py
@@ -6,7 +6,8 @@ SSE event sequence mirrors what the TUI does in
 matching ``setup`` progress indicator.
 
 Endpoints:
-    GET  /setup/crawler/status → { installed, component, browsers_path }
+    GET  /setup/crawler/status → { installed, package_installed,
+                                   chromium_installed, component, browsers_path }
     POST /setup/crawler         → text/event-stream of setup_start →
                                    setup_progress → setup_done → done
 """

--- a/src/lilbee/server/wiki.py
+++ b/src/lilbee/server/wiki.py
@@ -78,13 +78,17 @@ async def wiki_list_route() -> list[dict[str, Any]]:
     """
     _require_wiki()
     root = _wiki_root()
+    # The index regen walks and rewrites files and list_pages walks the tree;
+    # offload both so the listing doesn't block the event loop.
+    return await asyncio.to_thread(_list_wiki_pages_sync, root)
 
+
+def _list_wiki_pages_sync(root: Path) -> list[dict[str, Any]]:
+    """Blocking body of :func:`wiki_list_route`: refresh index, then walk pages."""
     index_path = root / "index.md"
     if index_path.is_file():
         update_wiki_index()
-
-    pages = list_pages(root)
-    return [p.to_dict() for p in pages]
+    return [p.to_dict() for p in list_pages(root)]
 
 
 @get("/api/wiki/drafts")
@@ -159,7 +163,8 @@ async def wiki_citations_reverse_route(
     _require_wiki()
     if not source:
         return []
-    records = svc_mod.get_services().store.get_citations_for_source(source)
+    # get_citations_for_source queries LanceDB; offload like wiki_lint_route.
+    records = await asyncio.to_thread(svc_mod.get_services().store.get_citations_for_source, source)
     return [WikiCitationRecord(**r) for r in records]
 
 
@@ -171,7 +176,7 @@ async def wiki_read_route(slug: str) -> WikiPageDetail | WikiCitationsResult:
     slug = slug.lstrip("/")
     if slug.endswith("/citations"):
         real_slug = slug.removesuffix("/citations")
-        return _citations_for_slug(real_slug)
+        return await _citations_for_slug(real_slug)
     result = read_page(_wiki_root(), slug)
     if result is None:
         raise NotFoundException(detail=f"wiki page not found: {slug}")
@@ -182,13 +187,16 @@ async def wiki_read_route(slug: str) -> WikiPageDetail | WikiCitationsResult:
     )
 
 
-def _citations_for_slug(slug: str) -> WikiCitationsResult:
+async def _citations_for_slug(slug: str) -> WikiCitationsResult:
     """Return citation chain for a wiki page."""
     path = _find_page(slug)
     if path is None:
         raise NotFoundException(detail=f"wiki page not found: {slug}")
     wiki_source = f"{cfg.wiki_dir}/{slug}.md"
-    records = svc_mod.get_services().store.get_citations_for_wiki(wiki_source)
+    # get_citations_for_wiki queries LanceDB; offload like wiki_lint_route.
+    records = await asyncio.to_thread(
+        svc_mod.get_services().store.get_citations_for_wiki, wiki_source
+    )
     return WikiCitationsResult(slug=slug, citations=[WikiCitationRecord(**r) for r in records])
 
 

--- a/tests/server/chat_completions_api/test_routes.py
+++ b/tests/server/chat_completions_api/test_routes.py
@@ -1382,7 +1382,10 @@ class TestRouteDispatchErrorBranches:
             messages=(CanonicalMessage(role="user", content="hi"),),
             stream=True,
         )
-        frames = [frame async for frame in _gated_completions_stream(req, ChatSlotGuard())]
+        frames = [
+            frame
+            async for frame in _gated_completions_stream(req, ChatSlotGuard(), model=req.model)
+        ]
         joined = b"".join(frames).decode()
         assert "model_not_found" in joined
 
@@ -1406,15 +1409,20 @@ class TestRouteDispatchErrorBranches:
             messages=(CanonicalMessage(role="user", content="hi"),),
             stream=True,
         )
-        frames = [frame async for frame in _gated_completions_stream(req, ChatSlotGuard())]
+        frames = [
+            frame
+            async for frame in _gated_completions_stream(req, ChatSlotGuard(), model=req.model)
+        ]
         joined = b"".join(frames).decode()
         assert "model_does_not_support_tools" in joined
 
     @pytest.mark.asyncio
-    async def test_preflush_reraises_unclassified_preflight_error(self, monkeypatch) -> None:
-        # Preflight only raises classifiable typed errors today; if it ever
-        # raised something else, the route re-raises rather than masking it.
-        from lilbee.server.chat_completions_api.routes import _preflush_or_none
+    async def test_preflight_unclassified_error_returns_openai_envelope(self, monkeypatch) -> None:
+        # An unclassified preflight failure rides the OpenAI internal_error
+        # envelope (matching the non-stream dispatch path), not a bare 500.
+        from litestar import Response
+
+        from lilbee.server.chat_completions_api.routes import _preflight_resolved_model
         from lilbee.server.chat_dispatch.canonical import CanonicalChatRequest, CanonicalMessage
 
         def _raise(req: object) -> str:
@@ -1427,16 +1435,19 @@ class TestRouteDispatchErrorBranches:
             model="vendor/m",
             messages=(CanonicalMessage(role="user", content="hi"),),
         )
-        with pytest.raises(RuntimeError, match="unexpected preflight failure"):
-            await _preflush_or_none(req)
+        result = await _preflight_resolved_model(req)
+        assert isinstance(result, Response)
+        assert result.status_code == 500
+        assert result.content["error"]["code"] == "internal_error"
 
     @pytest.mark.asyncio
-    async def test_preflush_runs_preflight_off_the_event_loop(self, monkeypatch) -> None:
+    async def test_preflight_returns_resolved_model_off_the_event_loop(self, monkeypatch) -> None:
         # Discovery probes inside the preflight are blocking HTTP; the async
-        # boundary must push them to a worker thread.
+        # boundary must push them to a worker thread, and the resolved model is
+        # returned so the streaming response echoes it.
         import threading
 
-        from lilbee.server.chat_completions_api.routes import _preflush_or_none
+        from lilbee.server.chat_completions_api.routes import _preflight_resolved_model
         from lilbee.server.chat_dispatch.canonical import CanonicalChatRequest, CanonicalMessage
 
         loop_thread = threading.current_thread()
@@ -1444,14 +1455,14 @@ class TestRouteDispatchErrorBranches:
 
         def _record(req: object) -> str:
             seen_threads.append(threading.current_thread())
-            return "vendor/m"
+            return "vendor/resolved"
 
         monkeypatch.setattr(
             "lilbee.server.chat_completions_api.routes.preflight_chat_request", _record
         )
         req = CanonicalChatRequest(
-            model="vendor/m",
+            model="vendor/requested",
             messages=(CanonicalMessage(role="user", content="hi"),),
         )
-        assert await _preflush_or_none(req) is None
+        assert await _preflight_resolved_model(req) == "vendor/resolved"
         assert seen_threads and seen_threads[0] is not loop_thread

--- a/tests/server/test_chat_stream_reasoning.py
+++ b/tests/server/test_chat_stream_reasoning.py
@@ -259,6 +259,8 @@ def mock_svc():
 
     searcher = MagicMock()
     searcher.build_rag_context.return_value = None
+    # These tests exercise the reasoning stream, not the no-embedder refusal.
+    searcher.search_unavailable.return_value = False
     services = make_mock_services(searcher=searcher)
     services.registry.list_installed = MagicMock(return_value=[_installed_manifest(cfg.chat_model)])
     set_services(services)

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -502,7 +502,7 @@ class TestAddIngestMutex:
         lock = await get_services().ingest_lock_registry.try_acquire("holdme.txt")
         assert lock is not None
         try:
-            events = await self._collect(add_files_stream({"paths": [str(src)]}))
+            events = await self._collect(add_files_stream([str(src)]))
         finally:
             lock.release()
 
@@ -528,7 +528,7 @@ class TestAddIngestMutex:
                 new_callable=Mock,
                 return_value=_make_kreuzberg_result(),
             ):
-                events = await self._collect(add_files_stream({"paths": [str(held), str(free)]}))
+                events = await self._collect(add_files_stream([str(held), str(free)]))
         finally:
             lock.release()
 
@@ -536,6 +536,11 @@ class TestAddIngestMutex:
         already = [d for t, d in events if t == "already_ingesting"]
         assert {"source": "held.txt"} in already
         assert "done" in event_types
+        # The contended path must not be ingested under the holder's lock: only
+        # the free path is copied (regression guard for the lock-bypass bug).
+        summary = [d for t, d in events if t == "done" and "copied" in d][-1]
+        assert "free.txt" in summary["copied"]
+        assert "held.txt" not in summary["copied"]
 
     async def test_concurrent_different_sources_run_in_parallel(self, isolated_env, tmp_path):
         """Disjoint sources do not contend: both requests complete with done."""
@@ -553,7 +558,7 @@ class TestAddIngestMutex:
                 new_callable=Mock,
                 return_value=_make_kreuzberg_result(),
             ):
-                async for frame in add_files_stream({"paths": [str(path)]}):
+                async for frame in add_files_stream([str(path)]):
                     text += frame
             return _parse_sse_events(text.encode())
 
@@ -575,7 +580,7 @@ class TestAddIngestMutex:
             raise RuntimeError("ingest exploded")
 
         with mock.patch("lilbee.data.ingest.sync", new=_boom):
-            events = await self._collect(add_files_stream({"paths": [str(src)]}))
+            events = await self._collect(add_files_stream([str(src)]))
 
         assert any(t == "error" for t, _ in events)
 
@@ -594,7 +599,7 @@ class TestAddIngestMutex:
         async def _hang(*_args, **_kwargs):
             await asyncio.sleep(30)
 
-        gen = add_files_stream({"paths": [str(src)]})
+        gen = add_files_stream([str(src)])
         with mock.patch("lilbee.data.ingest.sync", new=_hang):
             outer = asyncio.create_task(gen.__anext__())
             await asyncio.sleep(0.05)

--- a/tests/server/test_review_fixes.py
+++ b/tests/server/test_review_fixes.py
@@ -1,0 +1,231 @@
+"""Tests for server review-fix findings.
+
+Covers: chunk_type decoder unification, stop-sequence forwarding, crawl
+max_pages sentinel, one-shot memory extraction, chat search-unavailable
+refusal parity, the catalog installed filter, ?source= 422 mapping, the
+streaming model echo, and the add-files lock partition.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from litestar.testing import AsyncTestClient
+from pydantic import ValidationError
+
+import lilbee.server.handlers.rag as rag
+from lilbee.app.services import set_services
+from lilbee.data.store import ChunkType
+from lilbee.providers.base import filter_options
+from lilbee.retrieval.query.searcher import SEARCH_NEEDS_EMBEDDER, AskResult
+from lilbee.server import auth as _auth_mod
+from lilbee.server.models import CrawlRequest, decode_chunk_type
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_auth_mod.session_manager.token}"}
+
+
+class TestStopForwarding:
+    def test_filter_options_keeps_stop(self) -> None:
+        """A stop sequence survives the LLMOptions allowlist instead of being dropped."""
+        assert filter_options({"stop": ["END"], "temperature": 0.5})["stop"] == ["END"]
+
+    def test_filter_options_omits_absent_stop(self) -> None:
+        assert "stop" not in filter_options({"temperature": 0.5})
+
+
+class TestChunkTypeDecoder:
+    def test_raw_and_wiki_decode(self) -> None:
+        assert decode_chunk_type("raw") == ChunkType.RAW
+        assert decode_chunk_type("wiki") == ChunkType.WIKI
+
+    def test_both_and_none_mean_no_filter(self) -> None:
+        assert decode_chunk_type("both") is None
+        assert decode_chunk_type(None) is None
+
+    def test_invalid_gives_friendly_error(self) -> None:
+        with pytest.raises(ValueError, match="'raw', 'wiki', 'both'"):
+            decode_chunk_type("nonsense")
+
+
+class TestCrawlMaxPagesSentinel:
+    def test_zero_means_unlimited(self) -> None:
+        assert CrawlRequest(url="https://x", max_pages=0).max_pages == 0
+
+    def test_negative_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CrawlRequest(url="https://x", max_pages=-1)
+
+
+class TestStoreExtractedMemories:
+    async def test_disabled_returns_empty(self, monkeypatch) -> None:
+        monkeypatch.setattr(rag, "auto_extract_enabled", lambda: True)
+        called = MagicMock()
+        monkeypatch.setattr(rag, "auto_extract", called)
+        assert await rag._store_extracted_memories("q", "") == []
+        called.assert_not_called()
+
+    async def test_off_returns_empty(self, monkeypatch) -> None:
+        monkeypatch.setattr(rag, "auto_extract_enabled", lambda: False)
+        called = MagicMock()
+        monkeypatch.setattr(rag, "auto_extract", called)
+        assert await rag._store_extracted_memories("q", "a") == []
+        called.assert_not_called()
+
+    async def test_runs_when_enabled(self, monkeypatch) -> None:
+        monkeypatch.setattr(rag, "auto_extract_enabled", lambda: True)
+        sentinel = [MagicMock()]
+        monkeypatch.setattr(rag, "auto_extract", lambda q, a: sentinel)
+        assert await rag._store_extracted_memories("q", "a") is sentinel
+
+
+def _mock_searcher_services(*, search_unavailable: bool):
+    from tests.conftest import make_mock_services
+
+    searcher = MagicMock()
+    searcher.search_unavailable.return_value = search_unavailable
+    services = make_mock_services(searcher=searcher)
+    return services, searcher
+
+
+class TestAskMemoryExtraction:
+    async def test_ask_extracts_when_search_available(self, monkeypatch) -> None:
+        services, searcher = _mock_searcher_services(search_unavailable=False)
+        searcher.ask_raw.return_value = AskResult(answer="grounded", sources=[])
+        set_services(services)
+        extracted: list[tuple[str, str]] = []
+        monkeypatch.setattr(rag, "_store_extracted_memories", _record(extracted))
+        try:
+            resp = await rag.ask("q")
+        finally:
+            set_services(None)
+        assert resp.answer == "grounded"
+        assert extracted == [("q", "grounded")]
+
+    async def test_ask_skips_extraction_on_refusal(self, monkeypatch) -> None:
+        services, searcher = _mock_searcher_services(search_unavailable=True)
+        searcher.ask_raw.return_value = AskResult(answer=SEARCH_NEEDS_EMBEDDER, sources=[])
+        set_services(services)
+        extracted: list[tuple[str, str]] = []
+        monkeypatch.setattr(rag, "_store_extracted_memories", _record(extracted))
+        try:
+            resp = await rag.ask("q")
+        finally:
+            set_services(None)
+        assert resp.answer == SEARCH_NEEDS_EMBEDDER
+        assert extracted == []
+
+
+def _record(sink: list[tuple[str, str]]):
+    async def _store(question: str, answer: str) -> list:
+        sink.append((question, answer))
+        return []
+
+    return _store
+
+
+class TestChatSearchUnavailableParity:
+    async def test_chat_refuses_when_search_unavailable(self) -> None:
+        services, _ = _mock_searcher_services(search_unavailable=True)
+        set_services(services)
+        try:
+            resp = await rag.chat("q", [])
+        finally:
+            set_services(None)
+        assert resp.answer == SEARCH_NEEDS_EMBEDDER
+        assert resp.sources == []
+        assert resp.cited_sources == []
+
+    async def test_chat_stream_refuses_when_search_unavailable(self) -> None:
+        services, _ = _mock_searcher_services(search_unavailable=True)
+        set_services(services)
+        try:
+            frames = [f async for f in rag.chat_stream("q", [])]
+        finally:
+            set_services(None)
+        joined = "".join(frames)
+        assert SEARCH_NEEDS_EMBEDDER in joined
+        assert '"done"' in joined or "done" in joined
+
+
+class TestSourceErrorMapping:
+    async def test_delete_unknown_source_is_422(self) -> None:
+        from lilbee.server import app as app_module
+
+        async with AsyncTestClient(app_module.create_app()) as client:
+            resp = await client.delete(
+                "/api/models/whatever", params={"source": "bogus"}, headers=_auth_headers()
+            )
+        assert resp.status_code == 422
+
+    async def test_pull_unknown_source_is_422(self) -> None:
+        from lilbee.server import app as app_module
+
+        async with AsyncTestClient(app_module.create_app()) as client:
+            resp = await client.post(
+                "/api/models/pull",
+                json={"model": "x", "source": "bogus"},
+                headers=_auth_headers(),
+            )
+        assert resp.status_code == 422
+
+
+class TestCatalogInstalledFilter:
+    async def test_route_forwards_installed_filter(self, monkeypatch) -> None:
+        """The REST catalog route forwards installed + model_manager to get_catalog."""
+        from lilbee.server.handlers import models as models_handler
+
+        captured: dict[str, object] = {}
+
+        def _fake_get_catalog(**kwargs):
+            captured.update(kwargs)
+            return MagicMock(total=0, limit=20, offset=0, has_more=False, models=[])
+
+        monkeypatch.setattr(models_handler, "get_catalog", _fake_get_catalog)
+        monkeypatch.setattr(models_handler, "enrich_catalog", lambda result, refs: [])
+        services = MagicMock()
+        services.registry.list_installed.return_value = []
+        services.model_manager = MagicMock()
+        monkeypatch.setattr(models_handler, "get_services", lambda: services)
+
+        await models_handler.models_catalog(installed=True)
+        assert captured["installed"] is True
+        assert captured["model_manager"] is services.model_manager
+
+
+class TestStreamingModelEcho:
+    async def test_stream_passes_resolved_model_to_translator(self, monkeypatch) -> None:
+        """The streamed chunks are built with the resolved model, not the request model."""
+        from lilbee.server.chat_completions_api import routes
+        from lilbee.server.chat_dispatch.canonical import CanonicalChatRequest, CanonicalMessage
+        from lilbee.server.chat_dispatch.concurrency import ChatSlotGuard
+
+        captured: dict[str, object] = {}
+
+        async def _fake_stream(req: object):
+            return
+            yield  # pragma: no cover -- makes this an async generator
+
+        def _fake_chunks(events, *, model, response_id, include_usage):
+            captured["model"] = model
+
+            async def _empty():
+                return
+                yield  # pragma: no cover
+
+            return _empty()
+
+        monkeypatch.setattr(routes, "dispatch_chat_stream", _fake_stream)
+        monkeypatch.setattr(routes, "canonical_stream_to_completions_chunks", _fake_chunks)
+        req = CanonicalChatRequest(
+            model="requested/alias",
+            messages=(CanonicalMessage(role="user", content="hi"),),
+            stream=True,
+        )
+        async for _ in routes._gated_completions_stream(
+            req, ChatSlotGuard(), model="resolved/canonical"
+        ):
+            pass
+        assert captured["model"] == "resolved/canonical"

--- a/tests/server/test_review_fixes.py
+++ b/tests/server/test_review_fixes.py
@@ -60,7 +60,7 @@ class TestCrawlMaxPagesSentinel:
 
 
 class TestStoreExtractedMemories:
-    async def test_disabled_returns_empty(self, monkeypatch) -> None:
+    async def test_empty_answer_returns_empty(self, monkeypatch) -> None:
         monkeypatch.setattr(rag, "auto_extract_enabled", lambda: True)
         called = MagicMock()
         monkeypatch.setattr(rag, "auto_extract", called)

--- a/tests/server/test_wiki_routes.py
+++ b/tests/server/test_wiki_routes.py
@@ -863,13 +863,6 @@ class TestHelpers:
 
 
 class TestPydanticModels:
-    def test_wiki_page_summary_defaults(self):
-        from lilbee.server.models import WikiPageSummary
-
-        s = WikiPageSummary(slug="test", title="Test", page_type="summary")
-        assert s.source_count == 0
-        assert s.created_at == ""
-
     def test_wiki_citation_record_defaults(self):
         from lilbee.server.models import WikiCitationRecord
 

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -1088,7 +1088,7 @@ class TestAddFiles:
 
         with patch("lilbee.data.ingest.sync", side_effect=fake_sync):
             events = []
-            async for event in handlers.add_files_stream({"paths": [str(test_file)]}):
+            async for event in handlers.add_files_stream([str(test_file)]):
                 events.append(event)
             assert any("done" in e for e in events)
 
@@ -1102,7 +1102,7 @@ class TestAddFiles:
 
         with patch("lilbee.data.ingest.sync", side_effect=failing_sync):
             events = []
-            async for event in handlers.add_files_stream({"paths": [str(test_file)]}):
+            async for event in handlers.add_files_stream([str(test_file)]):
                 events.append(event)
 
         error_events = [e for e in events if e.startswith("event: error")]

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -2126,6 +2126,7 @@ class TestModelsCatalog:
             sort=CatalogSort.DOWNLOADS,
             limit=10,
             offset=5,
+            model_manager=mock_svc.model_manager,
         )
 
     @patch("lilbee.server.handlers.models.get_catalog")

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1307,9 +1307,17 @@ class TestCrawlRoute:
         assert resp.status_code == 201
         assert mock_stream.call_args.kwargs["render_mode"] is CrawlRenderMode.BROWSER
 
-    def test_post_crawl_rejects_zero_max_pages(self, client):
-        """max_pages=0 is invalid (use null for unbounded)."""
+    @mock.patch("lilbee.server.handlers.crawl_stream")
+    def test_post_crawl_accepts_zero_max_pages_as_unlimited(self, mock_stream, client):
+        """max_pages=0 is the explicit unlimited sentinel honored by TUI/crawler."""
+        mock_stream.return_value = mock_async_gen("event: done\ndata: {}\n\n")
         resp = client.post("/api/crawl", json={"url": "https://example.com", "max_pages": 0})
+        assert resp.status_code == 201
+        assert mock_stream.call_args.kwargs["max_pages"] == 0
+
+    def test_post_crawl_rejects_negative_max_pages(self, client):
+        """A negative max_pages is still a validation error."""
+        resp = client.post("/api/crawl", json={"url": "https://example.com", "max_pages": -1})
         assert resp.status_code == 400
 
 


### PR DESCRIPTION
## Problem

The server review (bb-bc6) found a batch of defects across the HTTP/MCP layer: filters that silently did nothing, client errors surfacing as 500s, behavior that differed between equivalent endpoints, and blocking work running on the async event loop.

## Solution

- REST catalog `installed` filter now actually filters native models (it was a silent no-op).
- Invalid `?source=` on pull/delete returns 422 instead of 500.
- Query-param and request-body routes share one `chunk_type` decoder, so errors are consistent.
- OpenAI `stop` sequences now reach the engine instead of being dropped.
- The crawl API accepts `max_pages=0` as "unlimited", matching the TUI and CLI.
- One-shot `/api/ask` and `/api/chat` extract memories like their streaming counterparts.
- `/api/chat` refuses cleanly when search has no embedder, instead of silently answering ungrounded.
- `/api/add` no longer re-ingests a file another request is already ingesting.
- Streaming `/v1/chat/completions` echoes the resolved model, matching the non-streaming response.
- Blocking retrieval, file, and LanceDB reads moved off the event loop so a slow call doesn't stall other requests.
- Dropped a dead response model, unused lazy imports, and a stale docstring.

Tests cover each behavioral change. The `models_pull` cancel-on-disconnect finding is tracked as a follow-up.