### PR TITLE
Placement changes restart only the roles that moved

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -223,6 +223,37 @@ flowchart TD
   hard-freezes the machine, so refusing is the safe outcome; chat slot count
   (`--parallel`) steps down the same way before refusing.
 
+- **Reload and the plan snapshot** (`planning.capture_plan_probe`,
+  `provider._reload_pass`): each role runs behind its own llama-swap process, and
+  a reload re-plans the whole fleet but restarts **only the roles whose launches
+  changed**. That diff is sound because launches are a pure function of config,
+  hardware capacity, and a **clean-box memory snapshot**: devices, usable VRAM,
+  and free system RAM are captured once per boot (right after stale-server
+  reaping, when nothing lilbee owns is loaded) and every re-plan reads the
+  snapshot instead of probing live. A live probe under a loaded fleet would
+  report the fleet's own residency as unavailable, shrinking chat context and
+  slot counts, widening splits, and (on unified memory) evicting roles outright.
+  Full fleet teardown clears the snapshot, so the next boot probes fresh and
+  still respects VRAM other processes hold. The read/view surfaces
+  (`GET /api/placement`, `placement show`, preview) keep a live short-TTL probe
+  so displayed free bytes stay current; they never feed the launch path.
+
+```mermaid
+flowchart TB
+    CFG[config + placement spec] --> PLAN[planner\nestimate + bin-pack + ctx fit]
+    SNAP[clean-box snapshot\ndevices / VRAM / RAM] --> PLAN
+    PLAN --> DIFF{per-role launch diff}
+    DIFF -->|unchanged| KEEP[role keeps serving\nmodel stays resident]
+    DIFF -->|changed| RESTART[stop role's llama-swap\nstart with new argv]
+    subgraph fleet [one llama-swap per role]
+        CHAT[chat group]
+        EMBED[embed group xN]
+        RERANK[rerank group]
+    end
+    RESTART --> fleet
+    KEEP --> fleet
+```
+
 #### Manual placement
 
 By default the auto planner runs every time a fleet is built. When a `placement`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,6 +162,40 @@ flowchart TD
     ES --> G1
 ```
 
+#### Supervision layout
+
+Follow the numbers: the planner measures, renders a config per role, each role's
+llama-swap spawns and watches that role's servers, and the provider routes live
+requests by role. Rerank and vision follow the same shape as embed. Because every
+role has its own supervisor, config, log, and state file, a placement change
+restarts only the roles whose launches changed (see the reload diff below).
+
+```mermaid
+flowchart LR
+    subgraph app ["lilbee"]
+        planner["placement planner"]
+        gguf["gguf-parser"]
+        provider["FleetProvider"]
+        planner -->|"1: measure each GGUF"| gguf
+    end
+    subgraph swaps ["llama-swap, one per role"]
+        sc["swap: chat<br/>own config, log, state"]
+        se["swap: embed<br/>own config, log, state"]
+    end
+    subgraph servers ["llama-server processes"]
+        chat["chat<br/>split across its GPUs"]
+        e1["embed replica"]
+        e2["embed replica"]
+    end
+    planner -->|"2: render JSON config per role"| sc
+    planner -->|"2: render JSON config per role"| se
+    sc -->|"3: spawn and watch"| chat
+    se -->|"3: spawn and watch"| e1
+    se -->|"3: spawn and watch"| e2
+    provider -->|"4: requests by role"| sc
+    provider -->|"4: requests by role"| se
+```
+
 - **Detection** (`devices.probe_devices`): GPUs come from the binary's own
   `llama-server --list-devices`, so enumeration and pinning share one backend-native
   index space. A device index from one API (Vulkan) is meaningless to another (CUDA),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,7 +197,7 @@ flowchart TD
   warm fleet's own resident models aren't double-counted, and unequal GPUs don't OOM
   the smaller one). For the chat model the planner does not stop at the fewest fitting
   cards: it sizes each candidate shard's served context the way the launch will
-  (`ctx.fit_split_ctx`, against **live free VRAM**) and **widens onto idle cards** when
+  (`ctx.fit_split_ctx`, against the **clean-box plan snapshot**) and **widens onto idle cards** when
   a tighter shard would starve KV below the context target, falling back to the
   largest-context shard when no shard reaches it. This keeps placement and launch in
   agreement, so a giant chat that just fits the fewest cards no longer collapses to the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -325,7 +325,13 @@ touching the running fleet.
 - **Loader flags** (`adapters.build_server_argv`): each server's flags derive from
   cfg and the model's GGUF metadata for that role and config. Chat carries
   `--jinja`, `--flash-attn` (on unless `flash_attention` is disabled) and
-  `--cache-type-k/-v` from `kv_cache_type`; embed and rerank raise
+  `--cache-type-k/-v` from `kv_cache_type`; it also loads with `--no-mmap`
+  (a malloc'd host copy) when its weights fit in at most half of total system
+  RAM -- a buffered sequential read reaches ready ~20% faster than mmap's
+  page-fault-driven upload (measured 33s vs 43s for a 112GB model on 3 GPUs),
+  while replicated roles keep mmap so their replicas share one set of
+  page-cache pages. The gate reads total (not free) memory so replans never
+  flap the flag; embed and rerank raise
   `--batch-size`/`--ubatch-size` to the full context (the server caps embeddings at
   `n_ubatch`, default 512); vision uses the full-core thread default and always
   offloads every layer. Embed and rerank requests also send `embd_normalize=-1` to
@@ -336,7 +342,7 @@ touching the running fleet.
   setting deliberately not forwarded: it selects a single card by global index, which
   is meaningless once a server is pinned to a subset, and placement owns card choice
   in fleet mode.
-- **Lifecycle** (`fleet.py`): each role runs behind its own llama-swap process
+- **Lifecycle** (`swap_manager.py` / `provider.py`): each role runs behind its own llama-swap process
   with its own config file, so restarting one role's group (a placement or
   per-role model change) never touches another role's loaded servers. A reload
   re-plans the whole fleet and diffs the fresh plan per role against the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -262,7 +262,7 @@ CLI (`lilbee placement show/preview/set/clear`), MCP
 (`get_placement`, `preview_placement`, `set_placement`, `clear_placement`),
 and the TUI Placement screen. Over HTTP the reads are always served
 (`GET /api/placement`, `POST /api/placement/preview`, `GET /api/gpus`).
-Applying or clearing placement rebuilds the shared fleet, so `PUT`/`DELETE
+Applying or clearing placement restarts the fleet's moved roles, so `PUT`/`DELETE
 /api/placement` are refused by default and gated on `allow_http_placement`
 (`LILBEE_ALLOW_HTTP_PLACEMENT`), which an operator enables for a single-client
 or owned deployment (the plugin's managed server, or a personally-owned pod) to
@@ -305,13 +305,19 @@ touching the running fleet.
   setting deliberately not forwarded: it selects a single card by global index, which
   is meaningless once a server is pinned to a subset, and placement owns card choice
   in fleet mode.
-- **Lifecycle** (`fleet.py`): each server runs in its own process group and claims
+- **Lifecycle** (`fleet.py`): each role runs behind its own llama-swap process
+  with its own config file, so restarting one role's group (a placement or
+  per-role model change) never touches another role's loaded servers. A reload
+  re-plans the whole fleet and diffs the fresh plan per role against the
+  running launches, restarting only the roles whose launches changed; an
+  untouched 100GB chat model stays resident while the embedder moves. Each
+  server runs in its own process group and claims
   its port at spawn (no racy batch allocation). Readiness is `/health` (200 only once
   the model loads); the cold-load health timeout scales with the heaviest member's
   weights at a conservative disk rate (ten-minute floor), so a multi-hundred-GB model
-  on a slow volume isn't killed mid-load. Each owner lilbee writes its own state file
-  (named with its pid, written atomically so a concurrent scan never reads a torn
-  file) recording the running llama-swap's pid, process group, and create time, the
+  on a slow volume isn't killed mid-load. Each owner lilbee writes one state file per role group
+  (named with the group and its pid, written atomically so a concurrent scan never reads a torn
+  file) recording that group's llama-swap pid, process group, and create time, the
   member servers' ports, plus the owner's pid and create time; before the next build
   launches the fleet (so the cards are actually free for it and the context sizer
   reads true free VRAM), every state file is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,11 +240,11 @@ flowchart TD
 
 ```mermaid
 flowchart TB
-    CFG[config + placement spec] --> PLAN[planner\nestimate + bin-pack + ctx fit]
-    SNAP[clean-box snapshot\ndevices / VRAM / RAM] --> PLAN
+    CFG[config + placement spec] --> PLAN[planner: estimate + bin-pack + ctx fit]
+    SNAP[clean-box snapshot: devices / VRAM / RAM] --> PLAN
     PLAN --> DIFF{per-role launch diff}
