### PR TITLE
Widen chat tensor-split onto idle GPUs to keep context usable

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,10 +192,18 @@ flowchart TD
   of the budget and 503-ing every search.
 - **Placement** (`placement.py`): first-fit-decreasing bin-pack with 90% headroom.
   A model that fits one GPU is a single pinned instance; small models co-locate; a
-  model too big for one GPU is tensor-split across the **fewest cards whose per-device
-  footprint each fits**, charged against each card's total VRAM capacity (so a warm
-  fleet's own resident models aren't double-counted, and unequal GPUs don't OOM the
-  smaller one). A tensor-split chat serves **one full-context sequence**
+  model too big for one GPU is tensor-split across enough cards that each card's
+  per-device footprint fits, charged against each card's total VRAM capacity (so a
+  warm fleet's own resident models aren't double-counted, and unequal GPUs don't OOM
+  the smaller one). For the chat model the planner does not stop at the fewest fitting
+  cards: it sizes each candidate shard's served context the way the launch will
+  (`ctx.fit_split_ctx`, against **live free VRAM**) and **widens onto idle cards** when
+  a tighter shard would starve KV below the context target, falling back to the
+  largest-context shard when no shard reaches it. This keeps placement and launch in
+  agreement, so a giant chat that just fits the fewest cards no longer collapses to the
+  512-token floor while spare cards sit idle; a chat already comfortable on few cards
+  stays there (no needless inter-GPU traffic), and the context target follows
+  `cfg.num_ctx` / `cfg.chat_n_ctx_target`. A tensor-split chat serves **one full-context sequence**
   (`--parallel 1`): a giant filling several cards has no room to divide its context
   across batching slots, so the planner reserves and launches it at the single-sequence
   footprint rather than `ceiling x` the single-GPU slot count (multi-slot batching is

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -9,7 +9,7 @@ that fits nowhere gets no server (its calls error). See docs/architecture.md.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
@@ -24,6 +24,11 @@ _SEARCH_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK)
 # vector aligned to that ratio. A split is accepted only when every card's entry
 # fits its own headroom, and each card is charged its own entry, not the sum.
 PeakEstimator = Callable[[WorkerRole, tuple[int, ...]], tuple[int, ...]]
+
+# (per-device tensor-split ratio, chosen cards' live free VRAM bytes) -> the per-slot
+# context the launch would serve on that chat shard. Lets the planner widen a chat
+# split onto idle cards when a tighter shard would starve KV below the target.
+SplitCtxFitter = Callable[[tuple[int, ...], Sequence[int]], int]
 
 
 @dataclass(frozen=True)
