### PR TITLE
Fleet: elastic ingest pool, VRAM-aware replica scale-down

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -62,6 +62,22 @@ tail -n 100 "<data root>/logs/llama-swap.log"
 tail -n 100 "<data root>/logs/server.log"
 ```
 
+## Ingest replicas and VRAM reclaim
+
+When an ingest job finishes, any extra embed or vision replicas that were started
+for it are unloaded automatically. This frees their VRAM so chat and search
+capacity is restored without a restart.
+
+If you set `embed_replicas` or `vision_replicas` explicitly in your config, that
+count is used during ingest and reclaimed the same way afterward. The default
+(`0`) picks one replica per GPU, capped by whatever VRAM remains after the
+persistent query servers (chat, embed-0, rerank, vision-0) are placed.
+
+If the fleet ever reports "no model server" transiently, lilbee now re-probes the
+engine and rebuilds a restarted llama-swap automatically before surfacing a
+failure. A single retry is attempted; if the rebuilt fleet still cannot serve the
+role, the normal `ProviderError` is returned.
+
 ## Using with the Obsidian plugin
 
 The [Obsidian plugin](https://github.com/tobocop2/obsidian-lilbee) in managed mode runs this server for you, with each vault's data root under the plugin's shared install at `vaults/<id>/`. The same `logs/` layout applies inside that directory.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,7 +216,10 @@ flowchart TD
 - **Resident tiers and the elastic ingest pool**: placement reserves a persistent
   query fleet first: chat, one embed server (`embed-0`), rerank, and one vision
   server (`vision-0`). These stay resident so a chat request issued during ingest
-  always has capacity. Extra embed and vision replicas (`embed-1..N`, additional
+  always has capacity. This reservation applies to discrete-GPU placement; the
+  shared-memory path on a unified-memory or CPU host packs the same pool
+  differently and does not hold back the elastic replicas. Extra embed and vision
+  replicas (`embed-1..N`, additional
   vision) are placed only into the VRAM that remains after the query fleet is
   committed. When an ingest finishes, each extra replica is unloaded individually
   via llama-swap's `POST /api/models/unload`, freeing its VRAM without disturbing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,15 +213,23 @@ flowchart TD
   RAM on a unified-memory host drives the OS into a swap-thrash OOM livelock that
   hard-freezes the machine, so refusing is the safe outcome; chat slot count
   (`--parallel`) steps down the same way before refusing.
+- **Resident tiers and the elastic ingest pool**: placement reserves a persistent
+  query fleet first: chat, one embed server (`embed-0`), rerank, and one vision
+  server (`vision-0`). These stay resident so a chat request issued during ingest
+  always has capacity. Extra embed and vision replicas (`embed-1..N`, additional
+  vision) are placed only into the VRAM that remains after the query fleet is
+  committed. When an ingest finishes, each extra replica is unloaded individually
+  via llama-swap's `POST /api/models/unload`, freeing its VRAM without disturbing
+  the resident servers. If llama-swap is restarted or found dead, the fleet
+  re-probes once and rebuilds its model config before reporting a failure.
 - **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
-  vision roles can run as N independent servers, one per GPU, so large-scale ingest
-  fans embedding / OCR across the whole box. The single roles (chat) are placed
-  first; each replica then lands on a distinct card with the most free VRAM (only
-  co-locating a second once every card has one), capped by what fits. The provider
-  holds a client pool per role and round-robins to the least-busy replica. With no
-  discrete GPU the replicas run as co-resident processes against the shared pool.
-  Each replica is its own llama-swap model id (`<role>-<n>`); a role is ready once
-  any replica is.
+  vision roles can run as N independent servers, fanning embedding and OCR across
+  the box during ingest. Setting either value to `0` (the default) means auto: one
+  replica per GPU, capped by how much VRAM remains after the query fleet is placed.
+  A positive value pins the replica count to exactly that number. The provider
+  holds a client pool per role and round-robins to the least-busy replica. Each
+  replica is its own llama-swap model id (`<role>-<n>`); a role is ready once any
+  replica is. Replicas are ingest-only and reclaimed after ingest completes.
 - **Loader flags** (`adapters.build_server_argv`): each server's flags derive from
   cfg and the model's GGUF metadata for that role and config. Chat carries
   `--jinja`, `--flash-attn` (on unless `flash_attention` is disabled) and

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -770,13 +770,13 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         int,
         nullable=False,
         group=SettingGroup.GENERATION,
-        help_text="Embedding servers to run in parallel, one per GPU, for large-scale ingest",
+        help_text="Embedding servers in parallel (0 = auto, one per GPU; positive pins the count)",
     ),
     "vision_replicas": SettingDef(
         int,
         nullable=False,
         group=SettingGroup.GENERATION,
-        help_text="Vision OCR servers to run in parallel, one per GPU, for large-scale ingest",
+        help_text="Vision OCR servers in parallel (0 = auto, one per GPU; positive pins the count)",
     ),
     "candidate_multiplier": SettingDef(
         int,

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -341,11 +341,14 @@ class Config(BaseSettings):
     gpu_memory_fraction: float = ConfigField(default=0.75, ge=0.1, le=1.0, writable=True)
 
     # Data-parallel replicas of the embed / vision role across GPUs: N independent
-    # servers (one per spare GPU), round-robined, so large-scale ingest fans the
-    # embedding / OCR work across the whole box. 1 = a single server (the default).
-    # Capped at runtime by the GPUs with room after the chat model is placed.
-    embed_replicas: int = ConfigField(default=1, ge=1, writable=True)
-    vision_replicas: int = ConfigField(default=1, ge=1, writable=True)
+    # servers, round-robined, so large-scale ingest fans the embedding / OCR work
+    # across the whole box. 0 means "auto": one replica per detected GPU, capped by
+    # the VRAM left after the persistent query fleet (chat, one embed, rerank, one
+    # vision) is reserved. A positive value pins the count. The extra replicas are
+    # ingest-only and reclaimed when ingest ends; the persistent query embedder /
+    # vision (replica 0) always exists if its model fits.
+    embed_replicas: int = ConfigField(default=0, ge=0, writable=True)
+    vision_replicas: int = ConfigField(default=0, ge=0, writable=True)
 
     # Seconds a model stays loaded after last use. 0 = unload immediately.
     model_keep_alive: int = ConfigField(default=300, ge=0, writable=True)

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -83,9 +83,12 @@ def _max_concurrent() -> int:
     few-core box with several GPUs would starve the extra cards.
     """
     from lilbee.core.config import cfg
+    from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
+    from lilbee.providers.roles import WorkerRole
 
     if cfg.vision_model:
-        return max(1, cfg.vision_replicas * cfg.vision_ocr_concurrency)
+        replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
+        return max(1, replicas * cfg.vision_ocr_concurrency)
     embed_slots = cfg.embed_replicas if cfg.embed_replicas > 1 else 0
     return max(cpu_quota(), embed_slots)
 

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -90,7 +90,7 @@ def _max_concurrent() -> int:
     if cfg.vision_model:
         replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
         return max(1, replicas * cfg.vision_ocr_concurrency)
-    embed_slots = cfg.embed_replicas if cfg.embed_replicas > 1 else 0
+    embed_slots = resolve_replica_count(WorkerRole.EMBED, gpu_device_count())
     return max(cpu_quota(), embed_slots)
 
 

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -50,6 +50,7 @@ from lilbee.data.store import (
     SourceType,
     source_stat,
 )
+from lilbee.providers.fleet.ingest_scale import ingest_scale
 from lilbee.runtime.asyncio_loop import is_executor_shutdown
 from lilbee.runtime.cancellation import TaskCancelledError
 from lilbee.runtime.cpu import cpu_quota
@@ -378,105 +379,108 @@ async def sync(
     When *retry_skipped* (or *force_rebuild*) is set, the failed-file skip
     markers are cleared so this sync attempts every file.
     """
-    _store = get_services().store
+    with ingest_scale():
+        _store = get_services().store
 
-    if force_rebuild:
-        # drop_all + memory re-embedding are heavy blocking store work; run them
-        # off the event loop so a rebuild doesn't stall other admitted requests.
-        await asyncio.to_thread(_force_rebuild_store, _store)
+        if force_rebuild:
+            # drop_all + memory re-embedding are heavy blocking store work; run them
+            # off the event loop so a rebuild doesn't stall other admitted requests.
+            await asyncio.to_thread(_force_rebuild_store, _store)
 
-    cfg.documents_dir.mkdir(parents=True, exist_ok=True)
+        cfg.documents_dir.mkdir(parents=True, exist_ok=True)
 
-    disk_files = discover_files()
-    sources = _store.get_sources()
-    existing_sources = {s["filename"]: s for s in sources}
-    skip_markers = _load_pruned_skip_markers(disk_files, clear_first=force_rebuild or retry_skipped)
-
-    removed: list[str] = []
-    failed: dict[str, None] = {}
-    skipped: dict[str, None] = {}
-    reasons: dict[str, str] = {}  # filename → why it was skipped/failed (for reporting)
-    flush_failed: set[str] = set()
-
-    # Find files to remove (document sources whose file is gone; imports are kept)
-    to_remove = _removable_sources(sources, disk_files)
-    if to_remove:
-        _store.remove_documents(to_remove)
-        removed.extend(to_remove)
-
-    # The planning pass stats (and where needed hashes) every file on disk;
-    # off the event loop so a large corpus doesn't freeze the TUI.
-    plan = await asyncio.to_thread(
-        _plan_file_changes, disk_files, existing_sources, cancel, skip_markers
-    )
-    files_to_process, added, updated = plan.files_to_process, plan.added, plan.updated
-    if plan.stat_backfills:
-        await asyncio.to_thread(_store.update_source_stats, plan.stat_backfills)
-    # Track skip markers for files processed this run, keyed by name → hash.
-    pending_hashes = {entry.name: entry.file_hash for entry in files_to_process}
-
-    # Snapshot the cumulative truncation counter so the delta over this sync can
-    # surface "N chunks truncated" instead of being lost in per-chunk debug logs.
-    truncated_before = get_services().embedder.truncated_total
-
-    # Ingest files (with optional progress bar)
-    if files_to_process:
-        get_services().embedder.validate_model()
-        await ingest_batch(
-            files_to_process,
-            added,
-            updated,
-            failed,
-            skipped,
-            quiet=quiet,
-            on_progress=on_progress,
-            cancel=cancel,
-            flush_failed=flush_failed,
-            reasons=reasons,
+        disk_files = discover_files()
+        sources = _store.get_sources()
+        existing_sources = {s["filename"]: s for s in sources}
+        skip_markers = _load_pruned_skip_markers(
+            disk_files, clear_first=force_rebuild or retry_skipped
         )
 
-    # A flush failure is a transient store-side problem, not a verdict on the
-    # file: leaving it unmarked re-plans it next sync instead of skipping it.
-    marker_failed = [name for name in (*failed, *skipped) if name not in flush_failed]
-    _persist_skip_markers(
-        skip_markers, pending_hashes, succeeded=[*added, *updated], failed=marker_failed
-    )
-    # Persist the human-readable reason for each skip-marked file (informational;
-    # the hash markers above drive the resume logic). Only marker_failed files,
-    # so a transient flush failure doesn't leave a stale reason behind.
-    write_skip_reasons(cfg.data_root, {n: reasons[n] for n in marker_failed if n in reasons})
+        removed: list[str] = []
+        failed: dict[str, None] = {}
+        skipped: dict[str, None] = {}
+        reasons: dict[str, str] = {}  # filename → why it was skipped/failed (for reporting)
+        flush_failed: set[str] = set()
 
-    if files_to_process or removed:
-        _store.ensure_fts_index()
-        _store.ensure_vector_index()
-        _store.optimize_sources()
-        await _rebuild_concept_clusters()
-        # circular: lilbee.wiki imports lilbee.data.ingest.file_hash, so the
-        # post-ingest hook stays function-local at this boundary.
-        from lilbee.wiki.ingest import incremental_update
+        # Find files to remove (document sources whose file is gone; imports are kept)
+        to_remove = _removable_sources(sources, disk_files)
+        if to_remove:
+            _store.remove_documents(to_remove)
+            removed.extend(to_remove)
 
-        await incremental_update(set(added) | set(updated) | set(removed))
+        # The planning pass stats (and where needed hashes) every file on disk;
+        # off the event loop so a large corpus doesn't freeze the TUI.
+        plan = await asyncio.to_thread(
+            _plan_file_changes, disk_files, existing_sources, cancel, skip_markers
+        )
+        files_to_process, added, updated = plan.files_to_process, plan.added, plan.updated
+        if plan.stat_backfills:
+            await asyncio.to_thread(_store.update_source_stats, plan.stat_backfills)
+        # Track skip markers for files processed this run, keyed by name → hash.
+        pending_hashes = {entry.name: entry.file_hash for entry in files_to_process}
 
-    result = SyncResult(
-        added=list(added),
-        updated=list(updated),
-        removed=removed,
-        unchanged=plan.unchanged,
-        failed=list(failed),
-        skipped=list(skipped),
-        truncated=get_services().embedder.truncated_total - truncated_before,
-    )
-    on_progress(
-        EventType.DONE,
-        SyncDoneEvent(
-            added=len(result.added),
-            updated=len(result.updated),
-            removed=len(result.removed),
-            failed=len(result.failed),
-            skipped=len(result.skipped),
-        ),
-    )
-    return result
+        # Snapshot the cumulative truncation counter so the delta over this sync can
+        # surface "N chunks truncated" instead of being lost in per-chunk debug logs.
+        truncated_before = get_services().embedder.truncated_total
+
+        # Ingest files (with optional progress bar)
+        if files_to_process:
+            get_services().embedder.validate_model()
+            await ingest_batch(
+                files_to_process,
+                added,
+                updated,
+                failed,
+                skipped,
+                quiet=quiet,
+                on_progress=on_progress,
+                cancel=cancel,
+                flush_failed=flush_failed,
+                reasons=reasons,
+            )
+
+        # A flush failure is a transient store-side problem, not a verdict on the
+        # file: leaving it unmarked re-plans it next sync instead of skipping it.
+        marker_failed = [name for name in (*failed, *skipped) if name not in flush_failed]
+        _persist_skip_markers(
+            skip_markers, pending_hashes, succeeded=[*added, *updated], failed=marker_failed
+        )
+        # Persist the human-readable reason for each skip-marked file (informational;
+        # the hash markers above drive the resume logic). Only marker_failed files,
+        # so a transient flush failure doesn't leave a stale reason behind.
+        write_skip_reasons(cfg.data_root, {n: reasons[n] for n in marker_failed if n in reasons})
+
+        if files_to_process or removed:
+            _store.ensure_fts_index()
+            _store.ensure_vector_index()
+            _store.optimize_sources()
+            await _rebuild_concept_clusters()
+            # circular: lilbee.wiki imports lilbee.data.ingest.file_hash, so the
+            # post-ingest hook stays function-local at this boundary.
+            from lilbee.wiki.ingest import incremental_update
+
+            await incremental_update(set(added) | set(updated) | set(removed))
+
+        result = SyncResult(
+            added=list(added),
+            updated=list(updated),
+            removed=removed,
+            unchanged=plan.unchanged,
+            failed=list(failed),
+            skipped=list(skipped),
+            truncated=get_services().embedder.truncated_total - truncated_before,
+        )
+        on_progress(
+            EventType.DONE,
+            SyncDoneEvent(
+                added=len(result.added),
+                updated=len(result.updated),
+                removed=len(result.removed),
+                failed=len(result.failed),
+                skipped=len(result.skipped),
+            ),
+        )
+        return result
 
 
 def _phase_progress_callback(

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -434,6 +434,10 @@ class LLMProvider(Protocol):
         """
         return
 
+    def release_ingest_pool(self) -> None:
+        """Unload elastic ingest replicas after the last active ingest exits. No-op default."""
+        return
+
     def role_ready(self, role: WorkerRole) -> bool:
         """Whether *role* has a healthy server now, without starting one.
 

--- a/src/lilbee/providers/fleet/ingest_scale.py
+++ b/src/lilbee/providers/fleet/ingest_scale.py
@@ -34,9 +34,9 @@ _counter = _IngestScaleCounter()
 
 
 def _provider() -> LLMProvider:  # late-bound so tests can patch it and to avoid an import cycle
-    from lilbee.app.services import get_services  # pragma: no cover - patched in tests
+    from lilbee.app.services import get_services
 
-    return get_services().provider  # pragma: no cover - patched in tests
+    return get_services().provider
 
 
 def ingest_scale() -> contextlib.AbstractContextManager[None]:

--- a/src/lilbee/providers/fleet/ingest_scale.py
+++ b/src/lilbee/providers/fleet/ingest_scale.py
@@ -15,6 +15,8 @@ class _IngestScaleCounter:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._active = 0
+        # The most recent release thread, exposed so tests can join it deterministically.
+        self.last_release_thread: threading.Thread | None = None
 
     @contextlib.contextmanager
     def scope(self) -> Iterator[None]:
@@ -27,10 +29,27 @@ class _IngestScaleCounter:
                 self._active -= 1
                 last = self._active == 0
             if last:
-                _provider().release_ingest_pool()
+                self._spawn_release()
+
+    def _spawn_release(self) -> None:
+        """Run the pool release off the calling loop so the serving loop never blocks.
+
+        The release fires sequential blocking ``httpx.post`` unloads; on the server
+        path the bracket exits on the shared request-serving loop, so running it
+        inline would stall concurrent chat and search. Fire-and-forget in a daemon
+        thread keeps that loop free; the unloads are best-effort.
+        """
+        thread = threading.Thread(target=_run_release, name="ingest-release", daemon=True)
+        self.last_release_thread = thread
+        thread.start()
 
 
 _counter = _IngestScaleCounter()
+
+
+def _run_release() -> None:
+    """Unload the elastic ingest pool (best-effort)."""
+    _provider().release_ingest_pool()
 
 
 def _provider() -> LLMProvider:  # late-bound so tests can patch it and to avoid an import cycle

--- a/src/lilbee/providers/fleet/ingest_scale.py
+++ b/src/lilbee/providers/fleet/ingest_scale.py
@@ -8,27 +8,37 @@ from collections.abc import Iterator
 
 from lilbee.providers.base import LLMProvider
 
-_lock = threading.Lock()
-_active = 0
+
+class _IngestScaleCounter:
+    """Refcounts active ingests; releases the elastic pool when the last one ends."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active = 0
+
+    @contextlib.contextmanager
+    def scope(self) -> Iterator[None]:
+        with self._lock:
+            self._active += 1
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._active -= 1
+                last = self._active == 0
+            if last:
+                _provider().release_ingest_pool()
+
+
+_counter = _IngestScaleCounter()
 
 
 def _provider() -> LLMProvider:  # late-bound so tests can patch it and to avoid an import cycle
-    from lilbee.app.services import get_services
+    from lilbee.app.services import get_services  # pragma: no cover - patched in tests
 
-    return get_services().provider
+    return get_services().provider  # pragma: no cover - patched in tests
 
 
-@contextlib.contextmanager
-def ingest_scale() -> Iterator[None]:
-    """Bracket an ingest run; release the elastic pool when the last active one exits."""
-    global _active
-    with _lock:
-        _active += 1
-    try:
-        yield
-    finally:
-        with _lock:
-            _active -= 1
-            last = _active == 0
-        if last:
-            _provider().release_ingest_pool()
+def ingest_scale() -> contextlib.AbstractContextManager[None]:
+    """Bracket an ingest; release the elastic pool when the last active one exits."""
+    return _counter.scope()

--- a/src/lilbee/providers/fleet/ingest_scale.py
+++ b/src/lilbee/providers/fleet/ingest_scale.py
@@ -1,0 +1,34 @@
+"""Refcounted ingest bracket: release the elastic ingest pool when the last ingest ends."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections.abc import Iterator
+
+from lilbee.providers.base import LLMProvider
+
+_lock = threading.Lock()
+_active = 0
+
+
+def _provider() -> LLMProvider:  # late-bound so tests can patch it and to avoid an import cycle
+    from lilbee.app.services import get_services
+
+    return get_services().provider
+
+
+@contextlib.contextmanager
+def ingest_scale() -> Iterator[None]:
+    """Bracket an ingest run; release the elastic pool when the last active one exits."""
+    global _active
+    with _lock:
+        _active += 1
+    try:
+        yield
+    finally:
+        with _lock:
+            _active -= 1
+            last = _active == 0
+        if last:
+            _provider().release_ingest_pool()

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -101,27 +101,36 @@ def plan_placement(
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
 
-    # Single-instance roles first; then data-parallel replicas fill the remaining
-    # headroom. Within the singles, place the search-critical roles (embed/rerank)
-    # before chat: chat tensor-splits across cards and, placed first, can claim
-    # them all and leave an essential search role unplaceable. Search-first here
-    # mirrors the shared-memory path's reservation.
+    # Reserve the persistent query fleet first, then fill residual VRAM with the
+    # elastic ingest pool. The persistent singles are: every replicas<=1 role plus
+    # replica 0 of each replicated role (the query embedder / vision that a search
+    # issued during ingest must always reach). Within the singles, place the
+    # search-critical roles (embed/rerank) before chat: chat tensor-splits across
+    # cards and, placed first, can claim them all and leave an essential search role
+    # unplaceable. Search-first here mirrors the shared-memory path's reservation.
+    # The extra replicas (1..N-1) are placed only into what VRAM remains, so a chat
+    # issued during ingest always fits and the query embedder always exists.
     singles = [m for m in models if m.replicas <= 1]
     replicated = [m for m in models if m.replicas > 1]
-    for model in sorted(singles, key=_shared_pool_order):
+    persistent_singles = singles + [_persistent_single(m) for m in replicated]
+    for model in sorted(persistent_singles, key=_shared_pool_order):
         plan = _place_single(model, remaining, estimate_peak)
         if plan is None:
             unplaceable.append(model.role)
         else:
             instances.append(plan)
+    placed_roles = {plan.role for plan in instances}
     for model in replicated:
-        replica_plans = _place_replicas(model, remaining)
-        if replica_plans:
-            instances.extend(replica_plans)
-        else:
-            unplaceable.append(model.role)
+        if model.role not in placed_roles:
+            continue  # the persistent single did not fit -> already unplaceable
+        instances.extend(_place_replicas(model, remaining, start=1))
 
     return Placement(instances=tuple(instances), unplaceable_roles=tuple(unplaceable))
+
+
+def _persistent_single(model: ModelPlacementInput) -> ModelPlacementInput:
+    """The replica-0 persistent instance of a replicated role, sized as one server."""
+    return ModelPlacementInput(role=model.role, est_vram_bytes=model.est_vram_bytes, replicas=1)
 
 
 def _place_single(
@@ -161,16 +170,20 @@ def _place_split(
     return None
 
 
-def _place_replicas(model: ModelPlacementInput, remaining: dict[int, float]) -> list[InstancePlan]:
-    """Place up to ``model.replicas`` instances, one per distinct GPU (most-free first).
+def _place_replicas(
+    model: ModelPlacementInput, remaining: dict[int, float], *, start: int = 0
+) -> list[InstancePlan]:
+    """Place the elastic replicas ``start..model.replicas-1``, one per distinct GPU
+    (most-free first).
 
     Spreads for throughput: each replica lands on a card not yet hosting one of this
     role's replicas, only co-locating a second round once every card has one. Stops
-    early when no card has room, so the pool shrinks to what fits.
+    early when no card has room, so the pool shrinks to the residual VRAM. ``start``
+    skips the indices already placed as persistent singles (1 for the elastic batch).
     """
     plans: list[InstancePlan] = []
     used: set[int] = set()
-    for replica in range(model.replicas):
+    for replica in range(start, model.replicas):
         candidates = [idx for idx, free in remaining.items() if free >= model.est_vram_bytes]
         if not candidates:
             break

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -28,6 +28,7 @@ from lilbee.providers.fleet.placement import (
     PeakEstimator,
     plan_placement,
 )
+from lilbee.providers.fleet.replicas import resolve_replica_count
 from lilbee.providers.fleet.vram import estimate_instance_footprint
 from lilbee.providers.roles import RerankMode, WorkerRole
 
@@ -350,16 +351,8 @@ def _role_kv_cache_type(role: WorkerRole) -> KvCacheType:
 
 
 def _replica_count(role: WorkerRole, device_count: int) -> int:
-    """Requested data-parallel instances for *role*: embed/vision honor their
-    ``*_replicas`` knob (0 = auto = one per GPU); others run one. The auto count
-    falls to one GPU-less. Capping to residual VRAM happens in placement."""
-    from lilbee.core.config import cfg
-
-    if role is WorkerRole.EMBED:
-        return cfg.embed_replicas or max(1, device_count)
-    if role is WorkerRole.VISION:
-        return cfg.vision_replicas or max(1, device_count)
-    return 1
+    """Requested data-parallel instances for *role* via the shared resolver."""
+    return resolve_replica_count(role, device_count)
 
 
 def _cache_type_flag() -> str | None:

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -349,15 +349,16 @@ def _role_kv_cache_type(role: WorkerRole) -> KvCacheType:
     return cfg.kv_cache_type if role is WorkerRole.CHAT else KvCacheType.F16
 
 
-def _replica_count(role: WorkerRole) -> int:
+def _replica_count(role: WorkerRole, device_count: int) -> int:
     """Requested data-parallel instances for *role*: embed/vision honor their
-    ``*_replicas`` knob (capped by available GPUs at placement); others run one."""
+    ``*_replicas`` knob (0 = auto = one per GPU); others run one. The auto count
+    falls to one GPU-less. Capping to residual VRAM happens in placement."""
     from lilbee.core.config import cfg
 
     if role is WorkerRole.EMBED:
-        return max(1, cfg.embed_replicas)
+        return cfg.embed_replicas or max(1, device_count)
     if role is WorkerRole.VISION:
-        return max(1, cfg.vision_replicas)
+        return cfg.vision_replicas or max(1, device_count)
     return 1
 
 
@@ -390,12 +391,14 @@ def _estimate_role(
     slots: int | None = None,
     unified_budget: int | None = None,
     chat_reservation: int = 0,
+    device_count: int = 0,
 ) -> ModelPlacementInput:
     """Estimate one role-model's footprint via gguf-parser (+ mmproj for vision).
 
     ``slots`` defaults to the role's resolved batching slots (chat and vision are
     memory-aware); ``chat_reservation`` shrinks chat to leave room for the search
-    roles. Charges the unified footprint with no discrete GPU, else the VRAM one.
+    roles; ``device_count`` resolves an auto (0) replica knob to one per GPU.
+    Charges the unified footprint with no discrete GPU, else the VRAM one.
     """
     from lilbee.providers.engine_params import resolve_model_path
     from lilbee.providers.gguf_meta import read_gguf_metadata
@@ -428,7 +431,7 @@ def _estimate_role(
     return ModelPlacementInput(
         role=role,
         est_vram_bytes=est.footprint(unified=unified_budget is not None),
-        replicas=_replica_count(role),
+        replicas=_replica_count(role, device_count),
     )
 
 
@@ -504,14 +507,16 @@ def _server_model_inputs(
     roles: tuple[WorkerRole, ...] | None = None,
     *,
     unified_budget: int | None = None,
+    device_count: int = 0,
 ) -> tuple[list[ModelPlacementInput], dict[WorkerRole, str], int]:
     """Build placement inputs for the configured server roles.
 
     The search and vision roles are estimated first; chat is then sized against the
     budget minus the search footprint (the ``reservation``) so a large chat cannot
-    starve embed/rerank on a shared-memory host. When *roles* is given, only those
-    are considered. Skips an unconfigured optional role, a vision model with no
-    resolvable mmproj projector, and a role whose model is not installed on disk.
+    starve embed/rerank on a shared-memory host. ``device_count`` resolves an auto
+    replica knob to one per GPU. When *roles* is given, only those are considered.
+    Skips an unconfigured optional role, a vision model with no resolvable mmproj
+    projector, and a role whose model is not installed on disk.
     """
     from lilbee.core.config import cfg
     from lilbee.providers.base import ProviderError
@@ -529,7 +534,11 @@ def _server_model_inputs(
             return  # no projector -> vision can't run on a server
         try:
             estimate = _estimate_role(
-                role, ref, unified_budget=unified_budget, chat_reservation=chat_reservation
+                role,
+                ref,
+                unified_budget=unified_budget,
+                chat_reservation=chat_reservation,
+                device_count=device_count,
             )
         except (ProviderError, OSError):
             # The configured model is not installed/resolvable. Skip this role
@@ -700,7 +709,9 @@ def plan_launches(
 ) -> list[InstanceLaunch]:
     """Plan placement for *roles* (``None`` = all configured) and build their launches."""
     unified_budget = _unified_memory_budget(devices)
-    inputs, model_refs, reservation = _server_model_inputs(roles, unified_budget=unified_budget)
+    inputs, model_refs, reservation = _server_model_inputs(
+        roles, unified_budget=unified_budget, device_count=len(devices)
+    )
     placement = plan_placement(
         inputs,
         [(d.index, d.free_bytes) for d in devices],

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -482,10 +482,19 @@ class FleetProvider:
         means the role is unconfigured or did not fit memory. llama-swap loads each
         upstream on its first request, so a returned client may still be cold. No
         in-process fallback, so a missing pool is a hard error.
+
+        When the pool is empty but a swap was previously built and its process has
+        since exited (detected via ``is_live()``), a one-shot rebuild is attempted
+        before raising so a transient llama-swap restart recovers transparently.
         """
         self._ensure_swap()
         with self._lock:
             clients = self._clients.get(role)
+            swap = self._swap
+        if not clients and swap is not None and not swap.is_live():
+            self._rebuild_swap()
+            with self._lock:
+                clients = self._clients.get(role)
         if not clients:
             raise ProviderError(
                 f"No {role.value} model server is running. Make sure a {role.value} "
@@ -493,6 +502,11 @@ class FleetProvider:
                 provider=_PROVIDER_NAME,
             )
         return list(clients)
+
+    def _rebuild_swap(self) -> None:
+        """Drop a dead swap and build a fresh one (new port, re-adopt clients)."""
+        self._drop_swap_refs()
+        self._ensure_swap()
 
     def release_ingest_pool(self) -> None:
         """Unload the elastic ingest replicas (embed/vision replica>=1), freeing VRAM.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
 
 # User-facing name for this engine in error messages.
 _PROVIDER_NAME = "llama-server"
+# Roles that can have replica >= 1 elastic instances (embed / vision data-parallel pools).
+_ELASTIC_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
 # Tokens held back from the served context for the model's own generation when the
 # request does not cap it, plus a margin for chat-template overhead and estimate drift.
 _DEFAULT_GENERATION_RESERVE = 1024
@@ -340,6 +342,9 @@ class FleetProvider:
 
     def __init__(self) -> None:
         self._swap: SwapManager | None = None
+        # Model ids of elastic ingest replicas (embed/vision replica>=1); populated
+        # by _adopt_swap and consumed by release_ingest_pool.
+        self._elastic_members: list[str] = []
         # A pool of OpenAI clients per placed role (one per data-parallel replica),
         # all pointed at the llama-swap endpoint and routed by replica model id;
         # rebuilt whenever the swap process (re)starts. Requests round-robin the pool.
@@ -442,6 +447,11 @@ class FleetProvider:
                 )
             )
         self._clients = clients
+        self._elastic_members = [
+            launch.model_id
+            for launch in launches
+            if launch.role in _ELASTIC_ROLES and launch.replica >= 1
+        ]
         chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
         self._chat_slots = chat.slots if chat is not None else 1
         self._chat_ctx = chat.ctx if chat is not None else None
@@ -483,6 +493,23 @@ class FleetProvider:
                 provider=_PROVIDER_NAME,
             )
         return list(clients)
+
+    def release_ingest_pool(self) -> None:
+        """Unload the elastic ingest replicas (embed/vision replica>=1), freeing VRAM.
+
+        Best-effort and non-disruptive: the persistent query fleet (chat, embed-0,
+        rerank, vision-0) stays loaded. Called when the last active ingest finishes.
+        """
+        with self._lock:
+            swap = self._swap
+            members = list(self._elastic_members)
+        if swap is None:
+            return
+        for model_id in members:
+            if not swap.unload(model_id):
+                log.info("ingest pool: unload of %s did not confirm (swap may be cold)", model_id)
+            else:
+                log.info("ingest pool: unloaded %s", model_id)
 
     def role_ready(self, role: WorkerRole) -> bool:
         """Whether *role*'s upstream is loaded and ready, without starting the swap.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -26,7 +26,11 @@ from lilbee.modelhub.registry import ModelRegistry
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet import planning
 from lilbee.providers.fleet.client import LlamaServerClient, is_connection_failure
-from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
+from lilbee.providers.fleet.replicas import (
+    REPLICATED_ROLES,
+    gpu_device_count,
+    resolve_replica_count,
+)
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
 from lilbee.providers.fleet.swap_manager import SwapManager
 from lilbee.providers.fleet.windowing import window_messages
@@ -51,8 +55,6 @@ if TYPE_CHECKING:
 
 # User-facing name for this engine in error messages.
 _PROVIDER_NAME = "llama-server"
-# Roles that can have replica >= 1 elastic instances (embed / vision data-parallel pools).
-_ELASTIC_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
 # Tokens held back from the served context for the model's own generation when the
 # request does not cap it, plus a margin for chat-template overhead and estimate drift.
 _DEFAULT_GENERATION_RESERVE = 1024
@@ -450,7 +452,7 @@ class FleetProvider:
         self._elastic_members = [
             launch.model_id
             for launch in launches
-            if launch.role in _ELASTIC_ROLES and launch.replica >= 1
+            if launch.role in REPLICATED_ROLES and launch.replica >= 1
         ]
         chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
         self._chat_slots = chat.slots if chat is not None else 1
@@ -504,7 +506,7 @@ class FleetProvider:
         return list(clients)
 
     def _rebuild_swap(self) -> None:
-        """Drop a dead swap and build a fresh one (new port, re-adopt clients)."""
+        """Drop a dead swap and build a fresh one (new port); ``_ensure_swap`` adopts clients."""
         self._drop_swap_refs()
         self._ensure_swap()
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -26,6 +26,7 @@ from lilbee.modelhub.registry import ModelRegistry
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet import planning
 from lilbee.providers.fleet.client import LlamaServerClient, is_connection_failure
+from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
 from lilbee.providers.fleet.swap_manager import SwapManager
 from lilbee.providers.fleet.windowing import window_messages
@@ -218,7 +219,8 @@ class _VisionRequestGate:
                 self._in_flight -= 1
 
     def _checkout(self) -> threading.BoundedSemaphore:
-        capacity = max(1, cfg.vision_replicas * cfg.vision_ocr_concurrency)
+        replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
+        capacity = max(1, replicas * cfg.vision_ocr_concurrency)
         with self._lock:
             # Resize only when idle: rebuilding while old-semaphore holders are
             # in flight would briefly double the real cap, so a capacity change

--- a/src/lilbee/providers/fleet/replicas.py
+++ b/src/lilbee/providers/fleet/replicas.py
@@ -1,0 +1,48 @@
+"""Shared 0-as-auto replica-count resolution used by planning, provider, and pipeline.
+
+The ``embed_replicas`` / ``vision_replicas`` knobs default to 0, meaning "auto:
+one replica per GPU". Resolving that consistently in one place keeps the planning
+hot path, the vision OCR gate, and the ingest fan-out from disagreeing on the
+effective replica count.
+"""
+
+from __future__ import annotations
+
+import functools
+
+from lilbee.providers.roles import WorkerRole
+
+# Roles whose ``*_replicas`` knob scales data-parallel instances; others run one.
+_REPLICATED_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
+# Auto resolves to at least one replica even when no GPU is enumerated.
+_MIN_REPLICAS = 1
+
+
+def resolve_replica_count(role: WorkerRole, device_count: int) -> int:
+    """Requested data-parallel instances for *role* (0 = auto = one per GPU).
+
+    Embed and vision honor their ``*_replicas`` knob; an explicit value wins,
+    0 means one replica per GPU (falling to one when GPU-less). Other roles run
+    one instance. Capping to residual VRAM happens in placement.
+    """
+    from lilbee.core.config import cfg
+
+    if role is WorkerRole.EMBED:
+        return cfg.embed_replicas or max(_MIN_REPLICAS, device_count)
+    if role is WorkerRole.VISION:
+        return cfg.vision_replicas or max(_MIN_REPLICAS, device_count)
+    return _MIN_REPLICAS
+
+
+@functools.cache
+def gpu_device_count() -> int:
+    """Effective GPU count lilbee will use, cached so per-OCR checkouts don't re-probe.
+
+    Resolved the same way planning does (binary ``--list-devices`` view), and
+    floored at one so auto means "one replica" on a GPU-less host.
+    """
+    from lilbee.providers.fleet.binary import resolve_llama_server
+    from lilbee.providers.fleet.planning import resolve_devices
+
+    devices = resolve_devices(resolve_llama_server())
+    return max(_MIN_REPLICAS, len(devices))

--- a/src/lilbee/providers/fleet/replicas.py
+++ b/src/lilbee/providers/fleet/replicas.py
@@ -38,7 +38,7 @@ def resolve_replica_count(role: WorkerRole, device_count: int) -> int:
 
 @functools.cache
 def gpu_device_count() -> int:
-    """Effective GPU count lilbee will use, cached so per-OCR checkouts don't re-probe.
+    """Effective GPU count lilbee will use; fixed for the process lifetime (cached).
 
     Resolved the same way planning does (binary ``--list-devices`` view), and
     floored at one so auto means "one replica" on a GPU-less host.

--- a/src/lilbee/providers/fleet/replicas.py
+++ b/src/lilbee/providers/fleet/replicas.py
@@ -13,7 +13,9 @@ import functools
 from lilbee.providers.roles import WorkerRole
 
 # Roles whose ``*_replicas`` knob scales data-parallel instances; others run one.
-_REPLICATED_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
+# Single source of truth for the elastic (embed/vision) roles, reused by the
+# fleet provider to mark which placed instances belong to the ingest pool.
+REPLICATED_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
 # Auto resolves to at least one replica even when no GPU is enumerated.
 _MIN_REPLICAS = 1
 
@@ -27,11 +29,11 @@ def resolve_replica_count(role: WorkerRole, device_count: int) -> int:
     """
     from lilbee.core.config import cfg
 
+    if role not in REPLICATED_ROLES:
+        return _MIN_REPLICAS
     if role is WorkerRole.EMBED:
         return cfg.embed_replicas or max(_MIN_REPLICAS, device_count)
-    if role is WorkerRole.VISION:
-        return cfg.vision_replicas or max(_MIN_REPLICAS, device_count)
-    return _MIN_REPLICAS
+    return cfg.vision_replicas or max(_MIN_REPLICAS, device_count)
 
 
 @functools.cache

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -257,6 +257,8 @@ class SwapManager:
 
     def unload(self, model_id: str) -> bool:
         """Unload one model from llama-swap, freeing its VRAM; best-effort, never raises."""
+        if self._port is None:
+            return False
         try:
             resp = httpx.post(
                 f"{self.endpoint()}{_UNLOAD_PATH}",

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -73,7 +73,6 @@ _HEALTH_PATH = "/health"
 _RUNNING_PATH = "/running"
 _UNLOAD_PATH = "/api/models/unload"
 _HTTP_TIMEOUT_S = 10.0
-_HTTP_ERROR_THRESHOLD = 400
 # llama-swap's own proxy answers within a second; upstream model loads have their
 # own (longer) budget inside llama-swap, so this only covers the proxy coming up.
 _BOOT_TIMEOUT_S = 30.0
@@ -267,7 +266,7 @@ class SwapManager:
             )
         except (OSError, httpx.HTTPError):
             return False
-        return resp.status_code < _HTTP_ERROR_THRESHOLD
+        return resp.status_code < httpx.codes.BAD_REQUEST
 
     def is_live(self) -> bool:
         """Whether the swap process is up and its proxy answers ``/running``."""
@@ -279,7 +278,7 @@ class SwapManager:
             resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_HTTP_TIMEOUT_S)
         except (OSError, httpx.HTTPError):
             return False
-        return resp.status_code < _HTTP_ERROR_THRESHOLD
+        return resp.status_code < httpx.codes.BAD_REQUEST
 
     def reload(self, launches: list[InstanceLaunch]) -> None:
         """Apply a changed model set by restarting llama-swap with a fresh config."""

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -72,7 +72,7 @@ _LISTEN_FLAG = "-listen"
 _HEALTH_PATH = "/health"
 _RUNNING_PATH = "/running"
 _UNLOAD_PATH = "/api/models/unload"
-_UNLOAD_TIMEOUT_S = 10.0
+_HTTP_TIMEOUT_S = 10.0
 _HTTP_ERROR_THRESHOLD = 400
 # llama-swap's own proxy answers within a second; upstream model loads have their
 # own (longer) budget inside llama-swap, so this only covers the proxy coming up.
@@ -263,7 +263,7 @@ class SwapManager:
             resp = httpx.post(
                 f"{self.endpoint()}{_UNLOAD_PATH}",
                 json={"model": model_id},
-                timeout=_UNLOAD_TIMEOUT_S,
+                timeout=_HTTP_TIMEOUT_S,
             )
         except (OSError, httpx.HTTPError):
             return False
@@ -273,8 +273,10 @@ class SwapManager:
         """Whether the swap process is up and its proxy answers ``/running``."""
         if self._proc is None or self._proc.poll() is not None:
             return False
+        if self._port is None:
+            return False
         try:
-            resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_UNLOAD_TIMEOUT_S)
+            resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_HTTP_TIMEOUT_S)
         except (OSError, httpx.HTTPError):
             return False
         return resp.status_code < _HTTP_ERROR_THRESHOLD

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -71,6 +71,9 @@ _CONFIG_FLAG = "-config"
 _LISTEN_FLAG = "-listen"
 _HEALTH_PATH = "/health"
 _RUNNING_PATH = "/running"
+_UNLOAD_PATH = "/api/models/unload"
+_UNLOAD_TIMEOUT_S = 10.0
+_HTTP_ERROR_THRESHOLD = 400
 # llama-swap's own proxy answers within a second; upstream model loads have their
 # own (longer) budget inside llama-swap, so this only covers the proxy coming up.
 _BOOT_TIMEOUT_S = 30.0
@@ -251,6 +254,28 @@ class SwapManager:
         """Whether at least one of *role*'s replica servers is loaded and ready."""
         prefix = role_model_prefix(role)
         return any(model.startswith(prefix) for model in self._ready_models())
+
+    def unload(self, model_id: str) -> bool:
+        """Unload one model from llama-swap, freeing its VRAM; best-effort, never raises."""
+        try:
+            resp = httpx.post(
+                f"{self.endpoint()}{_UNLOAD_PATH}",
+                json={"model": model_id},
+                timeout=_UNLOAD_TIMEOUT_S,
+            )
+        except (OSError, httpx.HTTPError):
+            return False
+        return resp.status_code < _HTTP_ERROR_THRESHOLD
+
+    def is_live(self) -> bool:
+        """Whether the swap process is up and its proxy answers ``/running``."""
+        if self._proc is None or self._proc.poll() is not None:
+            return False
+        try:
+            resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_UNLOAD_TIMEOUT_S)
+        except (OSError, httpx.HTTPError):
+            return False
+        return resp.status_code < _HTTP_ERROR_THRESHOLD
 
     def reload(self, launches: list[InstanceLaunch]) -> None:
         """Apply a changed model set by restarting llama-swap with a fresh config."""

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -315,6 +315,11 @@ class RoutingProvider(LLMProvider):
         if self._local is not None:
             self._local.reload_role(role, wait=wait)
 
+    def release_ingest_pool(self) -> None:
+        """Forward to the native engine; the SDK side has no elastic ingest pool."""
+        if self._local is not None:
+            self._local.release_ingest_pool()
+
     def role_ready(self, role: WorkerRole) -> bool:
         """Native readiness without building; True when no local engine exists yet."""
         if self._local is None:

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -427,3 +427,6 @@ class SdkLLMProvider(LLMProvider):
 
     def invalidate_load_cache(self, model_path: Path | None = None) -> None:
         """No-op: cloud backends have no local model cache to evict."""
+
+    def release_ingest_pool(self) -> None:
+        """No-op: cloud backends have no elastic ingest pool to release."""

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -332,3 +332,85 @@ class TestReplicas:
         embeds = self._embeds(plan)
         assert len(embeds) == 2
         assert {i.replica for i in embeds} == {0, 1}
+
+
+class TestPersistentSingleElasticSplit:
+    """A replicated embed/vision role reserves replica 0 as a persistent single in the
+    singles phase, then places the extra replicas into the residual VRAM."""
+
+    def _embeds(self, plan: Placement) -> list[InstancePlan]:
+        return [i for i in plan.instances if i.role is WorkerRole.EMBED]
+
+    def test_replica_zero_is_a_persistent_single_before_the_elastic_batch(self) -> None:
+        # embed replicas=3: replica 0 is reserved as the persistent query embedder,
+        # alongside chat/rerank, and replicas 1..2 are the elastic ingest pool.
+        plan = plan_placement(
+            [
+                ModelPlacementInput(WorkerRole.CHAT, 5 * _GB),
+                ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=3),
+            ],
+            [(0, 24 * _GB), (1, 24 * _GB), (2, 24 * _GB)],
+            estimate_peak=_never,
+        )
+        embeds = self._embeds(plan)
+        assert {i.replica for i in embeds} == {0, 1, 2}
+        # All three placed: one persistent single (replica 0) + two elastic.
+        assert len(embeds) == 3
+        assert plan.unplaceable_roles == ()
+
+    def test_query_embedder_persists_when_chat_claims_the_reserved_room(self) -> None:
+        # One card. Persistent fleet (chat + embed-0) is reserved first, so the
+        # query embedder always exists; the elastic replicas get only the residual,
+        # which here is exhausted, so embed-1/embed-2 never place.
+        plan = plan_placement(
+            [
+                ModelPlacementInput(WorkerRole.EMBED, 8 * _GB, replicas=3),
+                ModelPlacementInput(WorkerRole.CHAT, 10 * _GB),
+            ],
+            [(0, 24 * _GB)],  # 21.6 usable: embed-0 8 + chat 10 = 18, residual 3.6 < 8
+            estimate_peak=_never,
+        )
+        embeds = self._embeds(plan)
+        assert {i.replica for i in embeds} == {0}  # only the persistent query embedder
+        chat = [i for i in plan.instances if i.role is WorkerRole.CHAT]
+        assert len(chat) == 1
+        assert plan.unplaceable_roles == ()
+
+    def test_elastic_batch_capped_by_residual_vram(self) -> None:
+        # 2 cards (21.6 usable each). embed-0 single + chat take card room; the
+        # elastic batch fills only what residual VRAM is left, not all replicas.
+        plan = plan_placement(
+            [
+                ModelPlacementInput(WorkerRole.CHAT, 18 * _GB),
+                ModelPlacementInput(WorkerRole.EMBED, 10 * _GB, replicas=4),
+            ],
+            [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=_never,
+        )
+        embeds = self._embeds(plan)
+        # embed-0 single lands on one card; chat lands on the other (18 fits, 21.6);
+        # residual on embed-0's card is 11.6 -> one elastic 10GB replica fits there.
+        assert 0 in {i.replica for i in embeds}  # persistent single always present
+        assert len(embeds) < 4  # capped by residual, not all 4 requested
+        assert plan.unplaceable_roles == ()
+
+    def test_replicated_role_unplaceable_when_persistent_single_does_not_fit(self) -> None:
+        # If replica 0 (the persistent single) fits nowhere, the role is unplaceable.
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 100 * _GB, replicas=2)],
+            [(0, 24 * _GB)],
+            estimate_peak=_never,
+        )
+        assert self._embeds(plan) == []
+        assert plan.unplaceable_roles == (WorkerRole.EMBED,)
+
+    def test_single_replica_role_is_unchanged(self) -> None:
+        # replicas=1 still places exactly one replica-0 single, no elastic batch.
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=1)],
+            [(0, 24 * _GB)],
+            estimate_peak=_never,
+        )
+        embeds = self._embeds(plan)
+        assert len(embeds) == 1
+        assert embeds[0].replica == 0

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -364,7 +364,7 @@ def test_server_model_inputs_reserves_search_before_chat_on_shared_host(monkeypa
     seen: dict[str, int] = {}
     sizes = {WorkerRole.EMBED: 2 * _GB, WorkerRole.RERANK: 3 * _GB}
 
-    def _estimate(role, ref, *, unified_budget=None, chat_reservation=0):
+    def _estimate(role, ref, *, unified_budget=None, chat_reservation=0, device_count=0):
         if role is WorkerRole.CHAT:
             seen["chat_reservation"] = chat_reservation
         return ModelPlacementInput(role, sizes.get(role, 10 * _GB))
@@ -384,7 +384,7 @@ def test_server_model_inputs_no_reservation_on_discrete_gpu(monkeypatch) -> None
     monkeypatch.setattr(cfg, "vision_model", "")
     seen: dict[str, int] = {}
 
-    def _estimate(role, ref, *, unified_budget=None, chat_reservation=0):
+    def _estimate(role, ref, *, unified_budget=None, chat_reservation=0, device_count=0):
         if role is WorkerRole.CHAT:
             seen["chat_reservation"] = chat_reservation
         return ModelPlacementInput(role, 2 * _GB)
@@ -398,10 +398,26 @@ def test_server_model_inputs_no_reservation_on_discrete_gpu(monkeypatch) -> None
 def test_replica_count_reads_per_role_knobs(monkeypatch) -> None:
     monkeypatch.setattr(cfg, "embed_replicas", 3)
     monkeypatch.setattr(cfg, "vision_replicas", 2)
-    assert planning_mod._replica_count(WorkerRole.EMBED) == 3
-    assert planning_mod._replica_count(WorkerRole.VISION) == 2
-    assert planning_mod._replica_count(WorkerRole.CHAT) == 1  # chat never replicates
-    assert planning_mod._replica_count(WorkerRole.RERANK) == 1  # rerank never replicates
+    assert planning_mod._replica_count(WorkerRole.EMBED, device_count=4) == 3
+    assert planning_mod._replica_count(WorkerRole.VISION, device_count=4) == 2
+    assert (
+        planning_mod._replica_count(WorkerRole.CHAT, device_count=4) == 1
+    )  # chat never replicates
+    assert planning_mod._replica_count(WorkerRole.RERANK, device_count=4) == 1  # rerank never
+
+
+def test_replica_count_auto_uses_device_count(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 0)  # 0 = auto = one per GPU
+    monkeypatch.setattr(cfg, "vision_replicas", 0)
+    assert planning_mod._replica_count(WorkerRole.EMBED, device_count=4) == 4
+    assert planning_mod._replica_count(WorkerRole.VISION, device_count=3) == 3
+    # An explicit positive knob wins over the auto device count.
+    monkeypatch.setattr(cfg, "embed_replicas", 2)
+    assert planning_mod._replica_count(WorkerRole.EMBED, device_count=4) == 2
+    # Auto on a GPU-less host still resolves to at least one instance.
+    monkeypatch.setattr(cfg, "embed_replicas", 0)
+    assert planning_mod._replica_count(WorkerRole.EMBED, device_count=0) == 1
+    assert planning_mod._replica_count(WorkerRole.CHAT, device_count=4) == 1
 
 
 def test_estimate_role_carries_replica_count(monkeypatch, tmp_path) -> None:
@@ -412,8 +428,20 @@ def test_estimate_role_carries_replica_count(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
     monkeypatch.setattr(planning_mod, "_role_ctx", lambda _r, _p, _m, *_a: 16)
     monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=10))
-    inp = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1)
-    assert inp.replicas == 4
+    inp = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1, device_count=2)
+    assert inp.replicas == 4  # explicit knob wins over the device count
+
+
+def test_estimate_role_auto_replicas_follow_device_count(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 0)  # 0 = auto = one per GPU
+    model = tmp_path / "e.gguf"
+    model.write_bytes(b"x" * 1000)
+    monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+    monkeypatch.setattr(planning_mod, "_role_ctx", lambda _r, _p, _m, *_a: 16)
+    monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=10))
+    inp = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1, device_count=3)
+    assert inp.replicas == 3
 
 
 def test_search_reservation_scales_with_replicas() -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -823,6 +823,9 @@ def test_pdf_ocr_spends_one_document_budget_across_pages(monkeypatch) -> None:
     p = _provider_with_clients({WorkerRole.VISION: [_fake_client(0)]})
     monkeypatch.setattr(cfg, "vision_model", "")
     monkeypatch.setattr(cfg, "vision_load_budget_s", 300.0)
+    # Pin the device-count probe so _checkout() does not run a real subprocess
+    # and spend ~4s that would bleed into the budget timing assertion.
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr("lilbee.vision.pdf_page_count", lambda _p: 2)
     monkeypatch.setattr(
         "lilbee.vision.rasterize_pdf", lambda _p: iter([(0, b"png0"), (1, b"png1")])
@@ -2124,3 +2127,16 @@ def test_require_clients_no_reprobe_when_swap_live(monkeypatch) -> None:
     with pytest.raises(ProviderError, match="No chat model server is running"):
         p._require_clients(WorkerRole.CHAT)
     assert rebuilt["called"] is False
+
+
+def test_rebuild_swap_calls_drop_then_ensure(monkeypatch) -> None:
+    """_rebuild_swap calls _drop_swap_refs then _ensure_swap, in that order."""
+    p = FleetProvider()
+    order: list[str] = []
+
+    monkeypatch.setattr(p, "_drop_swap_refs", lambda: order.append("drop"), raising=False)
+    monkeypatch.setattr(p, "_ensure_swap", lambda: order.append("ensure"), raising=False)
+
+    p._rebuild_swap()
+
+    assert order == ["drop", "ensure"]

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -27,13 +27,14 @@ def _fake_client(in_flight: int = 0) -> MagicMock:
 
 
 def _fake_launch(
-    role: WorkerRole, *, slots: int = 1, ctx: int = 0, weights_bytes: int = 0
+    role: WorkerRole, *, slots: int = 1, ctx: int = 0, weights_bytes: int = 0, replica: int = 0
 ) -> MagicMock:
     launch = MagicMock()
     launch.role = role
     launch.slots = slots
     launch.ctx = ctx
     launch.weights_bytes = weights_bytes
+    launch.replica = replica
     return launch
 
 
@@ -734,6 +735,80 @@ def test_pdf_drain_budget_totals_pages_plus_load_grace(monkeypatch) -> None:
     assert prov_mod._pdf_drain_budget(2, 120.0) == 540.0
     assert prov_mod._pdf_drain_budget(5, None) is None
     assert prov_mod._pdf_drain_budget(5, 0.0) is None
+
+
+def test_release_ingest_pool_unloads_only_elastic_replicas() -> None:
+    from unittest import mock
+
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    p = FleetProvider()
+    p._elastic_members = ["embed-1", "embed-2", "vision-1"]
+    unloaded: list[str] = []
+    swap = mock.Mock()
+    swap.unload.side_effect = lambda mid: unloaded.append(mid) or True
+    p._swap = swap
+
+    p.release_ingest_pool()
+
+    assert unloaded == ["embed-1", "embed-2", "vision-1"]
+    swap.unload.assert_called()
+
+
+def test_release_ingest_pool_noop_when_no_swap() -> None:
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    p = FleetProvider()
+    p._elastic_members = ["embed-1"]
+    p._swap = None
+    p.release_ingest_pool()  # must not raise
+
+
+def test_release_ingest_pool_logs_unconfirmed(caplog) -> None:
+    import logging
+    from unittest import mock
+
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    p = FleetProvider()
+    p._elastic_members = ["embed-1"]
+    swap = mock.Mock()
+    swap.unload.return_value = False  # unload did not confirm
+    p._swap = swap
+
+    with caplog.at_level(logging.INFO, logger="lilbee.providers.fleet.provider"):
+        p.release_ingest_pool()
+
+    assert any("did not confirm" in r.message for r in caplog.records)
+
+
+def test_adopt_swap_records_elastic_members(monkeypatch) -> None:
+    from lilbee.providers.fleet.launch import InstanceLaunch
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    def _make_launch(role: WorkerRole, replica: int) -> InstanceLaunch:
+        return InstanceLaunch(
+            role=role,
+            argv=[],
+            env_overrides={},
+            model="dummy.gguf",
+            replica=replica,
+        )
+
+    launches = [
+        _make_launch(WorkerRole.CHAT, replica=0),
+        _make_launch(WorkerRole.EMBED, replica=0),
+        _make_launch(WorkerRole.EMBED, replica=1),
+        _make_launch(WorkerRole.RERANK, replica=0),
+        _make_launch(WorkerRole.VISION, replica=0),
+        _make_launch(WorkerRole.VISION, replica=1),
+    ]
+    swap = _install_engine(monkeypatch, launches=launches)
+    p = FleetProvider()
+    with p._lock:
+        p._adopt_swap(swap, launches)
+
+    assert p._elastic_members == ["embed-1", "vision-1"]
 
 
 def test_pdf_ocr_spends_one_document_budget_across_pages(monkeypatch) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -701,6 +701,9 @@ def test_pdf_ocr_runs_pages_concurrently_and_preserves_order(monkeypatch) -> Non
 
     monkeypatch.setattr(cfg, "vision_model", "")
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
+    # Auto replicas (vision_replicas left at its 0 default) resolves to one per
+    # GPU; pin the probe to a single GPU so the gate admits 1 x 4 = 4 in flight.
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     n = 8
     monkeypatch.setattr("lilbee.vision.pdf_page_count", lambda _p: n)
     monkeypatch.setattr(
@@ -1159,9 +1162,20 @@ def test_apply_fleet_gpu_env_honors_gpu_devices_pin(monkeypatch) -> None:
     for name in _GPU_VISIBLE_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setattr(cfg, "gpu_devices", "0")
-    gpu_env.apply_fleet_gpu_env()
-    for name in _GPU_VISIBLE_ENV_VARS:
-        assert os.environ[name] == "0"
+    # apply_fleet_gpu_env writes these vars in place; monkeypatch.delenv does not
+    # track app-side additions, so restore the pre-apply snapshot to avoid leaking
+    # the pin (CUDA_VISIBLE_DEVICES=0) into later tests that read os.environ.
+    snapshot = {name: os.environ.get(name) for name in _GPU_VISIBLE_ENV_VARS}
+    try:
+        gpu_env.apply_fleet_gpu_env()
+        for name in _GPU_VISIBLE_ENV_VARS:
+            assert os.environ[name] == "0"
+    finally:
+        for name, value in snapshot.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def test_apply_fleet_gpu_env_clears_empty_cuda_visible_devices(monkeypatch) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -59,6 +59,11 @@ class _FakeSwap:
     def endpoint(self) -> str:
         return "http://fake-endpoint"
 
+    def is_live(self) -> bool:
+        # Default: the fake swap is considered live so existing tests that have
+        # an empty client pool still raise ProviderError, not trigger a rebuild.
+        return True
+
     def role_ready(self, role: WorkerRole) -> bool:
         return role in self.ready
 
@@ -2055,3 +2060,67 @@ class TestWarmProgressTracking:
         p._warm_tracker.begin("repo/m.gguf")
         p._warm_tracker.ready()
         assert p.warm_progress().phase is WarmPhase.READY
+
+
+# --- _require_clients re-probe on a dead swap ---------------------------------
+
+
+def test_require_clients_reprobes_dead_swap(monkeypatch) -> None:
+    """Empty pool + dead swap triggers a one-shot rebuild; clients are returned after."""
+    from unittest import mock
+
+    p = FleetProvider()
+    p._clients = {}
+    dead = mock.Mock()
+    dead.is_live.return_value = False
+    p._swap = dead
+    rebuilt = {"called": False}
+
+    def fake_rebuild() -> None:
+        rebuilt["called"] = True
+        p._clients = {WorkerRole.CHAT: [_fake_client()]}
+
+    monkeypatch.setattr(p, "_rebuild_swap", fake_rebuild, raising=False)
+    clients = p._require_clients(WorkerRole.CHAT)
+    assert rebuilt["called"] is True
+    assert len(clients) == 1
+
+
+def test_require_clients_no_reprobe_when_swap_none(monkeypatch) -> None:
+    """Empty pool + no swap at all (unconfigured role) still raises, no rebuild."""
+    from lilbee.providers.base import ProviderError
+
+    rebuilt = {"called": False}
+
+    def fake_rebuild() -> None:
+        rebuilt["called"] = True
+
+    p = FleetProvider()
+    p._swap = None
+    p._clients = {}
+    monkeypatch.setattr(p, "_rebuild_swap", fake_rebuild, raising=False)
+    with pytest.raises(ProviderError, match="No chat model server is running"):
+        p._require_clients(WorkerRole.CHAT)
+    assert rebuilt["called"] is False
+
+
+def test_require_clients_no_reprobe_when_swap_live(monkeypatch) -> None:
+    """Empty pool + live swap (real misconfiguration) still raises, no rebuild."""
+    from unittest import mock
+
+    from lilbee.providers.base import ProviderError
+
+    rebuilt = {"called": False}
+
+    def fake_rebuild() -> None:
+        rebuilt["called"] = True
+
+    p = FleetProvider()
+    live = mock.Mock()
+    live.is_live.return_value = True
+    p._swap = live
+    p._clients = {}
+    monkeypatch.setattr(p, "_rebuild_swap", fake_rebuild, raising=False)
+    with pytest.raises(ProviderError, match="No chat model server is running"):
+        p._require_clients(WorkerRole.CHAT)
+    assert rebuilt["called"] is False

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -375,6 +375,7 @@ def test_vision_request_gate_tracks_fleet_capacity(monkeypatch) -> None:
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr(cfg, "vision_replicas", 3)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
     with prov_mod._VISION_GATE.slot():
@@ -395,6 +396,7 @@ def test_vision_gate_resize_deferred_while_in_flight(monkeypatch) -> None:
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr(cfg, "vision_replicas", 1)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 
@@ -438,6 +440,7 @@ def test_vision_gate_slot_decrements_in_flight_when_acquire_raises(monkeypatch) 
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr(cfg, "vision_replicas", 1)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 
@@ -470,6 +473,7 @@ def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr(cfg, "vision_replicas", 1)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -2065,9 +2065,6 @@ class TestWarmProgressTracking:
         assert p.warm_progress().phase is WarmPhase.READY
 
 
-# --- _require_clients re-probe on a dead swap ---------------------------------
-
-
 def test_require_clients_reprobes_dead_swap(monkeypatch) -> None:
     """Empty pool + dead swap triggers a one-shot rebuild; clients are returned after."""
     from unittest import mock

--- a/tests/test_fleet_replicas.py
+++ b/tests/test_fleet_replicas.py
@@ -1,0 +1,68 @@
+"""Unit tests for the shared replica-count resolver and cached GPU probe."""
+
+from __future__ import annotations
+
+from lilbee.core.config import cfg
+from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
+from lilbee.providers.roles import WorkerRole
+
+
+def test_auto_resolves_to_one_replica_per_gpu(monkeypatch) -> None:
+    # 0 (the default) means auto: one replica per enumerated GPU.
+    monkeypatch.setattr(cfg, "embed_replicas", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 0)
+    assert resolve_replica_count(WorkerRole.EMBED, 4) == 4
+    assert resolve_replica_count(WorkerRole.VISION, 3) == 3
+
+
+def test_auto_floors_at_one_replica_when_gpu_less(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 0)
+    assert resolve_replica_count(WorkerRole.EMBED, 0) == 1
+    assert resolve_replica_count(WorkerRole.VISION, 0) == 1
+
+
+def test_explicit_replica_count_wins_over_device_count(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 2)
+    monkeypatch.setattr(cfg, "vision_replicas", 5)
+    assert resolve_replica_count(WorkerRole.EMBED, 8) == 2
+    assert resolve_replica_count(WorkerRole.VISION, 1) == 5
+
+
+def test_non_replicated_roles_always_run_one(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 0)
+    assert resolve_replica_count(WorkerRole.CHAT, 8) == 1
+    assert resolve_replica_count(WorkerRole.RERANK, 8) == 1
+
+
+def test_gpu_device_count_returns_probe_length(monkeypatch) -> None:
+    gpu_device_count.cache_clear()
+    monkeypatch.setattr("lilbee.providers.fleet.binary.resolve_llama_server", lambda: object())
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.planning.resolve_devices", lambda _b: [object(), object(), object()]
+    )
+    assert gpu_device_count() == 3
+
+
+def test_gpu_device_count_floors_at_one_when_no_devices(monkeypatch) -> None:
+    gpu_device_count.cache_clear()
+    monkeypatch.setattr("lilbee.providers.fleet.binary.resolve_llama_server", lambda: object())
+    monkeypatch.setattr("lilbee.providers.fleet.planning.resolve_devices", lambda _b: [])
+    assert gpu_device_count() == 1
+
+
+def test_gpu_device_count_is_cached(monkeypatch) -> None:
+    gpu_device_count.cache_clear()
+    calls = {"n": 0}
+
+    def _probe(_b: object) -> list[object]:
+        calls["n"] += 1
+        return [object(), object()]
+
+    monkeypatch.setattr("lilbee.providers.fleet.binary.resolve_llama_server", lambda: object())
+    monkeypatch.setattr("lilbee.providers.fleet.planning.resolve_devices", _probe)
+    assert gpu_device_count() == 2
+    assert gpu_device_count() == 2
+    assert calls["n"] == 1  # cached: probed once, not per call
+    gpu_device_count.cache_clear()

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1171,9 +1171,7 @@ class TestIsLive:
         monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.get", boom)
         assert mgr.is_live() is False
 
-    def test_false_and_no_raise_when_proc_alive_but_port_not_yet_set(
-        self, tmp_path: Path
-    ) -> None:
+    def test_false_and_no_raise_when_proc_alive_but_port_not_yet_set(self, tmp_path: Path) -> None:
         # Startup-window race: _proc is alive (poll() returns None) but _port is
         # still None. is_live() must return False, not let endpoint()'s
         # ProviderError escape a -> bool method.

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1124,6 +1124,13 @@ class TestUnload:
         )
         assert mgr.unload("embed-1") is False
 
+    def test_returns_false_and_never_raises_before_start(self, tmp_path: Path) -> None:
+        # _port is None before start(); unload() must not let endpoint()'s
+        # ProviderError escape the never-raise contract.
+        mgr = SwapManager(tmp_path)
+        assert mgr._port is None
+        assert mgr.unload("embed-1") is False
+
 
 class TestIsLive:
     def test_true_when_proc_alive_and_running_answers(

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -16,7 +16,7 @@ import pytest
 from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet import swap_manager as sm
 from lilbee.providers.fleet.launch import InstanceLaunch
-from lilbee.providers.fleet.swap_manager import SwapManager
+from lilbee.providers.fleet.swap_manager import _UNLOAD_PATH, SwapManager
 from lilbee.providers.roles import WorkerRole
 
 
@@ -1081,3 +1081,85 @@ def test_running_reflects_the_spawned_process(
     assert mgr.running is True
     mgr.shutdown()
     assert mgr.running is False
+
+
+class TestUnload:
+    def test_posts_model_id_to_unload_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        calls: dict[str, object] = {}
+
+        def fake_post(url: str, json: object, timeout: float) -> object:
+            calls["url"] = url
+            calls["json"] = json
+            return _fake_response(status=200)
+
+        monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.post", fake_post)
+        assert mgr.unload("embed-1") is True
+        assert calls["url"] == f"http://127.0.0.1:41999{_UNLOAD_PATH}"
+        assert calls["json"] == {"model": "embed-1"}
+
+    def test_returns_false_and_never_raises_on_network_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+
+        def boom(url: str, json: object, timeout: float) -> object:
+            raise OSError("connection refused")
+
+        monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.post", boom)
+        assert mgr.unload("embed-1") is False
+
+    def test_returns_false_on_http_error_status(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.swap_manager.httpx.post",
+            lambda url, json, timeout: _fake_response(status=500),
+        )
+        assert mgr.unload("embed-1") is False
+
+
+class TestIsLive:
+    def test_true_when_proc_alive_and_running_answers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        mgr._proc = _FakeProc(poll_result=None)  # type: ignore[assignment]
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.swap_manager.httpx.get",
+            lambda url, timeout: _fake_response(status=200),
+        )
+        assert mgr.is_live() is True
+
+    def test_false_when_proc_is_none(self, tmp_path: Path) -> None:
+        mgr = SwapManager(tmp_path)
+        assert mgr._proc is None
+        assert mgr.is_live() is False
+
+    def test_false_when_proc_has_exited(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        mgr._proc = _FakeProc(poll_result=1)  # type: ignore[assignment]
+        assert mgr.is_live() is False
+
+    def test_false_when_running_probe_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        mgr._proc = _FakeProc(poll_result=None)  # type: ignore[assignment]
+
+        def boom(url: str, timeout: float) -> object:
+            raise OSError("connection refused")
+
+        monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.get", boom)
+        assert mgr.is_live() is False

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1170,3 +1170,15 @@ class TestIsLive:
 
         monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.get", boom)
         assert mgr.is_live() is False
+
+    def test_false_and_no_raise_when_proc_alive_but_port_not_yet_set(
+        self, tmp_path: Path
+    ) -> None:
+        # Startup-window race: _proc is alive (poll() returns None) but _port is
+        # still None. is_live() must return False, not let endpoint()'s
+        # ProviderError escape a -> bool method.
+        mgr = SwapManager(tmp_path)
+        mgr._proc = _FakeProc(poll_result=None)  # type: ignore[assignment]
+        assert mgr._port is None
+        result = mgr.is_live()
+        assert result is False

--- a/tests/test_ingest_scale.py
+++ b/tests/test_ingest_scale.py
@@ -1,0 +1,71 @@
+"""Tests for the refcounted ingest bracket in ``lilbee.providers.fleet.ingest_scale``."""
+
+from __future__ import annotations
+
+import contextlib
+from unittest import mock
+
+from lilbee.providers.fleet import ingest_scale
+
+
+def test_release_only_after_last_ingest(monkeypatch):
+    """``release_ingest_pool`` is called exactly once, when the outermost bracket exits."""
+    released = {"n": 0}
+    prov = mock.Mock()
+    prov.release_ingest_pool.side_effect = lambda: released.__setitem__("n", released["n"] + 1)
+    monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+
+    with ingest_scale.ingest_scale():
+        with ingest_scale.ingest_scale():
+            assert released["n"] == 0  # inner exit does not release
+        assert released["n"] == 0  # still one active
+    assert released["n"] == 1  # last exit releases once
+
+
+def test_release_runs_even_on_exception(monkeypatch):
+    """``release_ingest_pool`` is called even when the body raises."""
+    prov = mock.Mock()
+    monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    with contextlib.suppress(RuntimeError), ingest_scale.ingest_scale():
+        raise RuntimeError("boom")
+    prov.release_ingest_pool.assert_called_once()
+
+
+def test_release_not_called_on_non_last_exit(monkeypatch):
+    """Inner bracket exit does not call ``release_ingest_pool``."""
+    prov = mock.Mock()
+    monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    with ingest_scale.ingest_scale():
+        with ingest_scale.ingest_scale():
+            pass
+        prov.release_ingest_pool.assert_not_called()
+    prov.release_ingest_pool.assert_called_once()
+
+
+def test_routing_provider_release_ingest_pool_forwards_to_local():
+    """``RoutingProvider.release_ingest_pool`` forwards to the inner engine."""
+    from lilbee.providers.routing_provider import RoutingProvider
+
+    rp = RoutingProvider()
+    local = mock.MagicMock()
+    rp._local = local
+    rp.release_ingest_pool()
+    local.release_ingest_pool.assert_called_once_with()
+
+
+def test_routing_provider_release_ingest_pool_noop_without_local():
+    """``RoutingProvider.release_ingest_pool`` is a no-op when ``_local`` is None."""
+    from lilbee.providers.routing_provider import RoutingProvider
+
+    rp = RoutingProvider()  # _local is None
+    rp.release_ingest_pool()  # must not raise
+
+
+def test_sdk_llm_provider_release_ingest_pool_is_callable_noop():
+    """``SdkLLMProvider.release_ingest_pool`` is a callable no-op."""
+    from lilbee.providers.sdk_backend import LlmSdkBackend
+    from lilbee.providers.sdk_llm_provider import SdkLLMProvider
+
+    backend = mock.MagicMock(spec=LlmSdkBackend)
+    provider = SdkLLMProvider(backend)
+    provider.release_ingest_pool()  # must not raise

--- a/tests/test_ingest_scale.py
+++ b/tests/test_ingest_scale.py
@@ -8,17 +8,28 @@ from unittest import mock
 from lilbee.providers.fleet import ingest_scale
 
 
+def _join_release() -> None:
+    """Wait for the fire-and-forget release thread so assertions are deterministic."""
+    thread = ingest_scale._counter.last_release_thread
+    assert thread is not None
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+
 def test_release_only_after_last_ingest(monkeypatch):
     """``release_ingest_pool`` is called exactly once, when the outermost bracket exits."""
     released = {"n": 0}
     prov = mock.Mock()
     prov.release_ingest_pool.side_effect = lambda: released.__setitem__("n", released["n"] + 1)
     monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    monkeypatch.setattr(ingest_scale._counter, "last_release_thread", None)
 
     with ingest_scale.ingest_scale():
         with ingest_scale.ingest_scale():
             assert released["n"] == 0  # inner exit does not release
+            assert ingest_scale._counter.last_release_thread is None  # no release spawned yet
         assert released["n"] == 0  # still one active
+    _join_release()
     assert released["n"] == 1  # last exit releases once
 
 
@@ -26,8 +37,10 @@ def test_release_runs_even_on_exception(monkeypatch):
     """``release_ingest_pool`` is called even when the body raises."""
     prov = mock.Mock()
     monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    monkeypatch.setattr(ingest_scale._counter, "last_release_thread", None)
     with contextlib.suppress(RuntimeError), ingest_scale.ingest_scale():
         raise RuntimeError("boom")
+    _join_release()
     prov.release_ingest_pool.assert_called_once()
 
 
@@ -35,11 +48,22 @@ def test_release_not_called_on_non_last_exit(monkeypatch):
     """Inner bracket exit does not call ``release_ingest_pool``."""
     prov = mock.Mock()
     monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    monkeypatch.setattr(ingest_scale._counter, "last_release_thread", None)
     with ingest_scale.ingest_scale():
         with ingest_scale.ingest_scale():
             pass
         prov.release_ingest_pool.assert_not_called()
+        assert ingest_scale._counter.last_release_thread is None  # no release spawned yet
+    _join_release()
     prov.release_ingest_pool.assert_called_once()
+
+
+def test_run_release_invokes_provider(monkeypatch):
+    """``_run_release`` calls ``release_ingest_pool`` on the resolved provider."""
+    prov = mock.Mock()
+    monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    ingest_scale._run_release()
+    prov.release_ingest_pool.assert_called_once_with()
 
 
 def test_routing_provider_release_ingest_pool_forwards_to_local():

--- a/tests/test_ingest_scale.py
+++ b/tests/test_ingest_scale.py
@@ -61,6 +61,15 @@ def test_routing_provider_release_ingest_pool_noop_without_local():
     rp.release_ingest_pool()  # must not raise
 
 
+def test_provider_resolver_returns_provider_from_get_services(monkeypatch):
+    """``_provider()`` imports ``get_services`` at call time and returns ``.provider``."""
+    sentinel = mock.Mock()
+    services = mock.Mock()
+    services.provider = sentinel
+    monkeypatch.setattr("lilbee.app.services.get_services", lambda: services)
+    assert ingest_scale._provider() is sentinel
+
+
 def test_sdk_llm_provider_release_ingest_pool_is_callable_noop():
     """``SdkLLMProvider.release_ingest_pool`` is a callable no-op."""
     from lilbee.providers.sdk_backend import LlmSdkBackend

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -328,3 +328,16 @@ class TestMaxConcurrent:
         monkeypatch.setattr(cfg, "vision_model", "")
         monkeypatch.setattr(cfg, "embed_replicas", 8)
         assert pipeline._max_concurrent() == 8
+
+    def test_auto_embed_replicas_fans_out_to_gpu_count(self, monkeypatch) -> None:
+        # embed_replicas=0 (the auto default) must fan out to one slot per GPU so
+        # a multi-GPU box does not stall extra cards waiting for ingest work.
+        import lilbee.providers.fleet.replicas as replicas_mod
+        from lilbee.data.ingest import pipeline
+
+        monkeypatch.setattr(pipeline, "cpu_quota", lambda: 2)
+        monkeypatch.setattr(cfg, "vision_model", "")
+        monkeypatch.setattr(cfg, "embed_replicas", 0)
+        monkeypatch.setattr(replicas_mod, "gpu_device_count", lambda: 4)
+        result = pipeline._max_concurrent()
+        assert result >= 4, f"expected at least 4 (one per GPU), got {result}"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -196,6 +196,30 @@ class TestRerankerConfig:
         assert SETTINGS_MAP["reranker_type"].choices == ("auto", "cross_encoder", "llm")
 
 
+class TestReplicaDefaults:
+    """embed/vision replica counts default to 0 = auto (one per GPU at placement)."""
+
+    def test_replicas_default_to_auto_zero(self):
+        from lilbee.core.config import Config
+
+        assert Config().embed_replicas == 0
+        assert Config().vision_replicas == 0
+
+    def test_replicas_accept_zero(self):
+        from lilbee.core.config import Config
+
+        assert Config(embed_replicas=0, vision_replicas=0).embed_replicas == 0
+
+    def test_replicas_reject_negative(self):
+        import pydantic
+        import pytest
+
+        from lilbee.core.config import Config
+
+        with pytest.raises(pydantic.ValidationError):
+            Config(embed_replicas=-1)
+
+
 class TestMemoryTuningSettingsMap:
     """The dynamic-ctx tuning knobs are surfaced in the TUI settings map."""
 


### PR DESCRIPTION
## Problem

The multi-GPU fleet sizes embed and vision replicas for ingest throughput and then keeps them resident in VRAM forever (the generated llama-swap config sets `ttl: 0` on every member, with no idle-unload). After an ingest, the embed replicas stay pinned. When a large chat model loads on top, VRAM saturates, llama-swap thrashes and re-listens on new ports, and lilbee loses the chat server handle, surfacing "No chat model server is running" even though a chat process is alive (bb-naa). Replica counts also default to 1 and never use the extra GPUs, while a naive auto-default to GPU count would make the crowding worse (bb-s61).

## Solution

The fleet now reserves a persistent query fleet first (chat, one embed, rerank, one vision) and places the extra ingest replicas only into the VRAM that remains, so a chat issued during an ingest always fits. When an ingest finishes, the extra replicas are unloaded one by one via llama-swap's `/api/models/unload`, freeing their VRAM without disturbing the resident chat (the unload runs off the request-serving loop). `embed_replicas` and `vision_replicas` default to one replica per GPU, capped by residual VRAM, and the 0-means-auto value is resolved the same way everywhere it is read. A dead or restarted llama-swap is now re-probed and rebuilt once before the fleet reports no server.

100% coverage, mypy strict, full suite green.

Validation: the VRAM-reclaim behavior of `/api/models/unload` is being validated on a multi-GPU pod. A two-swap fallback is documented if that endpoint does not cleanly reclaim VRAM.

Note: the placement-interaction guard (skip the pool release when a manual placement spec is set) is deferred until the manual-placement feature (#429) merges, since `cfg.placement` is not on this base branch.

Closes bb-naa, bb-s61.