-    DIFF -->|unchanged| KEEP[role keeps serving\nmodel stays resident]
-    DIFF -->|changed| RESTART[stop role's llama-swap\nstart with new argv]
+    DIFF -->|unchanged| KEEP[role keeps serving, model stays resident]
+    DIFF -->|changed| RESTART[stop role's llama-swap, start with new argv]
     subgraph fleet [one llama-swap per role]
         CHAT[chat group]
         EMBED[embed group xN]

--- a/docs/placement_ux_prototype.py
+++ b/docs/placement_ux_prototype.py
@@ -16,6 +16,7 @@ real focusable widgets (one per GPU checkbox / advanced control) so Tab and
 arrow keys both work, consistent with the rest of the TUI.
 Run: uv run --with textual python proto.py
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -73,10 +74,50 @@ class PlacementProto(App):
         self.detail_key = ""
         self.toast = ""
         self.roles: list[Role] = [
-            Role("chat", "Chat", "Qwen2.5 72B", "the model you talk to", 56.0, FOAM, split=True, required=True),
-            Role("embed", "Embeddings", "nomic-embed", "indexes docs for search", 0.3, GOLD, split=False, required=True, replicable=True),
-            Role("rerank", "Reranker", "bge-reranker", "sharpens search results", 0.6, PINE, split=True, required=False, enabled=False),
-            Role("vision", "Vision", "Qwen2-VL OCR", "reads images & PDFs", 5.0, ROSE, split=False, required=False, replicable=True, enabled=False),
+            Role(
+                "chat",
+                "Chat",
+                "Qwen2.5 72B",
+                "the model you talk to",
+                56.0,
+                FOAM,
+                split=True,
+                required=True,
+            ),
+            Role(
+                "embed",
+                "Embeddings",
+                "nomic-embed",
+                "indexes docs for search",
+                0.3,
+                GOLD,
+                split=False,
+                required=True,
+                replicable=True,
+            ),
+            Role(
+                "rerank",
+                "Reranker",
+                "bge-reranker",
+                "sharpens search results",
+                0.6,
+                PINE,
+                split=True,
+                required=False,
+                enabled=False,
+            ),
+            Role(
+                "vision",
+                "Vision",
+                "Qwen2-VL OCR",
+                "reads images & PDFs",
+                5.0,
+                ROSE,
+                split=False,
+                required=False,
+                replicable=True,
+                enabled=False,
+            ),
         ]
         self.auto_layout()
 
@@ -178,9 +219,7 @@ class PlacementProto(App):
     # -- overview --------------------------------------------------------
     def _overview(self) -> str:
         L: list[str] = []
-        L.append(
-            f"[{MUTE}]Chat · Catalog · Status · Settings · Tasks · [/][{IRIS}]Placement[/]"
-        )
+        L.append(f"[{MUTE}]Chat · Catalog · Status · Settings · Tasks · [/][{IRIS}]Placement[/]")
         L.append("")
         status = (
             f"[{FOAM}]● Automatic[/] [{MUTE}](lilbee chose this)[/]"
@@ -216,7 +255,11 @@ class PlacementProto(App):
             L.append("  " + "    ".join(cells[i : i + 4]))
         L.append("")
         all_ok = all(self._role_ok(r)[0] for r in self.roles)
-        fit = f"[{FOAM}]Everything fits ✓[/]" if all_ok else f"[{LOVE}]Some models don't fit — open one to fix.[/]"
+        fit = (
+            f"[{FOAM}]Everything fits ✓[/]"
+            if all_ok
+            else f"[{LOVE}]Some models don't fit — open one to fix.[/]"
+        )
         L.append(fit)
         L.append("")
         L.append(
@@ -239,7 +282,9 @@ class PlacementProto(App):
             if r.size_gb > CARD_GB
             else f"[{MUTE}]{r.size_gb:.0f} GB · {r.job}[/]"
         )
-        L.append(f"[{MUTE}]‹ back[/]     [{r.color}]{r.label}[/] [{MUTE}]— {r.model}[/]   {size_note}")
+        L.append(
+            f"[{MUTE}]‹ back[/]     [{r.color}]{r.label}[/] [{MUTE}]— {r.model}[/]   {size_note}"
+        )
         L.append("")
         L.append(f"[{TEXT}]Which GPUs?[/]")
         for g in self.gpus():
@@ -252,7 +297,9 @@ class PlacementProto(App):
                 else (f"[{SUB}]{used:.0f}/{CARD_GB:.0f} GB[/]" if used > 0 else f"[{MUTE}]free[/]")
             )
             focus = cur == f"gpu:{g}"
-            line = f"   {box}  [{TEXT}]GPU {g}[/]  [{MUTE}]{GPU_NAME}[/]   {self._bar(g, 10)}  {tag}"
+            line = (
+                f"   {box}  [{TEXT}]GPU {g}[/]  [{MUTE}]{GPU_NAME}[/]   {self._bar(g, 10)}  {tag}"
+            )
             L.append(f"[{IRIS}]▸[/]{line[1:]}" if focus else f" {line}")
         L.append("")
         # how + fit
@@ -278,8 +325,10 @@ class PlacementProto(App):
             fit = f"[{GOLD}]Fits, but a card is over budget.[/]"
         else:
             spread = self._split_spread(r, d) if (r.split and len(d) > 1) else ""
-            detail = (
-                spread or (f"{each:.0f} GB on each of {len(d)} cards" if len(d) > 1 else f"{each:.0f} GB on Card {d[0]}")
+            detail = spread or (
+                f"{each:.0f} GB on each of {len(d)} cards"
+                if len(d) > 1
+                else f"{each:.0f} GB on Card {d[0]}"
             )
             fit = f"[{FOAM}]✓ Fits[/] [{MUTE}]— {detail}[/]"
         L.append(how)
@@ -323,18 +372,28 @@ class PlacementProto(App):
             choice = f"{radio(not r.split, 'Copies')}   {radio(r.split, 'Split')}"
             out.append(f"  {mark('mode')} [{TEXT}]Distribute[/]   {choice}")
             if cur == "mode":
-                out.append(f"      [{MUTE}]Copies = a full model per card (faster). Split = one model across cards (for big models).[/]")
+                out.append(
+                    f"      [{MUTE}]Copies = a full model per card (faster). Split = one model across cards (for big models).[/]"
+                )
         if r.split and len(r.devices) > 1:
-            choice = f"{radio(r.weights is None, 'Even')}   {radio(r.weights is not None, 'Custom')}"
+            choice = (
+                f"{radio(r.weights is None, 'Even')}   {radio(r.weights is not None, 'Custom')}"
+            )
             out.append(f"  {mark('weights')} [{TEXT}]Split weights[/]  {choice}")
             if r.weights is not None:
                 for g in sorted(r.devices):
                     w = r.weights.get(g, 1)
                     bar = f"[{r.color}]{'▮' * w}{'·' * (9 - w)}[/]"
                     tip = f"  [{MUTE}](+/- to adjust)[/]" if cur == f"w:{g}" else ""
-                    out.append(f"  {mark(f'w:{g}')}   [{MUTE}]GPU {g}[/]  {bar} [{MUTE}]weight {w} → {self.chunk(r, g):.0f} GB[/]{tip}")
+                    out.append(
+                        f"  {mark(f'w:{g}')}   [{MUTE}]GPU {g}[/]  {bar} [{MUTE}]weight {w} → {self.chunk(r, g):.0f} GB[/]{tip}"
+                    )
         if not r.required:
-            tip = f"  [{MUTE}](frees its VRAM; re-add it from the overview)[/]" if cur == "remove" else ""
+            tip = (
+                f"  [{MUTE}](frees its VRAM; re-add it from the overview)[/]"
+                if cur == "remove"
+                else ""
+            )
             out.append(f"  {mark('remove')} [{LOVE}]Remove this model[/]{tip}")
         return out
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -760,7 +760,7 @@ Only relevant when running the HTTP server.
 | `LILBEE_SERVER_PORT` | random | Port (overridden by `--port`) |
 | `LILBEE_CORS_ORIGINS` | *(none)* | Comma-separated list of extra allowed CORS origins, e.g. `https://my-app.com`. Additive; the default regex below still applies |
 | `LILBEE_CORS_ORIGIN_REGEX` | *(see usage)* | Regex for allowed origins. Default matches `app://obsidian.md`, `capacitor://localhost`, and any `http(s)://localhost`, `127.0.0.1`, or `[::1]` with any port. Set to `^$` to opt out and rely solely on `LILBEE_CORS_ORIGINS` |
-| `LILBEE_ALLOW_HTTP_PLACEMENT` | `false` | Allow `PUT`/`DELETE /api/placement` to apply or clear GPU placement over HTTP. Off by default because applying placement rebuilds the shared fleet, which is unsafe across concurrent clients. Turn it on only for a single-client or owned deployment (the Obsidian plugin's managed server, or a personally-owned pod where you run `lilbee serve` yourself) |
+| `LILBEE_ALLOW_HTTP_PLACEMENT` | `false` | Allow `PUT`/`DELETE /api/placement` to apply or clear GPU placement over HTTP. Off by default because applying placement restarts the fleet's moved roles, which is unsafe across concurrent clients. Turn it on only for a single-client or owned deployment (the Obsidian plugin's managed server, or a personally-owned pod where you run `lilbee serve` yourself) |
 
 ### Wiki tuning (experimental)
 

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -126,10 +126,10 @@ def set_placement(spec: PlacementSpec | None) -> PlacementView:
     The live fleet applies the change surgically (``reload_placement`` restarts
     only the roles whose placement moved), so an untouched role's loaded model
     stays resident; with no services built there is nothing running and the next
-    use plans fresh. The planner's device probe is deliberately NOT cleared on
-    the live path: plans are always diffed and charged against the same
-    clean-box probe (see the bb-a8f invariant in planning), and re-probing under
-    a loaded fleet would poison the chat context sizing.
+    use plans fresh. On the live path the planner re-plans against its clean-box
+    plan snapshot (see ``planning.capture_plan_probe``): probing under a loaded
+    fleet would report our own residency as unavailable and poison the chat
+    context sizing, while charging stays against total capacity (bb-a8f).
     """
     resolved = resolve_placement_plan(spec)
     if spec is None:

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 
-from lilbee.app.services import reset_services
+from lilbee.app.services import peek_services
 from lilbee.core import settings
 from lilbee.core.config import cfg
 from lilbee.providers.fleet.placement_spec import PlacementSpec
@@ -120,9 +120,16 @@ def placement_refused_message() -> str:
 
 
 def set_placement(spec: PlacementSpec | None) -> PlacementView:
-    """Validate, persist to config.toml, reset the fleet, and return the new view.
+    """Validate, persist to config.toml, apply to the live fleet, and return the new view.
 
     Raises PlacementError before any write when the spec does not fit the hardware.
+    The live fleet applies the change surgically (``reload_placement`` restarts
+    only the roles whose placement moved), so an untouched role's loaded model
+    stays resident; with no services built there is nothing running and the next
+    use plans fresh. The planner's device probe is deliberately NOT cleared on
+    the live path: plans are always diffed and charged against the same
+    clean-box probe (see the bb-a8f invariant in planning), and re-probing under
+    a loaded fleet would poison the chat context sizing.
     """
     resolved = resolve_placement_plan(spec)
     if spec is None:
@@ -132,6 +139,9 @@ def set_placement(spec: PlacementSpec | None) -> PlacementView:
         spec_json = spec.to_json()
         settings.update_values(cfg.data_root, {_PLACEMENT_KEY: spec_json})
         cfg.placement = spec_json
-    reset_services()
-    clear_read_device_cache()  # the reconfigure changes free VRAM; don't serve a stale probe
+    services = peek_services()
+    if services is None:
+        clear_read_device_cache()  # nothing running; let the next boot probe fresh
+    else:
+        services.provider.reload_placement(wait=True)
     return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -173,7 +173,7 @@ def _self_check_server(
         model=str(model_path),
         token_cap=ctx if is_embed else None,
     )
-    swap = SwapManager(work_dir)
+    swap = SwapManager(work_dir, role.value)
     try:
         swap.start([launch])
     except BaseException:

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -433,7 +433,7 @@ class Config(BaseSettings):
     placement: str | None = ConfigField(default=None, writable=True, public=False)
 
     # Allow PUT/DELETE /api/placement to apply or clear placement over HTTP.
-    # Off by default because applying placement rebuilds the shared fleet, which
+    # Off by default because applying placement restarts the shared fleet's moved roles, which
     # is unsafe across concurrent HTTP clients. Turn it on (LILBEE_ALLOW_HTTP_PLACEMENT=1)
     # only for a single-client / owned deployment: the plugin's managed local
     # server, or a personally-owned pod where one operator runs `lilbee serve`.

--- a/src/lilbee/mcp_server.py
+++ b/src/lilbee/mcp_server.py
@@ -1164,8 +1164,8 @@ def set_placement_tool(spec: dict[str, Any]) -> dict[str, Any]:
     """Set and apply a manual multi-GPU placement spec (persists to config)."""
     from lilbee.providers.fleet.placement_spec import PlacementSpec
 
-    # set_placement rebuilds the shared fleet: gate it on the shared HTTP
-    # transport exactly like the REST PUT/DELETE placement routes.
+    # set_placement restarts the shared fleet's moved roles: gate it on the
+    # shared HTTP transport exactly like the REST PUT/DELETE placement routes.
     if _transport.http_mounted and not cfg.allow_http_placement:
         return _error(placement_refused_message())
     # Always build a spec (even {}) so an empty/invalid one is rejected, not cleared.

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -436,6 +436,16 @@ class LLMProvider(Protocol):
         """
         return
 
+    def reload_placement(self, *, wait: bool = False) -> None:
+        """Re-plan GPU placement with current cfg, restarting only moved roles.
+
+        Default no-op for providers without GPU-placed servers. The fleet diffs
+        the fresh plan against the running fleet and respawns only the roles
+        whose placement changed, so an untouched role's loaded model stays
+        resident. ``wait=True`` blocks until the restarted proxies are healthy.
+        """
+        return
+
     def role_ready(self, role: WorkerRole) -> bool:
         """Whether *role* has a healthy server now, without starting one.
 

--- a/src/lilbee/providers/engine_params.py
+++ b/src/lilbee/providers/engine_params.py
@@ -120,13 +120,18 @@ def chat_ctx_ceiling(meta: dict[str, str] | None, model_path: Path) -> int:
     return training_ctx
 
 
-def resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
+def resolve_chat_ctx(
+    model_path: Path, meta: dict[str, str] | None, *, available_bytes: int | None = None
+) -> int:
     """Pick a single-GPU n_ctx aiming for ``cfg.chat_n_ctx_target``, clamped to model + host.
 
     When ``cfg.num_ctx_max`` is ``None`` the model's training_ctx is the only
     ceiling, so a long-context model can grow past the target if the host has
     the RAM to back it. A multi-GPU tensor-split chat is sized separately by the
     fleet against its per-device headroom (see :func:`lilbee.providers.fleet.ctx.fit_split_ctx`).
+    ``available_bytes`` overrides the live memory read: the fleet planner passes
+    its clean-box snapshot so a reload sizes ctx like the boot did, not against
+    VRAM its own loaded fleet is holding.
     """
     training_ctx = train_ctx_from_meta(meta, fallback=DEFAULT_NUM_CTX, model_path=model_path)
     ceiling = cfg.num_ctx_max if cfg.num_ctx_max is not None else training_ctx
@@ -134,9 +139,11 @@ def resolve_chat_ctx(model_path: Path, meta: dict[str, str] | None) -> int:
     try:
         model_bytes = model_path.stat().st_size
         kv_per_tok = kv_bytes_per_token(meta, _kv_elem_bytes_for_cfg())
+        if available_bytes is None:
+            available_bytes = get_available_memory(cfg.gpu_memory_fraction)
         return compute_dynamic_ctx(
             model_bytes=model_bytes,
-            available_bytes=get_available_memory(cfg.gpu_memory_fraction),
+            available_bytes=available_bytes,
             training_ctx=training_ctx,
             kv_bytes_per_tok=kv_per_tok,
             ceiling=ceiling,

--- a/src/lilbee/providers/fleet/adapters.py
+++ b/src/lilbee/providers/fleet/adapters.py
@@ -164,6 +164,7 @@ def build_server_argv(
     cache_type: str | None = None,
     batch_size: int | None = None,
     threads: int | None = None,
+    no_mmap: bool = False,
 ) -> list[str]:
     """Assemble the llama-server command line for one instance, minus ``--port``.
 
@@ -197,5 +198,7 @@ def build_server_argv(
     if len(devices) > 1:
         ratio = tensor_split or tuple(1 for _ in devices)
         argv += ["--tensor-split", ",".join(str(r) for r in ratio)]
+    if no_mmap:
+        argv += ["--no-mmap"]
     argv += list(spec.extra_args)
     return argv

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -26,7 +26,7 @@ _SEARCH_ROLES = tuple(role for role, info in ROLE_REGISTRY.items() if info.poole
 # fits its own headroom, and each card is charged its own entry, not the sum.
 PeakEstimator = Callable[[WorkerRole, tuple[int, ...]], tuple[int, ...]]
 
-# (per-device tensor-split ratio, chosen cards' live free VRAM bytes) -> the per-slot
+# (per-device tensor-split ratio, chosen cards' snapshot free-VRAM bytes) -> the per-slot
 # context the launch would serve on that chat shard. Lets the planner widen a chat
 # split onto idle cards when a tighter shard would starve KV below the target.
 SplitCtxFitter = Callable[[tuple[int, ...], Sequence[int]], int]
@@ -91,7 +91,8 @@ def plan_placement(
 
     A chat split widens past the fewest fitting cards when ``chat_ctx_fit`` shows a
     tighter shard would starve its served context below ``chat_ctx_target``; the
-    fitter is sized against ``free_headroom`` (live free VRAM per device index). See
+    fitter is sized against ``free_headroom`` (the plan snapshot's free VRAM per
+    device index; see ``planning.capture_plan_probe``). See
     docs/architecture.md (Placement). Other splits keep the fewest-cards behavior.
 
     No GPU devices is the CPU/unified-memory case (a GPU-less host, or an Apple

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -94,6 +94,17 @@ _LLM_RERANK_VRAM_FRACTION = 0.5
 _SYSTEM_MEMORY_FLOOR_CAP_BYTES = 4 * 1024**3
 _SYSTEM_MEMORY_FLOOR_DIVISOR = 4
 
+# The chat server loads its weights into a malloc'd host copy (--no-mmap) when
+# they fit in at most this fraction of total system RAM: a buffered sequential
+# read beats mmap's page-fault-driven upload measured on a hot cache (#474:
+# 33s vs 43s for a 112GB model on 3 GPUs), but the copy is unevictable, so a
+# host where the weights crowd RAM keeps mmap. Keyed on TOTAL memory (stable),
+# not free (fluctuates), so replans do not flap the launch argv and force
+# needless chat restarts. Replicated roles keep mmap regardless: their
+# replicas share one set of page-cache pages, and per-replica host copies
+# would multiply RAM use for no load-time win.
+_NO_MMAP_MAX_RAM_FRACTION = 0.5
+
 # llama.cpp split-GGUF shard naming ("%s-%05d-of-%05d.gguf"); the cold-load
 # timeout must scale with the SUM of the shards, not the first file alone.
 _SPLIT_GGUF_NAME = re.compile(r"^(?P<prefix>.+)-(?P<index>\d{5})-of-(?P<total>\d{5})\.gguf$")
@@ -716,6 +727,7 @@ def _launch_for(
         cache_type=_cache_type_flag() if is_chat else None,
         batch_size=_pooled_batch_size(plan.role, rerank_mode, ctx),
         threads=(os.cpu_count() or _DEFAULT_THREADS) if is_vision else None,
+        no_mmap=is_chat and _chat_no_mmap(weights_bytes),
     )
     return InstanceLaunch(
         role=plan.role,
@@ -802,6 +814,15 @@ _read_device_cache = _ReadDeviceCache(_DEVICE_PROBE_TTL_S)
 def clear_read_device_cache() -> None:
     """Drop the read-path device probe cache (e.g. after the fleet is reconfigured)."""
     _read_device_cache.clear()
+
+
+def _chat_no_mmap(weights_bytes: int) -> bool:
+    """Whether the chat server should malloc its weights instead of mmapping them.
+
+    See ``_NO_MMAP_MAX_RAM_FRACTION`` for the tradeoff and why the gate reads
+    total (not free) system memory.
+    """
+    return weights_bytes <= model_cache.total_system_memory() * _NO_MMAP_MAX_RAM_FRACTION
 
 
 def _unified_memory_budget(devices: list[FleetDevice]) -> int | None:

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -239,9 +239,7 @@ def _slot_budget(vram_fraction: float, unified_budget: int | None) -> int:
     """Memory budget for slot sizing: *vram_fraction* of usable VRAM, capped by
     ``unified_budget`` (free system RAM) when there is no discrete GPU so the count
     steps down to fit free memory instead of overcommitting."""
-    from lilbee.core.config import cfg
-
-    budget = int(model_cache.get_available_memory(cfg.gpu_memory_fraction) * vram_fraction)
+    budget = int(_plan_available_memory() * vram_fraction)
     if unified_budget is not None:
         budget = min(budget, unified_budget)
     return budget
@@ -300,7 +298,7 @@ def _role_ctx(role: WorkerRole, model_path: Path, meta: dict[str, str] | None) -
         return resolve_vision_ctx(model_path)
     if cfg.num_ctx is not None:
         return cfg.num_ctx
-    return resolve_chat_ctx(model_path, meta)
+    return resolve_chat_ctx(model_path, meta, available_bytes=_plan_available_memory())
 
 
 def _rerank_mode_for(meta: dict[str, str] | None) -> RerankMode:
@@ -784,8 +782,8 @@ class _ReadDeviceCache:
     Inspecting placement (GET placement/gpus, preview, ``placement show``)
     resolves devices on every call, which spawns a ``llama-server --list-devices``
     subprocess; a brief TTL collapses a burst of reads onto one probe. The launch
-    path is never served from here -- it reaps stale servers first and sizes KV
-    cache against live free VRAM, so it always probes fresh.
+    path is never served from here -- it sizes against the clean-box plan
+    snapshot below (captured after stale-server reaping).
     """
 
     def __init__(self, ttl_s: float) -> None:
@@ -816,6 +814,93 @@ def clear_read_device_cache() -> None:
     _read_device_cache.clear()
 
 
+@dataclass(frozen=True)
+class _PlanProbe:
+    """Clean-box memory snapshot every plan is sized against.
+
+    Captured once, right after stale-server reaping and before the first build,
+    when nothing lilbee owns is loaded. Reloads re-plan against this same
+    snapshot instead of re-probing: a live probe under a loaded fleet reports
+    our own residency as unavailable, which would shrink chat context and slot
+    counts, widen splits, and (on a unified-memory host) evict roles outright.
+    Launches stay a pure function of config + hardware + this snapshot, so the
+    reload diff restarts only real changes. Cleared on full fleet teardown so
+    the next boot probes the clean box afresh.
+    """
+
+    devices: tuple[FleetDevice, ...]
+    available_vram: int
+    free_system: int
+
+
+class _PlanProbeStore:
+    """Holds the captured plan snapshot; a single instance below (no bare global)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._probe: _PlanProbe | None = None
+
+    def set(self, probe: _PlanProbe) -> None:
+        with self._lock:
+            self._probe = probe
+
+    def get(self) -> _PlanProbe | None:
+        with self._lock:
+            return self._probe
+
+    def clear(self) -> None:
+        with self._lock:
+            self._probe = None
+
+
+_plan_probe_store = _PlanProbeStore()
+
+
+def capture_plan_probe() -> None:
+    """Snapshot devices and memory for planning; call only on a clean box."""
+    from lilbee.core.config import cfg
+    from lilbee.providers.fleet.cuda_runtime import apply_cuda_runtime_env
+    from lilbee.providers.fleet.gpu_env import apply_fleet_gpu_env
+
+    apply_fleet_gpu_env()
+    binary = resolve_llama_server()
+    apply_cuda_runtime_env()
+    _plan_probe_store.set(
+        _PlanProbe(
+            devices=tuple(resolve_devices(binary)),
+            available_vram=int(model_cache.get_available_memory(cfg.gpu_memory_fraction)),
+            free_system=model_cache.free_system_memory(),
+        )
+    )
+
+
+def clear_plan_probe() -> None:
+    """Drop the plan snapshot (full fleet teardown); the next build re-captures."""
+    _plan_probe_store.clear()
+
+
+def _plan_devices(binary: Path) -> list[FleetDevice]:
+    """Devices the plan paths size against: the snapshot, else a live probe."""
+    probe = _plan_probe_store.get()
+    return list(probe.devices) if probe is not None else resolve_devices(binary)
+
+
+def _plan_available_memory() -> int:
+    """Usable VRAM for ctx/slot sizing: the snapshot, else the live read."""
+    from lilbee.core.config import cfg
+
+    probe = _plan_probe_store.get()
+    if probe is not None:
+        return probe.available_vram
+    return int(model_cache.get_available_memory(cfg.gpu_memory_fraction))
+
+
+def _plan_free_system_memory() -> int:
+    """Free system RAM for the unified-memory budget: the snapshot, else live."""
+    probe = _plan_probe_store.get()
+    return probe.free_system if probe is not None else model_cache.free_system_memory()
+
+
 def _chat_no_mmap(weights_bytes: int) -> bool:
     """Whether the chat server should malloc its weights instead of mmapping them.
 
@@ -835,7 +920,7 @@ def _unified_memory_budget(devices: list[FleetDevice]) -> int | None:
         _SYSTEM_MEMORY_FLOOR_CAP_BYTES,
         model_cache.total_system_memory() // _SYSTEM_MEMORY_FLOOR_DIVISOR,
     )
-    return max(0, model_cache.free_system_memory() - floor)
+    return max(0, _plan_free_system_memory() - floor)
 
 
 def _resolve_placement(
@@ -960,6 +1045,6 @@ def plan_all_launches() -> list[InstanceLaunch]:
     # Put the CUDA-runtime wheels on the process path so the device probe sees the
     # same runtime the servers will, before resolve_devices enumerates GPUs.
     apply_cuda_runtime_env()
-    devices = resolve_devices(binary)
+    devices = _plan_devices(binary)
     by_index = {d.index: d for d in devices}
     return plan_launches(None, binary, by_index, devices)

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -946,7 +946,7 @@ def _resolve_placement(
             capacity,
             estimate_peak=estimate_peak,
         )
-    # The chat split's card count is decided against live free VRAM (what the launch
+    # The chat split's card count is decided against the snapshot's free VRAM (what the launch
     # sizes its context against) so placement and launch agree; charging still uses
     # total capacity above, preserving the bb-a8f no-double-count invariant. A split
     # needs >=2 GPUs, so skip the chat model's gguf read entirely below that.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -68,6 +68,10 @@ _WARM_MAX_TOKENS = 1
 # Read size for paging chat shards into the page cache during warm; large enough
 # to keep sequential reads efficient without holding much resident at once.
 _PREWARM_CHUNK_BYTES = 8 * 1024 * 1024
+# Shards fully paged in this boot, keyed on (path, size, mtime_ns); a fleet
+# rebuild (e.g. a placement change) skips re-reading a hot cache. Module-level so
+# it survives reset_services() replacing the provider instance.
+_PREWARMED_SHARDS: set[tuple[str, int, int]] = set()
 # Per-role client request budget: the first request covers the lazy cold load plus
 # generation, so the weights-scaled cold-load budget plus the margin raises this floor.
 _REQUEST_TIMEOUT_FLOOR_S = 900.0
@@ -78,6 +82,12 @@ _REQUEST_TIMEOUT_GENERATION_MARGIN_S = 120.0
 # whether to offer tools to a given model at all.
 _TOOL_TEMPLATE_PATTERN = re.compile(r"\{[%{][^}]*\b(?:tools|tool_calls|functions|function_calls)\b")
 _T = TypeVar("_T")
+
+
+def _prewarm_key(shard: Path) -> tuple[str, int, int]:
+    """The prewarm identity of *shard*: same path, size, and mtime -> same pages."""
+    stat = shard.stat()
+    return (str(shard), stat.st_size, stat.st_mtime_ns)
 
 
 def _request_timeout_s(weights_bytes: int) -> float:
@@ -964,11 +974,15 @@ class FleetProvider:
         around each role). A per-replica failure is logged and skipped; that replica
         still loads on its first real use. The chat role routes through
         :meth:`_warm_chat_role` so a launcher gets granular progress.
+
+        Roles warm concurrently: chat is the long pole (a large model's load
+        dominates), so the light roles load alongside it instead of before it.
         """
         with self._lock:
             pools = {role: list(clients) for role, clients in self._clients.items()}
             on_spawning, on_spawned = self._on_spawning, self._on_spawned
-        for role, clients in pools.items():
+
+        def _warm_one(role: WorkerRole, clients: list[LlamaServerClient]) -> None:
             if on_spawning is not None:
                 on_spawning(role)
             if role is WorkerRole.CHAT:
@@ -977,6 +991,13 @@ class FleetProvider:
                 self._warm_role_clients(role, clients)
             if on_spawned is not None:
                 on_spawned(role)
+
+        if not pools:
+            return
+        with ThreadPoolExecutor(max_workers=len(pools), thread_name_prefix="fleet-preload") as pool:
+            futures = [pool.submit(_warm_one, role, clients) for role, clients in pools.items()]
+            for future in futures:
+                future.result()
 
     def _warm_role_clients(self, role: WorkerRole, clients: list[LlamaServerClient]) -> bool:
         """Warm every replica of *role*; return whether at least one loaded."""
@@ -1027,10 +1048,15 @@ class FleetProvider:
             return
         if total <= 0:
             return
+        keys = [_prewarm_key(shard) for shard in shards]
+        if all(key in _PREWARMED_SHARDS for key in keys):
+            # Already paged in this boot (e.g. a placement rebuild); the cache is hot.
+            self._warm_tracker.reading(total, total)
+            return
         done = 0
         self._warm_tracker.reading(0, total)
         chunk = bytearray(_PREWARM_CHUNK_BYTES)
-        for index, shard in enumerate(shards):
+        for index, (shard, key) in enumerate(zip(shards, keys, strict=True)):
             detail = f"shard {index + 1}/{len(shards)}" if len(shards) > 1 else None
             try:
                 with shard.open("rb", buffering=0) as handle:
@@ -1040,6 +1066,7 @@ class FleetProvider:
                             break
                         done += read
                         self._warm_tracker.reading(done, total, detail=detail)
+                _PREWARMED_SHARDS.add(key)
             except OSError:
                 # A partial/locked shard just shortens the read bar; the engine load
                 # surfaces any real fault as a user-facing error on the warm request.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -452,11 +452,13 @@ class FleetProvider:
             # snapshot so the cards are actually free for this fleet (and the
             # context sizer reads true clean-box memory).
             reap_stale(cfg.data_dir)
-            # Snapshot the clean box; this plan and every later reload size ctx,
-            # slots, and budgets against it (a live probe under a loaded fleet
-            # would report our own residency as unavailable).
-            planning.capture_plan_probe()
             try:
+                # Snapshot the clean box; this plan and every later reload size
+                # ctx, slots, and budgets against it (a live probe under a loaded
+                # fleet would report our own residency as unavailable). Inside the
+                # try: capturing resolves the engine binary, and a binary-less
+                # host must serve nothing, not raise.
+                planning.capture_plan_probe()
                 launches = planning.plan_all_launches()
             except ProviderError:
                 log.debug("Engine binary unavailable; no swap started")

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -34,7 +34,7 @@ from lilbee.providers.fleet.replicas import (
     resolve_replica_count,
 )
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
-from lilbee.providers.fleet.swap_manager import SwapManager
+from lilbee.providers.fleet.swap_manager import SwapManager, reap_stale, sweep_owned
 from lilbee.providers.fleet.windowing import window_messages
 from lilbee.providers.roles import WorkerRole, configured_model_message
 from lilbee.providers.warm_progress import WarmProgress, WarmProgressTracker
@@ -86,6 +86,16 @@ def _request_timeout_s(weights_bytes: int) -> float:
         _REQUEST_TIMEOUT_FLOOR_S,
         cold_load_timeout_s(weights_bytes) + _REQUEST_TIMEOUT_GENERATION_MARGIN_S,
     )
+
+
+def _launches_by_role(
+    launches: list[InstanceLaunch],
+) -> dict[WorkerRole, tuple[InstanceLaunch, ...]]:
+    """Group a plan's launches by role, replica order preserved within each role."""
+    grouped: dict[WorkerRole, list[InstanceLaunch]] = {}
+    for launch in launches:
+        grouped.setdefault(launch.role, []).append(launch)
+    return {role: tuple(role_launches) for role, role_launches in grouped.items()}
 
 
 def _least_in_flight(clients: list[LlamaServerClient]) -> LlamaServerClient:
@@ -341,12 +351,19 @@ class FleetProvider:
     """Routes every role to the managed llama-server fleet (a fleet-of-one on one box)."""
 
     def __init__(self) -> None:
-        self._swap: SwapManager | None = None
+        # One llama-swap per placed role, so restarting one role's servers (a
+        # placement or per-role model change) never unloads another role's.
+        self._swaps: dict[WorkerRole, SwapManager] = {}
+        # The launches each running group was started with, kept so a reload can
+        # diff the fresh plan against what is running and restart only the roles
+        # whose launches actually changed. Launch argv is port-free (ports are
+        # injected at config render), so the comparison is stable across starts.
+        self._launches: dict[WorkerRole, tuple[InstanceLaunch, ...]] = {}
         # Latched once shutdown runs. A discarded provider (reset_services swaps
         # in a new one) can still have an in-flight warm-up or reload daemon
         # thread; without this latch that thread could start a llama-swap after
         # shutdown already ran, leaving a process no live provider owns.
-        # _ensure_swap checks it under the build lock so a post-shutdown build is
+        # _ensure_fleet checks it under the build lock so a post-shutdown build is
         # refused (the swap_manager reaper is the backstop if one slips through).
         self._shut_down = False
         # A pool of OpenAI clients per placed role (one per data-parallel replica),
@@ -393,77 +410,108 @@ class FleetProvider:
         # run its pending pass) has finished.
         self._reload_done = threading.Condition(self._lock)
 
-    def _ensure_swap(self) -> SwapManager | None:
-        """Start the llama-swap process exactly once across concurrent callers.
+    def _ensure_fleet(self) -> bool:
+        """Start one llama-swap per placed role exactly once across concurrent callers.
 
-        Returns ``None`` when no role is configured and installed (nothing to
-        serve), leaving no process spawned. The startup runs under ``_build_lock``
-        (not the routing lock), so the off-thread warm-up and an on-demand call
-        can't start two swaps -- which would double-allocate GPU and parse the same
-        GGUF twice. A second caller blocks on the build lock and reuses the swap the
-        first one started.
+        Returns whether any role group is running afterwards; ``False`` when no
+        role is configured and installed (nothing to serve), leaving no process
+        spawned. The startup runs under ``_build_lock`` (not the routing lock),
+        so the off-thread warm-up and an on-demand call can't start two fleets --
+        which would double-allocate GPU and parse the same GGUF twice. A second
+        caller blocks on the build lock and reuses the groups the first one
+        started. A group failing to start tears down the groups already started
+        in this build, so a partial fleet never leaks past the failure.
         """
         with self._lock:
-            if self._swap is not None:
-                return self._swap
+            if self._swaps:
+                return True
         with self._build_lock:
             with self._lock:
-                if self._swap is not None:
-                    return self._swap
+                if self._swaps:
+                    return True
                 if self._shut_down:
                     # Provider was shut down (and likely discarded by reset_services)
                     # while this warm-up/reload thread was in flight; do not spawn a
                     # llama-swap no live provider would ever reap.
-                    return None
+                    return False
             from lilbee.core.config import cfg
 
-            swap = SwapManager(cfg.data_dir)
             # A dead owner's surviving llama-swap holds VRAM; reap it before launching
             # so the cards are actually free for this fleet (and the context sizer
             # reads true free VRAM).
-            swap.reap_stale()
+            reap_stale(cfg.data_dir)
             try:
                 launches = planning.plan_all_launches()
             except ProviderError:
                 log.debug("Engine binary unavailable; no swap started")
-                return None
+                return False
             if not launches:
-                return None  # no installed/configured model -> serve nothing, spawn nothing
-            swap.start(launches)
+                return False  # no installed/configured model -> serve nothing, spawn nothing
+            by_role = _launches_by_role(launches)
+            started: dict[WorkerRole, SwapManager] = {}
+            try:
+                for role, role_launches in by_role.items():
+                    swap = SwapManager(cfg.data_dir, role.value)
+                    swap.start(list(role_launches))
+                    started[role] = swap
+            except BaseException:
+                for swap in started.values():
+                    swap.shutdown()
+                raise
             with self._lock:
-                self._adopt_swap(swap, launches)
-            return swap
+                for role, swap in started.items():
+                    self._adopt_role(role, swap, list(by_role[role]))
+            return True
 
-    def _adopt_swap(self, swap: SwapManager, launches: list[InstanceLaunch]) -> None:
-        """Record a freshly started swap and build a client pool per placed role.
+    def _adopt_role(
+        self, role: WorkerRole, swap: SwapManager, launches: list[InstanceLaunch]
+    ) -> None:
+        """Record *role*'s freshly started swap and build its client pool.
 
         Caller holds ``self._lock``. Each launch (one per replica) becomes a client
-        keyed by its replica model id; launches carry the chat slots/ctx so the
-        capacity and served context come from the launch, not a probe.
+        keyed by its replica model id against this group's own proxy endpoint;
+        the chat launch carries the slots/ctx so the capacity and served context
+        come from the launch, not a probe.
         """
-        # Retire the previous clients (a reload re-adopts over an existing pool):
-        # closing them now would error a reader still mid-call on an old client
-        # snapshot, and never closing leaks an httpx pool per replica per role.
-        old_clients = [client for pool in self._clients.values() for client in pool]
-        self._swap = swap
+        # Retire the role's previous clients (a reload re-adopts over an existing
+        # pool): closing them now would error a reader still mid-call on an old
+        # client snapshot, and never closing leaks an httpx pool per replica.
+        old_clients = list(self._clients.get(role, []))
+        self._swaps[role] = swap
+        self._launches[role] = tuple(launches)
         endpoint = swap.endpoint()
         # token_cap truncates oversize embed/rerank inputs to the per-slot context
         # (the in-process backstop); the longer timeout covers a cold upstream load.
-        clients: dict[WorkerRole, list[LlamaServerClient]] = {}
-        for launch in launches:
-            client = LlamaServerClient(
+        self._clients[role] = [
+            LlamaServerClient(
                 endpoint,
                 launch.model_id,
                 token_cap=launch.token_cap,
                 timeout=_request_timeout_s(launch.weights_bytes),
                 rerank_mode=launch.rerank_mode,
             )
-            clients.setdefault(launch.role, []).append(client)
-        self._clients = clients
-        chat = next((launch for launch in launches if launch.role is WorkerRole.CHAT), None)
-        self._chat_slots = chat.slots if chat is not None else 1
-        self._chat_ctx = chat.ctx if chat is not None else None
+            for launch in launches
+        ]
+        if role is WorkerRole.CHAT:
+            chat = launches[0]
+            self._chat_slots = chat.slots
+            self._chat_ctx = chat.ctx
         self._retire_clients(old_clients)
+
+    def _drop_role(self, role: WorkerRole) -> SwapManager | None:
+        """Forget *role*'s swap/launches/clients; return the swap for teardown.
+
+        Caller holds ``self._lock``. The role's clients are retired (closed at a
+        later reload or shutdown, never while a reader could still hold one) and
+        the chat capacity falls back to its defaults when chat itself is dropped.
+        """
+        swap = self._swaps.pop(role, None)
+        self._launches.pop(role, None)
+        self._retire_clients(self._clients.pop(role, []))
+        if role is WorkerRole.CHAT:
+            self._chat_slots = 1
+            self._chat_ctx = None
+        return swap
 
     def _retire_clients(self, old_clients: list[LlamaServerClient]) -> None:
         """Close the previously-retired clients, then retire *old_clients*.
@@ -495,12 +543,12 @@ class FleetProvider:
         since exited (detected via ``is_live()``), a one-shot rebuild is attempted
         before raising so a transient llama-swap restart recovers transparently.
         """
-        self._ensure_swap()
+        self._ensure_fleet()
         with self._lock:
             clients = self._clients.get(role)
-            swap = self._swap
+            swap = self._swaps.get(role)
         if not clients and swap is not None and not swap.is_live():
-            self._rebuild_swap()
+            self._rebuild_role(role)
             with self._lock:
                 clients = self._clients.get(role)
         if not clients:
@@ -511,10 +559,14 @@ class FleetProvider:
             )
         return list(clients)
 
-    def _rebuild_swap(self) -> None:
-        """Drop a dead swap and build a fresh one (new port); ``_ensure_swap`` adopts clients."""
-        self._drop_swap_refs()
-        self._ensure_swap()
+    def _rebuild_role(self, role: WorkerRole) -> None:
+        """Restart just *role*'s dead group (new port) from a fresh plan.
+
+        Other roles' groups keep serving; only the dead group is torn down and
+        respawned. Runs the same diff-driven pass as a reload, forcing *role*
+        into the restart set so an unchanged plan still replaces its dead swap.
+        """
+        self._reload_pass(force=frozenset((role,)))
 
     def role_ready(self, role: WorkerRole) -> bool:
         """Whether *role*'s upstream is loaded and ready, without starting the swap.
@@ -524,25 +576,25 @@ class FleetProvider:
         is up or while the role's upstream is still loading.
         """
         with self._lock:
-            swap = self._swap
+            swap = self._swaps.get(role)
         return swap is not None and swap.role_ready(role)
 
     def max_concurrent_chats(self) -> int:
         """The chat server's batching-slot capacity, so the gate admits that many.
 
-        Falls back to ``1`` before the swap is up, so chat is serialized until the
-        slot count is known (the launcher warms the engine before a client
-        connects, so the real capacity is in effect by the first chat).
+        Falls back to ``1`` before the chat group is up, so chat is serialized
+        until the slot count is known (the launcher warms the engine before a
+        client connects, so the real capacity is in effect by the first chat).
         """
         with self._lock:
-            if self._swap is None:
+            if WorkerRole.CHAT not in self._swaps:
                 return 1
             return self._chat_slots
 
     def served_chat_ctx(self) -> int | None:
         """Per-slot context the chat server runs with, or None if not up."""
         with self._lock:
-            return self._chat_ctx if self._swap is not None else None
+            return self._chat_ctx if WorkerRole.CHAT in self._swaps else None
 
     def warm_progress(self) -> WarmProgress | None:
         """Live cold-load progress for the chat role, or None before warm begins."""
@@ -558,31 +610,33 @@ class FleetProvider:
         with the current cfg.
         """
         # The build lock serializes shutdown against a concurrent reload/build:
-        # both mutate self._swap and the llama-swap process, so an unserialized
+        # both mutate self._swaps and the llama-swap processes, so an unserialized
         # loser would overwrite the winner's state and leak a live llama-swap.
         with self._build_lock:
             with self._lock:
-                swap = self._swap
+                swaps = dict(self._swaps)
                 if latch:
                     self._shut_down = True
             self._drop_swap_refs()
-            # Always tear down via the swap manager, even when this provider holds
-            # no tracked swap: an in-flight build may have started one this thread
-            # never adopted, and SwapManager.shutdown reaps every llama-swap this
-            # process spawned (keyed on our own children), not just a tracked handle.
-            if swap is None:
+            for swap in swaps.values():
+                swap.shutdown()
+            # Always sweep even when this provider holds no tracked swaps: an
+            # in-flight build may have started groups this thread never adopted,
+            # and the sweep stops every llama-swap this process spawned (keyed
+            # on the per-group config paths), not just tracked handles.
+            if not swaps:
                 from lilbee.core.config import cfg
 
-                swap = SwapManager(cfg.data_dir)
-            swap.shutdown()
+                sweep_owned(cfg.data_dir)
 
     def _drop_swap_refs(self) -> None:
-        """Clear the swap, its clients, and the chat capacity so the next call rebuilds."""
+        """Clear every group's swap/clients and the chat capacity so the next call rebuilds."""
         with self._lock:
-            # Close the live pool and any clients still awaiting retirement.
+            # Close the live pools and any clients still awaiting retirement.
             clients = [client for pool in self._clients.values() for client in pool]
             clients.extend(self._retiring_clients)
-            self._swap = None
+            self._swaps = {}
+            self._launches = {}
             self._clients = {}
             self._retiring_clients = []
             self._chat_slots = 1
@@ -590,17 +644,16 @@ class FleetProvider:
         for client in clients:
             client.close()
 
-    def _drop_dead_swap(self) -> None:
-        """Drop the refs to a swap whose process is gone so ``_ensure_swap`` rebuilds.
+    def _drop_dead_swaps(self) -> None:
+        """Drop the refs of groups whose process is gone so the next call rebuilds them.
 
-        A no-op while the swap process is still running (e.g. the failure was in
-        planning), so a live engine is never abandoned unstopped.
+        A no-op for groups still running (e.g. the failure was in planning), so
+        a live engine is never abandoned unstopped.
         """
         with self._build_lock:
             with self._lock:
-                swap = self._swap
-            if swap is not None and not swap.running:
-                self._drop_swap_refs()
+                for role in [r for r, swap in self._swaps.items() if not swap.running]:
+                    self._drop_role(role)
 
     def _require_configured_model(
         self, model: str | None, configured: str, role: WorkerRole
@@ -931,7 +984,7 @@ class FleetProvider:
         (or once the swap is up) is a no-op.
         """
         with self._lock:
-            if self._swap is not None or self._warming:
+            if self._swaps or self._warming:
                 return
             self._warming = True
         threading.Thread(
@@ -948,7 +1001,7 @@ class FleetProvider:
         user-facing ProviderError on the next call, not a thread traceback.
         """
         try:
-            self._ensure_swap()
+            self._ensure_fleet()
             self._preload_roles()
         except Exception:
             log.warning("Engine warm-up failed; roles will load on first use.", exc_info=True)
@@ -956,17 +1009,22 @@ class FleetProvider:
             with self._lock:
                 self._warming = False
 
-    def _preload_roles(self) -> None:
+    def _preload_roles(self, roles: frozenset[WorkerRole] | None = None) -> None:
         """Issue a cheap request per replica so llama-swap loads each upstream now.
 
         llama-swap starts an upstream on its first request, so warming sends a
         minimal call to every replica of every role (firing the spawn listeners
         around each role). A per-replica failure is logged and skipped; that replica
         still loads on its first real use. The chat role routes through
-        :meth:`_warm_chat_role` so a launcher gets granular progress.
+        :meth:`_warm_chat_role` so a launcher gets granular progress. *roles*
+        narrows the warm to just those roles (a reload warms only what restarted).
         """
         with self._lock:
-            pools = {role: list(clients) for role, clients in self._clients.items()}
+            pools = {
+                role: list(clients)
+                for role, clients in self._clients.items()
+                if roles is None or role in roles
+            }
             on_spawning, on_spawned = self._on_spawning, self._on_spawned
         for role, clients in pools.items():
             if on_spawning is not None:
@@ -1056,22 +1114,42 @@ class FleetProvider:
     def reload_role(self, role: WorkerRole, *, wait: bool = False) -> None:
         """Apply a model/settings change for *role* with current cfg.
 
+        The whole fleet is re-planned, but only the roles whose launches changed
+        restart, so the other roles' loaded models stay resident (*role* names
+        the change for the thread label; the diff decides what restarts).
+        """
+        self._dispatch_reload(f"fleet-reload-{role.value}", wait=wait)
+
+    def reload_placement(self, *, wait: bool = False) -> None:
+        """Apply a placement change with current cfg, restarting only moved roles.
+
+        The fresh plan is diffed per role against the running fleet: a role whose
+        devices (and so its launch argv) did not change keeps serving through the
+        change -- moving the embedder never unloads a 100GB chat model. When no
+        fleet is up, the next use plans fresh, so this returns at once.
+        """
+        self._dispatch_reload("fleet-reload-placement", wait=wait)
+
+    def _dispatch_reload(self, thread_name: str, *, wait: bool) -> None:
+        """Run the diff-driven reload once, off-thread unless *wait*.
+
         Dispatched to a background thread because the slow restart (rewrite config +
         respawn + wait-ready) must not block the settings/model-picker callback.
-        llama-swap reloads the whole proxy, so every role is re-planned. If the swap
-        isn't up yet, the next use starts it with current cfg. Single-flight: a
-        reload while one is in flight sets the pending flag (the in-flight pass may
-        have already snapshotted its plan), and the in-flight thread runs one more
-        pass per pending flag so the change is applied, not dropped.
+        If no group is up yet, the next use starts the fleet with current cfg.
+        Single-flight: a reload while one is in flight sets the pending flag (the
+        in-flight pass may have already snapshotted its plan), and the in-flight
+        thread runs one more pass per pending flag so the change is applied, not
+        dropped.
 
         ``wait=True`` runs the reload in the caller's thread and returns only once
         the restart (and any reload already in flight that will run the pending
-        pass) has finished and the proxy is healthy again, so a caller already off
-        the event loop gets a real completion signal. The role's model still loads
-        lazily on its next request. It propagates a reload failure as an exception.
+        pass) has finished and the proxies are healthy again, so a caller already
+        off the event loop gets a real completion signal. A restarted role's model
+        still loads lazily (the reload kicks an off-thread warm). It propagates a
+        reload failure as an exception.
         """
         with self._lock:
-            if self._swap is None:
+            if not self._swaps:
                 return
             if self._reloading:
                 self._reload_pending = True
@@ -1086,7 +1164,7 @@ class FleetProvider:
             return
         threading.Thread(
             target=self._reload_blocking,
-            name=f"fleet-reload-{role.value}",
+            name=thread_name,
             daemon=True,
         ).start()
 
@@ -1115,7 +1193,7 @@ class FleetProvider:
                         "Engine reload failed; retrying with the pending change.", exc_info=True
                     )
                     continue
-                self._drop_dead_swap()
+                self._drop_dead_swaps()
                 raise
             with self._lock:
                 if not self._reload_pending:
@@ -1124,23 +1202,66 @@ class FleetProvider:
                     return
                 self._reload_pending = False
 
-    def _reload_pass(self) -> None:
-        """One re-plan/restart of llama-swap from current cfg.
+    def _reload_pass(self, force: frozenset[WorkerRole] = frozenset()) -> None:
+        """One re-plan from current cfg, restarting only the roles that changed.
 
-        Runs under the build lock so a racing shutdown/build can't interleave with
-        the restart and leak a live llama-swap holding GPU memory.
+        The fresh plan is diffed per role against the launches each running group
+        was started with; a role restarts only when its launches differ (covers
+        added and removed roles too), so an untouched role's loaded model stays
+        resident through a placement or per-role model change. *force* adds roles
+        to the restart set even when their plan is unchanged (dead-swap recovery).
+        Changed groups stop before the new ones start, so the planned VRAM is
+        actually free when the new servers spawn. Runs under the build lock so a
+        racing shutdown/build can't interleave with the restart and leak a live
+        llama-swap holding GPU memory.
         """
+        from lilbee.core.config import cfg
+
         with self._build_lock:
             with self._lock:
-                swap = self._swap
-            if swap is None:
-                return
+                if self._shut_down:
+                    # Terminal shutdown landed while this reload was queued; a
+                    # rebuild here would spawn a fleet no live provider owns.
+                    return
+                running = set(self._swaps)
+                old = dict(self._launches)
             # Reap dead owners' swaps before re-planning, same as the first build.
-            swap.reap_stale()
-            launches = planning.plan_all_launches()
-            swap.reload(launches)
-            with self._lock:
-                self._adopt_swap(swap, launches)
+            reap_stale(cfg.data_dir)
+            new = _launches_by_role(planning.plan_all_launches())
+            # A role restarts when its launches changed OR its running/planned
+            # presence disagrees (covers a group the new plan drops or adds).
+            changed = {
+                role
+                for role in running | set(new)
+                if (role in running) != (role in new) or old.get(role, ()) != new.get(role, ())
+            }
+            changed |= set(force)
+            # Stop phase: free the changed roles' VRAM before their replacements
+            # (or another role's grown plan) spawn against it.
+            for role in sorted(changed, key=lambda r: r.value):
+                with self._lock:
+                    swap = self._drop_role(role)
+                if swap is not None:
+                    swap.shutdown()
+            # Start phase: spawn the changed roles present in the new plan.
+            restarted: list[WorkerRole] = []
+            for role in sorted(changed & set(new), key=lambda r: r.value):
+                role_launches = list(new[role])
+                swap = SwapManager(cfg.data_dir, role.value)
+                swap.start(role_launches)
+                with self._lock:
+                    self._adopt_role(role, swap, role_launches)
+                restarted.append(role)
+        if restarted:
+            # Load the restarted roles' models off-thread (llama-swap spawns an
+            # upstream on its first request): the reload returns once the proxies
+            # answer, and the UI's spawn listeners track the model loads.
+            threading.Thread(
+                target=self._preload_roles,
+                kwargs={"roles": frozenset(restarted)},
+                name="fleet-reload-warm",
+                daemon=True,
+            ).start()
 
     def add_spawn_listener(
         self,
@@ -1166,7 +1287,7 @@ class FleetProvider:
         than blocking the settings callback. A no-op when no swap is up.
         """
         with self._lock:
-            if self._swap is None:
+            if not self._swaps:
                 return
         threading.Thread(
             target=lambda: self._shutdown_swap(latch=False),

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -448,10 +448,14 @@ class FleetProvider:
                     return False
             from lilbee.core.config import cfg
 
-            # A dead owner's surviving llama-swap holds VRAM; reap it before launching
-            # so the cards are actually free for this fleet (and the context sizer
-            # reads true free VRAM).
+            # A dead owner's surviving llama-swap holds VRAM; reap it before the
+            # snapshot so the cards are actually free for this fleet (and the
+            # context sizer reads true clean-box memory).
             reap_stale(cfg.data_dir)
+            # Snapshot the clean box; this plan and every later reload size ctx,
+            # slots, and budgets against it (a live probe under a loaded fleet
+            # would report our own residency as unavailable).
+            planning.capture_plan_probe()
             try:
                 launches = planning.plan_all_launches()
             except ProviderError:
@@ -653,6 +657,9 @@ class FleetProvider:
             self._retiring_clients = []
             self._chat_slots = 1
             self._chat_ctx = None
+        # Full teardown: the next build starts from a clean box, so it must
+        # re-snapshot memory rather than plan against this boot's probe.
+        planning.clear_plan_probe()
         for client in clients:
             client.close()
 
@@ -1255,6 +1262,10 @@ class FleetProvider:
                 old = dict(self._launches)
             # Reap dead owners' swaps before re-planning, same as the first build.
             reap_stale(cfg.data_dir)
+            if not running:
+                # Nothing loaded (a resurrect after a failed pass): the box is
+                # clean, so refresh the plan snapshot like a first build would.
+                planning.capture_plan_probe()
             new = _launches_by_role(planning.plan_all_launches())
             # A role restarts when its launches changed OR its running/planned
             # presence disagrees (covers a group the new plan drops or adds).

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -1,11 +1,13 @@
 """FleetProvider: the local llama-server engine for every role.
 
-On first use it plans GPU placement and starts one llama-swap process that fronts
-a llama-server per configured role (chat/embed/rerank/vision) co-resident behind a
-single OpenAI endpoint; each call routes to that endpoint by role id. There is no
-in-process fallback, so a missing role surfaces a user-facing ``ProviderError``.
-Model management (list/show/capabilities) reads the registry and GGUF headers
-directly and needs no running server.
+On first use it plans GPU placement and starts one llama-swap process per
+configured role (chat/embed/rerank/vision), each fronting that role's
+llama-server(s); each call routes to its role's proxy by replica model id.
+Per-role processes let a reload restart only the roles whose launches changed,
+so a placement or model change never unloads an untouched role's model. There
+is no in-process fallback, so a missing role surfaces a user-facing
+``ProviderError``. Model management (list/show/capabilities) reads the registry
+and GGUF headers directly and needs no running server.
 """
 
 from __future__ import annotations
@@ -386,7 +388,7 @@ class FleetProvider:
         # potentially in use. See _retire_clients.
         self._retiring_clients: list[LlamaServerClient] = []
         # Chat batching slots and per-slot context from the chat launch, surfaced to
-        # the concurrency gate and clients; defaults until the swap is up.
+        # the concurrency gate and clients; defaults until the chat group is up.
         self._chat_slots = 1
         self._chat_ctx: int | None = None
         # Single-flight guard: the HTTP/MCP servers route concurrently, so two
@@ -660,10 +662,9 @@ class FleetProvider:
         A no-op for groups still running (e.g. the failure was in planning), so
         a live engine is never abandoned unstopped.
         """
-        with self._build_lock:
-            with self._lock:
-                for role in [r for r, swap in self._swaps.items() if not swap.running]:
-                    self._drop_role(role)
+        with self._build_lock, self._lock:
+            for role in [r for r, swap in self._swaps.items() if not swap.running]:
+                self._drop_role(role)
 
     def _require_configured_model(
         self, model: str | None, configured: str, role: WorkerRole
@@ -991,7 +992,7 @@ class FleetProvider:
         model) runs on a background thread and this returns at once: the eager-start
         at TUI mount must not freeze the UI. The spawn listeners fire per role as it
         loads, so the UI shows progress. A second call while warm-up is in flight
-        (or once the swap is up) is a no-op.
+        (or once the fleet is up) is a no-op.
         """
         with self._lock:
             if self._swaps or self._warming:
@@ -1004,7 +1005,7 @@ class FleetProvider:
         ).start()
 
     def _warm_up_blocking(self) -> None:
-        """Start the swap and pre-load every role on a background thread.
+        """Start the fleet and pre-load every role on a background thread.
 
         Runs on a daemon thread with no caller to catch failures, so a startup
         error is logged and swallowed: a role that can't load surfaces a

--- a/src/lilbee/providers/fleet/swap_config.py
+++ b/src/lilbee/providers/fleet/swap_config.py
@@ -1,6 +1,8 @@
-"""Generate a llama-swap config that keeps every fleet role co-resident.
+"""Generate one role group's llama-swap config (all its replicas co-resident).
 
-See docs/architecture.md (llama-swap) for the supervisor/proxy design.
+Each role runs behind its own llama-swap process with its own config, so a
+reload of one role never touches another's loaded servers. See
+docs/architecture.md (llama-swap) for the supervisor/proxy design.
 """
 
 from __future__ import annotations
@@ -16,8 +18,9 @@ if TYPE_CHECKING:
 
     from lilbee.providers.fleet.launch import InstanceLaunch
 
-# One group holds every role with swap disabled, so llama-swap brings them all up
-# and never evicts one to load another (the co-residency the fleet needs).
+# One group holds the role's members with swap disabled, so llama-swap brings
+# them all up and never evicts one to load another (the co-residency the fleet
+# needs across a role's replicas).
 _GROUP_NAME = "lilbee"
 # Cold-load ceiling floor; the heaviest member's weights scale it up from here.
 _HEALTH_CHECK_TIMEOUT_FLOOR_S = 600
@@ -50,10 +53,10 @@ _KEY_MEMBERS = "members"
 def build_swap_config(launches: list[InstanceLaunch], member_ports: Mapping[str, int]) -> str:
     """Render a llama-swap config (JSON, which is valid YAML) for *launches*.
 
-    Each role becomes a model whose id is the role name and whose command is the
-    role's llama-server argv plus the explicit port from *member_ports*; one
-    ``swap: false`` group holds them all co-resident behind the single OpenAI
-    endpoint. Ports are allocated fresh per start (never llama-swap's fixed
+    Each launch becomes a model whose id is its replica model id and whose
+    command is the llama-server argv plus the explicit port from *member_ports*;
+    one ``swap: false`` group holds them all co-resident behind this role's
+    proxy endpoint. Ports are allocated fresh per start (never llama-swap's fixed
     ``startPort`` range) so a previous instance's lingering server can't collide
     with the new fleet's bind.
     """

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -35,14 +35,18 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _HOST = "127.0.0.1"
-_CONFIG_FILENAME = "llama-swap.json"
+# One llama-swap per role group: the group name lands in the config filename so
+# each group's processes are identified (and stopped) by their own config path,
+# and a placement change can restart one group without touching the others.
+_CONFIG_FILENAME_TEMPLATE = "llama-swap-{group}.json"
+_CONFIG_FILE_GLOB = "llama-swap-*.json"
 # llama-swap's own stdout/stderr (its HTTP access log) is captured to a file under
 # the data root's ``logs/`` (beside server.log etc.) instead of inherited from the
 # parent: a TUI or CLI parent owns the terminal, and an inherited fd would bleed
 # llama-swap's request log onto the screen and corrupt the render. Per-model
 # upstream logs are unaffected (those go to llama-swap's /logs API).
 _LOGS_SUBDIR = "logs"
-_LOG_FILENAME = "llama-swap.log"
+_LOG_FILENAME_TEMPLATE = "llama-swap-{group}.log"
 # Cross-run reaping: each owner lilbee writes its own state file (named with its
 # pid) recording its swap's pid/pgid plus the owner's pid and create time, so the
 # next start can kill a dead owner's surviving llama-swap (it holds VRAM
@@ -100,9 +104,9 @@ _CREATE_NEW_PROCESS_GROUP: int = _platform_const(subprocess, "CREATE_NEW_PROCESS
 _SIGKILL: int = _platform_const(signal, "SIGKILL", signal.SIGTERM)
 
 
-def _state_filename(owner_pid: int) -> str:
-    """The per-owner state filename for the lilbee process *owner_pid*."""
-    return f"{_STATE_FILENAME_PREFIX}{owner_pid}{_STATE_FILENAME_SUFFIX}"
+def _state_filename(owner_pid: int, group: str) -> str:
+    """The per-owner, per-group state filename for the lilbee process *owner_pid*."""
+    return f"{_STATE_FILENAME_PREFIX}{group}.{owner_pid}{_STATE_FILENAME_SUFFIX}"
 
 
 @dataclass(frozen=True)
@@ -118,13 +122,18 @@ class _SwapState:
 
 
 class SwapManager:
-    """Owns one llama-swap process fronting every configured role co-resident."""
+    """Owns one llama-swap process fronting one role group's servers.
 
-    def __init__(self, data_dir: Path) -> None:
+    The provider runs one manager per role, so restarting a group (a placement
+    or model change) never touches another group's loaded servers.
+    """
+
+    def __init__(self, data_dir: Path, group: str) -> None:
         self._data_dir = data_dir
-        self._config_path = data_dir / _CONFIG_FILENAME
-        self._log_path = data_dir / _LOGS_SUBDIR / _LOG_FILENAME
-        self._state_path = data_dir / _state_filename(os.getpid())
+        self._group = group
+        self._config_path = data_dir / _CONFIG_FILENAME_TEMPLATE.format(group=group)
+        self._log_path = data_dir / _LOGS_SUBDIR / _LOG_FILENAME_TEMPLATE.format(group=group)
+        self._state_path = data_dir / _state_filename(os.getpid(), group)
         self._proc: subprocess.Popen[bytes] | None = None
         self._log_file: BinaryIO | None = None
         self._port: int | None = None
@@ -174,43 +183,8 @@ class SwapManager:
         self._await_health()
 
     def reap_stale(self) -> None:
-        """Kill every dead owner's surviving llama-swap.
-
-        An OOM-killed lilbee leaves llama-swap (and its servers) holding VRAM,
-        so planning would otherwise see artificially reduced free memory; the
-        provider calls this before its GPU probe. Every state file in the data
-        dir is scanned (including the legacy shared-name file): a dead owner's
-        swap is reaped and its file removed; a live owner's swap and file are
-        left alone, so a second lilbee at the same data_dir (e.g. ``lilbee
-        sync`` beside the server) never kills the live owner's healthy swap.
-        Recorded create times guard against owner- and swap-pid reuse; the
-        cmdline match covers legacy files without a swap create time. An
-        unparseable file is skipped, never deleted: it may be a sibling's
-        in-flight write, and a truly corrupt file is its owner's to overwrite.
-        When the swap itself is dead, its servers (each in its own process
-        group) may still be alive holding VRAM; they are matched by name plus
-        recorded member port and stopped before the file is removed.
-        """
-        self._clean_stale_tmp_files()
-        for state_path in sorted(self._data_dir.glob(_STATE_FILE_GLOB)):
-            state = _load_state(state_path)
-            if state is None:
-                continue
-            if _owner_alive(state.owner_pid, state.owner_created_at):
-                continue
-            if _is_live_llama_swap(state):
-                _stop_stale_swap(state)
-            else:
-                _reap_orphan_servers(state)
-            state_path.unlink(missing_ok=True)
-
-    def _clean_stale_tmp_files(self) -> None:
-        """Remove crash-leftover state tmp files whose writer is dead."""
-        tmp_glob = f"{_STATE_TMP_PREFIX}{_STATE_FILE_GLOB}{_STATE_TMP_SUFFIX}"
-        for tmp_path in self._data_dir.glob(tmp_glob):
-            writer_pid = _state_owner_pid(tmp_path.name)
-            if writer_pid is not None and not psutil.pid_exists(writer_pid):
-                tmp_path.unlink(missing_ok=True)
+        """Kill every dead owner's surviving llama-swap; see :func:`reap_stale`."""
+        reap_stale(self._data_dir)
 
     def _write_state(self) -> None:
         """Record the swap's pid/pgid/create time, member ports, and our identity.
@@ -427,6 +401,62 @@ def _live_sibling_swap_pids(data_dir: Path) -> set[int]:
     return protected
 
 
+def reap_stale(data_dir: Path) -> None:
+    """Kill every dead owner's surviving llama-swap at *data_dir*.
+
+    An OOM-killed lilbee leaves llama-swap (and its servers) holding VRAM,
+    so planning would otherwise see artificially reduced free memory; the
+    provider calls this before its GPU probe. Every state file in the data
+    dir is scanned (all groups, including the legacy shared-name file): a
+    dead owner's swap is reaped and its file removed; a live owner's swap
+    and file are left alone, so a second lilbee at the same data_dir (e.g.
+    ``lilbee sync`` beside the server) never kills the live owner's healthy
+    swap. Recorded create times guard against owner- and swap-pid reuse; the
+    cmdline match covers legacy files without a swap create time. An
+    unparseable file is skipped, never deleted: it may be a sibling's
+    in-flight write, and a truly corrupt file is its owner's to overwrite.
+    When the swap itself is dead, its servers (each in its own process
+    group) may still be alive holding VRAM; they are matched by name plus
+    recorded member port and stopped before the file is removed.
+
+    Module-level (not a method) because it must run before planning decides
+    which role groups exist, when no per-group manager has been built yet.
+    """
+    _clean_stale_tmp_files(data_dir)
+    for state_path in sorted(data_dir.glob(_STATE_FILE_GLOB)):
+        state = _load_state(state_path)
+        if state is None:
+            continue
+        if _owner_alive(state.owner_pid, state.owner_created_at):
+            continue
+        if _is_live_llama_swap(state):
+            _stop_stale_swap(state)
+        else:
+            _reap_orphan_servers(state)
+        state_path.unlink(missing_ok=True)
+
+
+def _clean_stale_tmp_files(data_dir: Path) -> None:
+    """Remove crash-leftover state tmp files whose writer is dead."""
+    tmp_glob = f"{_STATE_TMP_PREFIX}{_STATE_FILE_GLOB}{_STATE_TMP_SUFFIX}"
+    for tmp_path in data_dir.glob(tmp_glob):
+        writer_pid = _state_owner_pid(tmp_path.name)
+        if writer_pid is not None and not psutil.pid_exists(writer_pid):
+            tmp_path.unlink(missing_ok=True)
+
+
+def sweep_owned(data_dir: Path) -> None:
+    """Stop every llama-swap this process owns at *data_dir*, across all groups.
+
+    The provider's fallback teardown path: when it holds no tracked managers, an
+    in-flight build may still have spawned swaps it never adopted. Each group's
+    config file identifies that group's processes, so every group config present
+    is swept. Cross-run leftovers are ``reap_stale``'s job, not this sweep's.
+    """
+    for config_path in sorted(data_dir.glob(_CONFIG_FILE_GLOB)):
+        _stop_own_fleet(config_path, ())
+
+
 def _stop_own_fleet(config_path: Path, member_ports: tuple[int, ...]) -> None:
     """Stop every llama-swap this lilbee owns at *config_path* and reap upstreams.
 
@@ -603,11 +633,16 @@ def _find_orphan_servers(ports: tuple[int, ...]) -> list[psutil.Process]:
 
 
 def _state_owner_pid(name: str) -> int | None:
-    """Owner pid embedded in a state or state-tmp filename, ``None`` when absent."""
+    """Owner pid embedded in a state or state-tmp filename, ``None`` when absent.
+
+    Handles both the group-qualified form (``llama-swap.state.chat.123.json``)
+    and the legacy pre-group form (``llama-swap.state.123.json``): the pid is
+    always the last dotted segment of the stem.
+    """
     stem = name.removeprefix(_STATE_TMP_PREFIX).removesuffix(_STATE_TMP_SUFFIX)
     stem = stem.removeprefix(_STATE_FILENAME_PREFIX).removesuffix(_STATE_FILENAME_SUFFIX)
     try:
-        return int(stem)
+        return int(stem.rsplit(".", 1)[-1])
     except ValueError:
         return None
 

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -315,6 +315,11 @@ class RoutingProvider(LLMProvider):
         if self._local is not None:
             self._local.reload_role(role, wait=wait)
 
+    def reload_placement(self, *, wait: bool = False) -> None:
+        """Forward to the native engine; the SDK side has no GPU placement."""
+        if self._local is not None:
+            self._local.reload_placement(wait=wait)
+
     def role_ready(self, role: WorkerRole) -> bool:
         """Native readiness without building; True when no local engine exists yet."""
         if self._local is None:

--- a/src/lilbee/server/routes/placement.py
+++ b/src/lilbee/server/routes/placement.py
@@ -2,8 +2,8 @@
 
 Every route requires auth: even the reads run resolve_placement_plan, which
 spawns subprocess device probes, so none are marked @read_only. Applying or
-clearing placement rebuilds the shared fleet, which is unsafe across concurrent
-HTTP clients, so PUT/DELETE are refused by default. They are gated on the
+clearing placement restarts the shared fleet's moved roles, which is unsafe
+across concurrent HTTP clients, so PUT/DELETE are refused by default. They are gated on the
 ``allow_http_placement`` flag (LILBEE_ALLOW_HTTP_PLACEMENT), which an operator
 turns on for a single-client / owned deployment to get the same apply/clear
 capability the CLI and TUI have.

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -59,36 +59,52 @@ def test_preview_passes_candidate_spec(monkeypatch):
 def test_preview_has_no_side_effects(monkeypatch):
     monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
-    reset = {"called": False}
-    monkeypatch.setattr(app_placement, "reset_services", lambda: reset.__setitem__("called", True))
+    peeked = {"called": False}
+    monkeypatch.setattr(app_placement, "peek_services", lambda: peeked.__setitem__("called", True))
     app_placement.preview_placement(None)
-    assert reset["called"] is False
+    assert peeked["called"] is False  # no reload, no services touch
 
 
-def test_set_persists_and_resets(monkeypatch):
+class _FakeProviderServices:
+    """A peeked services container whose provider records reload_placement calls."""
+
+    class _Provider:
+        def __init__(self) -> None:
+            self.reloads: list[bool] = []
+
+        def reload_placement(self, *, wait: bool = False) -> None:
+            self.reloads.append(wait)
+
+    def __init__(self) -> None:
+        self.provider = self._Provider()
+
+
+def test_set_persists_and_reloads_live_fleet(monkeypatch):
     writes = {}
+    services = _FakeProviderServices()
     monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: writes.update(d))
-    monkeypatch.setattr(app_placement, "reset_services", lambda: writes.setdefault("reset", True))
+    monkeypatch.setattr(app_placement, "peek_services", lambda: services)
     prior = app_placement.cfg.placement
     spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(1, 1))})
     try:
         app_placement.set_placement(spec)
         assert writes["placement"] == spec.to_json()
