### PR TITLE
Ingest by uploaded content, not just server-readable paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,11 @@ allowed-confusables = ["｜", "▁"]
 [tool.ruff.lint.mccabe]
 max-complexity = 10
 
+[tool.ruff.lint.flake8-bugbear]
+# litestar's Body(), like Parameter() (already in ruff's B008 default allowlist),
+# is a declarative parameter marker that is safe as an argument default.
+extend-immutable-calls = ["litestar.params.Body"]
+
 [tool.ruff.lint.per-file-ignores]
 # Test-context S-rule noise. Each of these is either a test fixture
 # (hardcoded token/password literals, fake /tmp paths, 0.0.0.0 bind

--- a/src/lilbee/providers/fleet/ctx.py
+++ b/src/lilbee/providers/fleet/ctx.py
@@ -32,14 +32,18 @@ def fit_split_ctx(
     gpu_layers: int,
     flash_attn: bool,
     kv_cache_type: KvCacheType,
+    ctx_ceiling: int,
 ) -> int:
-    """Largest quantized per-slot n_ctx whose per-device shares all fit their cards.
+    """Largest quantized per-slot n_ctx that fits every card, capped at *ctx_ceiling*.
 
     Binary-searches the gguf-parser estimate at the launch tensor-split *ratio*:
     the server serves ``--ctx-size = per_slot x slots``, so each probe estimates
     that total and accepts the per-slot value when every device's own share stays
