### PR TITLE
Backport non-xberg fixes stranded on feat/kreuzberg-5

### DIFF
--- a/src/lilbee/core/settings.py
+++ b/src/lilbee/core/settings.py
@@ -93,7 +93,13 @@ def overlay_persisted_settings(root: Path) -> None:
     An explicit ``LILBEE_<FIELD>`` env var wins over config.toml (the documented
     precedence): cfg already holds the env-loaded value, so a key whose env var is
     set is left untouched rather than overwritten by the persisted file.
+
+    ``LILBEE_SKIP_TOML_CONFIG=1`` disables this overlay entirely, matching the
+    pydantic-settings source in ``config/model.py`` so the escape hatch is honored
+    on every config-read path (import-time load, CLI callback, MCP server).
     """
+    if os.environ.get("LILBEE_SKIP_TOML_CONFIG") == "1":
+        return
     log = logging.getLogger(__name__)
     try:
         persisted = load(root)

--- a/src/lilbee/modelhub/registry.py
+++ b/src/lilbee/modelhub/registry.py
@@ -279,6 +279,19 @@ class ModelRegistry:
                 if blob.exists():
                     return blob
         for filename in sorted(self._cached_gguf_names(hf_repo)):
+            shards = split_shard_filenames(filename)
+            if len(shards) > 1:
+                # A split set in the cache: skip its non-first shards and resolve
+                # the whole set from shard 1 so we hand back the snapshot symlink
+                # (siblings co-located, loadable) with shard accounting, not
+                # shard 1's blob as an unloadable single file.
+                if filename != shards[0]:
+                    continue
+                with contextlib.suppress(KeyError):
+                    return self._resolve_split(
+                        format_native_gguf_ref(hf_repo, filename), hf_repo, shards
+                    )
+                continue
             recovered = self._find_cached_gguf(hf_repo, filename)
             if recovered is not None:
                 self._reregister_from_cache(hf_repo, filename, recovered)

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -597,7 +597,7 @@ def _server_model_inputs(
     projector, and a role whose model is not installed on disk.
     """
     from lilbee.core.config import cfg
-    from lilbee.providers.base import ProviderError
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
 
     inputs: dict[WorkerRole, ModelPlacementInput] = {}
     model_refs: dict[WorkerRole, str] = {}
@@ -620,13 +620,19 @@ def _server_model_inputs(
                 chat_reservation=chat_reservation,
                 device_count=device_count,
             )
-        except (ProviderError, OSError):
-            # The configured model is not installed/resolvable. Skip this role
-            # rather than failing the whole fleet build: search-only indexing
-            # must not require an installed chat model, and a genuinely-needed
-            # role surfaces a clear per-role error on first use instead of a
-            # build-time traceback.
-            log.warning("Skipping %s server: model %r is not installed.", role.value, ref)
+        except (ProviderError, OSError) as exc:
+            # Skip this role rather than failing the whole fleet build: search-only
+            # indexing must not require an installed chat model, and a genuinely-
+            # needed role surfaces a clear per-role error on first use instead of a
+            # build-time traceback. Keep "not installed" for an actually-missing
+            # model; a sizing failure (estimator errored) must say so, not misdirect
+            # debugging toward the registry.
+            if isinstance(exc, ProviderError) and exc.kind is ProviderErrorKind.NOT_FOUND:
+                log.warning("Skipping %s server: model %r is not installed.", role.value, ref)
+            else:
+                log.warning(
+                    "Skipping %s server: could not size model %r (%s).", role.value, ref, exc
+                )
             return
         inputs[role] = estimate
         model_refs[role] = ref

