### PR TITLE
fix: multi-GPU fit chip, selective xet downloads, nav-crash guard

### DIFF
--- a/src/lilbee/__init__.py
+++ b/src/lilbee/__init__.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import os
 import threading
 
-# Disable huggingface_hub's xet transfer layer before any HF submodule loads.
-# huggingface_hub.constants reads HF_HUB_DISABLE_XET at import time, so this
-# must run before the first `import huggingface_hub` anywhere in the process.
-# Workaround for HF issue #4058: xet-core reports progress in 3-4 coarse jumps
-# instead of continuously, making download bars appear stuck on large files.
-# Forcing the HTTP path restores smooth per-chunk tqdm updates. Users can still
-# opt back into xet by setting HF_HUB_DISABLE_XET=0 in their environment.
+# Disable huggingface_hub's xet transfer by default so the download bar stays
+# smooth: xet reports progress in a few coarse jumps (the bar looks stuck),
+# while the plain HTTP path with small chunks updates several times a second.
+# The catalog re-enables xet per-download for large files (catalog/download.py),
+# where xet's speed is worth the coarser bar. Set HF_HUB_DISABLE_XET=0 to force
+# xet for every download.
 os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
 
 # Suppress HF-default tqdm bars (metadata probes, snapshot summaries) that

--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -59,11 +59,11 @@ an acceptable cost for a correct restore."""
 def _download_with_xet(config: DownloadConfig) -> Path:
     """Re-run the download with xet enabled, for files past the HTTP size cap.
 
-    lilbee disables xet by default (``HF_HUB_DISABLE_XET``) so download progress
-    bars stay smooth, but huggingface_hub refuses files over its HTTP size cap on
-    the regular path and only xet can fetch them. ``is_xet_available()`` reads the
-    constant live, so flip it for this one download (under ``_xet_flip_lock`` so
-    concurrent xet downloads cannot corrupt the restore) and restore it after.
+    xet is enabled by default, but a user can force the slow HTTP path with
+    ``HF_HUB_DISABLE_XET=1``; huggingface_hub then refuses files over its HTTP
+    size cap, and only xet can fetch them. ``is_xet_available()`` reads the
+    constant live, so flip it on for this one download (under ``_xet_flip_lock``
+    so concurrent xet downloads cannot corrupt the restore) and restore it after.
     hf_xet is a hard dependency, so the xet path is always available.
     """
     from huggingface_hub import constants, hf_hub_download
@@ -78,15 +78,21 @@ def _download_with_xet(config: DownloadConfig) -> Path:
             constants.HF_HUB_DISABLE_XET = original
 
 
-def _hf_download_or_translate(entry: CatalogModel, config: DownloadConfig) -> Path:
-    """Run the HF download and translate every error class into a clean exception."""
+def _hf_download_or_translate(
+    entry: CatalogModel, config: DownloadConfig, *, use_xet: bool = False
+) -> Path:
+    """Run the HF download and translate every error class into a clean exception.
+
+    *use_xet* forces xet for this file (large files, where xet's speed beats the
+    smoother HTTP bar). Otherwise the default HTTP path is used, with a one-shot
+    xet fallback for files past huggingface_hub's HTTP size cap.
+    """
     from huggingface_hub import hf_hub_download
     from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
 
     try:
-        # HF_HUB_DISABLE_XET is set in lilbee/__init__.py at import time; the
-        # _download_with_xet fallback flips the constant directly (not the env)
-        # for files that only xet can deliver.
+        if use_xet:
+            return _download_with_xet(config)
         return Path(hf_hub_download(**config.model_dump(exclude_none=True)))
     except TaskCancelledError:
         raise
@@ -102,13 +108,19 @@ def _hf_download_or_translate(entry: CatalogModel, config: DownloadConfig) -> Pa
     except OSError as exc:
         raise RuntimeError(f"I/O error downloading {entry.hf_repo}: {exc}") from None
     except ValueError as exc:
-        if _HTTP_TOO_LARGE_MARKER in str(exc):
+        if not use_xet and _HTTP_TOO_LARGE_MARKER in str(exc):
             return _download_with_xet(config)
         raise RuntimeError(f"Failed to download {entry.hf_repo}: ValueError: {exc}") from None
     except Exception as exc:
         raise RuntimeError(
             f"Failed to download {entry.hf_repo}: {type(exc).__name__}: {exc}"
         ) from None
+
+
+# Above this total model size, fetch via xet (much faster) even though its
+# progress bar is coarser; below it, the HTTP path's smooth per-chunk bar is
+# worth the wait. Read from the catalog's known size_gb, so no extra probe.
+_XET_SIZE_THRESHOLD_GB = 8.0
 
 
 _SPLIT_SHARD_RE = re.compile(r"^(?P<base>.+)-(?P<idx>\d{5})-of-(?P<total>\d{5})\.gguf$")
@@ -183,10 +195,19 @@ def download_model(
         if shard_sizes and all(size != _SIZE_UNKNOWN for size in shard_sizes)
         else 0
     )
+    # Big models go over xet (fast, coarser bar); small ones stay on the HTTP
+    # path for its smooth per-chunk progress. Decided once from the catalog size.
+    use_xet = entry.size_gb >= _XET_SIZE_THRESHOLD_GB
     tracker = _ProgressTracker(on_progress, grand_total=grand_total) if on_progress else None
     shard_paths: list[Path] = []
     for shard in shards:
-        log.info("Downloading %s/%s → %s", entry.hf_repo, shard, models_dir)
+        log.info(
+            "Downloading %s/%s → %s (%s)",
+            entry.hf_repo,
+            shard,
+            models_dir,
+            "xet" if use_xet else "http",
+        )
         config = DownloadConfig(
             repo_id=entry.hf_repo,
             filename=shard,
@@ -194,7 +215,7 @@ def download_model(
             cache_dir=str(models_dir),
             tqdm_class=tracker.make_tqdm_class() if tracker else None,
         )
-        shard_path = _hf_download_or_translate(entry, config)
+        shard_path = _hf_download_or_translate(entry, config, use_xet=use_xet)
         shard_paths.append(shard_path)
         if tracker is not None:
             tracker.shard_done(shard_path.stat().st_size)

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, ClassVar, cast
 
 from textual.app import App, ComposeResult
+from textual.await_complete import AwaitComplete
 from textual.binding import Binding, BindingType
 from textual.css.query import NoMatches
 from textual.screen import Screen
@@ -370,40 +371,49 @@ class LilbeeApp(App[None]):
     def switch_view(self, view_name: str) -> None:
         """Switch to a named view, installing each screen at most once.
 