-    under that device's usable headroom. Falls to the floor when even that
-    overflows.
+    under that device's usable headroom. *ctx_ceiling* is the working context the
+    caller planned for (``planning._placement_estimate_ctx``: a ``cfg.num_ctx`` pin,
+    else ``cfg.chat_n_ctx_target``); the search never exceeds it (nor the model's
+    trained context), so the launch cannot over-commit VRAM past what placement
+    reserved. Falls to the floor when even that overflows.
     """
     headrooms = [
         int(free * USABLE_VRAM_FRACTION) - _MAIN_GPU_SKEW_RESERVE_BYTES
@@ -47,7 +51,12 @@ def fit_split_ctx(
     ]
     if min(headrooms) <= 0:
         return _DYNAMIC_CTX_FLOOR
-    upper = chat_ctx_ceiling(meta, model_path)
+    # Bound the search by the planned working context, not just the model's trained
+    # max: filling VRAM to that max over-committed beyond the placement reserve and
+    # OOM'd large tensor-split models under load (bb-ev9: a 235B took the full
+    # 262144-token ctx and crashed). The caller passes the same target the placement
+    # estimate reserved KV for, so the launch stays within the plan.
+    upper = min(chat_ctx_ceiling(meta, model_path), ctx_ceiling)
 
     def _peak_fits(per_slot: int) -> bool:
         est = estimate_instance_footprint(

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -53,8 +53,9 @@ _SPLIT_CHAT_SLOTS = 1
 # single-carded into a KV corner too small for real use (a 17GB model on a 24GB
 # card leaves ~no KV room -> n_ctx collapses to a few hundred tokens). Sizing the
 # placement reserve against this floor forces a tensor-split when one card cannot
-# hold weights + a usable context; the served ctx is then grown to the chosen
-# cards' real headroom by resolve_chat_ctx (single) / fit_split_ctx (split).
+# hold weights + a usable context; the served ctx is then grown by resolve_chat_ctx
+# (single) / fit_split_ctx (split) toward the cards' real headroom, capped at the
+# working-context target so the launch never over-commits past the reserve.
 _MIN_USABLE_CHAT_CTX = 8192
 _AUX_SLOTS = 1
 # A tensor-split needs at least this many GPUs; below it the chat context objective
@@ -563,6 +564,7 @@ def _chat_split_ctx_objective(
             gpu_layers=_role_gpu_layers(WorkerRole.CHAT),
             flash_attn=_role_flash(WorkerRole.CHAT),
             kv_cache_type=_role_kv_cache_type(WorkerRole.CHAT),
+            ctx_ceiling=target,
         )
 
     return fit, target
@@ -681,6 +683,7 @@ def _launch_for(
             gpu_layers=_role_gpu_layers(WorkerRole.CHAT),
             flash_attn=_role_flash(WorkerRole.CHAT),
             kv_cache_type=_role_kv_cache_type(WorkerRole.CHAT),
+            ctx_ceiling=_placement_estimate_ctx(WorkerRole.CHAT, model_path, meta),
         )
     else:
         ctx = _role_ctx(plan.role, model_path, meta)

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -21,6 +21,7 @@ from lilbee.server.mcp_mount import build_mcp_mount
 from lilbee.server.routes.crawl import crawl_route
 from lilbee.server.routes.documents import (
     add_route,
+    add_upload_route,
     documents_list_route,
     documents_remove_route,
     export_route,
@@ -145,6 +146,7 @@ def create_app() -> Litestar:
             completions_router,
             sync_route,
             add_route,
+            add_upload_route,
             models_list_route,
             models_external_route,
             models_set_chat_route,

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -37,9 +37,11 @@ from lilbee.server.handlers.documents import (
 from lilbee.server.handlers.ingest import (
     MAX_ADD_FILES,
     add_files_stream,
+    add_uploads_stream,
     import_stream,
     sync_stream,
     validate_add_paths,
+    validate_uploads,
 )
 from lilbee.server.handlers.models import (
     TASK_ENDPOINT_PATH,
@@ -234,6 +236,7 @@ __all__ = [
     "ModelsResponse",
     "SseStream",
     "add_files_stream",
+    "add_uploads_stream",
     "ask",
     "ask_stream",
     "chat",
@@ -274,5 +277,6 @@ __all__ = [
     "sync_stream",
     "update_config",
     "validate_add_paths",
+    "validate_uploads",
     "warm_stream",
 ]

--- a/src/lilbee/server/handlers/ingest.py
+++ b/src/lilbee/server/handlers/ingest.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable, Coroutine
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from lilbee.app.ingest import copy_files
 from lilbee.app.services import get_services
@@ -24,6 +24,10 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 MAX_ADD_FILES = 100
+
+# Payload carried alongside each source key through _ingest_stream: a server
+# path (str) for /api/add, or an (filename, content) pair for /api/add/upload.
+_Payload = TypeVar("_Payload")
 
 
 async def _run_sync_with_sentinel(
@@ -142,40 +146,40 @@ def _parse_ocr_params(data: dict[str, Any]) -> tuple[bool | None, float | None]:
     return enable_ocr, ocr_timeout
 
 
-async def add_files_stream(
-    paths: list[str],
-    *,
-    force: bool = False,
-    enable_ocr: bool | None = None,
-    ocr_timeout: float | None = None,
+async def _ingest_stream(
+    items: list[tuple[str, _Payload]],
+    run: Callable[[list[_Payload], SseStream], Coroutine[Any, Any, AddSummary]],
+    label: str,
 ) -> AsyncGenerator[str, None]:
-    """Copy files, sync, and yield SSE progress events.
+    """Lock per source, run ``run`` over the acquired subset, and stream SSE.
 
-    Takes the already-validated/parsed values from ``validate_add_paths`` so the
-    request dict is decoded once. Contended sources emit ``already_ingesting``
-    and the stream closes without a ``done`` event, signalling the client to
-    wait rather than retry.
+    Shared by /api/add (server paths) and /api/add/upload (uploaded content).
+    Each item is ``(lock_key, payload)``: the key is the source identifier used
+    for the per-source ingest lock; the payload is what ``run`` receives for the
+    subset whose lock was acquired. Contended sources emit ``already_ingesting``
+    and the stream closes without a ``done`` event, signalling the client to wait
+    rather than retry.
     """
     registry = get_services().ingest_lock_registry
-    acquired, busy = await registry.acquire(paths)
+    acquired, busy = await registry.acquire([key for key, _payload in items])
     try:
         for name in busy:
-            log.info("Rejecting /api/add for %s: already ingesting", name)
+            log.info("Rejecting %s for %s: already ingesting", label, name)
             yield sse_event(SseEvent.ALREADY_INGESTING, {"source": name})
 
         if not acquired:
             return
 
