### PR TITLE
Fix leaked llama-swap orphans on fleet shutdown

### DIFF
--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -338,6 +338,13 @@ class FleetProvider:
 
     def __init__(self) -> None:
         self._swap: SwapManager | None = None
+        # Latched once shutdown runs. A discarded provider (reset_services swaps
+        # in a new one) can still have an in-flight warm-up or reload daemon
+        # thread; without this latch that thread could start a llama-swap after
+        # shutdown already ran, leaving a process no live provider owns.
+        # _ensure_swap checks it under the build lock so a post-shutdown build is
+        # refused (the swap_manager reaper is the backstop if one slips through).
+        self._shut_down = False
         # A pool of OpenAI clients per placed role (one per data-parallel replica),
         # all pointed at the llama-swap endpoint and routed by replica model id;
         # rebuilt whenever the swap process (re)starts. Requests round-robin the pool.
@@ -399,6 +406,11 @@ class FleetProvider:
             with self._lock:
                 if self._swap is not None:
                     return self._swap
+                if self._shut_down:
+                    # Provider was shut down (and likely discarded by reset_services)
+                    # while this warm-up/reload thread was in flight; do not spawn a
+                    # llama-swap no live provider would ever reap.
+                    return None
             from lilbee.core.config import cfg
 
             swap = SwapManager(cfg.data_dir)
@@ -521,9 +533,17 @@ class FleetProvider:
         with self._build_lock:
             with self._lock:
                 swap = self._swap
+                self._shut_down = True
             self._drop_swap_refs()
-            if swap is not None:
-                swap.shutdown()
+            # Always tear down via the swap manager, even when this provider holds
+            # no tracked swap: an in-flight build may have started one this thread
+            # never adopted, and SwapManager.shutdown reaps every llama-swap this
+            # process spawned (keyed on our own children), not just a tracked handle.
+            if swap is None:
+                from lilbee.core.config import cfg
+
+                swap = SwapManager(cfg.data_dir)
+            swap.shutdown()
 
     def _drop_swap_refs(self) -> None:
         """Clear the swap, its clients, and the chat capacity so the next call rebuilds."""

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -140,6 +140,10 @@ class SwapManager:
         # Idempotent safety net; the provider reaps before planning so the GPU
         # probe already saw the real free memory.
         self.reap_stale()
+        # Singleton guard: one llama-swap per process. Reap any llama-swap this
+        # process already started (a leaked duplicate from a prior race/reload)
+        # before spawning, so they can never accumulate and double-book a GPU.
+        _stop_own_fleet(tuple(self._member_ports))
         ports = _pick_free_ports(1 + len(launches))
         member_ports = dict(zip([launch.model_id for launch in launches], ports[1:], strict=True))
         self._member_ports = sorted(member_ports.values())
@@ -263,14 +267,18 @@ class SwapManager:
         return self._proc is not None
 
     def shutdown(self) -> None:
-        """Stop llama-swap and every server it spawned (a no-op when not running).
+        """Stop every llama-swap this process started and reap their servers.
 
-        Unlinks only this owner's state file; another instance's record stays.
+        Authoritative teardown keyed on this process's own children, not on the
+        single tracked ``Popen``: a warm-up/reset race or a reload can leave a
+        second, untracked llama-swap this process spawned, and trusting only the
+        tracked handle would leak it (it ends reparented to init, still holding
+        the engine binary open). Every llama-swap among our own children is
+        stopped and their upstreams reaped, so no duplicate survives. Unlinks
+        only this owner's state file; another instance's record stays.
         """
-        proc = self._proc
-        if proc is not None:
-            _stop_process_tree(proc)
-            self._state_path.unlink(missing_ok=True)
+        _stop_own_fleet(tuple(self._member_ports))
+        self._state_path.unlink(missing_ok=True)
         self._proc = None
         self._port = None
         self._close_log()
@@ -335,22 +343,6 @@ def _pick_free_ports(count: int) -> list[int]:
             sock.close()
 
 
-def _stop_process_tree(proc: subprocess.Popen[bytes]) -> None:
-    """Stop llama-swap and reap any llama-server that outlives it.
-
-    llama-swap starts each server in its own process group (its Setpgid), so
-    signalling llama-swap's group never reaches the servers; a survivor keeps
-    its port bound and that port's next bind fails. The children are captured
-    while llama-swap is still alive, then swept after it stops.
-    """
-    children = _live_children(proc.pid)
-    if sys.platform == "win32":
-        _hard_stop(proc)
-    else:
-        _terminate_group(proc)
-    _reap_survivors(children)
-
-
 def _live_children(pid: int) -> list[psutil.Process]:
     """The process's current descendants, or none when it already exited."""
     try:
@@ -382,26 +374,77 @@ def _await_killed(procs: list[psutil.Process]) -> None:
         log.warning("Process %s survived SIGKILL; its VRAM may still be held.", proc.pid)
 
 
-def _terminate_group(proc: subprocess.Popen[bytes]) -> None:
-    """SIGTERM the process group, escalating to SIGKILL on timeout."""
+def _own_llama_swaps() -> list[psutil.Process]:
+    """Every live llama-swap this process started (its own direct children).
+
+    Scoped to children of the current process: a sibling lilbee at the same
+    data_dir owns its swaps as *its* children, never ours, so this can never
+    reap another instance's fleet. Catches the tracked swap and any duplicate
+    this process leaked (an untracked swap a race or reload left behind is still
+    our child while we are alive).
+    """
+    try:
+        kids = psutil.Process().children(recursive=False)
+    except psutil.NoSuchProcess:  # pragma: no cover - self always exists
+        return []
+    swaps: list[psutil.Process] = []
+    for proc in kids:
+        try:
+            binary = Path(next(iter(proc.cmdline()), "")).name
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        if _LLAMA_SWAP_PROCESS_NAME in binary:
+            swaps.append(proc)
+    return swaps
+
+
+def _stop_own_fleet(member_ports: tuple[int, ...]) -> None:
+    """Stop every llama-swap this process started and reap their upstreams.
+
+    Each llama-swap runs in its own session, and it starts each llama-server in
+    yet another process group, so signalling one group never reaches the others.
+    The upstreams are captured as descendants while their swap is still alive,
+    the swaps are stopped, then every survivor -- those descendants plus any
+    llama-server still bound to one of our member ports (a respawned upstream the
+    descendant snapshot missed) -- is reaped and confirmed gone.
+    """
+    swaps = _own_llama_swaps()
+    children: list[psutil.Process] = []
+    for swap in swaps:
+        children.extend(_live_children(swap.pid))
+    for swap in swaps:
+        if sys.platform == "win32":
+            _hard_stop_proc(swap)
+        else:
+            _terminate_proc_group(swap)
+    _reap_survivors(children + _find_orphan_servers(member_ports))
+
+
+def _terminate_proc_group(proc: psutil.Process) -> None:
+    """SIGTERM a process's group, escalating to SIGKILL on timeout."""
     try:
         pgid = os.getpgid(proc.pid)