-        Guards against concurrent switches via ``self._switching`` so
-        rapid keypresses don't corrupt the screen stack.
-        ``active_view`` is updated after the switch completes.
+        Guards against concurrent switches via ``self._switching`` so rapid
+        keypresses can't corrupt the screen stack. ``active_view`` is updated
+        after the switch completes.
         """
         if self._switching:
             return
+        if view_name != "Chat" and get_views().get(view_name) is None:
+            return
         self._switching = True
 
+        awaitable: AwaitComplete | None = None
         if view_name == "Chat":
             from lilbee.cli.tui.screens.chat import ChatScreen
 
             if not isinstance(self.screen, ChatScreen):
-                self.switch_screen(_CHAT_SCREEN_NAME)
+                awaitable = self.switch_screen(_CHAT_SCREEN_NAME)
             # Already on Chat, just update state below.
         else:
-            factory = get_views().get(view_name)
-            if factory is None:
-                self._switching = False
-                return
             screen_name = _view_screen_name(view_name)
             if screen_name not in self._installed_screen_names:
-                self.install_screen(factory(), name=screen_name)
+                self.install_screen(get_views()[view_name](), name=screen_name)
                 self._installed_screen_names.add(screen_name)
-            self.switch_screen(screen_name)
+            awaitable = self.switch_screen(screen_name)
 
-        def _finish() -> None:
-            self.active_view = view_name
+        self.active_view = view_name
+        # ViewTabs.on_mount captured active_view before this runs, so the
+        # highlight would lag by one step without this push.
+        with contextlib.suppress(NoMatches):
+            self.screen.query_one(ViewTabs).active_view = view_name
+
+        async def _release() -> None:
+            # switch_screen updates the stack synchronously but finishes mounting
+            # in a deferred AwaitComplete. Releasing the guard on the next tick
+            # (the old call_later) let a rapid second nav re-enter switch_screen
+            # mid-transition and pop an empty result-callback stack (a Textual
+            # IndexError). Awaiting the transition first keeps the guard up for
+            # the whole switch; call_next is flushed by the same event loop, so a
+            # single completed switch still releases promptly.
+            if awaitable is not None:
+                await awaitable
             self._switching = False
-            # ViewTabs.on_mount captured active_view before this callback
-            # runs, so the highlight would lag by one step without this push.
-            with contextlib.suppress(NoMatches):
-                self.screen.query_one(ViewTabs).active_view = view_name
 
-        self.call_later(_finish)
+        self.call_next(_release)
 
     def action_push_help(self) -> None:
         if self.screen.query("HelpPanel"):

--- a/src/lilbee/providers/model_cache.py
+++ b/src/lilbee/providers/model_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import platform
+from collections.abc import Callable
 from enum import StrEnum
 from pathlib import Path
 
@@ -118,27 +119,29 @@ def compute_dynamic_ctx(
     return max(floor, quantized)
 
 
-def get_available_memory(fraction: float) -> int:
+def get_available_memory(fraction: float, *, total: bool = False) -> int:
     """Return usable GPU/unified memory in bytes, scaled by *fraction*.
     - macOS (Apple Silicon): unified memory via psutil
     - Linux with NVIDIA GPU: pynvml -> nvidia-smi -> psutil fallback
     - Other: psutil system memory