@@ -73,13 +78,20 @@ def plan_placement(
     *,
     estimate_peak: PeakEstimator,
     unified_budget: int | None = None,
+    chat_ctx_fit: SplitCtxFitter | None = None,
+    chat_ctx_target: int = 0,
+    free_headroom: dict[int, int] | None = None,
 ) -> Placement:
     """Bin-pack *models* onto *devices* (``[(index, vram_bytes), ...]``).
 
     First-fit-decreasing by footprint with a 90% headroom per GPU. A model that
     fits one GPU takes a single instance; one too big for any single GPU is
-    tensor-split across the fewest GPUs whose per-device share (from
-    *estimate_peak*) each fits; a model that fits nowhere is an unplaceable role.
+    tensor-split; a model that fits nowhere is an unplaceable role.
+
+    A chat split widens past the fewest fitting cards when ``chat_ctx_fit`` shows a
+    tighter shard would starve its served context below ``chat_ctx_target``; the
+    fitter is sized against ``free_headroom`` (live free VRAM per device index). See
+    docs/architecture.md (Placement). Other splits keep the fewest-cards behavior.
 
     No GPU devices is the CPU/unified-memory case (a GPU-less host, or an Apple
     Silicon box where the probe found nothing): roles run as single un-pinned
@@ -115,7 +127,14 @@ def plan_placement(
     replicated = [m for m in models if m.replicas > 1]
     persistent_singles = singles + [_persistent_single(m) for m in replicated]
     for model in sorted(persistent_singles, key=_shared_pool_order):
-        plan = _place_single(model, remaining, estimate_peak)
+        plan = _place_single(
+            model,
+            remaining,
+            estimate_peak,
+            chat_ctx_fit=chat_ctx_fit,
+            chat_ctx_target=chat_ctx_target,
+            free_headroom=free_headroom,
+        )
         if plan is None:
             unplaceable.append(model.role)
         else:
@@ -138,37 +157,78 @@ def _place_single(
     model: ModelPlacementInput,
     remaining: dict[int, float],
     estimate_peak: PeakEstimator,
+    *,
+    chat_ctx_fit: SplitCtxFitter | None = None,
+    chat_ctx_target: int = 0,
+    free_headroom: dict[int, int] | None = None,
 ) -> InstancePlan | None:
     """Place one instance: a single GPU when it fits, else a tensor-split, else None."""
     single = _best_single_device(model.est_vram_bytes, remaining)
     if single is not None:
         remaining[single] -= model.est_vram_bytes
         return InstancePlan(role=model.role, devices=(single,))
-    return _place_split(model, remaining, estimate_peak)
+    return _place_split(
+        model,
+        remaining,
+        estimate_peak,
+        chat_ctx_fit=chat_ctx_fit,
+        chat_ctx_target=chat_ctx_target,
+        free_headroom=free_headroom,
+    )
 
 
 def _place_split(
     model: ModelPlacementInput,
     remaining: dict[int, float],
     estimate_peak: PeakEstimator,
+    *,
+    chat_ctx_fit: SplitCtxFitter | None = None,
+    chat_ctx_target: int = 0,
+    free_headroom: dict[int, int] | None = None,
 ) -> InstancePlan | None:
-    """Tensor-split across the fewest most-free GPUs whose per-device share each fits.
+    """Tensor-split across the most-free GPUs whose per-device share each fits.
 
     Charges each chosen card its own entry from *estimate_peak*'s vector, so the
-    busiest card (which OOMs first) is what gates the split, not the summed pool.
+    busiest card (which OOMs first) gates the split, not the summed pool. A chat
+    split widens past the fewest fitting cards via *chat_ctx_fit* (see
+    :func:`plan_placement`); every other split takes the fewest that fit.
     """
     by_free = sorted(remaining, key=lambda idx: remaining[idx], reverse=True)
+    best: tuple[int, list[int], tuple[int, ...], tuple[int, ...]] | None = None
     for count in range(2, len(by_free) + 1):
         chosen = by_free[:count]
         ratio = tuple(max(1, int(remaining[idx] / 1024**3)) for idx in chosen)
         per_device = estimate_peak(model.role, ratio)