-    except ProcessLookupError:  # pragma: no cover - process exited between checks
+    except (ProcessLookupError, OSError):  # pragma: no cover - exited between checks
         return
-    os.killpg(pgid, signal.SIGTERM)
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGTERM)
     try:
         proc.wait(timeout=_STOP_TIMEOUT_S)
-    except subprocess.TimeoutExpired:
-        os.killpg(pgid, _SIGKILL)
+    except psutil.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(pgid, _SIGKILL)
+        _await_killed([proc])
 
 
-def _hard_stop(proc: subprocess.Popen[bytes]) -> None:
-    """Terminate the process, escalating to a hard kill on timeout (Windows path)."""
-    proc.terminate()
+def _hard_stop_proc(proc: psutil.Process) -> None:
+    """Terminate a process, escalating to a hard kill on timeout (Windows path)."""
+    with contextlib.suppress(psutil.NoSuchProcess):
+        proc.terminate()
     try:
         proc.wait(timeout=_STOP_TIMEOUT_S)
-    except subprocess.TimeoutExpired:
-        proc.kill()
+    except psutil.TimeoutExpired:
+        with contextlib.suppress(psutil.NoSuchProcess):
+            proc.kill()
 
 
 def _load_state(path: Path) -> _SwapState | None:

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -15,6 +15,7 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -98,6 +99,21 @@ def _platform_const(module: object, name: str, default: int) -> int:
 _CREATE_NEW_PROCESS_GROUP: int = _platform_const(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
 _SIGKILL: int = _platform_const(signal, "SIGKILL", signal.SIGTERM)
 
+# Every llama-swap pid THIS process has started, across all SwapManager / provider
+# instances. Process-global (not per-manager) so a duplicate a warm-up/reset/reload
+# race spawned on a since-discarded provider is still reaped at shutdown -- and
+# reaping keys on the recorded pid, not the live parent, so a llama-swap that
+# llama-swap's own restart leaves reparented to init is still caught. Scoped to
+# our own starts, so a sibling lilbee at the same data_dir is never touched.
+_OWN_SWAP_PIDS: set[int] = set()
+_OWN_SWAP_PIDS_LOCK = threading.Lock()
+
+
+def _register_own_swap(pid: int) -> None:
+    """Record a llama-swap pid this process started, for authoritative teardown."""
+    with _OWN_SWAP_PIDS_LOCK:
+        _OWN_SWAP_PIDS.add(pid)
+
 
 def _state_filename(owner_pid: int) -> str:
     """The per-owner state filename for the lilbee process *owner_pid*."""
@@ -168,6 +184,7 @@ class SwapManager:
             start_new_session=True,
             creationflags=_CREATE_NEW_PROCESS_GROUP,
         )
+        _register_own_swap(self._proc.pid)
         self._write_state()
         self._await_health()
 
@@ -375,26 +392,34 @@ def _await_killed(procs: list[psutil.Process]) -> None:
 
 
 def _own_llama_swaps() -> list[psutil.Process]:
-    """Every live llama-swap this process started (its own direct children).
+    """Every live llama-swap this process started, by recorded pid.
 
