### PR TITLE
Placement QA fixes: usable TUI editor + auto-split for large chat models

### DIFF
--- a/docs/placement_ux_prototype.py
+++ b/docs/placement_ux_prototype.py
@@ -1,0 +1,446 @@
+"""Placement screen UX prototype — calm overview + per-model drill-in + advanced controls.
+
+A design reference for the real TUI placement screen, not production code.
+Grounded in lilbee's real fleet: 4 models (Chat, Embeddings, Reranker, Vision).
+Chat/Reranker are single instances (tensor-split a big model across cards);
+Embeddings/Vision are data-parallel (a copy per card) for throughput. LM-Studio
+style: an overview, then one model at a time. Fake data, no fleet.
+
+The drill-in has an Advanced section (press 'a') that exposes the full
+RolePlacement surface: distribute mode (copies vs split) for replicable roles,
+custom per-card tensor-split weights, and removing an optional model.
+
+NOTE for the real implementation: this mock is a single Static with manual
+on_key handling, so it is NOT tab-navigable. The production screen must use
+real focusable widgets (one per GPU checkbox / advanced control) so Tab and
+arrow keys both work, consistent with the rest of the TUI.
+Run: uv run --with textual python proto.py
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+# rose-pine
+BG = "#191724"
+TEXT = "#e0def4"
+SUB = "#908caa"
+MUTE = "#6e6a86"
+IRIS = "#c4a7e7"
+FOAM = "#9ccfd8"
+GOLD = "#f6c177"
+PINE = "#3e8fb0"
+ROSE = "#ebbcba"
+LOVE = "#eb6f92"
+TRACK = "#26233a"
+SEL = "#403d52"
+GPU_NAME = "RTX 4090"
+CARD_GB = 24.0
+
+
+@dataclass
+class Role:
+    key: str
+    label: str
+    model: str
+    job: str
+    size_gb: float
+    color: str
+    split: bool  # True = tensor-split one model across cards; False = a copy per card
+    required: bool = True  # required roles (chat/embed) can't be removed
+    replicable: bool = False  # embed/vision can choose copies vs split
+    enabled: bool = True
+    devices: set[int] = field(default_factory=set)
+    weights: dict[int, int] | None = None  # custom tensor-split ratio per device; None = even
+
+
+class PlacementProto(App):
+    CSS = f"""
+    Screen {{ background: {BG}; color: {TEXT}; }}
+    #screen {{ padding: 1 4; }}
+    """
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.gpu_count = 4
+        self.mode = "overview"  # overview | detail
+        self.ov = 0  # focused model row in overview
+        self.det = 0  # focused item index in detail
+        self.adv = False  # advanced section expanded in detail
+        self.detail_key = ""
+        self.toast = ""
+        self.roles: list[Role] = [
+            Role("chat", "Chat", "Qwen2.5 72B", "the model you talk to", 56.0, FOAM, split=True, required=True),
+            Role("embed", "Embeddings", "nomic-embed", "indexes docs for search", 0.3, GOLD, split=False, required=True, replicable=True),
+            Role("rerank", "Reranker", "bge-reranker", "sharpens search results", 0.6, PINE, split=True, required=False, enabled=False),
+            Role("vision", "Vision", "Qwen2-VL OCR", "reads images & PDFs", 5.0, ROSE, split=False, required=False, replicable=True, enabled=False),
+        ]
+        self.auto_layout()
+
+    # -- model -----------------------------------------------------------
+    def gpus(self) -> list[int]:
+        return list(range(self.gpu_count))
+
+    def auto_layout(self) -> None:
+        for r in self.roles:
+            if not r.enabled:
+                r.devices = set()
+                continue
+            need = _cards_needed(r.size_gb, self.gpu_count) if r.split else 1
+            r.devices = set(range(min(max(1, need), self.gpu_count)))
+
+    def is_auto(self) -> bool:
+        for r in self.roles:
+            need = _cards_needed(r.size_gb, self.gpu_count) if r.split else 1
+            want = set(range(min(max(1, need), self.gpu_count))) if r.enabled else set()
+            if r.devices != want:
+                return False
+        return True
+
+    def chunk(self, r: Role, gpu: int) -> float:
+        if not r.enabled or gpu not in r.devices or not r.devices:
+            return 0.0
+        if not r.split:
+            return r.size_gb  # a copy on each card
+        if r.weights:  # custom tensor-split ratio
+            tot = sum(r.weights.get(g, 1) for g in r.devices) or 1
+            return r.size_gb * r.weights.get(gpu, 1) / tot
+        return r.size_gb / len(r.devices)  # even split
+
+    def _detail_items(self, r: Role) -> list[str]:
+        items = [f"gpu:{g}" for g in self.gpus()]
+        if self.adv:
+            if r.replicable:
+                items.append("mode")
+            if r.split and len(r.devices) > 1:
+                items.append("weights")
+                if r.weights is not None:
+                    items += [f"w:{g}" for g in sorted(r.devices)]
+            if not r.required:
+                items.append("remove")
+        return items
+
+    def used(self, gpu: int) -> float:
+        return sum(self.chunk(rr, gpu) for rr in self.roles)
+
+    def _role(self, key: str) -> Role:
+        return next(r for r in self.roles if r.key == key)
+
+    def _runs_on(self, r: Role) -> str:
+        """Colored 'runs on' summary padded to a fixed VISIBLE width (tags excluded)."""
+        if not r.enabled:
+            body, plain = f"[{MUTE}]—[/]", "—"
+        elif not r.devices:
+            body, plain = f"[{LOVE}]no GPU[/]", "no GPU"
+        else:
+            d = sorted(r.devices)
+            gpus = "GPU " + "·".join(map(str, d))
+            if r.split and len(d) > 1:
+                note = f"split across {len(d)}"
+            elif len(d) > 1:
+                note = "a copy on each"
+            else:
+                note = ""
+            plain = (gpus + ("  " + note if note else "")).rstrip()
+            body = f"[{TEXT}]{gpus}[/]" + (f"  [{MUTE}]{note}[/]" if note else "")
+        return body + " " * max(0, 30 - len(plain))
+
+    def _role_ok(self, r: Role) -> tuple[bool, str]:
+        if not r.enabled:
+            return True, ""
+        if not r.devices:
+            return False, f"[{LOVE}]add a GPU[/]"
+        each = self.chunk(r, sorted(r.devices)[0])
+        if each > CARD_GB:
+            return False, f"[{LOVE}]too big — add a card[/]"
+        if any(self.used(g) > CARD_GB for g in r.devices):
+            return False, f"[{GOLD}]a card is full[/]"
+        return True, f"[{FOAM}]✓[/]"
+
+    def _bar(self, gpu: int, width: int) -> str:
+        used = self.used(gpu)
+        over = used > CARD_GB
+        denom = used if over else CARD_GB
+        out, wsum = "", 0
+        for rr in self.roles:
+            c = self.chunk(rr, gpu)
+            if c > 0:
+                w = max(1, round(c / denom * width))
+                out += f"[{rr.color}]{'█' * w}[/]"
+                wsum += w
+        if not over:
+            out += f"[{TRACK}]{'░' * max(0, width - wsum)}[/]"
+        return out
+
+    # -- overview --------------------------------------------------------
+    def _overview(self) -> str:
+        L: list[str] = []
+        L.append(
+            f"[{MUTE}]Chat · Catalog · Status · Settings · Tasks · [/][{IRIS}]Placement[/]"
+        )
+        L.append("")
+        status = (
+            f"[{FOAM}]● Automatic[/] [{MUTE}](lilbee chose this)[/]"
+            if self.is_auto()
+            else f"[{GOLD}]● Custom[/] [{MUTE}](^r reset to automatic)[/]"
+        )
+        L.append(f"[{TEXT}]Placement[/]      {status}")
+        L.append("")
+        L.append(f"[{SUB}]Your models[/]                                 [{SUB}]Runs on[/]")
+        for i, r in enumerate(self.roles):
+            focus = i == self.ov
+            arrow = f"[{IRIS}]▸[/]" if focus else " "
+            name = f"[{r.color}]{r.label:<11}[/][{MUTE}]{r.model:<14}[/]"
+            ok, tag = self._role_ok(r)
+            trailing = (f"[{SUB} on {SEL}] enable [/]" if focus else "") if not r.enabled else tag
+            line = f"  {arrow} {name}  {self._runs_on(r)} {trailing}"
+            if focus:
+                line = f"[on {SEL}]{line}[/]"
+            L.append(line)
+        L.append("")
+        L.append(f"[{SUB}]Your GPUs[/]")
+        cells = []
+        for g in self.gpus():
+            used = self.used(g)
+            tag = (
+                f"[{LOVE}]{used:.0f}/{CARD_GB:.0f} over[/]"
+                if used > CARD_GB
+                else (f"[{SUB}]{used:.0f}/{CARD_GB:.0f}[/]" if used > 0 else f"[{MUTE}]free[/]")
+            )
+            cells.append(f"[{TEXT}]GPU {g}[/] {self._bar(g, 8)} {tag}")
+        # wrap 4 per line
+        for i in range(0, len(cells), 4):
+            L.append("  " + "    ".join(cells[i : i + 4]))
+        L.append("")
+        all_ok = all(self._role_ok(r)[0] for r in self.roles)
+        fit = f"[{FOAM}]Everything fits ✓[/]" if all_ok else f"[{LOVE}]Some models don't fit — open one to fix.[/]"
+        L.append(fit)
+        L.append("")
+        L.append(
+            f"[{MUTE}]↑↓ model · enter customize · ^a auto · ^r reset · ^s apply · "
+            f"1/2/4/8 GPUs · q[/]"
+        )
+        if self.toast:
+            L.append(f"\n[{FOAM}]{self.toast}[/]")
+        return "\n".join(L)
+
+    # -- detail ----------------------------------------------------------
+    def _detail(self) -> str:
+        r = self._role(self.detail_key)
+        items = self._detail_items(r)
+        self.det = max(0, min(len(items) - 1, self.det))
+        cur = items[self.det] if items else ""
+        L: list[str] = []
+        size_note = (
+            "[{}]too big for one card[/]".format(LOVE)
+            if r.size_gb > CARD_GB
+            else f"[{MUTE}]{r.size_gb:.0f} GB · {r.job}[/]"
+        )
+        L.append(f"[{MUTE}]‹ back[/]     [{r.color}]{r.label}[/] [{MUTE}]— {r.model}[/]   {size_note}")
+        L.append("")
+        L.append(f"[{TEXT}]Which GPUs?[/]")
+        for g in self.gpus():
+            on = g in r.devices
+            box = f"[{r.color}]☑[/]" if on else f"[{MUTE}]☐[/]"
+            used = self.used(g)
+            tag = (
+                f"[{LOVE}]{used:.0f}/{CARD_GB:.0f} full[/]"
+                if used > CARD_GB
+                else (f"[{SUB}]{used:.0f}/{CARD_GB:.0f} GB[/]" if used > 0 else f"[{MUTE}]free[/]")
+            )
+            focus = cur == f"gpu:{g}"
+            line = f"   {box}  [{TEXT}]GPU {g}[/]  [{MUTE}]{GPU_NAME}[/]   {self._bar(g, 10)}  {tag}"
+            L.append(f"[{IRIS}]▸[/]{line[1:]}" if focus else f" {line}")
+        L.append("")
+        # how + fit
+        d = sorted(r.devices)
+        each = self.chunk(r, d[0]) if d else 0
+        if r.split:
+            how = (
+                f"[{TEXT}]How:[/]  one model [{r.color}]split[/] across the selected cards"
+                if len(d) > 1
+                else f"[{TEXT}]How:[/]  runs on the selected card"
+            )
+        else:
+            how = (
+                f"[{TEXT}]How:[/]  [{r.color}]a copy on each[/] selected card [{MUTE}](more = faster {r.job.split()[0]})[/]"
+                if len(d) > 1
+                else f"[{TEXT}]How:[/]  one copy on the selected card"
+            )
+        if not d:
+            fit = f"[{LOVE}]Pick at least one GPU.[/]"
+        elif each > CARD_GB:
+            fit = f"[{LOVE}]Still too big — select another card.[/]"
+        elif any(self.used(g) > CARD_GB for g in d):
+            fit = f"[{GOLD}]Fits, but a card is over budget.[/]"
+        else:
+            spread = self._split_spread(r, d) if (r.split and len(d) > 1) else ""
+            detail = (
+                spread or (f"{each:.0f} GB on each of {len(d)} cards" if len(d) > 1 else f"{each:.0f} GB on Card {d[0]}")
+            )
+            fit = f"[{FOAM}]✓ Fits[/] [{MUTE}]— {detail}[/]"
+        L.append(how)
+        L.append(f"      {fit}")
+        L.append("")
+        L += self._advanced_block(r, cur)
+        L.append("")
+        L.append(self._detail_hints(r, cur))
+        return "\n".join(L)
+
+    def _split_spread(self, r: Role, d: list[int]) -> str:
+        return "split " + " / ".join(f"{self.chunk(r, g):.0f}" for g in d) + " GB"
+
+    def _advanced_block(self, r: Role, cur: str) -> list[str]:
+        controls = []
+        if r.replicable:
+            controls.append("distribute mode")
+        if r.split and len(r.devices) > 1:
+            controls.append("custom split weights")
+        if not r.required:
+            controls.append("remove model")
+        if not controls:
+            return [f"[{MUTE}]No advanced options for this model.[/]"]
+        arrow = "▾" if self.adv else "▸"
+        hint = "" if self.adv else f"  [{MUTE}]({', '.join(controls)})[/]"
+        out = [f"[{MUTE}]{arrow}[/] [{SUB}]Advanced[/]{hint}"]
+        if self.adv:
+            out += self._advanced_lines(r, cur)
+        return out
+
+    def _advanced_lines(self, r: Role, cur: str) -> list[str]:
+        out: list[str] = []
+
+        def mark(item: str) -> str:
+            return f"[{IRIS}]▸[/]" if cur == item else " "
+
+        def radio(on: bool, label: str) -> str:
+            return f"[{r.color}]● {label}[/]" if on else f"[{MUTE}]○ {label}[/]"
+
+        if r.replicable:
+            choice = f"{radio(not r.split, 'Copies')}   {radio(r.split, 'Split')}"
+            out.append(f"  {mark('mode')} [{TEXT}]Distribute[/]   {choice}")
+            if cur == "mode":
+                out.append(f"      [{MUTE}]Copies = a full model per card (faster). Split = one model across cards (for big models).[/]")
+        if r.split and len(r.devices) > 1:
+            choice = f"{radio(r.weights is None, 'Even')}   {radio(r.weights is not None, 'Custom')}"
+            out.append(f"  {mark('weights')} [{TEXT}]Split weights[/]  {choice}")
+            if r.weights is not None:
+                for g in sorted(r.devices):
+                    w = r.weights.get(g, 1)
+                    bar = f"[{r.color}]{'▮' * w}{'·' * (9 - w)}[/]"
+                    tip = f"  [{MUTE}](+/- to adjust)[/]" if cur == f"w:{g}" else ""
+                    out.append(f"  {mark(f'w:{g}')}   [{MUTE}]GPU {g}[/]  {bar} [{MUTE}]weight {w} → {self.chunk(r, g):.0f} GB[/]{tip}")
+        if not r.required:
+            tip = f"  [{MUTE}](frees its VRAM; re-add it from the overview)[/]" if cur == "remove" else ""
+            out.append(f"  {mark('remove')} [{LOVE}]Remove this model[/]{tip}")
+        return out
+
+    def _detail_hints(self, r: Role, cur: str) -> str:
+        nav = "↑↓ move · +/- adjust" if cur.startswith("w:") else "↑↓ move · space toggle"
+        has_adv = r.replicable or (r.split and len(r.devices) > 1) or not r.required
+        adv = "a advanced · " if has_adv else ""
+        return f"[{MUTE}]{nav} · {adv}enter done · esc back[/]"
+
+    # -- lifecycle -------------------------------------------------------
+    def compose(self) -> ComposeResult:
+        yield Static(id="screen")
+
+    def on_mount(self) -> None:
+        self._refresh()
+
+    def _refresh(self) -> None:
+        body = self._overview() if self.mode == "overview" else self._detail()
+        self.query_one("#screen", Static).update(body)
+
+    def on_key(self, event) -> None:  # noqa: C901
+        k = event.key
+        self.toast = ""
+        if k in ("1", "2", "4", "8"):
+            self.gpu_count = int(k)
+            self.ov = self.det = 0
+            self.auto_layout()
+            return self._refresh()
+        if self.mode == "overview":
+            if k in ("down", "j"):
+                self.ov = min(len(self.roles) - 1, self.ov + 1)
+            elif k in ("up", "k"):
+                self.ov = max(0, self.ov - 1)
+            elif k == "enter":
+                r = self.roles[self.ov]
+                if not r.enabled:
+                    r.enabled = True
+                    self.auto_layout()
+                else:
+                    self.detail_key = r.key
+                    self.det = 0
+                    self.adv = False
+                    self.mode = "detail"
+            elif k == "ctrl+a":
+                self.auto_layout()
+                self.toast = "Arranged automatically."
+            elif k == "ctrl+r":
+                self.auto_layout()
+            elif k == "ctrl+s":
+                self.toast = "Applied — fleet reconfigured."
+        else:  # detail
+            r = self._role(self.detail_key)
+            items = self._detail_items(r)
+            self.det = max(0, min(len(items) - 1, self.det))
+            cur = items[self.det] if items else ""
+            if k in ("down", "j"):
+                self.det = min(len(items) - 1, self.det + 1)
+            elif k in ("up", "k"):
+                self.det = max(0, self.det - 1)
+            elif k == "a":
+                self.adv = not self.adv
+            elif k in ("+", "=") and cur.startswith("w:") and r.weights is not None:
+                g = int(cur[2:])
+                r.weights[g] = min(9, r.weights.get(g, 1) + 1)
+            elif k in ("-", "_") and cur.startswith("w:") and r.weights is not None:
+                g = int(cur[2:])
+                r.weights[g] = max(1, r.weights.get(g, 1) - 1)
+            elif k == "space" or (k == "enter" and cur in ("mode", "weights", "remove")):
+                self._detail_act(r, cur)
+            elif k == "escape":
+                self.mode = "overview"
+            elif k == "enter":
+                self.mode = "overview"
+        self._refresh()
+
+    def _detail_act(self, r: Role, cur: str) -> None:
+        if cur.startswith("gpu:"):
+            g = int(cur[4:])
+            if g in r.devices:
+                if len(r.devices) > 1:
+                    r.devices.discard(g)
+            else:
+                r.devices.add(g)
+        elif cur == "mode":
+            r.split = not r.split
+            r.weights = None
+        elif cur == "weights":
+            r.weights = None if r.weights is not None else {g: 1 for g in sorted(r.devices)}
+        elif cur.startswith("w:") and r.weights is not None:
+            g = int(cur[2:])
+            r.weights[g] = (r.weights.get(g, 1) % 9) + 1
+        elif cur == "remove":
+            r.enabled = False
+            r.devices.clear()
+            r.weights = None
+            self.adv = False
+            self.mode = "overview"
+
+
+def _cards_needed(size_gb: float, available: int) -> int:
+    per = CARD_GB * 0.9
+    n = 1
+    while size_gb / n > per and n < max(1, available):
+        n += 1
+    return n
+
+
+if __name__ == "__main__":
+    PlacementProto().run()

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -1,25 +1,31 @@
-"""GPU placement screen: inspect, preview, and apply manual placement specs."""
+"""GPU placement screen: inspect and configure multi-GPU model placement.
+
+The editor is interactive: each role has a GPU toggle per device and a replica
+stepper, so placement is configured by clicking, not by hand-writing JSON. The
+equivalent spec is shown read-only for use with the CLI/HTTP/MCP surfaces.
+"""
 
 from __future__ import annotations
 
 import contextlib
-import json
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.screen import Screen
-from textual.widgets import DataTable, Footer, Static, TextArea
+from textual.widgets import Button, DataTable, Footer, Label, Static
 
 from lilbee.app.placement import get_placement, preview_placement, set_placement
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.thread_safe import call_from_thread
-from lilbee.providers.fleet.placement_spec import PlacementSpec
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
 
 if TYPE_CHECKING:
     from lilbee.app.placement import PlacementView
@@ -28,34 +34,35 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _GPU_TABLE_ID = "#placement-gpus"
-_ROLE_SUMMARY_ID = "#placement-role-summary"
-_SPEC_AREA_ID = "#placement-spec"
+_EDITOR_ID = "#placement-editor"
+_GENERATED_ID = "#placement-generated"
+_TITLE_ID = "#placement-title"
 
 _GIB = 1024**3
+# Only these roles run multiple replicas; the others always serve one instance.
+_REPLICA_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
+_HINT = (
+    "Toggle a GPU for each role; -/+ sets replicas.  ctrl+r preview · ctrl+s apply · ctrl+x auto"
+)
+
+
+@dataclass
+class _RoleEdit:
+    """Mutable editor state for one role."""
+
+    role: WorkerRole
+    model: str
+    devices: set[int]
+    replicas: int
 
 
 def _fmt_gib(n: int) -> str:
-    """Format bytes as GiB string."""
+    """Format bytes as a GiB string."""
     return f"{n / _GIB:.1f} GiB"
 
 
-def _render_roles(view: PlacementView) -> str:
-    """Build the role summary text from a PlacementView."""
-    lines: list[str] = []
-    for r in view.roles:
-        devs = ", ".join(str(d) for d in r.devices)
-        ts = str(r.tensor_split) if r.tensor_split else "auto"
-        lines.append(
-            f"[bold]{r.role.value}[/bold]  model={r.model}  "
-            f"devices=[{devs}]  tensor_split={ts}  replicas={r.replicas}"
-        )
-    for role in view.unplaceable:
-        lines.append(f"[red]UNPLACEABLE: {role.value}[/red]")
-    return "\n".join(lines) if lines else "(no roles placed)"
-
-
 class PlacementScreen(Screen[None]):
-    """GPU placement viewer and editor."""
+    """GPU placement viewer and interactive editor."""
 
     # Lilbee always hosts screens on a LilbeeApp, so narrowing the type lets
     # the screen call switch_view without per-call type: ignore comments.
@@ -63,26 +70,30 @@ class PlacementScreen(Screen[None]):
 
     CSS_PATH = "placement.tcss"
     AUTO_FOCUS = _GPU_TABLE_ID
-    HELP = "Inspect GPU placement. ctrl+r preview, ctrl+s apply, ctrl+x clear, q back."
+    HELP = "Configure GPU placement. ctrl+r preview, ctrl+s apply, ctrl+x auto, q back."
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "go_back", "Back", show=True),
         Binding("escape", "go_back", "Back", show=False),
-        Binding("ctrl+r", "preview", "Preview", show=True),
-        Binding("ctrl+s", "apply", "Apply", show=True),
-        Binding("ctrl+x", "clear", "Clear", show=True),
+        # priority so they fire even when a button/editor child has focus.
+        Binding("ctrl+r", "preview", "Preview", show=True, priority=True),
+        Binding("ctrl+s", "apply", "Apply", show=True, priority=True),
+        Binding("ctrl+x", "clear", "Auto", show=True, priority=True),
     ]
 
     applying: reactive[bool] = reactive(False)
 
     def __init__(self) -> None:
         super().__init__()
-        self._spec_text: str = ""
+        self._edits: dict[WorkerRole, _RoleEdit] = {}
+        self._device_indices: tuple[int, ...] = ()
+        self._gpu_meta: list[tuple[int, str, str, int, int]] = []
+        self._view_manual = False
 
     def watch_applying(self, applying: bool) -> None:
-        """Disable the spec editor while an apply/clear is in flight."""
+        """Disable the editor controls while an apply/clear is in flight."""
         with contextlib.suppress(NoMatches):
-            self.query_one(_SPEC_AREA_ID, TextArea).disabled = applying
+            self.query_one(_EDITOR_ID, Vertical).disabled = applying
 
     def compose(self) -> ComposeResult:
         from lilbee.cli.tui.widgets.bottom_bars import BottomBars
@@ -96,16 +107,18 @@ class PlacementScreen(Screen[None]):
         with TopBars():
             yield ViewTabs()
         with Vertical(id="placement-layout"):
+            yield Static("", id="placement-title")
             yield table
-            yield Static("", id="placement-role-summary")
-            yield TextArea(id="placement-spec")
+            yield Vertical(id="placement-editor")
+            yield Static("", id="placement-generated")
+            yield Static(_HINT, id="placement-hint")
         with BottomBars():
             yield TaskBar()
             yield Footer()
 
     def on_mount(self) -> None:
         table = self.query_one(_GPU_TABLE_ID, DataTable)
-        table.add_columns("Label", "Name", "Free", "Total")
+        table.add_columns("GPU", "Name", "Free", "Total", "Roles")
         self._load_placement()
 
     def _load_placement(self) -> None:
@@ -118,43 +131,135 @@ class PlacementScreen(Screen[None]):
             return
         self._render_view(view)
 
+    # -- rendering -------------------------------------------------------
+
     def _render_view(self, view: PlacementView) -> None:
-        """Populate the GPU table and role summary from a PlacementView."""
+        """Reset the screen (title, table, editor) from a resolved placement view."""
+        self._view_manual = view.manual
+        self._device_indices = tuple(g.index for g in view.gpus)
+        self._gpu_meta = [
+            (g.index, g.label, g.name, g.free_bytes, g.total_bytes) for g in view.gpus
+        ]
+        self._edits = {
+            r.role: _RoleEdit(r.role, r.model, set(r.devices), r.replicas) for r in view.roles
+        }
+        self._build_editor()
+        self._refresh_table()
+        self._refresh_title(dirty=False)
+        self._refresh_generated()
+        if view.unplaceable:
+            names = ", ".join(role.value for role in view.unplaceable)
+            self.notify(f"Does not fit: {names}", severity="warning")
+
+    def _build_editor(self) -> None:
+        """Mount one interactive row per role (GPU toggles + replica stepper)."""
+        container = self.query_one(_EDITOR_ID, Vertical)
+        container.remove_children()
+        rows: list[Horizontal] = []
+        for role, edit in self._edits.items():
+            children: list[Button | Label] = [Label(f"{role.value:<7}", classes="role-name")]
+            for idx in self._device_indices:
+                cls = "dev-toggle on" if idx in edit.devices else "dev-toggle"
+                children.append(Button(str(idx), id=f"dev-{role.value}-{idx}", classes=cls))
+            if role in _REPLICA_ROLES:
+                children.append(Button("-", id=f"rep-{role.value}-dec", classes="rep-btn"))
+                children.append(
+                    Label(f"x{edit.replicas}", id=f"repn-{role.value}", classes="rep-count")
+                )
+                children.append(Button("+", id=f"rep-{role.value}-inc", classes="rep-btn"))
+            rows.append(Horizontal(*children, classes="role-row"))
+        if rows:
+            container.mount(*rows)
+
+    def _refresh_table(self) -> None:
+        """Repaint the GPU table's Roles column from the current editor state."""
+        placed: dict[int, list[str]] = {}
+        for edit in self._edits.values():
+            for idx in edit.devices:
+                placed.setdefault(idx, []).append(edit.role.value)
         table = self.query_one(_GPU_TABLE_ID, DataTable)
         table.clear()
