### PR TITLE
clean up some unecessary lazy imports

### DIFF
--- a/src/lilbee/providers/fleet/binary.py
+++ b/src/lilbee/providers/fleet/binary.py
@@ -6,6 +6,7 @@ import shutil
 from enum import StrEnum
 from pathlib import Path
 
+from lilbee.core.config import cfg
 from lilbee.providers.base import ProviderError
 
 _INSTALL_HINT = (
@@ -49,8 +50,6 @@ def resolve_engine_tool(tool: EngineTool) -> Path:
     wheel, then ``PATH``.
     """
     if tool is EngineTool.LLAMA_SERVER:
-        from lilbee.core.config import cfg
-
         if cfg.llama_server_path:
             configured = Path(cfg.llama_server_path)
             if not configured.is_file():

--- a/src/lilbee/providers/fleet/gpu_select.py
+++ b/src/lilbee/providers/fleet/gpu_select.py
@@ -20,6 +20,7 @@ from ctypes import POINTER, byref, c_char, c_char_p, c_uint8, c_uint32, c_uint64
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 
+from lilbee.core.config import cfg
 from lilbee.providers.fleet.vulkan_icd_discovery import (
     iter_vulkan_manifest_paths,
 )
@@ -551,7 +552,6 @@ def disable_conflicting_vulkan_icds() -> str | None:
     from disk (registry on Windows, XDG on Linux); enumerating via
     ``vkCreateInstance`` would pre-load every vendor's ICD before the disable lands.
     """
-    from lilbee.core.config import cfg
 
     if not _platform_supports_icd_pin():
         return None

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from lilbee.core.config import cfg
 from lilbee.core.config.enums import KvCacheType
 from lilbee.providers import model_cache
 from lilbee.providers.fleet.adapters import (
@@ -189,7 +190,6 @@ def _resolve_vision_slots(
 ) -> int:
     """Largest OCR batching slot count (<= ``cfg.vision_ocr_concurrency``) that fits
     the memory budget; 1 when the ceiling is 1 or nothing larger fits."""
-    from lilbee.core.config import cfg
 
     ceiling = max(1, cfg.vision_ocr_concurrency)
     if ceiling == 1:
@@ -228,7 +228,6 @@ def _slot_budget(vram_fraction: float, unified_budget: int | None) -> int:
     """Memory budget for slot sizing: *vram_fraction* of usable VRAM, capped by
     ``unified_budget`` (free system RAM) when there is no discrete GPU so the count
     steps down to fit free memory instead of overcommitting."""
-    from lilbee.core.config import cfg
 
     budget = int(model_cache.get_available_memory(cfg.gpu_memory_fraction) * vram_fraction)
     if unified_budget is not None:
@@ -271,7 +270,6 @@ def _role_ctx(role: WorkerRole, model_path: Path, meta: dict[str, str] | None) -
     falls back to the single-GPU dynamic chat-ctx picker. A tensor-split chat is
     sized against its per-device headroom instead (see :func:`fit_split_ctx`).
     """
-    from lilbee.core.config import cfg
     from lilbee.providers.engine_params import (
         resolve_chat_ctx,
         resolve_embed_ctx,
@@ -294,7 +292,6 @@ def _role_ctx(role: WorkerRole, model_path: Path, meta: dict[str, str] | None) -
 
 def _rerank_mode_for(meta: dict[str, str] | None) -> RerankMode:
     """Resolve the RERANK serving mode from cfg + the reranker GGUF arch."""
-    from lilbee.core.config import cfg
 
     arch = meta.get("architecture") if meta else None
     return resolve_rerank_mode(cfg.reranker_type, arch)
@@ -334,7 +331,6 @@ def _role_gpu_layers(role: WorkerRole) -> int:
 
 def _flash_enabled() -> bool:
     """Flash attention is on unless ``cfg.flash_attention`` is explicitly ``False``."""
-    from lilbee.core.config import cfg
 
     return cfg.flash_attention is not False
 
@@ -351,7 +347,6 @@ def _role_flash(role: WorkerRole) -> bool:
 
 def _role_kv_cache_type(role: WorkerRole) -> KvCacheType:
     """Chat honors ``cfg.kv_cache_type``; embed/rerank/vision run f16 KV."""
-    from lilbee.core.config import cfg
 
     return cfg.kv_cache_type if role is WorkerRole.CHAT else KvCacheType.F16
 
@@ -363,9 +358,6 @@ def _replica_count(role: WorkerRole, device_count: int) -> int:
 
 def _cache_type_flag() -> str | None:
     """KV cache type for chat, or ``None`` to leave llama-server's f16 default."""
-    from lilbee.core.config import cfg
-    from lilbee.core.config.enums import KvCacheType
-
     if cfg.kv_cache_type is KvCacheType.F16:
         return None
     return cfg.kv_cache_type.value
@@ -451,7 +443,6 @@ def _chat_serve_budget_footprint(footprint: int) -> int:
     its context. Small models are unaffected -- they fit the serve budget with KV
     room to spare.
     """
-    from lilbee.core.config import cfg
 
     return int(footprint * (USABLE_VRAM_FRACTION / cfg.gpu_memory_fraction))
 
@@ -465,7 +456,6 @@ def _placement_estimate_ctx(role: WorkerRole, model_path: Path, meta: dict[str, 
     single-card placement) nor the full trained ceiling (which over-reserves). A
     model that cannot hold weights + this floor on one card is tensor-split.
     """
-    from lilbee.core.config import cfg
     from lilbee.providers.engine_params import chat_ctx_ceiling
 
     if role is WorkerRole.CHAT:
@@ -483,7 +473,6 @@ def _placement_estimate_slots(role: WorkerRole, meta: dict[str, str] | None) -> 
     A tensor-split chat serves a single full-context sequence, so the placement total
     is the per-sequence ceiling, not ``ceiling x _CHAT_SLOTS`` (KV no launch allocates).
     """
-    from lilbee.core.config import cfg
 
     if role is WorkerRole.CHAT:
         return _SPLIT_CHAT_SLOTS
@@ -587,7 +576,6 @@ def _server_model_inputs(
     Skips an unconfigured optional role, a vision model with no resolvable mmproj
     projector, and a role whose model is not installed on disk.
     """
-    from lilbee.core.config import cfg
     from lilbee.providers.base import ProviderError
 
     inputs: dict[WorkerRole, ModelPlacementInput] = {}
@@ -654,7 +642,6 @@ def _launch_for(
     model_path = resolve_model_path(model_ref)
     weights_bytes = _weights_bytes(model_path)
     meta = read_gguf_metadata(model_path)
-    from lilbee.core.config import cfg
 
     chosen = tuple(by_index[i] for i in plan.devices)
     is_chat = plan.role is WorkerRole.CHAT
@@ -897,7 +884,6 @@ def plan_launches(
     devices: list[FleetDevice],
 ) -> list[InstanceLaunch]:
     """Plan placement for *roles* (``None`` = all configured) and build their launches."""
-    from lilbee.core.config import cfg
 
     unified_budget = _unified_memory_budget(devices)
     inputs, model_refs, reservation = _server_model_inputs(

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -248,7 +248,6 @@ def _vision_call(
     a ``ProviderError`` so the page-level OCR caller can fail just that page.
     Callers hold ``_VISION_GATE`` so queue time isn't billed against the timeout.
     """
-    from lilbee.core.config import cfg
 
     options = {"max_tokens": cfg.vision_ocr_max_tokens}
     if timeout and timeout > 0:
@@ -355,7 +354,6 @@ class FleetProvider:
                     # while this warm-up/reload thread was in flight; do not spawn a
                     # llama-swap no live provider would ever reap.
                     return None
-            from lilbee.core.config import cfg
 
             swap = SwapManager(cfg.data_dir)
             # A dead owner's surviving llama-swap holds VRAM; reap it before launching
@@ -511,8 +509,6 @@ class FleetProvider:
             # never adopted, and SwapManager.shutdown reaps every llama-swap this
             # process spawned (keyed on our own children), not just a tracked handle.
             if swap is None:
-                from lilbee.core.config import cfg
-
                 swap = SwapManager(cfg.data_dir)
             swap.shutdown()
 
@@ -600,7 +596,6 @@ class FleetProvider:
         the server parses native tool calls, so tool support needs no per-family
         parser here.
         """
-        from lilbee.core.config import cfg
         from lilbee.providers.engine_params import chat_options_to_kwargs
 
         self._require_configured_model(model, str(cfg.chat_model), WorkerRole.CHAT)
@@ -631,7 +626,6 @@ class FleetProvider:
         model: str | None = None,
     ) -> ChatToolResult:
         """Route a tool-enabled chat turn to the least-busy chat server."""
-        from lilbee.core.config import cfg
         from lilbee.providers.engine_params import chat_options_to_kwargs
 
         self._require_configured_model(model, str(cfg.chat_model), WorkerRole.CHAT)
@@ -679,7 +673,6 @@ class FleetProvider:
     def vision_ocr(
         self, png_bytes: bytes, model: str, prompt: str = "", *, timeout: float | None = None
     ) -> str:
-        from lilbee.core.config import cfg
         from lilbee.vision import build_vision_messages, resolve_ocr_prompt
 
         self._require_configured_model(model, str(cfg.vision_model), WorkerRole.VISION)

--- a/src/lilbee/providers/fleet/replicas.py
+++ b/src/lilbee/providers/fleet/replicas.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import functools
 import logging
 
+from lilbee.core.config import cfg
 from lilbee.providers.roles import ROLE_REGISTRY, WorkerRole
 
 log = logging.getLogger(__name__)
@@ -26,7 +27,6 @@ def resolve_replica_count(role: WorkerRole, device_count: int) -> int:
     0 means one replica per GPU (falling to one when GPU-less). Other roles run
     one instance. Capping to residual VRAM happens in placement.
     """
-    from lilbee.core.config import cfg
 
     knob = ROLE_REGISTRY[role].replica_knob
     if knob is None:

--- a/src/lilbee/providers/sdk_backend.py
+++ b/src/lilbee/providers/sdk_backend.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 # Display name for the active backend the SDK is talking to. The
 # adapter's own identity is exposed separately via provider_name.
+from lilbee.core.config import cfg
 from lilbee.providers.backend_names import BackendName
 from lilbee.providers.local_servers import detect_local_server
 
@@ -56,7 +57,6 @@ def get_provider_api_key(provider: str) -> str | None:
     :data:`PROVIDER_API_KEY_FIELD`. Reads only the lilbee config field; use
     :func:`provider_has_key` to also honor the SDK's own env var.
     """
-    from lilbee.core.config import cfg
 
     field = PROVIDER_API_KEY_FIELD.get(provider.lower())
     if field is None:


### PR DESCRIPTION
## Problem

Several fleet and provider modules imported the config singleton lazily inside functions rather than at module scope. `planning.py` had 13 copies of `from lilbee.core.config import cfg` scattered across its functions, and `provider.py` had 6 more while already importing `cfg` at module level. This is the blanket-lazy-import habit, not deferral that earns its keep: `cfg` is built once and only mutated in place (it is never rebound), and none of these modules are pulled into the `Config()` construction chain, so a module-level import can neither go stale nor create a cycle.

## Solution

Consolidated the redundant lazy imports in six modules (`planning`, `provider`, `replicas`, `gpu_select`, `binary`, `sdk_backend`) to a single module-level `from lilbee.core.config import cfg`, matching how `registry.py` and the TUI screens already import it.

Deliberately left the lazy `cfg` imports that are genuinely load-bearing:
- `hf_client.py` breaks a real cycle (`config` -> model_ref validator -> `catalog` -> `hf_client` -> `config`), triggered because `Config()` is instantiated during config module load.
- `gpu_env.py` is a deliberately binding-free module that defers all of its lilbee imports.
- `services.py` follows its documented policy of deferring imports to keep CLI startup fast.

Verified no circular imports (fresh-interpreter import of every changed module plus `core.config`), and the full suite passes at 100% coverage.