### PR TITLE
Retry vision-OCR 429s instead of dropping the page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ All settings override via environment variables:
 - `LILBEE_VISION_MODEL` — vision OCR model (default: none)
 - `LILBEE_RERANKER_TYPE` — reranker serving mode: `auto` (default), `cross_encoder`, or `llm`.
 - `LILBEE_RERANKER_PROMPT` — relevance prompt for LLM rerankers (blank uses the built-in template).
-- `LILBEE_OCR_TIMEOUT` — per-page vision OCR timeout in seconds (default: `120`, `0` = no limit)
+- `LILBEE_OCR_TIMEOUT` — per-page vision OCR timeout in seconds (default: `300`, `0` = no limit)
 - `LILBEE_TESSERACT_TIMEOUT`: wall-clock timeout in seconds for the Tesseract OCR fallback (default: `60`, `0` = no limit). Only runs when no vision model is available.
 - `LILBEE_SSE_HEARTBEAT_INTERVAL` — seconds between SSE heartbeat events when the producer queue is idle (default: `30`). Set to `0` to disable.
 - `LILBEE_LLM_PROVIDER` — provider: `auto` (default; runs models locally on the managed `llama-server` fleet) or `remote` (external OpenAI-compatible endpoint; requires `pip install lilbee[litellm]`).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -685,7 +685,7 @@ The ones most users set at least once.
 | `LILBEE_CHAT_MODEL` | `Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf` | Chat model. Native GGUF by default; with `pip install --pre 'lilbee[litellm]'` (or `uv tool install --prerelease=allow 'lilbee[litellm]'`), any remote name the SDK backend understands |
 | `LILBEE_EMBEDDING_MODEL` | `nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q4_K_M.gguf` | Embedding model. Changing this requires `lilbee rebuild` |
 | `LILBEE_VISION_MODEL` | *(none)* | Vision OCR model. When set, takes precedence over Tesseract on scanned PDFs and images |
