### PR TITLE
build: native Intel-Mac standalone binaries (macos-15-intel)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,25 @@ jobs:
           - os: macos-latest
             asset_name: lilbee-macos-arm64
             backend: metal
-          # Intel Mac dropped: macos-13 hosted runners stay queued; pip wheel covers them.
+          # Intel Mac: built natively on macos-15-intel, GitHub's Intel image
+          # (Nuitka can't cross-compile arch from the arm64 runner). Soft because
+          # the Intel image can queue longer than the arm64 pool -- this asset must
+          # never block the release fan-out. Deployment target stays 11.0, so the
+          # AVX baseline covers every Mac that can run macOS 11+ (Ivy Bridge or newer).
+          - os: macos-15-intel
+            asset_name: lilbee-macos-x86_64
+            backend: cpu
+            soft: true
+          # Pre-Haswell-safe Intel Mac build: same self-contained model as the
+          # linux/windows compat cells (stock lancedb swapped for +compat, launcher
+          # held to x86-64-v2). Covers the AVX-but-no-AVX2 tail (e.g. 2013 Mac Pro)
+          # and guards against an AVX2-baselined stock lancedb SIGILL.
+          - os: macos-15-intel
+            asset_name: lilbee-compat-macos-x86_64
+            backend: cpu
+            compat: true
+            soft: true
+            march: x86-64-v2
           - os: windows-latest
             asset_name: lilbee-windows-x86_64.exe
             backend: vulkan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,29 @@ jobs:
 
       - name: Install dependencies
         # `pip` is required by build_llama_cpp.sh's `pip wheel` invocation.
+        if: matrix.os != 'macos-15-intel'
         run: uv sync --extra release && uv pip install 'nuitka[onefile]>=4.0,<5' pip
+
+      # Intel Mac: stock lancedb 0.33.0 ships no macosx_x86_64 wheel, so `uv sync`
+      # (locked to PyPI) can't resolve it. Pull lancedb from the +compat index --
+      # its 0.33.0+compat wheel is a PEP 440 drop-in for ==0.33.0 -- then resolve the
+      # rest fresh from PyPI (every other [release] dep has an x86_64 macOS wheel).
+      # CMAKE_ARGS + deployment target keep any throwaway llama-cpp-python sdist build
+      # at the cpu/x86_64/macOS-11 baseline; the dedicated step below builds the
+      # llama-cpp-python that actually ships. Fresh resolution can drift from uv.lock;
+      # the proper index-pinned relock lands in a follow-up.
+      - name: Install dependencies (Intel Mac)
+        if: matrix.os == 'macos-15-intel'
+        shell: bash
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
+        run: |
+          set -euxo pipefail
+          eval "$(BACKEND=cpu TARGET_ARCH=x86_64 tools/wheel-build/cmake_args.sh)"
+          export CMAKE_ARGS
+          uv venv
+          uv pip install --extra-index-url https://lilbee.sh/compat/ lancedb==0.33.0+compat
+          uv pip install '.[release]' 'nuitka[onefile]>=4.0,<5' pip
 
       # uv's package cache reuses by version key, so build via pip wheel + local-wheel install bypasses it.
       - name: Build llama-cpp-python from source (GPU + AVX baseline)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,11 @@ jobs:
         env:
           ASSET_NAME: ${{ matrix.asset_name }}
           PRODUCT_VERSION: ${{ env.LILBEE_NUITKA_VERSION }}