-        assert writes["reset"] is True
+        # The live fleet applied the change surgically and synchronously.
+        assert services.provider.reloads == [True]
         assert app_placement.cfg.placement == spec.to_json()
     finally:
         app_placement.cfg.placement = prior
 
 
-def test_set_clears_read_device_cache(monkeypatch):
-    """Applying a placement reconfigures the fleet, so the stale device probe is dropped."""
+def test_set_clears_read_device_cache_when_nothing_runs(monkeypatch):
+    """With no services built, the next boot should probe devices fresh."""
     cleared = {"called": False}
     monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
     monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
     monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: None)
-    monkeypatch.setattr(app_placement, "reset_services", lambda: None)
+    monkeypatch.setattr(app_placement, "peek_services", lambda: None)
     monkeypatch.setattr(
         app_placement, "clear_read_device_cache", lambda: cleared.__setitem__("called", True)
     )
@@ -100,6 +116,25 @@ def test_set_clears_read_device_cache(monkeypatch):
         app_placement.cfg.placement = prior
 
 
+def test_set_keeps_device_probe_on_the_live_path(monkeypatch):
+    """The surgical reload diffs plans against the same clean-box probe (bb-a8f):
+    re-probing under a loaded fleet would poison the chat context sizing."""
+    cleared = {"called": False}
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    monkeypatch.setattr(app_placement.settings, "update_values", lambda root, d: None)
+    monkeypatch.setattr(app_placement, "peek_services", _FakeProviderServices)
+    monkeypatch.setattr(
+        app_placement, "clear_read_device_cache", lambda: cleared.__setitem__("called", True)
+    )
+    prior = app_placement.cfg.placement
+    try:
+        app_placement.set_placement(PlacementSpec({WorkerRole.EMBED: RolePlacement(devices=(0,))}))
+        assert cleared["called"] is False
+    finally:
+        app_placement.cfg.placement = prior
+
+
 def test_set_none_clears(monkeypatch):
     deletes = {}
     monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
