### PR TITLE
Configurable model placement

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -53,6 +53,22 @@ When reporting a worker crash, attach the last ~100 lines of the worker log plus
 tail -n 100 "<data root>/logs/worker-embed.log"
 ```
 
+## Fleet refuses to start after a hardware change
+
+If you have a manual placement spec set and a GPU is removed, replaced, or
+renumbered, the fleet will refuse to start with an error naming the card that
+no longer fits. The error is intentional: lilbee won't silently start in a
+broken state.
+
+To return to automatic placement:
+
+```bash
+lilbee placement clear
+```
+
+After that, the auto planner takes over again and places models across whatever
+GPUs are now available.
+
 ## Using with the Obsidian plugin
 
 The [Obsidian plugin](https://github.com/tobocop2/obsidian-lilbee) in managed mode runs this server for you, with each vault's data root under the plugin's shared install at `vaults/<id>/`. The same `logs/` layout applies inside that directory.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,6 +213,49 @@ flowchart TD
   RAM on a unified-memory host drives the OS into a swap-thrash OOM livelock that
   hard-freezes the machine, so refusing is the safe outcome; chat slot count
   (`--parallel`) steps down the same way before refusing.
+
+#### Manual placement
+
+By default the auto planner runs every time a fleet is built. When a `placement`
+spec is set, it replaces the planner entirely: the spec's assignments are used
+as-is and the VRAM bin-pack does not run.
+
+The spec is per-role. Each role entry accepts:
+
+- `devices` (required): list of GPU indices to use for that role.
+- `tensor_split` (optional): per-device weight proportions for a tensor-split
+  instance. When omitted, a single-card placement is assumed.
+- `replicas` (optional): how many independent servers to run for embed and
+  vision roles. Defaults to 1.
+
+```json
+{
+  "chat":    { "devices": [0, 1], "tensor_split": [1, 1] },
+  "embed":   { "devices": [2], "replicas": 2 },
+  "rerank":  { "devices": [2] },
+  "vision":  { "devices": [3] }
+}
+```
+
+The `placement` field is stored as a JSON scalar in `config.toml` (a single
+`placement = '{"chat": ...}'` key), because the config store is a flat
+key-value file and cannot represent the nested shape natively. The placement
+surfaces (CLI, HTTP, MCP, TUI) handle encoding and decoding; editing
+`config.toml` by hand is not the intended path.
+
+When a pinned placement no longer fits the card it names, lilbee surfaces a
+hard error that identifies the card by name (e.g. `CUDA0: RTX 4090
+(23.7 GiB free, 24.0 GiB total)`) rather than failing silently. This makes
+hardware-change failures explicit.
+
+All four surfaces go through the one `app/placement.py` use-case:
+CLI (`lilbee placement show/preview/set/clear`), HTTP
+(`GET/POST/PUT/DELETE /api/placement`, `GET /api/gpus`), MCP
+(`get_placement`, `preview_placement`, `set_placement`, `clear_placement`),
+and the TUI Placement screen. The `preview` operation is a dry-run: it shows
+what the auto planner would assign (or what a candidate spec would assign)
+including each card's backend+index label, name, and free/total VRAM, without
+touching the running fleet.
 - **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
   vision roles can run as N independent servers, one per GPU, so large-scale ingest
   fans embedding / OCR across the whole box. The single roles (chat) are placed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,6 +256,7 @@ and the TUI Placement screen. The `preview` operation is a dry-run: it shows
 what the auto planner would assign (or what a candidate spec would assign)
 including each card's backend+index label, name, and free/total VRAM, without
 touching the running fleet.
+
 - **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
   vision roles can run as N independent servers, one per GPU, so large-scale ingest
   fans embedding / OCR across the whole box. The single roles (chat) are placed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -966,6 +966,64 @@ llama-server fleet, remote model names route to the SDK backend) and `remote`
 
 ---
 
+## Tuning GPU placement
+
+By default lilbee decides which GPUs each model goes on automatically. It
+bin-packs all four roles (chat, embed, rerank, vision) across your available
+GPUs and tensor-splits anything too large for one card. For most setups this is
+all you need.
+
+If you want to pin specific models to specific cards, you can set a placement
+spec. The spec is a JSON object with one entry per role you want to control:
+
+```json
+{
+  "chat":   { "devices": [0, 1], "tensor_split": [1, 1] },
+  "embed":  { "devices": [2] },
+  "rerank": { "devices": [2] },
+  "vision": { "devices": [3] }
+}
+```
+
+Each role takes `devices` (GPU indices), an optional `tensor_split` list for
+spreading a single model across cards, and an optional `replicas` count for the
+embed and vision roles. Omit a role and the auto planner handles it.
+
+**To see what the auto planner would assign** (without changing anything):
+
+```bash
+lilbee placement preview
+```
+
+**To apply a spec from a file:**
+
+```bash
+lilbee placement set --spec placement.json
+```
+
+**To see the current spec** (or confirm auto is active):
+
+```bash
+lilbee placement show
+```
+
+**To go back to automatic:**
+
+```bash
+lilbee placement clear
+```
+
+The same operations are available in the TUI under the Placement screen, and
+over HTTP (`PUT /api/placement`, `DELETE /api/placement`) and MCP
+(`set_placement`, `clear_placement`). The spec persists across restarts.
+
+If a pinned placement no longer fits the card it names (after a hardware
+change, for example), lilbee surfaces an error naming the card rather than
+starting in a broken state. `lilbee placement clear` returns to automatic
+placement in that case.
+
+---
+
 ## Cross-encoder reranking
 
 Built-in. Re-scores retrieval candidates with a cross-encoder for precision on

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -970,8 +970,7 @@ llama-server fleet, remote model names route to the SDK backend) and `remote`
 
 By default lilbee decides which GPUs each model goes on automatically. It
 bin-packs all four roles (chat, embed, rerank, vision) across your available
-GPUs and tensor-splits anything too large for one card. For most setups this is
-all you need.
+GPUs and tensor-splits anything too large for one card.
 
 If you want to pin specific models to specific cards, you can set a placement
 spec. The spec is a JSON object with one entry per role you want to control:

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -69,7 +69,8 @@ def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -
     for plan in resolved.instances:
         existing = by_role.get(plan.role)
         if existing is not None:
-            by_role[plan.role] = replace(existing, replicas=existing.replicas + 1)
+            devices = tuple(sorted(set(existing.devices) | set(plan.devices)))
+            by_role[plan.role] = replace(existing, devices=devices, replicas=existing.replicas + 1)
         else:
             by_role[plan.role] = RolePlacementView(
                 role=plan.role,

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -1,0 +1,112 @@
+"""Surface-agnostic placement use-cases: inspect, preview, and set GPU placement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lilbee.app.services import reset_services
+from lilbee.core import settings
+from lilbee.core.config import cfg
+from lilbee.providers.fleet.placement_spec import PlacementSpec
+from lilbee.providers.fleet.planning import ResolvedPlacement, resolve_placement_plan
+from lilbee.providers.roles import WorkerRole
+
+_PLACEMENT_KEY = "placement"
+
+
+@dataclass(frozen=True)
+class GpuInfo:
+    """One detected GPU as a surface can render it."""
+
+    index: int
+    backend: str
+    label: str
+    name: str
+    total_bytes: int
+    free_bytes: int
+
+
+@dataclass(frozen=True)
+class RolePlacementView:
+    """Where one role's model is placed in the resolved plan."""
+
+    role: WorkerRole
+    model: str
+    devices: tuple[int, ...]
+    tensor_split: tuple[int, ...] | None
+    replicas: int
+
+
+@dataclass(frozen=True)
+class PlacementView:
+    """The full placement picture: GPUs, per-role placement, and whether manual."""
+
+    gpus: tuple[GpuInfo, ...]
+    roles: tuple[RolePlacementView, ...]
+    unplaceable: tuple[WorkerRole, ...]
+    manual: bool
+    spec_json: str | None
+
+
+def _active_spec() -> PlacementSpec | None:
+    return cfg.placement
+
+
+def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -> PlacementView:
+    gpus = tuple(
+        GpuInfo(
+            index=d.index,
+            backend=d.backend,
+            label=f"{d.backend}{d.index}",
+            name=d.name,
+            total_bytes=d.total_bytes,
+            free_bytes=d.free_bytes,
+        )
+        for d in resolved.devices
+    )
+    by_role: dict[WorkerRole, RolePlacementView] = {}
+    for plan in resolved.instances:
+        existing = by_role.get(plan.role)
+        replicas = (existing.replicas + 1) if existing else 1
+        by_role[plan.role] = RolePlacementView(
+            role=plan.role,
+            model=resolved.model_refs.get(plan.role, ""),
+            devices=plan.devices,
+            tensor_split=plan.tensor_split or None,
+            replicas=replicas,
+        )
+    return PlacementView(
+        gpus=gpus,
+        roles=tuple(by_role.values()),
+        unplaceable=resolved.unplaceable_roles,
+        manual=manual,
+        spec_json=spec_json,
+    )
+
+
+def get_placement() -> PlacementView:
+    """The current effective placement (manual if a spec is set, else auto)."""
+    spec = _active_spec()
+    resolved = resolve_placement_plan(spec)
+    return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)
+
+
+def preview_placement(spec: PlacementSpec | None = None) -> PlacementView:
+    """Dry-run: what spec (or auto, when None) would place. No persistence or reload."""
+    resolved = resolve_placement_plan(spec)
+    return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)
+
+
+def set_placement(spec: PlacementSpec | None) -> PlacementView:
+    """Validate, persist to config.toml, reset the fleet, and return the new view.
+
+    Raises PlacementError before any write when the spec does not fit the hardware.
+    """
+    resolved = resolve_placement_plan(spec)
+    if spec is None:
+        settings.delete_values(cfg.data_root, [_PLACEMENT_KEY])
+    else:
+        settings.update_values(cfg.data_root, {_PLACEMENT_KEY: spec.to_json()})
+    cfg.placement = spec
+    reset_services()
+    return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from lilbee.app.services import reset_services
 from lilbee.core import settings
@@ -67,14 +67,16 @@ def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -
     by_role: dict[WorkerRole, RolePlacementView] = {}
     for plan in resolved.instances:
         existing = by_role.get(plan.role)
-        replicas = (existing.replicas + 1) if existing else 1
-        by_role[plan.role] = RolePlacementView(
-            role=plan.role,
-            model=resolved.model_refs.get(plan.role, ""),
-            devices=plan.devices,
-            tensor_split=plan.tensor_split or None,
-            replicas=replicas,
-        )
+        if existing is not None:
+            by_role[plan.role] = replace(existing, replicas=existing.replicas + 1)
+        else:
+            by_role[plan.role] = RolePlacementView(
+                role=plan.role,
+                model=resolved.model_refs.get(plan.role, ""),
+                devices=plan.devices,
+                tensor_split=plan.tensor_split or None,
+                replicas=1,
+            )
     return PlacementView(
         gpus=gpus,
         roles=tuple(by_role.values()),

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -49,7 +49,8 @@ class PlacementView:
 
 
 def _active_spec() -> PlacementSpec | None:
-    return cfg.placement
+    raw = cfg.placement
+    return PlacementSpec.from_json(raw) if raw else None
 
 
 def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -> PlacementView:
@@ -107,8 +108,10 @@ def set_placement(spec: PlacementSpec | None) -> PlacementView:
     resolved = resolve_placement_plan(spec)
     if spec is None:
         settings.delete_values(cfg.data_root, [_PLACEMENT_KEY])
+        cfg.placement = None
     else:
-        settings.update_values(cfg.data_root, {_PLACEMENT_KEY: spec.to_json()})
-    cfg.placement = spec
+        spec_json = spec.to_json()
+        settings.update_values(cfg.data_root, {_PLACEMENT_KEY: spec_json})
+        cfg.placement = spec_json
     reset_services()
     return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)

--- a/src/lilbee/cli/__init__.py
+++ b/src/lilbee/cli/__init__.py
@@ -6,8 +6,10 @@
 from lilbee.cli import commands as _commands  # noqa: F401  side-effect: command registration
 from lilbee.cli.app import app, apply_overrides, console
 from lilbee.cli.model import model_app
+from lilbee.cli.placement import placement_app
 
 app.add_typer(model_app)
+app.add_typer(placement_app)
 
 __all__ = [
     "app",

--- a/src/lilbee/cli/placement.py
+++ b/src/lilbee/cli/placement.py
@@ -93,7 +93,7 @@ def preview(
     apply_overrides(data_dir=data_dir, use_global=use_global)
     try:
         _render_view(preview_placement(_read_spec(spec)))
-    except PlacementError as exc:
+    except (PlacementError, OSError) as exc:
         console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
         raise typer.Exit(code=1) from exc
 
@@ -108,7 +108,7 @@ def set_cmd(
     apply_overrides(data_dir=data_dir, use_global=use_global)
     try:
         _render_view(set_placement(_read_spec(spec)))
-    except PlacementError as exc:
+    except (PlacementError, OSError) as exc:
         console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
         raise typer.Exit(code=1) from exc
 

--- a/src/lilbee/cli/placement.py
+++ b/src/lilbee/cli/placement.py
@@ -1,0 +1,123 @@
+"""`lilbee placement` sub-app: inspect, preview, and set GPU placement."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+from rich.table import Table
+
+from lilbee.app.placement import (
+    PlacementView,
+    get_placement,
+    preview_placement,
+    set_placement,
+)
+from lilbee.cli import theme
+from lilbee.cli.app import apply_overrides, console, data_dir_option, global_option
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
+placement_app = typer.Typer(
+    name="placement",
+    help="Inspect and override multi-GPU model placement.",
+    no_args_is_help=True,
+)
+
+_GIB = 1024**3
+
+
+def _read_spec(spec: str | None) -> PlacementSpec | None:
+    """Parse a spec from a file path or stdin ('-'); return None when omitted."""
+    if spec is None:
+        return None
+    raw = sys.stdin.read() if spec == "-" else Path(spec).read_text()
+    return PlacementSpec.from_json(raw)
+
+
+def _render_view(view: PlacementView) -> None:
+    """Print a Rich table of GPU rows plus per-role and unplaceable lines."""
+    title = "Placement (manual)" if view.manual else "Placement (auto)"
+    table = Table(title=title)
+    table.add_column("GPU")
+    table.add_column("Name")
+    table.add_column("Free / Total")
+    table.add_column("Roles")
+
+    placed: dict[int, list[str]] = {g.index: [] for g in view.gpus}
+    for role_view in view.roles:
+        for idx in role_view.devices:
+            placed.setdefault(idx, []).append(role_view.role.value)
+
+    for g in view.gpus:
+        free_gib = g.free_bytes / _GIB
+        total_gib = g.total_bytes / _GIB
+        table.add_row(
+            g.label,
+            g.name or "(unnamed)",
+            f"{free_gib:.0f} / {total_gib:.0f} GiB",
+            ", ".join(placed.get(g.index, [])) or "-",
+        )
+    console.print(table)
+
+    for role_view in view.roles:
+        split_info = f" split={list(role_view.tensor_split)}" if role_view.tensor_split else ""
+        console.print(
+            f"  {role_view.role.value}: devices={list(role_view.devices)}"
+            f" replicas={role_view.replicas}{split_info}  {role_view.model}"
+        )
+
+    for role in view.unplaceable:
+        console.print(f"  [{theme.ERROR}]{role.value}: does not fit, no server[/{theme.ERROR}]")
+
+
+@placement_app.command("show")
+def show(
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Show the current effective placement."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    _render_view(get_placement())
+
+
+@placement_app.command("preview")
+def preview(
+    spec: str | None = typer.Option(
+        None, "--spec", help="Spec JSON file, or - for stdin; omit for auto."
+    ),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Preview what a spec (or auto) would place, without applying it."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    try:
+        _render_view(preview_placement(_read_spec(spec)))
+    except PlacementError as exc:
+        console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(code=1) from exc
+
+
+@placement_app.command("set")
+def set_cmd(
+    spec: str = typer.Option(..., "--spec", help="Spec JSON file, or - for stdin."),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Validate, persist, and apply a manual placement spec."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    try:
+        _render_view(set_placement(_read_spec(spec)))
+    except PlacementError as exc:
+        console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(code=1) from exc
+
+
+@placement_app.command("clear")
+def clear(
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Clear the manual placement and return to automatic placement."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    _render_view(set_placement(None))

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -68,6 +68,12 @@ def _make_wiki() -> Screen:
     return WikiScreen()
 
 
+def _make_placement() -> Screen:
+    from lilbee.cli.tui.screens.placement import PlacementScreen
+
+    return PlacementScreen()
+
+
 # Screen factory per managed view name (Chat is special-cased in switch_view and
 # has no factory). The active set + order + wiki gate come from msg.get_nav_views,
 # so the view universe lives in exactly one place (messages.ALL_NAV_VIEWS).
@@ -77,6 +83,7 @@ _VIEW_FACTORIES: dict[str, Callable[[], Screen]] = {
     "Settings": _make_settings,
     "Tasks": _make_tasks,
     "Wiki": _make_wiki,
+    "Placement": _make_placement,
 }
 
 

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -390,11 +390,20 @@ COMPAT_MODAL_BODY = (
 )
 DEFAULT_VIEW = "Chat"
 WIKI_VIEW = "Wiki"
+PLACEMENT_VIEW = "Placement"
 # The full nav-view universe in order. Single source for the view set: the
 # settings bar pre-creates a tab per entry (toggling Wiki visibility at
 # runtime), get_nav_views() gates Wiki, and app.get_views() derives its
 # factory map from get_nav_views().
-ALL_NAV_VIEWS: tuple[str, ...] = (DEFAULT_VIEW, "Catalog", "Status", "Settings", "Tasks", WIKI_VIEW)
+ALL_NAV_VIEWS: tuple[str, ...] = (
+    DEFAULT_VIEW,
+    "Catalog",
+    "Status",
+    "Settings",
+    "Tasks",
+    WIKI_VIEW,
+    PLACEMENT_VIEW,
+)
 
 
 def get_nav_views() -> list[str]:

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -1,0 +1,203 @@
+"""GPU placement screen: inspect, preview, and apply manual placement specs."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, ClassVar
+
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Static, TextArea
+
+from lilbee.app.placement import get_placement, preview_placement, set_placement
+from lilbee.cli.tui.app import LilbeeApp
+from lilbee.cli.tui.thread_safe import call_from_thread
+from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+if TYPE_CHECKING:
+    from lilbee.app.placement import PlacementView
+
+
+class _LilbeeAppTestHost(LilbeeApp):
+    """LilbeeApp subclass that skips the heavyweight on_mount for test/demo harnesses."""
+
+    _test_skip_auto_init = True
+
+
+log = logging.getLogger(__name__)
+
+_GPU_TABLE_ID = "#placement-gpus"
+_ROLE_SUMMARY_ID = "#placement-role-summary"
+_SPEC_AREA_ID = "#placement-spec"
+
+_GIB = 1024**3
+
+
+def _fmt_gib(n: int) -> str:
+    """Format bytes as GiB string."""
+    return f"{n / _GIB:.1f} GiB"
+
+
+def _render_roles(view: PlacementView) -> str:
+    """Build the role summary text from a PlacementView."""
+    lines: list[str] = []
+    for r in view.roles:
+        devs = ", ".join(str(d) for d in r.devices)
+        ts = str(r.tensor_split) if r.tensor_split else "auto"
+        lines.append(
+            f"[bold]{r.role.value}[/bold]  model={r.model}  "
+            f"devices=[{devs}]  tensor_split={ts}  replicas={r.replicas}"
+        )
+    for role in view.unplaceable:
+        lines.append(f"[red]UNPLACEABLE: {role.value}[/red]")
+    return "\n".join(lines) if lines else "(no roles placed)"
+
+
+class PlacementScreen(Screen[None]):
+    """GPU placement viewer and editor."""
+
+    CSS_PATH = "placement.tcss"
+    AUTO_FOCUS = _GPU_TABLE_ID
+    HELP = "Inspect GPU placement. ctrl+r preview, ctrl+s apply, ctrl+x clear, q back."
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("q", "go_back", "Back", show=True),
+        Binding("escape", "go_back", "Back", show=False),
+        Binding("ctrl+r", "preview", "Preview", show=True),
+        Binding("ctrl+s", "apply", "Apply", show=True),
+        Binding("ctrl+x", "clear", "Clear", show=True),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._spec_text: str = ""
+
+    def compose(self) -> ComposeResult:
+        from lilbee.cli.tui.widgets.bottom_bars import BottomBars
+        from lilbee.cli.tui.widgets.status_bar import ViewTabs
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+        from lilbee.cli.tui.widgets.top_bars import TopBars
+
+        table: DataTable[str] = DataTable(id="placement-gpus")
+        table.cursor_type = "row"
+
+        with TopBars():
+            yield ViewTabs()
+        with Vertical(id="placement-layout"):
+            yield table
+            yield Static("", id="placement-role-summary")
+            yield TextArea(id="placement-spec")
+        with BottomBars():
+            yield TaskBar()
+            yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one(_GPU_TABLE_ID, DataTable)
+        table.add_columns("Label", "Name", "Free", "Total")
+        self._load_placement()
+
+    def _load_placement(self) -> None:
+        """Fetch placement and populate the screen synchronously."""
+        try:
+            view = get_placement()
+        except Exception as exc:
+            log.debug("Failed to load placement", exc_info=True)
+            self.notify(str(exc), severity="error")
+            return
+        self._render_view(view)
+
+    def _render_view(self, view: PlacementView) -> None:
+        """Populate the GPU table and role summary from a PlacementView."""
+        table = self.query_one(_GPU_TABLE_ID, DataTable)
+        table.clear()
+        for gpu in view.gpus:
+            table.add_row(
+                gpu.label,
+                gpu.name,
+                _fmt_gib(gpu.free_bytes),
+                _fmt_gib(gpu.total_bytes),
+                key=str(gpu.index),
+            )
+        summary = self.query_one(_ROLE_SUMMARY_ID, Static)
+        summary.update(_render_roles(view))
+        if view.spec_json:
+            self._spec_text = view.spec_json
+            self.query_one(_SPEC_AREA_ID, TextArea).load_text(view.spec_json)
+
+    def _parse_spec(self) -> PlacementSpec | None:
+        """Parse the current spec text into a PlacementSpec or None."""
+        raw = self._spec_text.strip()
+        if not raw:
+            return None
+        return PlacementSpec.from_json(raw)
+
+    def action_preview(self) -> None:
+        """Preview the current spec without applying it."""
+        try:
+            spec = self._parse_spec()
+        except (ValueError, json.JSONDecodeError, KeyError) as exc:
+            self.notify(str(exc), severity="error")
+            return
+        self._preview_worker(spec)
+
+    @work(thread=True, exit_on_error=False)
+    def _preview_worker(self, spec: PlacementSpec | None) -> None:
+        """Run preview_placement off the UI thread."""
+        try:
+            view = preview_placement(spec)
+            call_from_thread(self, self._render_view, view)
+        except Exception as exc:
+            call_from_thread(self, self.notify, str(exc), severity="error")
+
+    def action_apply(self) -> None:
+        """Apply the current spec and reload services."""
+        try:
+            spec = self._parse_spec()
+        except (ValueError, json.JSONDecodeError, KeyError) as exc:
+            self.notify(str(exc), severity="error")
+            return
+        self._apply_worker(spec)
+
+    @work(thread=True, exit_on_error=False)
+    def _apply_worker(self, spec: PlacementSpec | None) -> None:
+        """Run set_placement off the UI thread."""
+        try:
+            set_placement(spec)
+            view = get_placement()
+            call_from_thread(self, self._render_view, view)
+        except Exception as exc:
+            call_from_thread(self, self.notify, str(exc), severity="error")
+
+    def action_clear(self) -> None:
+        """Clear the manual spec (restore auto placement)."""
+        self._clear_worker()
+
+    @work(thread=True, exit_on_error=False)
+    def _clear_worker(self) -> None:
+        """Run set_placement(None) off the UI thread."""
+        try:
+            set_placement(None)
+            view = get_placement()
+            call_from_thread(self, self._render_view, view)
+        except Exception as exc:
+            call_from_thread(self, self.notify, str(exc), severity="error")
+
+    def action_go_back(self) -> None:
+        """Pop back to the previous screen."""
+        if len(self.app.screen_stack) > 1:
+            self.app.pop_screen()
+        else:
+            self.app.switch_view("Chat")  # type: ignore[attr-defined]
+
+
+class PlacementScreenApp(_LilbeeAppTestHost):
+    """Minimal app harness that mounts PlacementScreen for test/demo use."""
+
+    CSS = ""
+
+    def on_mount(self) -> None:
+        self.push_screen(PlacementScreen())

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from typing import TYPE_CHECKING, ClassVar
@@ -10,6 +11,8 @@ from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical
+from textual.css.query import NoMatches
+from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Static, TextArea
 
@@ -76,9 +79,16 @@ class PlacementScreen(Screen[None]):
         Binding("ctrl+x", "clear", "Clear", show=True),
     ]
 
+    applying: reactive[bool] = reactive(False)
+
     def __init__(self) -> None:
         super().__init__()
         self._spec_text: str = ""
+
+    def watch_applying(self, applying: bool) -> None:
+        """Disable the spec editor while an apply/clear is in flight."""
+        with contextlib.suppress(NoMatches):
+            self.query_one(_SPEC_AREA_ID, TextArea).disabled = applying
 
     def compose(self) -> ComposeResult:
         from lilbee.cli.tui.widgets.bottom_bars import BottomBars
@@ -159,11 +169,14 @@ class PlacementScreen(Screen[None]):
 
     def action_apply(self) -> None:
         """Apply the current spec and reload services."""
+        if self.applying:
+            return
         try:
             spec = self._parse_spec()
         except (ValueError, json.JSONDecodeError, KeyError) as exc:
             self.notify(str(exc), severity="error")
             return
+        self.applying = True
         self._apply_worker(spec)
 
     @work(thread=True, exit_on_error=False)
@@ -175,9 +188,14 @@ class PlacementScreen(Screen[None]):
             call_from_thread(self, self._render_view, view)
         except Exception as exc:
             call_from_thread(self, self.notify, str(exc), severity="error")
+        finally:
+            call_from_thread(self, setattr, self, "applying", False)
 
     def action_clear(self) -> None:
         """Clear the manual spec (restore auto placement)."""
+        if self.applying:
+            return
+        self.applying = True
         self._clear_worker()
 
     @work(thread=True, exit_on_error=False)
@@ -189,6 +207,8 @@ class PlacementScreen(Screen[None]):
             call_from_thread(self, self._render_view, view)
         except Exception as exc:
             call_from_thread(self, self.notify, str(exc), severity="error")
+        finally:
+            call_from_thread(self, setattr, self, "applying", False)
 
     def action_go_back(self) -> None:
         """Pop back to the previous screen."""

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -25,12 +25,6 @@ if TYPE_CHECKING:
     from lilbee.app.placement import PlacementView
 
 
-class _LilbeeAppTestHost(LilbeeApp):
-    """LilbeeApp subclass that skips the heavyweight on_mount for test/demo harnesses."""
-
-    _test_skip_auto_init = True
-
-
 log = logging.getLogger(__name__)
 
 _GPU_TABLE_ID = "#placement-gpus"
@@ -216,12 +210,3 @@ class PlacementScreen(Screen[None]):
             self.app.pop_screen()
         else:
             self.app.switch_view("Chat")
-
-
-class PlacementScreenApp(_LilbeeAppTestHost):
-    """Minimal app harness that mounts PlacementScreen for test/demo use."""
-
-    CSS = ""
-
-    def on_mount(self) -> None:
-        self.push_screen(PlacementScreen())

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -60,6 +60,10 @@ def _render_roles(view: PlacementView) -> str:
 class PlacementScreen(Screen[None]):
     """GPU placement viewer and editor."""
 
+    # Lilbee always hosts screens on a LilbeeApp, so narrowing the type lets
+    # the screen call switch_view without per-call type: ignore comments.
+    app: LilbeeApp  # type: ignore[assignment]
+
     CSS_PATH = "placement.tcss"
     AUTO_FOCUS = _GPU_TABLE_ID
     HELP = "Inspect GPU placement. ctrl+r preview, ctrl+s apply, ctrl+x clear, q back."
@@ -191,7 +195,7 @@ class PlacementScreen(Screen[None]):
         if len(self.app.screen_stack) > 1:
             self.app.pop_screen()
         else:
-            self.app.switch_view("Chat")  # type: ignore[attr-defined]
+            self.app.switch_view("Chat")
 
 
 class PlacementScreenApp(_LilbeeAppTestHost):

--- a/src/lilbee/cli/tui/screens/placement.tcss
+++ b/src/lilbee/cli/tui/screens/placement.tcss
@@ -1,0 +1,30 @@
+PlacementScreen {
+
+    #placement-layout {
+        height: 1fr;
+        padding: 0 1;
+    }
+
+    #placement-gpus {
+        height: auto;
+        max-height: 12;
+        border: solid $surface-lighten-2;
+        margin-bottom: 1;
+    }
+
+    #placement-role-summary {
+        height: auto;
+        margin-bottom: 1;
+        color: $text;
+    }
+
+    #placement-spec {
+        height: 1fr;
+        min-height: 8;
+        border: solid $surface-lighten-2;
+
+        &:focus-within {
+            border: tall $primary;
+        }
+    }
+}

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -15,7 +15,6 @@ from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from lilbee.core.system import scaled_chat_ctx_target_default
-from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 
 from .defaults import (
     DEFAULT_ALLOWED_NER_LABELS,
@@ -421,13 +420,13 @@ class Config(BaseSettings):
     # (default) lets llama.cpp pick (index 0).
     main_gpu: int | None = ConfigField(default=None, writable=True)
 
-    # Manual GPU placement override. When set, it fully replaces the automatic
-    # placement planner: each active role pins to the listed device indices, with
-    # an optional tensor_split and replica count. Persisted as a JSON scalar (the
-    # config.toml store is flat); edited via the placement CLI/MCP/HTTP/TUI surfaces
-    # rather than the generic settings list, so public=False. None hands off to the
-    # VRAM-aware auto planner.
-    placement: PlacementSpec | None = ConfigField(default=None, writable=True, public=False)
+    # Manual GPU placement override stored as a JSON scalar (the config.toml store
+    # is flat, and core must not depend on the provider PlacementSpec type). When
+    # set, it fully replaces the automatic placement planner: each active role pins
+    # to the listed device indices, with an optional tensor_split and replica count.
+    # Edited via the placement CLI/MCP/HTTP/TUI surfaces rather than the generic
+    # settings list, so public=False. None hands off to the VRAM-aware auto planner.
+    placement: str | None = ConfigField(default=None, writable=True, public=False)
 
     # True = Markdown widget for chat; False = plain Static (faster).
     markdown_rendering: bool = True
@@ -763,16 +762,19 @@ class Config(BaseSettings):
 
     @field_validator("placement", mode="before")
     @classmethod
-    def _parse_placement(cls, v: Any) -> PlacementSpec | None:
-        """Blank/None -> None; a JSON string -> PlacementSpec; a spec passes through."""
+    def _parse_placement(cls, v: Any) -> str | None:
+        """Blank/None -> None; validate a JSON string or PlacementSpec; store JSON."""
+        from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
         if v is None:
             return None
         if isinstance(v, PlacementSpec):
-            return v
+            return v.to_json()
         if isinstance(v, str):
             if v.strip() == "":
                 return None
-            return PlacementSpec.from_json(v)
+            PlacementSpec.from_json(v)
+            return v
         raise PlacementError("placement must be a JSON string or PlacementSpec")
 
     @field_validator("semantic_chunking", mode="before")

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -15,6 +15,7 @@ from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from lilbee.core.system import scaled_chat_ctx_target_default
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 
 from .defaults import (
     DEFAULT_ALLOWED_NER_LABELS,
@@ -420,6 +421,14 @@ class Config(BaseSettings):
     # (default) lets llama.cpp pick (index 0).
     main_gpu: int | None = ConfigField(default=None, writable=True)
 
+    # Manual GPU placement override. When set, it fully replaces the automatic
+    # placement planner: each active role pins to the listed device indices, with
+    # an optional tensor_split and replica count. Persisted as a JSON scalar (the
+    # config.toml store is flat); edited via the placement CLI/MCP/HTTP/TUI surfaces
+    # rather than the generic settings list, so public=False. None hands off to the
+    # VRAM-aware auto planner.
+    placement: PlacementSpec | None = ConfigField(default=None, writable=True, public=False)
+
     # True = Markdown widget for chat; False = plain Static (faster).
     markdown_rendering: bool = True
 
@@ -751,6 +760,20 @@ class Config(BaseSettings):
                     return None
             return ",".join(parts)
         return str(v)
+
+    @field_validator("placement", mode="before")
+    @classmethod
+    def _parse_placement(cls, v: Any) -> PlacementSpec | None:
+        """Blank/None -> None; a JSON string -> PlacementSpec; a spec passes through."""
+        if v is None:
+            return None
+        if isinstance(v, PlacementSpec):
+            return v
+        if isinstance(v, str):
+            if v.strip() == "":
+                return None
+            return PlacementSpec.from_json(v)
+        raise PlacementError("placement must be a JSON string or PlacementSpec")
 
     @field_validator("semantic_chunking", mode="before")
     @classmethod

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -157,16 +157,8 @@ def _error(msg: str) -> dict[str, Any]:
 def search(
     query: str, top_k: int | None = None, scope: str = SearchScope.BOTH.value
 ) -> list[dict[str, Any]] | dict[str, Any]:
-    """Search the user's indexed documents, code, and crawled pages.
-
-    Use this for any lookup about the user's own files or code, and prefer it
-    over web-fetch or file-read tools, which cannot see the index. Returns
-    chunks ranked by relevance with source and line citations.
-
-    ``top_k`` defaults to ``cfg.top_k``. ``scope`` is ``"both"`` (default) or
-    ``"raw"`` for ingested docs and code; use ``"wiki"`` only when ``status``
-    shows a built wiki, else it just falls back to the full pool.
-    """
+    """Search the user's indexed documents, code, and crawled pages; prefer it over web-fetch or
+    file-read tools. Returns chunks with citations. ``scope``: "both" (default) / "raw" / "wiki"."""
     if not query or not query.strip():
         return _error("query must not be empty")
     try:
@@ -241,12 +233,7 @@ async def add(
     render_mode: CrawlRenderMode | None = None,
 ) -> dict[str, Any]:
     """Add files, directories, or URLs to the knowledge base, then sync.
-
-    Paths must be absolute. URLs (http(s)://) are crawled as markdown.
-    ``enable_ocr`` forces OCR on/off; ``ocr_timeout`` overrides the per-page OCR
-    cap; ``render_mode`` ("http"/"browser") overrides the configured crawl render
-    mode for any URLs.
-    """
+    Paths must be absolute; URLs are crawled as markdown."""
     from lilbee.app.ingest import copy_files
     from lilbee.data.ingest import sync as run_sync
 
@@ -313,13 +300,7 @@ async def crawl(
     include_subdomains: bool = False,
 ) -> dict[str, Any]:
     """Start a non-blocking crawl; poll via ``crawl_status(task_id)``.
-
-    ``depth=None`` crawls the whole site, ``0`` is single-URL, positive ints cap
-    follow depth. ``max_pages=None`` uses the protective safety cap, ``0`` is
-    unlimited, positive ints cap the page count. ``render_mode``
-    ("http"/"browser") overrides the configured crawl render mode.
-    ``include_subdomains`` widens whole-site scope to the host's subdomains.
-    """
+    ``depth=None`` = whole site, ``0`` = single URL. ``render_mode``: "http"/"browser"."""
     from lilbee.crawler import crawler_available
 
     if not crawler_available():
@@ -676,12 +657,8 @@ def settings_get(key: str) -> dict[str, Any]:
 
 @_tool
 def settings_set(updates: dict[str, Any]) -> dict[str, Any]:
-    """Atomically update writable settings; rolls back on any validation error.
-
-    Persists to ``config.toml`` and invalidates in-process caches. Returns
-    ``{updated, reindex_required}``; ``reindex_required=true`` means run
-    ``sync(force_rebuild=true)`` to refresh the index.
-    """
+    """Atomically update writable settings; rolls back on validation error.
+    Persists to config.toml; returns ``{updated, reindex_required}``."""
     if _transport.http_mounted and requires_services_reset(updates):
         return _error(provider_reset_refused_message("Switching"))
     try:
@@ -739,14 +716,8 @@ def catalog_browse(
     limit: int = 20,
     offset: int = 0,
 ) -> dict[str, Any]:
-    """Browse the lilbee model catalog (featured + Hugging Face).
-
-    ``task`` is ``chat`` / ``embedding`` / ``vision`` / ``rerank``.
-    ``size`` is ``small`` / ``medium`` / ``large``. ``installed`` filters
-    by install state, ``featured`` toggles the curated list, ``sort`` is
-    one of ``featured`` / ``downloads`` / ``name`` / ``size_asc`` /
-    ``size_desc``. Returns paginated model records.
-    """
+    """Browse the lilbee model catalog. ``task``: chat/embedding/vision/rerank.
+    ``size``: small/medium/large. ``sort``: featured/downloads/name/size_asc/size_desc."""
     from lilbee.catalog.query import get_catalog
     from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
 
@@ -873,13 +844,8 @@ async def model_pull(
 
 @_tool
 def model_rm(model: str, source: str = "") -> dict[str, Any]:
-    """Remove an installed model.
-
-    Args:
-        model: Model ref to remove. lilbee removes only native models it
-            downloaded; Ollama and LM Studio models are read-only.
-        source: Restrict to a known source; empty = resolve from the ref.
-    """
+    """Remove an installed model. Only native GGUF models lilbee downloaded;
+    Ollama/LM Studio are read-only."""
     from lilbee.app.models import remove_model_data
 
     try:
@@ -940,9 +906,9 @@ def _strip_property_noise(prop: dict[str, Any]) -> None:
     """Drop tokens that don't change the model's behavior."""
     prop.pop("title", None)
     prop.pop("default", None)
+    _collapse_nullable_anyof(prop)
     if prop.get("additionalProperties") is True:
         prop.pop("additionalProperties", None)
-    _collapse_nullable_anyof(prop)
 
 
 def _flatten_tool_description(text: str) -> str:
@@ -1076,12 +1042,8 @@ def memory_remember(
     agent_id: str = "",
     ctx: Context | None = None,
 ) -> dict[str, Any]:
-    """Store a durable memory in this agent's own namespace.
-
-    ``kind`` is "fact" (recalled by similarity) or "preference" (always recalled).
-    ``shared`` also exposes it to the human's TUI/CLI. ``agent_id`` namespaces the
-    memory, else derived from LILBEE_AGENT_ID or the MCP client name.
-    """
+    """Store a durable memory. ``kind``: "fact" (similarity-recalled) or "preference" (always on).
+    ``shared`` exposes it to the human's TUI/CLI."""
     if not memory_enabled():
         return _error(MEMORY_DISABLED_HINT)
     owner = _derive_owner(agent_id, ctx)

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -126,6 +126,16 @@ def _tool(fn: _F) -> _F:
     return fn
 
 
+def _tool_named(name: str) -> Callable[[_F], _F]:
+    """Register an MCP tool under an explicit wire *name* (sync handlers offloaded)."""
+
+    def deco(fn: _F) -> _F:
+        mcp.tool(name=name)(_offload_sync(fn))
+        return fn
+
+    return deco
+
+
 def _tool_if(condition: bool) -> Callable[[_F], _F]:
     """Register an MCP tool only when *condition* is true.
 
@@ -1111,13 +1121,13 @@ def _placement_dict(view: PlacementView) -> dict[str, Any]:
     }
 
 
-@_tool
+@_tool_named("get_placement")
 def get_placement_tool() -> dict[str, Any]:
     """Show the current effective multi-GPU model placement."""
     return _placement_dict(get_placement())
 
 
-@_tool
+@_tool_named("preview_placement")
 def preview_placement_tool(spec: dict[str, Any] | None = None) -> dict[str, Any]:
     """Preview what a placement spec (or auto, when omitted) would place. No changes made."""
     from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
@@ -1129,7 +1139,7 @@ def preview_placement_tool(spec: dict[str, Any] | None = None) -> dict[str, Any]
         return _error(str(exc))
 
 
-@_tool
+@_tool_named("set_placement")
 def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
     """Set and apply a manual multi-GPU placement spec (persists to config)."""
     from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
@@ -1140,7 +1150,7 @@ def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
         return _error(str(exc))
 
 
-@_tool
+@_tool_named("clear_placement")
 def clear_placement_tool() -> dict[str, Any]:
     """Clear the manual placement and return to automatic placement."""
     return _placement_dict(set_placement(None))

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -6,6 +6,7 @@ import asyncio
 import concurrent.futures
 import functools
 import inspect
+import json
 import logging
 import os
 import re
@@ -27,6 +28,7 @@ from lilbee.app.memory import (
     recall,
     remember,
 )
+from lilbee.app.placement import PlacementView, get_placement, preview_placement, set_placement
 from lilbee.app.search import clean_result
 from lilbee.app.services import get_services, reset_services, reset_store
 from lilbee.app.settings import (
@@ -1126,6 +1128,60 @@ def memory_forget(memory_id: str, agent_id: str = "", ctx: Context | None = None
     if not forget(memory_id, owner=owner):
         return _error(f"No memory '{memory_id}' in this agent's namespace.")
     return {"ok": True, "id": memory_id}
+
+
+def _placement_dict(view: PlacementView) -> dict[str, Any]:
+    return {
+        "gpus": [vars(g) for g in view.gpus],
+        "roles": [
+            {
+                "role": r.role.value,
+                "model": r.model,
+                "devices": list(r.devices),
+                "tensor_split": list(r.tensor_split) if r.tensor_split else None,
+                "replicas": r.replicas,
+            }
+            for r in view.roles
+        ],
+        "unplaceable": [r.value for r in view.unplaceable],
+        "manual": view.manual,
+        "spec_json": view.spec_json,
+    }
+
+
+@_tool
+def get_placement_tool() -> dict[str, Any]:
+    """Show the current effective multi-GPU model placement."""
+    return _placement_dict(get_placement())
+
+
+@_tool
+def preview_placement_tool(spec: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Preview what a placement spec (or auto, when omitted) would place. No changes made."""
+    from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
+    try:
+        parsed = PlacementSpec.from_json(json.dumps(spec)) if spec else None
+        return _placement_dict(preview_placement(parsed))
+    except PlacementError as exc:
+        return _error(str(exc))
+
+
+@_tool
+def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
+    """Set and apply a manual multi-GPU placement spec (persists to config)."""
+    from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
+    try:
+        return _placement_dict(set_placement(PlacementSpec.from_json(json.dumps(spec))))
+    except PlacementError as exc:
+        return _error(str(exc))
+
+
+@_tool
+def clear_placement_tool() -> dict[str, Any]:
+    """Clear the manual placement and return to automatic placement."""
+    return _placement_dict(set_placement(None))
 
 
 _strip_schema_noise()

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -254,9 +254,9 @@ def placement_from_spec(
             for idx, peak in zip(rp.devices, per_device, strict=True):
                 if peak > remaining[idx]:
                     raise PlacementError(
-                        f"{role.value} pinned to device {idx} needs "
-                        f"{peak / 1024**3:.1f} GiB but device {idx} has "
-                        f"{device_free[idx] / 1024**3:.1f} GiB free"
+                        f"{role.value} pinned to device {idx} needs {peak / 1024**3:.1f} GiB but "
+                        f"device {idx} has {remaining[idx] / 1024**3:.1f} GiB usable "
+                        f"({device_free[idx] / 1024**3:.1f} GiB free, 90% headroom)"
                     )
             for idx, peak in zip(rp.devices, per_device, strict=True):
                 remaining[idx] -= peak

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION
 from lilbee.providers.roles import WorkerRole
 
@@ -220,3 +221,51 @@ def _best_single_device(need: int, remaining: dict[int, float]) -> int | None:
     if not candidates:
         return None
     return max(candidates, key=lambda idx: remaining[idx])
+
+
+def placement_from_spec(
+    spec: PlacementSpec,
+    active_roles: tuple[WorkerRole, ...],
+    device_free: dict[int, int],
+    *,
+    estimate_peak: PeakEstimator,
+) -> Placement:
+    """Build a Placement from a manual *spec*, charging each card and failing loud.
+
+    Every active role must have an entry; every device must exist; each card must
+    fit the sum of the per-device peaks charged to it. Mirrors the auto planner's
+    USABLE_VRAM_FRACTION headroom and busiest-card accounting.
+    """
+    remaining = {idx: free * USABLE_VRAM_FRACTION for idx, free in device_free.items()}
+    instances: list[InstancePlan] = []
+    for role in active_roles:
+        rp = spec.roles.get(role)
+        if rp is None:
+            raise PlacementError(f"{role.value} has a model but no placement entry in placement")
+        for idx in rp.devices:
+            if idx not in device_free:
+                raise PlacementError(
+                    f"{role.value} pinned to device {idx} but only "
+                    f"{len(device_free)} GPU(s) detected"
+                )
+        ratio = rp.tensor_split or tuple(1 for _ in rp.devices)
+        per_device = estimate_peak(role, ratio)
+        for replica in range(rp.replicas):
+            for idx, peak in zip(rp.devices, per_device, strict=True):
+                if peak > remaining[idx]:
+                    raise PlacementError(
+                        f"{role.value} pinned to device {idx} needs "
+                        f"{peak / 1024**3:.1f} GiB but device {idx} has "
+                        f"{device_free[idx] / 1024**3:.1f} GiB free"
+                    )
+            for idx, peak in zip(rp.devices, per_device, strict=True):
+                remaining[idx] -= peak
+            instances.append(
+                InstancePlan(
+                    role=role,
+                    devices=tuple(rp.devices),
+                    tensor_split=ratio if len(rp.devices) > 1 else (),
+                    replica=replica,
+                )
+            )
+    return Placement(instances=tuple(instances), unplaceable_roles=())

--- a/src/lilbee/providers/fleet/placement_spec.py
+++ b/src/lilbee/providers/fleet/placement_spec.py
@@ -1,0 +1,88 @@
+"""User-authored manual placement spec for the multi-GPU fleet."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from lilbee.providers.roles import WorkerRole
+
+_KEY_DEVICES = "devices"
+_KEY_TENSOR_SPLIT = "tensor_split"
+_KEY_REPLICAS = "replicas"
+
+
+class PlacementError(ValueError):
+    """A placement spec is malformed or does not fit the hardware."""
+
+
+@dataclass(frozen=True)
+class RolePlacement:
+    """One role's manual placement: device pins, optional split, replica count."""
+
+    devices: tuple[int, ...]
+    tensor_split: tuple[int, ...] | None = None
+    replicas: int = 1
+
+
+@dataclass(frozen=True)
+class PlacementSpec:
+    """A manual placement for every active role, keyed by role."""
+
+    roles: Mapping[WorkerRole, RolePlacement] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        """Serialize to a compact JSON string keyed by role value."""
+        out: dict[str, dict[str, object]] = {}
+        for role, rp in self.roles.items():
+            entry: dict[str, object] = {_KEY_DEVICES: list(rp.devices)}
+            if rp.tensor_split is not None:
+                entry[_KEY_TENSOR_SPLIT] = list(rp.tensor_split)
+            if rp.replicas != 1:
+                entry[_KEY_REPLICAS] = rp.replicas
+            out[role.value] = entry
+        return json.dumps(out, sort_keys=True)
+
+    def __str__(self) -> str:
+        return self.to_json()
+
+    @classmethod
+    def from_json(cls, raw: str) -> PlacementSpec:
+        """Parse a JSON string produced by ``to_json`` into a ``PlacementSpec``."""
+        try:
+            data = json.loads(raw)
+        except (ValueError, TypeError) as exc:
+            raise PlacementError(f"placement is not valid JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise PlacementError("placement must be a JSON object keyed by role")
+        roles: dict[WorkerRole, RolePlacement] = {}
+        for key, entry in data.items():
+            role = _role_for(key)
+            roles[role] = _role_placement(role, entry)
+        return cls(roles=roles)
+
+
+def _role_for(key: str) -> WorkerRole:
+    try:
+        return WorkerRole(key)
+    except ValueError as exc:
+        raise PlacementError(f"unknown role {key!r} in placement") from exc
+
+
+def _role_placement(role: WorkerRole, entry: object) -> RolePlacement:
+    if not isinstance(entry, dict):
+        raise PlacementError(f"{role.value}: placement entry must be an object")
+    devices = tuple(int(d) for d in entry.get(_KEY_DEVICES, []))
+    if not devices:
+        raise PlacementError(f"{role.value}: at least one device is required")
+    raw_split = entry.get(_KEY_TENSOR_SPLIT)
+    tensor_split = tuple(int(w) for w in raw_split) if raw_split is not None else None
+    if tensor_split is not None and len(tensor_split) != len(devices):
+        raise PlacementError(
+            f"{role.value}: tensor_split has {len(tensor_split)} weights for {len(devices)} devices"
+        )
+    replicas = int(entry.get(_KEY_REPLICAS, 1))
+    if replicas < 1:
+        raise PlacementError(f"{role.value}: replicas must be >= 1")
+    return RolePlacement(devices=devices, tensor_split=tensor_split, replicas=replicas)

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -764,9 +764,8 @@ def plan_launches(
 
     unified_budget = _unified_memory_budget(devices)
     inputs, model_refs, reservation = _server_model_inputs(roles, unified_budget=unified_budget)
-    placement = _resolve_placement(
-        cfg.placement, inputs, model_refs, devices, unified_budget=unified_budget
-    )
+    spec = PlacementSpec.from_json(cfg.placement) if cfg.placement else None
+    placement = _resolve_placement(spec, inputs, model_refs, devices, unified_budget=unified_budget)
     for role in placement.unplaceable_roles:
         log.warning(
             "%s model %s does not fit available memory and will not be served; "

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,8 +27,11 @@ from lilbee.providers.fleet.placement import (
     InstancePlan,
     ModelPlacementInput,
     PeakEstimator,
+    Placement,
+    placement_from_spec,
     plan_placement,
 )
+from lilbee.providers.fleet.placement_spec import PlacementSpec
 from lilbee.providers.fleet.vram import estimate_instance_footprint
 from lilbee.providers.roles import RerankMode, WorkerRole
 
@@ -692,6 +696,63 @@ def _unified_memory_budget(devices: list[FleetDevice]) -> int | None:
     return max(0, model_cache.free_system_memory() - floor)
 
 
+def _resolve_placement(
+    placement: PlacementSpec | None,
+    inputs: list[ModelPlacementInput],
+    model_refs: dict[WorkerRole, str],
+    devices: list[FleetDevice],
+    *,
+    unified_budget: int | None,
+) -> Placement:
+    """Resolve a Placement from the manual spec when set, else the auto planner."""
+    estimate_peak = _peak_estimator(model_refs)
+    if placement is not None:
+        return placement_from_spec(
+            placement,
+            tuple(model_refs),
+            {d.index: d.free_bytes for d in devices},
+            estimate_peak=estimate_peak,
+        )
+    return plan_placement(
+        inputs,
+        [(d.index, d.free_bytes) for d in devices],
+        estimate_peak=estimate_peak,
+        unified_budget=unified_budget,
+    )
+
+
+@dataclass(frozen=True)
+class ResolvedPlacement:
+    """Devices + resolved instance plans + model refs for the placement view."""
+
+    devices: tuple[FleetDevice, ...]
+    instances: tuple[InstancePlan, ...]
+    unplaceable_roles: tuple[WorkerRole, ...]
+    model_refs: dict[WorkerRole, str]
+
+
+def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement:
+    """Probe devices and resolve the auto-or-manual placement, without launching."""
+    from lilbee.providers.fleet.cuda_runtime import apply_cuda_runtime_env
+    from lilbee.providers.fleet.gpu_env import apply_fleet_gpu_env
+
+    apply_fleet_gpu_env()
+    binary = resolve_llama_server()
+    apply_cuda_runtime_env()
+    devices = resolve_devices(binary)
+    unified_budget = _unified_memory_budget(devices)
+    inputs, model_refs, _ = _server_model_inputs(None, unified_budget=unified_budget)
+    resolved = _resolve_placement(
+        placement, inputs, model_refs, devices, unified_budget=unified_budget
+    )
+    return ResolvedPlacement(
+        devices=tuple(devices),
+        instances=resolved.instances,
+        unplaceable_roles=resolved.unplaceable_roles,
+        model_refs=model_refs,
+    )
+
+
 def plan_launches(
     roles: tuple[WorkerRole, ...] | None,
     binary: Path,
@@ -699,13 +760,12 @@ def plan_launches(
     devices: list[FleetDevice],
 ) -> list[InstanceLaunch]:
     """Plan placement for *roles* (``None`` = all configured) and build their launches."""
+    from lilbee.core.config import cfg
+
     unified_budget = _unified_memory_budget(devices)
     inputs, model_refs, reservation = _server_model_inputs(roles, unified_budget=unified_budget)
-    placement = plan_placement(
-        inputs,
-        [(d.index, d.free_bytes) for d in devices],
-        estimate_peak=_peak_estimator(model_refs),
-        unified_budget=unified_budget,
+    placement = _resolve_placement(
+        cfg.placement, inputs, model_refs, devices, unified_budget=unified_budget
     )
     for role in placement.unplaceable_roles:
         log.warning(

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -55,6 +55,13 @@ from lilbee.server.routes.models import (
     models_set_vision_route,
     models_show_route,
 )
+from lilbee.server.routes.placement import (
+    gpus_route,
+    placement_clear_route,
+    placement_preview_route,
+    placement_route,
+    placement_set_route,
+)
 from lilbee.server.routes.search import (
     ask_route,
     ask_stream_route,
@@ -156,6 +163,11 @@ def create_app() -> Litestar:
             memories_remove_route,
             export_route,
             import_route,
+            placement_route,
+            placement_preview_route,
+            placement_set_route,
+            placement_clear_route,
+            gpus_route,
             crawl_route,
             setup_crawler_route,
             setup_crawler_status_route,

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -186,8 +186,9 @@ async def placement_clear() -> PlacementResponse:
 async def gpus() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
     from lilbee.app.placement import get_placement
+    from lilbee.server.models import GpuInfoResponse as _GpuInfoResponse
 
-    return [GpuInfoResponse(**vars(g)) for g in get_placement().gpus]
+    return [_GpuInfoResponse(**vars(g)) for g in get_placement().gpus]
 
 
 __all__ = [

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -152,14 +152,14 @@ def _placement_response(view: PlacementView) -> PlacementResponse:
     )
 
 
-def placement() -> PlacementResponse:
+async def placement() -> PlacementResponse:
     """Current effective placement."""
     from lilbee.app.placement import get_placement
 
     return _placement_response(get_placement())
 
 
-def placement_preview(spec_json: str | None) -> PlacementResponse:
+async def placement_preview(spec_json: str | None) -> PlacementResponse:
     """Preview a candidate spec (or auto when spec_json is None). No persistence."""
     from lilbee.app.placement import preview_placement
     from lilbee.providers.fleet.placement_spec import PlacementSpec
@@ -168,7 +168,7 @@ def placement_preview(spec_json: str | None) -> PlacementResponse:
     return _placement_response(preview_placement(spec))
 
 
-def placement_set(spec_json: str) -> PlacementResponse:
+async def placement_set(spec_json: str) -> PlacementResponse:
     """Validate, persist, and apply a manual placement spec."""
     from lilbee.app.placement import set_placement
     from lilbee.providers.fleet.placement_spec import PlacementSpec
@@ -176,17 +176,16 @@ def placement_set(spec_json: str) -> PlacementResponse:
     return _placement_response(set_placement(PlacementSpec.from_json(spec_json)))
 
 
-def placement_clear() -> PlacementResponse:
+async def placement_clear() -> PlacementResponse:
     """Clear the manual placement, returning to auto."""
     from lilbee.app.placement import set_placement
 
     return _placement_response(set_placement(None))
 
 
-def gpus() -> list[GpuInfoResponse]:
+async def gpus() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
     from lilbee.app.placement import get_placement
-    from lilbee.server.models import GpuInfoResponse
 
     return [GpuInfoResponse(**vars(g)) for g in get_placement().gpus]
 

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 
 from lilbee.app.services import get_services
 from lilbee.app.status import gather_status
@@ -72,6 +73,10 @@ from lilbee.server.handlers.sse import (
 )
 from lilbee.server.models import HealthResponse, StatusResponse
 
+if TYPE_CHECKING:
+    from lilbee.app.placement import PlacementView
+    from lilbee.server.models import GpuInfoResponse, PlacementResponse
+
 # How often the warm stream re-snapshots provider state; sub-second so the read
 # bar advances smoothly without busy-spinning.
 _WARM_POLL_INTERVAL_S = 0.25
@@ -125,6 +130,67 @@ async def status() -> StatusResponse:
     return StatusResponse(**raw.model_dump(exclude_none=True))
 
 
+def _placement_response(view: PlacementView) -> PlacementResponse:
+    """Map a PlacementView to a PlacementResponse."""
+    from lilbee.server.models import GpuInfoResponse, PlacementResponse, RolePlacementResponse
+
+    return PlacementResponse(
+        gpus=[GpuInfoResponse(**vars(g)) for g in view.gpus],
+        roles=[
+            RolePlacementResponse(
+                role=r.role,
+                model=r.model,
+                devices=list(r.devices),
+                tensor_split=list(r.tensor_split) if r.tensor_split else None,
+                replicas=r.replicas,
+            )
+            for r in view.roles
+        ],
+        unplaceable=[r.value for r in view.unplaceable],
+        manual=view.manual,
+        spec_json=view.spec_json,
+    )
+
+
+def placement() -> PlacementResponse:
+    """Current effective placement."""
+    from lilbee.app.placement import get_placement
+
+    return _placement_response(get_placement())
+
+
+def placement_preview(spec_json: str | None) -> PlacementResponse:
+    """Preview a candidate spec (or auto when spec_json is None). No persistence."""
+    from lilbee.app.placement import preview_placement
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    spec = PlacementSpec.from_json(spec_json) if spec_json else None
+    return _placement_response(preview_placement(spec))
+
+
+def placement_set(spec_json: str) -> PlacementResponse:
+    """Validate, persist, and apply a manual placement spec."""
+    from lilbee.app.placement import set_placement
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    return _placement_response(set_placement(PlacementSpec.from_json(spec_json)))
+
+
+def placement_clear() -> PlacementResponse:
+    """Clear the manual placement, returning to auto."""
+    from lilbee.app.placement import set_placement
+
+    return _placement_response(set_placement(None))
+
+
+def gpus() -> list[GpuInfoResponse]:
+    """Detected GPUs with free/total VRAM."""
+    from lilbee.app.placement import get_placement
+    from lilbee.server.models import GpuInfoResponse
+
+    return [GpuInfoResponse(**vars(g)) for g in get_placement().gpus]
+
+
 __all__ = [
     "MAX_ADD_FILES",
     "TASK_ENDPOINT_PATH",
@@ -144,6 +210,7 @@ __all__ = [
     "get_config",
     "get_config_defaults",
     "get_source_content",
+    "gpus",
     "health",
     "import_stream",
     "list_documents",
@@ -154,6 +221,10 @@ __all__ = [
     "models_installed",
     "models_pull",
     "models_show",
+    "placement",
+    "placement_clear",
+    "placement_preview",
+    "placement_set",
     "search",
     "set_chat_model",
     "set_embedding_model",

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, field_validator
 from lilbee.catalog.types import KeyStatus, ModelCompat, ModelSource, ModelTask
 from lilbee.core.config.enums import CrawlRenderMode
 from lilbee.data.store import ChunkType, MemoryKind, scope_to_chunk_type
+from lilbee.providers.roles import WorkerRole
 from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 
 
@@ -561,3 +562,40 @@ class MemoryExtractedEvent(BaseModel):
 
     count: int
     items: list[MemoryExtractedItem]
+
+
+class GpuInfoResponse(BaseModel):
+    """One GPU as returned by GET /api/gpus and embedded in PlacementResponse."""
+
+    index: int
+    backend: str
+    label: str
+    name: str
+    total_bytes: int
+    free_bytes: int
+
+
+class RolePlacementResponse(BaseModel):
+    """Where one role's model is placed in the resolved plan."""
+
+    role: WorkerRole
+    model: str
+    devices: list[int]
+    tensor_split: list[int] | None
+    replicas: int
+
+
+class PlacementResponse(BaseModel):
+    """Response for placement read, preview, set, and clear routes."""
+
+    gpus: list[GpuInfoResponse]
+    roles: list[RolePlacementResponse]
+    unplaceable: list[str]
+    manual: bool
+    spec_json: str | None
+
+
+class PlacementSpecBody(BaseModel):
+    """Request body for placement routes that accept a manual spec."""
+
+    spec: dict[str, dict[str, object]] | None = None

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -1,0 +1,59 @@
+"""Placement routes: inspect, preview, set, and clear GPU placement."""
+
+from __future__ import annotations
+
+import json
+
+from litestar import delete, get, post, put
+from litestar.exceptions import HTTPException
+
+from lilbee.providers.fleet.placement_spec import PlacementError
+from lilbee.server import handlers
+from lilbee.server.auth import read_only
+from lilbee.server.models import GpuInfoResponse, PlacementResponse, PlacementSpecBody
+
+
+def _spec_json(body: PlacementSpecBody) -> str | None:
+    """Serialize the optional spec dict to JSON, or return None when absent."""
+    return json.dumps(body.spec) if body.spec is not None else None
+
+
+@get("/api/placement")
+@read_only
+async def placement_route() -> PlacementResponse:
+    """Current effective placement."""
+    return handlers.placement()  # type: ignore[return-value]
+
+
+@post("/api/placement/preview", status_code=200)
+@read_only
+async def placement_preview_route(data: PlacementSpecBody) -> PlacementResponse:
+    """Preview a candidate spec (or auto when no spec)."""
+    try:
+        return handlers.placement_preview(_spec_json(data))  # type: ignore[return-value]
+    except PlacementError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@put("/api/placement")
+async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
+    """Validate, persist, and apply a manual placement spec."""
+    if data.spec is None:
+        raise HTTPException(status_code=422, detail="spec is required")
+    try:
+        return handlers.placement_set(json.dumps(data.spec))  # type: ignore[return-value]
+    except PlacementError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@delete("/api/placement", status_code=200)
+async def placement_clear_route() -> PlacementResponse:
+    """Clear the manual placement, returning to auto."""
+    return handlers.placement_clear()  # type: ignore[return-value]
+
+
+@get("/api/gpus")
+@read_only
+async def gpus_route() -> list[GpuInfoResponse]:
+    """Detected GPUs with free/total VRAM."""
+    return handlers.gpus()  # type: ignore[return-value]

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -22,7 +22,7 @@ def _spec_json(body: PlacementSpecBody) -> str | None:
 @read_only
 async def placement_route() -> PlacementResponse:
     """Current effective placement."""
-    return handlers.placement()  # type: ignore[return-value]
+    return await handlers.placement()
 
 
 @post("/api/placement/preview", status_code=200)
@@ -30,7 +30,7 @@ async def placement_route() -> PlacementResponse:
 async def placement_preview_route(data: PlacementSpecBody) -> PlacementResponse:
     """Preview a candidate spec (or auto when no spec)."""
     try:
-        return handlers.placement_preview(_spec_json(data))  # type: ignore[return-value]
+        return await handlers.placement_preview(_spec_json(data))
     except PlacementError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -41,7 +41,7 @@ async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
     if data.spec is None:
         raise HTTPException(status_code=422, detail="spec is required")
     try:
-        return handlers.placement_set(json.dumps(data.spec))  # type: ignore[return-value]
+        return await handlers.placement_set(json.dumps(data.spec))
     except PlacementError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -49,11 +49,11 @@ async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
 @delete("/api/placement", status_code=200)
 async def placement_clear_route() -> PlacementResponse:
     """Clear the manual placement, returning to auto."""
-    return handlers.placement_clear()  # type: ignore[return-value]
+    return await handlers.placement_clear()
 
 
 @get("/api/gpus")
 @read_only
 async def gpus_route() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
-    return handlers.gpus()  # type: ignore[return-value]
+    return await handlers.gpus()

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -115,7 +115,7 @@ def test_set_validates_before_persist(monkeypatch):
     assert wrote["any"] is False
 
 
-def test_view_multi_replica_keeps_first_devices():
+def test_view_multi_replica_unions_devices():
     resolved = ResolvedPlacement(
         devices=(
             FleetDevice("CUDA", 0, "NVIDIA A100", 80 * GIB, 72 * GIB),
@@ -133,4 +133,4 @@ def test_view_multi_replica_keeps_first_devices():
     assert len(embed_views) == 1
     role_view = embed_views[0]
     assert role_view.replicas == 2
-    assert role_view.devices == (0,)
+    assert role_view.devices == (0, 1)

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -27,6 +27,12 @@ def test_active_spec_reads_cfg(monkeypatch):
     assert app_placement._active_spec() is None
 
 
+def test_active_spec_parses_stored_json(monkeypatch):
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0, 1))})
+    monkeypatch.setattr(app_placement.cfg, "placement", spec.to_json())
+    assert app_placement._active_spec() == spec
+
+
 def test_get_placement_renders_view(monkeypatch):
     monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
@@ -71,7 +77,7 @@ def test_set_persists_and_resets(monkeypatch):
         app_placement.set_placement(spec)
         assert writes["placement"] == spec.to_json()
         assert writes["reset"] is True
-        assert app_placement.cfg.placement == spec
+        assert app_placement.cfg.placement == spec.to_json()
     finally:
         app_placement.cfg.placement = prior
 

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -1,0 +1,99 @@
+import pytest
+
+from lilbee.app import placement as app_placement
+from lilbee.providers.fleet.devices import FleetDevice
+from lilbee.providers.fleet.placement import InstancePlan
+from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
+from lilbee.providers.fleet.planning import ResolvedPlacement
+from lilbee.providers.roles import WorkerRole
+
+GIB = 1024**3
+
+
+def _resolved():
+    return ResolvedPlacement(
+        devices=(
+            FleetDevice("CUDA", 0, "NVIDIA A100", 80 * GIB, 72 * GIB),
+            FleetDevice("CUDA", 1, "NVIDIA A100", 80 * GIB, 80 * GIB),
+        ),
+        instances=(InstancePlan(role=WorkerRole.CHAT, devices=(0, 1), tensor_split=(1, 1)),),
+        unplaceable_roles=(),
+        model_refs={WorkerRole.CHAT: "org/chat.gguf"},
+    )
+
+
+def test_active_spec_reads_cfg(monkeypatch):
+    monkeypatch.setattr(app_placement.cfg, "placement", None)
+    assert app_placement._active_spec() is None
+
+
+def test_get_placement_renders_view(monkeypatch):
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    view = app_placement.get_placement()
+    assert view.manual is False
+    assert view.gpus[0].label == "CUDA0"
+    assert view.gpus[0].free_bytes == 72 * GIB
+    assert view.roles[0].role is WorkerRole.CHAT
+    assert view.roles[0].devices == (0, 1)
+
+
+def test_preview_passes_candidate_spec(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        app_placement,
+        "resolve_placement_plan",
+        lambda spec: seen.update({"spec": spec}) or _resolved(),
+    )
+    cand = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+    app_placement.preview_placement(cand)
+    assert seen["spec"] is cand
+
+
+def test_preview_has_no_side_effects(monkeypatch):
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    reset = {"called": False}
+    monkeypatch.setattr(app_placement, "reset_services", lambda: reset.__setitem__("called", True))
+    app_placement.preview_placement(None)
+    assert reset["called"] is False
+
+
+def test_set_persists_and_resets(monkeypatch):
+    writes = {}
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: writes.update(d))
+    monkeypatch.setattr(app_placement, "reset_services", lambda: writes.setdefault("reset", True))
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(1, 1))})
+    app_placement.set_placement(spec)
+    assert writes["placement"] == spec.to_json()
+    assert writes["reset"] is True
+
+
+def test_set_none_clears(monkeypatch):
+    deletes = {}
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    monkeypatch.setattr(
+        app_placement.settings, "delete_values", lambda root, keys: deletes.setdefault("keys", keys)
+    )
+    monkeypatch.setattr(app_placement, "reset_services", lambda: None)
+    app_placement.set_placement(None)
+    assert deletes["keys"] == ["placement"]
+
+
+def test_set_validates_before_persist(monkeypatch):
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    def boom(spec):
+        raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
+
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", boom)
+    wrote = {"any": False}
+    monkeypatch.setattr(
+        app_placement.settings, "update_values", lambda root, d: wrote.__setitem__("any", True)
+    )
+    with pytest.raises(PlacementError):
+        app_placement.set_placement(PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))}))
+    assert wrote["any"] is False

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -65,10 +65,15 @@ def test_set_persists_and_resets(monkeypatch):
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: writes.update(d))
     monkeypatch.setattr(app_placement, "reset_services", lambda: writes.setdefault("reset", True))
+    prior = app_placement.cfg.placement
     spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(1, 1))})
-    app_placement.set_placement(spec)
-    assert writes["placement"] == spec.to_json()
-    assert writes["reset"] is True
+    try:
+        app_placement.set_placement(spec)
+        assert writes["placement"] == spec.to_json()
+        assert writes["reset"] is True
+        assert app_placement.cfg.placement == spec
+    finally:
+        app_placement.cfg.placement = prior
 
 
 def test_set_none_clears(monkeypatch):
@@ -79,8 +84,13 @@ def test_set_none_clears(monkeypatch):
         app_placement.settings, "delete_values", lambda root, keys: deletes.setdefault("keys", keys)
     )
     monkeypatch.setattr(app_placement, "reset_services", lambda: None)
-    app_placement.set_placement(None)
-    assert deletes["keys"] == ["placement"]
+    prior = app_placement.cfg.placement
+    try:
+        app_placement.set_placement(None)
+        assert deletes["keys"] == ["placement"]
+        assert app_placement.cfg.placement is None
+    finally:
+        app_placement.cfg.placement = prior
 
 
 def test_set_validates_before_persist(monkeypatch):
@@ -97,3 +107,24 @@ def test_set_validates_before_persist(monkeypatch):
     with pytest.raises(PlacementError):
         app_placement.set_placement(PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))}))
     assert wrote["any"] is False
+
+
+def test_view_multi_replica_keeps_first_devices():
+    resolved = ResolvedPlacement(
+        devices=(
+            FleetDevice("CUDA", 0, "NVIDIA A100", 80 * GIB, 72 * GIB),
+            FleetDevice("CUDA", 1, "NVIDIA A100", 80 * GIB, 80 * GIB),
+        ),
+        instances=(
+            InstancePlan(role=WorkerRole.EMBED, devices=(0,), tensor_split=None),
+            InstancePlan(role=WorkerRole.EMBED, devices=(1,), tensor_split=None),
+        ),
+        unplaceable_roles=(),
+        model_refs={WorkerRole.EMBED: "org/embed.gguf"},
+    )
+    view = app_placement._view(resolved, manual=False, spec_json=None)
+    embed_views = [r for r in view.roles if r.role is WorkerRole.EMBED]
+    assert len(embed_views) == 1
+    role_view = embed_views[0]
+    assert role_view.replicas == 2
+    assert role_view.devices == (0,)

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -1,0 +1,133 @@
+"""Tests for the `lilbee placement` CLI sub-app."""
+
+from typer.testing import CliRunner
+
+import lilbee.cli.placement as cli_placement
+from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+from lilbee.cli.placement import placement_app
+from lilbee.providers.roles import WorkerRole
+
+runner = CliRunner()
+_GIB = 1024**3
+
+
+def _view(manual: bool = False) -> PlacementView:
+    return PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100-SXM4-80GB", 80 * _GIB, 72 * _GIB),),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=manual,
+        spec_json='{"chat": {"devices": [0]}}' if manual else None,
+    )
+
+
+def test_show_renders_cards(monkeypatch: object) -> None:
+    """show calls get_placement and renders GPU label, name, and roles."""
+    monkeypatch.setattr(cli_placement, "get_placement", lambda: _view())
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 0
+    assert "CUDA0" in result.stdout
+    assert "NVIDIA A100-SXM4-80GB" in result.stdout
+    assert "chat" in result.stdout
+
+
+def test_preview_auto(monkeypatch: object) -> None:
+    """preview with no --spec calls preview_placement(None)."""
+    monkeypatch.setattr(cli_placement, "preview_placement", lambda spec: _view())
+    result = runner.invoke(placement_app, ["preview"])
+    assert result.exit_code == 0
+    assert "CUDA0" in result.stdout
+
+
+def test_set_reads_spec_file(tmp_path: object, monkeypatch: object) -> None:
+    """set --spec FILE parses the JSON and passes a PlacementSpec to set_placement."""
+    seen: dict[str, object] = {}
+
+    def _fake_set(spec: object) -> PlacementView:
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(cli_placement, "set_placement", _fake_set)
+    f = tmp_path / "spec.json"
+    f.write_text('{"chat": {"devices": [0]}}')
+    result = runner.invoke(placement_app, ["set", "--spec", str(f)])
+    assert result.exit_code == 0
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    assert isinstance(seen["spec"], PlacementSpec)
+    assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
+
+
+def test_clear(monkeypatch: object) -> None:
+    """clear calls set_placement(None)."""
+    seen: dict[str, object] = {}
+
+    def _fake_set(spec: object) -> PlacementView:
+        seen["spec"] = spec
+        return _view()
+
+    monkeypatch.setattr(cli_placement, "set_placement", _fake_set)
+    result = runner.invoke(placement_app, ["clear"])
+    assert result.exit_code == 0
+    assert seen["spec"] is None
+
+
+def test_show_unplaceable_role(monkeypatch: object) -> None:
+    """show renders a red line for each unplaceable role."""
+    view = PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "A100", 80 * _GIB, 72 * _GIB),),
+        roles=(),
+        unplaceable=(WorkerRole.EMBED,),
+        manual=False,
+        spec_json=None,
+    )
+    monkeypatch.setattr(cli_placement, "get_placement", lambda: view)
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 0
+    assert "embed" in result.stdout
+
+
+def test_preview_with_spec_file(tmp_path: object, monkeypatch: object) -> None:
+    """preview --spec FILE parses the JSON and passes PlacementSpec to preview_placement."""
+    seen: dict[str, object] = {}
+
+    def _fake_preview(spec: object) -> PlacementView:
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(cli_placement, "preview_placement", _fake_preview)
+    f = tmp_path / "spec.json"
+    f.write_text('{"chat": {"devices": [0]}}')
+    result = runner.invoke(placement_app, ["preview", "--spec", str(f)])
+    assert result.exit_code == 0
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    assert isinstance(seen["spec"], PlacementSpec)
+
+
+def test_preview_placement_error(monkeypatch: object) -> None:
+    """preview prints the error and exits 1 when preview_placement raises PlacementError."""
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(
+        cli_placement,
+        "preview_placement",
+        lambda spec: (_ for _ in ()).throw(PlacementError("bad spec")),
+    )
+    result = runner.invoke(placement_app, ["preview"])
+    assert result.exit_code == 1
+    assert "bad spec" in result.stdout
+
+
+def test_set_placement_error(tmp_path: object, monkeypatch: object) -> None:
+    """set prints the error and exits 1 when set_placement raises PlacementError."""
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(
+        cli_placement, "set_placement", lambda spec: (_ for _ in ()).throw(PlacementError("no fit"))
+    )
+    f = tmp_path / "spec.json"
+    f.write_text('{"chat": {"devices": [0]}}')
+    result = runner.invoke(placement_app, ["set", "--spec", str(f)])
+    assert result.exit_code == 1
+    assert "no fit" in result.stdout

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 import lilbee.cli.placement as cli_placement
 from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
 from lilbee.cli.placement import placement_app
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 from lilbee.providers.roles import WorkerRole
 
 runner = CliRunner()
@@ -52,8 +53,23 @@ def test_set_reads_spec_file(tmp_path: object, monkeypatch: object) -> None:
     f.write_text('{"chat": {"devices": [0]}}')
     result = runner.invoke(placement_app, ["set", "--spec", str(f)])
     assert result.exit_code == 0
-    from lilbee.providers.fleet.placement_spec import PlacementSpec
+    assert isinstance(seen["spec"], PlacementSpec)
+    assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
 
+
+def test_set_reads_spec_from_stdin(monkeypatch: object) -> None:
+    """set --spec - reads JSON from stdin and passes a PlacementSpec to set_placement."""
+    seen: dict[str, object] = {}
+
+    def _fake_set(spec: object) -> PlacementView:
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(cli_placement, "set_placement", _fake_set)
+    result = runner.invoke(
+        placement_app, ["set", "--spec", "-"], input='{"chat": {"devices": [0]}}'
+    )
+    assert result.exit_code == 0
     assert isinstance(seen["spec"], PlacementSpec)
     assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
 
@@ -100,20 +116,16 @@ def test_preview_with_spec_file(tmp_path: object, monkeypatch: object) -> None:
     f.write_text('{"chat": {"devices": [0]}}')
     result = runner.invoke(placement_app, ["preview", "--spec", str(f)])
     assert result.exit_code == 0
-    from lilbee.providers.fleet.placement_spec import PlacementSpec
-
     assert isinstance(seen["spec"], PlacementSpec)
 
 
 def test_preview_placement_error(monkeypatch: object) -> None:
     """preview prints the error and exits 1 when preview_placement raises PlacementError."""
-    from lilbee.providers.fleet.placement_spec import PlacementError
 
-    monkeypatch.setattr(
-        cli_placement,
-        "preview_placement",
-        lambda spec: (_ for _ in ()).throw(PlacementError("bad spec")),
-    )
+    def _raise(spec: object) -> PlacementView:
+        raise PlacementError("bad spec")
+
+    monkeypatch.setattr(cli_placement, "preview_placement", _raise)
     result = runner.invoke(placement_app, ["preview"])
     assert result.exit_code == 1
     assert "bad spec" in result.stdout
@@ -121,11 +133,11 @@ def test_preview_placement_error(monkeypatch: object) -> None:
 
 def test_set_placement_error(tmp_path: object, monkeypatch: object) -> None:
     """set prints the error and exits 1 when set_placement raises PlacementError."""
-    from lilbee.providers.fleet.placement_spec import PlacementError
 
-    monkeypatch.setattr(
-        cli_placement, "set_placement", lambda spec: (_ for _ in ()).throw(PlacementError("no fit"))
-    )
+    def _raise(spec: object) -> PlacementView:
+        raise PlacementError("no fit")
+
+    monkeypatch.setattr(cli_placement, "set_placement", _raise)
     f = tmp_path / "spec.json"
     f.write_text('{"chat": {"devices": [0]}}')
     result = runner.invoke(placement_app, ["set", "--spec", str(f)])

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -143,3 +143,21 @@ def test_set_placement_error(tmp_path: object, monkeypatch: object) -> None:
     result = runner.invoke(placement_app, ["set", "--spec", str(f)])
     assert result.exit_code == 1
     assert "no fit" in result.stdout
+
+
+def test_set_missing_spec_file_exits_clean(tmp_path: object, monkeypatch: object) -> None:
+    """set --spec with a nonexistent file exits 1 without a traceback."""
+    monkeypatch.setattr(cli_placement, "set_placement", lambda spec: _view(True))
+    missing = tmp_path / "nope.json"
+    result = runner.invoke(placement_app, ["set", "--spec", str(missing)])
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_preview_missing_spec_file_exits_clean(tmp_path: object, monkeypatch: object) -> None:
+    """preview --spec with a nonexistent file exits 1 without a traceback."""
+    monkeypatch.setattr(cli_placement, "preview_placement", lambda spec: _view(True))
+    missing = tmp_path / "nope.json"
+    result = runner.invoke(placement_app, ["preview", "--spec", str(missing)])
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)

--- a/tests/core/config/test_placement_field.py
+++ b/tests/core/config/test_placement_field.py
@@ -6,15 +6,16 @@ from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
 from lilbee.providers.roles import WorkerRole
 
 
-def test_parses_json_string_to_spec():
+def test_validates_json_string_and_stores_it():
     cfg = Config(placement='{"chat": {"devices": [0, 1]}}')
-    assert isinstance(cfg.placement, PlacementSpec)
-    assert cfg.placement.roles[WorkerRole.CHAT].devices == (0, 1)
+    assert isinstance(cfg.placement, str)
+    spec = PlacementSpec.from_json(cfg.placement)
+    assert spec.roles[WorkerRole.CHAT].devices == (0, 1)
 
 
-def test_accepts_spec_object():
+def test_accepts_spec_object_and_stores_its_json():
     spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))})
-    assert Config(placement=spec).placement == spec
+    assert Config(placement=spec).placement == spec.to_json()
 
 
 def test_blank_is_none():

--- a/tests/core/config/test_placement_field.py
+++ b/tests/core/config/test_placement_field.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from lilbee.core.config.model import Config
+from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
+
+
+def test_parses_json_string_to_spec():
+    cfg = Config(placement='{"chat": {"devices": [0, 1]}}')
+    assert isinstance(cfg.placement, PlacementSpec)
+    assert cfg.placement.roles[WorkerRole.CHAT].devices == (0, 1)
+
+
+def test_accepts_spec_object():
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))})
+    assert Config(placement=spec).placement == spec
+
+
+def test_blank_is_none():
+    assert Config(placement="").placement is None
+    assert Config(placement=None).placement is None
+
+
+def test_invalid_json_raises():
+    with pytest.raises(ValidationError):
+        Config(placement="{nope")
+
+
+def test_placement_is_writable_not_public():
+    from lilbee.config_meta import PUBLIC_CONFIG_FIELDS, WRITABLE_CONFIG_FIELDS
+
+    assert "placement" in WRITABLE_CONFIG_FIELDS
+    assert "placement" not in PUBLIC_CONFIG_FIELDS

--- a/tests/core/config/test_placement_field.py
+++ b/tests/core/config/test_placement_field.py
@@ -32,3 +32,9 @@ def test_placement_is_writable_not_public():
 
     assert "placement" in WRITABLE_CONFIG_FIELDS
     assert "placement" not in PUBLIC_CONFIG_FIELDS
+
+
+def test_unexpected_type_raises():
+    """A non-string, non-PlacementSpec value must fail validation."""
+    with pytest.raises(ValidationError):
+        Config(placement=42)

--- a/tests/mcp/test_placement_tools.py
+++ b/tests/mcp/test_placement_tools.py
@@ -1,5 +1,7 @@
 """Tests for MCP placement tools (get/preview/set/clear)."""
 
+import pytest
+
 import lilbee.mcp_server as mcp_server
 from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
 from lilbee.providers.roles import WorkerRole
@@ -74,7 +76,7 @@ def test_preview_placement_tool_with_spec(monkeypatch):
 
     monkeypatch.setattr(mcp_server, "preview_placement", _capture)
     out = mcp_server.preview_placement_tool({"chat": {"devices": [0]}})
-    assert seen["spec"] is not None
+    assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
     assert "gpus" in out
 
 
@@ -88,3 +90,18 @@ def test_preview_placement_tool_error(monkeypatch):
     out = mcp_server.preview_placement_tool({"chat": {"devices": [99]}})
     assert "error" in out
     assert "no GPUs available" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_placement_tools_wire_names():
+    """Placement tools must be registered under clean wire names (no _tool suffix)."""
+    tools = await mcp_server.mcp.list_tools()
+    names = {t.name for t in tools}
+    assert "get_placement" in names
+    assert "preview_placement" in names
+    assert "set_placement" in names
+    assert "clear_placement" in names
+    assert "get_placement_tool" not in names
+    assert "preview_placement_tool" not in names
+    assert "set_placement_tool" not in names
+    assert "clear_placement_tool" not in names

--- a/tests/mcp/test_placement_tools.py
+++ b/tests/mcp/test_placement_tools.py
@@ -1,0 +1,90 @@
+"""Tests for MCP placement tools (get/preview/set/clear)."""
+
+import lilbee.mcp_server as mcp_server
+from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+from lilbee.providers.roles import WorkerRole
+
+GIB = 1024**3
+
+
+def _view(manual=False):
+    return PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=manual,
+        spec_json=None,
+    )
+
+
+def test_get_placement_tool(monkeypatch):
+    monkeypatch.setattr(mcp_server, "get_placement", lambda: _view())
+    out = mcp_server.get_placement_tool()
+    assert out["gpus"][0]["label"] == "CUDA0"
+    assert out["manual"] is False
+
+
+def test_set_placement_tool(monkeypatch):
+    seen = {}
+
+    def _capture(spec):
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(mcp_server, "set_placement", _capture)
+    out = mcp_server.set_placement_tool({"chat": {"devices": [0]}})
+    assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
+    assert out["manual"] is True
+
+
+def test_set_placement_tool_unfit_returns_error(monkeypatch):
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    def boom(spec):
+        raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
+
+    monkeypatch.setattr(mcp_server, "set_placement", boom)
+    out = mcp_server.set_placement_tool({"chat": {"devices": [0]}})
+    assert "error" in out
+    assert "40 GiB free" in out["error"]
+
+
+def test_clear_placement_tool(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        mcp_server, "set_placement", lambda spec: seen.setdefault("spec", spec) or _view()
+    )
+    mcp_server.clear_placement_tool()
+    assert seen["spec"] is None
+
+
+def test_preview_placement_tool_auto(monkeypatch):
+    monkeypatch.setattr(mcp_server, "preview_placement", lambda spec=None: _view())
+    out = mcp_server.preview_placement_tool()
+    assert out["gpus"][0]["label"] == "CUDA0"
+    assert out["manual"] is False
+
+
+def test_preview_placement_tool_with_spec(monkeypatch):
+    seen = {}
+
+    def _capture(spec=None):
+        seen["spec"] = spec
+        return _view()
+
+    monkeypatch.setattr(mcp_server, "preview_placement", _capture)
+    out = mcp_server.preview_placement_tool({"chat": {"devices": [0]}})
+    assert seen["spec"] is not None
+    assert "gpus" in out
+
+
+def test_preview_placement_tool_error(monkeypatch):
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    def boom(spec=None):
+        raise PlacementError("no GPUs available")
+
+    monkeypatch.setattr(mcp_server, "preview_placement", boom)
+    out = mcp_server.preview_placement_tool({"chat": {"devices": [99]}})
+    assert "error" in out
+    assert "no GPUs available" in out["error"]

--- a/tests/providers/fleet/test_placement_from_spec.py
+++ b/tests/providers/fleet/test_placement_from_spec.py
@@ -1,0 +1,77 @@
+import pytest
+
+from lilbee.providers.fleet.placement import InstancePlan, placement_from_spec
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
+
+GIB = 1024**3
+
+
+def _peak(per_device_gib):
+    # estimate_peak(role, ratio) -> per-device byte vector aligned to ratio length.
+    def estimate(role, ratio):
+        return tuple(per_device_gib[role][i] * GIB for i in range(len(ratio)))
+
+    return estimate
+
+
+def test_builds_plans_from_spec():
+    spec = PlacementSpec(
+        {
+            WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(1, 1)),
+            WorkerRole.EMBED: RolePlacement(devices=(2,)),
+        }
+    )
+    est = _peak({WorkerRole.CHAT: [30, 30], WorkerRole.EMBED: [4]})
+    placement = placement_from_spec(
+        spec,
+        (WorkerRole.CHAT, WorkerRole.EMBED),
+        {0: 80 * GIB, 1: 80 * GIB, 2: 80 * GIB},
+        estimate_peak=est,
+    )
+    assert placement.unplaceable_roles == ()
+    assert (
+        InstancePlan(role=WorkerRole.CHAT, devices=(0, 1), tensor_split=(1, 1))
+        in placement.instances
+    )
+    assert InstancePlan(role=WorkerRole.EMBED, devices=(2,)) in placement.instances
+
+
+def test_errors_when_active_role_missing_from_spec():
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+    with pytest.raises(PlacementError, match="embed has a model but no placement entry"):
+        placement_from_spec(
+            spec,
+            (WorkerRole.CHAT, WorkerRole.EMBED),
+            {0: 80 * GIB},
+            estimate_peak=_peak({WorkerRole.CHAT: [4]}),
+        )
+
+
+def test_errors_on_nonexistent_device():
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(5,))})
+    with pytest.raises(PlacementError, match="chat pinned to device 5 but only 1 GPU"):
+        placement_from_spec(
+            spec, (WorkerRole.CHAT,), {0: 80 * GIB}, estimate_peak=_peak({WorkerRole.CHAT: [4]})
+        )
+
+
+def test_errors_when_does_not_fit_naming_card():
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+    est = _peak({WorkerRole.CHAT: [70]})
+    with pytest.raises(PlacementError, match=r"chat .* device 0 .* 70.0 GiB .* 40.0 GiB free"):
+        placement_from_spec(spec, (WorkerRole.CHAT,), {0: 40 * GIB}, estimate_peak=est)
+
+
+def test_errors_when_two_roles_overbook_one_card():
+    spec = PlacementSpec(
+        {
+            WorkerRole.CHAT: RolePlacement(devices=(0,)),
+            WorkerRole.EMBED: RolePlacement(devices=(0,)),
+        }
+    )
+    est = _peak({WorkerRole.CHAT: [50], WorkerRole.EMBED: [40]})
+    with pytest.raises(PlacementError, match="device 0"):
+        placement_from_spec(
+            spec, (WorkerRole.CHAT, WorkerRole.EMBED), {0: 80 * GIB}, estimate_peak=est
+        )

--- a/tests/providers/fleet/test_placement_from_spec.py
+++ b/tests/providers/fleet/test_placement_from_spec.py
@@ -59,7 +59,10 @@ def test_errors_on_nonexistent_device():
 def test_errors_when_does_not_fit_naming_card():
     spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
     est = _peak({WorkerRole.CHAT: [70]})
-    with pytest.raises(PlacementError, match=r"chat .* device 0 .* 70.0 GiB .* 40.0 GiB free"):
+    with pytest.raises(
+        PlacementError,
+        match=r"chat .* device 0 .* 70.0 GiB .* 36.0 GiB usable .*40.0 GiB free",
+    ):
         placement_from_spec(spec, (WorkerRole.CHAT,), {0: 40 * GIB}, estimate_peak=est)
 
 

--- a/tests/providers/fleet/test_placement_spec.py
+++ b/tests/providers/fleet/test_placement_spec.py
@@ -45,3 +45,21 @@ def test_rejects_non_positive_replicas():
 def test_rejects_malformed_json():
     with pytest.raises(PlacementError, match="not valid JSON"):
         PlacementSpec.from_json("{not json")
+
+
+def test_to_json_includes_replicas_when_not_one():
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,), replicas=2)})
+    import json
+
+    data = json.loads(spec.to_json())
+    assert data["embed"]["replicas"] == 2
+
+
+def test_rejects_json_array_at_top_level():
+    with pytest.raises(PlacementError, match="must be a JSON object keyed by role"):
+        PlacementSpec.from_json("[1, 2, 3]")
+
+
+def test_rejects_non_dict_role_entry():
+    with pytest.raises(PlacementError, match="placement entry must be an object"):
+        PlacementSpec.from_json('{"chat": [0, 1]}')

--- a/tests/providers/fleet/test_placement_spec.py
+++ b/tests/providers/fleet/test_placement_spec.py
@@ -1,0 +1,47 @@
+import pytest
+
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
+
+
+def test_round_trips_through_json():
+    spec = PlacementSpec(
+        {
+            WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(60, 40)),
+            WorkerRole.EMBED: RolePlacement(devices=(2,)),
+        }
+    )
+    restored = PlacementSpec.from_json(spec.to_json())
+    assert restored == spec
+    assert restored.roles[WorkerRole.CHAT].tensor_split == (60, 40)
+    assert restored.roles[WorkerRole.EMBED].replicas == 1
+
+
+def test_str_is_json():
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))})
+    assert str(spec) == spec.to_json()
+
+
+def test_rejects_unknown_role():
+    with pytest.raises(PlacementError, match="unknown role 'planner'"):
+        PlacementSpec.from_json('{"planner": {"devices": [0]}}')
+
+
+def test_rejects_empty_devices():
+    with pytest.raises(PlacementError, match="chat: at least one device"):
+        PlacementSpec.from_json('{"chat": {"devices": []}}')
+
+
+def test_rejects_tensor_split_length_mismatch():
+    with pytest.raises(PlacementError, match="chat: tensor_split has 3 weights for 2 devices"):
+        PlacementSpec.from_json('{"chat": {"devices": [0, 1], "tensor_split": [1, 2, 3]}}')
+
+
+def test_rejects_non_positive_replicas():
+    with pytest.raises(PlacementError, match="embed: replicas must be >= 1"):
+        PlacementSpec.from_json('{"embed": {"devices": [0], "replicas": 0}}')
+
+
+def test_rejects_malformed_json():
+    with pytest.raises(PlacementError, match="not valid JSON"):
+        PlacementSpec.from_json("{not json")

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -1,0 +1,50 @@
+from lilbee.providers.fleet import planning
+from lilbee.providers.fleet.devices import FleetDevice
+from lilbee.providers.fleet.placement import InstancePlan, Placement
+from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
+
+GIB = 1024**3
+
+
+def test_spec_branch_calls_placement_from_spec(monkeypatch):
+    devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 80 * GIB)]
+    captured = {}
+
+    def fake_from_spec(spec, active_roles, device_free, *, estimate_peak):
+        captured["spec"] = spec
+        captured["roles"] = active_roles
+        return Placement(
+            instances=(InstancePlan(role=WorkerRole.CHAT, devices=(0,)),), unplaceable_roles=()
+        )
+
+    monkeypatch.setattr(planning, "placement_from_spec", fake_from_spec)
+    monkeypatch.setattr(
+        planning,
+        "_server_model_inputs",
+        lambda roles, *, unified_budget=None: ([], {WorkerRole.CHAT: "ref"}, 0),
+    )
+    monkeypatch.setattr(planning, "_peak_estimator", lambda refs: lambda role, ratio: (GIB,))
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+
+    placement = planning._resolve_placement(
+        spec, [], {WorkerRole.CHAT: "ref"}, devices, unified_budget=None
+    )
+
+    assert captured["spec"] is spec
+    assert captured["roles"] == (WorkerRole.CHAT,)
+    assert placement.instances[0].role is WorkerRole.CHAT
+
+
+def test_no_spec_uses_auto_planner(monkeypatch):
+    devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 80 * GIB)]
+    called = {}
+    monkeypatch.setattr(
+        planning,
+        "plan_placement",
+        lambda inputs, devs, *, estimate_peak, unified_budget: (
+            called.setdefault("auto", True) or Placement(instances=(), unplaceable_roles=())
+        ),
+    )
+    planning._resolve_placement(None, [], {}, devices, unified_budget=None)
+    assert called.get("auto") is True

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -1,0 +1,119 @@
+"""Tests for placement and gpus HTTP routes."""
+
+from __future__ import annotations
+
+from litestar.testing import create_test_client
+
+import lilbee.server.handlers as handlers
+from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+from lilbee.providers.roles import WorkerRole
+from lilbee.server.routes.placement import (
+    gpus_route,
+    placement_clear_route,
+    placement_preview_route,
+    placement_route,
+    placement_set_route,
+)
+
+GIB = 1024**3
+
+
+def _view(manual=False):
+    return PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=manual,
+        spec_json=None,
+    )
+
+
+def test_get_placement(monkeypatch):
+    monkeypatch.setattr(handlers, "placement", lambda: _view())
+    with create_test_client([placement_route]) as client:
+        r = client.get("/api/placement")
+        assert r.status_code == 200
+        assert r.json()["gpus"][0]["label"] == "CUDA0"
+
+
+def test_put_sets(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        handlers,
+        "placement_set",
+        lambda spec_json: seen.setdefault("json", spec_json) or _view(True),
+    )
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 200
+        assert '"chat"' in seen["json"]
+
+
+def test_delete_clears(monkeypatch):
+    monkeypatch.setattr(handlers, "placement_clear", lambda: _view())
+    with create_test_client([placement_clear_route]) as client:
+        assert client.delete("/api/placement").status_code == 200
+
+
+def test_preview_unfit_returns_422(monkeypatch):
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    def boom(spec_json):
+        raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
+
+    monkeypatch.setattr(handlers, "placement_preview", boom)
+    with create_test_client([placement_preview_route]) as client:
+        r = client.post("/api/placement/preview", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 422
+        assert "40 GiB free" in r.text
+
+
+def test_preview_auto(monkeypatch):
+    monkeypatch.setattr(handlers, "placement_preview", lambda spec_json: _view())
+    with create_test_client([placement_preview_route]) as client:
+        r = client.post("/api/placement/preview", json={})
+        assert r.status_code == 200
+        assert r.json()["manual"] is False
+
+
+def test_preview_with_spec(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        handlers,
+        "placement_preview",
+        lambda spec_json: captured.setdefault("json", spec_json) or _view(True),
+    )
+    with create_test_client([placement_preview_route]) as client:
+        r = client.post("/api/placement/preview", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 200
+        assert '"chat"' in captured["json"]
+
+
+def test_put_missing_spec_returns_422(monkeypatch):
+    monkeypatch.setattr(handlers, "placement_set", lambda spec_json: _view(True))
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={})
+        assert r.status_code == 422
+
+
+def test_get_gpus(monkeypatch):
+    from lilbee.server.models import GpuInfoResponse
+
+    monkeypatch.setattr(
+        handlers,
+        "gpus",
+        lambda: [
+            GpuInfoResponse(
+                index=0,
+                backend="CUDA",
+                label="CUDA0",
+                name="A100",
+                total_bytes=80 * GIB,
+                free_bytes=72 * GIB,
+            )
+        ],
+    )
+    with create_test_client([gpus_route]) as client:
+        r = client.get("/api/gpus")
+        assert r.status_code == 200
+        assert r.json()[0]["label"] == "CUDA0"

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -29,7 +29,10 @@ def _view(manual=False):
 
 
 def test_get_placement(monkeypatch):
-    monkeypatch.setattr(handlers, "placement", lambda: _view())
+    async def _placement():
+        return _view()
+
+    monkeypatch.setattr(handlers, "placement", _placement)
     with create_test_client([placement_route]) as client:
         r = client.get("/api/placement")
         assert r.status_code == 200
@@ -38,11 +41,12 @@ def test_get_placement(monkeypatch):
 
 def test_put_sets(monkeypatch):
     seen = {}
-    monkeypatch.setattr(
-        handlers,
-        "placement_set",
-        lambda spec_json: seen.setdefault("json", spec_json) or _view(True),
-    )
+
+    async def _set(spec_json):
+        seen["json"] = spec_json
+        return _view(True)
+
+    monkeypatch.setattr(handlers, "placement_set", _set)
     with create_test_client([placement_set_route]) as client:
         r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
         assert r.status_code == 200
@@ -50,15 +54,25 @@ def test_put_sets(monkeypatch):
 
 
 def test_delete_clears(monkeypatch):
-    monkeypatch.setattr(handlers, "placement_clear", lambda: _view())
+    cleared = {"called": False}
+
+    async def _clear():
+        cleared["called"] = True
+        return _view()
+
+    monkeypatch.setattr(handlers, "placement_clear", _clear)
     with create_test_client([placement_clear_route]) as client:
-        assert client.delete("/api/placement").status_code == 200
+        r = client.delete("/api/placement")
+        assert r.status_code == 200
+        assert r.json()["manual"] is False
+        assert r.json()["gpus"][0]["label"] == "CUDA0"
+        assert cleared["called"]
 
 
 def test_preview_unfit_returns_422(monkeypatch):
     from lilbee.providers.fleet.placement_spec import PlacementError
 
-    def boom(spec_json):
+    async def boom(spec_json):
         raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
 
     monkeypatch.setattr(handlers, "placement_preview", boom)
@@ -69,7 +83,10 @@ def test_preview_unfit_returns_422(monkeypatch):
 
 
 def test_preview_auto(monkeypatch):
-    monkeypatch.setattr(handlers, "placement_preview", lambda spec_json: _view())
+    async def _preview(spec_json):
+        return _view()
+
+    monkeypatch.setattr(handlers, "placement_preview", _preview)
     with create_test_client([placement_preview_route]) as client:
         r = client.post("/api/placement/preview", json={})
         assert r.status_code == 200
@@ -78,11 +95,12 @@ def test_preview_auto(monkeypatch):
 
 def test_preview_with_spec(monkeypatch):
     captured = {}
-    monkeypatch.setattr(
-        handlers,
-        "placement_preview",
-        lambda spec_json: captured.setdefault("json", spec_json) or _view(True),
-    )
+
+    async def _preview(spec_json):
+        captured["json"] = spec_json
+        return _view(True)
+
+    monkeypatch.setattr(handlers, "placement_preview", _preview)
     with create_test_client([placement_preview_route]) as client:
         r = client.post("/api/placement/preview", json={"spec": {"chat": {"devices": [0]}}})
         assert r.status_code == 200
@@ -90,7 +108,10 @@ def test_preview_with_spec(monkeypatch):
 
 
 def test_put_missing_spec_returns_422(monkeypatch):
-    monkeypatch.setattr(handlers, "placement_set", lambda spec_json: _view(True))
+    async def _set(spec_json):
+        return _view(True)
+
+    monkeypatch.setattr(handlers, "placement_set", _set)
     with create_test_client([placement_set_route]) as client:
         r = client.put("/api/placement", json={})
         assert r.status_code == 422
@@ -99,10 +120,8 @@ def test_put_missing_spec_returns_422(monkeypatch):
 def test_get_gpus(monkeypatch):
     from lilbee.server.models import GpuInfoResponse
 
-    monkeypatch.setattr(
-        handlers,
-        "gpus",
-        lambda: [
+    async def _gpus():
+        return [
             GpuInfoResponse(
                 index=0,
                 backend="CUDA",
@@ -111,8 +130,9 @@ def test_get_gpus(monkeypatch):
                 total_bytes=80 * GIB,
                 free_bytes=72 * GIB,
             )
-        ],
-    )
+        ]
+
+    monkeypatch.setattr(handlers, "gpus", _gpus)
     with create_test_client([gpus_route]) as client:
         r = client.get("/api/gpus")
         assert r.status_code == 200

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4315,3 +4315,61 @@ class TestSourceContentRoute:
         assert resp.headers["content-type"].startswith("image/avif")
         assert resp.headers["x-content-type-options"] == "nosniff"
         assert "content-disposition" not in resp.headers
+
+
+def _stub_placement_view():
+    """Minimal PlacementView with no GPUs or roles for handler-level tests."""
+    from lilbee.app.placement import PlacementView
+
+    return PlacementView(gpus=(), roles=(), unplaceable=(), manual=False, spec_json=None)
+
+
+class TestPlacementHandlers:
+    async def test_placement_returns_response(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.get_placement", return_value=view):
+            resp = await handlers.placement()
+        assert resp.manual is False
+        assert resp.gpus == []
+        assert resp.roles == []
+
+    async def test_placement_preview_without_spec(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.preview_placement", return_value=view):
+            resp = await handlers.placement_preview(None)
+        assert resp.manual is False
+
+    async def test_placement_preview_with_spec_json(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.preview_placement", return_value=view):
+            resp = await handlers.placement_preview('{"chat": {"devices": [0]}}')
+        assert resp.manual is False
+
+    async def test_placement_set_returns_response(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.set_placement", return_value=view):
+            resp = await handlers.placement_set('{"chat": {"devices": [0]}}')
+        assert resp.manual is False
+
+    async def test_placement_clear_returns_response(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.set_placement", return_value=view):
+            resp = await handlers.placement_clear()
+        assert resp.manual is False
+
+    async def test_gpus_returns_list(self):
+        from lilbee.app.placement import GpuInfo, PlacementView
+
+        gpu = GpuInfo(
+            index=0,
+            backend="cuda",
+            label="cuda0",
+            name="A100",
+            total_bytes=80 * 1024**3,
+            free_bytes=40 * 1024**3,
+        )
+        view = PlacementView(gpus=(gpu,), roles=(), unplaceable=(), manual=False, spec_json=None)
+        with patch("lilbee.app.placement.get_placement", return_value=view):
+            result = await handlers.gpus()
+        assert len(result) == 1
+        assert result[0].name == "A100"

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1843,3 +1843,18 @@ class TestImportRoute:
             auth_mod.session_manager.token = None
             auth_mod.session_manager._initialized = previous_init
         assert resp.status_code == 401
+
+
+class TestPlacementSetRoute:
+    def test_placement_error_returns_422(self, client):
+        """A PlacementError from placement_set must surface as 422."""
+        from lilbee.providers.fleet.placement_spec import PlacementError
+
+        with mock.patch(
+            "lilbee.server.handlers.placement_set",
+            new_callable=AsyncMock,
+            side_effect=PlacementError("invalid spec"),
+        ):
+            resp = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+        assert resp.status_code == 422
+        assert "invalid spec" in resp.json()["detail"]

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -296,7 +296,7 @@ class TestViewCycling:
                 await pilot.press("escape")
                 await pilot.pause()
 
-                expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
+                expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Placement", "Chat"]
                 for view in expected:
                     await pilot.press("right_square_bracket")
                     await pilot.pause()
@@ -498,7 +498,7 @@ class TestScreenTransitions:
                 # Blur the chat input so the app-level ] binding fires.
                 await pilot.press("escape")
                 await pilot.pause()
-                expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
+                expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Placement", "Chat"]
                 for view in expected:
                     await pilot.press("right_square_bracket")
                     await pilot.pause()
@@ -548,7 +548,7 @@ class TestScreenTransitions:
                 assert app.active_view == "Tasks"
 
     async def test_forward_cycle_full_loop(self, _mock_resolve):
-        """Chat->Catalog->Status->Settings->Tasks->Wiki->Chat via nav_next."""
+        """Chat->Catalog->Status->Settings->Tasks->Wiki->Placement->Chat via nav_next."""
         from lilbee.cli.tui.app import LilbeeApp
 
         with _mock_catalog_deps(), _mock_remote_models():
@@ -559,14 +559,14 @@ class TestScreenTransitions:
                 # Blur the chat input so the app-level ] binding fires.
                 await pilot.press("escape")
                 await pilot.pause()
-                full_cycle = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
+                full_cycle = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Placement", "Chat"]
                 for view in full_cycle:
                     await pilot.press("right_square_bracket")
                     await pilot.pause()
                     assert app.active_view == view
 
     async def test_backward_cycle_full_loop(self, _mock_resolve):
-        """Chat->Wiki->Tasks->Settings->Status->Catalog->Chat via nav_prev."""
+        """Chat->Placement->Wiki->Tasks->Settings->Status->Catalog->Chat via nav_prev."""
         from lilbee.cli.tui.app import LilbeeApp
 
         with _mock_catalog_deps(), _mock_remote_models():
@@ -577,7 +577,15 @@ class TestScreenTransitions:
                 # Blur the chat input so the app-level [ binding fires.
                 await pilot.press("escape")
                 await pilot.pause()
-                backward_cycle = ["Wiki", "Tasks", "Settings", "Status", "Catalog", "Chat"]
+                backward_cycle = [
+                    "Placement",
+                    "Wiki",
+                    "Tasks",
+                    "Settings",
+                    "Status",
+                    "Catalog",
+                    "Chat",
+                ]
                 for view in backward_cycle:
                     await pilot.press("left_square_bracket")
                     await pilot.pause()

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -16,6 +16,7 @@ from conftest import TEST_EMBED_REF, TEST_LOCAL_REF
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.screens.catalog import CatalogScreen
 from lilbee.cli.tui.screens.chat import ChatScreen
+from lilbee.cli.tui.screens.placement import PlacementScreen
 from lilbee.cli.tui.screens.settings import SettingsScreen
 from lilbee.cli.tui.screens.status import StatusScreen
 from lilbee.cli.tui.screens.task_center import TaskCenter
@@ -75,7 +76,7 @@ def _patch_chat_setup():
 
 
 async def test_bracket_keys_cycle_all_screens():
-    """Press ] through all 5 views from normal mode (Escape first on Chat)."""
+    """Press ] through all 6 views from normal mode (Escape first on Chat)."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
@@ -85,7 +86,14 @@ async def test_bracket_keys_cycle_all_screens():
         await pilot.press("escape")
         await pilot.pause()
 
-        expected = [CatalogScreen, StatusScreen, SettingsScreen, TaskCenter, ChatScreen]
+        expected = [
+            CatalogScreen,
+            StatusScreen,
+            SettingsScreen,
+            TaskCenter,
+            PlacementScreen,
+            ChatScreen,
+        ]
         for screen_type in expected:
             await pilot.press("right_square_bracket")
             await pilot.pause()
@@ -130,11 +138,11 @@ async def test_bracket_keys_cycle_backward():
 
         await pilot.press("left_square_bracket")
         await pilot.pause()
-        assert isinstance(app.screen, TaskCenter)
+        assert isinstance(app.screen, PlacementScreen)
 
         await pilot.press("left_square_bracket")
         await pilot.pause()
-        assert isinstance(app.screen, SettingsScreen)
+        assert isinstance(app.screen, TaskCenter)
 
 
 async def test_bracket_keys_work_from_settings():

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import threading
+
 import pytest
-from textual.widgets import DataTable
+from textual.widgets import DataTable, TextArea
 
 from tests._lilbee_app_test_host import LilbeeAppHost
 
@@ -397,3 +399,88 @@ async def test_apply_empty_spec_calls_set_placement_none(monkeypatch):
         await pilot.pause()
 
     assert set_calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_apply_disables_input_while_running(monkeypatch):
+    """ctrl+s sets applying=True and disables the TextArea until set_placement returns."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    gate = threading.Event()
+
+    def _blocking_set(spec):  # type: ignore[no-untyped-def]
+        gate.wait()
+
+    monkeypatch.setattr(screen_mod, "set_placement", _blocking_set)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        assert screen.applying is True
+        text_area = screen.query_one(screen_mod._SPEC_AREA_ID, TextArea)
+        assert text_area.disabled is True
+        gate.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert screen.applying is False
+        assert text_area.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_apply_ignored_while_applying(monkeypatch):
+    """ctrl+s is a no-op when applying is already True (double-apply guard)."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    set_calls: list[object] = []
+    gate = threading.Event()
+
+    def _blocking_set(spec):  # type: ignore[no-untyped-def]
+        set_calls.append(spec)
+        gate.wait()
+
+    monkeypatch.setattr(screen_mod, "set_placement", _blocking_set)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        assert screen.applying is True
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        gate.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert len(set_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_ignored_while_applying(monkeypatch):
+    """ctrl+x is a no-op when applying is already True."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    set_calls: list[object] = []
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        monkeypatch.setattr(screen_mod, "set_placement", lambda spec: set_calls.append(spec))
+        screen.applying = True
+        await pilot.press("ctrl+x")
+        await pilot.pause()
+
+    assert set_calls == []

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -353,3 +353,47 @@ async def test_placement_screen_app_harness(monkeypatch):
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         assert isinstance(app.screen, screen_mod.PlacementScreen)
+
+
+@pytest.mark.asyncio
+async def test_preview_bad_json_notifies(monkeypatch):
+    """ctrl+r with invalid JSON shows an error notification, not a crash."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    notes: list[str] = []
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = "not-valid-json"
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+r")
+        await pilot.pause()
+
+    assert any(notes)
+
+
+@pytest.mark.asyncio
+async def test_apply_empty_spec_calls_set_placement_none(monkeypatch):
+    """ctrl+s with an empty spec passes None to set_placement."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    set_calls: list[object] = []
+    monkeypatch.setattr(
+        screen_mod, "set_placement", lambda spec: set_calls.append(spec) or _make_view()
+    )
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = ""
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert set_calls == [None]

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -1,0 +1,355 @@
+"""Tests for the TUI PlacementScreen."""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import DataTable
+
+from tests._lilbee_app_test_host import LilbeeAppHost
+
+GIB = 1024**3
+
+
+def _make_view(*, manual: bool = False, unplaceable: tuple = ()):  # type: ignore[type-arg]
+    from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+    from lilbee.providers.roles import WorkerRole
+
+    return PlacementView(
+        gpus=(
+            GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),
+            GpuInfo(1, "CUDA", "CUDA1", "NVIDIA A100", 80 * GIB, 80 * GIB),
+        ),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0, 1), (1, 1), 1),),
+        unplaceable=unplaceable,
+        manual=manual,
+        spec_json=None,
+    )
+
+
+class PlacementTestApp(LilbeeAppHost):
+    """Minimal app host for PlacementScreen tests."""
+
+    CSS = ""
+
+    def on_mount(self) -> None:
+        from lilbee.cli.tui.screens.placement import PlacementScreen
+
+        self.push_screen(PlacementScreen())
+
+
+@pytest.mark.asyncio
+async def test_screen_lists_gpus(monkeypatch):
+    """GPU table renders one row per detected GPU."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        table = app.screen.query_one(screen_mod._GPU_TABLE_ID, DataTable)
+        assert table.row_count == 2
+
+
+@pytest.mark.asyncio
+async def test_screen_lists_roles(monkeypatch):
+    """Role summary reflects placed roles."""
+    from textual.widgets import Static
+
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        summary = app.screen.query_one(screen_mod._ROLE_SUMMARY_ID, Static)
+        rendered = str(summary.render())
+        assert "chat" in rendered.lower()
+
+
+@pytest.mark.asyncio
+async def test_screen_unplaceable_shown(monkeypatch):
+    """Unplaceable roles appear in the summary."""
+    from textual.widgets import Static
+
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.roles import WorkerRole
+
+    view = _make_view(unplaceable=(WorkerRole.VISION,))
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: view)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        summary = app.screen.query_one(screen_mod._ROLE_SUMMARY_ID, Static)
+        rendered = str(summary.render())
+        assert "vision" in rendered.lower()
+
+
+@pytest.mark.asyncio
+async def test_preview_rerenders(monkeypatch):
+    """ctrl+r with a valid spec re-renders the GPU table."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    preview_calls: list[object] = []
+
+    def _preview(spec):  # type: ignore[no-untyped-def]
+        preview_calls.append(spec)
+        return _make_view()
+
+    monkeypatch.setattr(screen_mod, "preview_placement", _preview)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.press("ctrl+r")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert len(preview_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_shows_fit_error(monkeypatch):
+    """ctrl+r surfaces a PlacementError as a notification, not a crash."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    def _boom(spec):  # type: ignore[no-untyped-def]
+        raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
+
+    monkeypatch.setattr(screen_mod, "preview_placement", _boom)
+
+    notes: list[str] = []
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+r")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert any("40 GiB free" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_apply_calls_set_placement(monkeypatch):
+    """ctrl+s calls set_placement with parsed spec."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    set_calls: list[object] = []
+    monkeypatch.setattr(
+        screen_mod, "set_placement", lambda spec: set_calls.append(spec) or _make_view()
+    )
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert len(set_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_calls_set_placement_none(monkeypatch):
+    """ctrl+x calls set_placement(None) to restore auto placement."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    set_calls: list[object] = []
+
+    def _set(spec):  # type: ignore[no-untyped-def]
+        set_calls.append(spec)
+        return _make_view()
+
+    monkeypatch.setattr(screen_mod, "set_placement", _set)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+x")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert set_calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_apply_bad_json_notifies(monkeypatch):
+    """ctrl+s with invalid JSON shows an error notification."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    notes: list[str] = []
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = "not-valid-json"
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+
+    assert any(notes)
+
+
+@pytest.mark.asyncio
+async def test_go_back_binding(monkeypatch):
+    """q pops the screen."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, screen_mod.PlacementScreen)
+        await pilot.press("q")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_load_placement_error_notifies(monkeypatch):
+    """An exception from get_placement on mount shows a notification."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    def _boom():
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(screen_mod, "get_placement", _boom)
+    notes: list[str] = []
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        screen._load_placement()
+        await pilot.pause()
+
+    assert any("probe failed" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_render_view_with_spec_json(monkeypatch):
+    """When spec_json is set on the view, the TextArea is seeded."""
+    from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.roles import WorkerRole
+
+    GIB = 1024**3
+    view_with_spec = PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=True,
+        spec_json='{"chat": {"devices": [0]}}',
+    )
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: view_with_spec)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert screen._spec_text == '{"chat": {"devices": [0]}}'
+
+
+@pytest.mark.asyncio
+async def test_apply_worker_error_notifies(monkeypatch):
+    """An exception from set_placement shows a notification."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    def _oom(spec):  # type: ignore[no-untyped-def]
+        raise PlacementError("oom")
+
+    monkeypatch.setattr(screen_mod, "set_placement", _oom)
+
+    notes: list[str] = []
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert any("oom" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_clear_worker_error_notifies(monkeypatch):
+    """An exception from set_placement(None) during clear shows a notification."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    def _fail(spec):  # type: ignore[no-untyped-def]
+        raise PlacementError("clear fail")
+
+    monkeypatch.setattr(screen_mod, "set_placement", _fail)
+
+    notes: list[str] = []
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+x")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert any("clear fail" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_go_back_single_screen(monkeypatch):
+    """action_go_back with a single-item screen_stack calls switch_view."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        called: list[str] = []
+        # Simulate single-screen stack so the else branch is taken.
+        monkeypatch.setattr(type(app), "screen_stack", property(lambda self: [screen]))
+        monkeypatch.setattr(app, "switch_view", lambda v: called.append(v))
+        screen.action_go_back()
+        await pilot.pause()
+
+    assert called == ["Chat"]
+
+
+@pytest.mark.asyncio
+async def test_placement_screen_app_harness(monkeypatch):
+    """PlacementScreenApp mounts PlacementScreen successfully."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = screen_mod.PlacementScreenApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, screen_mod.PlacementScreen)

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -345,19 +345,6 @@ async def test_go_back_single_screen(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_placement_screen_app_harness(monkeypatch):
-    """PlacementScreenApp mounts PlacementScreen successfully."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    app = screen_mod.PlacementScreenApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        assert isinstance(app.screen, screen_mod.PlacementScreen)
-
-
-@pytest.mark.asyncio
 async def test_preview_bad_json_notifies(monkeypatch):
     """ctrl+r with invalid JSON shows an error notification, not a crash."""
     from lilbee.cli.tui.screens import placement as screen_mod

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -7493,11 +7493,11 @@ async def test_app_nav_prev_cycles_views():
 
         app.action_nav_prev()
         await pilot.pause()
-        assert app.active_view == "Wiki"
+        assert app.active_view == "Placement"
 
         app.action_nav_prev()
         await pilot.pause()
-        assert app.active_view == "Tasks"
+        assert app.active_view == "Wiki"
 
 
 async def test_app_nav_next_cycles_views():


### PR DESCRIPTION
## Problem

lilbee places models across GPUs automatically with a VRAM-aware planner, but there is no way to override that decision or even see it. On a heterogeneous box, a card reserved for something else, or a model the heuristic splits badly, placement is a black box you cannot steer.

## Solution

Adds a manual placement spec. Per role you pin the GPU devices, and optionally set the tensor-split ratio and replica count. When a spec is present it replaces the automatic planner; a spec that does not fit VRAM fails fast and names the card that is short.

Placement is now visible and editable from four surfaces, all over one shared use-case: the CLI (`lilbee placement show/preview/set/clear`), the HTTP API, MCP, and a TUI screen. Preview is a dry-run that shows what auto placement (or a candidate spec) would choose, including each card's identifier and free VRAM, so you can check a change before applying it. The spec persists in config.toml and survives a restart.