-        for gpu in view.gpus:
+        for idx, label, name, free, total in self._gpu_meta:
             table.add_row(
-                gpu.label,
-                gpu.name,
-                _fmt_gib(gpu.free_bytes),
-                _fmt_gib(gpu.total_bytes),
-                key=str(gpu.index),
+                label,
+                name,
+                _fmt_gib(free),
+                _fmt_gib(total),
+                ", ".join(placed.get(idx, [])) or "-",
+                key=str(idx),
             )
-        summary = self.query_one(_ROLE_SUMMARY_ID, Static)
-        summary.update(_render_roles(view))
-        if view.spec_json:
-            self._spec_text = view.spec_json
-            self.query_one(_SPEC_AREA_ID, TextArea).load_text(view.spec_json)
 
-    def _parse_spec(self) -> PlacementSpec | None:
-        """Parse the current spec text into a PlacementSpec or None."""
-        raw = self._spec_text.strip()
-        if not raw:
+    def _refresh_title(self, *, dirty: bool) -> None:
+        if dirty:
+            text = "Placement (edited; ctrl+s to apply, ctrl+x for auto)"
+        else:
+            text = "Placement (manual)" if self._view_manual else "Placement (auto)"
+        self.query_one(_TITLE_ID, Static).update(f"[bold]{text}[/bold]")
+
+    def _refresh_generated(self) -> None:
+        """Show the spec the current controls produce (for CLI/HTTP/MCP parity)."""
+        out = self.query_one(_GENERATED_ID, Static)
+        try:
+            spec = self._spec_from_editor()
+        except PlacementError as exc:
+            out.update(f"[red]{exc}[/red]")
+            return
+        out.update(f"equivalent spec:  {spec.to_json() if spec else '(auto)'}")
+
+    # -- editor state ----------------------------------------------------
+
+    def _spec_from_editor(self) -> PlacementSpec | None:
+        """Build a PlacementSpec from the editor; None when nothing is configured."""
+        if not self._edits:
             return None