@@ -107,7 +142,7 @@ def test_set_none_clears(monkeypatch):
     monkeypatch.setattr(
         app_placement.settings, "delete_values", lambda root, keys: deletes.setdefault("keys", keys)
     )
-    monkeypatch.setattr(app_placement, "reset_services", lambda: None)
+    monkeypatch.setattr(app_placement, "peek_services", lambda: None)
     prior = app_placement.cfg.placement
     try:
         app_placement.set_placement(None)

--- a/tests/crawler/test_runner.py
+++ b/tests/crawler/test_runner.py
@@ -56,6 +56,13 @@ def isolated_env(tmp_path, monkeypatch):
     # import directly) are patched so the value is consistent across import paths.
     monkeypatch.setattr("lilbee.crawler.crawler_available", lambda: True)
     monkeypatch.setattr("lilbee.crawler.crawl4ai_fetcher.crawler_available", lambda: True)
+    # Periodic sync off: at the 30s default, a fresh services container (every
+    # test on the forked CI lane) fires a REAL ingest sync inside crawl_and_save,
+    # and that native work inside a forked child can deadlock past the 60s test
+    # timeout -- which pytest-timeout's parent-armed alarm then escalates to a
+    # dead xdist worker. The sync-behavior tests mock _maybe_periodic_sync
+    # directly, so nothing here loses coverage.
+    cfg.crawl_sync_interval = 0
     # Bypass SSRF DNS resolution by default so localhost-like test URLs
     # don't hit real DNS.
     monkeypatch.setattr(

--- a/tests/server/test_placement_routes.py
+++ b/tests/server/test_placement_routes.py
@@ -41,7 +41,7 @@ def test_get_placement(monkeypatch):
 
 
 def test_put_refused_on_daemon():
-    """PUT placement is refused on the HTTP daemon (rebuilds the shared fleet)."""
+    """PUT placement is refused on the HTTP daemon (restarts the fleet's moved roles)."""
     with create_test_client([placement_set_route]) as client:
         r = client.put("/api/placement", json={"spec": {"chat": {"devices": [0]}}})
         assert r.status_code == 409
@@ -49,7 +49,7 @@ def test_put_refused_on_daemon():
 
 
 def test_delete_refused_on_daemon():
-    """DELETE placement is refused on the HTTP daemon (rebuilds the shared fleet)."""
+    """DELETE placement is refused on the HTTP daemon (restarts the fleet's moved roles)."""
     with create_test_client([placement_clear_route]) as client:
         r = client.delete("/api/placement")
         assert r.status_code == 409

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4103,7 +4103,7 @@ class TestSelfCheckHelpers:
             lambda **_k: ["/bin/llama-server"],
         )
         swap.endpoint.return_value = "http://127.0.0.1:5800"
