### PR TITLE
Add Intel-Mac (macos-15-intel) standalone build cells

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,25 @@ jobs:
           - os: macos-latest
             asset_name: lilbee-macos-arm64
             backend: metal
-          # Intel Mac dropped: macos-13 hosted runners stay queued; pip wheel covers them.
+          # Intel Mac: built natively on macos-15-intel, GitHub's Intel image
+          # (Nuitka can't cross-compile arch from the arm64 runner). Soft because
+          # the Intel image can queue longer than the arm64 pool -- this asset must
+          # never block the release fan-out. Deployment target stays 11.0, so the
+          # AVX baseline covers every Mac that can run macOS 11+ (Ivy Bridge or newer).
+          - os: macos-15-intel
+            asset_name: lilbee-macos-x86_64
+            backend: cpu
+            soft: true
+          # Pre-Haswell-safe Intel Mac build: same self-contained model as the
+          # linux/windows compat cells (stock lancedb swapped for +compat, launcher
+          # held to x86-64-v2). Covers the AVX-but-no-AVX2 tail (e.g. 2013 Mac Pro)
+          # and guards against an AVX2-baselined stock lancedb SIGILL.
+          - os: macos-15-intel
+            asset_name: lilbee-compat-macos-x86_64
+            backend: cpu
+            compat: true
+            soft: true
+            march: x86-64-v2
           - os: windows-latest
             asset_name: lilbee-windows-x86_64.exe
             backend: vulkan
@@ -218,7 +236,32 @@ jobs:
           save: ${{ github.ref_type != 'tag' }}
 
       - name: Install dependencies
+        if: matrix.os != 'macos-15-intel'
         run: uv sync --extra release && uv pip install 'nuitka[onefile]>=4.0,<5' pip
+
+      # Intel Mac: `uv sync` can't run here for two reasons -- stock lancedb 0.33.0
+      # ships no macosx_x86_64 wheel, and xberg is pinned to a local arm64 dev wheel
+      # via [tool.uv.sources]. Resolve both from the +compat index (PEP 440 drop-ins),
+      # then install the rest of [release] fresh from PyPI (every other dep has an
+      # x86_64 macOS wheel). CMAKE_ARGS + deployment target hold any throwaway
+      # llama-cpp-python sdist build at the cpu/x86_64/macOS-11 baseline; the dedicated
+      # step below builds the llama-cpp-python that actually ships.
+      # NOTE: gated on xberg landing an x86_64 macOS wheel on the +compat index; until
+      # then this cell is expected to fail at install (it is soft, so it never blocks
+      # the release fan-out).
+      - name: Install dependencies (Intel Mac)
+        if: matrix.os == 'macos-15-intel'
+        shell: bash
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
+        run: |
+          set -euxo pipefail
+          eval "$(BACKEND=cpu TARGET_ARCH=x86_64 tools/wheel-build/cmake_args.sh)"
+          export CMAKE_ARGS
+          uv venv
+          uv pip install --extra-index-url https://lilbee.sh/compat/ \
+            lancedb==0.33.0+compat xberg==1.0.0rc5
+          uv pip install '.[release]' 'nuitka[onefile]>=4.0,<5' pip
 
       - name: Verify extras installed in build venv
         shell: bash
@@ -252,6 +295,11 @@ jobs:
         env:
           ASSET_NAME: ${{ matrix.asset_name }}
           PRODUCT_VERSION: ${{ env.LILBEE_NUITKA_VERSION }}