-        if len(per_device) == count and all(
+        if len(per_device) != count or not all(
             peak <= remaining[idx] for idx, peak in zip(chosen, per_device, strict=True)
         ):
-            for idx, peak in zip(chosen, per_device, strict=True):
-                remaining[idx] -= peak
-            return InstancePlan(role=model.role, devices=tuple(chosen), tensor_split=ratio)
+            continue
+        # Only chat is widened past the fewest fitting cards; everything else (and
+        # the no-fitter generic path) takes the first shard that fits.
+        if model.role is not WorkerRole.CHAT or chat_ctx_fit is None or free_headroom is None:
+            return _charge_split(model, chosen, ratio, per_device, remaining)
+        served = chat_ctx_fit(ratio, [free_headroom[idx] for idx in chosen])
+        if served >= chat_ctx_target:
+            return _charge_split(model, chosen, ratio, per_device, remaining)
+        if best is None or served > best[0]:
+            best = (served, chosen, ratio, per_device)
+    if best is not None:
+        _served, chosen, ratio, per_device = best
+        return _charge_split(model, chosen, ratio, per_device, remaining)
     return None
+
+
+def _charge_split(
+    model: ModelPlacementInput,
+    chosen: list[int],
+    ratio: tuple[int, ...],
+    per_device: tuple[int, ...],
+    remaining: dict[int, float],
+) -> InstancePlan:
+    """Debit each chosen card its own per-device share and return the split plan."""
+    for idx, peak in zip(chosen, per_device, strict=True):
+        remaining[idx] -= peak
+    return InstancePlan(role=model.role, devices=tuple(chosen), tensor_split=ratio)
 
 
 def _place_replicas(

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -30,6 +30,7 @@ from lilbee.providers.fleet.placement import (
     ModelPlacementInput,
     PeakEstimator,
     Placement,
+    SplitCtxFitter,
     placement_from_spec,
     plan_placement,
 )
@@ -41,7 +42,7 @@ from lilbee.providers.roles import RerankMode, WorkerRole
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
 # Fleet-only concurrency: continuous-batching slots (--parallel) per server.
 _CHAT_SLOTS = 4
@@ -56,6 +57,9 @@ _SPLIT_CHAT_SLOTS = 1
 # cards' real headroom by resolve_chat_ctx (single) / fit_split_ctx (split).
 _MIN_USABLE_CHAT_CTX = 8192
 _AUX_SLOTS = 1
+# A tensor-split needs at least this many GPUs; below it the chat context objective
+# (a gguf read) is pointless because the model can only single-card or stay unplaced.
+_MIN_SPLIT_GPUS = 2
 _EMBED_ROLES = (WorkerRole.EMBED, WorkerRole.RERANK)
 # Roles whose loaders offload every layer regardless of cfg.n_gpu_layers; only
 # chat honors cfg.n_gpu_layers.
@@ -528,6 +532,42 @@ def _peak_estimator(model_refs: dict[WorkerRole, str]) -> PeakEstimator:
     return estimate_peak
 
 
+def _chat_split_ctx_objective(
+    model_refs: dict[WorkerRole, str],
+) -> tuple[SplitCtxFitter | None, int]:
+    """The chat split's context fitter and target, or ``(None, 0)`` with no chat model.
+
+    The fitter sizes a candidate shard's served context exactly as the launch does
+    (:func:`fit_split_ctx`), so the planner widens chat onto idle cards only when a
+    tighter shard would starve KV below the target. See docs/architecture.md.
+    """
+    if WorkerRole.CHAT not in model_refs:
+        return None, 0
+    from lilbee.providers.engine_params import resolve_model_path
+    from lilbee.providers.gguf_meta import read_gguf_metadata
+
+    path = resolve_model_path(model_refs[WorkerRole.CHAT])
+    meta = read_gguf_metadata(path)
+    target = _placement_estimate_ctx(WorkerRole.CHAT, path, meta)
+
+    def fit(ratio: tuple[int, ...], per_device_free_bytes: Sequence[int]) -> int:
+        # circular: fleet.ctx -> engine_params -> app.services
+        from lilbee.providers.fleet.ctx import fit_split_ctx
+
+        return fit_split_ctx(
+            path,
+            meta=meta,
+            slots=_SPLIT_CHAT_SLOTS,
+            ratio=ratio,
+            per_device_free_bytes=per_device_free_bytes,
+            gpu_layers=_role_gpu_layers(WorkerRole.CHAT),
+            flash_attn=_role_flash(WorkerRole.CHAT),
+            kv_cache_type=_role_kv_cache_type(WorkerRole.CHAT),
+        )
+
+    return fit, target
+
+
 def _search_reservation(inputs: dict[WorkerRole, ModelPlacementInput]) -> int:
     """Total footprint of the placed search roles (all replicas), held back ahead
     of chat."""
@@ -803,11 +843,21 @@ def _resolve_placement(
             capacity,
             estimate_peak=estimate_peak,
         )
+    # The chat split's card count is decided against live free VRAM (what the launch
+    # sizes its context against) so placement and launch agree; charging still uses
+    # total capacity above, preserving the bb-a8f no-double-count invariant. A split
+    # needs >=2 GPUs, so skip the chat model's gguf read entirely below that.
+    chat_ctx_fit, chat_ctx_target = (
+        _chat_split_ctx_objective(model_refs) if len(capacity) >= _MIN_SPLIT_GPUS else (None, 0)
+    )
     return plan_placement(
         inputs,
         [(idx, total) for idx, total in capacity.items()],
         estimate_peak=estimate_peak,
         unified_budget=unified_budget,
+        chat_ctx_fit=chat_ctx_fit,
+        chat_ctx_target=chat_ctx_target,
+        free_headroom={d.index: d.free_bytes for d in devices},
     )
 
 

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -112,7 +112,7 @@ def test_auto_planner_charged_against_total_capacity(monkeypatch):
     devices = [FleetDevice("CUDA", 0, "A", 80 * GIB, 5 * GIB)]
     captured = {}
 
-    def fake_plan(inputs, devs, *, estimate_peak, unified_budget):
+    def fake_plan(inputs, devs, *, estimate_peak, unified_budget, **_kw):
         captured["devs"] = devs
         return Placement(instances=(), unplaceable_roles=())
 
@@ -127,7 +127,7 @@ def test_no_spec_uses_auto_planner(monkeypatch):
     monkeypatch.setattr(
         planning,
         "plan_placement",
-        lambda inputs, devs, *, estimate_peak, unified_budget: (
+        lambda inputs, devs, *, estimate_peak, unified_budget, **_kw: (
             called.setdefault("auto", True) or Placement(instances=(), unplaceable_roles=())
         ),
     )

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from lilbee.providers.fleet.placement import (
     InstancePlan,
     ModelPlacementInput,
@@ -12,6 +14,29 @@ from lilbee.providers.fleet.placement import (
 from lilbee.providers.roles import WorkerRole
 
 _GB = 1024**3
+_FOUR_24GB_CARDS = [(0, 24 * _GB), (1, 24 * _GB), (2, 24 * _GB), (3, 24 * _GB)]
+_FOUR_24GB_FREE = {0: 24 * _GB, 1: 24 * _GB, 2: 24 * _GB, 3: 24 * _GB}
+
+
+def _fits_any_count(model: ModelPlacementInput) -> PeakEstimator:
+    """Estimator whose even per-device share fits a 24 GB card at every split count."""
+
+    def estimate_peak(role: WorkerRole, ratio: tuple[int, ...]) -> tuple[int, ...]:
+        return tuple(model.est_vram_bytes // len(ratio) for _ in ratio)
+
+    return estimate_peak
+
+
+def _ctx_by_count(served_by_count: dict[int, int]):
+    """Fake chat-context fitter returning a fixed served ctx per shard card count."""
+    calls: list[Sequence[int]] = []
+
+    def fit(ratio: tuple[int, ...], per_device_free_bytes: Sequence[int]) -> int:
+        calls.append(list(per_device_free_bytes))
+        return served_by_count[len(ratio)]
+
+    fit.calls = calls  # type: ignore[attr-defined]
+    return fit
 
 
 def _never(_role: WorkerRole, _ratio: tuple[int, ...]) -> tuple[int, ...]:
@@ -247,6 +272,91 @@ class TestPerDeviceSplit:
             estimate_peak=peak,
         )
         assert plan.unplaceable_roles == (WorkerRole.CHAT,)
+
+
+class TestContextAwareChatSplit:
+    """A chat tensor-split widens onto idle cards when a tighter shard would starve
+    KV below the context target, instead of always bin-packing onto the fewest GPUs."""
+
+    def test_widens_onto_idle_cards_when_fewest_starves_context(self) -> None:
+        # 60 GB chat: a 2-card split overflows, 3 cards fits but only serves 4096,
+        # 4 cards serves 16384. Target 8192 -> the planner widens to all four cards
+        # rather than stopping at the first (3-card) shard that merely fits.
+        chat = ModelPlacementInput(WorkerRole.CHAT, 60 * _GB)
+        plan = plan_placement(
+            [chat],
+            _FOUR_24GB_CARDS,
+            estimate_peak=_fits_any_count(chat),
+            chat_ctx_fit=_ctx_by_count({3: 4096, 4: 16384}),
+            chat_ctx_target=8192,
+            free_headroom=_FOUR_24GB_FREE,
+        )
+        assert plan.instances[0].devices == (0, 1, 2, 3)
+        assert plan.unplaceable_roles == ()
+
+    def test_stays_at_fewest_when_context_is_already_usable(self) -> None:
+        # A 2-card split already serves 16384 >= target, so it does NOT over-spread
+        # onto the idle cards (preserving inference speed and residual VRAM).
+        chat = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
+        plan = plan_placement(
+            [chat],
+            _FOUR_24GB_CARDS,
+            estimate_peak=_fits_any_count(chat),
+            chat_ctx_fit=_ctx_by_count({2: 16384, 3: 24576, 4: 32768}),
+            chat_ctx_target=8192,
+            free_headroom=_FOUR_24GB_FREE,
+        )
+        assert plan.instances[0].devices == (0, 1)
+
+    def test_maximizes_context_when_target_unreachable(self) -> None:
+        # No shard reaches the 8192 target; the planner falls back to the shard that
+        # serves the MOST context (all cards) rather than the fewest.
+        chat = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
+        plan = plan_placement(
+            [chat],
+            _FOUR_24GB_CARDS,
+            estimate_peak=_fits_any_count(chat),
+            chat_ctx_fit=_ctx_by_count({2: 512, 3: 1024, 4: 2048}),
+            chat_ctx_target=8192,
+            free_headroom=_FOUR_24GB_FREE,
+        )
+        assert plan.instances[0].devices == (0, 1, 2, 3)
+
+    def test_fitter_receives_chosen_cards_live_free_headroom(self) -> None:
+        # The fitter is sized against the per-device LIVE free VRAM, not total
+        # capacity, so a fleet whose cards are partly occupied widens correctly.
+        chat = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
+        fit = _ctx_by_count({2: 16384})
+        plan_placement(
+            [chat],
+            [(0, 24 * _GB), (1, 24 * _GB)],
+            estimate_peak=_fits_any_count(chat),
+            chat_ctx_fit=fit,
+            chat_ctx_target=8192,
+            free_headroom={0: 9 * _GB, 1: 7 * _GB},
+        )
+        assert fit.calls[0] == [9 * _GB, 7 * _GB]  # type: ignore[attr-defined]
+
+    def test_non_chat_split_ignores_the_chat_fitter(self) -> None:
+        # The context-aware widening is chat-only: a vision split still takes the
+        # fewest fitting cards even when a chat fitter is passed.
+        vision = ModelPlacementInput(WorkerRole.VISION, 30 * _GB)
+        plan = plan_placement(
+            [vision],
+            _FOUR_24GB_CARDS,
+            estimate_peak=_fits_any_count(vision),
+            chat_ctx_fit=_ctx_by_count({2: 1, 3: 1, 4: 1}),
+            chat_ctx_target=8192,
+            free_headroom=_FOUR_24GB_FREE,
+        )
+        assert plan.instances[0].devices == (0, 1)  # fewest, unaffected by the fitter
+
+    def test_default_no_fitter_keeps_first_fit_behavior(self) -> None:
+        # Without a fitter (the planner's generic callers / tests), a chat split
+        # still takes the fewest fitting cards exactly as before.
+        chat = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
+        plan = plan_placement([chat], _FOUR_24GB_CARDS, estimate_peak=_fits_any_count(chat))
+        assert plan.instances[0].devices == (0, 1)
 
 
 class TestReplicas:

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -27,16 +27,17 @@ def _fits_any_count(model: ModelPlacementInput) -> PeakEstimator:
     return estimate_peak
 
 
-def _ctx_by_count(served_by_count: dict[int, int]):
-    """Fake chat-context fitter returning a fixed served ctx per shard card count."""
-    calls: list[Sequence[int]] = []
+class _CtxByCount:
+    """Fake chat-context fitter returning a fixed served ctx per shard card count,
+    recording the per-device free headroom it was asked about."""
 
-    def fit(ratio: tuple[int, ...], per_device_free_bytes: Sequence[int]) -> int:
-        calls.append(list(per_device_free_bytes))
-        return served_by_count[len(ratio)]
+    def __init__(self, served_by_count: dict[int, int]) -> None:
+        self._served_by_count = served_by_count
+        self.calls: list[list[int]] = []
 
-    fit.calls = calls  # type: ignore[attr-defined]
-    return fit
+    def __call__(self, ratio: tuple[int, ...], per_device_free_bytes: Sequence[int]) -> int:
+        self.calls.append(list(per_device_free_bytes))
+        return self._served_by_count[len(ratio)]
 
 
 def _never(_role: WorkerRole, _ratio: tuple[int, ...]) -> tuple[int, ...]:
@@ -287,7 +288,7 @@ class TestContextAwareChatSplit:
             [chat],
             _FOUR_24GB_CARDS,
             estimate_peak=_fits_any_count(chat),
-            chat_ctx_fit=_ctx_by_count({3: 4096, 4: 16384}),
+            chat_ctx_fit=_CtxByCount({3: 4096, 4: 16384}),
             chat_ctx_target=8192,
             free_headroom=_FOUR_24GB_FREE,
         )
@@ -302,7 +303,7 @@ class TestContextAwareChatSplit:
             [chat],
             _FOUR_24GB_CARDS,
             estimate_peak=_fits_any_count(chat),
-            chat_ctx_fit=_ctx_by_count({2: 16384, 3: 24576, 4: 32768}),
+            chat_ctx_fit=_CtxByCount({2: 16384, 3: 24576, 4: 32768}),
             chat_ctx_target=8192,
             free_headroom=_FOUR_24GB_FREE,
         )
@@ -316,7 +317,7 @@ class TestContextAwareChatSplit:
             [chat],
             _FOUR_24GB_CARDS,
             estimate_peak=_fits_any_count(chat),
-            chat_ctx_fit=_ctx_by_count({2: 512, 3: 1024, 4: 2048}),
+            chat_ctx_fit=_CtxByCount({2: 512, 3: 1024, 4: 2048}),
             chat_ctx_target=8192,
             free_headroom=_FOUR_24GB_FREE,
         )
@@ -326,7 +327,7 @@ class TestContextAwareChatSplit:
         # The fitter is sized against the per-device LIVE free VRAM, not total
         # capacity, so a fleet whose cards are partly occupied widens correctly.
         chat = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
-        fit = _ctx_by_count({2: 16384})
+        fit = _CtxByCount({2: 16384})
         plan_placement(
             [chat],
             [(0, 24 * _GB), (1, 24 * _GB)],
@@ -335,7 +336,7 @@ class TestContextAwareChatSplit:
             chat_ctx_target=8192,
             free_headroom={0: 9 * _GB, 1: 7 * _GB},
         )
-        assert fit.calls[0] == [9 * _GB, 7 * _GB]  # type: ignore[attr-defined]
+        assert fit.calls[0] == [9 * _GB, 7 * _GB]
 
     def test_non_chat_split_ignores_the_chat_fitter(self) -> None:
         # The context-aware widening is chat-only: a vision split still takes the
@@ -345,7 +346,7 @@ class TestContextAwareChatSplit:
             [vision],
             _FOUR_24GB_CARDS,
             estimate_peak=_fits_any_count(vision),
-            chat_ctx_fit=_ctx_by_count({2: 1, 3: 1, 4: 1}),
+            chat_ctx_fit=_CtxByCount({2: 1, 3: 1, 4: 1}),
             chat_ctx_target=8192,
             free_headroom=_FOUR_24GB_FREE,
         )

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1066,7 +1066,7 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(
             planning_mod,
             "plan_placement",
-            lambda inputs, devices, *, estimate_peak, unified_budget=None: Placement(
+            lambda inputs, devices, *, estimate_peak, unified_budget=None, **_kw: Placement(
                 instances=(InstancePlan(WorkerRole.CHAT, (0,)),), unplaceable_roles=()
             ),
         )
@@ -1092,13 +1092,78 @@ class TestBuildFleetWiring:
             ),
         )
 