-        return PlacementSpec.from_json(raw)
+        roles: dict[WorkerRole, RolePlacement] = {}
+        for edit in self._edits.values():
+            if not edit.devices:
+                raise PlacementError(f"{edit.role.value} needs at least one GPU")
+            roles[edit.role] = RolePlacement(
+                devices=tuple(sorted(edit.devices)), replicas=edit.replicas
+            )
+        return PlacementSpec(roles=roles)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle a GPU toggle or a replica -/+ press."""
+        bid = event.button.id or ""
+        if bid.startswith("dev-"):
+            _, role_value, idx_str = bid.split("-")
+            edit = self._edits[WorkerRole(role_value)]
+            idx = int(idx_str)
+            if idx in edit.devices:
+                if len(edit.devices) > 1:  # keep at least one GPU per role
+                    edit.devices.discard(idx)
+                    event.button.remove_class("on")
+            else:
+                edit.devices.add(idx)
+                event.button.add_class("on")
+        elif bid.startswith("rep-"):
+            _, role_value, op = bid.split("-")
+            role = WorkerRole(role_value)
+            edit = self._edits[role]
+            edit.replicas = max(1, edit.replicas + (1 if op == "inc" else -1))
+            self.query_one(f"#repn-{role.value}", Label).update(f"x{edit.replicas}")
+        else:
+            return
+        self._refresh_table()
+        self._refresh_title(dirty=True)
+        self._refresh_generated()
+
+    # -- actions ---------------------------------------------------------
 
     def action_preview(self) -> None:
-        """Preview the current spec without applying it."""
+        """Resolve the edited placement against the hardware without applying it."""
         try:
-            spec = self._parse_spec()
-        except (ValueError, json.JSONDecodeError, KeyError) as exc:
+            spec = self._spec_from_editor()
+        except PlacementError as exc:
             self.notify(str(exc), severity="error")
             return
         self._preview_worker(spec)
 
     @work(thread=True, exit_on_error=False)
     def _preview_worker(self, spec: PlacementSpec | None) -> None:
-        """Run preview_placement off the UI thread."""
         try:
             view = preview_placement(spec)
             call_from_thread(self, self._render_view, view)
@@ -162,12 +267,12 @@ class PlacementScreen(Screen[None]):
             call_from_thread(self, self.notify, str(exc), severity="error")
 
     def action_apply(self) -> None:
-        """Apply the current spec and reload services."""
+        """Apply the edited placement (persists and reloads the fleet)."""
         if self.applying:
             return
         try:
-            spec = self._parse_spec()
-        except (ValueError, json.JSONDecodeError, KeyError) as exc:
+            spec = self._spec_from_editor()
+        except PlacementError as exc:
             self.notify(str(exc), severity="error")
             return
         self.applying = True
@@ -175,7 +280,6 @@ class PlacementScreen(Screen[None]):
 
     @work(thread=True, exit_on_error=False)
     def _apply_worker(self, spec: PlacementSpec | None) -> None:
-        """Run set_placement off the UI thread."""
         try:
             set_placement(spec)
             view = get_placement()
@@ -186,7 +290,7 @@ class PlacementScreen(Screen[None]):
             call_from_thread(self, setattr, self, "applying", False)
 
     def action_clear(self) -> None:
-        """Clear the manual spec (restore auto placement)."""
+        """Restore automatic placement."""
         if self.applying:
             return
         self.applying = True
@@ -194,7 +298,6 @@ class PlacementScreen(Screen[None]):
 
     @work(thread=True, exit_on_error=False)
     def _clear_worker(self) -> None:
-        """Run set_placement(None) off the UI thread."""
         try:
             set_placement(None)
             view = get_placement()

--- a/src/lilbee/cli/tui/screens/placement.tcss
+++ b/src/lilbee/cli/tui/screens/placement.tcss
@@ -5,6 +5,11 @@ PlacementScreen {
         padding: 0 1;
     }
 
+    #placement-title {
+        height: 1;
+        margin-bottom: 1;
+    }
+
     #placement-gpus {
         height: auto;
         max-height: 12;
@@ -12,19 +17,51 @@ PlacementScreen {
         margin-bottom: 1;
     }
 
-    #placement-role-summary {
+    #placement-editor {
         height: auto;
-        margin-bottom: 1;
-        color: $text;
     }
 
-    #placement-spec {
-        height: 1fr;
-        min-height: 8;
-        border: solid $surface-lighten-2;
+    .role-row {
+        height: 3;
+        align-vertical: middle;
+    }
 
-        &:focus-within {
-            border: tall $primary;
-        }
+    .role-name {
+        width: 9;
+        content-align: left middle;
+    }
+
+    .dev-toggle {
+        min-width: 5;
+        width: 5;
+        margin: 0 1 0 0;
+    }
+
+    .dev-toggle.on {
+        background: $success;
+        color: $text;
+        text-style: bold;
+    }
+
+    .rep-btn {
+        min-width: 5;
+        width: 5;
+        margin: 0 1 0 0;
+    }
+
+    .rep-count {
+        width: 5;
+        content-align: center middle;
+    }
+
+    #placement-generated {
+        height: auto;
+        margin-top: 1;
+        color: $text-muted;
+    }
+
+    #placement-hint {
+        height: auto;
+        color: $text-muted;
     }
 }

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -32,7 +32,7 @@ from lilbee.providers.fleet.placement import (
     plan_placement,
 )
 from lilbee.providers.fleet.placement_spec import PlacementSpec
-from lilbee.providers.fleet.vram import estimate_instance_footprint
+from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION, estimate_instance_footprint
 from lilbee.providers.roles import RerankMode, WorkerRole
 
 log = logging.getLogger(__name__)
@@ -45,6 +45,13 @@ _CHAT_SLOTS = 4
 # A tensor-split chat fills its cards with one full-context sequence; concurrent
 # slots are for a chat that fits a single GPU, not a multi-card giant.
 _SPLIT_CHAT_SLOTS = 1
+# Floor context the PLACEMENT estimate reserves KV for, so a large model is never
+# single-carded into a KV corner too small for real use (a 17GB model on a 24GB
+# card leaves ~no KV room -> n_ctx collapses to a few hundred tokens). Sizing the
+# placement reserve against this floor forces a tensor-split when one card cannot
+# hold weights + a usable context; the served ctx is then grown to the chosen
+# cards' real headroom by resolve_chat_ctx (single) / fit_split_ctx (split).
+_MIN_USABLE_CHAT_CTX = 8192
 _AUX_SLOTS = 1
 _EMBED_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK)
 # Truncate embed/rerank inputs a few tokens below the per-slot context: the server
@@ -407,7 +414,11 @@ def _estimate_role(
     path = resolve_model_path(model_ref)
     mmproj = _vision_mmproj(model_ref) if role is WorkerRole.VISION else None
     meta = read_gguf_metadata(path)
-    ctx = _role_ctx(role, path, meta)
+    # Size the single-instance footprint against the placement reserve (a usable
+    # KV floor for chat), so a model that fits weights-only on one card but not
+    # weights + a usable context falls through to a tensor-split instead of being
+    # single-carded into a tiny n_ctx. Non-chat roles keep their launch ctx.
+    ctx = _placement_estimate_ctx(role, path, meta)
     rerank_mode = _role_rerank_mode(role, meta)
     if slots is None:
         slots = _slots_for(
@@ -429,20 +440,47 @@ def _estimate_role(
         mmproj_path=mmproj,
         batch_size=_pooled_batch_size(role, rerank_mode, ctx),
     )
-    return ModelPlacementInput(
-        role=role,
-        est_vram_bytes=est.footprint(unified=unified_budget is not None),
-        replicas=_replica_count(role),
-    )
+    fp = est.footprint(unified=unified_budget is not None)
+    if role is WorkerRole.CHAT and unified_budget is None:
+        fp = _chat_serve_budget_footprint(fp)
+    return ModelPlacementInput(role=role, est_vram_bytes=fp, replicas=_replica_count(role))
+
+
+def _chat_serve_budget_footprint(footprint: int) -> int:
+    """Charge a chat instance against the serve budget, not the placement headroom.
+
+    The planner fits instances within ``USABLE_VRAM_FRACTION`` of a card, but a
+    single-card chat then sizes its KV cache against the smaller
+    ``cfg.gpu_memory_fraction`` budget (``resolve_chat_ctx``). A model that fills a
+    card at 0.9 leaves no room for KV at 0.75 and collapses to a few hundred tokens,
+    so scale its placement footprint by the budget ratio: it then needs a
+    tensor-split (pooling VRAM across cards) whenever single-carding it would starve
+    its context. Small models are unaffected -- they fit the serve budget with KV
+    room to spare.
+    """
+    from lilbee.core.config import cfg
+
+    return int(footprint * (USABLE_VRAM_FRACTION / cfg.gpu_memory_fraction))
 
 
 def _placement_estimate_ctx(role: WorkerRole, model_path: Path, meta: dict[str, str] | None) -> int:
-    """Per-slot context the placement estimate sizes a role against (the launch ceiling)."""
+    """Per-slot context the placement estimate sizes a role against.
+
+    For chat this reserves KV for a usable floor (``_MIN_USABLE_CHAT_CTX``, or the
+    user's ``cfg.num_ctx`` pin), capped by the model's trained ceiling -- not the
+    single-GPU dynamic ctx (which shrinks to fit one card and then confirms a
+    single-card placement) nor the full trained ceiling (which over-reserves). A
+    model that cannot hold weights + this floor on one card is tensor-split.
+    """
     from lilbee.core.config import cfg
     from lilbee.providers.engine_params import chat_ctx_ceiling
 
     if role is WorkerRole.CHAT:
-        return cfg.num_ctx if cfg.num_ctx is not None else chat_ctx_ceiling(meta, model_path)
+        if cfg.num_ctx is not None:
+            return cfg.num_ctx
+        return min(
+            chat_ctx_ceiling(meta, model_path), max(cfg.chat_n_ctx_target, _MIN_USABLE_CHAT_CTX)
+        )
     return _role_ctx(role, model_path, meta)
 
 

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -425,15 +425,67 @@ def test_search_reservation_scales_with_replicas() -> None:
     assert planning_mod._search_reservation(inputs) == 3 * 2 * _GB + 1 * _GB
 
 
-def test_placement_estimate_ctx_chat_uses_ceiling(monkeypatch) -> None:
+def test_placement_estimate_ctx_chat_reserves_target(monkeypatch) -> None:
+    """A long-context model reserves the chat ctx target, not its full trained ceiling.
+
+    Reserving the full ceiling over-charges KV and can wrongly reject a split; the
+    target is the context we intend to serve, capped by the model and floored at a
+    usable minimum.
+    """
     monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 24576)
     monkeypatch.setattr("lilbee.providers.engine_params.chat_ctx_ceiling", lambda _m, _p: 131072)
-    assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 131072
+    assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 24576
+
+
+def test_placement_estimate_ctx_chat_floored_when_target_tiny(monkeypatch) -> None:
+    """A tiny target is floored at the usable minimum so placement still reserves room."""
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 1024)
+    monkeypatch.setattr("lilbee.providers.engine_params.chat_ctx_ceiling", lambda _m, _p: 131072)
+    assert (
+        planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {})
+        == planning_mod._MIN_USABLE_CHAT_CTX
+    )
+
+
+def test_placement_estimate_ctx_chat_capped_by_short_ceiling(monkeypatch) -> None:
+    """A short-context model reserves only its ceiling, below the usable floor."""
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr("lilbee.providers.engine_params.chat_ctx_ceiling", lambda _m, _p: 2048)
+    assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 2048
 
 
 def test_placement_estimate_ctx_chat_honors_num_ctx_pin(monkeypatch) -> None:
     monkeypatch.setattr(cfg, "num_ctx", 16384)
     assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 16384
+
+
+def test_estimate_role_chat_footprint_sized_at_target_ctx(monkeypatch) -> None:
+    """The single-instance chat footprint reserves KV for the target ctx, not the
+    single-card dynamic ctx (which collapses when a big model barely fits one card).
+
+    Regression for bb-9rn: sizing at the target is what lets a too-tight single-card
+    placement fall through to a tensor-split instead of a 512-token corner.
+    """
+    captured: dict[str, int] = {}
+
+    def _est(model_path, *, ctx, slots, **_kwargs) -> GgufVramEstimate:
+        captured["ctx"] = ctx
+        return GgufVramEstimate(vram_bytes=10**8, ram_bytes=0, unified_bytes=10**8)
+
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 24576)
+    monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _est)
+    monkeypatch.setattr(planning_mod, "_slots_for", lambda *a, **k: 1)
+    monkeypatch.setattr(
+        "lilbee.providers.engine_params.resolve_model_path", lambda _r: Path("/m/c.gguf")
+    )
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+    monkeypatch.setattr("lilbee.providers.engine_params.chat_ctx_ceiling", lambda _m, _p: 262144)
+
+    planning_mod._estimate_role(WorkerRole.CHAT, "org/chat.gguf")
+    assert captured["ctx"] == 24576
 
 
 def test_placement_estimate_ctx_non_chat_delegates_to_role_ctx(monkeypatch) -> None:
@@ -652,10 +704,34 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(
             planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=9000, unified=900)
         )
-        shared = planning_mod._estimate_role(WorkerRole.CHAT, "ref", slots=1, unified_budget=10**9)
-        discrete = planning_mod._estimate_role(WorkerRole.CHAT, "ref", slots=1)
+        shared = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1, unified_budget=10**9)
+        discrete = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1)
         assert shared.est_vram_bytes == 900
         assert discrete.est_vram_bytes == 9000
+
+    def test_estimate_role_chat_charged_at_serve_budget(self, monkeypatch) -> None:
+        """A chat instance's placement footprint is scaled up by the placement/serve
+        budget ratio, so a model that would starve its KV on one card is tensor-split.
+
+        Regression for bb-9rn: without this, a 17GB model fits one 24GB card at the 0.9
+        placement headroom but its served ctx (sized at 0.75) collapses to ~512 tokens.
+        """
+        monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.75)
+        monkeypatch.setattr(
+            "lilbee.providers.engine_params.resolve_model_path", lambda _r: Path("/m/c.gguf")
+        )
+        monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+        monkeypatch.setattr(planning_mod, "_role_ctx", lambda _r, _p, _m, *_a: 16)
+        monkeypatch.setattr(planning_mod, "_slots_for", lambda *a, **k: 1)
+        monkeypatch.setattr(
+            planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=10000)
+        )
+
+        chat = planning_mod._estimate_role(WorkerRole.CHAT, "ref")
+        embed = planning_mod._estimate_role(WorkerRole.EMBED, "ref")
+        # chat charged at the serve budget: 10000 * (USABLE_VRAM_FRACTION / 0.75); embed raw.
+        assert chat.est_vram_bytes == int(10000 * (planning_mod.USABLE_VRAM_FRACTION / 0.75))
+        assert embed.est_vram_bytes == 10000
 
     def test_launch_for_vision_passes_mmproj(self, tmp_path, monkeypatch) -> None:
         model = tmp_path / "v.gguf"
@@ -682,8 +758,8 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(
             planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=7777)
         )
-        inp = planning_mod._estimate_role(WorkerRole.CHAT, "ref", slots=2)
-        assert inp.role == WorkerRole.CHAT
+        inp = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=2)
+        assert inp.role == WorkerRole.EMBED
         assert inp.est_vram_bytes == 7777
 
     def test_launch_for_builds_instance_with_pinning(self, tmp_path, monkeypatch) -> None:

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -1,30 +1,37 @@
-"""Tests for the TUI PlacementScreen."""
+"""Tests for the interactive TUI PlacementScreen.
+
+These drive the real widgets (GPU toggle Buttons, replica steppers, key
+bindings) rather than poking private state, so the input path is actually
+exercised.
+"""
 
 from __future__ import annotations
 
 import threading
 
 import pytest
-from textual.widgets import DataTable, TextArea
+from textual.widgets import Button, DataTable, Static
 
 from tests._lilbee_app_test_host import LilbeeAppHost
 
 GIB = 1024**3
 
 
-def _make_view(*, manual: bool = False, unplaceable: tuple = ()):  # type: ignore[type-arg]
+def _make_view(*, manual: bool = False, unplaceable: tuple = (), spec_json=None):  # type: ignore[type-arg]
     from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
     from lilbee.providers.roles import WorkerRole
 
     return PlacementView(
-        gpus=(
-            GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),
-            GpuInfo(1, "CUDA", "CUDA1", "NVIDIA A100", 80 * GIB, 80 * GIB),
+        gpus=tuple(
+            GpuInfo(i, "CUDA", f"CUDA{i}", "NVIDIA A40", 44 * GIB, 44 * GIB) for i in range(4)
         ),
-        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0, 1), (1, 1), 1),),
+        roles=(
+            RolePlacementView(WorkerRole.EMBED, "org/embed.gguf", (0,), None, 1),
+            RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (1,), None, 1),
+        ),
         unplaceable=unplaceable,
         manual=manual,
-        spec_json=None,
+        spec_json=spec_json,
     )
 
 
@@ -39,85 +46,177 @@ class PlacementTestApp(LilbeeAppHost):
         self.push_screen(PlacementScreen())
 
 
+def _generated(app) -> str:  # type: ignore[no-untyped-def]
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    return str(app.screen.query_one(screen_mod._GENERATED_ID, Static).render())
+
+
 @pytest.mark.asyncio
-async def test_screen_lists_gpus(monkeypatch):
-    """GPU table renders one row per detected GPU."""
+async def test_screen_lists_gpus_with_roles(monkeypatch):
+    """GPU table renders one row per GPU and shows which role sits on each card."""
     from lilbee.cli.tui.screens import placement as screen_mod
 
     monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
         table = app.screen.query_one(screen_mod._GPU_TABLE_ID, DataTable)
-        assert table.row_count == 2
+        assert table.row_count == 4
+        # row 0 (CUDA0) Roles cell == "embed", row 1 (CUDA1) == "chat"
+        assert table.get_row_at(0)[4] == "embed"
+        assert table.get_row_at(1)[4] == "chat"
 
 
 @pytest.mark.asyncio
-async def test_screen_lists_roles(monkeypatch):
-    """Role summary reflects placed roles."""
-    from textual.widgets import Static
+async def test_toggle_device_updates_spec_and_table(monkeypatch):
+    """Clicking a GPU toggle for a role updates the spec and the table live."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.click("#dev-embed-2")  # add CUDA2 to embed
+        await pilot.pause()
+        assert '"embed": {"devices": [0, 2]}' in _generated(app)
+        table = app.screen.query_one(screen_mod._GPU_TABLE_ID, DataTable)
+        assert table.get_row_at(2)[4] == "embed"
+
+
+@pytest.mark.asyncio
+async def test_cannot_remove_last_device(monkeypatch):
+    """A role must keep at least one GPU; toggling its only device is a no-op."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.click("#dev-embed-0")  # embed's only device -> must stay
+        await pilot.pause()
+        assert '"embed": {"devices": [0]}' in _generated(app)
+
+
+@pytest.mark.asyncio
+async def test_replica_stepper(monkeypatch):
+    """The +/- stepper changes replicas (floored at 1) for a replicated role."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.click("#rep-embed-inc")  # 1 -> 2
+        await pilot.pause()
+        assert '"replicas": 2' in _generated(app)
+        await pilot.click("#rep-embed-dec")  # 2 -> 1 (omitted)
+        await pilot.pause()
+        assert "replicas" not in _generated(app)
+        await pilot.click("#rep-embed-dec")  # floored at 1
+        await pilot.pause()
+        assert "replicas" not in _generated(app)
+
+
+@pytest.mark.asyncio
+async def test_no_replica_stepper_for_chat(monkeypatch):
+    """Non-replicated roles (chat) have no replica stepper."""
+    from textual.css.query import NoMatches
 
     from lilbee.cli.tui.screens import placement as screen_mod
 
     monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
-        summary = app.screen.query_one(screen_mod._ROLE_SUMMARY_ID, Static)
-        rendered = str(summary.render())
-        assert "chat" in rendered.lower()
+        with pytest.raises(NoMatches):
+            app.screen.query_one("#rep-chat-inc", Button)
 
 
 @pytest.mark.asyncio
-async def test_screen_unplaceable_shown(monkeypatch):
-    """Unplaceable roles appear in the summary."""
-    from textual.widgets import Static
-
+async def test_preview_uses_edited_spec(monkeypatch):
+    """ctrl+r resolves the placement built from the toggles, not a stale value."""
     from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
     from lilbee.providers.roles import WorkerRole
 
-    view = _make_view(unplaceable=(WorkerRole.VISION,))
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: view)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        summary = app.screen.query_one(screen_mod._ROLE_SUMMARY_ID, Static)
-        rendered = str(summary.render())
-        assert "vision" in rendered.lower()
-
-
-@pytest.mark.asyncio
-async def test_preview_rerenders(monkeypatch):
-    """ctrl+r with a valid spec re-renders the GPU table."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
     monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    preview_calls: list[object] = []
+    calls: list[object] = []
 
     def _preview(spec):  # type: ignore[no-untyped-def]
-        preview_calls.append(spec)
+        calls.append(spec)
         return _make_view()
 
     monkeypatch.setattr(screen_mod, "preview_placement", _preview)
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.click("#dev-chat-3")  # chat now on CUDA1 + CUDA3
+        await pilot.pause()
         await pilot.press("ctrl+r")
         await pilot.pause()
         await pilot.pause()
 
-    assert len(preview_calls) == 1
+    assert calls and isinstance(calls[0], PlacementSpec)
+    assert calls[0].roles[WorkerRole.CHAT].devices == (1, 3)
 
 
 @pytest.mark.asyncio
-async def test_preview_shows_fit_error(monkeypatch):
-    """ctrl+r surfaces a PlacementError as a notification, not a crash."""
+async def test_apply_uses_edited_spec(monkeypatch):
+    """ctrl+s applies the placement built from the toggles."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+    from lilbee.providers.roles import WorkerRole
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    calls: list[object] = []
+    monkeypatch.setattr(
+        screen_mod, "set_placement", lambda spec: calls.append(spec) or _make_view(manual=True)
+    )
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.click("#dev-embed-3")
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert calls and isinstance(calls[0], PlacementSpec)
+    assert calls[0].roles[WorkerRole.EMBED].devices == (0, 3)
+
+
+@pytest.mark.asyncio
+async def test_clear_calls_set_placement_none(monkeypatch):
+    """ctrl+x restores auto placement via set_placement(None)."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    calls: list[object] = []
+    monkeypatch.setattr(
+        screen_mod, "set_placement", lambda spec: calls.append(spec) or _make_view()
+    )
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+x")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_preview_error_notifies(monkeypatch):
+    """A PlacementError from preview surfaces as a notification, not a crash."""
     from lilbee.cli.tui.screens import placement as screen_mod
     from lilbee.providers.fleet.placement_spec import PlacementError
 
@@ -130,11 +229,9 @@ async def test_preview_shows_fit_error(monkeypatch):
 
     notes: list[str] = []
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        monkeypatch.setattr(app.screen, "notify", lambda msg, **k: notes.append(msg))
         await pilot.press("ctrl+r")
         await pilot.pause()
         await pilot.pause()
@@ -143,136 +240,8 @@ async def test_preview_shows_fit_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_apply_calls_set_placement(monkeypatch):
-    """ctrl+s calls set_placement with parsed spec."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    set_calls: list[object] = []
-    monkeypatch.setattr(
-        screen_mod, "set_placement", lambda spec: set_calls.append(spec) or _make_view()
-    )
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        await pilot.pause()
-
-    assert len(set_calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_clear_calls_set_placement_none(monkeypatch):
-    """ctrl+x calls set_placement(None) to restore auto placement."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    set_calls: list[object] = []
-
-    def _set(spec):  # type: ignore[no-untyped-def]
-        set_calls.append(spec)
-        return _make_view()
-
-    monkeypatch.setattr(screen_mod, "set_placement", _set)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        await pilot.press("ctrl+x")
-        await pilot.pause()
-        await pilot.pause()
-
-    assert set_calls == [None]
-
-
-@pytest.mark.asyncio
-async def test_apply_bad_json_notifies(monkeypatch):
-    """ctrl+s with invalid JSON shows an error notification."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    notes: list[str] = []
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = "not-valid-json"
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-
-    assert any(notes)
-
-
-@pytest.mark.asyncio
-async def test_go_back_binding(monkeypatch):
-    """q pops the screen."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        assert isinstance(app.screen, screen_mod.PlacementScreen)
-        await pilot.press("q")
-        await pilot.pause()
-
-
-@pytest.mark.asyncio
-async def test_load_placement_error_notifies(monkeypatch):
-    """An exception from get_placement on mount shows a notification."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    def _boom():
-        raise RuntimeError("probe failed")
-
-    monkeypatch.setattr(screen_mod, "get_placement", _boom)
-    notes: list[str] = []
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        screen = app.screen
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
-        screen._load_placement()
-        await pilot.pause()
-
-    assert any("probe failed" in n for n in notes)
-
-
-@pytest.mark.asyncio
-async def test_render_view_with_spec_json(monkeypatch):
-    """When spec_json is set on the view, the TextArea is seeded."""
-    from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
-    from lilbee.cli.tui.screens import placement as screen_mod
-    from lilbee.providers.roles import WorkerRole
-
-    GIB = 1024**3
-    view_with_spec = PlacementView(
-        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),),
-        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
-        unplaceable=(),
-        manual=True,
-        spec_json='{"chat": {"devices": [0]}}',
-    )
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: view_with_spec)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        assert screen._spec_text == '{"chat": {"devices": [0]}}'
-
-
-@pytest.mark.asyncio
-async def test_apply_worker_error_notifies(monkeypatch):
-    """An exception from set_placement shows a notification."""
+async def test_apply_error_notifies(monkeypatch):
+    """A PlacementError from set_placement surfaces as a notification."""
     from lilbee.cli.tui.screens import placement as screen_mod
     from lilbee.providers.fleet.placement_spec import PlacementError
 
