### PR TITLE
Shared-home agent launcher: lilbee in opencode and hermes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,9 +448,9 @@ lilbee --json sync
 
 Every command returns a single JSON object on stdout. Errors return non-zero exit + `{"error": "message"}`.
 
-### Opencode integration
+### Agent integrations
 
-opencode is the supported agent integration today. `lilbee launch opencode` is the fast path. Pull chat models via the TUI catalog first (`lilbee` -> `/models`). `lilbee agent-config opencode` prints the same config block without launching. `lilbee serve` exposes `/v1/models` and `/v1/chat/completions` directly for anything custom.
+opencode and hermes are the supported agent integrations. `lilbee launch opencode` / `lilbee launch hermes` are the fast paths. Pull chat models via the TUI catalog first (`lilbee` -> `/models`). Launching registers lilbee as a provider (and the MCP search tool) directly in the agent's own config, sharing the user's existing setup rather than isolating it: only the `lilbee` keys and the active model are written, the token lives in the agent's secret store (not the config file), and `--no-mcp` (or `agent_mcp_enabled=false`) leaves lilbee as the model provider only. `lilbee agent-config opencode|hermes` prints the same block for pasting. `lilbee serve` exposes `/v1/models` and `/v1/chat/completions` directly for anything custom.
 
 See the [`lilbee-mcp` skill](docs/agent-skills/lilbee-mcp/SKILL.md) for the full MCP reference and the JSON CLI fallback for non-MCP agents.
 

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -741,7 +741,7 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         nullable=False,
         group=SettingGroup.SYSTEM,
         help_text=(
-            "Inject lilbee's MCP search tool into agent launchers (e.g. `launch opencode`). "
+            "Register lilbee's MCP search tool into agent launchers (opencode, hermes). "
             "Disable to bring your own MCP servers; lilbee stays the model provider"
         ),
     ),

--- a/src/lilbee/cli/agent_configs/config_file.py
+++ b/src/lilbee/cli/agent_configs/config_file.py
@@ -1,0 +1,55 @@
+"""Load and atomically write an agent's on-disk config, refusing to clobber a corrupt file."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import typer
+
+
+def load_config_dict(
+    path: Path,
+    *,
+    parse: Callable[[str], Any],
+    parse_error: type[Exception],
+    label: str,
+) -> dict[str, Any]:
+    """Return the parsed mapping at *path*, or ``{}`` when absent or empty.
+
+    Exits non-zero without writing when the file does not parse, so a corrupt
+    user config is never overwritten."""
+    if not path.exists():
+        return {}
+    raw = path.read_text(encoding="utf-8")
+    try:
+        parsed = parse(raw)
+    except parse_error as exc:
+        typer.secho(
+            f"Your {label} did not parse, so lilbee will not overwrite it. "
+            "Fix or remove it, then retry.",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1) from exc
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically (temp file + os.replace), creating parents."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent, suffix=".tmp", delete=False, mode="w", encoding="utf-8"
+        ) as tmp:
+            tmp_name = tmp.name
+            tmp.write(text)
+        os.replace(tmp_name, path)
+    except BaseException:
+        if tmp_name is not None:
+            Path(tmp_name).unlink(missing_ok=True)
+        raise

--- a/src/lilbee/cli/agent_configs/hermes.py
+++ b/src/lilbee/cli/agent_configs/hermes.py
@@ -10,6 +10,9 @@ _V1_SUFFIX = "/v1"
 _MCP_SUFFIX = "/mcp"
 _MCP_TRANSPORT = "streamable-http"
 _MCP_TIMEOUT_S = 120
+# hermes's custom provider defaults max_tokens to the full window, leaving ~no
+# room for input. Pin a sane output cap so the system prompt + history fit.
+_MAX_OUTPUT_TOKENS = 8192
 
 
 def hermes_config(
@@ -27,7 +30,11 @@ def hermes_config(
     ``${LILBEE_TOKEN}`` reference for the launcher (hermes expands it from the env
     at load, so the on-disk file never holds the literal token)."""
     pin = default_ref or (model_refs[0] if model_refs else None)
-    provider: dict[str, Any] = {"api": f"{base_url}{_V1_SUFFIX}", "api_key": api_key}
+    provider: dict[str, Any] = {
+        "api": f"{base_url}{_V1_SUFFIX}",
+        "api_key": api_key,
+        "max_tokens": _MAX_OUTPUT_TOKENS,
+    }
     if pin is not None:
         provider["default_model"] = pin
     if chat_ctx is not None:

--- a/src/lilbee/cli/agent_configs/hermes.py
+++ b/src/lilbee/cli/agent_configs/hermes.py
@@ -8,8 +8,6 @@ from lilbee.cli.agent_configs.merge import LILBEE_PROVIDER_KEY
 
 _V1_SUFFIX = "/v1"
 _MCP_SUFFIX = "/mcp"
-_MCP_TRANSPORT = "streamable-http"
-_MCP_TIMEOUT_S = 120
 # hermes's custom provider defaults max_tokens to the full window, leaving ~no
 # room for input. Pin a sane output cap so the system prompt + history fit.
 _MAX_OUTPUT_TOKENS = 8192
@@ -41,16 +39,24 @@ def hermes_config(
         provider["context_length"] = chat_ctx
     config: dict[str, Any] = {"providers": {LILBEE_PROVIDER_KEY: provider}}
     if include_mcp:
+        # An `url` (no `transport` key) is hermes's HTTP MCP shape; `headers`
+        # carries the bearer with ${VAR} env resolution. A `transport` string
+        # makes hermes reject the entry (it must be a mapping) -> 0 connected.
         config["mcp_servers"] = {
             LILBEE_PROVIDER_KEY: {
                 "url": f"{base_url}{_MCP_SUFFIX}",
-                "transport": _MCP_TRANSPORT,
                 "headers": {"Authorization": f"Bearer {api_key}"},
-                "timeout": _MCP_TIMEOUT_S,
             }
         }
     if pin is not None:
         # Dict form binds the active model to the lilbee provider explicitly, so the
         # pin is unambiguous even when another provider could serve the same ref.
-        config["model"] = {"default": pin, "provider": LILBEE_PROVIDER_KEY}
+        # `model.max_tokens` is hermes's documented winning output cap: without it
+        # hermes requests the full window as output, so input+output overflows and
+        # it misreads the error as "prompt too long" and compresses to nothing.
+        config["model"] = {
+            "default": pin,
+            "provider": LILBEE_PROVIDER_KEY,
+            "max_tokens": _MAX_OUTPUT_TOKENS,
+        }
     return config

--- a/src/lilbee/cli/agent_configs/hermes.py
+++ b/src/lilbee/cli/agent_configs/hermes.py
@@ -43,5 +43,7 @@ def hermes_config(
             }
         }
     if pin is not None:
-        config["model"] = pin
+        # Dict form binds the active model to the lilbee provider explicitly, so the
+        # pin is unambiguous even when another provider could serve the same ref.
+        config["model"] = {"default": pin, "provider": LILBEE_PROVIDER_KEY}
     return config

