### PR TITLE
Render model and user text literally so brackets can't crash the TUI

### DIFF
--- a/src/lilbee/cli/tui/widgets/message.py
+++ b/src/lilbee/cli/tui/widgets/message.py
@@ -40,7 +40,9 @@ class UserMessage(Vertical):
 
     def compose(self) -> ComposeResult:
         yield Static(_SPEAKER_YOU, classes="speaker-label")
-        yield Static(self._text, classes="message-content")
+        # Content() renders the question literally: a user asking about e.g. arr[0]
+        # or "[/]" must not have it parsed as console markup (which would crash).
+        yield Static(Content(self._text), classes="message-content")
 
 
 class AssistantMessage(Vertical):
@@ -99,10 +101,22 @@ class AssistantMessage(Vertical):
         old = self._content_widget
         new_widget = self._build_content_widget()
         text = "".join(self._content_parts)
-        new_widget.update(text)
+        self._set_content(new_widget, text)
         await self.mount(new_widget, after=old)
         self._content_widget = new_widget
         await old.remove()
+
+    @staticmethod
+    def _set_content(widget: Markdown | Static, text: str) -> None:
+        """Update a content widget with raw model text. A Markdown widget consumes
+        the raw markdown string, but a Static parses console markup -- so wrap the
+        text as literal Content. Otherwise a ``[..]`` in the answer (quoted code, an
+        option like ``[/path]``) raises MarkupError and crashes the whole TUI.
+        """
+        if isinstance(widget, Markdown):
+            widget.update(text)
+        else:
+            widget.update(Content(text))
 
     def append_reasoning(self, text: str) -> None:
         """Append a reasoning token; debounced at ``_MD_UPDATE_INTERVAL``."""
@@ -114,7 +128,7 @@ class AssistantMessage(Vertical):
         ready = now - self._last_reasoning_update >= _MD_UPDATE_INTERVAL
         if self._reasoning_static is not None and ready:
             self._last_reasoning_update = now
-            self._reasoning_static.update("".join(self._reasoning_parts))
+            self._reasoning_static.update(Content("".join(self._reasoning_parts)))
 
     def append_content(self, text: str) -> None:
         """Append response content token (debounced markdown updates)."""
@@ -126,7 +140,7 @@ class AssistantMessage(Vertical):
         now = time.monotonic()
         if self._content_widget is not None and now - self._last_md_update >= _MD_UPDATE_INTERVAL:
             self._last_md_update = now
-            self._content_widget.update("".join(self._content_parts))
+            self._set_content(self._content_widget, "".join(self._content_parts))
             self.refresh()
 
     def finish(self, sources: list[str] | None = None) -> None:
@@ -136,11 +150,11 @@ class AssistantMessage(Vertical):
         # (if mounted) carries the post-stream title.
         self._dismiss_thinking_header()
         if self._content_widget is not None and self._content_parts:
-            self._content_widget.update("".join(self._content_parts))
+            self._set_content(self._content_widget, "".join(self._content_parts))
             self.refresh()
         if self._reasoning_widget is not None and self._reasoning_parts:
             if self._reasoning_static is not None:
-                self._reasoning_static.update("".join(self._reasoning_parts))
+                self._reasoning_static.update(Content("".join(self._reasoning_parts)))
             token_count = len("".join(self._reasoning_parts).split())
             self._reasoning_widget.remove_class(_REASONING_STREAMING_CLASS)
             self._reasoning_widget.title = msg.CHAT_REASONING_FINISHED.format(tokens=token_count)

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -63,6 +63,20 @@ class TestUserMessage:
         children = list(msg.compose())
         assert len(children) == 2  # speaker label + content
 
+    async def test_question_with_markup_chars_does_not_crash(self) -> None:
+        """A question containing console-markup chars (``arr[0]``, ``[/]``) renders
+        literally; parsing it as markup would raise MarkupError and crash the TUI."""
+        from textual.app import App
+
+        from lilbee.cli.tui.widgets.message import UserMessage
+
+        class _App(App):
+            def compose(self) -> ComposeResult:  # module-level ComposeResult
+                yield UserMessage("what does arr[0] do? [/] and [bold")
+
+        async with _App().run_test() as pilot:
+            await pilot.pause()  # renders without raising MarkupError
+
 
 class TestAssistantMessageAsync:
     async def test_compose_yields_speaker_content_citation(self) -> None:
@@ -126,8 +140,25 @@ class TestAssistantMessageAsync:
                 am.finish(sources=None)
                 # finish() flushes the buffered tail.
                 assert mock_update.call_count == 1
+                # Reasoning is wrapped as literal Content (never parsed as markup).
                 last_call_text = mock_update.call_args_list[-1].args[0]
-                assert last_call_text == "a b c "
+                assert last_call_text.plain == "a b c "
+
+    async def test_reasoning_with_markup_chars_does_not_crash(self) -> None:
+        """Reasoning that quotes code with console-markup chars (e.g. ``[/]`` or an
+        unbalanced ``[bold]``) must render literally; passing the raw string to a
+        Static would raise MarkupError and kill the whole TUI."""
+        app = _MsgApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            am = app._am
+            am.append_reasoning("quoting yield from _flush(buffer) then [/] and [bold]x")
+            await pilot.pause()
+            am.finish(sources=None)
+            await pilot.pause()  # renders without raising MarkupError
+            assert am._reasoning_static is not None
+            # The markup chars are preserved verbatim in the reasoning, not parsed.
+            assert "[/]" in "".join(am._reasoning_parts)
 
     async def test_append_content_updates_markdown(self) -> None:
         app = _MsgApp()


### PR DESCRIPTION
## Problem

A `Static` parses console markup. When model output or a user question contained square-bracket text — quoted code like `yield from _flush(buffer)`, a path option like `[/some/path]`, a citation marker like `[1]`, or an unbalanced `[bold` — that text was fed straight into a `Static`, so a stray or unbalanced `[...]` raised `MarkupError` and crashed the entire TUI mid-stream. It reproduced live while streaming the Qwen3-235B Thinking model, whose reasoning quotes tensor-split code and citations.

## Solution

Render model and user text as literal `Content` instead of a markup-parsed string. The reasoning block and the plain-`Static` content path now wrap raw text in `Content`; a `Markdown` widget still receives the raw markdown string. `UserMessage` wraps the question the same way. Added regression tests that reproduce the crash (reasoning and a question containing `[/]`, `[bold]`, and `yield from`) and pass with the fix.