-        monkeypatch.setattr("lilbee.providers.fleet.swap_manager.SwapManager", lambda _d: swap)
+        monkeypatch.setattr("lilbee.providers.fleet.swap_manager.SwapManager", lambda _d, _g: swap)
         monkeypatch.setattr(
             "lilbee.providers.fleet.client.LlamaServerClient", lambda _endpoint, _model: client
         )

--- a/tests/test_fleet_adapters.py
+++ b/tests/test_fleet_adapters.py
@@ -274,3 +274,30 @@ def test_embed_spec_declared_none_falls_through_to_arch() -> None:
     # and an encoder arch keeps the plain spec.
     assert embed_spec({"architecture": "bert", "pooling_type": "0"}) is ROLE_SPECS[WorkerRole.EMBED]
     assert LLM_RERANK_SPEC.server_capable is True
+
+
+def test_build_argv_no_mmap_appends_the_flag() -> None:
+    argv = build_server_argv(
+        binary=Path("/bin/llama-server"),
+        spec=ROLE_SPECS[WorkerRole.CHAT],
+        model_path=Path("/models/chat.gguf"),
+        devices=(0,),
+        n_gpu_layers=-1,
+        slots=1,
+        ctx_per_slot=4096,
+        no_mmap=True,
+    )
+    assert "--no-mmap" in argv
+
+
+def test_build_argv_defaults_to_mmap() -> None:
+    argv = build_server_argv(
+        binary=Path("/bin/llama-server"),
+        spec=ROLE_SPECS[WorkerRole.CHAT],
+        model_path=Path("/models/chat.gguf"),
+        devices=(0,),
+        n_gpu_layers=-1,
+        slots=1,
+        ctx_per_slot=4096,
+    )
+    assert "--no-mmap" not in argv

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1400,7 +1400,5 @@ class TestChatNoMmap:
 
     def test_mmap_kept_when_weights_crowd_ram(self, monkeypatch) -> None:
         # A malloc'd copy is unevictable; a model over half of RAM keeps mmap.