--- a/src/lilbee/cli/agent_configs/hermes.py
+++ b/src/lilbee/cli/agent_configs/hermes.py
@@ -1,0 +1,47 @@
+"""hermes config.yaml fragment builder: lilbee as a provider plus MCP search tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lilbee.cli.agent_configs.merge import LILBEE_PROVIDER_KEY
+
+_V1_SUFFIX = "/v1"
+_MCP_SUFFIX = "/mcp"
+_MCP_TRANSPORT = "streamable-http"
+_MCP_TIMEOUT_S = 120
+
+
+def hermes_config(
+    *,
+    base_url: str,
+    api_key: str,
+    model_refs: list[str],
+    default_ref: str | None = None,
+    chat_ctx: int | None = None,
+    include_mcp: bool = True,
+) -> dict[str, Any]:
+    """Return the hermes config fragment registering lilbee as a provider (and MCP).
+
+    ``api_key`` is embedded verbatim: a literal token for the paste path, or the
+    ``${LILBEE_TOKEN}`` reference for the launcher (hermes expands it from the env
+    at load, so the on-disk file never holds the literal token)."""
+    pin = default_ref or (model_refs[0] if model_refs else None)
+    provider: dict[str, Any] = {"api": f"{base_url}{_V1_SUFFIX}", "api_key": api_key}
+    if pin is not None:
+        provider["default_model"] = pin
+    if chat_ctx is not None:
+        provider["context_length"] = chat_ctx
+    config: dict[str, Any] = {"providers": {LILBEE_PROVIDER_KEY: provider}}
+    if include_mcp:
+        config["mcp_servers"] = {
+            LILBEE_PROVIDER_KEY: {
+                "url": f"{base_url}{_MCP_SUFFIX}",
+                "transport": _MCP_TRANSPORT,
+                "headers": {"Authorization": f"Bearer {api_key}"},
+                "timeout": _MCP_TIMEOUT_S,
+            }
+        }
+    if pin is not None:
+        config["model"] = pin
+    return config

--- a/src/lilbee/cli/agent_configs/merge.py
+++ b/src/lilbee/cli/agent_configs/merge.py
@@ -1,0 +1,26 @@
+"""Non-destructive deep-merge of a lilbee config fragment into a user's agent config."""
+
+from __future__ import annotations
+
+from typing import Any
+
+LILBEE_PROVIDER_KEY = "lilbee"
+
+
+def deep_merge(base: dict[str, Any], fragment: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge *fragment* into *base*; fragment wins on leaf conflicts,
+    dict values merge key-by-key so unrelated keys in *base* survive."""
+    for key, value in fragment.items():
+        existing = base.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            deep_merge(existing, value)
+        else:
+            base[key] = value
+    return base
+
+
+def prune_lilbee(config: dict[str, Any], container_key: str) -> None:
+    """Remove the lilbee entry from ``config[container_key]`` if present (for --no-mcp)."""
+    container = config.get(container_key)
+    if isinstance(container, dict):
+        container.pop(LILBEE_PROVIDER_KEY, None)

--- a/src/lilbee/cli/commands/agent_config.py
+++ b/src/lilbee/cli/commands/agent_config.py
@@ -8,8 +8,9 @@ from pathlib import Path
 from typing import Any
 
 import typer
+import yaml
 
-from lilbee.cli.agent_configs import litellm, opencode
+from lilbee.cli.agent_configs import hermes, litellm, opencode
 from lilbee.cli.app import apply_overrides, data_dir_option, global_option
 from lilbee.cli.launchers.server import (
     LOOPBACK,
@@ -36,8 +37,8 @@ def _emit_block(builder: _JsonBuilder | _TextBuilder, **kwargs: Any) -> None:
         raise typer.Exit(1)
     token, port = session
     extra = dict(kwargs)
-    if builder is opencode.opencode_config:
-        # Match `launch opencode`: pin the served model as default and pass the
+    if builder in (opencode.opencode_config, hermes.hermes_config):
+        # Match the launchers: pin the served model as default and pass the
         # context window, so the pasted config opens on a lilbee model and trims
         # history to the right limit.
         extra.setdefault("default_ref", str(cfg.chat_model))
@@ -54,6 +55,8 @@ def _emit_block(builder: _JsonBuilder | _TextBuilder, **kwargs: Any) -> None:
         # Use typer.echo (no Rich word-wrap) so YAML stays parseable when
         # piped to a file or wrapped in narrow test terminals.
         typer.echo(block, nl=False)
+    elif builder is hermes.hermes_config:
+        typer.echo(yaml.safe_dump(block, sort_keys=False), nl=False)
     else:
         typer.echo(json.dumps(block, indent=2))
 
@@ -66,6 +69,16 @@ def _opencode_cmd(
     """Print an opencode.json block (OpenAI-compatible provider + MCP server)."""
     apply_overrides(data_dir=data_dir, use_global=use_global)
     _emit_block(opencode.opencode_config)
+
+
+@agent_config_app.command("hermes")
+def _hermes_cmd(
+    data_dir: Path | None = data_dir_option,
+    use_global: bool = global_option,
+) -> None:
+    """Print a hermes config.yaml block (OpenAI-compatible provider + MCP server)."""
+    apply_overrides(data_dir=data_dir, use_global=use_global)
+    _emit_block(hermes.hermes_config)
 
 
 @agent_config_app.command("litellm")

--- a/src/lilbee/cli/launchers/__init__.py
+++ b/src/lilbee/cli/launchers/__init__.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import typer
 
+from lilbee.cli.launchers.hermes import hermes_cmd
 from lilbee.cli.launchers.opencode import opencode_cmd
 
 launch_app = typer.Typer(help="Launch a third-party AI client wired to lilbee.")
 launch_app.command("opencode")(opencode_cmd)
+launch_app.command("hermes")(hermes_cmd)

--- a/src/lilbee/cli/launchers/hermes.py
+++ b/src/lilbee/cli/launchers/hermes.py
@@ -1,0 +1,106 @@
+"""hermes launcher: registers lilbee in the user's real ~/.hermes, then runs hermes."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import typer
+import yaml
+
+from lilbee.cli.agent_configs import config_file
+from lilbee.cli.agent_configs.hermes import hermes_config
+from lilbee.cli.agent_configs.merge import deep_merge, prune_lilbee
+from lilbee.cli.launchers.launcher import LILBEE_TOKEN_ENV_VAR, run_launcher
+from lilbee.cli.launchers.server import LOOPBACK, served_chat_ctx
+from lilbee.cli.launchers.skill_install import install_bundled_skill
+from lilbee.core.config import cfg
+
+_HERMES_INSTALL_HINT = (
+    "hermes binary not found on PATH. Install it from https://github.com/NousResearch/hermes-agent."
+)
+_TOKEN_REF = "${" + LILBEE_TOKEN_ENV_VAR + "}"
+_MCP_CONTAINER_KEY = "mcp_servers"
+_CONFIG_LABEL = "hermes config (config.yaml)"
+
+
+def _hermes_home() -> Path:
+    """The user's real hermes home; never relocated, so memory and skills are shared."""
+    return Path.home() / ".hermes"
+
+
+def _hermes_config_path() -> Path:
+    return _hermes_home() / "config.yaml"
+
+
+def _hermes_env_path() -> Path:
+    return _hermes_home() / ".env"
+
+
+def _hermes_skill_dest() -> Path:
+    return _hermes_home() / "skills" / "lilbee-mcp"
+
+
+def _upsert_env_token(path: Path, token: str) -> None:
+    """Set ``LILBEE_TOKEN=<token>`` in the hermes ``.env`` (0600), preserving other lines."""
+    line = f"{LILBEE_TOKEN_ENV_VAR}={token}"
+    existing = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+    kept = [ln for ln in existing if not ln.startswith(f"{LILBEE_TOKEN_ENV_VAR}=")]
+    config_file.atomic_write_text(path, "\n".join([*kept, line]) + "\n")
+    if os.name == "posix":
+        path.chmod(0o600)
+
+
+class HermesLauncher:
+    """``Launcher`` implementation for hermes-agent."""
+
+    name = "hermes"
+    install_hint = _HERMES_INSTALL_HINT
+
+    def __init__(self, *, include_mcp: bool = True) -> None:
+        self._include_mcp = include_mcp
+
+    def find_binary(self) -> str | None:
+        return shutil.which("hermes")
+
+    def prepare(
+        self, *, token: str, port: int, model_refs: list[str]
+    ) -> tuple[list[str], dict[str, str]]:
+        config = config_file.load_config_dict(
+            _hermes_config_path(),
+            parse=yaml.safe_load,
+            parse_error=yaml.YAMLError,
+            label=_CONFIG_LABEL,
+        )
+        fragment = hermes_config(
+            base_url=f"http://{LOOPBACK}:{port}",
+            api_key=_TOKEN_REF,
+            model_refs=model_refs,
+            default_ref=str(cfg.chat_model),
+            chat_ctx=served_chat_ctx(port),
+            include_mcp=self._include_mcp,
+        )
+        deep_merge(config, fragment)
+        if not self._include_mcp:
+            prune_lilbee(config, _MCP_CONTAINER_KEY)
+        config_file.atomic_write_text(
+            _hermes_config_path(), yaml.safe_dump(config, sort_keys=False)
+        )
+        _upsert_env_token(_hermes_env_path(), token)
+        if self._include_mcp:
+            install_bundled_skill(_hermes_skill_dest())
+        return ([], {**os.environ, LILBEE_TOKEN_ENV_VAR: token})
+
+
+def hermes_cmd(
+    mcp: bool | None = typer.Option(
+        None,
+        "--mcp/--no-mcp",
+        help="Register lilbee's MCP search tool into hermes. Defaults to the "
+        "agent_mcp_enabled config; --mcp/--no-mcp overrides it for this launch.",
+    ),
+) -> None:
+    """Launch hermes with lilbee registered as its model provider."""
+    include_mcp = cfg.agent_mcp_enabled if mcp is None else mcp
+    run_launcher(HermesLauncher(include_mcp=include_mcp))

--- a/src/lilbee/cli/launchers/launcher.py
+++ b/src/lilbee/cli/launchers/launcher.py
@@ -16,6 +16,10 @@ from lilbee.cli.launchers.server import (
 from lilbee.core.config import cfg
 from lilbee.providers.model_ref import with_configured_remote_chat
 
+# The env var each launcher sets to the live session token; the written config
+# references it (opencode `{env:...}`, hermes `${...}`) so no literal lands on disk.
+LILBEE_TOKEN_ENV_VAR = "LILBEE_TOKEN"  # noqa: S105 (env var name, not a secret)
+
 
 class Launcher(Protocol):
     """A third-party AI client that lilbee knows how to launch."""

--- a/src/lilbee/cli/launchers/opencode.py
+++ b/src/lilbee/cli/launchers/opencode.py
@@ -7,20 +7,26 @@ import os
 import shutil
 import sys
 import tempfile
-from importlib import resources
 from pathlib import Path
 
 import typer
 
+from lilbee.cli.agent_configs import config_file
+from lilbee.cli.agent_configs.merge import deep_merge, prune_lilbee
 from lilbee.cli.agent_configs.opencode import opencode_config
-from lilbee.cli.launchers.launcher import run_launcher
+from lilbee.cli.launchers.launcher import LILBEE_TOKEN_ENV_VAR, run_launcher
 from lilbee.cli.launchers.server import LOOPBACK, served_chat_ctx
+from lilbee.cli.launchers.skill_install import install_bundled_skill
 from lilbee.core.config import cfg
 
 _OPENCODE_INSTALL_HINT = "opencode binary not found on PATH. Install it from https://opencode.ai/."
-_SKILL_PACKAGE = "lilbee.skills.lilbee_mcp"
-_OPENCODE_CONFIG_ENV_VAR = "OPENCODE_CONFIG_CONTENT"
+_TOKEN_REF = "{env:" + LILBEE_TOKEN_ENV_VAR + "}"
 _SETUP_MARKER_NAME = "opencode-setup.json"
+_MCP_CONTAINER_KEY = "mcp"
+
+
+def _opencode_config_path() -> Path:
+    return Path.home() / ".config" / "opencode" / "opencode.json"
 
 
 def _opencode_skill_dest() -> Path:
@@ -55,11 +61,12 @@ def _record_setup() -> None:
 def _print_setup_plan() -> None:
     """Tell the user exactly which files the first-run setup writes."""
     typer.secho("First-time opencode setup will write:", fg=typer.colors.CYAN)
+    typer.echo(f"  - lilbee provider + MCP entry -> {_opencode_config_path()}")
     typer.echo(f"  - lilbee MCP skill -> {_opencode_skill_dest()}")
     typer.echo(
-        "The write is skipped if already present; everything else (provider, "
-        "MCP, model pin) is passed to opencode per session and persists nowhere. "
-        "To undo, delete the skill dir."
+        "Only the `lilbee` keys and the active model are written; your other "
+        "providers and settings are preserved. The token is referenced by env, "
+        "never written as a literal. To undo, remove the `lilbee` entries and the skill dir."
     )
 
 
@@ -88,31 +95,6 @@ def _confirm_setup(assume_yes: bool) -> bool:
     return True
 
 
-def _install_lilbee_skill() -> Path | None:
-    """Copy the bundled lilbee MCP skill into opencode's global skills dir.
-
-    Skip when the destination already exists so user customizations are
-    preserved. Returns the destination path on a fresh copy, else ``None``.
-    """
-    dest = _opencode_skill_dest()
-    if dest.exists():
-        return None
-    source = resources.files(_SKILL_PACKAGE)
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    # Build in a temp dir and atomically rename, so a failed/partial copy never
-    # leaves a half-written skill dir that exists() would then skip forever.
-    staging = Path(tempfile.mkdtemp(dir=dest.parent, prefix=".lilbee-mcp-"))
-    try:
-        for entry in source.iterdir():
-            if entry.is_file() and not entry.name.startswith("__"):
-                (staging / entry.name).write_bytes(entry.read_bytes())
-        os.replace(staging, dest)
-    except BaseException:
-        shutil.rmtree(staging, ignore_errors=True)
-        raise
-    return dest
-
-
 class OpencodeLauncher:
     """``Launcher`` implementation for opencode (https://opencode.ai/)."""
 
@@ -134,19 +116,28 @@ class OpencodeLauncher:
         # The lilbee-mcp guidance skill only helps when the MCP tool is wired in;
         # skip it when MCP is disabled (a previously-installed skill is left alone).
         if self._include_mcp:
-            _install_lilbee_skill()
-        # The block carries the session's ephemeral port and token; never persist
-        # it into user config.
+            install_bundled_skill(_opencode_skill_dest())
+        # The token is referenced via {env:...}; opencode expands it at load, so the
+        # written config never holds the literal. The launcher sets it in the env.
         block = opencode_config(
             base_url=f"http://{LOOPBACK}:{port}",
-            api_key=token,
+            api_key=_TOKEN_REF,
             model_refs=model_refs,
             chat_ctx=served_chat_ctx(port),
             default_ref=str(cfg.chat_model),
             include_mcp=self._include_mcp,
         )
-        env = {**os.environ, _OPENCODE_CONFIG_ENV_VAR: json.dumps(block)}
-        return ([], env)
+        config = config_file.load_config_dict(
+            _opencode_config_path(),
+            parse=json.loads,
+            parse_error=json.JSONDecodeError,
+            label="opencode config (opencode.json)",
+        )
+        deep_merge(config, block)
+        if not self._include_mcp:
+            prune_lilbee(config, _MCP_CONTAINER_KEY)
+        config_file.atomic_write_text(_opencode_config_path(), json.dumps(config, indent=2))
+        return ([], {**os.environ, LILBEE_TOKEN_ENV_VAR: token})
 
 
 def opencode_cmd(

--- a/src/lilbee/cli/launchers/opencode.py
+++ b/src/lilbee/cli/launchers/opencode.py
@@ -113,10 +113,6 @@ class OpencodeLauncher:
     ) -> tuple[list[str], dict[str, str]]:
         if not _confirm_setup(self._assume_yes):
             raise typer.Exit(0)
-        # The lilbee-mcp guidance skill only helps when the MCP tool is wired in;
-        # skip it when MCP is disabled (a previously-installed skill is left alone).
-        if self._include_mcp:
-            install_bundled_skill(_opencode_skill_dest())
         # The token is referenced via {env:...}; opencode expands it at load, so the
         # written config never holds the literal. The launcher sets it in the env.
         block = opencode_config(
@@ -127,6 +123,8 @@ class OpencodeLauncher:
             default_ref=str(cfg.chat_model),
             include_mcp=self._include_mcp,
         )
+        # Load (and validate) before any side effect, so a corrupt config aborts
+        # without writing or installing anything.
         config = config_file.load_config_dict(
             _opencode_config_path(),
             parse=json.loads,
@@ -137,6 +135,10 @@ class OpencodeLauncher:
         if not self._include_mcp:
             prune_lilbee(config, _MCP_CONTAINER_KEY)
         config_file.atomic_write_text(_opencode_config_path(), json.dumps(config, indent=2))
+        # The lilbee-mcp guidance skill only helps when the MCP tool is wired in;
+        # skip it when MCP is disabled (a previously-installed skill is left alone).
+        if self._include_mcp:
+            install_bundled_skill(_opencode_skill_dest())
         return ([], {**os.environ, LILBEE_TOKEN_ENV_VAR: token})
 
 

--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -245,7 +245,9 @@ def ensure_server_running() -> tuple[tuple[str, int], subprocess.Popen[bytes] | 
         return existing, None
     last_port = 0
     for _ in range(_SPAWN_ATTEMPTS):
-        last_port = free_port()
+        # Honor a user-pinned port so a persisted agent config keeps a valid URL;
+        # fall back to a free port when unset (0).
+        last_port = cfg.server_port or free_port()
         spawned = _spawn_and_wait(last_port)
         if spawned is not None:
             return _session_for_spawned(spawned), spawned

--- a/src/lilbee/cli/launchers/skill_install.py
+++ b/src/lilbee/cli/launchers/skill_install.py
@@ -1,0 +1,31 @@
+"""Install the bundled lilbee-mcp guidance skill into an agent's skills directory."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from importlib import resources
+from pathlib import Path
+
+_SKILL_PACKAGE = "lilbee.skills.lilbee_mcp"
+
+
+def install_bundled_skill(dest: Path) -> Path | None:
+    """Copy the bundled lilbee-mcp skill into *dest*; skip (return None) if it exists."""
+    if dest.exists():
+        return None
+    source = resources.files(_SKILL_PACKAGE)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Stage in a sibling temp dir and atomically rename so a partial copy never
+    # leaves a half-written skill dir that exists() would then skip forever.
+    staging = Path(tempfile.mkdtemp(dir=dest.parent, prefix=".lilbee-mcp-"))
+    try:
+        for entry in source.iterdir():
+            if entry.is_file() and not entry.name.startswith("__"):
+                (staging / entry.name).write_bytes(entry.read_bytes())
+        os.replace(staging, dest)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return dest

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -75,9 +75,8 @@ class Config(BaseSettings):
     # ~-substitution / left-truncation for project paths. Toggled by F4.
     show_lilbee_path: bool = ConfigField(default=False, writable=True)
 
-    # Whether an agent launcher (today only `launch opencode`) injects lilbee's
-    # MCP search tool into the agent's session config. Generic name so future
-    # launchers can read the same field. Per-launch --mcp/--no-mcp overrides it.
+    # Whether an agent launcher (opencode, hermes) registers lilbee's MCP search
+    # tool into the agent's config. Per-launch --mcp/--no-mcp overrides it.
     agent_mcp_enabled: bool = ConfigField(default=True, writable=True)
 
     chat_model: str = Field(default="Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf", min_length=1)

--- a/tests/cli/test_agent_config_hermes.py
+++ b/tests/cli/test_agent_config_hermes.py
@@ -1,0 +1,121 @@
+"""Tests for the hermes config-fragment builder and `lilbee agent-config hermes`."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from lilbee.catalog.types import ModelTask
+from lilbee.cli import app
+from lilbee.cli.agent_configs.hermes import hermes_config
+from lilbee.core.config import cfg
+from lilbee.server.auth import server_json_path
+
+runner = CliRunner()
+
+_REF = "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf"
+_TOKEN = "tok-abc"
+_PORT = 8123
+
+
+def test_provider_block_shape():
+    cfg_frag = hermes_config(
+        base_url="http://127.0.0.1:8080",
+        api_key="${LILBEE_TOKEN}",
+        model_refs=[_REF],
+        default_ref=_REF,
+        chat_ctx=8192,
+    )
+    prov = cfg_frag["providers"]["lilbee"]
+    assert prov["api"] == "http://127.0.0.1:8080/v1"
+    assert prov["api_key"] == "${LILBEE_TOKEN}"
+    assert prov["default_model"] == _REF
+    assert prov["context_length"] == 8192
+    assert cfg_frag["model"] == _REF
+
+
+def test_mcp_block_streamable_http_with_bearer():
+    cfg_frag = hermes_config(
+        base_url="http://127.0.0.1:8080", api_key="${LILBEE_TOKEN}", model_refs=[_REF]
+    )
+    mcp = cfg_frag["mcp_servers"]["lilbee"]
+    assert mcp["url"] == "http://127.0.0.1:8080/mcp"
+    assert mcp["transport"] == "streamable-http"
+    assert mcp["headers"]["Authorization"] == "Bearer ${LILBEE_TOKEN}"
+    assert mcp["timeout"] == 120
+
+
+def test_no_mcp_omits_block():
+    cfg_frag = hermes_config(
+        base_url="http://127.0.0.1:8080",
+        api_key="${LILBEE_TOKEN}",
+        model_refs=[_REF],
+        include_mcp=False,
+    )
+    assert "mcp_servers" not in cfg_frag
+
+
+def test_literal_api_key_inline_for_paste():
+    cfg_frag = hermes_config(
+        base_url="http://127.0.0.1:8080", api_key="literal-tok", model_refs=[_REF]
+    )
+    assert cfg_frag["providers"]["lilbee"]["api_key"] == "literal-tok"
+    assert cfg_frag["mcp_servers"]["lilbee"]["headers"]["Authorization"] == "Bearer literal-tok"
+
+
+def test_default_falls_back_to_first_model_ref():
+    cfg_frag = hermes_config(base_url="http://127.0.0.1:8080", api_key="k", model_refs=[_REF])
+    assert cfg_frag["model"] == _REF
+    assert cfg_frag["providers"]["lilbee"]["default_model"] == _REF
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("LILBEE_DATA", raising=False)
+    snapshot = cfg.model_copy()
+    cfg.data_root = tmp_path
+    cfg.data_dir = tmp_path / "data"
+    cfg.data_dir.mkdir(exist_ok=True)
+    yield tmp_path
+    for name in type(cfg).model_fields:
+        setattr(cfg, name, getattr(snapshot, name))
+
+
+@pytest.fixture(autouse=True)
+def _stub_registry():
+    manifest = MagicMock()
+    manifest.ref = _REF
+    manifest.task = ModelTask.CHAT
+    registry = MagicMock()
+    registry.list_installed.return_value = [manifest]
+    services = MagicMock()
+    services.registry = registry
+    with patch("lilbee.cli.launchers.server.get_services", return_value=services):
+        yield
+
+
+def _write_server_session() -> None:
+    server_json_path().write_text(json.dumps({"token": _TOKEN}))
+    (cfg.data_dir / "server.port").write_text(str(_PORT))
+
+
+def test_agent_config_hermes_prints_yaml_block(monkeypatch):
+    _write_server_session()
+    monkeypatch.setattr("lilbee.cli.commands.agent_config.served_chat_ctx", lambda _p: None)
+    result = runner.invoke(app, ["agent-config", "hermes"])
+    assert result.exit_code == 0
+    block = yaml.safe_load(result.stdout)
+    assert "lilbee" in block["providers"]
+    assert block["providers"]["lilbee"]["api"] == f"http://127.0.0.1:{_PORT}/v1"
+    # Paste path embeds the literal token (explicit copy), not an env ref.
+    assert block["providers"]["lilbee"]["api_key"] == _TOKEN
+
+
+def test_agent_config_hermes_requires_running_server():
+    result = runner.invoke(app, ["agent-config", "hermes"])
+    assert result.exit_code == 1
+    assert "lilbee serve" in result.stderr

--- a/tests/cli/test_agent_config_hermes.py
+++ b/tests/cli/test_agent_config_hermes.py
@@ -35,7 +35,7 @@ def test_provider_block_shape():
     assert prov["api_key"] == "${LILBEE_TOKEN}"
     assert prov["default_model"] == _REF
     assert prov["context_length"] == 8192
-    assert cfg_frag["model"] == _REF
+    assert cfg_frag["model"] == {"default": _REF, "provider": "lilbee"}
 
 
 def test_mcp_block_streamable_http_with_bearer():
@@ -69,7 +69,7 @@ def test_literal_api_key_inline_for_paste():
 
 def test_default_falls_back_to_first_model_ref():
     cfg_frag = hermes_config(base_url="http://127.0.0.1:8080", api_key="k", model_refs=[_REF])
-    assert cfg_frag["model"] == _REF
+    assert cfg_frag["model"] == {"default": _REF, "provider": "lilbee"}
     assert cfg_frag["providers"]["lilbee"]["default_model"] == _REF
 
 

--- a/tests/cli/test_agent_config_hermes.py
+++ b/tests/cli/test_agent_config_hermes.py
@@ -36,18 +36,18 @@ def test_provider_block_shape():
     assert prov["max_tokens"] == 8192  # output cap so input fits the window
     assert prov["default_model"] == _REF
     assert prov["context_length"] == 8192
-    assert cfg_frag["model"] == {"default": _REF, "provider": "lilbee"}
+    assert cfg_frag["model"] == {"default": _REF, "provider": "lilbee", "max_tokens": 8192}
 
 
-def test_mcp_block_streamable_http_with_bearer():
+def test_mcp_block_url_with_bearer_header():
     cfg_frag = hermes_config(
         base_url="http://127.0.0.1:8080", api_key="${LILBEE_TOKEN}", model_refs=[_REF]
     )
     mcp = cfg_frag["mcp_servers"]["lilbee"]
     assert mcp["url"] == "http://127.0.0.1:8080/mcp"
-    assert mcp["transport"] == "streamable-http"
+    # url alone = HTTP transport; a `transport` string makes hermes reject the entry.
+    assert "transport" not in mcp
     assert mcp["headers"]["Authorization"] == "Bearer ${LILBEE_TOKEN}"
-    assert mcp["timeout"] == 120
 
 
 def test_no_mcp_omits_block():
@@ -70,7 +70,7 @@ def test_literal_api_key_inline_for_paste():
 
 def test_default_falls_back_to_first_model_ref():
     cfg_frag = hermes_config(base_url="http://127.0.0.1:8080", api_key="k", model_refs=[_REF])
-    assert cfg_frag["model"] == {"default": _REF, "provider": "lilbee"}
+    assert cfg_frag["model"] == {"default": _REF, "provider": "lilbee", "max_tokens": 8192}
     assert cfg_frag["providers"]["lilbee"]["default_model"] == _REF
 
 

--- a/tests/cli/test_agent_config_hermes.py
+++ b/tests/cli/test_agent_config_hermes.py
@@ -33,6 +33,7 @@ def test_provider_block_shape():
     prov = cfg_frag["providers"]["lilbee"]
     assert prov["api"] == "http://127.0.0.1:8080/v1"
     assert prov["api_key"] == "${LILBEE_TOKEN}"
+    assert prov["max_tokens"] == 8192  # output cap so input fits the window
     assert prov["default_model"] == _REF
     assert prov["context_length"] == 8192
     assert cfg_frag["model"] == {"default": _REF, "provider": "lilbee"}

--- a/tests/cli/test_agent_config_merge.py
+++ b/tests/cli/test_agent_config_merge.py
@@ -1,0 +1,51 @@
+"""Tests for the non-destructive config deep-merge."""
+
+from __future__ import annotations
+
+from lilbee.cli.agent_configs.merge import LILBEE_PROVIDER_KEY, deep_merge, prune_lilbee
+
+
+def test_adds_lilbee_into_empty_config():
+    out = deep_merge({}, {"provider": {LILBEE_PROVIDER_KEY: {"name": "lilbee"}}})
+    assert out == {"provider": {LILBEE_PROVIDER_KEY: {"name": "lilbee"}}}
+
+
+def test_preserves_sibling_providers():
+    base = {"provider": {"anthropic": {"name": "anthropic"}}, "theme": "dark"}
+    deep_merge(base, {"provider": {LILBEE_PROVIDER_KEY: {"name": "lilbee"}}, "model": "lilbee/x"})
+    assert base["provider"]["anthropic"] == {"name": "anthropic"}
+    assert base["provider"][LILBEE_PROVIDER_KEY] == {"name": "lilbee"}
+    assert base["theme"] == "dark"
+    assert base["model"] == "lilbee/x"
+
+
+def test_refresh_overwrites_only_lilbee_leaf():
+    base = {"provider": {LILBEE_PROVIDER_KEY: {"options": {"baseURL": "old"}}}}
+    deep_merge(base, {"provider": {LILBEE_PROVIDER_KEY: {"options": {"baseURL": "new"}}}})
+    assert base["provider"][LILBEE_PROVIDER_KEY]["options"]["baseURL"] == "new"
+
+
+def test_idempotent():
+    frag = {"provider": {LILBEE_PROVIDER_KEY: {"name": "lilbee"}}, "model": "lilbee/x"}
+    a = deep_merge({}, frag)
+    b = deep_merge(deep_merge({}, frag), frag)
+    assert a == b
+
+
+def test_fragment_leaf_replaces_non_dict_base():
+    base = {"model": {"was": "dict"}}
+    deep_merge(base, {"model": "lilbee/x"})
+    assert base["model"] == "lilbee/x"
+
+
+def test_prune_removes_only_lilbee_entry():
+    base = {"mcp": {"lilbee": {"url": "x"}, "other": {"url": "y"}}}
+    prune_lilbee(base, "mcp")
+    assert base["mcp"] == {"other": {"url": "y"}}
+
+
+def test_prune_noop_when_absent():
+    base = {"mcp": {"other": {"url": "y"}}}
+    prune_lilbee(base, "mcp")
+    assert base["mcp"] == {"other": {"url": "y"}}
+    prune_lilbee({}, "mcp")  # missing container is a no-op

--- a/tests/cli/test_config_file.py
+++ b/tests/cli/test_config_file.py
@@ -1,0 +1,67 @@
+"""Tests for agent config-file load/atomic-write helpers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import typer
+
+from lilbee.cli.agent_configs import config_file
+
+
+def test_load_returns_empty_when_absent(tmp_path):
+    out = config_file.load_config_dict(
+        tmp_path / "missing.json", parse=json.loads, parse_error=json.JSONDecodeError, label="x"
+    )
+    assert out == {}
+
+
+def test_load_returns_parsed_mapping(tmp_path):
+    path = tmp_path / "c.json"
+    path.write_text(json.dumps({"a": 1}))
+    out = config_file.load_config_dict(
+        path, parse=json.loads, parse_error=json.JSONDecodeError, label="x"
+    )
+    assert out == {"a": 1}
+
+
+def test_load_returns_empty_for_non_mapping(tmp_path):
+    path = tmp_path / "c.json"
+    path.write_text(json.dumps([1, 2, 3]))
+    out = config_file.load_config_dict(
+        path, parse=json.loads, parse_error=json.JSONDecodeError, label="x"
+    )
+    assert out == {}
+
+
+def test_load_refuses_corrupt_file(tmp_path):
+    path = tmp_path / "c.json"
+    path.write_text("{ not valid")
+    with pytest.raises(typer.Exit) as exc:
+        config_file.load_config_dict(
+            path, parse=json.loads, parse_error=json.JSONDecodeError, label="opencode config"
+        )
+    assert exc.value.exit_code == 1
+    assert path.read_text() == "{ not valid"  # untouched
+
+
+def test_atomic_write_creates_parents_and_writes(tmp_path):
+    path = tmp_path / "nested" / "c.json"
+    config_file.atomic_write_text(path, '{"a": 1}')
+    assert json.loads(path.read_text()) == {"a": 1}
+    assert not list((tmp_path / "nested").glob("*.tmp"))
+
+
+def test_atomic_write_leaves_no_litter_on_failure(tmp_path, monkeypatch):
+    path = tmp_path / "c.json"
+    path.write_text("original")
+
+    def _boom(*_a, **_k):
+        raise OSError("rename failed")
+
+    monkeypatch.setattr(config_file.os, "replace", _boom)
+    with pytest.raises(OSError):
+        config_file.atomic_write_text(path, "new")
+    assert path.read_text() == "original"
+    assert not list(tmp_path.glob("*.tmp"))

--- a/tests/cli/test_launch_hermes.py
+++ b/tests/cli/test_launch_hermes.py
@@ -1,0 +1,182 @@
+"""Tests for ``lilbee launch hermes``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from lilbee.catalog.types import ModelTask
+from lilbee.cli import app
+from lilbee.core.config import cfg
+from lilbee.server.auth import server_json_path
+
+runner = CliRunner()
+
+_CHAT_REF = "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf"
+_TOKEN = "hermes-token-xyz"
+_PORT = 8771
+
+
+def _write_server_session() -> None:
+    server_json_path().write_text(json.dumps({"token": _TOKEN}))
+    (cfg.data_dir / "server.port").write_text(str(_PORT))
+
+
+def _hermes_config(home: Path) -> dict:
+    return yaml.safe_load((home / ".hermes" / "config.yaml").read_text())
+
+
+@pytest.fixture(autouse=True)
+def _stub_registry():
+    manifest = MagicMock()
+    manifest.ref = _CHAT_REF
+    manifest.task = ModelTask.CHAT
+    registry = MagicMock()
+    registry.list_installed.return_value = [manifest]
+    services = MagicMock()
+    services.registry = registry
+    with patch("lilbee.cli.launchers.server.get_services", return_value=services):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _healthy_and_warm(monkeypatch):
+    monkeypatch.setattr("lilbee.cli.launchers.server.health_ok", lambda _port: True)
+    monkeypatch.setattr("lilbee.cli.launchers.launcher.wait_for_chat_warm", lambda _port: True)
+    monkeypatch.setattr("lilbee.cli.launchers.hermes.served_chat_ctx", lambda _port: None)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path, monkeypatch) -> Path:
+    monkeypatch.delenv("LILBEE_DATA", raising=False)
+    snapshot = cfg.model_copy()
+    cfg.data_root = tmp_path
+    cfg.documents_dir = tmp_path / "documents"
+    cfg.documents_dir.mkdir(exist_ok=True)
+    cfg.data_dir = tmp_path / "data"
+    cfg.data_dir.mkdir(exist_ok=True)
+    cfg.lancedb_dir = tmp_path / "data" / "lancedb"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    yield tmp_path
+    for name in type(cfg).model_fields:
+        setattr(cfg, name, getattr(snapshot, name))
+
+
+def test_find_binary_miss_exits_1():
+    _write_server_session()
+    with patch("lilbee.cli.launchers.hermes.shutil.which", return_value=None):
+        result = runner.invoke(app, ["launch", "hermes"])
+    assert result.exit_code == 1
+    assert "hermes binary not found" in result.stderr
+
+
+def test_launch_hermes_writes_provider_token_not_literal(tmp_path):
+    _write_server_session()
+    completed = MagicMock(returncode=0)
+    with (
+        patch("lilbee.cli.launchers.hermes.shutil.which", return_value="/usr/local/bin/hermes"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed) as run,
+        patch("lilbee.cli.launchers.server.spawn_server"),
+    ):
+        result = runner.invoke(app, ["launch", "hermes"])
+
+    assert result.exit_code == 0
+    config = _hermes_config(tmp_path)
+    prov = config["providers"]["lilbee"]
+    assert prov["api"] == f"http://127.0.0.1:{_PORT}/v1"
+    assert prov["api_key"] == "${LILBEE_TOKEN}"
+    config_text = (tmp_path / ".hermes" / "config.yaml").read_text()
+    assert _TOKEN not in config_text  # token never in the config file
+    env_text = (tmp_path / ".hermes" / ".env").read_text()
+    assert f"LILBEE_TOKEN={_TOKEN}" in env_text  # only in the secret store
+    assert run.call_args.kwargs["env"]["LILBEE_TOKEN"] == _TOKEN
+
+
+def test_launch_hermes_preserves_existing_config(tmp_path):
+    _write_server_session()
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"providers": {"openrouter": {"api": "x"}}, "memory": {"k": 1}})
+    )
+    completed = MagicMock(returncode=0)
+    with (
+        patch("lilbee.cli.launchers.hermes.shutil.which", return_value="/usr/local/bin/hermes"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed),
+        patch("lilbee.cli.launchers.server.spawn_server"),
+    ):
+        runner.invoke(app, ["launch", "hermes"])
+
+    config = _hermes_config(tmp_path)
+    assert config["providers"]["openrouter"] == {"api": "x"}
+    assert config["memory"] == {"k": 1}
+    assert "lilbee" in config["providers"]
+
+
+def test_launch_hermes_refuses_corrupt_config(tmp_path):
+    _write_server_session()
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("{ this: is: not: yaml")
+    with (
+        patch("lilbee.cli.launchers.hermes.shutil.which", return_value="/usr/local/bin/hermes"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run") as run,
+        patch("lilbee.cli.launchers.server.spawn_server"),
+    ):
+        result = runner.invoke(app, ["launch", "hermes"])
+    assert result.exit_code == 1
+    assert "did not parse" in result.stderr
+    assert (home / "config.yaml").read_text() == "{ this: is: not: yaml"
+    run.assert_not_called()
+
+
+def test_launch_hermes_no_mcp_prunes_stale_entry(tmp_path):
+    _write_server_session()
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(yaml.safe_dump({"mcp_servers": {"lilbee": {"url": "old"}}}))
+    completed = MagicMock(returncode=0)
+    with (
+        patch("lilbee.cli.launchers.hermes.shutil.which", return_value="/usr/local/bin/hermes"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed),
+        patch("lilbee.cli.launchers.server.spawn_server"),
+    ):
+        runner.invoke(app, ["launch", "hermes", "--no-mcp"])
+    config = _hermes_config(tmp_path)
+    assert "lilbee" not in config.get("mcp_servers", {})
+    assert "lilbee" in config["providers"]  # provider stays; only MCP removed
+
+
+def test_launch_hermes_installs_skill(tmp_path):
+    _write_server_session()
+    completed = MagicMock(returncode=0)
+    with (
+        patch("lilbee.cli.launchers.hermes.shutil.which", return_value="/usr/local/bin/hermes"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed),
+        patch("lilbee.cli.launchers.server.spawn_server"),
+    ):
+        runner.invoke(app, ["launch", "hermes"])
+    assert (tmp_path / ".hermes" / "skills" / "lilbee-mcp" / "SKILL.md").exists()
+
+
+def test_launch_hermes_env_upsert_preserves_other_lines(tmp_path):
+    _write_server_session()
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text("OTHER=1\nLILBEE_TOKEN=stale\n")
+    completed = MagicMock(returncode=0)
+    with (
+        patch("lilbee.cli.launchers.hermes.shutil.which", return_value="/usr/local/bin/hermes"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed),
+        patch("lilbee.cli.launchers.server.spawn_server"),
+    ):
+        runner.invoke(app, ["launch", "hermes"])
+    env_text = (home / ".env").read_text()
+    assert "OTHER=1" in env_text
+    assert f"LILBEE_TOKEN={_TOKEN}" in env_text
+    assert "LILBEE_TOKEN=stale" not in env_text

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -93,7 +93,11 @@ def test_launch_opencode_without_binary_exits_1():
     assert "opencode binary not found" in result.stderr
 
 
-def test_launch_opencode_with_running_server_emits_inline_config_env(tmp_path):
+def _written_opencode_config(tmp_path: Path) -> dict:
+    return json.loads((tmp_path / ".config" / "opencode" / "opencode.json").read_text())
+
+
+def test_launch_opencode_with_running_server_writes_provider_into_config(tmp_path):
     _write_server_session()
     fake_opencode = "/usr/local/bin/opencode"
     completed = MagicMock(returncode=0)
@@ -107,18 +111,20 @@ def test_launch_opencode_with_running_server_emits_inline_config_env(tmp_path):
     assert result.exit_code == 0
     spawn.assert_not_called()
     run.assert_called_once()
-    _, call_kwargs = run.call_args
-    raw = call_kwargs["env"]["OPENCODE_CONFIG_CONTENT"]
-    payload = json.loads(raw)
+    env = run.call_args.kwargs["env"]
+    assert env["LILBEE_TOKEN"] == _TOKEN  # token reaches the child via env
+    assert "OPENCODE_CONFIG_CONTENT" not in env  # ephemeral injection is gone
+    payload = _written_opencode_config(tmp_path)
     options = payload["provider"]["lilbee"]["options"]
     assert options["baseURL"] == f"http://127.0.0.1:{_PORT}/v1"
-    assert options["apiKey"] == _TOKEN
+    assert options["apiKey"] == "{env:LILBEE_TOKEN}"  # reference, not the literal
+    assert _TOKEN not in json.dumps(payload)  # no literal token on disk
     assert _CHAT_REF in payload["provider"]["lilbee"]["models"]
     mcp_entry = payload["mcp"]["lilbee"]
     assert mcp_entry["type"] == "remote"
     assert mcp_entry["enabled"] is True
     assert mcp_entry["url"] == f"http://127.0.0.1:{_PORT}/mcp"
-    assert mcp_entry["headers"]["Authorization"] == f"Bearer {_TOKEN}"
+    assert mcp_entry["headers"]["Authorization"] == "Bearer {env:LILBEE_TOKEN}"
     # Startup pin: without the top-level model key opencode boots on its own
     # default provider instead of the lilbee-served chat model.
     assert payload["model"] == f"lilbee/{cfg.chat_model}"
@@ -397,31 +403,44 @@ def test_launch_opencode_installs_skill_into_global_skills_dir(tmp_path):
     assert "lilbee-mcp" in skill_path.read_text()
 
 
-def _config_block_from_launch(args: list[str]) -> dict:
+def _config_block_from_launch(args: list[str], tmp_path: Path) -> dict:
     """Invoke ``launch opencode`` (with given extra args) and return the
-    opencode config block prepare() injected into the child env."""
-    import json
-
-    from lilbee.cli.launchers.opencode import _OPENCODE_CONFIG_ENV_VAR
-
+    opencode config block prepare() merged into the user's opencode.json."""
     _write_server_session()
     completed = MagicMock(returncode=0)
     with (
         patch("lilbee.cli.launchers.opencode.shutil.which", return_value="/usr/local/bin/opencode"),
-        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed) as mock_run,
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed),
     ):
         runner.invoke(app, ["launch", *args])
