### PR TITLE
Retrieval review fixes: search-scope guards, temporal-filter parity, concept-boost + perf

### DIFF
--- a/src/lilbee/retrieval/concepts/community.py
+++ b/src/lilbee/retrieval/concepts/community.py
@@ -58,7 +58,7 @@ def _leiden_partition(
     ]
     _modularity, partition = leiden(edges=edges, seed=_LEIDEN_SEED)  # type: ignore[call-arg]
 
-    degree_map: dict[str, int] = Counter()
+    degree_map: Counter[str] = Counter()
     for row in edge_rows:
         degree_map[row["source"]] += 1
         degree_map[row["target"]] += 1

--- a/src/lilbee/retrieval/concepts/graph.py
+++ b/src/lilbee/retrieval/concepts/graph.py
@@ -58,6 +58,10 @@ class ConceptGraph:
         # StringStore). ConceptGraph is a Services singleton, so serialize every
         # nlp() / nlp.pipe() call on the shared daemon behind this lock.
         self._nlp_lock = threading.Lock()
+        # Single-entry memo: one search() extracts concepts for the same query
+        # twice (expansion + boost), so cache the last (text, max) -> result to
+        # spare the second spaCy pass without unbounded growth.
+        self._last_extract: tuple[tuple[str, int], list[str]] | None = None
 
     def _ensure_nlp(self) -> Any | None:
         """Lazy-load and cache the spaCy model. Returns None if unavailable."""
@@ -82,9 +86,14 @@ class ConceptGraph:
         nlp = self._ensure_nlp()
         if nlp is None:
             return []
+        cache_key = (text, max_concepts)
         with self._nlp_lock:
+            if self._last_extract is not None and self._last_extract[0] == cache_key:
+                return self._last_extract[1]
             doc = nlp(text)
-            return _filter_noun_chunks(doc, max_concepts)
+            result = _filter_noun_chunks(doc, max_concepts)
+            self._last_extract = (cache_key, result)
+            return result
 
     def extract_concepts_batch(self, texts: list[str]) -> list[list[str]]:
         """Batch-extract concepts from multiple texts."""
@@ -157,10 +166,13 @@ class ConceptGraph:
         """Boost search results whose chunks overlap with query concepts."""
         if not query_concepts or not results:
             return results
+        table = self._store.open_table(CHUNK_CONCEPTS_TABLE)
+        if table is None:
+            return results
         query_set = set(query_concepts)
         boosted: list[Any] = []
         for r in results:
-            chunk_concepts = set(self.get_chunk_concepts(r.source, r.chunk_index))
+            chunk_concepts = set(self._chunk_concepts_from(table, r.source, r.chunk_index))
             overlap = len(query_set & chunk_concepts)
             if overlap > 0:
                 boost = (overlap / len(query_set)) * self._config.concept_boost_weight
@@ -177,6 +189,15 @@ class ConceptGraph:
         table = self._store.open_table(CHUNK_CONCEPTS_TABLE)
         if table is None:
             return []