--- a/src/lilbee/retrieval/reasoning.py
+++ b/src/lilbee/retrieval/reasoning.py
@@ -44,6 +44,16 @@ CAP_CONTINUATION_PROMPT = (
 CAP_NOTICE_TEMPLATE = "\n[reasoning capped at {chars} chars, asking for a direct answer]\n"
 """User-visible marker emitted between the truncated reasoning and the continuation answer."""
 
+REASONING_EXHAUSTED_NOTICE = (
+    "The model spent its whole response budget on reasoning and produced no final "
+    "answer. Try a shorter question, raise the generation token limit, or lower the "
+    "reasoning effort."
+)
+"""Returned in place of an empty answer when reasoning consumed the entire generation.
+
+Lets a caller tell "the model thought itself to death" apart from a genuine empty
+response, which an empty string alone cannot."""
+
 
 @dataclass
 class StreamToken:

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -14,7 +14,7 @@ import asyncio
 import dataclasses
 import time
 from collections.abc import AsyncGenerator, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from lilbee.app.services import get_services
 from lilbee.app.status import gather_status
@@ -78,6 +78,7 @@ from lilbee.server.models import HealthResponse, StatusResponse
 
 if TYPE_CHECKING:
     from lilbee.app.placement import PlacementView
+    from lilbee.providers.base import LLMProvider
     from lilbee.server.models import GpuInfoResponse, PlacementResponse
 
 # How often the warm stream re-snapshots provider state; sub-second so the read
@@ -89,6 +90,21 @@ _WARM_POLL_INTERVAL_S = 0.25
 _WARM_STREAM_TIMEOUT_S = 1800.0
 
 
+def _chat_status(provider: LLMProvider) -> Literal["ready", "loading", "not_started", "error"]:
+    """Classify the chat engine's readiness for /api/health.
+
+    ``ready`` once the role serves; ``error`` when warm-up failed; ``loading``
+    while a warm is in flight; ``not_started`` when nothing is warming and the
+    role isn't up (no chat model planned, so the fleet won't come up on its own).
+    """
+    if provider.role_ready(WorkerRole.CHAT):
+        return "ready"
+    snapshot = provider.warm_progress()
+    if snapshot is None:
+        return "not_started"
+    return "error" if snapshot.phase is WarmPhase.ERROR else "loading"
+
+
 async def health() -> HealthResponse:
     """Return service health, version, and whether the chat engine is warm."""
     provider = get_services().provider
@@ -96,6 +112,7 @@ async def health() -> HealthResponse:
         status="ok",
         version=get_version(),
         chat_ready=provider.role_ready(WorkerRole.CHAT),
+        chat_status=_chat_status(provider),
         chat_ctx=provider.served_chat_ctx(),
     )
 

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -344,9 +344,12 @@ async def chat(
     if not answer.strip() and text.strip():
         # The model emitted only reasoning (stripped to nothing) and no final
         # answer. Surface that distinctly instead of a silent empty string the
-        # caller can't tell apart from a legitimate empty response (bb-cpu).
+        # caller can't tell apart from a legitimate empty response (bb-cpu). The
+        # synthetic notice is not an answer, so -- like the search-needs-embedder
+        # refusal -- it doesn't seed memory.
         answer = REASONING_EXHAUSTED_NOTICE
-    await _store_extracted_memories(question, answer)
+    else:
+        await _store_extracted_memories(question, answer)
     return AskResponse(
         answer=answer,
         sources=[CleanedChunk(**clean_result(s)) for s in sources],
@@ -410,7 +413,14 @@ async def _stream_chat_response(
     answer_parts: list[str] = []
     try:
         async for event in _cap_aware_chat_events(req):
-            if isinstance(event, StreamToken) and not event.is_reasoning:
+            if (
+                isinstance(event, StreamToken)
+                and not event.is_reasoning
+                # The reasoning-exhausted notice is streamed to the client but is
+                # not a real answer: keep it out of answer_parts so it seeds no
+                # memory and isn't treated as a citation source (bb-cpu).
+                and event.content != REASONING_EXHAUSTED_NOTICE
+            ):
                 answer_parts.append(event.content)
             yield _sse_for_chat_event(event)
     except Exception as exc:

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -23,6 +23,7 @@ from lilbee.retrieval.query.searcher import SEARCH_NEEDS_EMBEDDER
 from lilbee.retrieval.reasoning import (
     CAP_CONTINUATION_PROMPT,
     CAP_NOTICE_TEMPLATE,
+    REASONING_EXHAUSTED_NOTICE,
     CapNotice,
     StreamToken,
     TagParser,
@@ -64,6 +65,7 @@ from lilbee.server.models import (
 if TYPE_CHECKING:
     from lilbee.core.results import SearchChunk
     from lilbee.retrieval.query import ChatMessage
+    from lilbee.retrieval.query.searcher import Searcher
 
 log = logging.getLogger(__name__)
 
@@ -324,7 +326,7 @@ def ask_stream(
 async def chat(
     question: str,
     history: list[ChatMessage],
-    top_k: int = 0,
+    top_k: int | None = None,
     options: dict[str, Any] | None = None,
     chunk_type: ChunkType | None = None,
 ) -> AskResponse:
@@ -339,6 +341,11 @@ async def chat(
     response = await asyncio.to_thread(dispatch_chat, req)
     text = _join_text_blocks(response.content)
     answer = text if cfg.show_reasoning else strip_reasoning(text)
+    if not answer.strip() and text.strip():
+        # The model emitted only reasoning (stripped to nothing) and no final
+        # answer. Surface that distinctly instead of a silent empty string the
+        # caller can't tell apart from a legitimate empty response (bb-cpu).
+        answer = REASONING_EXHAUSTED_NOTICE
     await _store_extracted_memories(question, answer)
     return AskResponse(
         answer=answer,
@@ -350,7 +357,7 @@ async def chat(
 def chat_stream(
     question: str,
     history: list[ChatMessage],
-    top_k: int = 0,
+    top_k: int | None = None,
     options: dict[str, Any] | None = None,
     chunk_type: ChunkType | None = None,
 ) -> AsyncGenerator[str, None]:
@@ -363,7 +370,7 @@ def chat_stream(
 async def _stream_chat_response(
     question: str,
     history: list[ChatMessage],
-    top_k: int,
+    top_k: int | None,
     options: dict[str, Any] | None,
     chunk_type: ChunkType | None,
 ) -> AsyncGenerator[str, None]:
@@ -379,14 +386,15 @@ async def _stream_chat_response(
         yield sse_event(SseEvent.SOURCES, [])
         yield sse_done({})
         return
-    if searcher.skip_retrieval():
-        # Chat-only mode (or no embedder): answer directly with no RAG context.
+    if _retrieval_off(searcher, top_k):
+        # Chat-only mode, no embedder, or an explicit top_k:0 pure-LLM call:
+        # answer directly with no RAG context.
         sources: list[SearchChunk] = []
         messages = searcher.direct_messages(question, history)
     else:
         try:
             rag = searcher.build_rag_context(
-                question, top_k=top_k, history=history, chunk_type=chunk_type
+                question, top_k=top_k or 0, history=history, chunk_type=chunk_type
             )
         except EmbeddingModelMismatchError as exc:
             # detail carries the index's embedder so the client can offer to adopt it.
@@ -431,23 +439,32 @@ async def _cap_aware_chat_events(
     Mirrors :func:`stream_chat_with_cap` but consumes the canonical async
     stream. ``CapNotice`` is yielded once between the truncated reasoning
     and the continuation answer; ``StreamToken`` carries the
-    reasoning-vs-response split for downstream SSE shaping.
+    reasoning-vs-response split for downstream SSE shaping. When reasoning
+    runs but no final answer follows, a closing ``StreamToken`` carrying
+    ``REASONING_EXHAUSTED_NOTICE`` is yielded so the run isn't silent (bb-cpu).
     """
     cap_chars = effective_reasoning_cap()
     show = cfg.show_reasoning
+    answered = False
 
     first_parser = TagParser(show=show)
     async for tok in _drive_stream(dispatch_chat_stream(req), first_parser, cap_chars):
+        answered = answered or (not tok.is_reasoning and bool(tok.content))
         yield tok
-    if not (cap_chars > 0 and first_parser.reasoning_chars > cap_chars):
-        return
 
-    yield CapNotice(cap_chars=cap_chars)
-    nudged = _nudged_request(req)
-    cont_parser = TagParser(show=show)
-    async for tok in _drive_stream(dispatch_chat_stream(nudged), cont_parser, cap_chars=0):
-        # Continuation tokens are always treated as final-answer text.
-        yield StreamToken(content=tok.content, is_reasoning=False)
+    if cap_chars > 0 and first_parser.reasoning_chars > cap_chars:
+        yield CapNotice(cap_chars=cap_chars)
+        nudged = _nudged_request(req)
+        cont_parser = TagParser(show=show)
+        async for tok in _drive_stream(dispatch_chat_stream(nudged), cont_parser, cap_chars=0):
+            answered = answered or bool(tok.content)
+            # Continuation tokens are always treated as final-answer text.
+            yield StreamToken(content=tok.content, is_reasoning=False)
+
+    if first_parser.reasoning_chars > 0 and not answered:
+        # The model spent its budget reasoning and produced no final answer;
+        # a distinct notice tells a reasoning-only run apart from a completed one.
+        yield StreamToken(content=REASONING_EXHAUSTED_NOTICE, is_reasoning=False)
 
 
 async def _drive_stream(
@@ -513,10 +530,20 @@ def _text_from_event(event: Any) -> str:
     return ""
 
 
+def _retrieval_off(searcher: Searcher, top_k: int | None) -> bool:
+    """Whether this /api/chat turn bypasses RAG.
+
+    An explicit ``top_k == 0`` is a pure-LLM call: answer without retrieval. An
+    unspecified ``top_k`` (``None``) uses the configured default and grounds
+    normally. Chat-only mode or a missing embedder also bypass.
+    """
+    return top_k == 0 or searcher.skip_retrieval()
+
+
 def _build_chat_messages(
     question: str,
     history: list[ChatMessage],
-    top_k: int,
+    top_k: int | None,
     chunk_type: ChunkType | None,
 ) -> tuple[list[SearchChunk], list[ChatMessage]]:
     """Run retrieval and return (sources, message_list).
@@ -526,9 +553,11 @@ def _build_chat_messages(
     ``Searcher.build_rag_context``.
     """
     searcher = get_services().searcher
-    if searcher.skip_retrieval():
+    if _retrieval_off(searcher, top_k):
         return [], searcher.direct_messages(question, history)
-    rag = searcher.build_rag_context(question, top_k=top_k, history=history, chunk_type=chunk_type)
+    rag = searcher.build_rag_context(
+        question, top_k=top_k or 0, history=history, chunk_type=chunk_type
+    )
     if rag is None:
         return [], searcher.direct_messages(question, history)
     return rag

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -52,7 +52,9 @@ class ChatRequest(BaseModel):
 
     question: str
     history: list[ChatMessage] = []
-    top_k: int = Field(default=0, le=100)
+    # None (unspecified) grounds with the configured top_k; an explicit 0 is a
+    # pure-LLM call that skips retrieval entirely.
+    top_k: int | None = Field(default=None, le=100)
     options: dict[str, Any] | None = None
     chunk_type: ChunkType | None = None
 
@@ -175,6 +177,14 @@ class HealthResponse(BaseModel):
     A launcher polls this to wait out the cold model load before handing off to
     a client, so the client never lands on an apparently-dead stream.
     """
+    chat_status: Literal["ready", "loading", "not_started", "error"] = "not_started"
+    """Finer-grained chat readiness than the ``chat_ready`` bool.
+
+    Lets a polling client tell a fleet that is still loading (wait) apart from one
+    that never started warming (``not_started`` -- no chat model resolved / planned,
+    so it will not come up on its own) or failed (``error``). Without this a bare
+    ``chat_ready:false`` reads the same for "loading" and "hung", which looked like a
+    silent hang on a fresh box with no chat model installed."""
     chat_ctx: int | None = None
     """Per-slot context the chat engine serves, so a launcher can tell the client
     its window and the client trims history to fit. None until the engine is up."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,14 @@ import pytest
 # conftest runs, the sentinel half of the gate is satisfied here.
 os.environ.setdefault("LILBEE_SKIP_MODEL_TASK_VALIDATION", "1")
 
+# Build the cfg singleton hermetically: the first ``import lilbee.core.config``
+# below constructs ``cfg`` from env + defaults, so skip the developer's real
+# platform config.toml here (before that import) rather than only in an autouse
+# fixture that runs after cfg is already loaded. Without this, values like
+# ``vision_model`` / ``memory_enabled`` leak from the dev's machine into tests
+# that assert defaults. Matches CI, which has no config.toml. (bb-e7d)
+os.environ.setdefault("LILBEE_SKIP_TOML_CONFIG", "1")
+
 from lilbee.catalog import CatalogModel
 from lilbee.catalog.refs import format_native_gguf_ref
 from lilbee.core.config import cfg
@@ -193,6 +201,18 @@ def _ignore_user_global_config(monkeypatch):
     not to add the toml source: env + defaults only.
     """
     monkeypatch.setenv("LILBEE_SKIP_TOML_CONFIG", "1")
+
+
+@pytest.fixture
+def overlay_reads_config_toml(monkeypatch):
+    """Opt a test back into the config.toml overlay path.
+
+    The suite runs with ``LILBEE_SKIP_TOML_CONFIG=1`` for hermeticity, and
+    ``overlay_persisted_settings`` honors that flag. Tests that specifically
+    exercise the overlay-applies behavior (writing a config.toml to a controlled
+    root and asserting it lands on cfg) must clear the flag so overlay runs.
+    """
+    monkeypatch.delenv("LILBEE_SKIP_TOML_CONFIG", raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -664,7 +664,7 @@ class TestApplyOverrides:
         assert cfg.temperature == 0.7
         cfg.temperature = None
 
-    def test_data_dir_overlays_per_root_config_toml(self, tmp_path):
+    def test_data_dir_overlays_per_root_config_toml(self, tmp_path, overlay_reads_config_toml):
         """A per-vault config.toml in the data-dir must be re-read when --data-dir lands.
 
         Regression: cfg's scalar fields (chat_model, embedding_model, ...) were
@@ -688,7 +688,9 @@ class TestApplyOverrides:
         assert cfg.chat_model == "ollama/qwen3:4b"
         assert cfg.embedding_model == "ollama/nomic-embed-text:v1.5"
 
-    def test_data_dir_without_config_toml_leaves_cfg_unchanged(self, tmp_path):
+    def test_data_dir_without_config_toml_leaves_cfg_unchanged(
+        self, tmp_path, overlay_reads_config_toml
+    ):
         """An empty / missing config.toml must not stomp on existing cfg values."""
         from lilbee.cli import apply_overrides
 
@@ -701,7 +703,9 @@ class TestApplyOverrides:
         assert cfg.chat_model == "ollama/kept-from-import:latest"
         assert cfg.embedding_model == "ollama/kept-embed:latest"
 
-    def test_data_dir_overlay_covers_writable_scalar_fields(self, tmp_path):
+    def test_data_dir_overlay_covers_writable_scalar_fields(
+        self, tmp_path, overlay_reads_config_toml
+    ):
         """Writable scalar fields (e.g. temperature, top_k) overlay too, not just models."""
         from lilbee.cli import apply_overrides
 
@@ -715,7 +719,9 @@ class TestApplyOverrides:
         assert cfg.temperature == 0.2
         assert cfg.top_k == 20
 
-    def test_use_global_overlays_global_config_toml(self, tmp_path, monkeypatch):
+    def test_use_global_overlays_global_config_toml(
+        self, tmp_path, monkeypatch, overlay_reads_config_toml
+    ):
         """--global must also re-read the global root's config.toml."""
         from lilbee.cli import apply_overrides
 
@@ -731,7 +737,9 @@ class TestApplyOverrides:
         assert cfg.data_root == fake_global
         assert cfg.chat_model == "ollama/from-global:latest"
 
-    def test_lilbee_data_env_overlays_config_toml(self, tmp_path, monkeypatch):
+    def test_lilbee_data_env_overlays_config_toml(
+        self, tmp_path, monkeypatch, overlay_reads_config_toml
+    ):
         """The LILBEE_DATA env-var path must also overlay its config.toml."""
         from lilbee.cli import apply_overrides
 
@@ -772,7 +780,7 @@ class TestApplyOverrides:
         apply_overrides(use_global=True)
         assert os.environ.get("LILBEE_DATA") == str(fake_global)
 
-    def test_data_dir_overlay_skips_unknown_keys(self, tmp_path):
+    def test_data_dir_overlay_skips_unknown_keys(self, tmp_path, overlay_reads_config_toml):
         """Stale or unrecognised keys in config.toml don't blow up startup."""
         from lilbee.cli import apply_overrides
 
@@ -786,7 +794,9 @@ class TestApplyOverrides:
         assert cfg.chat_model == "ollama/from-vault:latest"
         assert not hasattr(cfg, "totally_unknown_key")
 
-    def test_data_dir_overlay_logs_and_skips_invalid_value(self, tmp_path, caplog):
+    def test_data_dir_overlay_logs_and_skips_invalid_value(
+        self, tmp_path, caplog, overlay_reads_config_toml
+    ):
         """A malformed persisted value is logged and skipped, not raised."""
         from lilbee.cli import apply_overrides
 
@@ -800,7 +810,9 @@ class TestApplyOverrides:
         assert cfg.top_k == 7
         assert any("top_k" in rec.message for rec in caplog.records)
 
-    def test_data_dir_overlay_handles_unreadable_config_toml(self, tmp_path, monkeypatch, caplog):
+    def test_data_dir_overlay_handles_unreadable_config_toml(
+        self, tmp_path, monkeypatch, caplog, overlay_reads_config_toml
+    ):
         """A read failure on config.toml is logged and treated as 'no overlay'."""
         from lilbee.cli import apply_overrides
         from lilbee.core import settings as settings_mod

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -85,16 +85,17 @@ def test_role_ctx_chat_uses_dynamic_picker_when_unset(monkeypatch) -> None:
 
 
 def test_role_ctx_embed_covers_chunk_size_plus_margin(monkeypatch) -> None:
-    # A 32K-trained embedder is sized to the chunk length plus the truncation margin
-    # (so a full chunk_size input is not truncated), not its full context, so its
+    # A 32K-trained embedder (and a plain non-LLM reranker) is sized to the chunker's
+    # character budget plus the truncation margin (chunk_size * CHARS_PER_TOKEN + margin
+    # -- the provable token ceiling for a full chunk), not its full context, so its
     # placement estimate doesn't balloon (200GB+) and starve the role alongside a giant.
     monkeypatch.setattr(
         "lilbee.providers.engine_params.train_ctx_from_meta",
         lambda _meta, *, fallback, model_path: 32768,
     )
     monkeypatch.setattr(cfg, "chunk_size", 512)
-    assert planning_mod._role_ctx(WorkerRole.EMBED, Path("/m/e.gguf"), {}) == 520
-    assert planning_mod._role_ctx(WorkerRole.RERANK, Path("/m/r.gguf"), {}) == 520
+    assert planning_mod._role_ctx(WorkerRole.EMBED, Path("/m/e.gguf"), {}) == 2056
+    assert planning_mod._role_ctx(WorkerRole.RERANK, Path("/m/r.gguf"), {}) == 2056
 
 
 def test_embed_ctx_token_cap_fits_full_chunk(monkeypatch) -> None:

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -657,6 +657,34 @@ class TestBuildFleetWiring:
         assert WorkerRole.CHAT not in refs
         assert {i.role for i in inputs} == {WorkerRole.EMBED}
 
+    def test_server_model_inputs_distinguishes_sizing_failure_from_missing(
+        self, monkeypatch, caplog
+    ) -> None:
+        # A sizing failure (estimator errored) must not be reported as "not
+        # installed" -- that misdirects debugging toward the registry when the
+        # real fault is the memory estimator.
+        import logging
+
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+        def _estimate(role, ref, **_k):
+            raise ProviderError(
+                "estimator returned no usable result",
+                provider="llama-server",
+                kind=ProviderErrorKind.SERVER,
+            )
+
+        monkeypatch.setattr(planning_mod, "_estimate_role", _estimate)
+        monkeypatch.setattr(cfg, "chat_model", "org/repo/chat.gguf")
+        monkeypatch.setattr(cfg, "embedding_model", "org/repo/embed.gguf")
+        monkeypatch.setattr(cfg, "reranker_model", "")
+        monkeypatch.setattr(cfg, "vision_model", "")
+        with caplog.at_level(logging.WARNING):
+            inputs, refs, _res = planning_mod._server_model_inputs()
+        assert not refs and not inputs
+        assert "is not installed" not in caplog.text
+        assert "could not size" in caplog.text
+
     def test_server_model_inputs_includes_configured_rerank(self, monkeypatch) -> None:
         monkeypatch.setattr(
             planning_mod, "_estimate_role", lambda role, ref, **_k: ModelPlacementInput(role, _GB)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -485,7 +485,7 @@ class TestInit:
         init(str(target))
         assert os.environ.get("LILBEE_DATA") == str(target)
 
-    def test_init_overlays_per_root_config_toml(self, tmp_path):
+    def test_init_overlays_per_root_config_toml(self, tmp_path, overlay_reads_config_toml):
         """init() must re-read the project base's config.toml, the same fix as
         the CLI's --data-dir entry point. Without this, switching the MCP
         session to a project that has its own model preferences silently

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -451,6 +451,25 @@ class TestModelRegistryResolve:
         assert len(manifest.shard_blobs) == 2
         assert manifest.total_size_bytes == sum(len(f"shard-{n}".encode()) for n in (1, 2, 3))
 
+    def test_bare_repo_recovers_subdir_split_gguf_from_raw_cache(self, tmp_path: Path) -> None:
+        """Real quant repos (e.g. unsloth) place their shards under a quant subdir;
+        a bare-repo ref must recover that split set from a raw cache too, not just a
+        flat one."""
+        registry = ModelRegistry(tmp_path)
+        repo = "unsloth/MiniMax-M2-GGUF"
+        for n in (1, 2, 3):
+            _seed_hf_cache(
+                tmp_path,
+                repo=repo,
+                filename=f"Q4_K_M/MiniMax-M2-Q4_K_M-0000{n}-of-00003.gguf",
+                content=f"shard-{n}".encode(),
+            )
+        resolved = registry.resolve(repo)
+        assert resolved == registry.resolve(f"{repo}/Q4_K_M/MiniMax-M2-Q4_K_M-00001-of-00003.gguf")
+        assert resolved.parent.name == "Q4_K_M"  # co-located under the quant subdir
+        for n in (2, 3):
+            assert (resolved.parent / f"MiniMax-M2-Q4_K_M-0000{n}-of-00003.gguf").exists()
+
     def test_shard_paths_returns_every_split_shard(self, tmp_path: Path) -> None:
         registry = ModelRegistry(tmp_path)
         repo = "ggml-org/gpt-oss-120b-GGUF"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -425,6 +425,32 @@ class TestModelRegistryResolve:
         for n in (2, 3):
             assert (resolved.parent / f"m-mxfp4-0000{n}-of-00003.gguf").exists()
 
+    def test_bare_repo_recovers_split_gguf_from_raw_cache(self, tmp_path: Path) -> None:
+        """bb-z59: a bare org/repo ref pointing at a raw-cache split GGUF (hf
+        download, no manifest) resolves to the first shard's snapshot symlink with
+        shard accounting, not shard 1's blob as an unloadable single file."""
+        registry = ModelRegistry(tmp_path)
+        repo = "ggml-org/gpt-oss-120b-GGUF"
+        for n in (1, 2, 3):
+            _seed_hf_cache(
+                tmp_path,
+                repo=repo,
+                filename=f"m-mxfp4-0000{n}-of-00003.gguf",
+                content=f"shard-{n}".encode(),
+            )
+        resolved = registry.resolve(repo)
+        # The bare-repo path lands on the same loadable snapshot symlink as the
+        # canonical first-shard ref, not a blob under blobs/.
+        assert resolved == registry.resolve(f"{repo}/m-mxfp4-00001-of-00003.gguf")
+        assert resolved.parent.name == _FAKE_REV
+        # Recovery wrote a manifest with full shard accounting, so it lists
+        # installed: shard_blobs holds the trailing shards (2 and 3); the first
+        # shard is the primary blob.
+        manifest = registry._read_manifest(repo, "m-mxfp4-00001-of-00003.gguf")
+        assert manifest is not None
+        assert len(manifest.shard_blobs) == 2
+        assert manifest.total_size_bytes == sum(len(f"shard-{n}".encode()) for n in (1, 2, 3))
+
     def test_shard_paths_returns_every_split_shard(self, tmp_path: Path) -> None:
         registry = ModelRegistry(tmp_path)
         repo = "ggml-org/gpt-oss-120b-GGUF"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -451,6 +451,23 @@ class TestModelRegistryResolve:
         assert len(manifest.shard_blobs) == 2
         assert manifest.total_size_bytes == sum(len(f"shard-{n}".encode()) for n in (1, 2, 3))
 
+    def test_bare_repo_split_gguf_missing_a_shard_reads_not_installed(self, tmp_path: Path) -> None:
+        """bb-z59: bare-repo recovery of a split set that's missing a shard skips
+        both the torn first shard and its trailing siblings and reports the model
+        as not installed, rather than handing back an unloadable partial set."""
+        registry = ModelRegistry(tmp_path)
+        repo = "ggml-org/gpt-oss-120b-GGUF"
+        # Shards 1 and 2 of a 3-shard set are cached; shard 3 never downloaded.
+        for n in (1, 2):
+            _seed_hf_cache(
+                tmp_path,
+                repo=repo,
+                filename=f"m-mxfp4-0000{n}-of-00003.gguf",
+                content=f"shard-{n}".encode(),
+            )
+        with pytest.raises(KeyError, match="not installed"):
+            registry.resolve(repo)
+
     def test_bare_repo_recovers_subdir_split_gguf_from_raw_cache(self, tmp_path: Path) -> None:
         """Real quant repos (e.g. unsloth) place their shards under a quant subdir;
         a bare-repo ref must recover that split set from a raw cache too, not just a

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -117,6 +117,25 @@ class TestHealth:
         mock_svc.provider.role_ready.return_value = True
         assert (await handlers.health()).chat_ready is True
 
+    async def test_chat_status_distinguishes_not_started_from_loading(self, mock_svc):
+        """bb-v3t: a polling client must tell a fleet that never started warming
+        apart from one that is loading, so a fresh box with no chat model doesn't
+        look like a silent hang."""
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        mock_svc.provider.role_ready.return_value = True
+        assert (await handlers.health()).chat_status == "ready"
+
+        mock_svc.provider.role_ready.return_value = False
+        mock_svc.provider.warm_progress.return_value = None
+        assert (await handlers.health()).chat_status == "not_started"
+
+        mock_svc.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.READING_WEIGHTS)
+        assert (await handlers.health()).chat_status == "loading"
+
+        mock_svc.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.ERROR)
+        assert (await handlers.health()).chat_status == "error"
+
 
 def _parse_warm_events(chunks: list[str]) -> list[dict]:
     """Pull the JSON payloads off ``warm`` SSE chunks, ignoring the [DONE] tail."""
@@ -707,6 +726,89 @@ class TestChat:
         assert result.sources == []  # direct-chat fallback carries no sources
         assert len(captured) == 1
 
+    async def test_top_k_zero_skips_retrieval(self, mock_svc, monkeypatch):
+        """bb-szm: an explicit top_k:0 is a pure-LLM call -- retrieval is
+        bypassed and no sources are attached, even in search mode."""
+        from lilbee.server.chat_dispatch.canonical import (
+            CanonicalResponse,
+            CanonicalUsage,
+            StopReason,
+            TextBlock,
+        )
+
+        monkeypatch.setattr(
+            _rag_h,
+            "dispatch_chat",
+            lambda req: CanonicalResponse(
+                id="msg_test",
+                model=req.model,
+                content=[TextBlock(text="direct")],
+                stop_reason=StopReason.END_TURN,
+                usage=CanonicalUsage(input_tokens=0, output_tokens=0),
+            ),
+        )
+        monkeypatch.setattr(cfg, "chat_mode", ChatMode.SEARCH.value)
+        mock_svc.searcher.direct_messages.return_value = [{"role": "user", "content": "q"}]
+        result = await handlers.chat("q", [], top_k=0)
+        mock_svc.searcher.build_rag_context.assert_not_called()
+        mock_svc.searcher.direct_messages.assert_called_once()
+        assert result.sources == []
+
+    async def test_top_k_none_grounds_normally(self, mock_svc, monkeypatch):
+        """Unspecified top_k (None) still runs retrieval -- only an explicit 0 skips."""
+        from lilbee.server.chat_dispatch.canonical import (
+            CanonicalResponse,
+            CanonicalUsage,
+            StopReason,
+            TextBlock,
+        )
+
+        monkeypatch.setattr(
+            _rag_h,
+            "dispatch_chat",
+            lambda req: CanonicalResponse(
+                id="msg_test",
+                model=req.model,
+                content=[TextBlock(text="ok")],
+                stop_reason=StopReason.END_TURN,
+                usage=CanonicalUsage(input_tokens=0, output_tokens=0),
+            ),
+        )
+        monkeypatch.setattr(cfg, "chat_mode", ChatMode.SEARCH.value)
+        mock_svc.searcher.build_rag_context.return_value = _rag_return()
+        await handlers.chat("q", [], top_k=None)
+        mock_svc.searcher.build_rag_context.assert_called_once()
+        # None resolves to the config default (0 -> searcher picks cfg.top_k).
+        assert mock_svc.searcher.build_rag_context.call_args.kwargs.get("top_k") == 0
+
+    async def test_reasoning_only_answer_surfaces_notice(self, mock_svc, monkeypatch):
+        """bb-cpu: when reasoning consumes the whole generation and no final answer
+        follows, /chat returns a clear notice instead of a silent empty string."""
+        from lilbee.retrieval.reasoning import REASONING_EXHAUSTED_NOTICE
+        from lilbee.server.chat_dispatch.canonical import (
+            CanonicalResponse,
+            CanonicalUsage,
+            StopReason,
+            TextBlock,
+        )
+
+        monkeypatch.setattr(
+            _rag_h,
+            "dispatch_chat",
+            lambda req: CanonicalResponse(
+                id="msg_test",
+                model=req.model,
+                content=[TextBlock(text="<think>a long chain of thought</think>")],
+                stop_reason=StopReason.MAX_TOKENS,
+                usage=CanonicalUsage(input_tokens=0, output_tokens=0),
+            ),
+        )
+        monkeypatch.setattr(cfg, "chat_mode", ChatMode.SEARCH.value)
+        monkeypatch.setattr(cfg, "show_reasoning", False)
+        mock_svc.searcher.build_rag_context.return_value = _rag_return()
+        result = await handlers.chat("q", [])
+        assert result.answer == REASONING_EXHAUSTED_NOTICE
+
 
 class TestChatStream:
     async def test_no_results_yields_error(self, mock_svc):
@@ -733,6 +835,36 @@ class TestChatStream:
         async for _ in handlers.chat_stream("q", [], chunk_type="raw"):
             pass
         assert mock_svc.searcher.build_rag_context.call_args.kwargs.get("chunk_type") == "raw"
+
+    async def test_top_k_zero_skips_retrieval(self, mock_svc, monkeypatch):
+        """bb-szm: streaming chat with an explicit top_k:0 bypasses retrieval and
+        emits an empty SOURCES event -- a pure-LLM call, not a grounded one."""
+        monkeypatch.setattr(cfg, "chat_mode", ChatMode.SEARCH.value)
+        mock_svc.searcher.direct_messages.return_value = [{"role": "user", "content": "q"}]
+        monkeypatch.setattr(
+            _rag_h, "dispatch_chat_stream", lambda req: _canonical_text_stream(["direct"])
+        )
+        events = [e async for e in handlers.chat_stream("q", [], top_k=0)]
+        mock_svc.searcher.build_rag_context.assert_not_called()
+        mock_svc.searcher.direct_messages.assert_called_once()
+        sources_event = next(e for e in events if e and e.startswith("event: sources"))
+        assert json.loads(sources_event.split("data: ")[1].strip()) == []
+
+    async def test_reasoning_only_stream_emits_notice(self, mock_svc, monkeypatch):
+        """bb-cpu: a reasoning-only stream (no final answer) emits the exhaustion
+        notice as a token, even with show_reasoning off, so it isn't silent."""
+        from lilbee.retrieval.reasoning import REASONING_EXHAUSTED_NOTICE
+
+        monkeypatch.setattr(cfg, "show_reasoning", False)
+        mock_svc.searcher.build_rag_context.return_value = _rag_return()
+        monkeypatch.setattr(
+            _rag_h,
+            "dispatch_chat_stream",
+            lambda req: _canonical_text_stream(["<think>", "endless reasoning", "</think>"]),
+        )
+        events = [e async for e in handlers.chat_stream("q", [])]
+        token_events = [e for e in events if e and e.startswith("event: token")]
+        assert any(REASONING_EXHAUSTED_NOTICE in e for e in token_events)
 
     async def test_sources_event_carries_cited_subset(self, mock_svc, monkeypatch):
         """The chat SOURCES event emits the cited subset (what the answer referenced),

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -806,8 +806,17 @@ class TestChat:
         monkeypatch.setattr(cfg, "chat_mode", ChatMode.SEARCH.value)
         monkeypatch.setattr(cfg, "show_reasoning", False)
         mock_svc.searcher.build_rag_context.return_value = _rag_return()
+        extract_calls: list[str] = []
+
+        async def _spy_extract(_question, answer):
+            extract_calls.append(answer)
+            return []
+
+        monkeypatch.setattr(_rag_h, "_store_extracted_memories", _spy_extract)
         result = await handlers.chat("q", [])
         assert result.answer == REASONING_EXHAUSTED_NOTICE
+        # The synthetic notice is not an answer: it must not seed memory.
+        assert extract_calls == []
 
 
 class TestChatStream:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -286,7 +286,7 @@ class TestChatRoute:
         resp = client.post("/api/chat", json={"question": "q", "history": history})
         assert resp.status_code == 201
         mock_chat.assert_awaited_once_with(
-            question="q", history=history, top_k=0, options=None, chunk_type=None
+            question="q", history=history, top_k=None, options=None, chunk_type=None
         )
 
     @mock.patch(
@@ -297,7 +297,7 @@ class TestChatRoute:
     def test_default_empty_history(self, mock_chat, client):
         client.post("/api/chat", json={"question": "q"})
         mock_chat.assert_awaited_once_with(
-            question="q", history=[], top_k=0, options=None, chunk_type=None
+            question="q", history=[], top_k=None, options=None, chunk_type=None
         )
 
     @mock.patch("lilbee.server.handlers.chat", new_callable=AsyncMock)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -356,11 +356,12 @@ class TestCrawlRenderModeConfig:
 
 
 class TestOverlayPersistedSettings:
-    def test_empty_string_value_is_skipped(self, tmp_path):
+    def test_empty_string_value_is_skipped(self, tmp_path, monkeypatch):
         """Legacy persisted empty strings (None written as "") skip overlay
         instead of corrupting the in-memory config or spamming warnings."""
         from lilbee.core.config import cfg
 
+        monkeypatch.delenv("LILBEE_SKIP_TOML_CONFIG", raising=False)
         original = cfg.chat_model
         try:
             (tmp_path / "config.toml").write_text('chat_model = ""\n')
@@ -375,6 +376,7 @@ class TestOverlayPersistedSettings:
 
         original = cfg.vision_replicas
         try:
+            monkeypatch.delenv("LILBEE_SKIP_TOML_CONFIG", raising=False)
             cfg.vision_replicas = 4  # value as loaded from LILBEE_VISION_REPLICAS
             monkeypatch.setenv("LILBEE_VISION_REPLICAS", "4")
             (tmp_path / "config.toml").write_text("vision_replicas = 2\n")
@@ -389,6 +391,7 @@ class TestOverlayPersistedSettings:
 
         original = cfg.vision_replicas
         try:
+            monkeypatch.delenv("LILBEE_SKIP_TOML_CONFIG", raising=False)
             monkeypatch.setenv("LILBEE_VISION_REPLICAS", "")
             cfg.vision_replicas = 1
             (tmp_path / "config.toml").write_text("vision_replicas = 3\n")
@@ -403,11 +406,28 @@ class TestOverlayPersistedSettings:
 
         original = cfg.vision_replicas
         try:
+            monkeypatch.delenv("LILBEE_SKIP_TOML_CONFIG", raising=False)
             monkeypatch.delenv("LILBEE_VISION_REPLICAS", raising=False)
             cfg.vision_replicas = 1
             (tmp_path / "config.toml").write_text("vision_replicas = 3\n")
             settings.overlay_persisted_settings(tmp_path)
             assert cfg.vision_replicas == 3
+        finally:
+            cfg.vision_replicas = original
+
+    def test_skip_toml_config_makes_overlay_noop(self, tmp_path, monkeypatch):
+        """LILBEE_SKIP_TOML_CONFIG=1 disables the overlay path too, so the escape
+        hatch is honored consistently with the pydantic-settings source (the CLI
+        and MCP overlay must not re-read config.toml behind the skip flag)."""
+        from lilbee.core.config import cfg
+
+        original = cfg.vision_replicas
+        try:
+            monkeypatch.setenv("LILBEE_SKIP_TOML_CONFIG", "1")
+            cfg.vision_replicas = 1
+            (tmp_path / "config.toml").write_text("vision_replicas = 3\n")
+            settings.overlay_persisted_settings(tmp_path)
+            assert cfg.vision_replicas == 1  # config.toml ignored while skipping
         finally:
             cfg.vision_replicas = original
 

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -24,7 +24,7 @@ _DEFAULT_LLAMA_CPP_VERSION="0.3.30"
 # Built from source (deterministic, no release-asset-name guessing); the wheel-build
 # job provides the Go toolchain. Bump deliberately.
 _LLAMA_SWAP_VERSION="v223"
-_GGUF_PARSER_REF="v0.9.3"
+_GGUF_PARSER_REF="v0.24.1"
 
 backend="${BACKEND:?BACKEND is required}"
 build_dir="${LLAMA_BUILD_DIR:-/tmp/llama-build}"


### PR DESCRIPTION
## Problem

Several genuine lilbee bug fixes were made on `feat/kreuzberg-5` and, because that branch also carries the whole xberg document-extraction migration, they were stranded there instead of landing on `feat/local-model-api` where they belong. `feat/kreuzberg-5` should be strictly the xberg integration; these fixes touch the fleet planner, model registry, chat/RAG server, health API, config loading, and the engine build, none of which have anything to do with document extraction.

Verified each fix is still present (unfixed) on `feat/local-model-api` before backporting, so none of these is redundant.

## Solution

Backport the three non-xberg fix commits, adapted to local-model-api's current code (the fleet/server files had drifted via merged PRs since the branches forked):

- **`fix(config)`** — `LILBEE_SKIP_TOML_CONFIG` was ignored on the config-overlay path; honor it there, and make the config tests hermetic.
- **`fix: resolve five local-model-api bugs (#482)`**
  - gguf-parser pinned at `v0.9.3` (JSON predates the schema `vram.py` reads), so every role estimate raised and planning logged "model is not installed" for an installed model. Bump to `v0.24.1` and split the planner warning: an actually-missing model still says "not installed", a sizing failure says "could not size model".
  - `/api/chat` treated `top_k:0` as "use the default" rather than "skip retrieval", so a pure-LLM call still grounded and returned sources. Unspecified now means default; explicit `0` skips retrieval on both one-shot and streaming paths.
  - When reasoning consumed the whole generation, `/api/chat` returned `answer:""` with 201, indistinguishable from a genuine empty answer. Both paths now surface a clear reasoning-exhausted notice.
  - `/api/health` could not tell a still-loading fleet from one that never started warming (both `chat_ready:false`). Add `chat_status` (ready / loading / not_started / error).
  - A bare `org/repo` ref to a raw-cache split GGUF resolved to shard 1's blob (unloadable) and wrote a single-file manifest. Recovery is now shard-aware.
- **`fix(chat)`** — keep the reasoning-exhausted notice out of memory extraction (follow-up to the notice above).

Also fixes a **pre-existing red test** on the base branch: `test_role_ctx_embed_covers_chunk_size_plus_margin` still asserted the old `chunk_size + margin` ceiling after `resolve_embed_ctx` was changed to the char budget (the provable token ceiling); it now asserts the actual value for both embed and non-LLM rerank.

### Scope / exhaustiveness

Deliberately excluded, since none is a bug fix: the `#475` lazy-import hoist (pure refactor, entangled with local-model-api's already-refactored provider), placement test coverage that targets a test file local-model-api deleted, a ruff reformat, and the ingest-trace diagnostics (hooks into the xberg-rewritten `extract.py`).

After this backport, every one of the fixed files is content-identical to `feat/kreuzberg-5`, and every remaining difference between the branches is xberg surface, the excluded cleanup, or changes already on local-model-api. No independent fix is left behind.

All checks green: full affected test surface passes, ruff / style-rules / mypy clean.
