### PR TITLE
SEO: intent landing pages, FAQ schema, and a regression guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
   <a href="https://github.com/tobocop2/lilbee#install"><img src="https://img.shields.io/badge/Scoop-bucket-555555?logo=windows&logoColor=white" alt="Scoop bucket"></a>
 </p>
 
-A batteries-included local search engine you can talk to: it runs the AI models, indexes your files and code, crawls the web, and plugs into your coding agent, so there's nothing else to install or set up. Ask in plain English; every answer cites the file and line.
+A batteries-included local search engine you can talk to: it runs the AI models, indexes your files and code, crawls the web, and plugs into your coding agent, so there's nothing else to install or set up. Ask in plain English; every answer cites the file and line. It is local RAG, done for you: the retrieval and the model both run on your own machine.
 
 ![ask lilbee "what is lilbee in one sentence?" and get a cited answer drawn from its own README](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/what_is_lilbee.gif)
 
@@ -410,6 +410,20 @@ lilbee stands on a stack of established open-source projects, all bundled into o
 - [Textual] draws the terminal; [Litestar] runs the HTTP server.
 - [MCP Python SDK] is the agent surface; [Typer] is the CLI; [Pydantic] is the config + validation backbone.
 - [Nuitka] compiles the whole thing into the standalone single-file binary, bundling its own Python runtime so there is nothing to install and nothing to compile.
