### PR TITLE
Env vars override config.toml for replica/all settings

### DIFF
--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -1,6 +1,7 @@
 """Persistent settings stored in config.toml alongside the data directory."""
 
 import logging
+import os
 import sys
 import threading
 import tomllib
@@ -87,7 +88,12 @@ def delete_values(data_root: Path, keys: list[str]) -> None:
 
 
 def overlay_persisted_settings(root: Path) -> None:
-    """Overlay persisted scalars from ``<root>/config.toml`` onto cfg, skipping bad values."""
+    """Overlay persisted scalars from ``<root>/config.toml`` onto cfg, skipping bad values.
+
+    An explicit ``LILBEE_<FIELD>`` env var wins over config.toml (the documented
+    precedence): cfg already holds the env-loaded value, so a key whose env var is
+    set is left untouched rather than overwritten by the persisted file.
+    """
     log = logging.getLogger(__name__)
     try:
         persisted = load(root)
@@ -97,8 +103,12 @@ def overlay_persisted_settings(root: Path) -> None:
     if not persisted:
         return
     overlayable = set(WRITABLE_CONFIG_FIELDS) | set(MODEL_ROLE_FIELDS)
+    env_prefix = cfg.model_config.get("env_prefix", "")
     for key, raw in persisted.items():
         if key not in overlayable:
+            continue
+        # Env var explicitly set: env overrides config.toml, so keep the env value.
+        if f"{env_prefix}{key.upper()}" in os.environ:
             continue
         # Legacy: set_setting used to persist None as "". Skip rather than
         # warn so a stale config doesn't spam logs on every CLI invocation.

--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -107,8 +107,8 @@ def overlay_persisted_settings(root: Path) -> None:
     for key, raw in persisted.items():
         if key not in overlayable:
             continue
-        # Env var explicitly set: env overrides config.toml, so keep the env value.
-        if f"{env_prefix}{key.upper()}" in os.environ:
+        # Non-empty env var wins over config.toml (matches pydantic env_ignore_empty=True).
+        if os.environ.get(f"{env_prefix}{key.upper()}", "") != "":
             continue
         # Legacy: set_setting used to persist None as "". Skip rather than
         # warn so a stale config doesn't spam logs on every CLI invocation.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -345,6 +345,34 @@ class TestOverlayPersistedSettings:
         finally:
             cfg.chat_model = original
 
+    def test_env_var_wins_over_config_toml(self, tmp_path, monkeypatch):
+        """An explicit LILBEE_<FIELD> env var overrides config.toml, as documented."""
+        from lilbee.core.config import cfg
+
+        original = cfg.vision_replicas
+        try:
+            cfg.vision_replicas = 4  # value as loaded from LILBEE_VISION_REPLICAS
+            monkeypatch.setenv("LILBEE_VISION_REPLICAS", "4")
+            (tmp_path / "config.toml").write_text("vision_replicas = 2\n")
+            settings.overlay_persisted_settings(tmp_path)
+            assert cfg.vision_replicas == 4
+        finally:
+            cfg.vision_replicas = original
+
+    def test_config_toml_applies_when_env_absent(self, tmp_path, monkeypatch):
+        """Without the env var, config.toml is still overlaid onto cfg."""
+        from lilbee.core.config import cfg
+
+        original = cfg.vision_replicas
+        try:
+            monkeypatch.delenv("LILBEE_VISION_REPLICAS", raising=False)
+            cfg.vision_replicas = 1
+            (tmp_path / "config.toml").write_text("vision_replicas = 3\n")
+            settings.overlay_persisted_settings(tmp_path)
+            assert cfg.vision_replicas == 3
+        finally:
+            cfg.vision_replicas = original
+
 
 class TestListSettingRegexMarker:
     def test_only_regex_list_validates_as_regex(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -359,6 +359,20 @@ class TestOverlayPersistedSettings:
         finally:
             cfg.vision_replicas = original
 
+    def test_empty_env_var_does_not_suppress_config_toml(self, tmp_path, monkeypatch):
+        """An empty LILBEE_<FIELD> env var is treated as unset; config.toml wins."""
+        from lilbee.core.config import cfg
+
+        original = cfg.vision_replicas
+        try:
+            monkeypatch.setenv("LILBEE_VISION_REPLICAS", "")
+            cfg.vision_replicas = 1
+            (tmp_path / "config.toml").write_text("vision_replicas = 3\n")
+            settings.overlay_persisted_settings(tmp_path)
+            assert cfg.vision_replicas == 3
+        finally:
+            cfg.vision_replicas = original
+
     def test_config_toml_applies_when_env_absent(self, tmp_path, monkeypatch):
         """Without the env var, config.toml is still overlaid onto cfg."""
         from lilbee.core.config import cfg


### PR DESCRIPTION
## Problem

The config module documents "All settings can be overridden via environment variables prefixed with LILBEE_", but config.toml actually wins. `overlay_persisted_settings` applies the persisted file on top of the already-env-loaded cfg, so an env var like `LILBEE_VISION_REPLICAS=4` is silently overridden by `vision_replicas = 1` in config.toml. On a multi-GPU box this capped OCR/embed to a single GPU unless the value was edited directly in the TOML.

## Solution

Skip the config.toml overlay for any key whose `LILBEE_<FIELD>` env var is set, so an explicit env var wins as documented. config.toml still applies for every key that has no env var override.

Closes bb-7lj