### PR TITLE
Catalog/modelhub review fixes

### DIFF
--- a/src/lilbee/catalog/__init__.py
+++ b/src/lilbee/catalog/__init__.py
@@ -9,7 +9,6 @@ Three levels:
 from lilbee.catalog.download import (
     DownloadConfig,
     download_model,
-    fetch_model_file_size,
     find_mmproj_file,
     resolve_filename,
 )
@@ -75,7 +74,6 @@ __all__ = [
     "download_task_name",
     "enrich_catalog",
     "extract_quant",
-    "fetch_model_file_size",
     "find_catalog_entry",
     "find_mmproj_file",
     "get_catalog",

--- a/src/lilbee/catalog/compat.py
+++ b/src/lilbee/catalog/compat.py
@@ -30,7 +30,13 @@ def classify(architecture: str) -> ModelCompat:
 
 
 def resolve_arch_for_pull(ref: str, hf_client: HfClient) -> str:
-    """Resolve general.architecture for *ref*: cache hit > Range-GET probe > empty (UNKNOWN)."""
+    """Resolve general.architecture for *ref*: cache hit > Range-GET probe > empty (UNKNOWN).
+
+    ``probe_architecture`` returns ``""`` on any failure (network, non-200, parse),
+    so an empty result means "undetermined", never a real verdict. Only a non-empty
+    arch is cached; otherwise a transient probe failure would be cached permanently
+    and disable the unsupported-arch guard for this ref on every later pull.
+    """
     cached = hf_client.get_cached_arch(ref)
     if cached is not None:
         return cached
@@ -38,7 +44,8 @@ def resolve_arch_for_pull(ref: str, hf_client: HfClient) -> str:
     if not url:
         return ""
     arch = probe_architecture(url)
-    hf_client.cache_arch(ref, arch)
+    if arch:
+        hf_client.cache_arch(ref, arch)
     return arch
 
 

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -293,10 +293,19 @@ def _resolve_mmproj_filename(hf_repo: str, pattern: str) -> str | None:
     return mmproj_files[0]
 
 
-def _mmproj_in_models_dir_matching(pattern: str) -> Path | None:
-    """Return the first ``*.gguf`` under the models dir that matches."""
-    models_dir: Path = _models_dir()
-    for p in models_dir.rglob("*.gguf"):
+def _mmproj_in_repo_cache(hf_repo: str, pattern: str) -> Path | None:
+    """Return an mmproj ``*.gguf`` from *hf_repo*'s own HF cache subtree, or None.
+
+    Scoped to the repo's ``models--<org>--<repo>`` directory so a different vision
+    repo's mmproj is never returned. An unscoped models-dir walk would let a chat
+    model inherit another model's mmproj and be misreported as vision-capable.
+    """
+    from huggingface_hub.constants import REPO_ID_SEPARATOR
+
+    repo_cache = _models_dir() / f"models--{hf_repo.replace('/', REPO_ID_SEPARATOR)}"
+    if not repo_cache.exists():
+        return None
+    for p in repo_cache.rglob("*.gguf"):
         if fnmatch.fnmatch(p.name, pattern) or "mmproj" in p.name.lower():
             return p
     return None
@@ -320,7 +329,7 @@ def find_mmproj_file(model_ref: str) -> Path | None:
         if model_ref not in entry.hf_repo and entry.hf_repo not in model_ref:
             continue
         pattern = VISION_MMPROJ_FILES.get(entry.hf_repo, DEFAULT_MMPROJ_PATTERN)
-        match = _mmproj_in_models_dir_matching(pattern)
+        match = _mmproj_in_repo_cache(entry.hf_repo, pattern)
         if match is not None:
             return match
     return None

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -415,31 +415,3 @@ def fetch_expected_file_size(hf_repo: str, filename: str) -> int:
         return _hf_file_size(hf_repo, filename) or _SIZE_UNKNOWN
     except Exception:
         return _SIZE_UNKNOWN
-
-
-def fetch_model_file_size(hf_repo: str) -> float:
-    """Fetch the best GGUF file size from HuggingFace tree API.
-    Returns size in GB, or 0.0 if unavailable.
-    """
-    try:
-        resp = httpx.get(
-            f"{HF_API_URL}/{hf_repo}/tree/main",
-            timeout=DEFAULT_TIMEOUT,
-            headers=hf_headers(),
-        )
-        resp.raise_for_status()
-        files = resp.json()
-    except Exception:
-        return 0.0
-
-    gguf_files = [
-        (f.get("path", ""), f.get("size", 0) or f.get("lfs", {}).get("size", 0))
-        for f in files
-        if isinstance(f, dict) and f.get("path", "").endswith(".gguf")
-    ]
-    if not gguf_files:
-        return 0.0
-
-    best_name = pick_best_gguf([name for name, _ in gguf_files])
-    size_bytes = next((s for n, s in gguf_files if n == best_name), 0)
-    return round(size_bytes / (1024**3), 1) if size_bytes else 0.0

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -285,7 +285,7 @@ def _resolve_mmproj_filename(hf_repo: str, pattern: str) -> str | None:
     if not mmproj_files:
         return None
 
-    # Prefer F16 over F32 (smaller), and any over BF16
+    # Prefer an F16 mmproj when one is offered; otherwise take the first match.
     for preference in ("f16", "F16"):
         for f in mmproj_files:
             if preference in f:

--- a/src/lilbee/catalog/families.py
+++ b/src/lilbee/catalog/families.py
@@ -77,8 +77,9 @@ def _build_families(models: tuple[CatalogModel, ...], task: ModelTask) -> list[M
 def get_families() -> list[ModelFamily]:
     """Get all featured models grouped into families.
     Returns families ordered: chat, then embedding, then vision, then reranker.
-    Within each family, variants are ordered smallest to largest, with
-    the largest marked as recommended (for multi-variant families).
+    Within each family, variants preserve the order they appear in the featured
+    lists. The recommended flag on each variant comes from the catalog entry's
+    own ``recommended`` value, not from size.
     """
     return (
         _build_families(FEATURED_CHAT, ModelTask.CHAT)

--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -128,13 +128,19 @@ def _resolve_sibling_gguf(siblings: list[RepoSibling]) -> str:
 
 
 def _estimate_size_from_siblings(siblings: list[RepoSibling]) -> float:
-    """Estimate model size in GB from the largest GGUF file in siblings."""
-    max_bytes = 0
-    for sib in siblings:
-        if sib.rfilename.endswith(".gguf"):
-            max_bytes = max(max_bytes, sib.size or 0)
-    if max_bytes > 0:
-        return round(max_bytes / _BYTES_PER_GB, 1)
+    """Estimate model size in GB from the GGUF the row will actually pull.
+
+    Sizes the same quant ``_resolve_sibling_gguf`` names (via ``pick_best_gguf``),
+    not the repo's largest GGUF. Sizing the largest (often an F16/BF16) while the
+    row names the Q4_K_M quant mis-buckets the model under size filtering.
+    """
+    gguf_files = [s for s in siblings if s.rfilename.endswith(".gguf")]
+    if not gguf_files:
+        return 0.0
+    picked = pick_best_gguf([s.rfilename for s in gguf_files])
+    for sib in gguf_files:
+        if sib.rfilename == picked and sib.size:
+            return round(sib.size / _BYTES_PER_GB, 1)
     return 0.0  # unknown: display as "?" in UI
 
 

--- a/src/lilbee/catalog/query.py
+++ b/src/lilbee/catalog/query.py
@@ -300,14 +300,21 @@ def reclassify_by_name(ref: str, declared_task: str) -> str:
     loaders, or embedders. Embedders on a chat decoder arch (e.g.
     ``Qwen3-Embedding-*``, a qwen3 backbone + pooling head) classify as chat by
     architecture, so the name is the only signal short of probing the GGUF
-    pooling type. Reranker is checked before embedding so ``bge-reranker`` (which
-    also matches the ``bge-`` embedder pattern) stays a reranker.
+    pooling type.
+
+    Check order (rerank, embedding, vision) matches
+    :func:`lilbee.modelhub.model_manager.discovery._classify_remote_task` so the
+    manifest and remote-discovery paths never disagree. Reranker is checked first
+    so ``bge-reranker`` (which also matches the ``bge-`` embedder pattern) stays a
+    reranker; embedding is checked before vision so an image embedder like
+    ``nomic-embed-vision`` (matching both ``embed`` and ``vision``) stays an
+    embedder.
     """
     name_lower = ref.lower()
     if any(rp in name_lower for rp in RERANKER_NAME_PATTERNS):
         return ModelTask.RERANK
-    if any(vp in name_lower for vp in VISION_NAME_PATTERNS):
-        return ModelTask.VISION
     if any(ep in name_lower for ep in EMBEDDING_NAME_PATTERNS):
         return ModelTask.EMBEDDING
+    if any(vp in name_lower for vp in VISION_NAME_PATTERNS):
+        return ModelTask.VISION
     return declared_task

--- a/src/lilbee/catalog/query.py
+++ b/src/lilbee/catalog/query.py
@@ -1,6 +1,7 @@
 """Catalog filtering, sorting, lookup, and ad-hoc HF resolution."""
 
 import functools
+import logging
 from typing import Any, NamedTuple
 
 from huggingface_hub.utils import HFValidationError, validate_repo_id
@@ -10,6 +11,8 @@ from lilbee.catalog.featured import FEATURED_ALL
 from lilbee.catalog.models import CatalogModel, CatalogResult
 from lilbee.catalog.refs import GGUF_GLOB, format_native_gguf_ref, hf_repo_from_ref
 from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
+
+log = logging.getLogger(__name__)
 
 
 def _search_blob(m: CatalogModel) -> str:
@@ -134,10 +137,16 @@ def pipeline_to_task(pipeline_tag: str) -> ModelTask:
 
 
 def _get_installed_models(model_manager: Any) -> set[str]:
-    """Get set of installed model names from model_manager."""
+    """Get set of installed model names from model_manager.
+
+    Treats a manager failure as "nothing installed" so the browse list still
+    renders, but logs it: silently swallowing would hide a broken registry that
+    makes every model look uninstalled.
+    """
     try:
         return set(model_manager.list_installed())
     except Exception:
+        log.warning("Could not read installed models; treating as none installed", exc_info=True)
         return set()
 
 

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 from collections.abc import Callable
@@ -161,10 +162,10 @@ class LilbeeApp(App[None]):
     # Production never sets it. See tests/_lilbee_app_test_host.py.
     _test_skip_auto_init: ClassVar[bool] = False
 
-    def on_mount(self) -> None:
+    async def on_mount(self) -> None:
         if self._test_skip_auto_init:
             return
-        self._canonicalize_persisted_models()
+        await self._canonicalize_persisted_models()
         self.title = msg.app_title(cfg.chat_model)
         # Restore the persisted theme so the TUI opens in whatever the user
         # picked last session, not always the default.
@@ -204,17 +205,24 @@ class LilbeeApp(App[None]):
 
         get_services().add_pool_listener(on_spawning=_on_spawning, on_spawned=_on_spawned)
 
-    def _canonicalize_persisted_models(self) -> None:
-        """Swap stale persisted refs to a working fallback, persist, and log once."""
+    async def _canonicalize_persisted_models(self) -> None:
+        """Swap stale persisted refs to a working fallback, persist, and log once.
+
+        Canonicalization can probe local model servers over HTTP/DNS, so it runs
+        off the event loop to keep the TUI from freezing at mount. The probes
+        finish before the chat screen installs, so it still sees a settled ref.
+        """
         from lilbee.modelhub.model_manager import (
             ValidationResult,
             canonicalize_chat_model,
             canonicalize_embedding_model,
         )
 
+        chat_canon = await asyncio.to_thread(canonicalize_chat_model)
+        embedding_canon = await asyncio.to_thread(canonicalize_embedding_model)
         for canon, field, label in (
-            (canonicalize_chat_model(), "chat_model", "Chat"),
-            (canonicalize_embedding_model(), "embedding_model", "Embedding"),
+            (chat_canon, "chat_model", "Chat"),
+            (embedding_canon, "embedding_model", "Embedding"),
         ):
             if canon.status == ValidationResult.OK:
                 continue

--- a/src/lilbee/modelhub/model_manager/discovery.py
+++ b/src/lilbee/modelhub/model_manager/discovery.py
@@ -258,7 +258,7 @@ class KnownModelCache:
         if model in refs:
             return model
         if "/" not in model and ":" in model:
-            prefixed = f"ollama/{model}"
+            prefixed = OLLAMA.qualify(model)
             if prefixed in refs:
                 return prefixed
         return None

--- a/src/lilbee/modelhub/model_manager/discovery.py
+++ b/src/lilbee/modelhub/model_manager/discovery.py
@@ -203,13 +203,22 @@ def detect_remote_embedding_models() -> list[str]:
     return [m.name for m in classify_all_remote_models() if m.task == ModelTask.EMBEDDING]
 
 
+def _installed_native_refs() -> set[str]:
+    """Canonical refs from the native registry; empty set if the walk fails."""
+    try:
+        return {m.ref for m in get_services().registry.list_installed()}
+    except Exception:
+        log.warning("Native registry walk failed; contributing no installed refs", exc_info=True)
+        return set()
+
+
 def gather_known_model_refs() -> set[str]:
     """Canonical refs from the native registry, every configured local server, and APIs.
 
     Each primitive swallows its own failures, so a backend being down contributes an
     empty subset rather than raising.
     """
-    refs = {m.ref for m in get_services().registry.list_installed()}
+    refs = _installed_native_refs()
     for rm in classify_all_remote_models():
         refs.add(format_remote_ref(rm.name, rm.provider))
     for models in discover_api_models().values():

--- a/src/lilbee/modelhub/model_manager/validation.py
+++ b/src/lilbee/modelhub/model_manager/validation.py
@@ -66,9 +66,8 @@ def _is_local_installed(ref: str) -> bool:
     """True iff ``ref`` resolves to an installed GGUF in the local registry."""
     try:
         registry = ModelRegistry(cfg.models_dir)
-        installed = {m.ref for m in registry.list_installed()} | {
-            m.hf_repo for m in registry.list_installed()
-        }
+        installed_models = registry.list_installed()
+        installed = {m.ref for m in installed_models} | {m.hf_repo for m in installed_models}
         return ref in installed
     except Exception:  # pragma: no cover - defensive for fresh installs
         log.debug("Local registry probe failed for %r", ref, exc_info=True)

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -470,10 +470,12 @@ class ModelRegistry:
             repo_dir.rmdir()
         # Free the primary blob and every extra shard blob; a split GGUF has more
         # than one, and leaving the others orphans them when a sibling quant keeps
-        # the repo cache dir alive.
+        # the repo cache dir alive. The surviving manifests for this repo are read
+        # once here rather than per digest (list_installed walks the whole tree).
+        siblings = [m for m in self.list_installed() if m.hf_repo == manifest.hf_repo]
         for digest in [manifest.blob, *shard_blobs]:
             if digest is not None:
-                self._gc_blob(manifest.hf_repo, digest)
+                self._gc_blob(manifest.hf_repo, digest, siblings=siblings)
         log.info("Removed model %s", ref)
         return True
 
@@ -489,7 +491,9 @@ class ModelRegistry:
             return [_blob_digest(path) for path in shards[1:]]
         return []
 
-    def _gc_blob(self, hf_repo: str, digest: str) -> None:
+    def _gc_blob(
+        self, hf_repo: str, digest: str, *, siblings: list[ModelManifest] | None = None
+    ) -> None:
         """Drop blob bytes and HuggingFace cache cruft now that *digest*
         and possibly the whole repo are unused.
 
@@ -498,6 +502,10 @@ class ModelRegistry:
         ``snapshots/``, and stale ``blobs/`` all go with it. Otherwise
         only the specific blob file is removed when no remaining
         manifest still references its digest.
+
+        ``siblings`` is the surviving-manifest list for *hf_repo*; callers
+        freeing several blobs at once pass it in so the manifest tree is walked
+        once instead of per digest. Defaults to reading it when omitted.
         """
         cache_path = self._repo_cache_dir(hf_repo)
         try:
@@ -505,7 +513,8 @@ class ModelRegistry:
         except ValueError:
             log.warning("Refusing to remove cache outside models_dir: %s", cache_path)
             return
-        siblings = [m for m in self.list_installed() if m.hf_repo == hf_repo]
+        if siblings is None:
+            siblings = [m for m in self.list_installed() if m.hf_repo == hf_repo]
         if not siblings:
             if cache_path.exists():
                 shutil.rmtree(cache_path)

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -513,6 +513,11 @@ class ModelRegistry:
         if any(digest == m.blob or digest in m.shard_blobs for m in siblings):
             return
         blob_file = cache_path / "blobs" / digest
+        try:
+            validate_path_within(blob_file, self._root)
+        except ValueError:
+            log.warning("Refusing to remove blob outside models_dir: %s", blob_file)
+            return
         if blob_file.exists():
             blob_file.unlink()
 

--- a/src/lilbee/modelhub/role_validator.py
+++ b/src/lilbee/modelhub/role_validator.py
@@ -2,9 +2,8 @@
 
 import os
 import sys
-from typing import Any
 
-from lilbee.catalog import find_catalog_entry
+from lilbee.catalog import CatalogModel, find_catalog_entry
 from lilbee.catalog.query import reclassify_by_name
 from lilbee.catalog.refs import is_bare_hf_repo
 from lilbee.catalog.types import ModelTask
@@ -62,7 +61,7 @@ def _skips_catalog_check(ref: str, *, allow_bypass: bool) -> bool:
     return ref.split("/", 1)[0] in PROVIDER_PREFIXES
 
 
-def _canonical_featured_ref(ref: str, entry: Any, want: ModelTask) -> str:
+def _canonical_featured_ref(ref: str, entry: CatalogModel, want: ModelTask) -> str:
     """Role-check a featured entry and pick the canonical ref to persist."""
     if entry.task != want:
         raise TaskMismatchError(ref, ModelTask(entry.task), want)
@@ -105,7 +104,7 @@ def validate_model_task_assignment(field_name: str, ref: str, *, allow_bypass: b
     if _skips_catalog_check(ref, allow_bypass=allow_bypass):
         return ref
     want = ModelTask(_MODEL_FIELD_TO_TASK[field_name])
-    entry: Any = find_catalog_entry(ref)
+    entry = find_catalog_entry(ref)
     if entry is not None:
         return _canonical_featured_ref(ref, entry, want)
     return _validate_installed_ref(ref, want)

--- a/src/lilbee/modelhub/role_validator.py
+++ b/src/lilbee/modelhub/role_validator.py
@@ -10,7 +10,7 @@ from lilbee.catalog.refs import is_bare_hf_repo
 from lilbee.catalog.types import ModelTask
 from lilbee.core.config import cfg
 from lilbee.modelhub.registry import ModelRegistry
-from lilbee.providers.model_ref import PROVIDER_PREFIXES
+from lilbee.providers.model_ref import PROVIDER_PREFIXES, is_native_gguf_ref
 
 # Test-only bypass. Both the env var and pytest must be present so a
 # leaked env var cannot disable validation in production.
@@ -22,10 +22,6 @@ _MODEL_FIELD_TO_TASK: dict[str, str] = {
     "vision_model": "vision",
     "reranker_model": "rerank",
 }
-
-# A native GGUF ref of the form ``<owner>/<repo>/<file>.gguf`` has at least
-# two ``/`` separators; one-slash refs are bare repo IDs.
-_NATIVE_GGUF_REF_MIN_SLASHES = 2
 
 
 class TaskMismatchError(ValueError):
@@ -72,7 +68,7 @@ def _canonical_featured_ref(ref: str, entry: Any, want: ModelTask) -> str:
         raise TaskMismatchError(ref, ModelTask(entry.task), want)
     # Keep a full ``<repo>/<file>.gguf`` so resolve_model_path lands on
     # the exact installed quant; fall back to the catalog ref otherwise.
-    if ref.endswith(".gguf") and ref.count("/") >= _NATIVE_GGUF_REF_MIN_SLASHES:
+    if is_native_gguf_ref(ref):
         return ref
     canonical: str = entry.ref
     return canonical

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -295,13 +295,16 @@ class TestResolveSiblingGguf:
 
 
 class TestEstimateSizeFromSiblings:
-    def test_returns_size_from_largest_gguf(self) -> None:
+    def test_sizes_the_picked_quant_not_the_largest(self) -> None:
+        # The row names the picked quant (Q4_K_M); size must match that file, not
+        # the larger Q8_0, or size-bucket filtering mis-buckets the model.
         siblings = [
             RepoSibling(rfilename="model-Q4_K_M.gguf", size=4_000_000_000),
             RepoSibling(rfilename="model-Q8_0.gguf", size=7_000_000_000),
         ]
+        assert _hf_client._resolve_sibling_gguf(siblings) == "model-Q4_K_M.gguf"
         result = _hf_client._estimate_size_from_siblings(siblings)
-        assert result == round(7_000_000_000 / (1024**3), 1)
+        assert result == round(4_000_000_000 / (1024**3), 1)
 
     def test_returns_zero_when_no_size(self) -> None:
         siblings = [RepoSibling(rfilename="model.gguf", size=0)]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1420,40 +1420,6 @@ class TestSortModels:
         assert len(sorted_m) == len(models)
 
 
-class TestFetchModelFileSize:
-    def test_returns_size_from_tree_api(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from unittest.mock import MagicMock
-
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = [
-            {"path": "model-Q4_K_M.gguf", "size": 5_000_000_000},
-            {"path": "model-Q8_0.gguf", "size": 9_000_000_000},
-            {"path": "README.md", "size": 100},
-        ]
-        mock_resp.raise_for_status = MagicMock()
-        monkeypatch.setattr("lilbee.catalog.download.httpx.get", lambda *a, **kw: mock_resp)
-
-        result = catalog.fetch_model_file_size("user/repo")
-        assert result == round(5_000_000_000 / (1024**3), 1)
-
-    def test_returns_zero_on_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(
-            "lilbee.catalog.download.httpx.get",
-            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("fail")),
-        )
-        assert catalog.fetch_model_file_size("user/repo") == 0.0
-
-    def test_returns_zero_no_gguf_files(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from unittest.mock import MagicMock
-
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = [{"path": "README.md", "size": 100}]
-        mock_resp.raise_for_status = MagicMock()
-        monkeypatch.setattr("lilbee.catalog.download.httpx.get", lambda *a, **kw: mock_resp)
-
-        assert catalog.fetch_model_file_size("user/repo") == 0.0
-
-
 class TestHfCacheEviction:
     """Tests for HfClient.fetch_models cache eviction and size cap."""
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1861,15 +1861,25 @@ class TestFindMmprojFile:
         result = find_mmproj_file("LightOnOCR-2")
         assert result is None
 
+    @staticmethod
+    def _write_repo_mmproj(models_dir: Path, hf_repo: str, filename: str) -> Path:
+        """Write *filename* into *hf_repo*'s HF cache subtree, as hf_hub_download would."""
+        snapshot = models_dir / f"models--{hf_repo.replace('/', '--')}" / "snapshots" / "rev0"
+        snapshot.mkdir(parents=True, exist_ok=True)
+        mmproj = snapshot / filename
+        mmproj.write_bytes(b"fake")
+        return mmproj
+
     def test_finds_mmproj_with_fnmatch_pattern(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """find_mmproj_file matches using VISION_MMPROJ_FILES patterns."""
         monkeypatch.setattr(cfg, "models_dir", tmp_path)
 
-        # Test with LightOnOCR-2 (featured vision model)
-        mmproj = tmp_path / "model-mmproj-f16.gguf"
-        mmproj.write_bytes(b"fake")
+        # Test with LightOnOCR-2 (featured vision model), in its own cache subtree.
+        mmproj = self._write_repo_mmproj(
+            tmp_path, "noctrex/LightOnOCR-2-1B-GGUF", "model-mmproj-f16.gguf"
+        )
 
         from lilbee.catalog import find_mmproj_file
 
@@ -1882,14 +1892,29 @@ class TestFindMmprojFile:
         """find_mmproj_file also matches against hf_repo."""
         monkeypatch.setattr(cfg, "models_dir", tmp_path)
 
-        mmproj = tmp_path / "model-mmproj-f16.gguf"
-        mmproj.write_bytes(b"fake")
+        mmproj = self._write_repo_mmproj(
+            tmp_path, "noctrex/LightOnOCR-2-1B-GGUF", "model-mmproj-f16.gguf"
+        )
 
         from lilbee.catalog import find_mmproj_file
 
         # Match against hf_repo instead of display name
         result = find_mmproj_file("noctrex/LightOnOCR-2-1B-GGUF")
         assert result == mmproj
+
+    def test_does_not_return_other_repos_mmproj(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An mmproj that belongs to a different repo must not be returned for a
+        repo whose own mmproj isn't present (cross-contamination guard)."""
+        monkeypatch.setattr(cfg, "models_dir", tmp_path)
+        # A different vision repo's mmproj sits in the cache, but the featured
+        # LightOnOCR repo has none of its own.
+        self._write_repo_mmproj(tmp_path, "someone/other-vision-GGUF", "mmproj-f16.gguf")
+
+        from lilbee.catalog import find_mmproj_file
+
+        assert find_mmproj_file("noctrex/LightOnOCR-2-1B-GGUF") is None
 
 
 class TestResolveMmprojFilename:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1380,6 +1380,20 @@ class TestPipelineToTask:
         assert _query.pipeline_to_task("sentence-similarity") == "embedding"
 
 
+class TestGetInstalledModels:
+    def test_returns_installed_names(self) -> None:
+        manager = MagicMock()
+        manager.list_installed.return_value = ["a/b", "c/d"]
+        assert _query._get_installed_models(manager) == {"a/b", "c/d"}
+
+    def test_manager_failure_returns_empty_and_logs(self, caplog) -> None:
+        manager = MagicMock()
+        manager.list_installed.side_effect = RuntimeError("registry broken")
+        with caplog.at_level("WARNING"):
+            assert _query._get_installed_models(manager) == set()
+        assert any("treating as none installed" in r.getMessage() for r in caplog.records)
+
+
 class TestFeaturedVisionModel:
     def test_featured_vision_is_lightonocr(self) -> None:
         assert len(FEATURED_VISION) == 1

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1899,6 +1899,18 @@ class TestFindMmprojFile:
 
         assert find_mmproj_file("noctrex/LightOnOCR-2-1B-GGUF") is None
 
+    def test_returns_none_when_repo_cache_has_no_mmproj(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The matched repo's cache exists but holds only a non-mmproj GGUF, so
+        the scoped walk finds nothing and returns None."""
+        monkeypatch.setattr(cfg, "models_dir", tmp_path)
+        self._write_repo_mmproj(tmp_path, "noctrex/LightOnOCR-2-1B-GGUF", "model-Q4_K_M.gguf")
+
+        from lilbee.catalog import find_mmproj_file
+
+        assert find_mmproj_file("noctrex/LightOnOCR-2-1B-GGUF") is None
+
 
 class TestResolveMmprojFilename:
     def test_exact_filename_passthrough(self) -> None:

--- a/tests/test_catalog_resolve_arch.py
+++ b/tests/test_catalog_resolve_arch.py
@@ -39,6 +39,22 @@ def test_resolve_writes_back_to_cache(client: HfClient, monkeypatch: pytest.Monk
     assert client.get_cached_arch("acme/bar-GGUF") == "gemma3"
 
 
+def test_resolve_does_not_cache_empty_arch_on_probe_failure(
+    client: HfClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient probe failure ('') must not be cached, or the unsupported-arch
+    guard would be permanently disabled for this ref. A later successful probe
+    must still be able to resolve and cache the real arch."""
+    monkeypatch.setattr(compat, "_resolve_blob_url", lambda _ref: "https://example.test/x.gguf")
+    monkeypatch.setattr(compat, "probe_architecture", lambda _url: "")
+    assert resolve_arch_for_pull("acme/flaky-GGUF", client) == ""
+    assert client.get_cached_arch("acme/flaky-GGUF") is None
+
+    monkeypatch.setattr(compat, "probe_architecture", lambda _url: "llama")
+    assert resolve_arch_for_pull("acme/flaky-GGUF", client) == "llama"
+    assert client.get_cached_arch("acme/flaky-GGUF") == "llama"
+
+
 def test_resolve_blob_url_returns_empty_for_glob_filename() -> None:
     """`*.gguf` filenames aren't unique blobs; resolver bails to UNKNOWN."""
     assert compat._resolve_blob_url("acme/foo-GGUF:*.gguf") == ""

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -561,7 +561,7 @@ class TestAppCanonicalizeFallbackNotice:
                 ) as mock_update_values,
                 caplog.at_level(logging.WARNING, logger="lilbee.cli.tui.app"),
             ):
-                app._canonicalize_persisted_models()
+                await app._canonicalize_persisted_models()
                 mock_update_values.assert_called_once()
                 persisted_args = mock_update_values.call_args.args
                 assert persisted_args[0] == cfg.data_root
@@ -611,7 +611,7 @@ class TestAppCanonicalizeFallbackNotice:
             caplog.at_level(logging.WARNING, logger="lilbee.cli.tui.app"),
         ):
             # Must not raise.
-            app._canonicalize_persisted_models()
+            await app._canonicalize_persisted_models()
         assert any("ollama/nomic-embed-text" in r.getMessage() for r in caplog.records), (
             "a rejected swap must be logged at WARNING"
         )
@@ -651,7 +651,7 @@ class TestAppCanonicalizeFallbackNotice:
                 mock.patch("lilbee.cli.tui.app.apply_settings_update") as mock_apply,
                 caplog.at_level(logging.WARNING, logger="lilbee.cli.tui.app"),
             ):
-                app._canonicalize_persisted_models()
+                await app._canonicalize_persisted_models()
                 mock_apply.assert_not_called()
             assert cfg.embedding_model == snapshot_embed, "an un-fallbackable ref is left intact"
             assert notifications, "the user must be told why before the wizard opens"

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1175,6 +1175,16 @@ class TestKnownModelCache:
         assert "ollama/gemma4:26b" in refs
         assert "openai/gpt-4o" in refs
 
+    def test_gather_swallows_registry_failure(self, monkeypatch) -> None:
+        """A broken native registry contributes no refs rather than raising, so a
+        remote-only resolution stays responsive (the documented contract)."""
+        from lilbee.modelhub.model_manager import discovery
+
+        self._stub_compose(monkeypatch, remote=[("a:1", "Ollama")])
+        discovery.get_services().registry.list_installed.side_effect = OSError("boom")
+        refs = discovery.gather_known_model_refs()
+        assert refs == {"ollama/a:1"}
+
     def test_refs_caches_until_ttl_expiry(self, monkeypatch) -> None:
         """Repeated reads inside the TTL window do not re-run discovery."""
         from lilbee.modelhub.model_manager.discovery import KnownModelCache

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -819,6 +819,17 @@ class TestClassifyRemoteTask:
 
         assert _classify_remote_task("llava:13b", "llama") == ModelTask.VISION
 
+    def test_embedding_wins_over_vision_for_image_embedder(self) -> None:
+        """An image embedder matches both 'embed' and 'vision'; embedding wins.
+
+        Mirrors catalog.query.reclassify_by_name so the remote and manifest
+        classification paths never disagree.
+        """
+        from lilbee.catalog.types import ModelTask
+        from lilbee.modelhub.model_manager.discovery import _classify_remote_task
+
+        assert _classify_remote_task("nomic-embed-vision-v1.5", "") == ModelTask.EMBEDDING
+
 
 class TestRemoteModelProvider:
     def test_classify_remote_models_sets_provider(self) -> None:

--- a/tests/test_reclassify_by_name.py
+++ b/tests/test_reclassify_by_name.py
@@ -60,3 +60,10 @@ def test_reranker_wins_over_embedding_pattern() -> None:
     # bge-reranker matches both the bge- embedder pattern and the rerank pattern;
     # rerank is checked first so it stays a reranker.
     assert reclassify_by_name("gpustack/bge-reranker-v2-m3-GGUF", "chat") == ModelTask.RERANK
+
+
+def test_embedding_wins_over_vision_pattern() -> None:
+    # nomic-embed-vision matches both the "embed" embedder pattern and the
+    # "vision" pattern; it is an image embedder, so embedding must win. This also
+    # keeps reclassify_by_name aligned with discovery._classify_remote_task.
+    assert reclassify_by_name("nomic-embed-vision-v1.5", "chat") == ModelTask.EMBEDDING

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -880,6 +880,28 @@ class TestModelRegistryRemove:
         assert not (blobs / "shard3digest").exists()
         assert registry.is_installed(f"{_REPO}/Sibling.gguf")
 
+    def test_remove_reads_manifests_once_for_multi_shard(self, tmp_path: Path) -> None:
+        """Freeing N shard blobs must not re-walk the manifest tree per shard;
+        list_installed is read once and shared across the blob GC calls."""
+        registry = ModelRegistry(tmp_path)
+        sib = tmp_path / "sib.gguf"
+        sib.write_bytes(b"GGUF" + b"\x09" * 30)
+        registry.install(_REPO, "Sibling.gguf", sib, _make_manifest(gguf_filename="Sibling.gguf"))
+        src = _write_source(tmp_path)
+        registry.install(_REPO, _FILENAME, src, _make_manifest())
+        blobs = tmp_path / f"models--{repo_to_dir(_REPO)}" / "blobs"
+        (blobs / "shard2digest").write_bytes(b"x" * 10)
+        (blobs / "shard3digest").write_bytes(b"x" * 10)
+        manifest = registry._read_manifest(_REPO, _FILENAME)
+        assert manifest is not None
+        manifest.shard_blobs = ["shard2digest", "shard3digest"]
+        registry._write_manifest(manifest)
+
+        # Primary + 2 shards = 3 blob GC calls, but only one manifest-tree walk.
+        with mock.patch.object(registry, "list_installed", wraps=registry.list_installed) as spy:
+            registry.remove(_REF)
+        assert spy.call_count == 1
+
     def test_remove_keeps_shard_blob_referenced_by_sibling(self, tmp_path: Path) -> None:
         """A shard digest still referenced by a sibling's shard_blobs survives."""
         registry = ModelRegistry(tmp_path)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1158,6 +1158,30 @@ class TestModelRegistryGCBlobPathGuard:
             "Refusing to remove cache outside models_dir" in r.message for r in caplog.records
         )
 
+    def test_refuses_blob_digest_with_traversal(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A digest with ``..`` resolves outside the repo's blobs dir; the blob
+        path guard must refuse to unlink it. A sibling manifest keeps the repo
+        cache alive so the no-siblings rmtree branch isn't taken first."""
+        import logging
+
+        from lilbee.modelhub import registry as registry_mod
+
+        registry = ModelRegistry(tmp_path)
+        src = _write_source(tmp_path)
+        registry.install(_REPO, _FILENAME, src, _make_manifest())
+        # A file outside the registry root that a traversal digest would target.
+        victim = tmp_path.parent / "victim.bin"
+        victim.write_bytes(b"keep me")
+        traversal_digest = f"../../../{victim.name}"
+        with caplog.at_level(logging.WARNING, logger=registry_mod.__name__):
+            registry._gc_blob(_REPO, traversal_digest)
+        assert victim.exists()
+        assert any(
+            "Refusing to remove blob outside models_dir" in r.message for r in caplog.records
+        )
+
 
 class TestShardAccounting:
     def test_single_file_returns_none_and_empty(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

A review of the catalog and modelhub code surfaced several correctness issues plus a batch of smaller cleanups:

- `find_mmproj_file` matched the right vision entry but then searched the whole models dir, so a chat or unrelated-vision model could pick up another model's mmproj and be misreported as vision-capable.
- A catalog row's size came from the largest GGUF in the repo while its filename names the picked Q4_K_M quant, so size-bucket filtering mis-bucketed models.
- A transient architecture-probe failure (empty result) was cached as if it were a verdict, permanently disabling the unsupported-arch guard for that ref.
- Vision-vs-embedding classification disagreed between the manifest path and the remote-discovery path, so an image embedder like `nomic-embed-vision` could be classified two different ways.
- Persisted-model canonicalization probed local model servers over HTTP/DNS synchronously at TUI mount, freezing the UI for the probe's duration.
- The native registry walk in model discovery was unguarded despite a docstring promising each source fails soft.
- `_gc_blob` validated the repo cache dir but not the blob path it deleted, and `remove()` re-walked the whole manifest tree once per shard of a split model.
- Smaller items: a swallowed installed-list error, dead code with no callers, redefined ref helpers, a magic prefix string, and a couple of overclaiming docstrings.

## Solution

Scoped the mmproj lookup to the matched repo's HF cache subtree; sized rows from the same quant the row names; stopped caching empty probe results; aligned both classification paths to rerank then embedding then vision; moved canonicalization off the event loop with an async mount; guarded the registry walk and the blob-deletion path; read the manifest tree once when freeing a multi-shard model's blobs; logged the swallowed installed-list error; removed the dead `fetch_model_file_size`; reused the canonical ref helpers; and corrected the docstrings.

Each fix has regression tests that fail against the old behavior. One related finding (catalog browse requesting only one HF pipeline tag) is tracked separately since a correct fix reshapes the browse pagination.