-        # Ingest only the paths this request actually locked; contended ones
-        # already got an ``already_ingesting`` event and must not be re-ingested
-        # under the holder's lock. ``acquired`` keys are canonical source names,
-        # so select the original path strings whose name was acquired.
         acquired_names = {name for name, _lock in acquired}
-        locked_paths = [p for p in paths if registry.canonical_source_name(p) in acquired_names]
+        locked = [
+            payload
+            for key, payload in items
+            if registry.canonical_source_name(key) in acquired_names
+        ]
         sse = SseStream()
-        task = asyncio.create_task(_run_add(locked_paths, force, enable_ocr, ocr_timeout, sse))
+        task = asyncio.create_task(run(locked, sse))
         try:
-            async for event in sse.drain(task, "Add files stream"):
+            async for event in sse.drain(task, label):
                 yield event
             if not sse.cancel.is_set() and task.done() and not task.cancelled():
                 exc = task.exception()
@@ -191,6 +195,91 @@ async def add_files_stream(
                     await task
     finally:
         registry.release(acquired)
+
+
+async def add_files_stream(
+    paths: list[str],
+    *,
+    force: bool = False,
+    enable_ocr: bool | None = None,
+    ocr_timeout: float | None = None,
+) -> AsyncGenerator[str, None]:
+    """Copy server-side files, sync, and yield SSE progress events.
+
+    Takes the already-validated/parsed values from ``validate_add_paths`` so the
+    request dict is decoded once.
+    """
+    async for event in _ingest_stream(
+        [(p, p) for p in paths],
+        lambda locked, sse: _run_add(locked, force, enable_ocr, ocr_timeout, sse),
+        "Add files stream",
+    ):
+        yield event
+
+
+def validate_uploads(files: list[tuple[str, bytes]]) -> list[tuple[str, bytes]]:
+    """Validate uploaded (filename, content) pairs. Raises ValueError on bad input.
+
+    Filenames are reduced to their basename and validated to stay inside
+    ``cfg.documents_dir`` so a crafted ``../`` name can't escape the corpus.
+    """
+    if not files:
+        raise ValueError("no files uploaded")
+    if len(files) > MAX_ADD_FILES:
+        raise ValueError(f"Too many files: {len(files)} exceeds limit of {MAX_ADD_FILES}")
+    cleaned: list[tuple[str, bytes]] = []
+    for name, content in files:
+        base = Path(name).name
+        if not base:
+            raise ValueError(f"invalid upload filename: {name!r}")
+        validate_path_within(cfg.documents_dir / base, cfg.documents_dir)
+        cleaned.append((base, content))
+    return cleaned
+
+
+async def _run_upload(files: list[tuple[str, bytes]], sse: SseStream) -> AddSummary:
+    """Write uploaded file bytes into ``cfg.documents_dir``, then sync.
+
+    The upload equivalent of :func:`_run_add`: instead of copying from a
+    server-readable path, the client's content is written straight into the
+    documents dir and the same ingest pipeline runs. This is what lets an
+    external-mode client (a remote lilbee / GPU box) ingest files that live only
+    on the client. Unchanged content is a no-op re-embed inside ``sync`` (it
+    hashes each source), so there is no separate force flag.
+    """
+    from lilbee.app.ingest import temporary_ocr_config
+    from lilbee.data.ingest import sync
+
+    try:
+        cfg.documents_dir.mkdir(parents=True, exist_ok=True)
+        written: list[str] = []
+        for name, content in files:
+            (cfg.documents_dir / name).write_bytes(content)
+            written.append(name)
+        with temporary_ocr_config(None):
+            sync_result = await sync(quiet=True, on_progress=sse.callback, cancel=sse.cancel)
+        return AddSummary(
+            copied=written,
+            skipped=[],
+            errors=[],
+            sync=SyncSummary(**sync_result.model_dump()),
+        )
+    finally:
+        sse.queue.put_nowait(None)
+
+
+async def add_uploads_stream(files: list[tuple[str, bytes]]) -> AsyncGenerator[str, None]:
+    """Ingest uploaded file content, yielding the same SSE progress as add_files_stream.
+
+    Locks per source name (the basename) so an upload never races an in-flight add
+    of the same source.
+    """
+    async for event in _ingest_stream(
+        [(name, (name, content)) for name, content in files],
+        lambda locked, sse: _run_upload(locked, sse),
+        "Add uploads stream",
+    ):
+        yield event
 
 
 async def _run_import_with_sentinel(sse: SseStream, data: bytes, fmt: str) -> ImportSummary:

--- a/src/lilbee/server/routes/documents.py
+++ b/src/lilbee/server/routes/documents.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from litestar import Request, Response, get, post
+from litestar.datastructures import UploadFile
+from litestar.enums import RequestEncodingType
 from litestar.exceptions import ValidationException
-from litestar.params import Parameter
+from litestar.params import Body, Parameter
 from litestar.response import Stream
 from pydantic import BaseModel, Field
 
@@ -57,6 +59,31 @@ async def add_route(data: AddRequest) -> Stream:
         handlers.add_files_stream(
             paths, force=force, enable_ocr=enable_ocr, ocr_timeout=ocr_timeout
         ),
+        media_type="text/event-stream",
+        status_code=201,
+    )
+
+
+@post("/api/add/upload")
+async def add_upload_route(
+    data: list[UploadFile] = Body(media_type=RequestEncodingType.MULTI_PART),
+) -> Stream:
+    """Ingest uploaded file content with streaming SSE progress.
+
+    Unlike /api/add, which reads server-side paths, this accepts the client's raw
+    file bytes. That lets a client whose files the server cannot read by path --
+    e.g. the plugin or CLI in external mode against a remote lilbee / GPU box --
+    ingest its own local files by uploading them straight to the server.
+    """
+    files: list[tuple[str, bytes]] = []
+    for upload in data:
+        files.append((upload.filename, await upload.read()))
+    try:
+        cleaned = handlers.validate_uploads(files)
+    except ValueError as exc:
+        raise ValidationException(str(exc)) from exc
+    return Stream(
+        handlers.add_uploads_stream(cleaned),
         media_type="text/event-stream",
         status_code=201,
     )

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -111,6 +111,66 @@ class TestAddEndpoint:
         assert "file_done" in event_types
         assert "done" in event_types
 
