### PR TITLE
Make vision-OCR busy-retry deadline-bound so a deep queue doesn't drop pages

### DIFF
--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -77,17 +77,21 @@ def _max_concurrent() -> int:
 
     ``cpu_quota()`` (cpu_count // 2) keeps worker storms from starving the TUI's asyncio
     main thread, and is the cap for text/code ingest. Vision OCR is different: every file
-    in compute holds a continuous-batching slot on a vision server, which returns 429 when
-    oversubscribed, so an OCR run is bounded by the vision slot capacity (replicas x
-    per-server pages) -- a single vision server included. Otherwise a many-core box fans
-    ``cpu_quota()`` requests (dozens) at one server's few slots and 429-drops files, while a
-    few-core box with several GPUs would starve the extra cards.
+    in compute holds a continuous-batching slot on a vision server, so an OCR run is bounded
+    by the vision slot capacity. Once the fleet is up that capacity is the servers' real
+    fitted ``--parallel`` slots (a memory-constrained card fits fewer than requested); until
+    then it is estimated from ``replicas x per-server pages``. Sizing to real capacity keeps
+    the OCR queue shallow instead of piling pages behind the dispatcher with their deadlines
+    ticking, and still keeps every slot fed.
     """
     from lilbee.providers.fleet.replicas import gpu_device_count, resolve_replica_count
     from lilbee.providers.roles import WorkerRole
 
     config = active_config()
     if config.vision_model:
+        fitted = get_services().provider.vision_slot_capacity()
+        if fitted is not None:
+            return fitted
         replicas = resolve_replica_count(WorkerRole.VISION, gpu_device_count())
         return max(1, replicas * config.vision_ocr_concurrency)
     embed_slots = resolve_replica_count(WorkerRole.EMBED, gpu_device_count())

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -333,6 +333,17 @@ class LLMProvider(Protocol):
         """
         ...
 
+    def vision_slot_capacity(self) -> int | None:
+        """Fitted concurrent-OCR slots if the vision fleet is running, else None.
+
+        The ingest fan-out uses this to size itself to the servers' real
+        continuous-batching capacity rather than the requested concurrency,
+        which a memory-constrained card cannot always fit. ``None`` means the
+        capacity isn't known yet (no local vision backend, or the fleet hasn't
+        started); the caller falls back to its own estimate.
+        """
+        ...
+
     def list_models(self) -> list[str]:
         """List available model identifiers."""
         ...

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -312,24 +312,35 @@ class ChatDeadlineError(ProviderError):
     """
 
 
-def retry_on_busy(call: Callable[[], _T], *, retries: int = _BUSY_RETRIES) -> _T:
+def retry_on_busy(
+    call: Callable[[], _T], *, retries: int = _BUSY_RETRIES, deadline: float | None = None
+) -> _T:
     """Run *call*, retrying a transient server-busy (RATE_LIMIT) with capped backoff.
 
     A cold replica fleet 429s the first fan-out until its slots load; backing
-    off and retrying turns those drops into successes. *retries* bounds the
-    attempts -- interactive callers fail fast, bulk ingest waits out a cold
-    start. Non-RATE_LIMIT errors (and a final still-busy response) propagate.
+    off and retrying turns those drops into successes. With a *deadline*
+    (``time.monotonic`` epoch) the retry waits out a busy server until that
+    deadline -- a page on a deep OCR queue keeps waiting for a genuinely free
+    slot instead of dropping after a fixed budget. Without one, *retries* bounds
+    the attempts. Non-RATE_LIMIT errors (and the final still-busy response)
+    propagate.
     """
     delay = _BUSY_BACKOFF_BASE_S
-    for _ in range(retries - 1):
+    attempt = 0
+    while True:
         try:
             return call()
         except ProviderError as exc:
             if exc.kind is not ProviderErrorKind.RATE_LIMIT:
                 raise
+            attempt += 1
+            exhausted = (
+                time.monotonic() + delay >= deadline if deadline is not None else attempt >= retries
+            )
+            if exhausted:
+                raise
             time.sleep(delay)
             delay = min(delay * 2, _BUSY_BACKOFF_MAX_S)
-    return call()
 
 
 class LlamaServerClient:

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -922,6 +922,19 @@ class FleetProvider:
                 provider=_PROVIDER_NAME,
             ) from None
 
+    def vision_slot_capacity(self) -> int | None:
+        """Total fitted ``--parallel`` slots across the running vision replicas.
+
+        ``None`` before the fleet is up (no launch snapshot yet), so the ingest
+        fan-out keeps its own estimate until real capacity is known. A modest
+        card that fit fewer slots than requested reports the smaller real number,
+        so the fan-out never queues more pages than the servers can serve.
+        """
+        launches = self._launches.get(WorkerRole.VISION)
+        if not launches:
+            return None
+        return max(1, sum(launch.slots for launch in launches))
+
     def _vision_pool(self) -> list[_VisionReplica]:
         """Each vision replica paired with its fitted ``--parallel`` slot count.
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -81,11 +81,10 @@ _REQUEST_TIMEOUT_GENERATION_MARGIN_S = 120.0
 # The server parses tool calls natively via ``--jinja``; this probe only decides
 # whether to offer tools to a given model at all.
 _TOOL_TEMPLATE_PATTERN = re.compile(r"\{[%{][^}]*\b(?:tools|tool_calls|functions|function_calls)\b")
-# Ingest OCR is background work: back off and re-request a 429'd page rather
-# than dropping it from the index. Slot dispatch already prevents self-inflicted
-# 429s, so a busy response is a cold vision start (weights plus mmproj loading)
-# or foreign traffic. Capped backoff keeps the total wait near ~110s; a page
-# still busy after that fails like any extraction error.
+# Attempt cap for the busy-retry only when a page has no deadline (ocr_timeout=0,
+# "no limit"): it backstops the retry so a persistently busy fleet can't spin
+# forever. A page with a deadline retries until that deadline instead (see
+# _ocr_dispatch), so the count doesn't bound the common case.
 _VISION_BUSY_RETRIES = 18
 # How often a waiter blocked on full replicas re-polls their health: an
 # unhealthy replica re-admits itself by cool-down expiry, which notifies nobody.
@@ -362,6 +361,36 @@ def _bounded_vision_chat(
         ) from None
 
 
+def _ocr_dispatch(
+    pool: Sequence[_VisionReplica],
+    messages: Sequence[Mapping[str, Any]],
+    deadline: float | None,
+) -> str:
+    """OCR *messages* on a free replica slot, retrying a busy server until *deadline*.
+
+    Backpressure (the dispatcher blocking until a slot frees) makes a
+    self-inflicted 429 unreachable; a residual busy response is a still-warming
+    server or foreign traffic. The retry is deadline-bound rather than
+    attempt-bound so a page on a deep queue waits for a genuinely free slot until
+    its own budget passes instead of dropping after a fixed count. Each attempt
+    is bounded by the budget remaining before *deadline*; an exhausted budget
+    raises :class:`_PageBudgetExhausted`. A ``None`` deadline (no limit) falls
+    back to a bounded attempt count so the retry can't spin forever.
+    """
+
+    def _attempt(client: LlamaServerClient) -> str:
+        remaining = max(0.0, deadline - time.monotonic()) if deadline is not None else None
+        if remaining == 0.0:
+            raise _PageBudgetExhausted
+        return _vision_call(client, messages, remaining)
+
+    return retry_on_busy(
+        lambda: _dispatch_vision(pool, _attempt),
+        retries=_VISION_BUSY_RETRIES,
+        deadline=deadline,
+    )
+
+
 def _ocr_pdf_page(
     idx: int,
     png: bytes,
@@ -375,23 +404,13 @@ def _ocr_pdf_page(
 
     The document-deadline clock is read only once a slot is held, so queue time
     isn't billed against the page's share; an exhausted budget skips the page
-    rather than running it un-timed. A busy server (429, still warming) is
-    retried with backoff before the page is given up on.
+    rather than running it un-timed.
     """
     from lilbee.vision import build_vision_messages
 
     messages = build_vision_messages(ocr_prompt, png)
-
-    def _page(client: LlamaServerClient) -> str:
-        remaining = max(0.0, deadline - time.monotonic()) if deadline is not None else None
-        if remaining == 0.0:
-            raise _PageBudgetExhausted
-        return _vision_call(client, messages, remaining)
-
     try:
-        return idx, retry_on_busy(
-            lambda: _dispatch_vision(pool, _page), retries=_VISION_BUSY_RETRIES
-        )
+        return idx, _ocr_dispatch(pool, messages, deadline)
     except _PageBudgetExhausted:
         log.warning(
             "Vision OCR budget exhausted before page %d of %s; skipping.",
@@ -422,6 +441,17 @@ def _pdf_drain_budget(total_pages: int, per_page_timeout_s: float | None) -> flo
     if not per_page_timeout_s or per_page_timeout_s <= 0:
         return None
     return total_pages * per_page_timeout_s + cfg.vision_load_budget_s
+
+
+def _ocr_deadline(per_page_timeout_s: float | None) -> float | None:
+    """Absolute monotonic deadline for one image OCR, or None when uncapped.
+
+    An image is a one-page document, so it gets the same budget as a PDF page:
+    the per-page timeout plus the cold-load grace, spanning queue wait and
+    generation together.
+    """
+    budget = _pdf_drain_budget(1, per_page_timeout_s)
+    return None if budget is None else time.monotonic() + budget
 
 
 class FleetProvider:
@@ -884,13 +914,13 @@ class FleetProvider:
         pool = self._vision_pool()
         effective = model or str(cfg.vision_model)
         messages = build_vision_messages(prompt or resolve_ocr_prompt(effective), png_bytes)
-        # Slot assignment makes a self-inflicted 429 impossible; a residual busy
-        # response is a still-warming server or foreign traffic. Backoff runs
-        # slot-free so a waiting sibling can use a replica that is ready.
-        return retry_on_busy(
-            lambda: _dispatch_vision(pool, lambda client: _vision_call(client, messages, timeout)),
-            retries=_VISION_BUSY_RETRIES,
-        )
+        try:
+            return _ocr_dispatch(pool, messages, _ocr_deadline(timeout))
+        except _PageBudgetExhausted:
+            raise ProviderError(
+                "Vision OCR timed out waiting for a free vision slot.",
+                provider=_PROVIDER_NAME,
+            ) from None
 
     def _vision_pool(self) -> list[_VisionReplica]:
         """Each vision replica paired with its fitted ``--parallel`` slot count.

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -200,6 +200,10 @@ class RoutingProvider(LLMProvider):
             on_progress=on_progress,
         )
 
+    def vision_slot_capacity(self) -> int | None:
+        """Delegate to the local fleet, but never build it just to size the fan-out."""
+        return self._local.vision_slot_capacity() if self._local is not None else None
+
     def list_models(self) -> list[str]:
         """Return the union of native and SDK-visible models.
 

--- a/src/lilbee/providers/sdk_llm_provider.py
+++ b/src/lilbee/providers/sdk_llm_provider.py
@@ -318,6 +318,10 @@ class SdkLLMProvider(LLMProvider):
             "Set LILBEE_VISION_MODEL to a local GGUF vision model to enable it."
         )
 
+    def vision_slot_capacity(self) -> int | None:
+        """Hosted backends have no local OCR slots; the caller estimates."""
+        return None
+
     def list_models(self) -> list[str]:
         """List models across every configured local server.
 

--- a/tests/providers/test_sdk_llm_provider.py
+++ b/tests/providers/test_sdk_llm_provider.py
@@ -281,6 +281,10 @@ class TestChatNonStream:
         assert provider.supports_tools("openai/gpt-4o") is True
         assert backend.supports_tools_calls == ["openai/gpt-4o"]
 
+    def test_vision_slot_capacity_is_none(self) -> None:
+        # Hosted backends have no local OCR slots; the ingest fan-out estimates.
+        assert SdkLLMProvider(FakeBackend()).vision_slot_capacity() is None
+
     def test_builds_completion_request_with_parsed_ref(self) -> None:
         backend = FakeBackend()
         provider = SdkLLMProvider(backend)

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -131,6 +131,50 @@ def test_embed_rides_out_cold_start_past_interactive_budget(monkeypatch) -> None
     assert calls["n"] == warmup + 1
 
 
+def test_retry_on_busy_deadline_retries_past_attempt_cap(monkeypatch) -> None:
+    # Under deep-queue contention the queue drains far slower than the fixed
+    # attempt budget, so a deadline-bound retry must keep waiting past
+    # _BUSY_RETRIES until the caller's own deadline, not drop the page.
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+    from lilbee.providers.fleet.client import _BUSY_RETRIES, retry_on_busy
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.monotonic", lambda: 0.0)
+    busy = ProviderError("busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT)
+    attempts = _BUSY_RETRIES + 5  # more 429s than the attempt cap would tolerate
+    calls = {"n": 0}
+
+    def _call() -> str:
+        calls["n"] += 1
+        if calls["n"] <= attempts:
+            raise busy
+        return "ok"
+
+    assert retry_on_busy(_call, deadline=100.0) == "ok"
+    assert calls["n"] == attempts + 1
+
+
+def test_retry_on_busy_deadline_gives_up_when_deadline_passes(monkeypatch) -> None:
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+    from lilbee.providers.fleet.client import retry_on_busy
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    clock = {"t": 0.0}
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.monotonic", lambda: clock["t"])
+    busy = ProviderError("busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT)
+    calls = {"n": 0}
+
+    def _call() -> str:
+        calls["n"] += 1
+        clock["t"] += 1.0  # each attempt advances the clock toward the deadline
+        raise busy
+
+    with pytest.raises(ProviderError) as excinfo:
+        retry_on_busy(_call, deadline=3.0)
+    assert excinfo.value.kind is ProviderErrorKind.RATE_LIMIT
+    assert calls["n"] < 10  # bounded by the deadline, not looping forever
+
+
 def test_busy_backoff_is_capped(monkeypatch) -> None:
     # Backoff must not balloon past the cap even across the long ingest budget.
     from lilbee.providers.fleet.client import _BUSY_BACKOFF_MAX_S, _EMBED_BUSY_RETRIES

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -518,6 +518,21 @@ def test_vision_pool_falls_back_on_launch_client_mismatch(monkeypatch) -> None:
     assert [replica.slots for replica in p._vision_pool()] == [4, 4]
 
 
+def test_vision_slot_capacity_sums_fitted_launch_slots() -> None:
+    # The ingest fan-out sizes to this: the sum of the running servers' fitted slots.
+    p = _provider_with_clients({WorkerRole.VISION: [_fake_client(), _fake_client()]})
+    p._launches[WorkerRole.VISION] = (
+        _fake_launch(WorkerRole.VISION, slots=3),
+        _fake_launch(WorkerRole.VISION, slots=2, replica=1),
+    )
+    assert p.vision_slot_capacity() == 5
+
+
+def test_vision_slot_capacity_none_before_fleet_up() -> None:
+    # No launch snapshot yet: the fan-out keeps its own estimate.
+    assert FleetProvider().vision_slot_capacity() is None
+
+
 def test_vision_dispatcher_caps_each_replica_at_its_slots() -> None:
     # The ingest fan-out can launch far more concurrent OCR requests than the
     # servers have slots; the dispatcher assigns a request to a replica only while

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -412,21 +412,61 @@ def test_vision_ocr_retries_busy_then_succeeds(monkeypatch) -> None:
     assert client.chat.call_count == 3
 
 
-def test_vision_ocr_gives_up_when_persistently_busy(monkeypatch) -> None:
-    # The retry budget is bounded; a fleet that never frees a slot fails the page.
+def test_vision_ocr_retries_past_attempt_cap_until_deadline(monkeypatch) -> None:
+    # On a deep OCR queue the drain time exceeds the fixed attempt budget, so a
+    # 429'd image must keep retrying until its own deadline rather than being
+    # dropped after _VISION_BUSY_RETRIES attempts (bb-z34 regression).
     from lilbee.providers.base import ProviderError, ProviderErrorKind
 
     monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.monotonic", lambda: 0.0)
     monkeypatch.setattr(cfg, "vision_model", "org/repo/v.gguf")
+    busy = ProviderError("busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT)
     client = _fake_client()
-    client.chat.side_effect = ProviderError(
-        "busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT
-    )
+    # timeout > 0 routes through the bounded (chat_bounded) path.
+    client.chat_bounded.side_effect = [busy] * (prov_mod._VISION_BUSY_RETRIES + 5) + ["ocr text"]
+    p = _provider_with_clients({WorkerRole.VISION: [client]})
+    assert p.vision_ocr(b"png", "org/repo/v.gguf", timeout=300.0) == "ocr text"
+    assert client.chat_bounded.call_count == prov_mod._VISION_BUSY_RETRIES + 6
+
+
+def test_vision_ocr_gives_up_when_deadline_passes(monkeypatch) -> None:
+    # A fleet that never frees a slot fails the page once its deadline passes.
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    clock = {"t": 0.0}
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.monotonic", lambda: clock["t"])
+    monkeypatch.setattr("lilbee.providers.fleet.provider.time.monotonic", lambda: clock["t"])
+    monkeypatch.setattr(cfg, "vision_model", "org/repo/v.gguf")
+    monkeypatch.setattr(cfg, "vision_load_budget_s", 0.0)  # deadline == the 20s timeout
+
+    def _busy(*_a, **_k):
+        clock["t"] += 5.0  # each attempt advances the clock toward the deadline
+        raise ProviderError("busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT)
+
+    client = _fake_client()
+    client.chat_bounded.side_effect = _busy
     p = _provider_with_clients({WorkerRole.VISION: [client]})
     with pytest.raises(ProviderError) as excinfo:
-        p.vision_ocr(b"png", "org/repo/v.gguf")
+        p.vision_ocr(b"png", "org/repo/v.gguf", timeout=20.0)
     assert excinfo.value.kind is ProviderErrorKind.RATE_LIMIT
-    assert client.chat.call_count == prov_mod._VISION_BUSY_RETRIES
+
+
+def test_vision_ocr_deadline_passed_before_generation_raises_timeout(monkeypatch) -> None:
+    # A slot that only frees after the image's deadline has already passed yields a
+    # user-facing timeout, not the internal budget-exhausted signal.
+    from lilbee.providers.base import ProviderError
+
+    monkeypatch.setattr(cfg, "vision_model", "org/repo/v.gguf")
+    monkeypatch.setattr(cfg, "vision_load_budget_s", 0.0)  # deadline == the 20s timeout
+    ticks = iter([0.0, 100.0])  # deadline computed at 0; the slot frees at 100 (past 20)
+    monkeypatch.setattr("lilbee.providers.fleet.provider.time.monotonic", lambda: next(ticks))
+    client = _fake_client()
+    p = _provider_with_clients({WorkerRole.VISION: [client]})
+    with pytest.raises(ProviderError, match="timed out waiting for a free vision slot"):
+        p.vision_ocr(b"png", "org/repo/v.gguf", timeout=20.0)
+    client.chat.assert_not_called()  # the deadline lapsed before any generation ran
 
 
 def test_vision_ocr_does_not_retry_non_busy_errors(monkeypatch) -> None:
@@ -633,6 +673,31 @@ def test_ocr_pdf_page_retries_busy_then_keeps_text(monkeypatch) -> None:
     )
     assert (idx, text) == (0, "page text")
     assert client.chat.call_count == 3
+
+
+def test_ocr_pdf_page_retries_past_attempt_cap_until_deadline(monkeypatch) -> None:
+    # The per-page path is deadline-bound too: a deep queue that 429s past the
+    # attempt cap still lands the page while the document deadline holds (bb-z34).
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.monotonic", lambda: 0.0)
+    monkeypatch.setattr("lilbee.providers.fleet.provider.time.monotonic", lambda: 0.0)
+    monkeypatch.setattr("lilbee.vision.build_vision_messages", lambda *_a, **_k: [])
+    busy = ProviderError("busy", provider="llama-server", kind=ProviderErrorKind.RATE_LIMIT)
+    client = _fake_client()
+    # A positive remaining budget routes through the bounded (chat_bounded) path.
+    client.chat_bounded.side_effect = [busy] * (prov_mod._VISION_BUSY_RETRIES + 5) + ["page text"]
+    idx, text = prov_mod._ocr_pdf_page(
+        0,
+        b"\x89PNG",
+        pool=[prov_mod._VisionReplica(client, 2)],
+        ocr_prompt="describe",
+        deadline=100.0,
+        page_path=Path("doc.pdf"),
+    )
+    assert (idx, text) == (0, "page text")
+    assert client.chat_bounded.call_count == prov_mod._VISION_BUSY_RETRIES + 6
 
 
 def test_chat_streams_from_server() -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -277,6 +277,18 @@ class TestSourceTracking:
 class TestMaxConcurrent:
     """``_max_concurrent`` scales ingest file-concurrency to the replica fleet."""
 
+    @staticmethod
+    def _stub_vision_capacity(monkeypatch, value: int | None) -> None:
+        """Force ``provider.vision_slot_capacity()`` so the estimate vs fitted path is
+        deterministic without a running fleet."""
+        from unittest.mock import MagicMock
+
+        from lilbee.data.ingest import pipeline
+
+        services = MagicMock()
+        services.provider.vision_slot_capacity.return_value = value
+        monkeypatch.setattr(pipeline, "get_services", lambda: services)
+
     def test_defaults_to_cpu_quota_without_vision(self, monkeypatch) -> None:
         from lilbee.data.ingest import pipeline
 
@@ -286,10 +298,11 @@ class TestMaxConcurrent:
         assert pipeline._max_concurrent() == 6
 
     def test_scales_to_total_vision_slots_when_replicated(self, monkeypatch) -> None:
-        # 8 vision replicas x 4 OCR slots each = 32, which must outvote a 4-core quota
-        # so the extra GPUs are not starved.
+        # Before the fleet is up (capacity None) the estimate stands: 8 vision replicas
+        # x 4 OCR slots each = 32, which must outvote a 4-core quota so GPUs aren't starved.
         from lilbee.data.ingest import pipeline
 
+        self._stub_vision_capacity(monkeypatch, None)
         monkeypatch.setattr(pipeline, "cpu_quota", lambda: 4)
         monkeypatch.setattr(cfg, "vision_model", "org/repo/model.gguf")
         monkeypatch.setattr(cfg, "vision_replicas", 8)
@@ -297,11 +310,25 @@ class TestMaxConcurrent:
         monkeypatch.setattr(cfg, "embed_replicas", 1)
         assert pipeline._max_concurrent() == 32
 
+    def test_prefers_fitted_vision_slots_when_fleet_up(self, monkeypatch) -> None:
+        # Once the fleet is up the fan-out sizes to the servers' real fitted slots, not
+        # the requested concurrency a modest card could not fit.
+        from lilbee.data.ingest import pipeline
+
+        self._stub_vision_capacity(monkeypatch, 5)
+        monkeypatch.setattr(pipeline, "cpu_quota", lambda: 4)
+        monkeypatch.setattr(cfg, "vision_model", "org/repo/model.gguf")
+        monkeypatch.setattr(cfg, "vision_replicas", 8)
+        monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)  # would estimate 32
+        monkeypatch.setattr(cfg, "embed_replicas", 1)
+        assert pipeline._max_concurrent() == 5
+
     def test_single_replica_caps_at_vision_slots(self, monkeypatch) -> None:
         # A single vision server has vision_ocr_concurrency continuous-batching slots;
         # file-concurrency tracks that capacity so all slots stay fed.
         from lilbee.data.ingest import pipeline
 
+        self._stub_vision_capacity(monkeypatch, None)
         monkeypatch.setattr(pipeline, "cpu_quota", lambda: 4)
         monkeypatch.setattr(cfg, "vision_model", "org/repo/model.gguf")
         monkeypatch.setattr(cfg, "vision_replicas", 1)
@@ -314,6 +341,7 @@ class TestMaxConcurrent:
         # requests at one vision server's few slots; the cap is the vision capacity.
         from lilbee.data.ingest import pipeline
 
+        self._stub_vision_capacity(monkeypatch, None)
         monkeypatch.setattr(pipeline, "cpu_quota", lambda: 32)
         monkeypatch.setattr(cfg, "vision_model", "org/repo/model.gguf")
         monkeypatch.setattr(cfg, "vision_replicas", 1)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -274,6 +274,20 @@ class TestRoutingProvider:
         rp._local = None
         assert rp.warm_progress() is None
 
+    def test_vision_slot_capacity_delegates_to_local_engine(self) -> None:
+        rp = self._make_provider()
+        mock_local = mock.MagicMock()
+        mock_local.vision_slot_capacity.return_value = 5
+        rp._local = mock_local
+        assert rp.vision_slot_capacity() == 5
+        mock_local.vision_slot_capacity.assert_called_once_with()
+
+    def test_vision_slot_capacity_none_without_a_local_engine(self) -> None:
+        # Sizing the fan-out must not build the fleet; before it exists, None.
+        rp = self._make_provider()
+        rp._local = None
+        assert rp.vision_slot_capacity() is None
+
     def test_warm_progress_delegates_to_local_engine(self) -> None:
         from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 


### PR DESCRIPTION
## Problem

A follow-up to the vision-OCR 429 fix. That change (per-replica slot dispatch plus a bounded busy-retry) stopped the mass drops, but a live single-L40S run over 23,204 page-images still lost about 6% of pages, every one an HTTP 429 'busy'.

Two things caused the residual loss. First, the busy-retry budget: a single modest GPU sustains roughly half a page per second, so a 23k-image fan-out backs the OCR queue up hundreds of seconds deep, while the retry was attempt-bound (18 attempts, about 112 seconds). When the queue is far deeper than the retry budget, a page that gets a 429 while every slot is busy exhausts its retries long before a slot frees and is dropped. Second, the ingest fan-out was sized to the requested per-server concurrency (replicas x vision_ocr_concurrency), which a memory-constrained card cannot always fit, so a modest GPU was handed more concurrent pages than its servers could serve in the first place.

## Solution

Two changes, one per commit.

The busy-retry is now bounded by the page's own OCR deadline instead of an attempt count. Each page already has a budget (its per-page timeout plus the cold-load grace); a 429'd page now keeps backing off and waiting for a genuinely free slot until that deadline passes, and only then fails. On a deep queue the page waits for real capacity rather than giving up early, so a page is dropped only when its true deadline lapses, never because an arbitrary attempt count ran out. Both OCR entry points, single images and rasterized PDF pages, share one dispatch helper so their retry, deadline, and completeness behavior are identical. The old attempt count survives only as the backstop for the explicit no-limit case.

The ingest fan-out now sizes to the vision servers' real fitted continuous-batching slots once the fleet is up, via a new provider accessor, instead of the requested concurrency. A modest card that fit fewer slots than requested reports the smaller real number, so lilbee never pulls more pages into compute than the servers can serve, and the excess no longer piles up behind the dispatcher with deadlines ticking. Before the fleet is up the accessor returns None and the previous estimate stands, so a cold first batch is unchanged and no fleet is ever built merely to size the semaphore.

Together these mean a page is dropped only when its genuine deadline passes, regardless of how modest the hardware is, and the fan-out no longer oversubscribes a small card in the first place.