-    Scoped to children of the current process: a sibling lilbee at the same
-    data_dir owns its swaps as *its* children, never ours, so this can never
-    reap another instance's fleet. Catches the tracked swap and any duplicate
-    this process leaked (an untracked swap a race or reload left behind is still
-    our child while we are alive).
+    Keyed on the process-global pid registry rather than the live process tree:
+    a llama-swap that has been reparented to init (llama-swap restarts an upstream
+    by respawning, and a leaked duplicate ends owned by init once its provider is
+    gone) is no longer our child, so a ``children()`` scan would miss it -- but
+    its pid is still valid and killable. A recorded pid that now belongs to a
+    different process (pid reuse) or to something that is not llama-swap is
+    skipped via the binary-name check, and dead pids are pruned from the registry.
     """
-    try:
-        kids = psutil.Process().children(recursive=False)
-    except psutil.NoSuchProcess:  # pragma: no cover - self always exists
-        return []
+    with _OWN_SWAP_PIDS_LOCK:
+        pids = sorted(_OWN_SWAP_PIDS)
     swaps: list[psutil.Process] = []
-    for proc in kids:
+    dead: set[int] = set()
+    for pid in pids:
         try:
+            proc = psutil.Process(pid)
             binary = Path(next(iter(proc.cmdline()), "")).name
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            dead.add(pid)
             continue
         if _LLAMA_SWAP_PROCESS_NAME in binary:
             swaps.append(proc)
+        else:
+            dead.add(pid)  # pid reused by an unrelated process
+    if dead:
+        with _OWN_SWAP_PIDS_LOCK:
+            _OWN_SWAP_PIDS.difference_update(dead)
     return swaps
 
 
@@ -418,6 +443,9 @@ def _stop_own_fleet(member_ports: tuple[int, ...]) -> None:
         else:
             _terminate_proc_group(swap)
     _reap_survivors(children + _find_orphan_servers(member_ports))
+    if swaps:
+        with _OWN_SWAP_PIDS_LOCK:
+            _OWN_SWAP_PIDS.difference_update(swap.pid for swap in swaps)
 
 
 def _terminate_proc_group(proc: psutil.Process) -> None:

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -15,7 +15,6 @@ import signal
 import socket
 import subprocess
 import sys
-import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -99,21 +98,6 @@ def _platform_const(module: object, name: str, default: int) -> int:
 _CREATE_NEW_PROCESS_GROUP: int = _platform_const(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
 _SIGKILL: int = _platform_const(signal, "SIGKILL", signal.SIGTERM)
 
-# Every llama-swap pid THIS process has started, across all SwapManager / provider
-# instances. Process-global (not per-manager) so a duplicate a warm-up/reset/reload
-# race spawned on a since-discarded provider is still reaped at shutdown -- and
-# reaping keys on the recorded pid, not the live parent, so a llama-swap that
-# llama-swap's own restart leaves reparented to init is still caught. Scoped to
-# our own starts, so a sibling lilbee at the same data_dir is never touched.
-_OWN_SWAP_PIDS: set[int] = set()
-_OWN_SWAP_PIDS_LOCK = threading.Lock()
-
-
-def _register_own_swap(pid: int) -> None:
-    """Record a llama-swap pid this process started, for authoritative teardown."""
-    with _OWN_SWAP_PIDS_LOCK:
-        _OWN_SWAP_PIDS.add(pid)
-
 
 def _state_filename(owner_pid: int) -> str:
     """The per-owner state filename for the lilbee process *owner_pid*."""
@@ -156,10 +140,11 @@ class SwapManager:
         # Idempotent safety net; the provider reaps before planning so the GPU
         # probe already saw the real free memory.
         self.reap_stale()
-        # Singleton guard: one llama-swap per process. Reap any llama-swap this
-        # process already started (a leaked duplicate from a prior race/reload)
-        # before spawning, so they can never accumulate and double-book a GPU.
-        _stop_own_fleet(tuple(self._member_ports))
+        # Singleton guard: one llama-swap per data_dir for this lilbee. Reap any
+        # llama-swap we already started against this config (a leaked duplicate
+        # from a prior race/reload) before spawning, so they cannot accumulate
+        # and double-book a GPU.
+        _stop_own_fleet(self._config_path, tuple(self._member_ports))
         ports = _pick_free_ports(1 + len(launches))
         member_ports = dict(zip([launch.model_id for launch in launches], ports[1:], strict=True))
         self._member_ports = sorted(member_ports.values())
@@ -184,7 +169,6 @@ class SwapManager:
             start_new_session=True,
             creationflags=_CREATE_NEW_PROCESS_GROUP,
         )
-        _register_own_swap(self._proc.pid)
         self._write_state()
         self._await_health()
 
@@ -284,17 +268,17 @@ class SwapManager:
         return self._proc is not None
 
     def shutdown(self) -> None:
-        """Stop every llama-swap this process started and reap their servers.
+        """Stop every llama-swap this lilbee owns at our config and reap servers.
 
-        Authoritative teardown keyed on this process's own children, not on the
-        single tracked ``Popen``: a warm-up/reset race or a reload can leave a
-        second, untracked llama-swap this process spawned, and trusting only the
-        tracked handle would leak it (it ends reparented to init, still holding
-        the engine binary open). Every llama-swap among our own children is
-        stopped and their upstreams reaped, so no duplicate survives. Unlinks
-        only this owner's state file; another instance's record stays.
+        Authoritative teardown keyed on config-path identity, not the single
+        tracked ``Popen``: a warm-up/reset race or a reload can leave several
+        llama-swap processes this lilbee spawned, any of them reparented to init
+        (still holding the engine binary open) -- trusting one handle would leak
+        them. Every llama-swap running against our config is reaped (sparing a
+        live sibling lilbee at the same data_dir). Unlinks only this owner's state
+        file; another instance's record stays.
         """
-        _stop_own_fleet(tuple(self._member_ports))
+        _stop_own_fleet(self._config_path, tuple(self._member_ports))
         self._state_path.unlink(missing_ok=True)
         self._proc = None
         self._port = None
@@ -391,49 +375,60 @@ def _await_killed(procs: list[psutil.Process]) -> None:
         log.warning("Process %s survived SIGKILL; its VRAM may still be held.", proc.pid)
 
 
-def _own_llama_swaps() -> list[psutil.Process]:
-    """Every live llama-swap this process started, by recorded pid.
+def _swaps_for_config(config_path: Path) -> list[psutil.Process]:
+    """Every live llama-swap (any owner) running against *config_path*.
 
-    Keyed on the process-global pid registry rather than the live process tree:
-    a llama-swap that has been reparented to init (llama-swap restarts an upstream
-    by respawning, and a leaked duplicate ends owned by init once its provider is
-    gone) is no longer our child, so a ``children()`` scan would miss it -- but
-    its pid is still valid and killable. A recorded pid that now belongs to a
-    different process (pid reuse) or to something that is not llama-swap is
-    skipped via the binary-name check, and dead pids are pruned from the registry.
+    Identity is the ``-config <path>`` argument, which every llama-swap this
+    lilbee starts carries and which survives reparenting to init -- so this finds
+    a leaked duplicate or a swap reparented away from us, neither of which a
+    tracked Popen handle nor a ``children()`` scan would catch.
     """
-    with _OWN_SWAP_PIDS_LOCK:
-        pids = sorted(_OWN_SWAP_PIDS)
+    target = str(config_path)
     swaps: list[psutil.Process] = []
-    dead: set[int] = set()
-    for pid in pids:
+    for proc in psutil.process_iter():
         try:
-            proc = psutil.Process(pid)
-            binary = Path(next(iter(proc.cmdline()), "")).name
+            cmdline = proc.cmdline()
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
-            dead.add(pid)
             continue
-        if _LLAMA_SWAP_PROCESS_NAME in binary:
+        binary = Path(next(iter(cmdline), "")).name
+        if _LLAMA_SWAP_PROCESS_NAME in binary and target in cmdline:
             swaps.append(proc)
-        else:
-            dead.add(pid)  # pid reused by an unrelated process
-    if dead:
-        with _OWN_SWAP_PIDS_LOCK:
-            _OWN_SWAP_PIDS.difference_update(dead)
     return swaps
 
 
-def _stop_own_fleet(member_ports: tuple[int, ...]) -> None:
-    """Stop every llama-swap this process started and reap their upstreams.
+def _live_sibling_swap_pids(data_dir: Path) -> set[int]:
+    """Swap pids a live *other* owner recorded at *data_dir* (spare these).
 
-    Each llama-swap runs in its own session, and it starts each llama-server in
-    yet another process group, so signalling one group never reaches the others.
-    The upstreams are captured as descendants while their swap is still alive,
-    the swaps are stopped, then every survivor -- those descendants plus any
-    llama-server still bound to one of our member ports (a respawned upstream the
-    descendant snapshot missed) -- is reaped and confirmed gone.
+    A concurrent sibling lilbee on the same data_dir (e.g. ``lilbee sync`` beside
+    the server) shares the config path, so a config-path reap would otherwise
+    kill its healthy swap. Its state file names the swap pid to protect.
     """
