### PR TITLE
Fix file/PDF add crash on a null-stat source row

### DIFF
--- a/src/lilbee/data/store/types.py
+++ b/src/lilbee/data/store/types.py
@@ -185,13 +185,21 @@ class SourceStat(NamedTuple):
 
 
 def source_stat(record: SourceRecord) -> SourceStat | None:
-    """Stored stat for a source row, or None when unknown."""
-    size = record.get("size_bytes", SOURCE_STAT_UNKNOWN)
-    mtime = record.get("mtime_ns", SOURCE_STAT_UNKNOWN)
-    captured = record.get("stat_captured_ns", SOURCE_STAT_UNKNOWN)
-    if size == SOURCE_STAT_UNKNOWN or mtime == SOURCE_STAT_UNKNOWN:
+    """Stored stat for a source row, or None when unknown.
+
+    The stat columns are nullable ``int64``, so a row can carry an explicit
+    ``None`` (an import, or a write before the columns existed) as well as a
+    missing key or the ``SOURCE_STAT_UNKNOWN`` sentinel. All three mean "no
+    usable stat": return None so the caller re-hashes instead of crashing on
+    ``int(None)``.
+    """
+    size = record.get("size_bytes")
+    mtime = record.get("mtime_ns")
+    captured = record.get("stat_captured_ns")
+    if size is None or mtime is None or size == SOURCE_STAT_UNKNOWN or mtime == SOURCE_STAT_UNKNOWN:
         return None
-    return SourceStat(int(size), int(mtime), int(captured))
+    captured_ns = SOURCE_STAT_UNKNOWN if captured is None else int(captured)
+    return SourceStat(int(size), int(mtime), captured_ns)
 
 
 class SourceStatBackfill(NamedTuple):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1839,6 +1839,31 @@ class TestSourceStatColumns:
         store.upsert_source("a.md", "h1", 2)
         assert source_stat(store.get_sources()[0]) is None
 
+    def test_null_stat_columns_read_as_unknown_not_crash(self):
+        """A row whose nullable stat columns are NULL must read as unknown, not
+        crash with int(None). Regression: adding a file when the store already
+        held a null-stat row failed every add with 'int() argument ... NoneType'."""
+        from lilbee.data.store import source_stat
+
+        # NULL columns (present-but-None), as a nullable int64 column yields --
+        # distinct from a missing key, which .get already handled.
+        record = {"name": "a.pdf", "file_hash": "h", "size_bytes": None, "mtime_ns": None}
+        assert source_stat(record) is None  # type: ignore[arg-type]
+
+    def test_null_captured_with_valid_size_mtime_reads_stat(self):
+        """A null stat_captured_ns alongside valid size/mtime must not crash; the
+        capture time falls back to the unknown sentinel."""
+        from lilbee.data.store import SOURCE_STAT_UNKNOWN, SourceStat, source_stat
+
+        record = {
+            "name": "a.pdf",
+            "file_hash": "h",
+            "size_bytes": 10,
+            "mtime_ns": 20,
+            "stat_captured_ns": None,
+        }
+        assert source_stat(record) == SourceStat(10, 20, SOURCE_STAT_UNKNOWN)  # type: ignore[arg-type]
+
     def test_write_chunks_batch_persists_stat(self, store):
         from lilbee.data.store import ChunkWrite, SourceStat, source_stat
 


### PR DESCRIPTION
## Problem

Adding any file (the user hit it on PDFs) fails immediately with `int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` when the knowledge base already holds a source row whose stat columns are NULL.

`source_stat()` reads a row's `size_bytes` / `mtime_ns` / `stat_captured_ns` to decide whether a file can skip re-hashing. Those columns are nullable `int64`, but the reader only handled two "unknown" cases: a missing key (via `.get(key, SOURCE_STAT_UNKNOWN)`) and the `-1` sentinel. An explicit NULL is neither, so it slipped past the guard into `int(None)` and crashed. The capture-time column wasn't checked at all, so a NULL there crashed even with valid size/mtime.

## Solution

Treat a NULL stat column the same as unknown: return `None` so the caller re-hashes the file (the documented "no usable stat" path), and coerce a NULL capture time to the sentinel instead of calling `int()` on it. No behavior change for rows that already carry real stats or the sentinel.

Reproduced with two regression tests (NULL size/mtime, and NULL capture time alongside valid size/mtime) that fail with the exact error before the fix.