### PR TITLE
Fleet drawer keeps chat focus so you can type while it is open

### DIFF
--- a/src/lilbee/cli/tui/widgets/fleet_drawer.py
+++ b/src/lilbee/cli/tui/widgets/fleet_drawer.py
@@ -40,19 +40,9 @@ class FleetDrawer(Vertical):
     def compose(self) -> ComposeResult:
         yield FleetBody()
 
-    def on_mount(self) -> None:
-        """Focus the first GPU toggle once FleetBody has built its editor.
-
-        The editor rows mount during FleetBody's own on_mount, so defer to the
-        next refresh; that also puts focus inside the drawer so esc and the
-        preview/apply/clear keys route here rather than to the screen behind.
-        """
-        self.call_after_refresh(self._focus_editor)
-
-    def _focus_editor(self) -> None:
-        toggles = self.query(".dev-toggle")
-        if toggles:
-            toggles.first().focus()
+    # No on_mount focus grab: opening the drawer must NOT steal focus from the
+    # chat prompt, so you can keep typing while it stays open. Click a toggle (or
+    # tab) to focus the drawer; ctrl+g closes it from anywhere, esc when focused.
 
     def action_close(self) -> None:
         """Remove the drawer, returning full width to the screen underneath."""

--- a/tests/test_tui_fleet_drawer.py
+++ b/tests/test_tui_fleet_drawer.py
@@ -59,6 +59,9 @@ async def test_ctrl_g_opens_drawer_and_esc_closes(_patched):
         await pilot.pause()
         await pilot.pause()
         assert app.screen.query(FleetDrawer)
+        # opening does not steal focus, so focus a toggle before esc routes here
+        app.screen.query_one(FleetDrawer).query(".dev-toggle").first().focus()
+        await pilot.pause()
         await pilot.press("escape")
         await pilot.pause()
         assert not app.screen.query(FleetDrawer)
@@ -91,9 +94,9 @@ async def test_chat_stays_interactive_while_drawer_open(_patched):
         await pilot.press("ctrl+g")
         await pilot.pause()
         assert app.screen.query(FleetDrawer)
+        # opening the drawer must NOT steal focus from the prompt
         probe = app.query_one("#probe-input", Input)
-        probe.focus()
-        await pilot.pause()
+        assert app.focused is probe
         await pilot.press("h", "i")
         await pilot.pause()
         assert probe.value == "hi"
@@ -184,28 +187,3 @@ async def test_drawer_delegates_editor_actions(_patched, monkeypatch):
         drawer.action_apply()
         drawer.action_clear()
     assert calls == ["preview", "apply", "clear"]
-
-
-def _empty_view():  # type: ignore[no-untyped-def]
-    from lilbee.app.placement import PlacementView
-
-    return PlacementView(gpus=(), roles=(), unplaceable=(), manual=False, spec_json=None)
-
-
-@pytest.mark.asyncio
-async def test_drawer_focus_skips_when_no_toggles(monkeypatch):
-    """With no placement configured (no toggles) the drawer mounts without error."""
-    from lilbee.cli.tui.widgets import fleet_body as fbm
-    from lilbee.cli.tui.widgets import gpu_fleet_panel as gfp
-    from lilbee.cli.tui.widgets.fleet_drawer import FleetDrawer
-
-    monkeypatch.setattr(fbm, "get_placement", lambda: _empty_view())
-    monkeypatch.setattr(gfp, "probe_gpu_stats", lambda devices: {})
-
-    app = _DrawerApp()
-    async with app.run_test(size=(120, 30)) as pilot:
-        await pilot.pause()
-        await pilot.press("ctrl+g")
-        await pilot.pause()
-        await pilot.pause()
-        assert app.screen.query(FleetDrawer)


### PR DESCRIPTION
## Problem

The side drawer grabbed focus to a GPU toggle when it opened, so the chat prompt lost focus and you could not keep typing while placement was docked -- which defeats the point of the side-by-side view (type in chat while the placement editor and live GPU bars sit beside the conversation).

## Solution

Opening the drawer no longer steals focus: the chat prompt stays focused, so you can keep typing while the drawer is docked. Click a toggle or tab to drive the placement editor; ctrl+g closes it from anywhere, esc when the drawer itself is focused.