+
+## FAQ
+
+**What is lilbee, in one line?** A local AI search engine: it runs the models and searches your files, code, and the web, with answers that cite the source.
+
+**Is it really one program?** Yes. The model runtime (llama.cpp) and the index (LanceDB) run inside lilbee. No separate model server, no vector database, no container.
+
+**Does my data leave my machine?** No. Your files stay on disk and search runs locally. A cloud model is used only when you pick one.
+
+**Is lilbee a model manager?** Yes, a complete one. It browses Hugging Face, downloads models, assigns roles, runs them on Metal, Vulkan, or CUDA, and places large models across multiple GPUs, so you do not need a separate model runner. Already use Ollama or LM Studio? Point lilbee at them instead.
+
+**Will a model fit my GPU?** lilbee reads the GGUF file and your devices and estimates fit before you download, and splits large models across multiple GPUs. More at [lilbee.sh/gpu](https://lilbee.sh/gpu/).
+
+**Can my coding agent use it?** Yes, over MCP. The agent reads your real code and docs before answering, cited to the file and line. More at [lilbee.sh/mcp](https://lilbee.sh/mcp/).
 
 ## Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ license = "Elastic-2.0"
 authors = [{ name = "tobocop2", email = "5562156+tobocop2@users.noreply.github.com" }]
 requires-python = ">=3.11"
 keywords = [
-    "rag", "local-llm", "local-ai",
-    "mcp", "mcp-server",
+    "rag", "local-rag", "local-llm", "local-ai",
+    "mcp", "mcp-server", "model-context-protocol",
     "semantic-search", "vector-search", "retrieval",
     "embeddings", "knowledge-base", "knowledge-management",
     "huggingface", "ocr", "web-crawler",
-    "model-manager", "llama-cpp", "gguf", "ollama", "lm-studio",
-    "second-brain", "personal-ai", "self-hosted", "privacy", "cli", "tui",
+    "model-manager", "llama-cpp", "gguf", "multi-gpu", "ollama", "lm-studio",
+    "obsidian", "second-brain", "personal-ai", "self-hosted", "privacy", "cli", "tui",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/site/code-search/index.html
+++ b/site/code-search/index.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G8F65BKGRJ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-G8F65BKGRJ');
+</script>
+
+<title>Local code search: ask your codebase, cited to the line | lilbee</title>
+<meta name="description" content="lilbee is local AI code search: index a repo and ask in plain English. It chunks code with tree-sitter so functions stay whole, ranks the best matches, and cites the exact file and line. Runs offline on your machine.">
+<link rel="canonical" href="https://lilbee.sh/code-search/">
+
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="lilbee">
+<meta property="og:title" content="Local code search: ask your codebase, cited to the line | lilbee">
+<meta property="og:description" content="Local AI code search: index a repo and ask in plain English. Code-aware chunking with tree-sitter, ranked matches, and citations to the exact file and line. Runs offline.">
+<meta property="og:url" content="https://lilbee.sh/code-search/">
+<meta property="og:image" content="https://lilbee.sh/social-card.png">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="lilbee answering a question about a codebase with a file and line citation">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Local code search: ask your codebase, cited to the line | lilbee">
+<meta name="twitter:description" content="Local AI code search: index a repo and ask in plain English. Code-aware chunking, ranked matches, and citations to the exact file and line. Runs offline.">
+<meta name="twitter:image" content="https://lilbee.sh/social-card.png">
+<meta name="twitter:image:alt" content="lilbee answering a question about a codebase with a file and line citation">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "lilbee", "item": "https://lilbee.sh/" },
+    { "@type": "ListItem", "position": 2, "name": "Code search", "item": "https://lilbee.sh/code-search/" }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "How is this different from grep?", "acceptedAnswer": { "@type": "Answer", "text": "grep matches exact text. lilbee searches by meaning, ranks the results by how well they answer your question, and writes a reply that cites the file and line. You ask in plain English instead of guessing the right pattern." } },
+    { "@type": "Question", "name": "What languages does it handle?", "acceptedAnswer": { "@type": "Answer", "text": "lilbee chunks code with tree-sitter using a broad language pack, so functions and definitions stay whole across many common languages instead of being split mid-body." } },
+    { "@type": "Question", "name": "Does my code leave my machine?", "acceptedAnswer": { "@type": "Answer", "text": "No. Indexing and search run locally. lilbee uses a cloud model only if you choose one; the code search itself stays on your machine." } },
+    { "@type": "Question", "name": "Can my coding agent use it?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. lilbee runs as an MCP server, so an MCP-aware coding agent can search your codebase through it and answer with file and line citations." } },
+    { "@type": "Question", "name": "Does it work offline?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. With local models in place, lilbee indexes and answers with no internet connection." } }
+  ]
+}
+</script>
+
+<link rel="stylesheet" href="../style.css?v=20260515a">
+<script src="../main.js?v=20260515a" defer></script>
+</head>
+<body>
+<div class="layout">
+  <main class="main">
+
+    <div class="topstrip">
+      <div><a class="badge" href="/">lilbee</a> <span>code search</span></div>
+      <div>
+        <span class="pill">tree-sitter</span>
+        <span class="pill">file:line</span>
+        <span class="pill">offline</span>
+      </div>
+    </div>
+
+    <p class="crumb"><a href="/">lilbee</a> / code search</p>
+
+    <section class="hero">
+<pre class="wordmark" aria-hidden="true">888 d8b 888 888
+888 Y8P 888 888
+888     888 888
+888 888 888 88888b.  .d88b.  .d88b.
+888 888 888 888 "88bd8P  Y8bd8P  Y8b
+888 888 888 888  88888888888888888888
+888 888 888 888 d88PY8b.    Y8b.
+888 888 888 88888P"  "Y8888  "Y8888</pre>
+      <h1 class="tagline">Ask questions about your <strong>codebase</strong>, answers cite the file and line. lilbee indexes a repo and searches it by meaning, all on your own machine.</h1>
+      <p class="sub">Local AI code search in one program. It chunks code so functions stay whole, ranks the matches that actually answer you, and points you at the exact line.</p>
+    </section>
+
+    <section>
+      <h2 class="label">search by meaning, not by pattern</h2>
+      <p class="lede">grep finds the text you typed. lilbee finds the code you meant. Ask in plain English, and it retrieves the functions and definitions that answer the question, ranks them by relevance, and replies with a citation back to the file and line. When nothing matches well, it says so rather than inventing an answer.</p>
+    </section>
+
+    <section>
+      <h2 class="label">code-aware from the ground up</h2>
+      <div class="caps">
+        <div class="cap">
+          <h3>chunked with tree-sitter</h3>
+          <p>Code is split along its real structure, so a function or class stays whole instead of being cut mid-body. Retrieval is only as good as the chunks underneath it.</p>
+        </div>
+        <div class="cap">
+          <h3>cited to the line</h3>
+          <p>Every answer links back to the file and line, so you can jump straight to the source and confirm it.</p>
+        </div>
+        <div class="cap">
+          <h3>a library per project</h3>
+          <p>Each repo gets its own scoped library, so one codebase never bleeds into another's results.</p>
+        </div>
+        <div class="cap">
+          <h3>reach it any way</h3>
+          <p>Use it as a terminal app, a command-line tool, or an MCP server your coding agent talks to.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="label">for you and for your agent</h2>
+      <p class="lede">Search your own codebase from the terminal, or hand the same retrieval to your coding agent over MCP so it reads the real code before it answers. lilbee runs the models itself on Metal, Vulkan, or CUDA, or works with your existing Ollama or LM Studio setup.</p>
+    </section>
+
+    <section>
+      <h2 class="label">questions</h2>
+      <div class="faq">
+        <details><summary>How is this different from grep?</summary><p>grep matches exact text. lilbee searches by meaning, ranks the results by how well they answer your question, and cites the file and line. You ask in plain English instead of guessing the right pattern.</p></details>
+        <details><summary>What languages does it handle?</summary><p>lilbee chunks code with tree-sitter using a broad language pack, so functions and definitions stay whole across many common languages.</p></details>
+        <details><summary>Does my code leave my machine?</summary><p>No. Indexing and search run locally. lilbee uses a cloud model only if you choose one; the code search itself stays on your machine.</p></details>
+        <details><summary>Can my coding agent use it?</summary><p>Yes. lilbee runs as an MCP server, so an MCP-aware coding agent can search your codebase through it and answer with file and line citations.</p></details>
+        <details><summary>Does it work offline?</summary><p>Yes. With local models in place, lilbee indexes and answers with no internet connection.</p></details>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="label">go deeper</h2>
+      <div class="links">
+        <a href="/"><span class="num">[1]</span><span>lilbee</span><span class="dots">·······································</span><span class="desc">home</span></a>
+        <a href="/mcp/"><span class="num">[2]</span><span>MCP server</span><span class="dots">·······································</span><span class="desc">for agents</span></a>
+        <a href="/local-rag/"><span class="num">[3]</span><span>Local RAG</span><span class="dots">·······································</span><span class="desc">your docs</span></a>
+        <a href="https://github.com/tobocop2/lilbee"><span class="num">[4]</span><span>GitHub</span><span class="dots">·······································</span><span class="desc">source</span></a>
+        <a href="https://pypi.org/project/lilbee/"><span class="num">[5]</span><span>PyPI</span><span class="dots">·······································</span><span class="desc">install</span></a>
+      </div>
+    </section>
+
+    <footer>
+      <div>
+<pre aria-hidden="true">+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|t|o|b|i|a|s|@|l|i|l|b|e|e|.|s|h|
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+</pre>
+      </div>
+      <div class="meta"><a href="https://github.com/tobocop2/lilbee">lilbee</a> &nbsp;.&nbsp; Elastic License 2.0</div>
+    </footer>
+  </main>
+
+  <aside class="bee-art" aria-hidden="true"><pre>     %           %
+         %           %
+            %           %
+               %          %
+                 %          %
+                   %          %                   :::
+                    %          %                ::::::
+                 %%%%%%  %%%%%%%%%            ::::::::
+              %%%%%ZZZZ%%%%%%   %%%ZZZZ     ::::::::::         ::::::
+             %%%ZZZZZ%%%%%%%%%%%%%%ZZZZZZ  :::::::::::    :::::::::::::::::
+             ZZZ%ZZZ%%%%%%%%%%%%%%%ZZZZZZZ::::::::::***:::::::::::::::::::::
+          ZZZ%ZZZZZZ%%%%%%%%%%%%%%ZZZZZZZZZ::::::***:::::::::::::::::::::::
+        ZZZ%ZZZZZZZZZZ%%%%%%%%%%ZZZZZZ%ZZZZ:::***:::::::::::::::::::::::
+       ZZ%ZZZZZZZZZZZZZZZZZZZZZZZ%%%%% %ZZZ:**::::::::::::::::::::::
+      ZZ%ZZZZZZZZZZZZZZZZZZZ%%%%% | | %ZZZ *:::::::::::::::::::
+      Z%ZZZZZZZZZZZZZZZ%%%%%%%%%%%%%%%ZZZ::::::::::::::::::::::::::
+       ZZZZZZZZZZZ%%%%%ZZZZZZZZZZZZZZZZZ%%%%:::ZZZZ:::::::::::::::::
+         ZZZZ%%%%%ZZZZZZZZZZZZZZZZZZ%%%%%ZZZ%%ZZZ%ZZ%%*:::::::::::
+            ZZZZZZZZZZZZZZZZZZ%%%%%%%%%ZZZZZZZZZZ%ZZ%:::*:::::::
+            *:::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZZZZZZ%%%*::::*::::
+          *:::::::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZ%%      *:::Z
+         **:ZZZZ:::%%%%%%%%%%%%%%%%%%%%%%%%%%%ZZ      ZZZZZ
+        *:ZZZZZZZ       %%%%%%%%%%%%%%%%%%%%%ZZZZ    ZZZZZZZ
+       *::::ZZZZZZ         %%%%%%%%%%%%%%%ZZZZZZZ      ZZZ
+        *::ZZZZZZ           Z%%%%%%%%%%%ZZZZZZZ%%
+          ZZZZ              ZZZZZZZZZZZZZZZZ%%%%%
+                           %%%ZZZZZZZZZZZ%%%%%%%%
+                          Z%%%%%%%%%%%%%%%%%%%%%
+                          ZZ%%%%%%%%%%%%%%%%%%%
+                          %ZZZZZZZZZZZZZZZZZZZ
+                          %%ZZZZZZZZZZZZZZZZZ
+                           %%%%%%%%%%%%%%%%
+                            %%%%%%%%%%%%%
+                             %%%%%%%%%
+                              ZZZZ
+                              ZZZ
+                             ZZ
+                            Z</pre></aside>
+</div>
+</body>
+</html>

