### PR TITLE
Native GPU fleet panel in the TUI (placement screen)

### DIFF
--- a/src/lilbee/cli/tui/screens/placement.py
+++ b/src/lilbee/cli/tui/screens/placement.py
@@ -24,6 +24,7 @@ from textual.widgets import Button, DataTable, Footer, Label, Static
 from lilbee.app.placement import get_placement, preview_placement, set_placement
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.thread_safe import call_from_thread
+from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
 from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
 from lilbee.providers.roles import WorkerRole
 
@@ -37,6 +38,7 @@ _GPU_TABLE_ID = "#placement-gpus"
 _EDITOR_ID = "#placement-editor"
 _GENERATED_ID = "#placement-generated"
 _TITLE_ID = "#placement-title"
+_FLEET_PANEL_ID = "#gpu-fleet-panel"
 
 _GIB = 1024**3
 # Only these roles run multiple replicas; the others always serve one instance.
@@ -109,6 +111,7 @@ class PlacementScreen(Screen[None]):
         with Vertical(id="placement-layout"):
             yield Static("", id="placement-title")
             yield table
+            yield GpuFleetPanel()
             yield Vertical(id="placement-editor")
             yield Static("", id="placement-generated")
             yield Static(_HINT, id="placement-hint")
@@ -147,6 +150,7 @@ class PlacementScreen(Screen[None]):
         self._refresh_table()
         self._refresh_title(dirty=False)
         self._refresh_generated()
+        self._update_fleet_panel(view)
         if view.unplaceable:
             names = ", ".join(role.value for role in view.unplaceable)
             self.notify(f"Does not fit: {names}", severity="warning")
@@ -205,6 +209,16 @@ class PlacementScreen(Screen[None]):
             out.update(f"[red]{exc}[/red]")
             return
         out.update(f"equivalent spec:  {spec.to_json() if spec else '(auto)'}")
+
+    def _update_fleet_panel(self, view: PlacementView) -> None:
+        """Push the current device list into the fleet panel after a placement load."""
+        try:
+            panel = self.query_one(_FLEET_PANEL_ID, GpuFleetPanel)
+        except NoMatches:
+            return
+        labels = {g.index: g.label for g in view.gpus}
+        names = {g.index: g.name for g in view.gpus}
+        panel.set_devices(view.gpus, labels=labels, names=names)
 
     # -- editor state ----------------------------------------------------
 

