### PR TITLE
Let users disable lilbee's MCP injection in launch opencode (--mcp/--no-mcp)

### DIFF
--- a/docs/opencode-models.md
+++ b/docs/opencode-models.md
@@ -11,6 +11,12 @@ opencode sends a prompt, the model calls `lilbee_search`, opencode runs the tool
 against an indexed workspace, and the model writes a final answer from the
 results. Each family below completed that loop.
 
+To bring your own MCP servers instead of lilbee's search tool, launch with
+`--no-mcp`: lilbee stays the model provider but omits its MCP block, leaving
+your own opencode MCP config untouched. The default is set by the
+`agent_mcp_enabled` config field (env `LILBEE_AGENT_MCP_ENABLED`); `--mcp` /
+`--no-mcp` override it for a single launch.
+
 ## Verified families
 
 | Family | Example model | Notes |

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -730,6 +730,15 @@ SETTINGS_MAP: dict[str, SettingDef] = {
             "Trades cold-start time per role for first-call latency"
         ),
     ),
+    "agent_mcp_enabled": SettingDef(
+        bool,
+        nullable=False,
+        group=SettingGroup.SYSTEM,
+        help_text=(
+            "Inject lilbee's MCP search tool into agent launchers (e.g. `launch opencode`). "
+            "Disable to bring your own MCP servers; lilbee stays the model provider"
+        ),
+    ),
     "max_tokens": SettingDef(
         int,
         nullable=True,

--- a/src/lilbee/cli/agent_configs/opencode.py
+++ b/src/lilbee/cli/agent_configs/opencode.py
@@ -66,6 +66,7 @@ def opencode_config(
     model_refs: list[str],
     chat_ctx: int | None = None,
     default_ref: str | None = None,
+    include_mcp: bool = True,
 ) -> dict[str, Any]:
     """Return the opencode.json block wiring lilbee as a provider.
 
@@ -78,6 +79,10 @@ def opencode_config(
     to fit instead of overflowing on a long agentic session. ``default_ref``
     pins opencode's startup model via the top-level ``model`` key
     (``provider/model-id`` form).
+
+    ``include_mcp=False`` omits the ``mcp`` block entirely (rather than emitting
+    ``enabled: false``) so a user who brings their own MCP servers keeps them via
+    opencode's own config merge, while lilbee stays the model provider.
     """
     config: dict[str, Any] = {
         "$schema": "https://opencode.ai/config.json",
@@ -92,7 +97,9 @@ def opencode_config(
                 "models": {ref: _model_entry(ref, chat_ctx) for ref in sorted(model_refs)},
             }
         },
-        "mcp": {
+    }
+    if include_mcp:
+        config["mcp"] = {
             "lilbee": {
                 "type": "remote",
                 "url": f"{base_url}/mcp",
@@ -100,8 +107,7 @@ def opencode_config(
                 "headers": {"Authorization": f"Bearer {api_key}"},
                 "timeout": _MCP_TIMEOUT_MS,
             }
-        },
-    }
+        }
     if default_ref is not None:
         config["model"] = f"lilbee/{default_ref}"
     return config

--- a/src/lilbee/cli/launchers/opencode.py
+++ b/src/lilbee/cli/launchers/opencode.py
@@ -119,8 +119,9 @@ class OpencodeLauncher:
     name = "opencode"
     install_hint = _OPENCODE_INSTALL_HINT
 
-    def __init__(self, *, assume_yes: bool = False) -> None:
+    def __init__(self, *, assume_yes: bool = False, include_mcp: bool = True) -> None:
         self._assume_yes = assume_yes
+        self._include_mcp = include_mcp
 
     def find_binary(self) -> str | None:
         return shutil.which("opencode")
@@ -130,7 +131,10 @@ class OpencodeLauncher:
     ) -> tuple[list[str], dict[str, str]]:
         if not _confirm_setup(self._assume_yes):
             raise typer.Exit(0)
-        _install_lilbee_skill()
+        # The lilbee-mcp guidance skill only helps when the MCP tool is wired in;
+        # skip it when MCP is disabled (a previously-installed skill is left alone).
+        if self._include_mcp:
+            _install_lilbee_skill()
         # The block carries the session's ephemeral port and token; never persist
         # it into user config.
         block = opencode_config(
@@ -139,6 +143,7 @@ class OpencodeLauncher:
             model_refs=model_refs,
             chat_ctx=served_chat_ctx(port),
             default_ref=str(cfg.chat_model),
+            include_mcp=self._include_mcp,
         )
         env = {**os.environ, _OPENCODE_CONFIG_ENV_VAR: json.dumps(block)}
         return ([], env)
@@ -152,6 +157,13 @@ def opencode_cmd(
         "-y",
         help="Proceed with first-run setup without the interactive prompt (for scripts/CI).",
     ),
+    mcp: bool | None = typer.Option(
+        None,
+        "--mcp/--no-mcp",
+        help="Inject lilbee's MCP search tool into opencode. Defaults to the "
+        "agent_mcp_enabled config; --mcp/--no-mcp overrides it for this launch.",
+    ),
 ) -> None:
     """Launch opencode with lilbee as its model provider."""