-        monkeypatch.setattr(
-            "lilbee.providers.model_cache.total_system_memory", lambda: 32 * 10**9
-        )
+        monkeypatch.setattr("lilbee.providers.model_cache.total_system_memory", lambda: 32 * 10**9)
         assert planning_mod._chat_no_mmap(20 * 10**9) is False

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1226,6 +1226,7 @@ _NON_SIZING_LAUNCH_FLAGS = {
     "--host",
     "--cont-batching",
     "--jinja",
+    "--no-mmap",
     "--reasoning-format",
     "--embeddings",
     "--pooling",
@@ -1388,3 +1389,18 @@ def test_server_spec_other_role_uses_role_default() -> None:
 
     spec = planning_mod._server_spec(WorkerRole.CHAT, None, None)
     assert spec is ROLE_SPECS[WorkerRole.CHAT]
+
+
+class TestChatNoMmap:
+    def test_no_mmap_when_weights_fit_half_of_ram(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "lilbee.providers.model_cache.total_system_memory", lambda: 1000 * 10**9
+        )
+        assert planning_mod._chat_no_mmap(112 * 10**9) is True
+
+    def test_mmap_kept_when_weights_crowd_ram(self, monkeypatch) -> None:
+        # A malloc'd copy is unevictable; a model over half of RAM keeps mmap.
+        monkeypatch.setattr(
+            "lilbee.providers.model_cache.total_system_memory", lambda: 32 * 10**9
+        )
+        assert planning_mod._chat_no_mmap(20 * 10**9) is False

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -78,7 +78,9 @@ def test_role_ctx_chat_honors_configured_num_ctx(monkeypatch) -> None:
 
 def test_role_ctx_chat_uses_dynamic_picker_when_unset(monkeypatch) -> None:
     monkeypatch.setattr(cfg, "num_ctx", None)
-    monkeypatch.setattr("lilbee.providers.engine_params.resolve_chat_ctx", lambda _p, _m, *_a: 4096)
+    monkeypatch.setattr(
+        "lilbee.providers.engine_params.resolve_chat_ctx", lambda _p, _m, **_kw: 4096
+    )
     assert planning_mod._role_ctx(WorkerRole.CHAT, Path("/m/c.gguf"), None) == 4096
 
 
@@ -1402,3 +1404,59 @@ class TestChatNoMmap:
         # A malloc'd copy is unevictable; a model over half of RAM keeps mmap.
         monkeypatch.setattr("lilbee.providers.model_cache.total_system_memory", lambda: 32 * 10**9)
         assert planning_mod._chat_no_mmap(20 * 10**9) is False
+
+
+class TestPlanProbe:
+    """The clean-box plan snapshot: reloads size against it, never a live probe."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_probe(self):
+        planning_mod.clear_plan_probe()
+        yield
+        planning_mod.clear_plan_probe()
+
+    def _capture(self, monkeypatch, *, free_vram: int, free_ram: int) -> None:
+        monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/srv"))
+        monkeypatch.setattr("lilbee.providers.fleet.gpu_env.apply_fleet_gpu_env", lambda: None)
+        monkeypatch.setattr(
+            "lilbee.providers.fleet.cuda_runtime.apply_cuda_runtime_env", lambda: None
+        )
+        monkeypatch.setattr(
+            planning_mod,
+            "resolve_devices",
+            lambda _b: [FleetDevice("CUDA", 0, "A", 24 * _GB, free_vram)],
+        )
+        monkeypatch.setattr(
+            "lilbee.providers.model_cache.get_available_memory", lambda _f: free_vram
+        )
+        monkeypatch.setattr("lilbee.providers.model_cache.free_system_memory", lambda: free_ram)
+        planning_mod.capture_plan_probe()
+
+    def test_readers_serve_the_snapshot_not_the_live_state(self, monkeypatch) -> None:
+        self._capture(monkeypatch, free_vram=20 * _GB, free_ram=64 * _GB)
+        # The box "fills up" (a loaded fleet): live reads collapse...
+        monkeypatch.setattr("lilbee.providers.model_cache.get_available_memory", lambda _f: 1 * _GB)
+        monkeypatch.setattr("lilbee.providers.model_cache.free_system_memory", lambda: 1 * _GB)
+        monkeypatch.setattr(
+            planning_mod,
+            "resolve_devices",
+            lambda _b: [FleetDevice("CUDA", 0, "A", 24 * _GB, 1 * _GB)],
+        )
+        # ...but the plan paths keep the clean-box numbers.
+        assert planning_mod._plan_available_memory() == 20 * _GB
+        assert planning_mod._plan_free_system_memory() == 64 * _GB
+        assert planning_mod._plan_devices(Path("/bin/srv"))[0].free_bytes == 20 * _GB
+
+    def test_clear_returns_readers_to_live_state(self, monkeypatch) -> None:
+        self._capture(monkeypatch, free_vram=20 * _GB, free_ram=64 * _GB)
+        planning_mod.clear_plan_probe()
+        monkeypatch.setattr("lilbee.providers.model_cache.get_available_memory", lambda _f: 3 * _GB)
+        monkeypatch.setattr("lilbee.providers.model_cache.free_system_memory", lambda: 2 * _GB)
+        assert planning_mod._plan_available_memory() == 3 * _GB
+        assert planning_mod._plan_free_system_memory() == 2 * _GB
+
+    def test_uncaptured_readers_pass_through_live_state(self, monkeypatch) -> None:
+        monkeypatch.setattr("lilbee.providers.model_cache.get_available_memory", lambda _f: 7 * _GB)
+        monkeypatch.setattr("lilbee.providers.model_cache.free_system_memory", lambda: 5 * _GB)
+        assert planning_mod._plan_available_memory() == 7 * _GB
+        assert planning_mod._plan_free_system_memory() == 5 * _GB

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -1164,6 +1164,82 @@ def test_preload_roles_skips_failing_role(monkeypatch) -> None:
     embed.embed.assert_called_once()
 
 
+def test_preload_roles_warms_roles_concurrently(monkeypatch) -> None:
+    # The light roles must not queue behind the chat load: with the chat warm
+    # blocked mid-flight, the embed warm still completes.
+    chat_started = threading.Event()
+    release_chat = threading.Event()
+    embed_warmed = threading.Event()
+
+    chat, embed = _fake_client(), _fake_client()
+
+    def _blocked_chat(*args, **kwargs) -> MagicMock:
+        chat_started.set()
+        release_chat.wait(timeout=5.0)
+        return MagicMock()
+
+    chat.chat.side_effect = _blocked_chat
+    embed.embed.side_effect = lambda *a, **k: (embed_warmed.set(), [[0.1]])[1]
+    p = _provider_with_clients({WorkerRole.CHAT: [chat], WorkerRole.EMBED: [embed]})
+    monkeypatch.setattr(p, "_prewarm_chat_weights", lambda: None)
+    preload = threading.Thread(target=p._preload_roles, daemon=True)
+    preload.start()
+    assert chat_started.wait(timeout=5.0)
+    assert embed_warmed.wait(timeout=5.0)  # embed warmed while chat still loading
+    release_chat.set()
+    preload.join(timeout=5.0)
+    assert not preload.is_alive()
+
+
+def _registry_with_shards(monkeypatch, shards: list[Path]) -> None:
+    registry = MagicMock()
+    registry.shard_paths.return_value = shards
+    monkeypatch.setattr(prov_mod, "ModelRegistry", MagicMock(return_value=registry))
+
+
+def test_prewarm_skips_shards_already_paged_this_boot(monkeypatch, tmp_path) -> None:
+    shard = tmp_path / "model.gguf"
+    shard.write_bytes(b"x" * 64)
+    _registry_with_shards(monkeypatch, [shard])
+    monkeypatch.setattr(prov_mod, "_PREWARMED_SHARDS", set())
+    p = _provider_with_clients({})
+    p._prewarm_chat_weights()  # first pass reads and records the shard
+
+    opens = {"n": 0}
+    real_open = Path.open
+
+    def _counting_open(self, *args, **kwargs):
+        if self == shard:
+            opens["n"] += 1
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _counting_open)
+    p._prewarm_chat_weights()  # second pass: cache is hot, no re-read
+    assert opens["n"] == 0
+
+
+def test_prewarm_rereads_when_a_shard_changed(monkeypatch, tmp_path) -> None:
+    shard = tmp_path / "model.gguf"
+    shard.write_bytes(b"x" * 64)
+    _registry_with_shards(monkeypatch, [shard])
+    monkeypatch.setattr(prov_mod, "_PREWARMED_SHARDS", set())
+    p = _provider_with_clients({})
+    p._prewarm_chat_weights()
+    shard.write_bytes(b"y" * 128)  # new size + mtime -> new prewarm identity
+
+    opens = {"n": 0}
+    real_open = Path.open
+
+    def _counting_open(self, *args, **kwargs):
+        if self == shard:
+            opens["n"] += 1
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _counting_open)
+    p._prewarm_chat_weights()
+    assert opens["n"] == 1  # changed shard is read again
+
+
 def test_warm_role_dispatches_per_role() -> None:
     chat, embed, rerank, vision = (_fake_client() for _ in range(4))
     prov_mod._warm_role(WorkerRole.CHAT, chat)

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -160,7 +160,7 @@ def test_embed_routes_to_least_busy_replica() -> None:
     busy.embed.assert_not_called()
 
 
-def test_adopt_swap_builds_a_client_per_replica(monkeypatch) -> None:
+def test_adopt_role_builds_a_client_per_replica(monkeypatch) -> None:
     launches = [_fake_launch(WorkerRole.EMBED), _fake_launch(WorkerRole.EMBED)]
     _install_engine(monkeypatch, launches=launches)
     p = FleetProvider()
@@ -179,7 +179,7 @@ def test_ensure_fleet_refused_after_shutdown(monkeypatch) -> None:
     assert swap.started == []  # no swap started after shutdown
 
 
-def test_adopt_swap_retires_old_clients_without_closing(monkeypatch) -> None:
+def test_adopt_role_retires_old_clients_without_closing(monkeypatch) -> None:
     # Re-adopting (a reload) must not close old clients in place (a
     # reader may still hold one); they are retired for deferred close.
     launch = _fake_launch(WorkerRole.EMBED)
@@ -239,7 +239,7 @@ def test_drop_swap_refs_closes_retiring_clients() -> None:
     assert p._retiring_clients == []
 
 
-def test_adopt_swap_threads_rerank_mode(monkeypatch) -> None:
+def test_adopt_role_threads_rerank_mode(monkeypatch) -> None:
     launch = _fake_launch(WorkerRole.RERANK)
     launch.rerank_mode = RerankMode.LLM
     captured: dict[str, object] = {}

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -75,6 +75,18 @@ class _FakeSwap:
         self.running = False
 
 
+@pytest.fixture(autouse=True)
+def _no_real_probe(monkeypatch):
+    """No test in this module may probe real hardware or resolve real binaries.
+
+    capture_plan_probe resolves the engine binary and spawns device probes; on a
+    host without the bundled engine (CI) it raises, and on a dev box it silently
+    probes the real GPUs. Tests that exercise the capture lifecycle override
+    this stub with their own recorder.
+    """
+    monkeypatch.setattr(planning_mod, "capture_plan_probe", lambda: None)
+
+
 def _install_engine(monkeypatch, *, launches: list, swap: _FakeSwap | None = None) -> _FakeSwap:
     """Patch the swap, client, and planner so _ensure_fleet builds controllable fakes."""
     swap = swap or _FakeSwap()
@@ -1984,11 +1996,17 @@ class TestReloadSingleFlight:
         assert p._reloading is False
         p.reload_role(WorkerRole.CHAT)  # guard released -> a new reload can dispatch
 
-    def test_reload_blocking_noops_when_swap_already_gone(self) -> None:
+    def test_reload_blocking_noops_when_swap_already_gone(self, monkeypatch) -> None:
+        # Nothing running and nothing planned: the pass replans (a resurrect
+        # would start whatever the fresh plan holds), finds nothing, and the
+        # guard is still released.
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [])
         p = FleetProvider()
         p._reloading = True
-        p._reload_blocking()  # no swap -> nothing to reload, guard still released
+        p._reload_blocking()
         assert p._reloading is False
+        assert p._swaps == {}
 
     def test_reload_racing_shutdown_serializes_and_leaks_nothing(self, monkeypatch) -> None:
         order: list[str] = []

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -2241,3 +2241,62 @@ def test_rebuild_role_restarts_only_that_role(monkeypatch) -> None:
     assert p._swaps[WorkerRole.EMBED] is fresh  # ...and replaced from the fresh plan
     assert p._swaps[WorkerRole.CHAT] is live  # the healthy group was never touched
     assert live.shutdowns == 0
+
+
+def test_ensure_fleet_partial_failure_tears_down_started_groups(monkeypatch) -> None:
+    """A later group failing to start must stop the groups already started, so a
+    half-built fleet never leaks past the failure."""
+    built: list[_FakeSwap] = []
+
+    class _SecondExplodes(_FakeSwap):
+        def start(self, launches: list) -> None:
+            if len(built) > 1:
+                raise RuntimeError("second group failed")
+            super().start(launches)
+
+    def _factory(_d: object, _g: object) -> _FakeSwap:
+        built.append(_SecondExplodes())
+        return built[-1]
+
+    monkeypatch.setattr(prov_mod, "SwapManager", _factory)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+    monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
+    monkeypatch.setattr(
+        planning_mod,
+        "plan_all_launches",
+        lambda: [_fake_launch(WorkerRole.CHAT), _fake_launch(WorkerRole.EMBED)],
+    )
+    p = FleetProvider()
+    with pytest.raises(RuntimeError, match="second group failed"):
+        p._ensure_fleet()
+    assert built[0].shutdowns == 1  # the group that did start was torn down
+    assert p._swaps == {}
+
+
+def test_drop_dead_swaps_drops_only_dead_groups() -> None:
+    p = FleetProvider()
+    dead, live = _FakeSwap(), _FakeSwap()
+    dead.running = False
+    p._swaps = {WorkerRole.EMBED: dead, WorkerRole.CHAT: live}
+    p._drop_dead_swaps()
+    assert set(p._swaps) == {WorkerRole.CHAT}  # the live group is untouched
+
+
+def test_reload_placement_dispatches_the_diff_reload(monkeypatch) -> None:
+    passes: list[bool] = []
+    p = FleetProvider()
+    p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+    monkeypatch.setattr(p, "_reload_pass", lambda force=frozenset(): passes.append(True))
+    p.reload_placement(wait=True)
+    assert passes == [True]
+
+
+def test_reload_pass_refuses_after_terminal_shutdown(monkeypatch) -> None:
+    """A reload queued behind a terminal shutdown must not resurrect the fleet."""
+    plans: list[int] = []
+    monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: plans.append(1) or [])
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+    p = FleetProvider()
+    p._shut_down = True
+    p._reload_pass(force=frozenset((WorkerRole.CHAT,)))
+    assert plans == []  # returned before planning; nothing can spawn

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -81,6 +81,7 @@ def _install_engine(monkeypatch, *, launches: list, swap: _FakeSwap | None = Non
     monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir, _group: swap)
     monkeypatch.setattr(prov_mod, "reap_stale", lambda _data_dir: None)
     monkeypatch.setattr(prov_mod, "sweep_owned", lambda _data_dir: None)
+    monkeypatch.setattr(planning_mod, "capture_plan_probe", lambda: None)
     monkeypatch.setattr(
         prov_mod, "LlamaServerClient", lambda _endpoint, _model, **_kw: _fake_client()
     )
@@ -2300,3 +2301,53 @@ def test_reload_pass_refuses_after_terminal_shutdown(monkeypatch) -> None:
     p._shut_down = True
     p._reload_pass(force=frozenset((WorkerRole.CHAT,)))
     assert plans == []  # returned before planning; nothing can spawn
+
+
+class TestPlanProbeLifecycle:
+    """The provider owns the plan snapshot: captured on clean-box builds only."""
+
+    def _wire(self, monkeypatch, order: list[str]) -> None:
+        monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _FakeSwap())
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: order.append("reap"))
+        monkeypatch.setattr(planning_mod, "capture_plan_probe", lambda: order.append("capture"))
+        monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
+        monkeypatch.setattr(
+            planning_mod,
+            "plan_all_launches",
+            lambda: order.append("plan") or [_fake_launch(WorkerRole.CHAT)],
+        )
+
+    def test_first_build_snapshots_after_reaping(self, monkeypatch) -> None:
+        # Capture must follow the reap (a dead owner's servers still hold VRAM
+        # before it) and precede planning (the plan sizes against the snapshot).
+        order: list[str] = []
+        self._wire(monkeypatch, order)
+        FleetProvider()._ensure_fleet()
+        assert order == ["reap", "capture", "plan"]
+
+    def test_reload_with_a_loaded_fleet_reuses_the_snapshot(self, monkeypatch) -> None:
+        # THE #474 follow-up regression guard: re-planning while our own fleet
+        # holds VRAM must not re-probe (which would shrink ctx/slots and diff
+        # every launch); the boot snapshot stays the sizing basis.
+        order: list[str] = []
+        self._wire(monkeypatch, order)
+        p = FleetProvider()
+        monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._reload_pass()
+        assert "capture" not in order
+        assert "plan" in order
+
+    def test_resurrect_reload_recaptures_the_clean_box(self, monkeypatch) -> None:
+        order: list[str] = []
+        self._wire(monkeypatch, order)
+        p = FleetProvider()
+        monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
+        p._reload_pass(force=frozenset((WorkerRole.CHAT,)))  # nothing running
+        assert order.index("capture") < order.index("plan")
+
+    def test_full_teardown_clears_the_snapshot(self, monkeypatch) -> None:
+        cleared: list[bool] = []
+        monkeypatch.setattr(planning_mod, "clear_plan_probe", lambda: cleared.append(True))
+        FleetProvider()._drop_swap_refs()
+        assert cleared == [True]

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -76,9 +76,11 @@ class _FakeSwap:
 
 
 def _install_engine(monkeypatch, *, launches: list, swap: _FakeSwap | None = None) -> _FakeSwap:
-    """Patch the swap, client, and planner so _ensure_swap builds controllable fakes."""
+    """Patch the swap, client, and planner so _ensure_fleet builds controllable fakes."""
     swap = swap or _FakeSwap()
-    monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir: swap)
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir, _group: swap)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _data_dir: None)
+    monkeypatch.setattr(prov_mod, "sweep_owned", lambda _data_dir: None)
     monkeypatch.setattr(
         prov_mod, "LlamaServerClient", lambda _endpoint, _model, **_kw: _fake_client()
     )
@@ -89,7 +91,8 @@ def _install_engine(monkeypatch, *, launches: list, swap: _FakeSwap | None = Non
 def _provider_with_clients(clients: dict[WorkerRole, list[MagicMock]]) -> FleetProvider:
     """A provider with a fake swap already up and a client pool per role (no real start)."""
     p = FleetProvider()
-    p._swap = _FakeSwap()  # non-None so _ensure_swap short-circuits
+    # Non-empty so _ensure_fleet short-circuits; roles without clients still error.
+    p._swaps = {role: _FakeSwap() for role in clients} or {WorkerRole.CHAT: _FakeSwap()}
     p._clients = {role: list(cs) for role, cs in clients.items() if cs}
     return p
 
@@ -161,18 +164,18 @@ def test_adopt_swap_builds_a_client_per_replica(monkeypatch) -> None:
     launches = [_fake_launch(WorkerRole.EMBED), _fake_launch(WorkerRole.EMBED)]
     _install_engine(monkeypatch, launches=launches)
     p = FleetProvider()
-    p._ensure_swap()
+    p._ensure_fleet()
     assert len(p._clients[WorkerRole.EMBED]) == 2  # one client per replica launch
 
 
-def test_ensure_swap_refused_after_shutdown(monkeypatch) -> None:
+def test_ensure_fleet_refused_after_shutdown(monkeypatch) -> None:
     """bb-dpp source guard: once shut down (and likely discarded by reset_services),
-    a lingering warm-up/reload thread's _ensure_swap must not spawn a new llama-swap
+    a lingering warm-up/reload thread's _ensure_fleet must not spawn a new llama-swap
     on the dead provider -- that is exactly the duplicate that leaks on teardown."""
     swap = _install_engine(monkeypatch, launches=[_fake_launch(WorkerRole.CHAT)])
     p = FleetProvider()
     p._shutdown_swap()  # latches _shut_down (and reaps via a fresh SwapManager)
-    assert p._ensure_swap() is None
+    assert p._ensure_fleet() is False
     assert swap.started == []  # no swap started after shutdown
 
 
@@ -186,7 +189,7 @@ def test_adopt_swap_retires_old_clients_without_closing(monkeypatch) -> None:
     p._clients = {WorkerRole.EMBED: old}
 
     with p._lock:
-        p._adopt_swap(swap, [launch])
+        p._adopt_role(WorkerRole.EMBED, swap, [launch])
 
     assert p._retiring_clients == old  # retired, not closed yet
     for client in old:
@@ -245,10 +248,10 @@ def test_adopt_swap_threads_rerank_mode(monkeypatch) -> None:
         captured["rerank_mode"] = kw.get("rerank_mode")
         return _fake_client()
 
-    monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir: _FakeSwap())
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir, _group: _FakeSwap())
     monkeypatch.setattr(prov_mod, "LlamaServerClient", _capture)
     monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [launch])
-    FleetProvider()._ensure_swap()
+    FleetProvider()._ensure_fleet()
     assert captured["rerank_mode"] is RerankMode.LLM
 
 
@@ -811,23 +814,23 @@ def test_pdf_ocr_without_server_raises() -> None:
 # --- llama-swap lifecycle ----------------------------------------------------
 
 
-def test_ensure_swap_starts_once_and_builds_clients(monkeypatch) -> None:
+def test_ensure_fleet_starts_once_and_builds_clients(monkeypatch) -> None:
     launches = [_fake_launch(WorkerRole.CHAT, slots=4, ctx=32768), _fake_launch(WorkerRole.EMBED)]
     swap = _install_engine(monkeypatch, launches=launches)
     p = FleetProvider()
-    assert p._ensure_swap() is swap
-    assert len(swap.started) == 1  # the swap was started with the planned launches
+    assert p._ensure_fleet() is True
+    assert len(swap.started) == 2  # one start per placed role group
     assert set(p._clients) == {WorkerRole.CHAT, WorkerRole.EMBED}  # one client per placed role
     assert p._chat_slots == 4  # chat capacity / ctx taken from the chat launch
     assert p._chat_ctx == 32768
-    p._ensure_swap()  # second call reuses the running swap
-    assert len(swap.started) == 1
+    p._ensure_fleet()  # second call reuses the running groups
+    assert len(swap.started) == 2
 
 
-def test_ensure_swap_defaults_chat_slots_without_chat_launch(monkeypatch) -> None:
+def test_ensure_fleet_defaults_chat_slots_without_chat_launch(monkeypatch) -> None:
     _install_engine(monkeypatch, launches=[_fake_launch(WorkerRole.EMBED)])
     p = FleetProvider()
-    p._ensure_swap()
+    p._ensure_fleet()
     assert p._chat_slots == 1  # no chat launch -> default capacity
     assert p._chat_ctx is None
 
@@ -854,35 +857,36 @@ def _ordered_planner(order: list[str], launches: list) -> object:
     return _plan
 
 
-def test_ensure_swap_reaps_stale_swaps_before_planning(monkeypatch) -> None:
+def test_ensure_fleet_reaps_stale_swaps_before_planning(monkeypatch) -> None:
     # An OOM-survivor llama-swap holds VRAM; reaping after planning would let
     # the device probe see artificially reduced free memory and misplace.
     order: list[str] = []
-    swap = _OrderedReapSwap(order)
-    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d: swap)
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _FakeSwap())
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: order.append("reap"))
     monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
     monkeypatch.setattr(
         planning_mod, "plan_all_launches", _ordered_planner(order, [_fake_launch(WorkerRole.CHAT)])
     )
-    FleetProvider()._ensure_swap()
+    FleetProvider()._ensure_fleet()
     assert order == ["reap", "plan"]
 
 
 def test_reload_pass_reaps_stale_swaps_before_planning(monkeypatch) -> None:
     order: list[str] = []
-    swap = _OrderedReapSwap(order)
+    swap = _FakeSwap()
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: swap)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: order.append("reap"))
     monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
     monkeypatch.setattr(
         planning_mod, "plan_all_launches", _ordered_planner(order, [_fake_launch(WorkerRole.CHAT)])
     )
     p = FleetProvider()
-    p._swap = swap
+    p._swaps = {WorkerRole.CHAT: swap}
     p._reload_pass()
     assert order == ["reap", "plan"]
-    assert swap.reloads == 1
 
 
-def test_ensure_swap_spawns_nothing_when_no_models(monkeypatch) -> None:
+def test_ensure_fleet_spawns_nothing_when_no_models(monkeypatch) -> None:
     # No configured/installed model -> no launches -> no swap process at all
     # (matches the old supervisor, which spawned nothing for an empty launch set).
     started = {"swaps": 0}
@@ -894,30 +898,30 @@ def test_ensure_swap_spawns_nothing_when_no_models(monkeypatch) -> None:
 
     _install_engine(monkeypatch, launches=[], swap=_CountingSwap())
     p = FleetProvider()
-    assert p._ensure_swap() is None
+    assert p._ensure_fleet() is False
     assert started["swaps"] == 0  # never started
-    assert p._swap is None
+    assert p._swaps == {}
     assert p._clients == {}
 
 
-def test_ensure_swap_returns_none_when_engine_binary_unavailable(monkeypatch) -> None:
+def test_ensure_fleet_returns_none_when_engine_binary_unavailable(monkeypatch) -> None:
     """plan_all_launches raising ProviderError (no engine binary) yields no swap."""
     from lilbee.providers.base import ProviderError
 
-    monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir: _FakeSwap())
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir, _group: _FakeSwap())
 
     def _no_binary() -> list:
         raise ProviderError("Engine binary unavailable")
 
     monkeypatch.setattr(planning_mod, "plan_all_launches", _no_binary)
     p = FleetProvider()
-    assert p._ensure_swap() is None
-    assert p._swap is None
+    assert p._ensure_fleet() is False
+    assert p._swaps == {}
 
 
 def _captured_client_kwargs(monkeypatch, launch) -> dict:
     """Build the engine around *launch* and return the client constructor kwargs."""
-    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d: _FakeSwap())
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _FakeSwap())
     monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [launch])
     captured: list[dict] = []
 
@@ -926,7 +930,7 @@ def _captured_client_kwargs(monkeypatch, launch) -> dict:
         return _fake_client()
 
     monkeypatch.setattr(prov_mod, "LlamaServerClient", _capture)
-    FleetProvider()._ensure_swap()
+    FleetProvider()._ensure_fleet()
     return captured[0]
 
 
@@ -975,7 +979,7 @@ def test_chat_starts_swap_on_first_use(monkeypatch) -> None:
         return client
 
     swap = _FakeSwap()
-    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d: swap)
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: swap)
     monkeypatch.setattr(prov_mod, "LlamaServerClient", _make_client)
     monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [_fake_launch(WorkerRole.CHAT)])
     p = FleetProvider()
@@ -993,7 +997,7 @@ def test_concurrent_first_requests_start_swap_once(monkeypatch) -> None:
             super().start(launches)
 
     swap = _SlowSwap()
-    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d: swap)
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: swap)
 
     def _make_client(_endpoint, _model, **_kw):
         client = _fake_client()
@@ -1023,29 +1027,30 @@ def test_concurrent_first_requests_start_swap_once(monkeypatch) -> None:
 def test_shutdown_tears_down_swap_and_closes_clients() -> None:
     client = _fake_client()
     p = _provider_with_clients({WorkerRole.CHAT: [client]})
-    swap = p._swap
+    swap = next(iter(p._swaps.values()))
     p.shutdown()
     assert swap.shutdowns == 1
     client.close.assert_called_once()
-    assert p._swap is None
+    assert p._swaps == {}
 
 
 def test_invalidate_load_cache_drops_swap() -> None:
     p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
-    swap = p._swap
+    swap = next(iter(p._swaps.values()))
     p.invalidate_load_cache()
     assert swap.shutdowns == 1
-    assert p._swap is None
+    assert p._swaps == {}
 
 
 def test_invalidate_load_cache_leaves_provider_reusable(monkeypatch) -> None:
     """A cache drop is not terminal: the next use rebuilds the swap."""
     swap = _install_engine(monkeypatch, launches=[_fake_launch(WorkerRole.CHAT)])
     p = FleetProvider()
-    assert p._ensure_swap() is swap
+    assert p._ensure_fleet() is True
     p.invalidate_load_cache()
-    assert p._swap is None
-    assert p._ensure_swap() is swap  # rebuilt with current cfg, not refused
+    assert p._swaps == {}
+    assert p._ensure_fleet() is True  # rebuilt with current cfg, not refused
+    assert p._swaps.get(WorkerRole.CHAT) is swap
 
 
 def test_drop_loaded_models_async_leaves_provider_reusable(monkeypatch) -> None:
@@ -1057,10 +1062,11 @@ def test_drop_loaded_models_async_leaves_provider_reusable(monkeypatch) -> None:
     """
     swap = _install_engine(monkeypatch, launches=[_fake_launch(WorkerRole.CHAT)])
     p = FleetProvider()
-    assert p._ensure_swap() is swap
+    assert p._ensure_fleet() is True
     p.drop_loaded_models_async()
-    assert _wait_until(lambda: p._swap is None)
-    assert p._ensure_swap() is swap
+    assert _wait_until(lambda: p._swaps == {})
+    assert p._ensure_fleet() is True  # rebuilt with current cfg, not refused
+    assert p._swaps.get(WorkerRole.CHAT) is swap
 
 
 def _wait_until(predicate, timeout: float = 5.0) -> bool:
@@ -1089,9 +1095,9 @@ def test_warm_up_pool_starts_swap_off_thread(monkeypatch) -> None:
     p = FleetProvider()
     p.warm_up_pool()
     assert started.wait(timeout=5.0)  # start runs on a background thread
-    assert p._swap is None  # warm_up_pool returned before start completed
+    assert p._swaps == {}  # warm_up_pool returned before start completed
     release.set()
-    assert _wait_until(lambda: p._swap is swap)
+    assert _wait_until(lambda: p._swaps.get(WorkerRole.CHAT) is swap)
 
 
 def test_warm_up_pool_single_flight_does_not_double_start(monkeypatch) -> None:
@@ -1112,7 +1118,7 @@ def test_warm_up_pool_single_flight_does_not_double_start(monkeypatch) -> None:
     assert in_start.wait(timeout=5.0)  # first start genuinely in flight
     p.warm_up_pool()  # second call while warming: must not start a second swap
     release.set()
-    assert _wait_until(lambda: p._swap is swap)
+    assert _wait_until(lambda: p._swaps.get(WorkerRole.CHAT) is swap)
     assert starts["n"] == 1
 
 
@@ -1121,7 +1127,7 @@ def test_warm_up_pool_noop_when_swap_already_up(monkeypatch) -> None:
     swap = _install_engine(monkeypatch, launches=[])
     monkeypatch.setattr(swap, "start", lambda launches: starts.__setitem__("n", starts["n"] + 1))
     p = FleetProvider()
-    p._swap = _FakeSwap()  # already up
+    p._swaps = {WorkerRole.CHAT: _FakeSwap()}  # already up
     p.warm_up_pool()
     assert starts["n"] == 0  # no start dispatched
 
@@ -1134,7 +1140,7 @@ def test_warm_up_blocking_logs_and_clears_guard_on_failure(monkeypatch, caplog) 
     p = FleetProvider()
     with caplog.at_level("WARNING", logger="lilbee.providers.fleet.provider"):
         p._warm_up_blocking()  # runs the body synchronously for the assertion
-    assert p._swap is None
+    assert p._swaps == {}
     assert p._warming is False  # guard cleared so a later warm-up can retry
     assert "warm-up failed" in caplog.text.lower()
 
@@ -1185,25 +1191,25 @@ def test_role_ready_reflects_swap_running_state() -> None:
     p = FleetProvider()
     swap = _FakeSwap()
     swap.ready = {WorkerRole.CHAT}
-    p._swap = swap
+    p._swaps = {WorkerRole.CHAT: swap}
     assert p.role_ready(WorkerRole.CHAT) is True
     assert p.role_ready(WorkerRole.EMBED) is False
 
 
 def test_drop_loaded_models_async_tears_down_off_thread() -> None:
     p = _provider_with_clients({WorkerRole.CHAT: [_fake_client()]})
-    swap = p._swap
+    swap = next(iter(p._swaps.values()))
     p.drop_loaded_models_async()
     # Wait on the actual shutdown rather than ``_swap is None``: the worker clears
     # the ref before it calls swap.shutdown(), so the latter is the later signal.
     assert _wait_until(lambda: swap.shutdowns == 1)
-    assert p._swap is None
+    assert p._swaps == {}
 
 
 def test_drop_loaded_models_async_noop_without_swap() -> None:
     p = FleetProvider()  # _swap is None
     p.drop_loaded_models_async()  # must not raise or spawn a thread
-    assert p._swap is None
+    assert p._swaps == {}
 
 
 def test_apply_fleet_gpu_env_skips_autoselect(monkeypatch) -> None:
@@ -1353,7 +1359,7 @@ class TestLifecycleMethods:
     def test_reload_role_dispatches_background_restart(self) -> None:
         done = threading.Event()
         p = FleetProvider()
-        p._swap = _FakeSwap()  # non-None so reload dispatches
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}  # non-None so reload dispatches
         p._reload_blocking = lambda: done.set()  # type: ignore[method-assign]
         p.reload_role(WorkerRole.EMBED)
         assert done.wait(timeout=2.0)  # the spawned thread ran the blocking restart