--- a/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
+++ b/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
@@ -1,0 +1,205 @@
+"""Live GPU fleet panel widget for the Placement screen.
+
+Renders per-card utilization and VRAM bars in the rose-pine palette and
+refreshes on a ~1 s interval.  The probe runs off the UI thread so the
+event loop is never blocked by the nvidia-smi subprocess.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+from textual import work
+from textual.timer import Timer
+from textual.widgets import Static
+
+from lilbee.cli.tui.thread_safe import call_from_thread
+from lilbee.providers.fleet.gpu_stats import GpuStat, probe_gpu_stats
+
+if TYPE_CHECKING:
+    from lilbee.providers.fleet.gpu_stats import _DeviceLike
+
+log = logging.getLogger(__name__)
+
+_CSS_FILE = Path(__file__).parent / "gpu_fleet_panel.tcss"
+
+# Rose-pine palette (hex literals for Rich markup)
+_COLOR_IRIS = "#c4a7e7"
+_COLOR_FOAM = "#9ccfd8"
+_COLOR_GOLD = "#f6c177"
+_COLOR_LOVE = "#eb6f92"
+_COLOR_TEXT = "#e0def4"
+_COLOR_SUBTLE = "#908caa"
+_COLOR_MUTED = "#6e6a86"
+_COLOR_TRACK = "#403d52"
+
+# Bar render constants
+_BAR_FILL = "█"  # full block █
+_BAR_TRACK = "─"  # horizontal box-drawing line ─
+_BAR_WIDTH = 14  # number of cells in each bar
+_BULLET = "●"  # ● colored dot before card label
+
+# Utilization thresholds (%)
+_UTIL_WARM = 40
+_UTIL_HOT = 80
+
+# VRAM saturation threshold (fraction)
+_VRAM_HIGH = 0.85
+
+# Refresh interval
+_TICK_INTERVAL_S = 1.0
+
+_GIB = 1024**3
+
+# Column labels
+_LABEL_UTIL = "util"
+_LABEL_VRAM = "vram"
+_TITLE_TEXT = "G P U   F L E E T"
+
+# Displayed when no GPU info is available
+_EMPTY_TEXT = "(no GPUs detected)"
+
+# Shown as the util reading when utilization_pct is None
+_UTIL_DASH = " -- "
+
+
+def _heat_color(utilization_pct: int) -> str:
+    """Rose-pine heat color keyed on utilization percentage."""
+    if utilization_pct < _UTIL_WARM:
+        return _COLOR_FOAM
+    if utilization_pct < _UTIL_HOT:
+        return _COLOR_GOLD
+    return _COLOR_LOVE
+
+
+def _bar(fraction: float, width: int, fill_color: str) -> str:
+    """Render a filled bar with rose-pine track for the remainder."""
+    clamped = max(0.0, min(1.0, fraction))
+    filled = round(clamped * width)
+    return (
+        f"[{fill_color}]{_BAR_FILL * filled}[/][{_COLOR_TRACK}]{_BAR_TRACK * (width - filled)}[/]"
+    )
+
+
+def _render_stats(stats: dict[int, GpuStat], labels: dict[int, str], names: dict[int, str]) -> str:
+    """Build the Rich markup string for all GPUs from a stat snapshot."""
+    if not stats:
+        return f"[{_COLOR_MUTED}]  {_EMPTY_TEXT}[/]"
+    lines: list[str] = [
+        f"[bold {_COLOR_IRIS}]  {_TITLE_TEXT}[/]",
+        f"[{_COLOR_TRACK}]{'─' * (_BAR_WIDTH + 24)}[/]",
+        "",
+    ]
+    for idx in sorted(stats):
+        s = stats[idx]
+        label = labels.get(idx, f"GPU{idx}")
+        name = names.get(idx, "")
+        used_bytes = s.total_bytes - s.free_bytes
+        vram_frac = used_bytes / s.total_bytes if s.total_bytes else 0.0
+        used_gib = used_bytes / _GIB
+        total_gib = s.total_bytes / _GIB
+        vram_color = _COLOR_LOVE if vram_frac >= _VRAM_HIGH else _COLOR_IRIS
+
+        # Card heading row
+        if s.utilization_pct is not None:
+            dot_color = _heat_color(s.utilization_pct)
+        else:
+            dot_color = _COLOR_MUTED
+        heading = (
+            f"  [{dot_color}]{_BULLET}[/] [bold {_COLOR_TEXT}]{label}[/]  [{_COLOR_MUTED}]{name}[/]"
+        )
+        lines.append(heading)
+
+        # Utilization bar
+        if s.utilization_pct is not None:
+            heat = _heat_color(s.utilization_pct)
+            util_bar = _bar(s.utilization_pct / 100, _BAR_WIDTH, heat)
+            util_pct = f"[{heat}]{s.utilization_pct:>3}%[/]"
+        else:
+            util_bar = f"[{_COLOR_TRACK}]{_BAR_TRACK * _BAR_WIDTH}[/]"
+            util_pct = f"[{_COLOR_MUTED}]{_UTIL_DASH}[/]"
+        lines.append(f"     [{_COLOR_SUBTLE}]{_LABEL_UTIL}[/]  {util_bar} {util_pct}")
+
+        # VRAM bar
+        vram_bar = _bar(vram_frac, _BAR_WIDTH, vram_color)
+        lines.append(
+            f"     [{_COLOR_SUBTLE}]{_LABEL_VRAM}[/]  {vram_bar}"
+            f" [{_COLOR_SUBTLE}]{used_gib:>4.1f}/{total_gib:>2.0f}G[/]"
+        )
+        lines.append("")
+    return "\n".join(lines)
+
+
+class GpuFleetPanel(Static):
+    """Live GPU utilization and VRAM panel, refreshed every ~1 s.
+
+    Mount on any Screen or Widget; devices must be set via `set_devices`
+    before the first tick fires meaningful data.
+    """
+
+    DEFAULT_CSS: ClassVar[str] = _CSS_FILE.read_text(encoding="utf-8")
+
+    def __init__(self) -> None:
+        super().__init__(_EMPTY_TEXT, id="gpu-fleet-panel")
+        self._devices: Sequence[_DeviceLike] = []
+        self._labels: dict[int, str] = {}
+        self._names: dict[int, str] = {}
+        self._timer: Timer | None = None
+
+    def set_devices(
+        self,
+        devices: Sequence[_DeviceLike],
+        *,
+        labels: dict[int, str],
+        names: dict[int, str],
+    ) -> None:
+        """Register the GPU devices the panel probes on each tick.
+
+        `labels` maps device index to the short display label (e.g. "CUDA0").
+        `names` maps device index to the GPU name (e.g. "NVIDIA A40").
+        """
+        self._devices = list(devices)
+        self._labels = dict(labels)
+        self._names = dict(names)
+
+    def on_mount(self) -> None:
+        self._timer = self.set_interval(_TICK_INTERVAL_S, self._request_stats)
+        # Populate immediately instead of waiting one full interval
+        self._request_stats()
+
+    def on_unmount(self) -> None:
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None
+
+    def _request_stats(self) -> None:
+        """Kick off an off-thread stats probe."""
+        self._probe_worker(list(self._devices), self._labels.copy(), self._names.copy())
+
+    @work(thread=True, exit_on_error=False)
+    def _probe_worker(
+        self,
+        devices: list[_DeviceLike],
+        labels: dict[int, str],
+        names: dict[int, str],
+    ) -> None:
+        """Probe GPU stats off the UI thread and push the result back."""
+        try:
+            stats = probe_gpu_stats(devices)
+        except Exception:
+            log.debug("gpu_fleet_panel: probe failed", exc_info=True)
+            return
+        call_from_thread(self, self._apply_stats, stats, labels, names)
+
+    def _apply_stats(
+        self,
+        stats: dict[int, GpuStat],
+        labels: dict[int, str],
+        names: dict[int, str],
+    ) -> None:
+        """Update the rendered content with fresh stat data (main thread)."""
+        markup = _render_stats(stats, labels, names)
+        self.update(markup)

--- a/src/lilbee/cli/tui/widgets/gpu_fleet_panel.tcss
+++ b/src/lilbee/cli/tui/widgets/gpu_fleet_panel.tcss
@@ -1,0 +1,6 @@
+GpuFleetPanel {
+    height: auto;
+    padding: 1 0;
+    border: solid $surface-lighten-2;
+    margin-bottom: 1;
+}

--- a/tests/test_tui_gpu_fleet_panel.py
+++ b/tests/test_tui_gpu_fleet_panel.py
@@ -1,0 +1,307 @@
+"""Tests for the GpuFleetPanel widget.
+
+Drives the real widget via a minimal Textual app host.  GPU probes are
+monkeypatched at the module boundary (probe_gpu_stats) so no nvidia-smi
+subprocess is needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from textual.app import ComposeResult
+
+from tests._lilbee_app_test_host import LilbeeAppHost
+
+GIB = 1024**3
+
+
+@dataclass(frozen=True)
+class _FakeDevice:
+    """Minimal _DeviceLike-compatible stub for tests."""
+
+    index: int
+    backend: str
+    total_bytes: int
+    free_bytes: int
+
+
+def _make_stat(
+    index: int,
+    utilization_pct: int | None = 42,
+    used_bytes: int = 10 * GIB,
+    total_bytes: int = 24 * GIB,
+) -> object:
+    from lilbee.providers.fleet.gpu_stats import GpuStat
+
+    free = total_bytes - used_bytes
+    return GpuStat(
+        index=index,
+        utilization_pct=utilization_pct,
+        free_bytes=free,
+        total_bytes=total_bytes,
+    )
+
+
+def _make_device(index: int, backend: str = "CUDA", total_bytes: int = 24 * GIB) -> _FakeDevice:
+    """Return a _DeviceLike-compatible stub."""
+    return _FakeDevice(
+        index=index, backend=backend, total_bytes=total_bytes, free_bytes=total_bytes
+    )
+
+
+class _PanelHost(LilbeeAppHost):
+    """Minimal app host that mounts GpuFleetPanel directly."""
+
+    CSS = ""
+
+    def compose(self) -> ComposeResult:
+        from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+        yield GpuFleetPanel()
+
+
+@pytest.mark.asyncio
+async def test_panel_renders_empty_state_with_no_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without any devices the panel shows the empty-state text."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {})
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        rendered = str(panel.render())
+        assert panel_mod._EMPTY_TEXT in rendered
+
+
+@pytest.mark.asyncio
+async def test_panel_renders_card_label_and_vram(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With one CUDA GPU the panel renders the label and VRAM figures."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    stat = _make_stat(0, utilization_pct=55, used_bytes=10 * GIB, total_bytes=24 * GIB)
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {0: stat})
+
+    device = _make_device(0)
+    labels = {0: "CUDA0"}
+    names = {0: "NVIDIA A40"}
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel.set_devices([device], labels=labels, names=names)
+        # Trigger a manual tick so we don't wait for the 1 s timer.
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        rendered = str(panel.render())
+        assert "CUDA0" in rendered
+        # VRAM numerics: 10.0/24G
+        assert "10.0" in rendered
+        assert "24" in rendered
+
+
+@pytest.mark.asyncio
+async def test_panel_renders_utilization_percentage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Utilization percentage appears in the rendered output for a CUDA GPU."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    stat = _make_stat(0, utilization_pct=73)
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {0: stat})
+
+    device = _make_device(0)
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel.set_devices([device], labels={0: "CUDA0"}, names={0: "RTX 3090"})
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        rendered = str(panel.render())
+        assert "73%" in rendered
+
+
+@pytest.mark.asyncio
+async def test_panel_shows_dash_when_util_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-CUDA backends (utilization_pct=None) render a dash, not a number."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import _UTIL_DASH, GpuFleetPanel
+
+    stat = _make_stat(0, utilization_pct=None)
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {0: stat})
+
+    device = _make_device(0, backend="Vulkan")
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel.set_devices([device], labels={0: "Vulkan0"}, names={0: "AMD Radeon"})
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        rendered = str(panel.render())
+        assert _UTIL_DASH.strip() in rendered
+
+
+@pytest.mark.asyncio
+async def test_panel_updates_on_second_tick(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The panel re-renders when stats change between ticks.
+
+    The initial on_mount probe fires with empty devices (empty result); the
+    two explicit ticks return 10% then 90% and we assert each change lands.
+    """
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    results = [
+        {},  # initial on_mount probe (no devices yet)
+        {0: _make_stat(0, utilization_pct=10)},
+        {0: _make_stat(0, utilization_pct=90)},
+    ]
+    probe_calls: list[int] = []
+
+    def _probe(devices: object) -> object:  # type: ignore[no-untyped-def]
+        idx = len(probe_calls)
+        probe_calls.append(idx)
+        return results[min(idx, len(results) - 1)]
+
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", _probe)
+
+    device = _make_device(0)
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        # Set devices after mount so explicit ticks have the right labels.
+        panel.set_devices([device], labels={0: "CUDA0"}, names={0: "A100"})
+        await app.workers.wait_for_complete()
+
+        # First explicit tick
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        first_render = str(panel.render())
+        assert "10%" in first_render
+
+        # Second explicit tick
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        second_render = str(panel.render())
+        assert "90%" in second_render
+
+
+@pytest.mark.asyncio
+async def test_panel_graceful_on_probe_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing probe leaves the previous content intact and does not crash.
+
+    The initial on_mount probe returns an empty dict (no devices set yet).
+    The first explicit tick returns good stats with the right labels set.
+    The second explicit tick raises; the panel must keep the previous content.
+    """
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    good_stat = _make_stat(0, utilization_pct=50)
+    probe_calls: list[int] = []
+
+    def _probe(devices: object) -> object:  # type: ignore[no-untyped-def]
+        idx = len(probe_calls)
+        probe_calls.append(idx)
+        if idx == 0:
+            # on_mount probe: no devices registered yet
+            return {}
+        if idx == 1:
+            return {0: good_stat}
+        raise OSError("nvidia-smi not found")
+
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", _probe)
+
+    device = _make_device(0)
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel.set_devices([device], labels={0: "CUDA0"}, names={0: "A100"})
+        await app.workers.wait_for_complete()
+
+        # First explicit tick returns good stats
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        content_after_good = str(panel.render())
+        assert "CUDA0" in content_after_good
+
+        # Second explicit tick raises; content must remain unchanged
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        content_after_fail = str(panel.render())
+        assert "CUDA0" in content_after_fail
+
+
+@pytest.mark.asyncio
+async def test_panel_timer_stops_on_unmount(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The internal timer is cleared when the panel is unmounted."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {})
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        # Timer is set after mount
+        assert panel._timer is not None
+    # After the context exits the app stops; the timer must be None or stopped.
+    # The on_unmount callback is the mechanism; we verify it ran without error.
+    assert panel._timer is None
+
+
+@pytest.mark.asyncio
+async def test_placement_screen_mounts_panel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The PlacementScreen composes a GpuFleetPanel alongside the GPU table."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+    from tests.test_tui_placement import PlacementTestApp, _make_view
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        # Panel must be present in the placement screen's DOM.
+        panel = app.screen.query_one(GpuFleetPanel)
+        assert panel is not None
+
+
+@pytest.mark.asyncio
+async def test_placement_screen_passes_devices_to_panel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After loading placement the fleet panel receives the GPU device list."""
+    from lilbee.cli.tui.screens import placement as screen_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+    from tests.test_tui_placement import PlacementTestApp, _make_view
+
+    monkeypatch.setattr(screen_mod, "get_placement", lambda: _make_view())
+
+    app = PlacementTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        panel = app.screen.query_one(GpuFleetPanel)
+        # The placement view has 4 GPUs (indices 0-3); all must be in the panel.
+        assert len(panel._devices) == 4
+        assert panel._labels[0] == "CUDA0"
+        assert panel._names[0] == "NVIDIA A40"


### PR DESCRIPTION
## Problem
The live per-GPU "GPU FLEET" view (utilization + VRAM bars) only existed as an external script in a tmux split for demos — there was no native in-TUI GPU monitor. The placement screen showed a static GPU table but no live load, so a faithful demo of the multi-GPU fleet meant compositing a separate process beside the TUI.

## Solution
Add a `GpuFleetPanel` widget on the Placement screen that renders per-card utilization + VRAM bars (rose-pine) and refreshes on a ~1s tick. It reuses the existing `gpu_stats.probe_gpu_stats` sampler, run off the UI thread (`@work(thread=True)` + `call_from_thread`) so the event loop is never blocked by the probe subprocess. VRAM is cross-vendor (from the device probe); utilization is NVIDIA-only today — the per-vendor backends (AMD/Apple/Intel) + temperature are the follow-up (bb-dzc). Graceful empty state when no GPUs or `nvidia-smi` is absent, and a transient probe failure keeps the last content rather than blanking.

Tests drive the widget and the placement integration via pilot (empty state, util/VRAM rendering, the None-utilization dash, tick updates, probe-failure resilience, timer cleanup on unmount). CSS lives in a `.tcss` loaded via the widget `DEFAULT_CSS` convention; ruff/format/mypy-strict clean.