### PR TITLE
Fix two pre-existing integration test failures

### DIFF
--- a/tests/integration/test_litellm_integration.py
+++ b/tests/integration/test_litellm_integration.py
@@ -13,7 +13,12 @@ import pytest
 litellm = pytest.importorskip("litellm")
 
 from lilbee.core.config import cfg  # noqa: E402
-from lilbee.providers.base import ChatResult, ToolCallDelta  # noqa: E402
+from lilbee.providers.base import (  # noqa: E402
+    ChatResult,
+    StreamFinish,
+    TokenUsage,
+    ToolCallDelta,
+)
 from lilbee.providers.litellm_sdk import LitellmSdkBackend  # noqa: E402
 from lilbee.providers.sdk_llm_provider import SdkLLMProvider  # noqa: E402
 
@@ -87,7 +92,7 @@ class TestSdkChat:
         assert len(result.text) > 0
 
     def test_chat_stream_yields_tokens(self) -> None:
-        """Streaming chat yields text and (optionally) tool-call deltas."""
+        """Streaming chat yields text, tool-call deltas, and a closing finish frame."""
         cfg.chat_model = OLLAMA_MODEL
         provider = SdkLLMProvider(LitellmSdkBackend())
         result = provider.chat(
@@ -98,9 +103,10 @@ class TestSdkChat:
 
         items = list(result)
         assert len(items) > 0
-        assert all(isinstance(t, (str, ToolCallDelta)) for t in items)
+        assert all(isinstance(t, (str, ToolCallDelta, TokenUsage, StreamFinish)) for t in items)
         full_text = "".join(t for t in items if isinstance(t, str))
         assert len(full_text) > 0
+        assert any(isinstance(t, StreamFinish) for t in items)
 
     def test_chat_with_model_override(self) -> None:
         """Model override in chat() works."""

--- a/tests/integration/test_tui_integration.py
+++ b/tests/integration/test_tui_integration.py
@@ -179,8 +179,13 @@ class TestDelete:
         sources_after = [r.source for r in results_after]
         assert "specs.md" not in sources_after, "specs.md should be gone after delete"
 
+        # Durable delete skip-marks specs.md so sync won't resurrect it; clear the
+        # marker before re-syncing to restore the shared session fixture for the
+        # downstream status test, which expects specs.md present.
         from lilbee.data.ingest import sync
+        from lilbee.data.ingest.skip_marker import clear_skip_markers
 
+        clear_skip_markers(cfg.data_root)
         await sync(quiet=True)
         get_services().store.ensure_fts_index()
 


### PR DESCRIPTION
## Problem

The `integration` CI job fails on `feat/local-model-api` (and every PR branched off it) on two tests, independent of any feature work:

- `test_chat_stream_yields_tokens` asserts every streamed item is `str` or `ToolCallDelta`. The SDK stream also yields a closing `StreamFinish` frame, which is a documented member of the `ChatStreamItem` contract. The assertion predates that frame and was never updated, so it fails with `assert False`.
- `test_status_shows_real_stats` expects `specs.md` among the indexed documents. The `/delete specs.md` test that runs earlier in the shared session-scoped `rag_pipeline` fixture calls `remove_documents_durably()`, which skip-marks the file so a later `sync()` intentionally will not resurrect it. That test's restore re-synced but never cleared the skip marker, so `specs.md` stayed gone and the status test failed under CI's `--dist loadgroup` ordering. (It passed in isolation, which is why it looked flaky.)

## Solution

- Widen the stream assertion to the full `ChatStreamItem` contract and additionally assert the finish frame is present, so the test verifies the real contract instead of a stale subset.
- Clear the skip markers before the delete test re-syncs, so `specs.md` is genuinely re-ingested and the shared fixture is restored for the downstream status test. No product code changes; the durable-delete behavior is correct as-is.

Both root causes were reproduced locally in the failing add -> delete -> status order, and the full integration suite now passes 108/5-skipped under the CI-style `-n logical --dist loadgroup` run.