### PR TITLE
Ingest tracing + OCR token and embed-context fixes

### DIFF
--- a/src/lilbee/data/ingest/extract.py
+++ b/src/lilbee/data/ingest/extract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import time
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
@@ -14,6 +15,7 @@ from lilbee.app.services import get_services
 from lilbee.core.config import active_config
 from lilbee.data.chunk import build_chunking_config, chunk_text
 from lilbee.data.ingest.offload import to_ingest_thread
+from lilbee.data.ingest.trace import ExtractionTrace, trace_extraction, trace_log
 from lilbee.data.ingest.types import (
     IMAGE_CONTENT_TYPE,
     MARKDOWN_OUTPUT,
@@ -246,10 +248,29 @@ async def ingest_document(
             ExtractEvent(file=source_name, page=page_seen, total_pages=0),
         )
 
+    trace_log.debug("extract-start source=%r type=%s", source_name, content_type)
+    started = time.perf_counter()
     with ocr_request(on_page=_tick, timeout=_effective_ocr_timeout()) as token:
         config = extraction_config(content_type_to_mode(content_type), ocr_token=token)
         # xberg's extract is async; awaiting it keeps the OCR page loop off this thread.
         doc = await aextract_document(path.read_bytes(), filename=path.name, config=config)
+    elapsed = time.perf_counter() - started
+
+    # One trace line per xberg extraction (filename, timing, counts, OCR pages),
+    # plus a dedicated vision line for scanned files -- the diagnostics an xberg
+    # author needs. Emitted for empty results too: a slow file that yields nothing
+    # is exactly the case worth surfacing.
+    trace_extraction(
+        ExtractionTrace(
+            source=source_name,
+            content_type=content_type,
+            elapsed_s=elapsed,
+            page_count=len(doc.pages or []) or len(doc.chunks or []),
+            chunk_count=len(doc.chunks or []),
+            ocr_pages=page_seen,
+            vision_configured=bool(active_config().vision_model),
+        )
+    )
 
     if not doc.chunks:
         if content_type in (PDF_CONTENT_TYPE, IMAGE_CONTENT_TYPE):

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -33,6 +33,7 @@ from lilbee.data.ingest.skip_marker import (
     write_skip_markers,
     write_skip_reasons,
 )
+from lilbee.data.ingest.trace import configure_from_env as configure_trace_from_env
 from lilbee.data.ingest.types import (
     ChunkRecord,
     FileChangePlan,
@@ -531,6 +532,9 @@ async def ingest_batch(
     ingesting new ones so the two operations are atomic per file.
     When *cancel* is set, pending files raise CancelledError before starting.
     """
+    # Honor LILBEE_INGEST_TRACE once per batch: it raises the trace loggers above
+    # the default WARNING so per-file extraction lines actually surface.
+    configure_trace_from_env()
     semaphore = asyncio.Semaphore(_max_concurrent())
     window = _max_concurrent() * _TASK_WINDOW_MULTIPLIER
     total_files = len(files_to_process)

--- a/src/lilbee/data/ingest/trace.py
+++ b/src/lilbee/data/ingest/trace.py
@@ -1,0 +1,87 @@
+"""Structured per-file extraction tracing, for sharing ingest diagnostics.
+
+Every xberg extraction emits one machine-parseable line on the ``lilbee.ingest.trace``
+logger: filename, wall-clock, chunk and page counts, and how many pages fell through
+to OCR. Files that needed the vision model also emit a line on ``lilbee.ingest.vision``
+so ``grep vision`` yields exactly the set of scanned files. Enable with
+``LILBEE_INGEST_TRACE=1`` (sets both loggers to DEBUG).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+trace_log = logging.getLogger("lilbee.ingest.trace")
+vision_log = logging.getLogger("lilbee.ingest.vision")
+
+_TRACE_ENV = "LILBEE_INGEST_TRACE"
+
+
+@dataclass(frozen=True)
+class ExtractionTrace:
+    """One xberg extraction's measured outcome."""
+
+    source: str
+    content_type: str
+    elapsed_s: float
+    page_count: int
+    chunk_count: int
+    ocr_pages: int
+    vision_configured: bool
+
+    @property
+    def used_vision(self) -> bool:
+        """A page fell through to OCR and the OCR backend is the vision model."""
+        return self.ocr_pages > 0 and self.vision_configured
+
+    def as_line(self) -> str:
+        """A stable key=value line, easy to grep, diff, and hand to the xberg author."""
+        return (
+            f"extract source={self.source!r} type={self.content_type} "
+            f"elapsed_ms={self.elapsed_s * 1000:.0f} pages={self.page_count} "
+            f"chunks={self.chunk_count} ocr_pages={self.ocr_pages} "
+            f"vision={'yes' if self.used_vision else 'no'}"
+        )
+
+
+def configure_from_env() -> None:
+    """Enable trace/vision logging per LILBEE_INGEST_TRACE; mirror to a file when
+    LILBEE_INGEST_TRACE_FILE is set.
+
+    The file handler exists because host apps own the root handlers: the TUI
+    logs WARNING+ to its file, so INFO trace lines vanish there even with the
+    loggers enabled. A dedicated handler on these two loggers makes the trace
+    destination independent of whichever front-end is running."""
+    if os.environ.get("LILBEE_INGEST_TRACE", "").strip().lower() not in {"1", "true", "yes"}:
+        return
+    trace_log.setLevel(logging.DEBUG)
+    vision_log.setLevel(logging.INFO)
+    target = os.environ.get("LILBEE_INGEST_TRACE_FILE", "").strip()
+    if not target:
+        return
+    resolved = str(Path(target).absolute())
+    for logger in (trace_log, vision_log):
+        if any(
+            isinstance(h, logging.FileHandler) and h.baseFilename == resolved
+            for h in logger.handlers
+        ):
+            continue
+        handler = logging.FileHandler(resolved)
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+        logger.addHandler(handler)
+
+
+def trace_extraction(trace: ExtractionTrace) -> None:
+    """Log one extraction's outcome, plus a dedicated line if it needed vision."""
+    trace_log.info("%s", trace.as_line())
+    if trace.used_vision:
+        vision_log.info(
+            "vision-ocr source=%r ocr_pages=%d elapsed_ms=%.0f",
+            trace.source,
+            trace.ocr_pages,
+            trace.elapsed_s * 1000,
+        )

--- a/src/lilbee/data/ingest/vision_ocr_backend.py
+++ b/src/lilbee/data/ingest/vision_ocr_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 import uuid
 from contextlib import contextmanager
@@ -16,7 +17,13 @@ from lilbee.vision import resolve_ocr_prompt
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
-    from xberg import ExtractedDocument, OcrBackendType, OcrConfig
+    from xberg import ExtractedDocument, OcrBackendType
+
+    # The OcrBackend Protocol and the runtime trait callbacks use the native
+    # OcrConfig (xberg._xberg.OcrConfig), which is a different type from the public
+    # xberg.OcrConfig re-exported from xberg.options; a backend typed against the
+    # public one cannot satisfy the Protocol. Filed upstream (xberg).
+    from xberg._xberg import OcrConfig
 
 # Token key inside OcrConfig.backend_options JSON. xberg does not propagate
 # contextvars into process_image (xberg-4w9), so per-request state travels as
@@ -79,8 +86,8 @@ def backend_options_for(token: str) -> dict[str, str]:
 class _OcrConfigView:
     """Typed reader over the xberg OcrConfig object passed to process_image.
 
-    xberg hands the callback the public ``xberg.OcrConfig`` dataclass, so its
-    fields are read directly as attributes; ``backend_options`` is a dict.
+    xberg hands the callback a native OcrConfig (alef typed trait callbacks), so
+    its fields are read directly as attributes; ``backend_options`` is a dict.
     """
 
     def __init__(self, config: OcrConfig) -> None:
@@ -92,7 +99,16 @@ class _OcrConfigView:
 
     @property
     def request_token(self) -> str | None:
+        # The native round-trip hands backend_options back as a JSON STRING, not
+        # the dict lilbee put in (alef serializes the map). Accept both shapes,
+        # or the token -- and with it on_page progress and the OCR timeout --
+        # silently vanishes for every OCR call.
         options = self._config.backend_options
+        if isinstance(options, str):
+            try:
+                options = json.loads(options)
+            except json.JSONDecodeError:
+                return None
         token = options.get(_REQUEST_TOKEN_KEY) if isinstance(options, dict) else None
         return token if isinstance(token, str) else None
 
@@ -154,9 +170,9 @@ class VisionOcrBackend:
         return False
 
     def process_image(self, image_bytes: bytes, config: OcrConfig) -> ExtractedDocument:
-        # xberg passes the public OcrConfig dataclass and expects a native
-        # ExtractedDocument back; read the request token and prompt override off
-        # the config, return the OCR text as markdown.
+        # xberg passes the OcrConfig as a native object and expects a native
+        # ExtractedDocument back (alef typed trait callbacks); read the request
+        # token and prompt override off the config, return the OCR text as markdown.
         from xberg import ExtractedDocument
 
         view = _OcrConfigView(config)

--- a/src/lilbee/providers/engine_params.py
+++ b/src/lilbee/providers/engine_params.py
@@ -40,9 +40,19 @@ _EMBED_CTX_MARGIN = 8
 
 
 def resolve_embed_ctx(meta: dict[str, str] | None, model_path: Path) -> int:
-    """Embed/rerank context: chunk length plus truncation margin, capped by trained context."""
+    """Embed/rerank context: worst-case chunk tokenization, capped by trained context.
+
+    ``chunk_size`` is token-denominated but the chunker enforces a CHARACTER
+    budget (``chunk_size * CHARS_PER_TOKEN``). A BPE token is at least one
+    character, so that char budget is also the PROVABLE token ceiling for any
+    chunk the chunker can emit: size the context to it and embed-time
+    truncation becomes impossible, not merely rare. (Observed live before the
+    fix: numeric-table chunks at ~1.5 chars/token reached 1982 tokens against a
+    2x-chunk_size cap and lost their tails -- silently unsearchable text.)"""
+    from lilbee.data.chunk import CHARS_PER_TOKEN
+
     train_ctx = train_ctx_from_meta(meta, fallback=EMBED_FALLBACK_CTX, model_path=model_path)
-    return min(train_ctx, cfg.chunk_size + _EMBED_CTX_MARGIN)
+    return min(train_ctx, cfg.chunk_size * CHARS_PER_TOKEN + _EMBED_CTX_MARGIN)
 
 
 _LLM_RERANK_HEADROOM = 512

--- a/tests/test_ingest_trace.py
+++ b/tests/test_ingest_trace.py
@@ -1,0 +1,111 @@
+"""The extraction trace: one parseable line per file, a vision line when OCR fired."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lilbee.data.ingest.trace import (
+    ExtractionTrace,
+    configure_from_env,
+    trace_extraction,
+    trace_log,
+    vision_log,
+)
+
+
+def _trace(**kw: object) -> ExtractionTrace:
+    base = {
+        "source": "docs/report.pdf",
+        "content_type": "application/pdf",
+        "elapsed_s": 1.234,
+        "page_count": 10,
+        "chunk_count": 42,
+        "ocr_pages": 0,
+        "vision_configured": True,
+    }
+    base.update(kw)
+    return ExtractionTrace(**base)  # type: ignore[arg-type]
+
+
+def test_line_carries_filename_timing_and_counts() -> None:
+    line = _trace().as_line()
+    assert "source='docs/report.pdf'" in line
+    assert "elapsed_ms=1234" in line
+    assert "pages=10" in line
+    assert "chunks=42" in line
+    assert "ocr_pages=0" in line
+    assert "vision=no" in line
+
+
+def test_used_vision_requires_ocr_pages_and_a_configured_model() -> None:
+    assert _trace(ocr_pages=5, vision_configured=True).used_vision is True
+    assert _trace(ocr_pages=5, vision_configured=False).used_vision is False  # tesseract
+    assert _trace(ocr_pages=0, vision_configured=True).used_vision is False  # all native
+
+
+def test_native_only_file_emits_no_vision_line(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="lilbee.ingest.vision")
+    caplog.set_level(logging.INFO, logger="lilbee.ingest.trace")
+    trace_extraction(_trace(ocr_pages=0))
+    assert any(r.name == "lilbee.ingest.trace" for r in caplog.records)
+    assert not any(r.name == "lilbee.ingest.vision" for r in caplog.records)
+
+
+def test_scanned_file_emits_a_dedicated_vision_line(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="lilbee.ingest.vision")
+    trace_extraction(_trace(ocr_pages=7, vision_configured=True))
+    vision_records = [r for r in caplog.records if r.name == "lilbee.ingest.vision"]
+    assert len(vision_records) == 1
+    assert "ocr_pages=7" in vision_records[0].getMessage()
+    assert "docs/report.pdf" in vision_records[0].getMessage()
+
+
+def test_env_flag_enables_both_loggers(monkeypatch: pytest.MonkeyPatch) -> None:
+    trace_log.setLevel(logging.WARNING)
+    vision_log.setLevel(logging.WARNING)
+    monkeypatch.setenv("LILBEE_INGEST_TRACE", "1")
+    configure_from_env()
+    assert trace_log.level == logging.DEBUG  # includes the extract-start debug line
+    assert vision_log.level == logging.INFO  # vision lines are INFO, and emit
+
+
+def test_trace_file_receives_records_when_host_handlers_filter(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    # The TUI's root file handler is WARNING+; the dedicated trace file must
+    # still receive every INFO line or the extraction report starves.
+    from pathlib import Path
+
+    target = Path(str(tmp_path)) / "trace.log"
+    monkeypatch.setenv("LILBEE_INGEST_TRACE", "1")
+    monkeypatch.setenv("LILBEE_INGEST_TRACE_FILE", str(target))
+    configure_from_env()
+    try:
+        trace_extraction(_trace(ocr_pages=3, vision_configured=True))
+        for handler in [*trace_log.handlers, *vision_log.handlers]:
+            handler.flush()
+        text = target.read_text()
+        assert "extract source=" in text and "vision-ocr source=" in text
+        configure_from_env()  # idempotent: same file re-configured adds no dup handler
+        resolved = str(target.absolute())
+        dups = [h for h in trace_log.handlers if getattr(h, "baseFilename", "") == resolved]
+        assert len(dups) == 1
+    finally:
+        for logger in (trace_log, vision_log):
+            for handler in list(logger.handlers):
+                logger.removeHandler(handler)
+                handler.close()
+
+
+def test_trace_surfaces_under_a_warning_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The real failure mode: root at WARNING (lilbee's default) silently drops
+    # INFO trace lines. The env flag must lift the named loggers so records emit.
+    logging.getLogger().setLevel(logging.WARNING)
+    trace_log.setLevel(logging.WARNING)
+    vision_log.setLevel(logging.WARNING)
+    monkeypatch.setenv("LILBEE_INGEST_TRACE", "1")
+    configure_from_env()
+    assert trace_log.isEnabledFor(logging.INFO)
+    assert vision_log.isEnabledFor(logging.INFO)

--- a/tests/test_vision_ocr_backend.py
+++ b/tests/test_vision_ocr_backend.py
@@ -126,6 +126,22 @@ class TestProcessImage:
         assert calls[0][3] == 12.5
         assert ticks == [1]
 
+    def test_json_string_backend_options_resolve(self):
+        # The native round-trip hands backend_options back as a JSON STRING
+        # (alef serializes the map). The token must resolve from that shape or
+        # per-page progress and the OCR timeout silently vanish on every real
+        # extraction, while dict-based unit tests stay green.
+        import json
+
+        ticks: list[int] = []
+        be, calls = _backend()
+        with ocr_request(on_page=lambda: ticks.append(1), timeout=7.5) as token:
+            be.process_image(
+                b"PNG", _cfg(backend_options=json.dumps(backend_options_for(token)))
+            )
+        assert calls[0][3] == 7.5
+        assert ticks == [1]
+
     def test_no_context_uses_zero_timeout_and_no_tick(self):
         be, calls = _backend()
         be.process_image(b"PNG", _cfg(backend_options=backend_options_for("unknown-token")))


### PR DESCRIPTION
## Problem

A large batch-ingest run surfaced three silent-loss bugs in the extraction pipeline, and diagnosing them required per-file visibility the pipeline didn't have.

1. `OcrConfig.backend_options` crosses the native boundary as a JSON string, not the dict lilbee supplied, so the per-page OCR progress callback and the configured `ocr_timeout` were silently dropped on every vision OCR call.
2. The embed server context was sized in tokens from `chunk_size`, but the chunker enforces a character budget (`chunk_size * CHARS_PER_TOKEN`). Token-dense text tokenizes near 1.5-2.5 chars/token, so real chunks approached 2000 tokens against a 512-token cap and lost their tails at embed time -- silently unsearchable text.
3. There was no per-file extraction visibility, and INFO-level diagnostics never reach disk under the TUI (its root handler is WARNING+).

## Solution

- Per-file extraction tracing behind `LILBEE_INGEST_TRACE=1`: one parseable line per file (source, type, elapsed, pages, chunks, ocr_pages, vision attribution) plus a vision line when OCR fires; `LILBEE_INGEST_TRACE_FILE` mirrors the stream to a file independent of the host front-end.
- The OCR config view accepts both dict and JSON-string `backend_options`, restoring progress ticks and timeouts.
- Embed context is now the chunker's character budget capped by the embedder's trained context. A BPE token is at least one character, so that bound is provable: embed-time truncation cannot occur for chunker-emitted chunks. Verified on a live multi-GPU run -- zero truncation warnings end to end.

Each change is covered by unit tests, including the JSON-string and WARNING-root regression cases.