### PR TITLE
Live GPU utilization stream for the placement view

### DIFF
--- a/src/lilbee/providers/fleet/gpu_stats.py
+++ b/src/lilbee/providers/fleet/gpu_stats.py
@@ -1,0 +1,120 @@
+"""Live per-GPU activity stats for the placement view.
+
+devices.py enumerates GPUs once (structural: index, name, total VRAM). This reads
+the moving numbers, compute utilization and current free memory, so a client can
+animate a per-card load bar. CUDA cards report utilization via nvidia-smi; other
+backends report memory only (utilization stays None).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+_CUDA_BACKEND = "CUDA"
+_MIB = 1024 * 1024
+_SMI_TIMEOUT_S = 5.0
+_SMI_QUERY = "index,utilization.gpu,memory.used,memory.total"
+_SMI_FIELDS = 4
+# A nvidia-smi spawn costs tens of milliseconds. Cache it just under the stream's
+# tick so concurrent placement views coalesce to one probe per window instead of
+# one each. nvidia-smi indexes by PCI bus order, matching the CUDA enumeration.
+_SMI_CACHE_TTL_S = 0.9
+_NVIDIA_SMI = shutil.which("nvidia-smi") or "nvidia-smi"
+
+
+class _DeviceLike(Protocol):
+    """Structural view of a probed GPU (FleetDevice or app-layer GpuInfo)."""
+
+    @property
+    def index(self) -> int: ...
+    @property
+    def backend(self) -> str: ...
+    @property
+    def total_bytes(self) -> int: ...
+    @property
+    def free_bytes(self) -> int: ...
+
+
+@dataclass(frozen=True)
+class GpuStat:
+    """A live snapshot of one GPU, keyed to its structural index."""
+
+    index: int
+    utilization_pct: int | None
+    free_bytes: int
+    total_bytes: int
+
+
+class _SmiCache:
+    """Shares one nvidia-smi probe across streams that ask within the TTL."""
+
+    def __init__(self) -> None:
+        self._at = 0.0
+        self._value: dict[int, GpuStat] = {}
+        self._primed = False
+
+    def stats(self) -> dict[int, GpuStat]:
+        now = time.monotonic()
+        if not self._primed or now - self._at >= _SMI_CACHE_TTL_S:
+            self._value = _nvidia_smi_stats()
+            self._at = now
+            self._primed = True
+        return self._value
+
+    def reset(self) -> None:
+        self._primed = False
+
+
+_smi_cache = _SmiCache()
+
+
+def probe_gpu_stats(devices: Sequence[_DeviceLike]) -> dict[int, GpuStat]:
+    """Live stats keyed by device index. Empty when no probe is available.
+
+    CUDA devices are read from nvidia-smi (utilization + live memory). Any device
+    the probe can't cover falls back to its structural totals with a None
+    utilization, so the caller always has an entry per known GPU.
+    """
+    stats: dict[int, GpuStat] = {
+        d.index: GpuStat(d.index, None, d.free_bytes, d.total_bytes) for d in devices
+    }
+    if any(d.backend == _CUDA_BACKEND for d in devices):
+        stats.update(_smi_cache.stats())
+    return {i: stats[i] for i in sorted(stats)}
+
+
+def _nvidia_smi_stats() -> dict[int, GpuStat]:
+    """Parse nvidia-smi utilization + memory, or {} when it can't run."""
+    out = _nvidia_smi_output()
+    stats: dict[int, GpuStat] = {}
+    for line in out.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) != _SMI_FIELDS:
+            continue
+        try:
+            index, util, used_mib, total_mib = (int(p) for p in parts)
+        except ValueError:
+            continue
+        total = total_mib * _MIB
+        stats[index] = GpuStat(index, util, max(total - used_mib * _MIB, 0), total)
+    return stats
+
+
+def _nvidia_smi_output() -> str:
+    """nvidia-smi query stdout, or "" when it can't run."""
+    try:
+        proc = subprocess.run(  # noqa: S603 - fixed query against the resolved nvidia-smi
+            [_NVIDIA_SMI, f"--query-gpu={_SMI_QUERY}", "--format=csv,noheader,nounits"],
+            capture_output=True,
+            text=True,
+            timeout=_SMI_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return proc.stdout if proc.returncode == 0 else ""

--- a/src/lilbee/runtime/progress/types.py
+++ b/src/lilbee/runtime/progress/types.py
@@ -36,6 +36,7 @@ class SseEvent(StrEnum):
     WARMING = "warming"
     WARM = "warm"
     MEMORY_EXTRACTED = "memory_extracted"
+    GPU_STATS = "gpu_stats"
 
 
 class SseErrorCode(StrEnum):

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -56,6 +56,7 @@ from lilbee.server.routes.models import (
     models_show_route,
 )
 from lilbee.server.routes.placement import (
+    gpu_stats_stream_route,
     gpus_route,
     placement_clear_route,
     placement_preview_route,
@@ -168,6 +169,7 @@ def create_app() -> Litestar:
             placement_set_route,
             placement_clear_route,
             gpus_route,
+            gpu_stats_stream_route,
             crawl_route,
             setup_crawler_route,
             setup_crawler_status_route,

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -124,6 +124,44 @@ async def warm_stream() -> AsyncGenerator[str, None]:
     yield sse_done({})
 
 
+_GPU_STATS_INTERVAL_S = 1.0
+
+
+async def gpu_stats_stream(
+    interval_s: float = _GPU_STATS_INTERVAL_S,
+    max_ticks: int | None = None,
+) -> AsyncGenerator[str, None]:
+    """Stream live per-GPU utilization + free memory as SSE for the placement view.
+
+    Structural devices are probed once (a subprocess); each tick only runs the
+    light ``nvidia-smi`` query, so the loop is cheap. The client (placement view)
+    keeps the stream open while visible; ``max_ticks`` bounds it for tests.
+    """
+    from lilbee.app.placement import get_placement
+    from lilbee.providers.fleet.gpu_stats import probe_gpu_stats
+    from lilbee.server.models import GpuStatEvent
+
+    devices = get_placement().gpus
+    tick = 0
+    while max_ticks is None or tick < max_ticks:
+        stats = probe_gpu_stats(devices)
+        payload = {
+            "gpus": [
+                GpuStatEvent(
+                    index=s.index,
+                    utilization_pct=s.utilization_pct,
+                    free_bytes=s.free_bytes,
+                    total_bytes=s.total_bytes,
+                ).model_dump()
+                for s in stats.values()
+            ]
+        }
+        yield sse_event(SseEvent.GPU_STATS, payload)
+        tick += 1
+        if max_ticks is None or tick < max_ticks:
+            await asyncio.sleep(interval_s)
+
+
 async def status() -> StatusResponse:
     """Return config, sources, and chunk counts."""
     raw = gather_status()
@@ -210,6 +248,7 @@ __all__ = [
     "get_config",
     "get_config_defaults",
     "get_source_content",
+    "gpu_stats_stream",
     "gpus",
     "health",
     "import_stream",

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -575,6 +575,19 @@ class GpuInfoResponse(BaseModel):
     free_bytes: int
 
 
+class GpuStatEvent(BaseModel):
+    """A live per-GPU activity snapshot streamed by GET /api/gpus/stream.
+
+    ``utilization_pct`` is the compute load (0-100), or ``None`` for backends
+    that don't report it. ``free_bytes`` moves as models load and ingest runs.
+    """
+
+    index: int
+    utilization_pct: int | None
+    free_bytes: int
+    total_bytes: int
+
+
 class RolePlacementResponse(BaseModel):
     """Where one role's model is placed in the resolved plan."""
 

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -15,6 +15,7 @@ import json
 
 from litestar import delete, get, post, put
 from litestar.exceptions import HTTPException
+from litestar.response import Stream
 
 from lilbee.core.config import cfg
 from lilbee.providers.base import ProviderError
@@ -98,3 +99,9 @@ async def gpus_route() -> list[GpuInfoResponse]:
         return await handlers.gpus()
     except ProviderError as exc:
         raise HTTPException(status_code=_HTTP_UNAVAILABLE, detail=str(exc)) from exc
+
+
+@get("/api/gpus/stream")
+async def gpu_stats_stream_route() -> Stream:
+    """Live per-GPU utilization + free memory as SSE for the placement view."""
+    return Stream(handlers.gpu_stats_stream(), media_type="text/event-stream")

--- a/tests/providers/fleet/test_gpu_stats.py
+++ b/tests/providers/fleet/test_gpu_stats.py
@@ -1,0 +1,97 @@
+"""Tests for live per-GPU stats (utilization + free memory) probing."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from lilbee.providers.fleet import gpu_stats as stats_mod
+from lilbee.providers.fleet.devices import _MIB, FleetDevice
+from lilbee.providers.fleet.gpu_stats import GpuStat, probe_gpu_stats
+
+_CUDA = (
+    FleetDevice("CUDA", 0, "NVIDIA A40", 48 * 1024 * _MIB, 47 * 1024 * _MIB),
+    FleetDevice("CUDA", 1, "NVIDIA A40", 48 * 1024 * _MIB, 47 * 1024 * _MIB),
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache() -> None:
+    """The nvidia-smi probe cache is process-wide; reset it so each test re-probes."""
+    stats_mod._smi_cache.reset()
+
+
+def _fake_run(stdout: str, returncode: int = 0):
+    def _run(*_a: object, **_k: object) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+    return _run
+
+
+def test_parses_nvidia_smi_utilization_and_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        stats_mod.subprocess, "run", _fake_run("0, 37, 3536, 46068\n1, 12, 3352, 46068\n")
+    )
+    result = probe_gpu_stats(_CUDA)
+    assert result[0] == GpuStat(0, 37, (46068 - 3536) * _MIB, 46068 * _MIB)
+    assert result[1] == GpuStat(1, 12, (46068 - 3352) * _MIB, 46068 * _MIB)
+
+
+def test_non_cuda_devices_skip_nvidia_smi(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> subprocess.CompletedProcess:
+        raise AssertionError("nvidia-smi should not run for non-CUDA backends")
+
+    monkeypatch.setattr(stats_mod.subprocess, "run", _boom)
+    metal = (FleetDevice("metal", 0, "Apple M3", 32 * 1024 * _MIB, 20 * 1024 * _MIB),)
+    (stat,) = probe_gpu_stats(metal).values()
+    assert stat == GpuStat(0, None, 20 * 1024 * _MIB, 32 * 1024 * _MIB)
+
+
+def test_falls_back_to_structural_totals_on_smi_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: object, **_k: object) -> subprocess.CompletedProcess:
+        raise OSError("nvidia-smi missing")
+
+    monkeypatch.setattr(stats_mod.subprocess, "run", _boom)
+    result = probe_gpu_stats(_CUDA)
+    assert result[0] == GpuStat(0, None, 47 * 1024 * _MIB, 48 * 1024 * _MIB)
+
+
+def test_nonzero_returncode_yields_no_smi_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(stats_mod.subprocess, "run", _fake_run("0, 50, 100, 200\n", returncode=9))
+    result = probe_gpu_stats(_CUDA)
+    assert result[0].utilization_pct is None
+
+
+def test_malformed_lines_are_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        stats_mod.subprocess, "run", _fake_run("garbage\n0, x, y, z\n1, 20, 1024, 46068\n")
+    )
+    result = probe_gpu_stats(_CUDA)
+    assert result[0].utilization_pct is None  # device 0 had no valid smi row
+    assert result[1].utilization_pct == 20
+
+
+def test_empty_device_list_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(stats_mod.subprocess, "run", _fake_run(""))
+    assert probe_gpu_stats(()) == {}
+
+
+def test_concurrent_probes_coalesce_to_one_nvidia_smi_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+
+    def _counting_run(*_a: object, **_k: object) -> subprocess.CompletedProcess:
+        calls["n"] += 1
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="0, 30, 100, 46068\n", stderr=""
+        )
+
+    monkeypatch.setattr(stats_mod.subprocess, "run", _counting_run)
+    # Two probes inside the TTL window share one nvidia-smi spawn.
+    probe_gpu_stats(_CUDA)
+    probe_gpu_stats(_CUDA)
+    assert calls["n"] == 1
+    # After a reset (or once the window lapses) the next probe spawns again.
+    stats_mod._smi_cache.reset()
+    probe_gpu_stats(_CUDA)
+    assert calls["n"] == 2

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4375,3 +4375,29 @@ class TestPlacementHandlers:
             result = await handlers.gpus()
         assert len(result) == 1
         assert result[0].name == "A100"
+
+    async def test_gpu_stats_stream_emits_live_snapshots(self):
+        from lilbee.app.placement import GpuInfo, PlacementView
+        from lilbee.providers.fleet.gpu_stats import GpuStat
+
+        gpu = GpuInfo(
+            index=0, backend="CUDA", label="CUDA0", name="A40", total_bytes=200, free_bytes=200
+        )
+        view = PlacementView(gpus=(gpu,), roles=(), unplaceable=(), manual=False, spec_json=None)
+        stat = {0: GpuStat(0, 64, 150, 200)}
+        with (
+            patch("lilbee.app.placement.get_placement", return_value=view),
+            patch("lilbee.providers.fleet.gpu_stats.probe_gpu_stats", return_value=stat) as probe,
+        ):
+            chunks = [c async for c in handlers.gpu_stats_stream(interval_s=0, max_ticks=2)]
+        events = [
+            json.loads(line[len("data:") :].strip())
+            for chunk in chunks
+            for line in chunk.splitlines()
+            if line.startswith("data:")
+        ]
+        assert len(events) == 2
+        assert events[0] == {
+            "gpus": [{"index": 0, "utilization_pct": 64, "free_bytes": 150, "total_bytes": 200}]
+        }
+        assert probe.call_count == 2

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -91,6 +91,19 @@ class TestWarmStreamRoute:
         assert '"phase": "ready"' in resp.text
 
 
+class TestGpuStatsStreamRoute:
+    def test_streams_gpu_stats(self, client):
+        async def _fake_stats():
+            gpu = {"index": 0, "utilization_pct": 71, "free_bytes": 1, "total_bytes": 2}
+            yield f"event: gpu_stats\ndata: {json.dumps({'gpus': [gpu]})}\n\n"
+
+        with mock.patch("lilbee.server.handlers.gpu_stats_stream", return_value=_fake_stats()):
+            resp = client.get("/api/gpus/stream")
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+        assert '"utilization_pct": 71' in resp.text
+
+
 class TestSearchRoute:
     @mock.patch("lilbee.server.handlers.search", new_callable=AsyncMock, return_value=[])
     def test_empty_results(self, mock_search, client):


### PR DESCRIPTION
## Why

The placement view's GPU cards were static. The only live value was free memory, which barely moves on a 48 GB card, so you couldn't see a card actually working during model load or indexing. This streams real per-GPU activity so the cards animate.

## What was built

**Endpoint:** `GET /api/gpus/stream` (`routes/placement.py`) returns a `text/event-stream`. Emits a `gpu_stats` SSE event about once per second, each carrying a snapshot for every detected GPU: `index`, `utilization_pct` (0-100, or `null`), `free_bytes`, `total_bytes`.

**Probe:** new `providers/fleet/gpu_stats.py` -> `probe_gpu_stats(devices)`. For CUDA devices it parses `nvidia-smi --query-gpu=index,utilization.gpu,memory.used,memory.total`. Any device the probe can't cover falls back to its structural totals with `utilization_pct=null`, so non-NVIDIA and Apple hosts still get live memory and just omit the load bar.

**Handler:** `handlers.gpu_stats_stream(interval_s, max_ticks)` probes the structural device list once (a subprocess), then each tick reads the live stats. `max_ticks` bounds it for tests.

**Wiring:** `GpuStatEvent` response model (`server/models.py`), `SseEvent.GPU_STATS` (`runtime/progress/types.py`), route registered in `server/app.py`.

## Performance

The `nvidia-smi` spawn (tens of ms) is shared across streams by a short-TTL cache (`_SmiCache`, 0.9s, just under the tick), so N open placement views on a shared server cost one probe per window instead of N. `nvidia-smi` is resolved once via `shutil.which`. The heavy placement plan runs once per stream, never per tick.

## Tests

- `tests/providers/fleet/test_gpu_stats.py`: utilization/memory parsing, non-CUDA memory-only fallback, `nvidia-smi` failure, non-zero return code, malformed rows, and probe coalescing under the cache.
- `tests/test_server_handlers.py`: stream emits per-tick snapshots, honors `max_ticks`.
- `tests/test_server_litestar.py`: route returns `text/event-stream`.