+          # Pin Nuitka's clang output to macOS 11.0. Unset, clang defaults the
+          # deployment target to the build host (now macOS 15 on the Intel image),
+          # which would stamp the launcher minos=15 and refuse to launch on macOS
+          # 11-14 even though every bundled dylib targets 11.0. No-op off macOS.
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
           # compat cell only: hold Nuitka's C output to the pre-Haswell baseline so
           # the launcher layer (not just lancedb) runs on old silicon. Empty elsewhere.
           CFLAGS: ${{ matrix.march && format('-march={0}', matrix.march) || '' }}

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Pre-2013 Intel or pre-Zen AMD CPUs lack [AVX2](https://en.wikipedia.org/wiki/Adv
 | **Scoop**    | `scoop install lilbee-compat`                                                                                                                                                           |
 | **Flatpak**  | `flatpak install lilbee io.github.tobocop2.lilbee.compat`                                                                                                                               |
 | **Snap**     | `curl -LO https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-compat-linux-x86_64.snap && sudo snap install ./lilbee-compat-linux-x86_64.snap --dangerous --classic`    |
-| **Binary**   | [`lilbee-compat-linux-x86_64`](https://github.com/tobocop2/lilbee/releases/latest) or [`lilbee-compat-windows-x86_64.exe`](https://github.com/tobocop2/lilbee/releases/latest)         |
+| **Binary**   | [`lilbee-compat-linux-x86_64`](https://github.com/tobocop2/lilbee/releases/latest), [`lilbee-compat-windows-x86_64.exe`](https://github.com/tobocop2/lilbee/releases/latest), or [`lilbee-compat-macos-x86_64`](https://github.com/tobocop2/lilbee/releases/latest) (pre-AVX2 Intel Macs, e.g. the 2013 Mac Pro) |
 
 Same `lilbee` command after install. The crash is from [lancedb](https://lancedb.github.io/lancedb/)'s AVX2-compiled wheels; this build swaps in a [lancedb fork](https://github.com/tobocop2/lance) that picks instructions at runtime. A 👍 or comment on the upstream [lance PR](https://github.com/lance-format/lance/pull/6630) helps it land.
 

--- a/site/index.html
+++ b/site/index.html
@@ -535,6 +535,18 @@
 
         <div class="binary-row">
           <div class="binary-row-h">
+            <span class="oschip">macOS x86_64</span>
+            <a class="binary-dl" href="https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-macos-x86_64">download lilbee-macos-x86_64 &rarr;</a>
+          </div>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">curl -L https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-macos-x86_64 -o lilbee &amp;&amp; chmod +x lilbee &amp;&amp; xattr -d com.apple.quarantine ./lilbee</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
+
+        <div class="binary-row">
+          <div class="binary-row-h">
             <span class="oschip">Windows x86_64</span>
             <a class="binary-dl" href="https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-windows-x86_64.exe">download lilbee-windows-x86_64.exe &rarr;</a>
           </div>
@@ -583,6 +595,17 @@
         </div>
         <div class="binary-row">
           <div class="binary-row-h">
+            <span class="oschip">macOS x86_64</span>
+            <a class="binary-dl" href="https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-compat-macos-x86_64">download lilbee-compat-macos-x86_64 &rarr;</a>
+          </div>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">curl -L https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-compat-macos-x86_64 -o lilbee &amp;&amp; chmod +x lilbee &amp;&amp; xattr -d com.apple.quarantine ./lilbee</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
+        <div class="binary-row">
+          <div class="binary-row-h">
             <span class="oschip">Windows x86_64</span>
             <a class="binary-dl" href="https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-compat-windows-x86_64.exe">download lilbee-compat-windows-x86_64.exe &rarr;</a>
           </div>
@@ -595,7 +618,7 @@
 
         <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-binary">details</button>
         <div class="notes-body" id="notes-binary" hidden>
-          <p class="extras"><span class="k">unsigned:</span> the macOS arm64 and Windows builds aren't code-signed. The macOS one-liner clears quarantine for you; Homebrew does the same. On Windows, SmartScreen may warn the first time.</p>
+          <p class="extras"><span class="k">unsigned:</span> the macOS and Windows builds aren't code-signed. The macOS one-liner clears quarantine for you; Homebrew does the same. On Windows, SmartScreen may warn the first time.</p>
           <p class="extras">older CPU on Windows also via <code>scoop install lilbee-compat</code> &nbsp;.&nbsp; CUDA <code>cu124</code> / <code>cu121</code> for older drivers on the <a href="https://github.com/tobocop2/lilbee/releases">releases page</a></p>
         </div>
       </div>

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -6588,3 +6588,12 @@ class TestCatalogFocusEdgeGuards:
         assert screen.load_more_called is True
         assert screen.focus_next_called is False
         assert scroll_end_calls, "last-grid LeaveDown must scroll to end to reveal hint"
+
+
+class TestPathExists:
+    def test_returns_false_when_path_resolution_raises(self) -> None:
+        """A path that can't even be resolved reports as absent, not an error."""
+        from lilbee.cli.tui.widgets import autocomplete
+
+        with mock.patch.object(autocomplete, "Path", side_effect=OSError("boom")):
+            assert autocomplete._path_exists("~/whatever") is False


### PR DESCRIPTION
## Problem

lilbee shipped no download-and-run standalone binary for Intel Macs. The
`pip` path already works there (main cross-compiles `macosx_11_0_x86_64`
wheels and documents `--extra-index-url https://lilbee.sh/cpu/`), but the
standalone executable was dropped back when the old `macos-13` Intel runner
was flaky, leaving Homebrew/direct-download users on Apple Silicon or Linux
only.

## Solution

GitHub now offers a native Intel image, `macos-15-intel` (the old `macos-13`
is retired). Nuitka can't cross-compile arch from the arm64 runner, so this
builds natively there and runs the full smoke test on real Intel hardware —
no cross-compiled-and-unverified asset.

Two soft cells, mirroring the existing linux/windows pattern:

- `lilbee-macos-x86_64` — stock AVX baseline. Covers every Mac that can run
  macOS 11+ (all Ivy Bridge or newer); deployment target stays 11.0.
- `lilbee-compat-macos-x86_64` — pre-Haswell build (launcher held to
  `x86-64-v2`, stock lancedb swapped for `+compat`), covering the
  AVX-but-no-AVX2 tail such as the 2013 Mac Pro and guarding against an
  AVX2-baselined lancedb SIGILL.

Both are `continue-on-error`, so a queued or missing Intel runner never
blocks the release fan-out. A pre-AVX (2008-era) engine was considered and
skipped: no Mac that runs macOS 11/12 is pre-AVX, so it would help nobody
without also lowering the OS floor to High Sierra.

README lists the new compat binary in the older-CPU download row.
