### PR TITLE
fix(fleet): keep query embeds off released ingest replicas

### DIFF
--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -347,6 +347,9 @@ class FleetProvider:
         # Model ids of elastic ingest replicas (embed/vision replica>=1); populated
         # by _adopt_swap and consumed by release_ingest_pool.
         self._elastic_members: list[str] = []
+        # The client objects for those elastic replicas, so release_ingest_pool can
+        # mark them unhealthy and keep query routing on the persistent replica-0.
+        self._elastic_clients: list[LlamaServerClient] = []
         # Latched once shutdown runs. A discarded provider (reset_services swaps
         # in a new one) can still have an in-flight warm-up or reload daemon
         # thread; without this latch that thread could start a llama-swap after
@@ -451,22 +454,25 @@ class FleetProvider:
         # token_cap truncates oversize embed/rerank inputs to the per-slot context
         # (the in-process backstop); the longer timeout covers a cold upstream load.
         clients: dict[WorkerRole, list[LlamaServerClient]] = {}
+        elastic_clients: list[LlamaServerClient] = []
         for launch in launches:
-            clients.setdefault(launch.role, []).append(
-                LlamaServerClient(
-                    endpoint,
-                    launch.model_id,
-                    token_cap=launch.token_cap,
-                    timeout=_request_timeout_s(launch.weights_bytes),
-                    rerank_mode=launch.rerank_mode,
-                )
+            client = LlamaServerClient(
+                endpoint,
+                launch.model_id,
+                token_cap=launch.token_cap,
+                timeout=_request_timeout_s(launch.weights_bytes),
+                rerank_mode=launch.rerank_mode,
             )
+            clients.setdefault(launch.role, []).append(client)
+            if launch.role in REPLICATED_ROLES and launch.replica >= 1:
+                elastic_clients.append(client)
         self._clients = clients
         self._elastic_members = [
             launch.model_id
             for launch in launches
             if launch.role in REPLICATED_ROLES and launch.replica >= 1
         ]
+        self._elastic_clients = elastic_clients
         chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
         self._chat_slots = chat.slots if chat is not None else 1
         self._chat_ctx = chat.ctx if chat is not None else None
@@ -528,12 +534,21 @@ class FleetProvider:
 
         Best-effort and non-disruptive: the persistent query fleet (chat, embed-0,
         rerank, vision-0) stays loaded. Called when the last active ingest finishes.
+
+        The replica clients are marked unhealthy first, so least-busy routing keeps
+        query traffic on the persistent replica-0 instead of picking an idle
+        replica we just unloaded -- which would force an on-demand reload that
+        contends for VRAM with a large chat model and surfaces as a 500. A reload
+        re-adopts a fresh, healthy pool.
         """
         with self._lock:
             swap = self._swap
             members = list(self._elastic_members)
+            clients = list(self._elastic_clients)
         if swap is None:
             return
+        for client in clients:
+            client.mark_unhealthy()
         for model_id in members:
             if not swap.unload(model_id):
                 log.info("ingest pool: unload of %s did not confirm (swap may be cold)", model_id)

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -63,7 +63,9 @@ def test_resolve_placement_plan_uses_read_cache(monkeypatch):
         planning, "_server_model_inputs", lambda roles, *, unified_budget=None: ([], {}, 0)
     )
     monkeypatch.setattr(
-        planning, "_resolve_placement", lambda *a, **k: Placement(instances=(), unplaceable_roles=())
+        planning,
+        "_resolve_placement",
+        lambda *a, **k: Placement(instances=(), unplaceable_roles=()),
     )
     planning.resolve_placement_plan(None)
     planning.resolve_placement_plan(None)

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -775,6 +775,39 @@ def test_release_ingest_pool_unloads_only_elastic_replicas() -> None:
     swap.unload.assert_called()
 
 
+def test_adopt_swap_tracks_elastic_clients(monkeypatch) -> None:
+    # replica-0 is the persistent server; replica>=1 are the elastic ingest pool.
+    launches = [
+        _fake_launch(WorkerRole.EMBED, replica=0),
+        _fake_launch(WorkerRole.EMBED, replica=1),
+    ]
+    _install_engine(monkeypatch, launches=launches)
+    p = FleetProvider()
+    p._ensure_swap()
+    assert len(p._elastic_clients) == 1  # only the replica>=1 client is elastic
+    assert p._elastic_clients[0] in p._clients[WorkerRole.EMBED]
+
+
+def test_release_ingest_pool_marks_elastic_clients_unhealthy() -> None:
+    from unittest import mock
+
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    # An unloaded replica left healthy + idle would be picked by least-busy routing
+    # and force a VRAM-contending reload; marking it unhealthy keeps query traffic
+    # on the persistent replica-0.
+    p = FleetProvider()
+    p._elastic_members = ["embed-1"]
+    elastic = mock.Mock()
+    p._elastic_clients = [elastic]
+    p._swap = mock.Mock()
+    p._swap.unload.return_value = True
+
+    p.release_ingest_pool()
+
+    elastic.mark_unhealthy.assert_called_once()
+
+
 def test_release_ingest_pool_noop_when_no_swap() -> None:
     from lilbee.providers.fleet.provider import FleetProvider
 


### PR DESCRIPTION
## Problem
After an ingest, `release_ingest_pool` unloads the elastic embed/vision replicas to free VRAM, but leaves them in the client pool — still marked healthy and idle. Least-busy routing then picks one of those idle-but-unloaded replicas for the next query, which forces an on-demand reload that contends for VRAM with a large chat model and surfaces as a 500 / "model unloaded", aborting the fleet. This is what blocked loading a 235B chat model alongside embed on a 4-GPU box.

## Solution
Track the elastic replica clients in `_adopt_swap` and mark them unhealthy in `release_ingest_pool` (before unloading), so least-busy routing keeps query traffic on the persistent replica-0 (which stays loaded). A reload re-adopts a fresh, healthy pool.

## Tests
`_adopt_swap` tracks the elastic clients; `release_ingest_pool` marks them unhealthy. `provider.py` stays at 100% coverage; lint/format/typecheck green.

Note: this hardens a race identified from the code and logs; it has not yet been reproduced/validated on a multi-GPU pod (deferred per cost). The next hardware run of the 235B-across-4-GPU scenario is the empirical gate.