--- a/site/gpu/index.html
+++ b/site/gpu/index.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G8F65BKGRJ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-G8F65BKGRJ');
+</script>
+
+<title>Will this model fit your GPU? See before you download | lilbee</title>
+<meta name="description" content="lilbee checks whether a GGUF model fits your GPU's VRAM before you download it, and splits large models across multiple GPUs with the right tensor split. VRAM estimates up front, no failed loads, no guesswork.">
+<link rel="canonical" href="https://lilbee.sh/gpu/">
+
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="lilbee">
+<meta property="og:title" content="Will this model fit your GPU? See before you download | lilbee">
+<meta property="og:description" content="lilbee estimates whether a GGUF model fits your VRAM before download, and splits large models across multiple GPUs. No failed loads, no guesswork.">
+<meta property="og:url" content="https://lilbee.sh/gpu/">
+<meta property="og:image" content="https://lilbee.sh/social-card.png">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="lilbee showing whether a model fits available GPU VRAM before download">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Will this model fit your GPU? See before you download | lilbee">
+<meta name="twitter:description" content="lilbee estimates whether a GGUF model fits your VRAM before download, and splits large models across multiple GPUs. No failed loads, no guesswork.">
+<meta name="twitter:image" content="https://lilbee.sh/social-card.png">
+<meta name="twitter:image:alt" content="lilbee showing whether a model fits available GPU VRAM before download">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "lilbee", "item": "https://lilbee.sh/" },
+    { "@type": "ListItem", "position": 2, "name": "Will it fit your GPU", "item": "https://lilbee.sh/gpu/" }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "How much VRAM do I need to run a model?", "acceptedAnswer": { "@type": "Answer", "text": "It depends on the parameter count and the quantization. As a rough guide at a 4-bit quant: a 7B model needs around 5 GB, a 13B around 9 GB, a 34B around 22 GB, and a 70B around 42 GB, plus a little more for the context window. lilbee reads the actual file to estimate your case rather than guessing." } },
+    { "@type": "Question", "name": "How does lilbee know if a model fits?", "acceptedAnswer": { "@type": "Answer", "text": "lilbee reads the GGUF file's headers with a gguf parser and probes your devices for free and total VRAM, then estimates whether the model plus its context will fit. If it will not, lilbee tells you before you download." } },
+    { "@type": "Question", "name": "Can it use multiple GPUs?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. lilbee places a large model across multiple GPUs with a tensor split sized to each device's VRAM, so a model that does not fit on one card can still run." } },
+    { "@type": "Question", "name": "What about Apple Silicon and Metal?", "acceptedAnswer": { "@type": "Answer", "text": "On Apple Silicon the GPU shares system memory, so the limit is your unified memory rather than a separate VRAM pool. lilbee runs on Metal and sizes the model to what is available." } },
+    { "@type": "Question", "name": "What if a model is too big?", "acceptedAnswer": { "@type": "Answer", "text": "lilbee flags it before download. You can pick a smaller quant, offload part of the model to system RAM, or spread it across more GPUs." } }
+  ]
+}
+</script>
+
+<link rel="stylesheet" href="../style.css?v=20260515a">
+<script src="../main.js?v=20260515a" defer></script>
+</head>
+<body>
+<div class="layout">
+  <main class="main">
+
+    <div class="topstrip">
+      <div><a class="badge" href="/">lilbee</a> <span>will it fit</span></div>
+      <div>
+        <span class="pill">gguf</span>
+        <span class="pill">vram-aware</span>
+        <span class="pill">multi-gpu</span>
+      </div>
+    </div>
+
+    <p class="crumb"><a href="/">lilbee</a> / will it fit your GPU</p>
+
+    <section class="hero">
+<pre class="wordmark" aria-hidden="true">888 d8b 888 888
+888 Y8P 888 888
+888     888 888
+888 888 888 88888b.  .d88b.  .d88b.
+888 888 888 888 "88bd8P  Y8bd8P  Y8b
+888 888 888 888  88888888888888888888
+888 888 888 888 d88PY8b.    Y8b.
+888 888 888 88888P"  "Y8888  "Y8888</pre>
+      <h1 class="tagline"><strong>Will this model fit your GPU?</strong> See before you download. lilbee reads the model file and your hardware, then tells you whether it fits, and splits big models across GPUs.</h1>
+      <p class="sub">No more downloading a 40 GB model only to watch it fail to load. lilbee estimates VRAM up front from the real GGUF file and the devices it finds on your machine.</p>
+    </section>
+
+    <section>
+      <h2 class="label">the problem with guesswork</h2>
+      <p class="lede">Picking a local model is usually trial and error: download something, try to load it, watch it run out of memory, pick a smaller quant, try again. lilbee does the arithmetic before the download. It reads the GGUF headers, checks the free and total VRAM on each device, and tells you whether the model and its context window will fit.</p>
+    </section>
+
+    <section>
+      <h2 class="label">a rough VRAM guide</h2>
+      <p class="lede">A starting point for a common 4-bit quant. Your exact numbers depend on the quant, the context length, and the runtime, which is why lilbee estimates from the actual file rather than a table.</p>
+      <div class="caps">
+        <div class="cap"><h3>7B</h3><p>about 5 GB at a 4-bit quant. Comfortable on an 8 GB card.</p></div>
+        <div class="cap"><h3>13B</h3><p>about 9 GB at a 4-bit quant. Fits a 12 GB card with room for context.</p></div>
+        <div class="cap"><h3>34B</h3><p>about 22 GB at a 4-bit quant. Wants a 24 GB card, or two smaller ones.</p></div>
+        <div class="cap"><h3>70B</h3><p>about 42 GB at a 4-bit quant. Needs multiple GPUs, where the tensor split matters.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="label">multiple GPUs, sized to each card</h2>
+      <p class="lede">When a model is too big for one card, lilbee spreads it across the GPUs you have, with a tensor split sized to each device's free VRAM rather than an even cut that overflows the smallest card. It runs on Metal, Vulkan, and CUDA, and can offload part of a model to system RAM when you want to stretch a tight setup.</p>
+    </section>
+
+    <section>
+      <h2 class="label">questions</h2>
+      <div class="faq">
+        <details><summary>How much VRAM do I need to run a model?</summary><p>It depends on the parameter count and the quantization. As a rough guide at a 4-bit quant: 7B is around 5 GB, 13B around 9 GB, 34B around 22 GB, and 70B around 42 GB, plus a little for the context window. lilbee reads the actual file to estimate your case.</p></details>
+        <details><summary>How does lilbee know if a model fits?</summary><p>It reads the GGUF file's headers with a gguf parser and probes your devices for free and total VRAM, then estimates whether the model plus its context will fit. If it will not, it tells you before you download.</p></details>
+        <details><summary>Can it use multiple GPUs?</summary><p>Yes. lilbee places a large model across multiple GPUs with a tensor split sized to each device's VRAM, so a model that does not fit on one card can still run.</p></details>
+        <details><summary>What about Apple Silicon and Metal?</summary><p>On Apple Silicon the GPU shares system memory, so the limit is your unified memory rather than a separate VRAM pool. lilbee runs on Metal and sizes the model to what is available.</p></details>
+        <details><summary>What if a model is too big?</summary><p>lilbee flags it before download. You can pick a smaller quant, offload part of the model to system RAM, or spread it across more GPUs.</p></details>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="label">go deeper</h2>
+      <div class="links">
+        <a href="/"><span class="num">[1]</span><span>lilbee</span><span class="dots">·······································</span><span class="desc">home</span></a>
+        <a href="/local-rag/"><span class="num">[2]</span><span>Local RAG</span><span class="dots">·······································</span><span class="desc">your docs</span></a>
+        <a href="/mcp/"><span class="num">[3]</span><span>MCP server</span><span class="dots">·······································</span><span class="desc">for agents</span></a>
+        <a href="https://github.com/tobocop2/lilbee"><span class="num">[4]</span><span>GitHub</span><span class="dots">·······································</span><span class="desc">source</span></a>
+        <a href="https://pypi.org/project/lilbee/"><span class="num">[5]</span><span>PyPI</span><span class="dots">·······································</span><span class="desc">install</span></a>
+      </div>
+    </section>
+
+    <footer>
+      <div>
+<pre aria-hidden="true">+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|t|o|b|i|a|s|@|l|i|l|b|e|e|.|s|h|
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+</pre>
+      </div>
+      <div class="meta"><a href="https://github.com/tobocop2/lilbee">lilbee</a> &nbsp;.&nbsp; Elastic License 2.0</div>
+    </footer>
+  </main>
+
+  <aside class="bee-art" aria-hidden="true"><pre>     %           %
+         %           %
+            %           %
+               %          %
+                 %          %
+                   %          %                   :::
+                    %          %                ::::::
+                 %%%%%%  %%%%%%%%%            ::::::::
+              %%%%%ZZZZ%%%%%%   %%%ZZZZ     ::::::::::         ::::::
+             %%%ZZZZZ%%%%%%%%%%%%%%ZZZZZZ  :::::::::::    :::::::::::::::::
+             ZZZ%ZZZ%%%%%%%%%%%%%%%ZZZZZZZ::::::::::***:::::::::::::::::::::
+          ZZZ%ZZZZZZ%%%%%%%%%%%%%%ZZZZZZZZZ::::::***:::::::::::::::::::::::
+        ZZZ%ZZZZZZZZZZ%%%%%%%%%%ZZZZZZ%ZZZZ:::***:::::::::::::::::::::::
+       ZZ%ZZZZZZZZZZZZZZZZZZZZZZZ%%%%% %ZZZ:**::::::::::::::::::::::
+      ZZ%ZZZZZZZZZZZZZZZZZZZ%%%%% | | %ZZZ *:::::::::::::::::::
+      Z%ZZZZZZZZZZZZZZZ%%%%%%%%%%%%%%%ZZZ::::::::::::::::::::::::::
+       ZZZZZZZZZZZ%%%%%ZZZZZZZZZZZZZZZZZ%%%%:::ZZZZ:::::::::::::::::
+         ZZZZ%%%%%ZZZZZZZZZZZZZZZZZZ%%%%%ZZZ%%ZZZ%ZZ%%*:::::::::::
+            ZZZZZZZZZZZZZZZZZZ%%%%%%%%%ZZZZZZZZZZ%ZZ%:::*:::::::
+            *:::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZZZZZZ%%%*::::*::::
+          *:::::::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZ%%      *:::Z
+         **:ZZZZ:::%%%%%%%%%%%%%%%%%%%%%%%%%%%ZZ      ZZZZZ
+        *:ZZZZZZZ       %%%%%%%%%%%%%%%%%%%%%ZZZZ    ZZZZZZZ
+       *::::ZZZZZZ         %%%%%%%%%%%%%%%ZZZZZZZ      ZZZ
+        *::ZZZZZZ           Z%%%%%%%%%%%ZZZZZZZ%%
+          ZZZZ              ZZZZZZZZZZZZZZZZ%%%%%
+                           %%%ZZZZZZZZZZZ%%%%%%%%
+                          Z%%%%%%%%%%%%%%%%%%%%%
+                          ZZ%%%%%%%%%%%%%%%%%%%
+                          %ZZZZZZZZZZZZZZZZZZZ
+                          %%ZZZZZZZZZZZZZZZZZ
+                           %%%%%%%%%%%%%%%%
+                            %%%%%%%%%%%%%
+                             %%%%%%%%%
+                              ZZZZ
+                              ZZZ
+                             ZZ
+                            Z</pre></aside>
+</div>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -58,6 +58,32 @@
 }
 </script>
 
