### PR TITLE
Fix placement back-navigation crash

### DIFF
--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -308,8 +308,5 @@ class PlacementScreen(Screen[None]):
             call_from_thread(self, setattr, self, "applying", False)
 
     def action_go_back(self) -> None:
-        """Pop back to the previous screen."""
-        if len(self.app.screen_stack) > 1:
-            self.app.pop_screen()
-        else:
-            self.app.switch_view("Chat")
+        """Return to Chat via the guarded switch_view, the inverse of how Placement is entered."""
+        self.app.switch_view("Chat")

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -230,6 +230,50 @@ async def test_settings_escape_returns_to_chat():
         assert isinstance(app.screen, ChatScreen)
 
 
+async def test_placement_escape_returns_to_chat():
+    """Escape on Placement returns to Chat, not the bare default screen.
+
+    Placement is entered via switch_view (a switch_screen replace), so its back
+    action must use the inverse switch_view. A raw pop_screen would reveal
+    Textual's bare default screen instead of Chat.
+    """
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.switch_view("Placement")
+        await pilot.pause()
+        assert isinstance(app.screen, PlacementScreen)
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(app.screen, ChatScreen)
+
+
+async def test_rapid_placement_back_does_not_corrupt_screen_stack():
+    """Rapid back-to-back placement transitions must not crash or corrupt the
+    stack. A raw pop_screen on go_back let a second transition race in and pop
+    Textual's result-callback stack while empty (IndexError, bb-ce4)."""
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        for _ in range(5):
+            app.switch_view("Placement")
+            await pilot.pause()
+            placement = app.screen
+            if not isinstance(placement, PlacementScreen):
+                continue
+            # Two back actions fired before the first transition settles: the
+            # guard must drop the second instead of underflowing the stack.
+            placement.action_go_back()
+            placement.action_go_back()
+            await pilot.pause()
+        # No IndexError raised; we are back on Chat. Asserting on Textual's
+        # private _result_callbacks is intentional: this regression is about that
+        # internal stack underflowing, and one entry confirms it never did.
+        assert isinstance(app.screen, ChatScreen)
+        assert len(app.screen._result_callbacks) == 1
+
+
 async def test_slash_catalog_routes_through_switch_view_under_lilbee_app():
     """/models from Chat under LilbeeApp must use switch_view, not push_screen."""
     app = LilbeeApp()

--- a/tests/test_tui_placement.py
+++ b/tests/test_tui_placement.py
@@ -339,7 +339,7 @@ async def test_apply_ignored_while_applying(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_go_back_binding(monkeypatch):
-    """q pops the screen."""
+    """q routes back to Chat via the guarded switch_view."""
     from lilbee.cli.tui.screens import placement as screen_mod
 
     monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
@@ -348,25 +348,9 @@ async def test_go_back_binding(monkeypatch):
     async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
         assert isinstance(app.screen, screen_mod.PlacementScreen)
-        await pilot.press("q")
-        await pilot.pause()
-
-
-@pytest.mark.asyncio
-async def test_go_back_single_screen(monkeypatch):
-    """action_go_back with a single-item screen_stack calls switch_view('Chat')."""
-    from lilbee.cli.tui.screens import placement as screen_mod
-
-    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
-
-    app = PlacementTestApp()
-    async with app.run_test(size=(140, 44)) as pilot:
-        await pilot.pause()
-        screen = app.screen
         called: list[str] = []
-        monkeypatch.setattr(type(app), "screen_stack", property(lambda self: [screen]))
         monkeypatch.setattr(app, "switch_view", lambda v: called.append(v))
-        screen.action_go_back()
+        await pilot.press("q")
         await pilot.pause()
 
     assert called == ["Chat"]


### PR DESCRIPTION
## Problem
The placement editor's back action (`action_go_back`) used a raw `pop_screen()`. Placement is entered as a managed view via `switch_view` (a `switch_screen` *replace*, not a `push_screen`), so leaving it through `pop_screen` underflowed Textual's result-callback stack on a rapid second back, crashing the TUI with `IndexError: pop from empty list` (textual/screen.py `_pop_result_callback`). Intermittent — a timing race, easy to hit under rapid navigation.

## Solution
Route the back action through the guarded `switch_view("Chat")`, the inverse of how Placement is entered, so a racing second transition is dropped by the existing `_switching` guard instead of underflowing the screen stack. The now-dead `stack > 1` / `pop_screen` branch is removed.

Regression tests drive rapid back-to-back placement transitions and assert no underflow (the test reproduces the exact `IndexError` on the old code and passes on the fix), plus an escape-returns-to-Chat test. ruff/format/mypy-strict clean; TUI navigation + placement suites green.