### PR TITLE
Modernize logging docs for the fleet engine (+ llama-swap.log in logs/)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ For day-to-day coding conventions and the full set of project rules, [`AGENTS.md
 - [uv](https://docs.astral.sh/uv/) for dependency management
 - `git`
 
-No external services are required. lilbee downloads and runs models locally via in-process `llama.cpp` (native GGUF). There is no Ollama dependency, though lilbee can talk to a running Ollama or LM Studio if you have one.
+No external services are required. lilbee downloads models locally (native GGUF) and runs each one in its own bundled `llama-server` process, supervised by llama-swap. There is no Ollama dependency, though lilbee can talk to a running Ollama or LM Studio if you have one.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ lilbee stands on a stack of established open-source projects, all bundled into o
 
 ## Support
 
-Having trouble? See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for log locations and common failures.
+Having trouble? See [TROUBLESHOOTING.md](https://github.com/tobocop2/lilbee/blob/main/TROUBLESHOOTING.md) for log locations and common failures.
 
 lilbee is built and maintained by one person. If it is useful to you, you can chip in via [PayPal](https://paypal.me/lilbeedotsh). Bug reports and pull requests help just as much.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -10,8 +10,14 @@ Everything lands in `logs/` under your data root:
 | --- | --- |
 | `server.log` | Everything `lilbee serve` does at INFO and above: startup, requests, indexing, errors. Rotates at 2 MiB; the previous files are kept as `server.log.1` through `server.log.3`. |
 | `server-fault.log` | Native crash tracebacks from `faulthandler`. Usually empty. If the server died without a Python traceback (a segfault in llama.cpp, for instance), this is where the evidence is. |
-| `worker-<role>.log` | One file per model worker subprocess: `worker-chat.log`, `worker-embed.log`, `worker-rerank.log`, `worker-vision.log`. Model load output and per-request activity for that role. |
+| `llama-swap.log` | Output from the engine supervisor (llama-swap) that fronts every model server: its HTTP access log plus the lines around a model server starting, stopping, or exiting. Check this when a model won't load or a request fails with "exited prematurely". |
+| `launcher-serve.log` | Captures the `lilbee serve` a launcher (e.g. `lilbee launch opencode`) spawns for you, so a crash during a launched session leaves a trace. Capped at 5 MB. |
 | `tui.log` | Logs from the full-screen terminal app, routed here so they don't draw over the screen. |
+
+Each model runs in its own `llama-server` subprocess behind llama-swap; that
+server's own startup/inference output is not a file on disk, it is streamed by
+llama-swap and embedded into the error you get back (see "Model server crashes"
+below).
 
 **The data root is resolved in this order**, highest precedence first:
 
@@ -37,20 +43,23 @@ lilbee --log-level DEBUG serve
 
 **The file log is more verbose than the console.** `server.log` captures INFO and above even at the default level, so the console staying quiet doesn't mean the file is empty. Check `server.log` first; raise the level only when you need DEBUG detail.
 
-## Worker crashes
+## Model server crashes
 
-lilbee runs each model in its own subprocess. When one dies mid-request you get a `WorkerCrashError` naming the role, for example:
+lilbee runs each model (chat, embed, rerank, vision) in its own `llama-server`
+subprocess, supervised by llama-swap. When one dies mid-request, llama-swap
+reports it as **"exited prematurely"** and lilbee surfaces the server's own recent
+output inline with the error, so the cause is usually right there in the message.
+The usual causes are a model that doesn't fit in memory, an unsupported GGUF
+architecture, or a GPU driver issue.
 
-```
-WorkerCrashError: Worker 'embed' subprocess exited unexpectedly. See <data root>/logs/worker-embed.log for details.
-```
-
-The error already includes the last few log lines, but the full story is in the worker's own file: `worker-chat.log`, `worker-embed.log`, `worker-rerank.log`, or `worker-vision.log`. The usual causes are a model that doesn't fit in memory, an unsupported GGUF architecture, or a GPU driver issue, and the log tail names which.
-
-When reporting a worker crash, attach the last ~100 lines of the worker log plus `server-fault.log` if it's non-empty:
+For the fuller picture, check `llama-swap.log` (the supervisor's view of every
+server starting and stopping) and `server.log` (what `lilbee serve` was doing
+around the failure). When reporting one, attach the last ~100 lines of each plus
+`server-fault.log` if it's non-empty:
 
 ```bash
-tail -n 100 "<data root>/logs/worker-embed.log"
+tail -n 100 "<data root>/logs/llama-swap.log"
+tail -n 100 "<data root>/logs/server.log"
 ```
 
 ## Using with the Obsidian plugin

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -60,8 +60,7 @@ SYNC_SKIPPED_NO_VISION = (
 )
 SYNC_SKIPPED_VISION_FAILED = (
     "Skipped (vision OCR returned no text): {files}. "
-    "See ~/Library/Application Support/lilbee/logs/server.log "
-    "for the underlying error."
+    "See {log_path} for the underlying error."
 )
 CMD_RETRY_SKIPPED_NONE = "No skipped files to retry; running a normal sync."
 CMD_RETRY_SKIPPED_SOME = "Cleared {count} skip marker(s); retrying those files."
@@ -76,7 +75,8 @@ def sync_skipped_message(files: str) -> str:
     do something they have already done.
     """
     if cfg.vision_model:
-        return SYNC_SKIPPED_VISION_FAILED.format(files=files)
+        log_path = cfg.data_root / "logs" / "server.log"
+        return SYNC_SKIPPED_VISION_FAILED.format(files=files, log_path=log_path)
     return SYNC_SKIPPED_NO_VISION.format(files=files)
 
 

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -60,7 +60,7 @@ SYNC_SKIPPED_NO_VISION = (
 )
 SYNC_SKIPPED_VISION_FAILED = (
     "Skipped (vision OCR returned no text): {files}. "
-    "See ~/Library/Application Support/lilbee/logs/worker-vision.log "
+    "See ~/Library/Application Support/lilbee/logs/server.log "
     "for the underlying error."
 )
 CMD_RETRY_SKIPPED_NONE = "No skipped files to retry; running a normal sync."

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -36,10 +36,12 @@ log = logging.getLogger(__name__)
 
 _HOST = "127.0.0.1"
 _CONFIG_FILENAME = "llama-swap.json"
-# llama-swap's own stdout/stderr (its HTTP access log) is captured here instead of
-# inherited from the parent: a TUI or CLI parent owns the terminal, and an inherited
-# fd would bleed llama-swap's request log straight onto the screen and corrupt the
-# render. Per-model upstream logs are unaffected (those go to llama-swap's /logs API).
+# llama-swap's own stdout/stderr (its HTTP access log) is captured to a file under
+# the data root's ``logs/`` (beside server.log etc.) instead of inherited from the
+# parent: a TUI or CLI parent owns the terminal, and an inherited fd would bleed
+# llama-swap's request log onto the screen and corrupt the render. Per-model
+# upstream logs are unaffected (those go to llama-swap's /logs API).
+_LOGS_SUBDIR = "logs"
 _LOG_FILENAME = "llama-swap.log"
 # Cross-run reaping: each owner lilbee writes its own state file (named with its
 # pid) recording its swap's pid/pgid plus the owner's pid and create time, so the
@@ -120,7 +122,7 @@ class SwapManager:
     def __init__(self, data_dir: Path) -> None:
         self._data_dir = data_dir
         self._config_path = data_dir / _CONFIG_FILENAME
-        self._log_path = data_dir / _LOG_FILENAME
+        self._log_path = data_dir / _LOGS_SUBDIR / _LOG_FILENAME
         self._state_path = data_dir / _state_filename(os.getpid())
         self._proc: subprocess.Popen[bytes] | None = None
         self._log_file: BinaryIO | None = None
@@ -147,6 +149,7 @@ class SwapManager:
         # Capture llama-swap's stdout/stderr to a file so its access log never
         # reaches an inherited terminal (a TUI/CLI parent) and garbles the screen.
         self._close_log()
+        self._log_path.parent.mkdir(parents=True, exist_ok=True)
         self._log_file = self._log_path.open("ab")
         self._proc = subprocess.Popen(  # noqa: S603 - argv[0] is the resolved llama-swap
             [

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -1352,7 +1352,11 @@ class TestSyncSkippedMessageBranches:
         from lilbee.cli.tui.messages import sync_skipped_message
 
         cfg.vision_model = "stub/vision"
-        assert "vision OCR returned no text" in sync_skipped_message("a.pdf")
+        msg = sync_skipped_message("a.pdf")
+        assert "vision OCR returned no text" in msg
+        # The log path must be the resolved, per-platform location (not a
+        # hardcoded macOS string), so it's correct on Linux/Windows too.
+        assert str(cfg.data_root / "logs" / "server.log") in msg
 
     def test_returns_no_vision_when_vision_model_unset(self) -> None:
         from lilbee.cli.tui.messages import sync_skipped_message

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -112,7 +112,7 @@ class TestStart:
         mgr = SwapManager(tmp_path)
         mgr.start([_launch(WorkerRole.CHAT)])
 
-        log_path = tmp_path / "llama-swap.log"
+        log_path = tmp_path / "logs" / "llama-swap.log"
         assert log_path.exists()
         # stdout is the opened log file (its .name is the path), not None
         # (inherited terminal) nor a PIPE; stderr merges into the same file.


### PR DESCRIPTION
## Problem

The docs still describe the old in-process model worker pool. That architecture is gone: each model now runs in its own `llama-server` process behind llama-swap. So TROUBLESHOOTING documents log files that are never written (`worker-chat/embed/rerank/vision.log`) and an error type that no longer exists (`WorkerCrashError`), and CONTRIBUTING says models run "in-process".

## Solution

Bring the docs in sync with the fleet, and tidy one path:
- TROUBLESHOOTING: drop the dead `worker-<role>.log` row and the `WorkerCrashError` section; document the real logs (`llama-swap.log`, `launcher-serve.log`) and rewrite "model server crashes" around llama-swap's "exited prematurely" error, which already embeds the server's recent output.
- CONTRIBUTING: "in-process llama.cpp" becomes "a bundled `llama-server` process per model, supervised by llama-swap".
- Point the vision-OCR skip message at `server.log` (the `worker-vision.log` it named never exists).
- Move `llama-swap.log` into the data root's `logs/` so it sits beside `server.log` and friends instead of the data root, creating the dir on first write. Updates the regression test.