+<!-- WebSite JSON-LD: names the site for search engines. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "lilbee",
+  "url": "https://lilbee.sh/",
+  "description": "A local AI search engine that runs the models and searches your files, code, and the web, with answers that cite the source."
+}
+</script>
+
+<!-- FAQPage JSON-LD: the questions people ask before they install. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "What is lilbee?", "acceptedAnswer": { "@type": "Answer", "text": "lilbee is a local AI search engine. It runs the models, indexes your files, code, and crawled web pages, and answers your questions in plain English with a citation to the exact source. It is one program, with no separate model server or vector database to set up." } },
+    { "@type": "Question", "name": "Is it really one program?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. The model runtime (llama.cpp) and the vector index (LanceDB) run inside lilbee. You install one thing and reach it as a terminal app, a command-line tool, an MCP server, a web API, or a Python library." } },
+    { "@type": "Question", "name": "Is lilbee a model manager? Do I need Ollama or LM Studio?", "acceptedAnswer": { "@type": "Answer", "text": "lilbee is a complete model manager on its own. It browses Hugging Face, downloads models, gives each one a role, and runs them on your GPU across Metal, Vulkan, or CUDA, and it places large models across multiple GPUs. You do not need a separate model runner. If you already use Ollama or LM Studio, you can point lilbee at them instead." } },
+    { "@type": "Question", "name": "Does my data leave my machine?", "acceptedAnswer": { "@type": "Answer", "text": "No. Your files stay on disk and search runs locally. lilbee uses a cloud model only when you pick one." } },
+    { "@type": "Question", "name": "What can I search?", "acceptedAnswer": { "@type": "Answer", "text": "Files and markdown, code, PDFs, office documents, ebooks, and scanned images through OCR, plus whole websites you crawl into markdown. Over 150 file types." } }
+  ]
+}
+</script>
+
 <link rel="stylesheet" href="style.css?v=20260515a">
 <script src="main.js?v=20260515a" defer></script>
 </head>
@@ -519,6 +545,27 @@
     <section>
       <h2 class="label">a note on answers</h2>
       <p class="note">Answers are only as good as the model you pick and the settings behind it. lilbee ships sane defaults, but exposes <strong>50+ settings</strong> you can tune: search, the answers, how your files get read.</p>
+    </section>
+
+    <section>
+      <h2 class="label">use it for</h2>
+      <div class="links">
+        <a href="local-rag/"><span class="num">[1]</span><span>Local RAG</span><span class="dots">·······································</span><span class="desc">your docs, cited</span></a>
+        <a href="code-search/"><span class="num">[2]</span><span>Code search</span><span class="dots">·······································</span><span class="desc">ask your codebase</span></a>
+        <a href="mcp/"><span class="num">[3]</span><span>MCP server</span><span class="dots">·······································</span><span class="desc">for your agent</span></a>
+        <a href="gpu/"><span class="num">[4]</span><span>Will it fit your GPU</span><span class="dots">·······································</span><span class="desc">vram, multi-gpu</span></a>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="label">questions</h2>
+      <div class="faq">
+        <details><summary>What is lilbee?</summary><p>lilbee is a local AI search engine. It runs the models, indexes your files, code, and crawled web pages, and answers your questions in plain English with a citation to the exact source. It is one program, with no separate model server or vector database to set up.</p></details>
+        <details><summary>Is it really one program?</summary><p>Yes. The model runtime (llama.cpp) and the vector index (LanceDB) run inside lilbee. You install one thing and reach it as a terminal app, a command-line tool, an MCP server, a web API, or a Python library.</p></details>
+        <details><summary>Is lilbee a model manager? Do I need Ollama or LM Studio?</summary><p>lilbee is a complete model manager on its own. It browses Hugging Face, downloads models, gives each one a role, and runs them on your GPU across Metal, Vulkan, or CUDA, and it places large models across multiple GPUs. You do not need a separate model runner. If you already use Ollama or LM Studio, you can point lilbee at them instead.</p></details>
+        <details><summary>Does my data leave my machine?</summary><p>No. Your files stay on disk and search runs locally. lilbee uses a cloud model only when you pick one.</p></details>
+        <details><summary>What can I search?</summary><p>Files and markdown, code, PDFs, office documents, ebooks, and scanned images through OCR, plus whole websites you crawl into markdown. Over 150 file types.</p></details>
+      </div>
     </section>
 
     <section>

