### PR TITLE
Stop embed/rerank from truncating full-size chunks

### DIFF
--- a/src/lilbee/providers/engine_params.py
+++ b/src/lilbee/providers/engine_params.py
@@ -35,11 +35,18 @@ log = logging.getLogger(__name__)
 EMBED_FALLBACK_CTX = 2048
 """Context used for embed/rerank when a GGUF reports junk (e.g. context_length=0)."""
 
+# Truncate embed/rerank inputs a few tokens below the per-slot context: the server
+# re-tokenizes the truncated text with add_special, so a truncate-to-exactly-n_ctx
+# input overflows by the re-added BOS (plus detokenize/tokenize round-trip drift).
+# The embed server is therefore sized chunk_size + this margin, so a full
+# chunk_size input survives truncation instead of losing its tail tokens.
+_EMBED_CTX_MARGIN = 8
+
 
 def resolve_embed_ctx(meta: dict[str, str] | None, model_path: Path) -> int:
-    """Embed/rerank context: the configured chunk length, capped by the model's trained context."""
+    """Embed/rerank context: chunk length plus truncation margin, capped by trained context."""
     train_ctx = train_ctx_from_meta(meta, fallback=EMBED_FALLBACK_CTX, model_path=model_path)
-    return min(train_ctx, cfg.chunk_size)
+    return min(train_ctx, cfg.chunk_size + _EMBED_CTX_MARGIN)
 
 
 _LLM_RERANK_HEADROOM = 512

--- a/src/lilbee/providers/engine_params.py
+++ b/src/lilbee/providers/engine_params.py
@@ -35,11 +35,7 @@ log = logging.getLogger(__name__)
 EMBED_FALLBACK_CTX = 2048
 """Context used for embed/rerank when a GGUF reports junk (e.g. context_length=0)."""
 
-# Truncate embed/rerank inputs a few tokens below the per-slot context: the server
-# re-tokenizes the truncated text with add_special, so a truncate-to-exactly-n_ctx
-# input overflows by the re-added BOS (plus detokenize/tokenize round-trip drift).
-# The embed server is therefore sized chunk_size + this margin, so a full
-# chunk_size input survives truncation instead of losing its tail tokens.
+# Sized above chunk_size so BOS re-added on re-tokenization doesn't overflow a full-chunk input.
 _EMBED_CTX_MARGIN = 8
 
 

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -43,10 +43,6 @@ _CHAT_SLOTS = 4
 _SPLIT_CHAT_SLOTS = 1
 _AUX_SLOTS = 1
 _EMBED_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK)
-# Truncate embed/rerank inputs a few tokens below the per-slot context: the server
-# re-tokenizes the truncated text with add_special, so a truncate-to-exactly-n_ctx
-# input overflows by the re-added BOS (plus detokenize/tokenize round-trip drift).
-_EMBED_CTX_MARGIN = 8
 # Roles whose loaders offload every layer regardless of cfg.n_gpu_layers; only
 # chat honors cfg.n_gpu_layers.
 _ALL_LAYER_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK, WorkerRole.VISION)
@@ -565,7 +561,7 @@ def _launch_for(
     chat_reservation: int = 0,
 ) -> InstanceLaunch:
     """Build the launch spec (argv + device-pinning env) for one planned instance."""
-    from lilbee.providers.engine_params import resolve_model_path
+    from lilbee.providers.engine_params import _EMBED_CTX_MARGIN, resolve_model_path
     from lilbee.providers.gguf_meta import read_gguf_metadata
 
     model_path = resolve_model_path(model_ref)

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -561,7 +561,10 @@ def _launch_for(
     chat_reservation: int = 0,
 ) -> InstanceLaunch:
     """Build the launch spec (argv + device-pinning env) for one planned instance."""
-    from lilbee.providers.engine_params import _EMBED_CTX_MARGIN, resolve_model_path
+    from lilbee.providers.engine_params import (
+        _EMBED_CTX_MARGIN,
+        resolve_model_path,
+    )  # circular: fleet.planning -> engine_params -> app.services
     from lilbee.providers.gguf_meta import read_gguf_metadata
 
     model_path = resolve_model_path(model_ref)

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -96,7 +96,7 @@ def test_role_ctx_embed_covers_chunk_size_plus_margin(monkeypatch) -> None:
 
 
 def test_embed_ctx_token_cap_fits_full_chunk(monkeypatch) -> None:
-    # bb-4ry: the embed input truncates at ctx - _EMBED_CTX_MARGIN, so the server must
+    # The embed input truncates at ctx - _EMBED_CTX_MARGIN, so the server must
     # be sized so a full chunk_size input survives (token_cap >= chunk_size), not 8 short.
     from lilbee.providers.engine_params import _EMBED_CTX_MARGIN, resolve_embed_ctx
 

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -82,16 +82,31 @@ def test_role_ctx_chat_uses_dynamic_picker_when_unset(monkeypatch) -> None:
     assert planning_mod._role_ctx(WorkerRole.CHAT, Path("/m/c.gguf"), None) == 4096
 
 
-def test_role_ctx_embed_caps_to_chunk_size(monkeypatch) -> None:
-    # A 32K-trained embedder is sized to the chunk length, not its full context, so its
+def test_role_ctx_embed_covers_chunk_size_plus_margin(monkeypatch) -> None:
+    # A 32K-trained embedder is sized to the chunk length plus the truncation margin
+    # (so a full chunk_size input is not truncated), not its full context, so its
     # placement estimate doesn't balloon (200GB+) and starve the role alongside a giant.
     monkeypatch.setattr(
         "lilbee.providers.engine_params.train_ctx_from_meta",
         lambda _meta, *, fallback, model_path: 32768,
     )
     monkeypatch.setattr(cfg, "chunk_size", 512)
-    assert planning_mod._role_ctx(WorkerRole.EMBED, Path("/m/e.gguf"), {}) == 512
-    assert planning_mod._role_ctx(WorkerRole.RERANK, Path("/m/r.gguf"), {}) == 512
+    assert planning_mod._role_ctx(WorkerRole.EMBED, Path("/m/e.gguf"), {}) == 520
+    assert planning_mod._role_ctx(WorkerRole.RERANK, Path("/m/r.gguf"), {}) == 520
+
+
+def test_embed_ctx_token_cap_fits_full_chunk(monkeypatch) -> None:
+    # bb-4ry: the embed input truncates at ctx - _EMBED_CTX_MARGIN, so the server must
+    # be sized so a full chunk_size input survives (token_cap >= chunk_size), not 8 short.
+    from lilbee.providers.engine_params import _EMBED_CTX_MARGIN, resolve_embed_ctx
+
+    monkeypatch.setattr(
+        "lilbee.providers.engine_params.train_ctx_from_meta",
+        lambda _meta, *, fallback, model_path: 32768,
+    )
+    monkeypatch.setattr(cfg, "chunk_size", 512)
+    ctx = resolve_embed_ctx({}, Path("/m/e.gguf"))
+    assert ctx - _EMBED_CTX_MARGIN >= cfg.chunk_size
 
 
 def test_role_ctx_embed_uses_train_ctx_when_below_chunk_size(monkeypatch) -> None:
@@ -800,9 +815,11 @@ class TestBuildFleetWiring:
 
     @pytest.mark.parametrize("role", [WorkerRole.EMBED, WorkerRole.RERANK])
     def test_launch_for_embed_roles_set_token_cap(self, tmp_path, monkeypatch, role) -> None:
+        from lilbee.providers.engine_params import _EMBED_CTX_MARGIN
+
         launch = self._launch_for_role(tmp_path, monkeypatch, role, ctx=8192)
         # Truncate a few tokens below the per-slot ctx so the server's re-added BOS fits.
-        assert launch.token_cap == 8192 - planning_mod._EMBED_CTX_MARGIN
+        assert launch.token_cap == 8192 - _EMBED_CTX_MARGIN
 
     @pytest.mark.parametrize("role", [WorkerRole.CHAT, WorkerRole.VISION])
     def test_launch_for_non_embed_roles_have_no_token_cap(


### PR DESCRIPTION
## Problem

The embed/rerank server's context was sized to exactly `chunk_size`, but the input truncation reserves an 8-token margin (the server re-tokenizes with add_special, and a truncate-to-exactly-n_ctx input overflows by the re-added BOS). So a full `chunk_size` (512-token) chunk was truncated to 504, silently dropping its last 8 tokens from the embedding, and from cross-encoder rerank inputs.

## Solution

Size the embed/rerank context to `chunk_size + margin` (still capped by the model's trained context), so a full chunk survives truncation. The margin constant moves to `engine_params` so the context sizing and the launch token-cap share one source of truth.