### PR TITLE
docs: add GitHub release downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
   <a href="https://mypy-lang.org/"><img src="https://img.shields.io/badge/typed-mypy-2A6DB2" alt="Typed"></a>
   <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
   <a href="https://pepy.tech/project/lilbee"><img src="https://img.shields.io/pepy/dt/lilbee?label=downloads&logo=python&logoColor=white&color=3776AB" alt="PyPI downloads"></a>
+  <a href="https://github.com/tobocop2/lilbee/releases"><img src="https://img.shields.io/github/downloads/tobocop2/lilbee/total?label=release%20downloads&logo=github&logoColor=white&color=2C3E50" alt="GitHub release downloads"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Problem

The badge row surfaces the PyPI version and PyPI (pip) download counts, but nothing for standalone binary downloads from GitHub Releases, which is a real install path (currently a few thousand downloads).

## Solution

Add a GitHub release-downloads badge next to the PyPI downloads badge, labeled `release downloads` so it reads distinctly from the pip `downloads` badge, linking to the releases page.
