### PR TITLE
fleet(client): let bulk ingest wait out a cold-start embedder warmup

### DIFF
--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -284,10 +284,17 @@ _DEFAULT_TIMEOUT_S = 300.0
 # Short, separate timeout for /health: a server can wedge under heavy prompt
 # processing, and readiness/monitor polls must not block on the request timeout.
 _HEALTH_TIMEOUT_S = 5.0
-# Retry a server-busy (HTTP 429) response this many times with exponential backoff:
-# a cold replica fleet 429s the first ingest fan-out until its slots load.
+# Retry a server-busy (HTTP 429) response with exponential backoff (capped): a
+# cold replica fleet 429s the first fan-out until its slots load. Interactive
+# callers fail fast after this short budget (~15s).
 _BUSY_RETRIES = 6
 _BUSY_BACKOFF_BASE_S = 0.5
+_BUSY_BACKOFF_MAX_S = 8.0
+# Bulk embed ingest is background work, so it waits out a full cold start rather
+# than dropping files: an 8B embedder warming while a large chat model loads on
+# neighboring cards can take well past the interactive budget. Capped backoff
+# keeps the total near ~80s (0.5+1+2+4 then 8 each), which covers a real warmup.
+_EMBED_BUSY_RETRIES = 14
 # Half-open recovery: a replica marked unhealthy becomes routable again after
 # this cool-down. Recovery is probe-by-traffic and unmetered: every concurrent
 # caller sees it routable once cooled down (a success restores it, another
@@ -730,22 +737,23 @@ class LlamaServerClient:
 
         return _llm_rerank_score(_first_token_top_logprobs(self._retry_on_busy(_call)))
 
-    def _retry_on_busy(self, call: Callable[[], _T]) -> _T:
-        """Run *call*, retrying a transient server-busy (RATE_LIMIT) with backoff.
+    def _retry_on_busy(self, call: Callable[[], _T], *, retries: int = _BUSY_RETRIES) -> _T:
+        """Run *call*, retrying a transient server-busy (RATE_LIMIT) with capped backoff.
 
-        A cold replica fleet 429s the first ingest fan-out until its slots load;
-        backing off and retrying turns those drops into successes. Non-RATE_LIMIT
-        errors (and a final still-busy response) propagate to the caller.
+        A cold replica fleet 429s the first fan-out until its slots load; backing
+        off and retrying turns those drops into successes. *retries* bounds the
+        attempts -- interactive callers fail fast, bulk ingest waits out a cold
+        start. Non-RATE_LIMIT errors (and a final still-busy response) propagate.
         """
         delay = _BUSY_BACKOFF_BASE_S
-        for _ in range(_BUSY_RETRIES - 1):
+        for _ in range(retries - 1):
             try:
                 return call()
             except ProviderError as exc:
                 if exc.kind is not ProviderErrorKind.RATE_LIMIT:
                     raise
                 time.sleep(delay)
-                delay *= 2
+                delay = min(delay * 2, _BUSY_BACKOFF_MAX_S)
         return call()
 
     def _embeddings_call(self, inputs: list[str]) -> list[dict[str, Any]]:
@@ -770,7 +778,8 @@ class LlamaServerClient:
                 )
             return list(data)
 
-        return self._retry_on_busy(_call)
+        # Bulk ingest can afford to wait out a cold-start warmup rather than drop files.
+        return self._retry_on_busy(_call, retries=_EMBED_BUSY_RETRIES)
 
     def _truncate_and_subbatch(self, texts: list[str], *, estimate: bool) -> list[list[str]]:
         """Token-truncate over-cap inputs, then pack into server-sized sub-batches.

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -94,7 +94,7 @@ def test_embed_retries_on_busy_then_succeeds(monkeypatch) -> None:
 
 def test_embed_gives_up_after_retries_when_persistently_busy(monkeypatch) -> None:
     from lilbee.providers.base import ProviderErrorKind