+    async def test_add_upload_writes_content_and_indexes(
+        self, mock_extract_file, isolated_env, tmp_path
+    ):
+        """POST /api/add/upload writes the uploaded bytes into documents_dir and ingests them."""
+        from lilbee.server.app import create_app
+
+        content = b"Uploaded content that the server could not have read by path."
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.post(
+                "/api/add/upload",
+                files=[("data", ("notes.txt", content, "text/plain"))],
+                headers=_auth_headers(),
+            )
+
+        assert resp.status_code == 201
+        event_types = [e[0] for e in _parse_sse_events(resp.content)]
+        assert "file_start" in event_types
+        assert "done" in event_types
+        # The client's bytes landed in the corpus even though no server path existed.
+        assert (isolated_env / "notes.txt").read_bytes() == content
+
+    async def test_add_upload_strips_path_traversal_from_filename(
+        self, mock_extract_file, isolated_env, tmp_path
+    ):
+        """A crafted ../ filename is reduced to its basename inside documents_dir."""
+        from lilbee.server.app import create_app
+
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.post(
+                "/api/add/upload",
+                files=[("data", ("../../escape.txt", b"safe", "text/plain"))],
+                headers=_auth_headers(),
+            )
+
+        assert resp.status_code == 201
+        assert (isolated_env / "escape.txt").read_bytes() == b"safe"
+        assert not (isolated_env.parent.parent / "escape.txt").exists()
+
+    async def test_add_upload_too_many_is_400(self, mock_extract_file, isolated_env, tmp_path):
+        """More than MAX_ADD_FILES uploads is a clean 400 from validate_uploads."""
+        from lilbee.server.app import create_app
+
+        files = [("data", (f"f{i}.txt", b"x", "text/plain")) for i in range(MAX_ADD_FILES + 1)]
+        async with AsyncTestClient(create_app()) as client:
+            resp = await client.post("/api/add/upload", files=files, headers=_auth_headers())
+        assert resp.status_code == 400
+
+    def test_validate_uploads_rejects_bad_input(self, mock_extract_file, isolated_env):
+        """validate_uploads guards empty/oversized/malformed uploads and strips paths."""
+        from lilbee.server.handlers import MAX_ADD_FILES, validate_uploads
+
+        with pytest.raises(ValueError, match="no files"):
+            validate_uploads([])
+        with pytest.raises(ValueError, match="Too many"):
+            validate_uploads([(f"f{i}.txt", b"x") for i in range(MAX_ADD_FILES + 1)])
+        with pytest.raises(ValueError, match="invalid upload filename"):
+            validate_uploads([("", b"x")])
+        # A crafted path is reduced to its basename.
+        assert validate_uploads([("../../a/b.txt", b"x")]) == [("b.txt", b"x")]
+
     async def test_add_nonexistent_file_in_errors(self, mock_extract_file, isolated_env, tmp_path):
         """Nonexistent paths appear in the summary errors list."""
         from lilbee.server.app import create_app