-    swaps = _own_llama_swaps()
+    our_pid = os.getpid()
+    protected: set[int] = set()
+    for state_path in data_dir.glob(_STATE_FILE_GLOB):
+        state = _load_state(state_path)
+        if state is None or state.owner_pid in (None, our_pid):
+            continue
+        if _owner_alive(state.owner_pid, state.owner_created_at):
+            protected.add(state.pid)
+    return protected
+
+
+def _stop_own_fleet(config_path: Path, member_ports: tuple[int, ...]) -> None:
+    """Stop every llama-swap this lilbee owns at *config_path* and reap upstreams.
+
+    Keyed on config-path identity rather than a tracked Popen or the live process
+    tree: a warm-up/reload race can leave several llama-swap processes this lilbee
+    started, any of which may be reparented to init, so no single handle or child
+    scan finds them all. Every llama-swap running against our config is reaped
+    EXCEPT one a live *other* owner recorded -- a concurrent sibling lilbee at the
+    same data_dir is left alone. Each swap runs each llama-server in its own
+    process group, so the upstreams are swept separately: captured descendants
+    plus any llama-server still bound to one of our member ports (a respawned
+    upstream the descendant snapshot missed), then confirmed gone.
+    """
+    protected = _live_sibling_swap_pids(config_path.parent)
+    swaps = [swap for swap in _swaps_for_config(config_path) if swap.pid not in protected]
     children: list[psutil.Process] = []
     for swap in swaps:
         children.extend(_live_children(swap.pid))
@@ -443,9 +438,6 @@ def _stop_own_fleet(member_ports: tuple[int, ...]) -> None:
         else:
             _terminate_proc_group(swap)
     _reap_survivors(children + _find_orphan_servers(member_ports))
-    if swaps:
-        with _OWN_SWAP_PIDS_LOCK:
-            _OWN_SWAP_PIDS.difference_update(swap.pid for swap in swaps)
 
 
 def _terminate_proc_group(proc: psutil.Process) -> None:

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -434,6 +434,19 @@ def _stop_own_fleet(member_ports: tuple[int, ...]) -> None:
     descendant snapshot missed) -- is reaped and confirmed gone.
     """
     swaps = _own_llama_swaps()
+    with _OWN_SWAP_PIDS_LOCK:
+        _dbg_registry = sorted(_OWN_SWAP_PIDS)
+    _dbg_all = subprocess.run(
+        ["pgrep", "-af", "llama-swap"], capture_output=True, text=True, check=False
+    ).stdout.strip()
+    log.warning(
+        "DBG _stop_own_fleet: pid=%s registry=%s own_swaps=%s member_ports=%s all_llama_swap=%r",
+        os.getpid(),
+        _dbg_registry,
+        [s.pid for s in swaps],
+        member_ports,
+        _dbg_all,
+    )
     children: list[psutil.Process] = []
     for swap in swaps:
         children.extend(_live_children(swap.pid))
@@ -446,6 +459,10 @@ def _stop_own_fleet(member_ports: tuple[int, ...]) -> None:
     if swaps:
         with _OWN_SWAP_PIDS_LOCK:
             _OWN_SWAP_PIDS.difference_update(swap.pid for swap in swaps)
+    _dbg_after = subprocess.run(
+        ["pgrep", "-af", "llama-swap"], capture_output=True, text=True, check=False
+    ).stdout.strip()
+    log.warning("DBG _stop_own_fleet done: surviving_llama_swap=%r", _dbg_after)
 
 
 def _terminate_proc_group(proc: psutil.Process) -> None:

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -434,19 +434,6 @@ def _stop_own_fleet(member_ports: tuple[int, ...]) -> None:
     descendant snapshot missed) -- is reaped and confirmed gone.
     """
     swaps = _own_llama_swaps()
-    with _OWN_SWAP_PIDS_LOCK:
-        _dbg_registry = sorted(_OWN_SWAP_PIDS)
-    _dbg_all = subprocess.run(
-        ["pgrep", "-af", "llama-swap"], capture_output=True, text=True, check=False
-    ).stdout.strip()
-    log.warning(
-        "DBG _stop_own_fleet: pid=%s registry=%s own_swaps=%s member_ports=%s all_llama_swap=%r",
-        os.getpid(),
-        _dbg_registry,
-        [s.pid for s in swaps],
-        member_ports,
-        _dbg_all,
-    )
     children: list[psutil.Process] = []
     for swap in swaps:
         children.extend(_live_children(swap.pid))
@@ -459,10 +446,6 @@ def _stop_own_fleet(member_ports: tuple[int, ...]) -> None:
     if swaps:
         with _OWN_SWAP_PIDS_LOCK:
             _OWN_SWAP_PIDS.difference_update(swap.pid for swap in swaps)
-    _dbg_after = subprocess.run(
-        ["pgrep", "-af", "llama-swap"], capture_output=True, text=True, check=False
-    ).stdout.strip()
-    log.warning("DBG _stop_own_fleet done: surviving_llama_swap=%r", _dbg_after)
 
 
 def _terminate_proc_group(proc: psutil.Process) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -159,6 +159,17 @@ def test_adopt_swap_builds_a_client_per_replica(monkeypatch) -> None:
     assert len(p._clients[WorkerRole.EMBED]) == 2  # one client per replica launch
 
 
+def test_ensure_swap_refused_after_shutdown(monkeypatch) -> None:
+    """bb-dpp source guard: once shut down (and likely discarded by reset_services),
+    a lingering warm-up/reload thread's _ensure_swap must not spawn a new llama-swap
+    on the dead provider -- that is exactly the duplicate that leaks on teardown."""
+    swap = _install_engine(monkeypatch, launches=[_fake_launch(WorkerRole.CHAT)])
+    p = FleetProvider()
+    p._shutdown_swap()  # latches _shut_down (and reaps via a fresh SwapManager)
+    assert p._ensure_swap() is None
+    assert swap.started == []  # no swap started after shutdown
+
+
 def test_adopt_swap_retires_old_clients_without_closing(monkeypatch) -> None:
     # Re-adopting (a reload) must not close old clients in place (a
     # reader may still hold one); they are retired for deferred close.

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -389,6 +389,30 @@ class TestProcessTeardown:
         result = sm._swaps_for_config(Path("/data/llama-swap.json"))
         assert [p.pid for p in result] == [10]
 
