### PR TITLE
Export the page dataset in one columnar scan instead of a query per source

### DIFF
--- a/src/lilbee/app/dataset.py
+++ b/src/lilbee/app/dataset.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
@@ -21,6 +22,9 @@ from lilbee.data.export import (
 )
 from lilbee.data.store import EmbeddingModelMismatchError, PageTextRecord
 from lilbee.runtime.progress import DetailedProgressCallback, noop_callback
+
+if TYPE_CHECKING:
+    import pyarrow as pa
 
 
 class DatasetError(Exception):
@@ -66,15 +70,15 @@ def require_format(value: str) -> DatasetFormat:
         raise DatasetError(str(exc)) from None
 
 
-def _build_validated(source: str | None) -> list[PageTextRecord]:
-    """Build the dataset rows for *source* (or all), validating the request."""
+def _build_validated(source: str | None) -> pa.Table:
+    """Build the dataset table for *source* (or all), validating the request."""
     store = get_services().store
     if source is not None and source not in {s["filename"] for s in store.get_sources()}:
         raise DatasetError(f"Source not found: {source}")
-    rows = build_page_dataset(store, source)
-    if not rows:
+    table = build_page_dataset(store, source)
+    if table.num_rows == 0:
         raise DatasetError("Nothing to export: the store has no indexed pages.")
-    return rows
+    return table
 
 
 def export_to_path(output: Path, fmt_value: str, source: str | None) -> ExportSummary:
@@ -83,25 +87,25 @@ def export_to_path(output: Path, fmt_value: str, source: str | None) -> ExportSu
         fmt = resolve_format(fmt_value, output)
     except ValueError as exc:
         raise DatasetError(str(exc)) from None
-    rows = _build_validated(source)
-    write_dataset(rows, output, fmt)
+    table = _build_validated(source)
+    write_dataset(table, output, fmt)
     return ExportSummary(
         format=str(fmt),
         output=str(output),
-        pages=len(rows),
-        sources=len({row["source"] for row in rows}),
+        pages=table.num_rows,
+        sources=len(table.column("source").unique()),
     )
 
 
 def export_to_bytes(fmt_value: str, source: str | None) -> ExportPayload:
     """Encode the per-page dataset to bytes; empty *fmt_value* defaults to parquet."""
     fmt = require_format(fmt_value) if fmt_value else DatasetFormat.PARQUET
-    rows = _build_validated(source)
+    table = _build_validated(source)
     return ExportPayload(
-        data=serialize_dataset(rows, fmt),
+        data=serialize_dataset(table, fmt),
         fmt=fmt,
-        pages=len(rows),
-        sources=len({row["source"] for row in rows}),
+        pages=table.num_rows,
+        sources=len(table.column("source").unique()),
     )
 
 

--- a/src/lilbee/data/export.py
+++ b/src/lilbee/data/export.py
@@ -14,6 +14,8 @@ from lilbee.data.store import ChunkWrite, PageTextRecord, SourceType
 from lilbee.runtime.progress import DetailedProgressCallback, noop_callback
 
 if TYPE_CHECKING:
+    import pyarrow as pa
+
     from lilbee.data.store import Store
 
 
@@ -58,24 +60,49 @@ def resolve_format(value: str, path: Path) -> DatasetFormat:
         ) from None
 
 
-def build_page_dataset(store: Store, source: str | None = None) -> list[PageTextRecord]:
-    """Collect per-page text rows for every source (or just *source*).
+def build_page_dataset(store: Store, source: str | None = None) -> pa.Table:
+    """Collect per-page text rows as an Arrow table for every source (or *source*).
 