--- a/tests/test_fleet_ctx.py
+++ b/tests/test_fleet_ctx.py
@@ -35,6 +35,9 @@ def _fit(model_path: Path, **overrides: object) -> int:
         "gpu_layers": -1,
         "flash_attn": True,
         "kv_cache_type": KvCacheType.F16,
+        # Large by default so the fit-logic tests are gated by the monkeypatched
+        # chat_ctx_ceiling; the ceiling-cap test lowers it.
+        "ctx_ceiling": 1_000_000,
     }
     kwargs.update(overrides)
     return fit_split_ctx(model_path, **kwargs)  # type: ignore[arg-type]
@@ -107,6 +110,16 @@ class TestFitSplitCtx:
         assert all(
             share <= room for share, room in zip(accepted.per_device_vram, headrooms, strict=True)
         )
+
+    def test_caps_at_ctx_ceiling_below_the_model_max(self, monkeypatch) -> None:
+        # Even when the model + cards could hold the full trained context, the split
+        # never exceeds the caller's planned working context (bb-ev9): a 235B whose
+        # trained ceiling is 262144, planned for a 24576 ctx_ceiling, is capped there
+        # so it can't over-commit VRAM and OOM under load.
+        monkeypatch.setattr(ctx_mod, "chat_ctx_ceiling", lambda _m, _p: 262144)
+        monkeypatch.setattr(ctx_mod, "estimate_instance_footprint", _peak_estimator(lambda _c: 1))
+        result = _fit(Path("/m.gguf"), ctx_ceiling=24576)
+        assert 24576 - _DYNAMIC_CTX_QUANTUM < result <= 24576
 
     def test_falls_back_to_peak_when_breakdown_is_missing(self, monkeypatch) -> None:
         # An estimate with no usable per-device breakdown gates the peak against

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1133,6 +1133,8 @@ class TestChatSplitCtxObjective:
         assert captured["ratio"] == (21, 21)
         assert captured["per_device_free_bytes"] == [24 * _GB, 18 * _GB]
         assert captured["slots"] == planning_mod._SPLIT_CHAT_SLOTS
+        # The fit is bounded by the planned working context (bb-ev9), not the model max.
+        assert captured["ctx_ceiling"] == 8192
 
     def test_resolve_placement_wires_objective_and_keeps_total_charging(self, monkeypatch) -> None:
         # The chat fitter is sized against LIVE free VRAM, but charging stays on TOTAL


### PR DESCRIPTION
`/api/add` reads files from paths on the server's own filesystem, which only works when the client and server share a disk (managed mode). A client pointed at a remote lilbee — the Obsidian plugin or CLI in external mode against a GPU box — can't ingest its own files that way: the paths it sends don't exist on the server, and there was no way to hand over the bytes.

This adds `POST /api/add/upload`, a multipart endpoint that takes the client's file content, writes it into the documents dir, and runs the exact same chunk-embed-index pipeline, streaming the same SSE progress as `/api/add`. The lock-and-stream machinery is now shared between the two via `_ingest_stream`, so the path-based and upload-based ingests behave identically and only differ in how the source bytes are acquired. Filenames are reduced to their basename and validated to stay inside the documents dir.

With this, an external-mode client can ingest files that live only on the client by uploading them straight to the server. The plugin/CLI side that switches to uploads when the server is remote is a separate change.