### PR TITLE
fix(fleet): stream mid-content braces 1:1 and surface llama-server reasoning

### DIFF
--- a/src/lilbee/providers/fleet/adapters.py
+++ b/src/lilbee/providers/fleet/adapters.py
@@ -42,7 +42,10 @@ ROLE_SPECS: dict[WorkerRole, RoleServerSpec] = {
         endpoint_path="/v1/chat/completions",
         # --jinja renders the model's own chat template and parses native
         # tool-call syntax into structured message.tool_calls.
-        extra_args=("--jinja",),
+        # --reasoning-format none keeps <think>...</think> inline in content;
+        # without it, recent llama-server extracts reasoning into a separate
+        # reasoning_content field and lilbee's <think>-based parser sees none.
+        extra_args=("--jinja", "--reasoning-format", "none"),
         server_capable=True,
     ),
     WorkerRole.EMBED: RoleServerSpec(

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -1128,20 +1128,23 @@ def _recover_bare_json_stream(
     call it is flushed and all later text passes straight through.
     """
     buffer = ""  # leading text held back as a potential bare call until resolved
-    saw_native = False
+    # True once leading text has streamed as plain (or a native call was seen):
+    # past that, a later '{'/'[' is content, not a bare call -- never buffer again.
+    committed = False
     try:
         for item in items:
             if isinstance(item, ToolCallDelta):
                 yield from _flush_plain(buffer)
-                buffer, saw_native = "", True
+                buffer, committed = "", True
                 yield item
             elif isinstance(item, TokenUsage | StreamFinish):
                 yield from _recover_buffer(buffer)
                 buffer = ""
                 yield item
-            elif saw_native or _passthrough_text(buffer, item):
+            elif committed or _passthrough_text(buffer, item):
                 yield from _flush_plain(buffer)
                 buffer = ""
+                committed = True
                 yield item
             else:
                 buffer += item

--- a/tests/test_fleet_adapters.py
+++ b/tests/test_fleet_adapters.py
@@ -197,6 +197,19 @@ def test_chat_server_spec_enables_jinja() -> None:
     assert "--jinja" in ROLE_SPECS[WorkerRole.CHAT].extra_args
 
 
+def test_chat_server_spec_keeps_reasoning_inline() -> None:
+    from lilbee.providers.fleet.adapters import ROLE_SPECS
+    from lilbee.providers.roles import WorkerRole
+
+    # Recent llama-server defaults to EXTRACTING reasoning into a separate
+    # reasoning_content field, which strips <think>...</think> out of content
+    # and leaves lilbee's <think>-based parser nothing to surface. Forcing
+    # --reasoning-format none keeps the tags inline so reasoning streams through.
+    extra_args = ROLE_SPECS[WorkerRole.CHAT].extra_args
+    idx = extra_args.index("--reasoning-format")
+    assert extra_args[idx + 1] == "none"
+
+
 @pytest.mark.parametrize(
     ("reranker_type", "arch", "expected"),
     [

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -1251,6 +1251,28 @@ def test_chat_stream_items_streams_normal_text_incrementally() -> None:
     assert items == ["He", "llo", " there"]
 
 
+def test_chat_stream_items_midstream_brace_does_not_rebuffer() -> None:
+    """A '{' or '[' token that appears AFTER plain text already streamed must keep
+    streaming token-by-token. Bare-call recovery only applies to the leading text;
+    once committed to plain text the wrapper must never buffer again, or an answer
+    containing a JSON/code example freezes mid-stream and dumps at the end."""
+    body = (
+        _content_sse("Here is ")
+        + _content_sse("a config: ")
+        + _content_sse("{\n")
+        + _content_sse('  "k": 1\n}')
+        + _content_sse(" -- done")
+        + "data: [DONE]\n\n"
+    )
+    items = list(
+        _client(_stream_handler(body)).chat_stream_items(
+            [{"role": "user", "content": "show config"}], tools=_tools()
+        )
+    )
+    # Every token is its own frame; nothing coalesces after the brace token.
+    assert items == ["Here is ", "a config: ", "{\n", '  "k": 1\n}', " -- done"]
+
+
 def test_chat_stream_items_leading_whitespace_then_text_keeps_order() -> None:
     """A whitespace-only first token is buffered (its first non-ws char is unknown),
     then flushed in order once plain text resolves it -- not reordered to the end."""

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1224,6 +1224,7 @@ _NON_SIZING_LAUNCH_FLAGS = {
     "--host",
     "--cont-batching",
     "--jinja",
+    "--reasoning-format",
     "--embeddings",
     "--pooling",
     "--threads",


### PR DESCRIPTION
## Problem

Two streaming defects on the fleet chat path, both reproduced on-pod with no tunnel:

- **Chat streaming freezes mid-answer, then dumps.** `/api/chat/stream` and `/api/ask/stream` stream a few tokens, freeze for the rest of generation, then emit the whole remainder in one SSE event. `_recover_bare_json_stream` buffers the leading text to detect a bare-JSON tool call, but it re-evaluated the passthrough check per token with no memory that it had already committed to plain text. The first mid-stream token whose head is `{` or `[` (a JSON/code example, a Qwen `{\n` token, even a pure-whitespace token) re-entered buffering and held every later token until the stream finished. Any answer containing braces was affected, independent of reasoning.

- **Reasoning never surfaces from modern llama-server.** Thinking models show no reasoning even with `show_reasoning` on. Recent llama-server defaults to extracting reasoning into a separate `reasoning_content` field, stripping `<think>...</think>` out of `content` — and lilbee's parser only scans `content` for those tags, so it emitted zero reasoning events. Verified against Qwen3-235B-Thinking: a direct call returned `content=''` with the full thinking in `reasoning_content`.

## Solution

- Track a `committed` flag in `_recover_bare_json_stream`: once the leading text has streamed as plain text (or a native tool-call delta arrives), pass everything straight through; only the leading region is ever buffered for bare-call recovery. Bare-call recovery for genuinely brace-leading streams is preserved.
- Launch the CHAT server with `--reasoning-format none` so `<think>` tags stay inline in `content` and the existing parser catches them. `--reasoning-format` joins the non-sizing launch-flag set since it has no bearing on the VRAM estimate.

Regression tests: a mid-stream brace token must stream 1:1 (no coalescing), and the CHAT spec must keep reasoning inline.