-    env = mock_run.call_args.kwargs["env"]
-    return json.loads(env[_OPENCODE_CONFIG_ENV_VAR])
+    return _written_opencode_config(tmp_path)
 
 
-def test_launch_opencode_no_mcp_omits_block_and_skips_skill(tmp_path):
+def test_launch_opencode_no_mcp_removes_block_and_skips_skill(tmp_path):
     """--no-mcp drops the mcp block and does not install the lilbee-mcp skill."""
-    block = _config_block_from_launch(["opencode", "--no-mcp"])
+    block = _config_block_from_launch(["opencode", "--no-mcp"], tmp_path)
     assert "mcp" not in block
     assert "lilbee" in block["provider"]  # still the model provider
     skill_path = tmp_path / ".config" / "opencode" / "skills" / "lilbee-mcp"
     assert not skill_path.exists()
+
+
+def test_launch_opencode_no_mcp_prunes_stale_lilbee_entry(tmp_path):
+    """--no-mcp actively removes a previously-registered lilbee MCP entry."""
+    _write_server_session()
+    config_path = tmp_path / ".config" / "opencode" / "opencode.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(json.dumps({"mcp": {"lilbee": {"url": "old"}, "other": {"url": "y"}}}))
+    completed = MagicMock(returncode=0)
+    with (
+        patch("lilbee.cli.launchers.opencode.shutil.which", return_value="/usr/local/bin/opencode"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run", return_value=completed),
+    ):
+        runner.invoke(app, ["launch", "opencode", "--no-mcp"])
+    payload = json.loads(config_path.read_text())
+    assert "lilbee" not in payload["mcp"]  # stale lilbee entry removed
+    assert payload["mcp"]["other"] == {"url": "y"}  # other servers preserved
+    assert "lilbee" in payload["provider"]  # provider still registered
 
 
 def test_launch_opencode_mcp_flag_overrides_disabled_config(tmp_path, monkeypatch):
@@ -429,7 +448,7 @@ def test_launch_opencode_mcp_flag_overrides_disabled_config(tmp_path, monkeypatc
     from lilbee.core.config import cfg
 
     monkeypatch.setattr(cfg, "agent_mcp_enabled", False)
-    block = _config_block_from_launch(["opencode", "--mcp"])
+    block = _config_block_from_launch(["opencode", "--mcp"], tmp_path)
     assert "mcp" in block
 
 
@@ -438,7 +457,7 @@ def test_launch_opencode_defaults_to_config_when_no_flag(tmp_path, monkeypatch):
     from lilbee.core.config import cfg
 
     monkeypatch.setattr(cfg, "agent_mcp_enabled", False)
-    block = _config_block_from_launch(["opencode"])
+    block = _config_block_from_launch(["opencode"], tmp_path)
     assert "mcp" not in block
 
 
@@ -886,14 +905,15 @@ def test_run_launcher_disables_eager_warm_in_launcher_process():
         cfg.worker_pool_eager_start = old
 
 
-def test_launch_opencode_persists_nothing_outside_the_skill(tmp_path):
-    """The session contract is env-only: no picker state, no opencode.json write.
-
-    Earlier versions merged the provider (with the session's ephemeral port and
-    bearer token) into the user's persistent opencode.json and wrote picker
-    state that current opencode discards; both left stale artifacts behind.
-    """
+def test_launch_opencode_merges_into_real_config_preserving_others(tmp_path):
+    """The launcher registers lilbee into the real opencode.json, leaving the
+    user's other providers and settings intact and never writing a literal token."""
     _write_server_session()
+    config_path = tmp_path / ".config" / "opencode" / "opencode.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps({"provider": {"anthropic": {"name": "anthropic"}}, "theme": "x"})
+    )
     fake_opencode = "/usr/local/bin/opencode"
     completed = MagicMock(returncode=0)
     with (
@@ -904,8 +924,28 @@ def test_launch_opencode_persists_nothing_outside_the_skill(tmp_path):
         result = runner.invoke(app, ["launch", "opencode"])
 
     assert result.exit_code == 0
-    assert not (tmp_path / ".local" / "state" / "opencode" / "model.json").exists()
-    assert not (tmp_path / ".config" / "opencode" / "opencode.json").exists()
+    payload = json.loads(config_path.read_text())
+    assert payload["provider"]["anthropic"] == {"name": "anthropic"}  # preserved
+    assert payload["theme"] == "x"  # preserved
+    assert "lilbee" in payload["provider"]  # registered
+    assert _TOKEN not in config_path.read_text()  # no literal token on disk
+
+
+def test_launch_opencode_refuses_to_overwrite_corrupt_config(tmp_path):
+    """A corrupt opencode.json is never clobbered; the launcher exits non-zero."""
+    _write_server_session()
+    config_path = tmp_path / ".config" / "opencode" / "opencode.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("{ not: valid json")
+    with (
+        patch("lilbee.cli.launchers.opencode.shutil.which", return_value="/usr/local/bin/opencode"),
+        patch("lilbee.cli.launchers.launcher.subprocess.run") as run,
+    ):
+        result = runner.invoke(app, ["launch", "opencode"])
+    assert result.exit_code == 1
+    assert "did not parse" in result.stderr
+    assert config_path.read_text() == "{ not: valid json"  # untouched
+    run.assert_not_called()
 
 
 def test_opencode_config_sets_generous_mcp_timeout():
@@ -958,21 +998,3 @@ def test_chat_warm_budget_scales_with_split_giant_weights(tmp_path):
 
     budget = launch_mod.chat_warm_budget_s()
     assert budget == max(launch_mod._WARM_TIMEOUT_S, float(cold_load_timeout_s(total)))
-
-
-def test_install_skill_is_atomic_on_failure(tmp_path, monkeypatch):
-    """A failed copy must not leave a half-written skill dir (which exists()
-    would skip forever) or any staging litter."""
-    from lilbee.cli.launchers import opencode
-
-    dest = tmp_path / "skills" / "lilbee-mcp"
-    monkeypatch.setattr(opencode, "_opencode_skill_dest", lambda: dest)
-
-    def _boom(*_a, **_k):
-        raise OSError("rename failed")
-
-    monkeypatch.setattr(opencode.os, "replace", _boom)
-    with pytest.raises(OSError):
-        opencode._install_lilbee_skill()
-    assert not dest.exists()
-    assert not list((tmp_path / "skills").glob(".lilbee-mcp-*"))

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -946,6 +946,8 @@ def test_launch_opencode_refuses_to_overwrite_corrupt_config(tmp_path):
     assert "did not parse" in result.stderr
     assert config_path.read_text() == "{ not: valid json"  # untouched
     run.assert_not_called()
+    # Load-before-side-effects: a corrupt config aborts before the skill install too.
+    assert not (tmp_path / ".config" / "opencode" / "skills" / "lilbee-mcp").exists()
 
 
 def test_opencode_config_sets_generous_mcp_timeout():

--- a/tests/cli/test_launcher_spawn_server.py
+++ b/tests/cli/test_launcher_spawn_server.py
@@ -171,3 +171,28 @@ class TestEnsureServerRunningRetries:
         assert spawn.call_count == server_mod._SPAWN_ATTEMPTS
         for proc in procs:
             proc.terminate.assert_called_once()
+
+    def test_honors_configured_server_port(self, monkeypatch) -> None:
+        import typer
+
+        monkeypatch.setattr(cfg, "server_port", 8080)
+        monkeypatch.setattr(server_mod, "running_server_session", lambda: None)
+        monkeypatch.setattr(server_mod, "free_port", mock.MagicMock(side_effect=[1, 2, 3]))
+        seen: list[int] = []
+        monkeypatch.setattr(server_mod, "_spawn_and_wait", lambda port: seen.append(port) or None)
+        with pytest.raises(typer.Exit):
+            server_mod.ensure_server_running()
+        # The pinned port is used every attempt so a persisted URL stays valid.
+        assert seen == [8080] * server_mod._SPAWN_ATTEMPTS
+
+    def test_falls_back_to_free_port_when_server_port_unset(self, monkeypatch) -> None:
+        import typer
+
+        monkeypatch.setattr(cfg, "server_port", 0)
+        monkeypatch.setattr(server_mod, "running_server_session", lambda: None)
+        monkeypatch.setattr(server_mod, "free_port", mock.MagicMock(side_effect=[7, 8, 9]))
+        seen: list[int] = []
+        monkeypatch.setattr(server_mod, "_spawn_and_wait", lambda port: seen.append(port) or None)
+        with pytest.raises(typer.Exit):
+            server_mod.ensure_server_running()
+        assert seen == [7, 8, 9]

--- a/tests/cli/test_skill_install.py
+++ b/tests/cli/test_skill_install.py
@@ -1,0 +1,38 @@
+"""Tests for the shared bundled-skill installer."""
+
+from __future__ import annotations
+
+import pytest
+
+from lilbee.cli.launchers import skill_install
+from lilbee.cli.launchers.skill_install import install_bundled_skill
+
+
+def test_installs_into_empty_dest(tmp_path):
+    dest = tmp_path / "skills" / "lilbee-mcp"
+    result = install_bundled_skill(dest)
+    assert result == dest
+    assert dest.is_dir()
+    assert (dest / "SKILL.md").exists()
+
+
+def test_skips_when_present(tmp_path):
+    dest = tmp_path / "skills" / "lilbee-mcp"
+    dest.mkdir(parents=True)
+    (dest / "SKILL.md").write_text("user edit")
+    assert install_bundled_skill(dest) is None
+    assert (dest / "SKILL.md").read_text() == "user edit"
+
+
+def test_atomic_on_failure(tmp_path, monkeypatch):
+    """A failed copy must not leave a half-written skill dir or staging litter."""
+    dest = tmp_path / "skills" / "lilbee-mcp"
+
+    def _boom(*_a, **_k):
+        raise OSError("rename failed")
+
+    monkeypatch.setattr(skill_install.os, "replace", _boom)
+    with pytest.raises(OSError):
+        install_bundled_skill(dest)
+    assert not dest.exists()
+    assert not list((tmp_path / "skills").glob(".lilbee-mcp-*"))

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -63,7 +63,9 @@ def test_resolve_placement_plan_uses_read_cache(monkeypatch):
         planning, "_server_model_inputs", lambda roles, *, unified_budget=None: ([], {}, 0)
     )
     monkeypatch.setattr(
-        planning, "_resolve_placement", lambda *a, **k: Placement(instances=(), unplaceable_roles=())
+        planning,
+        "_resolve_placement",
+        lambda *a, **k: Placement(instances=(), unplaceable_roles=()),
     )
     planning.resolve_placement_plan(None)
     planning.resolve_placement_plan(None)

--- a/tools/qa/lilbee_reels/pod-a100.sky.yaml
+++ b/tools/qa/lilbee_reels/pod-a100.sky.yaml
@@ -1,0 +1,27 @@
+# Re-record both reels on A100 ONLY. The prebuilt cu124 engine has no sm_90
+# kernels, so it fails on H100 ("no CUDA-capable device"); A100 (sm_80) is the
+# known-good GPU for every prior reel. Reuses the lilbee-agentqa volume, which
+# already has the model + built engine cached, so warm is fast.
+#   sky launch -c lilbee-reels tools/qa/lilbee_reels/pod-a100.sky.yaml --retry-until-up -y
+name: lilbee-reels
+resources:
+  cloud: runpod
+  disk_size: 100
+  ordered:
+    - accelerators: A100-80GB-SXM:1
+    - accelerators: A100-80GB:1
+volumes:
+  /workspace: lilbee-agentqa
+envs:
+  BRANCH: feat/agent-launcher-shared-home
+  BACKEND: cu124
+  REEL_MODEL: "unsloth/Qwen3-Coder-Next-GGUF/Qwen3-Coder-Next-Q4_K_M.gguf"
+  HF_TOKEN: ""
+setup: |
+  curl -fsSL "https://raw.githubusercontent.com/tobocop2/lilbee/${BRANCH}/tools/qa/opencode/pod_bootstrap.sh" -o /tmp/pod_bootstrap.sh
+  BRANCH="${BRANCH}" BACKEND="${BACKEND}" bash /tmp/pod_bootstrap.sh
+run: |
+  cd /workspace/lilbee
+  source /workspace/qa_env.sh
+  REEL_MODEL="${REEL_MODEL}" bash tools/qa/lilbee_reels/run.sh
+  REEL_MODEL="${REEL_MODEL}" bash tools/qa/lilbee_reels/run-hermes.sh

--- a/tools/qa/lilbee_reels/pod-both.sky.yaml
+++ b/tools/qa/lilbee_reels/pod-both.sky.yaml
@@ -1,0 +1,27 @@
+# Record BOTH reels (opencode + hermes) in one pod session, reusing the cached
+# volume (model + engine + lilbee index + hermes install + TUI deps). Records
+# opencode first, then hermes; both must finish their feature with a green test.
+#   sky launch -c lilbee-agentqa tools/qa/lilbee_reels/pod-both.sky.yaml --retry-until-up -y -d
+name: lilbee-agentqa
+resources:
+  cloud: runpod
+  disk_size: 100
+  ordered:
+    - accelerators: A100-80GB-SXM:1
+    - accelerators: A100-80GB:1
+    - accelerators: H100:1
+volumes:
+  /workspace: lilbee-agentqa
+envs:
+  BRANCH: feat/agent-launcher-shared-home
+  BACKEND: cu124
+  REEL_MODEL: "unsloth/Qwen3-Coder-Next-GGUF/Qwen3-Coder-Next-Q4_K_M.gguf"
+  HF_TOKEN: ""
+setup: |
+  curl -fsSL "https://raw.githubusercontent.com/tobocop2/lilbee/${BRANCH}/tools/qa/opencode/pod_bootstrap.sh" -o /tmp/pod_bootstrap.sh
+  BRANCH="${BRANCH}" BACKEND="${BACKEND}" bash /tmp/pod_bootstrap.sh
+run: |
+  cd /workspace/lilbee
+  source /workspace/qa_env.sh
+  REEL_MODEL="${REEL_MODEL}" bash tools/qa/lilbee_reels/run.sh
+  REEL_MODEL="${REEL_MODEL}" bash tools/qa/lilbee_reels/run-hermes.sh

--- a/tools/qa/lilbee_reels/pod-hermes.sky.yaml
+++ b/tools/qa/lilbee_reels/pod-hermes.sky.yaml
@@ -1,0 +1,26 @@
+# Hermes reel pod. Reuses the lilbee-agentqa volume (cached model + engine +
+# lilbee index from the opencode run), so this only installs hermes + records.
+#   sky launch -c lilbee-agentqa tools/qa/lilbee_reels/pod-hermes.sky.yaml --retry-until-up -y -d
+#   # then poll /workspace/reels-out/DONE-hermes, scp hermes.*, and sky down.
+name: lilbee-agentqa
+resources:
+  cloud: runpod
+  disk_size: 100
+  ordered:
+    - accelerators: A100-80GB-SXM:1
+    - accelerators: A100-80GB:1
+    - accelerators: H100:1
+volumes:
+  /workspace: lilbee-agentqa
+envs:
+  BRANCH: feat/agent-launcher-shared-home
+  BACKEND: cu124
+  REEL_MODEL: "unsloth/Qwen3-Coder-Next-GGUF/Qwen3-Coder-Next-Q4_K_M.gguf"
+  HF_TOKEN: ""
+setup: |
+  curl -fsSL "https://raw.githubusercontent.com/tobocop2/lilbee/${BRANCH}/tools/qa/opencode/pod_bootstrap.sh" -o /tmp/pod_bootstrap.sh
+  BRANCH="${BRANCH}" BACKEND="${BACKEND}" bash /tmp/pod_bootstrap.sh
+run: |
+  cd /workspace/lilbee
+  source /workspace/qa_env.sh
+  REEL_MODEL="${REEL_MODEL}" bash tools/qa/lilbee_reels/run-hermes.sh

--- a/tools/qa/lilbee_reels/pod.sky.yaml
+++ b/tools/qa/lilbee_reels/pod.sky.yaml
@@ -1,7 +1,7 @@
 # Dedicated pod for the agent-launcher reels (opencode + hermes) on the LILBEE
 # codebase. Separate from the QA matrix pod: its own fresh volume (never the
-# protected lilbee-qa volume), a single A100 (the reel model is Qwen3-Coder-30B-A3B,
-# ~17GB, which fits one card), and a run that indexes the lilbee source, records
+# protected lilbee-qa volume), a single A100 (the reel model Qwen3-Coder-Next
+# (Q4, ~48GB) fits one 80GB card), and a run that indexes the lilbee source, records
 # both reels, then signals done so the driver can tear the pod down immediately.
 #
 # Launch (from repo root, branch under test must be pushed):
@@ -15,8 +15,7 @@ name: lilbee-agentqa
 resources:
   cloud: runpod
   disk_size: 100
-  # One 80GB card holds Qwen3-Coder-30B-A3B (Q4, ~17GB) + the embedder with room
-  # to spare. The giant-family matrix (3-card) is a separate, later run.
+  # One 80GB card holds Qwen3-Coder-Next (Q4, ~48GB) + the embedder. The giant-family matrix (3-card) is a separate, later run.
   ordered:
     - accelerators: A100-80GB-SXM:1
     - accelerators: A100-80GB:1
@@ -28,7 +27,8 @@ volumes:
 envs:
   BRANCH: feat/agent-launcher-shared-home
   BACKEND: cu124
-  REEL_MODEL: "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf"
+  # Qwen3-Coder-Next (Feb 2026): 80B-A3B agentic coder, 256K ctx, Q4 ~48GB fits one 80GB card.
+  REEL_MODEL: "unsloth/Qwen3-Coder-Next-GGUF/Qwen3-Coder-Next-Q4_K_M.gguf"
   HF_TOKEN: ""
 
 setup: |

--- a/tools/qa/lilbee_reels/pod.sky.yaml
+++ b/tools/qa/lilbee_reels/pod.sky.yaml
@@ -1,0 +1,41 @@
+# Dedicated pod for the agent-launcher reels (opencode + hermes) on the LILBEE
+# codebase. Separate from the QA matrix pod: its own fresh volume (never the
+# protected lilbee-qa volume), a single A100 (the reel model is Qwen3-Coder-30B-A3B,
+# ~17GB, which fits one card), and a run that indexes the lilbee source, records
+# both reels, then signals done so the driver can tear the pod down immediately.
+#
+# Launch (from repo root, branch under test must be pushed):
+#   sky volumes apply tools/qa/lilbee_reels/volume.sky.yaml   # once
+#   sky launch -c lilbee-agentqa tools/qa/lilbee_reels/pod.sky.yaml --retry-until-up -y
+#   sky logs lilbee-agentqa                                   # follow
+#   # reels land in /workspace/reels-out/ ; pull them, then:
+#   sky down lilbee-agentqa -y                                # TEAR DOWN
+name: lilbee-agentqa
+
+resources:
+  cloud: runpod
+  disk_size: 100
+  # One 80GB card holds Qwen3-Coder-30B-A3B (Q4, ~17GB) + the embedder with room
+  # to spare. The giant-family matrix (3-card) is a separate, later run.
+  ordered:
+    - accelerators: A100-80GB-SXM:1
+    - accelerators: A100-80GB:1
+    - accelerators: H100:1
+
+volumes:
+  /workspace: lilbee-agentqa
+
+envs:
+  BRANCH: feat/agent-launcher-shared-home
+  BACKEND: cu124
+  REEL_MODEL: "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf"
+  HF_TOKEN: ""
+
+setup: |
+  curl -fsSL "https://raw.githubusercontent.com/tobocop2/lilbee/${BRANCH}/tools/qa/opencode/pod_bootstrap.sh" -o /tmp/pod_bootstrap.sh
+  BRANCH="${BRANCH}" BACKEND="${BACKEND}" bash /tmp/pod_bootstrap.sh
+
+run: |
+  cd /workspace/lilbee
+  source /workspace/qa_env.sh
+  REEL_MODEL="${REEL_MODEL}" bash tools/qa/lilbee_reels/run.sh

--- a/tools/qa/lilbee_reels/pull.sky.yaml
+++ b/tools/qa/lilbee_reels/pull.sky.yaml
@@ -1,0 +1,18 @@
+# Minimal pull-only pod: mounts the lilbee-agentqa volume (where the recorded
+# reels live) and idles, so the reel artifacts can be scp'd off. No setup, no
+# re-record. Tear down immediately after the scp.
+name: lilbee-agentqa
+resources:
+  cloud: runpod
+  disk_size: 20
+  ordered:
+    - accelerators: A100-80GB-SXM:1
+    - accelerators: A100-80GB:1
+volumes:
+  /workspace: lilbee-agentqa
+setup: |
+  echo "pull-only - skip setup"
+run: |
+  echo "PULL-ONLY reels at /workspace/reels-out"
+  ls -la /workspace/reels-out || echo "no reels-out"
+  sleep 1800

--- a/tools/qa/lilbee_reels/run-hermes.sh
+++ b/tools/qa/lilbee_reels/run-hermes.sh
@@ -45,6 +45,7 @@ mkdir -p "$HOME/.hermes"
 cat > "$HOME/.hermes/config.yaml" <<'HCFG'
 display:
   interface: tui
+  skin: slate
 onboarding:
   seen:
     welcome: true
@@ -67,7 +68,7 @@ log "warm ready"
 
 # 5. Record the hermes reel: launch hermes (registers lilbee in ~/.hermes), ask a
 #    lilbee-codebase question + a small code change.
-PROMPT="Using my indexed lilbee source, explain how lilbee's fleet decides which GPU a model loads on, citing the files. Then add a small unit test under tests/ that verifies prune_lilbee removes the lilbee MCP entry while keeping sibling servers. Read the real code, keep it minimal, and do not ask me questions."
+PROMPT="Using my indexed lilbee source, briefly explain how lilbee's fleet decides which GPU a model loads on (cite the files). Then add a small unit test under tests/cli/ that verifies prune_lilbee removes the lilbee MCP entry while keeping sibling servers, and run ONLY that one test file with 'uv run pytest <thatfile> -q' to confirm it passes green. Do NOT run the full suite or 'make check'. Read the real code, keep it minimal, and do not ask me questions."
 cat > "$OUT/hermes.tape" <<TAPE
 Output hermes.gif
 Output hermes.mp4
@@ -90,7 +91,7 @@ Sleep 1s
 Enter
 Sleep 1s
 Enter
-Sleep 135s
+Sleep 185s
 Screenshot hermes.png
 TAPE
 

--- a/tools/qa/lilbee_reels/run-hermes.sh
+++ b/tools/qa/lilbee_reels/run-hermes.sh
@@ -21,10 +21,12 @@ log(){ echo "[hermes-reel $(date +%H:%M:%S)] $*"; }
 log "installing hermes-agent"
 command -v rg >/dev/null || (apt-get update -qq && apt-get install -y -qq ripgrep) >>"$OUT/hermes-install.log" 2>&1
 [ -d "$HERMES_DIR/.git" ] || git clone --depth 1 https://github.com/NousResearch/hermes-agent "$HERMES_DIR" >>"$OUT/hermes-install.log" 2>&1
-( cd "$HERMES_DIR" && uv sync >>"$OUT/hermes-install.log" 2>&1 ) || log "hermes uv sync issues (see hermes-install.log)"
+# CRITICAL: unset UV_PROJECT_ENVIRONMENT (qa_env points it at lilbee's venv) so
+# hermes syncs into its OWN .venv instead of clobbering lilbee's.
+( cd "$HERMES_DIR" && env -u UV_PROJECT_ENVIRONMENT uv sync >>"$OUT/hermes-install.log" 2>&1 ) || log "hermes uv sync issues (see hermes-install.log)"
 cat > /usr/local/bin/hermes <<WRAP
 #!/usr/bin/env bash
-exec uv run --project $HERMES_DIR hermes "\$@"
+exec env -u UV_PROJECT_ENVIRONMENT uv run --project $HERMES_DIR hermes "\$@"
 WRAP
 chmod +x /usr/local/bin/hermes
 command -v hermes >/dev/null && log "hermes shim ready: $(command -v hermes)" || { log "hermes NOT on PATH"; echo "REELS_FAILED hermes-install" > "$OUT/DONE-hermes"; exit 2; }

--- a/tools/qa/lilbee_reels/run-hermes.sh
+++ b/tools/qa/lilbee_reels/run-hermes.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Record the HERMES agent-launcher reel on the lilbee codebase. Installs
+# hermes-agent on the pod, reuses the cached model/engine/index on the volume,
+# then records `lilbee launch hermes` doing real work on the lilbee source.
+set -uo pipefail
+
+source /workspace/qa_env.sh 2>/dev/null || true
+REPO=/workspace/lilbee
+REEL_MODEL="${REEL_MODEL:?set REEL_MODEL}"
+OUT=/workspace/reels-out
+DATA=/workspace/.lilbee-reels
+HERMES_DIR=/workspace/hermes-agent
+PORT=41751
+mkdir -p "$OUT"
+export LILBEE_DATA="$DATA" LILBEE_CHAT_MODEL="$REEL_MODEL" LILBEE_CHAT_N_CTX_TARGET=65536
+export COLORTERM=truecolor TERM=xterm-256color
+log(){ echo "[hermes-reel $(date +%H:%M:%S)] $*"; }
+
+# 1. Install hermes-agent (clone + uv sync) and a `hermes` PATH shim so the
+#    launcher's shutil.which("hermes") resolves it. ripgrep is a hermes dep.
+log "installing hermes-agent"
+command -v rg >/dev/null || (apt-get update -qq && apt-get install -y -qq ripgrep) >>"$OUT/hermes-install.log" 2>&1
+[ -d "$HERMES_DIR/.git" ] || git clone --depth 1 https://github.com/NousResearch/hermes-agent "$HERMES_DIR" >>"$OUT/hermes-install.log" 2>&1
+( cd "$HERMES_DIR" && uv sync >>"$OUT/hermes-install.log" 2>&1 ) || log "hermes uv sync issues (see hermes-install.log)"
+cat > /usr/local/bin/hermes <<WRAP
+#!/usr/bin/env bash
+exec uv run --project $HERMES_DIR hermes "\$@"
+WRAP
+chmod +x /usr/local/bin/hermes
+command -v hermes >/dev/null && log "hermes shim ready: $(command -v hermes)" || { log "hermes NOT on PATH"; echo "REELS_FAILED hermes-install" > "$OUT/DONE-hermes"; exit 2; }
+
+# 2. Pre-seed ~/.hermes so the launcher's non-destructive merge adds lilbee on top
+#    and hermes opens straight to the TUI (no setup wizard). Mark onboarding seen.
+mkdir -p "$HOME/.hermes"
+cat > "$HOME/.hermes/config.yaml" <<'HCFG'
+display:
+  interface: tui
+onboarding:
+  seen:
+    welcome: true
+HCFG
+
+# 3. Index is cached on the volume from the opencode run; ensure it exists.
+( cd "$REPO" && uv run lilbee add src/lilbee AGENTS.md >>"$OUT/index.log" 2>&1 ) || log "index issues"
+
+# 4. Warm a serve on the cached model.
+log "warming serve on $PORT"
+pkill -f 'lilbee serve' 2>/dev/null; pkill -f 'llama-server' 2>/dev/null; pkill -f 'llama-swap' 2>/dev/null; sleep 2
+tmux kill-session -t warmh 2>/dev/null
+tmux new-session -d -s warmh "bash -c 'source /workspace/qa_env.sh; export LILBEE_DATA=$DATA LILBEE_CHAT_MODEL=\"$REEL_MODEL\" LILBEE_CHAT_N_CTX_TARGET=65536; cd $REPO; lilbee serve --port $PORT 2>&1 | tee $OUT/serve-hermes.log; sleep 7200'"
+for _ in $(seq 1 240); do
+  curl -s "http://127.0.0.1:$PORT/api/health" 2>/dev/null | grep -q '"chat_ready":true' && break
+  sleep 10
+done
+curl -s "http://127.0.0.1:$PORT/api/health" | grep -q '"chat_ready":true' || { log "warm FAILED"; tail -8 "$OUT/serve-hermes.log"; echo "REELS_FAILED warm" > "$OUT/DONE-hermes"; exit 3; }
+log "warm ready"
+
+# 5. Record the hermes reel: launch hermes (registers lilbee in ~/.hermes), ask a
+#    lilbee-codebase question + a small code change.
+PROMPT="Using my indexed lilbee source, explain how lilbee's fleet decides which GPU a model loads on, citing the files. Then add a small unit test under tests/ that verifies prune_lilbee removes the lilbee MCP entry while keeping sibling servers. Read the real code, keep it minimal, and do not ask me questions."
+cat > "$OUT/hermes.tape" <<TAPE
+Output hermes.gif
+Output hermes.mp4
+Set Shell bash
+Set Width 1600
+Set Height 900
+Set FontSize 14
+Set Theme { "name": "rose-pine", "background": "#191724", "foreground": "#e0def4", "cursor": "#e0def4", "selection": "#403d52", "black": "#26233a", "red": "#eb6f92", "green": "#9ccfd8", "yellow": "#f6c177", "blue": "#31748f", "magenta": "#c4a7e7", "cyan": "#ebbcba", "white": "#e0def4", "brightBlack": "#6e6a86", "brightRed": "#eb6f92", "brightGreen": "#9ccfd8", "brightYellow": "#f6c177", "brightBlue": "#31748f", "brightMagenta": "#c4a7e7", "brightCyan": "#ebbcba", "brightWhite": "#e0def4" }
+Env PATH "/root/lilbee_venv/bin:/usr/local/bin:/root/.local/bin:/usr/local/go/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
+Env LILBEE_DATA "$DATA"
+Env LILBEE_CHAT_MODEL "$REEL_MODEL"
+Env COLORTERM "truecolor"
+Sleep 2s
+Type "cd $REPO && lilbee launch hermes"
+Sleep 500ms
+Enter
+Sleep 22s
+Type "$PROMPT"
+Sleep 1s
+Enter
+Sleep 140s
+Screenshot hermes.png
+TAPE
+
+log "recording hermes reel"
+( cd "$OUT" && VHS_NO_SANDBOX=true vhs hermes.tape > "$OUT/vhs-hermes.log" 2>&1 ) \
+  && log "hermes reel recorded" \
+  || { log "vhs FAILED"; tail -8 "$OUT/vhs-hermes.log"; echo "REELS_FAILED vhs" > "$OUT/DONE-hermes"; exit 4; }
+
+mkdir -p "$OUT/frames-hermes"
+ffmpeg -y -loglevel error -i "$OUT/hermes.mp4" -vf fps=1 "$OUT/frames-hermes/f_%04d.png" 2>/dev/null || true
+echo "REELS_DONE hermes $(date -u +%FT%TZ)" > "$OUT/DONE-hermes"
+log "DONE (hermes)."

--- a/tools/qa/lilbee_reels/run-hermes.sh
+++ b/tools/qa/lilbee_reels/run-hermes.sh
@@ -42,10 +42,12 @@ log "hermes TUI deps ready"
 # 2. Pre-seed ~/.hermes so the launcher's non-destructive merge adds lilbee on top
 #    and hermes opens straight to the TUI (no setup wizard). Mark onboarding seen.
 mkdir -p "$HOME/.hermes"
+# skin: mono inherits the terminal palette (rose-pine via VHS) instead of
+# painting slate's hardcoded blue, so the TUI reads rose-pine end to end.
 cat > "$HOME/.hermes/config.yaml" <<'HCFG'
 display:
   interface: tui
-  skin: slate
+  skin: mono
 onboarding:
   seen:
     welcome: true
@@ -68,15 +70,21 @@ log "warm ready"
 
 # 5. Record the hermes reel: launch hermes (registers lilbee in ~/.hermes), ask a
 #    lilbee-codebase question + a small code change.
-PROMPT="Be concise and efficient; minimal explanation. Read src/lilbee/cli/agent_configs/merge.py, then write tests/cli/test_prune_siblings.py with one test that verifies prune_lilbee removes the lilbee MCP entry while keeping sibling servers, and run exactly 'uv run pytest tests/cli/test_prune_siblings.py -q'. Stop as soon as it passes green. Do NOT run the full suite or make check, and do NOT explore beyond what you need."
+PROMPT="Add a 'lilbee launch list' subcommand that prints the agents you can launch, reading the launcher registry in src/lilbee/cli/launchers/__init__.py. Run it to make sure it works, then add a focused test under tests/cli/ and run just that test."
+# Same verified rose-pine recipe as the opencode tape (named theme + window chrome).
 cat > "$OUT/hermes.tape" <<TAPE
 Output hermes.gif
 Output hermes.mp4
 Set Shell bash
-Set Width 1600
+Set Width 1400
 Set Height 900
 Set FontSize 14
-Set Theme { "name": "rose-pine", "background": "#191724", "foreground": "#e0def4", "cursor": "#e0def4", "selection": "#403d52", "black": "#26233a", "red": "#eb6f92", "green": "#9ccfd8", "yellow": "#f6c177", "blue": "#31748f", "magenta": "#c4a7e7", "cyan": "#ebbcba", "white": "#e0def4", "brightBlack": "#6e6a86", "brightRed": "#eb6f92", "brightGreen": "#9ccfd8", "brightYellow": "#f6c177", "brightBlue": "#31748f", "brightMagenta": "#c4a7e7", "brightCyan": "#ebbcba", "brightWhite": "#e0def4" }
+Set Padding 20
+Set Theme "rose-pine"
+Set Margin 30
+Set MarginFill "#100f1a"
+Set BorderRadius 10
+Set WindowBar Colorful
 Env PATH "/root/lilbee_venv/bin:/usr/local/bin:/root/.local/bin:/usr/local/go/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 Env LILBEE_DATA "$DATA"
 Env LILBEE_CHAT_MODEL "$REEL_MODEL"
@@ -102,5 +110,7 @@ log "recording hermes reel"
 
 mkdir -p "$OUT/frames-hermes"
 ffmpeg -y -loglevel error -i "$OUT/hermes.mp4" -vf fps=1 "$OUT/frames-hermes/f_%04d.png" 2>/dev/null || true
-echo "REELS_DONE hermes $(date -u +%FT%TZ)" > "$OUT/DONE-hermes"
+BG=$(ffmpeg -v error -i "$OUT/hermes.png" -vf "crop=2:2:700:650,scale=1:1" -f rawvideo -pix_fmt rgb24 - 2>/dev/null | xxd -p | head -c6)
+log "hermes reel bg hex => #$BG  (rose-pine base ~#1c1c2c)"
+echo "REELS_DONE hermes bg=#$BG $(date -u +%FT%TZ)" > "$OUT/DONE-hermes"
 log "DONE (hermes)."

--- a/tools/qa/lilbee_reels/run-hermes.sh
+++ b/tools/qa/lilbee_reels/run-hermes.sh
@@ -68,7 +68,7 @@ log "warm ready"
 
 # 5. Record the hermes reel: launch hermes (registers lilbee in ~/.hermes), ask a
 #    lilbee-codebase question + a small code change.
-PROMPT="Using my indexed lilbee source, briefly explain how lilbee's fleet decides which GPU a model loads on (cite the files). Then add a small unit test under tests/cli/ that verifies prune_lilbee removes the lilbee MCP entry while keeping sibling servers, and run ONLY that one test file with 'uv run pytest <thatfile> -q' to confirm it passes green. Do NOT run the full suite or 'make check'. Read the real code, keep it minimal, and do not ask me questions."
+PROMPT="Be concise and efficient; minimal explanation. Read src/lilbee/cli/agent_configs/merge.py, then write tests/cli/test_prune_siblings.py with one test that verifies prune_lilbee removes the lilbee MCP entry while keeping sibling servers, and run exactly 'uv run pytest tests/cli/test_prune_siblings.py -q'. Stop as soon as it passes green. Do NOT run the full suite or make check, and do NOT explore beyond what you need."
 cat > "$OUT/hermes.tape" <<TAPE
 Output hermes.gif
 Output hermes.mp4
@@ -91,7 +91,7 @@ Sleep 1s
 Enter
 Sleep 1s
 Enter
-Sleep 185s
+Sleep 270s
 Screenshot hermes.png
 TAPE
 

--- a/tools/qa/lilbee_reels/run-hermes.sh
+++ b/tools/qa/lilbee_reels/run-hermes.sh
@@ -26,10 +26,18 @@ command -v rg >/dev/null || (apt-get update -qq && apt-get install -y -qq ripgre
 ( cd "$HERMES_DIR" && env -u UV_PROJECT_ENVIRONMENT uv sync >>"$OUT/hermes-install.log" 2>&1 ) || log "hermes uv sync issues (see hermes-install.log)"
 cat > /usr/local/bin/hermes <<WRAP
 #!/usr/bin/env bash
-exec env -u UV_PROJECT_ENVIRONMENT uv run --project $HERMES_DIR hermes "\$@"
+exec env -u UV_PROJECT_ENVIRONMENT -u VIRTUAL_ENV uv run --project $HERMES_DIR hermes "\$@"
 WRAP
 chmod +x /usr/local/bin/hermes
 command -v hermes >/dev/null && log "hermes shim ready: $(command -v hermes)" || { log "hermes NOT on PATH"; echo "REELS_FAILED hermes-install" > "$OUT/DONE-hermes"; exit 2; }
+
+# hermes builds its TUI deps on the FIRST TUI launch ("Installing TUI dependencies").
+# Trigger that now (cached on the volume) so the reel's `lilbee launch hermes` opens
+# instantly instead of burning the launch window on the build.
+log "pre-building hermes TUI deps"
+timeout 300 hermes </dev/null >>"$OUT/hermes-install.log" 2>&1 || true
+pkill -f "hermes_cli" 2>/dev/null; sleep 2
+log "hermes TUI deps ready"
 
 # 2. Pre-seed ~/.hermes so the launcher's non-destructive merge adds lilbee on top
 #    and hermes opens straight to the TUI (no setup wizard). Mark onboarding seen.
@@ -76,11 +84,13 @@ Sleep 2s
 Type "cd $REPO && lilbee launch hermes"
 Sleep 500ms
 Enter
-Sleep 22s
+Sleep 30s
 Type "$PROMPT"
 Sleep 1s
 Enter
-Sleep 140s
+Sleep 1s
+Enter
+Sleep 135s
 Screenshot hermes.png
 TAPE
 

--- a/tools/qa/lilbee_reels/run-hermes.sh
+++ b/tools/qa/lilbee_reels/run-hermes.sh
@@ -42,12 +42,48 @@ log "hermes TUI deps ready"
 # 2. Pre-seed ~/.hermes so the launcher's non-destructive merge adds lilbee on top
 #    and hermes opens straight to the TUI (no setup wizard). Mark onboarding seen.
 mkdir -p "$HOME/.hermes"
-# skin: mono inherits the terminal palette (rose-pine via VHS) instead of
-# painting slate's hardcoded blue, so the TUI reads rose-pine end to end.
+# Custom rose-pine skin: the bordered response box + colored tool names give the
+# same visual structure opencode has (mono is monochrome, so the structure blends
+# into a flat, hard-to-follow stream). Foreground is rose-pine; the bg stays the
+# rose-pine VHS terminal, so the whole TUI reads rose-pine and legible.
+mkdir -p "$HOME/.hermes/skins"
+cat > "$HOME/.hermes/skins/lilbee-rose-pine.yaml" <<'SKIN'
+name: lilbee-rose-pine
+description: lilbee rose-pine
+colors:
+  banner_border: "#c4a7e7"
+  banner_title: "#f6c177"
+  banner_accent: "#ebbcba"
+  banner_dim: "#6e6a86"
+  banner_text: "#e0def4"
+  ui_accent: "#c4a7e7"
+  ui_label: "#9ccfd8"
+  ui_ok: "#9ccfd8"
+  ui_error: "#eb6f92"
+  ui_warn: "#f6c177"
+  prompt: "#e0def4"
+  input_rule: "#c4a7e7"
+  response_border: "#c4a7e7"
+  status_bar_bg: "#1f1d2e"
+  status_bar_text: "#e0def4"
+  status_bar_strong: "#c4a7e7"
+  status_bar_dim: "#6e6a86"
+  status_bar_good: "#9ccfd8"
+  status_bar_warn: "#f6c177"
+  status_bar_bad: "#eb6f92"
+  status_bar_critical: "#eb6f92"
+  session_label: "#9ccfd8"
+  session_border: "#403d52"
+branding:
+  agent_name: "Hermes Agent"
+  response_label: " ⚕ Hermes "
+  prompt_symbol: "❯"
+tool_prefix: "┊"
+SKIN
 cat > "$HOME/.hermes/config.yaml" <<'HCFG'
 display:
   interface: tui
-  skin: mono
+  skin: lilbee-rose-pine
 onboarding:
   seen:
     welcome: true
@@ -78,7 +114,7 @@ Output hermes.mp4
 Set Shell bash
 Set Width 1400
 Set Height 900
-Set FontSize 14
+Set FontSize 18
 Set Padding 20
 Set Theme "rose-pine"
 Set Margin 30

--- a/tools/qa/lilbee_reels/run.sh
+++ b/tools/qa/lilbee_reels/run.sh
@@ -65,16 +65,24 @@ log "warm ready"
 
 # 5. The reel tape: launch opencode (reuses the warm serve), ask one prompt that
 #    forces a lilbee_search over the lilbee source AND a real code change.
-PROMPT="Be concise and efficient; minimal explanation. Add a 'lilbee launch --list' subcommand that prints the supported agent names, reading src/lilbee/cli/launchers/__init__.py to match its style. Then write tests/cli/test_launch_list.py with one test and run exactly 'uv run pytest tests/cli/test_launch_list.py -q'. Stop as soon as it passes green. Do NOT run the full suite or make check, and do NOT explore beyond what you need."
+PROMPT="Add a 'lilbee launch list' subcommand that prints the agents you can launch, reading the launcher registry in src/lilbee/cli/launchers/__init__.py. Run it to make sure it works, then add a focused test under tests/cli/ and run just that test."
 WS="$REPO"
+# Verified rose-pine recipe: VHS's BUILT-IN named theme (an inline JSON theme
+# silently falls back to gray), plus the macOS window chrome the existing agent
+# demos use. Matches demos/mcp-code.png (bg ~#1c1c2c).
 cat > "$OUT/opencode.tape" <<TAPE
 Output opencode.gif
 Output opencode.mp4
 Set Shell bash
-Set Width 1600
+Set Width 1400
 Set Height 900
 Set FontSize 14
-Set Theme { "name": "rose-pine", "background": "#191724", "foreground": "#e0def4", "cursor": "#e0def4", "selection": "#403d52", "black": "#26233a", "red": "#eb6f92", "green": "#9ccfd8", "yellow": "#f6c177", "blue": "#31748f", "magenta": "#c4a7e7", "cyan": "#ebbcba", "white": "#e0def4", "brightBlack": "#6e6a86", "brightRed": "#eb6f92", "brightGreen": "#9ccfd8", "brightYellow": "#f6c177", "brightBlue": "#31748f", "brightMagenta": "#c4a7e7", "brightCyan": "#ebbcba", "brightWhite": "#e0def4" }
+Set Padding 20
+Set Theme "rose-pine"
+Set Margin 30
+Set MarginFill "#100f1a"
+Set BorderRadius 10
+Set WindowBar Colorful
 Env PATH "/root/lilbee_venv/bin:/root/.opencode/bin:/usr/local/go/bin:/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Env LILBEE_DATA "$DATA"
 Env LILBEE_CHAT_MODEL "$REEL_MODEL"
@@ -102,5 +110,9 @@ log "recording opencode reel"
 mkdir -p "$OUT/frames-opencode"
 ffmpeg -y -loglevel error -i "$OUT/opencode.mp4" -vf fps=1 "$OUT/frames-opencode/f_%04d.png" 2>/dev/null || true
 
-echo "REELS_DONE opencode $(date -u +%FT%TZ)" > "$OUT/DONE"
+# Sanity: log the reel's background hex (rose-pine base is ~#1c1c2c, purple-tinted;
+# a neutral gray like #131313 means the theme didn't apply). PIL-free via ffmpeg.
+BG=$(ffmpeg -v error -i "$OUT/opencode.png" -vf "crop=2:2:700:650,scale=1:1" -f rawvideo -pix_fmt rgb24 - 2>/dev/null | xxd -p | head -c6)
+log "opencode reel bg hex => #$BG  (rose-pine base ~#1c1c2c)"
+echo "REELS_DONE opencode bg=#$BG $(date -u +%FT%TZ)" > "$OUT/DONE"
 log "DONE (opencode). reels in $OUT"

--- a/tools/qa/lilbee_reels/run.sh
+++ b/tools/qa/lilbee_reels/run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Record the agent-launcher reels on the LILBEE codebase, on the pod.
+# Indexes the lilbee source, pulls one modern coder model, then records the
+# opencode reel (search the lilbee source + make a real code change) with VHS.
+# Writes /workspace/reels-out/ and a DONE marker so the driver can tear down.
+set -uo pipefail
+
+source /workspace/qa_env.sh 2>/dev/null || true
+REPO=/workspace/lilbee
+REEL_MODEL="${REEL_MODEL:?set REEL_MODEL}"
+OUT=/workspace/reels-out
+DATA=/workspace/.lilbee-reels
+PORT=41750
+mkdir -p "$OUT"
+export LILBEE_DATA="$DATA"
+export LILBEE_CHAT_MODEL="$REEL_MODEL"
+export COLORTERM=truecolor TERM=xterm-256color
+log(){ echo "[reels $(date +%H:%M:%S)] $*"; }
+
+# 1. Pull the reel model (cached on the volume across retakes).
+log "pulling reel model $REEL_MODEL"
+uv run lilbee model pull "$REEL_MODEL" >>"$OUT/pull.log" 2>&1 || { log "model pull FAILED"; tail -5 "$OUT/pull.log"; }
+
+# 2. Index the lilbee source so lilbee_search has real code to ground on.
+log "indexing lilbee source"
+( cd "$REPO" && uv run lilbee add src/lilbee AGENTS.md >>"$OUT/index.log" 2>&1 ) || log "index issues (see index.log)"
+
+# 3. Pre-seed opencode's global config: edit:allow (no human to approve the write
+#    in an automated reel) + no autoupdate. The launcher's non-destructive merge
+#    preserves these and adds the lilbee provider on top.
+mkdir -p "$HOME/.config/opencode"
+cat > "$HOME/.config/opencode/opencode.json" <<'OC'
+{ "$schema": "https://opencode.ai/config.json",
+  "permission": { "edit": "allow" },
+  "tools": { "webfetch": false },
+  "autoupdate": false }
+OC
+mkdir -p "$DATA/launchers"; echo '{"accepted": true}' > "$DATA/launchers/opencode-setup.json"
+
+# 4. Pre-warm a serve so the launch is instant and the answer is the subject.
+log "warming serve on $PORT"
+pkill -f 'lilbee serve' 2>/dev/null; pkill -f 'llama-server' 2>/dev/null; pkill -f 'llama-swap' 2>/dev/null; sleep 2
+tmux kill-session -t warmserve 2>/dev/null
+tmux new-session -d -s warmserve "bash -c 'source /workspace/qa_env.sh; export LILBEE_DATA=$DATA LILBEE_CHAT_MODEL=\"$REEL_MODEL\"; cd $REPO; lilbee serve --port $PORT 2>&1 | tee $OUT/serve.log; sleep 7200'"
+for _ in $(seq 1 240); do
+  curl -s "http://127.0.0.1:$PORT/api/health" 2>/dev/null | grep -q '"chat_ready":true' && break
+  sleep 10
+done
+curl -s "http://127.0.0.1:$PORT/api/health" | grep -q '"chat_ready":true' || { log "warm FAILED"; tail -8 "$OUT/serve.log"; echo "REELS_FAILED warm" > "$OUT/DONE"; exit 3; }
+log "warm ready"
+
+# 5. The reel tape: launch opencode (reuses the warm serve), ask one prompt that
+#    forces a lilbee_search over the lilbee source AND a real code change.
+PROMPT="Using my indexed lilbee source, first explain how lilbee registers itself into opencode's configuration, citing the exact files. Then add a 'lilbee launch --list' subcommand that prints the supported agent names by reading the real launcher module to match its style. Keep it minimal, pick sensible defaults, and do not ask me any questions."
+WS="$REPO"
+cat > "$OUT/opencode.tape" <<TAPE
+Output $OUT/opencode.gif
+Output $OUT/opencode.mp4
+Set Shell bash
+Set Width 1600
+Set Height 900
+Set FontSize 14
+Set Theme { "name": "rose-pine", "background": "#191724", "foreground": "#e0def4", "cursor": "#e0def4", "selection": "#403d52", "black": "#26233a", "red": "#eb6f92", "green": "#9ccfd8", "yellow": "#f6c177", "blue": "#31748f", "magenta": "#c4a7e7", "cyan": "#ebbcba", "white": "#e0def4", "brightBlack": "#6e6a86", "brightRed": "#eb6f92", "brightGreen": "#9ccfd8", "brightYellow": "#f6c177", "brightBlue": "#31748f", "brightMagenta": "#c4a7e7", "brightCyan": "#ebbcba", "brightWhite": "#e0def4" }
+Env PATH "/root/lilbee_venv/bin:/root/.opencode/bin:/usr/local/go/bin:/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Env LILBEE_DATA "$DATA"
+Env LILBEE_CHAT_MODEL "$REEL_MODEL"
+Env COLORTERM "truecolor"
+Sleep 2s
+Type "cd $WS && lilbee launch opencode"
+Sleep 500ms
+Enter
+Sleep 12s
+Type "$PROMPT"
+Sleep 1s
+Enter
+Sleep 220s
+Screenshot $OUT/opencode.png
+TAPE
+
+log "recording opencode reel"
+( cd "$WS" && VHS_NO_SANDBOX=true vhs "$OUT/opencode.tape" > "$OUT/vhs-opencode.log" 2>&1 ) \
+  && log "opencode reel recorded" \
+  || { log "vhs FAILED"; tail -8 "$OUT/vhs-opencode.log"; echo "REELS_FAILED vhs" > "$OUT/DONE"; exit 4; }
+
+# 6. Extract unique frames for review (frame-by-frame QA happens off-pod).
+mkdir -p "$OUT/frames-opencode"
+ffmpeg -y -loglevel error -i "$OUT/opencode.mp4" -vf fps=1 "$OUT/frames-opencode/f_%04d.png" 2>/dev/null || true
+
+echo "REELS_DONE opencode $(date -u +%FT%TZ)" > "$OUT/DONE"
+log "DONE (opencode). reels in $OUT"

--- a/tools/qa/lilbee_reels/run.sh
+++ b/tools/qa/lilbee_reels/run.sh
@@ -35,7 +35,16 @@ cat > "$HOME/.config/opencode/opencode.json" <<'OC'
   "tools": { "webfetch": false },
   "autoupdate": false }
 OC
-mkdir -p "$DATA/launchers"; echo '{"accepted": true}' > "$DATA/launchers/opencode-setup.json"
+# Pre-accept the launcher's first-run consent at the EXACT cfg.data_dir (a shell
+# guess at the path misses it, and the prompt then eats the typed reel prompt).
+( cd "$REPO" && LILBEE_DATA="$DATA" uv run python -c "
+from lilbee.core.config import cfg
+import json
+m = cfg.data_dir / 'launchers' / 'opencode-setup.json'
+m.parent.mkdir(parents=True, exist_ok=True)
+m.write_text(json.dumps({'accepted': True}))
+print('setup marker ->', m)
+" )
 
 # 4. Pre-warm a serve so the launch is instant and the answer is the subject.
 log "warming serve on $PORT"
@@ -66,10 +75,10 @@ Env LILBEE_DATA "$DATA"
 Env LILBEE_CHAT_MODEL "$REEL_MODEL"
 Env COLORTERM "truecolor"
 Sleep 2s
-Type "cd $WS && lilbee launch opencode"
+Type "cd $WS && lilbee launch opencode -y"
 Sleep 500ms
 Enter
-Sleep 12s
+Sleep 16s
 Type "$PROMPT"
 Sleep 1s
 Enter

--- a/tools/qa/lilbee_reels/run.sh
+++ b/tools/qa/lilbee_reels/run.sh
@@ -14,6 +14,10 @@ PORT=41750
 mkdir -p "$OUT"
 export LILBEE_DATA="$DATA"
 export LILBEE_CHAT_MODEL="$REEL_MODEL"
+# opencode's system prompt + MCP tool defs are ~28K tokens; the default served
+# window (24576 on a big-RAM host) overflows. Qwen3-Coder-Next is 256K-capable and
+# the 80GB card has KV headroom, so serve a generous 64K window.
+export LILBEE_CHAT_N_CTX_TARGET=65536
 export COLORTERM=truecolor TERM=xterm-256color
 log(){ echo "[reels $(date +%H:%M:%S)] $*"; }
 
@@ -50,7 +54,7 @@ print('setup marker ->', m)
 log "warming serve on $PORT"
 pkill -f 'lilbee serve' 2>/dev/null; pkill -f 'llama-server' 2>/dev/null; pkill -f 'llama-swap' 2>/dev/null; sleep 2
 tmux kill-session -t warmserve 2>/dev/null
-tmux new-session -d -s warmserve "bash -c 'source /workspace/qa_env.sh; export LILBEE_DATA=$DATA LILBEE_CHAT_MODEL=\"$REEL_MODEL\"; cd $REPO; lilbee serve --port $PORT 2>&1 | tee $OUT/serve.log; sleep 7200'"
+tmux new-session -d -s warmserve "bash -c 'source /workspace/qa_env.sh; export LILBEE_DATA=$DATA LILBEE_CHAT_MODEL=\"$REEL_MODEL\" LILBEE_CHAT_N_CTX_TARGET=65536; cd $REPO; lilbee serve --port $PORT 2>&1 | tee $OUT/serve.log; sleep 7200'"
 for _ in $(seq 1 240); do
   curl -s "http://127.0.0.1:$PORT/api/health" 2>/dev/null | grep -q '"chat_ready":true' && break
   sleep 10
@@ -82,7 +86,7 @@ Sleep 16s
 Type "$PROMPT"
 Sleep 1s
 Enter
-Sleep 220s
+Sleep 130s
 Screenshot opencode.png
 TAPE
 

--- a/tools/qa/lilbee_reels/run.sh
+++ b/tools/qa/lilbee_reels/run.sh
@@ -35,6 +35,7 @@ log "indexing lilbee source"
 mkdir -p "$HOME/.config/opencode"
 cat > "$HOME/.config/opencode/opencode.json" <<'OC'
 { "$schema": "https://opencode.ai/config.json",
+  "theme": "rose-pine",
   "permission": { "edit": "allow" },
   "tools": { "webfetch": false },
   "autoupdate": false }
@@ -64,7 +65,7 @@ log "warm ready"
 
 # 5. The reel tape: launch opencode (reuses the warm serve), ask one prompt that
 #    forces a lilbee_search over the lilbee source AND a real code change.
-PROMPT="Using my indexed lilbee source, first explain how lilbee registers itself into opencode's configuration, citing the exact files. Then add a 'lilbee launch --list' subcommand that prints the supported agent names by reading the real launcher module to match its style. Keep it minimal, pick sensible defaults, and do not ask me any questions."
+PROMPT="Using my indexed lilbee source, briefly explain how lilbee registers itself into opencode's config (cite the files). Then add a 'lilbee launch --list' subcommand that prints the supported agent names, reading the real launcher module to match its style. Add a focused test for it under tests/cli/ and run ONLY that one test file with 'uv run pytest <thatfile> -q' to confirm it passes green. Do NOT run the full suite or 'make check'. Keep it minimal and do not ask me questions."
 WS="$REPO"
 cat > "$OUT/opencode.tape" <<TAPE
 Output opencode.gif
@@ -86,7 +87,7 @@ Sleep 16s
 Type "$PROMPT"
 Sleep 1s
 Enter
-Sleep 130s
+Sleep 175s
 Screenshot opencode.png
 TAPE
 

--- a/tools/qa/lilbee_reels/run.sh
+++ b/tools/qa/lilbee_reels/run.sh
@@ -32,14 +32,41 @@ log "indexing lilbee source"
 # 3. Pre-seed opencode's global config: edit:allow (no human to approve the write
 #    in an automated reel) + no autoupdate. The launcher's non-destructive merge
 #    preserves these and adds the lilbee provider on top.
-mkdir -p "$HOME/.config/opencode"
+mkdir -p "$HOME/.config/opencode/themes"
+# opencode 1.17.1's built-in "rose-pine" renders a near-black panel; ship an
+# explicit rose-pine theme (purple #191724 base) so opencode matches the existing
+# rose-pine agent demos. Verified to render bg ~#191724 (vs the built-in #0a0a0a).
+cat > "$HOME/.config/opencode/themes/lilbee-rose-pine.json" <<'THEME'
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "defs": {
+    "base": "#191724", "surface": "#1f1d2e", "overlay": "#26233a",
+    "muted": "#6e6a86", "subtle": "#908caa", "text": "#e0def4",
+    "love": "#eb6f92", "gold": "#f6c177", "rose": "#ebbcba",
+    "pine": "#31748f", "foam": "#9ccfd8", "iris": "#c4a7e7", "highlightMed": "#403d52"
+  },
+  "theme": {
+    "primary": "iris", "secondary": "foam", "accent": "rose",
+    "error": "love", "warning": "gold", "success": "pine", "info": "foam",
+    "text": "text", "textMuted": "muted",
+    "background": "base", "backgroundPanel": "surface", "backgroundElement": "overlay",
+    "border": "highlightMed", "borderActive": "iris", "borderSubtle": "overlay",
+    "syntaxComment": "muted", "syntaxKeyword": "pine", "syntaxFunction": "rose",
+    "syntaxVariable": "text", "syntaxString": "gold", "syntaxNumber": "gold",
+    "syntaxType": "foam", "syntaxOperator": "subtle", "syntaxPunctuation": "subtle"
+  }
+}
+THEME
 cat > "$HOME/.config/opencode/opencode.json" <<'OC'
 { "$schema": "https://opencode.ai/config.json",
-  "theme": "rose-pine",
+  "theme": "lilbee-rose-pine",
   "permission": { "edit": "allow" },
   "tools": { "webfetch": false },
   "autoupdate": false }
 OC
+# opencode persists the active theme in a state db that overrides the config file;
+# clear it so the custom theme applies cleanly on this run.
+rm -f "$HOME/.local/share/opencode/opencode.db"* 2>/dev/null || true
 # Pre-accept the launcher's first-run consent at the EXACT cfg.data_dir (a shell
 # guess at the path misses it, and the prompt then eats the typed reel prompt).
 ( cd "$REPO" && LILBEE_DATA="$DATA" uv run python -c "

--- a/tools/qa/lilbee_reels/run.sh
+++ b/tools/qa/lilbee_reels/run.sh
@@ -103,7 +103,7 @@ Output opencode.mp4
 Set Shell bash
 Set Width 1400
 Set Height 900
-Set FontSize 14
+Set FontSize 18
 Set Padding 20
 Set Theme "rose-pine"
 Set Margin 30

--- a/tools/qa/lilbee_reels/run.sh
+++ b/tools/qa/lilbee_reels/run.sh
@@ -65,7 +65,7 @@ log "warm ready"
 
 # 5. The reel tape: launch opencode (reuses the warm serve), ask one prompt that
 #    forces a lilbee_search over the lilbee source AND a real code change.
-PROMPT="Using my indexed lilbee source, briefly explain how lilbee registers itself into opencode's config (cite the files). Then add a 'lilbee launch --list' subcommand that prints the supported agent names, reading the real launcher module to match its style. Add a focused test for it under tests/cli/ and run ONLY that one test file with 'uv run pytest <thatfile> -q' to confirm it passes green. Do NOT run the full suite or 'make check'. Keep it minimal and do not ask me questions."
+PROMPT="Be concise and efficient; minimal explanation. Add a 'lilbee launch --list' subcommand that prints the supported agent names, reading src/lilbee/cli/launchers/__init__.py to match its style. Then write tests/cli/test_launch_list.py with one test and run exactly 'uv run pytest tests/cli/test_launch_list.py -q'. Stop as soon as it passes green. Do NOT run the full suite or make check, and do NOT explore beyond what you need."
 WS="$REPO"
 cat > "$OUT/opencode.tape" <<TAPE
 Output opencode.gif
@@ -87,7 +87,7 @@ Sleep 16s
 Type "$PROMPT"
 Sleep 1s
 Enter
-Sleep 175s
+Sleep 270s
 Screenshot opencode.png
 TAPE
 

--- a/tools/qa/lilbee_reels/run.sh
+++ b/tools/qa/lilbee_reels/run.sh
@@ -54,8 +54,8 @@ log "warm ready"
 PROMPT="Using my indexed lilbee source, first explain how lilbee registers itself into opencode's configuration, citing the exact files. Then add a 'lilbee launch --list' subcommand that prints the supported agent names by reading the real launcher module to match its style. Keep it minimal, pick sensible defaults, and do not ask me any questions."
 WS="$REPO"
 cat > "$OUT/opencode.tape" <<TAPE
-Output $OUT/opencode.gif
-Output $OUT/opencode.mp4
+Output opencode.gif
+Output opencode.mp4
 Set Shell bash
 Set Width 1600
 Set Height 900
@@ -74,11 +74,13 @@ Type "$PROMPT"
 Sleep 1s
 Enter
 Sleep 220s
-Screenshot $OUT/opencode.png
+Screenshot opencode.png
 TAPE
 
 log "recording opencode reel"
-( cd "$WS" && VHS_NO_SANDBOX=true vhs "$OUT/opencode.tape" > "$OUT/vhs-opencode.log" 2>&1 ) \
+# VHS must run from the tape's dir with RELATIVE Output paths (absolute trips its
+# parser on the pod); the tape itself cd's into the repo for the commands.
+( cd "$OUT" && VHS_NO_SANDBOX=true vhs opencode.tape > "$OUT/vhs-opencode.log" 2>&1 ) \
   && log "opencode reel recorded" \
   || { log "vhs FAILED"; tail -8 "$OUT/vhs-opencode.log"; echo "REELS_FAILED vhs" > "$OUT/DONE"; exit 4; }
 

--- a/tools/qa/lilbee_reels/volume.sky.yaml
+++ b/tools/qa/lilbee_reels/volume.sky.yaml
@@ -1,0 +1,12 @@
+# Dedicated, fresh volume for the agent-launcher reels. SEPARATE from the
+# protected lilbee-qa volume (which this project never touches). Small, because
+# the reels need one ~17GB model + the engine cache, not the giant matrix set.
+# Kept only so retakes don't re-pull the model; delete it once the reels are done:
+#   sky volumes delete lilbee-agentqa
+#
+# Same DC as the (idle) lilbee-qa volume — CA-MTL-3 has A100-80GB-SXM — but a
+# distinct volume, so nothing of the protected one is mounted or modified.
+name: lilbee-agentqa
+type: runpod-network-volume
+infra: runpod/CA/CA-MTL-3
+size: 120Gi

--- a/tools/qa/opencode/pod_bootstrap.sh
+++ b/tools/qa/opencode/pod_bootstrap.sh
@@ -89,6 +89,13 @@ if [[ "$BACKEND" == cu* ]] && ! ldconfig -p 2>/dev/null | grep -q 'libcudart\.so
   # on a pod there is no such boundary, so source it ourselves (nvcc on PATH) and
   # refresh the linker cache so the engine resolves libcudart at runtime.
   source /tmp/toolkit-env.sh
+  # The toolkit drops the runtime libs under /usr/local/cuda*/targets/.../lib but
+  # does not add that dir to the linker search path, so `ldconfig` alone never
+  # indexes libcudart.so.12 and a cached-engine boot dies with "cannot open
+  # libcudart.so.12". Register the dir in ld.so.conf so the engine resolves it
+  # system-wide (no per-process LD_LIBRARY_PATH needed).
+  CUDA_LIB_DIR=$(ls -d /usr/local/cuda*/targets/x86_64-linux/lib 2>/dev/null | head -1)
+  [ -n "$CUDA_LIB_DIR" ] && echo "$CUDA_LIB_DIR" > /etc/ld.so.conf.d/cuda-lilbee.conf
   ldconfig
 fi
 if [ ! -x "$ENGINE_CACHE/llama-server" ]; then


### PR DESCRIPTION
## Problem

lilbee could be a model provider for opencode, but the wiring was ephemeral: it injected an inline config per session and persisted nothing, so lilbee only existed while `lilbee launch opencode` was driving. There was no hermes support, and nothing shared the user's existing agent setup.

## Solution

`lilbee launch opencode` and the new `lilbee launch hermes` register lilbee as a durable provider (and MCP search tool) directly in the user's own config (`~/.config/opencode/opencode.json`, `~/.hermes/config.yaml`) via a non-destructive deep-merge. Only the `lilbee` keys and the active model are written; the user's other providers, settings, memory, and skills stay intact and shared, not isolated. The session token is referenced by interpolation (`{env:LILBEE_TOKEN}` / `${LILBEE_TOKEN}`) and lives only in the agent's secret store, never as a literal in the config file. `--no-mcp` (or `agent_mcp_enabled=false`) cleanly removes the MCP entry and leaves lilbee as the model provider only. The launcher honors `cfg.server_port` so a persisted URL stays valid, and `lilbee agent-config hermes` prints the paste-ready block.

Shared helpers (config deep-merge, corrupt-config-refusing load/atomic-write, bundled-skill installer) back both launchers, and the opencode launcher drops its old `OPENCODE_CONFIG_CONTENT` path.

Tests cover the merge/prune, corrupt-config refusal, token-never-on-disk, preserve-existing-config, and the server-port branch; the full suite is green at 100% coverage.

Two notes for reviewers: hermes is not installable in CI, so the live behavior (opens onto the lilbee model, skips the setup wizard) needs a manual smoke test against a real hermes; the config shape follows hermes's documented custom-provider plus `${VAR}` expansion. And five pre-existing `test_cli_memory.py::TestDisabled` failures on this branch are unrelated to this change (they fail identically with these commits stashed).
