### PR TITLE
Cut fleet rebuild time by warming roles concurrently and skipping redundant shard rereads

### DIFF
--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -68,6 +68,10 @@ _WARM_MAX_TOKENS = 1
 # Read size for paging chat shards into the page cache during warm; large enough
 # to keep sequential reads efficient without holding much resident at once.
 _PREWARM_CHUNK_BYTES = 8 * 1024 * 1024
+# Shards fully paged in this boot, keyed on (path, size, mtime_ns); a fleet
+# rebuild (e.g. a placement change) skips re-reading a hot cache. Module-level so
+# it survives reset_services() replacing the provider instance.
+_PREWARMED_SHARDS: set[tuple[str, int, int]] = set()
 # Per-role client request budget: the first request covers the lazy cold load plus
 # generation, so the weights-scaled cold-load budget plus the margin raises this floor.
 _REQUEST_TIMEOUT_FLOOR_S = 900.0
@@ -78,6 +82,12 @@ _REQUEST_TIMEOUT_GENERATION_MARGIN_S = 120.0
 # whether to offer tools to a given model at all.
 _TOOL_TEMPLATE_PATTERN = re.compile(r"\{[%{][^}]*\b(?:tools|tool_calls|functions|function_calls)\b")
 _T = TypeVar("_T")
+
+
+def _prewarm_key(shard: Path) -> tuple[str, int, int]:
+    """The prewarm identity of *shard*: same path, size, and mtime -> same pages."""
+    stat = shard.stat()
+    return (str(shard), stat.st_size, stat.st_mtime_ns)
 
 
 def _request_timeout_s(weights_bytes: int) -> float:
@@ -964,11 +974,15 @@ class FleetProvider:
         around each role). A per-replica failure is logged and skipped; that replica
         still loads on its first real use. The chat role routes through
         :meth:`_warm_chat_role` so a launcher gets granular progress.