+        return self._chunk_concepts_from(table, source, chunk_index)
+
+    @staticmethod
+    def _chunk_concepts_from(table: Any, source: str, chunk_index: int) -> list[str]:
+        """Query one chunk's concepts from an already-open table.
+
+        Split out so a batch caller (``boost_results``) opens the table once
+        instead of re-opening it per result (an N+1 LanceDB access).
+        """
         escaped = escape_sql_string(source)
         try:
             rows = (

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -330,7 +330,10 @@ class Searcher:
             return self._hyde_search(query, top_k, chunk_type=chunk_type)
         if mode in (ChunkType.WIKI, ChunkType.RAW):
             # Explicit ``chunk_type`` arg beats the ``wiki:``/``raw:`` prefix shortcut.
-            effective = chunk_type if chunk_type is not None else ChunkType(mode)
+            # Route the prefix-derived type through the same wiki-disabled guard the
+            # explicit arg gets, so ``wiki:`` doesn't bypass it and search an empty pool.
+            requested = chunk_type if chunk_type is not None else ChunkType(mode)
+            effective = self._normalize_chunk_type(requested)
             query_vec = self._embedder.embed_query(query)
             return self._store.search(
                 query_vec, top_k=top_k, query_text=query, chunk_type=effective
@@ -440,12 +443,14 @@ class Searcher:
             query_text=question,
             chunk_type=chunk_type,
         )
-        if self._should_skip_expansion(question, chunk_type):
-            return results[: top_k * 2]
-        seen = {(r.source, r.chunk_index) for r in results}
-        self._merge_variant_results(question, query_vec, results, seen, top_k, chunk_type)
-        if self._config.hyde:
-            self._merge_hyde_results(question, results, seen, top_k, chunk_type)
+        # Query expansion (variant + HyDE searches) is skipped for short/term
+        # queries, but concept boost is a separate graph re-rank that should still
+        # apply -- the early return used to drop it on the skip path.
+        if not self._should_skip_expansion(question, chunk_type):
+            seen = {(r.source, r.chunk_index) for r in results}
+            self._merge_variant_results(question, query_vec, results, seen, top_k, chunk_type)
+            if self._config.hyde:
+                self._merge_hyde_results(question, results, seen, top_k, chunk_type)
         results = self._apply_concept_boost(results, question)
         return results[: top_k * 2]
 

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -259,11 +259,11 @@ class Searcher:
             if not query_concepts:
                 return results
             boosted = self._concepts.boost_results(results, query_concepts)
-            # boost_results mutates relevance_score/distance but preserves input
-            # order; re-sort so the boost actually re-ranks for callers that consume
-            # search() order directly (CLI search, MCP lilbee_search). order_by_fusion
-            # normalizes per scoring family so HyDE (distance) hits can't outrank a
-            # strong hybrid (RRF) hit purely on scale.
+            # boost_results returns copies with adjusted relevance_score/distance in
+            # input order; re-sort so the boost actually re-ranks for callers that
+            # consume search() order directly (CLI search, MCP lilbee_search).
+            # order_by_fusion normalizes per scoring family so HyDE (distance) hits
+            # can't outrank a strong hybrid (RRF) hit purely on scale.
             return order_by_fusion(boosted)
         except Exception:
             log.debug("Concept boost failed", exc_info=True)
@@ -452,6 +452,9 @@ class Searcher:
             if self._config.hyde:
                 self._merge_hyde_results(question, results, seen, top_k, chunk_type)
         results = self._apply_concept_boost(results, question)
+        # Apply the date-range filter here so the bare search() path (e.g. /api/search)
+        # honors a "recent"/"today" query, matching the chat/ask path.
+        results = self._apply_temporal_filter(results, question)
         return results[: top_k * 2]
 
     def build_rag_context(
@@ -476,7 +479,7 @@ class Searcher:
         results = prepare_results(results)
         if self._config.reranker_model:
             results = self._reranker.rerank(question, results)
-        results = self._apply_temporal_filter(results, question)
+        # Temporal filtering already ran inside search(); no need to repeat it here.
         results = self.select_context(results, question)
         system = self._system_with_memory(self._config.rag_system_prompt, question)
         results = self._fit_context_budget(results, system, question, history)

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -436,13 +436,20 @@ class Searcher:
         config, the filter is normalized to ``None`` (mixed pool) and a
         warning is logged: with wiki off the chunks table has no wiki rows,
         so honouring the filter would silently return zero results.
+
+        A ``mode:`` prefix (``term:``/``vec:``/``hyde:``/``wiki:``/``raw:``)
+        forces a single explicit retrieval strategy and so skips expansion and
+        concept boost, but the temporal date-range filter still applies -- it is
+        a filter, not a re-ranking, and a "recent" query must be honored in any
+        mode.
         """
         if top_k == 0:
             top_k = self._config.top_k
         chunk_type = self._normalize_chunk_type(chunk_type)
         mode, clean_query = self._parse_structured_query(question)
         if mode is not None:
-            return self._search_structured(mode, clean_query, top_k, chunk_type=chunk_type)
+            structured = self._search_structured(mode, clean_query, top_k, chunk_type=chunk_type)
+            return self._apply_temporal_filter(structured, clean_query)
         query_vec = self._embedder.embed_query(question)
         results = self._store.search(
             query_vec,

--- a/src/lilbee/retrieval/query/searcher.py
+++ b/src/lilbee/retrieval/query/searcher.py
@@ -60,6 +60,11 @@ log = logging.getLogger(__name__)
 # scores for the expansion-skip heuristic.
 _MIN_BM25_PROBE_RESULTS = 2
 
+# Structured-query mode names (the ``mode:`` prefix shortcut). Single source for
+# both the prefix parser and the dispatch in ``_search_structured``. "term"/"vec"/
+# "hyde" pick a retrieval strategy; "wiki"/"raw" are ChunkType scope shortcuts.
+_STRUCTURED_QUERY_MODES = ("term", "vec", "hyde", ChunkType.WIKI.value, ChunkType.RAW.value)
+
 
 def _bm25_confidence(score: float | None) -> float:
     """Squash a raw, unbounded BM25 score into the (0, 1) confidence that the
@@ -307,9 +312,11 @@ class Searcher:
         return chunk_type
 
     def _parse_structured_query(self, question: str) -> tuple[str | None, str]:
-        for prefix in ("term:", "vec:", "hyde:", "wiki:", "raw:"):
-            if question.strip().lower().startswith(prefix):
-                return prefix[:-1], question.strip()[len(prefix) :].strip()
+        stripped = question.strip()
+        for mode in _STRUCTURED_QUERY_MODES:
+            prefix = f"{mode}:"
+            if stripped.lower().startswith(prefix):
+                return mode, stripped[len(prefix) :].strip()
         return None, question
 
     def _search_structured(

--- a/src/lilbee/retrieval/reasoning.py
+++ b/src/lilbee/retrieval/reasoning.py
@@ -8,8 +8,10 @@ Reasoning models (Qwen3, DeepSeek-R1) wrap their thinking process in
   caller-supplied cap.
 - ``stream_chat_with_cap``: the high-level orchestrator. Wraps a
   provider call with the filter; when the cap fires, re-issues the
-  chat with a "stop thinking, answer directly" nudge. All chat surfaces
-  (HTTP/SSE, CLI, TUI) consume this so cap behavior is uniform.
+  chat with a "stop thinking, answer directly" nudge. The ask/search
+  streaming path and CLI/TUI consume it directly; the canonical
+  chat-dispatch path mirrors the same filter + cap-nudge behavior over
+  its own async driver.
 - ``effective_reasoning_cap``: resolves the cap from the global config
   with per-model ``ModelDefaults`` overrides.
 """

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -518,6 +518,13 @@ class TestBoostResults:
         boosted = cg.boost_results(results, ["python"])
         assert boosted[0].distance == 0.5
 
+    def test_boost_results_returns_unchanged_when_table_missing(self, cg, mock_svc):
+        """No chunk_concepts table -> results pass through (table opened once, up front)."""
+        results = [_make_result(distance=0.5, chunk_index=0)]
+        mock_svc.store.open_table.return_value = None
+        boosted = cg.boost_results(results, ["python"])
+        assert boosted == results
+
     def test_boost_results_empty_query_concepts(self, cg):
         results = [_make_result()]
         boosted = cg.boost_results(results, [])

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -205,6 +205,20 @@ class TestExtractConcepts:
         assert locked_during == [True]  # lock held while nlp() runs
         assert not cg._nlp_lock.locked()  # released afterwards
 
+    @patch("lilbee.retrieval.concepts.graph._ensure_spacy_model")
+    def test_repeated_query_reuses_memo(self, mock_spacy, cg):
+        """One search() extracts the same query twice (expand + boost); the second
+        call hits the single-entry memo instead of re-running spaCy."""
+        nlp = MagicMock(return_value=_make_mock_doc(["good concept"]))
+        mock_spacy.return_value = nlp
+        first = cg.extract_concepts("same query")
+        second = cg.extract_concepts("same query")
+        assert first == second == ["good concept"]
+        assert nlp.call_count == 1  # second call served from the memo
+        # A different query is not served from the memo.
+        cg.extract_concepts("other query")
+        assert nlp.call_count == 2
+
 
 class TestExtractConceptsBatch:
     @patch("lilbee.retrieval.concepts.graph._ensure_spacy_model")

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -525,6 +525,17 @@ class TestBoostResults:
         boosted = cg.boost_results(results, ["python"])
         assert boosted == results
 
+    def test_boost_results_opens_table_once_for_many_results(self, cg, mock_svc):
+        """The chunk_concepts table is opened once per call, not once per result (N+1)."""
+        results = [_make_result(distance=0.5, chunk_index=i) for i in range(4)]
+        mock_table = MagicMock()
+        mock_table.search.return_value.where.return_value.to_list.return_value = [
+            {"concept": "python"}
+        ]
+        mock_svc.store.open_table.return_value = mock_table
+        cg.boost_results(results, ["python"])
+        mock_svc.store.open_table.assert_called_once()
+
     def test_boost_results_empty_query_concepts(self, cg):
         results = [_make_result()]
         boosted = cg.boost_results(results, [])

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1105,6 +1105,25 @@ class TestShouldSkipExpansion:
         assert get_services().searcher._should_skip_expansion("test") is False
 
 
+class TestSearchAppliesConceptBoostOnExpansionSkip:
+    def test_concept_boost_runs_even_when_expansion_skipped(self, mock_svc, monkeypatch):
+        """Skipping query expansion must not also skip the concept-graph re-rank."""
+        searcher = get_services().searcher
+        mock_svc.store.search.return_value = [_make_result()]
+        monkeypatch.setattr(searcher, "_should_skip_expansion", lambda *a, **k: True)
+        called: list[bool] = []
+
+        def _boost(results, question):
+            called.append(True)
+            return results
+
+        monkeypatch.setattr(searcher, "_apply_concept_boost", _boost)
+        searcher.search("test query")
+        assert called == [True]
+        # Expansion was skipped: no variant searches ran.
+        mock_svc.store.search.assert_called_once()
+
+
 class TestBm25Confidence:
     def test_squashes_and_floors(self):
         from lilbee.retrieval.query.searcher import _bm25_confidence
@@ -1719,11 +1738,24 @@ class TestStructuredQueryScopeInteraction:
         kwargs = mock_svc.store.search.call_args.kwargs
         assert kwargs.get("chunk_type") == "raw"
 
-    def test_wiki_prefix_alone_still_filters_to_wiki(self, mock_svc):
+    def test_wiki_prefix_alone_filters_to_wiki_when_enabled(self, mock_svc):
+        cfg.wiki = True
+        try:
+            mock_svc.store.search.return_value = []
+            get_services().searcher.search("wiki: energy")
+            kwargs = mock_svc.store.search.call_args.kwargs
+            assert kwargs.get("chunk_type") == "wiki"
+        finally:
+            cfg.wiki = False
+
+    def test_wiki_prefix_falls_back_to_full_pool_when_wiki_disabled(self, mock_svc):
+        """The ``wiki:`` prefix goes through the same wiki-disabled guard as the
+        explicit chunk_type arg, so it can't search an empty wiki pool."""
+        cfg.wiki = False
         mock_svc.store.search.return_value = []
         get_services().searcher.search("wiki: energy")
         kwargs = mock_svc.store.search.call_args.kwargs
-        assert kwargs.get("chunk_type") == "wiki"
+        assert kwargs.get("chunk_type") is None
 
 
 class TestStructuredQueryWikiRaw:
@@ -1738,10 +1770,14 @@ class TestStructuredQueryWikiRaw:
         assert query == "python typing"
 
     def test_wiki_mode_passes_chunk_type(self, mock_svc):
-        mock_svc.store.search.return_value = [_make_result()]
-        get_services().searcher._search_structured("wiki", "test", 5)
-        mock_svc.store.search.assert_called_once()
-        assert mock_svc.store.search.call_args[1]["chunk_type"] == "wiki"
+        cfg.wiki = True
+        try:
+            mock_svc.store.search.return_value = [_make_result()]
+            get_services().searcher._search_structured("wiki", "test", 5)
+            mock_svc.store.search.assert_called_once()
+            assert mock_svc.store.search.call_args[1]["chunk_type"] == "wiki"
+        finally:
+            cfg.wiki = False
 
     def test_raw_mode_passes_chunk_type(self, mock_svc):
         mock_svc.store.search.return_value = [_make_result()]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1211,6 +1211,21 @@ class TestTemporalFilter:
         searcher = get_services().searcher
         assert searcher._apply_temporal_filter(results, "how does auth work") == results
 
+    def test_bare_search_applies_temporal_filter(self, mock_svc, monkeypatch):
+        """The bare search() path runs the temporal filter, matching chat/ask."""
+        searcher = get_services().searcher
+        mock_svc.store.search.return_value = [_make_result()]
+        monkeypatch.setattr(searcher, "_should_skip_expansion", lambda *a, **k: True)
+        seen: list[str] = []
+
+        def _temporal(results, question):
+            seen.append(question)
+            return results
+
+        monkeypatch.setattr(searcher, "_apply_temporal_filter", _temporal)
+        searcher.search("recent changes")
+        assert seen == ["recent changes"]
+
     def test_disabled_via_config(self, mock_svc):
         old = cfg.temporal_filtering
         cfg.temporal_filtering = False

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1226,6 +1226,24 @@ class TestTemporalFilter:
         searcher.search("recent changes")
         assert seen == ["recent changes"]
 
+    def test_structured_query_still_applies_temporal_filter(self, mock_svc, monkeypatch):
+        """A ``mode:`` prefix skips expansion/boost but the date filter still runs."""
+        cfg.wiki = True
+        try:
+            searcher = get_services().searcher
+            mock_svc.store.search.return_value = [_make_result()]
+            seen: list[str] = []
+
+            def _temporal(results, question):
+                seen.append(question)
+                return results
+
+            monkeypatch.setattr(searcher, "_apply_temporal_filter", _temporal)
+            searcher.search("wiki: recent changes")
+            assert seen == ["recent changes"]  # prefix stripped, filter applied
+        finally:
+            cfg.wiki = False
+
     def test_disabled_via_config(self, mock_svc):
         old = cfg.temporal_filtering
         cfg.temporal_filtering = False


### PR DESCRIPTION
## Problem

The retrieval review (bb-raj) found several search bugs: the ``wiki:``/``raw:`` query prefix bypassed the wiki-disabled guard that the explicit scope arg respects (so a ``wiki:`` query against a wiki-off install searched an empty pool); concept-graph re-ranking was silently dropped whenever the query-expansion-skip heuristic fired; and temporal date-range filtering only ran on the chat/ask path, not the bare ``search()`` used by ``/api/search``. Plus a few smaller issues: an N+1 LanceDB table open in concept boost, duplicated structured-mode strings, double spaCy NER over the same query, and a couple of stale docstrings.

## Solution

- The ``wiki:``/``raw:`` prefix goes through the same wiki-disabled guard as the explicit scope arg, so it falls back to the full pool instead of an empty one.
- Concept boost runs even when query expansion is skipped.
- Bare ``search()`` applies the temporal date filter, matching chat/ask; it also applies to ``mode:`` prefix queries (the filter is mode-independent).
- Concept boost opens the chunk-concepts table once per call instead of once per result.
- A repeated query (extracted for both expansion and boost) runs spaCy once via a single-entry memo.
- Single-sourced the structured-query mode names; corrected the boost-copies and reasoning-cap docstrings and a degree-map type.

Each behavioral change has a test; full coverage and lint pass locally. A verified review pass flagged that the first temporal fix missed structured queries, which this addresses.