--- a/site/local-rag/index.html
+++ b/site/local-rag/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G8F65BKGRJ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-G8F65BKGRJ');
+</script>
+
+<title>Local RAG: cited answers from your own documents | lilbee</title>
+<meta name="description" content="lilbee is a local RAG engine: it indexes your files, code, PDFs, and crawled pages, then answers in plain English with a citation to the exact source. Runs on your machine, no cloud, no separate vector database.">
+<link rel="canonical" href="https://lilbee.sh/local-rag/">
+
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="lilbee">
+<meta property="og:title" content="Local RAG: cited answers from your own documents | lilbee">
+<meta property="og:description" content="A local RAG engine in one program: index your files, code, PDFs, and crawled pages, then ask in plain English and get answers that cite the source. No cloud, no separate vector database.">
+<meta property="og:url" content="https://lilbee.sh/local-rag/">
+<meta property="og:image" content="https://lilbee.sh/social-card.png">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="lilbee answering a question from your own documents with a cited source, shown in the terminal UI">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Local RAG: cited answers from your own documents | lilbee">
+<meta name="twitter:description" content="A local RAG engine in one program: index your files, code, PDFs, and crawled pages, then ask and get answers that cite the source. No cloud, no separate vector database.">
+<meta name="twitter:image" content="https://lilbee.sh/social-card.png">
+<meta name="twitter:image:alt" content="lilbee answering from your own documents with a cited source, shown in the terminal UI">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "lilbee", "item": "https://lilbee.sh/" },
+    { "@type": "ListItem", "position": 2, "name": "Local RAG", "item": "https://lilbee.sh/local-rag/" }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "What is local RAG?", "acceptedAnswer": { "@type": "Answer", "text": "Local RAG (retrieval-augmented generation) means the model reads your own documents before it answers, and all of it runs on your own machine. lilbee indexes your files, finds the passages that answer your question, and writes a reply that cites them, with no data sent to a cloud service." } },
+    { "@type": "Question", "name": "Does lilbee need a separate vector database?", "acceptedAnswer": { "@type": "Answer", "text": "No. The vector index (LanceDB) runs inside lilbee, so there is no database server to stand up or keep alive. It is one program." } },
+    { "@type": "Question", "name": "Can it run fully offline?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. lilbee downloads and runs local models, so once your models are in place it answers with no internet connection. A cloud model is used only if you pick one." } },
+    { "@type": "Question", "name": "What can it index?", "acceptedAnswer": { "@type": "Answer", "text": "Text and markdown, code, PDFs, office documents, ebooks, and scanned images through OCR, plus whole websites you crawl into markdown. Over 150 file types in all." } },
+    { "@type": "Question", "name": "Do I have to use lilbee's own models?", "acceptedAnswer": { "@type": "Answer", "text": "No. lilbee has its own model manager, but it also works with your existing Ollama or LM Studio setup, or a cloud model when you want one." } }
+  ]
+}
+</script>
+
+<link rel="stylesheet" href="../style.css?v=20260515a">
+<script src="../main.js?v=20260515a" defer></script>
+</head>
+<body>
+<div class="layout">
+  <main class="main">
+
+    <div class="topstrip">
+      <div><a class="badge" href="/">lilbee</a> <span>local RAG</span></div>
+      <div>
+        <span class="pill">local-first</span>
+        <span class="pill">cited answers</span>
+        <span class="pill">no vector DB</span>
+      </div>
+    </div>
+
+    <p class="crumb"><a href="/">lilbee</a> / local RAG</p>
+
+    <section class="hero">
+<pre class="wordmark" aria-hidden="true">888 d8b 888 888
+888 Y8P 888 888
+888     888 888
+888 888 888 88888b.  .d88b.  .d88b.
+888 888 888 888 "88bd8P  Y8bd8P  Y8b
+888 888 888 888  88888888888888888888
+888 888 888 888 d88PY8b.    Y8b.
+888 888 888 88888P"  "Y8888  "Y8888</pre>
+      <h1 class="tagline"><strong>Local RAG</strong>: cited answers from your own documents, fully offline. lilbee indexes your files, code, and PDFs, then answers in plain English with a link to the exact source.</h1>
+      <p class="sub">Retrieval-augmented generation that runs on your own machine. It is one program: the model runtime and the search index live inside it, so there is no model server and no vector database to stand up.</p>
+    </section>
+
+    <section>
+      <h2 class="label">what local RAG means here</h2>
+      <p class="lede">Point lilbee at a folder and it builds a real retrieval pipeline over it: your documents are chunked, embedded, and ranked by how well they answer the question you asked. The best passage comes back first, and the answer cites the file and line it came from, so you can check it. When lilbee does not find a good match, it says so instead of guessing.</p>
+    </section>
+
+    <section>
+      <h2 class="label">one program, not a stack</h2>
+      <p class="lede">The usual local-RAG setup is a model server, a vector database, glue code to connect them, and an app on top. lilbee folds all of that into a single program. The model runtime is llama.cpp and the index is LanceDB, both running inside lilbee. You install one thing, point it at your files, and ask.</p>
+      <div class="caps">
+        <div class="cap">
+          <h3>chunked so it makes sense</h3>
+          <p>Prose and code are chunked differently, so each piece keeps its meaning instead of being cut mid-thought. A retrieval pipeline is only as good as the chunks underneath it.</p>
+        </div>
+        <div class="cap">
+          <h3>every answer is sourced</h3>
+          <p>Replies carry citations back to the file and line, and a scoped library per project keeps one domain from bleeding into another.</p>
+        </div>
+        <div class="cap">
+          <h3>more than text</h3>
+          <p>PDFs, office files, ebooks, and scanned images go through extraction and OCR, and whole websites can be crawled to markdown and searched offline.</p>
+        </div>
+        <div class="cap">
+          <h3>tune it when you want</h3>
+          <p>Sane defaults out of the install, with 50+ settings for search depth, reranking, and how your files are read once you want to push quality further.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="label">bring your own models</h2>
+      <p class="lede">lilbee has its own model manager that browses Hugging Face, downloads a model, and runs it on Metal, Vulkan, or CUDA. If you already run Ollama or LM Studio, point lilbee at your setup instead. A cloud model is there when you want one, and never used unless you pick it.</p>
+    </section>
+
+    <section>
+      <h2 class="label">questions</h2>
+      <div class="faq">
+        <details><summary>What is local RAG?</summary><p>Local RAG means the model reads your own documents before it answers, and all of it runs on your own machine. lilbee finds the passages that answer your question and writes a reply that cites them, with nothing sent to a cloud service.</p></details>
+        <details><summary>Does lilbee need a separate vector database?</summary><p>No. The vector index (LanceDB) runs inside lilbee, so there is no database server to stand up or keep alive.</p></details>
+        <details><summary>Can it run fully offline?</summary><p>Yes. lilbee downloads and runs local models, so once your models are in place it answers with no internet connection. A cloud model is used only if you pick one.</p></details>
+        <details><summary>What can it index?</summary><p>Text and markdown, code, PDFs, office documents, ebooks, and scanned images through OCR, plus whole websites you crawl into markdown. Over 150 file types.</p></details>
+        <details><summary>Do I have to use lilbee's own models?</summary><p>No. It works with its own model manager, or your existing Ollama or LM Studio setup, or a cloud model when you want one.</p></details>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="label">go deeper</h2>
+      <div class="links">
+        <a href="/"><span class="num">[1]</span><span>lilbee</span><span class="dots">·······································</span><span class="desc">home</span></a>
+        <a href="/code-search/"><span class="num">[2]</span><span>Code search</span><span class="dots">·······································</span><span class="desc">file:line</span></a>
+        <a href="/mcp/"><span class="num">[3]</span><span>MCP server</span><span class="dots">·······································</span><span class="desc">for agents</span></a>
+        <a href="https://github.com/tobocop2/lilbee"><span class="num">[4]</span><span>GitHub</span><span class="dots">·······································</span><span class="desc">source</span></a>
+        <a href="https://pypi.org/project/lilbee/"><span class="num">[5]</span><span>PyPI</span><span class="dots">·······································</span><span class="desc">install</span></a>
+      </div>
+    </section>
+
+    <footer>
+      <div>
+<pre aria-hidden="true">+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|t|o|b|i|a|s|@|l|i|l|b|e|e|.|s|h|
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+</pre>
+      </div>
+      <div class="meta"><a href="https://github.com/tobocop2/lilbee">lilbee</a> &nbsp;.&nbsp; Elastic License 2.0</div>
+    </footer>
+  </main>
+
+  <aside class="bee-art" aria-hidden="true"><pre>     %           %
+         %           %
+            %           %
+               %          %
+                 %          %
+                   %          %                   :::
+                    %          %                ::::::
+                 %%%%%%  %%%%%%%%%            ::::::::
+              %%%%%ZZZZ%%%%%%   %%%ZZZZ     ::::::::::         ::::::
+             %%%ZZZZZ%%%%%%%%%%%%%%ZZZZZZ  :::::::::::    :::::::::::::::::
+             ZZZ%ZZZ%%%%%%%%%%%%%%%ZZZZZZZ::::::::::***:::::::::::::::::::::
+          ZZZ%ZZZZZZ%%%%%%%%%%%%%%ZZZZZZZZZ::::::***:::::::::::::::::::::::
+        ZZZ%ZZZZZZZZZZ%%%%%%%%%%ZZZZZZ%ZZZZ:::***:::::::::::::::::::::::
+       ZZ%ZZZZZZZZZZZZZZZZZZZZZZZ%%%%% %ZZZ:**::::::::::::::::::::::
+      ZZ%ZZZZZZZZZZZZZZZZZZZ%%%%% | | %ZZZ *:::::::::::::::::::
+      Z%ZZZZZZZZZZZZZZZ%%%%%%%%%%%%%%%ZZZ::::::::::::::::::::::::::
+       ZZZZZZZZZZZ%%%%%ZZZZZZZZZZZZZZZZZ%%%%:::ZZZZ:::::::::::::::::
+         ZZZZ%%%%%ZZZZZZZZZZZZZZZZZZ%%%%%ZZZ%%ZZZ%ZZ%%*:::::::::::
+            ZZZZZZZZZZZZZZZZZZ%%%%%%%%%ZZZZZZZZZZ%ZZ%:::*:::::::
+            *:::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZZZZZZ%%%*::::*::::
+          *:::::::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZ%%      *:::Z
+         **:ZZZZ:::%%%%%%%%%%%%%%%%%%%%%%%%%%%ZZ      ZZZZZ
+        *:ZZZZZZZ       %%%%%%%%%%%%%%%%%%%%%ZZZZ    ZZZZZZZ
+       *::::ZZZZZZ         %%%%%%%%%%%%%%%ZZZZZZZ      ZZZ
+        *::ZZZZZZ           Z%%%%%%%%%%%ZZZZZZZ%%
+          ZZZZ              ZZZZZZZZZZZZZZZZ%%%%%
+                           %%%ZZZZZZZZZZZ%%%%%%%%
+                          Z%%%%%%%%%%%%%%%%%%%%%
+                          ZZ%%%%%%%%%%%%%%%%%%%
+                          %ZZZZZZZZZZZZZZZZZZZ
+                          %%ZZZZZZZZZZZZZZZZZ
+                           %%%%%%%%%%%%%%%%
+                            %%%%%%%%%%%%%
+                             %%%%%%%%%
+                              ZZZZ
+                              ZZZ
+                             ZZ
+                            Z</pre></aside>
+</div>
+</body>
+</html>

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-G8F65BKGRJ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-G8F65BKGRJ');
+</script>
+
+<title>An MCP server that gives your agent local search | lilbee</title>
+<meta name="description" content="lilbee is a Model Context Protocol (MCP) server for local search. Point your coding agent at it and it reads your real code and docs before answering, with file and line citations. Self-hosted retrieval, nothing leaves your machine.">
+<link rel="canonical" href="https://lilbee.sh/mcp/">
+
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="lilbee">
+<meta property="og:title" content="An MCP server that gives your agent local search | lilbee">
+<meta property="og:description" content="A Model Context Protocol server for local search: your coding agent reads your real code and docs before answering, and cites the file and line. Self-hosted, nothing leaves your machine.">
+<meta property="og:url" content="https://lilbee.sh/mcp/">
+<meta property="og:image" content="https://lilbee.sh/social-card.png">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="a coding agent querying lilbee's MCP server and getting a cited answer from local code">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="An MCP server that gives your agent local search | lilbee">
+<meta name="twitter:description" content="A Model Context Protocol server for local search: your coding agent reads your real code and docs before answering, and cites the file and line. Self-hosted.">
+<meta name="twitter:image" content="https://lilbee.sh/social-card.png">
+<meta name="twitter:image:alt" content="a coding agent querying lilbee's MCP server and getting a cited answer from local code">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "lilbee", "item": "https://lilbee.sh/" },
+    { "@type": "ListItem", "position": 2, "name": "MCP server", "item": "https://lilbee.sh/mcp/" }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "What is the lilbee MCP server?", "acceptedAnswer": { "@type": "Answer", "text": "lilbee runs as a Model Context Protocol server, so any MCP-aware coding agent can search your local files and code through it. The agent reads the real source before it answers and cites the file and line." } },
+    { "@type": "Question", "name": "Which agents work with it?", "acceptedAnswer": { "@type": "Answer", "text": "Any MCP-aware coding agent. lilbee exposes standard MCP tools, so you add it the same way you add any other MCP server in your agent's configuration." } },
+    { "@type": "Question", "name": "What tools does it expose?", "acceptedAnswer": { "@type": "Answer", "text": "Search, add files, sync the index, crawl a web page, manage per-project libraries, build a wiki over a library, and export or import a dataset." } },
+    { "@type": "Question", "name": "Does my code leave my machine?", "acceptedAnswer": { "@type": "Answer", "text": "No. Indexing and retrieval run locally. lilbee uses a cloud model only if you pick one; the search itself stays on your machine." } },
+    { "@type": "Question", "name": "Can lilbee run the models too?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. lilbee has its own model manager and runs models on your GPU, or it works with your existing Ollama or LM Studio setup." } }
+  ]
+}
+</script>
+
+<link rel="stylesheet" href="../style.css?v=20260515a">
+<script src="../main.js?v=20260515a" defer></script>
+</head>
+<body>
+<div class="layout">
+  <main class="main">
+
+    <div class="topstrip">
+      <div><a class="badge" href="/">lilbee</a> <span>MCP server</span></div>
+      <div>
+        <span class="pill">model context protocol</span>
+        <span class="pill">cited</span>
+        <span class="pill">self-hosted</span>
+      </div>
+    </div>
+
+    <p class="crumb"><a href="/">lilbee</a> / MCP server</p>
+
+    <section class="hero">
+<pre class="wordmark" aria-hidden="true">888 d8b 888 888
+888 Y8P 888 888
+888     888 888
+888 888 888 88888b.  .d88b.  .d88b.
+888 888 888 888 "88bd8P  Y8bd8P  Y8b
+888 888 888 888  88888888888888888888
+888 888 888 888 d88PY8b.    Y8b.
+888 888 888 88888P"  "Y8888  "Y8888</pre>
+      <h1 class="tagline">An <strong>MCP server</strong> that gives your coding agent local search. Point your agent at lilbee and it reads your real code and docs before it answers, with file and line citations.</h1>
+      <p class="sub">lilbee speaks the Model Context Protocol, so any MCP-aware agent can search the files and code on your own machine. Retrieval stays local; nothing is shipped to a cloud service to answer.</p>
+    </section>
+
+    <section>
+      <h2 class="label">why retrieval before the answer</h2>
+      <p class="lede">An agent that guesses from memory is confident and wrong. With lilbee in the loop, the agent retrieves the relevant passages from your indexed code and docs first, answers from what it actually found, and cites the file and line so you can check it. When there is no good match, it says so instead of inventing one.</p>
+    </section>
+
+    <section>
+      <h2 class="label">what the server gives the agent</h2>
+      <div class="caps">
+        <div class="cap">
+          <h3>search</h3>
+          <p>Ranked retrieval over a project library, the same pipeline the terminal app uses, returned in a shape an agent can act on.</p>
+        </div>
+        <div class="cap">
+          <h3>add &amp; sync</h3>
+          <p>The agent can pull a file or folder into a library and keep the index current, so what it searches matches what is on disk.</p>
+        </div>
+        <div class="cap">
+          <h3>crawl</h3>
+          <p>Fetch a web page or a docs site into the library as markdown, then search it offline alongside your local files.</p>
+        </div>
+        <div class="cap">
+          <h3>wiki &amp; datasets</h3>
+          <p>Build a wiki over a library, and export or import a library as a dataset to move it between machines.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="label">it runs the models too</h2>
+      <p class="lede">lilbee is not only the retrieval layer. It downloads and runs the models itself on Metal, Vulkan, or CUDA, so one program covers both the search and the model behind it. Already running Ollama or LM Studio? Point lilbee at your setup and keep it.</p>
+    </section>
+
+    <section>
+      <h2 class="label">questions</h2>
+      <div class="faq">
+        <details><summary>What is the lilbee MCP server?</summary><p>lilbee runs as a Model Context Protocol server, so any MCP-aware coding agent can search your local files and code through it. The agent reads the real source before it answers and cites the file and line.</p></details>
+        <details><summary>Which agents work with it?</summary><p>Any MCP-aware coding agent. lilbee exposes standard MCP tools, so you add it the same way you add any other MCP server in your agent's configuration.</p></details>
+        <details><summary>What tools does it expose?</summary><p>Search, add files, sync the index, crawl a web page, manage per-project libraries, build a wiki over a library, and export or import a dataset.</p></details>
+        <details><summary>Does my code leave my machine?</summary><p>No. Indexing and retrieval run locally. lilbee uses a cloud model only if you pick one; the search itself stays on your machine.</p></details>
+        <details><summary>Can lilbee run the models too?</summary><p>Yes. It has its own model manager and runs models on your GPU, or it works with your existing Ollama or LM Studio setup.</p></details>
+      </div>
+    </section>
+
+    <section>
+      <h2 class="label">go deeper</h2>
+      <div class="links">
+        <a href="/"><span class="num">[1]</span><span>lilbee</span><span class="dots">·······································</span><span class="desc">home</span></a>
+        <a href="/code-search/"><span class="num">[2]</span><span>Code search</span><span class="dots">·······································</span><span class="desc">file:line</span></a>
+        <a href="/local-rag/"><span class="num">[3]</span><span>Local RAG</span><span class="dots">·······································</span><span class="desc">your docs</span></a>
+        <a href="https://github.com/tobocop2/lilbee#agent-integration"><span class="num">[4]</span><span>Agent setup</span><span class="dots">·······································</span><span class="desc">mcp / cli</span></a>
+        <a href="https://pypi.org/project/lilbee/"><span class="num">[5]</span><span>PyPI</span><span class="dots">·······································</span><span class="desc">install</span></a>
+      </div>
+    </section>
+
+    <footer>
+      <div>
+<pre aria-hidden="true">+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|t|o|b|i|a|s|@|l|i|l|b|e|e|.|s|h|
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+</pre>
+      </div>
+      <div class="meta"><a href="https://github.com/tobocop2/lilbee">lilbee</a> &nbsp;.&nbsp; Elastic License 2.0</div>
+    </footer>
+  </main>
+
+  <aside class="bee-art" aria-hidden="true"><pre>     %           %
+         %           %
+            %           %
+               %          %
+                 %          %
+                   %          %                   :::
+                    %          %                ::::::
+                 %%%%%%  %%%%%%%%%            ::::::::
+              %%%%%ZZZZ%%%%%%   %%%ZZZZ     ::::::::::         ::::::
+             %%%ZZZZZ%%%%%%%%%%%%%%ZZZZZZ  :::::::::::    :::::::::::::::::
+             ZZZ%ZZZ%%%%%%%%%%%%%%%ZZZZZZZ::::::::::***:::::::::::::::::::::
+          ZZZ%ZZZZZZ%%%%%%%%%%%%%%ZZZZZZZZZ::::::***:::::::::::::::::::::::
+        ZZZ%ZZZZZZZZZZ%%%%%%%%%%ZZZZZZ%ZZZZ:::***:::::::::::::::::::::::
+       ZZ%ZZZZZZZZZZZZZZZZZZZZZZZ%%%%% %ZZZ:**::::::::::::::::::::::
+      ZZ%ZZZZZZZZZZZZZZZZZZZ%%%%% | | %ZZZ *:::::::::::::::::::
+      Z%ZZZZZZZZZZZZZZZ%%%%%%%%%%%%%%%ZZZ::::::::::::::::::::::::::
+       ZZZZZZZZZZZ%%%%%ZZZZZZZZZZZZZZZZZ%%%%:::ZZZZ:::::::::::::::::
+         ZZZZ%%%%%ZZZZZZZZZZZZZZZZZZ%%%%%ZZZ%%ZZZ%ZZ%%*:::::::::::
+            ZZZZZZZZZZZZZZZZZZ%%%%%%%%%ZZZZZZZZZZ%ZZ%:::*:::::::
+            *:::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZZZZZZ%%%*::::*::::
+          *:::::::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZ%%      *:::Z
+         **:ZZZZ:::%%%%%%%%%%%%%%%%%%%%%%%%%%%ZZ      ZZZZZ
+        *:ZZZZZZZ       %%%%%%%%%%%%%%%%%%%%%ZZZZ    ZZZZZZZ
+       *::::ZZZZZZ         %%%%%%%%%%%%%%%ZZZZZZZ      ZZZ
+        *::ZZZZZZ           Z%%%%%%%%%%%ZZZZZZZ%%
+          ZZZZ              ZZZZZZZZZZZZZZZZ%%%%%
+                           %%%ZZZZZZZZZZZ%%%%%%%%
+                          Z%%%%%%%%%%%%%%%%%%%%%
+                          ZZ%%%%%%%%%%%%%%%%%%%
+                          %ZZZZZZZZZZZZZZZZZZZ
+                          %%ZZZZZZZZZZZZZZZZZ
+                           %%%%%%%%%%%%%%%%
+                            %%%%%%%%%%%%%
+                             %%%%%%%%%
+                              ZZZZ
+                              ZZZ
+                             ZZ
+                            Z</pre></aside>
+</div>
+</body>
+</html>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,14 +2,38 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://lilbee.sh/</loc>
-    <lastmod>2026-06-18</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://lilbee.sh/tutorial/</loc>
-    <lastmod>2026-06-18</lastmod>
-    <changefreq>weekly</changefreq>
+    <loc>https://lilbee.sh/local-rag/</loc>
+    <lastmod>2026-06-29</lastmod>
+    <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://lilbee.sh/code-search/</loc>
+    <lastmod>2026-06-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://lilbee.sh/mcp/</loc>
+    <lastmod>2026-06-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://lilbee.sh/gpu/</loc>
+    <lastmod>2026-06-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://lilbee.sh/tutorial/</loc>
+    <lastmod>2026-06-29</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
 </urlset>

