### PR TITLE
Make TUI document delete durable (skip-marker, keep file)

### DIFF
--- a/src/lilbee/app/ingest.py
+++ b/src/lilbee/app/ingest.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from lilbee.core.config import cfg
 from lilbee.core.security import validate_path_within
 from lilbee.core.system import is_ignored_dir
+from lilbee.data.store.types import RemoveResult
 
 
 @dataclass
@@ -45,6 +46,43 @@ def copy_files(paths: list[Path], *, force: bool = False) -> CopyResult:
         else:
             shutil.copy2(p, dest)
         result.copied.append(p.name)
+    return result
+
+
+_REMOVED_SKIP_REASON = "removed via delete (re-add the file or run retry-skipped to restore)"
+
+
+def remove_documents_durably(names: list[str]) -> RemoveResult:
+    """Remove documents from the index and skip-mark them so sync won't re-ingest.
+
+    The source files stay on disk (non-destructive), but each removed file gets a
+    skip-marker keyed on its current hash, so the next sync treats it as
+    unchanged-and-skipped instead of re-ingesting it and resurrecting the doc.
+    Editing the file (new hash), ``retry-skipped``, or ``rebuild`` restores it.
+    """
+    from lilbee.app.services import get_services
+    from lilbee.data.ingest.discovery import file_hash
+    from lilbee.data.ingest.skip_marker import (
+        load_skip_markers,
+        load_skip_reasons,
+        write_skip_markers,
+        write_skip_reasons,
+    )
+
+    result = get_services().store.remove_documents(names)
+    if not result.removed:
+        return result
+    markers = load_skip_markers(cfg.data_root)
+    reasons = load_skip_reasons(cfg.data_root)
+    for name in result.removed:
+        path = cfg.documents_dir / name
+        # Imported sources have no file on disk; sync never re-ingests them, so a
+        # marker is only needed for real files that would otherwise be re-found.
+        if path.exists():
+            markers[name] = file_hash(path)
+            reasons[name] = _REMOVED_SKIP_REASON
+    write_skip_markers(cfg.data_root, markers)
+    write_skip_reasons(cfg.data_root, reasons)
     return result
 
 

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -113,9 +113,12 @@ class LilbeeCommandProvider(Provider):
             app.title = msg.app_title(value)
 
     def _delete_doc(self, name: str) -> None:
+        from lilbee.app.ingest import remove_documents_durably
         from lilbee.cli.tui.widgets.autocomplete import invalidate_document_cache
 
-        get_services().store.remove_documents([name])
+        # Skip-mark so the next sync doesn't re-ingest the kept file (durable,
+        # non-destructive delete; the file stays on disk).
+        remove_documents_durably([name])
         # Invalidate the document cache like the chat /delete path, so the
         # deleted file stops being offered by autocomplete and the palette.
         invalidate_document_cache()

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -946,9 +946,12 @@ class ChatScreen(Screen[None]):
             )
             return
 
-        get_services().store.remove_documents([name])
+        from lilbee.app.ingest import remove_documents_durably
         from lilbee.cli.tui.widgets.autocomplete import invalidate_document_cache
 
+        # Skip-mark so the next sync doesn't re-ingest the kept file (durable,
+        # non-destructive delete; the file stays on disk).
+        remove_documents_durably([name])
         invalidate_document_cache()
         call_from_thread(self, self.notify, msg.CMD_DELETE_SUCCESS.format(name=name))
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3083,3 +3083,35 @@ class TestUnsupportedFileInSync:
 
             with pytest.raises(ValueError, match="Unsupported file slipped through"):
                 await sync(quiet=True)
+
+
+class TestRemoveDocumentsDurably:
+    def test_writes_skip_marker_for_kept_file(self, isolated_env, mock_svc):
+        """A durable delete keeps the file but skip-marks it so sync won't re-ingest."""
+        from lilbee.app.ingest import remove_documents_durably
+        from lilbee.data.ingest.discovery import file_hash
+        from lilbee.data.ingest.skip_marker import load_skip_markers, load_skip_reasons
+        from lilbee.data.store.types import RemoveResult
+
+        doc = isolated_env / "keep.txt"
+        doc.write_text("content")
+        mock_svc.store.remove_documents.side_effect = None
+        mock_svc.store.remove_documents.return_value = RemoveResult(
+            removed=["keep.txt"], not_found=[]
+        )
+
+        remove_documents_durably(["keep.txt"])
+
+        assert doc.exists()  # non-destructive: file stays on disk
+        assert load_skip_markers(cfg.data_root)["keep.txt"] == file_hash(doc)
+        assert "keep.txt" in load_skip_reasons(cfg.data_root)
+
+    def test_no_marker_when_nothing_removed(self, isolated_env, mock_svc):
+        from lilbee.app.ingest import remove_documents_durably
+        from lilbee.data.ingest.skip_marker import load_skip_markers
+        from lilbee.data.store.types import RemoveResult
+
+        mock_svc.store.remove_documents.side_effect = None
+        mock_svc.store.remove_documents.return_value = RemoveResult(removed=[], not_found=["gone"])
+        remove_documents_durably(["gone"])
+        assert load_skip_markers(cfg.data_root) == {}


### PR DESCRIPTION
## Problem

Deleting a document from the TUI (`/delete` and the command palette) dropped its index records but left the source file on disk, so the next sync re-ingested it and the document reappeared.

## Solution

TUI delete now goes through `remove_documents_durably`, which removes the index records and writes a hash-keyed skip-marker for the kept file. The next sync treats that file as unchanged-and-skipped instead of re-ingesting it, so a deleted doc stays gone. It's non-destructive: the file remains on disk, and editing it (new hash) or running retry-skipped / rebuild restores it. Imported sources (no file on disk) need no marker.