-    from lilbee.providers.fleet.client import _BUSY_RETRIES
+    from lilbee.providers.fleet.client import _EMBED_BUSY_RETRIES
 
     monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
     calls = {"n": 0}
@@ -106,7 +106,44 @@ def test_embed_gives_up_after_retries_when_persistently_busy(monkeypatch) -> Non
     with pytest.raises(ProviderError) as excinfo:
         _client(handler).embed(["x"])
     assert excinfo.value.kind is ProviderErrorKind.RATE_LIMIT
-    assert calls["n"] == _BUSY_RETRIES
+    assert calls["n"] == _EMBED_BUSY_RETRIES
+
+
+def test_embed_rides_out_cold_start_past_interactive_budget(monkeypatch) -> None:
+    # A cold embedder can 429 more times than the short interactive budget allows;
+    # bulk ingest must wait it out (via _EMBED_BUSY_RETRIES) instead of dropping the
+    # file. With the old shared budget this warmup would have raised.
+    from lilbee.providers.fleet.client import _BUSY_RETRIES, _EMBED_BUSY_RETRIES
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    warmup = _BUSY_RETRIES + 2  # more 429s than the interactive budget tolerates
+    assert warmup < _EMBED_BUSY_RETRIES
+    calls = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] <= warmup:
+            return httpx.Response(429, json={"error": "warming"})
+        return httpx.Response(200, json={"data": [{"embedding": [0.3]}]})
+
+    assert _client(handler).embed(["x"]) == [[0.3]]
+    assert calls["n"] == warmup + 1
+
+
+def test_busy_backoff_is_capped(monkeypatch) -> None:
+    # Backoff must not balloon past the cap even across the long ingest budget.
+    from lilbee.providers.fleet.client import _BUSY_BACKOFF_MAX_S, _EMBED_BUSY_RETRIES
+
+    delays: list[float] = []
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", delays.append)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, json={"error": "busy"})
+
+    with pytest.raises(ProviderError):
+        _client(handler).embed(["x"])
+    assert len(delays) == _EMBED_BUSY_RETRIES - 1
+    assert max(delays) <= _BUSY_BACKOFF_MAX_S
 
 
 def test_embed_does_not_retry_non_busy_errors(monkeypatch) -> None:


### PR DESCRIPTION
## Problem

During the first index after startup (or a chat-model reload that shares the fleet), bulk ingest fans out embed requests before the embedder replica has finished loading. The replica is up (`/health` 200 = liveness) but not ready (model still loading), so it returns HTTP 429 "llama-server is busy; replicas may still be warming". The busy-retry in `_retry_on_busy` budgeted only ~15.5s (6 attempts, uncapped `0.5*2^n` backoff), shared by interactive chat and bulk ingest alike. On a big fleet — an 8B embedder warming while a 235B loads on neighboring cards, all competing for disk/PCIe — warmup exceeds that budget and the first files are dropped with a user-visible error.

Root cause is architectural: the fleet tracks liveness but has no readiness signal, so it routes ingest traffic on liveness and leans on a fixed retry budget to survive the warmup race.

## Solution

Targeted fix: bulk ingest is background work and can afford to wait out a cold start, so the embed path now retries on a longer, capped budget (`_EMBED_BUSY_RETRIES`, ~80s with backoff capped at `_BUSY_BACKOFF_MAX_S`), while interactive chat keeps the short fail-fast budget (`_BUSY_RETRIES`, unchanged). Capping the backoff keeps it from ballooning across the longer budget. All the changed symbols are private to `client.py`; the `retries` parameter defaults to the interactive budget, so existing callers are unaffected.

The deeper architectural fix — a real readiness gate that waits for the replica to accept a probe before fan-out, instead of a magic retry constant — is tracked in bb-9wl as a follow-up.

Tests: embed rides out a warmup longer than the interactive budget; the backoff stays capped; interactive paths still fail fast. Full `test_fleet_client.py` green.