-        def _capture(inputs, devices, *, estimate_peak, unified_budget=None):
+        def _capture(inputs, devices, *, estimate_peak, unified_budget=None, **_kw):
             seen["devices"] = devices
             return Placement(instances=(), unplaceable_roles=(WorkerRole.CHAT,))
 
         monkeypatch.setattr(planning_mod, "plan_placement", _capture)
         planning_mod.plan_all_launches()
         assert seen["devices"] == [(0, 24 * _GB)]  # synthesized from the Vulkan fallback
+
+
+class TestChatSplitCtxObjective:
+    """The chat split's context fitter/target wiring and the bb-a8f charging basis."""
+
+    def test_no_chat_model_yields_no_objective(self) -> None:
+        fit, target = planning_mod._chat_split_ctx_objective({WorkerRole.EMBED: "e"})
+        assert fit is None
+        assert target == 0
+
+    def test_fitter_delegates_to_fit_split_ctx_with_launch_sizing(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "lilbee.providers.engine_params.resolve_model_path", lambda _ref: Path("/m.gguf")
+        )
+        monkeypatch.setattr(
+            "lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {"arch": "x"}
+        )
+        monkeypatch.setattr(planning_mod, "_placement_estimate_ctx", lambda *_a: 8192)
+        captured: dict[str, object] = {}
+
+        def _fake_fit(model_path, **kw):
+            captured.update(kw)
+            captured["model_path"] = model_path
+            return 4096
+
+        monkeypatch.setattr("lilbee.providers.fleet.ctx.fit_split_ctx", _fake_fit)
+        fit, target = planning_mod._chat_split_ctx_objective({WorkerRole.CHAT: "ref"})
+        assert target == 8192
+        assert fit is not None
+        assert fit((21, 21), [24 * _GB, 18 * _GB]) == 4096
+        assert captured["model_path"] == Path("/m.gguf")
+        assert captured["ratio"] == (21, 21)
+        assert captured["per_device_free_bytes"] == [24 * _GB, 18 * _GB]
+        assert captured["slots"] == planning_mod._SPLIT_CHAT_SLOTS
+
+    def test_resolve_placement_wires_objective_and_keeps_total_charging(self, monkeypatch) -> None:
+        # The chat fitter is sized against LIVE free VRAM, but charging stays on TOTAL
+        # capacity (bb-a8f), so a warm fleet's own residents aren't double-counted.
+        devices = [
+            FleetDevice("CUDA", 0, "gpu", 24 * _GB, 20 * _GB),
+            FleetDevice("CUDA", 1, "gpu", 24 * _GB, 18 * _GB),
+        ]
+        monkeypatch.setattr(
+            "lilbee.providers.engine_params.resolve_model_path", lambda _ref: Path("/m.gguf")
+        )
+        monkeypatch.setattr(
+            "lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: {"arch": "x"}
+        )
+        monkeypatch.setattr(planning_mod, "_placement_estimate_ctx", lambda *_a: 8192)
+        monkeypatch.setattr(planning_mod, "_peak_estimator", lambda _refs: lambda *_a: (1,))
+        captured: dict[str, object] = {}
+
+        def _capture(inputs, devs, *, estimate_peak, unified_budget=None, **kw):
+            captured.update(kw)
+            captured["devs"] = devs
+            return Placement(instances=(), unplaceable_roles=())
+
+        monkeypatch.setattr(planning_mod, "plan_placement", _capture)
+        planning_mod._resolve_placement(
+            None, [], {WorkerRole.CHAT: "ref"}, devices, unified_budget=None
+        )
+        assert captured["chat_ctx_target"] == 8192
+        assert callable(captured["chat_ctx_fit"])
+        assert captured["free_headroom"] == {0: 20 * _GB, 1: 18 * _GB}
+        assert captured["devs"] == [(0, 24 * _GB), (1, 24 * _GB)]
 
 
 class TestResolveDevicesProbeFailureWarning:


### PR DESCRIPTION
## Problem

A large chat model that just barely fits across several GPUs got bin-packed onto the fewest of them. That left each card with almost no room for the KV cache, so the served context window collapsed to the 512-token floor and the model became unusable for RAG or any real conversation: every prompt over a few hundred tokens errored out, while spare cards sat idle. The only workaround was hand-writing a placement spec to spread chat across every card, which restored a usable 40960-token window.

## Solution

When the planner has to tensor-split the chat model, it no longer stops at the fewest cards that merely fit. It now sizes each candidate shard's served context the same way the launch does (against live free VRAM) and widens onto idle cards when a tighter shard would starve the context below the target, falling back to the largest-context shard when none can reach it. A chat that's already comfortable on a couple of cards stays there, so there's no needless inter-GPU traffic, and the context target follows the existing `num_ctx` / `chat_n_ctx_target` settings. Charging still uses each card's total capacity, so a warm fleet's own resident models aren't double-counted.

The upshot: point lilbee at a big chat model on a multi-GPU box and it just works, with no manual placement spec.