+
+    With multiple NVIDIA GPUs, *total* sums every card's memory (whole-fleet
+    capacity, for deciding whether a model can run tensor-split across all of
+    them); the default sizes against the smallest single card.
     """
     import psutil
 
     system = platform.system()
 
     if system == "Darwin":
-        total = psutil.virtual_memory().total
-        return int(total * fraction)
+        return int(psutil.virtual_memory().total * fraction)
 
     if system in ("Linux", "Windows"):
-        nvidia_mem = _try_nvidia_memory()
+        nvidia_mem = _try_nvidia_memory(sum if total else min)
         if nvidia_mem is not None:
             return int(nvidia_mem * fraction)
 
-    total = psutil.virtual_memory().total
-    return int(total * fraction)
+    return int(psutil.virtual_memory().total * fraction)
 
 
 def free_system_memory() -> int:
@@ -164,11 +167,13 @@ def has_nvidia_gpu() -> bool:
     return _try_nvidia_memory() is not None
 
 
-def _try_nvidia_memory() -> int | None:
+def _try_nvidia_memory(reducer: Callable[[list[int]], int] = min) -> int | None:
     """NVIDIA GPU total memory via pynvml, then nvidia-smi.
 
-    Takes the MINIMUM total across visible devices: sizing against the smallest
-    card is conservative on a heterogeneous-GPU host.
+    *reducer* combines the per-device totals. ``min`` (the default) sizes against
+    the smallest card, the safe budget for a single server or a per-card
+    tensor-split share. ``sum`` gives whole-fleet capacity, used only by the
+    catalog fit chip to decide whether a model can run split across every card.
     """
     try:
         import pynvml  # type: ignore[import-untyped]
@@ -180,7 +185,7 @@ def _try_nvidia_memory() -> int | None:
         ]
         pynvml.nvmlShutdown()
         if totals:
-            return min(totals)
+            return reducer(totals)
     except Exception:  # noqa: S110 -- optional GPU detect; absence is expected on non-NVIDIA hosts
         pass
 
@@ -198,7 +203,7 @@ def _try_nvidia_memory() -> int | None:
         if result.returncode == 0:
             mibs = [int(line) for line in result.stdout.strip().splitlines() if line.strip()]
             if mibs:
-                return min(mibs) * 1024 * 1024
+                return reducer(mibs) * 1024 * 1024
     except Exception:  # noqa: S110 -- optional GPU detect; same rationale as above
         pass
 

--- a/src/lilbee/runtime/hardware.py
+++ b/src/lilbee/runtime/hardware.py
@@ -48,6 +48,11 @@ def compute_fit(model_size_bytes: int, available_bytes: int) -> FitChip:
 def available_memory_for_fit() -> int | None:
     """Bytes available to a model after ``cfg.gpu_memory_fraction``, or None on probe failure.
 
