### PR TITLE
Wiki review fixes: frontmatter escaping, citation accuracy, read-only lint, dedup

### DIFF
--- a/src/lilbee/cli/commands/wiki.py
+++ b/src/lilbee/cli/commands/wiki.py
@@ -163,7 +163,8 @@ def wiki_status(
 
     from lilbee.wiki.lint import lint_all as _lint_all
 
-    report = _lint_all(get_services().store)
+    # Read-only status: lint for counts without appending to the audit log.
+    report = _lint_all(get_services().store, record_log=False)
 
     if cfg.json_mode:
         json_output(

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -523,7 +523,8 @@ def wiki_status() -> dict[str, Any]:
     summaries = list(summaries_dir.rglob("*.md")) if summaries_dir.exists() else []
     drafts = list(drafts_dir.rglob("*.md")) if drafts_dir.exists() else []
 
-    report = lint_all(get_services().store)
+    # Read-only status: lint for counts without appending to the audit log.
+    report = lint_all(get_services().store, record_log=False)
     return {
         "wiki_enabled": cfg.wiki,
         WikiSubdir.SUMMARIES: len(summaries),

--- a/src/lilbee/wiki/citations.py
+++ b/src/lilbee/wiki/citations.py
@@ -18,6 +18,7 @@ from lilbee.core.config import Config
 from lilbee.data.store import CitationRecord, SearchChunk
 from lilbee.wiki.cache import normalize_whitespace
 from lilbee.wiki.citation import ParsedCitation
+from lilbee.wiki.entity_extractor.factory import effective_entity_mode
 
 log = logging.getLogger(__name__)
 
@@ -178,7 +179,9 @@ def render_provenance(config: Config, chunks: list[SearchChunk]) -> str:
     """
     block = {
         "provenance": {
-            "extraction_method": config.wiki_entity_mode.value,
+            # Record the extractor that actually runs (config mode may fall back),
+            # so the audit reflects reality, not the requested setting.
+            "extraction_method": effective_entity_mode(config.wiki_entity_mode).value,
             "chunks": [{"source": c.source, "chunk_index": c.chunk_index} for c in chunks],
         }
     }

--- a/src/lilbee/wiki/citations.py
+++ b/src/lilbee/wiki/citations.py
@@ -236,8 +236,12 @@ def resolve_multi_source_citations(
 
 
 def _match_citation_source(source_ref: str, source_names: list[str]) -> str:
-    """Find which source a citation references by matching filenames in the ref."""
-    for name in source_names:
+    """Find which source a citation references by matching filenames in the ref.
+
+    Checks longest names first so a filename that is a substring of another
+    (e.g. ``doc.md`` within ``mydoc.md``) can't shadow the more specific match.
+    """
+    for name in sorted(source_names, key=len, reverse=True):
         if name in source_ref:
             return name
     return ""

--- a/src/lilbee/wiki/citations.py
+++ b/src/lilbee/wiki/citations.py
@@ -70,10 +70,16 @@ def _find_excerpt_location(
     excerpt: str,
     chunks: list[SearchChunk],
 ) -> tuple[int, int, int, int]:
-    """Find page/line location of an excerpt within chunks."""
+    """Find page/line location of an excerpt within chunks.
+
+    Matches on whitespace-normalized text, the same way ``verify_citations``
+    does, so a citation that verifies doesn't then lose its location to a
+    raw-vs-normalized whitespace mismatch.
+    """
     if excerpt:
+        needle = normalize_whitespace(excerpt)
         for chunk in chunks:
-            if excerpt in chunk.chunk:
+            if needle in normalize_whitespace(chunk.chunk):
                 return chunk.page_start, chunk.page_end, chunk.line_start, chunk.line_end
     return 0, 0, 0, 0
 

--- a/src/lilbee/wiki/drafts.py
+++ b/src/lilbee/wiki/drafts.py
@@ -221,18 +221,6 @@ def _parse_pending_kind(text: str) -> str | None:
     return None
 
 
-def _strip_drift_marker(text: str) -> str:
-    """Remove the drift-review marker so accepted content lands clean."""
-    return _DRIFT_MARKER_RE.sub("", text, count=1).lstrip()
-
-
-def _strip_pending_markers(text: str) -> str:
-    """Remove PENDING-PARSE/COLLISION markers on the way into a published page."""
-    text = _PENDING_PARSE_MARKER_RE.sub("", text, count=1)
-    text = _PENDING_COLLISION_MARKER_RE.sub("", text, count=1)
-    return text.lstrip()
-
-
 def _classify_and_strip_markers(text: str) -> tuple[str | None, float | None, str]:
     """Single-pass read: parse kind, drift ratio, and return marker-stripped body.
 
@@ -346,7 +334,9 @@ def accept_draft(slug: str, wiki_root: Path, store: Store) -> AcceptResult:
     if not draft.is_file():
         raise FileNotFoundError(f"draft not found: {slug}")
     raw = draft.read_text(encoding="utf-8")
-    pending_kind = _parse_pending_kind(raw)
+    # Single-pass classify + strip (kind plus the three-marker removal), instead
+    # of re-deriving the kind and re-stripping the markers separately.
+    pending_kind, _drift, clean = _classify_and_strip_markers(raw)
 
     if pending_kind == PendingKind.PARSE:
         draft.unlink()
@@ -356,8 +346,6 @@ def accept_draft(slug: str, wiki_root: Path, store: Store) -> AcceptResult:
             slug,
         )
         return AcceptResult(slug=slug, requested_slug=slug, moved_to=draft, reindexed_chunks=0)
-
-    clean = _strip_pending_markers(_strip_drift_marker(raw))
 
     target_slug = _base_slug_for_collision(slug) if pending_kind == PendingKind.COLLISION else slug
     published = _find_published(wiki_root, target_slug)

--- a/src/lilbee/wiki/entity_extractor/factory.py
+++ b/src/lilbee/wiki/entity_extractor/factory.py
@@ -35,6 +35,15 @@ _EXTRACTOR_BY_MODE: dict[
 _IMPLEMENTED_MODES: frozenset[WikiEntityMode] = frozenset({WikiEntityMode.NER_ENTITIES})
 
 
+def effective_entity_mode(mode: WikiEntityMode) -> WikiEntityMode:
+    """The mode that will actually run for *mode*, applying the fallback.
+
+    Unimplemented strategies resolve to ``NER_ENTITIES``; provenance records this
+    so the audit reflects the extractor that ran, not the configured request.
+    """
+    return mode if mode in _IMPLEMENTED_MODES else WikiEntityMode.NER_ENTITIES
+
+
 def get_entity_extractor(
     mode: WikiEntityMode, provider: LLMProvider, config: Config
 ) -> EntityExtractor:
@@ -50,6 +59,6 @@ def get_entity_extractor(
             mode.value,
             WikiEntityMode.NER_ENTITIES.value,
         )
-        mode = WikiEntityMode.NER_ENTITIES
-    factory = _EXTRACTOR_BY_MODE[mode]
+    effective = effective_entity_mode(mode)
+    factory = _EXTRACTOR_BY_MODE[effective]
     return factory(provider, config)

--- a/src/lilbee/wiki/index.py
+++ b/src/lilbee/wiki/index.py
@@ -47,9 +47,14 @@ def parse_title(text: str) -> str:
 
 
 def _title_from_frontmatter(fm: dict[str, object], text: str) -> str:
-    """Return ``fm['title']`` when present, else the first H1 heading, else ``""``."""
-    if "title" in fm:
-        return str(fm["title"])
+    """Return ``fm['title']`` when set, else the first H1 heading, else ``""``.
+
+    Uses ``get(...) is not None`` (not key-presence) so an explicit empty
+    ``title:`` falls back to the H1, matching ``browse._resolve_page_title``
+    instead of rendering the literal ``"None"``.
+    """
+    if (fm_title := fm.get("title")) is not None:
+        return str(fm_title)
     for line in text.splitlines():
         stripped = line.strip()
         if stripped.startswith("# "):

--- a/src/lilbee/wiki/lint.py
+++ b/src/lilbee/wiki/lint.py
@@ -248,8 +248,14 @@ def lint_changed_sources(
 def lint_all(
     store: Store,
     config: Config | None = None,
+    *,
+    record_log: bool = True,
 ) -> LintReport:
-    """Full lint: check every wiki page in the store."""
+    """Full lint: check every wiki page in the store.
+
+    ``record_log=False`` skips the audit-log append so a read-only status check
+    can reuse this without mutating ``log.md``.
+    """
     if config is None:
         config = cfg
     report = LintReport()
@@ -268,11 +274,12 @@ def lint_all(
             report.issues.extend(lint_wiki_page(wiki_source, store, config))
 
     report.issues.extend(_lint_orphans(wiki_root, config))
-    append_wiki_log(
-        WikiLogAction.LINT,
-        f"{report.error_count} error(s), {report.warning_count} warning(s)",
-        config,
-    )
+    if record_log:
+        append_wiki_log(
+            WikiLogAction.LINT,
+            f"{report.error_count} error(s), {report.warning_count} warning(s)",
+            config,
+        )
     return report
 
 

--- a/src/lilbee/wiki/page.py
+++ b/src/lilbee/wiki/page.py
@@ -10,6 +10,7 @@ so wiki content participates in retrieval.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -148,14 +149,17 @@ def build_frontmatter(
     the generator and the extraction method from config, so a bad page
     is auditable without re-running the pipeline.
     """
-    sources_yaml = ", ".join(f'"{s}"' for s in sorted(source_names))
+    # JSON-serialize the list: a JSON array is valid YAML flow syntax and escapes
+    # quotes/backslashes/unicode, so a filename like ``a"b\c.txt`` can't corrupt
+    # the frontmatter (the hand-rolled per-name quoting did).
+    sources_yaml = json.dumps(sorted(source_names))
     hash_line = f"leaf_hash: {leaf_hash}\n" if leaf_hash else ""
     provenance_block = render_provenance(config, chunks) if chunks is not None else ""
     return (
         f"---\n"
         f"generated_by: {config.chat_model}\n"
         f"generated_at: {datetime.now(UTC).isoformat()}\n"
-        f"sources: [{sources_yaml}]\n"
+        f"sources: {sources_yaml}\n"
         f"faithfulness_score: {score:.2f}\n"
         f"{hash_line}"
         f"{provenance_block}"

--- a/src/lilbee/wiki/prune.py
+++ b/src/lilbee/wiki/prune.py
@@ -23,6 +23,7 @@ from lilbee.wiki.lint import IssueType, lint_wiki_page
 from lilbee.wiki.shared import (
     MIN_CLUSTER_SOURCES,
     WIKI_CONTENT_SUBDIRS,
+    WikiLogAction,
     WikiSubdir,
 )
 
@@ -189,7 +190,11 @@ def _finalize_prune(report: PruneReport, config: Config) -> None:
     )
     update_wiki_index(config)
     for rec in report.records:
-        append_wiki_log(f"pruned ({rec.action.value})", f"{rec.wiki_source}: {rec.reason}", config)
+        append_wiki_log(
+            WikiLogAction.PRUNE,
+            f"{rec.action.value} {rec.wiki_source}: {rec.reason}",
+            config,
+        )
 
 
 def prune_wiki(store: Store, config: Config | None = None) -> PruneReport:

--- a/src/lilbee/wiki/shared.py
+++ b/src/lilbee/wiki/shared.py
@@ -100,6 +100,7 @@ class WikiLogAction(StrEnum):
     BUILD = "build"
     INGEST = "ingest"
     LINT = "lint"
+    PRUNE = "prune"
 
 
 SUBDIR_TO_TYPE: dict[str, WikiPageType] = {

--- a/src/lilbee/wiki/synthesis.py
+++ b/src/lilbee/wiki/synthesis.py
@@ -147,11 +147,11 @@ def _split_batched_output(
         if kind_label is None:
             kind_label = match_label(lowered, concepts, EntityKind.CONCEPT)
         if kind_label is None:
-            # Concept labels come from the LLM itself: tag any
-            # unmatched section as CONCEPT only when the caller is
-            # expecting concept curation; otherwise drop it as
-            # noise.
-            if concepts is not None and expected_concept_labels is not None:
+            # Concept labels come from the LLM itself: tag any unmatched section as
+            # CONCEPT only when the caller is expecting concept curation; otherwise
+            # drop it as noise. ``concepts`` is always a set (``... or set()``), so
+            # the real signal is the raw ``expected_concept_labels`` arg.
+            if expected_concept_labels is not None:
                 recovered.setdefault(name, (EntityKind.CONCEPT, _prefix_heading(name, body)))
             continue
         kind, label = kind_label

--- a/tests/test_citation.py
+++ b/tests/test_citation.py
@@ -360,3 +360,17 @@ class TestCitationRecordTypedDict:
         }
         assert rec["page_start"] == 0
         assert rec["citation_key"] == "src1"
+
+
+class TestMatchCitationSource:
+    def test_longest_filename_wins_over_substring(self):
+        """A filename that is a substring of another must not shadow it."""
+        from lilbee.wiki.citations import _match_citation_source
+
+        names = ["doc.md", "mydoc.md"]
+        assert _match_citation_source("see mydoc.md p.2", names) == "mydoc.md"
+
+    def test_returns_empty_when_no_match(self):
+        from lilbee.wiki.citations import _match_citation_source
+
+        assert _match_citation_source("see other.md", ["doc.md"]) == ""

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -1324,6 +1324,18 @@ class TestBuildFrontmatter:
         assert "chunk_index: 0" in fm
         assert "chunk_index: 1" in fm
 
+    def test_provenance_records_effective_mode_not_configured(self, monkeypatch):
+        """When the configured entity mode falls back, provenance names the one that ran."""
+        from lilbee.core.config.enums import WikiEntityMode
+        from lilbee.wiki.page import build_frontmatter
+
+        monkeypatch.setattr(cfg, "wiki_entity_mode", WikiEntityMode.LLM_TAGGED)
+        chunks = [_make_chunk("body", source="doc.md", chunk_index=0)]
+        fm = build_frontmatter(cfg, ["doc.md"], 0.85, chunks=chunks)
+        # LLM_TAGGED isn't implemented; it falls back to ner_entities at run time.
+        assert "extraction_method: ner_entities" in fm
+        assert "llm_tagged" not in fm
+
     def test_provenance_round_trips_through_parse_frontmatter(self):
         from lilbee.wiki.page import build_frontmatter
         from lilbee.wiki.shared import parse_frontmatter

--- a/tests/test_wiki_gen.py
+++ b/tests/test_wiki_gen.py
@@ -1287,6 +1287,28 @@ class TestBuildFrontmatter:
         fm = build_frontmatter(cfg, ["doc.md"], 0.9)
         assert "provenance:" not in fm
 
+    def test_source_with_quotes_and_backslashes_round_trips(self):
+        """A filename with quotes/backslashes stays valid YAML, not corrupt frontmatter."""
+        import yaml
+
+        from lilbee.wiki.page import build_frontmatter
+
+        nasty = 'weird"name\\path.txt'
+        fm = build_frontmatter(cfg, [nasty, "plain.md"], 0.9)
+        parsed = yaml.safe_load(fm.strip().strip("-").strip())
+        assert set(parsed["sources"]) == {nasty, "plain.md"}
+
+    def test_find_excerpt_location_matches_across_whitespace(self):
+        """A verified excerpt finds its page/line even when the chunk wraps it
+        across newlines (verify normalizes whitespace; location must too)."""
+        from lilbee.wiki.citations import _find_excerpt_location
+
+        chunk = _make_chunk(
+            "the quick\nbrown   fox jumps", page_start=3, page_end=3, line_start=7, line_end=8
+        )
+        loc = _find_excerpt_location("the quick brown fox", [chunk])
+        assert loc == (3, 3, 7, 8)
+
     def test_with_chunks_renders_provenance_block(self):
         from lilbee.wiki.page import build_frontmatter
 

--- a/tests/test_wiki_index.py
+++ b/tests/test_wiki_index.py
@@ -50,6 +50,11 @@ class TestParseTitle:
     def test_empty_string(self):
         assert parse_title("") == ""
 
+    def test_empty_title_falls_back_to_h1(self):
+        """An explicit empty ``title:`` falls back to the H1, not the literal 'None'
+        (matches browse._resolve_page_title)."""
+        assert parse_title("---\ntitle:\n---\n# Real Heading\nbody") == "Real Heading"
+
 
 class TestParseSourceCount:
     def test_single_source(self):

--- a/tests/test_wiki_lint.py
+++ b/tests/test_wiki_lint.py
@@ -248,6 +248,14 @@ class TestLintWritesLogEntry:
         content = log_path.read_text()
         assert "lint |" in content
 
+    def test_lint_all_record_log_false_does_not_write_log(self, tmp_path: Path) -> None:
+        """A read-only status check (record_log=False) must not mutate log.md."""
+        write_wiki_page(tmp_path, "concepts", "braking", "# Braking\n\nText.\n")
+        store = MagicMock(spec=Store)
+        store.get_citations_for_wiki.return_value = []
+        lint_all(store, record_log=False)
+        assert not (tmp_path / "wiki" / "log.md").exists()
+
 
 class TestOrphanDetection:
     def test_orphan_concept_flagged(self, tmp_path: Path):


### PR DESCRIPTION
## Problem

The wiki review (bb-9gs) found correctness and consistency bugs: source filenames with quotes/backslashes corrupted the YAML frontmatter; verified citations lost their page/line because the location lookup matched raw text while verification matched whitespace-normalized text; provenance recorded the configured entity mode even when it fell back to a different extractor; and a read-only wiki status check mutated the audit log. Plus several smaller issues: a prune log verb built by hand instead of the shared enum, a permanently-true synthesis condition, two page-title resolvers disagreeing on an empty title, bare-substring citation source matching, and a re-implemented marker strip.

## Solution

- Frontmatter ``sources`` is JSON-serialized (valid YAML) so any filename round-trips intact.
- Citation location lookup normalizes whitespace the same way verification does, so verified citations keep their page/line.
- Provenance records the extractor that actually ran, not the configured-but-unimplemented mode.
- A read-only status check lints without appending to ``log.md``.
- Prune entries use the shared ``WikiLogAction`` enum; an empty ``title:`` falls back to the H1 (matching the other resolver); citation source matching prefers the longest filename; ``accept_draft`` reuses the existing marker-strip helper; and a dead condition is gone.

Each behavioral change has a test; full coverage, lint, and a verified review pass are green.