### PR TITLE
Make lilbee ask auto-sync skippable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ All settings override via environment variables:
 - `LILBEE_ANN_INDEX_THRESHOLD` — chunk count at/above which sync builds an approximate (ANN) vector index for fast search at scale (default: `50000`, `0` = always exact flat search)
 - `LILBEE_MAX_DISTANCE` — cosine distance threshold, 0-1 (default: `0.9`). Higher = more results, lower = stricter filtering
 - `LILBEE_ADAPTIVE_THRESHOLD` — enable adaptive threshold widening (default: `false`). When true, widens distance threshold if too few results found
+- `LILBEE_AUTO_SYNC` — run a sync before `lilbee ask` (default: `true`); set to `false` on large static corpora to skip the pre-answer re-hash
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
 - `LILBEE_RERANKER_TYPE` — reranker serving mode: `auto` (default), `cross_encoder`, or `llm`.
 - `LILBEE_RERANKER_PROMPT` — relevance prompt for LLM rerankers (blank uses the built-in template).

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -134,6 +134,12 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         group=SettingGroup.INGEST,
         help_text="Pages OCR'd concurrently per vision server; each slot adds KV cache memory",
     ),
+    "auto_sync": SettingDef(
+        bool,
+        nullable=False,
+        group=SettingGroup.INGEST,
+        help_text="Run a sync before `lilbee ask` (disable on large static corpora)",
+    ),
     "semantic_chunking": SettingDef(
         bool,
         nullable=False,

--- a/src/lilbee/cli/commands/search_chat.py
+++ b/src/lilbee/cli/commands/search_chat.py
@@ -169,8 +169,11 @@ def ask(
     repeat_penalty: float | None = repeat_penalty_option,
     num_ctx: int | None = num_ctx_option,
     seed: int | None = seed_option,
+    no_sync: bool = typer.Option(
+        False, "--no-sync", help="Skip the pre-answer auto-sync (useful on large static corpora)."
+    ),
 ) -> None:
-    """Ask a one-shot question (auto-syncs first)."""
+    """Ask a one-shot question (auto-syncs first unless --no-sync or auto_sync=false)."""
     apply_overrides(
         data_dir=data_dir,
         model=model,
@@ -192,12 +195,13 @@ def ask(
         if pulled is not None:
             apply_settings_update({"chat_model": pulled})
         get_services().embedder.validate_model()
-        if cfg.json_mode:
-            from rich.console import Console as _QuietConsole
+        if cfg.auto_sync and not no_sync:
+            if cfg.json_mode:
+                from rich.console import Console as _QuietConsole
 
-            auto_sync(_QuietConsole(quiet=True))
-        else:
-            auto_sync(console)
+                auto_sync(_QuietConsole(quiet=True))
+            else:
+                auto_sync(console)
 
         chunk_type = scope_to_chunk_type(scope)
 

--- a/src/lilbee/cli/commands/search_chat.py
+++ b/src/lilbee/cli/commands/search_chat.py
@@ -173,7 +173,7 @@ def ask(
         False, "--no-sync", help="Skip the pre-answer auto-sync (useful on large static corpora)."
     ),
 ) -> None:
-    """Ask a one-shot question (auto-syncs first unless --no-sync or auto_sync=false)."""
+    """Ask a one-shot question."""
     apply_overrides(
         data_dir=data_dir,
         model=model,

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -91,9 +91,7 @@ class Config(BaseSettings):
     embedding_dim: int = Field(default=768, ge=1)
     chunk_size: int = ConfigField(default=512, ge=64, writable=True, reindex=True)
     chunk_overlap: int = ConfigField(default=100, ge=0, writable=True, reindex=True)
-    # Re-validate the index before a one-shot ``lilbee ask``. Disable on large
-    # static corpora where the pre-answer sync re-hashes the whole index and
-    # stalls every question; ``--no-sync`` overrides it per invocation.
+    # Gate for the pre-ask sync; --no-sync overrides per invocation.
     auto_sync: bool = ConfigField(default=True, writable=True)
     max_embed_chars: int = Field(default=2000, ge=1)
     top_k: int = ConfigField(default=12, ge=1, writable=True)

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -91,6 +91,10 @@ class Config(BaseSettings):
     embedding_dim: int = Field(default=768, ge=1)
     chunk_size: int = ConfigField(default=512, ge=64, writable=True, reindex=True)
     chunk_overlap: int = ConfigField(default=100, ge=0, writable=True, reindex=True)
+    # Re-validate the index before a one-shot ``lilbee ask``. Disable on large
+    # static corpora where the pre-answer sync re-hashes the whole index and
+    # stalls every question; ``--no-sync`` overrides it per invocation.
+    auto_sync: bool = ConfigField(default=True, writable=True)
     max_embed_chars: int = Field(default=2000, ge=1)
     top_k: int = ConfigField(default=12, ge=1, writable=True)
     max_distance: float = ConfigField(default=0.75, ge=0.0, writable=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -310,6 +310,31 @@ class TestAsk:
         assert result.exit_code == 0
         assert mock_svc.searcher.ask_stream.call_args.kwargs.get("chunk_type") is None
 
+    @mock.patch("lilbee.cli.commands.search_chat.auto_sync")
+    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_syncs_by_default(self, mock_sync, mock_auto, mock_svc):
+        mock_svc.searcher.ask_stream.return_value = _mock_stream("a")
+        result = runner.invoke(app, ["ask", "q"])
+        assert result.exit_code == 0
+        mock_auto.assert_called_once()
+
+    @mock.patch("lilbee.cli.commands.search_chat.auto_sync")
+    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_no_sync_flag_skips_auto_sync(self, mock_sync, mock_auto, mock_svc):
+        mock_svc.searcher.ask_stream.return_value = _mock_stream("a")
+        result = runner.invoke(app, ["ask", "--no-sync", "q"])
+        assert result.exit_code == 0
+        mock_auto.assert_not_called()
+
+    @mock.patch("lilbee.cli.commands.search_chat.auto_sync")
+    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
+    def test_ask_auto_sync_config_false_skips(self, mock_sync, mock_auto, mock_svc, monkeypatch):
+        monkeypatch.setattr(cfg, "auto_sync", False)
+        mock_svc.searcher.ask_stream.return_value = _mock_stream("a")
+        result = runner.invoke(app, ["ask", "q"])
+        assert result.exit_code == 0
+        mock_auto.assert_not_called()
+
     @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
     def test_ask_invalid_scope_exits_nonzero(self, mock_sync, mock_svc):
         result = runner.invoke(app, ["ask", "--scope", "bogus", "q"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -311,24 +311,21 @@ class TestAsk:
         assert mock_svc.searcher.ask_stream.call_args.kwargs.get("chunk_type") is None
 
     @mock.patch("lilbee.cli.commands.search_chat.auto_sync")
-    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
-    def test_ask_syncs_by_default(self, mock_sync, mock_auto, mock_svc):
+    def test_ask_syncs_by_default(self, mock_auto, mock_svc):
         mock_svc.searcher.ask_stream.return_value = _mock_stream("a")
         result = runner.invoke(app, ["ask", "q"])
         assert result.exit_code == 0
         mock_auto.assert_called_once()
 
     @mock.patch("lilbee.cli.commands.search_chat.auto_sync")
-    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
-    def test_ask_no_sync_flag_skips_auto_sync(self, mock_sync, mock_auto, mock_svc):
+    def test_ask_no_sync_flag_skips_auto_sync(self, mock_auto, mock_svc):
         mock_svc.searcher.ask_stream.return_value = _mock_stream("a")
         result = runner.invoke(app, ["ask", "--no-sync", "q"])
         assert result.exit_code == 0
         mock_auto.assert_not_called()
 
     @mock.patch("lilbee.cli.commands.search_chat.auto_sync")
-    @mock.patch("lilbee.data.ingest.sync", new_callable=AsyncMock, return_value=_SYNC_NOOP)
-    def test_ask_auto_sync_config_false_skips(self, mock_sync, mock_auto, mock_svc, monkeypatch):
+    def test_ask_auto_sync_config_false_skips(self, mock_auto, mock_svc, monkeypatch):
         monkeypatch.setattr(cfg, "auto_sync", False)
         mock_svc.searcher.ask_stream.return_value = _mock_stream("a")
         result = runner.invoke(app, ["ask", "q"])

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -346,6 +346,18 @@ class TestOverlayPersistedSettings:
             cfg.chat_model = original
 
 
+class TestAutoSyncConfig:
+    def test_auto_sync_defaults_true(self):
+        from lilbee.core.config import Config
+
+        assert Config().auto_sync is True
+
+    def test_auto_sync_is_writable(self):
+        from lilbee.config_meta import WRITABLE_CONFIG_FIELDS
+
+        assert "auto_sync" in WRITABLE_CONFIG_FIELDS
+
+
 class TestListSettingRegexMarker:
     def test_only_regex_list_validates_as_regex(self):
         from lilbee.app.settings_map import SETTINGS_MAP

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -357,6 +357,11 @@ class TestAutoSyncConfig:
 
         assert "auto_sync" in WRITABLE_CONFIG_FIELDS
 
+    def test_auto_sync_in_settings_map(self):
+        from lilbee.app.settings_map import SETTINGS_MAP
+
+        assert "auto_sync" in SETTINGS_MAP
+
 
 class TestListSettingRegexMarker:
     def test_only_regex_list_validates_as_regex(self):


### PR DESCRIPTION
## Problem

`lilbee ask` unconditionally runs a blocking foreground auto-sync before every answer, with no way to skip it. On a large static index (a 346k-file corpus, for example) the sync re-validates the whole corpus per question and stalls for minutes before generating, even when nothing has changed.

## Solution

Add a `--no-sync` flag to `lilbee ask` and an `auto_sync` config toggle (default true). When either disables it, ask answers immediately without the pre-answer sync. Sync still runs by default, so existing behavior is unchanged.

A deeper follow-up (a fresh-index fast-path so auto-sync itself stays cheap on a static corpus) is left for a separate change.

Closes bb-j7n