### PR TITLE
Allow applying GPU placement over HTTP on owned deployments

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -252,10 +252,13 @@ hardware-change failures explicit.
 The surfaces go through the one `app/placement.py` use-case:
 CLI (`lilbee placement show/preview/set/clear`), MCP
 (`get_placement`, `preview_placement`, `set_placement`, `clear_placement`),
-and the TUI Placement screen. Over HTTP only the reads are served
-(`GET /api/placement`, `POST /api/placement/preview`, `GET /api/gpus`):
-applying or clearing placement rebuilds the shared fleet, so `PUT`/`DELETE
-/api/placement` are refused on the server. The `preview` operation is a dry-run: it shows
+and the TUI Placement screen. Over HTTP the reads are always served
+(`GET /api/placement`, `POST /api/placement/preview`, `GET /api/gpus`).
+Applying or clearing placement rebuilds the shared fleet, so `PUT`/`DELETE
+/api/placement` are refused by default and gated on `allow_http_placement`
+(`LILBEE_ALLOW_HTTP_PLACEMENT`), which an operator enables for a single-client
+or owned deployment (the plugin's managed server, or a personally-owned pod) to
+get the same apply/clear capability as the CLI and TUI. The `preview` operation is a dry-run: it shows
 what the auto planner would assign (or what a candidate spec would assign)
 including each card's backend+index label, name, and free/total VRAM, without
 touching the running fleet.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -760,6 +760,7 @@ Only relevant when running the HTTP server.
 | `LILBEE_SERVER_PORT` | random | Port (overridden by `--port`) |
 | `LILBEE_CORS_ORIGINS` | *(none)* | Comma-separated list of extra allowed CORS origins, e.g. `https://my-app.com`. Additive; the default regex below still applies |
 | `LILBEE_CORS_ORIGIN_REGEX` | *(see usage)* | Regex for allowed origins. Default matches `app://obsidian.md`, `capacitor://localhost`, and any `http(s)://localhost`, `127.0.0.1`, or `[::1]` with any port. Set to `^$` to opt out and rely solely on `LILBEE_CORS_ORIGINS` |
+| `LILBEE_ALLOW_HTTP_PLACEMENT` | `false` | Allow `PUT`/`DELETE /api/placement` to apply or clear GPU placement over HTTP. Off by default because applying placement rebuilds the shared fleet, which is unsafe across concurrent clients. Turn it on only for a single-client or owned deployment (the Obsidian plugin's managed server, or a personally-owned pod where you run `lilbee serve` yourself) |
 
 ### Wiki tuning (experimental)
 
@@ -1014,8 +1015,11 @@ lilbee placement clear
 
 The same operations are available in the TUI under the Placement screen and over
 MCP (`set_placement`, `clear_placement`). Applying or clearing placement rebuilds
-the shared fleet, so it is not exposed over HTTP: `PUT`/`DELETE /api/placement`
-are refused on the server (use the CLI or TUI). The spec persists across restarts.
+the shared fleet, so over HTTP `PUT`/`DELETE /api/placement` are refused by
+default. Set `allow_http_placement` (or `LILBEE_ALLOW_HTTP_PLACEMENT=1`) to enable
+them on a single-client or owned deployment, such as the Obsidian plugin's managed
+server or a personally-owned pod where you run `lilbee serve` yourself. The spec
+persists across restarts.
 
 If a pinned placement no longer fits the card it names (after a hardware
 change, for example), lilbee surfaces an error naming the card rather than

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -433,6 +433,13 @@ class Config(BaseSettings):
     # settings list, so public=False. None hands off to the VRAM-aware auto planner.
     placement: str | None = ConfigField(default=None, writable=True, public=False)
 
+    # Allow PUT/DELETE /api/placement to apply or clear placement over HTTP.
+    # Off by default because applying placement rebuilds the shared fleet, which
+    # is unsafe across concurrent HTTP clients. Turn it on (LILBEE_ALLOW_HTTP_PLACEMENT=1)
+    # only for a single-client / owned deployment: the plugin's managed local
+    # server, or a personally-owned pod where one operator runs `lilbee serve`.
+    allow_http_placement: bool = Field(default=False)
+
     # True = Markdown widget for chat; False = plain Static (faster).
     markdown_rendering: bool = True
 

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -168,6 +168,21 @@ async def placement_preview(spec_json: str | None) -> PlacementResponse:
     return _placement_response(preview_placement(spec))
 
 
+async def placement_set(spec_json: str) -> PlacementResponse:
+    """Apply a manual placement spec; persists and rebuilds the fleet."""
+    from lilbee.app.placement import set_placement
+    from lilbee.providers.fleet.placement_spec import PlacementSpec
+
+    return _placement_response(set_placement(PlacementSpec.from_json(spec_json)))
+
+
+async def placement_clear() -> PlacementResponse:
+    """Clear manual placement; returns to the auto planner and rebuilds the fleet."""
+    from lilbee.app.placement import set_placement
+
+    return _placement_response(set_placement(None))
+
+
 async def gpus() -> list[GpuInfoResponse]:
     """Detected GPUs with free/total VRAM."""
     from lilbee.app.placement import get_placement
@@ -207,7 +222,9 @@ __all__ = [
     "models_pull",
     "models_show",
     "placement",
+    "placement_clear",
     "placement_preview",
+    "placement_set",
     "search",
     "set_chat_model",
     "set_embedding_model",

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -1,10 +1,12 @@
-"""Placement routes: inspect and preview GPU placement.
+"""Placement routes: inspect, preview, and (when enabled) apply GPU placement.
 
 Every route requires auth: even the reads run resolve_placement_plan, which
-spawns subprocess device probes, so none are marked @read_only. Mutation
-(set/clear) is intentionally not served here: applying a placement rebuilds the
-shared fleet, which is unsafe on the always-concurrent HTTP daemon, so PUT/DELETE
-are refused and placement is changed from the CLI or TUI.
+spawns subprocess device probes, so none are marked @read_only. Applying or
+clearing placement rebuilds the shared fleet, which is unsafe across concurrent
+HTTP clients, so PUT/DELETE are refused by default. They are gated on the
+``allow_http_placement`` flag (LILBEE_ALLOW_HTTP_PLACEMENT), which an operator
+turns on for a single-client / owned deployment to get the same apply/clear
+capability the CLI and TUI have.
 """
 
 from __future__ import annotations
@@ -14,6 +16,7 @@ import json
 from litestar import delete, get, post, put
 from litestar.exceptions import HTTPException
 
+from lilbee.core.config import cfg
 from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet.placement_spec import PlacementError
 from lilbee.server import handlers
@@ -25,8 +28,11 @@ _HTTP_UNAVAILABLE = 503
 _INPUT_ERRORS = (PlacementError, ValueError, OSError)
 _REFUSED_DETAIL = (
     "Changing placement on the HTTP server is unavailable: it rebuilds the shared "
-    "fleet for every connected client. Change it from the CLI or TUI."
+    "fleet for every connected client. Enable allow_http_placement "
+    "(LILBEE_ALLOW_HTTP_PLACEMENT) on a single-client deployment, or change it "
+    "from the CLI or TUI."
 )
+_MISSING_SPEC_DETAIL = "spec is required to apply placement; send {} to DELETE for auto."
 
 
 def _spec_json(body: PlacementSpecBody) -> str | None:
@@ -59,15 +65,30 @@ async def placement_preview_route(data: PlacementSpecBody) -> PlacementResponse:
 
 
 @put("/api/placement")
-async def placement_set_route() -> PlacementResponse:
-    """Refused on the HTTP daemon: applying placement rebuilds the shared fleet."""
-    raise _refused()
+async def placement_set_route(data: PlacementSpecBody) -> PlacementResponse:
+    """Apply a manual spec. Refused unless allow_http_placement is enabled."""
+    if not cfg.allow_http_placement:
+        raise _refused()
+    spec_json = _spec_json(data)
+    if spec_json is None:
+        raise HTTPException(status_code=_HTTP_UNPROCESSABLE, detail=_MISSING_SPEC_DETAIL)
+    try:
+        return await handlers.placement_set(spec_json)
+    except ProviderError as exc:
+        raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
+    except _INPUT_ERRORS as exc:
+        raise HTTPException(status_code=_HTTP_UNPROCESSABLE, detail=str(exc)) from exc
 
 
-@delete("/api/placement")
-async def placement_clear_route() -> None:
-    """Refused on the HTTP daemon: clearing placement rebuilds the shared fleet."""
-    raise _refused()
+@delete("/api/placement", status_code=200)
+async def placement_clear_route() -> PlacementResponse:
+    """Clear placement (back to auto). Refused unless allow_http_placement is enabled."""
+    if not cfg.allow_http_placement:
+        raise _refused()
+    try:
+        return await handlers.placement_clear()
+    except ProviderError as exc:
+        raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
 
 
 @get("/api/gpus")

--- a/tests/core/config/test_placement_field.py
+++ b/tests/core/config/test_placement_field.py
@@ -46,3 +46,14 @@ def test_unexpected_type_raises():
     """A non-string, non-PlacementSpec value must fail validation."""
     with pytest.raises(ValidationError):
         Config(placement=42)
+
+
+def test_allow_http_placement_defaults_off():
+    assert Config(placement=None).allow_http_placement is False
+
+
+def test_allow_http_placement_env_override(monkeypatch):
+    """A pod's `lilbee serve` can enable HTTP placement via the env var."""
+    monkeypatch.setenv("LILBEE_SKIP_TOML_CONFIG", "1")
+    monkeypatch.setenv("LILBEE_ALLOW_HTTP_PLACEMENT", "1")
+    assert Config().allow_http_placement is True

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -146,6 +146,100 @@ def test_put_refused_regardless_of_body():
         assert r.status_code == 409
 
 
+def _enable_http_placement(monkeypatch):
+    """Flip the allow_http_placement gate the routes read."""
+    from lilbee.server.routes import placement as placement_routes
+
+    monkeypatch.setattr(placement_routes.cfg, "allow_http_placement", True)
+
+
+def test_put_applies_when_enabled(monkeypatch):
+    """With the flag on, PUT applies the spec and returns the new placement."""
+    _enable_http_placement(monkeypatch)
+    captured = {}
+
+    async def _set(spec_json):
+        captured["json"] = spec_json
+        return _view(True)
+
+    monkeypatch.setattr(handlers, "placement_set", _set)
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 200
+        assert r.json()["manual"] is True
+        assert '"chat"' in captured["json"]
+
+
+def test_put_missing_spec_returns_422_when_enabled(monkeypatch):
+    """With the flag on, PUT without a spec is a 422 (clear via DELETE for auto)."""
+    _enable_http_placement(monkeypatch)
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={})
+        assert r.status_code == 422
+        assert "spec is required" in r.text
+
+
+def test_put_unfit_spec_returns_422_when_enabled(monkeypatch):
+    """An infeasible spec surfaces PlacementError as a 422 even with the flag on."""
+    from lilbee.providers.fleet.placement_spec import PlacementError
+
+    _enable_http_placement(monkeypatch)
+
+    async def boom(spec_json):
+        raise PlacementError("chat needs 70 GiB but device 0 has 40 GiB free")
+
+    monkeypatch.setattr(handlers, "placement_set", boom)
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 422
+        assert "40 GiB free" in r.text
+
+
+def test_put_provider_error_returns_503_when_enabled(monkeypatch):
+    """A provider failure while applying surfaces as a 503."""
+    from lilbee.providers.base import ProviderError
+
+    _enable_http_placement(monkeypatch)
+
+    async def boom(spec_json):
+        raise ProviderError("llama-server binary not found")
+
+    monkeypatch.setattr(handlers, "placement_set", boom)
+    with create_test_client([placement_set_route]) as client:
+        r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
+        assert r.status_code == 503
+        assert "llama-server" in r.text
+
+
+def test_delete_clears_when_enabled(monkeypatch):
+    """With the flag on, DELETE clears placement and returns the auto plan."""
+    _enable_http_placement(monkeypatch)
+
+    async def _clear():
+        return _view(False)
+
+    monkeypatch.setattr(handlers, "placement_clear", _clear)
+    with create_test_client([placement_clear_route]) as client:
+        r = client.delete("/api/placement")
+        assert r.status_code == 200
+        assert r.json()["manual"] is False
+
+
+def test_delete_provider_error_returns_503_when_enabled(monkeypatch):
+    """A provider failure while clearing surfaces as a 503."""
+    from lilbee.providers.base import ProviderError
+
+    _enable_http_placement(monkeypatch)
+
+    async def boom():
+        raise ProviderError("no engine")
+
+    monkeypatch.setattr(handlers, "placement_clear", boom)
+    with create_test_client([placement_clear_route]) as client:
+        r = client.delete("/api/placement")
+        assert r.status_code == 503
+
+
 def test_get_gpus(monkeypatch):
     from lilbee.server.models import GpuInfoResponse
 


### PR DESCRIPTION
## Problem

- The HTTP daemon refuses placement changes: `PUT`/`DELETE /api/placement` return 409, because applying rebuilds the shared fleet and would break other clients mid-request.
- That default is right for a shared `lilbee serve`, but a single-client deployment (the Obsidian plugin's managed server, or a personal multi-GPU pod you run yourself) then can't change placement over HTTP at all. Its only option is the CLI or TUI.

## Solution

- Add an opt-in flag `allow_http_placement` (env `LILBEE_ALLOW_HTTP_PLACEMENT`), off by default.
- When on: `PUT /api/placement` applies a manual spec and `DELETE` clears back to auto. Both go through the same `set_placement` path the TUI uses, so an HTTP client gets the same capability.
- When off: unchanged, still 409, with a message that now also names the flag.
- Validation matches the rest of the surface: missing spec is a 422, an infeasible or malformed spec (`PlacementError`) is a 422, a provider failure is a 503. Auth is unchanged; these still require the session token.

## Tests

- Gated-off: 409 on both verbs.
- Gated-on: apply, clear, missing spec, unfit spec, provider error.
- Flag default and env override.
- Architecture and usage docs updated.
