### PR TITLE
Test-quality review fixes

### DIFF
--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -59,8 +59,7 @@ SYNC_SKIPPED_NO_VISION = (
     "Configure a vision_model in Settings to OCR scanned PDFs."
 )
 SYNC_SKIPPED_VISION_FAILED = (
-    "Skipped (vision OCR returned no text): {files}. "
-    "See {log_path} for the underlying error."
+    "Skipped (vision OCR returned no text): {files}. See {log_path} for the underlying error."
 )
 CMD_RETRY_SKIPPED_NONE = "No skipped files to retry; running a normal sync."
 CMD_RETRY_SKIPPED_SOME = "Cleared {count} skip marker(s); retrying those files."

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -350,33 +350,45 @@ class TestOptionsPassthrough:
 
     async def test_ask_passes_options(self, isolated_env):
         from lilbee.server.app import create_app
+        from lilbee.server.handlers.sse import _resolve_generation_options
 
-        async with AsyncTestClient(create_app()) as client:
-            resp = await client.post(
-                "/api/ask",
-                json={"question": "test", "options": {"temperature": 0.3}},
-                headers=_auth_headers(),
-            )
+        with mock.patch(
+            "lilbee.server.handlers.rag._resolve_generation_options",
+            wraps=_resolve_generation_options,
+        ) as spy:
+            async with AsyncTestClient(create_app()) as client:
+                resp = await client.post(
+                    "/api/ask",
+                    json={"question": "test", "options": {"temperature": 0.3}},
+                    headers=_auth_headers(),
+                )
         assert resp.status_code == 201
-        body = resp.json()
-        assert "answer" in body
+        assert "answer" in resp.json()
+        # The body's options must actually reach the generation-options resolver,
+        # not just produce a successful response.
+        spy.assert_any_call({"temperature": 0.3})
 
     async def test_chat_passes_options(self, isolated_env):
         from lilbee.server.app import create_app
+        from lilbee.server.handlers.sse import _resolve_generation_options
 
-        async with AsyncTestClient(create_app()) as client:
-            resp = await client.post(
-                "/api/chat",
-                json={
-                    "question": "test",
-                    "history": [],
-                    "options": {"seed": 42},
-                },
-                headers=_auth_headers(),
-            )
+        with mock.patch(
+            "lilbee.server.handlers.rag._resolve_generation_options",
+            wraps=_resolve_generation_options,
+        ) as spy:
+            async with AsyncTestClient(create_app()) as client:
+                resp = await client.post(
+                    "/api/chat",
+                    json={
+                        "question": "test",
+                        "history": [],
+                        "options": {"seed": 42},
+                    },
+                    headers=_auth_headers(),
+                )
         assert resp.status_code == 201
-        body = resp.json()
-        assert "answer" in body
+        assert "answer" in resp.json()
+        spy.assert_any_call({"seed": 42})
 
     async def test_ask_without_options(self, isolated_env):
         """Request without options field still works."""

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1634,10 +1634,11 @@ class TestVisionMmprojFiles:
 
         for entry in FEATURED_VISION:
             assert entry.hf_repo in VISION_MMPROJ_FILES, (
-                f"Vision model {entry.name} ({entry.hf_repo}) missing from VISION_MMPROJ_FILES"
+                f"Vision model {entry.display_name} ({entry.hf_repo}) "
+                "missing from VISION_MMPROJ_FILES"
             )
             assert VISION_MMPROJ_FILES[entry.hf_repo], (
-                f"Vision model {entry.name} has empty mmproj pattern"
+                f"Vision model {entry.display_name} has empty mmproj pattern"
             )
 
     def test_download_model_calls_mmproj_for_vision(

--- a/tests/test_setup_task_routing.py
+++ b/tests/test_setup_task_routing.py
@@ -29,7 +29,9 @@ def _patch_setup_scan(chat: list[str] | None = None, embed: list[str] | None = N
 
 
 def _patch_setup_ram(ram_gb: float = 16.0):
-    return patch("lilbee.modelhub.models.get_system_ram_gb", return_value=ram_gb)
+    # setup.py does `from lilbee.modelhub.models import get_system_ram_gb`, so the
+    # name must be patched where it's looked up, not at its definition module.
+    return patch("lilbee.cli.tui.screens.setup.get_system_ram_gb", return_value=ram_gb)
 
 
 def _no_api_fallback():


### PR DESCRIPTION
## Problem

A review of the test suite found a few tests that didn't actually verify what they claimed:

- `_patch_setup_ram` patched `get_system_ram_gb` at its definition module, but the setup screen imports the name into its own namespace, so the mock never took effect and the setup tests silently ran against the host's real RAM.
- The `TestOptionsPassthrough` tests asserted only that the request succeeded, not that the generation options from the request body were actually forwarded.
- A featured-vision assertion message referenced `entry.name`, which `CatalogModel` doesn't have, so the message would raise `AttributeError` if the assertion ever failed.

## Solution

Patched `get_system_ram_gb` where the setup screen looks it up so the mock pins RAM deterministically. Made the options-passthrough tests spy on the generation-options resolver and assert the request body's options reach it. Used `entry.display_name` in the assertion messages.

All test-only changes; no production code touched.