@@ -285,11 +254,9 @@ async def test_apply_worker_error_notifies(monkeypatch):
 
     notes: list[str] = []
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        monkeypatch.setattr(app.screen, "notify", lambda msg, **k: notes.append(msg))
         await pilot.press("ctrl+s")
         await pilot.pause()
         await pilot.pause()
@@ -298,44 +265,105 @@ async def test_apply_worker_error_notifies(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_clear_worker_error_notifies(monkeypatch):
-    """An exception from set_placement(None) during clear shows a notification."""
+async def test_unplaceable_warns(monkeypatch):
+    """A role that does not fit is surfaced as a warning on load."""
     from lilbee.cli.tui.screens import placement as screen_mod
-    from lilbee.providers.fleet.placement_spec import PlacementError
+    from lilbee.providers.roles import WorkerRole
 
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    def _fail(spec):  # type: ignore[no-untyped-def]
-        raise PlacementError("clear fail")
-
-    monkeypatch.setattr(screen_mod, "set_placement", _fail)
+    view = _make_view(unplaceable=(WorkerRole.VISION,))
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: view)
 
     notes: list[str] = []
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
-        await pilot.press("ctrl+x")
-        await pilot.pause()
+    async with app.run_test(size=(140, 44)) as pilot:
+        app.screen.notify = lambda msg, **k: notes.append(msg)  # type: ignore[method-assign]
+        app.screen._load_placement()
         await pilot.pause()
 
