### PR TITLE
tui(autocomplete): let /add submit a complete directory path

### DIFF
--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -65,11 +65,7 @@ def _get_arg_completions(cmd: str, partial: str) -> list[str]:
         # Without this a complete directory path lists its contents forever and
         # Enter accepts a child instead of submitting. A trailing separator still
         # descends to list the directory's contents.
-        if (
-            partial
-            and not partial.endswith(_PATH_SEPARATORS)
-            and Path(partial).expanduser().exists()
-        ):
+        if partial and not partial.endswith(_PATH_SEPARATORS) and _path_exists(partial):
             return []
         # _path_options already prefix-filters against the basename and returns
         # bare segment names (not the typed prefix), so the generic startswith
@@ -119,6 +115,15 @@ def invalidate_document_cache() -> None:
 
 def _theme_options() -> list[str]:
     return list(DARK_THEMES)
+
+
+def _path_exists(partial: str) -> bool:
+    """True if *partial* resolves to an existing file or directory."""
+    try:
+        return Path(partial).expanduser().exists()
+    except Exception:
+        log.debug("Failed to check path existence for autocomplete", exc_info=True)
+        return False
 
 
 def _path_options(partial: str = "") -> list[str]:

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -60,6 +60,17 @@ def _get_arg_completions(cmd: str, partial: str) -> list[str]:
     if sources is None:
         return []
     if cmd == "/add":
+        # A fully-typed existing path (no trailing separator) should submit on
+        # Enter rather than keep offering completions, so collapse the dropdown.
+        # Without this a complete directory path lists its contents forever and
+        # Enter accepts a child instead of submitting. A trailing separator still
+        # descends to list the directory's contents.
+        if (
+            partial
+            and not partial.endswith(_PATH_SEPARATORS)
+            and Path(partial).expanduser().exists()
+        ):
+            return []
         # _path_options already prefix-filters against the basename and returns
         # bare segment names (not the typed prefix), so the generic startswith
         # filter below would wrongly wipe them.

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2405,6 +2405,24 @@ class TestGetCompletions:
         r = get_completions(f"/add {d}/")
         assert any("testfile.txt" in x for x in r)
 
+    def test_add_complete_path_collapses_so_enter_submits(self, tmp_path: object) -> None:
+        """Regression (bb-7wq): a fully-typed existing directory or file (no
+        trailing separator) yields no completions, so the dropdown collapses and
+        Enter submits ``/add <path>`` instead of accepting a child entry."""
+        from pathlib import Path as P
+
+        from lilbee.cli.tui.widgets.autocomplete import get_completions
+
+        d = P(str(tmp_path))
+        (d / "sub").mkdir()
+        (d / "sub" / "a.py").touch()
+        # complete directory path, no trailing slash -> collapse (Enter submits)
+        assert get_completions(f"/add {d}/sub") == []
+        # complete file path -> collapse too
+        assert get_completions(f"/add {d}/sub/a.py") == []
+        # a trailing separator still descends to list the directory's contents
+        assert any("a.py" in x for x in get_completions(f"/add {d}/sub/"))
+
     def test_add_tilde_completions_not_filtered_out(self, tmp_path, monkeypatch) -> None:
         """Regression: ``~/`` expands to absolute paths that do not start with
         the raw ``~/`` partial, so the arg filter must not wipe them."""


### PR DESCRIPTION
## Problem

Typing a fully-qualified existing directory path for `/add` in the TUI and pressing Enter does not submit the command -- it accepts an autocomplete completion instead, snapping the typed path to a child/sibling entry (e.g. `/add .../providers/fleet` becomes `/add .../providers/__init__.py`) and ingesting nothing. Files may work by luck; directories do not.

Root cause: for a path that is itself an existing directory, `_path_options` lists that directory's contents as completions, so the dropdown always has options. The collapse-when-fully-typed rule (`[o for o in options if o.lower() != partial.lower()]`) compares the full typed path against bare basenames, which never match -- so the dropdown never collapses for a complete directory path, and with it open Enter accepts the highlighted completion instead of submitting.

## Solution

In `_get_arg_completions` for `/add`, if the typed path is an existing file or directory and does not end in a path separator, return no completions -- the dropdown collapses and Enter submits `/add <path>`. A trailing separator still descends to list the directory's contents. Regression test covers a complete dir path and file path collapsing, and a trailing separator still listing contents.

Found while recording the fleet-drawer demo: a live `/add <lilbee source>` fresh index could not be scripted because Enter never submitted the directory. Tracked in bb-7wq.