### PR TITLE
Multi-GPU model placement (config, TUI, auto-split, elastic ingest pool) + hardening

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -53,6 +53,22 @@ When reporting a worker crash, attach the last ~100 lines of the worker log plus
 tail -n 100 "<data root>/logs/worker-embed.log"
 ```
 
+## Fleet refuses to start after a hardware change
+
+If you have a manual placement spec set and a GPU is removed, replaced, or
+renumbered, the fleet will refuse to start with an error naming the card that
+no longer fits. The error is intentional: lilbee won't silently start in a
+broken state.
+
+To return to automatic placement:
+
+```bash
+lilbee placement clear
+```
+
+After that, the auto planner takes over again and places models across whatever
+GPUs are now available.
+
 ## Using with the Obsidian plugin
 
 The [Obsidian plugin](https://github.com/tobocop2/obsidian-lilbee) in managed mode runs this server for you, with each vault's data root under the plugin's shared install at `vaults/<id>/`. The same `logs/` layout applies inside that directory.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -62,6 +62,22 @@ tail -n 100 "<data root>/logs/llama-swap.log"
 tail -n 100 "<data root>/logs/server.log"
 ```
 
+## Ingest replicas and VRAM reclaim
+
+When an ingest job finishes, any extra embed or vision replicas that were started
+for it are unloaded automatically. This frees their VRAM so chat and search
+capacity is restored without a restart.
+
+If you set `embed_replicas` or `vision_replicas` explicitly in your config, that
+count is used during ingest and reclaimed the same way afterward. The default
+(`0`) picks one replica per GPU, capped by whatever VRAM remains after the
+persistent query servers (chat, embed-0, rerank, vision-0) are placed.
+
+If the fleet ever reports "no model server" transiently, lilbee now re-probes the
+engine and rebuilds a restarted llama-swap automatically before surfacing a
+failure. A single retry is attempted; if the rebuilt fleet still cannot serve the
+role, the normal `ProviderError` is returned.
+
 ## Using with the Obsidian plugin
 
 The [Obsidian plugin](https://github.com/tobocop2/obsidian-lilbee) in managed mode runs this server for you, with each vault's data root under the plugin's shared install at `vaults/<id>/`. The same `logs/` layout applies inside that directory.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,11 +248,13 @@ hard error that identifies the card by name (e.g. `CUDA0: RTX 4090
 (23.7 GiB free, 24.0 GiB total)`) rather than failing silently. This makes
 hardware-change failures explicit.
 
-All four surfaces go through the one `app/placement.py` use-case:
-CLI (`lilbee placement show/preview/set/clear`), HTTP
-(`GET/POST/PUT/DELETE /api/placement`, `GET /api/gpus`), MCP
+The surfaces go through the one `app/placement.py` use-case:
+CLI (`lilbee placement show/preview/set/clear`), MCP
 (`get_placement`, `preview_placement`, `set_placement`, `clear_placement`),
-and the TUI Placement screen. The `preview` operation is a dry-run: it shows
+and the TUI Placement screen. Over HTTP only the reads are served
+(`GET /api/placement`, `POST /api/placement/preview`, `GET /api/gpus`):
+applying or clearing placement rebuilds the shared fleet, so `PUT`/`DELETE
+/api/placement` are refused on the server. The `preview` operation is a dry-run: it shows
 what the auto planner would assign (or what a candidate spec would assign)
 including each card's backend+index label, name, and free/total VRAM, without
 touching the running fleet.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,7 +216,10 @@ flowchart TD
 - **Resident tiers and the elastic ingest pool**: placement reserves a persistent
   query fleet first: chat, one embed server (`embed-0`), rerank, and one vision
   server (`vision-0`). These stay resident so a chat request issued during ingest
-  always has capacity. Extra embed and vision replicas (`embed-1..N`, additional
+  always has capacity. This reservation applies to discrete-GPU placement; the
+  shared-memory path on a unified-memory or CPU host packs the same pool
+  differently and does not hold back the elastic replicas. Extra embed and vision
+  replicas (`embed-1..N`, additional
   vision) are placed only into the VRAM that remains after the query fleet is
   committed. When an ingest finishes, each extra replica is unloaded individually
   via llama-swap's `POST /api/models/unload`, freeing its VRAM without disturbing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,15 +213,23 @@ flowchart TD
   RAM on a unified-memory host drives the OS into a swap-thrash OOM livelock that
   hard-freezes the machine, so refusing is the safe outcome; chat slot count
   (`--parallel`) steps down the same way before refusing.
+- **Resident tiers and the elastic ingest pool**: placement reserves a persistent
+  query fleet first: chat, one embed server (`embed-0`), rerank, and one vision
+  server (`vision-0`). These stay resident so a chat request issued during ingest
+  always has capacity. Extra embed and vision replicas (`embed-1..N`, additional
+  vision) are placed only into the VRAM that remains after the query fleet is
+  committed. When an ingest finishes, each extra replica is unloaded individually
+  via llama-swap's `POST /api/models/unload`, freeing its VRAM without disturbing
+  the resident servers. If llama-swap is restarted or found dead, the fleet
+  re-probes once and rebuilds its model config before reporting a failure.
 - **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
-  vision roles can run as N independent servers, one per GPU, so large-scale ingest
-  fans embedding / OCR across the whole box. The single roles (chat) are placed
-  first; each replica then lands on a distinct card with the most free VRAM (only
-  co-locating a second once every card has one), capped by what fits. The provider
-  holds a client pool per role and round-robins to the least-busy replica. With no
-  discrete GPU the replicas run as co-resident processes against the shared pool.
-  Each replica is its own llama-swap model id (`<role>-<n>`); a role is ready once
-  any replica is.
+  vision roles can run as N independent servers, fanning embedding and OCR across
+  the box during ingest. Setting either value to `0` (the default) means auto: one
+  replica per GPU, capped by how much VRAM remains after the query fleet is placed.
+  A positive value pins the replica count to exactly that number. The provider
+  holds a client pool per role and round-robins to the least-busy replica. Each
+  replica is its own llama-swap model id (`<role>-<n>`); a role is ready once any
+  replica is. Replicas are ingest-only and reclaimed after ingest completes.
 - **Loader flags** (`adapters.build_server_argv`): each server's flags derive from
   cfg and the model's GGUF metadata for that role and config. Chat carries
   `--jinja`, `--flash-attn` (on unless `flash_attention` is disabled) and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,6 +213,49 @@ flowchart TD
   RAM on a unified-memory host drives the OS into a swap-thrash OOM livelock that
   hard-freezes the machine, so refusing is the safe outcome; chat slot count
   (`--parallel`) steps down the same way before refusing.
+
+#### Manual placement
+
+By default the auto planner runs every time a fleet is built. When a `placement`
+spec is set, it replaces the planner entirely: the spec's assignments are used
+as-is and the VRAM bin-pack does not run.
+
+The spec is per-role. Each role entry accepts:
+
+- `devices` (required): list of GPU indices to use for that role.
+- `tensor_split` (optional): per-device weight proportions for a tensor-split
+  instance. When omitted, a single-card placement is assumed.
+- `replicas` (optional): how many independent servers to run for embed and
+  vision roles. Defaults to 1.
+
+```json
+{
+  "chat":    { "devices": [0, 1], "tensor_split": [1, 1] },
+  "embed":   { "devices": [2], "replicas": 2 },
+  "rerank":  { "devices": [2] },
+  "vision":  { "devices": [3] }
+}
+```
+
+The `placement` field is stored as a JSON scalar in `config.toml` (a single
+`placement = '{"chat": ...}'` key), because the config store is a flat
+key-value file and cannot represent the nested shape natively. The placement
+surfaces (CLI, HTTP, MCP, TUI) handle encoding and decoding; editing
+`config.toml` by hand is not the intended path.
+
+When a pinned placement no longer fits the card it names, lilbee surfaces a
+hard error that identifies the card by name (e.g. `CUDA0: RTX 4090
+(23.7 GiB free, 24.0 GiB total)`) rather than failing silently. This makes
+hardware-change failures explicit.
+
+All four surfaces go through the one `app/placement.py` use-case:
+CLI (`lilbee placement show/preview/set/clear`), HTTP
+(`GET/POST/PUT/DELETE /api/placement`, `GET /api/gpus`), MCP
+(`get_placement`, `preview_placement`, `set_placement`, `clear_placement`),
+and the TUI Placement screen. The `preview` operation is a dry-run: it shows
+what the auto planner would assign (or what a candidate spec would assign)
+including each card's backend+index label, name, and free/total VRAM, without
+touching the running fleet.
 - **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
   vision roles can run as N independent servers, one per GPU, so large-scale ingest
   fans embedding / OCR across the whole box. The single roles (chat) are placed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,6 +256,7 @@ and the TUI Placement screen. The `preview` operation is a dry-run: it shows
 what the auto planner would assign (or what a candidate spec would assign)
 including each card's backend+index label, name, and free/total VRAM, without
 touching the running fleet.
+
 - **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
   vision roles can run as N independent servers, one per GPU, so large-scale ingest
   fans embedding / OCR across the whole box. The single roles (chat) are placed

--- a/docs/placement_ux_prototype.py
+++ b/docs/placement_ux_prototype.py
@@ -1,0 +1,446 @@
+"""Placement screen UX prototype — calm overview + per-model drill-in + advanced controls.
+
+A design reference for the real TUI placement screen, not production code.
+Grounded in lilbee's real fleet: 4 models (Chat, Embeddings, Reranker, Vision).
+Chat/Reranker are single instances (tensor-split a big model across cards);
+Embeddings/Vision are data-parallel (a copy per card) for throughput. LM-Studio
+style: an overview, then one model at a time. Fake data, no fleet.
+
+The drill-in has an Advanced section (press 'a') that exposes the full
+RolePlacement surface: distribute mode (copies vs split) for replicable roles,
+custom per-card tensor-split weights, and removing an optional model.
+
+NOTE for the real implementation: this mock is a single Static with manual
+on_key handling, so it is NOT tab-navigable. The production screen must use
+real focusable widgets (one per GPU checkbox / advanced control) so Tab and
+arrow keys both work, consistent with the rest of the TUI.
+Run: uv run --with textual python proto.py
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+# rose-pine
+BG = "#191724"
+TEXT = "#e0def4"
+SUB = "#908caa"
+MUTE = "#6e6a86"
+IRIS = "#c4a7e7"
+FOAM = "#9ccfd8"
+GOLD = "#f6c177"
+PINE = "#3e8fb0"
+ROSE = "#ebbcba"
+LOVE = "#eb6f92"
+TRACK = "#26233a"
+SEL = "#403d52"
+GPU_NAME = "RTX 4090"
+CARD_GB = 24.0
+
+
+@dataclass
+class Role:
+    key: str
+    label: str
+    model: str
+    job: str
+    size_gb: float
+    color: str
+    split: bool  # True = tensor-split one model across cards; False = a copy per card
+    required: bool = True  # required roles (chat/embed) can't be removed
+    replicable: bool = False  # embed/vision can choose copies vs split
+    enabled: bool = True
+    devices: set[int] = field(default_factory=set)
+    weights: dict[int, int] | None = None  # custom tensor-split ratio per device; None = even
+
+
+class PlacementProto(App):
+    CSS = f"""
+    Screen {{ background: {BG}; color: {TEXT}; }}
+    #screen {{ padding: 1 4; }}
+    """
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.gpu_count = 4
+        self.mode = "overview"  # overview | detail
+        self.ov = 0  # focused model row in overview
+        self.det = 0  # focused item index in detail
+        self.adv = False  # advanced section expanded in detail
+        self.detail_key = ""
+        self.toast = ""
+        self.roles: list[Role] = [
+            Role("chat", "Chat", "Qwen2.5 72B", "the model you talk to", 56.0, FOAM, split=True, required=True),
+            Role("embed", "Embeddings", "nomic-embed", "indexes docs for search", 0.3, GOLD, split=False, required=True, replicable=True),
+            Role("rerank", "Reranker", "bge-reranker", "sharpens search results", 0.6, PINE, split=True, required=False, enabled=False),
+            Role("vision", "Vision", "Qwen2-VL OCR", "reads images & PDFs", 5.0, ROSE, split=False, required=False, replicable=True, enabled=False),
+        ]
+        self.auto_layout()
+
+    # -- model -----------------------------------------------------------
+    def gpus(self) -> list[int]:
+        return list(range(self.gpu_count))
+
+    def auto_layout(self) -> None:
+        for r in self.roles:
+            if not r.enabled:
+                r.devices = set()
+                continue
+            need = _cards_needed(r.size_gb, self.gpu_count) if r.split else 1
+            r.devices = set(range(min(max(1, need), self.gpu_count)))
+
+    def is_auto(self) -> bool:
+        for r in self.roles:
+            need = _cards_needed(r.size_gb, self.gpu_count) if r.split else 1
+            want = set(range(min(max(1, need), self.gpu_count))) if r.enabled else set()
+            if r.devices != want:
+                return False
+        return True
+
+    def chunk(self, r: Role, gpu: int) -> float:
+        if not r.enabled or gpu not in r.devices or not r.devices:
+            return 0.0
+        if not r.split:
+            return r.size_gb  # a copy on each card
+        if r.weights:  # custom tensor-split ratio
+            tot = sum(r.weights.get(g, 1) for g in r.devices) or 1
+            return r.size_gb * r.weights.get(gpu, 1) / tot
+        return r.size_gb / len(r.devices)  # even split
+
+    def _detail_items(self, r: Role) -> list[str]:
+        items = [f"gpu:{g}" for g in self.gpus()]
+        if self.adv:
+            if r.replicable:
+                items.append("mode")
+            if r.split and len(r.devices) > 1:
+                items.append("weights")
+                if r.weights is not None:
+                    items += [f"w:{g}" for g in sorted(r.devices)]
+            if not r.required:
+                items.append("remove")
+        return items
+
+    def used(self, gpu: int) -> float:
+        return sum(self.chunk(rr, gpu) for rr in self.roles)
+
+    def _role(self, key: str) -> Role:
+        return next(r for r in self.roles if r.key == key)
+
+    def _runs_on(self, r: Role) -> str:
+        """Colored 'runs on' summary padded to a fixed VISIBLE width (tags excluded)."""
+        if not r.enabled:
+            body, plain = f"[{MUTE}]—[/]", "—"
+        elif not r.devices:
+            body, plain = f"[{LOVE}]no GPU[/]", "no GPU"
+        else:
+            d = sorted(r.devices)
+            gpus = "GPU " + "·".join(map(str, d))
+            if r.split and len(d) > 1:
+                note = f"split across {len(d)}"
+            elif len(d) > 1:
+                note = "a copy on each"
+            else:
+                note = ""
+            plain = (gpus + ("  " + note if note else "")).rstrip()
+            body = f"[{TEXT}]{gpus}[/]" + (f"  [{MUTE}]{note}[/]" if note else "")
+        return body + " " * max(0, 30 - len(plain))
+
+    def _role_ok(self, r: Role) -> tuple[bool, str]:
+        if not r.enabled:
+            return True, ""
+        if not r.devices:
+            return False, f"[{LOVE}]add a GPU[/]"
+        each = self.chunk(r, sorted(r.devices)[0])
+        if each > CARD_GB:
+            return False, f"[{LOVE}]too big — add a card[/]"
+        if any(self.used(g) > CARD_GB for g in r.devices):
+            return False, f"[{GOLD}]a card is full[/]"
+        return True, f"[{FOAM}]✓[/]"
+
+    def _bar(self, gpu: int, width: int) -> str:
+        used = self.used(gpu)
+        over = used > CARD_GB
+        denom = used if over else CARD_GB
+        out, wsum = "", 0
+        for rr in self.roles:
+            c = self.chunk(rr, gpu)
+            if c > 0:
+                w = max(1, round(c / denom * width))
+                out += f"[{rr.color}]{'█' * w}[/]"
+                wsum += w
+        if not over:
+            out += f"[{TRACK}]{'░' * max(0, width - wsum)}[/]"
+        return out
+
+    # -- overview --------------------------------------------------------
+    def _overview(self) -> str:
+        L: list[str] = []
+        L.append(
+            f"[{MUTE}]Chat · Catalog · Status · Settings · Tasks · [/][{IRIS}]Placement[/]"
+        )
+        L.append("")
+        status = (
+            f"[{FOAM}]● Automatic[/] [{MUTE}](lilbee chose this)[/]"
+            if self.is_auto()
+            else f"[{GOLD}]● Custom[/] [{MUTE}](^r reset to automatic)[/]"
+        )
+        L.append(f"[{TEXT}]Placement[/]      {status}")
+        L.append("")
+        L.append(f"[{SUB}]Your models[/]                                 [{SUB}]Runs on[/]")
+        for i, r in enumerate(self.roles):
+            focus = i == self.ov
+            arrow = f"[{IRIS}]▸[/]" if focus else " "
+            name = f"[{r.color}]{r.label:<11}[/][{MUTE}]{r.model:<14}[/]"
+            ok, tag = self._role_ok(r)
+            trailing = (f"[{SUB} on {SEL}] enable [/]" if focus else "") if not r.enabled else tag
+            line = f"  {arrow} {name}  {self._runs_on(r)} {trailing}"
+            if focus:
+                line = f"[on {SEL}]{line}[/]"
+            L.append(line)
+        L.append("")
+        L.append(f"[{SUB}]Your GPUs[/]")
+        cells = []
+        for g in self.gpus():
+            used = self.used(g)
+            tag = (
+                f"[{LOVE}]{used:.0f}/{CARD_GB:.0f} over[/]"
+                if used > CARD_GB
+                else (f"[{SUB}]{used:.0f}/{CARD_GB:.0f}[/]" if used > 0 else f"[{MUTE}]free[/]")
+            )
+            cells.append(f"[{TEXT}]GPU {g}[/] {self._bar(g, 8)} {tag}")
+        # wrap 4 per line
+        for i in range(0, len(cells), 4):
+            L.append("  " + "    ".join(cells[i : i + 4]))
+        L.append("")
+        all_ok = all(self._role_ok(r)[0] for r in self.roles)
+        fit = f"[{FOAM}]Everything fits ✓[/]" if all_ok else f"[{LOVE}]Some models don't fit — open one to fix.[/]"
+        L.append(fit)
+        L.append("")
+        L.append(
+            f"[{MUTE}]↑↓ model · enter customize · ^a auto · ^r reset · ^s apply · "
+            f"1/2/4/8 GPUs · q[/]"
+        )
+        if self.toast:
+            L.append(f"\n[{FOAM}]{self.toast}[/]")
+        return "\n".join(L)
+
+    # -- detail ----------------------------------------------------------
+    def _detail(self) -> str:
+        r = self._role(self.detail_key)
+        items = self._detail_items(r)
+        self.det = max(0, min(len(items) - 1, self.det))
+        cur = items[self.det] if items else ""
+        L: list[str] = []
+        size_note = (
+            "[{}]too big for one card[/]".format(LOVE)
+            if r.size_gb > CARD_GB
+            else f"[{MUTE}]{r.size_gb:.0f} GB · {r.job}[/]"
+        )
+        L.append(f"[{MUTE}]‹ back[/]     [{r.color}]{r.label}[/] [{MUTE}]— {r.model}[/]   {size_note}")
+        L.append("")
+        L.append(f"[{TEXT}]Which GPUs?[/]")
+        for g in self.gpus():
+            on = g in r.devices
+            box = f"[{r.color}]☑[/]" if on else f"[{MUTE}]☐[/]"
+            used = self.used(g)
+            tag = (
+                f"[{LOVE}]{used:.0f}/{CARD_GB:.0f} full[/]"
+                if used > CARD_GB
+                else (f"[{SUB}]{used:.0f}/{CARD_GB:.0f} GB[/]" if used > 0 else f"[{MUTE}]free[/]")
+            )
+            focus = cur == f"gpu:{g}"
+            line = f"   {box}  [{TEXT}]GPU {g}[/]  [{MUTE}]{GPU_NAME}[/]   {self._bar(g, 10)}  {tag}"
+            L.append(f"[{IRIS}]▸[/]{line[1:]}" if focus else f" {line}")
+        L.append("")
+        # how + fit
+        d = sorted(r.devices)
+        each = self.chunk(r, d[0]) if d else 0
+        if r.split:
+            how = (
+                f"[{TEXT}]How:[/]  one model [{r.color}]split[/] across the selected cards"
+                if len(d) > 1
+                else f"[{TEXT}]How:[/]  runs on the selected card"
+            )
+        else:
+            how = (
+                f"[{TEXT}]How:[/]  [{r.color}]a copy on each[/] selected card [{MUTE}](more = faster {r.job.split()[0]})[/]"
+                if len(d) > 1
+                else f"[{TEXT}]How:[/]  one copy on the selected card"
+            )
+        if not d:
+            fit = f"[{LOVE}]Pick at least one GPU.[/]"
+        elif each > CARD_GB:
+            fit = f"[{LOVE}]Still too big — select another card.[/]"
+        elif any(self.used(g) > CARD_GB for g in d):
+            fit = f"[{GOLD}]Fits, but a card is over budget.[/]"
+        else:
+            spread = self._split_spread(r, d) if (r.split and len(d) > 1) else ""
+            detail = (
+                spread or (f"{each:.0f} GB on each of {len(d)} cards" if len(d) > 1 else f"{each:.0f} GB on Card {d[0]}")
+            )
+            fit = f"[{FOAM}]✓ Fits[/] [{MUTE}]— {detail}[/]"
+        L.append(how)
+        L.append(f"      {fit}")
+        L.append("")
+        L += self._advanced_block(r, cur)
+        L.append("")
+        L.append(self._detail_hints(r, cur))
+        return "\n".join(L)
+
+    def _split_spread(self, r: Role, d: list[int]) -> str:
+        return "split " + " / ".join(f"{self.chunk(r, g):.0f}" for g in d) + " GB"
+
+    def _advanced_block(self, r: Role, cur: str) -> list[str]:
+        controls = []
+        if r.replicable:
+            controls.append("distribute mode")
+        if r.split and len(r.devices) > 1:
+            controls.append("custom split weights")
+        if not r.required:
+            controls.append("remove model")
+        if not controls:
+            return [f"[{MUTE}]No advanced options for this model.[/]"]
+        arrow = "▾" if self.adv else "▸"
+        hint = "" if self.adv else f"  [{MUTE}]({', '.join(controls)})[/]"
+        out = [f"[{MUTE}]{arrow}[/] [{SUB}]Advanced[/]{hint}"]
+        if self.adv:
+            out += self._advanced_lines(r, cur)
+        return out
+
+    def _advanced_lines(self, r: Role, cur: str) -> list[str]:
+        out: list[str] = []
+
+        def mark(item: str) -> str:
+            return f"[{IRIS}]▸[/]" if cur == item else " "
+
+        def radio(on: bool, label: str) -> str:
+            return f"[{r.color}]● {label}[/]" if on else f"[{MUTE}]○ {label}[/]"
+
+        if r.replicable:
+            choice = f"{radio(not r.split, 'Copies')}   {radio(r.split, 'Split')}"
+            out.append(f"  {mark('mode')} [{TEXT}]Distribute[/]   {choice}")
+            if cur == "mode":
+                out.append(f"      [{MUTE}]Copies = a full model per card (faster). Split = one model across cards (for big models).[/]")
+        if r.split and len(r.devices) > 1:
+            choice = f"{radio(r.weights is None, 'Even')}   {radio(r.weights is not None, 'Custom')}"
+            out.append(f"  {mark('weights')} [{TEXT}]Split weights[/]  {choice}")
+            if r.weights is not None:
+                for g in sorted(r.devices):
+                    w = r.weights.get(g, 1)
+                    bar = f"[{r.color}]{'▮' * w}{'·' * (9 - w)}[/]"
+                    tip = f"  [{MUTE}](+/- to adjust)[/]" if cur == f"w:{g}" else ""
+                    out.append(f"  {mark(f'w:{g}')}   [{MUTE}]GPU {g}[/]  {bar} [{MUTE}]weight {w} → {self.chunk(r, g):.0f} GB[/]{tip}")
+        if not r.required:
+            tip = f"  [{MUTE}](frees its VRAM; re-add it from the overview)[/]" if cur == "remove" else ""
+            out.append(f"  {mark('remove')} [{LOVE}]Remove this model[/]{tip}")
+        return out
+
+    def _detail_hints(self, r: Role, cur: str) -> str:
+        nav = "↑↓ move · +/- adjust" if cur.startswith("w:") else "↑↓ move · space toggle"
+        has_adv = r.replicable or (r.split and len(r.devices) > 1) or not r.required
+        adv = "a advanced · " if has_adv else ""
+        return f"[{MUTE}]{nav} · {adv}enter done · esc back[/]"
+
+    # -- lifecycle -------------------------------------------------------
+    def compose(self) -> ComposeResult:
+        yield Static(id="screen")
+
+    def on_mount(self) -> None:
+        self._refresh()
+
+    def _refresh(self) -> None:
+        body = self._overview() if self.mode == "overview" else self._detail()
+        self.query_one("#screen", Static).update(body)
+
+    def on_key(self, event) -> None:  # noqa: C901
+        k = event.key
+        self.toast = ""
+        if k in ("1", "2", "4", "8"):
+            self.gpu_count = int(k)
+            self.ov = self.det = 0
+            self.auto_layout()
+            return self._refresh()
+        if self.mode == "overview":
+            if k in ("down", "j"):
+                self.ov = min(len(self.roles) - 1, self.ov + 1)
+            elif k in ("up", "k"):
+                self.ov = max(0, self.ov - 1)
+            elif k == "enter":
+                r = self.roles[self.ov]
+                if not r.enabled:
+                    r.enabled = True
+                    self.auto_layout()
+                else:
+                    self.detail_key = r.key
+                    self.det = 0
+                    self.adv = False
+                    self.mode = "detail"
+            elif k == "ctrl+a":
+                self.auto_layout()
+                self.toast = "Arranged automatically."
+            elif k == "ctrl+r":
+                self.auto_layout()
+            elif k == "ctrl+s":
+                self.toast = "Applied — fleet reconfigured."
+        else:  # detail
+            r = self._role(self.detail_key)
+            items = self._detail_items(r)
+            self.det = max(0, min(len(items) - 1, self.det))
+            cur = items[self.det] if items else ""
+            if k in ("down", "j"):
+                self.det = min(len(items) - 1, self.det + 1)
+            elif k in ("up", "k"):
+                self.det = max(0, self.det - 1)
+            elif k == "a":
+                self.adv = not self.adv
+            elif k in ("+", "=") and cur.startswith("w:") and r.weights is not None:
+                g = int(cur[2:])
+                r.weights[g] = min(9, r.weights.get(g, 1) + 1)
+            elif k in ("-", "_") and cur.startswith("w:") and r.weights is not None:
+                g = int(cur[2:])
+                r.weights[g] = max(1, r.weights.get(g, 1) - 1)
+            elif k == "space" or (k == "enter" and cur in ("mode", "weights", "remove")):
+                self._detail_act(r, cur)
+            elif k == "escape":
+                self.mode = "overview"
+            elif k == "enter":
+                self.mode = "overview"
+        self._refresh()
+
+    def _detail_act(self, r: Role, cur: str) -> None:
+        if cur.startswith("gpu:"):
+            g = int(cur[4:])
+            if g in r.devices:
+                if len(r.devices) > 1:
+                    r.devices.discard(g)
+            else:
+                r.devices.add(g)
+        elif cur == "mode":
+            r.split = not r.split
+            r.weights = None
+        elif cur == "weights":
+            r.weights = None if r.weights is not None else {g: 1 for g in sorted(r.devices)}
+        elif cur.startswith("w:") and r.weights is not None:
+            g = int(cur[2:])
+            r.weights[g] = (r.weights.get(g, 1) % 9) + 1
+        elif cur == "remove":
+            r.enabled = False
+            r.devices.clear()
+            r.weights = None
+            self.adv = False
+            self.mode = "overview"
+
+
+def _cards_needed(size_gb: float, available: int) -> int:
+    per = CARD_GB * 0.9
+    n = 1
+    while size_gb / n > per and n < max(1, available):
+        n += 1
+    return n
+
+
+if __name__ == "__main__":
+    PlacementProto().run()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1012,9 +1012,10 @@ lilbee placement show
 lilbee placement clear
 ```
 
-The same operations are available in the TUI under the Placement screen, and
-over HTTP (`PUT /api/placement`, `DELETE /api/placement`) and MCP
-(`set_placement`, `clear_placement`). The spec persists across restarts.
+The same operations are available in the TUI under the Placement screen and over
+MCP (`set_placement`, `clear_placement`). Applying or clearing placement rebuilds
+the shared fleet, so it is not exposed over HTTP: `PUT`/`DELETE /api/placement`
+are refused on the server (use the CLI or TUI). The spec persists across restarts.
 
 If a pinned placement no longer fits the card it names (after a hardware
 change, for example), lilbee surfaces an error naming the card rather than

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -966,6 +966,64 @@ llama-server fleet, remote model names route to the SDK backend) and `remote`
 
 ---
 
+## Tuning GPU placement
+
+By default lilbee decides which GPUs each model goes on automatically. It
+bin-packs all four roles (chat, embed, rerank, vision) across your available
+GPUs and tensor-splits anything too large for one card. For most setups this is
+all you need.
+
+If you want to pin specific models to specific cards, you can set a placement
+spec. The spec is a JSON object with one entry per role you want to control:
+
+```json
+{
+  "chat":   { "devices": [0, 1], "tensor_split": [1, 1] },
+  "embed":  { "devices": [2] },
+  "rerank": { "devices": [2] },
+  "vision": { "devices": [3] }
+}
+```
+
+Each role takes `devices` (GPU indices), an optional `tensor_split` list for
+spreading a single model across cards, and an optional `replicas` count for the
+embed and vision roles. Omit a role and the auto planner handles it.
+
+**To see what the auto planner would assign** (without changing anything):
+
+```bash
+lilbee placement preview
+```
+
+**To apply a spec from a file:**
+
+```bash
+lilbee placement set --spec placement.json
+```
+
+**To see the current spec** (or confirm auto is active):
+
+```bash
+lilbee placement show
+```
+
+**To go back to automatic:**
+
+```bash
+lilbee placement clear
+```
+
+The same operations are available in the TUI under the Placement screen, and
+over HTTP (`PUT /api/placement`, `DELETE /api/placement`) and MCP
+(`set_placement`, `clear_placement`). The spec persists across restarts.
+
+If a pinned placement no longer fits the card it names (after a hardware
+change, for example), lilbee surfaces an error naming the card rather than
+starting in a broken state. `lilbee placement clear` returns to automatic
+placement in that case.
+
+---
+
 ## Cross-encoder reranking
 
 Built-in. Re-scores retrieval candidates with a cross-encoder for precision on

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -970,8 +970,7 @@ llama-server fleet, remote model names route to the SDK backend) and `remote`
 
 By default lilbee decides which GPUs each model goes on automatically. It
 bin-packs all four roles (chat, embed, rerank, vision) across your available
-GPUs and tensor-splits anything too large for one card. For most setups this is
-all you need.
+GPUs and tensor-splits anything too large for one card.
 
 If you want to pin specific models to specific cards, you can set a placement
 spec. The spec is a JSON object with one entry per role you want to control:

--- a/scripts/qa/cli_surface_qa.py
+++ b/scripts/qa/cli_surface_qa.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""CLI surface QA: every subcommand registers + key read paths run clean.
+
+Catches import/registration breakage (common after a multi-PR merge) and
+tracebacks in read-only command paths. Run from the repo root:
+  LILBEE_QA_CLI=lilbee uv run --no-sync python scripts/qa/cli_surface_qa.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+CLI = os.environ.get("LILBEE_QA_CLI", "lilbee")
+RESULTS: list[tuple[str, bool, str]] = []
+
+
+def rec(cid: str, ok: bool, detail: str = "") -> None:
+    RESULTS.append((cid, ok, detail))
+    print(f"[{'PASS' if ok else 'FAIL'}] {cid}" + (f"  -- {detail}" if detail else ""), flush=True)
+
+
+def run(args: list[str], timeout: int = 120) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([CLI, *args], capture_output=True, text=True, timeout=timeout)
+
+
+def _traceback(cp: subprocess.CompletedProcess[str]) -> bool:
+    return "Traceback (most recent call last)" in (cp.stderr + cp.stdout)
+
+
+# Every top-level command (from the `lilbee --help` Commands panel). --help must
+# register cleanly -- a failure here means a command's module fails to import.
+COMMANDS = [
+    "add", "agent-config", "ask", "chat", "chunks", "export", "import", "index",
+    "init", "launch", "login", "mcp", "memory", "model", "placement", "rebuild",
+    "remove", "reset", "search", "self-check", "self-check-extras", "serve",
+    "setup", "status", "sync", "token", "topics", "use-embedder", "version", "wiki",
+]
+
+# Read-only invocations that must exit 0 (GPU listing is `placement show`, not a
+# command). A traceback with rc==0 is a handled warning, reported as observation.
+READ_INVOCATIONS = [
+    ("status", ["status"]),
+    ("model-list", ["model", "list"]),
+    ("placement-show", ["placement", "show"]),
+    ("placement-preview", ["placement", "preview"]),
+    ("memory-list", ["memory", "list"]),
+    ("search", ["search", "lilbee"]),
+    ("version", ["version"]),
+]
+
+
+def main() -> int:
+    print("=== CLI --help registration ===", flush=True)
+    for cmd in COMMANDS:
+        try:
+            cp = run([cmd, "--help"], timeout=90)
+            ok = cp.returncode == 0 and not _traceback(cp)
+            rec(f"help:{cmd}", ok, "" if ok else f"rc={cp.returncode} {(cp.stderr or cp.stdout).strip().splitlines()[-1][:100] if (cp.stderr or cp.stdout).strip() else ''}")
+        except subprocess.TimeoutExpired:
+            rec(f"help:{cmd}", False, "timed out")
+        except Exception as exc:  # noqa: BLE001
+            rec(f"help:{cmd}", False, f"{type(exc).__name__}: {exc}")
+
+    print("\n=== read-only invocations ===", flush=True)
+    # A crash = nonzero exit. A traceback printed with rc==0 is an exc_info on a
+    # handled WARNING (e.g. engine warm-up lost the health race), not a failure;
+    # it is surfaced as an observation, not a FAIL.
+    for cid, args in READ_INVOCATIONS:
+        try:
+            cp = run(args, timeout=150)
+            ok = cp.returncode == 0
+            note = ""
+            if ok and _traceback(cp):
+                note = "(rc=0 but a handled traceback was logged -- check it is intentional)"
+            elif not ok:
+                tail = (cp.stderr or cp.stdout).strip().splitlines()
+                note = f"rc={cp.returncode}: {tail[-1][:120] if tail else ''}"
+            rec(f"run:{cid}", ok, note)
+        except subprocess.TimeoutExpired:
+            rec(f"run:{cid}", False, "timed out")
+        except Exception as exc:  # noqa: BLE001
+            rec(f"run:{cid}", False, f"{type(exc).__name__}: {exc}")
+
+    failed = [c for c, ok, _ in RESULTS if not ok]
+    print(f"\n{len(RESULTS) - len(failed)}/{len(RESULTS)} passed, {len(failed)} failed", flush=True)
+    if failed:
+        print("FAILURES:", flush=True)
+        for cid, ok, detail in RESULTS:
+            if not ok:
+                print(f"  [FAIL] {cid}: {detail}", flush=True)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qa/placement_qa.py
+++ b/scripts/qa/placement_qa.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Fleet placement QA matrix.
+
+Drives the entire placement surface on a multi-GPU pod and reports PASS/FAIL
+per case. Sections:
+  1. Spec validation (pure)            -- no server, no GPU
+  2. App layer (get/preview/set/clear) -- needs GPU detection
+  3. CLI surface (subprocess)          -- needs GPU detection
+  4. MCP surface (tool functions)      -- needs GPU detection
+  5. HTTP surface (curl a live server) -- needs `lilbee serve` running
+  6. Empirical VRAM (chat split)       -- needs models + nvidia-smi
+
+Run static sections:   uv run python placement_qa.py
+Include HTTP:           LILBEE_QA_BASE=http://127.0.0.1:8765 LILBEE_QA_KEY=... uv run python placement_qa.py
+Empirical VRAM is driven separately by placement_qa_live.sh (asks + nvidia-smi).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import traceback
+from collections.abc import Callable
+
+RESULTS: list[tuple[str, str, bool, str]] = []
+
+
+def rec(cid: str, desc: str, ok: bool, detail: str = "") -> None:
+    RESULTS.append((cid, desc, ok, detail))
+    flag = "PASS" if ok else "FAIL"
+    line = f"[{flag}] {cid:<16} {desc}"
+    if detail:
+        line += f"\n                   -> {detail}"
+    print(line, flush=True)
+
+
+def section(name: str) -> None:
+    print(f"\n{'=' * 70}\n{name}\n{'=' * 70}", flush=True)
+
+
+# --------------------------------------------------------------------------
+# Section 1: spec validation (pure)
+# --------------------------------------------------------------------------
+def run_validation() -> None:
+    section("1. SPEC VALIDATION (PlacementSpec.from_json)")
+    from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
+    def expect_ok(cid: str, desc: str, raw: str) -> None:
+        try:
+            PlacementSpec.from_json(raw)
+            rec(cid, desc, True)
+        except Exception as exc:  # noqa: BLE001
+            rec(cid, desc, False, f"rejected: {type(exc).__name__}: {exc}")
+
+    def expect_err(cid: str, desc: str, raw: str) -> None:
+        try:
+            PlacementSpec.from_json(raw)
+            rec(cid, desc, False, "ACCEPTED (expected PlacementError)")
+        except PlacementError as exc:
+            rec(cid, desc, True, str(exc))
+        except Exception as exc:  # noqa: BLE001
+            rec(cid, desc, False, f"wrong exc {type(exc).__name__}: {exc}")
+
+    # valid specs
+    expect_ok("V-valid", "chat+embed valid", '{"chat":{"devices":[0,1]},"embed":{"devices":[0]}}')
+    expect_ok("V-split", "valid tensor_split", '{"chat":{"devices":[0,1],"tensor_split":[1,1]}}')
+    expect_ok("V-repl", "valid replicas", '{"embed":{"devices":[0],"replicas":2}}')
+    expect_ok("V-splitskew", "skewed tensor_split", '{"chat":{"devices":[0,1],"tensor_split":[3,1]}}')
+
+    # already-validated malformed input (should already PASS)
+    expect_err("V-json", "malformed JSON", "{bad}")
+    expect_err("V-notobj", "non-object root", "[1,2]")
+    expect_err("V-role", "unknown role", '{"frobnicate":{"devices":[0]}}')
+    expect_err("V-empty", "empty devices", '{"chat":{"devices":[]}}')
+    expect_err("V-noentry", "entry not an object", '{"chat":[0,1]}')
+    expect_err("V-replneg", "replicas < 1", '{"embed":{"devices":[0],"replicas":0}}')
+    expect_err("V-splitlen", "tensor_split length mismatch", '{"chat":{"devices":[0,1],"tensor_split":[1]}}')
+
+    # bb-26o gaps -- currently ACCEPTED (FAIL), should be rejected after fix
+    expect_err("V-dupdev", "duplicate devices rejected", '{"chat":{"devices":[0,0]}}')
+    expect_err("V-dupdev3", "duplicate devices (3)", '{"chat":{"devices":[0,1,1]}}')
+    expect_err("V-splitzero", "tensor_split zero weight rejected", '{"chat":{"devices":[0,1],"tensor_split":[0,1]}}')
+    expect_err("V-splitneg", "tensor_split negative weight rejected", '{"chat":{"devices":[0,1],"tensor_split":[1,-1]}}')
+    expect_err("V-unknownkey", "unknown entry key rejected", '{"chat":{"devices":[0],"frobnicate":1}}')
+    expect_err("V-devneg", "negative device index rejected", '{"chat":{"devices":[-1]}}')
+
+    # round-trip stability
+    try:
+        from lilbee.providers.fleet.placement_spec import PlacementSpec as PS
+
+        raw = '{"chat":{"devices":[0,1],"tensor_split":[1,1]},"embed":{"devices":[0],"replicas":2}}'
+        rt = PS.from_json(PS.from_json(raw).to_json()).to_json()
+        rec("V-roundtrip", "from_json/to_json round-trips", rt == PS.from_json(raw).to_json(), rt)
+    except Exception as exc:  # noqa: BLE001
+        rec("V-roundtrip", "from_json/to_json round-trips", False, repr(exc))
+
+
+# --------------------------------------------------------------------------
+# Section 2: app layer
+# --------------------------------------------------------------------------
+def run_app_layer() -> None:
+    section("2. APP LAYER (lilbee.app.placement)")
+    from lilbee.app import placement as P
+    from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
+    try:
+        v = P.get_placement()
+        rec("A-get", "get_placement() returns a view", v is not None, f"gpus={len(v.gpus)} manual={v.manual}")
+    except Exception as exc:  # noqa: BLE001
+        rec("A-get", "get_placement()", False, f"{type(exc).__name__}: {exc}")
+
+    try:
+        v = P.preview_placement(None)
+        rec("A-preview-auto", "preview auto", v is not None, f"roles={[r.role.value for r in v.roles]}")
+    except Exception as exc:  # noqa: BLE001
+        rec("A-preview-auto", "preview auto", False, f"{type(exc).__name__}: {exc}")
+
+    # preview a complete manual spec pinning chat to GPU1+2 (a spec must cover
+    # every active role, so include embed)
+    try:
+        spec = PlacementSpec.from_json('{"chat":{"devices":[1,2]},"embed":{"devices":[0]}}')
+        v = P.preview_placement(spec)
+        chat = next((r for r in v.roles if r.role.value == "chat"), None)
+        ok = chat is not None and set(chat.devices) <= {1, 2}
+        rec("A-preview-pin", "preview honors device pin", ok, f"chat devices={getattr(chat,'devices',None)}")
+    except Exception as exc:  # noqa: BLE001
+        rec("A-preview-pin", "preview honors device pin", False, f"{type(exc).__name__}: {exc}")
+
+    # bb-a8f: preview a spec that fits TOTAL but maybe not FREE VRAM should not be
+    # rejected purely because a model is resident. Recorded as observation here;
+    # the load-then-preview check is in the live section.
+    rec("A-a8f-note", "bb-a8f free-vs-total checked live", True, "see live section L-a8f")
+
+
+# --------------------------------------------------------------------------
+# Section 3: CLI surface
+# --------------------------------------------------------------------------
+_LILBEE_BIN = os.environ.get("LILBEE_QA_CLI", "lilbee")
+
+
+def _cli(args: list[str], stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [_LILBEE_BIN, *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env={**os.environ},
+    )
+
+
+def run_cli() -> None:
+    section("3. CLI SURFACE (lilbee placement / gpus)")
+
+    cp = _cli(["placement", "show"])
+    traceback_leak = "Traceback (most recent call last)" in cp.stderr
+    rec("C-show", "placement show works without traceback", cp.returncode == 0 and not traceback_leak,
+        f"rc={cp.returncode} tb={traceback_leak} {cp.stderr.strip()[:120]}")
+
+    cp = _cli(["placement", "preview"])
+    rec("C-preview-auto", "placement preview (auto)", cp.returncode == 0, f"rc={cp.returncode}")
+
+    # valid complete spec via stdin (covers every active role)
+    cp = _cli(["placement", "preview", "--spec", "-"], stdin='{"chat":{"devices":[1,2]},"embed":{"devices":[0]}}')
+    rec("C-preview-stdin", "preview --spec - (stdin)", cp.returncode == 0, f"rc={cp.returncode} {(cp.stderr or cp.stdout).strip()[:100]}")
+
+    # malformed spec -> clean error, exit 1, no traceback
+    cp = _cli(["placement", "preview", "--spec", "-"], stdin="{bad json")
+    clean = cp.returncode != 0 and "Traceback (most recent call last)" not in cp.stderr
+    rec("C-preview-badjson", "bad JSON -> clean error (no traceback)", clean,
+        f"rc={cp.returncode} {(cp.stderr or cp.stdout).strip()[:120]}")
+
+    # unknown role -> clean error
+    cp = _cli(["placement", "preview", "--spec", "-"], stdin='{"frobnicate":{"devices":[0]}}')
+    clean = cp.returncode != 0 and "Traceback (most recent call last)" not in cp.stderr
+    rec("C-preview-badrole", "unknown role -> clean error", clean, f"rc={cp.returncode}")
+
+    # out-of-range device -> clean error (embed present so the chat error surfaces)
+    cp = _cli(["placement", "preview", "--spec", "-"], stdin='{"chat":{"devices":[99]},"embed":{"devices":[0]}}')
+    clean = cp.returncode != 0 and "Traceback (most recent call last)" not in cp.stderr
+    rec("C-preview-oor", "out-of-range device -> clean error", clean, f"rc={cp.returncode} {(cp.stderr or cp.stdout).strip()[:120]}")
+
+    # missing spec file -> clean error not traceback
+    cp = _cli(["placement", "set", "--spec", "/nonexistent/spec.json"])
+    clean = cp.returncode != 0 and "Traceback (most recent call last)" not in cp.stderr
+    rec("C-set-nofile", "missing spec file -> clean error", clean, f"rc={cp.returncode} {(cp.stderr or cp.stdout).strip()[:120]}")
+
+    # inline JSON to --spec (bb-z9w): parsed as JSON, not mistaken for a file path
+    cp = _cli(["placement", "preview", "--spec", '{"chat":{"devices":[1,2]},"embed":{"devices":[0]}}'])
+    out = cp.stderr + cp.stdout
+    inline_ok = cp.returncode == 0 and "No such file" not in out and "Traceback" not in cp.stderr
+    rec("C-set-inline", "inline JSON to --spec is parsed, not treated as a file", inline_ok,
+        f"rc={cp.returncode} {out.strip()[:120]}")
+
+    # gpus listing
+    cp = _cli(["gpus"]) if _has_cmd("gpus") else _cli(["placement", "show"])
+    rec("C-gpus", "gpu listing works", cp.returncode == 0, f"rc={cp.returncode}")
+
+
+def _has_cmd(name: str) -> bool:
+    cp = _cli(["--help"])
+    return name in cp.stdout
+
+
+# --------------------------------------------------------------------------
+# Section 4: MCP surface
+# --------------------------------------------------------------------------
+def run_mcp() -> None:
+    section("4. MCP SURFACE (mcp_server tool fns)")
+    import lilbee.mcp_server as M
+
+    try:
+        d = M.get_placement_tool()
+        rec("M-get", "get_placement_tool returns dict", isinstance(d, dict), f"keys={list(d)[:6]}")
+    except Exception as exc:  # noqa: BLE001
+        rec("M-get", "get_placement_tool", False, f"{type(exc).__name__}: {exc}")
+
+    try:
+        d = M.preview_placement_tool(None)
+        rec("M-preview-auto", "preview_placement_tool(None)", isinstance(d, dict))
+    except Exception as exc:  # noqa: BLE001
+        rec("M-preview-auto", "preview_placement_tool(None)", False, f"{type(exc).__name__}: {exc}")
+
+    try:
+        d = M.preview_placement_tool({"chat": {"devices": [1, 2]}, "embed": {"devices": [0]}})
+        rec("M-preview-spec", "preview_placement_tool(spec)", isinstance(d, dict) and "error" not in d, str(d)[:80])
+    except Exception as exc:  # noqa: BLE001
+        rec("M-preview-spec", "preview_placement_tool(spec)", False, f"{type(exc).__name__}: {exc}")
+
+    # bad spec via MCP -> should return a structured error dict, never a raw crash
+    for cid, desc, spec in [
+        ("M-bad-empty", "empty devices", {"chat": {"devices": []}}),
+        ("M-bad-role", "unknown role", {"frobnicate": {"devices": [0]}}),
+        ("M-bad-dup", "duplicate devices", {"chat": {"devices": [0, 0]}, "embed": {"devices": [0]}}),
+    ]:
+        try:
+            out = M.preview_placement_tool(spec)
+            ok = isinstance(out, dict) and "error" in out
+            rec(cid, f"{desc} -> structured error", ok, str(out)[:90])
+        except Exception as exc:  # noqa: BLE001
+            rec(cid, f"{desc} -> structured error", False, f"raised {type(exc).__name__}: {str(exc)[:80]}")
+
+
+# --------------------------------------------------------------------------
+# Section 5: HTTP surface (live server)
+# --------------------------------------------------------------------------
+def run_http() -> None:
+    base = os.environ.get("LILBEE_QA_BASE")
+    if not base:
+        section("5. HTTP SURFACE -- SKIPPED (set LILBEE_QA_BASE to enable)")
+        return
+    section(f"5. HTTP SURFACE ({base})")
+    key = os.environ.get("LILBEE_QA_KEY", "")
+
+    def curl(method: str, path: str, body: str | None = None, auth: bool = True) -> tuple[int, str]:
+        cmd = ["curl", "-sS", "-o", "-", "-w", "\n%{http_code}", "-X", method, f"{base}{path}"]
+        if auth and key:
+            cmd += ["-H", f"Authorization: Bearer {key}"]
+        if body is not None:
+            cmd += ["-H", "Content-Type: application/json", "-d", body]
+        cp = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        out = cp.stdout
+        code = out.rsplit("\n", 1)[-1].strip()
+        payload = out.rsplit("\n", 1)[0]
+        try:
+            return int(code), payload
+        except ValueError:
+            return -1, out
+
+    code, _ = curl("GET", "/api/placement")
+    rec("H-get", "GET /api/placement 200", code == 200, f"code={code}")
+
+    code, _ = curl("GET", "/api/gpus")
+    rec("H-gpus", "GET /api/gpus 200", code == 200, f"code={code}")
+
+    code, _ = curl("POST", "/api/placement/preview", '{"spec":{"chat":{"devices":[1,2]},"embed":{"devices":[0]}}}')
+    rec("H-preview", "POST preview valid 200", code == 200, f"code={code}")
+
+    # malformed spec -> 4xx not 500 (bb-x0o)
+    code, body = curl("POST", "/api/placement/preview", '{"spec":{"chat":{"devices":[]}}}')
+    rec("H-preview-bad", "POST preview bad spec -> 4xx not 500", 400 <= code < 500, f"code={code} {body[:100]}")
+
+    # out-of-range device -> 4xx not 500 (bb-x0o; ProviderError/ValueError)
+    code, body = curl("POST", "/api/placement/preview", '{"spec":{"chat":{"devices":[99]},"embed":{"devices":[0]}}}')
+    rec("H-preview-oor", "POST preview oor device -> 4xx not 500", 400 <= code < 500, f"code={code} {body[:100]}")
+
+    # dup devices -> 4xx after fix (bb-26o)
+    code, body = curl("POST", "/api/placement/preview", '{"spec":{"chat":{"devices":[0,0]}}}')
+    rec("H-preview-dup", "POST preview dup devices -> 4xx", 400 <= code < 500, f"code={code} {body[:100]}")
+
+    # PUT/DELETE refused on the shared daemon (bb-fhi) -> 409 regardless of auth
+    code, body = curl("PUT", "/api/placement", '{"spec":{"chat":{"devices":[1,2]},"embed":{"devices":[0]}}}')
+    rec("H-put-refused", "PUT placement -> 409 refused on daemon (bb-fhi)", code == 409, f"code={code} {body[:80]}")
+    code, body = curl("DELETE", "/api/placement")
+    rec("H-del-refused", "DELETE placement -> 409 refused on daemon (bb-fhi)", code == 409, f"code={code} {body[:80]}")
+
+    # preview auth (bb-895): only meaningful when the server enforces auth (a key
+    # is set). Localhost dev servers skip auth; the enforcement is unit-tested.
+    if key:
+        code, _ = curl("POST", "/api/placement/preview", '{"spec":{"chat":{"devices":[0]}}}', auth=False)
+        rec("H-preview-noauth", "preview without key -> 401/403 (bb-895)", code in (401, 403), f"code={code}")
+    else:
+        rec("H-preview-noauth", "preview auth enforcement (bb-895)", True, "server has no auth key; see unit test test_preview_requires_auth")
+
+
+# --------------------------------------------------------------------------
+def summary() -> int:
+    section("SUMMARY")
+    passed = sum(1 for _, _, ok, _ in RESULTS if ok)
+    failed = [r for r in RESULTS if not r[2]]
+    print(f"{passed}/{len(RESULTS)} passed, {len(failed)} failed\n")
+    if failed:
+        print("FAILURES:")
+        for cid, desc, _, detail in failed:
+            print(f"  [FAIL] {cid:<16} {desc}\n         {detail}")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    runners: list[Callable[[], None]] = [run_validation, run_app_layer, run_cli, run_mcp, run_http]
+    for fn in runners:
+        try:
+            fn()
+        except Exception:  # noqa: BLE001
+            print(f"\n!!! section {fn.__name__} crashed:\n{traceback.format_exc()}", flush=True)
+            rec(fn.__name__, "section crashed", False, "see traceback above")
+    return summary()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qa/placement_qa.py
+++ b/scripts/qa/placement_qa.py
@@ -302,7 +302,7 @@ def run_http() -> None:
         code, _ = curl("POST", "/api/placement/preview", '{"spec":{"chat":{"devices":[0]}}}', auth=False)
         rec("H-preview-noauth", "preview without key -> 401/403 (bb-895)", code in (401, 403), f"code={code}")
     else:
-        rec("H-preview-noauth", "preview auth enforcement (bb-895)", True, "server has no auth key; see unit test test_preview_requires_auth")
+        rec("H-preview-noauth", "preview auth enforcement (bb-895)", True, "server has no auth key; see unit test test_placement_routes_require_auth")
 
 
 # --------------------------------------------------------------------------

--- a/scripts/qa/placement_qa.py
+++ b/scripts/qa/placement_qa.py
@@ -306,6 +306,69 @@ def run_http() -> None:
 
 
 # --------------------------------------------------------------------------
+# Section 6: TUI surface (real PlacementScreen via Textual pilot)
+# --------------------------------------------------------------------------
+def run_tui() -> None:
+    section("6. TUI SURFACE (PlacementScreen via Textual pilot)")
+    try:
+        import asyncio
+
+        from textual.widgets import DataTable, Static
+
+        from lilbee.cli.tui.app import LilbeeApp
+        from lilbee.cli.tui.screens import placement as scr
+        from lilbee.cli.tui.screens.placement import PlacementScreen
+    except Exception as exc:  # noqa: BLE001
+        rec("T-import", "TUI imports", False, f"{type(exc).__name__}: {exc}")
+        return
+
+    class _Host(LilbeeApp):
+        _test_skip_auto_init = True
+
+        def on_mount(self) -> None:
+            self.push_screen(PlacementScreen())
+
+    def generated(app: object) -> str:
+        return str(app.screen.query_one(scr._GENERATED_ID, Static).render())
+
+    async def drive() -> None:
+        app = _Host()
+        async with app.run_test(size=(150, 48)) as pilot:
+            await pilot.pause()
+            try:
+                table = app.screen.query_one(scr._GPU_TABLE_ID, DataTable)
+            except Exception as exc:  # noqa: BLE001
+                rec("T-mount", "PlacementScreen mounts", False, f"{type(exc).__name__}: {exc}")
+                return
+            rec("T-mount", "PlacementScreen mounts with a GPU table", True, f"rows={table.row_count}")
+            if table.row_count == 0:
+                rec("T-gpus", "GPU table populated", False, "0 GPUs detected -- run on a multi-GPU pod for full TUI coverage")
+                return
+            rec("T-gpus", "GPU table lists detected GPUs", table.row_count >= 1, f"rows={table.row_count}")
+            last = table.row_count - 1
+            btn = f"#dev-chat-{last}"
+            try:
+                await pilot.click(btn)
+                await pilot.pause()
+                ok = f"{last}" in generated(app)
+                rec("T-toggle", f"clicking {btn} updates the generated spec", ok, generated(app)[:90])
+            except Exception as exc:  # noqa: BLE001
+                rec("T-toggle", "device toggle button", False, f"{type(exc).__name__}: {exc}")
+            try:
+                await pilot.press("ctrl+r")
+                await pilot.pause()
+                still = app.screen.query_one(scr._GPU_TABLE_ID, DataTable).row_count >= 1
+                rec("T-preview", "ctrl+r preview keeps the screen populated (no blank-on-error)", still)
+            except Exception as exc:  # noqa: BLE001
+                rec("T-preview", "ctrl+r preview", False, f"{type(exc).__name__}: {exc}")
+
+    try:
+        asyncio.run(drive())
+    except Exception as exc:  # noqa: BLE001
+        rec("T-run", "TUI pilot session", False, f"{type(exc).__name__}: {exc}")
+
+
+# --------------------------------------------------------------------------
 def summary() -> int:
     section("SUMMARY")
     passed = sum(1 for _, _, ok, _ in RESULTS if ok)
@@ -319,7 +382,7 @@ def summary() -> int:
 
 
 def main() -> int:
-    runners: list[Callable[[], None]] = [run_validation, run_app_layer, run_cli, run_mcp, run_http]
+    runners: list[Callable[[], None]] = [run_validation, run_app_layer, run_cli, run_mcp, run_http, run_tui]
     for fn in runners:
         try:
             fn()

--- a/scripts/qa/tui_surface_qa.py
+++ b/scripts/qa/tui_surface_qa.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""TUI surface QA: boot the real LilbeeApp headless and drive every screen.
+
+Uses Textual's pilot (not a terminal) so it works reliably in CI/headless and
+surfaces real bugs: exceptions on mount/navigation, error-level logs, and error
+notifications. Run: uv run --no-sync python scripts/qa/tui_surface_qa.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import traceback
+
+RESULTS: list[tuple[str, bool, str]] = []
+LOG_RECORDS: list[logging.LogRecord] = []
+
+
+def rec(cid: str, ok: bool, detail: str = "") -> None:
+    RESULTS.append((cid, ok, detail))
+    print(f"[{'PASS' if ok else 'FAIL'}] {cid}" + (f"  -- {detail}" if detail else ""), flush=True)
+
+
+class _Collector(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        LOG_RECORDS.append(record)
+
+
+def _install_logging() -> None:
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    root.addHandler(_Collector())
+
+
+async def drive() -> None:
+    from textual.widgets import Static
+
+    from lilbee.cli.tui.app import LilbeeApp
+
+    notes: list[tuple[str, str]] = []
+
+    class _QAApp(LilbeeApp):
+        def notify(self, message, *args, **kwargs):  # type: ignore[no-untyped-def, override]
+            sev = str(kwargs.get("severity", "information"))
+            notes.append((sev, str(message)))
+            return super().notify(message, *args, **kwargs)
+
+    app = _QAApp()
+    try:
+        async with app.run_test(size=(160, 50)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            # 1. did the app mount a real screen with content?
+            scr = app.screen
+            widget_count = len(list(scr.query("*")))
+            rec("TUI-boot", widget_count > 3, f"initial screen={type(scr).__name__} widgets={widget_count}")
+
+            # 2. navigate every managed view and confirm it mounts
+            from lilbee.cli.tui import messages as msg
+
+            for view in [*msg.get_nav_views(), "Chat"]:
+                before = len(notes)
+                try:
+                    app.switch_view(view)
+                    await pilot.pause()
+                    await pilot.pause()
+                    scr = app.screen
+                    n = len(list(scr.query("*")))
+                    err_notes = [m for s, m in notes[before:] if s == "error"]
+                    ok = n > 1 and not err_notes
+                    rec(f"TUI-view:{view}", ok, f"{type(scr).__name__} widgets={n}" + (f" ERR={err_notes}" if err_notes else ""))
+                except Exception:
+                    rec(f"TUI-view:{view}", False, f"EXC: {traceback.format_exc().splitlines()[-1]}")
+
+            # 3. on the chat screen, type into the prompt (no send -> no model load)
+            try:
+                app.switch_view("Chat")
+                await pilot.pause()
+                await pilot.press("h", "i")
+                await pilot.pause()
+                rec("TUI-input", True, "typed into prompt without crash")
+            except Exception:
+                rec("TUI-input", False, f"EXC: {traceback.format_exc().splitlines()[-1]}")
+
+            # 4. error notifications raised during the whole run
+            errs = [m for s, m in notes if s == "error"]
+            rec("TUI-no-error-toasts", not errs, f"error toasts: {errs[:3]}" if errs else "none")
+    except Exception:
+        rec("TUI-run", False, f"app.run_test crashed: {traceback.format_exc().splitlines()[-1]}")
+
+
+def main() -> int:
+    _install_logging()
+    try:
+        asyncio.run(drive())
+    except Exception:
+        rec("TUI-asyncio", False, traceback.format_exc().splitlines()[-1])
+
+    # report error/exception logs captured during the run
+    errs = [r for r in LOG_RECORDS if r.levelno >= logging.ERROR]
+    warns = [r for r in LOG_RECORDS if r.levelno == logging.WARNING]
+    print(f"\n=== captured logs: {len(errs)} ERROR, {len(warns)} WARNING ===", flush=True)
+    for r in errs[:15]:
+        print(f"  ERROR {r.name}: {r.getMessage()[:200]}", flush=True)
+        if r.exc_info:
+            print("    " + "".join(traceback.format_exception(*r.exc_info)).splitlines()[-1], flush=True)
+    seen: set[str] = set()
+    for r in warns:
+        key = f"{r.name}:{r.getMessage()[:80]}"
+        if key in seen:
+            continue
+        seen.add(key)
+        print(f"  WARN  {r.name}: {r.getMessage()[:160]}", flush=True)
+
+    failed = [c for c, ok, _ in RESULTS if not ok]
+    print(f"\n{len(RESULTS) - len(failed)}/{len(RESULTS)} passed, {len(failed)} failed", flush=True)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -69,7 +69,8 @@ def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -
     for plan in resolved.instances:
         existing = by_role.get(plan.role)
         if existing is not None:
-            by_role[plan.role] = replace(existing, replicas=existing.replicas + 1)
+            devices = tuple(sorted(set(existing.devices) | set(plan.devices)))
+            by_role[plan.role] = replace(existing, devices=devices, replicas=existing.replicas + 1)
         else:
             by_role[plan.role] = RolePlacementView(
                 role=plan.role,

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -8,7 +8,11 @@ from lilbee.app.services import reset_services
 from lilbee.core import settings
 from lilbee.core.config import cfg
 from lilbee.providers.fleet.placement_spec import PlacementSpec
-from lilbee.providers.fleet.planning import ResolvedPlacement, resolve_placement_plan
+from lilbee.providers.fleet.planning import (
+    ResolvedPlacement,
+    clear_read_device_cache,
+    resolve_placement_plan,
+)
 from lilbee.providers.roles import WorkerRole
 
 _PLACEMENT_KEY = "placement"
@@ -115,4 +119,5 @@ def set_placement(spec: PlacementSpec | None) -> PlacementView:
         settings.update_values(cfg.data_root, {_PLACEMENT_KEY: spec_json})
         cfg.placement = spec_json
     reset_services()
+    clear_read_device_cache()  # the reconfigure changes free VRAM; don't serve a stale probe
     return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -1,0 +1,112 @@
+"""Surface-agnostic placement use-cases: inspect, preview, and set GPU placement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lilbee.app.services import reset_services
+from lilbee.core import settings
+from lilbee.core.config import cfg
+from lilbee.providers.fleet.placement_spec import PlacementSpec
+from lilbee.providers.fleet.planning import ResolvedPlacement, resolve_placement_plan
+from lilbee.providers.roles import WorkerRole
+
+_PLACEMENT_KEY = "placement"
+
+
+@dataclass(frozen=True)
+class GpuInfo:
+    """One detected GPU as a surface can render it."""
+
+    index: int
+    backend: str
+    label: str
+    name: str
+    total_bytes: int
+    free_bytes: int
+
+
+@dataclass(frozen=True)
+class RolePlacementView:
+    """Where one role's model is placed in the resolved plan."""
+
+    role: WorkerRole
+    model: str
+    devices: tuple[int, ...]
+    tensor_split: tuple[int, ...] | None
+    replicas: int
+
+
+@dataclass(frozen=True)
+class PlacementView:
+    """The full placement picture: GPUs, per-role placement, and whether manual."""
+
+    gpus: tuple[GpuInfo, ...]
+    roles: tuple[RolePlacementView, ...]
+    unplaceable: tuple[WorkerRole, ...]
+    manual: bool
+    spec_json: str | None
+
+
+def _active_spec() -> PlacementSpec | None:
+    return cfg.placement
+
+
+def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -> PlacementView:
+    gpus = tuple(
+        GpuInfo(
+            index=d.index,
+            backend=d.backend,
+            label=f"{d.backend}{d.index}",
+            name=d.name,
+            total_bytes=d.total_bytes,
+            free_bytes=d.free_bytes,
+        )
+        for d in resolved.devices
+    )
+    by_role: dict[WorkerRole, RolePlacementView] = {}
+    for plan in resolved.instances:
+        existing = by_role.get(plan.role)
+        replicas = (existing.replicas + 1) if existing else 1
+        by_role[plan.role] = RolePlacementView(
+            role=plan.role,
+            model=resolved.model_refs.get(plan.role, ""),
+            devices=plan.devices,
+            tensor_split=plan.tensor_split or None,
+            replicas=replicas,
+        )
+    return PlacementView(
+        gpus=gpus,
+        roles=tuple(by_role.values()),
+        unplaceable=resolved.unplaceable_roles,
+        manual=manual,
+        spec_json=spec_json,
+    )
+
+
+def get_placement() -> PlacementView:
+    """The current effective placement (manual if a spec is set, else auto)."""
+    spec = _active_spec()
+    resolved = resolve_placement_plan(spec)
+    return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)
+
+
+def preview_placement(spec: PlacementSpec | None = None) -> PlacementView:
+    """Dry-run: what spec (or auto, when None) would place. No persistence or reload."""
+    resolved = resolve_placement_plan(spec)
+    return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)
+
+
+def set_placement(spec: PlacementSpec | None) -> PlacementView:
+    """Validate, persist to config.toml, reset the fleet, and return the new view.
+
+    Raises PlacementError before any write when the spec does not fit the hardware.
+    """
+    resolved = resolve_placement_plan(spec)
+    if spec is None:
+        settings.delete_values(cfg.data_root, [_PLACEMENT_KEY])
+    else:
+        settings.update_values(cfg.data_root, {_PLACEMENT_KEY: spec.to_json()})
+    cfg.placement = spec
+    reset_services()
+    return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from lilbee.app.services import reset_services
 from lilbee.core import settings
@@ -67,14 +67,16 @@ def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -
     by_role: dict[WorkerRole, RolePlacementView] = {}
     for plan in resolved.instances:
         existing = by_role.get(plan.role)
-        replicas = (existing.replicas + 1) if existing else 1
-        by_role[plan.role] = RolePlacementView(
-            role=plan.role,
-            model=resolved.model_refs.get(plan.role, ""),
-            devices=plan.devices,
-            tensor_split=plan.tensor_split or None,
-            replicas=replicas,
-        )
+        if existing is not None:
+            by_role[plan.role] = replace(existing, replicas=existing.replicas + 1)
+        else:
+            by_role[plan.role] = RolePlacementView(
+                role=plan.role,
+                model=resolved.model_refs.get(plan.role, ""),
+                devices=plan.devices,
+                tensor_split=plan.tensor_split or None,
+                replicas=1,
+            )
     return PlacementView(
         gpus=gpus,
         roles=tuple(by_role.values()),

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -49,7 +49,8 @@ class PlacementView:
 
 
 def _active_spec() -> PlacementSpec | None:
-    return cfg.placement
+    raw = cfg.placement
+    return PlacementSpec.from_json(raw) if raw else None
 
 
 def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -> PlacementView:
@@ -107,8 +108,10 @@ def set_placement(spec: PlacementSpec | None) -> PlacementView:
     resolved = resolve_placement_plan(spec)
     if spec is None:
         settings.delete_values(cfg.data_root, [_PLACEMENT_KEY])
+        cfg.placement = None
     else:
-        settings.update_values(cfg.data_root, {_PLACEMENT_KEY: spec.to_json()})
-    cfg.placement = spec
+        spec_json = spec.to_json()
+        settings.update_values(cfg.data_root, {_PLACEMENT_KEY: spec_json})
+        cfg.placement = spec_json
     reset_services()
     return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -770,13 +770,13 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         int,
         nullable=False,
         group=SettingGroup.GENERATION,
-        help_text="Embedding servers to run in parallel, one per GPU, for large-scale ingest",
+        help_text="Embedding servers in parallel (0 = auto, one per GPU; positive pins the count)",
     ),
     "vision_replicas": SettingDef(
         int,
         nullable=False,
         group=SettingGroup.GENERATION,
-        help_text="Vision OCR servers to run in parallel, one per GPU, for large-scale ingest",
+        help_text="Vision OCR servers in parallel (0 = auto, one per GPU; positive pins the count)",
     ),
     "candidate_multiplier": SettingDef(
         int,

--- a/src/lilbee/cli/__init__.py
+++ b/src/lilbee/cli/__init__.py
@@ -6,8 +6,10 @@
 from lilbee.cli import commands as _commands  # noqa: F401  side-effect: command registration
 from lilbee.cli.app import app, apply_overrides, console
 from lilbee.cli.model import model_app
+from lilbee.cli.placement import placement_app
 
 app.add_typer(model_app)
+app.add_typer(placement_app)
 
 __all__ = [
     "app",

--- a/src/lilbee/cli/placement.py
+++ b/src/lilbee/cli/placement.py
@@ -93,7 +93,7 @@ def preview(
     apply_overrides(data_dir=data_dir, use_global=use_global)
     try:
         _render_view(preview_placement(_read_spec(spec)))
-    except PlacementError as exc:
+    except (PlacementError, OSError) as exc:
         console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
         raise typer.Exit(code=1) from exc
 
@@ -108,7 +108,7 @@ def set_cmd(
     apply_overrides(data_dir=data_dir, use_global=use_global)
     try:
         _render_view(set_placement(_read_spec(spec)))
-    except PlacementError as exc:
+    except (PlacementError, OSError) as exc:
         console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
         raise typer.Exit(code=1) from exc
 

--- a/src/lilbee/cli/placement.py
+++ b/src/lilbee/cli/placement.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import typer
@@ -16,7 +17,10 @@ from lilbee.app.placement import (
 )
 from lilbee.cli import theme
 from lilbee.cli.app import apply_overrides, console, data_dir_option, global_option
+from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
+_PLACEMENT_ERRORS = (PlacementError, ProviderError, OSError)
 
 placement_app = typer.Typer(
     name="placement",
@@ -31,8 +35,22 @@ def _read_spec(spec: str | None) -> PlacementSpec | None:
     """Parse a spec from a file path or stdin ('-'); return None when omitted."""
     if spec is None:
         return None
-    raw = sys.stdin.read() if spec == "-" else Path(spec).read_text()
+    if spec == "-":
+        raw = sys.stdin.read()
+    elif spec.lstrip().startswith("{"):
+        raw = spec  # inline JSON rather than a file path
+    else:
+        raw = Path(spec).read_text()
     return PlacementSpec.from_json(raw)
+
+
+def _guard(action: Callable[[], PlacementView]) -> None:
+    """Run a placement action and render it, turning known failures into a clean exit."""
+    try:
+        _render_view(action())
+    except _PLACEMENT_ERRORS as exc:
+        console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(code=1) from exc
 
 
 def _render_view(view: PlacementView) -> None:
@@ -78,7 +96,7 @@ def show(
 ) -> None:
     """Show the current effective placement."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    _render_view(get_placement())
+    _guard(get_placement)
 
 
 @placement_app.command("preview")
@@ -91,11 +109,7 @@ def preview(
 ) -> None:
     """Preview what a spec (or auto) would place, without applying it."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    try:
-        _render_view(preview_placement(_read_spec(spec)))
-    except (PlacementError, OSError) as exc:
-        console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
-        raise typer.Exit(code=1) from exc
+    _guard(lambda: preview_placement(_read_spec(spec)))
 
 
 @placement_app.command("set")
@@ -106,11 +120,7 @@ def set_cmd(
 ) -> None:
     """Validate, persist, and apply a manual placement spec."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    try:
-        _render_view(set_placement(_read_spec(spec)))
-    except (PlacementError, OSError) as exc:
-        console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
-        raise typer.Exit(code=1) from exc
+    _guard(lambda: set_placement(_read_spec(spec)))
 
 
 @placement_app.command("clear")
@@ -120,4 +130,4 @@ def clear(
 ) -> None:
     """Clear the manual placement and return to automatic placement."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
-    _render_view(set_placement(None))
+    _guard(lambda: set_placement(None))

--- a/src/lilbee/cli/placement.py
+++ b/src/lilbee/cli/placement.py
@@ -1,0 +1,123 @@
+"""`lilbee placement` sub-app: inspect, preview, and set GPU placement."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+from rich.table import Table
+
+from lilbee.app.placement import (
+    PlacementView,
+    get_placement,
+    preview_placement,
+    set_placement,
+)
+from lilbee.cli import theme
+from lilbee.cli.app import apply_overrides, console, data_dir_option, global_option
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
+placement_app = typer.Typer(
+    name="placement",
+    help="Inspect and override multi-GPU model placement.",
+    no_args_is_help=True,
+)
+
+_GIB = 1024**3
+
+
+def _read_spec(spec: str | None) -> PlacementSpec | None:
+    """Parse a spec from a file path or stdin ('-'); return None when omitted."""
+    if spec is None:
+        return None
+    raw = sys.stdin.read() if spec == "-" else Path(spec).read_text()
+    return PlacementSpec.from_json(raw)
+
+
+def _render_view(view: PlacementView) -> None:
+    """Print a Rich table of GPU rows plus per-role and unplaceable lines."""
+    title = "Placement (manual)" if view.manual else "Placement (auto)"
+    table = Table(title=title)
+    table.add_column("GPU")
+    table.add_column("Name")
+    table.add_column("Free / Total")
+    table.add_column("Roles")
+
+    placed: dict[int, list[str]] = {g.index: [] for g in view.gpus}
+    for role_view in view.roles:
+        for idx in role_view.devices:
+            placed.setdefault(idx, []).append(role_view.role.value)
+
+    for g in view.gpus:
+        free_gib = g.free_bytes / _GIB
+        total_gib = g.total_bytes / _GIB
+        table.add_row(
+            g.label,
+            g.name or "(unnamed)",
+            f"{free_gib:.0f} / {total_gib:.0f} GiB",
+            ", ".join(placed.get(g.index, [])) or "-",
+        )
+    console.print(table)
+
+    for role_view in view.roles:
+        split_info = f" split={list(role_view.tensor_split)}" if role_view.tensor_split else ""
+        console.print(
+            f"  {role_view.role.value}: devices={list(role_view.devices)}"
+            f" replicas={role_view.replicas}{split_info}  {role_view.model}"
+        )
+
+    for role in view.unplaceable:
+        console.print(f"  [{theme.ERROR}]{role.value}: does not fit, no server[/{theme.ERROR}]")
+
+
+@placement_app.command("show")
+def show(
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Show the current effective placement."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    _render_view(get_placement())
+
+
+@placement_app.command("preview")
+def preview(
+    spec: str | None = typer.Option(
+        None, "--spec", help="Spec JSON file, or - for stdin; omit for auto."
+    ),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Preview what a spec (or auto) would place, without applying it."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    try:
+        _render_view(preview_placement(_read_spec(spec)))
+    except PlacementError as exc:
+        console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(code=1) from exc
+
+
+@placement_app.command("set")
+def set_cmd(
+    spec: str = typer.Option(..., "--spec", help="Spec JSON file, or - for stdin."),
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Validate, persist, and apply a manual placement spec."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    try:
+        _render_view(set_placement(_read_spec(spec)))
+    except PlacementError as exc:
+        console.print(f"[{theme.ERROR}]{exc}[/{theme.ERROR}]")
+        raise typer.Exit(code=1) from exc
+
+
+@placement_app.command("clear")
+def clear(
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Clear the manual placement and return to automatic placement."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    _render_view(set_placement(None))

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -68,6 +68,12 @@ def _make_wiki() -> Screen:
     return WikiScreen()
 
 
+def _make_placement() -> Screen:
+    from lilbee.cli.tui.screens.placement import PlacementScreen
+
+    return PlacementScreen()
+
+
 # Screen factory per managed view name (Chat is special-cased in switch_view and
 # has no factory). The active set + order + wiki gate come from msg.get_nav_views,
 # so the view universe lives in exactly one place (messages.ALL_NAV_VIEWS).
@@ -77,6 +83,7 @@ _VIEW_FACTORIES: dict[str, Callable[[], Screen]] = {
     "Settings": _make_settings,
     "Tasks": _make_tasks,
     "Wiki": _make_wiki,
+    "Placement": _make_placement,
 }
 
 

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -390,11 +390,20 @@ COMPAT_MODAL_BODY = (
 )
 DEFAULT_VIEW = "Chat"
 WIKI_VIEW = "Wiki"
+PLACEMENT_VIEW = "Placement"
 # The full nav-view universe in order. Single source for the view set: the
 # settings bar pre-creates a tab per entry (toggling Wiki visibility at
 # runtime), get_nav_views() gates Wiki, and app.get_views() derives its
 # factory map from get_nav_views().
-ALL_NAV_VIEWS: tuple[str, ...] = (DEFAULT_VIEW, "Catalog", "Status", "Settings", "Tasks", WIKI_VIEW)
+ALL_NAV_VIEWS: tuple[str, ...] = (
+    DEFAULT_VIEW,
+    "Catalog",
+    "Status",
+    "Settings",
+    "Tasks",
+    WIKI_VIEW,
+    PLACEMENT_VIEW,
+)
 
 
 def get_nav_views() -> list[str]:

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -1,0 +1,203 @@
+"""GPU placement screen: inspect, preview, and apply manual placement specs."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, ClassVar
+
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Static, TextArea
+
+from lilbee.app.placement import get_placement, preview_placement, set_placement
+from lilbee.cli.tui.app import LilbeeApp
+from lilbee.cli.tui.thread_safe import call_from_thread
+from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+if TYPE_CHECKING:
+    from lilbee.app.placement import PlacementView
+
+
+class _LilbeeAppTestHost(LilbeeApp):
+    """LilbeeApp subclass that skips the heavyweight on_mount for test/demo harnesses."""
+
+    _test_skip_auto_init = True
+
+
+log = logging.getLogger(__name__)
+
+_GPU_TABLE_ID = "#placement-gpus"
+_ROLE_SUMMARY_ID = "#placement-role-summary"
+_SPEC_AREA_ID = "#placement-spec"
+
+_GIB = 1024**3
+
+
+def _fmt_gib(n: int) -> str:
+    """Format bytes as GiB string."""
+    return f"{n / _GIB:.1f} GiB"
+
+
+def _render_roles(view: PlacementView) -> str:
+    """Build the role summary text from a PlacementView."""
+    lines: list[str] = []
+    for r in view.roles:
+        devs = ", ".join(str(d) for d in r.devices)
+        ts = str(r.tensor_split) if r.tensor_split else "auto"
+        lines.append(
+            f"[bold]{r.role.value}[/bold]  model={r.model}  "
+            f"devices=[{devs}]  tensor_split={ts}  replicas={r.replicas}"
+        )
+    for role in view.unplaceable:
+        lines.append(f"[red]UNPLACEABLE: {role.value}[/red]")
+    return "\n".join(lines) if lines else "(no roles placed)"
+
+
+class PlacementScreen(Screen[None]):
+    """GPU placement viewer and editor."""
+
+    CSS_PATH = "placement.tcss"
+    AUTO_FOCUS = _GPU_TABLE_ID
+    HELP = "Inspect GPU placement. ctrl+r preview, ctrl+s apply, ctrl+x clear, q back."
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("q", "go_back", "Back", show=True),
+        Binding("escape", "go_back", "Back", show=False),
+        Binding("ctrl+r", "preview", "Preview", show=True),
+        Binding("ctrl+s", "apply", "Apply", show=True),
+        Binding("ctrl+x", "clear", "Clear", show=True),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._spec_text: str = ""
+
+    def compose(self) -> ComposeResult:
+        from lilbee.cli.tui.widgets.bottom_bars import BottomBars
+        from lilbee.cli.tui.widgets.status_bar import ViewTabs
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+        from lilbee.cli.tui.widgets.top_bars import TopBars
+
+        table: DataTable[str] = DataTable(id="placement-gpus")
+        table.cursor_type = "row"
+
+        with TopBars():
+            yield ViewTabs()
+        with Vertical(id="placement-layout"):
+            yield table
+            yield Static("", id="placement-role-summary")
+            yield TextArea(id="placement-spec")
+        with BottomBars():
+            yield TaskBar()
+            yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one(_GPU_TABLE_ID, DataTable)
+        table.add_columns("Label", "Name", "Free", "Total")
+        self._load_placement()
+
+    def _load_placement(self) -> None:
+        """Fetch placement and populate the screen synchronously."""
+        try:
+            view = get_placement()
+        except Exception as exc:
+            log.debug("Failed to load placement", exc_info=True)
+            self.notify(str(exc), severity="error")
+            return
+        self._render_view(view)
+
+    def _render_view(self, view: PlacementView) -> None:
+        """Populate the GPU table and role summary from a PlacementView."""
+        table = self.query_one(_GPU_TABLE_ID, DataTable)
+        table.clear()
+        for gpu in view.gpus:
+            table.add_row(
+                gpu.label,
+                gpu.name,
+                _fmt_gib(gpu.free_bytes),
+                _fmt_gib(gpu.total_bytes),
+                key=str(gpu.index),
+            )
+        summary = self.query_one(_ROLE_SUMMARY_ID, Static)
+        summary.update(_render_roles(view))
+        if view.spec_json:
+            self._spec_text = view.spec_json
+            self.query_one(_SPEC_AREA_ID, TextArea).load_text(view.spec_json)
+
+    def _parse_spec(self) -> PlacementSpec | None:
+        """Parse the current spec text into a PlacementSpec or None."""
+        raw = self._spec_text.strip()
+        if not raw:
+            return None
+        return PlacementSpec.from_json(raw)
+
+    def action_preview(self) -> None:
+        """Preview the current spec without applying it."""
+        try:
+            spec = self._parse_spec()
+        except (ValueError, json.JSONDecodeError, KeyError) as exc:
+            self.notify(str(exc), severity="error")
+            return
+        self._preview_worker(spec)
+
+    @work(thread=True, exit_on_error=False)
+    def _preview_worker(self, spec: PlacementSpec | None) -> None:
+        """Run preview_placement off the UI thread."""
+        try:
+            view = preview_placement(spec)
+            call_from_thread(self, self._render_view, view)
+        except Exception as exc:
+            call_from_thread(self, self.notify, str(exc), severity="error")
+
+    def action_apply(self) -> None:
+        """Apply the current spec and reload services."""
+        try:
+            spec = self._parse_spec()
+        except (ValueError, json.JSONDecodeError, KeyError) as exc:
+            self.notify(str(exc), severity="error")
+            return
+        self._apply_worker(spec)
+
+    @work(thread=True, exit_on_error=False)
+    def _apply_worker(self, spec: PlacementSpec | None) -> None:
+        """Run set_placement off the UI thread."""
+        try:
+            set_placement(spec)
+            view = get_placement()
+            call_from_thread(self, self._render_view, view)
+        except Exception as exc:
+            call_from_thread(self, self.notify, str(exc), severity="error")
+
+    def action_clear(self) -> None:
+        """Clear the manual spec (restore auto placement)."""
+        self._clear_worker()
+
+    @work(thread=True, exit_on_error=False)
+    def _clear_worker(self) -> None:
+        """Run set_placement(None) off the UI thread."""
+        try:
+            set_placement(None)
+            view = get_placement()
+            call_from_thread(self, self._render_view, view)
+        except Exception as exc:
+            call_from_thread(self, self.notify, str(exc), severity="error")
+
+    def action_go_back(self) -> None:
+        """Pop back to the previous screen."""
+        if len(self.app.screen_stack) > 1:
+            self.app.pop_screen()
+        else:
+            self.app.switch_view("Chat")  # type: ignore[attr-defined]
+
+
+class PlacementScreenApp(_LilbeeAppTestHost):
+    """Minimal app harness that mounts PlacementScreen for test/demo use."""
+
+    CSS = ""
+
+    def on_mount(self) -> None:
+        self.push_screen(PlacementScreen())

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -1,25 +1,31 @@
-"""GPU placement screen: inspect, preview, and apply manual placement specs."""
+"""GPU placement screen: inspect and configure multi-GPU model placement.
+
+The editor is interactive: each role has a GPU toggle per device and a replica
+stepper, so placement is configured by clicking, not by hand-writing JSON. The
+equivalent spec is shown read-only for use with the CLI/HTTP/MCP surfaces.
+"""
 
 from __future__ import annotations
 
 import contextlib
-import json
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.screen import Screen
-from textual.widgets import DataTable, Footer, Static, TextArea
+from textual.widgets import Button, DataTable, Footer, Label, Static
 
 from lilbee.app.placement import get_placement, preview_placement, set_placement
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.thread_safe import call_from_thread
-from lilbee.providers.fleet.placement_spec import PlacementSpec
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
 
 if TYPE_CHECKING:
     from lilbee.app.placement import PlacementView
@@ -28,34 +34,35 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _GPU_TABLE_ID = "#placement-gpus"
-_ROLE_SUMMARY_ID = "#placement-role-summary"
-_SPEC_AREA_ID = "#placement-spec"
+_EDITOR_ID = "#placement-editor"
+_GENERATED_ID = "#placement-generated"
+_TITLE_ID = "#placement-title"
 
 _GIB = 1024**3
+# Only these roles run multiple replicas; the others always serve one instance.
+_REPLICA_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
+_HINT = (
+    "Toggle a GPU for each role; -/+ sets replicas.  ctrl+r preview · ctrl+s apply · ctrl+x auto"
+)
+
+
+@dataclass
+class _RoleEdit:
+    """Mutable editor state for one role."""
+
+    role: WorkerRole
+    model: str
+    devices: set[int]
+    replicas: int
 
 
 def _fmt_gib(n: int) -> str:
-    """Format bytes as GiB string."""
+    """Format bytes as a GiB string."""
     return f"{n / _GIB:.1f} GiB"
 
 
-def _render_roles(view: PlacementView) -> str:
-    """Build the role summary text from a PlacementView."""
-    lines: list[str] = []
-    for r in view.roles:
-        devs = ", ".join(str(d) for d in r.devices)
-        ts = str(r.tensor_split) if r.tensor_split else "auto"
-        lines.append(
-            f"[bold]{r.role.value}[/bold]  model={r.model}  "
-            f"devices=[{devs}]  tensor_split={ts}  replicas={r.replicas}"
-        )
-    for role in view.unplaceable:
-        lines.append(f"[red]UNPLACEABLE: {role.value}[/red]")
-    return "\n".join(lines) if lines else "(no roles placed)"
-
-
 class PlacementScreen(Screen[None]):
-    """GPU placement viewer and editor."""
+    """GPU placement viewer and interactive editor."""
 
     # Lilbee always hosts screens on a LilbeeApp, so narrowing the type lets
     # the screen call switch_view without per-call type: ignore comments.
@@ -63,26 +70,30 @@ class PlacementScreen(Screen[None]):
 
     CSS_PATH = "placement.tcss"
     AUTO_FOCUS = _GPU_TABLE_ID
-    HELP = "Inspect GPU placement. ctrl+r preview, ctrl+s apply, ctrl+x clear, q back."
+    HELP = "Configure GPU placement. ctrl+r preview, ctrl+s apply, ctrl+x auto, q back."
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "go_back", "Back", show=True),
         Binding("escape", "go_back", "Back", show=False),
-        Binding("ctrl+r", "preview", "Preview", show=True),
-        Binding("ctrl+s", "apply", "Apply", show=True),
-        Binding("ctrl+x", "clear", "Clear", show=True),
+        # priority so they fire even when a button/editor child has focus.
+        Binding("ctrl+r", "preview", "Preview", show=True, priority=True),
+        Binding("ctrl+s", "apply", "Apply", show=True, priority=True),
+        Binding("ctrl+x", "clear", "Auto", show=True, priority=True),
     ]
 
     applying: reactive[bool] = reactive(False)
 
     def __init__(self) -> None:
         super().__init__()
-        self._spec_text: str = ""
+        self._edits: dict[WorkerRole, _RoleEdit] = {}
+        self._device_indices: tuple[int, ...] = ()
+        self._gpu_meta: list[tuple[int, str, str, int, int]] = []
+        self._view_manual = False
 
     def watch_applying(self, applying: bool) -> None:
-        """Disable the spec editor while an apply/clear is in flight."""
+        """Disable the editor controls while an apply/clear is in flight."""
         with contextlib.suppress(NoMatches):
-            self.query_one(_SPEC_AREA_ID, TextArea).disabled = applying
+            self.query_one(_EDITOR_ID, Vertical).disabled = applying
 
     def compose(self) -> ComposeResult:
         from lilbee.cli.tui.widgets.bottom_bars import BottomBars
@@ -96,16 +107,18 @@ class PlacementScreen(Screen[None]):
         with TopBars():
             yield ViewTabs()
         with Vertical(id="placement-layout"):
+            yield Static("", id="placement-title")
             yield table
-            yield Static("", id="placement-role-summary")
-            yield TextArea(id="placement-spec")
+            yield Vertical(id="placement-editor")
+            yield Static("", id="placement-generated")
+            yield Static(_HINT, id="placement-hint")
         with BottomBars():
             yield TaskBar()
             yield Footer()
 
     def on_mount(self) -> None:
         table = self.query_one(_GPU_TABLE_ID, DataTable)
-        table.add_columns("Label", "Name", "Free", "Total")
+        table.add_columns("GPU", "Name", "Free", "Total", "Roles")
         self._load_placement()
 
     def _load_placement(self) -> None:
@@ -118,43 +131,135 @@ class PlacementScreen(Screen[None]):
             return
         self._render_view(view)
 
+    # -- rendering -------------------------------------------------------
+
     def _render_view(self, view: PlacementView) -> None:
-        """Populate the GPU table and role summary from a PlacementView."""
+        """Reset the screen (title, table, editor) from a resolved placement view."""
+        self._view_manual = view.manual
+        self._device_indices = tuple(g.index for g in view.gpus)
+        self._gpu_meta = [
+            (g.index, g.label, g.name, g.free_bytes, g.total_bytes) for g in view.gpus
+        ]
+        self._edits = {
+            r.role: _RoleEdit(r.role, r.model, set(r.devices), r.replicas) for r in view.roles
+        }
+        self._build_editor()
+        self._refresh_table()
+        self._refresh_title(dirty=False)
+        self._refresh_generated()
+        if view.unplaceable:
+            names = ", ".join(role.value for role in view.unplaceable)
+            self.notify(f"Does not fit: {names}", severity="warning")
+
+    def _build_editor(self) -> None:
+        """Mount one interactive row per role (GPU toggles + replica stepper)."""
+        container = self.query_one(_EDITOR_ID, Vertical)
+        container.remove_children()
+        rows: list[Horizontal] = []
+        for role, edit in self._edits.items():
+            children: list[Button | Label] = [Label(f"{role.value:<7}", classes="role-name")]
+            for idx in self._device_indices:
+                cls = "dev-toggle on" if idx in edit.devices else "dev-toggle"
+                children.append(Button(str(idx), id=f"dev-{role.value}-{idx}", classes=cls))
+            if role in _REPLICA_ROLES:
+                children.append(Button("-", id=f"rep-{role.value}-dec", classes="rep-btn"))
+                children.append(
+                    Label(f"x{edit.replicas}", id=f"repn-{role.value}", classes="rep-count")
+                )
+                children.append(Button("+", id=f"rep-{role.value}-inc", classes="rep-btn"))
+            rows.append(Horizontal(*children, classes="role-row"))
+        if rows:
+            container.mount(*rows)
+
+    def _refresh_table(self) -> None:
+        """Repaint the GPU table's Roles column from the current editor state."""
+        placed: dict[int, list[str]] = {}
+        for edit in self._edits.values():
+            for idx in edit.devices:
+                placed.setdefault(idx, []).append(edit.role.value)
         table = self.query_one(_GPU_TABLE_ID, DataTable)
         table.clear()
-        for gpu in view.gpus:
+        for idx, label, name, free, total in self._gpu_meta:
             table.add_row(
-                gpu.label,
-                gpu.name,
-                _fmt_gib(gpu.free_bytes),
-                _fmt_gib(gpu.total_bytes),
-                key=str(gpu.index),
+                label,
+                name,
+                _fmt_gib(free),
+                _fmt_gib(total),
+                ", ".join(placed.get(idx, [])) or "-",
+                key=str(idx),
             )
-        summary = self.query_one(_ROLE_SUMMARY_ID, Static)
-        summary.update(_render_roles(view))
-        if view.spec_json:
-            self._spec_text = view.spec_json
-            self.query_one(_SPEC_AREA_ID, TextArea).load_text(view.spec_json)
 
-    def _parse_spec(self) -> PlacementSpec | None:
-        """Parse the current spec text into a PlacementSpec or None."""
-        raw = self._spec_text.strip()
-        if not raw:
+    def _refresh_title(self, *, dirty: bool) -> None:
+        if dirty:
+            text = "Placement (edited; ctrl+s to apply, ctrl+x for auto)"
+        else:
+            text = "Placement (manual)" if self._view_manual else "Placement (auto)"
+        self.query_one(_TITLE_ID, Static).update(f"[bold]{text}[/bold]")
+
+    def _refresh_generated(self) -> None:
+        """Show the spec the current controls produce (for CLI/HTTP/MCP parity)."""
+        out = self.query_one(_GENERATED_ID, Static)
+        try:
+            spec = self._spec_from_editor()
+        except PlacementError as exc:
+            out.update(f"[red]{exc}[/red]")
+            return
+        out.update(f"equivalent spec:  {spec.to_json() if spec else '(auto)'}")
+
+    # -- editor state ----------------------------------------------------
+
+    def _spec_from_editor(self) -> PlacementSpec | None:
+        """Build a PlacementSpec from the editor; None when nothing is configured."""
+        if not self._edits:
             return None
-        return PlacementSpec.from_json(raw)
+        roles: dict[WorkerRole, RolePlacement] = {}
+        for edit in self._edits.values():
+            if not edit.devices:
+                raise PlacementError(f"{edit.role.value} needs at least one GPU")
+            roles[edit.role] = RolePlacement(
+                devices=tuple(sorted(edit.devices)), replicas=edit.replicas
+            )
+        return PlacementSpec(roles=roles)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle a GPU toggle or a replica -/+ press."""
+        bid = event.button.id or ""
+        if bid.startswith("dev-"):
+            _, role_value, idx_str = bid.split("-")
+            edit = self._edits[WorkerRole(role_value)]
+            idx = int(idx_str)
+            if idx in edit.devices:
+                if len(edit.devices) > 1:  # keep at least one GPU per role
+                    edit.devices.discard(idx)
+                    event.button.remove_class("on")
+            else:
+                edit.devices.add(idx)
+                event.button.add_class("on")
+        elif bid.startswith("rep-"):
+            _, role_value, op = bid.split("-")
+            role = WorkerRole(role_value)
+            edit = self._edits[role]
+            edit.replicas = max(1, edit.replicas + (1 if op == "inc" else -1))
+            self.query_one(f"#repn-{role.value}", Label).update(f"x{edit.replicas}")
+        else:
+            return
+        self._refresh_table()
+        self._refresh_title(dirty=True)
+        self._refresh_generated()
+
+    # -- actions ---------------------------------------------------------
 
     def action_preview(self) -> None:
-        """Preview the current spec without applying it."""
+        """Resolve the edited placement against the hardware without applying it."""
         try:
-            spec = self._parse_spec()
-        except (ValueError, json.JSONDecodeError, KeyError) as exc:
+            spec = self._spec_from_editor()
+        except PlacementError as exc:
             self.notify(str(exc), severity="error")
             return
         self._preview_worker(spec)
 
     @work(thread=True, exit_on_error=False)
     def _preview_worker(self, spec: PlacementSpec | None) -> None:
-        """Run preview_placement off the UI thread."""
         try:
             view = preview_placement(spec)
             call_from_thread(self, self._render_view, view)
@@ -162,12 +267,12 @@ class PlacementScreen(Screen[None]):
             call_from_thread(self, self.notify, str(exc), severity="error")
 
     def action_apply(self) -> None:
-        """Apply the current spec and reload services."""
+        """Apply the edited placement (persists and reloads the fleet)."""
         if self.applying:
             return
         try:
-            spec = self._parse_spec()
-        except (ValueError, json.JSONDecodeError, KeyError) as exc:
+            spec = self._spec_from_editor()
+        except PlacementError as exc:
             self.notify(str(exc), severity="error")
             return
         self.applying = True
@@ -175,7 +280,6 @@ class PlacementScreen(Screen[None]):
 
     @work(thread=True, exit_on_error=False)
     def _apply_worker(self, spec: PlacementSpec | None) -> None:
-        """Run set_placement off the UI thread."""
         try:
             set_placement(spec)
             view = get_placement()
@@ -186,7 +290,7 @@ class PlacementScreen(Screen[None]):
             call_from_thread(self, setattr, self, "applying", False)
 
     def action_clear(self) -> None:
-        """Clear the manual spec (restore auto placement)."""
+        """Restore automatic placement."""
         if self.applying:
             return
         self.applying = True
@@ -194,7 +298,6 @@ class PlacementScreen(Screen[None]):
 
     @work(thread=True, exit_on_error=False)
     def _clear_worker(self) -> None:
-        """Run set_placement(None) off the UI thread."""
         try:
             set_placement(None)
             view = get_placement()

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from typing import TYPE_CHECKING, ClassVar
@@ -10,6 +11,8 @@ from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical
+from textual.css.query import NoMatches
+from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Static, TextArea
 
@@ -76,9 +79,16 @@ class PlacementScreen(Screen[None]):
         Binding("ctrl+x", "clear", "Clear", show=True),
     ]
 
+    applying: reactive[bool] = reactive(False)
+
     def __init__(self) -> None:
         super().__init__()
         self._spec_text: str = ""
+
+    def watch_applying(self, applying: bool) -> None:
+        """Disable the spec editor while an apply/clear is in flight."""
+        with contextlib.suppress(NoMatches):
+            self.query_one(_SPEC_AREA_ID, TextArea).disabled = applying
 
     def compose(self) -> ComposeResult:
         from lilbee.cli.tui.widgets.bottom_bars import BottomBars
@@ -159,11 +169,14 @@ class PlacementScreen(Screen[None]):
 
     def action_apply(self) -> None:
         """Apply the current spec and reload services."""
+        if self.applying:
+            return
         try:
             spec = self._parse_spec()
         except (ValueError, json.JSONDecodeError, KeyError) as exc:
             self.notify(str(exc), severity="error")
             return
+        self.applying = True
         self._apply_worker(spec)
 
     @work(thread=True, exit_on_error=False)
@@ -175,9 +188,14 @@ class PlacementScreen(Screen[None]):
             call_from_thread(self, self._render_view, view)
         except Exception as exc:
             call_from_thread(self, self.notify, str(exc), severity="error")
+        finally:
+            call_from_thread(self, setattr, self, "applying", False)
 
     def action_clear(self) -> None:
         """Clear the manual spec (restore auto placement)."""
+        if self.applying:
+            return
+        self.applying = True
         self._clear_worker()
 
     @work(thread=True, exit_on_error=False)
@@ -189,6 +207,8 @@ class PlacementScreen(Screen[None]):
             call_from_thread(self, self._render_view, view)
         except Exception as exc:
             call_from_thread(self, self.notify, str(exc), severity="error")
+        finally:
+            call_from_thread(self, setattr, self, "applying", False)
 
     def action_go_back(self) -> None:
         """Pop back to the previous screen."""

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -25,12 +25,6 @@ if TYPE_CHECKING:
     from lilbee.app.placement import PlacementView
 
 
-class _LilbeeAppTestHost(LilbeeApp):
-    """LilbeeApp subclass that skips the heavyweight on_mount for test/demo harnesses."""
-
-    _test_skip_auto_init = True
-
-
 log = logging.getLogger(__name__)
 
 _GPU_TABLE_ID = "#placement-gpus"
@@ -216,12 +210,3 @@ class PlacementScreen(Screen[None]):
             self.app.pop_screen()
         else:
             self.app.switch_view("Chat")
-
-
-class PlacementScreenApp(_LilbeeAppTestHost):
-    """Minimal app harness that mounts PlacementScreen for test/demo use."""
-
-    CSS = ""
-
-    def on_mount(self) -> None:
-        self.push_screen(PlacementScreen())

--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -60,6 +60,10 @@ def _render_roles(view: PlacementView) -> str:
 class PlacementScreen(Screen[None]):
     """GPU placement viewer and editor."""
 
+    # Lilbee always hosts screens on a LilbeeApp, so narrowing the type lets
+    # the screen call switch_view without per-call type: ignore comments.
+    app: LilbeeApp  # type: ignore[assignment]
+
     CSS_PATH = "placement.tcss"
     AUTO_FOCUS = _GPU_TABLE_ID
     HELP = "Inspect GPU placement. ctrl+r preview, ctrl+s apply, ctrl+x clear, q back."
@@ -191,7 +195,7 @@ class PlacementScreen(Screen[None]):
         if len(self.app.screen_stack) > 1:
             self.app.pop_screen()
         else:
-            self.app.switch_view("Chat")  # type: ignore[attr-defined]
+            self.app.switch_view("Chat")
 
 
 class PlacementScreenApp(_LilbeeAppTestHost):

--- a/src/lilbee/cli/tui/screens/placement.tcss
+++ b/src/lilbee/cli/tui/screens/placement.tcss
@@ -5,6 +5,11 @@ PlacementScreen {
         padding: 0 1;
     }
 
+    #placement-title {
+        height: 1;
+        margin-bottom: 1;
+    }
+
     #placement-gpus {
         height: auto;
         max-height: 12;
@@ -12,19 +17,51 @@ PlacementScreen {
         margin-bottom: 1;
     }
 
-    #placement-role-summary {
+    #placement-editor {
         height: auto;
-        margin-bottom: 1;
-        color: $text;
     }
 
-    #placement-spec {
-        height: 1fr;
-        min-height: 8;
-        border: solid $surface-lighten-2;
+    .role-row {
+        height: 3;
+        align-vertical: middle;
+    }
 
-        &:focus-within {
-            border: tall $primary;
-        }
+    .role-name {
+        width: 9;
+        content-align: left middle;
+    }
+
+    .dev-toggle {
+        min-width: 5;
+        width: 5;
+        margin: 0 1 0 0;
+    }
+
+    .dev-toggle.on {
+        background: $success;
+        color: $text;
+        text-style: bold;
+    }
+
+    .rep-btn {
+        min-width: 5;
+        width: 5;
+        margin: 0 1 0 0;
+    }
+
+    .rep-count {
+        width: 5;
+        content-align: center middle;
+    }
+
+    #placement-generated {
+        height: auto;
+        margin-top: 1;
+        color: $text-muted;
+    }
+
+    #placement-hint {
+        height: auto;
+        color: $text-muted;
     }
 }

--- a/src/lilbee/cli/tui/screens/placement.tcss
+++ b/src/lilbee/cli/tui/screens/placement.tcss
@@ -1,0 +1,30 @@
+PlacementScreen {
+
+    #placement-layout {
+        height: 1fr;
+        padding: 0 1;
+    }
+
+    #placement-gpus {
+        height: auto;
+        max-height: 12;
+        border: solid $surface-lighten-2;
+        margin-bottom: 1;
+    }
+
+    #placement-role-summary {
+        height: auto;
+        margin-bottom: 1;
+        color: $text;
+    }
+
+    #placement-spec {
+        height: 1fr;
+        min-height: 8;
+        border: solid $surface-lighten-2;
+
+        &:focus-within {
+            border: tall $primary;
+        }
+    }
+}

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -15,7 +15,6 @@ from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from lilbee.core.system import scaled_chat_ctx_target_default
-from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 
 from .defaults import (
     DEFAULT_ALLOWED_NER_LABELS,
@@ -421,13 +420,13 @@ class Config(BaseSettings):
     # (default) lets llama.cpp pick (index 0).
     main_gpu: int | None = ConfigField(default=None, writable=True)
 
-    # Manual GPU placement override. When set, it fully replaces the automatic
-    # placement planner: each active role pins to the listed device indices, with
-    # an optional tensor_split and replica count. Persisted as a JSON scalar (the
-    # config.toml store is flat); edited via the placement CLI/MCP/HTTP/TUI surfaces
-    # rather than the generic settings list, so public=False. None hands off to the
-    # VRAM-aware auto planner.
-    placement: PlacementSpec | None = ConfigField(default=None, writable=True, public=False)
+    # Manual GPU placement override stored as a JSON scalar (the config.toml store
+    # is flat, and core must not depend on the provider PlacementSpec type). When
+    # set, it fully replaces the automatic placement planner: each active role pins
+    # to the listed device indices, with an optional tensor_split and replica count.
+    # Edited via the placement CLI/MCP/HTTP/TUI surfaces rather than the generic
+    # settings list, so public=False. None hands off to the VRAM-aware auto planner.
+    placement: str | None = ConfigField(default=None, writable=True, public=False)
 
     # True = Markdown widget for chat; False = plain Static (faster).
     markdown_rendering: bool = True
@@ -763,16 +762,19 @@ class Config(BaseSettings):
 
     @field_validator("placement", mode="before")
     @classmethod
-    def _parse_placement(cls, v: Any) -> PlacementSpec | None:
-        """Blank/None -> None; a JSON string -> PlacementSpec; a spec passes through."""
+    def _parse_placement(cls, v: Any) -> str | None:
+        """Blank/None -> None; validate a JSON string or PlacementSpec; store JSON."""
+        from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
         if v is None:
             return None
         if isinstance(v, PlacementSpec):
-            return v
+            return v.to_json()
         if isinstance(v, str):
             if v.strip() == "":
                 return None
-            return PlacementSpec.from_json(v)
+            PlacementSpec.from_json(v)
+            return v
         raise PlacementError("placement must be a JSON string or PlacementSpec")
 
     @field_validator("semantic_chunking", mode="before")

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -341,11 +341,14 @@ class Config(BaseSettings):
     gpu_memory_fraction: float = ConfigField(default=0.75, ge=0.1, le=1.0, writable=True)
 
     # Data-parallel replicas of the embed / vision role across GPUs: N independent
-    # servers (one per spare GPU), round-robined, so large-scale ingest fans the
-    # embedding / OCR work across the whole box. 1 = a single server (the default).
-    # Capped at runtime by the GPUs with room after the chat model is placed.
-    embed_replicas: int = ConfigField(default=1, ge=1, writable=True)
-    vision_replicas: int = ConfigField(default=1, ge=1, writable=True)
+    # servers, round-robined, so large-scale ingest fans the embedding / OCR work
+    # across the whole box. 0 means "auto": one replica per detected GPU, capped by
+    # the VRAM left after the persistent query fleet (chat, one embed, rerank, one
+    # vision) is reserved. A positive value pins the count. The extra replicas are
+    # ingest-only and reclaimed when ingest ends; the persistent query embedder /
+    # vision (replica 0) always exists if its model fits.
+    embed_replicas: int = ConfigField(default=0, ge=0, writable=True)
+    vision_replicas: int = ConfigField(default=0, ge=0, writable=True)
 
     # Seconds a model stays loaded after last use. 0 = unload immediately.
     model_keep_alive: int = ConfigField(default=300, ge=0, writable=True)

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -15,6 +15,7 @@ from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from lilbee.core.system import scaled_chat_ctx_target_default
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 
 from .defaults import (
     DEFAULT_ALLOWED_NER_LABELS,
@@ -420,6 +421,14 @@ class Config(BaseSettings):
     # (default) lets llama.cpp pick (index 0).
     main_gpu: int | None = ConfigField(default=None, writable=True)
 
+    # Manual GPU placement override. When set, it fully replaces the automatic
+    # placement planner: each active role pins to the listed device indices, with
+    # an optional tensor_split and replica count. Persisted as a JSON scalar (the
+    # config.toml store is flat); edited via the placement CLI/MCP/HTTP/TUI surfaces
+    # rather than the generic settings list, so public=False. None hands off to the
+    # VRAM-aware auto planner.
+    placement: PlacementSpec | None = ConfigField(default=None, writable=True, public=False)
+
     # True = Markdown widget for chat; False = plain Static (faster).
     markdown_rendering: bool = True
 
@@ -751,6 +760,20 @@ class Config(BaseSettings):
                     return None
             return ",".join(parts)
         return str(v)
+
+    @field_validator("placement", mode="before")
+    @classmethod
+    def _parse_placement(cls, v: Any) -> PlacementSpec | None:
+        """Blank/None -> None; a JSON string -> PlacementSpec; a spec passes through."""
+        if v is None:
+            return None
+        if isinstance(v, PlacementSpec):
+            return v
+        if isinstance(v, str):
+            if v.strip() == "":
+                return None
+            return PlacementSpec.from_json(v)
+        raise PlacementError("placement must be a JSON string or PlacementSpec")
 
     @field_validator("semantic_chunking", mode="before")
     @classmethod

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -774,7 +774,9 @@ class Config(BaseSettings):
         if v is None:
             return None
         if isinstance(v, PlacementSpec):
-            return v.to_json()
+            json_str = v.to_json()
+            PlacementSpec.from_json(json_str)  # re-validate a directly-built spec
+            return json_str
         if isinstance(v, str):
             if v.strip() == "":
                 return None

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -83,9 +83,12 @@ def _max_concurrent() -> int:
     few-core box with several GPUs would starve the extra cards.
     """
     from lilbee.core.config import cfg
+    from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
+    from lilbee.providers.roles import WorkerRole
 
     if cfg.vision_model:
-        return max(1, cfg.vision_replicas * cfg.vision_ocr_concurrency)
+        replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
+        return max(1, replicas * cfg.vision_ocr_concurrency)
     embed_slots = cfg.embed_replicas if cfg.embed_replicas > 1 else 0
     return max(cpu_quota(), embed_slots)
 

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -90,7 +90,7 @@ def _max_concurrent() -> int:
     if cfg.vision_model:
         replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
         return max(1, replicas * cfg.vision_ocr_concurrency)
-    embed_slots = cfg.embed_replicas if cfg.embed_replicas > 1 else 0
+    embed_slots = resolve_replica_count(WorkerRole.EMBED, gpu_device_count())
     return max(cpu_quota(), embed_slots)
 
 

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -50,6 +50,7 @@ from lilbee.data.store import (
     SourceType,
     source_stat,
 )
+from lilbee.providers.fleet.ingest_scale import ingest_scale
 from lilbee.runtime.asyncio_loop import is_executor_shutdown
 from lilbee.runtime.cancellation import TaskCancelledError
 from lilbee.runtime.cpu import cpu_quota
@@ -378,105 +379,108 @@ async def sync(
     When *retry_skipped* (or *force_rebuild*) is set, the failed-file skip
     markers are cleared so this sync attempts every file.
     """
-    _store = get_services().store
+    with ingest_scale():
+        _store = get_services().store
 
-    if force_rebuild:
-        # drop_all + memory re-embedding are heavy blocking store work; run them
-        # off the event loop so a rebuild doesn't stall other admitted requests.
-        await asyncio.to_thread(_force_rebuild_store, _store)
+        if force_rebuild:
+            # drop_all + memory re-embedding are heavy blocking store work; run them
+            # off the event loop so a rebuild doesn't stall other admitted requests.
+            await asyncio.to_thread(_force_rebuild_store, _store)
 
-    cfg.documents_dir.mkdir(parents=True, exist_ok=True)
+        cfg.documents_dir.mkdir(parents=True, exist_ok=True)
 
-    disk_files = discover_files()
-    sources = _store.get_sources()
-    existing_sources = {s["filename"]: s for s in sources}
-    skip_markers = _load_pruned_skip_markers(disk_files, clear_first=force_rebuild or retry_skipped)
-
-    removed: list[str] = []
-    failed: dict[str, None] = {}
-    skipped: dict[str, None] = {}
-    reasons: dict[str, str] = {}  # filename → why it was skipped/failed (for reporting)
-    flush_failed: set[str] = set()
-
-    # Find files to remove (document sources whose file is gone; imports are kept)
-    to_remove = _removable_sources(sources, disk_files)
-    if to_remove:
-        _store.remove_documents(to_remove)
-        removed.extend(to_remove)
-
-    # The planning pass stats (and where needed hashes) every file on disk;
-    # off the event loop so a large corpus doesn't freeze the TUI.
-    plan = await asyncio.to_thread(
-        _plan_file_changes, disk_files, existing_sources, cancel, skip_markers
-    )
-    files_to_process, added, updated = plan.files_to_process, plan.added, plan.updated
-    if plan.stat_backfills:
-        await asyncio.to_thread(_store.update_source_stats, plan.stat_backfills)
-    # Track skip markers for files processed this run, keyed by name → hash.
-    pending_hashes = {entry.name: entry.file_hash for entry in files_to_process}
-
-    # Snapshot the cumulative truncation counter so the delta over this sync can
-    # surface "N chunks truncated" instead of being lost in per-chunk debug logs.
-    truncated_before = get_services().embedder.truncated_total
-
-    # Ingest files (with optional progress bar)
-    if files_to_process:
-        get_services().embedder.validate_model()
-        await ingest_batch(
-            files_to_process,
-            added,
-            updated,
-            failed,
-            skipped,
-            quiet=quiet,
-            on_progress=on_progress,
-            cancel=cancel,
-            flush_failed=flush_failed,
-            reasons=reasons,
+        disk_files = discover_files()
+        sources = _store.get_sources()
+        existing_sources = {s["filename"]: s for s in sources}
+        skip_markers = _load_pruned_skip_markers(
+            disk_files, clear_first=force_rebuild or retry_skipped
         )
 
-    # A flush failure is a transient store-side problem, not a verdict on the
-    # file: leaving it unmarked re-plans it next sync instead of skipping it.
-    marker_failed = [name for name in (*failed, *skipped) if name not in flush_failed]
-    _persist_skip_markers(
-        skip_markers, pending_hashes, succeeded=[*added, *updated], failed=marker_failed
-    )
-    # Persist the human-readable reason for each skip-marked file (informational;
-    # the hash markers above drive the resume logic). Only marker_failed files,
-    # so a transient flush failure doesn't leave a stale reason behind.
-    write_skip_reasons(cfg.data_root, {n: reasons[n] for n in marker_failed if n in reasons})
+        removed: list[str] = []
+        failed: dict[str, None] = {}
+        skipped: dict[str, None] = {}
+        reasons: dict[str, str] = {}  # filename → why it was skipped/failed (for reporting)
+        flush_failed: set[str] = set()
 
-    if files_to_process or removed:
-        _store.ensure_fts_index()
-        _store.ensure_vector_index()
-        _store.optimize_sources()
-        await _rebuild_concept_clusters()
-        # circular: lilbee.wiki imports lilbee.data.ingest.file_hash, so the
-        # post-ingest hook stays function-local at this boundary.
-        from lilbee.wiki.ingest import incremental_update
+        # Find files to remove (document sources whose file is gone; imports are kept)
+        to_remove = _removable_sources(sources, disk_files)
+        if to_remove:
+            _store.remove_documents(to_remove)
+            removed.extend(to_remove)
 
-        await incremental_update(set(added) | set(updated) | set(removed))
+        # The planning pass stats (and where needed hashes) every file on disk;
+        # off the event loop so a large corpus doesn't freeze the TUI.
+        plan = await asyncio.to_thread(
+            _plan_file_changes, disk_files, existing_sources, cancel, skip_markers
+        )
+        files_to_process, added, updated = plan.files_to_process, plan.added, plan.updated
+        if plan.stat_backfills:
+            await asyncio.to_thread(_store.update_source_stats, plan.stat_backfills)
+        # Track skip markers for files processed this run, keyed by name → hash.
+        pending_hashes = {entry.name: entry.file_hash for entry in files_to_process}
 
-    result = SyncResult(
-        added=list(added),
-        updated=list(updated),
-        removed=removed,
-        unchanged=plan.unchanged,
-        failed=list(failed),
-        skipped=list(skipped),
-        truncated=get_services().embedder.truncated_total - truncated_before,
-    )
-    on_progress(
-        EventType.DONE,
-        SyncDoneEvent(
-            added=len(result.added),
-            updated=len(result.updated),
-            removed=len(result.removed),
-            failed=len(result.failed),
-            skipped=len(result.skipped),
-        ),
-    )
-    return result
+        # Snapshot the cumulative truncation counter so the delta over this sync can
+        # surface "N chunks truncated" instead of being lost in per-chunk debug logs.
+        truncated_before = get_services().embedder.truncated_total
+
+        # Ingest files (with optional progress bar)
+        if files_to_process:
+            get_services().embedder.validate_model()
+            await ingest_batch(
+                files_to_process,
+                added,
+                updated,
+                failed,
+                skipped,
+                quiet=quiet,
+                on_progress=on_progress,
+                cancel=cancel,
+                flush_failed=flush_failed,
+                reasons=reasons,
+            )
+
+        # A flush failure is a transient store-side problem, not a verdict on the
+        # file: leaving it unmarked re-plans it next sync instead of skipping it.
+        marker_failed = [name for name in (*failed, *skipped) if name not in flush_failed]
+        _persist_skip_markers(
+            skip_markers, pending_hashes, succeeded=[*added, *updated], failed=marker_failed
+        )
+        # Persist the human-readable reason for each skip-marked file (informational;
+        # the hash markers above drive the resume logic). Only marker_failed files,
+        # so a transient flush failure doesn't leave a stale reason behind.
+        write_skip_reasons(cfg.data_root, {n: reasons[n] for n in marker_failed if n in reasons})
+
+        if files_to_process or removed:
+            _store.ensure_fts_index()
+            _store.ensure_vector_index()
+            _store.optimize_sources()
+            await _rebuild_concept_clusters()
+            # circular: lilbee.wiki imports lilbee.data.ingest.file_hash, so the
+            # post-ingest hook stays function-local at this boundary.
+            from lilbee.wiki.ingest import incremental_update
+
+            await incremental_update(set(added) | set(updated) | set(removed))
+
+        result = SyncResult(
+            added=list(added),
+            updated=list(updated),
+            removed=removed,
+            unchanged=plan.unchanged,
+            failed=list(failed),
+            skipped=list(skipped),
+            truncated=get_services().embedder.truncated_total - truncated_before,
+        )
+        on_progress(
+            EventType.DONE,
+            SyncDoneEvent(
+                added=len(result.added),
+                updated=len(result.updated),
+                removed=len(result.removed),
+                failed=len(result.failed),
+                skipped=len(result.skipped),
+            ),
+        )
+        return result
 
 
 def _phase_progress_callback(

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -1158,8 +1158,7 @@ def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
     """Set and apply a manual multi-GPU placement spec (persists to config)."""
     from lilbee.providers.fleet.placement_spec import PlacementSpec
 
-    # A set always builds a spec (even {}) so an empty or invalid one is rejected;
-    # clearing back to auto is the separate clear_placement tool.
+    # Always build a spec (even {}) so an empty/invalid one is rejected, not cleared.
     return _placement_result(lambda: set_placement(PlacementSpec.from_json(json.dumps(spec))))
 
 

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -157,16 +157,8 @@ def _error(msg: str) -> dict[str, Any]:
 def search(
     query: str, top_k: int | None = None, scope: str = SearchScope.BOTH.value
 ) -> list[dict[str, Any]] | dict[str, Any]:
-    """Search the user's indexed documents, code, and crawled pages.
-
-    Use this for any lookup about the user's own files or code, and prefer it
-    over web-fetch or file-read tools, which cannot see the index. Returns
-    chunks ranked by relevance with source and line citations.
-
-    ``top_k`` defaults to ``cfg.top_k``. ``scope`` is ``"both"`` (default) or
-    ``"raw"`` for ingested docs and code; use ``"wiki"`` only when ``status``
-    shows a built wiki, else it just falls back to the full pool.
-    """
+    """Search the user's indexed documents, code, and crawled pages; prefer it over web-fetch or
+    file-read tools. Returns chunks with citations. ``scope``: "both" (default) / "raw" / "wiki"."""
     if not query or not query.strip():
         return _error("query must not be empty")
     try:
@@ -241,12 +233,7 @@ async def add(
     render_mode: CrawlRenderMode | None = None,
 ) -> dict[str, Any]:
     """Add files, directories, or URLs to the knowledge base, then sync.
-
-    Paths must be absolute. URLs (http(s)://) are crawled as markdown.
-    ``enable_ocr`` forces OCR on/off; ``ocr_timeout`` overrides the per-page OCR
-    cap; ``render_mode`` ("http"/"browser") overrides the configured crawl render
-    mode for any URLs.
-    """
+    Paths must be absolute; URLs are crawled as markdown."""
     from lilbee.app.ingest import copy_files
     from lilbee.data.ingest import sync as run_sync
 
@@ -313,13 +300,7 @@ async def crawl(
     include_subdomains: bool = False,
 ) -> dict[str, Any]:
     """Start a non-blocking crawl; poll via ``crawl_status(task_id)``.
-
-    ``depth=None`` crawls the whole site, ``0`` is single-URL, positive ints cap
-    follow depth. ``max_pages=None`` uses the protective safety cap, ``0`` is
-    unlimited, positive ints cap the page count. ``render_mode``
-    ("http"/"browser") overrides the configured crawl render mode.
-    ``include_subdomains`` widens whole-site scope to the host's subdomains.
-    """
+    ``depth=None`` = whole site, ``0`` = single URL. ``render_mode``: "http"/"browser"."""
     from lilbee.crawler import crawler_available
 
     if not crawler_available():
@@ -676,12 +657,8 @@ def settings_get(key: str) -> dict[str, Any]:
 
 @_tool
 def settings_set(updates: dict[str, Any]) -> dict[str, Any]:
-    """Atomically update writable settings; rolls back on any validation error.
-
-    Persists to ``config.toml`` and invalidates in-process caches. Returns
-    ``{updated, reindex_required}``; ``reindex_required=true`` means run
-    ``sync(force_rebuild=true)`` to refresh the index.
-    """
+    """Atomically update writable settings; rolls back on validation error.
+    Persists to config.toml; returns ``{updated, reindex_required}``."""
     if _transport.http_mounted and requires_services_reset(updates):
         return _error(provider_reset_refused_message("Switching"))
     try:
@@ -739,14 +716,8 @@ def catalog_browse(
     limit: int = 20,
     offset: int = 0,
 ) -> dict[str, Any]:
-    """Browse the lilbee model catalog (featured + Hugging Face).
-
-    ``task`` is ``chat`` / ``embedding`` / ``vision`` / ``rerank``.
-    ``size`` is ``small`` / ``medium`` / ``large``. ``installed`` filters
-    by install state, ``featured`` toggles the curated list, ``sort`` is
-    one of ``featured`` / ``downloads`` / ``name`` / ``size_asc`` /
-    ``size_desc``. Returns paginated model records.
-    """
+    """Browse the lilbee model catalog. ``task``: chat/embedding/vision/rerank.
+    ``size``: small/medium/large. ``sort``: featured/downloads/name/size_asc/size_desc."""
     from lilbee.catalog.query import get_catalog
     from lilbee.catalog.types import CatalogSize, CatalogSort, ModelTask
 
@@ -873,13 +844,8 @@ async def model_pull(
 
 @_tool
 def model_rm(model: str, source: str = "") -> dict[str, Any]:
-    """Remove an installed model.
-
-    Args:
-        model: Model ref to remove. lilbee removes only native models it
-            downloaded; Ollama and LM Studio models are read-only.
-        source: Restrict to a known source; empty = resolve from the ref.
-    """
+    """Remove an installed model. Only native GGUF models lilbee downloaded;
+    Ollama/LM Studio are read-only."""
     from lilbee.app.models import remove_model_data
 
     try:
@@ -940,9 +906,9 @@ def _strip_property_noise(prop: dict[str, Any]) -> None:
     """Drop tokens that don't change the model's behavior."""
     prop.pop("title", None)
     prop.pop("default", None)
+    _collapse_nullable_anyof(prop)
     if prop.get("additionalProperties") is True:
         prop.pop("additionalProperties", None)
-    _collapse_nullable_anyof(prop)
 
 
 def _flatten_tool_description(text: str) -> str:
@@ -1076,12 +1042,8 @@ def memory_remember(
     agent_id: str = "",
     ctx: Context | None = None,
 ) -> dict[str, Any]:
-    """Store a durable memory in this agent's own namespace.
-
-    ``kind`` is "fact" (recalled by similarity) or "preference" (always recalled).
-    ``shared`` also exposes it to the human's TUI/CLI. ``agent_id`` namespaces the
-    memory, else derived from LILBEE_AGENT_ID or the MCP client name.
-    """
+    """Store a durable memory. ``kind``: "fact" (similarity-recalled) or "preference" (always on).
+    ``shared`` exposes it to the human's TUI/CLI."""
     if not memory_enabled():
         return _error(MEMORY_DISABLED_HINT)
     owner = _derive_owner(agent_id, ctx)

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -126,6 +126,16 @@ def _tool(fn: _F) -> _F:
     return fn
 
 
+def _tool_named(name: str) -> Callable[[_F], _F]:
+    """Register an MCP tool under an explicit wire *name* (sync handlers offloaded)."""
+
+    def deco(fn: _F) -> _F:
+        mcp.tool(name=name)(_offload_sync(fn))
+        return fn
+
+    return deco
+
+
 def _tool_if(condition: bool) -> Callable[[_F], _F]:
     """Register an MCP tool only when *condition* is true.
 
@@ -1111,13 +1121,13 @@ def _placement_dict(view: PlacementView) -> dict[str, Any]:
     }
 
 
-@_tool
+@_tool_named("get_placement")
 def get_placement_tool() -> dict[str, Any]:
     """Show the current effective multi-GPU model placement."""
     return _placement_dict(get_placement())
 
 
-@_tool
+@_tool_named("preview_placement")
 def preview_placement_tool(spec: dict[str, Any] | None = None) -> dict[str, Any]:
     """Preview what a placement spec (or auto, when omitted) would place. No changes made."""
     from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
@@ -1129,7 +1139,7 @@ def preview_placement_tool(spec: dict[str, Any] | None = None) -> dict[str, Any]
         return _error(str(exc))
 
 
-@_tool
+@_tool_named("set_placement")
 def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
     """Set and apply a manual multi-GPU placement spec (persists to config)."""
     from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
@@ -1140,7 +1150,7 @@ def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
         return _error(str(exc))
 
 
-@_tool
+@_tool_named("clear_placement")
 def clear_placement_tool() -> dict[str, Any]:
     """Clear the manual placement and return to automatic placement."""
     return _placement_dict(set_placement(None))

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -30,9 +30,6 @@ from lilbee.app.memory import (
 )
 from lilbee.app.placement import PlacementView, get_placement, preview_placement, set_placement
 from lilbee.app.search import clean_result
-
-if TYPE_CHECKING:
-    from lilbee.providers.fleet.placement_spec import PlacementSpec
 from lilbee.app.services import get_services, reset_services, reset_store
 from lilbee.app.settings import (
     SettingInfo,
@@ -63,6 +60,9 @@ from lilbee.wiki.shared import (
     WikiSubdir,
     total_wiki_pages,
 )
+
+if TYPE_CHECKING:
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
 
 log = logging.getLogger(__name__)
 
@@ -1156,7 +1156,11 @@ def preview_placement_tool(spec: dict[str, Any] | None = None) -> dict[str, Any]
 @_tool_named("set_placement")
 def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
     """Set and apply a manual multi-GPU placement spec (persists to config)."""
-    return _placement_result(lambda: set_placement(_parse_spec(spec)))
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    # A set always builds a spec (even {}) so an empty or invalid one is rejected;
+    # clearing back to auto is the separate clear_placement tool.
+    return _placement_result(lambda: set_placement(PlacementSpec.from_json(json.dumps(spec))))
 
 
 @_tool_named("clear_placement")

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -6,6 +6,7 @@ import asyncio
 import concurrent.futures
 import functools
 import inspect
+import json
 import logging
 import os
 import re
@@ -27,6 +28,7 @@ from lilbee.app.memory import (
     recall,
     remember,
 )
+from lilbee.app.placement import PlacementView, get_placement, preview_placement, set_placement
 from lilbee.app.search import clean_result
 from lilbee.app.services import get_services, reset_services, reset_store
 from lilbee.app.settings import (
@@ -1126,6 +1128,60 @@ def memory_forget(memory_id: str, agent_id: str = "", ctx: Context | None = None
     if not forget(memory_id, owner=owner):
         return _error(f"No memory '{memory_id}' in this agent's namespace.")
     return {"ok": True, "id": memory_id}
+
+
+def _placement_dict(view: PlacementView) -> dict[str, Any]:
+    return {
+        "gpus": [vars(g) for g in view.gpus],
+        "roles": [
+            {
+                "role": r.role.value,
+                "model": r.model,
+                "devices": list(r.devices),
+                "tensor_split": list(r.tensor_split) if r.tensor_split else None,
+                "replicas": r.replicas,
+            }
+            for r in view.roles
+        ],
+        "unplaceable": [r.value for r in view.unplaceable],
+        "manual": view.manual,
+        "spec_json": view.spec_json,
+    }
+
+
+@_tool
+def get_placement_tool() -> dict[str, Any]:
+    """Show the current effective multi-GPU model placement."""
+    return _placement_dict(get_placement())
+
+
+@_tool
+def preview_placement_tool(spec: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Preview what a placement spec (or auto, when omitted) would place. No changes made."""
+    from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
+    try:
+        parsed = PlacementSpec.from_json(json.dumps(spec)) if spec else None
+        return _placement_dict(preview_placement(parsed))
+    except PlacementError as exc:
+        return _error(str(exc))
+
+
+@_tool
+def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
+    """Set and apply a manual multi-GPU placement spec (persists to config)."""
+    from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+
+    try:
+        return _placement_dict(set_placement(PlacementSpec.from_json(json.dumps(spec))))
+    except PlacementError as exc:
+        return _error(str(exc))
+
+
+@_tool
+def clear_placement_tool() -> dict[str, Any]:
+    """Clear the manual placement and return to automatic placement."""
+    return _placement_dict(set_placement(None))
 
 
 _strip_schema_noise()

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -14,7 +14,7 @@ import threading
 import uuid
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from weakref import WeakKeyDictionary
 
 import anyio
@@ -30,6 +30,9 @@ from lilbee.app.memory import (
 )
 from lilbee.app.placement import PlacementView, get_placement, preview_placement, set_placement
 from lilbee.app.search import clean_result
+
+if TYPE_CHECKING:
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
 from lilbee.app.services import get_services, reset_services, reset_store
 from lilbee.app.settings import (
     SettingInfo,
@@ -1121,39 +1124,45 @@ def _placement_dict(view: PlacementView) -> dict[str, Any]:
     }
 
 
+def _placement_result(action: Callable[[], PlacementView]) -> dict[str, Any]:
+    """Run a placement action and serialize it, returning a structured error on failure."""
+    from lilbee.providers.base import ProviderError
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    try:
+        return _placement_dict(action())
+    except (PlacementError, ProviderError) as exc:
+        return _error(str(exc))
+
+
+def _parse_spec(spec: dict[str, Any] | None) -> PlacementSpec | None:
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    return PlacementSpec.from_json(json.dumps(spec)) if spec else None
+
+
 @_tool_named("get_placement")
 def get_placement_tool() -> dict[str, Any]:
     """Show the current effective multi-GPU model placement."""
-    return _placement_dict(get_placement())
+    return _placement_result(get_placement)
 
 
 @_tool_named("preview_placement")
 def preview_placement_tool(spec: dict[str, Any] | None = None) -> dict[str, Any]:
     """Preview what a placement spec (or auto, when omitted) would place. No changes made."""
-    from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
-
-    try:
-        parsed = PlacementSpec.from_json(json.dumps(spec)) if spec else None
-        return _placement_dict(preview_placement(parsed))
-    except PlacementError as exc:
-        return _error(str(exc))
+    return _placement_result(lambda: preview_placement(_parse_spec(spec)))
 
 
 @_tool_named("set_placement")
 def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
     """Set and apply a manual multi-GPU placement spec (persists to config)."""
-    from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
-
-    try:
-        return _placement_dict(set_placement(PlacementSpec.from_json(json.dumps(spec))))
-    except PlacementError as exc:
-        return _error(str(exc))
+    return _placement_result(lambda: set_placement(_parse_spec(spec)))
 
 
 @_tool_named("clear_placement")
 def clear_placement_tool() -> dict[str, Any]:
     """Clear the manual placement and return to automatic placement."""
-    return _placement_dict(set_placement(None))
+    return _placement_result(lambda: set_placement(None))
 
 
 _strip_schema_noise()

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -434,6 +434,10 @@ class LLMProvider(Protocol):
         """
         return
 
+    def release_ingest_pool(self) -> None:
+        """Unload elastic ingest replicas after the last active ingest exits. No-op default."""
+        return
+
     def role_ready(self, role: WorkerRole) -> bool:
         """Whether *role* has a healthy server now, without starting one.
 

--- a/src/lilbee/providers/fleet/ingest_scale.py
+++ b/src/lilbee/providers/fleet/ingest_scale.py
@@ -34,9 +34,9 @@ _counter = _IngestScaleCounter()
 
 
 def _provider() -> LLMProvider:  # late-bound so tests can patch it and to avoid an import cycle
-    from lilbee.app.services import get_services  # pragma: no cover - patched in tests
+    from lilbee.app.services import get_services
 
-    return get_services().provider  # pragma: no cover - patched in tests
+    return get_services().provider
 
 
 def ingest_scale() -> contextlib.AbstractContextManager[None]:

--- a/src/lilbee/providers/fleet/ingest_scale.py
+++ b/src/lilbee/providers/fleet/ingest_scale.py
@@ -15,6 +15,8 @@ class _IngestScaleCounter:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._active = 0
+        # The most recent release thread, exposed so tests can join it deterministically.
+        self.last_release_thread: threading.Thread | None = None
 
     @contextlib.contextmanager
     def scope(self) -> Iterator[None]:
@@ -27,10 +29,27 @@ class _IngestScaleCounter:
                 self._active -= 1
                 last = self._active == 0
             if last:
-                _provider().release_ingest_pool()
+                self._spawn_release()
+
+    def _spawn_release(self) -> None:
+        """Run the pool release off the calling loop so the serving loop never blocks.
+
+        The release fires sequential blocking ``httpx.post`` unloads; on the server
+        path the bracket exits on the shared request-serving loop, so running it
+        inline would stall concurrent chat and search. Fire-and-forget in a daemon
+        thread keeps that loop free; the unloads are best-effort.
+        """
+        thread = threading.Thread(target=_run_release, name="ingest-release", daemon=True)
+        self.last_release_thread = thread
+        thread.start()
 
 
 _counter = _IngestScaleCounter()
+
+
+def _run_release() -> None:
+    """Unload the elastic ingest pool (best-effort)."""
+    _provider().release_ingest_pool()
 
 
 def _provider() -> LLMProvider:  # late-bound so tests can patch it and to avoid an import cycle

--- a/src/lilbee/providers/fleet/ingest_scale.py
+++ b/src/lilbee/providers/fleet/ingest_scale.py
@@ -8,27 +8,37 @@ from collections.abc import Iterator
 
 from lilbee.providers.base import LLMProvider
 
-_lock = threading.Lock()
-_active = 0
+
+class _IngestScaleCounter:
+    """Refcounts active ingests; releases the elastic pool when the last one ends."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active = 0
+
+    @contextlib.contextmanager
+    def scope(self) -> Iterator[None]:
+        with self._lock:
+            self._active += 1
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._active -= 1
+                last = self._active == 0
+            if last:
+                _provider().release_ingest_pool()
+
+
+_counter = _IngestScaleCounter()
 
 
 def _provider() -> LLMProvider:  # late-bound so tests can patch it and to avoid an import cycle
-    from lilbee.app.services import get_services
+    from lilbee.app.services import get_services  # pragma: no cover - patched in tests
 
-    return get_services().provider
+    return get_services().provider  # pragma: no cover - patched in tests
 
 
-@contextlib.contextmanager
-def ingest_scale() -> Iterator[None]:
-    """Bracket an ingest run; release the elastic pool when the last active one exits."""
-    global _active
-    with _lock:
-        _active += 1
-    try:
-        yield
-    finally:
-        with _lock:
-            _active -= 1
-            last = _active == 0
-        if last:
-            _provider().release_ingest_pool()
+def ingest_scale() -> contextlib.AbstractContextManager[None]:
+    """Bracket an ingest; release the elastic pool when the last active one exits."""
+    return _counter.scope()

--- a/src/lilbee/providers/fleet/ingest_scale.py
+++ b/src/lilbee/providers/fleet/ingest_scale.py
@@ -1,0 +1,34 @@
+"""Refcounted ingest bracket: release the elastic ingest pool when the last ingest ends."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections.abc import Iterator
+
+from lilbee.providers.base import LLMProvider
+
+_lock = threading.Lock()
+_active = 0
+
+
+def _provider() -> LLMProvider:  # late-bound so tests can patch it and to avoid an import cycle
+    from lilbee.app.services import get_services
+
+    return get_services().provider
+
+
+@contextlib.contextmanager
+def ingest_scale() -> Iterator[None]:
+    """Bracket an ingest run; release the elastic pool when the last active one exits."""
+    global _active
+    with _lock:
+        _active += 1
+    try:
+        yield
+    finally:
+        with _lock:
+            _active -= 1
+            last = _active == 0
+        if last:
+            _provider().release_ingest_pool()

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -101,27 +101,36 @@ def plan_placement(
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
 
-    # Single-instance roles first; then data-parallel replicas fill the remaining
-    # headroom. Within the singles, place the search-critical roles (embed/rerank)
-    # before chat: chat tensor-splits across cards and, placed first, can claim
-    # them all and leave an essential search role unplaceable. Search-first here
-    # mirrors the shared-memory path's reservation.
+    # Reserve the persistent query fleet first, then fill residual VRAM with the
+    # elastic ingest pool. The persistent singles are: every replicas<=1 role plus
+    # replica 0 of each replicated role (the query embedder / vision that a search
+    # issued during ingest must always reach). Within the singles, place the
+    # search-critical roles (embed/rerank) before chat: chat tensor-splits across
+    # cards and, placed first, can claim them all and leave an essential search role
+    # unplaceable. Search-first here mirrors the shared-memory path's reservation.
+    # The extra replicas (1..N-1) are placed only into what VRAM remains, so a chat
+    # issued during ingest always fits and the query embedder always exists.
     singles = [m for m in models if m.replicas <= 1]
     replicated = [m for m in models if m.replicas > 1]
-    for model in sorted(singles, key=_shared_pool_order):
+    persistent_singles = singles + [_persistent_single(m) for m in replicated]
+    for model in sorted(persistent_singles, key=_shared_pool_order):
         plan = _place_single(model, remaining, estimate_peak)
         if plan is None:
             unplaceable.append(model.role)
         else:
             instances.append(plan)
+    placed_roles = {plan.role for plan in instances}
     for model in replicated:
-        replica_plans = _place_replicas(model, remaining)
-        if replica_plans:
-            instances.extend(replica_plans)
-        else:
-            unplaceable.append(model.role)
+        if model.role not in placed_roles:
+            continue  # the persistent single did not fit -> already unplaceable
+        instances.extend(_place_replicas(model, remaining, start=1))
 
     return Placement(instances=tuple(instances), unplaceable_roles=tuple(unplaceable))
+
+
+def _persistent_single(model: ModelPlacementInput) -> ModelPlacementInput:
+    """The replica-0 persistent instance of a replicated role, sized as one server."""
+    return ModelPlacementInput(role=model.role, est_vram_bytes=model.est_vram_bytes, replicas=1)
 
 
 def _place_single(
@@ -161,16 +170,20 @@ def _place_split(
     return None
 
 
-def _place_replicas(model: ModelPlacementInput, remaining: dict[int, float]) -> list[InstancePlan]:
-    """Place up to ``model.replicas`` instances, one per distinct GPU (most-free first).
+def _place_replicas(
+    model: ModelPlacementInput, remaining: dict[int, float], *, start: int = 0
+) -> list[InstancePlan]:
+    """Place the elastic replicas ``start..model.replicas-1``, one per distinct GPU
+    (most-free first).
 
     Spreads for throughput: each replica lands on a card not yet hosting one of this
     role's replicas, only co-locating a second round once every card has one. Stops
-    early when no card has room, so the pool shrinks to what fits.
+    early when no card has room, so the pool shrinks to the residual VRAM. ``start``
+    skips the indices already placed as persistent singles (1 for the elastic batch).
     """
     plans: list[InstancePlan] = []
     used: set[int] = set()
-    for replica in range(model.replicas):
+    for replica in range(start, model.replicas):
         candidates = [idx for idx, free in remaining.items() if free >= model.est_vram_bytes]
         if not candidates:
             break

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -254,9 +254,9 @@ def placement_from_spec(
             for idx, peak in zip(rp.devices, per_device, strict=True):
                 if peak > remaining[idx]:
                     raise PlacementError(
-                        f"{role.value} pinned to device {idx} needs "
-                        f"{peak / 1024**3:.1f} GiB but device {idx} has "
-                        f"{device_free[idx] / 1024**3:.1f} GiB free"
+                        f"{role.value} pinned to device {idx} needs {peak / 1024**3:.1f} GiB but "
+                        f"device {idx} has {remaining[idx] / 1024**3:.1f} GiB usable "
+                        f"({device_free[idx] / 1024**3:.1f} GiB free, 90% headroom)"
                     )
             for idx, peak in zip(rp.devices, per_device, strict=True):
                 remaining[idx] -= peak

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION
 from lilbee.providers.roles import WorkerRole
 
@@ -220,3 +221,51 @@ def _best_single_device(need: int, remaining: dict[int, float]) -> int | None:
     if not candidates:
         return None
     return max(candidates, key=lambda idx: remaining[idx])
+
+
+def placement_from_spec(
+    spec: PlacementSpec,
+    active_roles: tuple[WorkerRole, ...],
+    device_free: dict[int, int],
+    *,
+    estimate_peak: PeakEstimator,
+) -> Placement:
+    """Build a Placement from a manual *spec*, charging each card and failing loud.
+
+    Every active role must have an entry; every device must exist; each card must
+    fit the sum of the per-device peaks charged to it. Mirrors the auto planner's
+    USABLE_VRAM_FRACTION headroom and busiest-card accounting.
+    """
+    remaining = {idx: free * USABLE_VRAM_FRACTION for idx, free in device_free.items()}
+    instances: list[InstancePlan] = []
+    for role in active_roles:
+        rp = spec.roles.get(role)
+        if rp is None:
+            raise PlacementError(f"{role.value} has a model but no placement entry in placement")
+        for idx in rp.devices:
+            if idx not in device_free:
+                raise PlacementError(
+                    f"{role.value} pinned to device {idx} but only "
+                    f"{len(device_free)} GPU(s) detected"
+                )
+        ratio = rp.tensor_split or tuple(1 for _ in rp.devices)
+        per_device = estimate_peak(role, ratio)
+        for replica in range(rp.replicas):
+            for idx, peak in zip(rp.devices, per_device, strict=True):
+                if peak > remaining[idx]:
+                    raise PlacementError(
+                        f"{role.value} pinned to device {idx} needs "
+                        f"{peak / 1024**3:.1f} GiB but device {idx} has "
+                        f"{device_free[idx] / 1024**3:.1f} GiB free"
+                    )
+            for idx, peak in zip(rp.devices, per_device, strict=True):
+                remaining[idx] -= peak
+            instances.append(
+                InstancePlan(
+                    role=role,
+                    devices=tuple(rp.devices),
+                    tensor_split=ratio if len(rp.devices) > 1 else (),
+                    replica=replica,
+                )
+            )
+    return Placement(instances=tuple(instances), unplaceable_roles=())

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -239,27 +239,29 @@ def _best_single_device(need: int, remaining: dict[int, float]) -> int | None:
 def placement_from_spec(
     spec: PlacementSpec,
     active_roles: tuple[WorkerRole, ...],
-    device_free: dict[int, int],
+    device_capacity: dict[int, int],
     *,
     estimate_peak: PeakEstimator,
 ) -> Placement:
     """Build a Placement from a manual *spec*, charging each card and failing loud.
 
-    Every active role must have an entry; every device must exist; each card must
-    fit the sum of the per-device peaks charged to it. Mirrors the auto planner's
-    USABLE_VRAM_FRACTION headroom and busiest-card accounting.
+    ``device_capacity`` is each card's total VRAM (not instantaneous free): the
+    plan defines the fleet's full intended residency, so charging it against live
+    free VRAM would double-count models already loaded. Every active role must
+    have an entry; every device must exist; each card must fit the sum of the
+    per-device peaks charged to it, within the USABLE_VRAM_FRACTION headroom.
     """
-    remaining = {idx: free * USABLE_VRAM_FRACTION for idx, free in device_free.items()}
+    remaining = {idx: total * USABLE_VRAM_FRACTION for idx, total in device_capacity.items()}
     instances: list[InstancePlan] = []
     for role in active_roles:
         rp = spec.roles.get(role)
         if rp is None:
             raise PlacementError(f"{role.value} has a model but no placement entry in placement")
         for idx in rp.devices:
-            if idx not in device_free:
+            if idx not in device_capacity:
                 raise PlacementError(
                     f"{role.value} pinned to device {idx} but only "
-                    f"{len(device_free)} GPU(s) detected"
+                    f"{len(device_capacity)} GPU(s) detected"
                 )
         ratio = rp.tensor_split or tuple(1 for _ in rp.devices)
         per_device = estimate_peak(role, ratio)
@@ -269,7 +271,7 @@ def placement_from_spec(
                     raise PlacementError(
                         f"{role.value} pinned to device {idx} needs {peak / 1024**3:.1f} GiB but "
                         f"device {idx} has {remaining[idx] / 1024**3:.1f} GiB usable "
-                        f"({device_free[idx] / 1024**3:.1f} GiB free, 90% headroom)"
+                        f"({device_capacity[idx] / 1024**3:.1f} GiB total, 90% headroom)"
                     )
             for idx, peak in zip(rp.devices, per_device, strict=True):
                 remaining[idx] -= peak

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
 from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION
 from lilbee.providers.roles import WorkerRole
 
@@ -254,33 +254,50 @@ def placement_from_spec(
     remaining = {idx: total * USABLE_VRAM_FRACTION for idx, total in device_capacity.items()}
     instances: list[InstancePlan] = []
     for role in active_roles:
-        rp = spec.roles.get(role)
-        if rp is None:
-            raise PlacementError(f"{role.value} has a model but no placement entry in placement")
-        for idx in rp.devices:
-            if idx not in device_capacity:
-                raise PlacementError(
-                    f"{role.value} pinned to device {idx} but only "
-                    f"{len(device_capacity)} GPU(s) detected"
-                )
+        rp = _required_entry(spec, role, device_capacity)
         ratio = rp.tensor_split or tuple(1 for _ in rp.devices)
         per_device = estimate_peak(role, ratio)
+        split = ratio if len(rp.devices) > 1 else ()
         for replica in range(rp.replicas):
-            for idx, peak in zip(rp.devices, per_device, strict=True):
-                if peak > remaining[idx]:
-                    raise PlacementError(
-                        f"{role.value} pinned to device {idx} needs {peak / 1024**3:.1f} GiB but "
-                        f"device {idx} has {remaining[idx] / 1024**3:.1f} GiB usable "
-                        f"({device_capacity[idx] / 1024**3:.1f} GiB total, 90% headroom)"
-                    )
-            for idx, peak in zip(rp.devices, per_device, strict=True):
-                remaining[idx] -= peak
+            _charge_devices(role, rp.devices, per_device, remaining, device_capacity)
             instances.append(
                 InstancePlan(
-                    role=role,
-                    devices=tuple(rp.devices),
-                    tensor_split=ratio if len(rp.devices) > 1 else (),
-                    replica=replica,
+                    role=role, devices=tuple(rp.devices), tensor_split=split, replica=replica
                 )
             )
     return Placement(instances=tuple(instances), unplaceable_roles=())
+
+
+def _required_entry(
+    spec: PlacementSpec, role: WorkerRole, device_capacity: dict[int, int]
+) -> RolePlacement:
+    """Return *role*'s placement entry, failing loud if absent or pinned off-hardware."""
+    rp = spec.roles.get(role)
+    if rp is None:
+        raise PlacementError(f"{role.value} has a model but no placement entry in placement")
+    for idx in rp.devices:
+        if idx not in device_capacity:
+            raise PlacementError(
+                f"{role.value} pinned to device {idx} but only "
+                f"{len(device_capacity)} GPU(s) detected"
+            )
+    return rp
+
+
+def _charge_devices(
+    role: WorkerRole,
+    devices: tuple[int, ...],
+    per_device: tuple[int, ...],
+    remaining: dict[int, float],
+    device_capacity: dict[int, int],
+) -> None:
+    """Subtract one instance's per-device peaks from *remaining*; fail loud if a card overflows."""
+    for idx, peak in zip(devices, per_device, strict=True):
+        if peak > remaining[idx]:
+            raise PlacementError(
+                f"{role.value} pinned to device {idx} needs {peak / 1024**3:.1f} GiB but "
+                f"device {idx} has {remaining[idx] / 1024**3:.1f} GiB usable "
+                f"({device_capacity[idx] / 1024**3:.1f} GiB total, 90% headroom)"
+            )
+    for idx, peak in zip(devices, per_device, strict=True):
+        remaining[idx] -= peak

--- a/src/lilbee/providers/fleet/placement_spec.py
+++ b/src/lilbee/providers/fleet/placement_spec.py
@@ -1,0 +1,88 @@
+"""User-authored manual placement spec for the multi-GPU fleet."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from lilbee.providers.roles import WorkerRole
+
+_KEY_DEVICES = "devices"
+_KEY_TENSOR_SPLIT = "tensor_split"
+_KEY_REPLICAS = "replicas"
+
+
+class PlacementError(ValueError):
+    """A placement spec is malformed or does not fit the hardware."""
+
+
+@dataclass(frozen=True)
+class RolePlacement:
+    """One role's manual placement: device pins, optional split, replica count."""
+
+    devices: tuple[int, ...]
+    tensor_split: tuple[int, ...] | None = None
+    replicas: int = 1
+
+
+@dataclass(frozen=True)
+class PlacementSpec:
+    """A manual placement for every active role, keyed by role."""
+
+    roles: Mapping[WorkerRole, RolePlacement] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        """Serialize to a compact JSON string keyed by role value."""
+        out: dict[str, dict[str, object]] = {}
+        for role, rp in self.roles.items():
+            entry: dict[str, object] = {_KEY_DEVICES: list(rp.devices)}
+            if rp.tensor_split is not None:
+                entry[_KEY_TENSOR_SPLIT] = list(rp.tensor_split)
+            if rp.replicas != 1:
+                entry[_KEY_REPLICAS] = rp.replicas
+            out[role.value] = entry
+        return json.dumps(out, sort_keys=True)
+
+    def __str__(self) -> str:
+        return self.to_json()
+
+    @classmethod
+    def from_json(cls, raw: str) -> PlacementSpec:
+        """Parse a JSON string produced by ``to_json`` into a ``PlacementSpec``."""
+        try:
+            data = json.loads(raw)
+        except (ValueError, TypeError) as exc:
+            raise PlacementError(f"placement is not valid JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise PlacementError("placement must be a JSON object keyed by role")
+        roles: dict[WorkerRole, RolePlacement] = {}
+        for key, entry in data.items():
+            role = _role_for(key)
+            roles[role] = _role_placement(role, entry)
+        return cls(roles=roles)
+
+
+def _role_for(key: str) -> WorkerRole:
+    try:
+        return WorkerRole(key)
+    except ValueError as exc:
+        raise PlacementError(f"unknown role {key!r} in placement") from exc
+
+
+def _role_placement(role: WorkerRole, entry: object) -> RolePlacement:
+    if not isinstance(entry, dict):
+        raise PlacementError(f"{role.value}: placement entry must be an object")
+    devices = tuple(int(d) for d in entry.get(_KEY_DEVICES, []))
+    if not devices:
+        raise PlacementError(f"{role.value}: at least one device is required")
+    raw_split = entry.get(_KEY_TENSOR_SPLIT)
+    tensor_split = tuple(int(w) for w in raw_split) if raw_split is not None else None
+    if tensor_split is not None and len(tensor_split) != len(devices):
+        raise PlacementError(
+            f"{role.value}: tensor_split has {len(tensor_split)} weights for {len(devices)} devices"
+        )
+    replicas = int(entry.get(_KEY_REPLICAS, 1))
+    if replicas < 1:
+        raise PlacementError(f"{role.value}: replicas must be >= 1")
+    return RolePlacement(devices=devices, tensor_split=tensor_split, replicas=replicas)

--- a/src/lilbee/providers/fleet/placement_spec.py
+++ b/src/lilbee/providers/fleet/placement_spec.py
@@ -76,6 +76,8 @@ def _role_for(key: str) -> WorkerRole:
 def _coerce_int(role: WorkerRole, field: str, value: object) -> int:
     if isinstance(value, bool) or not isinstance(value, (int, float, str)):
         raise PlacementError(f"{role.value}: {field} must be integers, got {value!r}")
+    if isinstance(value, float) and not value.is_integer():
+        raise PlacementError(f"{role.value}: {field} must be integers, got {value!r}")
     try:
         return int(value)
     except (TypeError, ValueError) as exc:

--- a/src/lilbee/providers/fleet/placement_spec.py
+++ b/src/lilbee/providers/fleet/placement_spec.py
@@ -63,6 +63,9 @@ class PlacementSpec:
         return cls(roles=roles)
 
 
+_ALLOWED_KEYS = frozenset({_KEY_DEVICES, _KEY_TENSOR_SPLIT, _KEY_REPLICAS})
+
+
 def _role_for(key: str) -> WorkerRole:
     try:
         return WorkerRole(key)
@@ -70,19 +73,51 @@ def _role_for(key: str) -> WorkerRole:
         raise PlacementError(f"unknown role {key!r} in placement") from exc
 
 
+def _coerce_int(role: WorkerRole, field: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise PlacementError(f"{role.value}: {field} must be integers, got {value!r}")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise PlacementError(f"{role.value}: {field} must be integers, got {value!r}") from exc
+
+
+def _int_list(role: WorkerRole, field: str, value: object) -> tuple[int, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise PlacementError(f"{role.value}: {field} must be a list, got {type(value).__name__}")
+    return tuple(_coerce_int(role, field, item) for item in value)
+
+
 def _role_placement(role: WorkerRole, entry: object) -> RolePlacement:
     if not isinstance(entry, dict):
         raise PlacementError(f"{role.value}: placement entry must be an object")
-    devices = tuple(int(d) for d in entry.get(_KEY_DEVICES, []))
+    unknown = set(entry) - _ALLOWED_KEYS
+    if unknown:
+        allowed = ", ".join(sorted(_ALLOWED_KEYS))
+        raise PlacementError(
+            f"{role.value}: unknown placement key(s) {sorted(unknown)}; allowed: {allowed}"
+        )
+    devices = _int_list(role, _KEY_DEVICES, entry.get(_KEY_DEVICES, []))
     if not devices:
         raise PlacementError(f"{role.value}: at least one device is required")
+    if any(d < 0 for d in devices):
+        raise PlacementError(f"{role.value}: device indices must be >= 0, got {list(devices)}")
+    if len(set(devices)) != len(devices):
+        raise PlacementError(f"{role.value}: duplicate device indices in {list(devices)}")
     raw_split = entry.get(_KEY_TENSOR_SPLIT)
-    tensor_split = tuple(int(w) for w in raw_split) if raw_split is not None else None
-    if tensor_split is not None and len(tensor_split) != len(devices):
-        raise PlacementError(
-            f"{role.value}: tensor_split has {len(tensor_split)} weights for {len(devices)} devices"
-        )
-    replicas = int(entry.get(_KEY_REPLICAS, 1))
+    tensor_split: tuple[int, ...] | None = None
+    if raw_split is not None:
+        tensor_split = _int_list(role, _KEY_TENSOR_SPLIT, raw_split)
+        if len(tensor_split) != len(devices):
+            raise PlacementError(
+                f"{role.value}: tensor_split has {len(tensor_split)} weights "
+                f"for {len(devices)} devices"
+            )
+        if any(w <= 0 for w in tensor_split):
+            raise PlacementError(
+                f"{role.value}: tensor_split weights must be > 0, got {list(tensor_split)}"
+            )
+    replicas = _coerce_int(role, _KEY_REPLICAS, entry.get(_KEY_REPLICAS, 1))
     if replicas < 1:
         raise PlacementError(f"{role.value}: replicas must be >= 1")
     return RolePlacement(devices=devices, tensor_split=tensor_split, replicas=replicas)

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -28,6 +28,7 @@ from lilbee.providers.fleet.placement import (
     PeakEstimator,
     plan_placement,
 )
+from lilbee.providers.fleet.replicas import resolve_replica_count
 from lilbee.providers.fleet.vram import estimate_instance_footprint
 from lilbee.providers.roles import RerankMode, WorkerRole
 
@@ -350,16 +351,8 @@ def _role_kv_cache_type(role: WorkerRole) -> KvCacheType:
 
 
 def _replica_count(role: WorkerRole, device_count: int) -> int:
-    """Requested data-parallel instances for *role*: embed/vision honor their
-    ``*_replicas`` knob (0 = auto = one per GPU); others run one. The auto count
-    falls to one GPU-less. Capping to residual VRAM happens in placement."""
-    from lilbee.core.config import cfg
-
-    if role is WorkerRole.EMBED:
-        return cfg.embed_replicas or max(1, device_count)
-    if role is WorkerRole.VISION:
-        return cfg.vision_replicas or max(1, device_count)
-    return 1
+    """Requested data-parallel instances for *role* via the shared resolver."""
+    return resolve_replica_count(role, device_count)
 
 
 def _cache_type_flag() -> str | None:

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -349,15 +349,16 @@ def _role_kv_cache_type(role: WorkerRole) -> KvCacheType:
     return cfg.kv_cache_type if role is WorkerRole.CHAT else KvCacheType.F16
 
 
-def _replica_count(role: WorkerRole) -> int:
+def _replica_count(role: WorkerRole, device_count: int) -> int:
     """Requested data-parallel instances for *role*: embed/vision honor their
-    ``*_replicas`` knob (capped by available GPUs at placement); others run one."""
+    ``*_replicas`` knob (0 = auto = one per GPU); others run one. The auto count
+    falls to one GPU-less. Capping to residual VRAM happens in placement."""
     from lilbee.core.config import cfg
 
     if role is WorkerRole.EMBED:
-        return max(1, cfg.embed_replicas)
+        return cfg.embed_replicas or max(1, device_count)
     if role is WorkerRole.VISION:
-        return max(1, cfg.vision_replicas)
+        return cfg.vision_replicas or max(1, device_count)
     return 1
 
 
@@ -390,12 +391,14 @@ def _estimate_role(
     slots: int | None = None,
     unified_budget: int | None = None,
     chat_reservation: int = 0,
+    device_count: int = 0,
 ) -> ModelPlacementInput:
     """Estimate one role-model's footprint via gguf-parser (+ mmproj for vision).
 
     ``slots`` defaults to the role's resolved batching slots (chat and vision are
     memory-aware); ``chat_reservation`` shrinks chat to leave room for the search
-    roles. Charges the unified footprint with no discrete GPU, else the VRAM one.
+    roles; ``device_count`` resolves an auto (0) replica knob to one per GPU.
+    Charges the unified footprint with no discrete GPU, else the VRAM one.
     """
     from lilbee.providers.engine_params import resolve_model_path
     from lilbee.providers.gguf_meta import read_gguf_metadata
@@ -428,7 +431,7 @@ def _estimate_role(
     return ModelPlacementInput(
         role=role,
         est_vram_bytes=est.footprint(unified=unified_budget is not None),
-        replicas=_replica_count(role),
+        replicas=_replica_count(role, device_count),
     )
 
 
@@ -504,14 +507,16 @@ def _server_model_inputs(
     roles: tuple[WorkerRole, ...] | None = None,
     *,
     unified_budget: int | None = None,
+    device_count: int = 0,
 ) -> tuple[list[ModelPlacementInput], dict[WorkerRole, str], int]:
     """Build placement inputs for the configured server roles.
 
     The search and vision roles are estimated first; chat is then sized against the
     budget minus the search footprint (the ``reservation``) so a large chat cannot
-    starve embed/rerank on a shared-memory host. When *roles* is given, only those
-    are considered. Skips an unconfigured optional role, a vision model with no
-    resolvable mmproj projector, and a role whose model is not installed on disk.
+    starve embed/rerank on a shared-memory host. ``device_count`` resolves an auto
+    replica knob to one per GPU. When *roles* is given, only those are considered.
+    Skips an unconfigured optional role, a vision model with no resolvable mmproj
+    projector, and a role whose model is not installed on disk.
     """
     from lilbee.core.config import cfg
     from lilbee.providers.base import ProviderError
@@ -529,7 +534,11 @@ def _server_model_inputs(
             return  # no projector -> vision can't run on a server
         try:
             estimate = _estimate_role(
-                role, ref, unified_budget=unified_budget, chat_reservation=chat_reservation
+                role,
+                ref,
+                unified_budget=unified_budget,
+                chat_reservation=chat_reservation,
+                device_count=device_count,
             )
         except (ProviderError, OSError):
             # The configured model is not installed/resolvable. Skip this role
@@ -700,7 +709,9 @@ def plan_launches(
 ) -> list[InstanceLaunch]:
     """Plan placement for *roles* (``None`` = all configured) and build their launches."""
     unified_budget = _unified_memory_budget(devices)
-    inputs, model_refs, reservation = _server_model_inputs(roles, unified_budget=unified_budget)
+    inputs, model_refs, reservation = _server_model_inputs(
+        roles, unified_budget=unified_budget, device_count=len(devices)
+    )
     placement = plan_placement(
         inputs,
         [(d.index, d.free_bytes) for d in devices],

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import os
 import re
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -724,6 +726,47 @@ def resolve_devices(binary: Path) -> list[FleetDevice]:
     return devices
 
 
+_DEVICE_PROBE_TTL_S = 2.0
+
+
+class _ReadDeviceCache:
+    """Short-TTL device-probe cache for the read/view path.
+
+    Inspecting placement (GET placement/gpus, preview, ``placement show``)
+    resolves devices on every call, which spawns a ``llama-server --list-devices``
+    subprocess; a brief TTL collapses a burst of reads onto one probe. The launch
+    path is never served from here -- it reaps stale servers first and sizes KV
+    cache against live free VRAM, so it always probes fresh.
+    """
+
+    def __init__(self, ttl_s: float) -> None:
+        self._ttl_s = ttl_s
+        self._lock = threading.Lock()
+        self._at: float | None = None
+        self._devices: list[FleetDevice] | None = None
+
+    def get(self, binary: Path) -> list[FleetDevice]:
+        with self._lock:
+            fresh = self._at is not None and time.monotonic() - self._at < self._ttl_s
+            if self._devices is None or not fresh:
+                self._devices = resolve_devices(binary)
+                self._at = time.monotonic()
+            return self._devices
+
+    def clear(self) -> None:
+        with self._lock:
+            self._at = None
+            self._devices = None
+
+
+_read_device_cache = _ReadDeviceCache(_DEVICE_PROBE_TTL_S)
+
+
+def clear_read_device_cache() -> None:
+    """Drop the read-path device probe cache (e.g. after the fleet is reconfigured)."""
+    _read_device_cache.clear()
+
+
 def _unified_memory_budget(devices: list[FleetDevice]) -> int | None:
     """Shared-RAM placement budget (free RAM minus the OS floor) when there is no
     discrete GPU, else ``None``. Discrete GPUs load into dedicated VRAM, so system
@@ -786,7 +829,7 @@ def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement
     apply_fleet_gpu_env()
     binary = resolve_llama_server()
     apply_cuda_runtime_env()
-    devices = resolve_devices(binary)
+    devices = _read_device_cache.get(binary)
     unified_budget = _unified_memory_budget(devices)
     inputs, model_refs, _ = _server_model_inputs(None, unified_budget=unified_budget)
     resolved = _resolve_placement(

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -32,7 +32,7 @@ from lilbee.providers.fleet.placement import (
     plan_placement,
 )
 from lilbee.providers.fleet.placement_spec import PlacementSpec
-from lilbee.providers.fleet.vram import estimate_instance_footprint
+from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION, estimate_instance_footprint
 from lilbee.providers.roles import RerankMode, WorkerRole
 
 log = logging.getLogger(__name__)
@@ -45,6 +45,13 @@ _CHAT_SLOTS = 4
 # A tensor-split chat fills its cards with one full-context sequence; concurrent
 # slots are for a chat that fits a single GPU, not a multi-card giant.
 _SPLIT_CHAT_SLOTS = 1
+# Floor context the PLACEMENT estimate reserves KV for, so a large model is never
+# single-carded into a KV corner too small for real use (a 17GB model on a 24GB
+# card leaves ~no KV room -> n_ctx collapses to a few hundred tokens). Sizing the
+# placement reserve against this floor forces a tensor-split when one card cannot
+# hold weights + a usable context; the served ctx is then grown to the chosen
+# cards' real headroom by resolve_chat_ctx (single) / fit_split_ctx (split).
+_MIN_USABLE_CHAT_CTX = 8192
 _AUX_SLOTS = 1
 _EMBED_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK)
 # Truncate embed/rerank inputs a few tokens below the per-slot context: the server
@@ -407,7 +414,11 @@ def _estimate_role(
     path = resolve_model_path(model_ref)
     mmproj = _vision_mmproj(model_ref) if role is WorkerRole.VISION else None
     meta = read_gguf_metadata(path)
-    ctx = _role_ctx(role, path, meta)
+    # Size the single-instance footprint against the placement reserve (a usable
+    # KV floor for chat), so a model that fits weights-only on one card but not
+    # weights + a usable context falls through to a tensor-split instead of being
+    # single-carded into a tiny n_ctx. Non-chat roles keep their launch ctx.
+    ctx = _placement_estimate_ctx(role, path, meta)
     rerank_mode = _role_rerank_mode(role, meta)
     if slots is None:
         slots = _slots_for(
@@ -429,20 +440,47 @@ def _estimate_role(
         mmproj_path=mmproj,
         batch_size=_pooled_batch_size(role, rerank_mode, ctx),
     )
-    return ModelPlacementInput(
-        role=role,
-        est_vram_bytes=est.footprint(unified=unified_budget is not None),
-        replicas=_replica_count(role),
-    )
+    fp = est.footprint(unified=unified_budget is not None)
+    if role is WorkerRole.CHAT and unified_budget is None:
+        fp = _chat_serve_budget_footprint(fp)
+    return ModelPlacementInput(role=role, est_vram_bytes=fp, replicas=_replica_count(role))
+
+
+def _chat_serve_budget_footprint(footprint: int) -> int:
+    """Charge a chat instance against the serve budget, not the placement headroom.
+
+    The planner fits instances within ``USABLE_VRAM_FRACTION`` of a card, but a
+    single-card chat then sizes its KV cache against the smaller
+    ``cfg.gpu_memory_fraction`` budget (``resolve_chat_ctx``). A model that fills a
+    card at 0.9 leaves no room for KV at 0.75 and collapses to a few hundred tokens,
+    so scale its placement footprint by the budget ratio: it then needs a
+    tensor-split (pooling VRAM across cards) whenever single-carding it would starve
+    its context. Small models are unaffected -- they fit the serve budget with KV
+    room to spare.
+    """
+    from lilbee.core.config import cfg
+
+    return int(footprint * (USABLE_VRAM_FRACTION / cfg.gpu_memory_fraction))
 
 
 def _placement_estimate_ctx(role: WorkerRole, model_path: Path, meta: dict[str, str] | None) -> int:
-    """Per-slot context the placement estimate sizes a role against (the launch ceiling)."""
+    """Per-slot context the placement estimate sizes a role against.
+
+    For chat this reserves KV for a usable floor (``_MIN_USABLE_CHAT_CTX``, or the
+    user's ``cfg.num_ctx`` pin), capped by the model's trained ceiling -- not the
+    single-GPU dynamic ctx (which shrinks to fit one card and then confirms a
+    single-card placement) nor the full trained ceiling (which over-reserves). A
+    model that cannot hold weights + this floor on one card is tensor-split.
+    """
     from lilbee.core.config import cfg
     from lilbee.providers.engine_params import chat_ctx_ceiling
 
     if role is WorkerRole.CHAT:
-        return cfg.num_ctx if cfg.num_ctx is not None else chat_ctx_ceiling(meta, model_path)
+        if cfg.num_ctx is not None:
+            return cfg.num_ctx
+        return min(
+            chat_ctx_ceiling(meta, model_path), max(cfg.chat_n_ctx_target, _MIN_USABLE_CHAT_CTX)
+        )
     return _role_ctx(role, model_path, meta)
 
 

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -747,16 +747,22 @@ def _resolve_placement(
 ) -> Placement:
     """Resolve a Placement from the manual spec when set, else the auto planner."""
     estimate_peak = _peak_estimator(model_refs)
+    # Size placement against each card's TOTAL capacity, not its instantaneous
+    # free VRAM. plan_launches always plans the complete fleet, so the plan
+    # defines the full intended residency; charging it against live free_bytes
+    # double-counts models the fleet has already loaded (a warm get_placement or
+    # reload would then falsely report the plan as unplaceable). bb-a8f.
+    capacity = {d.index: d.total_bytes for d in devices}
     if placement is not None:
         return placement_from_spec(
             placement,
             tuple(model_refs),
-            {d.index: d.free_bytes for d in devices},
+            capacity,
             estimate_peak=estimate_peak,
         )
     return plan_placement(
         inputs,
-        [(d.index, d.free_bytes) for d in devices],
+        [(idx, total) for idx, total in capacity.items()],
         estimate_peak=estimate_peak,
         unified_budget=unified_budget,
     )

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -764,9 +764,8 @@ def plan_launches(
 
     unified_budget = _unified_memory_budget(devices)
     inputs, model_refs, reservation = _server_model_inputs(roles, unified_budget=unified_budget)
-    placement = _resolve_placement(
-        cfg.placement, inputs, model_refs, devices, unified_budget=unified_budget
-    )
+    spec = PlacementSpec.from_json(cfg.placement) if cfg.placement else None
+    placement = _resolve_placement(spec, inputs, model_refs, devices, unified_budget=unified_budget)
     for role in placement.unplaceable_roles:
         log.warning(
             "%s model %s does not fit available memory and will not be served; "

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,8 +27,11 @@ from lilbee.providers.fleet.placement import (
     InstancePlan,
     ModelPlacementInput,
     PeakEstimator,
+    Placement,
+    placement_from_spec,
     plan_placement,
 )
+from lilbee.providers.fleet.placement_spec import PlacementSpec
 from lilbee.providers.fleet.vram import estimate_instance_footprint
 from lilbee.providers.roles import RerankMode, WorkerRole
 
@@ -692,6 +696,63 @@ def _unified_memory_budget(devices: list[FleetDevice]) -> int | None:
     return max(0, model_cache.free_system_memory() - floor)
 
 
+def _resolve_placement(
+    placement: PlacementSpec | None,
+    inputs: list[ModelPlacementInput],
+    model_refs: dict[WorkerRole, str],
+    devices: list[FleetDevice],
+    *,
+    unified_budget: int | None,
+) -> Placement:
+    """Resolve a Placement from the manual spec when set, else the auto planner."""
+    estimate_peak = _peak_estimator(model_refs)
+    if placement is not None:
+        return placement_from_spec(
+            placement,
+            tuple(model_refs),
+            {d.index: d.free_bytes for d in devices},
+            estimate_peak=estimate_peak,
+        )
+    return plan_placement(
+        inputs,
+        [(d.index, d.free_bytes) for d in devices],
+        estimate_peak=estimate_peak,
+        unified_budget=unified_budget,
+    )
+
+
+@dataclass(frozen=True)
+class ResolvedPlacement:
+    """Devices + resolved instance plans + model refs for the placement view."""
+
+    devices: tuple[FleetDevice, ...]
+    instances: tuple[InstancePlan, ...]
+    unplaceable_roles: tuple[WorkerRole, ...]
+    model_refs: dict[WorkerRole, str]
+
+
+def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement:
+    """Probe devices and resolve the auto-or-manual placement, without launching."""
+    from lilbee.providers.fleet.cuda_runtime import apply_cuda_runtime_env
+    from lilbee.providers.fleet.gpu_env import apply_fleet_gpu_env
+
+    apply_fleet_gpu_env()
+    binary = resolve_llama_server()
+    apply_cuda_runtime_env()
+    devices = resolve_devices(binary)
+    unified_budget = _unified_memory_budget(devices)
+    inputs, model_refs, _ = _server_model_inputs(None, unified_budget=unified_budget)
+    resolved = _resolve_placement(
+        placement, inputs, model_refs, devices, unified_budget=unified_budget
+    )
+    return ResolvedPlacement(
+        devices=tuple(devices),
+        instances=resolved.instances,
+        unplaceable_roles=resolved.unplaceable_roles,
+        model_refs=model_refs,
+    )
+
+
 def plan_launches(
     roles: tuple[WorkerRole, ...] | None,
     binary: Path,
@@ -699,13 +760,12 @@ def plan_launches(
     devices: list[FleetDevice],
 ) -> list[InstanceLaunch]:
     """Plan placement for *roles* (``None`` = all configured) and build their launches."""
+    from lilbee.core.config import cfg
+
     unified_budget = _unified_memory_budget(devices)
     inputs, model_refs, reservation = _server_model_inputs(roles, unified_budget=unified_budget)
-    placement = plan_placement(
-        inputs,
-        [(d.index, d.free_bytes) for d in devices],
-        estimate_peak=_peak_estimator(model_refs),
-        unified_budget=unified_budget,
+    placement = _resolve_placement(
+        cfg.placement, inputs, model_refs, devices, unified_budget=unified_budget
     )
     for role in placement.unplaceable_roles:
         log.warning(

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -423,8 +423,9 @@ class FleetProvider:
             from lilbee.core.config import cfg
 
             swap = SwapManager(cfg.data_dir)
-            # A dead owner's surviving llama-swap holds VRAM; reap before planning
-            # so the device probe sees the real free memory.
+            # A dead owner's surviving llama-swap holds VRAM; reap it before launching
+            # so the cards are actually free for this fleet (and the context sizer
+            # reads true free VRAM).
             swap.reap_stale()
             launches = planning.plan_all_launches()
             if not launches:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -482,10 +482,19 @@ class FleetProvider:
         means the role is unconfigured or did not fit memory. llama-swap loads each
         upstream on its first request, so a returned client may still be cold. No
         in-process fallback, so a missing pool is a hard error.
+
+        When the pool is empty but a swap was previously built and its process has
+        since exited (detected via ``is_live()``), a one-shot rebuild is attempted
+        before raising so a transient llama-swap restart recovers transparently.
         """
         self._ensure_swap()
         with self._lock:
             clients = self._clients.get(role)
+            swap = self._swap
+        if not clients and swap is not None and not swap.is_live():
+            self._rebuild_swap()
+            with self._lock:
+                clients = self._clients.get(role)
         if not clients:
             raise ProviderError(
                 f"No {role.value} model server is running. Make sure a {role.value} "
@@ -493,6 +502,11 @@ class FleetProvider:
                 provider=_PROVIDER_NAME,
             )
         return list(clients)
+
+    def _rebuild_swap(self) -> None:
+        """Drop a dead swap and build a fresh one (new port, re-adopt clients)."""
+        self._drop_swap_refs()
+        self._ensure_swap()
 
     def release_ingest_pool(self) -> None:
         """Unload the elastic ingest replicas (embed/vision replica>=1), freeing VRAM.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
 
 # User-facing name for this engine in error messages.
 _PROVIDER_NAME = "llama-server"
+# Roles that can have replica >= 1 elastic instances (embed / vision data-parallel pools).
+_ELASTIC_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
 # Tokens held back from the served context for the model's own generation when the
 # request does not cap it, plus a margin for chat-template overhead and estimate drift.
 _DEFAULT_GENERATION_RESERVE = 1024
@@ -340,6 +342,9 @@ class FleetProvider:
 
     def __init__(self) -> None:
         self._swap: SwapManager | None = None
+        # Model ids of elastic ingest replicas (embed/vision replica>=1); populated
+        # by _adopt_swap and consumed by release_ingest_pool.
+        self._elastic_members: list[str] = []
         # A pool of OpenAI clients per placed role (one per data-parallel replica),
         # all pointed at the llama-swap endpoint and routed by replica model id;
         # rebuilt whenever the swap process (re)starts. Requests round-robin the pool.
@@ -442,6 +447,11 @@ class FleetProvider:
                 )
             )
         self._clients = clients
+        self._elastic_members = [
+            launch.model_id
+            for launch in launches
+            if launch.role in _ELASTIC_ROLES and launch.replica >= 1
+        ]
         chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
         self._chat_slots = chat.slots if chat is not None else 1
         self._chat_ctx = chat.ctx if chat is not None else None
@@ -483,6 +493,23 @@ class FleetProvider:
                 provider=_PROVIDER_NAME,
             )
         return list(clients)
+
+    def release_ingest_pool(self) -> None:
+        """Unload the elastic ingest replicas (embed/vision replica>=1), freeing VRAM.
+
+        Best-effort and non-disruptive: the persistent query fleet (chat, embed-0,
+        rerank, vision-0) stays loaded. Called when the last active ingest finishes.
+        """
+        with self._lock:
+            swap = self._swap
+            members = list(self._elastic_members)
+        if swap is None:
+            return
+        for model_id in members:
+            if not swap.unload(model_id):
+                log.info("ingest pool: unload of %s did not confirm (swap may be cold)", model_id)
+            else:
+                log.info("ingest pool: unloaded %s", model_id)
 
     def role_ready(self, role: WorkerRole) -> bool:
         """Whether *role*'s upstream is loaded and ready, without starting the swap.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -26,7 +26,11 @@ from lilbee.modelhub.registry import ModelRegistry
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet import planning
 from lilbee.providers.fleet.client import LlamaServerClient, is_connection_failure
-from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
+from lilbee.providers.fleet.replicas import (
+    REPLICATED_ROLES,
+    gpu_device_count,
+    resolve_replica_count,
+)
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
 from lilbee.providers.fleet.swap_manager import SwapManager
 from lilbee.providers.fleet.windowing import window_messages
@@ -51,8 +55,6 @@ if TYPE_CHECKING:
 
 # User-facing name for this engine in error messages.
 _PROVIDER_NAME = "llama-server"
-# Roles that can have replica >= 1 elastic instances (embed / vision data-parallel pools).
-_ELASTIC_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
 # Tokens held back from the served context for the model's own generation when the
 # request does not cap it, plus a margin for chat-template overhead and estimate drift.
 _DEFAULT_GENERATION_RESERVE = 1024
@@ -450,7 +452,7 @@ class FleetProvider:
         self._elastic_members = [
             launch.model_id
             for launch in launches
-            if launch.role in _ELASTIC_ROLES and launch.replica >= 1
+            if launch.role in REPLICATED_ROLES and launch.replica >= 1
         ]
         chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
         self._chat_slots = chat.slots if chat is not None else 1
@@ -504,7 +506,7 @@ class FleetProvider:
         return list(clients)
 
     def _rebuild_swap(self) -> None:
-        """Drop a dead swap and build a fresh one (new port, re-adopt clients)."""
+        """Drop a dead swap and build a fresh one (new port); ``_ensure_swap`` adopts clients."""
         self._drop_swap_refs()
         self._ensure_swap()
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -26,6 +26,7 @@ from lilbee.modelhub.registry import ModelRegistry
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet import planning
 from lilbee.providers.fleet.client import LlamaServerClient, is_connection_failure
+from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
 from lilbee.providers.fleet.swap_manager import SwapManager
 from lilbee.providers.fleet.windowing import window_messages
@@ -218,7 +219,8 @@ class _VisionRequestGate:
                 self._in_flight -= 1
 
     def _checkout(self) -> threading.BoundedSemaphore:
-        capacity = max(1, cfg.vision_replicas * cfg.vision_ocr_concurrency)
+        replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
+        capacity = max(1, replicas * cfg.vision_ocr_concurrency)
         with self._lock:
             # Resize only when idle: rebuilding while old-semaphore holders are
             # in flight would briefly double the real cap, so a capacity change

--- a/src/lilbee/providers/fleet/replicas.py
+++ b/src/lilbee/providers/fleet/replicas.py
@@ -1,0 +1,48 @@
+"""Shared 0-as-auto replica-count resolution used by planning, provider, and pipeline.
+
+The ``embed_replicas`` / ``vision_replicas`` knobs default to 0, meaning "auto:
+one replica per GPU". Resolving that consistently in one place keeps the planning
+hot path, the vision OCR gate, and the ingest fan-out from disagreeing on the
+effective replica count.
+"""
+
+from __future__ import annotations
+
+import functools
+
+from lilbee.providers.roles import WorkerRole
+
+# Roles whose ``*_replicas`` knob scales data-parallel instances; others run one.
+_REPLICATED_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
+# Auto resolves to at least one replica even when no GPU is enumerated.
+_MIN_REPLICAS = 1
+
+
+def resolve_replica_count(role: WorkerRole, device_count: int) -> int:
+    """Requested data-parallel instances for *role* (0 = auto = one per GPU).
+
+    Embed and vision honor their ``*_replicas`` knob; an explicit value wins,
+    0 means one replica per GPU (falling to one when GPU-less). Other roles run
+    one instance. Capping to residual VRAM happens in placement.
+    """
+    from lilbee.core.config import cfg
+
+    if role is WorkerRole.EMBED:
+        return cfg.embed_replicas or max(_MIN_REPLICAS, device_count)
+    if role is WorkerRole.VISION:
+        return cfg.vision_replicas or max(_MIN_REPLICAS, device_count)
+    return _MIN_REPLICAS
+
+
+@functools.cache
+def gpu_device_count() -> int:
+    """Effective GPU count lilbee will use, cached so per-OCR checkouts don't re-probe.
+
+    Resolved the same way planning does (binary ``--list-devices`` view), and
+    floored at one so auto means "one replica" on a GPU-less host.
+    """
+    from lilbee.providers.fleet.binary import resolve_llama_server
+    from lilbee.providers.fleet.planning import resolve_devices
+
+    devices = resolve_devices(resolve_llama_server())
+    return max(_MIN_REPLICAS, len(devices))

--- a/src/lilbee/providers/fleet/replicas.py
+++ b/src/lilbee/providers/fleet/replicas.py
@@ -38,7 +38,7 @@ def resolve_replica_count(role: WorkerRole, device_count: int) -> int:
 
 @functools.cache
 def gpu_device_count() -> int:
-    """Effective GPU count lilbee will use, cached so per-OCR checkouts don't re-probe.
+    """Effective GPU count lilbee will use; fixed for the process lifetime (cached).
 
     Resolved the same way planning does (binary ``--list-devices`` view), and
     floored at one so auto means "one replica" on a GPU-less host.

--- a/src/lilbee/providers/fleet/replicas.py
+++ b/src/lilbee/providers/fleet/replicas.py
@@ -13,7 +13,9 @@ import functools
 from lilbee.providers.roles import WorkerRole
 
 # Roles whose ``*_replicas`` knob scales data-parallel instances; others run one.
-_REPLICATED_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
+# Single source of truth for the elastic (embed/vision) roles, reused by the
+# fleet provider to mark which placed instances belong to the ingest pool.
+REPLICATED_ROLES = (WorkerRole.EMBED, WorkerRole.VISION)
 # Auto resolves to at least one replica even when no GPU is enumerated.
 _MIN_REPLICAS = 1
 
@@ -27,11 +29,11 @@ def resolve_replica_count(role: WorkerRole, device_count: int) -> int:
     """
     from lilbee.core.config import cfg
 
+    if role not in REPLICATED_ROLES:
+        return _MIN_REPLICAS
     if role is WorkerRole.EMBED:
         return cfg.embed_replicas or max(_MIN_REPLICAS, device_count)
-    if role is WorkerRole.VISION:
-        return cfg.vision_replicas or max(_MIN_REPLICAS, device_count)
-    return _MIN_REPLICAS
+    return cfg.vision_replicas or max(_MIN_REPLICAS, device_count)
 
 
 @functools.cache

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -257,6 +257,8 @@ class SwapManager:
 
     def unload(self, model_id: str) -> bool:
         """Unload one model from llama-swap, freeing its VRAM; best-effort, never raises."""
+        if self._port is None:
+            return False
         try:
             resp = httpx.post(
                 f"{self.endpoint()}{_UNLOAD_PATH}",

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -73,7 +73,6 @@ _HEALTH_PATH = "/health"
 _RUNNING_PATH = "/running"
 _UNLOAD_PATH = "/api/models/unload"
 _HTTP_TIMEOUT_S = 10.0
-_HTTP_ERROR_THRESHOLD = 400
 # llama-swap's own proxy answers within a second; upstream model loads have their
 # own (longer) budget inside llama-swap, so this only covers the proxy coming up.
 _BOOT_TIMEOUT_S = 30.0
@@ -267,7 +266,7 @@ class SwapManager:
             )
         except (OSError, httpx.HTTPError):
             return False
-        return resp.status_code < _HTTP_ERROR_THRESHOLD
+        return resp.status_code < httpx.codes.BAD_REQUEST
 
     def is_live(self) -> bool:
         """Whether the swap process is up and its proxy answers ``/running``."""
@@ -279,7 +278,7 @@ class SwapManager:
             resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_HTTP_TIMEOUT_S)
         except (OSError, httpx.HTTPError):
             return False
-        return resp.status_code < _HTTP_ERROR_THRESHOLD
+        return resp.status_code < httpx.codes.BAD_REQUEST
 
     def reload(self, launches: list[InstanceLaunch]) -> None:
         """Apply a changed model set by restarting llama-swap with a fresh config."""

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -72,7 +72,7 @@ _LISTEN_FLAG = "-listen"
 _HEALTH_PATH = "/health"
 _RUNNING_PATH = "/running"
 _UNLOAD_PATH = "/api/models/unload"
-_UNLOAD_TIMEOUT_S = 10.0
+_HTTP_TIMEOUT_S = 10.0
 _HTTP_ERROR_THRESHOLD = 400
 # llama-swap's own proxy answers within a second; upstream model loads have their
 # own (longer) budget inside llama-swap, so this only covers the proxy coming up.
@@ -263,7 +263,7 @@ class SwapManager:
             resp = httpx.post(
                 f"{self.endpoint()}{_UNLOAD_PATH}",
                 json={"model": model_id},
-                timeout=_UNLOAD_TIMEOUT_S,
+                timeout=_HTTP_TIMEOUT_S,
             )
         except (OSError, httpx.HTTPError):
             return False
@@ -273,8 +273,10 @@ class SwapManager:
         """Whether the swap process is up and its proxy answers ``/running``."""
         if self._proc is None or self._proc.poll() is not None:
             return False
+        if self._port is None:
+            return False
         try:
-            resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_UNLOAD_TIMEOUT_S)
+            resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_HTTP_TIMEOUT_S)
         except (OSError, httpx.HTTPError):
             return False
         return resp.status_code < _HTTP_ERROR_THRESHOLD

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -71,6 +71,9 @@ _CONFIG_FLAG = "-config"
 _LISTEN_FLAG = "-listen"
 _HEALTH_PATH = "/health"
 _RUNNING_PATH = "/running"
+_UNLOAD_PATH = "/api/models/unload"
+_UNLOAD_TIMEOUT_S = 10.0
+_HTTP_ERROR_THRESHOLD = 400
 # llama-swap's own proxy answers within a second; upstream model loads have their
 # own (longer) budget inside llama-swap, so this only covers the proxy coming up.
 _BOOT_TIMEOUT_S = 30.0
@@ -251,6 +254,28 @@ class SwapManager:
         """Whether at least one of *role*'s replica servers is loaded and ready."""
         prefix = role_model_prefix(role)
         return any(model.startswith(prefix) for model in self._ready_models())
+
+    def unload(self, model_id: str) -> bool:
+        """Unload one model from llama-swap, freeing its VRAM; best-effort, never raises."""
+        try:
+            resp = httpx.post(
+                f"{self.endpoint()}{_UNLOAD_PATH}",
+                json={"model": model_id},
+                timeout=_UNLOAD_TIMEOUT_S,
+            )
+        except (OSError, httpx.HTTPError):
+            return False
+        return resp.status_code < _HTTP_ERROR_THRESHOLD
+
+    def is_live(self) -> bool:
+        """Whether the swap process is up and its proxy answers ``/running``."""
+        if self._proc is None or self._proc.poll() is not None:
+            return False
+        try:
+            resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_UNLOAD_TIMEOUT_S)
+        except (OSError, httpx.HTTPError):
+            return False
+        return resp.status_code < _HTTP_ERROR_THRESHOLD
 
     def reload(self, launches: list[InstanceLaunch]) -> None:
         """Apply a changed model set by restarting llama-swap with a fresh config."""

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -315,6 +315,11 @@ class RoutingProvider(LLMProvider):
         if self._local is not None:
             self._local.reload_role(role, wait=wait)
 
+    def release_ingest_pool(self) -> None:
+        """Forward to the native engine; the SDK side has no elastic ingest pool."""
+        if self._local is not None:
+            self._local.release_ingest_pool()
+
     def role_ready(self, role: WorkerRole) -> bool:
         """Native readiness without building; True when no local engine exists yet."""
         if self._local is None:

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -427,3 +427,6 @@ class SdkLLMProvider(LLMProvider):
 
     def invalidate_load_cache(self, model_path: Path | None = None) -> None:
         """No-op: cloud backends have no local model cache to evict."""
+
+    def release_ingest_pool(self) -> None:
+        """No-op: cloud backends have no elastic ingest pool to release."""

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -55,6 +55,13 @@ from lilbee.server.routes.models import (
     models_set_vision_route,
     models_show_route,
 )
+from lilbee.server.routes.placement import (
+    gpus_route,
+    placement_clear_route,
+    placement_preview_route,
+    placement_route,
+    placement_set_route,
+)
 from lilbee.server.routes.search import (
     ask_route,
     ask_stream_route,
@@ -156,6 +163,11 @@ def create_app() -> Litestar:
             memories_remove_route,
             export_route,
             import_route,
+            placement_route,
+            placement_preview_route,
+            placement_set_route,
+            placement_clear_route,
+            gpus_route,
             crawl_route,
             setup_crawler_route,
             setup_crawler_status_route,

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -186,8 +186,9 @@ async def placement_clear() -> PlacementResponse:
 async def gpus() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
     from lilbee.app.placement import get_placement
+    from lilbee.server.models import GpuInfoResponse as _GpuInfoResponse
 
-    return [GpuInfoResponse(**vars(g)) for g in get_placement().gpus]
+    return [_GpuInfoResponse(**vars(g)) for g in get_placement().gpus]
 
 
 __all__ = [

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -152,14 +152,14 @@ def _placement_response(view: PlacementView) -> PlacementResponse:
     )
 
 
-def placement() -> PlacementResponse:
+async def placement() -> PlacementResponse:
     """Current effective placement."""
     from lilbee.app.placement import get_placement
 
     return _placement_response(get_placement())
 
 
-def placement_preview(spec_json: str | None) -> PlacementResponse:
+async def placement_preview(spec_json: str | None) -> PlacementResponse:
     """Preview a candidate spec (or auto when spec_json is None). No persistence."""
     from lilbee.app.placement import preview_placement
     from lilbee.providers.fleet.placement_spec import PlacementSpec
@@ -168,7 +168,7 @@ def placement_preview(spec_json: str | None) -> PlacementResponse:
     return _placement_response(preview_placement(spec))
 
 
-def placement_set(spec_json: str) -> PlacementResponse:
+async def placement_set(spec_json: str) -> PlacementResponse:
     """Validate, persist, and apply a manual placement spec."""
     from lilbee.app.placement import set_placement
     from lilbee.providers.fleet.placement_spec import PlacementSpec
@@ -176,17 +176,16 @@ def placement_set(spec_json: str) -> PlacementResponse:
     return _placement_response(set_placement(PlacementSpec.from_json(spec_json)))
 
 
-def placement_clear() -> PlacementResponse:
+async def placement_clear() -> PlacementResponse:
     """Clear the manual placement, returning to auto."""
     from lilbee.app.placement import set_placement
 
     return _placement_response(set_placement(None))
 
 
-def gpus() -> list[GpuInfoResponse]:
+async def gpus() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
     from lilbee.app.placement import get_placement
-    from lilbee.server.models import GpuInfoResponse
 
     return [GpuInfoResponse(**vars(g)) for g in get_placement().gpus]
 

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -168,21 +168,6 @@ async def placement_preview(spec_json: str | None) -> PlacementResponse:
     return _placement_response(preview_placement(spec))
 
 
-async def placement_set(spec_json: str) -> PlacementResponse:
-    """Validate, persist, and apply a manual placement spec."""
-    from lilbee.app.placement import set_placement
-    from lilbee.providers.fleet.placement_spec import PlacementSpec
-
-    return _placement_response(set_placement(PlacementSpec.from_json(spec_json)))
-
-
-async def placement_clear() -> PlacementResponse:
-    """Clear the manual placement, returning to auto."""
-    from lilbee.app.placement import set_placement
-
-    return _placement_response(set_placement(None))
-
-
 async def gpus() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
     from lilbee.app.placement import get_placement
@@ -222,9 +207,7 @@ __all__ = [
     "models_pull",
     "models_show",
     "placement",
-    "placement_clear",
     "placement_preview",
-    "placement_set",
     "search",
     "set_chat_model",
     "set_embedding_model",

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 
 from lilbee.app.services import get_services
 from lilbee.app.status import gather_status
@@ -72,6 +73,10 @@ from lilbee.server.handlers.sse import (
 )
 from lilbee.server.models import HealthResponse, StatusResponse
 
+if TYPE_CHECKING:
+    from lilbee.app.placement import PlacementView
+    from lilbee.server.models import GpuInfoResponse, PlacementResponse
+
 # How often the warm stream re-snapshots provider state; sub-second so the read
 # bar advances smoothly without busy-spinning.
 _WARM_POLL_INTERVAL_S = 0.25
@@ -125,6 +130,67 @@ async def status() -> StatusResponse:
     return StatusResponse(**raw.model_dump(exclude_none=True))
 
 
+def _placement_response(view: PlacementView) -> PlacementResponse:
+    """Map a PlacementView to a PlacementResponse."""
+    from lilbee.server.models import GpuInfoResponse, PlacementResponse, RolePlacementResponse
+
+    return PlacementResponse(
+        gpus=[GpuInfoResponse(**vars(g)) for g in view.gpus],
+        roles=[
+            RolePlacementResponse(
+                role=r.role,
+                model=r.model,
+                devices=list(r.devices),
+                tensor_split=list(r.tensor_split) if r.tensor_split else None,
+                replicas=r.replicas,
+            )
+            for r in view.roles
+        ],
+        unplaceable=[r.value for r in view.unplaceable],
+        manual=view.manual,
+        spec_json=view.spec_json,
+    )
+
+
+def placement() -> PlacementResponse:
+    """Current effective placement."""
+    from lilbee.app.placement import get_placement
+
+    return _placement_response(get_placement())
+
+
+def placement_preview(spec_json: str | None) -> PlacementResponse:
+    """Preview a candidate spec (or auto when spec_json is None). No persistence."""
+    from lilbee.app.placement import preview_placement
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    spec = PlacementSpec.from_json(spec_json) if spec_json else None
+    return _placement_response(preview_placement(spec))
+
+
+def placement_set(spec_json: str) -> PlacementResponse:
+    """Validate, persist, and apply a manual placement spec."""
+    from lilbee.app.placement import set_placement
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    return _placement_response(set_placement(PlacementSpec.from_json(spec_json)))
+
+
+def placement_clear() -> PlacementResponse:
+    """Clear the manual placement, returning to auto."""
+    from lilbee.app.placement import set_placement
+
+    return _placement_response(set_placement(None))
+
+
+def gpus() -> list[GpuInfoResponse]:
+    """Detected GPUs with free/total VRAM."""
+    from lilbee.app.placement import get_placement
+    from lilbee.server.models import GpuInfoResponse
+
+    return [GpuInfoResponse(**vars(g)) for g in get_placement().gpus]
+
+
 __all__ = [
     "MAX_ADD_FILES",
     "TASK_ENDPOINT_PATH",
@@ -144,6 +210,7 @@ __all__ = [
     "get_config",
     "get_config_defaults",
     "get_source_content",
+    "gpus",
     "health",
     "import_stream",
     "list_documents",
@@ -154,6 +221,10 @@ __all__ = [
     "models_installed",
     "models_pull",
     "models_show",
+    "placement",
+    "placement_clear",
+    "placement_preview",
+    "placement_set",
     "search",
     "set_chat_model",
     "set_embedding_model",

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, field_validator
 from lilbee.catalog.types import KeyStatus, ModelCompat, ModelSource, ModelTask
 from lilbee.core.config.enums import CrawlRenderMode
 from lilbee.data.store import ChunkType, MemoryKind, scope_to_chunk_type
+from lilbee.providers.roles import WorkerRole
 from lilbee.runtime.hardware import FitLevel, SizeVariantInfo
 
 
@@ -561,3 +562,40 @@ class MemoryExtractedEvent(BaseModel):
 
     count: int
     items: list[MemoryExtractedItem]
+
+
+class GpuInfoResponse(BaseModel):
+    """One GPU as returned by GET /api/gpus and embedded in PlacementResponse."""
+
+    index: int
+    backend: str
+    label: str
+    name: str
+    total_bytes: int
+    free_bytes: int
+
+
+class RolePlacementResponse(BaseModel):
+    """Where one role's model is placed in the resolved plan."""
+
+    role: WorkerRole
+    model: str
+    devices: list[int]
+    tensor_split: list[int] | None
+    replicas: int
+
+
+class PlacementResponse(BaseModel):
+    """Response for placement read, preview, set, and clear routes."""
+
+    gpus: list[GpuInfoResponse]
+    roles: list[RolePlacementResponse]
+    unplaceable: list[str]
+    manual: bool
+    spec_json: str | None
+
+
+class PlacementSpecBody(BaseModel):
+    """Request body for placement routes that accept a manual spec."""
+
+    spec: dict[str, dict[str, object]] | None = None

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -12,7 +12,6 @@ import json
 from litestar import delete, get, post, put
 from litestar.exceptions import HTTPException
 
-from lilbee.app.settings import provider_reset_refused_message
 from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet.placement_spec import PlacementError
 from lilbee.server import handlers
@@ -23,6 +22,10 @@ _HTTP_UNPROCESSABLE = 422
 _HTTP_CONFLICT = 409
 _HTTP_UNAVAILABLE = 503
 _INPUT_ERRORS = (PlacementError, ValueError, OSError)
+_REFUSED_DETAIL = (
+    "Changing placement on the HTTP server is unavailable: it rebuilds the shared "
+    "fleet for every connected client. Change it from the CLI or TUI."
+)
 
 
 def _spec_json(body: PlacementSpecBody) -> str | None:
@@ -31,9 +34,7 @@ def _spec_json(body: PlacementSpecBody) -> str | None:
 
 
 def _refused() -> HTTPException:
-    return HTTPException(
-        status_code=_HTTP_CONFLICT, detail=provider_reset_refused_message("Changing placement on")
-    )
+    return HTTPException(status_code=_HTTP_CONFLICT, detail=_REFUSED_DETAIL)
 
 
 @get("/api/placement")

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -1,0 +1,59 @@
+"""Placement routes: inspect, preview, set, and clear GPU placement."""
+
+from __future__ import annotations
+
+import json
+
+from litestar import delete, get, post, put
+from litestar.exceptions import HTTPException
+
+from lilbee.providers.fleet.placement_spec import PlacementError
+from lilbee.server import handlers
+from lilbee.server.auth import read_only
+from lilbee.server.models import GpuInfoResponse, PlacementResponse, PlacementSpecBody
+
+
+def _spec_json(body: PlacementSpecBody) -> str | None:
+    """Serialize the optional spec dict to JSON, or return None when absent."""
+    return json.dumps(body.spec) if body.spec is not None else None
+
+
+@get("/api/placement")
+@read_only
+async def placement_route() -> PlacementResponse:
+    """Current effective placement."""
+    return handlers.placement()  # type: ignore[return-value]
+
+
+@post("/api/placement/preview", status_code=200)
+@read_only
+async def placement_preview_route(data: PlacementSpecBody) -> PlacementResponse:
+    """Preview a candidate spec (or auto when no spec)."""
+    try:
+        return handlers.placement_preview(_spec_json(data))  # type: ignore[return-value]
+    except PlacementError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@put("/api/placement")
+async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
+    """Validate, persist, and apply a manual placement spec."""
+    if data.spec is None:
+        raise HTTPException(status_code=422, detail="spec is required")
+    try:
+        return handlers.placement_set(json.dumps(data.spec))  # type: ignore[return-value]
+    except PlacementError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@delete("/api/placement", status_code=200)
+async def placement_clear_route() -> PlacementResponse:
+    """Clear the manual placement, returning to auto."""
+    return handlers.placement_clear()  # type: ignore[return-value]
+
+
+@get("/api/gpus")
+@read_only
+async def gpus_route() -> list[GpuInfoResponse]:
+    """Detected GPUs with free/total VRAM."""
+    return handlers.gpus()  # type: ignore[return-value]

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -1,4 +1,9 @@
-"""Placement routes: inspect, preview, set, and clear GPU placement."""
+"""Placement routes: inspect and preview GPU placement.
+
+Mutation (set/clear) is intentionally not served here. Applying a placement
+rebuilds the shared fleet, which is unsafe on the always-concurrent HTTP
+daemon, so PUT/DELETE are refused and placement is changed from the CLI or TUI.
+"""
 
 from __future__ import annotations
 
@@ -7,10 +12,17 @@ import json
 from litestar import delete, get, post, put
 from litestar.exceptions import HTTPException
 
+from lilbee.app.settings import provider_reset_refused_message
+from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet.placement_spec import PlacementError
 from lilbee.server import handlers
 from lilbee.server.auth import read_only
 from lilbee.server.models import GpuInfoResponse, PlacementResponse, PlacementSpecBody
+
+_HTTP_UNPROCESSABLE = 422
+_HTTP_CONFLICT = 409
+_HTTP_UNAVAILABLE = 503
+_INPUT_ERRORS = (PlacementError, ValueError, OSError)
 
 
 def _spec_json(body: PlacementSpecBody) -> str | None:
@@ -18,42 +30,50 @@ def _spec_json(body: PlacementSpecBody) -> str | None:
     return json.dumps(body.spec) if body.spec is not None else None
 
 
+def _refused() -> HTTPException:
+    return HTTPException(
+        status_code=_HTTP_CONFLICT, detail=provider_reset_refused_message("Changing placement on")
+    )
+
+
 @get("/api/placement")
 @read_only
 async def placement_route() -> PlacementResponse:
     """Current effective placement."""
-    return await handlers.placement()
+    try:
+        return await handlers.placement()
+    except ProviderError as exc:
+        raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
 
 
 @post("/api/placement/preview", status_code=200)
-@read_only
 async def placement_preview_route(data: PlacementSpecBody) -> PlacementResponse:
-    """Preview a candidate spec (or auto when no spec)."""
+    """Preview a candidate spec (or auto when no spec). Requires auth: runs subprocess probes."""
     try:
         return await handlers.placement_preview(_spec_json(data))
-    except PlacementError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except ProviderError as exc:
+        raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
+    except _INPUT_ERRORS as exc:
+        raise HTTPException(status_code=_HTTP_UNPROCESSABLE, detail=str(exc)) from exc
 
 
 @put("/api/placement")
-async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
-    """Validate, persist, and apply a manual placement spec."""
-    if data.spec is None:
-        raise HTTPException(status_code=422, detail="spec is required")
-    try:
-        return await handlers.placement_set(json.dumps(data.spec))
-    except PlacementError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+async def placement_set_route() -> PlacementResponse:
+    """Refused on the HTTP daemon: applying placement rebuilds the shared fleet."""
+    raise _refused()
 
 
-@delete("/api/placement", status_code=200)
-async def placement_clear_route() -> PlacementResponse:
-    """Clear the manual placement, returning to auto."""
-    return await handlers.placement_clear()
+@delete("/api/placement")
+async def placement_clear_route() -> None:
+    """Refused on the HTTP daemon: clearing placement rebuilds the shared fleet."""
+    raise _refused()
 
 
 @get("/api/gpus")
 @read_only
 async def gpus_route() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
-    return await handlers.gpus()
+    try:
+        return await handlers.gpus()
+    except ProviderError as exc:
+        raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -22,7 +22,7 @@ def _spec_json(body: PlacementSpecBody) -> str | None:
 @read_only
 async def placement_route() -> PlacementResponse:
     """Current effective placement."""
-    return handlers.placement()  # type: ignore[return-value]
+    return await handlers.placement()
 
 
 @post("/api/placement/preview", status_code=200)
@@ -30,7 +30,7 @@ async def placement_route() -> PlacementResponse:
 async def placement_preview_route(data: PlacementSpecBody) -> PlacementResponse:
     """Preview a candidate spec (or auto when no spec)."""
     try:
-        return handlers.placement_preview(_spec_json(data))  # type: ignore[return-value]
+        return await handlers.placement_preview(_spec_json(data))
     except PlacementError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -41,7 +41,7 @@ async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
     if data.spec is None:
         raise HTTPException(status_code=422, detail="spec is required")
     try:
-        return handlers.placement_set(json.dumps(data.spec))  # type: ignore[return-value]
+        return await handlers.placement_set(json.dumps(data.spec))
     except PlacementError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -49,11 +49,11 @@ async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
 @delete("/api/placement", status_code=200)
 async def placement_clear_route() -> PlacementResponse:
     """Clear the manual placement, returning to auto."""
-    return handlers.placement_clear()  # type: ignore[return-value]
+    return await handlers.placement_clear()
 
 
 @get("/api/gpus")
 @read_only
 async def gpus_route() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
-    return handlers.gpus()  # type: ignore[return-value]
+    return await handlers.gpus()

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -1,8 +1,10 @@
 """Placement routes: inspect and preview GPU placement.
 
-Mutation (set/clear) is intentionally not served here. Applying a placement
-rebuilds the shared fleet, which is unsafe on the always-concurrent HTTP
-daemon, so PUT/DELETE are refused and placement is changed from the CLI or TUI.
+Every route requires auth: even the reads run resolve_placement_plan, which
+spawns subprocess device probes, so none are marked @read_only. Mutation
+(set/clear) is intentionally not served here: applying a placement rebuilds the
+shared fleet, which is unsafe on the always-concurrent HTTP daemon, so PUT/DELETE
+are refused and placement is changed from the CLI or TUI.
 """
 
 from __future__ import annotations
@@ -15,7 +17,6 @@ from litestar.exceptions import HTTPException
 from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet.placement_spec import PlacementError
 from lilbee.server import handlers
-from lilbee.server.auth import read_only
 from lilbee.server.models import GpuInfoResponse, PlacementResponse, PlacementSpecBody
 
 _HTTP_UNPROCESSABLE = 422
@@ -38,7 +39,6 @@ def _refused() -> HTTPException:
 
 
 @get("/api/placement")
-@read_only
 async def placement_route() -> PlacementResponse:
     """Current effective placement."""
     try:
@@ -71,7 +71,6 @@ async def placement_clear_route() -> None:
 
 
 @get("/api/gpus")
-@read_only
 async def gpus_route() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
     try:

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -82,6 +82,24 @@ def test_set_persists_and_resets(monkeypatch):
         app_placement.cfg.placement = prior
 
 
+def test_set_clears_read_device_cache(monkeypatch):
+    """Applying a placement reconfigures the fleet, so the stale device probe is dropped."""
+    cleared = {"called": False}
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: None)
+    monkeypatch.setattr(app_placement, "reset_services", lambda: None)
+    monkeypatch.setattr(
+        app_placement, "clear_read_device_cache", lambda: cleared.__setitem__("called", True)
+    )
+    prior = app_placement.cfg.placement
+    try:
+        app_placement.set_placement(PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))}))
+        assert cleared["called"] is True
+    finally:
+        app_placement.cfg.placement = prior
+
+
 def test_set_none_clears(monkeypatch):
     deletes = {}
     monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -115,7 +115,7 @@ def test_set_validates_before_persist(monkeypatch):
     assert wrote["any"] is False
 
 
-def test_view_multi_replica_keeps_first_devices():
+def test_view_multi_replica_unions_devices():
     resolved = ResolvedPlacement(
         devices=(
             FleetDevice("CUDA", 0, "NVIDIA A100", 80 * GIB, 72 * GIB),
@@ -133,4 +133,4 @@ def test_view_multi_replica_keeps_first_devices():
     assert len(embed_views) == 1
     role_view = embed_views[0]
     assert role_view.replicas == 2
-    assert role_view.devices == (0,)
+    assert role_view.devices == (0, 1)

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -27,6 +27,12 @@ def test_active_spec_reads_cfg(monkeypatch):
     assert app_placement._active_spec() is None
 
 
+def test_active_spec_parses_stored_json(monkeypatch):
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0, 1))})
+    monkeypatch.setattr(app_placement.cfg, "placement", spec.to_json())
+    assert app_placement._active_spec() == spec
+
+
 def test_get_placement_renders_view(monkeypatch):
     monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
@@ -71,7 +77,7 @@ def test_set_persists_and_resets(monkeypatch):
         app_placement.set_placement(spec)
         assert writes["placement"] == spec.to_json()
         assert writes["reset"] is True
-        assert app_placement.cfg.placement == spec
+        assert app_placement.cfg.placement == spec.to_json()
     finally:
         app_placement.cfg.placement = prior
 

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -1,0 +1,99 @@
+import pytest
+
+from lilbee.app import placement as app_placement
+from lilbee.providers.fleet.devices import FleetDevice
+from lilbee.providers.fleet.placement import InstancePlan
+from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
+from lilbee.providers.fleet.planning import ResolvedPlacement
+from lilbee.providers.roles import WorkerRole
+
+GIB = 1024**3
+
+
+def _resolved():
+    return ResolvedPlacement(
+        devices=(
+            FleetDevice("CUDA", 0, "NVIDIA A100", 80 * GIB, 72 * GIB),
+            FleetDevice("CUDA", 1, "NVIDIA A100", 80 * GIB, 80 * GIB),
+        ),
+        instances=(InstancePlan(role=WorkerRole.CHAT, devices=(0, 1), tensor_split=(1, 1)),),
+        unplaceable_roles=(),
+        model_refs={WorkerRole.CHAT: "org/chat.gguf"},
+    )
+
+
+def test_active_spec_reads_cfg(monkeypatch):
+    monkeypatch.setattr(app_placement.cfg, "placement", None)
+    assert app_placement._active_spec() is None
+
+
+def test_get_placement_renders_view(monkeypatch):
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    view = app_placement.get_placement()
+    assert view.manual is False
+    assert view.gpus[0].label == "CUDA0"
+    assert view.gpus[0].free_bytes == 72 * GIB
+    assert view.roles[0].role is WorkerRole.CHAT
+    assert view.roles[0].devices == (0, 1)
+
+
+def test_preview_passes_candidate_spec(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        app_placement,
+        "resolve_placement_plan",
+        lambda spec: seen.update({"spec": spec}) or _resolved(),
+    )
+    cand = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+    app_placement.preview_placement(cand)
+    assert seen["spec"] is cand
+
+
+def test_preview_has_no_side_effects(monkeypatch):
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    reset = {"called": False}
+    monkeypatch.setattr(app_placement, "reset_services", lambda: reset.__setitem__("called", True))
+    app_placement.preview_placement(None)
+    assert reset["called"] is False
+
+
+def test_set_persists_and_resets(monkeypatch):
+    writes = {}
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: writes.update(d))
+    monkeypatch.setattr(app_placement, "reset_services", lambda: writes.setdefault("reset", True))
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(1, 1))})
+    app_placement.set_placement(spec)
+    assert writes["placement"] == spec.to_json()
+    assert writes["reset"] is True
+
+
+def test_set_none_clears(monkeypatch):
+    deletes = {}
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    monkeypatch.setattr(
+        app_placement.settings, "delete_values", lambda root, keys: deletes.setdefault("keys", keys)
+    )
+    monkeypatch.setattr(app_placement, "reset_services", lambda: None)
+    app_placement.set_placement(None)
+    assert deletes["keys"] == ["placement"]
+
+
+def test_set_validates_before_persist(monkeypatch):
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    def boom(spec):
+        raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
+
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", boom)
+    wrote = {"any": False}
+    monkeypatch.setattr(
+        app_placement.settings, "update_values", lambda root, d: wrote.__setitem__("any", True)
+    )
+    with pytest.raises(PlacementError):
+        app_placement.set_placement(PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))}))
+    assert wrote["any"] is False

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -65,10 +65,15 @@ def test_set_persists_and_resets(monkeypatch):
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: writes.update(d))
     monkeypatch.setattr(app_placement, "reset_services", lambda: writes.setdefault("reset", True))
+    prior = app_placement.cfg.placement
     spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(1, 1))})
-    app_placement.set_placement(spec)
-    assert writes["placement"] == spec.to_json()
-    assert writes["reset"] is True
+    try:
+        app_placement.set_placement(spec)
+        assert writes["placement"] == spec.to_json()
+        assert writes["reset"] is True
+        assert app_placement.cfg.placement == spec
+    finally:
+        app_placement.cfg.placement = prior
 
 
 def test_set_none_clears(monkeypatch):
@@ -79,8 +84,13 @@ def test_set_none_clears(monkeypatch):
         app_placement.settings, "delete_values", lambda root, keys: deletes.setdefault("keys", keys)
     )
     monkeypatch.setattr(app_placement, "reset_services", lambda: None)
-    app_placement.set_placement(None)
-    assert deletes["keys"] == ["placement"]
+    prior = app_placement.cfg.placement
+    try:
+        app_placement.set_placement(None)
+        assert deletes["keys"] == ["placement"]
+        assert app_placement.cfg.placement is None
+    finally:
+        app_placement.cfg.placement = prior
 
 
 def test_set_validates_before_persist(monkeypatch):
@@ -97,3 +107,24 @@ def test_set_validates_before_persist(monkeypatch):
     with pytest.raises(PlacementError):
         app_placement.set_placement(PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))}))
     assert wrote["any"] is False
+
+
+def test_view_multi_replica_keeps_first_devices():
+    resolved = ResolvedPlacement(
+        devices=(
+            FleetDevice("CUDA", 0, "NVIDIA A100", 80 * GIB, 72 * GIB),
+            FleetDevice("CUDA", 1, "NVIDIA A100", 80 * GIB, 80 * GIB),
+        ),
+        instances=(
+            InstancePlan(role=WorkerRole.EMBED, devices=(0,), tensor_split=None),
+            InstancePlan(role=WorkerRole.EMBED, devices=(1,), tensor_split=None),
+        ),
+        unplaceable_roles=(),
+        model_refs={WorkerRole.EMBED: "org/embed.gguf"},
+    )
+    view = app_placement._view(resolved, manual=False, spec_json=None)
+    embed_views = [r for r in view.roles if r.role is WorkerRole.EMBED]
+    assert len(embed_views) == 1
+    role_view = embed_views[0]
+    assert role_view.replicas == 2
+    assert role_view.devices == (0,)

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -1,0 +1,133 @@
+"""Tests for the `lilbee placement` CLI sub-app."""
+
+from typer.testing import CliRunner
+
+import lilbee.cli.placement as cli_placement
+from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+from lilbee.cli.placement import placement_app
+from lilbee.providers.roles import WorkerRole
+
+runner = CliRunner()
+_GIB = 1024**3
+
+
+def _view(manual: bool = False) -> PlacementView:
+    return PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100-SXM4-80GB", 80 * _GIB, 72 * _GIB),),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=manual,
+        spec_json='{"chat": {"devices": [0]}}' if manual else None,
+    )
+
+
+def test_show_renders_cards(monkeypatch: object) -> None:
+    """show calls get_placement and renders GPU label, name, and roles."""
+    monkeypatch.setattr(cli_placement, "get_placement", lambda: _view())
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 0
+    assert "CUDA0" in result.stdout
+    assert "NVIDIA A100-SXM4-80GB" in result.stdout
+    assert "chat" in result.stdout
+
+
+def test_preview_auto(monkeypatch: object) -> None:
+    """preview with no --spec calls preview_placement(None)."""
+    monkeypatch.setattr(cli_placement, "preview_placement", lambda spec: _view())
+    result = runner.invoke(placement_app, ["preview"])
+    assert result.exit_code == 0
+    assert "CUDA0" in result.stdout
+
+
+def test_set_reads_spec_file(tmp_path: object, monkeypatch: object) -> None:
+    """set --spec FILE parses the JSON and passes a PlacementSpec to set_placement."""
+    seen: dict[str, object] = {}
+
+    def _fake_set(spec: object) -> PlacementView:
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(cli_placement, "set_placement", _fake_set)
+    f = tmp_path / "spec.json"
+    f.write_text('{"chat": {"devices": [0]}}')
+    result = runner.invoke(placement_app, ["set", "--spec", str(f)])
+    assert result.exit_code == 0
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    assert isinstance(seen["spec"], PlacementSpec)
+    assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
+
+
+def test_clear(monkeypatch: object) -> None:
+    """clear calls set_placement(None)."""
+    seen: dict[str, object] = {}
+
+    def _fake_set(spec: object) -> PlacementView:
+        seen["spec"] = spec
+        return _view()
+
+    monkeypatch.setattr(cli_placement, "set_placement", _fake_set)
+    result = runner.invoke(placement_app, ["clear"])
+    assert result.exit_code == 0
+    assert seen["spec"] is None
+
+
+def test_show_unplaceable_role(monkeypatch: object) -> None:
+    """show renders a red line for each unplaceable role."""
+    view = PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "A100", 80 * _GIB, 72 * _GIB),),
+        roles=(),
+        unplaceable=(WorkerRole.EMBED,),
+        manual=False,
+        spec_json=None,
+    )
+    monkeypatch.setattr(cli_placement, "get_placement", lambda: view)
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 0
+    assert "embed" in result.stdout
+
+
+def test_preview_with_spec_file(tmp_path: object, monkeypatch: object) -> None:
+    """preview --spec FILE parses the JSON and passes PlacementSpec to preview_placement."""
+    seen: dict[str, object] = {}
+
+    def _fake_preview(spec: object) -> PlacementView:
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(cli_placement, "preview_placement", _fake_preview)
+    f = tmp_path / "spec.json"
+    f.write_text('{"chat": {"devices": [0]}}')
+    result = runner.invoke(placement_app, ["preview", "--spec", str(f)])
+    assert result.exit_code == 0
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    assert isinstance(seen["spec"], PlacementSpec)
+
+
+def test_preview_placement_error(monkeypatch: object) -> None:
+    """preview prints the error and exits 1 when preview_placement raises PlacementError."""
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(
+        cli_placement,
+        "preview_placement",
+        lambda spec: (_ for _ in ()).throw(PlacementError("bad spec")),
+    )
+    result = runner.invoke(placement_app, ["preview"])
+    assert result.exit_code == 1
+    assert "bad spec" in result.stdout
+
+
+def test_set_placement_error(tmp_path: object, monkeypatch: object) -> None:
+    """set prints the error and exits 1 when set_placement raises PlacementError."""
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(
+        cli_placement, "set_placement", lambda spec: (_ for _ in ()).throw(PlacementError("no fit"))
+    )
+    f = tmp_path / "spec.json"
+    f.write_text('{"chat": {"devices": [0]}}')
+    result = runner.invoke(placement_app, ["set", "--spec", str(f)])
+    assert result.exit_code == 1
+    assert "no fit" in result.stdout

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 import lilbee.cli.placement as cli_placement
 from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
 from lilbee.cli.placement import placement_app
+from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 from lilbee.providers.roles import WorkerRole
 
@@ -161,3 +162,56 @@ def test_preview_missing_spec_file_exits_clean(tmp_path: object, monkeypatch: ob
     result = runner.invoke(placement_app, ["preview", "--spec", str(missing)])
     assert result.exit_code == 1
     assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def _raises_provider_error() -> PlacementView:
+    raise ProviderError("llama-server binary not found")
+
+
+def test_show_provider_error_exits_clean(monkeypatch: object) -> None:
+    """show exits 1 with a clean message when get_placement raises ProviderError."""
+    monkeypatch.setattr(cli_placement, "get_placement", _raises_provider_error)
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 1
+    assert "llama-server binary not found" in result.stdout
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_clear_provider_error_exits_clean(monkeypatch: object) -> None:
+    """clear exits 1 with a clean message when set_placement raises ProviderError."""
+
+    def _raise(spec: object) -> PlacementView:
+        raise ProviderError("no engine")
+
+    monkeypatch.setattr(cli_placement, "set_placement", _raise)
+    result = runner.invoke(placement_app, ["clear"])
+    assert result.exit_code == 1
+    assert "no engine" in result.stdout
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_preview_provider_error_exits_clean(monkeypatch: object) -> None:
+    """preview exits 1 cleanly when preview_placement raises ProviderError."""
+
+    def _raise(spec: object) -> PlacementView:
+        raise ProviderError("no engine")
+
+    monkeypatch.setattr(cli_placement, "preview_placement", _raise)
+    result = runner.invoke(placement_app, ["preview"])
+    assert result.exit_code == 1
+    assert "no engine" in result.stdout
+
+
+def test_set_inline_json_spec(monkeypatch: object) -> None:
+    """set --spec accepts inline JSON (not only a file path)."""
+    seen: dict[str, object] = {}
+
+    def _fake_set(spec: object) -> PlacementView:
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(cli_placement, "set_placement", _fake_set)
+    result = runner.invoke(placement_app, ["set", "--spec", '{"chat": {"devices": [0, 1]}}'])
+    assert result.exit_code == 0
+    assert isinstance(seen["spec"], PlacementSpec)
+    assert seen["spec"].roles[WorkerRole.CHAT].devices == (0, 1)

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 import lilbee.cli.placement as cli_placement
 from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
 from lilbee.cli.placement import placement_app
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec
 from lilbee.providers.roles import WorkerRole
 
 runner = CliRunner()
@@ -52,8 +53,23 @@ def test_set_reads_spec_file(tmp_path: object, monkeypatch: object) -> None:
     f.write_text('{"chat": {"devices": [0]}}')
     result = runner.invoke(placement_app, ["set", "--spec", str(f)])
     assert result.exit_code == 0
-    from lilbee.providers.fleet.placement_spec import PlacementSpec
+    assert isinstance(seen["spec"], PlacementSpec)
+    assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
 
+
+def test_set_reads_spec_from_stdin(monkeypatch: object) -> None:
+    """set --spec - reads JSON from stdin and passes a PlacementSpec to set_placement."""
+    seen: dict[str, object] = {}
+
+    def _fake_set(spec: object) -> PlacementView:
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(cli_placement, "set_placement", _fake_set)
+    result = runner.invoke(
+        placement_app, ["set", "--spec", "-"], input='{"chat": {"devices": [0]}}'
+    )
+    assert result.exit_code == 0
     assert isinstance(seen["spec"], PlacementSpec)
     assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
 
@@ -100,20 +116,16 @@ def test_preview_with_spec_file(tmp_path: object, monkeypatch: object) -> None:
     f.write_text('{"chat": {"devices": [0]}}')
     result = runner.invoke(placement_app, ["preview", "--spec", str(f)])
     assert result.exit_code == 0
-    from lilbee.providers.fleet.placement_spec import PlacementSpec
-
     assert isinstance(seen["spec"], PlacementSpec)
 
 
 def test_preview_placement_error(monkeypatch: object) -> None:
     """preview prints the error and exits 1 when preview_placement raises PlacementError."""
-    from lilbee.providers.fleet.placement_spec import PlacementError
 
-    monkeypatch.setattr(
-        cli_placement,
-        "preview_placement",
-        lambda spec: (_ for _ in ()).throw(PlacementError("bad spec")),
-    )
+    def _raise(spec: object) -> PlacementView:
+        raise PlacementError("bad spec")
+
+    monkeypatch.setattr(cli_placement, "preview_placement", _raise)
     result = runner.invoke(placement_app, ["preview"])
     assert result.exit_code == 1
     assert "bad spec" in result.stdout
@@ -121,11 +133,11 @@ def test_preview_placement_error(monkeypatch: object) -> None:
 
 def test_set_placement_error(tmp_path: object, monkeypatch: object) -> None:
     """set prints the error and exits 1 when set_placement raises PlacementError."""
-    from lilbee.providers.fleet.placement_spec import PlacementError
 
-    monkeypatch.setattr(
-        cli_placement, "set_placement", lambda spec: (_ for _ in ()).throw(PlacementError("no fit"))
-    )
+    def _raise(spec: object) -> PlacementView:
+        raise PlacementError("no fit")
+
+    monkeypatch.setattr(cli_placement, "set_placement", _raise)
     f = tmp_path / "spec.json"
     f.write_text('{"chat": {"devices": [0]}}')
     result = runner.invoke(placement_app, ["set", "--spec", str(f)])

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -143,3 +143,21 @@ def test_set_placement_error(tmp_path: object, monkeypatch: object) -> None:
     result = runner.invoke(placement_app, ["set", "--spec", str(f)])
     assert result.exit_code == 1
     assert "no fit" in result.stdout
+
+
+def test_set_missing_spec_file_exits_clean(tmp_path: object, monkeypatch: object) -> None:
+    """set --spec with a nonexistent file exits 1 without a traceback."""
+    monkeypatch.setattr(cli_placement, "set_placement", lambda spec: _view(True))
+    missing = tmp_path / "nope.json"
+    result = runner.invoke(placement_app, ["set", "--spec", str(missing)])
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_preview_missing_spec_file_exits_clean(tmp_path: object, monkeypatch: object) -> None:
+    """preview --spec with a nonexistent file exits 1 without a traceback."""
+    monkeypatch.setattr(cli_placement, "preview_placement", lambda spec: _view(True))
+    missing = tmp_path / "nope.json"
+    result = runner.invoke(placement_app, ["preview", "--spec", str(missing)])
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)

--- a/tests/core/config/test_placement_field.py
+++ b/tests/core/config/test_placement_field.py
@@ -6,15 +6,16 @@ from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
 from lilbee.providers.roles import WorkerRole
 
 
-def test_parses_json_string_to_spec():
+def test_validates_json_string_and_stores_it():
     cfg = Config(placement='{"chat": {"devices": [0, 1]}}')
-    assert isinstance(cfg.placement, PlacementSpec)
-    assert cfg.placement.roles[WorkerRole.CHAT].devices == (0, 1)
+    assert isinstance(cfg.placement, str)
+    spec = PlacementSpec.from_json(cfg.placement)
+    assert spec.roles[WorkerRole.CHAT].devices == (0, 1)
 
 
-def test_accepts_spec_object():
+def test_accepts_spec_object_and_stores_its_json():
     spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))})
-    assert Config(placement=spec).placement == spec
+    assert Config(placement=spec).placement == spec.to_json()
 
 
 def test_blank_is_none():

--- a/tests/core/config/test_placement_field.py
+++ b/tests/core/config/test_placement_field.py
@@ -18,6 +18,13 @@ def test_accepts_spec_object_and_stores_its_json():
     assert Config(placement=spec).placement == spec.to_json()
 
 
+def test_rejects_directly_built_malformed_spec():
+    """A directly-constructed spec is re-validated, not stored unchecked."""
+    bad = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0, 0))})
+    with pytest.raises(ValidationError, match="duplicate device"):
+        Config(placement=bad)
+
+
 def test_blank_is_none():
     assert Config(placement="").placement is None
     assert Config(placement=None).placement is None

--- a/tests/core/config/test_placement_field.py
+++ b/tests/core/config/test_placement_field.py
@@ -1,0 +1,34 @@
+import pytest
+from pydantic import ValidationError
+
+from lilbee.core.config.model import Config
+from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
+
+
+def test_parses_json_string_to_spec():
+    cfg = Config(placement='{"chat": {"devices": [0, 1]}}')
+    assert isinstance(cfg.placement, PlacementSpec)
+    assert cfg.placement.roles[WorkerRole.CHAT].devices == (0, 1)
+
+
+def test_accepts_spec_object():
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))})
+    assert Config(placement=spec).placement == spec
+
+
+def test_blank_is_none():
+    assert Config(placement="").placement is None
+    assert Config(placement=None).placement is None
+
+
+def test_invalid_json_raises():
+    with pytest.raises(ValidationError):
+        Config(placement="{nope")
+
+
+def test_placement_is_writable_not_public():
+    from lilbee.config_meta import PUBLIC_CONFIG_FIELDS, WRITABLE_CONFIG_FIELDS
+
+    assert "placement" in WRITABLE_CONFIG_FIELDS
+    assert "placement" not in PUBLIC_CONFIG_FIELDS

--- a/tests/core/config/test_placement_field.py
+++ b/tests/core/config/test_placement_field.py
@@ -32,3 +32,9 @@ def test_placement_is_writable_not_public():
 
     assert "placement" in WRITABLE_CONFIG_FIELDS
     assert "placement" not in PUBLIC_CONFIG_FIELDS
+
+
+def test_unexpected_type_raises():
+    """A non-string, non-PlacementSpec value must fail validation."""
+    with pytest.raises(ValidationError):
+        Config(placement=42)

--- a/tests/mcp/test_placement_tools.py
+++ b/tests/mcp/test_placement_tools.py
@@ -1,5 +1,7 @@
 """Tests for MCP placement tools (get/preview/set/clear)."""
 
+import pytest
+
 import lilbee.mcp_server as mcp_server
 from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
 from lilbee.providers.roles import WorkerRole
@@ -74,7 +76,7 @@ def test_preview_placement_tool_with_spec(monkeypatch):
 
     monkeypatch.setattr(mcp_server, "preview_placement", _capture)
     out = mcp_server.preview_placement_tool({"chat": {"devices": [0]}})
-    assert seen["spec"] is not None
+    assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
     assert "gpus" in out
 
 
@@ -88,3 +90,18 @@ def test_preview_placement_tool_error(monkeypatch):
     out = mcp_server.preview_placement_tool({"chat": {"devices": [99]}})
     assert "error" in out
     assert "no GPUs available" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_placement_tools_wire_names():
+    """Placement tools must be registered under clean wire names (no _tool suffix)."""
+    tools = await mcp_server.mcp.list_tools()
+    names = {t.name for t in tools}
+    assert "get_placement" in names
+    assert "preview_placement" in names
+    assert "set_placement" in names
+    assert "clear_placement" in names
+    assert "get_placement_tool" not in names
+    assert "preview_placement_tool" not in names
+    assert "set_placement_tool" not in names
+    assert "clear_placement_tool" not in names

--- a/tests/mcp/test_placement_tools.py
+++ b/tests/mcp/test_placement_tools.py
@@ -51,6 +51,22 @@ def test_set_placement_tool_unfit_returns_error(monkeypatch):
     assert "40 GiB free" in out["error"]
 
 
+def test_set_placement_tool_empty_spec_does_not_clear(monkeypatch):
+    """set_placement({}) builds an empty spec (rejected downstream), never a clear."""
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    seen = {}
+
+    def _capture(spec):
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(mcp_server, "set_placement", _capture)
+    mcp_server.set_placement_tool({})
+    assert isinstance(seen["spec"], PlacementSpec)
+    assert seen["spec"].roles == {}
+
+
 def test_clear_placement_tool(monkeypatch):
     seen = {}
     monkeypatch.setattr(

--- a/tests/mcp/test_placement_tools.py
+++ b/tests/mcp/test_placement_tools.py
@@ -1,0 +1,90 @@
+"""Tests for MCP placement tools (get/preview/set/clear)."""
+
+import lilbee.mcp_server as mcp_server
+from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+from lilbee.providers.roles import WorkerRole
+
+GIB = 1024**3
+
+
+def _view(manual=False):
+    return PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=manual,
+        spec_json=None,
+    )
+
+
+def test_get_placement_tool(monkeypatch):
+    monkeypatch.setattr(mcp_server, "get_placement", lambda: _view())
+    out = mcp_server.get_placement_tool()
+    assert out["gpus"][0]["label"] == "CUDA0"
+    assert out["manual"] is False
+
+
+def test_set_placement_tool(monkeypatch):
+    seen = {}
+
+    def _capture(spec):
+        seen["spec"] = spec
+        return _view(True)
+
+    monkeypatch.setattr(mcp_server, "set_placement", _capture)
+    out = mcp_server.set_placement_tool({"chat": {"devices": [0]}})
+    assert seen["spec"].roles[WorkerRole.CHAT].devices == (0,)
+    assert out["manual"] is True
+
+
+def test_set_placement_tool_unfit_returns_error(monkeypatch):
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    def boom(spec):
+        raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
+
+    monkeypatch.setattr(mcp_server, "set_placement", boom)
+    out = mcp_server.set_placement_tool({"chat": {"devices": [0]}})
+    assert "error" in out
+    assert "40 GiB free" in out["error"]
+
+
+def test_clear_placement_tool(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        mcp_server, "set_placement", lambda spec: seen.setdefault("spec", spec) or _view()
+    )
+    mcp_server.clear_placement_tool()
+    assert seen["spec"] is None
+
+
+def test_preview_placement_tool_auto(monkeypatch):
+    monkeypatch.setattr(mcp_server, "preview_placement", lambda spec=None: _view())
+    out = mcp_server.preview_placement_tool()
+    assert out["gpus"][0]["label"] == "CUDA0"
+    assert out["manual"] is False
+
+
+def test_preview_placement_tool_with_spec(monkeypatch):
+    seen = {}
+
+    def _capture(spec=None):
+        seen["spec"] = spec
+        return _view()
+
+    monkeypatch.setattr(mcp_server, "preview_placement", _capture)
+    out = mcp_server.preview_placement_tool({"chat": {"devices": [0]}})
+    assert seen["spec"] is not None
+    assert "gpus" in out
+
+
+def test_preview_placement_tool_error(monkeypatch):
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    def boom(spec=None):
+        raise PlacementError("no GPUs available")
+
+    monkeypatch.setattr(mcp_server, "preview_placement", boom)
+    out = mcp_server.preview_placement_tool({"chat": {"devices": [99]}})
+    assert "error" in out
+    assert "no GPUs available" in out["error"]

--- a/tests/mcp/test_placement_tools.py
+++ b/tests/mcp/test_placement_tools.py
@@ -92,6 +92,31 @@ def test_preview_placement_tool_error(monkeypatch):
     assert "no GPUs available" in out["error"]
 
 
+def test_get_placement_tool_provider_error(monkeypatch):
+    """get_placement surfaces ProviderError as a structured error, not a raw exception."""
+    from lilbee.providers.base import ProviderError
+
+    def boom():
+        raise ProviderError("llama-server binary not found")
+
+    monkeypatch.setattr(mcp_server, "get_placement", boom)
+    out = mcp_server.get_placement_tool()
+    assert "error" in out
+    assert "llama-server" in out["error"]
+
+
+def test_clear_placement_tool_provider_error(monkeypatch):
+    """clear_placement surfaces ProviderError as a structured error."""
+    from lilbee.providers.base import ProviderError
+
+    def boom(spec):
+        raise ProviderError("no engine")
+
+    monkeypatch.setattr(mcp_server, "set_placement", boom)
+    out = mcp_server.clear_placement_tool()
+    assert out.get("error") == "no engine"
+
+
 @pytest.mark.asyncio
 async def test_placement_tools_wire_names():
     """Placement tools must be registered under clean wire names (no _tool suffix)."""

--- a/tests/providers/fleet/test_placement_from_spec.py
+++ b/tests/providers/fleet/test_placement_from_spec.py
@@ -61,7 +61,7 @@ def test_errors_when_does_not_fit_naming_card():
     est = _peak({WorkerRole.CHAT: [70]})
     with pytest.raises(
         PlacementError,
-        match=r"chat .* device 0 .* 70.0 GiB .* 36.0 GiB usable .*40.0 GiB free",
+        match=r"chat .* device 0 .* 70.0 GiB .* 36.0 GiB usable .*40.0 GiB total",
     ):
         placement_from_spec(spec, (WorkerRole.CHAT,), {0: 40 * GIB}, estimate_peak=est)
 

--- a/tests/providers/fleet/test_placement_from_spec.py
+++ b/tests/providers/fleet/test_placement_from_spec.py
@@ -1,0 +1,77 @@
+import pytest
+
+from lilbee.providers.fleet.placement import InstancePlan, placement_from_spec
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
+
+GIB = 1024**3
+
+
+def _peak(per_device_gib):
+    # estimate_peak(role, ratio) -> per-device byte vector aligned to ratio length.
+    def estimate(role, ratio):
+        return tuple(per_device_gib[role][i] * GIB for i in range(len(ratio)))
+
+    return estimate
+
+
+def test_builds_plans_from_spec():
+    spec = PlacementSpec(
+        {
+            WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(1, 1)),
+            WorkerRole.EMBED: RolePlacement(devices=(2,)),
+        }
+    )
+    est = _peak({WorkerRole.CHAT: [30, 30], WorkerRole.EMBED: [4]})
+    placement = placement_from_spec(
+        spec,
+        (WorkerRole.CHAT, WorkerRole.EMBED),
+        {0: 80 * GIB, 1: 80 * GIB, 2: 80 * GIB},
+        estimate_peak=est,
+    )
+    assert placement.unplaceable_roles == ()
+    assert (
+        InstancePlan(role=WorkerRole.CHAT, devices=(0, 1), tensor_split=(1, 1))
+        in placement.instances
+    )
+    assert InstancePlan(role=WorkerRole.EMBED, devices=(2,)) in placement.instances
+
+
+def test_errors_when_active_role_missing_from_spec():
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+    with pytest.raises(PlacementError, match="embed has a model but no placement entry"):
+        placement_from_spec(
+            spec,
+            (WorkerRole.CHAT, WorkerRole.EMBED),
+            {0: 80 * GIB},
+            estimate_peak=_peak({WorkerRole.CHAT: [4]}),
+        )
+
+
+def test_errors_on_nonexistent_device():
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(5,))})
+    with pytest.raises(PlacementError, match="chat pinned to device 5 but only 1 GPU"):
+        placement_from_spec(
+            spec, (WorkerRole.CHAT,), {0: 80 * GIB}, estimate_peak=_peak({WorkerRole.CHAT: [4]})
+        )
+
+
+def test_errors_when_does_not_fit_naming_card():
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+    est = _peak({WorkerRole.CHAT: [70]})
+    with pytest.raises(PlacementError, match=r"chat .* device 0 .* 70.0 GiB .* 40.0 GiB free"):
+        placement_from_spec(spec, (WorkerRole.CHAT,), {0: 40 * GIB}, estimate_peak=est)
+
+
+def test_errors_when_two_roles_overbook_one_card():
+    spec = PlacementSpec(
+        {
+            WorkerRole.CHAT: RolePlacement(devices=(0,)),
+            WorkerRole.EMBED: RolePlacement(devices=(0,)),
+        }
+    )
+    est = _peak({WorkerRole.CHAT: [50], WorkerRole.EMBED: [40]})
+    with pytest.raises(PlacementError, match="device 0"):
+        placement_from_spec(
+            spec, (WorkerRole.CHAT, WorkerRole.EMBED), {0: 80 * GIB}, estimate_peak=est
+        )

--- a/tests/providers/fleet/test_placement_from_spec.py
+++ b/tests/providers/fleet/test_placement_from_spec.py
@@ -59,7 +59,10 @@ def test_errors_on_nonexistent_device():
 def test_errors_when_does_not_fit_naming_card():
     spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
     est = _peak({WorkerRole.CHAT: [70]})
-    with pytest.raises(PlacementError, match=r"chat .* device 0 .* 70.0 GiB .* 40.0 GiB free"):
+    with pytest.raises(
+        PlacementError,
+        match=r"chat .* device 0 .* 70.0 GiB .* 36.0 GiB usable .*40.0 GiB free",
+    ):
         placement_from_spec(spec, (WorkerRole.CHAT,), {0: 40 * GIB}, estimate_peak=est)
 
 

--- a/tests/providers/fleet/test_placement_spec.py
+++ b/tests/providers/fleet/test_placement_spec.py
@@ -45,3 +45,21 @@ def test_rejects_non_positive_replicas():
 def test_rejects_malformed_json():
     with pytest.raises(PlacementError, match="not valid JSON"):
         PlacementSpec.from_json("{not json")
+
+
+def test_to_json_includes_replicas_when_not_one():
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,), replicas=2)})
+    import json
+
+    data = json.loads(spec.to_json())
+    assert data["embed"]["replicas"] == 2
+
+
+def test_rejects_json_array_at_top_level():
+    with pytest.raises(PlacementError, match="must be a JSON object keyed by role"):
+        PlacementSpec.from_json("[1, 2, 3]")
+
+
+def test_rejects_non_dict_role_entry():
+    with pytest.raises(PlacementError, match="placement entry must be an object"):
+        PlacementSpec.from_json('{"chat": [0, 1]}')

--- a/tests/providers/fleet/test_placement_spec.py
+++ b/tests/providers/fleet/test_placement_spec.py
@@ -108,3 +108,14 @@ def test_rejects_fractional_float_device():
 def test_accepts_integral_float_device():
     spec = PlacementSpec.from_json('{"chat": {"devices": [2.0]}}')
     assert spec.roles[WorkerRole.CHAT].devices == (2,)
+
+
+def test_rejects_boolean_device():
+    # bool is an int subclass; without the guard ``true`` would silently pin device 1.
+    with pytest.raises(PlacementError, match="devices must be integers"):
+        PlacementSpec.from_json('{"chat": {"devices": [true]}}')
+
+
+def test_rejects_boolean_replicas():
+    with pytest.raises(PlacementError, match="replicas must be integers"):
+        PlacementSpec.from_json('{"embed": {"devices": [0], "replicas": true}}')

--- a/tests/providers/fleet/test_placement_spec.py
+++ b/tests/providers/fleet/test_placement_spec.py
@@ -1,0 +1,47 @@
+import pytest
+
+from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
+
+
+def test_round_trips_through_json():
+    spec = PlacementSpec(
+        {
+            WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(60, 40)),
+            WorkerRole.EMBED: RolePlacement(devices=(2,)),
+        }
+    )
+    restored = PlacementSpec.from_json(spec.to_json())
+    assert restored == spec
+    assert restored.roles[WorkerRole.CHAT].tensor_split == (60, 40)
+    assert restored.roles[WorkerRole.EMBED].replicas == 1
+
+
+def test_str_is_json():
+    spec = PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))})
+    assert str(spec) == spec.to_json()
+
+
+def test_rejects_unknown_role():
+    with pytest.raises(PlacementError, match="unknown role 'planner'"):
+        PlacementSpec.from_json('{"planner": {"devices": [0]}}')
+
+
+def test_rejects_empty_devices():
+    with pytest.raises(PlacementError, match="chat: at least one device"):
+        PlacementSpec.from_json('{"chat": {"devices": []}}')
+
+
+def test_rejects_tensor_split_length_mismatch():
+    with pytest.raises(PlacementError, match="chat: tensor_split has 3 weights for 2 devices"):
+        PlacementSpec.from_json('{"chat": {"devices": [0, 1], "tensor_split": [1, 2, 3]}}')
+
+
+def test_rejects_non_positive_replicas():
+    with pytest.raises(PlacementError, match="embed: replicas must be >= 1"):
+        PlacementSpec.from_json('{"embed": {"devices": [0], "replicas": 0}}')
+
+
+def test_rejects_malformed_json():
+    with pytest.raises(PlacementError, match="not valid JSON"):
+        PlacementSpec.from_json("{not json")

--- a/tests/providers/fleet/test_placement_spec.py
+++ b/tests/providers/fleet/test_placement_spec.py
@@ -98,3 +98,13 @@ def test_rejects_non_integer_device():
 def test_rejects_non_list_devices():
     with pytest.raises(PlacementError, match="devices must be a list"):
         PlacementSpec.from_json('{"chat": {"devices": 5}}')
+
+
+def test_rejects_fractional_float_device():
+    with pytest.raises(PlacementError, match="devices must be integers"):
+        PlacementSpec.from_json('{"chat": {"devices": [1.9]}}')
+
+
+def test_accepts_integral_float_device():
+    spec = PlacementSpec.from_json('{"chat": {"devices": [2.0]}}')
+    assert spec.roles[WorkerRole.CHAT].devices == (2,)

--- a/tests/providers/fleet/test_placement_spec.py
+++ b/tests/providers/fleet/test_placement_spec.py
@@ -63,3 +63,38 @@ def test_rejects_json_array_at_top_level():
 def test_rejects_non_dict_role_entry():
     with pytest.raises(PlacementError, match="placement entry must be an object"):
         PlacementSpec.from_json('{"chat": [0, 1]}')
+
+
+def test_rejects_duplicate_devices():
+    with pytest.raises(PlacementError, match="duplicate device indices"):
+        PlacementSpec.from_json('{"chat": {"devices": [0, 0]}}')
+
+
+def test_rejects_negative_device_index():
+    with pytest.raises(PlacementError, match="device indices must be >= 0"):
+        PlacementSpec.from_json('{"chat": {"devices": [-1]}}')
+
+
+def test_rejects_non_positive_tensor_split_weight():
+    with pytest.raises(PlacementError, match="tensor_split weights must be > 0"):
+        PlacementSpec.from_json('{"chat": {"devices": [0, 1], "tensor_split": [0, 1]}}')
+
+
+def test_rejects_negative_tensor_split_weight():
+    with pytest.raises(PlacementError, match="tensor_split weights must be > 0"):
+        PlacementSpec.from_json('{"chat": {"devices": [0, 1], "tensor_split": [1, -2]}}')
+
+
+def test_rejects_unknown_entry_key():
+    with pytest.raises(PlacementError, match="unknown placement key"):
+        PlacementSpec.from_json('{"chat": {"devices": [0], "tensor-split": [1]}}')
+
+
+def test_rejects_non_integer_device():
+    with pytest.raises(PlacementError, match="devices must be integers"):
+        PlacementSpec.from_json('{"chat": {"devices": ["bad"]}}')
+
+
+def test_rejects_non_list_devices():
+    with pytest.raises(PlacementError, match="devices must be a list"):
+        PlacementSpec.from_json('{"chat": {"devices": 5}}')

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -8,12 +8,15 @@ GIB = 1024**3
 
 
 def test_spec_branch_calls_placement_from_spec(monkeypatch):
-    devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 80 * GIB)]
+    # free_bytes is far below total_bytes (a model is resident): placement must
+    # still be charged against total capacity, not the warm free VRAM (bb-a8f).
+    devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 10 * GIB)]
     captured = {}
 
-    def fake_from_spec(spec, active_roles, device_free, *, estimate_peak):
+    def fake_from_spec(spec, active_roles, device_capacity, *, estimate_peak):
         captured["spec"] = spec
         captured["roles"] = active_roles
+        captured["capacity"] = device_capacity
         return Placement(
             instances=(InstancePlan(role=WorkerRole.CHAT, devices=(0,)),), unplaceable_roles=()
         )
@@ -33,7 +36,23 @@ def test_spec_branch_calls_placement_from_spec(monkeypatch):
 
     assert captured["spec"] is spec
     assert captured["roles"] == (WorkerRole.CHAT,)
+    assert captured["capacity"] == {0: 80 * GIB}  # total, not the 10 GiB free
     assert placement.instances[0].role is WorkerRole.CHAT
+
+
+def test_auto_planner_charged_against_total_capacity(monkeypatch):
+    # The auto planner is fed total capacity too, so a warm fleet's resident
+    # models are not double-counted when it re-plans (bb-a8f).
+    devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 5 * GIB)]
+    captured = {}
+
+    def fake_plan(inputs, devs, *, estimate_peak, unified_budget):
+        captured["devs"] = devs
+        return Placement(instances=(), unplaceable_roles=())
+
+    monkeypatch.setattr(planning, "plan_placement", fake_plan)
+    planning._resolve_placement(None, [], {}, devices, unified_budget=None)
+    assert captured["devs"] == [(0, 80 * GIB)]  # total, not the 5 GiB free
 
 
 def test_no_spec_uses_auto_planner(monkeypatch):

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from lilbee.providers.fleet import planning
 from lilbee.providers.fleet.devices import FleetDevice
 from lilbee.providers.fleet.placement import InstancePlan, Placement
@@ -5,6 +7,68 @@ from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
 from lilbee.providers.roles import WorkerRole
 
 GIB = 1024**3
+
+
+def test_read_device_cache_collapses_repeat_probes(monkeypatch):
+    """A burst of reads within the TTL probes the engine once."""
+    cache = planning._ReadDeviceCache(ttl_s=1000)
+    calls = {"n": 0}
+
+    def fake(_binary):
+        calls["n"] += 1
+        return [FleetDevice("CUDA", 0, "A", GIB, GIB)]
+
+    monkeypatch.setattr(planning, "resolve_devices", fake)
+    first = cache.get(Path("/x"))
+    second = cache.get(Path("/x"))
+    assert calls["n"] == 1
+    assert first == second
+    cache.clear()
+    cache.get(Path("/x"))
+    assert calls["n"] == 2  # cleared -> re-probe
+
+
+def test_read_device_cache_ttl_zero_always_probes(monkeypatch):
+    """A zero TTL disables caching (every read re-probes)."""
+    cache = planning._ReadDeviceCache(ttl_s=0)
+    calls = {"n": 0}
+
+    def fake(_binary):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(planning, "resolve_devices", fake)
+    cache.get(Path("/x"))
+    cache.get(Path("/x"))
+    assert calls["n"] == 2
+
+
+def test_resolve_placement_plan_uses_read_cache(monkeypatch):
+    """The read/view path serves repeat plans from the device cache (one probe)."""
+    import lilbee.providers.fleet.cuda_runtime as cuda_runtime
+    import lilbee.providers.fleet.gpu_env as gpu_env
+
+    planning.clear_read_device_cache()
+    calls = {"n": 0}
+
+    def counting(_binary):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(planning, "resolve_llama_server", lambda: Path("/fake"))
+    monkeypatch.setattr(gpu_env, "apply_fleet_gpu_env", lambda: None)
+    monkeypatch.setattr(cuda_runtime, "apply_cuda_runtime_env", lambda: None)
+    monkeypatch.setattr(planning, "resolve_devices", counting)
+    monkeypatch.setattr(
+        planning, "_server_model_inputs", lambda roles, *, unified_budget=None: ([], {}, 0)
+    )
+    monkeypatch.setattr(
+        planning, "_resolve_placement", lambda *a, **k: Placement(instances=(), unplaceable_roles=())
+    )
+    planning.resolve_placement_plan(None)
+    planning.resolve_placement_plan(None)
+    assert calls["n"] == 1
+    planning.clear_read_device_cache()
 
 
 def test_spec_branch_calls_placement_from_spec(monkeypatch):

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -1,0 +1,50 @@
+from lilbee.providers.fleet import planning
+from lilbee.providers.fleet.devices import FleetDevice
+from lilbee.providers.fleet.placement import InstancePlan, Placement
+from lilbee.providers.fleet.placement_spec import PlacementSpec, RolePlacement
+from lilbee.providers.roles import WorkerRole
+
+GIB = 1024**3
+
+
+def test_spec_branch_calls_placement_from_spec(monkeypatch):
+    devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 80 * GIB)]
+    captured = {}
+
+    def fake_from_spec(spec, active_roles, device_free, *, estimate_peak):
+        captured["spec"] = spec
+        captured["roles"] = active_roles
+        return Placement(
+            instances=(InstancePlan(role=WorkerRole.CHAT, devices=(0,)),), unplaceable_roles=()
+        )
+
+    monkeypatch.setattr(planning, "placement_from_spec", fake_from_spec)
+    monkeypatch.setattr(
+        planning,
+        "_server_model_inputs",
+        lambda roles, *, unified_budget=None: ([], {WorkerRole.CHAT: "ref"}, 0),
+    )
+    monkeypatch.setattr(planning, "_peak_estimator", lambda refs: lambda role, ratio: (GIB,))
+    spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})
+
+    placement = planning._resolve_placement(
+        spec, [], {WorkerRole.CHAT: "ref"}, devices, unified_budget=None
+    )
+
+    assert captured["spec"] is spec
+    assert captured["roles"] == (WorkerRole.CHAT,)
+    assert placement.instances[0].role is WorkerRole.CHAT
+
+
+def test_no_spec_uses_auto_planner(monkeypatch):
+    devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 80 * GIB)]
+    called = {}
+    monkeypatch.setattr(
+        planning,
+        "plan_placement",
+        lambda inputs, devs, *, estimate_peak, unified_budget: (
+            called.setdefault("auto", True) or Placement(instances=(), unplaceable_roles=())
+        ),
+    )
+    planning._resolve_placement(None, [], {}, devices, unified_budget=None)
+    assert called.get("auto") is True

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -1,0 +1,119 @@
+"""Tests for placement and gpus HTTP routes."""
+
+from __future__ import annotations
+
+from litestar.testing import create_test_client
+
+import lilbee.server.handlers as handlers
+from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+from lilbee.providers.roles import WorkerRole
+from lilbee.server.routes.placement import (
+    gpus_route,
+    placement_clear_route,
+    placement_preview_route,
+    placement_route,
+    placement_set_route,
+)
+
+GIB = 1024**3
+
+
+def _view(manual=False):
+    return PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=manual,
+        spec_json=None,
+    )
+
+
+def test_get_placement(monkeypatch):
+    monkeypatch.setattr(handlers, "placement", lambda: _view())
+    with create_test_client([placement_route]) as client:
+        r = client.get("/api/placement")
+        assert r.status_code == 200
+        assert r.json()["gpus"][0]["label"] == "CUDA0"
+
+
+def test_put_sets(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        handlers,
+        "placement_set",
+        lambda spec_json: seen.setdefault("json", spec_json) or _view(True),
+    )
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 200
+        assert '"chat"' in seen["json"]
+
+
+def test_delete_clears(monkeypatch):
+    monkeypatch.setattr(handlers, "placement_clear", lambda: _view())
+    with create_test_client([placement_clear_route]) as client:
+        assert client.delete("/api/placement").status_code == 200
+
+
+def test_preview_unfit_returns_422(monkeypatch):
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    def boom(spec_json):
+        raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
+
+    monkeypatch.setattr(handlers, "placement_preview", boom)
+    with create_test_client([placement_preview_route]) as client:
+        r = client.post("/api/placement/preview", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 422
+        assert "40 GiB free" in r.text
+
+
+def test_preview_auto(monkeypatch):
+    monkeypatch.setattr(handlers, "placement_preview", lambda spec_json: _view())
+    with create_test_client([placement_preview_route]) as client:
+        r = client.post("/api/placement/preview", json={})
+        assert r.status_code == 200
+        assert r.json()["manual"] is False
+
+
+def test_preview_with_spec(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        handlers,
+        "placement_preview",
+        lambda spec_json: captured.setdefault("json", spec_json) or _view(True),
+    )
+    with create_test_client([placement_preview_route]) as client:
+        r = client.post("/api/placement/preview", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 200
+        assert '"chat"' in captured["json"]
+
+
+def test_put_missing_spec_returns_422(monkeypatch):
+    monkeypatch.setattr(handlers, "placement_set", lambda spec_json: _view(True))
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={})
+        assert r.status_code == 422
+
+
+def test_get_gpus(monkeypatch):
+    from lilbee.server.models import GpuInfoResponse
+
+    monkeypatch.setattr(
+        handlers,
+        "gpus",
+        lambda: [
+            GpuInfoResponse(
+                index=0,
+                backend="CUDA",
+                label="CUDA0",
+                name="A100",
+                total_bytes=80 * GIB,
+                free_bytes=72 * GIB,
+            )
+        ],
+    )
+    with create_test_client([gpus_route]) as client:
+        r = client.get("/api/gpus")
+        assert r.status_code == 200
+        assert r.json()[0]["label"] == "CUDA0"

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -29,7 +29,10 @@ def _view(manual=False):
 
 
 def test_get_placement(monkeypatch):
-    monkeypatch.setattr(handlers, "placement", lambda: _view())
+    async def _placement():
+        return _view()
+
+    monkeypatch.setattr(handlers, "placement", _placement)
     with create_test_client([placement_route]) as client:
         r = client.get("/api/placement")
         assert r.status_code == 200
@@ -38,11 +41,12 @@ def test_get_placement(monkeypatch):
 
 def test_put_sets(monkeypatch):
     seen = {}
-    monkeypatch.setattr(
-        handlers,
-        "placement_set",
-        lambda spec_json: seen.setdefault("json", spec_json) or _view(True),
-    )
+
+    async def _set(spec_json):
+        seen["json"] = spec_json
+        return _view(True)
+
+    monkeypatch.setattr(handlers, "placement_set", _set)
     with create_test_client([placement_set_route]) as client:
         r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
         assert r.status_code == 200
@@ -50,15 +54,25 @@ def test_put_sets(monkeypatch):
 
 
 def test_delete_clears(monkeypatch):
-    monkeypatch.setattr(handlers, "placement_clear", lambda: _view())
+    cleared = {"called": False}
+
+    async def _clear():
+        cleared["called"] = True
+        return _view()
+
+    monkeypatch.setattr(handlers, "placement_clear", _clear)
     with create_test_client([placement_clear_route]) as client:
-        assert client.delete("/api/placement").status_code == 200
+        r = client.delete("/api/placement")
+        assert r.status_code == 200
+        assert r.json()["manual"] is False
+        assert r.json()["gpus"][0]["label"] == "CUDA0"
+        assert cleared["called"]
 
 
 def test_preview_unfit_returns_422(monkeypatch):
     from lilbee.providers.fleet.placement_spec import PlacementError
 
-    def boom(spec_json):
+    async def boom(spec_json):
         raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
 
     monkeypatch.setattr(handlers, "placement_preview", boom)
@@ -69,7 +83,10 @@ def test_preview_unfit_returns_422(monkeypatch):
 
 
 def test_preview_auto(monkeypatch):
-    monkeypatch.setattr(handlers, "placement_preview", lambda spec_json: _view())
+    async def _preview(spec_json):
+        return _view()
+
+    monkeypatch.setattr(handlers, "placement_preview", _preview)
     with create_test_client([placement_preview_route]) as client:
         r = client.post("/api/placement/preview", json={})
         assert r.status_code == 200
@@ -78,11 +95,12 @@ def test_preview_auto(monkeypatch):
 
 def test_preview_with_spec(monkeypatch):
     captured = {}
-    monkeypatch.setattr(
-        handlers,
-        "placement_preview",
-        lambda spec_json: captured.setdefault("json", spec_json) or _view(True),
-    )
+
+    async def _preview(spec_json):
+        captured["json"] = spec_json
+        return _view(True)
+
+    monkeypatch.setattr(handlers, "placement_preview", _preview)
     with create_test_client([placement_preview_route]) as client:
         r = client.post("/api/placement/preview", json={"spec": {"chat": {"devices": [0]}}})
         assert r.status_code == 200
@@ -90,7 +108,10 @@ def test_preview_with_spec(monkeypatch):
 
 
 def test_put_missing_spec_returns_422(monkeypatch):
-    monkeypatch.setattr(handlers, "placement_set", lambda spec_json: _view(True))
+    async def _set(spec_json):
+        return _view(True)
+
+    monkeypatch.setattr(handlers, "placement_set", _set)
     with create_test_client([placement_set_route]) as client:
         r = client.put("/api/placement", json={})
         assert r.status_code == 422
@@ -99,10 +120,8 @@ def test_put_missing_spec_returns_422(monkeypatch):
 def test_get_gpus(monkeypatch):
     from lilbee.server.models import GpuInfoResponse
 
-    monkeypatch.setattr(
-        handlers,
-        "gpus",
-        lambda: [
+    async def _gpus():
+        return [
             GpuInfoResponse(
                 index=0,
                 backend="CUDA",
@@ -111,8 +130,9 @@ def test_get_gpus(monkeypatch):
                 total_bytes=80 * GIB,
                 free_bytes=72 * GIB,
             )
-        ],
-    )
+        ]
+
+    monkeypatch.setattr(handlers, "gpus", _gpus)
     with create_test_client([gpus_route]) as client:
         r = client.get("/api/gpus")
         assert r.status_code == 200

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -39,34 +39,54 @@ def test_get_placement(monkeypatch):
         assert r.json()["gpus"][0]["label"] == "CUDA0"
 
 
-def test_put_sets(monkeypatch):
-    seen = {}
-
-    async def _set(spec_json):
-        seen["json"] = spec_json
-        return _view(True)
-
-    monkeypatch.setattr(handlers, "placement_set", _set)
+def test_put_refused_on_daemon():
+    """PUT placement is refused on the HTTP daemon (rebuilds the shared fleet)."""
     with create_test_client([placement_set_route]) as client:
         r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
-        assert r.status_code == 200
-        assert '"chat"' in seen["json"]
+        assert r.status_code == 409
+        assert "CLI" in r.text
 
 
-def test_delete_clears(monkeypatch):
-    cleared = {"called": False}
-
-    async def _clear():
-        cleared["called"] = True
-        return _view()
-
-    monkeypatch.setattr(handlers, "placement_clear", _clear)
+def test_delete_refused_on_daemon():
+    """DELETE placement is refused on the HTTP daemon (rebuilds the shared fleet)."""
     with create_test_client([placement_clear_route]) as client:
         r = client.delete("/api/placement")
-        assert r.status_code == 200
-        assert r.json()["manual"] is False
-        assert r.json()["gpus"][0]["label"] == "CUDA0"
-        assert cleared["called"]
+        assert r.status_code == 409
+        assert "CLI" in r.text
+
+
+def test_preview_requires_auth():
+    """preview is not read-only: it runs subprocess probes and must require auth (bb-895)."""
+    from lilbee.server.auth import is_read_only
+
+    assert not is_read_only(placement_preview_route.fn)
+    assert is_read_only(placement_route.fn)
+    assert is_read_only(gpus_route.fn)
+
+
+def test_preview_provider_error_returns_503(monkeypatch):
+    from lilbee.providers.base import ProviderError
+
+    async def boom(spec_json):
+        raise ProviderError("llama-server binary not found")
+
+    monkeypatch.setattr(handlers, "placement_preview", boom)
+    with create_test_client([placement_preview_route]) as client:
+        r = client.post("/api/placement/preview", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 503
+        assert "llama-server" in r.text
+
+
+def test_get_placement_provider_error_returns_503(monkeypatch):
+    from lilbee.providers.base import ProviderError
+
+    async def boom():
+        raise ProviderError("no engine")
+
+    monkeypatch.setattr(handlers, "placement", boom)
+    with create_test_client([placement_route]) as client:
+        r = client.get("/api/placement")
+        assert r.status_code == 503
 
 
 def test_preview_unfit_returns_422(monkeypatch):
@@ -107,14 +127,11 @@ def test_preview_with_spec(monkeypatch):
         assert '"chat"' in captured["json"]
 
 
-def test_put_missing_spec_returns_422(monkeypatch):
-    async def _set(spec_json):
-        return _view(True)
-
-    monkeypatch.setattr(handlers, "placement_set", _set)
+def test_put_refused_regardless_of_body():
+    """PUT is refused even with an empty body (refusal precedes validation)."""
     with create_test_client([placement_set_route]) as client:
         r = client.put("/api/placement", json={})
-        assert r.status_code == 422
+        assert r.status_code == 409
 
 
 def test_get_gpus(monkeypatch):

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -55,13 +55,13 @@ def test_delete_refused_on_daemon():
         assert "CLI" in r.text
 
 
-def test_preview_requires_auth():
-    """preview is not read-only: it runs subprocess probes and must require auth (bb-895)."""
+def test_placement_routes_require_auth():
+    """No placement route is read-only: they all run subprocess device probes."""
     from lilbee.server.auth import is_read_only
 
     assert not is_read_only(placement_preview_route.fn)
-    assert is_read_only(placement_route.fn)
-    assert is_read_only(gpus_route.fn)
+    assert not is_read_only(placement_route.fn)
+    assert not is_read_only(gpus_route.fn)
 
 
 def test_preview_provider_error_returns_503(monkeypatch):
@@ -86,6 +86,18 @@ def test_get_placement_provider_error_returns_503(monkeypatch):
     monkeypatch.setattr(handlers, "placement", boom)
     with create_test_client([placement_route]) as client:
         r = client.get("/api/placement")
+        assert r.status_code == 503
+
+
+def test_get_gpus_provider_error_returns_503(monkeypatch):
+    from lilbee.providers.base import ProviderError
+
+    async def boom():
+        raise ProviderError("no engine")
+
+    monkeypatch.setattr(handlers, "gpus", boom)
+    with create_test_client([gpus_route]) as client:
+        r = client.get("/api/gpus")
         assert r.status_code == 503
 
 

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -332,3 +332,85 @@ class TestReplicas:
         embeds = self._embeds(plan)
         assert len(embeds) == 2
         assert {i.replica for i in embeds} == {0, 1}
+
+
+class TestPersistentSingleElasticSplit:
+    """A replicated embed/vision role reserves replica 0 as a persistent single in the
+    singles phase, then places the extra replicas into the residual VRAM."""
+
+    def _embeds(self, plan: Placement) -> list[InstancePlan]:
+        return [i for i in plan.instances if i.role is WorkerRole.EMBED]
+
+    def test_replica_zero_is_a_persistent_single_before_the_elastic_batch(self) -> None:
+        # embed replicas=3: replica 0 is reserved as the persistent query embedder,
+        # alongside chat/rerank, and replicas 1..2 are the elastic ingest pool.
+        plan = plan_placement(
+            [
+                ModelPlacementInput(WorkerRole.CHAT, 5 * _GB),
+                ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=3),
+            ],
+            [(0, 24 * _GB), (1, 24 * _GB), (2, 24 * _GB)],
+            estimate_peak=_never,
+        )
+        embeds = self._embeds(plan)
+        assert {i.replica for i in embeds} == {0, 1, 2}
+        # All three placed: one persistent single (replica 0) + two elastic.
+        assert len(embeds) == 3
+        assert plan.unplaceable_roles == ()
+
+    def test_query_embedder_persists_when_chat_claims_the_reserved_room(self) -> None:
+        # One card. Persistent fleet (chat + embed-0) is reserved first, so the
+        # query embedder always exists; the elastic replicas get only the residual,
+        # which here is exhausted, so embed-1/embed-2 never place.
+        plan = plan_placement(
+            [
+                ModelPlacementInput(WorkerRole.EMBED, 8 * _GB, replicas=3),
+                ModelPlacementInput(WorkerRole.CHAT, 10 * _GB),
+            ],
+            [(0, 24 * _GB)],  # 21.6 usable: embed-0 8 + chat 10 = 18, residual 3.6 < 8
+            estimate_peak=_never,
+        )
+        embeds = self._embeds(plan)
+        assert {i.replica for i in embeds} == {0}  # only the persistent query embedder
+        chat = [i for i in plan.instances if i.role is WorkerRole.CHAT]
+        assert len(chat) == 1
+        assert plan.unplaceable_roles == ()
+
+    def test_elastic_batch_capped_by_residual_vram(self) -> None:
+        # 2 cards (21.6 usable each). embed-0 single + chat take card room; the
+        # elastic batch fills only what residual VRAM is left, not all replicas.
+        plan = plan_placement(
+            [
+                ModelPlacementInput(WorkerRole.CHAT, 18 * _GB),
+                ModelPlacementInput(WorkerRole.EMBED, 10 * _GB, replicas=4),
+            ],
+            [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=_never,
+        )
+        embeds = self._embeds(plan)
+        # embed-0 single lands on one card; chat lands on the other (18 fits, 21.6);
+        # residual on embed-0's card is 11.6 -> one elastic 10GB replica fits there.
+        assert 0 in {i.replica for i in embeds}  # persistent single always present
+        assert len(embeds) < 4  # capped by residual, not all 4 requested
+        assert plan.unplaceable_roles == ()
+
+    def test_replicated_role_unplaceable_when_persistent_single_does_not_fit(self) -> None:
+        # If replica 0 (the persistent single) fits nowhere, the role is unplaceable.
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 100 * _GB, replicas=2)],
+            [(0, 24 * _GB)],
+            estimate_peak=_never,
+        )
+        assert self._embeds(plan) == []
+        assert plan.unplaceable_roles == (WorkerRole.EMBED,)
+
+    def test_single_replica_role_is_unchanged(self) -> None:
+        # replicas=1 still places exactly one replica-0 single, no elastic batch.
+        plan = plan_placement(
+            [ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=1)],
+            [(0, 24 * _GB)],
+            estimate_peak=_never,
+        )
+        embeds = self._embeds(plan)
+        assert len(embeds) == 1
+        assert embeds[0].replica == 0

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -364,7 +364,7 @@ def test_server_model_inputs_reserves_search_before_chat_on_shared_host(monkeypa
     seen: dict[str, int] = {}
     sizes = {WorkerRole.EMBED: 2 * _GB, WorkerRole.RERANK: 3 * _GB}
 
-    def _estimate(role, ref, *, unified_budget=None, chat_reservation=0):
+    def _estimate(role, ref, *, unified_budget=None, chat_reservation=0, device_count=0):
         if role is WorkerRole.CHAT:
             seen["chat_reservation"] = chat_reservation
         return ModelPlacementInput(role, sizes.get(role, 10 * _GB))
@@ -384,7 +384,7 @@ def test_server_model_inputs_no_reservation_on_discrete_gpu(monkeypatch) -> None
     monkeypatch.setattr(cfg, "vision_model", "")
     seen: dict[str, int] = {}
 
-    def _estimate(role, ref, *, unified_budget=None, chat_reservation=0):
+    def _estimate(role, ref, *, unified_budget=None, chat_reservation=0, device_count=0):
         if role is WorkerRole.CHAT:
             seen["chat_reservation"] = chat_reservation
         return ModelPlacementInput(role, 2 * _GB)
@@ -398,10 +398,26 @@ def test_server_model_inputs_no_reservation_on_discrete_gpu(monkeypatch) -> None
 def test_replica_count_reads_per_role_knobs(monkeypatch) -> None:
     monkeypatch.setattr(cfg, "embed_replicas", 3)
     monkeypatch.setattr(cfg, "vision_replicas", 2)
-    assert planning_mod._replica_count(WorkerRole.EMBED) == 3
-    assert planning_mod._replica_count(WorkerRole.VISION) == 2
-    assert planning_mod._replica_count(WorkerRole.CHAT) == 1  # chat never replicates
-    assert planning_mod._replica_count(WorkerRole.RERANK) == 1  # rerank never replicates
+    assert planning_mod._replica_count(WorkerRole.EMBED, device_count=4) == 3
+    assert planning_mod._replica_count(WorkerRole.VISION, device_count=4) == 2
+    assert (
+        planning_mod._replica_count(WorkerRole.CHAT, device_count=4) == 1
+    )  # chat never replicates
+    assert planning_mod._replica_count(WorkerRole.RERANK, device_count=4) == 1  # rerank never
+
+
+def test_replica_count_auto_uses_device_count(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 0)  # 0 = auto = one per GPU
+    monkeypatch.setattr(cfg, "vision_replicas", 0)
+    assert planning_mod._replica_count(WorkerRole.EMBED, device_count=4) == 4
+    assert planning_mod._replica_count(WorkerRole.VISION, device_count=3) == 3
+    # An explicit positive knob wins over the auto device count.
+    monkeypatch.setattr(cfg, "embed_replicas", 2)
+    assert planning_mod._replica_count(WorkerRole.EMBED, device_count=4) == 2
+    # Auto on a GPU-less host still resolves to at least one instance.
+    monkeypatch.setattr(cfg, "embed_replicas", 0)
+    assert planning_mod._replica_count(WorkerRole.EMBED, device_count=0) == 1
+    assert planning_mod._replica_count(WorkerRole.CHAT, device_count=4) == 1
 
 
 def test_estimate_role_carries_replica_count(monkeypatch, tmp_path) -> None:
@@ -412,8 +428,20 @@ def test_estimate_role_carries_replica_count(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
     monkeypatch.setattr(planning_mod, "_role_ctx", lambda _r, _p, _m, *_a: 16)
     monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=10))
-    inp = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1)
-    assert inp.replicas == 4
+    inp = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1, device_count=2)
+    assert inp.replicas == 4  # explicit knob wins over the device count
+
+
+def test_estimate_role_auto_replicas_follow_device_count(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 0)  # 0 = auto = one per GPU
+    model = tmp_path / "e.gguf"
+    model.write_bytes(b"x" * 1000)
+    monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+    monkeypatch.setattr(planning_mod, "_role_ctx", lambda _r, _p, _m, *_a: 16)
+    monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=10))
+    inp = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1, device_count=3)
+    assert inp.replicas == 3
 
 
 def test_search_reservation_scales_with_replicas() -> None:

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -425,15 +425,67 @@ def test_search_reservation_scales_with_replicas() -> None:
     assert planning_mod._search_reservation(inputs) == 3 * 2 * _GB + 1 * _GB
 
 
-def test_placement_estimate_ctx_chat_uses_ceiling(monkeypatch) -> None:
+def test_placement_estimate_ctx_chat_reserves_target(monkeypatch) -> None:
+    """A long-context model reserves the chat ctx target, not its full trained ceiling.
+
+    Reserving the full ceiling over-charges KV and can wrongly reject a split; the
+    target is the context we intend to serve, capped by the model and floored at a
+    usable minimum.
+    """
     monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 24576)
     monkeypatch.setattr("lilbee.providers.engine_params.chat_ctx_ceiling", lambda _m, _p: 131072)
-    assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 131072
+    assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 24576
+
+
+def test_placement_estimate_ctx_chat_floored_when_target_tiny(monkeypatch) -> None:
+    """A tiny target is floored at the usable minimum so placement still reserves room."""
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 1024)
+    monkeypatch.setattr("lilbee.providers.engine_params.chat_ctx_ceiling", lambda _m, _p: 131072)
+    assert (
+        planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {})
+        == planning_mod._MIN_USABLE_CHAT_CTX
+    )
+
+
+def test_placement_estimate_ctx_chat_capped_by_short_ceiling(monkeypatch) -> None:
+    """A short-context model reserves only its ceiling, below the usable floor."""
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr("lilbee.providers.engine_params.chat_ctx_ceiling", lambda _m, _p: 2048)
+    assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 2048
 
 
 def test_placement_estimate_ctx_chat_honors_num_ctx_pin(monkeypatch) -> None:
     monkeypatch.setattr(cfg, "num_ctx", 16384)
     assert planning_mod._placement_estimate_ctx(WorkerRole.CHAT, Path("/m.gguf"), {}) == 16384
+
+
+def test_estimate_role_chat_footprint_sized_at_target_ctx(monkeypatch) -> None:
+    """The single-instance chat footprint reserves KV for the target ctx, not the
+    single-card dynamic ctx (which collapses when a big model barely fits one card).
+
+    Regression for bb-9rn: sizing at the target is what lets a too-tight single-card
+    placement fall through to a tensor-split instead of a 512-token corner.
+    """
+    captured: dict[str, int] = {}
+
+    def _est(model_path, *, ctx, slots, **_kwargs) -> GgufVramEstimate:
+        captured["ctx"] = ctx
+        return GgufVramEstimate(vram_bytes=10**8, ram_bytes=0, unified_bytes=10**8)
+
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 24576)
+    monkeypatch.setattr(planning_mod, "estimate_instance_footprint", _est)
+    monkeypatch.setattr(planning_mod, "_slots_for", lambda *a, **k: 1)
+    monkeypatch.setattr(
+        "lilbee.providers.engine_params.resolve_model_path", lambda _r: Path("/m/c.gguf")
+    )
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+    monkeypatch.setattr("lilbee.providers.engine_params.chat_ctx_ceiling", lambda _m, _p: 262144)
+
+    planning_mod._estimate_role(WorkerRole.CHAT, "org/chat.gguf")
+    assert captured["ctx"] == 24576
 
 
 def test_placement_estimate_ctx_non_chat_delegates_to_role_ctx(monkeypatch) -> None:
@@ -652,10 +704,34 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(
             planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=9000, unified=900)
         )
-        shared = planning_mod._estimate_role(WorkerRole.CHAT, "ref", slots=1, unified_budget=10**9)
-        discrete = planning_mod._estimate_role(WorkerRole.CHAT, "ref", slots=1)
+        shared = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1, unified_budget=10**9)
+        discrete = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=1)
         assert shared.est_vram_bytes == 900
         assert discrete.est_vram_bytes == 9000
+
+    def test_estimate_role_chat_charged_at_serve_budget(self, monkeypatch) -> None:
+        """A chat instance's placement footprint is scaled up by the placement/serve
+        budget ratio, so a model that would starve its KV on one card is tensor-split.
+
+        Regression for bb-9rn: without this, a 17GB model fits one 24GB card at the 0.9
+        placement headroom but its served ctx (sized at 0.75) collapses to ~512 tokens.
+        """
+        monkeypatch.setattr(cfg, "gpu_memory_fraction", 0.75)
+        monkeypatch.setattr(
+            "lilbee.providers.engine_params.resolve_model_path", lambda _r: Path("/m/c.gguf")
+        )
+        monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {})
+        monkeypatch.setattr(planning_mod, "_role_ctx", lambda _r, _p, _m, *_a: 16)
+        monkeypatch.setattr(planning_mod, "_slots_for", lambda *a, **k: 1)
+        monkeypatch.setattr(
+            planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=10000)
+        )
+
+        chat = planning_mod._estimate_role(WorkerRole.CHAT, "ref")
+        embed = planning_mod._estimate_role(WorkerRole.EMBED, "ref")
+        # chat charged at the serve budget: 10000 * (USABLE_VRAM_FRACTION / 0.75); embed raw.
+        assert chat.est_vram_bytes == int(10000 * (planning_mod.USABLE_VRAM_FRACTION / 0.75))
+        assert embed.est_vram_bytes == 10000
 
     def test_launch_for_vision_passes_mmproj(self, tmp_path, monkeypatch) -> None:
         model = tmp_path / "v.gguf"
@@ -682,8 +758,8 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(
             planning_mod, "estimate_instance_footprint", _fixed_estimator(vram=7777)
         )
-        inp = planning_mod._estimate_role(WorkerRole.CHAT, "ref", slots=2)
-        assert inp.role == WorkerRole.CHAT
+        inp = planning_mod._estimate_role(WorkerRole.EMBED, "ref", slots=2)
+        assert inp.role == WorkerRole.EMBED
         assert inp.est_vram_bytes == 7777
 
     def test_launch_for_builds_instance_with_pinning(self, tmp_path, monkeypatch) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -823,6 +823,9 @@ def test_pdf_ocr_spends_one_document_budget_across_pages(monkeypatch) -> None:
     p = _provider_with_clients({WorkerRole.VISION: [_fake_client(0)]})
     monkeypatch.setattr(cfg, "vision_model", "")
     monkeypatch.setattr(cfg, "vision_load_budget_s", 300.0)
+    # Pin the device-count probe so _checkout() does not run a real subprocess
+    # and spend ~4s that would bleed into the budget timing assertion.
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr("lilbee.vision.pdf_page_count", lambda _p: 2)
     monkeypatch.setattr(
         "lilbee.vision.rasterize_pdf", lambda _p: iter([(0, b"png0"), (1, b"png1")])
@@ -2124,3 +2127,16 @@ def test_require_clients_no_reprobe_when_swap_live(monkeypatch) -> None:
     with pytest.raises(ProviderError, match="No chat model server is running"):
         p._require_clients(WorkerRole.CHAT)
     assert rebuilt["called"] is False
+
+
+def test_rebuild_swap_calls_drop_then_ensure(monkeypatch) -> None:
+    """_rebuild_swap calls _drop_swap_refs then _ensure_swap, in that order."""
+    p = FleetProvider()
+    order: list[str] = []
+
+    monkeypatch.setattr(p, "_drop_swap_refs", lambda: order.append("drop"), raising=False)
+    monkeypatch.setattr(p, "_ensure_swap", lambda: order.append("ensure"), raising=False)
+
+    p._rebuild_swap()
+
+    assert order == ["drop", "ensure"]

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -27,13 +27,14 @@ def _fake_client(in_flight: int = 0) -> MagicMock:
 
 
 def _fake_launch(
-    role: WorkerRole, *, slots: int = 1, ctx: int = 0, weights_bytes: int = 0
+    role: WorkerRole, *, slots: int = 1, ctx: int = 0, weights_bytes: int = 0, replica: int = 0
 ) -> MagicMock:
     launch = MagicMock()
     launch.role = role
     launch.slots = slots
     launch.ctx = ctx
     launch.weights_bytes = weights_bytes
+    launch.replica = replica
     return launch
 
 
@@ -734,6 +735,80 @@ def test_pdf_drain_budget_totals_pages_plus_load_grace(monkeypatch) -> None:
     assert prov_mod._pdf_drain_budget(2, 120.0) == 540.0
     assert prov_mod._pdf_drain_budget(5, None) is None
     assert prov_mod._pdf_drain_budget(5, 0.0) is None
+
+
+def test_release_ingest_pool_unloads_only_elastic_replicas() -> None:
+    from unittest import mock
+
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    p = FleetProvider()
+    p._elastic_members = ["embed-1", "embed-2", "vision-1"]
+    unloaded: list[str] = []
+    swap = mock.Mock()
+    swap.unload.side_effect = lambda mid: unloaded.append(mid) or True
+    p._swap = swap
+
+    p.release_ingest_pool()
+
+    assert unloaded == ["embed-1", "embed-2", "vision-1"]
+    swap.unload.assert_called()
+
+
+def test_release_ingest_pool_noop_when_no_swap() -> None:
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    p = FleetProvider()
+    p._elastic_members = ["embed-1"]
+    p._swap = None
+    p.release_ingest_pool()  # must not raise
+
+
+def test_release_ingest_pool_logs_unconfirmed(caplog) -> None:
+    import logging
+    from unittest import mock
+
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    p = FleetProvider()
+    p._elastic_members = ["embed-1"]
+    swap = mock.Mock()
+    swap.unload.return_value = False  # unload did not confirm
+    p._swap = swap
+
+    with caplog.at_level(logging.INFO, logger="lilbee.providers.fleet.provider"):
+        p.release_ingest_pool()
+
+    assert any("did not confirm" in r.message for r in caplog.records)
+
+
+def test_adopt_swap_records_elastic_members(monkeypatch) -> None:
+    from lilbee.providers.fleet.launch import InstanceLaunch
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    def _make_launch(role: WorkerRole, replica: int) -> InstanceLaunch:
+        return InstanceLaunch(
+            role=role,
+            argv=[],
+            env_overrides={},
+            model="dummy.gguf",
+            replica=replica,
+        )
+
+    launches = [
+        _make_launch(WorkerRole.CHAT, replica=0),
+        _make_launch(WorkerRole.EMBED, replica=0),
+        _make_launch(WorkerRole.EMBED, replica=1),
+        _make_launch(WorkerRole.RERANK, replica=0),
+        _make_launch(WorkerRole.VISION, replica=0),
+        _make_launch(WorkerRole.VISION, replica=1),
+    ]
+    swap = _install_engine(monkeypatch, launches=launches)
+    p = FleetProvider()
+    with p._lock:
+        p._adopt_swap(swap, launches)
+
+    assert p._elastic_members == ["embed-1", "vision-1"]
 
 
 def test_pdf_ocr_spends_one_document_budget_across_pages(monkeypatch) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -701,6 +701,9 @@ def test_pdf_ocr_runs_pages_concurrently_and_preserves_order(monkeypatch) -> Non
 
     monkeypatch.setattr(cfg, "vision_model", "")
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
+    # Auto replicas (vision_replicas left at its 0 default) resolves to one per
+    # GPU; pin the probe to a single GPU so the gate admits 1 x 4 = 4 in flight.
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     n = 8
     monkeypatch.setattr("lilbee.vision.pdf_page_count", lambda _p: n)
     monkeypatch.setattr(
@@ -1159,9 +1162,20 @@ def test_apply_fleet_gpu_env_honors_gpu_devices_pin(monkeypatch) -> None:
     for name in _GPU_VISIBLE_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setattr(cfg, "gpu_devices", "0")
-    gpu_env.apply_fleet_gpu_env()
-    for name in _GPU_VISIBLE_ENV_VARS:
-        assert os.environ[name] == "0"
+    # apply_fleet_gpu_env writes these vars in place; monkeypatch.delenv does not
+    # track app-side additions, so restore the pre-apply snapshot to avoid leaking
+    # the pin (CUDA_VISIBLE_DEVICES=0) into later tests that read os.environ.
+    snapshot = {name: os.environ.get(name) for name in _GPU_VISIBLE_ENV_VARS}
+    try:
+        gpu_env.apply_fleet_gpu_env()
+        for name in _GPU_VISIBLE_ENV_VARS:
+            assert os.environ[name] == "0"
+    finally:
+        for name, value in snapshot.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def test_apply_fleet_gpu_env_clears_empty_cuda_visible_devices(monkeypatch) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -59,6 +59,11 @@ class _FakeSwap:
     def endpoint(self) -> str:
         return "http://fake-endpoint"
 
+    def is_live(self) -> bool:
+        # Default: the fake swap is considered live so existing tests that have
+        # an empty client pool still raise ProviderError, not trigger a rebuild.
+        return True
+
     def role_ready(self, role: WorkerRole) -> bool:
         return role in self.ready
 
@@ -2055,3 +2060,67 @@ class TestWarmProgressTracking:
         p._warm_tracker.begin("repo/m.gguf")
         p._warm_tracker.ready()
         assert p.warm_progress().phase is WarmPhase.READY
+
+
+# --- _require_clients re-probe on a dead swap ---------------------------------
+
+
+def test_require_clients_reprobes_dead_swap(monkeypatch) -> None:
+    """Empty pool + dead swap triggers a one-shot rebuild; clients are returned after."""
+    from unittest import mock
+
+    p = FleetProvider()
+    p._clients = {}
+    dead = mock.Mock()
+    dead.is_live.return_value = False
+    p._swap = dead
+    rebuilt = {"called": False}
+
+    def fake_rebuild() -> None:
+        rebuilt["called"] = True
+        p._clients = {WorkerRole.CHAT: [_fake_client()]}
+
+    monkeypatch.setattr(p, "_rebuild_swap", fake_rebuild, raising=False)
+    clients = p._require_clients(WorkerRole.CHAT)
+    assert rebuilt["called"] is True
+    assert len(clients) == 1
+
+
+def test_require_clients_no_reprobe_when_swap_none(monkeypatch) -> None:
+    """Empty pool + no swap at all (unconfigured role) still raises, no rebuild."""
+    from lilbee.providers.base import ProviderError
+
+    rebuilt = {"called": False}
+
+    def fake_rebuild() -> None:
+        rebuilt["called"] = True
+
+    p = FleetProvider()
+    p._swap = None
+    p._clients = {}
+    monkeypatch.setattr(p, "_rebuild_swap", fake_rebuild, raising=False)
+    with pytest.raises(ProviderError, match="No chat model server is running"):
+        p._require_clients(WorkerRole.CHAT)
+    assert rebuilt["called"] is False
+
+
+def test_require_clients_no_reprobe_when_swap_live(monkeypatch) -> None:
+    """Empty pool + live swap (real misconfiguration) still raises, no rebuild."""
+    from unittest import mock
+
+    from lilbee.providers.base import ProviderError
+
+    rebuilt = {"called": False}
+
+    def fake_rebuild() -> None:
+        rebuilt["called"] = True
+
+    p = FleetProvider()
+    live = mock.Mock()
+    live.is_live.return_value = True
+    p._swap = live
+    p._clients = {}
+    monkeypatch.setattr(p, "_rebuild_swap", fake_rebuild, raising=False)
+    with pytest.raises(ProviderError, match="No chat model server is running"):
+        p._require_clients(WorkerRole.CHAT)
+    assert rebuilt["called"] is False

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -375,6 +375,7 @@ def test_vision_request_gate_tracks_fleet_capacity(monkeypatch) -> None:
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr(cfg, "vision_replicas", 3)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
     with prov_mod._VISION_GATE.slot():
@@ -395,6 +396,7 @@ def test_vision_gate_resize_deferred_while_in_flight(monkeypatch) -> None:
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr(cfg, "vision_replicas", 1)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 
@@ -438,6 +440,7 @@ def test_vision_gate_slot_decrements_in_flight_when_acquire_raises(monkeypatch) 
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr(cfg, "vision_replicas", 1)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 
@@ -470,6 +473,7 @@ def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr(cfg, "vision_replicas", 1)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -2065,9 +2065,6 @@ class TestWarmProgressTracking:
         assert p.warm_progress().phase is WarmPhase.READY
 
 
-# --- _require_clients re-probe on a dead swap ---------------------------------
-
-
 def test_require_clients_reprobes_dead_swap(monkeypatch) -> None:
     """Empty pool + dead swap triggers a one-shot rebuild; clients are returned after."""
     from unittest import mock

--- a/tests/test_fleet_replicas.py
+++ b/tests/test_fleet_replicas.py
@@ -1,0 +1,68 @@
+"""Unit tests for the shared replica-count resolver and cached GPU probe."""
+
+from __future__ import annotations
+
+from lilbee.core.config import cfg
+from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
+from lilbee.providers.roles import WorkerRole
+
+
+def test_auto_resolves_to_one_replica_per_gpu(monkeypatch) -> None:
+    # 0 (the default) means auto: one replica per enumerated GPU.
+    monkeypatch.setattr(cfg, "embed_replicas", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 0)
+    assert resolve_replica_count(WorkerRole.EMBED, 4) == 4
+    assert resolve_replica_count(WorkerRole.VISION, 3) == 3
+
+
+def test_auto_floors_at_one_replica_when_gpu_less(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 0)
+    assert resolve_replica_count(WorkerRole.EMBED, 0) == 1
+    assert resolve_replica_count(WorkerRole.VISION, 0) == 1
+
+
+def test_explicit_replica_count_wins_over_device_count(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 2)
+    monkeypatch.setattr(cfg, "vision_replicas", 5)
+    assert resolve_replica_count(WorkerRole.EMBED, 8) == 2
+    assert resolve_replica_count(WorkerRole.VISION, 1) == 5
+
+
+def test_non_replicated_roles_always_run_one(monkeypatch) -> None:
+    monkeypatch.setattr(cfg, "embed_replicas", 0)
+    monkeypatch.setattr(cfg, "vision_replicas", 0)
+    assert resolve_replica_count(WorkerRole.CHAT, 8) == 1
+    assert resolve_replica_count(WorkerRole.RERANK, 8) == 1
+
+
+def test_gpu_device_count_returns_probe_length(monkeypatch) -> None:
+    gpu_device_count.cache_clear()
+    monkeypatch.setattr("lilbee.providers.fleet.binary.resolve_llama_server", lambda: object())
+    monkeypatch.setattr(
+        "lilbee.providers.fleet.planning.resolve_devices", lambda _b: [object(), object(), object()]
+    )
+    assert gpu_device_count() == 3
+
+
+def test_gpu_device_count_floors_at_one_when_no_devices(monkeypatch) -> None:
+    gpu_device_count.cache_clear()
+    monkeypatch.setattr("lilbee.providers.fleet.binary.resolve_llama_server", lambda: object())
+    monkeypatch.setattr("lilbee.providers.fleet.planning.resolve_devices", lambda _b: [])
+    assert gpu_device_count() == 1
+
+
+def test_gpu_device_count_is_cached(monkeypatch) -> None:
+    gpu_device_count.cache_clear()
+    calls = {"n": 0}
+
+    def _probe(_b: object) -> list[object]:
+        calls["n"] += 1
+        return [object(), object()]
+
+    monkeypatch.setattr("lilbee.providers.fleet.binary.resolve_llama_server", lambda: object())
+    monkeypatch.setattr("lilbee.providers.fleet.planning.resolve_devices", _probe)
+    assert gpu_device_count() == 2
+    assert gpu_device_count() == 2
+    assert calls["n"] == 1  # cached: probed once, not per call
+    gpu_device_count.cache_clear()

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1171,9 +1171,7 @@ class TestIsLive:
         monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.get", boom)
         assert mgr.is_live() is False
 
-    def test_false_and_no_raise_when_proc_alive_but_port_not_yet_set(
-        self, tmp_path: Path
-    ) -> None:
+    def test_false_and_no_raise_when_proc_alive_but_port_not_yet_set(self, tmp_path: Path) -> None:
         # Startup-window race: _proc is alive (poll() returns None) but _port is
         # still None. is_live() must return False, not let endpoint()'s
         # ProviderError escape a -> bool method.

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1124,6 +1124,13 @@ class TestUnload:
         )
         assert mgr.unload("embed-1") is False
 
+    def test_returns_false_and_never_raises_before_start(self, tmp_path: Path) -> None:
+        # _port is None before start(); unload() must not let endpoint()'s
+        # ProviderError escape the never-raise contract.
+        mgr = SwapManager(tmp_path)
+        assert mgr._port is None
+        assert mgr.unload("embed-1") is False
+
 
 class TestIsLive:
     def test_true_when_proc_alive_and_running_answers(

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -16,7 +16,7 @@ import pytest
 from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet import swap_manager as sm
 from lilbee.providers.fleet.launch import InstanceLaunch
-from lilbee.providers.fleet.swap_manager import SwapManager
+from lilbee.providers.fleet.swap_manager import _UNLOAD_PATH, SwapManager
 from lilbee.providers.roles import WorkerRole
 
 
@@ -1081,3 +1081,85 @@ def test_running_reflects_the_spawned_process(
     assert mgr.running is True
     mgr.shutdown()
     assert mgr.running is False
+
+
+class TestUnload:
+    def test_posts_model_id_to_unload_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        calls: dict[str, object] = {}
+
+        def fake_post(url: str, json: object, timeout: float) -> object:
+            calls["url"] = url
+            calls["json"] = json
+            return _fake_response(status=200)
+
+        monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.post", fake_post)
+        assert mgr.unload("embed-1") is True
+        assert calls["url"] == f"http://127.0.0.1:41999{_UNLOAD_PATH}"
+        assert calls["json"] == {"model": "embed-1"}
+
+    def test_returns_false_and_never_raises_on_network_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+
+        def boom(url: str, json: object, timeout: float) -> object:
+            raise OSError("connection refused")
+
+        monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.post", boom)
+        assert mgr.unload("embed-1") is False
+
+    def test_returns_false_on_http_error_status(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.swap_manager.httpx.post",
+            lambda url, json, timeout: _fake_response(status=500),
+        )
+        assert mgr.unload("embed-1") is False
+
+
+class TestIsLive:
+    def test_true_when_proc_alive_and_running_answers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        mgr._proc = _FakeProc(poll_result=None)  # type: ignore[assignment]
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.swap_manager.httpx.get",
+            lambda url, timeout: _fake_response(status=200),
+        )
+        assert mgr.is_live() is True
+
+    def test_false_when_proc_is_none(self, tmp_path: Path) -> None:
+        mgr = SwapManager(tmp_path)
+        assert mgr._proc is None
+        assert mgr.is_live() is False
+
+    def test_false_when_proc_has_exited(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        mgr._proc = _FakeProc(poll_result=1)  # type: ignore[assignment]
+        assert mgr.is_live() is False
+
+    def test_false_when_running_probe_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mgr = SwapManager(tmp_path)
+        mgr._port = 41999
+        mgr._proc = _FakeProc(poll_result=None)  # type: ignore[assignment]
+
+        def boom(url: str, timeout: float) -> object:
+            raise OSError("connection refused")
+
+        monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.get", boom)
+        assert mgr.is_live() is False

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1170,3 +1170,15 @@ class TestIsLive:
 
         monkeypatch.setattr("lilbee.providers.fleet.swap_manager.httpx.get", boom)
         assert mgr.is_live() is False
+
+    def test_false_and_no_raise_when_proc_alive_but_port_not_yet_set(
+        self, tmp_path: Path
+    ) -> None:
+        # Startup-window race: _proc is alive (poll() returns None) but _port is
+        # still None. is_live() must return False, not let endpoint()'s
+        # ProviderError escape a -> bool method.
+        mgr = SwapManager(tmp_path)
+        mgr._proc = _FakeProc(poll_result=None)  # type: ignore[assignment]
+        assert mgr._port is None
+        result = mgr.is_live()
+        assert result is False

--- a/tests/test_ingest_scale.py
+++ b/tests/test_ingest_scale.py
@@ -1,0 +1,71 @@
+"""Tests for the refcounted ingest bracket in ``lilbee.providers.fleet.ingest_scale``."""
+
+from __future__ import annotations
+
+import contextlib
+from unittest import mock
+
+from lilbee.providers.fleet import ingest_scale
+
+
+def test_release_only_after_last_ingest(monkeypatch):
+    """``release_ingest_pool`` is called exactly once, when the outermost bracket exits."""
+    released = {"n": 0}
+    prov = mock.Mock()
+    prov.release_ingest_pool.side_effect = lambda: released.__setitem__("n", released["n"] + 1)
+    monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+
+    with ingest_scale.ingest_scale():
+        with ingest_scale.ingest_scale():
+            assert released["n"] == 0  # inner exit does not release
+        assert released["n"] == 0  # still one active
+    assert released["n"] == 1  # last exit releases once
+
+
+def test_release_runs_even_on_exception(monkeypatch):
+    """``release_ingest_pool`` is called even when the body raises."""
+    prov = mock.Mock()
+    monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    with contextlib.suppress(RuntimeError), ingest_scale.ingest_scale():
+        raise RuntimeError("boom")
+    prov.release_ingest_pool.assert_called_once()
+
+
+def test_release_not_called_on_non_last_exit(monkeypatch):
+    """Inner bracket exit does not call ``release_ingest_pool``."""
+    prov = mock.Mock()
+    monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    with ingest_scale.ingest_scale():
+        with ingest_scale.ingest_scale():
+            pass
+        prov.release_ingest_pool.assert_not_called()
+    prov.release_ingest_pool.assert_called_once()
+
+
+def test_routing_provider_release_ingest_pool_forwards_to_local():
+    """``RoutingProvider.release_ingest_pool`` forwards to the inner engine."""
+    from lilbee.providers.routing_provider import RoutingProvider
+
+    rp = RoutingProvider()
+    local = mock.MagicMock()
+    rp._local = local
+    rp.release_ingest_pool()
+    local.release_ingest_pool.assert_called_once_with()
+
+
+def test_routing_provider_release_ingest_pool_noop_without_local():
+    """``RoutingProvider.release_ingest_pool`` is a no-op when ``_local`` is None."""
+    from lilbee.providers.routing_provider import RoutingProvider
+
+    rp = RoutingProvider()  # _local is None
+    rp.release_ingest_pool()  # must not raise
+
+
+def test_sdk_llm_provider_release_ingest_pool_is_callable_noop():
+    """``SdkLLMProvider.release_ingest_pool`` is a callable no-op."""
+    from lilbee.providers.sdk_backend import LlmSdkBackend
+    from lilbee.providers.sdk_llm_provider import SdkLLMProvider
+
+    backend = mock.MagicMock(spec=LlmSdkBackend)
+    provider = SdkLLMProvider(backend)
+    provider.release_ingest_pool()  # must not raise

--- a/tests/test_ingest_scale.py
+++ b/tests/test_ingest_scale.py
@@ -8,17 +8,28 @@ from unittest import mock
 from lilbee.providers.fleet import ingest_scale
 
 
+def _join_release() -> None:
+    """Wait for the fire-and-forget release thread so assertions are deterministic."""
+    thread = ingest_scale._counter.last_release_thread
+    assert thread is not None
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+
 def test_release_only_after_last_ingest(monkeypatch):
     """``release_ingest_pool`` is called exactly once, when the outermost bracket exits."""
     released = {"n": 0}
     prov = mock.Mock()
     prov.release_ingest_pool.side_effect = lambda: released.__setitem__("n", released["n"] + 1)
     monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    monkeypatch.setattr(ingest_scale._counter, "last_release_thread", None)
 
     with ingest_scale.ingest_scale():
         with ingest_scale.ingest_scale():
             assert released["n"] == 0  # inner exit does not release
+            assert ingest_scale._counter.last_release_thread is None  # no release spawned yet
         assert released["n"] == 0  # still one active
+    _join_release()
     assert released["n"] == 1  # last exit releases once
 
 
@@ -26,8 +37,10 @@ def test_release_runs_even_on_exception(monkeypatch):
     """``release_ingest_pool`` is called even when the body raises."""
     prov = mock.Mock()
     monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    monkeypatch.setattr(ingest_scale._counter, "last_release_thread", None)
     with contextlib.suppress(RuntimeError), ingest_scale.ingest_scale():
         raise RuntimeError("boom")
+    _join_release()
     prov.release_ingest_pool.assert_called_once()
 
 
@@ -35,11 +48,22 @@ def test_release_not_called_on_non_last_exit(monkeypatch):
     """Inner bracket exit does not call ``release_ingest_pool``."""
     prov = mock.Mock()
     monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    monkeypatch.setattr(ingest_scale._counter, "last_release_thread", None)
     with ingest_scale.ingest_scale():
         with ingest_scale.ingest_scale():
             pass
         prov.release_ingest_pool.assert_not_called()
+        assert ingest_scale._counter.last_release_thread is None  # no release spawned yet
+    _join_release()
     prov.release_ingest_pool.assert_called_once()
+
+
+def test_run_release_invokes_provider(monkeypatch):
+    """``_run_release`` calls ``release_ingest_pool`` on the resolved provider."""
+    prov = mock.Mock()
+    monkeypatch.setattr(ingest_scale, "_provider", lambda: prov)
+    ingest_scale._run_release()
+    prov.release_ingest_pool.assert_called_once_with()
 
 
 def test_routing_provider_release_ingest_pool_forwards_to_local():

--- a/tests/test_ingest_scale.py
+++ b/tests/test_ingest_scale.py
@@ -61,6 +61,15 @@ def test_routing_provider_release_ingest_pool_noop_without_local():
     rp.release_ingest_pool()  # must not raise
 
 
+def test_provider_resolver_returns_provider_from_get_services(monkeypatch):
+    """``_provider()`` imports ``get_services`` at call time and returns ``.provider``."""
+    sentinel = mock.Mock()
+    services = mock.Mock()
+    services.provider = sentinel
+    monkeypatch.setattr("lilbee.app.services.get_services", lambda: services)
+    assert ingest_scale._provider() is sentinel
+
+
 def test_sdk_llm_provider_release_ingest_pool_is_callable_noop():
     """``SdkLLMProvider.release_ingest_pool`` is a callable no-op."""
     from lilbee.providers.sdk_backend import LlmSdkBackend

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -328,3 +328,16 @@ class TestMaxConcurrent:
         monkeypatch.setattr(cfg, "vision_model", "")
         monkeypatch.setattr(cfg, "embed_replicas", 8)
         assert pipeline._max_concurrent() == 8
+
+    def test_auto_embed_replicas_fans_out_to_gpu_count(self, monkeypatch) -> None:
+        # embed_replicas=0 (the auto default) must fan out to one slot per GPU so
+        # a multi-GPU box does not stall extra cards waiting for ingest work.
+        import lilbee.providers.fleet.replicas as replicas_mod
+        from lilbee.data.ingest import pipeline
+
+        monkeypatch.setattr(pipeline, "cpu_quota", lambda: 2)
+        monkeypatch.setattr(cfg, "vision_model", "")
+        monkeypatch.setattr(cfg, "embed_replicas", 0)
+        monkeypatch.setattr(replicas_mod, "gpu_device_count", lambda: 4)
+        result = pipeline._max_concurrent()
+        assert result >= 4, f"expected at least 4 (one per GPU), got {result}"

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4315,3 +4315,61 @@ class TestSourceContentRoute:
         assert resp.headers["content-type"].startswith("image/avif")
         assert resp.headers["x-content-type-options"] == "nosniff"
         assert "content-disposition" not in resp.headers
+
+
+def _stub_placement_view():
+    """Minimal PlacementView with no GPUs or roles for handler-level tests."""
+    from lilbee.app.placement import PlacementView
+
+    return PlacementView(gpus=(), roles=(), unplaceable=(), manual=False, spec_json=None)
+
+
+class TestPlacementHandlers:
+    async def test_placement_returns_response(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.get_placement", return_value=view):
+            resp = await handlers.placement()
+        assert resp.manual is False
+        assert resp.gpus == []
+        assert resp.roles == []
+
+    async def test_placement_preview_without_spec(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.preview_placement", return_value=view):
+            resp = await handlers.placement_preview(None)
+        assert resp.manual is False
+
+    async def test_placement_preview_with_spec_json(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.preview_placement", return_value=view):
+            resp = await handlers.placement_preview('{"chat": {"devices": [0]}}')
+        assert resp.manual is False
+
+    async def test_placement_set_returns_response(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.set_placement", return_value=view):
+            resp = await handlers.placement_set('{"chat": {"devices": [0]}}')
+        assert resp.manual is False
+
+    async def test_placement_clear_returns_response(self):
+        view = _stub_placement_view()
+        with patch("lilbee.app.placement.set_placement", return_value=view):
+            resp = await handlers.placement_clear()
+        assert resp.manual is False
+
+    async def test_gpus_returns_list(self):
+        from lilbee.app.placement import GpuInfo, PlacementView
+
+        gpu = GpuInfo(
+            index=0,
+            backend="cuda",
+            label="cuda0",
+            name="A100",
+            total_bytes=80 * 1024**3,
+            free_bytes=40 * 1024**3,
+        )
+        view = PlacementView(gpus=(gpu,), roles=(), unplaceable=(), manual=False, spec_json=None)
+        with patch("lilbee.app.placement.get_placement", return_value=view):
+            result = await handlers.gpus()
+        assert len(result) == 1
+        assert result[0].name == "A100"

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4345,18 +4345,6 @@ class TestPlacementHandlers:
             resp = await handlers.placement_preview('{"chat": {"devices": [0]}}')
         assert resp.manual is False
 
-    async def test_placement_set_returns_response(self):
-        view = _stub_placement_view()
-        with patch("lilbee.app.placement.set_placement", return_value=view):
-            resp = await handlers.placement_set('{"chat": {"devices": [0]}}')
-        assert resp.manual is False
-
-    async def test_placement_clear_returns_response(self):
-        view = _stub_placement_view()
-        with patch("lilbee.app.placement.set_placement", return_value=view):
-            resp = await handlers.placement_clear()
-        assert resp.manual is False
-
     async def test_gpus_returns_list(self):
         from lilbee.app.placement import GpuInfo, PlacementView
 

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1843,3 +1843,18 @@ class TestImportRoute:
             auth_mod.session_manager.token = None
             auth_mod.session_manager._initialized = previous_init
         assert resp.status_code == 401
+
+
+class TestPlacementSetRoute:
+    def test_placement_error_returns_422(self, client):
+        """A PlacementError from placement_set must surface as 422."""
+        from lilbee.providers.fleet.placement_spec import PlacementError
+
+        with mock.patch(
+            "lilbee.server.handlers.placement_set",
+            new_callable=AsyncMock,
+            side_effect=PlacementError("invalid spec"),
+        ):
+            resp = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+        assert resp.status_code == 422
+        assert "invalid spec" in resp.json()["detail"]

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1846,15 +1846,13 @@ class TestImportRoute:
 
 
 class TestPlacementSetRoute:
-    def test_placement_error_returns_422(self, client):
-        """A PlacementError from placement_set must surface as 422."""
-        from lilbee.providers.fleet.placement_spec import PlacementError
+    def test_put_refused_on_daemon(self, client):
+        """PUT placement is refused on the shared HTTP daemon; change it from the CLI/TUI."""
+        resp = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+        assert resp.status_code == 409
+        assert "CLI" in resp.json()["detail"]
 
-        with mock.patch(
-            "lilbee.server.handlers.placement_set",
-            new_callable=AsyncMock,
-            side_effect=PlacementError("invalid spec"),
-        ):
-            resp = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
-        assert resp.status_code == 422
-        assert "invalid spec" in resp.json()["detail"]
+    def test_delete_refused_on_daemon(self, client):
+        """DELETE placement is refused on the shared HTTP daemon."""
+        resp = client.delete("/api/placement")
+        assert resp.status_code == 409

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -196,6 +196,30 @@ class TestRerankerConfig:
         assert SETTINGS_MAP["reranker_type"].choices == ("auto", "cross_encoder", "llm")
 
 
+class TestReplicaDefaults:
+    """embed/vision replica counts default to 0 = auto (one per GPU at placement)."""
+
+    def test_replicas_default_to_auto_zero(self):
+        from lilbee.core.config import Config
+
+        assert Config().embed_replicas == 0
+        assert Config().vision_replicas == 0
+
+    def test_replicas_accept_zero(self):
+        from lilbee.core.config import Config
+
+        assert Config(embed_replicas=0, vision_replicas=0).embed_replicas == 0
+
+    def test_replicas_reject_negative(self):
+        import pydantic
+        import pytest
+
+        from lilbee.core.config import Config
+
+        with pytest.raises(pydantic.ValidationError):
+            Config(embed_replicas=-1)
+
+
 class TestMemoryTuningSettingsMap:
     """The dynamic-ctx tuning knobs are surfaced in the TUI settings map."""
 

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -296,7 +296,7 @@ class TestViewCycling:
                 await pilot.press("escape")
                 await pilot.pause()
 
-                expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
+                expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Placement", "Chat"]
                 for view in expected:
                     await pilot.press("right_square_bracket")
                     await pilot.pause()
@@ -498,7 +498,7 @@ class TestScreenTransitions:
                 # Blur the chat input so the app-level ] binding fires.
                 await pilot.press("escape")
                 await pilot.pause()
-                expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
+                expected = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Placement", "Chat"]
                 for view in expected:
                     await pilot.press("right_square_bracket")
                     await pilot.pause()
@@ -548,7 +548,7 @@ class TestScreenTransitions:
                 assert app.active_view == "Tasks"
 
     async def test_forward_cycle_full_loop(self, _mock_resolve):
-        """Chat->Catalog->Status->Settings->Tasks->Wiki->Chat via nav_next."""
+        """Chat->Catalog->Status->Settings->Tasks->Wiki->Placement->Chat via nav_next."""
         from lilbee.cli.tui.app import LilbeeApp
 
         with _mock_catalog_deps(), _mock_remote_models():
@@ -559,14 +559,14 @@ class TestScreenTransitions:
                 # Blur the chat input so the app-level ] binding fires.
                 await pilot.press("escape")
                 await pilot.pause()
-                full_cycle = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Chat"]
+                full_cycle = ["Catalog", "Status", "Settings", "Tasks", "Wiki", "Placement", "Chat"]
                 for view in full_cycle:
                     await pilot.press("right_square_bracket")
                     await pilot.pause()
                     assert app.active_view == view
 
     async def test_backward_cycle_full_loop(self, _mock_resolve):
-        """Chat->Wiki->Tasks->Settings->Status->Catalog->Chat via nav_prev."""
+        """Chat->Placement->Wiki->Tasks->Settings->Status->Catalog->Chat via nav_prev."""
         from lilbee.cli.tui.app import LilbeeApp
 
         with _mock_catalog_deps(), _mock_remote_models():
@@ -577,7 +577,15 @@ class TestScreenTransitions:
                 # Blur the chat input so the app-level [ binding fires.
                 await pilot.press("escape")
                 await pilot.pause()
-                backward_cycle = ["Wiki", "Tasks", "Settings", "Status", "Catalog", "Chat"]
+                backward_cycle = [
+                    "Placement",
+                    "Wiki",
+                    "Tasks",
+                    "Settings",
+                    "Status",
+                    "Catalog",
+                    "Chat",
+                ]
                 for view in backward_cycle:
                     await pilot.press("left_square_bracket")
                     await pilot.pause()

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -16,6 +16,7 @@ from conftest import TEST_EMBED_REF, TEST_LOCAL_REF
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.screens.catalog import CatalogScreen
 from lilbee.cli.tui.screens.chat import ChatScreen
+from lilbee.cli.tui.screens.placement import PlacementScreen
 from lilbee.cli.tui.screens.settings import SettingsScreen
 from lilbee.cli.tui.screens.status import StatusScreen
 from lilbee.cli.tui.screens.task_center import TaskCenter
@@ -75,7 +76,7 @@ def _patch_chat_setup():
 
 
 async def test_bracket_keys_cycle_all_screens():
-    """Press ] through all 5 views from normal mode (Escape first on Chat)."""
+    """Press ] through all 6 views from normal mode (Escape first on Chat)."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
@@ -85,7 +86,14 @@ async def test_bracket_keys_cycle_all_screens():
         await pilot.press("escape")
         await pilot.pause()
 
-        expected = [CatalogScreen, StatusScreen, SettingsScreen, TaskCenter, ChatScreen]
+        expected = [
+            CatalogScreen,
+            StatusScreen,
+            SettingsScreen,
+            TaskCenter,
+            PlacementScreen,
+            ChatScreen,
+        ]
         for screen_type in expected:
             await pilot.press("right_square_bracket")
             await pilot.pause()
@@ -130,11 +138,11 @@ async def test_bracket_keys_cycle_backward():
 
         await pilot.press("left_square_bracket")
         await pilot.pause()
-        assert isinstance(app.screen, TaskCenter)
+        assert isinstance(app.screen, PlacementScreen)
 
         await pilot.press("left_square_bracket")
         await pilot.pause()
-        assert isinstance(app.screen, SettingsScreen)
+        assert isinstance(app.screen, TaskCenter)
 
 
 async def test_bracket_keys_work_from_settings():

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import threading
+
 import pytest
-from textual.widgets import DataTable
+from textual.widgets import DataTable, TextArea
 
 from tests._lilbee_app_test_host import LilbeeAppHost
 
@@ -397,3 +399,88 @@ async def test_apply_empty_spec_calls_set_placement_none(monkeypatch):
         await pilot.pause()
 
     assert set_calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_apply_disables_input_while_running(monkeypatch):
+    """ctrl+s sets applying=True and disables the TextArea until set_placement returns."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    gate = threading.Event()
+
+    def _blocking_set(spec):  # type: ignore[no-untyped-def]
+        gate.wait()
+
+    monkeypatch.setattr(screen_mod, "set_placement", _blocking_set)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        assert screen.applying is True
+        text_area = screen.query_one(screen_mod._SPEC_AREA_ID, TextArea)
+        assert text_area.disabled is True
+        gate.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert screen.applying is False
+        assert text_area.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_apply_ignored_while_applying(monkeypatch):
+    """ctrl+s is a no-op when applying is already True (double-apply guard)."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    set_calls: list[object] = []
+    gate = threading.Event()
+
+    def _blocking_set(spec):  # type: ignore[no-untyped-def]
+        set_calls.append(spec)
+        gate.wait()
+
+    monkeypatch.setattr(screen_mod, "set_placement", _blocking_set)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        assert screen.applying is True
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        gate.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert len(set_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_ignored_while_applying(monkeypatch):
+    """ctrl+x is a no-op when applying is already True."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    set_calls: list[object] = []
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        monkeypatch.setattr(screen_mod, "set_placement", lambda spec: set_calls.append(spec))
+        screen.applying = True
+        await pilot.press("ctrl+x")
+        await pilot.pause()
+
+    assert set_calls == []

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -353,3 +353,47 @@ async def test_placement_screen_app_harness(monkeypatch):
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         assert isinstance(app.screen, screen_mod.PlacementScreen)
+
+
+@pytest.mark.asyncio
+async def test_preview_bad_json_notifies(monkeypatch):
+    """ctrl+r with invalid JSON shows an error notification, not a crash."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    notes: list[str] = []
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = "not-valid-json"
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+r")
+        await pilot.pause()
+
+    assert any(notes)
+
+
+@pytest.mark.asyncio
+async def test_apply_empty_spec_calls_set_placement_none(monkeypatch):
+    """ctrl+s with an empty spec passes None to set_placement."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    set_calls: list[object] = []
+    monkeypatch.setattr(
+        screen_mod, "set_placement", lambda spec: set_calls.append(spec) or _make_view()
+    )
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = ""
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert set_calls == [None]

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -1,0 +1,355 @@
+"""Tests for the TUI PlacementScreen."""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import DataTable
+
+from tests._lilbee_app_test_host import LilbeeAppHost
+
+GIB = 1024**3
+
+
+def _make_view(*, manual: bool = False, unplaceable: tuple = ()):  # type: ignore[type-arg]
+    from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+    from lilbee.providers.roles import WorkerRole
+
+    return PlacementView(
+        gpus=(
+            GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),
+            GpuInfo(1, "CUDA", "CUDA1", "NVIDIA A100", 80 * GIB, 80 * GIB),
+        ),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0, 1), (1, 1), 1),),
+        unplaceable=unplaceable,
+        manual=manual,
+        spec_json=None,
+    )
+
+
+class PlacementTestApp(LilbeeAppHost):
+    """Minimal app host for PlacementScreen tests."""
+
+    CSS = ""
+
+    def on_mount(self) -> None:
+        from lilbee.cli.tui.screens.placement import PlacementScreen
+
+        self.push_screen(PlacementScreen())
+
+
+@pytest.mark.asyncio
+async def test_screen_lists_gpus(monkeypatch):
+    """GPU table renders one row per detected GPU."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        table = app.screen.query_one(screen_mod._GPU_TABLE_ID, DataTable)
+        assert table.row_count == 2
+
+
+@pytest.mark.asyncio
+async def test_screen_lists_roles(monkeypatch):
+    """Role summary reflects placed roles."""
+    from textual.widgets import Static
+
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        summary = app.screen.query_one(screen_mod._ROLE_SUMMARY_ID, Static)
+        rendered = str(summary.render())
+        assert "chat" in rendered.lower()
+
+
+@pytest.mark.asyncio
+async def test_screen_unplaceable_shown(monkeypatch):
+    """Unplaceable roles appear in the summary."""
+    from textual.widgets import Static
+
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.roles import WorkerRole
+
+    view = _make_view(unplaceable=(WorkerRole.VISION,))
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: view)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        summary = app.screen.query_one(screen_mod._ROLE_SUMMARY_ID, Static)
+        rendered = str(summary.render())
+        assert "vision" in rendered.lower()
+
+
+@pytest.mark.asyncio
+async def test_preview_rerenders(monkeypatch):
+    """ctrl+r with a valid spec re-renders the GPU table."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    preview_calls: list[object] = []
+
+    def _preview(spec):  # type: ignore[no-untyped-def]
+        preview_calls.append(spec)
+        return _make_view()
+
+    monkeypatch.setattr(screen_mod, "preview_placement", _preview)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.press("ctrl+r")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert len(preview_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_shows_fit_error(monkeypatch):
+    """ctrl+r surfaces a PlacementError as a notification, not a crash."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    def _boom(spec):  # type: ignore[no-untyped-def]
+        raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
+
+    monkeypatch.setattr(screen_mod, "preview_placement", _boom)
+
+    notes: list[str] = []
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+r")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert any("40 GiB free" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_apply_calls_set_placement(monkeypatch):
+    """ctrl+s calls set_placement with parsed spec."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    set_calls: list[object] = []
+    monkeypatch.setattr(
+        screen_mod, "set_placement", lambda spec: set_calls.append(spec) or _make_view()
+    )
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert len(set_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_calls_set_placement_none(monkeypatch):
+    """ctrl+x calls set_placement(None) to restore auto placement."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    set_calls: list[object] = []
+
+    def _set(spec):  # type: ignore[no-untyped-def]
+        set_calls.append(spec)
+        return _make_view()
+
+    monkeypatch.setattr(screen_mod, "set_placement", _set)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+x")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert set_calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_apply_bad_json_notifies(monkeypatch):
+    """ctrl+s with invalid JSON shows an error notification."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    notes: list[str] = []
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = "not-valid-json"
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+
+    assert any(notes)
+
+
+@pytest.mark.asyncio
+async def test_go_back_binding(monkeypatch):
+    """q pops the screen."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, screen_mod.PlacementScreen)
+        await pilot.press("q")
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_load_placement_error_notifies(monkeypatch):
+    """An exception from get_placement on mount shows a notification."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    def _boom():
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(screen_mod, "get_placement", _boom)
+    notes: list[str] = []
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = app.screen
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        screen._load_placement()
+        await pilot.pause()
+
+    assert any("probe failed" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_render_view_with_spec_json(monkeypatch):
+    """When spec_json is set on the view, the TextArea is seeded."""
+    from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.roles import WorkerRole
+
+    GIB = 1024**3
+    view_with_spec = PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),),
+        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=True,
+        spec_json='{"chat": {"devices": [0]}}',
+    )
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: view_with_spec)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert screen._spec_text == '{"chat": {"devices": [0]}}'
+
+
+@pytest.mark.asyncio
+async def test_apply_worker_error_notifies(monkeypatch):
+    """An exception from set_placement shows a notification."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    def _oom(spec):  # type: ignore[no-untyped-def]
+        raise PlacementError("oom")
+
+    monkeypatch.setattr(screen_mod, "set_placement", _oom)
+
+    notes: list[str] = []
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._spec_text = '{"chat": {"devices": [0]}}'
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert any("oom" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_clear_worker_error_notifies(monkeypatch):
+    """An exception from set_placement(None) during clear shows a notification."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    def _fail(spec):  # type: ignore[no-untyped-def]
+        raise PlacementError("clear fail")
+
+    monkeypatch.setattr(screen_mod, "set_placement", _fail)
+
+    notes: list[str] = []
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        await pilot.press("ctrl+x")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert any("clear fail" in n for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_go_back_single_screen(monkeypatch):
+    """action_go_back with a single-item screen_stack calls switch_view."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        called: list[str] = []
+        # Simulate single-screen stack so the else branch is taken.
+        monkeypatch.setattr(type(app), "screen_stack", property(lambda self: [screen]))
+        monkeypatch.setattr(app, "switch_view", lambda v: called.append(v))
+        screen.action_go_back()
+        await pilot.pause()
+
+    assert called == ["Chat"]
+
+
+@pytest.mark.asyncio
+async def test_placement_screen_app_harness(monkeypatch):
+    """PlacementScreenApp mounts PlacementScreen successfully."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = screen_mod.PlacementScreenApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, screen_mod.PlacementScreen)

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -1,30 +1,37 @@
-"""Tests for the TUI PlacementScreen."""
+"""Tests for the interactive TUI PlacementScreen.
+
+These drive the real widgets (GPU toggle Buttons, replica steppers, key
+bindings) rather than poking private state, so the input path is actually
+exercised.
+"""
 
 from __future__ import annotations
 
 import threading
 
 import pytest
-from textual.widgets import DataTable, TextArea
+from textual.widgets import Button, DataTable, Static
 
 from tests._lilbee_app_test_host import LilbeeAppHost
 
 GIB = 1024**3
 
 
-def _make_view(*, manual: bool = False, unplaceable: tuple = ()):  # type: ignore[type-arg]
+def _make_view(*, manual: bool = False, unplaceable: tuple = (), spec_json=None):  # type: ignore[type-arg]
     from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
     from lilbee.providers.roles import WorkerRole
 
     return PlacementView(
-        gpus=(
-            GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),
-            GpuInfo(1, "CUDA", "CUDA1", "NVIDIA A100", 80 * GIB, 80 * GIB),
+        gpus=tuple(
+            GpuInfo(i, "CUDA", f"CUDA{i}", "NVIDIA A40", 44 * GIB, 44 * GIB) for i in range(4)
         ),
-        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0, 1), (1, 1), 1),),
+        roles=(
+            RolePlacementView(WorkerRole.EMBED, "org/embed.gguf", (0,), None, 1),
+            RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (1,), None, 1),
+        ),
         unplaceable=unplaceable,
         manual=manual,
-        spec_json=None,
+        spec_json=spec_json,
     )
 
 
@@ -39,85 +46,177 @@ class PlacementTestApp(LilbeeAppHost):
         self.push_screen(PlacementScreen())
 
 
+def _generated(app) -> str:  # type: ignore[no-untyped-def]
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    return str(app.screen.query_one(screen_mod._GENERATED_ID, Static).render())
+
+
 @pytest.mark.asyncio
-async def test_screen_lists_gpus(monkeypatch):
-    """GPU table renders one row per detected GPU."""
+async def test_screen_lists_gpus_with_roles(monkeypatch):
+    """GPU table renders one row per GPU and shows which role sits on each card."""
     from lilbee.cli.tui.screens import placement as screen_mod
 
     monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
         table = app.screen.query_one(screen_mod._GPU_TABLE_ID, DataTable)
-        assert table.row_count == 2
+        assert table.row_count == 4
+        # row 0 (CUDA0) Roles cell == "embed", row 1 (CUDA1) == "chat"
+        assert table.get_row_at(0)[4] == "embed"
+        assert table.get_row_at(1)[4] == "chat"
 
 
 @pytest.mark.asyncio
-async def test_screen_lists_roles(monkeypatch):
-    """Role summary reflects placed roles."""
-    from textual.widgets import Static
+async def test_toggle_device_updates_spec_and_table(monkeypatch):
+    """Clicking a GPU toggle for a role updates the spec and the table live."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.click("#dev-embed-2")  # add CUDA2 to embed
+        await pilot.pause()
+        assert '"embed": {"devices": [0, 2]}' in _generated(app)
+        table = app.screen.query_one(screen_mod._GPU_TABLE_ID, DataTable)
+        assert table.get_row_at(2)[4] == "embed"
+
+
+@pytest.mark.asyncio
+async def test_cannot_remove_last_device(monkeypatch):
+    """A role must keep at least one GPU; toggling its only device is a no-op."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.click("#dev-embed-0")  # embed's only device -> must stay
+        await pilot.pause()
+        assert '"embed": {"devices": [0]}' in _generated(app)
+
+
+@pytest.mark.asyncio
+async def test_replica_stepper(monkeypatch):
+    """The +/- stepper changes replicas (floored at 1) for a replicated role."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.click("#rep-embed-inc")  # 1 -> 2
+        await pilot.pause()
+        assert '"replicas": 2' in _generated(app)
+        await pilot.click("#rep-embed-dec")  # 2 -> 1 (omitted)
+        await pilot.pause()
+        assert "replicas" not in _generated(app)
+        await pilot.click("#rep-embed-dec")  # floored at 1
+        await pilot.pause()
+        assert "replicas" not in _generated(app)
+
+
+@pytest.mark.asyncio
+async def test_no_replica_stepper_for_chat(monkeypatch):
+    """Non-replicated roles (chat) have no replica stepper."""
+    from textual.css.query import NoMatches
 
     from lilbee.cli.tui.screens import placement as screen_mod
 
     monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
-        summary = app.screen.query_one(screen_mod._ROLE_SUMMARY_ID, Static)
-        rendered = str(summary.render())
-        assert "chat" in rendered.lower()
+        with pytest.raises(NoMatches):
+            app.screen.query_one("#rep-chat-inc", Button)
 
 
 @pytest.mark.asyncio
-async def test_screen_unplaceable_shown(monkeypatch):
-    """Unplaceable roles appear in the summary."""
-    from textual.widgets import Static
-
+async def test_preview_uses_edited_spec(monkeypatch):
+    """ctrl+r resolves the placement built from the toggles, not a stale value."""
     from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
     from lilbee.providers.roles import WorkerRole
 
-    view = _make_view(unplaceable=(WorkerRole.VISION,))
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: view)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        summary = app.screen.query_one(screen_mod._ROLE_SUMMARY_ID, Static)
-        rendered = str(summary.render())
-        assert "vision" in rendered.lower()
-
-
-@pytest.mark.asyncio
-async def test_preview_rerenders(monkeypatch):
-    """ctrl+r with a valid spec re-renders the GPU table."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
     monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    preview_calls: list[object] = []
+    calls: list[object] = []
 
     def _preview(spec):  # type: ignore[no-untyped-def]
-        preview_calls.append(spec)
+        calls.append(spec)
         return _make_view()
 
     monkeypatch.setattr(screen_mod, "preview_placement", _preview)
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
+        await pilot.click("#dev-chat-3")  # chat now on CUDA1 + CUDA3
+        await pilot.pause()
         await pilot.press("ctrl+r")
         await pilot.pause()
         await pilot.pause()
 
-    assert len(preview_calls) == 1
+    assert calls and isinstance(calls[0], PlacementSpec)
+    assert calls[0].roles[WorkerRole.CHAT].devices == (1, 3)
 
 
 @pytest.mark.asyncio
-async def test_preview_shows_fit_error(monkeypatch):
-    """ctrl+r surfaces a PlacementError as a notification, not a crash."""
+async def test_apply_uses_edited_spec(monkeypatch):
+    """ctrl+s applies the placement built from the toggles."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+    from lilbee.providers.roles import WorkerRole
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    calls: list[object] = []
+    monkeypatch.setattr(
+        screen_mod, "set_placement", lambda spec: calls.append(spec) or _make_view(manual=True)
+    )
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.click("#dev-embed-3")
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert calls and isinstance(calls[0], PlacementSpec)
+    assert calls[0].roles[WorkerRole.EMBED].devices == (0, 3)
+
+
+@pytest.mark.asyncio
+async def test_clear_calls_set_placement_none(monkeypatch):
+    """ctrl+x restores auto placement via set_placement(None)."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    calls: list[object] = []
+    monkeypatch.setattr(
+        screen_mod, "set_placement", lambda spec: calls.append(spec) or _make_view()
+    )
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+x")
+        await pilot.pause()
+        await pilot.pause()
+
+    assert calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_preview_error_notifies(monkeypatch):
+    """A PlacementError from preview surfaces as a notification, not a crash."""
     from lilbee.cli.tui.screens import placement as screen_mod
     from lilbee.providers.fleet.placement_spec import PlacementError
 
@@ -130,11 +229,9 @@ async def test_preview_shows_fit_error(monkeypatch):
 
     notes: list[str] = []
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        monkeypatch.setattr(app.screen, "notify", lambda msg, **k: notes.append(msg))
         await pilot.press("ctrl+r")
         await pilot.pause()
         await pilot.pause()
@@ -143,136 +240,8 @@ async def test_preview_shows_fit_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_apply_calls_set_placement(monkeypatch):
-    """ctrl+s calls set_placement with parsed spec."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    set_calls: list[object] = []
-    monkeypatch.setattr(
-        screen_mod, "set_placement", lambda spec: set_calls.append(spec) or _make_view()
-    )
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        await pilot.pause()
-
-    assert len(set_calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_clear_calls_set_placement_none(monkeypatch):
-    """ctrl+x calls set_placement(None) to restore auto placement."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    set_calls: list[object] = []
-
-    def _set(spec):  # type: ignore[no-untyped-def]
-        set_calls.append(spec)
-        return _make_view()
-
-    monkeypatch.setattr(screen_mod, "set_placement", _set)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        await pilot.press("ctrl+x")
-        await pilot.pause()
-        await pilot.pause()
-
-    assert set_calls == [None]
-
-
-@pytest.mark.asyncio
-async def test_apply_bad_json_notifies(monkeypatch):
-    """ctrl+s with invalid JSON shows an error notification."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    notes: list[str] = []
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = "not-valid-json"
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-
-    assert any(notes)
-
-
-@pytest.mark.asyncio
-async def test_go_back_binding(monkeypatch):
-    """q pops the screen."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        assert isinstance(app.screen, screen_mod.PlacementScreen)
-        await pilot.press("q")
-        await pilot.pause()
-
-
-@pytest.mark.asyncio
-async def test_load_placement_error_notifies(monkeypatch):
-    """An exception from get_placement on mount shows a notification."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    def _boom():
-        raise RuntimeError("probe failed")
-
-    monkeypatch.setattr(screen_mod, "get_placement", _boom)
-    notes: list[str] = []
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        screen = app.screen
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
-        screen._load_placement()
-        await pilot.pause()
-
-    assert any("probe failed" in n for n in notes)
-
-
-@pytest.mark.asyncio
-async def test_render_view_with_spec_json(monkeypatch):
-    """When spec_json is set on the view, the TextArea is seeded."""
-    from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
-    from lilbee.cli.tui.screens import placement as screen_mod
-    from lilbee.providers.roles import WorkerRole
-
-    GIB = 1024**3
-    view_with_spec = PlacementView(
-        gpus=(GpuInfo(0, "CUDA", "CUDA0", "NVIDIA A100", 80 * GIB, 72 * GIB),),
-        roles=(RolePlacementView(WorkerRole.CHAT, "org/chat.gguf", (0,), None, 1),),
-        unplaceable=(),
-        manual=True,
-        spec_json='{"chat": {"devices": [0]}}',
-    )
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: view_with_spec)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        assert screen._spec_text == '{"chat": {"devices": [0]}}'
-
-
-@pytest.mark.asyncio
-async def test_apply_worker_error_notifies(monkeypatch):
-    """An exception from set_placement shows a notification."""
+async def test_apply_error_notifies(monkeypatch):
+    """A PlacementError from set_placement surfaces as a notification."""
     from lilbee.cli.tui.screens import placement as screen_mod
     from lilbee.providers.fleet.placement_spec import PlacementError
 
@@ -285,11 +254,9 @@ async def test_apply_worker_error_notifies(monkeypatch):
 
     notes: list[str] = []
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
+        monkeypatch.setattr(app.screen, "notify", lambda msg, **k: notes.append(msg))
         await pilot.press("ctrl+s")
         await pilot.pause()
         await pilot.pause()
@@ -298,44 +265,105 @@ async def test_apply_worker_error_notifies(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_clear_worker_error_notifies(monkeypatch):
-    """An exception from set_placement(None) during clear shows a notification."""
+async def test_unplaceable_warns(monkeypatch):
+    """A role that does not fit is surfaced as a warning on load."""
     from lilbee.cli.tui.screens import placement as screen_mod
-    from lilbee.providers.fleet.placement_spec import PlacementError
+    from lilbee.providers.roles import WorkerRole
 
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    def _fail(spec):  # type: ignore[no-untyped-def]
-        raise PlacementError("clear fail")
-
-    monkeypatch.setattr(screen_mod, "set_placement", _fail)
+    view = _make_view(unplaceable=(WorkerRole.VISION,))
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: view)
 
     notes: list[str] = []
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
-        await pilot.press("ctrl+x")
-        await pilot.pause()
+    async with app.run_test(size=(140, 44)) as pilot:
+        app.screen.notify = lambda msg, **k: notes.append(msg)  # type: ignore[method-assign]
+        app.screen._load_placement()
         await pilot.pause()
 
-    assert any("clear fail" in n for n in notes)
+    assert any("vision" in n.lower() for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_apply_disables_editor_while_running(monkeypatch):
+    """ctrl+s sets applying=True and disables the editor until set_placement returns."""
+    from textual.containers import Vertical
+
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    gate = threading.Event()
+    monkeypatch.setattr(screen_mod, "set_placement", lambda spec: gate.wait())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        screen = app.screen
+        assert screen.applying is True
+        assert screen.query_one(screen_mod._EDITOR_ID, Vertical).disabled is True
+        gate.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert screen.applying is False
+
+
+@pytest.mark.asyncio
+async def test_apply_ignored_while_applying(monkeypatch):
+    """A second ctrl+s while applying is a no-op (single-flight guard)."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    calls: list[object] = []
+    gate = threading.Event()
+
+    def _blocking(spec):  # type: ignore[no-untyped-def]
+        calls.append(spec)
+        gate.wait()
+
+    monkeypatch.setattr(screen_mod, "set_placement", _blocking)
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        gate.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_go_back_binding(monkeypatch):
+    """q pops the screen."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        assert isinstance(app.screen, screen_mod.PlacementScreen)
+        await pilot.press("q")
+        await pilot.pause()
 
 
 @pytest.mark.asyncio
 async def test_go_back_single_screen(monkeypatch):
-    """action_go_back with a single-item screen_stack calls switch_view."""
+    """action_go_back with a single-item screen_stack calls switch_view('Chat')."""
     from lilbee.cli.tui.screens import placement as screen_mod
 
     monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
+    async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
         screen = app.screen
         called: list[str] = []
-        # Simulate single-screen stack so the else branch is taken.
         monkeypatch.setattr(type(app), "screen_stack", property(lambda self: [screen]))
         monkeypatch.setattr(app, "switch_view", lambda v: called.append(v))
         screen.action_go_back()
@@ -345,129 +373,21 @@ async def test_go_back_single_screen(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_preview_bad_json_notifies(monkeypatch):
-    """ctrl+r with invalid JSON shows an error notification, not a crash."""
+async def test_load_placement_error_notifies(monkeypatch):
+    """An exception from get_placement on load shows a notification."""
     from lilbee.cli.tui.screens import placement as screen_mod
 
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+    def _boom():
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(screen_mod, "get_placement", _boom)
     notes: list[str] = []
 
     app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
+    async with app.run_test(size=(140, 44)) as pilot:
         screen = app.screen
-        screen._spec_text = "not-valid-json"
-        monkeypatch.setattr(screen, "notify", lambda msg, **k: notes.append(msg))
-        await pilot.press("ctrl+r")
+        screen.notify = lambda msg, **k: notes.append(msg)  # type: ignore[method-assign]
+        screen._load_placement()
         await pilot.pause()
 
-    assert any(notes)
-
-
-@pytest.mark.asyncio
-async def test_apply_empty_spec_calls_set_placement_none(monkeypatch):
-    """ctrl+s with an empty spec passes None to set_placement."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-    set_calls: list[object] = []
-    monkeypatch.setattr(
-        screen_mod, "set_placement", lambda spec: set_calls.append(spec) or _make_view()
-    )
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = ""
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        await pilot.pause()
-
-    assert set_calls == [None]
-
-
-@pytest.mark.asyncio
-async def test_apply_disables_input_while_running(monkeypatch):
-    """ctrl+s sets applying=True and disables the TextArea until set_placement returns."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    gate = threading.Event()
-
-    def _blocking_set(spec):  # type: ignore[no-untyped-def]
-        gate.wait()
-
-    monkeypatch.setattr(screen_mod, "set_placement", _blocking_set)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        assert screen.applying is True
-        text_area = screen.query_one(screen_mod._SPEC_AREA_ID, TextArea)
-        assert text_area.disabled is True
-        gate.set()
-        await app.workers.wait_for_complete()
-        await pilot.pause()
-        assert screen.applying is False
-        assert text_area.disabled is False
-
-
-@pytest.mark.asyncio
-async def test_apply_ignored_while_applying(monkeypatch):
-    """ctrl+s is a no-op when applying is already True (double-apply guard)."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    set_calls: list[object] = []
-    gate = threading.Event()
-
-    def _blocking_set(spec):  # type: ignore[no-untyped-def]
-        set_calls.append(spec)
-        gate.wait()
-
-    monkeypatch.setattr(screen_mod, "set_placement", _blocking_set)
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        screen._spec_text = '{"chat": {"devices": [0]}}'
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        assert screen.applying is True
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        gate.set()
-        await app.workers.wait_for_complete()
-        await pilot.pause()
-
-    assert len(set_calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_clear_ignored_while_applying(monkeypatch):
-    """ctrl+x is a no-op when applying is already True."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    set_calls: list[object] = []
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        monkeypatch.setattr(screen_mod, "set_placement", lambda spec: set_calls.append(spec))
-        screen.applying = True
-        await pilot.press("ctrl+x")
-        await pilot.pause()
-
-    assert set_calls == []
+    assert any("probe failed" in n for n in notes)

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -345,19 +345,6 @@ async def test_go_back_single_screen(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_placement_screen_app_harness(monkeypatch):
-    """PlacementScreenApp mounts PlacementScreen successfully."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    app = screen_mod.PlacementScreenApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        assert isinstance(app.screen, screen_mod.PlacementScreen)
-
-
-@pytest.mark.asyncio
 async def test_preview_bad_json_notifies(monkeypatch):
     """ctrl+r with invalid JSON shows an error notification, not a crash."""
     from lilbee.cli.tui.screens import placement as screen_mod

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -7493,11 +7493,11 @@ async def test_app_nav_prev_cycles_views():
 
         app.action_nav_prev()
         await pilot.pause()
-        assert app.active_view == "Wiki"
+        assert app.active_view == "Placement"
 
         app.action_nav_prev()
         await pilot.pause()
-        assert app.active_view == "Tasks"
+        assert app.active_view == "Wiki"
 
 
 async def test_app_nav_next_cycles_views():


### PR DESCRIPTION
## Problem

The multi-GPU fleet had no way to control where models land, replica sizing was tuned for ingest throughput and could saturate VRAM, and the manual-placement surface added across the stacked PRs had a cluster of correctness gaps found in a blast-radius audit. The worst one validated placement against each card's live free VRAM, so once the fleet was warm it double-counted the resident model and reported roles as unplaceable, crashing reads (HTTP 500, CLI traceback, blank TUI editor). The spec parser also accepted nonsense (duplicate devices, zero/negative split weights, typo'd keys) and several errors surfaced as raw tracebacks or 500s.

## Solution

Consolidates the placement work that was split across #429 (configurable placement spec + CLI/HTTP/MCP/TUI), #437 (usable TUI editor + auto-split for large chat models), and #434 (elastic ingest pool with VRAM-aware replica scale-down) into one branch, and hardens the whole surface:

- Placement is charged against each card's total capacity, not its instantaneous free VRAM, so a warm fleet no longer double-counts resident models.
- The spec parser rejects duplicate devices, non-positive tensor-split weights, unknown keys, and non-integer values.
- CLI, HTTP, and MCP turn placement and provider errors into clean messages (4xx/503) instead of tracebacks and 500s. Preview now requires auth, and HTTP PUT/DELETE refuse on the shared daemon and point you to the CLI/TUI.

Validated end to end on a 4xA40 pod (driver in scripts/qa/placement_qa.py): with the chat model resident on two cards (13 GiB free against a 39 GiB per-card footprint), placement now renders instead of crashing, and the spec, error, and HTTP cases all behave.

Supersedes #429, #437, #434.