+    Sums every GPU's memory (``total=True``) because lilbee tensor-splits a model
+    too large for one card across the whole fleet; sizing the fit chip against a
+    single card would wrongly mark a runnable split model "won't run". The actual
+    per-card placement is decided precisely by the fleet planner at load time.
+
     Single entry point so the TUI and the HTTP catalog handler classify fit
     against the same number; otherwise the same model would chip differently in
     each surface.
@@ -55,7 +60,7 @@ def available_memory_for_fit() -> int | None:
     try:
         from lilbee.providers.model_cache import get_available_memory
 
-        return get_available_memory(cfg.gpu_memory_fraction)
+        return get_available_memory(cfg.gpu_memory_fraction, total=True)
     except Exception:
         return None
 

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -63,7 +63,9 @@ def test_resolve_placement_plan_uses_read_cache(monkeypatch):
         planning, "_server_model_inputs", lambda roles, *, unified_budget=None: ([], {}, 0)
     )
     monkeypatch.setattr(
-        planning, "_resolve_placement", lambda *a, **k: Placement(instances=(), unplaceable_roles=())
+        planning,
+        "_resolve_placement",
+        lambda *a, **k: Placement(instances=(), unplaceable_roles=()),
     )
     planning.resolve_placement_plan(None)
     planning.resolve_placement_plan(None)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1014,7 +1014,7 @@ class TestSplitShardDownload:
         import huggingface_hub.constants as hc
 
         monkeypatch.setattr(cfg, "models_dir", tmp_path)
-        monkeypatch.setattr(hc, "HF_HUB_DISABLE_XET", True)  # lilbee's default
+        monkeypatch.setattr(hc, "HF_HUB_DISABLE_XET", True)  # a user who forced the HTTP path
         entry = FEATURED_EMBEDDING[0]
         monkeypatch.setattr(catalog.download, "resolve_filename", lambda e: e.gguf_filename)
 
@@ -1036,6 +1036,27 @@ class TestSplitShardDownload:
         assert calls["n"] == 2  # original attempt + xet retry
         assert disable_during_retry == [False]  # xet was on for the retry
         assert hc.HF_HUB_DISABLE_XET is True  # flag restored afterwards