+          # Pin Nuitka's clang output to macOS 11.0. Unset, clang defaults the
+          # deployment target to the build host (macOS 15 on the Intel image), which
+          # would stamp the launcher minos=15 and refuse to launch on macOS 11-14 even
+          # though every bundled dylib targets 11.0. No-op off macOS.
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
           # compat cell only: hold Nuitka's C output to the pre-Haswell baseline so
           # the launcher layer (not just lancedb) runs on old silicon. Empty elsewhere.
           CFLAGS: ${{ matrix.march && format('-march={0}', matrix.march) || '' }}

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Pre-2013 Intel or pre-Zen AMD CPUs lack [AVX2](https://en.wikipedia.org/wiki/Adv
 | **Scoop**    | `scoop install lilbee-compat`                                                                                                                                                           |
 | **Flatpak**  | `flatpak install lilbee io.github.tobocop2.lilbee.compat`                                                                                                                               |
 | **Snap**     | `curl -LO https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-compat-linux-x86_64.snap && sudo snap install ./lilbee-compat-linux-x86_64.snap --dangerous --classic`    |
-| **Binary**   | [`lilbee-compat-linux-x86_64`](https://github.com/tobocop2/lilbee/releases/latest) or [`lilbee-compat-windows-x86_64.exe`](https://github.com/tobocop2/lilbee/releases/latest)         |
+| **Binary**   | [`lilbee-compat-linux-x86_64`](https://github.com/tobocop2/lilbee/releases/latest), [`lilbee-compat-windows-x86_64.exe`](https://github.com/tobocop2/lilbee/releases/latest), or [`lilbee-compat-macos-x86_64`](https://github.com/tobocop2/lilbee/releases/latest) (pre-AVX2 Intel Macs, e.g. the 2013 Mac Pro) |
 
 Same `lilbee` command after install. The crash is from [lancedb](https://lancedb.github.io/lancedb/)'s AVX2-compiled wheels; this build swaps in a [lancedb fork](https://github.com/tobocop2/lance) that picks instructions at runtime. A 👍 or comment on the upstream [lance PR](https://github.com/lance-format/lance/pull/6630) helps it land.
 

--- a/site/index.html
+++ b/site/index.html
@@ -551,6 +551,18 @@
 
         <div class="binary-row">
           <div class="binary-row-h">
+            <span class="oschip">macOS x86_64</span>
+            <a class="binary-dl" href="https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-macos-x86_64">download lilbee-macos-x86_64 &rarr;</a>
+          </div>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">curl -L https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-macos-x86_64 -o lilbee &amp;&amp; chmod +x lilbee &amp;&amp; xattr -d com.apple.quarantine ./lilbee</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
+
+        <div class="binary-row">
+          <div class="binary-row-h">
             <span class="oschip">Windows x86_64</span>
             <a class="binary-dl" href="https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-windows-x86_64.exe">download lilbee-windows-x86_64.exe &rarr;</a>
           </div>
@@ -599,6 +611,17 @@
         </div>
         <div class="binary-row">
           <div class="binary-row-h">
+            <span class="oschip">macOS x86_64</span>
+            <a class="binary-dl" href="https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-compat-macos-x86_64">download lilbee-compat-macos-x86_64 &rarr;</a>
+          </div>
+          <div class="install">
+            <span class="prompt">$</span>
+            <span class="cmd">curl -L https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-compat-macos-x86_64 -o lilbee &amp;&amp; chmod +x lilbee &amp;&amp; xattr -d com.apple.quarantine ./lilbee</span>
+            <button type="button" class="copy" aria-label="Copy command">[ COPY ]</button>
+          </div>
+        </div>
+        <div class="binary-row">
+          <div class="binary-row-h">
             <span class="oschip">Windows x86_64</span>
             <a class="binary-dl" href="https://github.com/tobocop2/lilbee/releases/latest/download/lilbee-compat-windows-x86_64.exe">download lilbee-compat-windows-x86_64.exe &rarr;</a>
           </div>
@@ -611,7 +634,7 @@
 
         <button type="button" class="notes-toggle" aria-expanded="false" aria-controls="notes-binary">details</button>
         <div class="notes-body" id="notes-binary" hidden>
-          <p class="extras"><span class="k">unsigned:</span> the macOS arm64 and Windows builds aren't code-signed. The macOS one-liner clears quarantine for you; Homebrew does the same. On Windows, SmartScreen may warn the first time.</p>
+          <p class="extras"><span class="k">unsigned:</span> the macOS and Windows builds aren't code-signed. The macOS one-liner clears quarantine for you; Homebrew does the same. On Windows, SmartScreen may warn the first time.</p>
           <p class="extras">older CPU on Windows also via <code>scoop install lilbee-compat</code> &nbsp;.&nbsp; CUDA <code>cu124</code> / <code>cu121</code> for older drivers on the <a href="https://github.com/tobocop2/lilbee/releases">releases page</a></p>
         </div>
       </div>


### PR DESCRIPTION
## Problem

`feat/kreuzberg-5` drops the Intel-Mac standalone binary (the release matrix has a stale "Intel Mac dropped: macos-13 runners stay queued" note), even though xberg now ships x86_64 macOS wheels and GitHub offers a native Intel image. macOS x86_64 users have no standalone binary.

## Solution

Bring back the native Intel-Mac build, mirroring the recipe already proven on `feat/intel-mac-support`:

- Two soft `macos-15-intel` matrix cells in `release.yml`: the stock AVX `lilbee-macos-x86_64` and a pre-Haswell `lilbee-compat-macos-x86_64` held to `x86-64-v2` (same self-contained model as the linux/windows compat cells). Both `soft`, so a queued or failing Intel runner never blocks the release fan-out.
- A dedicated Intel dep-install step, because `uv sync` can't run there: stock lancedb 0.33.0 has no x86_64 macOS wheel and xberg is pinned to a local arm64 dev wheel, so both are pulled from the `lilbee.sh/compat` index.
- The macOS 11.0 deployment-target pin on the Nuitka step, so the launcher runs on macOS 11-14 instead of stamping the build host's macOS 15.
- x86_64 download entries on the marketing site and in the README compat row.

Note: the Intel cells are gated on xberg publishing an x86_64 macOS wheel to the compat index; until then the cell fails at install, but it is `soft` so it never blocks a release. The workflow only runs on dispatch/call (not push/PR), so this doesn't add red CI to the branch.