+    def test_live_sibling_swap_pids_protects_only_live_other_owner(self, tmp_path: Path) -> None:
+        # Only a swap recorded by a LIVE OTHER owner is protected: our own record
+        # is excluded (we reap our own), and a dead owner's record is not spared.
+        def _write(owner_pid: int, owner_created_at: float, swap_pid: int) -> None:
+            (tmp_path / sm._state_filename(owner_pid)).write_text(
+                json.dumps(
+                    {
+                        "pid": swap_pid,
+                        "pgid": swap_pid,
+                        "owner_pid": owner_pid,
+                        "owner_created_at": owner_created_at,
+                        "created_at": None,
+                        "member_ports": [],
+                    }
+                )
+            )
+
+        other_pid = os.getppid()  # a real live process that is not us
+        other_created = sm.psutil.Process(other_pid).create_time()
+        _write(os.getpid(), sm.psutil.Process().create_time(), 111)  # ours -> excluded
+        _write(other_pid, other_created, 222)  # live other -> protected
+        _write(999_999, 1.0, 333)  # dead owner -> not protected
+        assert sm._live_sibling_swap_pids(tmp_path) == {222}
+
     def test_reap_survivors_kills_after_grace(self, monkeypatch: pytest.MonkeyPatch) -> None:
         stubborn = _FakeChild(running=True)
         monkeypatch.setattr(sm.psutil, "wait_procs", lambda procs, timeout: ([], [stubborn]))

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -56,7 +56,7 @@ def _patch_spawn(monkeypatch: pytest.MonkeyPatch, proc: _FakeProc) -> None:
     monkeypatch.setattr(sm, "resolve_llama_swap", lambda: Path("/fake/llama-swap"))
     monkeypatch.setattr(sm.subprocess, "Popen", lambda *a, **k: proc)
     # Isolate lifecycle tests from the real process-tree teardown.
-    monkeypatch.setattr(sm, "_stop_process_tree", lambda p: None)
+    monkeypatch.setattr(sm, "_stop_own_fleet", lambda ports: None)
 
 
 def _patch_http(monkeypatch: pytest.MonkeyPatch, responder) -> None:
@@ -106,7 +106,7 @@ class TestStart:
 
         monkeypatch.setattr(sm, "resolve_llama_swap", lambda: Path("/fake/llama-swap"))
         monkeypatch.setattr(sm.subprocess, "Popen", _capturing_popen)
-        monkeypatch.setattr(sm, "_stop_process_tree", lambda p: None)
+        monkeypatch.setattr(sm, "_stop_own_fleet", lambda ports: None)
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
 
         mgr = SwapManager(tmp_path)
@@ -208,17 +208,28 @@ class TestLifecycle:
     def test_shutdown_is_noop_when_not_started(self, tmp_path: Path) -> None:
         SwapManager(tmp_path).shutdown()  # must not raise
 