@@ -1362,11 +1368,18 @@ class TestLifecycleMethods:
         launches = [_fake_launch(WorkerRole.CHAT, slots=2, ctx=4096)]
         monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: launches)
         monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
+        fresh = _FakeSwap()
+        monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: fresh)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
         p = FleetProvider()
-        swap = _FakeSwap()
-        p._swap = swap
+        stale = _FakeSwap()
+        p._swaps = {WorkerRole.CHAT: stale}
         p._reload_blocking()
-        assert swap.reloads == 1
+        # The chat launches changed (old running set unknown -> differs), so the
+        # old group was stopped and a fresh one started and adopted.
+        assert stale.shutdowns == 1
+        assert len(fresh.started) == 1
+        assert p._swaps[WorkerRole.CHAT] is fresh
         assert p._chat_slots == 2  # capacity re-adopted from the new launch set
         assert set(p._clients) == {WorkerRole.CHAT}
 
@@ -1379,7 +1392,7 @@ class TestLifecycleMethods:
         spawned = {"thread": False}
         monkeypatch.setattr("threading.Thread", lambda *a, **k: spawned.__setitem__("thread", True))
         p = FleetProvider()
-        p._swap = _FakeSwap()
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
         ran = {"blocking": False}
         p._reload_blocking = lambda: ran.__setitem__("blocking", True)  # type: ignore[method-assign]
         p.reload_role(WorkerRole.CHAT, wait=True)
@@ -1388,7 +1401,7 @@ class TestLifecycleMethods:
 
     def test_reload_role_wait_propagates_failure(self) -> None:
         p = FleetProvider()
-        p._swap = _FakeSwap()
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
 
         def boom() -> None:
             raise RuntimeError("reload failed")
@@ -1399,7 +1412,7 @@ class TestLifecycleMethods:
 
     def test_reload_role_wait_blocks_until_in_flight_done(self) -> None:
         p = FleetProvider()
-        p._swap = _FakeSwap()
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
         with p._lock:
             p._reloading = True  # simulate a reload already in flight
         returned = threading.Event()
@@ -1472,7 +1485,7 @@ class TestChatCapacityAndCtxGetters:
 
     def test_max_concurrent_chats_reads_chat_slots_when_up(self) -> None:
         p = FleetProvider()
-        p._swap = _FakeSwap()
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
         p._chat_slots = 4
         assert p.max_concurrent_chats() == 4
 
@@ -1481,7 +1494,7 @@ class TestChatCapacityAndCtxGetters:
 
     def test_served_chat_ctx_reads_chat_ctx_when_up(self) -> None:
         p = FleetProvider()
-        p._swap = _FakeSwap()
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
         p._chat_ctx = 32768
         assert p.served_chat_ctx() == 32768
 
@@ -1757,15 +1770,24 @@ class TestReloadSingleFlight:
         assert p._reload_pending is True  # queued for the in-flight thread, not dropped
 
     def test_reload_requested_mid_flight_runs_a_second_pass(self, monkeypatch) -> None:
-        swap = _FakeSwap()
+        plans: list[int] = []
+
+        def _plan() -> list:
+            plans.append(len(plans))
+            return [_fake_launch(WorkerRole.CHAT)]  # fresh object -> differs -> restarts
+
+        monkeypatch.setattr(planning_mod, "plan_all_launches", _plan)
+        monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _FakeSwap())
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
         p = FleetProvider()
-        p._swap = swap
+        monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
         p._reloading = True  # an in-flight reload that already snapshotted its plan
-        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [])
         p.reload_role(WorkerRole.EMBED)  # the second settings change arrives mid-flight
         assert p._reload_pending is True
         p._reload_blocking()  # the in-flight thread runs to completion
-        assert swap.reloads == 2  # one pass per request: the change was applied
+        assert len(plans) == 2  # one pass per request: the change was applied
         assert p._reloading is False
         assert p._reload_pending is False
 
@@ -1788,61 +1810,80 @@ class TestReloadSingleFlight:
 
     def test_reload_pass_failure_clears_guards_and_propagates(self, monkeypatch) -> None:
         class _ExplodingSwap(_FakeSwap):
-            def reload(self, launches: list) -> None:
-                super().reload(launches)
+            def start(self, launches: list) -> None:
                 raise RuntimeError("respawn failed")
 
-        swap = _ExplodingSwap()
+        plans: list[int] = []
+
+        def _plan() -> list:
+            plans.append(len(plans))
+            return [_fake_launch(WorkerRole.CHAT)]
+
+        monkeypatch.setattr(planning_mod, "plan_all_launches", _plan)
+        monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _ExplodingSwap())
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
         p = FleetProvider()
-        p._swap = swap
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
         p._reloading = True
         p._reload_pending = True
-        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [])
         with pytest.raises(RuntimeError, match="respawn failed"):
             p._reload_blocking()
-        assert swap.reloads == 2  # the pending pass still ran before the failure surfaced
+        assert len(plans) == 2  # the pending pass still ran before the failure surfaced
         assert p._reloading is False
         assert p._reload_pending is False
 
     def test_failed_pass_still_applies_the_pending_change(self, monkeypatch) -> None:
-        class _FlakySwap(_FakeSwap):
-            def reload(self, launches: list) -> None:
-                super().reload(launches)
-                if self.reloads == 1:
-                    self.running = False  # the failed restart tore the process down
-                    raise RuntimeError("first pass failed")
-                self.running = True
+        built: list[_FakeSwap] = []
 
-        swap = _FlakySwap()
+        class _FlakyFirstSwap(_FakeSwap):
+            def start(self, launches: list) -> None:
+                if len(built) == 1:  # only the first fresh manager fails its spawn
+                    raise RuntimeError("first pass failed")
+                super().start(launches)
+
+        def _factory(_d: object, _g: object) -> _FakeSwap:
+            built.append(_FlakyFirstSwap())
+            return built[-1]
+
+        monkeypatch.setattr(prov_mod, "SwapManager", _factory)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
+        monkeypatch.setattr(
+            planning_mod, "plan_all_launches", lambda: [_fake_launch(WorkerRole.CHAT)]
+        )
         p = FleetProvider()
-        p._swap = swap
+        monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
         p._reloading = True
         p._reload_pending = True  # a settings change arrived during the failing pass
-        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [])
         p._reload_blocking()  # must not raise: the pending pass succeeded
-        assert swap.reloads == 2
-        assert p._swap is swap  # re-adopted by the successful pass
+        assert len(built) == 2
+        assert p._swaps.get(WorkerRole.CHAT) is built[-1]  # adopted by the successful pass
         assert p._reloading is False
         assert p._reload_pending is False
 
     def test_final_pass_failure_drops_the_dead_swap(self, monkeypatch) -> None:
         class _ExplodingSwap(_FakeSwap):
-            def reload(self, launches: list) -> None:
+            def start(self, launches: list) -> None:
                 self.running = False  # the failed restart tore the process down
                 raise RuntimeError("respawn failed")
 
+        monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _ExplodingSwap())
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(
+            planning_mod, "plan_all_launches", lambda: [_fake_launch(WorkerRole.CHAT)]
+        )
         p = FleetProvider()
-        p._swap = _ExplodingSwap()
+        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
         p._reloading = True
-        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [])
         with pytest.raises(RuntimeError, match="respawn failed"):
             p._reload_blocking()
-        assert p._swap is None  # the next call rebuilds instead of hitting a dead swap
+        assert p._swaps == {}  # the next call rebuilds instead of hitting a dead swap
 
     def test_planning_failure_keeps_a_live_swap(self, monkeypatch) -> None:
         swap = _FakeSwap()
         p = FleetProvider()
-        p._swap = swap
+        p._swaps = {WorkerRole.CHAT: swap}
         p._reloading = True
 
         def _broken_plan() -> list:
@@ -1851,17 +1892,18 @@ class TestReloadSingleFlight:
         monkeypatch.setattr(planning_mod, "plan_all_launches", _broken_plan)
         with pytest.raises(RuntimeError, match="no devices"):
             p._reload_blocking()
-        assert p._swap is swap  # still running and serving the old config
+        assert p._swaps.get(WorkerRole.CHAT) is swap  # still running and serving the old config
         assert swap.shutdowns == 0
 
     def test_reload_clears_the_guard_when_done(self, monkeypatch) -> None:
         swap = _FakeSwap()
         p = FleetProvider()
-        p._swap = swap
+        p._swaps = {WorkerRole.CHAT: swap}
         p._reloading = True
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
         monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [])
         p._reload_blocking()
-        assert swap.reloads == 1
+        assert swap.shutdowns == 1  # nothing planned -> the running group stops
         assert p._reloading is False
         p.reload_role(WorkerRole.CHAT)  # guard released -> a new reload can dispatch
 
@@ -1876,17 +1918,13 @@ class TestReloadSingleFlight:
         gate = threading.Event()
 
         class _OrderedSwap(_FakeSwap):
-            def reload(self, launches: list) -> None:
-                order.append("reload")
-                super().reload(launches)
-
             def shutdown(self) -> None:
                 order.append("shutdown")
                 super().shutdown()
 
         swap = _OrderedSwap()
         p = FleetProvider()
-        p._swap = swap
+        p._swaps = {WorkerRole.CHAT: swap}
         p._reloading = True
 
         reload_entered = threading.Event()
@@ -1896,6 +1934,8 @@ class TestReloadSingleFlight:
             gate.wait(5.0)
             return []
 
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "sweep_owned", lambda _d: None)
         monkeypatch.setattr(planning_mod, "plan_all_launches", _slow_plan)
         reloader = threading.Thread(target=p._reload_blocking)
         reloader.start()
@@ -1907,8 +1947,10 @@ class TestReloadSingleFlight:
         gate.set()
         reloader.join(timeout=5.0)
         shutter.join(timeout=5.0)
-        assert order == ["reload", "shutdown"]  # serialized, no interleaving
-        assert p._swap is None  # the shutdown's state cleanup still landed
+        # The reload's stop phase ran first (nothing planned -> group stops), then
+        # the terminal shutdown's sweep; serialized on the build lock either way.
+        assert order == ["shutdown"]
+        assert p._swaps == {}  # the shutdown's state cleanup still landed
 
 
 class TestWarmProgressTracking:
@@ -2047,14 +2089,14 @@ def test_require_clients_reprobes_dead_swap(monkeypatch) -> None:
     p._clients = {}
     dead = mock.Mock()
     dead.is_live.return_value = False
-    p._swap = dead
+    p._swaps = {WorkerRole.CHAT: dead}
     rebuilt = {"called": False}
 
-    def fake_rebuild() -> None:
+    def fake_rebuild(role: WorkerRole) -> None:
         rebuilt["called"] = True
         p._clients = {WorkerRole.CHAT: [_fake_client()]}
 
-    monkeypatch.setattr(p, "_rebuild_swap", fake_rebuild, raising=False)
+    monkeypatch.setattr(p, "_rebuild_role", fake_rebuild, raising=False)
     clients = p._require_clients(WorkerRole.CHAT)
     assert rebuilt["called"] is True
     assert len(clients) == 1
@@ -2066,13 +2108,13 @@ def test_require_clients_no_reprobe_when_swap_none(monkeypatch) -> None:
 
     rebuilt = {"called": False}
 
-    def fake_rebuild() -> None:
+    def fake_rebuild(role: WorkerRole) -> None:
         rebuilt["called"] = True
 
     p = FleetProvider()
-    p._swap = None
+    p._swaps = {}
     p._clients = {}
-    monkeypatch.setattr(p, "_rebuild_swap", fake_rebuild, raising=False)
+    monkeypatch.setattr(p, "_rebuild_role", fake_rebuild, raising=False)
     with pytest.raises(ProviderError, match="No chat model server is running"):
         p._require_clients(WorkerRole.CHAT)
     assert rebuilt["called"] is False
@@ -2086,28 +2128,40 @@ def test_require_clients_no_reprobe_when_swap_live(monkeypatch) -> None:
 
     rebuilt = {"called": False}
 
-    def fake_rebuild() -> None:
+    def fake_rebuild(role: WorkerRole) -> None:
         rebuilt["called"] = True
 
     p = FleetProvider()
     live = mock.Mock()
     live.is_live.return_value = True
-    p._swap = live
+    p._swaps = {WorkerRole.CHAT: live}
     p._clients = {}
-    monkeypatch.setattr(p, "_rebuild_swap", fake_rebuild, raising=False)
+    monkeypatch.setattr(p, "_rebuild_role", fake_rebuild, raising=False)
     with pytest.raises(ProviderError, match="No chat model server is running"):
         p._require_clients(WorkerRole.CHAT)
     assert rebuilt["called"] is False
 
 
-def test_rebuild_swap_calls_drop_then_ensure(monkeypatch) -> None:
-    """_rebuild_swap calls _drop_swap_refs then _ensure_swap, in that order."""
+def test_rebuild_role_restarts_only_that_role(monkeypatch) -> None:
+    """A dead group's rebuild replaces just that role's swap; the live one stays."""
+    fresh = _FakeSwap()
+    monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: fresh)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+    monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
+    chat_launch, embed_launch = _fake_launch(WorkerRole.CHAT), _fake_launch(WorkerRole.EMBED)
+    monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [chat_launch, embed_launch])
     p = FleetProvider()
-    order: list[str] = []
-
-    monkeypatch.setattr(p, "_drop_swap_refs", lambda: order.append("drop"), raising=False)
-    monkeypatch.setattr(p, "_ensure_swap", lambda: order.append("ensure"), raising=False)
-
-    p._rebuild_swap()
-
-    assert order == ["drop", "ensure"]
+    monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
+    dead, live = _FakeSwap(), _FakeSwap()
+    p._swaps = {WorkerRole.EMBED: dead, WorkerRole.CHAT: live}
+    # The running launches match the plan, so nothing restarts on its own; the
+    # force set is what replaces the dead embed group.
+    p._launches = {
+        WorkerRole.EMBED: (embed_launch,),
+        WorkerRole.CHAT: (chat_launch,),
+    }
+    p._rebuild_role(WorkerRole.EMBED)
+    assert dead.shutdowns == 1  # the dead group was torn down...
+    assert p._swaps[WorkerRole.EMBED] is fresh  # ...and replaced from the fresh plan
+    assert p._swaps[WorkerRole.CHAT] is live  # the healthy group was never touched
+    assert live.shutdowns == 0

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -19,6 +19,9 @@ from lilbee.providers.fleet.launch import InstanceLaunch
 from lilbee.providers.fleet.swap_manager import SwapManager
 from lilbee.providers.roles import WorkerRole
 
+# All lifecycle tests run one manager for the chat group unless stated otherwise.
+_GROUP = "chat"
+
 
 class _FakeProc:
     """A stand-in subprocess that records teardown and reports a poll result."""
@@ -78,10 +81,10 @@ class TestStart:
     ) -> None:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr.start([_launch(WorkerRole.CHAT), _launch(WorkerRole.EMBED)])
         # Config was written and the endpoint is live.
-        config = json.loads((tmp_path / "llama-swap.json").read_text())
+        config = json.loads((tmp_path / "llama-swap-chat.json").read_text())
         assert mgr.endpoint().startswith("http://127.0.0.1:")
         # Each member got its own freshly allocated port, distinct from the proxy's.
         member_ports = {
@@ -109,10 +112,10 @@ class TestStart:
         monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: None)
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
 
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr.start([_launch(WorkerRole.CHAT)])
 
-        log_path = tmp_path / "logs" / "llama-swap.log"
+        log_path = tmp_path / "logs" / "llama-swap-chat.log"
         assert log_path.exists()
         # stdout is the opened log file (its .name is the path), not None
         # (inherited terminal) nor a PIPE; stderr merges into the same file.
@@ -129,7 +132,7 @@ class TestStart:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=1))  # already exited
         _patch_http(monkeypatch, lambda _url: _fake_response(status=503))
         with pytest.raises(ProviderError, match="exited before it was ready"):
-            SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+            SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
 
     def test_raises_when_never_healthy_in_time(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -147,20 +150,20 @@ class TestStart:
         clock = itertools.count(0.0, 10.4)
         monkeypatch.setattr(sm.time, "monotonic", lambda: next(clock))
         with pytest.raises(ProviderError, match="did not start in time"):
-            SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+            SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
 
 
 class TestEndpoint:
     def test_raises_before_start(self, tmp_path: Path) -> None:
         with pytest.raises(ProviderError, match="not running"):
-            SwapManager(tmp_path).endpoint()
+            SwapManager(tmp_path, _GROUP).endpoint()
 
 
 class TestRoleReady:
     def _started(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, responder) -> SwapManager:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda url: _fake_response(status=200))
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr.start([_launch(WorkerRole.CHAT)])
         _patch_http(monkeypatch, responder)
         return mgr
@@ -200,13 +203,13 @@ class TestRoleReady:
     def test_false_when_shutdown_clears_port_mid_probe(self, tmp_path: Path) -> None:
         # A concurrent shutdown clears _port, so endpoint() raises
         # ProviderError; the read-only probe must report False, not throw.
-        mgr = SwapManager(tmp_path)  # never started -> _port is None
+        mgr = SwapManager(tmp_path, _GROUP)  # never started -> _port is None
         assert mgr.role_ready(WorkerRole.CHAT) is False
 
 
 class TestLifecycle:
     def test_shutdown_is_noop_when_not_started(self, tmp_path: Path) -> None:
-        SwapManager(tmp_path).shutdown()  # must not raise
+        SwapManager(tmp_path, _GROUP).shutdown()  # must not raise
 
     def test_shutdown_reaps_owned_fleet_even_without_a_tracked_proc(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -216,7 +219,7 @@ class TestLifecycle:
         Teardown runs even when no swap is tracked."""
         reaped: list[Path] = []
         monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: reaped.append(cfg))
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr.shutdown()  # never started -> _proc is None
         assert reaped == [mgr._config_path]  # the config-path reaper still ran
 
@@ -227,7 +230,7 @@ class TestLifecycle:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
         monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: terminated.append(cfg))
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr.start([_launch(WorkerRole.CHAT)])
         mgr.shutdown()
         assert terminated  # the owned fleet was torn down
@@ -240,7 +243,7 @@ class TestLifecycle:
         starts: list[int] = []
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr.start([_launch(WorkerRole.CHAT)])
         monkeypatch.setattr(
             SwapManager, "start", lambda self, launches: starts.append(len(launches))
@@ -397,7 +400,7 @@ class TestProcessTeardown:
         # Only a swap recorded by a LIVE OTHER owner is protected: our own record
         # is excluded (we reap our own), and a dead owner's record is not spared.
         def _write(owner_pid: int, owner_created_at: float, swap_pid: int) -> None:
-            (tmp_path / sm._state_filename(owner_pid)).write_text(
+            (tmp_path / sm._state_filename(owner_pid, _GROUP)).write_text(
                 json.dumps(
                     {
                         "pid": swap_pid,
@@ -487,7 +490,7 @@ class TestProcessTeardown:
 
 def _own_state_path(tmp_path: Path) -> Path:
     """The state file this process's SwapManager writes for itself."""
-    return tmp_path / sm._state_filename(os.getpid())
+    return tmp_path / sm._state_filename(os.getpid(), _GROUP)
 
 
 def _swap_state(*, pid: int = 123, created_at: float | None = None) -> sm._SwapState:
@@ -581,7 +584,7 @@ class TestCrossRunReaping:
     ) -> None:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         state = json.loads(_own_state_path(tmp_path).read_text())
         assert state["pid"] == 4321
         assert state["name"] == "llama-swap"
@@ -591,7 +594,7 @@ class TestCrossRunReaping:
     ) -> None:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr.start([_launch(WorkerRole.CHAT)])
         assert _own_state_path(tmp_path).exists()
         mgr.shutdown()
@@ -606,7 +609,7 @@ class TestCrossRunReaping:
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         assert stopped == []  # nothing alive to kill
         # the stale file is gone; this owner's own file records the NEW swap
         assert not (tmp_path / "llama-swap.state.json").exists()
