### PR TITLE
Manual placement derives planner-style tensor splits instead of even shares

### DIFF
--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -199,7 +199,7 @@ def _place_split(
     best: tuple[int, list[int], tuple[int, ...], tuple[int, ...]] | None = None
     for count in range(2, len(by_free) + 1):
         chosen = by_free[:count]
-        ratio = tuple(max(1, int(remaining[idx] / 1024**3)) for idx in chosen)
+        ratio = _vram_proportional_split(chosen, remaining)
         per_device = estimate_peak(model.role, ratio)
         if len(per_device) != count or not all(
             peak <= remaining[idx] for idx, peak in zip(chosen, per_device, strict=True)
@@ -317,7 +317,7 @@ def placement_from_spec(
     instances: list[InstancePlan] = []
     for role in active_roles:
         rp = _required_entry(spec, role, device_capacity)
-        ratio = rp.tensor_split or tuple(1 for _ in rp.devices)
+        ratio = rp.tensor_split or _vram_proportional_split(rp.devices, remaining)
         per_device = estimate_peak(role, ratio)
         split = ratio if len(rp.devices) > 1 else ()
         for replica in range(rp.replicas):
@@ -328,6 +328,22 @@ def placement_from_spec(
                 )
             )
     return Placement(instances=tuple(instances), unplaceable_roles=())
+
+
+def _vram_proportional_split(
+    devices: Sequence[int], remaining: dict[int, float]
+) -> tuple[int, ...]:
+    """Tensor-split ratio proportional to each card's remaining usable VRAM.
+
+    Each card's shard tracks its remaining VRAM (whole GiB, min 1), so a card
+    already carrying other roles takes a smaller share. This is the single source
+    of the proportion for both placement paths: the auto planner (:func:`_place_split`)
+    and a manual spec entry with no explicit ``tensor_split`` (:func:`placement_from_spec`).
+    Keeping it in one place is what guarantees a manually-applied layout is charged
+    the same way the planner charges the identical layout, instead of an even split
+    that would falsely reject a fit the planner itself serves.
+    """
+    return tuple(max(1, int(remaining[idx] / 1024**3)) for idx in devices)
 
 
 def _required_entry(

--- a/tests/providers/fleet/test_placement_from_spec.py
+++ b/tests/providers/fleet/test_placement_from_spec.py
@@ -78,3 +78,51 @@ def test_errors_when_two_roles_overbook_one_card():
         placement_from_spec(
             spec, (WorkerRole.CHAT, WorkerRole.EMBED), {0: 80 * GIB}, estimate_peak=est
         )
+
+
+def _proportional_peak(totals_gib):
+    # Like the real estimator: a role's total bytes split proportionally to ratio.
+    def estimate(role, ratio):
+        total = totals_gib[role] * GIB
+        s = sum(ratio)
+        return tuple(int(total * r / s) for r in ratio)
+
+    return estimate
+
+
+def test_derives_planner_style_split_when_spec_has_none():
+    # bb-lt7: three 48 GiB cards with the embedder resident on card 0. An even
+    # chat split (~36.7 GiB per card) overflows card 0 (43.2 usable minus 8.5
+    # embed = 34.7), so the even-split validator rejects the exact layout the
+    # auto planner serves. A remaining-proportional split shrinks card 0's
+    # shard and the same layout fits.
+    spec = PlacementSpec(
+        {
+            WorkerRole.EMBED: RolePlacement(devices=(0,)),
+            WorkerRole.CHAT: RolePlacement(devices=(0, 1, 2)),
+        }
+    )
+    est = _proportional_peak({WorkerRole.CHAT: 110, WorkerRole.EMBED: 8.5})
+    placement = placement_from_spec(
+        spec,
+        (WorkerRole.EMBED, WorkerRole.CHAT),  # planning registers non-chat roles first
+        {0: 48 * GIB, 1: 48 * GIB, 2: 48 * GIB},
+        estimate_peak=est,
+    )
+    assert placement.unplaceable_roles == ()
+    chat = next(i for i in placement.instances if i.role is WorkerRole.CHAT)
+    assert len(chat.tensor_split) == 3
+    assert chat.tensor_split[0] < chat.tensor_split[1]  # co-resident card takes the smaller shard
+
+
+def test_explicit_tensor_split_still_wins():
+    # A spec that names its own split is honored verbatim, even when uneven.
+    spec = PlacementSpec(
+        {WorkerRole.CHAT: RolePlacement(devices=(0, 1), tensor_split=(3, 1))}
+    )
+    est = _proportional_peak({WorkerRole.CHAT: 40})
+    placement = placement_from_spec(
+        spec, (WorkerRole.CHAT,), {0: 80 * GIB, 1: 80 * GIB}, estimate_peak=est
+    )
+    chat = next(i for i in placement.instances if i.role is WorkerRole.CHAT)
+    assert chat.tensor_split == (3, 1)


### PR DESCRIPTION
## Problem

Applying a manual GPU placement validated each multi-card role with an even per-card share whenever the spec didn't name a tensor split. On tight hardware that rejects layouts the auto planner itself serves happily: on three 48 GB L40s, auto runs chat across cards 0, 1, and 2 beside the embedder on card 0 by giving that card a smaller shard, but manually applying the identical layout failed with "chat pinned to device 0 needs 36.9 GiB but device 0 has 31.5 GiB usable". Manual placement was effectively unusable anywhere the fit depends on uneven splits.

## Solution

`placement_from_spec` now derives the same remaining-VRAM-proportional ratio the planner computes (whole GiB per card, minimum 1) when the spec has no explicit split, so a card already carrying other roles takes a smaller shard and the applied plan carries that derived split through to `--tensor-split`. Specs that name their own split are honored verbatim, and single-card entries are unchanged. Role ordering already charges the non-chat roles first, which is what lets the derivation see the co-resident footprints.

Covered by tests for the L40 case (an even split is rejected, the derived split fits, and the co-resident card takes the smaller shard) plus a guard that an explicit uneven split still wins.