-| `LILBEE_VISION_TIMEOUT` | `120` | Per-page vision OCR timeout in seconds (`0` = no limit) |
+| `LILBEE_OCR_TIMEOUT` | `300` | Per-page vision OCR timeout in seconds (`0` = no limit) |
 | `LILBEE_LOG_LEVEL` | `WARNING` | Logging level (DEBUG, INFO, WARNING, ERROR) |
 | `LILBEE_SYSTEM_PROMPT` | *(built-in)* | Custom system prompt for RAG answers |
 | `LILBEE_SHOW_REASONING` | `false` | Show the model's `<think>` reasoning tokens in chat output. Useful with Qwen3, DeepSeek-R1, and other reasoning models |

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -126,7 +126,10 @@ SETTINGS_MAP: dict[str, SettingDef] = {
         int,
         nullable=False,
         group=SettingGroup.INGEST,
-        help_text="Hard cap on tokens generated per OCR page (bounds runaway repetition loops)",
+        help_text=(
+            "Hard cap on tokens generated per OCR page (bounds runaway repetition"
+            " loops); raising it lengthens page generation, so give ocr_timeout headroom"
+        ),
     ),
     "vision_ocr_concurrency": SettingDef(
         int,

--- a/src/lilbee/cli/commands/ingest_sync.py
+++ b/src/lilbee/cli/commands/ingest_sync.py
@@ -42,7 +42,7 @@ _retry_skipped_option = typer.Option(
 _ocr_timeout_option = typer.Option(
     None,
     "--ocr-timeout",
-    help="Per-page timeout in seconds for vision OCR (default: 120, 0 = no limit).",
+    help="Per-page timeout in seconds for vision OCR (default: 300, 0 = no limit).",
 )
 
 

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -125,6 +125,8 @@ class Config(BaseSettings):
     # Hard cap on tokens generated per OCR page. A real page is well under this;
     # the cap bounds the occasional runaway repetition loop (a page that loops to
     # tens of thousands of chars) which otherwise dominates a scan's OCR time.
+    # Raising it lengthens per-page generation on dense scans, so give ocr_timeout
+    # matching headroom.
     vision_ocr_max_tokens: int = ConfigField(default=4096, ge=256, writable=True)
     # Pages OCR'd concurrently, and the vision server's continuous-batching slots.
     # A single-page decode underutilizes a modern GPU (~half SM); batching several

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -115,8 +115,10 @@ class Config(BaseSettings):
     # True = force OCR regardless of detection.
     # False = disable OCR entirely.
     enable_ocr: bool | None = ConfigField(default=None, writable=True)
-    # Per-page timeout in seconds for vision OCR (0 = no limit).
-    ocr_timeout: float = ConfigField(default=120.0, ge=0.0, writable=True)
+    # Per-page timeout in seconds for vision OCR (0 = no limit). Sized so a dense
+    # full-page scan finishes on modest hardware; a raised vision_ocr_max_tokens
+    # needs matching headroom here.
+    ocr_timeout: float = ConfigField(default=300.0, ge=0.0, writable=True)
     # Outer wall-clock budget for the streamed pool drain: load grace plus
     # per_page * pages. Tune up for slow hardware (M1 Pro vision is
     # ~5min/page) or down for fast hardware. ocr_timeout still governs the

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -312,6 +312,26 @@ class ChatDeadlineError(ProviderError):
     """
 
 
+def retry_on_busy(call: Callable[[], _T], *, retries: int = _BUSY_RETRIES) -> _T:
+    """Run *call*, retrying a transient server-busy (RATE_LIMIT) with capped backoff.
+
+    A cold replica fleet 429s the first fan-out until its slots load; backing
+    off and retrying turns those drops into successes. *retries* bounds the
+    attempts -- interactive callers fail fast, bulk ingest waits out a cold
+    start. Non-RATE_LIMIT errors (and a final still-busy response) propagate.
+    """
+    delay = _BUSY_BACKOFF_BASE_S
+    for _ in range(retries - 1):
+        try:
+            return call()
+        except ProviderError as exc:
+            if exc.kind is not ProviderErrorKind.RATE_LIMIT:
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, _BUSY_BACKOFF_MAX_S)
+    return call()
+
+
 class LlamaServerClient:
     """Calls one llama-server's OpenAI surface. Tracks in-flight requests so the
     fleet router can pick the least-busy replica."""
@@ -777,26 +797,7 @@ class LlamaServerClient:
                 _raise_for_status(resp)
                 return dict(resp.json())
 
-        return _llm_rerank_score(_first_token_top_logprobs(self._retry_on_busy(_call)))
-
-    def _retry_on_busy(self, call: Callable[[], _T], *, retries: int = _BUSY_RETRIES) -> _T:
-        """Run *call*, retrying a transient server-busy (RATE_LIMIT) with capped backoff.
-
-        A cold replica fleet 429s the first fan-out until its slots load; backing
-        off and retrying turns those drops into successes. *retries* bounds the
-        attempts -- interactive callers fail fast, bulk ingest waits out a cold
-        start. Non-RATE_LIMIT errors (and a final still-busy response) propagate.
-        """
-        delay = _BUSY_BACKOFF_BASE_S
-        for _ in range(retries - 1):
-            try:
-                return call()
-            except ProviderError as exc:
-                if exc.kind is not ProviderErrorKind.RATE_LIMIT:
-                    raise
-                time.sleep(delay)
-                delay = min(delay * 2, _BUSY_BACKOFF_MAX_S)
-        return call()
+        return _llm_rerank_score(_first_token_top_logprobs(retry_on_busy(_call)))
 
     def _embeddings_call(self, inputs: list[str]) -> list[dict[str, Any]]:
         """POST one already-budgeted sub-batch to ``/v1/embeddings``; return its data."""
@@ -821,7 +822,7 @@ class LlamaServerClient:
             return list(data)
 
         # Bulk ingest can afford to wait out a cold-start warmup rather than drop files.
-        return self._retry_on_busy(_call, retries=_EMBED_BUSY_RETRIES)
+        return retry_on_busy(_call, retries=_EMBED_BUSY_RETRIES)
 
     def _truncate_and_subbatch(self, texts: list[str], *, estimate: bool) -> list[list[str]]:
         """Token-truncate over-cap inputs, then pack into server-sized sub-batches.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -31,6 +31,7 @@ from lilbee.providers.fleet.client import (
     ChatDeadlineError,
     LlamaServerClient,
     is_connection_failure,
+    retry_on_busy,
 )
 from lilbee.providers.fleet.replicas import (
     gpu_device_count,
@@ -84,6 +85,11 @@ _REQUEST_TIMEOUT_GENERATION_MARGIN_S = 120.0
 # The server parses tool calls natively via ``--jinja``; this probe only decides
 # whether to offer tools to a given model at all.
 _TOOL_TEMPLATE_PATTERN = re.compile(r"\{[%{][^}]*\b(?:tools|tool_calls|functions|function_calls)\b")
+# Ingest OCR is background work: back off and re-request a 429'd page (a cold
+# vision start loading weights plus mmproj, or a transient slot-contention burst)
+# rather than dropping it from the index. Capped backoff keeps the total wait
+# near ~110s; a page still busy after that fails like any extraction error.
+_VISION_BUSY_RETRIES = 18
 _T = TypeVar("_T")
 
 
@@ -215,9 +221,10 @@ class _VisionRequestGate:
 
     The ingest file fan-out runs many files at once and each file's ``pdf_ocr`` opens
     its own ``vision_ocr_concurrency`` page pool, so without a shared cap the aggregate
-    over-subscribes a single-replica vision server into a 429 storm. The semaphore is
-    rebuilt to the configured capacity (``vision_replicas * vision_ocr_concurrency``)
-    only while the gate is idle, so a capacity change never doubles the live cap.
+    over-subscribes a single-replica vision server into a 429 storm. *capacity* is
+    the fleet's real slot count (see ``_vision_gate_capacity``); the semaphore is
+    rebuilt to it only while the gate is idle, so a capacity change never doubles
+    the live cap.
     """
 
     def __init__(self) -> None:
@@ -227,13 +234,13 @@ class _VisionRequestGate:
         self._semaphore: threading.BoundedSemaphore | None = None
 
     @contextmanager
-    def slot(self) -> Iterator[None]:
-        """Hold one vision-request slot for the duration of the block.
+    def slot(self, capacity: int) -> Iterator[None]:
+        """Hold one of *capacity* vision-request slots for the duration of the block.
 
         The acquired semaphore is captured and released by this same call, so a
         concurrent capacity change cannot release the wrong object.
         """
-        sem = self._checkout()
+        sem = self._checkout(capacity)
         # _checkout incremented _in_flight; decrement on every exit path,
         # including one where acquire() raises, or a leaked count pins the gate
         # non-idle and defers every later capacity resize forever.
@@ -247,9 +254,7 @@ class _VisionRequestGate:
             with self._lock:
                 self._in_flight -= 1
 
-    def _checkout(self) -> threading.BoundedSemaphore:
-        replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
-        capacity = max(1, replicas * cfg.vision_ocr_concurrency)
+    def _checkout(self, capacity: int) -> threading.BoundedSemaphore:
         with self._lock:
             # Resize only when idle: rebuilding while old-semaphore holders are
             # in flight would briefly double the real cap, so a capacity change
@@ -312,17 +317,19 @@ def _ocr_pdf_page(
     ocr_prompt: str,
     deadline: float | None,
     page_path: Path,
+    gate_capacity: int,
 ) -> tuple[int, str]:
     """OCR one rasterized page through the gated vision server; empty text on failure.
 
     Acquires the gate before reading the clock so queue time isn't billed against the
     page's share of the document-wide deadline; an exhausted budget skips the page
-    rather than running it un-timed.
+    rather than running it un-timed. A busy fleet (429) is retried with backoff
+    inside the held slot before the page is given up on.
     """
     from lilbee.vision import build_vision_messages
 
     messages = build_vision_messages(ocr_prompt, png)
-    with _VISION_GATE.slot():
+    with _VISION_GATE.slot(gate_capacity):
         remaining = max(0.0, deadline - time.monotonic()) if deadline is not None else None
         if remaining == 0.0:
             log.warning(
@@ -332,8 +339,11 @@ def _ocr_pdf_page(
             )
             return idx, ""
         try:
-            return idx, _call_with_failover(
-                clients, lambda client: _vision_call(client, messages, remaining)
+            return idx, retry_on_busy(
+                lambda: _call_with_failover(
+                    clients, lambda client: _vision_call(client, messages, remaining)
+                ),
+                retries=_VISION_BUSY_RETRIES,
             )
         except ProviderError:
             # One failed/timed-out page yields empty text; siblings continue.
@@ -820,10 +830,30 @@ class FleetProvider:
         clients = self._require_clients(WorkerRole.VISION)
         effective = model or str(cfg.vision_model)
         messages = build_vision_messages(prompt or resolve_ocr_prompt(effective), png_bytes)
-        with _VISION_GATE.slot():
-            return _call_with_failover(
-                clients, lambda client: _vision_call(client, messages, timeout)
+        # Retry a busy fleet inside the held slot: backoff time must not free the
+        # slot for more work, and each attempt re-picks the least-busy replica.
+        with _VISION_GATE.slot(self._vision_gate_capacity()):
+            return retry_on_busy(
+                lambda: _call_with_failover(
+                    clients, lambda client: _vision_call(client, messages, timeout)
+                ),
+                retries=_VISION_BUSY_RETRIES,
             )
+
+    def _vision_gate_capacity(self) -> int:
+        """The vision servers' total continuous-batching slots, the 429-free ceiling.
+
+        Summed from the adopted launches' fitted ``--parallel`` counts, which can
+        be lower than ``vision_ocr_concurrency`` when memory forced a smaller fit;
+        capping at the configured ceiling instead over-subscribes the servers.
+        Falls back to the configured formula when no launch snapshot exists (a
+        reload can momentarily drop it between two reads).
+        """
+        launches = self._launches.get(WorkerRole.VISION)
+        if launches:
+            return max(1, sum(launch.slots for launch in launches))
+        replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
+        return max(1, replicas * cfg.vision_ocr_concurrency)
 
     def pdf_ocr(
         self,
@@ -871,6 +901,7 @@ class FleetProvider:
             ocr_prompt=ocr_prompt,
             deadline=deadline,
             page_path=path,
+            gate_capacity=self._vision_gate_capacity(),
         )
 
         # OCR pages concurrently (a single-page decode underuses the GPU; the vision

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -936,7 +936,17 @@ class FleetProvider:
                             ExtractEvent(file=path.name, page=page_idx + 1, total_pages=total),
                         )
                     _submit_next()
-        return [PageText(idx + 1, results[idx]) for idx in sorted(results)]
+        pages = [PageText(idx + 1, results[idx]) for idx in sorted(results)]
+        unrecovered = sum(1 for page in pages if not page.text)
+        if unrecovered:
+            log.warning(
+                "Vision OCR produced no text for %d of %d pages of %s "
+                "(timed out or server still busy); those pages are blank in the index.",
+                unrecovered,
+                total,
+                path.name,
+            )
+        return pages
 
     def rerank(self, query: str, candidates: list[str]) -> list[float]:
         clients = self._require_clients(WorkerRole.RERANK)

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -21,7 +21,7 @@ import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar, overload
 
 from lilbee.core.config import cfg
 from lilbee.modelhub.registry import ModelRegistry
@@ -32,10 +32,6 @@ from lilbee.providers.fleet.client import (
     LlamaServerClient,
     is_connection_failure,
     retry_on_busy,
-)
-from lilbee.providers.fleet.replicas import (
-    gpu_device_count,
-    resolve_replica_count,
 )
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
 from lilbee.providers.fleet.swap_manager import SwapManager, reap_stale, sweep_owned
@@ -85,11 +81,15 @@ _REQUEST_TIMEOUT_GENERATION_MARGIN_S = 120.0
 # The server parses tool calls natively via ``--jinja``; this probe only decides
 # whether to offer tools to a given model at all.
 _TOOL_TEMPLATE_PATTERN = re.compile(r"\{[%{][^}]*\b(?:tools|tool_calls|functions|function_calls)\b")
-# Ingest OCR is background work: back off and re-request a 429'd page (a cold
-# vision start loading weights plus mmproj, or a transient slot-contention burst)
-# rather than dropping it from the index. Capped backoff keeps the total wait
-# near ~110s; a page still busy after that fails like any extraction error.
+# Ingest OCR is background work: back off and re-request a 429'd page rather
+# than dropping it from the index. Slot dispatch already prevents self-inflicted
+# 429s, so a busy response is a cold vision start (weights plus mmproj loading)
+# or foreign traffic. Capped backoff keeps the total wait near ~110s; a page
+# still busy after that fails like any extraction error.
 _VISION_BUSY_RETRIES = 18
+# How often a waiter blocked on full replicas re-polls their health: an
+# unhealthy replica re-admits itself by cool-down expiry, which notifies nobody.
+_DISPATCH_HEALTH_RECHECK_S = 0.5
 _T = TypeVar("_T")
 
 
@@ -216,57 +216,110 @@ def _supports_tools_cached(path_str: str, _mtime_ns: int) -> bool:
     return _TOOL_TEMPLATE_PATTERN.search(template) is not None
 
 
-class _VisionRequestGate:
-    """Process-wide cap on concurrent vision-server requests at the fleet's OCR slots.
+class _VisionReplica(NamedTuple):
+    """One vision server paired with its fitted ``--parallel`` slot count."""
 
-    The ingest file fan-out runs many files at once and each file's ``pdf_ocr`` opens
-    its own ``vision_ocr_concurrency`` page pool, so without a shared cap the aggregate
-    over-subscribes a single-replica vision server into a 429 storm. *capacity* is
-    the fleet's real slot count (see ``_vision_gate_capacity``); the semaphore is
-    rebuilt to it only while the gate is idle, so a capacity change never doubles
-    the live cap.
+    client: LlamaServerClient
+    slots: int
+
+
+class _PageBudgetExhausted(Exception):  # noqa: N818 - internal control flow, not an error API
+    """A PDF page's document-wide OCR budget ran out before its slot came up."""
+
+
+class _VisionDispatcher:
+    """Process-wide per-replica slot assignment for vision requests.
+
+    The ingest file fan-out runs many OCR requests at once; each request is
+    assigned one specific replica and only while that replica has a free
+    continuous-batching slot, so lilbee's own traffic can never oversubscribe a
+    vision server into a 429 (an aggregate cap plus racy least-busy routing
+    can). Requests past capacity wait in-process until any usable replica
+    frees a slot; unhealthy replicas take no new work until their half-open
+    cool-down re-admits them.
     """
 
     def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._capacity = 0
-        self._in_flight = 0
-        self._semaphore: threading.BoundedSemaphore | None = None
+        self._cond = threading.Condition()
+        self._assigned: dict[LlamaServerClient, int] = {}
 
     @contextmanager
-    def slot(self, capacity: int) -> Iterator[None]:
-        """Hold one of *capacity* vision-request slots for the duration of the block.
-
-        The acquired semaphore is captured and released by this same call, so a
-        concurrent capacity change cannot release the wrong object.
-        """
-        sem = self._checkout(capacity)
-        # _checkout incremented _in_flight; decrement on every exit path,
-        # including one where acquire() raises, or a leaked count pins the gate
-        # non-idle and defers every later capacity resize forever.
+    def slot(self, pool: Sequence[_VisionReplica]) -> Iterator[LlamaServerClient]:
+        """Hold one batching slot on the pool's best replica; yields that client."""
+        client = self._acquire(pool)
         try:
-            sem.acquire()
-            try:
-                yield
-            finally:
-                sem.release()
+            yield client
         finally:
-            with self._lock:
-                self._in_flight -= 1
+            self._release(client)
 
-    def _checkout(self, capacity: int) -> threading.BoundedSemaphore:
-        with self._lock:
-            # Resize only when idle: rebuilding while old-semaphore holders are
-            # in flight would briefly double the real cap, so a capacity change
-            # waits for the current batch to drain.
-            if self._semaphore is None or (self._capacity != capacity and self._in_flight == 0):
-                self._capacity = capacity
-                self._semaphore = threading.BoundedSemaphore(capacity)
-            self._in_flight += 1
-            return self._semaphore
+    def _acquire(self, pool: Sequence[_VisionReplica]) -> LlamaServerClient:
+        with self._cond:
+            while True:
+                client = self._pick(pool)
+                if client is not None:
+                    self._assigned[client] = self._assigned.get(client, 0) + 1
+                    return client
+                # The timed wait re-polls health: a replica can become routable
+                # again by cool-down expiry alone, which notifies no waiter.
+                self._cond.wait(timeout=_DISPATCH_HEALTH_RECHECK_S)
+
+    def _pick(self, pool: Sequence[_VisionReplica]) -> LlamaServerClient | None:
+        """The usable replica with the most free slots, or None while all are full.
+
+        Falls back to the full pool when every replica is unhealthy (mirrors
+        ``_least_in_flight``), so a dead pool surfaces the error instead of
+        queueing forever.
+        """
+        usable = [replica for replica in pool if replica.client.healthy] or list(pool)
+        best = max(usable, key=self._free_slots)
+        return best.client if self._free_slots(best) > 0 else None
+
+    def _free_slots(self, replica: _VisionReplica) -> int:
+        return replica.slots - self._assigned.get(replica.client, 0)
+
+    def _release(self, client: LlamaServerClient) -> None:
+        with self._cond:
+            remaining = self._assigned.get(client, 0) - 1
+            if remaining <= 0:
+                self._assigned.pop(client, None)
+            else:
+                self._assigned[client] = remaining
+            self._cond.notify_all()
 
 
-_VISION_GATE = _VisionRequestGate()
+_VISION_DISPATCHER = _VisionDispatcher()
+
+
+def _dispatch_vision(pool: Sequence[_VisionReplica], call: Callable[[LlamaServerClient], _T]) -> _T:
+    """Run *call* on a replica with a free batching slot, failing over once.
+
+    Blocks until a slot frees rather than racing requests at a full server. A
+    connection-level failure marks the replica unhealthy and retries once on
+    another replica's slot; with no other replica the failure surfaces.
+    """
+    with _VISION_DISPATCHER.slot(pool) as client:
+        try:
+            result = call(client)
+        except Exception as exc:
+            if not is_connection_failure(exc):
+                raise
+            client.mark_unhealthy()
+            failed, cause = client, exc
+        else:
+            client.mark_healthy()
+            return result
+    others = [replica for replica in pool if replica.client is not failed]
+    if not others:
+        raise _no_healthy_replica_error() from cause
+    with _VISION_DISPATCHER.slot(others) as retry_client:
+        try:
+            retry_result = call(retry_client)
+        except Exception as retry_exc:
+            if is_connection_failure(retry_exc):
+                retry_client.mark_unhealthy()
+            raise
+        retry_client.mark_healthy()
+        return retry_result
 
 
 def _vision_call(
@@ -278,7 +331,7 @@ def _vision_call(
     on one page (seen looping to tens of thousands of chars) can't dominate a
     scan's OCR time; a real page stays well under the cap. A timeout surfaces as
     a ``ProviderError`` so the page-level OCR caller can fail just that page.
-    Callers hold ``_VISION_GATE`` so queue time isn't billed against the timeout.
+    Callers hold a dispatcher slot, so queue time isn't billed against the timeout.
     """
     from lilbee.core.config import cfg
 
@@ -313,47 +366,48 @@ def _ocr_pdf_page(
     idx: int,
     png: bytes,
     *,
-    clients: list[LlamaServerClient],
+    pool: list[_VisionReplica],
     ocr_prompt: str,
     deadline: float | None,
     page_path: Path,
-    gate_capacity: int,
 ) -> tuple[int, str]:
-    """OCR one rasterized page through the gated vision server; empty text on failure.
+    """OCR one rasterized page on a replica with a free slot; empty text on failure.
 
-    Acquires the gate before reading the clock so queue time isn't billed against the
-    page's share of the document-wide deadline; an exhausted budget skips the page
-    rather than running it un-timed. A busy fleet (429) is retried with backoff
-    inside the held slot before the page is given up on.
+    The document-deadline clock is read only once a slot is held, so queue time
+    isn't billed against the page's share; an exhausted budget skips the page
+    rather than running it un-timed. A busy server (429, still warming) is
+    retried with backoff before the page is given up on.
     """
     from lilbee.vision import build_vision_messages
 
     messages = build_vision_messages(ocr_prompt, png)
-    with _VISION_GATE.slot(gate_capacity):
+
+    def _page(client: LlamaServerClient) -> str:
         remaining = max(0.0, deadline - time.monotonic()) if deadline is not None else None
         if remaining == 0.0:
-            log.warning(
-                "Vision OCR budget exhausted before page %d of %s; skipping.",
-                idx + 1,
-                page_path.name,
-            )
-            return idx, ""
-        try:
-            return idx, retry_on_busy(
-                lambda: _call_with_failover(
-                    clients, lambda client: _vision_call(client, messages, remaining)
-                ),
-                retries=_VISION_BUSY_RETRIES,
-            )
-        except ProviderError:
-            # One failed/timed-out page yields empty text; siblings continue.
-            log.warning(
-                "Vision OCR failed for page %d of %s; skipping that page.",
-                idx + 1,
-                page_path.name,
-                exc_info=True,
-            )
-            return idx, ""
+            raise _PageBudgetExhausted
+        return _vision_call(client, messages, remaining)
+
+    try:
+        return idx, retry_on_busy(
+            lambda: _dispatch_vision(pool, _page), retries=_VISION_BUSY_RETRIES
+        )
+    except _PageBudgetExhausted:
+        log.warning(
+            "Vision OCR budget exhausted before page %d of %s; skipping.",
+            idx + 1,
+            page_path.name,
+        )
+        return idx, ""
+    except ProviderError:
+        # One failed/timed-out page yields empty text; siblings continue.
+        log.warning(
+            "Vision OCR failed for page %d of %s; skipping that page.",
+            idx + 1,
+            page_path.name,
+            exc_info=True,
+        )
+        return idx, ""
 
 
 def _pdf_drain_budget(total_pages: int, per_page_timeout_s: float | None) -> float | None:
@@ -827,33 +881,35 @@ class FleetProvider:
         from lilbee.vision import build_vision_messages, resolve_ocr_prompt
 
         self._require_configured_model(model, str(cfg.vision_model), WorkerRole.VISION)
-        clients = self._require_clients(WorkerRole.VISION)
+        pool = self._vision_pool()
         effective = model or str(cfg.vision_model)
         messages = build_vision_messages(prompt or resolve_ocr_prompt(effective), png_bytes)
-        # Retry a busy fleet inside the held slot: backoff time must not free the
-        # slot for more work, and each attempt re-picks the least-busy replica.
-        with _VISION_GATE.slot(self._vision_gate_capacity()):
-            return retry_on_busy(
-                lambda: _call_with_failover(
-                    clients, lambda client: _vision_call(client, messages, timeout)
-                ),
-                retries=_VISION_BUSY_RETRIES,
-            )
+        # Slot assignment makes a self-inflicted 429 impossible; a residual busy
+        # response is a still-warming server or foreign traffic. Backoff runs
+        # slot-free so a waiting sibling can use a replica that is ready.
+        return retry_on_busy(
+            lambda: _dispatch_vision(pool, lambda client: _vision_call(client, messages, timeout)),
+            retries=_VISION_BUSY_RETRIES,
+        )
 
-    def _vision_gate_capacity(self) -> int:
-        """The vision servers' total continuous-batching slots, the 429-free ceiling.
+    def _vision_pool(self) -> list[_VisionReplica]:
+        """Each vision replica paired with its fitted ``--parallel`` slot count.
 
-        Summed from the adopted launches' fitted ``--parallel`` counts, which can
-        be lower than ``vision_ocr_concurrency`` when memory forced a smaller fit;
-        capping at the configured ceiling instead over-subscribes the servers.
-        Falls back to the configured formula when no launch snapshot exists (a
-        reload can momentarily drop it between two reads).
+        The fitted count can be lower than ``vision_ocr_concurrency`` when memory
+        forced a smaller fit; dispatching at the configured ceiling instead
+        over-subscribes that server. The configured ceiling applies per replica
+        only when no matching launch snapshot exists (a reload can momentarily
+        drop it between two reads).
         """
+        clients = self._require_clients(WorkerRole.VISION)
         launches = self._launches.get(WorkerRole.VISION)
-        if launches:
-            return max(1, sum(launch.slots for launch in launches))
-        replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
-        return max(1, replicas * cfg.vision_ocr_concurrency)
+        if launches and len(launches) == len(clients):
+            return [
+                _VisionReplica(client, max(1, launch.slots))
+                for client, launch in zip(clients, launches, strict=True)
+            ]
+        fallback_slots = max(1, cfg.vision_ocr_concurrency)
+        return [_VisionReplica(client, fallback_slots) for client in clients]
 
     def pdf_ocr(
         self,
@@ -884,7 +940,7 @@ class FleetProvider:
 
         del quiet  # protocol parity; no server-side Rich progress to suppress.
         self._require_configured_model(model, str(cfg.vision_model), WorkerRole.VISION)
-        clients = self._require_clients(WorkerRole.VISION)
+        replicas = self._vision_pool()
         # The model is fixed for the whole document, so resolve its prompt once.
         ocr_prompt = resolve_ocr_prompt(model or str(cfg.vision_model))
         log.debug("OCR prompt for %s -> %r", model or cfg.vision_model, ocr_prompt)
@@ -897,18 +953,18 @@ class FleetProvider:
 
         _ocr = functools.partial(
             _ocr_pdf_page,
-            clients=clients,
+            pool=replicas,
             ocr_prompt=ocr_prompt,
             deadline=deadline,
             page_path=path,
-            gate_capacity=self._vision_gate_capacity(),
         )
 
-        # OCR pages concurrently (a single-page decode underuses the GPU; the vision
-        # server runs cfg.vision_ocr_concurrency batching slots). A bounded sliding
-        # window keeps that many pages in flight without rasterizing the whole PDF
-        # into memory; results are reassembled in page order.
-        concurrency = max(1, cfg.vision_ocr_concurrency)
+        # OCR pages concurrently (a single-page decode underuses the GPU). The
+        # window is the fleet's total batching slots so one large document can
+        # saturate every replica; a bounded sliding window keeps that many pages
+        # in flight without rasterizing the whole PDF into memory, and results
+        # are reassembled in page order.
+        concurrency = max(1, sum(replica.slots for replica in replicas))
         raster = rasterize_pdf(path)
         results: dict[int, str] = {}
         with ThreadPoolExecutor(max_workers=concurrency) as pool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -803,10 +803,10 @@ class TestParseBool:
 
 
 class TestOcrTimeoutConfig:
-    def test_default_is_120(self, tmp_path) -> None:
+    def test_default_is_300(self, tmp_path) -> None:
         with mock.patch.dict(os.environ, _clean_env(tmp_path), clear=True):
             c = Config()
-            assert c.ocr_timeout == 120.0
+            assert c.ocr_timeout == 300.0
 
     def test_from_env(self) -> None:
         with mock.patch.dict(os.environ, {"LILBEE_OCR_TIMEOUT": "60.5"}):

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -397,20 +397,84 @@ def test_vision_call_caps_output_tokens(monkeypatch) -> None:
     assert client.chat.call_args.kwargs["options"] == {"max_tokens": 4096}
 
 
-def test_vision_request_gate_tracks_fleet_capacity(monkeypatch) -> None:
-    # The gate must cap in-flight vision requests at the fleet's real OCR capacity
-    # (replicas x per-server slots) and rebuild to a new capacity while idle.
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+def test_vision_ocr_retries_busy_then_succeeds(monkeypatch) -> None:
+    # A 429 mid-ingest is transient (cold replicas, slot contention); the vision
+    # path must back off and retry so the page is ingested, not dropped.
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    monkeypatch.setattr(cfg, "vision_model", "org/repo/v.gguf")
+    busy = ProviderError("busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT)
+    client = _fake_client()
+    client.chat.side_effect = [busy, busy, "ocr text"]
+    p = _provider_with_clients({WorkerRole.VISION: [client]})
+    assert p.vision_ocr(b"png", "org/repo/v.gguf") == "ocr text"
+    assert client.chat.call_count == 3
+
+
+def test_vision_ocr_gives_up_when_persistently_busy(monkeypatch) -> None:
+    # The retry budget is bounded; a fleet that never frees a slot fails the page.
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    monkeypatch.setattr(cfg, "vision_model", "org/repo/v.gguf")
+    client = _fake_client()
+    client.chat.side_effect = ProviderError(
+        "busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT
+    )
+    p = _provider_with_clients({WorkerRole.VISION: [client]})
+    with pytest.raises(ProviderError) as excinfo:
+        p.vision_ocr(b"png", "org/repo/v.gguf")
+    assert excinfo.value.kind is ProviderErrorKind.RATE_LIMIT
+    assert client.chat.call_count == prov_mod._VISION_BUSY_RETRIES
+
+
+def test_vision_ocr_does_not_retry_non_busy_errors(monkeypatch) -> None:
+    # A genuine extraction failure must surface immediately, not burn the budget.
+    from lilbee.providers.base import ProviderError
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    monkeypatch.setattr(cfg, "vision_model", "org/repo/v.gguf")
+    client = _fake_client()
+    client.chat.side_effect = ProviderError("boom", provider="llama-server")
+    p = _provider_with_clients({WorkerRole.VISION: [client]})
+    with pytest.raises(ProviderError, match="boom"):
+        p.vision_ocr(b"png", "org/repo/v.gguf")
+    assert client.chat.call_count == 1
+
+
+def test_vision_gate_capacity_sums_real_launch_slots(monkeypatch) -> None:
+    # The gate caps at the servers' fitted --parallel slots: planning can fit
+    # fewer slots than vision_ocr_concurrency asks for, and a cap above the real
+    # slot count oversubscribes the servers into a 429 storm.
+    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 16)
+    p = _provider_with_clients({WorkerRole.VISION: [_fake_client(), _fake_client()]})
+    p._launches[WorkerRole.VISION] = (
+        _fake_launch(WorkerRole.VISION, slots=3),
+        _fake_launch(WorkerRole.VISION, slots=2, replica=1),
+    )
+    assert p._vision_gate_capacity() == 5
+
+
+def test_vision_gate_capacity_falls_back_to_configured_formula(monkeypatch) -> None:
+    # Without a launch snapshot (mid-reload) the configured ceiling still bounds it.
     monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr(cfg, "vision_replicas", 3)
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
-    with prov_mod._VISION_GATE.slot():
+    p = _provider_with_clients({WorkerRole.VISION: [_fake_client()]})
+    assert p._vision_gate_capacity() == 12
+
+
+def test_vision_request_gate_tracks_fleet_capacity(monkeypatch) -> None:
+    # The gate must cap in-flight vision requests at the caller-supplied capacity
+    # and rebuild to a new capacity while idle.
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    with prov_mod._VISION_GATE.slot(12):
         first = prov_mod._VISION_GATE._semaphore
     assert prov_mod._VISION_GATE._capacity == 12
-    monkeypatch.setattr(cfg, "vision_replicas", 1)
-    with prov_mod._VISION_GATE.slot():
+    with prov_mod._VISION_GATE.slot(4):
         assert prov_mod._VISION_GATE._semaphore is not first  # rebuilt while idle
     assert prov_mod._VISION_GATE._capacity == 4
 
@@ -424,16 +488,13 @@ def test_vision_gate_resize_deferred_while_in_flight(monkeypatch) -> None:
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
-    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
-    monkeypatch.setattr(cfg, "vision_replicas", 1)
-    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 
     entered = threading.Event()
     release = threading.Event()
     held: list[object] = []
 
     def _hold() -> None:
-        with prov_mod._VISION_GATE.slot():
+        with prov_mod._VISION_GATE.slot(2):
             held.append(prov_mod._VISION_GATE._semaphore)
             entered.set()
             release.wait(timeout=5)
@@ -444,8 +505,7 @@ def test_vision_gate_resize_deferred_while_in_flight(monkeypatch) -> None:
         assert entered.wait(timeout=5)
         # Capacity change arrives mid-flight; a checkout must reuse the live
         # semaphore rather than swap, so the cap is never doubled.
-        monkeypatch.setattr(cfg, "vision_replicas", 4)
-        reused = prov_mod._VISION_GATE._checkout()
+        reused = prov_mod._VISION_GATE._checkout(8)
         try:
             assert reused is held[0]
             assert prov_mod._VISION_GATE._capacity == 2
@@ -457,7 +517,7 @@ def test_vision_gate_resize_deferred_while_in_flight(monkeypatch) -> None:
         worker.join()
 
     # Once idle again, the next checkout applies the deferred capacity.
-    with prov_mod._VISION_GATE.slot():
+    with prov_mod._VISION_GATE.slot(8):
         assert prov_mod._VISION_GATE._capacity == 8
 
 
@@ -468,9 +528,6 @@ def test_vision_gate_slot_decrements_in_flight_when_acquire_raises(monkeypatch) 
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
-    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
-    monkeypatch.setattr(cfg, "vision_replicas", 1)
-    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 
     real_checkout = prov_mod._VISION_GATE._checkout
 
@@ -478,13 +535,13 @@ def test_vision_gate_slot_decrements_in_flight_when_acquire_raises(monkeypatch) 
         def acquire(self) -> None:
             raise KeyboardInterrupt
 
-    def _checkout_returning_boom():
-        real_checkout()  # increments _in_flight like the real path
+    def _checkout_returning_boom(capacity):
+        real_checkout(capacity)  # increments _in_flight like the real path
         return _BoomSemaphore()
 
     monkeypatch.setattr(prov_mod._VISION_GATE, "_checkout", _checkout_returning_boom)
 
-    with pytest.raises(KeyboardInterrupt), prov_mod._VISION_GATE.slot():
+    with pytest.raises(KeyboardInterrupt), prov_mod._VISION_GATE.slot(2):
         pass  # pragma: no cover - acquire raises before the body
 
     assert prov_mod._VISION_GATE._in_flight == 0  # counter not leaked
@@ -493,17 +550,14 @@ def test_vision_gate_slot_decrements_in_flight_when_acquire_raises(monkeypatch) 
 def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
     # The ingest file fan-out can launch far more concurrent OCR requests than the
     # vision server has slots; the gate (held by every vision entry point) caps
-    # concurrent holders at vision_replicas * vision_ocr_concurrency so a
-    # single-replica server isn't 429-stormed. All callers still run.
+    # concurrent holders at the fleet's real slot capacity so a single-replica
+    # server isn't 429-stormed. All callers still run.
     import threading
     import time
 
     monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
     monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
-    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
-    monkeypatch.setattr(cfg, "vision_replicas", 1)
-    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 2)
 
     lock = threading.Lock()
     live = 0
@@ -512,7 +566,7 @@ def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
 
     def _hold() -> None:
         nonlocal live, peak, ran
-        with prov_mod._VISION_GATE.slot():
+        with prov_mod._VISION_GATE.slot(2):
             with lock:
                 live += 1
                 peak = max(peak, live)
@@ -545,9 +599,34 @@ def test_ocr_pdf_page_skips_when_budget_exhausted(monkeypatch) -> None:
         ocr_prompt="describe",
         deadline=time.monotonic() - 1.0,  # already past
         page_path=Path("doc.pdf"),
+        gate_capacity=2,
     )
     assert (idx, text) == (3, "")
     assert called == []  # _vision_call never ran
+
+
+def test_ocr_pdf_page_retries_busy_then_keeps_text(monkeypatch) -> None:
+    # A 429 on a PDF page is retried like the image path, so the page text lands
+    # instead of the page being skipped to empty.
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
+    monkeypatch.setattr("lilbee.vision.build_vision_messages", lambda *_a, **_k: [])
+    busy = ProviderError("busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT)
+    client = _fake_client()
+    client.chat.side_effect = [busy, busy, "page text"]
+    idx, text = prov_mod._ocr_pdf_page(
+        0,
+        b"\x89PNG",
+        clients=[client],
+        ocr_prompt="describe",
+        deadline=None,
+        page_path=Path("doc.pdf"),
+        gate_capacity=2,
+    )
+    assert (idx, text) == (0, "page text")
+    assert client.chat.call_count == 3
 
 
 def test_chat_streams_from_server() -> None:
@@ -1716,6 +1795,7 @@ class TestReplicaHealthRouting:
             ocr_prompt="read it",
             deadline=None,
             page_path=Path("doc.pdf"),
+            gate_capacity=2,
         )
         assert (idx, text) == (0, "ocr text")
         assert dead.healthy is False

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -443,163 +443,171 @@ def test_vision_ocr_does_not_retry_non_busy_errors(monkeypatch) -> None:
     assert client.chat.call_count == 1
 
 
-def test_vision_gate_capacity_sums_real_launch_slots(monkeypatch) -> None:
-    # The gate caps at the servers' fitted --parallel slots: planning can fit
-    # fewer slots than vision_ocr_concurrency asks for, and a cap above the real
-    # slot count oversubscribes the servers into a 429 storm.
+def test_vision_pool_pairs_each_replica_with_its_fitted_slots(monkeypatch) -> None:
+    # Dispatch admits per replica at the servers' fitted --parallel slots: planning
+    # can fit fewer slots than vision_ocr_concurrency asks for, and admitting more
+    # than the real slot count oversubscribes that server into a 429 storm.
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 16)
-    p = _provider_with_clients({WorkerRole.VISION: [_fake_client(), _fake_client()]})
+    first_client, second_client = _fake_client(), _fake_client()
+    p = _provider_with_clients({WorkerRole.VISION: [first_client, second_client]})
     p._launches[WorkerRole.VISION] = (
         _fake_launch(WorkerRole.VISION, slots=3),
         _fake_launch(WorkerRole.VISION, slots=2, replica=1),
     )
-    assert p._vision_gate_capacity() == 5
+    assert p._vision_pool() == [
+        prov_mod._VisionReplica(first_client, 3),
+        prov_mod._VisionReplica(second_client, 2),
+    ]
 
 
-def test_vision_gate_capacity_falls_back_to_configured_formula(monkeypatch) -> None:
-    # Without a launch snapshot (mid-reload) the configured ceiling still bounds it.
-    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
-    monkeypatch.setattr(cfg, "vision_replicas", 3)
+def test_vision_pool_falls_back_to_configured_slots(monkeypatch) -> None:
+    # Without a launch snapshot (mid-reload) the configured per-server ceiling holds.
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
-    p = _provider_with_clients({WorkerRole.VISION: [_fake_client()]})
-    assert p._vision_gate_capacity() == 12
+    client = _fake_client()
+    p = _provider_with_clients({WorkerRole.VISION: [client]})
+    assert p._vision_pool() == [prov_mod._VisionReplica(client, 4)]
 
 
-def test_vision_request_gate_tracks_fleet_capacity(monkeypatch) -> None:
-    # The gate must cap in-flight vision requests at the caller-supplied capacity
-    # and rebuild to a new capacity while idle.
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
-    with prov_mod._VISION_GATE.slot(12):
-        first = prov_mod._VISION_GATE._semaphore
-    assert prov_mod._VISION_GATE._capacity == 12
-    with prov_mod._VISION_GATE.slot(4):
-        assert prov_mod._VISION_GATE._semaphore is not first  # rebuilt while idle
-    assert prov_mod._VISION_GATE._capacity == 4
+def test_vision_pool_falls_back_on_launch_client_mismatch(monkeypatch) -> None:
+    # A launch snapshot that no longer matches the client pool (mid-reload race)
+    # must not misassign slot counts; the configured ceiling applies instead.
+    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
+    clients = [_fake_client(), _fake_client()]
+    p = _provider_with_clients({WorkerRole.VISION: clients})
+    p._launches[WorkerRole.VISION] = (_fake_launch(WorkerRole.VISION, slots=3),)
+    assert [replica.slots for replica in p._vision_pool()] == [4, 4]
 
 
-def test_vision_gate_resize_deferred_while_in_flight(monkeypatch) -> None:
-    # Resizing the gate while a request is in flight would build a
-    # fresh full-capacity semaphore beside the old holders and momentarily double
-    # the real cap. The resize must wait until the gate drains to idle.
-    import threading
-
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
-
-    entered = threading.Event()
-    release = threading.Event()
-    held: list[object] = []
-
-    def _hold() -> None:
-        with prov_mod._VISION_GATE.slot(2):
-            held.append(prov_mod._VISION_GATE._semaphore)
-            entered.set()
-            release.wait(timeout=5)
-
-    worker = threading.Thread(target=_hold)
-    worker.start()
-    try:
-        assert entered.wait(timeout=5)
-        # Capacity change arrives mid-flight; a checkout must reuse the live
-        # semaphore rather than swap, so the cap is never doubled.
-        reused = prov_mod._VISION_GATE._checkout(8)
-        try:
-            assert reused is held[0]
-            assert prov_mod._VISION_GATE._capacity == 2
-        finally:
-            with prov_mod._VISION_GATE._lock:  # balance the raw _checkout increment
-                prov_mod._VISION_GATE._in_flight -= 1
-    finally:
-        release.set()
-        worker.join()
-
-    # Once idle again, the next checkout applies the deferred capacity.
-    with prov_mod._VISION_GATE.slot(8):
-        assert prov_mod._VISION_GATE._capacity == 8
-
-
-def test_vision_gate_slot_decrements_in_flight_when_acquire_raises(monkeypatch) -> None:
-    # If acquire() raises (e.g. an interrupted blocking acquire), the in-flight
-    # counter must still be decremented, or a leaked count would pin the gate
-    # non-idle and defer every later capacity resize forever.
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
-
-    real_checkout = prov_mod._VISION_GATE._checkout
-
-    class _BoomSemaphore:
-        def acquire(self) -> None:
-            raise KeyboardInterrupt
-
-    def _checkout_returning_boom(capacity):
-        real_checkout(capacity)  # increments _in_flight like the real path
-        return _BoomSemaphore()
-
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_checkout", _checkout_returning_boom)
-
-    with pytest.raises(KeyboardInterrupt), prov_mod._VISION_GATE.slot(2):
-        pass  # pragma: no cover - acquire raises before the body
-
-    assert prov_mod._VISION_GATE._in_flight == 0  # counter not leaked
-
-
-def test_vision_gate_bounds_concurrency_to_capacity(monkeypatch) -> None:
-    # The ingest file fan-out can launch far more concurrent OCR requests than the
-    # vision server has slots; the gate (held by every vision entry point) caps
-    # concurrent holders at the fleet's real slot capacity so a single-replica
-    # server isn't 429-stormed. All callers still run.
+def test_vision_dispatcher_caps_each_replica_at_its_slots() -> None:
+    # The ingest fan-out can launch far more concurrent OCR requests than the
+    # servers have slots; the dispatcher assigns a request to a replica only while
+    # that replica has a free slot, so no server can ever be oversubscribed by
+    # lilbee's own traffic. All callers still run.
     import threading
     import time
 
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_capacity", 0)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_in_flight", 0)
+    dispatcher = prov_mod._VisionDispatcher()
+    replica_a, replica_b = _fake_client(), _fake_client()
+    pool = [prov_mod._VisionReplica(replica_a, 2), prov_mod._VisionReplica(replica_b, 1)]
 
     lock = threading.Lock()
-    live = 0
-    peak = 0
+    live: dict[int, int] = {}
+    peaks: dict[int, int] = {}
     ran = 0
 
     def _hold() -> None:
-        nonlocal live, peak, ran
-        with prov_mod._VISION_GATE.slot(2):
+        nonlocal ran
+        with dispatcher.slot(pool) as client:
+            key = id(client)
             with lock:
-                live += 1
-                peak = max(peak, live)
+                live[key] = live.get(key, 0) + 1
+                peaks[key] = max(peaks.get(key, 0), live[key])
             time.sleep(0.02)
             with lock:
-                live -= 1
+                live[key] -= 1
                 ran += 1
 
-    threads = [threading.Thread(target=_hold) for _ in range(8)]
+    threads = [threading.Thread(target=_hold) for _ in range(9)]
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join()
 
-    assert peak == 2  # the cap is both reached and never exceeded
-    assert ran == 8  # every caller ran, just serialized through the gate
+    assert ran == 9  # every caller ran, queued in-process instead of 429ing
+    assert peaks[id(replica_a)] <= 2 and peaks[id(replica_b)] <= 1  # per-replica cap
+    assert set(peaks) == {id(replica_a), id(replica_b)}  # both replicas pulled work
+
+
+def test_vision_dispatcher_prefers_replica_with_most_free_slots() -> None:
+    # Balanced routing drains fastest: the next request goes to the replica with
+    # the most free slots, not to whichever raced ahead.
+    dispatcher = prov_mod._VisionDispatcher()
+    roomy, tight = _fake_client(), _fake_client()
+    pool = [prov_mod._VisionReplica(tight, 1), prov_mod._VisionReplica(roomy, 3)]
+    with dispatcher.slot(pool) as first, dispatcher.slot(pool) as second:
+        assert first is roomy  # 3 free beats 1
+        assert second is roomy  # still 2 free vs 1
+        with dispatcher.slot(pool) as third:
+            assert third is tight  # 1 free each; the earlier pool entry wins the tie
+
+
+def test_vision_dispatcher_skips_unhealthy_replica() -> None:
+    # A replica marked unhealthy takes no new assignments; its slots are dead
+    # weight until the half-open cooldown re-admits it.
+    dispatcher = prov_mod._VisionDispatcher()
+    dead, alive = _fake_client(), _fake_client()
+    dead.healthy = False
+    pool = [prov_mod._VisionReplica(dead, 4), prov_mod._VisionReplica(alive, 1)]
+    with dispatcher.slot(pool) as client:
+        assert client is alive
+
+
+def test_vision_dispatcher_falls_back_when_all_unhealthy() -> None:
+    # With every replica unhealthy the dispatcher still assigns (mirrors
+    # _least_in_flight): the call surfaces the error instead of queueing forever,
+    # and a success restores the replica.
+    dispatcher = prov_mod._VisionDispatcher()
+    dead = _fake_client()
+    dead.healthy = False
+    pool = [prov_mod._VisionReplica(dead, 1)]
+    with dispatcher.slot(pool) as client:
+        assert client is dead
+
+
+def test_dispatch_vision_fails_over_and_marks_health() -> None:
+    # A connection-dead replica is marked unhealthy and the request retries once
+    # on another replica, mirroring _call_with_failover.
+    import httpx as _httpx
+
+    from lilbee.providers.base import ProviderError
+
+    dead, alive = _fake_client(), _fake_client()
+    dead.chat.side_effect = _httpx.ConnectError("refused")
+    alive.chat.return_value = "ocr text"
+    pool = [prov_mod._VisionReplica(dead, 2), prov_mod._VisionReplica(alive, 1)]
+    result = prov_mod._dispatch_vision(pool, lambda c: c.chat([], options={}, stream=False))
+    assert result == "ocr text"
+    dead.mark_unhealthy.assert_called_once()
+    alive.mark_healthy.assert_called_once()
+
+    # With no other replica the failure surfaces as the no-replica error.
+    lone = _fake_client()
+    lone.chat.side_effect = _httpx.ConnectError("refused")
+    with pytest.raises(ProviderError, match="no healthy replica"):
+        prov_mod._dispatch_vision(
+            [prov_mod._VisionReplica(lone, 1)],
+            lambda c: c.chat([], options={}, stream=False),
+        )
+
+
+def test_dispatch_vision_marks_second_replica_unhealthy_on_retry_failure() -> None:
+    # The failover leg stamps health too: a second dead replica is marked
+    # unhealthy and the failure propagates.
+    import httpx as _httpx
+
+    dead_a, dead_b = _fake_client(), _fake_client()
+    dead_a.chat.side_effect = _httpx.ConnectError("refused")
+    dead_b.chat.side_effect = _httpx.ConnectError("refused")
+    pool = [prov_mod._VisionReplica(dead_a, 2), prov_mod._VisionReplica(dead_b, 1)]
+    with pytest.raises(_httpx.ConnectError):
+        prov_mod._dispatch_vision(pool, lambda c: c.chat([], options={}, stream=False))
+    dead_a.mark_unhealthy.assert_called_once()
+    dead_b.mark_unhealthy.assert_called_once()
 
 
 def test_ocr_pdf_page_skips_when_budget_exhausted(monkeypatch) -> None:
     # A page that waited out the document deadline while queued is skipped (empty
     # text), not run un-timed -- a 0 timeout would disable the per-page cap.
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr("lilbee.vision.build_vision_messages", lambda *_a, **_k: [])
     called: list[object] = []
     monkeypatch.setattr(prov_mod, "_vision_call", lambda *a, **_k: called.append(a) or "ocr")
     idx, text = prov_mod._ocr_pdf_page(
         3,
         b"\x89PNG",
-        clients=[_fake_client()],
+        pool=[prov_mod._VisionReplica(_fake_client(), 2)],
         ocr_prompt="describe",
         deadline=time.monotonic() - 1.0,  # already past
         page_path=Path("doc.pdf"),
-        gate_capacity=2,
     )
     assert (idx, text) == (3, "")
     assert called == []  # _vision_call never ran
@@ -611,7 +619,6 @@ def test_ocr_pdf_page_retries_busy_then_keeps_text(monkeypatch) -> None:
     from lilbee.providers.base import ProviderError, ProviderErrorKind
 
     monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
-    monkeypatch.setattr(prov_mod._VISION_GATE, "_semaphore", None)
     monkeypatch.setattr("lilbee.vision.build_vision_messages", lambda *_a, **_k: [])
     busy = ProviderError("busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT)
     client = _fake_client()
@@ -619,11 +626,10 @@ def test_ocr_pdf_page_retries_busy_then_keeps_text(monkeypatch) -> None:
     idx, text = prov_mod._ocr_pdf_page(
         0,
         b"\x89PNG",
-        clients=[client],
+        pool=[prov_mod._VisionReplica(client, 2)],
         ocr_prompt="describe",
         deadline=None,
         page_path=Path("doc.pdf"),
-        gate_capacity=2,
     )
     assert (idx, text) == (0, "page text")
     assert client.chat.call_count == 3
@@ -840,10 +846,7 @@ def test_pdf_ocr_runs_pages_concurrently_and_preserves_order(monkeypatch) -> Non
     import time as _time
 
     monkeypatch.setattr(cfg, "vision_model", "")
-    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
-    # Auto replicas (vision_replicas left at its 0 default) resolves to one per
-    # GPU; pin the probe to a single GPU so the gate admits 1 x 4 = 4 in flight.
-    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
+    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)  # fallback pool: 4 slots
     n = 8
     monkeypatch.setattr("lilbee.vision.pdf_page_count", lambda _p: n)
     monkeypatch.setattr(
@@ -883,9 +886,6 @@ def test_pdf_ocr_spends_one_document_budget_across_pages(monkeypatch) -> None:
     p = _provider_with_clients({WorkerRole.VISION: [_fake_client(0)]})
     monkeypatch.setattr(cfg, "vision_model", "")
     monkeypatch.setattr(cfg, "vision_load_budget_s", 300.0)
-    # Pin the device-count probe so _checkout() does not run a real subprocess
-    # and spend ~4s that would bleed into the budget timing assertion.
-    monkeypatch.setattr(prov_mod, "gpu_device_count", lambda: 1)
     monkeypatch.setattr("lilbee.vision.pdf_page_count", lambda _p: 2)
     monkeypatch.setattr(
         "lilbee.vision.rasterize_pdf", lambda _p: iter([(0, b"png0"), (1, b"png1")])
@@ -1814,11 +1814,10 @@ class TestReplicaHealthRouting:
         idx, text = prov._ocr_pdf_page(
             0,
             b"\x89PNG",
-            clients=[dead, alive],
+            pool=[prov._VisionReplica(dead, 2), prov._VisionReplica(alive, 2)],
             ocr_prompt="read it",
             deadline=None,
             page_path=Path("doc.pdf"),
-            gate_capacity=2,
         )
         assert (idx, text) == (0, "ocr text")
         assert dead.healthy is False

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -810,6 +810,29 @@ def test_pdf_ocr_ocrs_each_page_over_vision_server(monkeypatch) -> None:
     assert events == [(EventType.EXTRACT, 1, 2), (EventType.EXTRACT, 2, 2)]
 
 
+def test_pdf_ocr_tallies_unrecovered_pages(monkeypatch, caplog) -> None:
+    # A page skipped to empty text (timeout, persistently busy fleet) must surface
+    # in one end-of-run tally, not vanish silently as a blank index entry.
+    import logging
+
+    from lilbee.providers.base import ProviderError
+    from lilbee.vision import PageText
+
+    client = _fake_client(0)
+    client.chat.side_effect = [ProviderError("boom", provider="llama-server"), "page two"]
+    p = _provider_with_clients({WorkerRole.VISION: [client]})
+    monkeypatch.setattr(cfg, "vision_model", "")
+    monkeypatch.setattr(cfg, "vision_ocr_concurrency", 1)
+    monkeypatch.setattr("lilbee.vision.pdf_page_count", lambda _p: 2)
+    monkeypatch.setattr(
+        "lilbee.vision.rasterize_pdf", lambda _p: iter([(0, b"png0"), (1, b"png1")])
+    )
+    with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.provider"):
+        result = p.pdf_ocr(Path("doc.pdf"), backend="vision")  # type: ignore[arg-type]
+    assert result == [PageText(1, ""), PageText(2, "page two")]
+    assert "no text for 1 of 2 pages" in caplog.text
+
+
 def test_pdf_ocr_runs_pages_concurrently_and_preserves_order(monkeypatch) -> None:
     # OCR fans pages across the vision server's batching slots; results must still
     # come back in page order, and more than one page must be in flight at once.


### PR DESCRIPTION
## Problem

A full-corpus ingest on a 7xH200 fleet dropped 22,469 of 25,577 scanned page images. The vision servers answered a sustained stream of HTTP 429s, and although the client tags a 429 as a transient rate limit so the caller can back off and retry, no caller ever did: both vision OCR entry points (single images and rasterized PDF pages) treated each one as a terminal extraction failure, dropping the image from the index or blanking the page.

The 429 stream itself was self-inflicted. The cap on concurrent vision requests was an aggregate: it sized itself from the configured per-server concurrency (which can exceed the real batching slots placement fit into memory), and even a correctly sized aggregate cap plus least-busy routing can race two requests onto one replica's last slot, or converge all traffic onto surviving replicas when one dies.

Two smaller gaps compounded the loss: the 120s per-page timeout default has no headroom for dense scans at a raised token cap (the run's slowest successful page took 179s), and a PDF page that failed OCR vanished as a blank index entry with no end-of-run signal.

## Solution

Vision OCR requests are now dispatched per replica slot instead of gated in aggregate. Each request is assigned one specific replica, only while that replica has a free continuous-batching slot, so lilbee's own traffic can never oversubscribe a vision server: requests past capacity wait in-process and are routed to the replica with the most free slots, which also drains fastest. Unhealthy replicas take no new work until their cool-down re-admits them, and a connection failure fails over to another replica's slot, as the other roles already do.

With oversubscription impossible by construction, a 429 can only mean a still-warming server or traffic from outside this process. Those residual cases get the same bounded retry with capped backoff that bulk embedding already uses, running slot-free so a waiting page can use a replica that is actually ready. Genuine extraction failures and timeouts are not retried.

The per-page OCR timeout default rises from 120s to 300s, matching the vision load budget, and the token-cap setting now documents that raising it needs matching timeout headroom. PDF OCR finishes with a tally of pages that produced no text, so an incomplete scan is visible at the end of the run instead of silently blank; single-image failures were already reported per file by the sync summary. A single large PDF can now also saturate the whole fleet rather than one server's worth of slots.