@@ -622,7 +625,7 @@ class TestCrossRunReaping:
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         assert [state.pid for state in stopped] == [7777]
 
     def test_pid_reuse_with_foreign_cmdline_is_not_killed(
@@ -636,7 +639,7 @@ class TestCrossRunReaping:
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         assert stopped == []
 
     def test_corrupt_state_file_is_skipped_not_deleted(
@@ -648,14 +651,14 @@ class TestCrossRunReaping:
         corrupt.write_text("{not json")
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         assert corrupt.read_text() == "{not json"
         assert json.loads(_own_state_path(tmp_path).read_text())["pid"] == 4321
 
     def test_torn_state_file_is_left_in_place_by_reap(self, tmp_path: Path) -> None:
         torn = tmp_path / "llama-swap.state.json"
         torn.write_text('{"pid": 77')  # a sibling's write, caught mid-flight
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert torn.read_text() == '{"pid": 77'
 
     def test_load_state_returns_none_when_absent(self, tmp_path: Path) -> None:
@@ -689,7 +692,7 @@ class TestCrossRunReaping:
         _patch_psutil_process(monkeypatch, {7777: other_swap})
         stopped: list[object] = []
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert stopped == []
 
     def test_swap_with_matching_create_time_is_killed(
@@ -700,7 +703,7 @@ class TestCrossRunReaping:
         _patch_psutil_process(monkeypatch, {7777: stale})
         stopped: list[sm._SwapState] = []
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert [state.pid for state in stopped] == [7777]
 
     def test_legacy_state_without_swap_create_time_falls_back_to_cmdline(
@@ -711,7 +714,7 @@ class TestCrossRunReaping:
         _patch_psutil_process(monkeypatch, {7777: stale})
         stopped: list[sm._SwapState] = []
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert [state.pid for state in stopped] == [7777]
 
     def test_start_records_the_swap_create_time(
@@ -722,7 +725,7 @@ class TestCrossRunReaping:
         )
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         assert json.loads(_own_state_path(tmp_path).read_text())["created_at"] == 777.0
 
     def test_start_records_the_owner_lilbee_pid(
@@ -730,7 +733,7 @@ class TestCrossRunReaping:
     ) -> None:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         state = json.loads(_own_state_path(tmp_path).read_text())
         assert state["owner_pid"] == os.getpid()
         assert state["owner_created_at"] == pytest.approx(
@@ -745,7 +748,7 @@ class TestCrossRunReaping:
         monkeypatch.setattr(sm.os, "getpgid", lambda pid: 999, raising=False)
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         assert json.loads(_own_state_path(tmp_path).read_text())["pgid"] == 999
 
     def test_live_owner_leaves_swap_running_and_state_file_intact(
@@ -760,7 +763,7 @@ class TestCrossRunReaping:
         _patch_psutil_process(monkeypatch, {999: owner, 7777: swap})
         stopped: list[object] = []
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert stopped == []
         assert state_path.read_text() == original  # the live owner still needs it
 
@@ -774,7 +777,7 @@ class TestCrossRunReaping:
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         assert [state.pid for state in stopped] == [7777]
 
     def test_zombie_owner_counts_as_dead(
@@ -786,7 +789,7 @@ class TestCrossRunReaping:
         _patch_psutil_process(monkeypatch, {999: zombie, 7777: swap})
         stopped: list[sm._SwapState] = []
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert [state.pid for state in stopped] == [7777]
 
     def test_owner_alive_false_for_missing_owner_pid(self) -> None:
@@ -824,16 +827,16 @@ class TestCrossRunReaping:
             pid=7777,
             owner_pid=999,
             owner_created_at=100.0,
-            filename=sm._state_filename(999),
+            filename=sm._state_filename(999, _GROUP),
         )
         impostor = _FakePsProcess(999, cmdline=["sleep"], create_time=5000.0)
         swap = _FakePsProcess(7777, cmdline=["/opt/llama-swap"])
         _patch_psutil_process(monkeypatch, {999: impostor, 7777: swap})
         stopped: list[sm._SwapState] = []
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert [state.pid for state in stopped] == [7777]
-        assert not (tmp_path / sm._state_filename(999)).exists()
+        assert not (tmp_path / sm._state_filename(999, _GROUP)).exists()
 
     def test_two_owners_coexist_without_clobbering_state(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -846,12 +849,12 @@ class TestCrossRunReaping:
             pid=7777,
             owner_pid=999,
             owner_created_at=100.0,
-            filename=sm._state_filename(999),
+            filename=sm._state_filename(999, _GROUP),
         )
         original = a_path.read_text()
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        mgr_b = SwapManager(tmp_path)
+        mgr_b = SwapManager(tmp_path, _GROUP)
         mgr_b.start([_launch(WorkerRole.CHAT)])
         assert a_path.read_text() == original  # A's record untouched
         assert _own_state_path(tmp_path).exists()  # B wrote its own
@@ -863,13 +866,13 @@ class TestCrossRunReaping:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         state_path = _write_state(
-            tmp_path, pid=7777, owner_pid=999, filename=sm._state_filename(999)
+            tmp_path, pid=7777, owner_pid=999, filename=sm._state_filename(999, _GROUP)
         )
         swap = _FakePsProcess(7777, cmdline=["/opt/llama-swap"])
         _patch_psutil_process(monkeypatch, {7777: swap})  # owner pid 999 is gone
         stopped: list[sm._SwapState] = []
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert [state.pid for state in stopped] == [7777]
         assert not state_path.exists()
 
@@ -882,10 +885,10 @@ class TestCrossRunReaping:
         _patch_psutil_process(monkeypatch, {7777: swap})
         stopped: list[sm._SwapState] = []
         monkeypatch.setattr(sm, "_stop_stale_swap", lambda state: stopped.append(state))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert [state.pid for state in stopped] == [7777]
         assert not legacy.exists()
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert len(stopped) == 1  # nothing left to reap a second time
 
 
@@ -974,7 +977,7 @@ class TestAtomicStateWrite:
         monkeypatch.setattr(sm.os, "replace", _spy)
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT)])
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT)])
         assert replaced == [str(_own_state_path(tmp_path))]
         assert json.loads(_own_state_path(tmp_path).read_text())["pid"] == 4321
         assert [path for path in tmp_path.iterdir() if path.name.endswith(".tmp")] == []
@@ -984,7 +987,7 @@ class TestAtomicStateWrite:
         # record nor removed; dead-writer leftovers are TestStaleTmpCleanup's.
         in_flight = tmp_path / f".llama-swap.state.{os.getpid()}.json.tmp"
         in_flight.write_text('{"pid":')
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert in_flight.exists()
 
 
@@ -1047,8 +1050,8 @@ class TestOrphanServerReaping:
     ) -> None:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path).start([_launch(WorkerRole.CHAT), _launch(WorkerRole.EMBED)])
-        config = json.loads((tmp_path / "llama-swap.json").read_text())
+        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT), _launch(WorkerRole.EMBED)])
+        config = json.loads((tmp_path / "llama-swap-chat.json").read_text())
         expected = sorted(
             int(entry["cmd"].rsplit(" ", 1)[-1]) for entry in config["models"].values()
         )
@@ -1072,7 +1075,7 @@ class TestOrphanServerReaping:
             lambda: iter([orphan, recycled, other_port, no_port, vanished]),
         )
         monkeypatch.setattr(sm.psutil, "wait_procs", lambda procs, timeout: (list(procs), []))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert orphan.terminated is True
         assert recycled.terminated is False  # recycled port, foreign binary
         assert other_port.terminated is False
@@ -1093,7 +1096,7 @@ class TestOrphanServerReaping:
         )
         monkeypatch.setattr(sm.psutil, "process_iter", lambda: iter([adopted]))
         monkeypatch.setattr(sm.psutil, "wait_procs", lambda procs, timeout: (list(procs), []))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert adopted.terminated is False
         assert not (tmp_path / "llama-swap.state.json").exists()
 
@@ -1114,7 +1117,7 @@ class TestOrphanServerReaping:
         )
         monkeypatch.setattr(sm.psutil, "process_iter", lambda: iter([orphan, parent_vanished]))
         monkeypatch.setattr(sm.psutil, "wait_procs", lambda procs, timeout: (list(procs), []))
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert orphan.terminated is True
         assert parent_vanished.terminated is True
 
@@ -1128,7 +1131,7 @@ class TestOrphanServerReaping:
             raise AssertionError("process_iter must not run without recorded ports")
 
         monkeypatch.setattr(sm.psutil, "process_iter", _forbidden)
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert not (tmp_path / "llama-swap.state.json").exists()
 
 
@@ -1139,7 +1142,7 @@ class TestStaleTmpCleanup:
         stale = tmp_path / ".llama-swap.state.424242.json.tmp"
         stale.write_text("{partial")
         monkeypatch.setattr(sm.psutil, "pid_exists", lambda pid: False)
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert not stale.exists()
 
     def test_live_writers_tmp_file_is_kept(
@@ -1148,13 +1151,13 @@ class TestStaleTmpCleanup:
         in_flight = tmp_path / f".llama-swap.state.{os.getpid()}.json.tmp"
         in_flight.write_text("{partial")
         monkeypatch.setattr(sm.psutil, "pid_exists", lambda pid: True)
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert in_flight.exists()
 
     def test_tmp_file_without_a_pid_is_kept(self, tmp_path: Path) -> None:
         legacy = tmp_path / ".llama-swap.state.json.tmp"
         legacy.write_text("{partial")
-        SwapManager(tmp_path).reap_stale()
+        SwapManager(tmp_path, _GROUP).reap_stale()
         assert legacy.exists()
 
 
@@ -1165,7 +1168,7 @@ def test_state_owner_pid_parses_state_and_tmp_names() -> None:
 
 
 def test_write_state_is_noop_without_a_process(tmp_path: Path) -> None:
-    mgr = SwapManager(tmp_path)
+    mgr = SwapManager(tmp_path, _GROUP)
     mgr._write_state()
     assert not _own_state_path(tmp_path).exists()
 
@@ -1175,7 +1178,7 @@ def test_running_reflects_the_spawned_process(
 ) -> None:
     _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
     _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-    mgr = SwapManager(tmp_path)
+    mgr = SwapManager(tmp_path, _GROUP)
     assert mgr.running is False
     mgr.start([_launch(WorkerRole.CHAT)])
     assert mgr.running is True
@@ -1187,7 +1190,7 @@ class TestIsLive:
     def test_true_when_proc_alive_and_running_answers(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr._port = 41999
         mgr._proc = _FakeProc(poll_result=None)  # type: ignore[assignment]
         monkeypatch.setattr(
@@ -1197,14 +1200,14 @@ class TestIsLive:
         assert mgr.is_live() is True
 
     def test_false_when_proc_is_none(self, tmp_path: Path) -> None:
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         assert mgr._proc is None
         assert mgr.is_live() is False
 
     def test_false_when_proc_has_exited(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr._port = 41999
         mgr._proc = _FakeProc(poll_result=1)  # type: ignore[assignment]
         assert mgr.is_live() is False
@@ -1212,7 +1215,7 @@ class TestIsLive:
     def test_false_when_running_probe_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr._port = 41999
         mgr._proc = _FakeProc(poll_result=None)  # type: ignore[assignment]
 
@@ -1226,8 +1229,56 @@ class TestIsLive:
         # Startup-window race: _proc is alive (poll() returns None) but _port is
         # still None. is_live() must return False, not let endpoint()'s
         # ProviderError escape a -> bool method.
-        mgr = SwapManager(tmp_path)
+        mgr = SwapManager(tmp_path, _GROUP)
         mgr._proc = _FakeProc(poll_result=None)  # type: ignore[assignment]
         assert mgr._port is None
         result = mgr.is_live()
         assert result is False
+
+
+class TestPerGroupNaming:
+    def test_groups_get_distinct_config_and_state_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
+        _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
+        chat = SwapManager(tmp_path, "chat")
+        embed = SwapManager(tmp_path, "embed")
+        chat.start([_launch(WorkerRole.CHAT)])
+        embed.start([_launch(WorkerRole.EMBED)])
+        # Each group runs against its own config, so stopping one group's fleet
+        # (keyed on config-path identity) can never touch the other's servers.
+        assert (tmp_path / "llama-swap-chat.json").exists()
+        assert (tmp_path / "llama-swap-embed.json").exists()
+        state_names = {path.name for path in tmp_path.glob("llama-swap.state.*")}
+        assert sm._state_filename(os.getpid(), "chat") in state_names
+        assert sm._state_filename(os.getpid(), "embed") in state_names
+
+    def test_state_owner_pid_parses_group_qualified_names(self) -> None:
+        assert sm._state_owner_pid("llama-swap.state.chat.123.json") == 123
+        assert sm._state_owner_pid(".llama-swap.state.embed.456.json.tmp") == 456
+
+
+class TestSweepOwned:
+    def test_sweeps_every_group_config_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        swept: list[Path] = []
+        monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: swept.append(cfg))
+        (tmp_path / "llama-swap-chat.json").write_text("{}")
+        (tmp_path / "llama-swap-embed.json").write_text("{}")
+        # State files match "llama-swap*" but not the group-config glob: never swept.
+        (tmp_path / "llama-swap.state.chat.1.json").write_text("{}")
+        sm.sweep_owned(tmp_path)
+        assert [path.name for path in swept] == [
+            "llama-swap-chat.json",
+            "llama-swap-embed.json",
+        ]
+
+    def test_noop_when_no_group_configs_exist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        swept: list[Path] = []
+        monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: swept.append(cfg))
+        sm.sweep_owned(tmp_path)
+        assert swept == []

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -396,6 +396,38 @@ class TestProcessTeardown:
         result = sm._swaps_for_config(Path("/data/llama-swap.json"))
         assert [p.pid for p in result] == [10]
 
+    def test_swaps_for_config_skips_processes_that_vanish_mid_scan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A process can exit (or deny access) between enumeration and cmdline();
+        # the scan must skip it, not abort, or a busy box could never be reaped.
+        class _GoneProc:
+            pid = 20
+
+            def cmdline(self) -> list[str]:
+                raise sm.psutil.NoSuchProcess(self.pid)
+
+        class _DeniedProc:
+            pid = 21
+
+            def cmdline(self) -> list[str]:
+                raise sm.psutil.AccessDenied(self.pid)
+
+        swap_bin = "/x/bin/llama-swap"
+        our_cfg = str(Path("/data/llama-swap.json"))
+
+        class _LiveProc:
+            pid = 22
+
+            def cmdline(self) -> list[str]:
+                return [swap_bin, "-config", our_cfg]
+
+        monkeypatch.setattr(
+            sm.psutil, "process_iter", lambda: [_GoneProc(), _DeniedProc(), _LiveProc()]
+        )
+        result = sm._swaps_for_config(Path("/data/llama-swap.json"))
+        assert [p.pid for p in result] == [22]
+
     def test_live_sibling_swap_pids_protects_only_live_other_owner(self, tmp_path: Path) -> None:
         # Only a swap recorded by a LIVE OTHER owner is protected: our own record
         # is excluded (we reap our own), and a dead owner's record is not spared.

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3678,6 +3678,8 @@ class TestRoutingLifecycleForwarding:
         local.cancel_inference.assert_called_once_with()
         rp.reload_role(WorkerRole.EMBED)
         local.reload_role.assert_called_once_with(WorkerRole.EMBED, wait=False)
+        rp.reload_placement(wait=True)
+        local.reload_placement.assert_called_once_with(wait=True)
 
     def test_cancel_and_reload_are_noop_without_local(self) -> None:
         from lilbee.providers.roles import WorkerRole
@@ -3686,6 +3688,7 @@ class TestRoutingLifecycleForwarding:
         rp = RoutingProvider()  # _local is None
         rp.cancel_inference()  # must not raise
         rp.reload_role(WorkerRole.CHAT)  # must not raise
+        rp.reload_placement()  # must not raise
 
     def test_drop_loaded_models_async_forwards_to_local(self) -> None:
         from lilbee.providers.routing_provider import RoutingProvider


### PR DESCRIPTION
## Problem

Applying or clearing a GPU placement rebuilt the whole fleet through the cold-boot path. On a 3x A100 box serving a 112GB chat model plus an embedder, moving just the embedder took 72 to 88 seconds and unloaded the chat model along the way; from the TUI or the plugin it reads as the app hanging (#474).

Two causes compound. One llama-swap process fronted every role, and llama-swap kills all of its upstreams on any config reload, at every version — verified in its source at the vendored v223 and at v234: a reload builds a new server and shuts the old one down, with no process adoption. So there was no way to touch one role without unloading the rest. And the chat bring-up itself spent most of its time in mmap page faults, uploading 112GB at about 3.7GB/s even with the file already in the page cache.

## Solution

Each role now runs behind its own llama-swap with its own config, log, and state file. Teardown and cross-run reaping stay keyed on config-path identity, so stopping one role's group can never touch another's servers. A reload re-plans the whole fleet but diffs the fresh plan per role against what each group is actually running, and restarts only the roles whose launches changed. Applying a placement goes through the live fleet instead of tearing every service down, and the planner keeps diffing against the same clean-box device probe so a loaded fleet can't poison the context sizing.

### Before: one llama-swap for everything

Follow the numbers. One supervisor fronted every role behind a single shared config, and llama-swap kills all of its upstreams on any config reload, so step 1 is the disease: touching the embedder reloads the one config, and the reload takes the chat model down with it.

```mermaid
flowchart LR
    subgraph lilbee ["lilbee"]
        planner["placement planner"]
        provider["FleetProvider"]
    end
    swap["llama-swap<br/>one process, every role,<br/>one shared config"]
    subgraph fleet ["llama-server processes"]
        chat["chat<br/>split GPU 1+2"]
        e1["embed<br/>GPU 0"]
    end
    planner -->|"1: one JSON config for the whole fleet;<br/>any change reloads it all"| swap
    swap -->|"2: reload kills and respawns<br/>every server, chat included"| chat
    swap -->|"2: reload kills and respawns<br/>every server, chat included"| e1
    provider -->|"3: requests by role"| swap
```

### After: one llama-swap per role

Each role gets its own supervisor with its own config, log, and state file. A placement change still re-plans the whole fleet, but the plan is diffed per role against what each group is actually running, so only the roles whose launches changed restart.

```mermaid
flowchart LR
    subgraph lilbee2 ["lilbee"]
        planner2["placement planner"]
        provider2["FleetProvider"]
    end
    subgraph swaps ["llama-swap, one per role"]
        sc["swap: chat<br/>own config, log, state"]
        se["swap: embed<br/>own config, log, state"]
    end
    subgraph fleet2 ["llama-server processes"]
        chat2["chat<br/>split GPU 1+2"]
        e21["embed<br/>GPU 0"]
    end
    planner2 -->|"1: diff the fresh plan per role,<br/>rewrite only changed configs"| sc
    planner2 -->|"1: diff the fresh plan per role,<br/>rewrite only changed configs"| se
    sc -->|"2: restart only its own role"| chat2
    se -->|"2: restart only its own role"| e21
    provider2 -->|"3: requests by role"| sc
    provider2 -->|"3: requests by role"| se
```

The chat server also loads its weights with `--no-mmap` when they fit in at most half of total RAM. Chat only: replicated roles share page-cache pages under mmap, so per-replica host copies would cost RAM for no win. Measured hot-cache bring-up: 33.3s vs 42.7 to 43.8s with mmap.

This carries #476's concurrent role warms and prewarm skip (same commit) and supersedes it.

Measured on the #474 box (3x A100-80GB, Qwen3-235B Q3_K_M + Qwen3-Embedding-8B), against a live server applying placement over the REST route:

- Embed-only change (replicas 3 to 1): apply returned in 2.6s, the chat server kept its PID, and `chat_ready` stayed true throughout. Before: 72 to 88 seconds with the chat model reloaded.
- Chat placement change: 36.9s total (3.0s apply + 33.8s back to ready), `--no-mmap` confirmed in the spawned command line. The 33.8s matches the isolated bench.
- Moving the embedder onto one of chat's cards restarts chat too, correctly: its tensor split and fitted context change, so its launch really is different. The diff is on the actual command line, not just device lists.

Closes #474.