+    def test_shutdown_reaps_owned_fleet_even_without_a_tracked_proc(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """bb-dpp: a duplicate llama-swap this process leaked is never recorded in
+        ``_proc``, so shutdown must reap by our own children regardless. Teardown
+        runs even when no swap is tracked."""
+        reaped: list[tuple[int, ...]] = []
+        monkeypatch.setattr(sm, "_stop_own_fleet", lambda ports: reaped.append(ports))
+        SwapManager(tmp_path).shutdown()  # never started -> _proc is None
+        assert reaped == [()]  # the owned-fleet reaper still ran
+
     def test_shutdown_terminates_and_clears(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         terminated: list[object] = []
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        monkeypatch.setattr(sm, "_stop_process_tree", lambda p: terminated.append(p))
+        monkeypatch.setattr(sm, "_stop_own_fleet", lambda ports: terminated.append(ports))
         mgr = SwapManager(tmp_path)
         mgr.start([_launch(WorkerRole.CHAT)])
         mgr.shutdown()
-        assert terminated  # the process tree was torn down
+        assert terminated  # the owned fleet was torn down
         with pytest.raises(ProviderError):
             mgr.endpoint()  # port cleared after shutdown
 
@@ -262,16 +273,16 @@ class TestProcessTeardown:
         assert len(set(ports)) == 3
         assert all(1024 < port <= 65535 for port in ports)
 
-    def test_terminate_group_posix_sigterm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_terminate_proc_group_posix_sigterm(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sm.os, "getpgid", lambda _pid: 99, raising=False)
         signals: list[int] = []
         monkeypatch.setattr(
             sm.os, "killpg", lambda _pgid, signum: signals.append(signum), raising=False
         )
-        sm._terminate_group(_FakeProc(poll_result=None))
+        sm._terminate_proc_group(_FakeProc(poll_result=None))
         assert signals == [sm.signal.SIGTERM]
 
-    def test_terminate_group_escalates_to_sigkill_on_timeout(
+    def test_terminate_proc_group_escalates_to_sigkill_on_timeout(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(sm.os, "getpgid", lambda _pid: 99, raising=False)
@@ -279,43 +290,83 @@ class TestProcessTeardown:
         monkeypatch.setattr(
             sm.os, "killpg", lambda _pgid, signum: signals.append(signum), raising=False
         )
+        monkeypatch.setattr(sm, "_await_killed", lambda procs: None)
 
         class _Stuck(_FakeProc):
             def wait(self, timeout: float | None = None) -> int:
-                raise subprocess.TimeoutExpired("llama-swap", timeout or 0)
+                raise sm.psutil.TimeoutExpired(timeout or 0)
 
-        sm._terminate_group(_Stuck(poll_result=None))
+        sm._terminate_proc_group(_Stuck(poll_result=None))
         assert signals == [sm.signal.SIGTERM, sm._SIGKILL]
 
-    def test_stop_process_tree_windows_hard_stops(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sm.sys, "platform", "win32")
-        monkeypatch.setattr(sm, "_live_children", lambda _pid: [])
+    def test_stop_own_fleet_windows_hard_stops_each_swap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         proc = _FakeProc(poll_result=None)
-        sm._stop_process_tree(proc)
+        monkeypatch.setattr(sm.sys, "platform", "win32")
+        monkeypatch.setattr(sm, "_own_llama_swaps", lambda: [proc])
+        monkeypatch.setattr(sm, "_live_children", lambda _pid: [])
+        monkeypatch.setattr(sm, "_find_orphan_servers", lambda ports: [])
+        monkeypatch.setattr(sm, "_reap_survivors", lambda procs: None)
+        sm._stop_own_fleet(())
         assert proc.terminated is True
 
-    def test_stop_process_tree_posix_terminates_group(
+    def test_stop_own_fleet_posix_terminates_each_owned_swap(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        proc = _FakeProc(poll_result=None)
         monkeypatch.setattr(sm.sys, "platform", "linux")
+        monkeypatch.setattr(sm, "_own_llama_swaps", lambda: [proc])
         monkeypatch.setattr(sm, "_live_children", lambda _pid: [])
+        monkeypatch.setattr(sm, "_find_orphan_servers", lambda ports: [])
         groups: list[object] = []
-        monkeypatch.setattr(sm, "_terminate_group", lambda p: groups.append(p))
-        sm._stop_process_tree(_FakeProc(poll_result=None))
-        assert groups
+        monkeypatch.setattr(sm, "_terminate_proc_group", lambda p: groups.append(p))
+        monkeypatch.setattr(sm, "_reap_survivors", lambda procs: None)
+        sm._stop_own_fleet(())
+        assert groups == [proc]
 
-    def test_stop_process_tree_reaps_surviving_children(
+    def test_stop_own_fleet_reaps_children_and_port_servers(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # llama-swap puts each server in its own process group, so the group
-        # kill misses them; a survivor must be swept or it keeps its port.
-        survivor = _FakeChild(running=True)
+        # llama-swap puts each server in its own process group, so terminating
+        # the swap misses them; both a captured descendant and a member-port
+        # server the snapshot missed (a respawned upstream) must be swept.
+        child = _FakeChild(running=True)
+        port_server = _FakeChild(running=True)
+        reaped: list[object] = []
         monkeypatch.setattr(sm.sys, "platform", "linux")
-        monkeypatch.setattr(sm, "_live_children", lambda _pid: [survivor])
-        monkeypatch.setattr(sm, "_terminate_group", lambda p: None)
-        monkeypatch.setattr(sm.psutil, "wait_procs", lambda procs, timeout: ([], []))
-        sm._stop_process_tree(_FakeProc(poll_result=None))
-        assert survivor.terminated is True
+        monkeypatch.setattr(sm, "_own_llama_swaps", lambda: [_FakeProc(poll_result=None)])
+        monkeypatch.setattr(sm, "_live_children", lambda _pid: [child])
+        monkeypatch.setattr(sm, "_find_orphan_servers", lambda ports: [port_server])
+        monkeypatch.setattr(sm, "_terminate_proc_group", lambda p: None)
+        monkeypatch.setattr(sm, "_reap_survivors", lambda procs: reaped.extend(procs))
+        sm._stop_own_fleet((1234,))
+        assert child in reaped
+        assert port_server in reaped
+
+    def test_own_llama_swaps_returns_only_own_swap_children(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Scoped to this process's children and to the llama-swap binary: a
+        # sibling lilbee's swap (not our child) and our non-swap children are
+        # excluded, so reaping can never touch another instance's fleet.
+        class _Kid:
+            def __init__(self, argv: str) -> None:
+                self.pid = abs(hash(argv)) % 100000
+                self._argv = argv
+
+            def cmdline(self) -> list[str]:
+                return [self._argv]
+
+        swap_kid = _Kid("/x/bin/llama-swap")
+        server_kid = _Kid("/x/bin/llama-server")
+        monkeypatch.setattr(
+            sm.psutil,
+            "Process",
+            lambda *a: type("P", (), {"children": lambda self, **k: [swap_kid, server_kid]})(),
+        )
+        result = sm._own_llama_swaps()
+        assert result == [swap_kid]
 
     def test_reap_survivors_kills_after_grace(self, monkeypatch: pytest.MonkeyPatch) -> None:
         stubborn = _FakeChild(running=True)
@@ -375,13 +426,13 @@ class TestProcessTeardown:
             proc.kill()
             proc.wait()
 
-    def test_hard_stop_kills_on_timeout(self) -> None:
+    def test_hard_stop_proc_kills_on_timeout(self) -> None:
         class _Stuck(_FakeProc):
             def wait(self, timeout: float | None = None) -> int:
-                raise subprocess.TimeoutExpired("llama-swap", timeout or 0)
+                raise sm.psutil.TimeoutExpired(timeout or 0)
 
         proc = _Stuck(poll_result=None)
-        sm._hard_stop(proc)
+        sm._hard_stop_proc(proc)
         assert proc.killed is True
 
 

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -344,29 +344,33 @@ class TestProcessTeardown:
         assert child in reaped
         assert port_server in reaped
 
-    def test_own_llama_swaps_returns_only_own_swap_children(
+    def test_own_llama_swaps_resolves_registered_pids_and_prunes(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Scoped to this process's children and to the llama-swap binary: a
-        # sibling lilbee's swap (not our child) and our non-swap children are
-        # excluded, so reaping can never touch another instance's fleet.
-        class _Kid:
-            def __init__(self, argv: str) -> None:
-                self.pid = abs(hash(argv)) % 100000
+        # Keyed on the recorded-pid registry (immune to reparenting), not the
+        # live child tree. A live llama-swap pid is returned; a dead pid and a
+        # reused pid now running something else are dropped from the registry.
+        class _Proc:
+            def __init__(self, pid: int, argv: str) -> None:
+                self.pid = pid
                 self._argv = argv
 
             def cmdline(self) -> list[str]:
                 return [self._argv]
 
-        swap_kid = _Kid("/x/bin/llama-swap")
-        server_kid = _Kid("/x/bin/llama-server")
-        monkeypatch.setattr(
-            sm.psutil,
-            "Process",
-            lambda *a: type("P", (), {"children": lambda self, **k: [swap_kid, server_kid]})(),
-        )
+        live = {10: "/x/bin/llama-swap", 11: "/x/bin/python"}  # 11 = reused pid
+
+        def _fake_process(pid: int) -> _Proc:
+            if pid not in live:
+                raise sm.psutil.NoSuchProcess(pid)
+            return _Proc(pid, live[pid])
+
+        monkeypatch.setattr(sm.psutil, "Process", _fake_process)
+        monkeypatch.setattr(sm, "_OWN_SWAP_PIDS", {10, 11, 12})  # 12 = dead
         result = sm._own_llama_swaps()
-        assert result == [swap_kid]
+        assert [p.pid for p in result] == [10]
+        # The dead (12) and pid-reused (11) entries are pruned; the live one stays.
+        assert sm._OWN_SWAP_PIDS == {10}
 
     def test_reap_survivors_kills_after_grace(self, monkeypatch: pytest.MonkeyPatch) -> None:
         stubborn = _FakeChild(running=True)

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -56,7 +56,7 @@ def _patch_spawn(monkeypatch: pytest.MonkeyPatch, proc: _FakeProc) -> None:
     monkeypatch.setattr(sm, "resolve_llama_swap", lambda: Path("/fake/llama-swap"))
     monkeypatch.setattr(sm.subprocess, "Popen", lambda *a, **k: proc)
     # Isolate lifecycle tests from the real process-tree teardown.
-    monkeypatch.setattr(sm, "_stop_own_fleet", lambda ports: None)
+    monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: None)
 
 
 def _patch_http(monkeypatch: pytest.MonkeyPatch, responder) -> None:
@@ -106,7 +106,7 @@ class TestStart:
 
         monkeypatch.setattr(sm, "resolve_llama_swap", lambda: Path("/fake/llama-swap"))
         monkeypatch.setattr(sm.subprocess, "Popen", _capturing_popen)
-        monkeypatch.setattr(sm, "_stop_own_fleet", lambda ports: None)
+        monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: None)
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
 
         mgr = SwapManager(tmp_path)
@@ -211,13 +211,14 @@ class TestLifecycle:
     def test_shutdown_reaps_owned_fleet_even_without_a_tracked_proc(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """bb-dpp: a duplicate llama-swap this process leaked is never recorded in
-        ``_proc``, so shutdown must reap by our own children regardless. Teardown
-        runs even when no swap is tracked."""
-        reaped: list[tuple[int, ...]] = []
-        monkeypatch.setattr(sm, "_stop_own_fleet", lambda ports: reaped.append(ports))
-        SwapManager(tmp_path).shutdown()  # never started -> _proc is None
-        assert reaped == [()]  # the owned-fleet reaper still ran
+        """bb-dpp: a duplicate llama-swap this lilbee leaked is never recorded in
+        ``_proc``, so shutdown must reap by config-path identity regardless.
+        Teardown runs even when no swap is tracked."""
+        reaped: list[Path] = []
+        monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: reaped.append(cfg))
+        mgr = SwapManager(tmp_path)
+        mgr.shutdown()  # never started -> _proc is None
+        assert reaped == [mgr._config_path]  # the config-path reaper still ran
 
     def test_shutdown_terminates_and_clears(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -225,7 +226,7 @@ class TestLifecycle:
         terminated: list[object] = []
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        monkeypatch.setattr(sm, "_stop_own_fleet", lambda ports: terminated.append(ports))
+        monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: terminated.append(cfg))
         mgr = SwapManager(tmp_path)
         mgr.start([_launch(WorkerRole.CHAT)])
         mgr.shutdown()
@@ -299,16 +300,19 @@ class TestProcessTeardown:
         sm._terminate_proc_group(_Stuck(poll_result=None))
         assert signals == [sm.signal.SIGTERM, sm._SIGKILL]
 
+    _CFG = Path("/data/llama-swap.json")
+
     def test_stop_own_fleet_windows_hard_stops_each_swap(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         proc = _FakeProc(poll_result=None)
         monkeypatch.setattr(sm.sys, "platform", "win32")
-        monkeypatch.setattr(sm, "_own_llama_swaps", lambda: [proc])
+        monkeypatch.setattr(sm, "_swaps_for_config", lambda _cfg: [proc])
+        monkeypatch.setattr(sm, "_live_sibling_swap_pids", lambda _dir: set())
         monkeypatch.setattr(sm, "_live_children", lambda _pid: [])
         monkeypatch.setattr(sm, "_find_orphan_servers", lambda ports: [])
         monkeypatch.setattr(sm, "_reap_survivors", lambda procs: None)
-        sm._stop_own_fleet(())
+        sm._stop_own_fleet(self._CFG, ())
         assert proc.terminated is True
 
     def test_stop_own_fleet_posix_terminates_each_owned_swap(
@@ -316,14 +320,33 @@ class TestProcessTeardown:
     ) -> None:
         proc = _FakeProc(poll_result=None)
         monkeypatch.setattr(sm.sys, "platform", "linux")
-        monkeypatch.setattr(sm, "_own_llama_swaps", lambda: [proc])
+        monkeypatch.setattr(sm, "_swaps_for_config", lambda _cfg: [proc])
+        monkeypatch.setattr(sm, "_live_sibling_swap_pids", lambda _dir: set())
         monkeypatch.setattr(sm, "_live_children", lambda _pid: [])
         monkeypatch.setattr(sm, "_find_orphan_servers", lambda ports: [])
         groups: list[object] = []
         monkeypatch.setattr(sm, "_terminate_proc_group", lambda p: groups.append(p))
         monkeypatch.setattr(sm, "_reap_survivors", lambda procs: None)
-        sm._stop_own_fleet(())
+        sm._stop_own_fleet(self._CFG, ())
         assert groups == [proc]
+
+    def test_stop_own_fleet_spares_live_sibling_swap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A swap a live OTHER owner recorded (a concurrent sibling lilbee at the
+        # same data_dir) must never be reaped, even though it shares the config.
+        ours = _FakeProc(poll_result=None)
+        ours.pid = 100
+        sibling = _FakeProc(poll_result=None)
+        sibling.pid = 200
+        terminated: list[int] = []
+        monkeypatch.setattr(sm.sys, "platform", "linux")
+        monkeypatch.setattr(sm, "_swaps_for_config", lambda _cfg: [ours, sibling])
+        monkeypatch.setattr(sm, "_live_sibling_swap_pids", lambda _dir: {200})
+        monkeypatch.setattr(sm, "_live_children", lambda _pid: [])
+        monkeypatch.setattr(sm, "_find_orphan_servers", lambda ports: [])
+        monkeypatch.setattr(sm, "_terminate_proc_group", lambda p: terminated.append(p.pid))
+        monkeypatch.setattr(sm, "_reap_survivors", lambda procs: None)
+        sm._stop_own_fleet(self._CFG, ())
+        assert terminated == [100]  # ours reaped, the sibling's swap spared
 
     def test_stop_own_fleet_reaps_children_and_port_servers(
         self, monkeypatch: pytest.MonkeyPatch
@@ -335,42 +358,36 @@ class TestProcessTeardown:
         port_server = _FakeChild(running=True)
         reaped: list[object] = []
         monkeypatch.setattr(sm.sys, "platform", "linux")
-        monkeypatch.setattr(sm, "_own_llama_swaps", lambda: [_FakeProc(poll_result=None)])
+        monkeypatch.setattr(sm, "_swaps_for_config", lambda _cfg: [_FakeProc(poll_result=None)])
+        monkeypatch.setattr(sm, "_live_sibling_swap_pids", lambda _dir: set())
         monkeypatch.setattr(sm, "_live_children", lambda _pid: [child])
         monkeypatch.setattr(sm, "_find_orphan_servers", lambda ports: [port_server])
         monkeypatch.setattr(sm, "_terminate_proc_group", lambda p: None)
         monkeypatch.setattr(sm, "_reap_survivors", lambda procs: reaped.extend(procs))
-        sm._stop_own_fleet((1234,))
+        sm._stop_own_fleet(self._CFG, (1234,))
         assert child in reaped
         assert port_server in reaped
 
-    def test_own_llama_swaps_resolves_registered_pids_and_prunes(
+    def test_swaps_for_config_matches_only_our_config(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Keyed on the recorded-pid registry (immune to reparenting), not the
-        # live child tree. A live llama-swap pid is returned; a dead pid and a
-        # reused pid now running something else are dropped from the registry.
+        # Identity is the -config path argument: a llama-swap on a different
+        # config (another data_dir) and a non-swap process are both excluded.
         class _Proc:
-            def __init__(self, pid: int, argv: str) -> None:
+            def __init__(self, pid: int, argv: list[str]) -> None:
                 self.pid = pid
                 self._argv = argv
 
             def cmdline(self) -> list[str]:
-                return [self._argv]
+                return self._argv
 
-        live = {10: "/x/bin/llama-swap", 11: "/x/bin/python"}  # 11 = reused pid
-
-        def _fake_process(pid: int) -> _Proc:
-            if pid not in live:
-                raise sm.psutil.NoSuchProcess(pid)
-            return _Proc(pid, live[pid])
-
-        monkeypatch.setattr(sm.psutil, "Process", _fake_process)
-        monkeypatch.setattr(sm, "_OWN_SWAP_PIDS", {10, 11, 12})  # 12 = dead
-        result = sm._own_llama_swaps()
+        swap_bin = "/x/bin/llama-swap"
+        ours = _Proc(10, [swap_bin, "-config", "/data/llama-swap.json", "-listen", "x"])
+        other = _Proc(11, [swap_bin, "-config", "/other/llama-swap.json"])
+        notswap = _Proc(12, ["/x/bin/python", "-config", "/data/llama-swap.json"])
+        monkeypatch.setattr(sm.psutil, "process_iter", lambda: [ours, other, notswap])
+        result = sm._swaps_for_config(Path("/data/llama-swap.json"))
         assert [p.pid for p in result] == [10]
-        # The dead (12) and pid-reused (11) entries are pruned; the live one stays.
-        assert sm._OWN_SWAP_PIDS == {10}
 
     def test_reap_survivors_kills_after_grace(self, monkeypatch: pytest.MonkeyPatch) -> None:
         stubborn = _FakeChild(running=True)

--- a/tools/qa/multi_gpu_smoke.py
+++ b/tools/qa/multi_gpu_smoke.py
@@ -174,18 +174,28 @@ def _check_restart(provider: LLMProvider) -> None:
 
 
 def _check_no_orphans(provider: LLMProvider, baseline: dict[int, int]) -> None:
+    """Assert shutdown stranded no process or VRAM, reporting EVERY class at once.
+
+    Both ``llama-server`` and ``llama-swap`` are checked and all failures are
+    collected before failing: bailing on the first orphan once hid a leaked
+    llama-swap supervisor behind a leaked upstream (bb-dpp).
+    """
     provider.shutdown()
     time.sleep(2.0)
+    failures: list[str] = []
     for name in ("llama-server", "llama-swap"):
         survivors = subprocess.run(
             ["pgrep", "-fa", name], capture_output=True, text=True, check=False
         ).stdout.strip()
-        _require(not survivors, f"orphaned {name} processes after shutdown:\n{survivors}")
+        if survivors:
+            failures.append(f"orphaned {name} processes after shutdown:\n{survivors}")
     after = nvidia_smi_free_mib()
     for idx, free_after in after.items():
         free_before = baseline.get(idx, free_after)
         leaked = free_before - free_after
-        _require(leaked < 1024, f"GPU {idx} did not release VRAM: {leaked} MiB still held")
+        if leaked >= 1024:
+            failures.append(f"GPU {idx} did not release VRAM: {leaked} MiB still held")
+    _require(not failures, "; ".join(failures))
     print("[6] no orphaned llama-server / llama-swap processes; VRAM returned to baseline")
 
 


### PR DESCRIPTION
## Problem

Tearing down the multi-GPU fleet (e.g. on `provider.shutdown()` or a config/model change) could leave `llama-swap` supervisor processes running, reparented to init. A warm-up/reload race starts more than one `llama-swap` for a session, and teardown only stopped the single one it held a handle to. The survivors hold GPU memory and keep the engine binary open, so a later fleet start fails ("Text file busy") and VRAM stays pinned. Found on real hardware via `tools/qa/multi_gpu_smoke.py` (2-GPU box, embedding replicas): the no-orphans check failed, and the leak compounded across runs.

## Solution

Reap by durable identity instead of an in-memory handle. Every `llama-swap` this lilbee starts carries the same `-config <path>` argument, so shutdown (and the pre-start singleton guard) now stop every `llama-swap` running against our config and sweep their upstream `llama-server` processes (descendants plus anything still bound to a member port), confirming they exit. A swap a live *other* owner recorded in its state file is spared, so a concurrent lilbee at the same data dir is never touched. A discarded provider also latches a shut-down flag so an in-flight warm-up/reload thread can't spawn a new swap after teardown. The smoke check now reports every orphan class instead of stopping at the first.

Verified on hardware (2× RTX A5000, RunPod): `multi_gpu_smoke.py` passes twice back-to-back with zero orphaned processes and VRAM returned to baseline.