### PR TITLE
fix(hermes): set up hermes's mcp extra so lilbee search connects

### DIFF
--- a/docs/tutorial-reel.md
+++ b/docs/tutorial-reel.md
@@ -4,7 +4,7 @@ Same demos as on [lilbee.sh/](https://lilbee.sh/),
 with the captions long-form and a handful of extras that don't fit in the site's
 tab list.
 
-The nine that match the site reel, in order:
+The ten that match the site reel, in order:
 
 1. [First run](#first-run)
 2. [TUI tour](#tui-tour)
@@ -15,6 +15,7 @@ The nine that match the site reel, in order:
 7. [Settings](#settings)
 8. [Agent: code (lilbee talking to lilbee)](#agent-code-lilbee-talking-to-lilbee)
 9. [Agent: PDF](#agent-pdf)
+10. [Run a model bigger than one card](#run-a-model-bigger-than-one-card)
 
 Extras: [agent: live indexing](#agent-live-indexing), [agent: Godot codegen against the full class reference](#agent-godot-codegen-against-the-full-class-reference), [command surface](#command-surface).
 
@@ -82,6 +83,22 @@ The agent finds `cv-manual.pdf` in the project, delegates the index to
 `lilbee-worker`, then `lilbee_search`-es and returns a page-cited answer.
 
 ![mcp + manual](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/mcp-manual.gif)
+
+## Run a model bigger than one card
+
+A chat model too large for any single GPU is split across as many cards as it
+needs. Here lilbee indexes its own source live, then answers "what is lilbee"
+and "how does lilbee run a model too big for one GPU", with a 235B model
+tensor-split across three A40s and the GPU monitor showing the load alongside.
+
+![a model too big for one card auto-split across the GPUs, answering from lilbee's own indexed source](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-multi-gpu-self-index.gif)
+
+You can also place each role by hand. The placement editor refuses a layout
+that won't fit with the exact shortfall (pinning chat to one 40 GiB card when
+it needs 97.5 GiB), then accepts the model spread back across the cards and
+answers on the fleet you chose, citing `placement.py`.
+
+![the placement editor: a too-small layout refused with the exact shortfall, then spread across the cards and applied](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-manual-placement.gif)
 
 ## Extras
 

--- a/src/lilbee/cli/commands/agent_config.py
+++ b/src/lilbee/cli/commands/agent_config.py
@@ -12,6 +12,7 @@ import yaml
 
 from lilbee.cli.agent_configs import hermes, litellm, opencode
 from lilbee.cli.app import apply_overrides, data_dir_option, global_option
+from lilbee.cli.launchers.hermes_mcp import MCP_EXTRA_HINT
 from lilbee.cli.launchers.server import (
     LOOPBACK,
     installed_chat_model_refs,
@@ -24,6 +25,7 @@ from lilbee.providers.model_ref import with_configured_remote_chat
 agent_config_app = typer.Typer(help="Print a paste-ready config block for an AI client.")
 
 _SERVE_HINT = "Start `lilbee serve --port 8080` first, then re-run this command."
+_MCP_CONTAINER_KEY = "mcp_servers"  # hermes config key holding the MCP server entries
 
 
 _JsonBuilder = Callable[..., dict[str, Any]]
@@ -57,6 +59,11 @@ def _emit_block(builder: _JsonBuilder | _TextBuilder, **kwargs: Any) -> None:
         typer.echo(block, nl=False)
     elif builder is hermes.hermes_config:
         typer.echo(yaml.safe_dump(block, sort_keys=False), nl=False)
+        if _MCP_CONTAINER_KEY in block:
+            # Parity with `lilbee launch hermes`: the MCP block only works once
+            # hermes has its `mcp` extra. The paste path can't install it, so
+            # surface the same hint (to stderr, keeping the YAML pipe-clean).
+            typer.secho(MCP_EXTRA_HINT, err=True, fg=typer.colors.YELLOW)
     else:
         typer.echo(json.dumps(block, indent=2))
 

--- a/src/lilbee/cli/launchers/hermes.py
+++ b/src/lilbee/cli/launchers/hermes.py
@@ -12,6 +12,7 @@ import yaml
 from lilbee.cli.agent_configs import config_file
 from lilbee.cli.agent_configs.hermes import hermes_config
 from lilbee.cli.agent_configs.merge import deep_merge, prune_lilbee
+from lilbee.cli.launchers.hermes_mcp import ensure_hermes_http_mcp
 from lilbee.cli.launchers.launcher import LILBEE_TOKEN_ENV_VAR, run_launcher
 from lilbee.cli.launchers.server import LOOPBACK, served_chat_ctx
 from lilbee.cli.launchers.skill_install import install_bundled_skill
@@ -23,6 +24,9 @@ _HERMES_INSTALL_HINT = (
 _TOKEN_REF = "${" + LILBEE_TOKEN_ENV_VAR + "}"
 _MCP_CONTAINER_KEY = "mcp_servers"
 _CONFIG_LABEL = "hermes config (config.yaml)"
+# hermes config keys gating its own auto-installs (security.allow_lazy_installs).
+_SECURITY_KEY = "security"
+_ALLOW_LAZY_INSTALLS_KEY = "allow_lazy_installs"
 
 
 def _hermes_home() -> Path:
@@ -90,6 +94,15 @@ class HermesLauncher:
         _upsert_env_token(_hermes_env_path(), token)
         if self._include_mcp:
             install_bundled_skill(_hermes_skill_dest())
+            # hermes ships HTTP MCP behind the optional `mcp` extra; without it
+            # lilbee's MCP search shows "0 connected". Set it up before launch,
+            # honoring hermes's own auto-install security gate.
+            binary = self.find_binary()
+            if binary is not None:
+                allow_lazy = bool(
+                    (config.get(_SECURITY_KEY) or {}).get(_ALLOW_LAZY_INSTALLS_KEY, True)
+                )
+                ensure_hermes_http_mcp(binary, allow_lazy_installs=allow_lazy, echo=typer.echo)
         return ([], {**os.environ, LILBEE_TOKEN_ENV_VAR: token})
 
 

--- a/src/lilbee/cli/launchers/hermes_mcp.py
+++ b/src/lilbee/cli/launchers/hermes_mcp.py
@@ -1,0 +1,105 @@
+"""Ensure hermes has its optional ``mcp`` extra (HTTP MCP) before lilbee wires in over it."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+# The module hermes imports to enable Streamable-HTTP MCP; its absence is what
+# produces "MCP Servers (0) connected".
+_HTTP_MCP_PROBE = "import mcp.client.streamable_http"
+# hermes's own documented command (tools/mcp_tool.py); pins the mcp + starlette
+# versions hermes expects. Shown when we don't (or can't) auto-install.
+MCP_EXTRA_HINT = (
+    "Enable lilbee's search in hermes by installing hermes's MCP extra:\n"
+    "  pip install 'hermes-agent[mcp]'\n"
+    "(or `uv tool install 'hermes-agent[mcp]'` / `pipx inject hermes-agent mcp`)."
+)
+# Reads hermes's pinned `[mcp]` extra requirements from its own metadata, so we
+# install exactly what hermes expects rather than an unpinned `mcp`.
+_EXTRA_REQS_SNIPPET = (
+    "import importlib.metadata as m, json\n"
+    "try: reqs = m.requires('hermes-agent') or []\n"
+    "except Exception: reqs = []\n"
+    "out = [r.split(';')[0].strip() for r in reqs\n"
+    '       if len(r.split(";")) > 1 and "extra" in r.split(";")[1] and "mcp" in r.split(";")[1]]\n'
+    "print(json.dumps(out))"
+)
+
+
+def hermes_interpreter(binary: str) -> str | None:
+    """The Python that runs hermes, read from its console-script shebang (or None)."""
+    try:
+        first_line = Path(binary).read_text(encoding="utf-8", errors="replace").splitlines()[0]
+    except (OSError, IndexError):
+        return None
+    if first_line.startswith("#!") and "python" in first_line:
+        return first_line[2:].strip().split()[0] or None
+    return None
+
+
+def has_http_mcp(interpreter: str) -> bool:
+    """Whether ``interpreter`` can import hermes's Streamable-HTTP MCP client."""
+    try:
+        return (
+            subprocess.run(  # noqa: S603 - hermes's own resolved interpreter, fixed argv
+                [interpreter, "-c", _HTTP_MCP_PROBE],
+                capture_output=True,
+                check=False,
+            ).returncode
+            == 0
+        )
+    except OSError:
+        return False
+
+
+def _mcp_extra_requirements(interpreter: str) -> list[str]:
+    """hermes's pinned ``[mcp]`` extra requirements, or ``["mcp"]`` if unreadable."""
+    try:
+        result = subprocess.run(  # noqa: S603 - hermes's own resolved interpreter, fixed argv
+            [interpreter, "-c", _EXTRA_REQS_SNIPPET],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        reqs = json.loads(result.stdout or "[]")
+    except (OSError, json.JSONDecodeError):
+        reqs = []
+    return reqs or ["mcp"]
+
+
+def ensure_hermes_http_mcp(
+    binary: str, *, allow_lazy_installs: bool, echo: Callable[[str], None]
+) -> bool:
+    """Make sure hermes can speak HTTP MCP, returning whether it ends up supported.
+
+    When support is missing: auto-installs hermes's pinned ``[mcp]`` extra into
+    hermes's own environment (only if ``allow_lazy_installs``), otherwise echoes
+    hermes's documented install command. Idempotent and cheap when already present."""
+    interpreter = hermes_interpreter(binary)
+    if interpreter is None:
+        echo(MCP_EXTRA_HINT)
+        return False
+    if has_http_mcp(interpreter):
+        return True
+    if not allow_lazy_installs:
+        # Respect the user's hermes security setting; don't pip-install behind it.
+        echo(MCP_EXTRA_HINT)
+        return False
+    echo("Setting up hermes MCP support (installing hermes's mcp extra)...")
+    try:
+        subprocess.run(  # noqa: S603 - hermes's own resolved interpreter, fixed argv
+            [interpreter, "-m", "pip", "install", *_mcp_extra_requirements(interpreter)],
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        echo(MCP_EXTRA_HINT)
+        return False
+    if has_http_mcp(interpreter):
+        echo("hermes MCP support ready.")
+        return True
+    echo(MCP_EXTRA_HINT)
+    return False

--- a/tests/cli/test_agent_config_hermes.py
+++ b/tests/cli/test_agent_config_hermes.py
@@ -116,6 +116,17 @@ def test_agent_config_hermes_prints_yaml_block(monkeypatch):
     assert block["providers"]["lilbee"]["api_key"] == _TOKEN
 
 
+def test_agent_config_hermes_notes_mcp_extra(monkeypatch):
+    # Entry-point parity with `lilbee launch hermes`: the paste path can't install
+    # hermes's `mcp` extra, so it must at least tell the user it's needed.
+    _write_server_session()
+    monkeypatch.setattr("lilbee.cli.commands.agent_config.served_chat_ctx", lambda _p: None)
+    result = runner.invoke(app, ["agent-config", "hermes"])
+    assert result.exit_code == 0
+    assert "hermes-agent[mcp]" in result.stderr
+    assert yaml.safe_load(result.stdout) is not None  # YAML stays clean on stdout
+
+
 def test_agent_config_hermes_requires_running_server():
     result = runner.invoke(app, ["agent-config", "hermes"])
     assert result.exit_code == 1

--- a/tests/cli/test_hermes_mcp.py
+++ b/tests/cli/test_hermes_mcp.py
@@ -1,0 +1,112 @@
+"""Tests for ensuring hermes has HTTP MCP support before the launcher wires lilbee in."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from lilbee.cli.launchers import hermes_mcp
+
+
+def _script(tmp_path, shebang: str):
+    p = tmp_path / "hermes"
+    p.write_text(f"{shebang}\nprint('hermes')\n")
+    return str(p)
+
+
+def _ensure(binary, msgs, *, allow_lazy_installs=True):
+    return hermes_mcp.ensure_hermes_http_mcp(
+        binary, allow_lazy_installs=allow_lazy_installs, echo=msgs.append
+    )
+
+
+def test_interpreter_read_from_shebang(tmp_path):
+    binary = _script(tmp_path, "#!/opt/venv/bin/python3")
+    assert hermes_mcp.hermes_interpreter(binary) == "/opt/venv/bin/python3"
+
+
+def test_interpreter_none_for_non_python_shebang(tmp_path):
+    assert hermes_mcp.hermes_interpreter(_script(tmp_path, "#!/bin/sh")) is None
+
+
+def test_interpreter_none_for_missing_binary():
+    assert hermes_mcp.hermes_interpreter("/no/such/hermes") is None
+
+
+def test_has_http_mcp_true_on_success():
+    with patch.object(hermes_mcp.subprocess, "run", return_value=SimpleNamespace(returncode=0)):
+        assert hermes_mcp.has_http_mcp("/py") is True
+
+
+def test_has_http_mcp_false_on_import_error():
+    with patch.object(hermes_mcp.subprocess, "run", return_value=SimpleNamespace(returncode=1)):
+        assert hermes_mcp.has_http_mcp("/py") is False
+
+
+def test_extra_requirements_reads_pinned_extra():
+    out = '["mcp==1.26.0", "starlette==1.0.1"]'
+    with patch.object(hermes_mcp.subprocess, "run", return_value=SimpleNamespace(stdout=out)):
+        assert hermes_mcp._mcp_extra_requirements("/py") == ["mcp==1.26.0", "starlette==1.0.1"]
+
+
+def test_extra_requirements_falls_back_to_mcp_when_unreadable():
+    with patch.object(hermes_mcp.subprocess, "run", return_value=SimpleNamespace(stdout="")):
+        assert hermes_mcp._mcp_extra_requirements("/py") == ["mcp"]
+
+
+def test_ensure_noops_when_already_supported(tmp_path):
+    binary = _script(tmp_path, "#!/opt/venv/bin/python")
+    msgs: list[str] = []
+    with (
+        patch.object(hermes_mcp, "has_http_mcp", return_value=True),
+        patch.object(hermes_mcp.subprocess, "run") as run,
+    ):
+        assert _ensure(binary, msgs) is True
+    run.assert_not_called()  # already supported -> no install attempt
+    assert msgs == []
+
+
+def test_ensure_installs_pinned_extra_when_missing_and_allowed(tmp_path):
+    binary = _script(tmp_path, "#!/opt/venv/bin/python")
+    msgs: list[str] = []
+    with (
+        patch.object(hermes_mcp, "has_http_mcp", side_effect=[False, True]),
+        patch.object(hermes_mcp, "_mcp_extra_requirements", return_value=["mcp==1.26.0"]),
+        patch.object(hermes_mcp.subprocess, "run") as run,
+    ):
+        assert _ensure(binary, msgs) is True
+    # installs hermes's pinned extra, not an unpinned `mcp`
+    assert run.call_args[0][0][1:] == ["-m", "pip", "install", "mcp==1.26.0"]
+    assert any("Setting up hermes MCP support" in m for m in msgs)
+    assert any("ready" in m for m in msgs)
+
+
+def test_ensure_respects_security_gate_and_guides(tmp_path):
+    binary = _script(tmp_path, "#!/opt/venv/bin/python")
+    msgs: list[str] = []
+    with (
+        patch.object(hermes_mcp, "has_http_mcp", return_value=False),
+        patch.object(hermes_mcp.subprocess, "run") as run,
+    ):
+        assert _ensure(binary, msgs, allow_lazy_installs=False) is False
+    run.assert_not_called()  # gate off -> never pip-installs behind hermes's setting
+    assert any("hermes-agent[mcp]" in m for m in msgs)
+
+
+def test_ensure_guides_when_install_did_not_take(tmp_path):
+    binary = _script(tmp_path, "#!/opt/venv/bin/python")
+    msgs: list[str] = []
+    with (
+        patch.object(hermes_mcp, "has_http_mcp", side_effect=[False, False]),
+        patch.object(hermes_mcp, "_mcp_extra_requirements", return_value=["mcp"]),
+        patch.object(hermes_mcp.subprocess, "run"),
+    ):
+        assert _ensure(binary, msgs) is False
+    assert any("hermes-agent[mcp]" in m for m in msgs)
+
+
+def test_ensure_guides_when_interpreter_unknown(tmp_path):
+    binary = _script(tmp_path, "#!/bin/sh")  # not a python shebang
+    msgs: list[str] = []
+    assert _ensure(binary, msgs) is False
+    assert any("hermes-agent[mcp]" in m for m in msgs)

--- a/tools/qa/lilbee_reels/run-hermes.sh
+++ b/tools/qa/lilbee_reels/run-hermes.sh
@@ -23,7 +23,9 @@ command -v rg >/dev/null || (apt-get update -qq && apt-get install -y -qq ripgre
 [ -d "$HERMES_DIR/.git" ] || git clone --depth 1 https://github.com/NousResearch/hermes-agent "$HERMES_DIR" >>"$OUT/hermes-install.log" 2>&1
 # CRITICAL: unset UV_PROJECT_ENVIRONMENT (qa_env points it at lilbee's venv) so
 # hermes syncs into its OWN .venv instead of clobbering lilbee's.
-( cd "$HERMES_DIR" && env -u UV_PROJECT_ENVIRONMENT uv sync >>"$OUT/hermes-install.log" 2>&1 ) || log "hermes uv sync issues (see hermes-install.log)"
+# --extra mcp: hermes ships HTTP MCP transport behind the optional `mcp` extra;
+# without it `lilbee_search` shows "0 connected".
+( cd "$HERMES_DIR" && env -u UV_PROJECT_ENVIRONMENT uv sync --extra mcp >>"$OUT/hermes-install.log" 2>&1 ) || log "hermes uv sync issues (see hermes-install.log)"
 cat > /usr/local/bin/hermes <<WRAP
 #!/usr/bin/env bash
 exec env -u UV_PROJECT_ENVIRONMENT -u VIRTUAL_ENV uv run --project $HERMES_DIR hermes "\$@"


### PR DESCRIPTION
## Problem

`lilbee launch hermes` showed **MCP Servers (0) connected** — lilbee's `lilbee_search` never wired into hermes. Traced through hermes's source and reproduced locally: the lilbee config was correct all along (top-level `url` + `Authorization: Bearer ${LILBEE_TOKEN}` matches hermes's own example, resolves, and connects). The real cause: hermes ships HTTP MCP behind the **optional** `mcp` extra (`hermes-agent[mcp]`, which pins `mcp==1.26.0` + `starlette==1.0.1`). A default install (plain `uv sync` / `pip install hermes-agent`, what the reel and most users do) has no `mcp` package, so `mcp.client.streamable_http` is unavailable and **every** HTTP MCP server reports 0 connected. With the extra, `hermes mcp test lilbee` connects and lists every lilbee tool.

## Solution

`lilbee launch hermes` mirrors hermes's own design rather than working around it:

- Reads hermes's interpreter from its console-script shebang and probes for `mcp.client.streamable_http`.
- When missing, installs hermes's **pinned** `[mcp]` extra — read from hermes's own metadata, not an unpinned `mcp` — into hermes's environment, **only when hermes's `security.allow_lazy_installs` gate is on** (respecting the user's hermes security setting), with a visible "Setting up hermes MCP support…" message.
- When the gate is off or the install can't run, falls back to hermes's documented `pip install 'hermes-agent[mcp]'`.
- `lilbee agent-config hermes` (the manual paste path) surfaces the same hint to stderr — entry-point parity, since it can't auto-install.
- The reel install uses `uv sync --extra mcp`.

Verified locally end-to-end: gate-off guides without installing; gate-on installs the pinned extra and hermes goes from "0 connected" to listing all lilbee tools. Covered by unit tests (interpreter detection, capability probe, pinned-extra read + fallback, install path, the security gate, both guidance fallbacks, and the agent-config parity note).