--- a/site/style.css
+++ b/site/style.css
@@ -869,3 +869,29 @@ footer .meta { text-align: right; font-size: 12px; }
   .installtabs .tab { padding: 0.45rem 0.6rem; font-size: 12px; }
   .extra { flex-direction: column; gap: 0.2rem; }
 }
+
+/* satellite landing pages: breadcrumb + FAQ disclosure --------------- */
+.crumb { font-size: 12px; color: var(--ink-3); margin: 0 0 1.6rem; letter-spacing: 0.02em; }
+.crumb a { color: var(--ink-2); text-decoration: none; }
+.crumb a:hover { color: var(--accent); }
+
+.faq { display: flex; flex-direction: column; gap: 0.5rem; }
+.faq details {
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+  background: var(--bg-elev);
+  padding: 0.1rem 0.9rem;
+}
+.faq summary {
+  cursor: pointer;
+  padding: 0.7rem 0;
+  color: var(--ink);
+  font-weight: 600;
+  list-style: none;
+}
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary::before { content: '+'; color: var(--accent); margin-right: 0.6rem; }
+.faq details[open] summary::before { content: '−'; }
+.faq details[open] summary { border-bottom: 1px solid var(--rule); }
+.faq p { color: var(--ink-2); margin: 0.6rem 0 0.9rem; }
+.faq a { color: var(--accent); }

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -1,0 +1,129 @@
+"""SEO invariants for the marketing site.
+
+Encodes the on-page SEO rules as assertions so a stale canonical, a missing
+Open Graph tag, a duplicate title, or a page that drops out of the sitemap is
+caught in CI instead of silently costing rankings.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+SITE = Path(__file__).resolve().parents[1] / "site"
+BASE = "https://lilbee.sh/"
+
+# Each marketing page mapped to the canonical URL it must declare.
+MARKETING_PAGES: dict[str, str] = {
+    "index.html": BASE,
+    "local-rag/index.html": BASE + "local-rag/",
+    "code-search/index.html": BASE + "code-search/",
+    "mcp/index.html": BASE + "mcp/",
+    "gpu/index.html": BASE + "gpu/",
+}
+
+_PAGE_ITEMS = list(MARKETING_PAGES.items())
+
+
+def _html(rel: str) -> str:
+    return (SITE / rel).read_text(encoding="utf-8")
+
+
+def _meta(html: str, key: str, attr: str = "property") -> str | None:
+    m = re.search(rf'<meta {attr}="{re.escape(key)}" content="([^"]*)"', html)
+    return m.group(1) if m else None
+
+
+def _title(html: str) -> str | None:
+    m = re.search(r"<title>(.*?)</title>", html, re.S)
+    return m.group(1).strip() if m else None
+
+
+def _canonical(html: str) -> str | None:
+    m = re.search(r'<link rel="canonical" href="([^"]+)"', html)
+    return m.group(1) if m else None
+
+
+def _jsonld_blocks(html: str) -> list[str]:
+    return re.findall(r'<script type="application/ld\+json">(.*?)</script>', html, re.S)
+
+
+@pytest.mark.parametrize("rel,url", _PAGE_ITEMS)
+def test_title_present_and_bounded(rel: str, url: str) -> None:
+    title = _title(_html(rel))
+    assert title, f"{rel} missing <title>"
+    assert 20 <= len(title) <= 70, f"{rel} title length {len(title)}: {title!r}"
+
+
+@pytest.mark.parametrize("rel,url", _PAGE_ITEMS)
+def test_description_present_and_bounded(rel: str, url: str) -> None:
+    desc = _meta(_html(rel), "description", attr="name")
+    assert desc, f"{rel} missing meta description"
+    assert 50 <= len(desc) <= 320, f"{rel} description length {len(desc)}"
+
+
+@pytest.mark.parametrize("rel,url", _PAGE_ITEMS)
+def test_canonical_self_referential(rel: str, url: str) -> None:
+    assert _canonical(_html(rel)) == url, f"{rel} canonical is not self-referential"
+
+
+@pytest.mark.parametrize("rel,url", _PAGE_ITEMS)
+def test_open_graph_and_twitter_complete(rel: str, url: str) -> None:
+    html = _html(rel)
+    for prop in ("og:type", "og:title", "og:description", "og:url", "og:image"):
+        assert _meta(html, prop), f"{rel} missing {prop}"
+    assert _meta(html, "og:url") == url, f"{rel} og:url does not match canonical"
+    assert _meta(html, "twitter:card", attr="name"), f"{rel} missing twitter:card"
+
+
+@pytest.mark.parametrize("rel,url", _PAGE_ITEMS)
+def test_exactly_one_h1(rel: str, url: str) -> None:
+    count = len(re.findall(r"<h1[\s>]", _html(rel)))
+    assert count == 1, f"{rel} has {count} <h1> elements, expected 1"
+
+
+@pytest.mark.parametrize("rel,url", _PAGE_ITEMS)
+def test_images_have_alt(rel: str, url: str) -> None:
+    for tag in re.findall(r"<img\b[^>]*>", _html(rel)):
+        m = re.search(r'alt="([^"]*)"', tag)
+        assert m and m.group(1).strip(), f"{rel} has an <img> without alt text: {tag}"
+
+
+@pytest.mark.parametrize("rel,url", _PAGE_ITEMS)
+def test_jsonld_parses_with_required_fields(rel: str, url: str) -> None:
+    blocks = _jsonld_blocks(_html(rel))
+    assert blocks, f"{rel} has no JSON-LD"
+    for block in blocks:
+        data = json.loads(block)
+        assert data.get("@context"), f"{rel} JSON-LD missing @context"
+        assert data.get("@type"), f"{rel} JSON-LD missing @type"
+
+
+def test_titles_unique() -> None:
+    titles = [_title(_html(rel)) for rel in MARKETING_PAGES]
+    assert len(set(titles)) == len(titles), "duplicate <title> across pages"
+
+
+def test_descriptions_unique() -> None:
+    descs = [_meta(_html(rel), "description", attr="name") for rel in MARKETING_PAGES]
+    assert len(set(descs)) == len(descs), "duplicate meta description across pages"
+
+
+def test_sitemap_bidirectional() -> None:
+    sitemap = (SITE / "sitemap.xml").read_text(encoding="utf-8")
+    locs = set(re.findall(r"<loc>([^<]+)</loc>", sitemap))
+    for url in MARKETING_PAGES.values():
+        assert url in locs, f"{url} missing from sitemap.xml"
+    for loc in locs:
+        rel = loc.removeprefix(BASE)
+        path = SITE / (f"{rel}index.html" if rel.endswith("/") or rel == "" else rel)
+        assert path.exists(), f"sitemap URL {loc} has no file on disk ({path})"
+
+
+def test_satellites_linked_from_home() -> None:
+    home = _html("index.html")
+    for slug in ("local-rag/", "code-search/", "mcp/", "gpu/"):
+        assert f'href="{slug}"' in home, f"home does not link to satellite {slug}"


### PR DESCRIPTION
## Problem

The home page has solid technical SEO, but the site is only two indexable pages, so it cannot rank for the problem-intent queries people actually search (local RAG, ask your codebase, MCP retrieval for an agent, will a model fit my GPU). There was also no guard against on-page SEO regressions like a stale canonical or a duplicate title.

## Solution

Four hand-authored satellite landing pages in the existing style, each targeting one query cluster, with `FAQPage` and `BreadcrumbList` structured data and internal links back to the home: `local-rag`, `code-search`, `mcp`, and `gpu` (will it fit your GPU).

The home gains `WebSite` and `FAQPage` schema, a visible FAQ, and crawlable links to the new pages. The FAQ now leads with lilbee being a complete model manager (browse, download, run, multi-GPU), so you do not need a separate model runner. README picks up a local-RAG line and an FAQ section, and `pyproject` keywords add `local-rag`, `obsidian`, `model-context-protocol`, and `multi-gpu`. The sitemap is expanded accordingly.

A new pytest module encodes the on-page SEO invariants (unique titles, self-referential canonicals, complete Open Graph, valid JSON-LD, bidirectional sitemap coverage) so they fail CI if they regress.

Obsidian search intent is left to obsidian.lilbee.sh to avoid cannibalizing that property; it gets the same treatment in a separate PR.