-    assert any("clear fail" in n for n in notes)
+    assert any("vision" in n.lower() for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_apply_disables_editor_while_running(monkeypatch):
+    """ctrl+s sets applying=True and disables the editor until set_placement returns."""
+    from textual.containers import Vertical
+
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    gate = threading.Event()
+    monkeypatch.setattr(screen_mod, "set_placement", lambda spec: gate.wait())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        screen = app.screen
+        assert screen.applying is True
+        assert screen.query_one(screen_mod._EDITOR_ID, Vertical).disabled is True
+        gate.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert screen.applying is False
+
+
+@pytest.mark.asyncio
+async def test_apply_ignored_while_applying(monkeypatch):
+    """A second ctrl+s while applying is a no-op (single-flight guard)."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    calls: list[object] = []
+    gate = threading.Event()
+
+    def _blocking(spec):  # type: ignore[no-untyped-def]
+        calls.append(spec)
+        gate.wait()
+
+    monkeypatch.setattr(screen_mod, "set_placement", _blocking)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        gate.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_go_back_binding(monkeypatch):
+    """q pops the screen."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, screen_mod.PlacementScreen)
+        await pilot.press("q")
+        await pilot.pause()
 
 
 @pytest.mark.asyncio
 async def test_go_back_single_screen(monkeypatch):
-    """action_go_back with a single-item screen_stack calls switch_view."""
+    """action_go_back with a single-item screen_stack calls switch_view('Chat')."""
     from lilbee.cli.tui.screens import placement as screen_mod
 
     monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
         screen = app.screen
         called: list[str] = []
-        # Simulate single-screen stack so the else branch is taken.
         monkeypatch.setattr(type(app), "screen_stack", property(lambda self: [screen]))
         monkeypatch.setattr(app, "switch_view", lambda v: called.append(v))
         screen.action_go_back()
@@ -345,129 +373,21 @@ async def test_go_back_single_screen(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_preview_bad_json_notifies(monkeypatch):
-    """ctrl+r with invalid JSON shows an error notification, not a crash."""
+async def test_load_placement_error_notifies(monkeypatch):
+    """An exception from get_placement on load shows a notification."""
     from lilbee.cli.tui.screens import placement as screen_mod
 
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    def _boom():
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(screen_mod, "get_placement", _boom)
     notes: list[str] = []
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
+    async with app.run_test(size=(140, 44)) as pilot:
         screen = app.screen
-        screen._spec_text = "not-valid-json"
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
-        await pilot.press("ctrl+r")
+        screen.notify = lambda msg, **k: notes.append(msg)  # type: ignore[method-assign]
+        screen._load_placement()
         await pilot.pause()
 
-    assert any(notes)
-
-
-@pytest.mark.asyncio
-async def test_apply_empty_spec_calls_set_placement_none(monkeypatch):
-    """ctrl+s with an empty spec passes None to set_placement."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    set_calls: list[object] = []
-    monkeypatch.setattr(
-        screen_mod, "set_placement", lambda spec: set_calls.append(spec) or _make_view()
-    )
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = ""
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        await pilot.pause()
-
-    assert set_calls == [None]
-
-
-@pytest.mark.asyncio
-async def test_apply_disables_input_while_running(monkeypatch):
-    """ctrl+s sets applying=True and disables the TextArea until set_placement returns."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    gate = threading.Event()
-
-    def _blocking_set(spec):  # type: ignore[no-untyped-def]
-        gate.wait()
-
-    monkeypatch.setattr(screen_mod, "set_placement", _blocking_set)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        assert screen.applying is True
-        text_area = screen.query_one(screen_mod._SPEC_AREA_ID, TextArea)
-        assert text_area.disabled is True
-        gate.set()
-        await app.workers.wait_for_complete()
-        await pilot.pause()
-        assert screen.applying is False
-        assert text_area.disabled is False
-
-
-@pytest.mark.asyncio
-async def test_apply_ignored_while_applying(monkeypatch):
-    """ctrl+s is a no-op when applying is already True (double-apply guard)."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    set_calls: list[object] = []
-    gate = threading.Event()
-
-    def _blocking_set(spec):  # type: ignore[no-untyped-def]
-        set_calls.append(spec)
-        gate.wait()
-
-    monkeypatch.setattr(screen_mod, "set_placement", _blocking_set)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        assert screen.applying is True
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        gate.set()
-        await app.workers.wait_for_complete()
-        await pilot.pause()
-
-    assert len(set_calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_clear_ignored_while_applying(monkeypatch):
-    """ctrl+x is a no-op when applying is already True."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    set_calls: list[object] = []
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        monkeypatch.setattr(screen_mod, "set_placement", lambda spec: set_calls.append(spec))
-        screen.applying = True
-        await pilot.press("ctrl+x")
-        await pilot.pause()
-
-    assert set_calls == []
+    assert any("probe failed" in n for n in notes)


### PR DESCRIPTION
## Problem

Two issues surfaced while QA-ing the placement feature on real multi-GPU hardware:

1. **The TUI placement editor ignored everything typed into it.** The screen parsed a private field that was never updated from the spec TextArea, so pressing Apply or Preview acted on an empty spec; the auto placement re-resolving to different cards made it *look* like the edit had applied. Every existing test masked this by assigning the field directly instead of driving the widget. Beyond the bug, a raw-JSON text box is a poor primary UX for picking GPUs per role.

2. **Auto placement collapsed a large chat model's context to ~512 tokens.** A ~17GB model fits one 24GB card under the planner's 0.9 headroom, so it was single-carded; but the served KV cache is sized at `gpu_memory_fraction` (0.75), leaving almost no room, so `n_ctx` dropped to ~512 and real chat/agent prompts returned 400. The user had to hand-write a placement spec to split the model across cards just to make it usable.

## Solution

**TUI:** read the live editor instead of a stale field, and replace the JSON box with an interactive per-role editor: GPU toggle buttons and a replica stepper per role, a live auto/manual/edited title, a Roles column on the GPU table, and a read-only equivalent-spec line (so the JSON is still copyable for the CLI/HTTP/MCP surfaces). Action bindings are priority so they fire from the editor. Tests now click the real widgets.

**Planner:** charge the chat placement footprint against the serve budget rather than the placement headroom (and reserve KV for the ctx target, floored at a usable minimum). A model that would starve its context on a single card is now tensor-split to pool VRAM across cards automatically. Small models are unaffected.

Validated on a 2x RTX A5000 box: auto placement now splits a 30B coder model (`devices=[1, 0]`) and a query succeeds with no manual spec, where before it errored on the 512-token window. Fixes bb-9rn.