-    run_launcher(OpencodeLauncher(assume_yes=yes))
+    include_mcp = cfg.agent_mcp_enabled if mcp is None else mcp
+    run_launcher(OpencodeLauncher(assume_yes=yes, include_mcp=include_mcp))

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -75,6 +75,11 @@ class Config(BaseSettings):
     # ~-substitution / left-truncation for project paths. Toggled by F4.
     show_lilbee_path: bool = ConfigField(default=False, writable=True)
 
+    # Whether an agent launcher (today only `launch opencode`) injects lilbee's
+    # MCP search tool into the agent's session config. Generic name so future
+    # launchers can read the same field. Per-launch --mcp/--no-mcp overrides it.
+    agent_mcp_enabled: bool = ConfigField(default=True, writable=True)
+
     chat_model: str = Field(default="Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf", min_length=1)
     embedding_model: str = Field(
         default="nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q4_K_M.gguf",

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -328,6 +328,27 @@ def test_opencode_config_pins_default_model_when_ref_given():
     assert block["model"] == "lilbee/a/M/m.gguf"
 
 
+def test_opencode_config_includes_mcp_by_default():
+    from lilbee.cli.agent_configs.opencode import opencode_config
+
+    block = opencode_config(base_url="http://127.0.0.1:9", api_key="k", model_refs=["a/M/m.gguf"])
+    assert block["mcp"]["lilbee"]["url"] == "http://127.0.0.1:9/mcp"
+
+
+def test_opencode_config_omits_mcp_block_when_disabled():
+    """include_mcp=False drops the mcp block entirely but keeps lilbee as provider."""
+    from lilbee.cli.agent_configs.opencode import opencode_config
+
+    block = opencode_config(
+        base_url="http://127.0.0.1:9",
+        api_key="k",
+        model_refs=["a/M/m.gguf"],
+        include_mcp=False,
+    )
+    assert "mcp" not in block
+    assert "lilbee" in block["provider"]
+
+
 def test_opencode_config_omits_model_key_without_default_ref():
     from lilbee.cli.agent_configs.opencode import opencode_config
 
@@ -374,6 +395,51 @@ def test_launch_opencode_installs_skill_into_global_skills_dir(tmp_path):
     skill_path = tmp_path / ".config" / "opencode" / "skills" / "lilbee-mcp" / "SKILL.md"
     assert skill_path.exists()
     assert "lilbee-mcp" in skill_path.read_text()
+
+
+def _config_block_from_launch(args: list[str]) -> dict:
+    """Invoke ``launch opencode`` (with given extra args) and return the
+    opencode config block prepare() injected into the child env."""
+    import json
+
+    from lilbee.cli.launchers.opencode import _OPENCODE_CONFIG_ENV_VAR
+
+    _write_server_session()
+    completed = MagicMock(returncode=0)
+    with (
+        patch("lilbee.cli.launchers.opencode.shutil.which", return_value="/usr/local/bin/opencode"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed) as mock_run,
+    ):
+        runner.invoke(app, ["launch", *args])
+    env = mock_run.call_args.kwargs["env"]
+    return json.loads(env[_OPENCODE_CONFIG_ENV_VAR])
+
+
+def test_launch_opencode_no_mcp_omits_block_and_skips_skill(tmp_path):
+    """--no-mcp drops the mcp block and does not install the lilbee-mcp skill."""
+    block = _config_block_from_launch(["opencode", "--no-mcp"])
+    assert "mcp" not in block
+    assert "lilbee" in block["provider"]  # still the model provider
+    skill_path = tmp_path / ".config" / "opencode" / "skills" / "lilbee-mcp"
+    assert not skill_path.exists()
+
+
+def test_launch_opencode_mcp_flag_overrides_disabled_config(tmp_path, monkeypatch):
+    """--mcp forces the block on even when agent_mcp_enabled is False."""
+    from lilbee.core.config import cfg
+
+    monkeypatch.setattr(cfg, "agent_mcp_enabled", False)
+    block = _config_block_from_launch(["opencode", "--mcp"])
+    assert "mcp" in block
+
+
+def test_launch_opencode_defaults_to_config_when_no_flag(tmp_path, monkeypatch):
+    """With no flag, the config field decides; agent_mcp_enabled=False omits mcp."""
+    from lilbee.core.config import cfg
+
+    monkeypatch.setattr(cfg, "agent_mcp_enabled", False)
+    block = _config_block_from_launch(["opencode"])
+    assert "mcp" not in block
 
 
 def test_launch_opencode_skips_skill_install_when_already_present(tmp_path):


### PR DESCRIPTION
## Problem

`lilbee launch opencode` always injects an `mcp.lilbee` block into opencode's session config, forcing the `lilbee_search` tool on every session. Some users don't want the forced search tool, or want to bring their own MCP servers.

## Solution

Add an opt-out. A generic `agent_mcp_enabled` config field (default true, env `LILBEE_AGENT_MCP_ENABLED`) sets the default; a tri-state `--mcp/--no-mcp` flag on `launch opencode` overrides it per launch. When disabled, the opencode config omits the mcp block entirely (so the user's own MCP servers still apply and lilbee stays the model provider) and the lilbee-mcp guidance skill install is skipped. Surfaced in the Settings screen and the opencode docs. Default stays on, so existing behavior is unchanged.