+
+        Roles warm concurrently: chat is the long pole (a large model's load
+        dominates), so the light roles load alongside it instead of before it.
         """
         with self._lock:
             pools = {role: list(clients) for role, clients in self._clients.items()}
             on_spawning, on_spawned = self._on_spawning, self._on_spawned
-        for role, clients in pools.items():
+
+        def _warm_one(role: WorkerRole, clients: list[LlamaServerClient]) -> None:
             if on_spawning is not None:
                 on_spawning(role)
             if role is WorkerRole.CHAT:
@@ -977,6 +991,13 @@ class FleetProvider:
                 self._warm_role_clients(role, clients)
             if on_spawned is not None:
                 on_spawned(role)
+
+        if not pools:
+            return
+        with ThreadPoolExecutor(max_workers=len(pools), thread_name_prefix="fleet-preload") as pool:
+            futures = [pool.submit(_warm_one, role, clients) for role, clients in pools.items()]
+            for future in futures:
+                future.result()
 
     def _warm_role_clients(self, role: WorkerRole, clients: list[LlamaServerClient]) -> bool:
         """Warm every replica of *role*; return whether at least one loaded."""
@@ -1027,10 +1048,15 @@ class FleetProvider:
             return
         if total <= 0:
             return
+        keys = [_prewarm_key(shard) for shard in shards]
+        if all(key in _PREWARMED_SHARDS for key in keys):
+            # Already paged in this boot (e.g. a placement rebuild); the cache is hot.
+            self._warm_tracker.reading(total, total)
+            return
         done = 0
         self._warm_tracker.reading(0, total)
         chunk = bytearray(_PREWARM_CHUNK_BYTES)
-        for index, shard in enumerate(shards):
+        for index, (shard, key) in enumerate(zip(shards, keys, strict=True)):
             detail = f"shard {index + 1}/{len(shards)}" if len(shards) > 1 else None
             try:
                 with shard.open("rb", buffering=0) as handle:
@@ -1040,6 +1066,7 @@ class FleetProvider:
                             break
                         done += read
                         self._warm_tracker.reading(done, total, detail=detail)
+                _PREWARMED_SHARDS.add(key)
             except OSError:
                 # A partial/locked shard just shortens the read bar; the engine load
                 # surfaces any real fault as a user-facing error on the warm request.

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -1164,6 +1164,82 @@ def test_preload_roles_skips_failing_role(monkeypatch) -> None:
     embed.embed.assert_called_once()
 
 
+def test_preload_roles_warms_roles_concurrently(monkeypatch) -> None:
+    # The light roles must not queue behind the chat load: with the chat warm
+    # blocked mid-flight, the embed warm still completes.
+    chat_started = threading.Event()
+    release_chat = threading.Event()
+    embed_warmed = threading.Event()
+
+    chat, embed = _fake_client(), _fake_client()
+
+    def _blocked_chat(*args, **kwargs) -> MagicMock:
+        chat_started.set()
+        release_chat.wait(timeout=5.0)
+        return MagicMock()
+
+    chat.chat.side_effect = _blocked_chat
+    embed.embed.side_effect = lambda *a, **k: (embed_warmed.set(), [[0.1]])[1]
+    p = _provider_with_clients({WorkerRole.CHAT: [chat], WorkerRole.EMBED: [embed]})
+    monkeypatch.setattr(p, "_prewarm_chat_weights", lambda: None)
+    preload = threading.Thread(target=p._preload_roles, daemon=True)
+    preload.start()
+    assert chat_started.wait(timeout=5.0)
+    assert embed_warmed.wait(timeout=5.0)  # embed warmed while chat still loading
+    release_chat.set()
+    preload.join(timeout=5.0)
+    assert not preload.is_alive()
+
+
+def _registry_with_shards(monkeypatch, shards: list[Path]) -> None:
+    registry = MagicMock()
+    registry.shard_paths.return_value = shards
+    monkeypatch.setattr(prov_mod, "ModelRegistry", MagicMock(return_value=registry))
+
+
+def test_prewarm_skips_shards_already_paged_this_boot(monkeypatch, tmp_path) -> None:
+    shard = tmp_path / "model.gguf"
+    shard.write_bytes(b"x" * 64)
+    _registry_with_shards(monkeypatch, [shard])
+    monkeypatch.setattr(prov_mod, "_PREWARMED_SHARDS", set())
+    p = _provider_with_clients({})
+    p._prewarm_chat_weights()  # first pass reads and records the shard
+
+    opens = {"n": 0}
+    real_open = Path.open
+
+    def _counting_open(self, *args, **kwargs):
+        if self == shard:
+            opens["n"] += 1
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _counting_open)
+    p._prewarm_chat_weights()  # second pass: cache is hot, no re-read
+    assert opens["n"] == 0
+
+
+def test_prewarm_rereads_when_a_shard_changed(monkeypatch, tmp_path) -> None:
+    shard = tmp_path / "model.gguf"
+    shard.write_bytes(b"x" * 64)
+    _registry_with_shards(monkeypatch, [shard])
+    monkeypatch.setattr(prov_mod, "_PREWARMED_SHARDS", set())
+    p = _provider_with_clients({})
+    p._prewarm_chat_weights()
+    shard.write_bytes(b"y" * 128)  # new size + mtime -> new prewarm identity
+
+    opens = {"n": 0}
+    real_open = Path.open
+
+    def _counting_open(self, *args, **kwargs):
+        if self == shard:
+            opens["n"] += 1
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _counting_open)
+    p._prewarm_chat_weights()
+    assert opens["n"] == 1  # changed shard is read again
+
+
 def test_warm_role_dispatches_per_role() -> None:
     chat, embed, rerank, vision = (_fake_client() for _ in range(4))
     prov_mod._warm_role(WorkerRole.CHAT, chat)


### PR DESCRIPTION
Applying or clearing a GPU placement reruns the cold boot warm path, and on a 3x A100 box serving Qwen3-235B Q3_K_M it took 72 to 88 seconds before chat came back. Profiling (issue #474) showed most of that time never touches the model load itself: `_preload_roles` warmed roles in a sequential loop so the chat load queued behind the embedder and reranker, and `_prewarm_chat_weights` reread all 112GB of shards on every rebuild even though the page cache was already hot from the previous load.

Two changes, both in the warm path. Roles now warm concurrently, which matches the co-resident swap group (`swap: false, exclusive: false`) and the architecture doc's "brings every role up at once" description; the light roles load alongside the chat long pole instead of before it. And the shard preread now records what it has paged this boot (keyed on path, size, and mtime) and skips the reread when nothing changed, so it only pays the read once per boot per model. A replaced or redownloaded shard gets a new key and rereads as before.

Measured on the A100 box: rebuilds drop from 72-88s to 47-49s. The remaining time is llama-server's own engine bring-up, tracked separately in #474.