+
+    def test_import_disables_xet_by_default(self) -> None:
+        """Importing lilbee disables xet by default so the download bar stays
+        smooth; the catalog re-enables it per-download for large files."""
+        import os
+        import subprocess
+        import sys
+
+        env = {k: v for k, v in os.environ.items() if k != "HF_HUB_DISABLE_XET"}
+        out = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import os, lilbee; print(os.environ.get('HF_HUB_DISABLE_XET'))",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+        assert out.stdout.strip() == "1"
 
     def test_xet_flip_holds_lock_during_download(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1158,6 +1179,45 @@ class TestDownloadModel:
         monkeypatch.setattr("huggingface_hub.hf_hub_download", _fake_download)
         result = download_model(entry)
         assert result.exists()
+
+    def test_large_model_uses_xet_small_uses_http(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Models over the size threshold fetch via xet (fast); smaller ones stay
+        on the HTTP path for its smooth progress bar."""
+        monkeypatch.setattr(cfg, "models_dir", tmp_path)
+        monkeypatch.setattr(catalog.download, "resolve_filename", lambda e: "model.gguf")
+
+        xet_files: list[str] = []
+        http_files: list[str] = []
+
+        def fake_xet(config: Any) -> Path:
+            xet_files.append(config.filename)
+            return Path(_fake_download(repo_id=config.repo_id, cache_dir=config.cache_dir))
+
+        def fake_http(**kwargs: Any) -> str:
+            http_files.append(kwargs["filename"])
+            return _fake_download(**kwargs)
+
+        monkeypatch.setattr(catalog.download, "_download_with_xet", fake_xet)
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_http)
+
+        def _entry(size_gb: float) -> CatalogModel:
+            return CatalogModel(
+                hf_repo="org/Test-GGUF",
+                gguf_filename="model.gguf",
+                size_gb=size_gb,
+                min_ram_gb=1.0,
+                description="",
+                featured=False,
+                downloads=0,
+                task=ModelTask.CHAT,
+            )
+
+        download_model(_entry(20.0))  # large -> xet
+        download_model(_entry(1.0))  # small -> http
+        assert xet_files == ["model.gguf"]
+        assert http_files == ["model.gguf"]
 
     def test_calls_progress_callback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(cfg, "models_dir", tmp_path)

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -192,15 +192,33 @@ class TestGetAvailableMemory:
         fake_psutil.virtual_memory.return_value.total = 800_000_000
         monkeypatch.setitem(__import__("sys").modules, "psutil", fake_psutil)
         monkeypatch.setattr(platform, "system", lambda: "Linux")
-        monkeypatch.setattr("lilbee.providers.model_cache._try_nvidia_memory", lambda: None)
+        monkeypatch.setattr(
+            "lilbee.providers.model_cache._try_nvidia_memory", lambda reducer=min: None
+        )
         assert get_available_memory(0.25) == 200_000_000
 
     def test_linux_with_nvidia_uses_gpu_total(self, monkeypatch) -> None:
         monkeypatch.setattr(platform, "system", lambda: "Linux")
         monkeypatch.setattr(
-            "lilbee.providers.model_cache._try_nvidia_memory", lambda: 4_000_000_000
+            "lilbee.providers.model_cache._try_nvidia_memory",
+            lambda reducer=min: 4_000_000_000,
         )
         assert get_available_memory(0.5) == 2_000_000_000
+
+    def test_total_uses_sum_reducer_default_uses_min(self, monkeypatch) -> None:
+        """total=True sums every card; the default sizes against the smallest."""
+        captured: dict[str, object] = {}
+
+        def fake(reducer=min):  # per-card totals for a 3-GPU host
+            captured["reducer"] = reducer
+            return reducer([10, 20, 30])
+
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr("lilbee.providers.model_cache._try_nvidia_memory", fake)
+        assert get_available_memory(1.0) == 10
+        assert captured["reducer"] is min
+        assert get_available_memory(1.0, total=True) == 60
+        assert captured["reducer"] is sum
 
 
 class TestFreeSystemMemory:
@@ -283,6 +301,16 @@ class TestHeterogeneousGpuSizing:
         monkeypatch.setitem(__import__("sys").modules, "pynvml", fake_pynvml)
         assert _try_nvidia_memory() == 8 * 1024**3
 
+    def test_pynvml_sum_reducer_totals_every_device(self, monkeypatch) -> None:
+        # The fit chip sums all cards: a model can tensor-split across the fleet.
+        fake_pynvml = mock.MagicMock()
+        fake_pynvml.nvmlDeviceGetCount.return_value = 2
+        infos = {0: mock.MagicMock(total=24 * 1024**3), 1: mock.MagicMock(total=8 * 1024**3)}
+        fake_pynvml.nvmlDeviceGetHandleByIndex.side_effect = lambda i: i
+        fake_pynvml.nvmlDeviceGetMemoryInfo.side_effect = lambda handle: infos[handle]
+        monkeypatch.setitem(__import__("sys").modules, "pynvml", fake_pynvml)
+        assert _try_nvidia_memory(sum) == 32 * 1024**3
+
     def test_pynvml_zero_devices_falls_through_to_nvidia_smi(self, monkeypatch) -> None:
         fake_pynvml = mock.MagicMock()
         fake_pynvml.nvmlDeviceGetCount.return_value = 0
@@ -303,6 +331,19 @@ class TestHeterogeneousGpuSizing:
         result = mock.MagicMock(returncode=0, stdout="24576\n8192\n")
         monkeypatch.setattr("subprocess.run", mock.MagicMock(return_value=result))
         assert _try_nvidia_memory() == 8192 * 1024 * 1024
+
+    def test_nvidia_smi_sum_reducer_totals_every_line(self, monkeypatch) -> None:
+        original_import = __import__("builtins").__import__
+
+        def _no_pynvml(name, *args, **kwargs):
+            if name == "pynvml":
+                raise ImportError("not installed")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", _no_pynvml)
+        result = mock.MagicMock(returncode=0, stdout="24576\n8192\n")
+        monkeypatch.setattr("subprocess.run", mock.MagicMock(return_value=result))
+        assert _try_nvidia_memory(sum) == (24576 + 8192) * 1024 * 1024
 
 
 class TestHasNvidiaGpu:

--- a/tests/test_runtime_hardware.py
+++ b/tests/test_runtime_hardware.py
@@ -55,19 +55,29 @@ def test_chip_is_immutable() -> None:
     raise AssertionError("FitChip should be frozen")
 
 
-def test_available_memory_for_fit_returns_bytes_from_probe(monkeypatch) -> None:
+def test_available_memory_for_fit_sums_whole_fleet(monkeypatch) -> None:
+    """The fit chip must ask for the whole-fleet total (total=True) so a model
+    that tensor-splits across cards isn't wrongly marked 'won't run'."""
     import lilbee.providers.model_cache as mc
     from lilbee.core.config import cfg
 
     cfg.gpu_memory_fraction = 0.5
-    monkeypatch.setattr(mc, "get_available_memory", lambda fraction: int(16 * _GB * fraction))
-    assert available_memory_for_fit() == 8 * _GB
+    captured: dict[str, object] = {}
+
+    def fake(fraction: float, *, total: bool = False) -> int:
+        captured["total"] = total
+        # one 16 GB card vs four 16 GB cards summed
+        return int((64 if total else 16) * _GB * fraction)
+
+    monkeypatch.setattr(mc, "get_available_memory", fake)
+    assert available_memory_for_fit() == 32 * _GB
+    assert captured["total"] is True
 
 
 def test_available_memory_for_fit_returns_none_when_probe_raises(monkeypatch) -> None:
     import lilbee.providers.model_cache as mc
 
-    def boom(_fraction: float) -> int:
+    def boom(_fraction: float, *, total: bool = False) -> int:
         raise RuntimeError("psutil missing")
 
     monkeypatch.setattr(mc, "get_available_memory", boom)

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -102,6 +102,31 @@ async def test_bracket_keys_cycle_all_screens():
             )
 
 
+async def test_view_switch_guard_held_until_transition_completes():
+    """The switch guard stays up until Textual's deferred transition completes,
+    so a rapid second switch is dropped instead of re-entering switch_screen
+    mid-transition and crashing on an empty result-callback stack.
+    """
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        app.switch_view("Catalog")
+        # Guard is set synchronously; a re-entrant switch is dropped.
+        assert app._switching is True
+        app.switch_view("Settings")
+        assert app.active_view == "Catalog"
+
+        await pilot.pause()
+        # Guard releases only after the transition finishes; now the next
+        # switch is accepted.
+        assert app._switching is False
+        assert isinstance(app.screen, CatalogScreen)
+        app.switch_view("Settings")
+        await pilot.pause()
+        assert isinstance(app.screen, SettingsScreen)
+
+
 async def test_bracket_keys_typed_literally_when_chat_input_focused():
     """Pressing [ or ] with the chat input focused must insert text, not switch screens."""
     app = LilbeeApp()


### PR DESCRIPTION
## Problem
- The catalog "fit" chip sized a model against the smallest single GPU, so a model that runs fine split across the cards showed "won't run".
- Large model downloads forced the plain HTTP path and ran far below the link speed, while xet (much faster) reports progress in a few coarse jumps that make the bar look stuck.
- Spamming the view-nav keys crashed the TUI: a second switch re-entered the screen change before the previous one finished.

## Solution
- The fit chip now sums all GPUs, so a model that tensor-splits reads as runnable. Per-card sizing (engine params, planning) still uses the smallest card, and the fleet planner still decides exact placement at load.
- Pick the download transport by size: large models (>8 GB) go over xet for the speed, where its coarser bar is an acceptable trade; smaller models stay on the HTTP path for its smooth per-chunk progress. xet stays disabled by default and the catalog re-enables it per large download.
- Hold the nav guard until the screen transition actually completes, so a rapid second keypress is ignored instead of corrupting the screen stack.

## Tests
Coverage for the all-GPU sum, the fit chip using it, xet disabled on import, the large-vs-small transport choice, and the nav guard holding across a transition. Full suite passes apart from the known local memory-test env artifact (passes in CI); lint, format, and typecheck are green.