-    Sources captured at ingest are returned verbatim from the page-text table.
-    Sources without captured text (older indexes, code) are reconstructed from
-    the chunks table; that reconstruction concatenates chunk text per page, so
-    chunk overlap may repeat a little text across page boundaries.
+    Sources captured at ingest are read verbatim from the page-text table in a
+    single columnar scan. Sources without captured text (older indexes, code) are
+    reconstructed from the chunks table; that reconstruction concatenates chunk
+    text per page, so chunk overlap may repeat a little text across page
+    boundaries. The whole set stays in Arrow so the writers avoid per-row Python
+    objects, and the per-source query loop that hung a large export is gone
+    (bb-bqg).
     """
-    names = [source] if source is not None else sorted(s["filename"] for s in store.get_sources())
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
     captured = store.page_text_sources()
-    rows: list[PageTextRecord] = []
-    for name in names:
-        if name in captured:
-            rows.extend(store.get_page_texts(name))
-        else:
-            rows.extend(_reconstruct_from_chunks(store, name))
-    rows.sort(key=lambda r: (r["source"], r["page"]))
-    return rows
+    if source is not None:
+        table = store.page_texts_arrow(source)
+        if source not in captured:
+            table = _reconstructed_arrow(store, [source], table.schema)
+    else:
+        # One scan for every captured page instead of a filtered query per source:
+        # the per-source loop was O(sources) and its fixed per-query overhead, not
+        # data size, hung the export on a large store. Restrict to tracked sources
+        # so an orphaned page-text row (source record gone) stays out, matching the
+        # old get_sources()-scoped universe.
+        names = {s["filename"] for s in store.get_sources()}
+        table = store.page_texts_arrow()
+        if names:
+            table = table.filter(
+                pc.is_in(table.column("source"), value_set=pa.array(sorted(names), pa.string()))
+            )
+        extra = _reconstructed_arrow(store, sorted(names - captured), table.schema)
+        if extra.num_rows:
+            table = pa.concat_tables([table, extra])
+    return table.sort_by([("source", "ascending"), ("page", "ascending")])
+
+
+def _reconstructed_arrow(store: Store, sources: list[str], schema: pa.Schema) -> pa.Table:
+    """Chunk-reconstructed pages for *sources* as an Arrow table in *schema*."""
+    import pyarrow as pa
+
+    records = [dict(r) for name in sources for r in _reconstruct_from_chunks(store, name)]
+    return pa.Table.from_pylist(records, schema=schema)
 
 
 def _reconstruct_from_chunks(store: Store, source: str) -> list[PageTextRecord]:
@@ -96,33 +123,33 @@ def _reconstruct_from_chunks(store: Store, source: str) -> list[PageTextRecord]:
     return rows
 
 
-def _serialize_parquet(rows: list[PageTextRecord]) -> bytes:
+def _serialize_parquet(table: pa.Table) -> bytes:
     import io
 
-    import pyarrow as pa
     import pyarrow.parquet as pq
 
-    table = pa.Table.from_pylist([dict(r) for r in rows])
     buffer = io.BytesIO()
     pq.write_table(table, buffer)
     return buffer.getvalue()
 
 
-def _serialize_jsonl(rows: list[PageTextRecord]) -> bytes:
-    return "".join(json.dumps(dict(row)) + "\n" for row in rows).encode("utf-8")
+def _serialize_jsonl(table: pa.Table) -> bytes:
+    # One JSON object per row, keyed by the table's columns, so jsonl stays in
+    # step with the schema (and with parquet) rather than a hardcoded field list.
+    return "".join(json.dumps(row) + "\n" for row in table.to_pylist()).encode("utf-8")
 
 
 _SERIALIZERS = {DatasetFormat.PARQUET: _serialize_parquet, DatasetFormat.JSONL: _serialize_jsonl}
 
 
-def serialize_dataset(rows: list[PageTextRecord], fmt: DatasetFormat) -> bytes:
-    """Encode *rows* to dataset bytes in the given format."""
-    return _SERIALIZERS[fmt](rows)
+def serialize_dataset(table: pa.Table, fmt: DatasetFormat) -> bytes:
+    """Encode the dataset *table* to bytes in the given format."""
+    return _SERIALIZERS[fmt](table)
 
 
-def write_dataset(rows: list[PageTextRecord], path: Path, fmt: DatasetFormat) -> None:
-    """Write *rows* to *path* in the given format."""
-    path.write_bytes(serialize_dataset(rows, fmt))
+def write_dataset(table: pa.Table, path: Path, fmt: DatasetFormat) -> None:
+    """Write the dataset *table* to *path* in the given format."""
+    path.write_bytes(serialize_dataset(table, fmt))
 
 
 def _coerce_row(raw: dict) -> PageTextRecord:

--- a/src/lilbee/data/store/core.py
+++ b/src/lilbee/data/store/core.py
@@ -685,6 +685,21 @@ class Store:
         rows: list[PageTextRecord] = query.limit(None).to_list()
         return rows
 
+    def page_texts_arrow(self, source: str | None = None) -> pa.Table:
+        """Return per-page text rows as an Arrow table in a single scan.
+
+        The columnar sibling of :meth:`get_page_texts`: the export path keeps the
+        whole set in Arrow (no per-row Python objects) from read through file
+        write. Empty with the canonical schema when the table or *source* is empty.
+        """
+        table = self.open_table(PAGE_TEXTS_TABLE)
+        if table is None:
+            return _page_texts_schema().empty_table()
+        query = table.search().select(["source", "page", "text", "content_type"])
+        if source is not None:
+            query = query.where(f"source = '{escape_sql_string(source)}'")
+        return query.limit(None).to_arrow()
+
     def page_text_sources(self) -> set[str]:
         """Return the distinct sources present in the page-text table."""
         table = self.open_table(PAGE_TEXTS_TABLE)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pyarrow as pa
 import pytest
 
 from lilbee.app import services as svc_mod
@@ -89,9 +90,9 @@ class TestResolveFormat:
 class TestWriteRoundTrip:
     @pytest.mark.parametrize("fmt", [DatasetFormat.PARQUET, DatasetFormat.JSONL])
     def test_round_trip(self, tmp_path, fmt):
-        rows = [_page("a.pdf", 1, "hello"), _page("a.pdf", 2, "world")]
+        table = pa.Table.from_pylist([_page("a.pdf", 1, "hello"), _page("a.pdf", 2, "world")])
         path = tmp_path / f"pages.{fmt}"
-        write_dataset(rows, path, fmt)
+        write_dataset(table, path, fmt)
         loaded = load_page_dataset(path, fmt)
         assert [(r["source"], r["page"], r["text"]) for r in loaded] == [
             ("a.pdf", 1, "hello"),
@@ -118,14 +119,14 @@ class TestBuildPageDataset:
     def test_clean_path_uses_captured_text(self, store):
         store.add_page_texts([_page("a.pdf", 1, "clean one"), _page("a.pdf", 2, "clean two")])
         store.upsert_source("a.pdf", "h", 2)
-        rows = build_page_dataset(store)
+        rows = build_page_dataset(store).to_pylist()
         assert [(r["page"], r["text"]) for r in rows] == [(1, "clean one"), (2, "clean two")]
 
     def test_fallback_reconstructs_from_chunks(self, store):
         # No page texts captured; reconstruct from chunks, ordered by chunk_index.
         store.add_chunks([_chunk("b.pdf", 1, 1, "second"), _chunk("b.pdf", 1, 0, "first")])
         store.upsert_source("b.pdf", "h", 2)
-        rows = build_page_dataset(store)
+        rows = build_page_dataset(store).to_pylist()
         assert len(rows) == 1
         assert rows[0]["page"] == 1
         assert rows[0]["text"] == "first\nsecond"
@@ -135,8 +136,60 @@ class TestBuildPageDataset:
         store.add_page_texts([_page("b.pdf", 1, "b-text")])
         store.upsert_source("a.pdf", "h", 1)
         store.upsert_source("b.pdf", "h", 1)
-        rows = build_page_dataset(store, source="b.pdf")
+        rows = build_page_dataset(store, source="b.pdf").to_pylist()
         assert {r["source"] for r in rows} == {"b.pdf"}
+
+    def test_single_source_reconstructs_when_not_captured(self, store):
+        # Exporting one source that has chunks but no captured page text
+        # reconstructs just that source from its chunks.
+        store.add_chunks([_chunk("only-chunks.pdf", 1, 0, "rebuilt body")])
+        store.upsert_source("only-chunks.pdf", "h", 1)
+        rows = build_page_dataset(store, source="only-chunks.pdf").to_pylist()
+        assert [(r["source"], r["text"]) for r in rows] == [("only-chunks.pdf", "rebuilt body")]
+
+    def test_all_sources_scans_page_texts_once(self, store, monkeypatch):
+        # Regression (bb-bqg): the all-sources export must read the page-text
+        # table in a single Arrow scan, not one filtered query per source. The
+        # per-source loop was O(sources) and hung for >25 min on a 346k-source
+        # store; the fixed-per-query overhead, not data size, dominated.
+        for i in range(5):
+            store.add_page_texts([_page(f"s{i}.pdf", 1, f"t{i}")])
+            store.upsert_source(f"s{i}.pdf", "h", 1)
+        calls: list[str | None] = []
+        real = store.page_texts_arrow
+
+        def spy(source=None):
+            calls.append(source)
+            return real(source)
+
+        monkeypatch.setattr(store, "page_texts_arrow", spy)
+        table = build_page_dataset(store)
+        assert table.num_rows == 5
+        # Exactly one full-table scan (source=None); never a per-source query.
+        assert calls == [None]
+
+    def test_orphaned_page_text_without_source_is_excluded(self, store):
+        # A page-text row whose source has no tracking record (e.g. the source was
+        # removed) is left out: the scan is restricted to get_sources(), matching
+        # the universe the old per-source loop walked.
+        store.add_page_texts([_page("real.pdf", 1, "kept")])
+        store.upsert_source("real.pdf", "h", 1)
+        store.add_page_texts([_page("orphan.pdf", 1, "dropped")])  # no upsert_source
+        rows = build_page_dataset(store).to_pylist()
+        assert {r["source"] for r in rows} == {"real.pdf"}
+
+    def test_mixed_captured_and_reconstructed_sources(self, store):
+        # Captured sources come from the single scan; only sources with no
+        # captured text fall back to per-source chunk reconstruction.
+        store.add_page_texts([_page("cap.pdf", 1, "captured")])
+        store.upsert_source("cap.pdf", "h", 1)
+        store.add_chunks([_chunk("recon.pdf", 1, 0, "rebuilt")])
+        store.upsert_source("recon.pdf", "h", 1)
+        rows = build_page_dataset(store).to_pylist()
+        assert [(r["source"], r["text"]) for r in rows] == [
+            ("cap.pdf", "captured"),
+            ("recon.pdf", "rebuilt"),
+        ]
 
     def test_sorted_by_source_and_page(self, store):
         store.add_page_texts(
@@ -144,7 +197,7 @@ class TestBuildPageDataset:
         )
         store.upsert_source("a.pdf", "h", 2)
         store.upsert_source("b.pdf", "h", 1)
-        rows = build_page_dataset(store)
+        rows = build_page_dataset(store).to_pylist()
         assert [(r["source"], r["page"]) for r in rows] == [
             ("a.pdf", 1),
             ("a.pdf", 2),


### PR DESCRIPTION
## Problem

`build_page_dataset` looped over every source and issued a separate page-text query per source, materializing each row as a Python object. On a 346k-source / 562k-page store the export ran over 25 minutes with no output; the cost was per-query round-trips, not data size.

## Solution

Read the whole `_page_texts` table in one Arrow scan (`Store.page_texts_arrow`), keep it columnar through the sort and the parquet/jsonl writers, and reconstruct from chunks only for sources with no captured text. `build_page_dataset`, `serialize_dataset`, and `write_dataset` now take/return a `pyarrow.Table`; `export_to_path`/`export_to_bytes` and their HTTP/MCP/TUI callers keep the same `ExportSummary`/`ExportPayload`. Output is unchanged; the export finishes in seconds.
