### PR TITLE
Make first-run readiness legible, and fix input wrap + gpt-oss token leak

### DIFF
--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -15,7 +15,7 @@ from lilbee.providers.fleet.planning import (
     resolve_placement_plan,
 )
 from lilbee.providers.roles import WorkerRole
-from lilbee.providers.warm_progress import WarmPhase
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 
 _PLACEMENT_KEY = "placement"
 
@@ -55,6 +55,14 @@ class RolePlacementView:
 
 
 @dataclass(frozen=True)
+class SkippedRole:
+    """A configured role left unplaced because its model isn't downloaded."""
+
+    role: WorkerRole
+    model: str
+
+
+@dataclass(frozen=True)
 class PlacementView:
     """The full placement picture: GPUs, per-role placement, and whether manual."""
 
@@ -63,6 +71,9 @@ class PlacementView:
     unplaceable: tuple[WorkerRole, ...]
     manual: bool
     spec_json: str | None
+    # Configured roles absent from the plan because their model isn't installed,
+    # so a surface can show "not downloaded" instead of an unexplained empty table.
+    skipped_not_installed: tuple[SkippedRole, ...] = ()
 
 
 def _active_spec() -> PlacementSpec | None:
@@ -102,6 +113,10 @@ def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -
         unplaceable=resolved.unplaceable_roles,
         manual=manual,
         spec_json=spec_json,
+        skipped_not_installed=tuple(
+            SkippedRole(role=role, model=ref)
+            for role, ref in resolved.skipped_not_installed.items()
+        ),
     )
 
 
@@ -187,3 +202,22 @@ def wait_chat_ready(timeout_s: float = _CHAT_READY_TIMEOUT_S) -> bool:
             return False
         time.sleep(_CHAT_READY_POLL_S)
     return False
+
+
+def active_chat_warm_progress() -> WarmProgress | None:
+    """The chat warm snapshot while a cold load is genuinely in flight, else None.
+
+    A surface gates interactive input on this: ``None`` covers ready, no fleet, a
+    missing model, and a finished or failed warm, so nothing traps the input in a
+    locked state. Non-``None`` carries the phase and byte progress to render.
+    """
+    services = peek_services()
+    if services is None:
+        return None
+    provider = services.provider
+    if provider.role_ready(WorkerRole.CHAT):
+        return None
+    snapshot = provider.warm_progress()
+    if snapshot is not None and snapshot.phase in _ACTIVE_WARM_PHASES:
+        return snapshot
+    return None

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -182,7 +182,10 @@ def _self_check_server(
         swap.shutdown()
         shutil.rmtree(work_dir, ignore_errors=True)
         raise
-    return swap, LlamaServerClient(swap.endpoint(), launch.model_id), work_dir
+    client = LlamaServerClient(
+        swap.endpoint(), launch.model_id, inline_reasoning=role is WorkerRole.CHAT
+    )
+    return swap, client, work_dir
 
 
 def _self_check_chat(model_path: Path, max_tokens: int) -> str:

--- a/src/lilbee/cli/placement.py
+++ b/src/lilbee/cli/placement.py
@@ -100,6 +100,12 @@ def _render_view(view: PlacementView) -> None:
     for role in view.unplaceable:
         console.print(f"  [{theme.ERROR}]{role.value}: does not fit, no server[/{theme.ERROR}]")
 
+    for skipped in view.skipped_not_installed:
+        console.print(
+            f"  [{theme.WARNING}]{skipped.role.value}: {skipped.model} not downloaded, "
+            f"pull it to place it[/{theme.WARNING}]"
+        )
+
 
 @placement_app.command("show")
 def show(

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -211,6 +211,7 @@ SCOPE_PILL_BOTH = "Both"
 SCOPE_PILL_WIKI = "Wiki"
 SCOPE_PILL_RAW = "Raw"
 CHAT_BUSY = "Already answering. Press Ctrl+C to cancel, then submit your next prompt."
+CHAT_WARMING = "Loading the chat model. One moment, then send your prompt."
 CHAT_MODEL_DOWNLOADING = "{name} is still downloading. Wait for it to finish, then submit."
 MODEL_BEING_DOWNLOADED = (
     "{name} is still downloading. Wait for it to finish before setting it active."
@@ -398,6 +399,9 @@ FLEET_STATE_EDITED = "edited · ctrl+s to apply"
 FLEET_SINGLE_GPU_NOTE = "One graphics card: everything runs here."
 FLEET_GPU_PROBING = "probing GPUs…"
 FLEET_NO_GPUS = "(no GPUs detected)"
+# Shown for a role that has no placement because its model isn't downloaded, so the
+# empty slot reads as a fixable state instead of "GPU placement is broken".
+FLEET_MODEL_NOT_DOWNLOADED = "{role}: {model} not downloaded, pull it to place it"
 FLEET_CMD_PREVIEW = "Preview"
 FLEET_CMD_APPLY = "Apply"
 FLEET_CMD_AUTO = "Auto"
@@ -445,6 +449,12 @@ STATUS_DOCS_EMPTY = "(no documents yet)"
 STATUS_DOCS_TITLE = "Documents"
 TASKBAR_STARTING_WORKER = "Starting {labels} worker..."
 TASKBAR_STARTING_WORKERS = "Starting {labels} workers..."
+# Cold-start chat warm line: phase (and byte % while paging weights) so the held
+# input reads as "loading", not "stuck".
+TASKBAR_WARM = "loading chat · {detail}"
+TASKBAR_WARM_STARTING = "starting"
+TASKBAR_WARM_READING = "reading weights {pct}%"
+TASKBAR_WARM_LOADING = "loading engine"
 
 TASK_CENTER_TITLE = "Background Tasks"
 TASK_CENTER_COUNTS = "{active} running  ·  {queued} queued  ·  {done} done"

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -122,6 +122,9 @@ _CRAWL_FLAG_RENDER = "--render"
 # event loop.
 _MODEL_SWAP_WORKER = "model_swap_reset"
 
+# Cadence for polling whether the chat model is still warming on a cold start.
+_WARM_POLL_INTERVAL_S = 0.3
+
 
 def _parse_add_paths(args: str) -> list[Path]:
     """Resolve ``/add`` arguments to filesystem paths.
@@ -181,6 +184,10 @@ class ChatScreen(Screen[None]):
     # True while a placement apply/clear reloads the fleet (from the Fleet drawer);
     # holds chat submissions so they don't race the reload into a 429.
     reloading_placement: reactive[bool] = reactive(False)
+    # True while the chat model is warming on a cold start. Disables the input and
+    # holds submits until the model can serve, so a prompt can't land on a not-yet-warm
+    # fleet and render an error inside a chat bubble; cleared on the ready transition.
+    chat_warming: reactive[bool] = reactive(False)
 
     HELP = (
         "# Chat\n\n"
@@ -317,6 +324,8 @@ class ChatScreen(Screen[None]):
         self._update_input_style()
         self.app.settings_changed_signal.subscribe(self, self._on_settings_changed)
         self._setup_check_worker()
+        self._poll_chat_warming()
+        self.set_interval(_WARM_POLL_INTERVAL_S, self._poll_chat_warming)
 
     @work(thread=True, name="chat_setup_check", exit_on_error=False)
     def _setup_check_worker(self) -> None:
@@ -539,6 +548,11 @@ class ChatScreen(Screen[None]):
             return True
         if self.reloading_placement:
             self.notify(msg.FLEET_RELOADING, severity="warning", timeout=3)
+            return True
+        if self.chat_warming:
+            # The model is still warming; hold the prompt (input keeps the typed text)
+            # rather than firing it into a not-warm fleet and erroring in a bubble.
+            self.notify(msg.CHAT_WARMING, severity="warning", timeout=3)
             return True
         if self.streaming:
             # Only one chat message may be in flight at a time; surface a toast
@@ -1571,7 +1585,7 @@ class ChatScreen(Screen[None]):
         because the unblock can fire (via ``call_from_thread`` or a bubbled
         message) after the user navigated away and the input is no longer mounted.
         """
-        busy = self.swapping_model or self.reloading_placement
+        busy = self.swapping_model or self.reloading_placement or self.chat_warming
         with contextlib.suppress(NoMatches):
             self._chat_input.disabled = busy
             if not busy and self._insert_mode:
@@ -1582,6 +1596,15 @@ class ChatScreen(Screen[None]):
 
     def watch_reloading_placement(self, reloading: bool) -> None:
         self._apply_input_busy_state()
+
+    def watch_chat_warming(self, warming: bool) -> None:
+        self._apply_input_busy_state()
+
+    def _poll_chat_warming(self) -> None:
+        """Track whether the chat model is still warming so input stays held until ready."""
+        from lilbee.app.placement import active_chat_warm_progress
+
+        self.chat_warming = active_chat_warm_progress() is not None
 
     def on_fleet_body_placement_reloading(self, event: FleetBody.PlacementReloading) -> None:
         """Hold chat submissions while the Fleet drawer reloads the fleet."""

--- a/src/lilbee/cli/tui/widgets/chat_input.py
+++ b/src/lilbee/cli/tui/widgets/chat_input.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import ClassVar
 
-from textual import on
+from textual import events, on
 from textual.actions import SkipAction
 from textual.binding import Binding, BindingType
 from textual.message import Message
@@ -94,7 +94,15 @@ class ChatInput(TextArea):
         last_col = len(self.document.get_line(last_line))
         self.move_cursor((last_line, last_col))
 
-    @on(TextArea.Changed)
-    def _track_multiline(self, _event: TextArea.Changed) -> None:
+    def _sync_multiline(self) -> None:
         """Add ``-multiline`` when the prompt spans more than one wrapped row."""
         self.set_class(self.wrapped_document.height > 1, "-multiline")
+
+    @on(TextArea.Changed)
+    def _track_multiline(self, _event: TextArea.Changed) -> None:
+        self._sync_multiline()
+
+    def on_resize(self, _event: events.Resize) -> None:
+        # A narrower terminal can wrap a prompt that fit one row when typed; re-check
+        # after the refresh (so the document has re-wrapped) and grow instead of clip.
+        self.call_after_refresh(self._sync_multiline)

--- a/src/lilbee/cli/tui/widgets/chat_input.py
+++ b/src/lilbee/cli/tui/widgets/chat_input.py
@@ -39,10 +39,9 @@ class ChatInput(TextArea):
     _UNCONSUMED_KEYS: ClassVar[frozenset[str]] = frozenset()
 
     # Per-keystroke layout cost is dominated by ``height: auto`` reflow.
-    # Pin the visual height to a single row while the content has no
-    # newline; flip to auto-grow only once a newline appears (Shift+Enter
-    # or pasted multi-line text). The CSS hook is the ``-multiline``
-    # class added by :meth:`_track_multiline`.
+    # Pin the visual height to a single row while the content fits one row;
+    # flip to auto-grow once it wraps or holds a newline. The CSS hook is the
+    # ``-multiline`` class added by :meth:`_track_multiline`.
 
     @dataclass
     class Submitted(Message):
@@ -97,6 +96,5 @@ class ChatInput(TextArea):
 
     @on(TextArea.Changed)
     def _track_multiline(self, _event: TextArea.Changed) -> None:
-        """Toggle the ``-multiline`` class so CSS can pin height for the
-        single-line case and let it grow only when newlines are present."""
-        self.set_class("\n" in self.text, "-multiline")
+        """Add ``-multiline`` when the prompt spans more than one wrapped row."""
+        self.set_class(self.wrapped_document.height > 1, "-multiline")

--- a/src/lilbee/cli/tui/widgets/fleet_body.py
+++ b/src/lilbee/cli/tui/widgets/fleet_body.py
@@ -63,6 +63,7 @@ def _clean_model_name(ref: str) -> str:
 _CSS_FILE = Path(__file__).parent / "fleet_body.tcss"
 
 _EDITOR_ID = "#placement-editor"
+_SKIPPED_ID = "#placement-skipped"
 _TITLE_ID = "#placement-title"
 _STATE_ID = "#placement-state"
 _COMMANDS_ID = "#placement-commands"
@@ -191,6 +192,7 @@ class FleetBody(Widget):
                 help_icon.tooltip = msg.FLEET_HELP_TOOLTIP
                 yield help_icon
             yield GpuFleetPanel()
+            yield Static("", id="placement-skipped")
             yield Vertical(id="placement-editor")
             with Horizontal(id="placement-commands"):
                 yield FleetPill(msg.FLEET_CMD_PREVIEW, id=_CMD_PREVIEW, classes="cmd-pill")
@@ -233,9 +235,23 @@ class FleetBody(Widget):
         self._build_editor()
         self._refresh_title(dirty=False)
         self._update_fleet_panel(view)
+        self._render_skipped(view)
         if view.unplaceable:
             names = ", ".join(role.value for role in view.unplaceable)
             self.notify(f"Does not fit: {names}", severity="warning")
+
+    def _render_skipped(self, view: PlacementView) -> None:
+        """Show a 'not downloaded' line per role skipped for a missing model."""
+        widget = self.query_one(_SKIPPED_ID, Static)
+        widget.display = bool(view.skipped_not_installed)
+        widget.update(
+            "\n".join(
+                msg.FLEET_MODEL_NOT_DOWNLOADED.format(
+                    role=skipped.role.value, model=_clean_model_name(skipped.model)
+                )
+                for skipped in view.skipped_not_installed
+            )
+        )
 
     def _page_devices(self) -> tuple[int, ...]:
         """The GPU indices visible on the current page."""

--- a/src/lilbee/cli/tui/widgets/fleet_body.tcss
+++ b/src/lilbee/cli/tui/widgets/fleet_body.tcss
@@ -42,6 +42,15 @@ FleetBody {
         color: $text-muted;
     }
 
+    /* Hidden until a configured role is skipped for a missing model; then it
+     * explains the empty slot instead of leaving the panel looking broken. */
+    #placement-skipped {
+        display: none;
+        height: auto;
+        margin-bottom: 1;
+        color: $warning;
+    }
+
     /* One hover-help for the whole drawer; keeps the surface otherwise minimal. */
     #placement-help {
         width: 3;

--- a/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
+++ b/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
@@ -135,11 +135,19 @@ def _render_stats(
     labels: dict[int, str],
     roles: dict[int, str],
     theme: dict[str, str],
+    *,
+    probed: bool,
 ) -> str:
-    """Build the unified GPU table (one row per GPU) from a stat snapshot."""
+    """Build the unified GPU table (one row per GPU) from a stat snapshot.
+
+    With no stats, ``probed`` picks the placeholder: the empty-GPUs text only
+    once the device probe has completed, else the probing placeholder so a cold
+    start never flashes '(no GPUs detected)' before the first device list lands.
+    """
     if not stats:
         muted = _theme_color(theme, "text-muted")
-        return f"[{muted}]  {msg.FLEET_NO_GPUS}[/]"
+        text = msg.FLEET_NO_GPUS if probed else msg.FLEET_GPU_PROBING
+        return f"[{muted}]  {text}[/]"
     return "\n".join(
         _render_row(stats[idx], labels.get(idx, f"GPU{idx}"), roles.get(idx, ""), theme)
         for idx in sorted(stats)
@@ -167,6 +175,9 @@ class GpuFleetPanel(Static):
         # slower than the tick interval skips ticks instead of stacking
         # threads (and their nvidia-smi subprocesses) without bound.
         self._probing = False
+        # False until the parent device probe reports its result via set_devices;
+        # gates the empty-GPUs text so a cold start holds the probing placeholder.
+        self._probed = False
 
     def set_devices(
         self,
@@ -183,6 +194,7 @@ class GpuFleetPanel(Static):
         self._devices = list(devices)
         self._labels = dict(labels)
         self._roles = dict(roles) if roles is not None else {}
+        self._probed = True
 
     def on_mount(self) -> None:
         self._timer = self.set_interval(_TICK_INTERVAL_S, self._request_stats)
@@ -238,5 +250,5 @@ class GpuFleetPanel(Static):
     ) -> None:
         """Update the rendered content with fresh stat data (main thread)."""
         theme = self._resolve_theme()
-        markup = _render_stats(stats, labels, roles, theme)
+        markup = _render_stats(stats, labels, roles, theme, probed=self._probed)
         self.update(markup)

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -15,6 +15,7 @@ from textual.widgets import Label, Static
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.task_queue import TaskQueue, TaskStatus
 from lilbee.cli.tui.widgets.task_bar_controller import TaskBarController
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.app import LilbeeApp
@@ -32,6 +33,24 @@ _POLL_INTERVAL_IDLE_S = 1.0
 # matching the active-row rail pulse in the Task Center.
 _DOT_PULSE_HALF_TICKS = 5
 _DOT_GLYPH = "●"
+
+
+def _warm_detail(progress: WarmProgress | None) -> str | None:
+    """Phase (and byte % while paging weights) for the cold-start chat warm line.
+
+    None once the warm is past an active phase, so the line reads as progress, not
+    a stuck spinner.
+    """
+    if progress is None:
+        return None
+    if progress.phase is WarmPhase.STARTING:
+        return msg.TASKBAR_WARM_STARTING
+    if progress.phase is WarmPhase.LOADING_ENGINE:
+        return msg.TASKBAR_WARM_LOADING
+    if progress.phase is WarmPhase.READING_WEIGHTS:
+        pct = int(progress.bytes_done / progress.bytes_total * 100) if progress.bytes_total else 0
+        return msg.TASKBAR_WARM_READING.format(pct=pct)
+    return None
 
 
 class TaskBar(Static):
@@ -207,7 +226,8 @@ class TaskBar(Static):
         idle = not active and not queued and not in_flash and self._flash_outcome is None
         pending = self._controller.pending_sync_count if idle else 0
         spawning_roles = sorted(self._controller.spawning_roles) if idle else []
-        fully_idle = idle and pending == 0 and not spawning_roles
+        warm_line = self._warm_line() if idle else None
+        fully_idle = idle and pending == 0 and not spawning_roles and warm_line is None
         self._sync_poll_cadence(fully_idle)
         if fully_idle:
             self.display = False
@@ -215,15 +235,9 @@ class TaskBar(Static):
             return
 
         self.display = True
-        if idle and spawning_roles:
-            dot_color = "$primary"
-            summary = self._spawning_workers_template(spawning_roles)
-        elif idle and pending > 0:
-            dot_color = "$text-muted"
-            key = self._pending_sync_template(pending)
-            summary = key.format(count=pending)
-        else:
-            dot_color, summary = self._compose_segments(active, queued)
+        dot_color, summary = self._status_line(
+            active, queued, spawning_roles, pending, warm_line, idle=idle
+        )
         hint_text = self._hint_copy()
         # Fingerprint captures every variable the label content depends
         # on. Recomputing it is essentially free; the win comes from
@@ -237,6 +251,7 @@ class TaskBar(Static):
             self._flash_outcome,
             pending,
             tuple(spawning_roles),
+            warm_line,
         )
         if fingerprint == self._last_render_fingerprint:
             return
@@ -246,6 +261,32 @@ class TaskBar(Static):
         with contextlib.suppress(Exception):
             label = self.query_one("#task-status-label", Label)
             label.update(label_text)
+
+    def _status_line(
+        self,
+        active: list,  # type: ignore[type-arg]
+        queued: list,  # type: ignore[type-arg]
+        spawning_roles: list[str],
+        pending: int,
+        warm_line: str | None,
+        *,
+        idle: bool,
+    ) -> tuple[str, str]:
+        """Pick the dot color and summary text for the current bar state."""
+        if idle and warm_line is not None:
+            return "$primary", warm_line
+        if idle and spawning_roles:
+            return "$primary", self._spawning_workers_template(spawning_roles)
+        if idle and pending > 0:
+            return "$text-muted", self._pending_sync_template(pending).format(count=pending)
+        return self._compose_segments(active, queued)
+
+    def _warm_line(self) -> str | None:
+        """The cold-start chat warm line, or None when chat isn't warming."""
+        from lilbee.app.placement import active_chat_warm_progress
+
+        detail = _warm_detail(active_chat_warm_progress())
+        return msg.TASKBAR_WARM.format(detail=detail) if detail else None
 
     def _spawning_workers_template(self, roles: list[str]) -> str:
         """Render the active worker-warmup hint for the bottom bar."""

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -34,22 +34,47 @@ _POLL_INTERVAL_IDLE_S = 1.0
 _DOT_PULSE_HALF_TICKS = 5
 _DOT_GLYPH = "●"
 
+# Warm progress bar: filled/track glyphs and width, matching the fleet panel bars.
+_WARM_BAR_FILL = "▓"
+_WARM_BAR_TRACK = "░"
+_WARM_BAR_WIDTH = 12
+# Indeterminate sweep (loading engine has no byte signal): a lit window that walks
+# the track so the bar reads as "working", not stalled. Advanced by the poll tick.
+_WARM_SWEEP_WIDTH = 3
 
-def _warm_detail(progress: WarmProgress | None) -> str | None:
-    """Phase (and byte % while paging weights) for the cold-start chat warm line.
 
-    None once the warm is past an active phase, so the line reads as progress, not
-    a stuck spinner.
+def _progress_bar(fraction: float) -> str:
+    """A determinate fill bar for the byte-progress (reading-weights) phase."""
+    filled = round(max(0.0, min(1.0, fraction)) * _WARM_BAR_WIDTH)
+    return _WARM_BAR_FILL * filled + _WARM_BAR_TRACK * (_WARM_BAR_WIDTH - filled)
+
+
+def _sweep_bar(tick: int) -> str:
+    """An indeterminate bar with a lit window of fixed width walking (and wrapping)
+    across the track, keyed to *tick*, so it always shows motion, never a blank."""
+    start = tick % _WARM_BAR_WIDTH
+    lit = {(start + offset) % _WARM_BAR_WIDTH for offset in range(_WARM_SWEEP_WIDTH)}
+    return "".join(_WARM_BAR_FILL if i in lit else _WARM_BAR_TRACK for i in range(_WARM_BAR_WIDTH))
+
+
+def _warm_detail(progress: WarmProgress | None, tick: int = 0) -> str | None:
+    """Phase word plus a progress bar for the cold-start chat warm line.
+
+    A determinate byte bar while paging weights, an indeterminate sweep while the
+    engine loads (no byte signal). None once past an active phase, so the line
+    reads as live progress, not a stalled spinner.
     """
     if progress is None:
         return None
     if progress.phase is WarmPhase.STARTING:
-        return msg.TASKBAR_WARM_STARTING
+        return f"{_sweep_bar(tick)}  {msg.TASKBAR_WARM_STARTING}"
     if progress.phase is WarmPhase.LOADING_ENGINE:
-        return msg.TASKBAR_WARM_LOADING
+        return f"{_sweep_bar(tick)}  {msg.TASKBAR_WARM_LOADING}"
     if progress.phase is WarmPhase.READING_WEIGHTS:
-        pct = int(progress.bytes_done / progress.bytes_total * 100) if progress.bytes_total else 0
-        return msg.TASKBAR_WARM_READING.format(pct=pct)
+        fraction = progress.bytes_done / progress.bytes_total if progress.bytes_total else 0.0
+        return (
+            f"{_progress_bar(fraction)}  {msg.TASKBAR_WARM_READING.format(pct=int(fraction * 100))}"
+        )
     return None
 
 
@@ -285,7 +310,7 @@ class TaskBar(Static):
         """The cold-start chat warm line, or None when chat isn't warming."""
         from lilbee.app.placement import active_chat_warm_progress
 
-        detail = _warm_detail(active_chat_warm_progress())
+        detail = _warm_detail(active_chat_warm_progress(), self._tick_count)
         return msg.TASKBAR_WARM.format(detail=detail) if detail else None
 
     def _spawning_workers_template(self, roles: list[str]) -> str:

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -17,6 +17,12 @@ if TYPE_CHECKING:
 
 T_co = TypeVar("T_co", covariant=True)
 
+# The inline reasoning markers lilbee's pipeline speaks. A provider whose server
+# extracts reasoning into a separate field re-inlines it with these tags at the
+# client boundary, so every downstream consumer parses one format.
+THINK_OPEN_TAG = "<think>"
+THINK_CLOSE_TAG = "</think>"
+
 
 @runtime_checkable
 class ClosableIterator(Iterator[T_co], Protocol[T_co]):

--- a/src/lilbee/providers/fleet/adapters.py
+++ b/src/lilbee/providers/fleet/adapters.py
@@ -42,10 +42,11 @@ ROLE_SPECS: dict[WorkerRole, RoleServerSpec] = {
         endpoint_path="/v1/chat/completions",
         # --jinja renders the model's own chat template and parses native
         # tool-call syntax into structured message.tool_calls.
-        # --reasoning-format none keeps <think>...</think> inline in content;
-        # without it, recent llama-server extracts reasoning into a separate
-        # reasoning_content field and lilbee's <think>-based parser sees none.
-        extra_args=("--jinja", "--reasoning-format", "none"),
+        # --reasoning-format deepseek makes the server parse every model's native
+        # reasoning dialect (<think>, gpt-oss harmony, ...) into reasoning_content;
+        # the chat client re-inlines it as <think> so downstream parsing stays
+        # format-agnostic and control tokens never leak into answers.
+        extra_args=("--jinja", "--reasoning-format", "deepseek"),
         server_capable=True,
     ),
     WorkerRole.EMBED: RoleServerSpec(

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -6,6 +6,7 @@ import contextlib
 import json
 import logging
 import math
+import ssl
 import threading
 import time
 from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
@@ -31,6 +32,15 @@ from lilbee.providers.fleet.normalize import ChatMessage, to_alternating
 from lilbee.providers.roles import RerankMode
 
 _PROVIDER_NAME = "llama-server"
+
+# Fleet clients only ever talk to a loopback llama-server over plain HTTP, so TLS is
+# never negotiated. httpx still builds a default SSL context per client (loads the
+# system CA bundle, ~13 ms each and slower on macOS via the keychain), which is pure
+# overhead paid on every fleet reload. Build one minimal context and share it so a
+# reload doesn't reload the CA bundle for each replica.
+_LOOPBACK_SSL_CONTEXT = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+_LOOPBACK_SSL_CONTEXT.check_hostname = False
+_LOOPBACK_SSL_CONTEXT.verify_mode = ssl.CERT_NONE
 # Reranker pair format: query and candidate are joined with this separator into
 # one document so a cross-encoder GGUF scores the pair as a single sequence.
 _RERANK_PAIR_SEPARATOR = "</s></s>"
@@ -359,7 +369,9 @@ class LlamaServerClient:
     ) -> None:
         self._base = base_url.rstrip("/")
         self._model = model
-        self._http = http or httpx.Client(base_url=self._base, timeout=timeout)
+        self._http = http or httpx.Client(
+            base_url=self._base, timeout=timeout, verify=_LOOPBACK_SSL_CONTEXT
+        )
         self._owns_http = http is None
         # Per-slot context for embed/rerank servers: inputs longer than this are
         # token-truncated (via the server's tokenizer) before embedding, mirroring

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -17,6 +17,8 @@ import httpx
 
 from lilbee.core.config import cfg
 from lilbee.providers.base import (
+    THINK_CLOSE_TAG,
+    THINK_OPEN_TAG,
     ChatResult,
     ChatToolResult,
     FinishReason,
@@ -366,6 +368,7 @@ class LlamaServerClient:
         token_cap: int | None = None,
         timeout: float = _DEFAULT_TIMEOUT_S,
         rerank_mode: RerankMode | None = None,
+        inline_reasoning: bool = False,
     ) -> None:
         self._base = base_url.rstrip("/")
         self._model = model
@@ -373,6 +376,9 @@ class LlamaServerClient:
             base_url=self._base, timeout=timeout, verify=_LOOPBACK_SSL_CONTEXT
         )
         self._owns_http = http is None
+        # Chat-role clients re-inline server-extracted reasoning as <think> text;
+        # the other roles (vision OCR) keep dropping it, as their servers already did.
+        self._inline_reasoning = inline_reasoning
         # Per-slot context for embed/rerank servers: inputs longer than this are
         # token-truncated (via the server's tokenizer) before embedding, mirroring
         # the in-process backstop. None for chat/vision, which don't truncate inputs.
@@ -476,11 +482,14 @@ class LlamaServerClient:
             _raise_for_status(resp)
             # content is null for a refusal / content-filter stop / empty completion;
             # coerce to "" (like chat_result/chat_tools) so callers never see "None".
-            return resp.json()["choices"][0]["message"].get("content") or ""
+            return _inline_message_reasoning(
+                resp.json()["choices"][0]["message"], enabled=self._inline_reasoning
+            )
 
     def _chat_stream(
         self, payload: dict[str, Any], timeout: Any = httpx.USE_CLIENT_DEFAULT
     ) -> Iterator[str]:
+        inliner = _ThinkInliner(enabled=self._inline_reasoning)
         with (
             self._track(),
             self._http.stream(
@@ -489,9 +498,12 @@ class LlamaServerClient:
         ):
             _raise_for_status(resp)
             for line in resp.iter_lines():
-                delta = _parse_sse_delta(line)
+                delta = inliner.feed(*_parse_sse_deltas(line))
                 if delta:
                     yield delta
+            tail = inliner.finish()
+            if tail:
+                yield tail
 
     def chat_bounded(
         self,
@@ -511,6 +523,7 @@ class LlamaServerClient:
         """
         payload: dict[str, Any] = {"model": self._model, "messages": messages, **(options or {})}
         deadline = time.monotonic() + deadline_s
+        inliner = _ThinkInliner(enabled=self._inline_reasoning)
         parts: list[str] = []
         with (
             self._track(),
@@ -523,7 +536,8 @@ class LlamaServerClient:
                         f"llama-server chat exceeded its {deadline_s:.0f}s deadline.",
                         provider=_PROVIDER_NAME,
                     )
-                parts.append(_parse_sse_delta(line))
+                parts.append(inliner.feed(*_parse_sse_deltas(line)))
+            parts.append(inliner.finish())
         return "".join(parts)
 
     def chat_tools(
@@ -553,7 +567,7 @@ class LlamaServerClient:
             resp = self._http.post(_CHAT_PATH, json=payload)
             _raise_for_status(resp)
             message = resp.json()["choices"][0]["message"]
-        content = message.get("content") or ""
+        content = _inline_message_reasoning(message, enabled=self._inline_reasoning)
         native = _parse_native_tool_calls(message.get("tool_calls"))
         if native:
             return ChatToolResult(content=content, tool_calls=native)
@@ -586,7 +600,7 @@ class LlamaServerClient:
         choice = body["choices"][0]
         usage = _usage_from_body(body) or TokenUsage()
         message = choice["message"]
-        content = message.get("content") or ""
+        content = _inline_message_reasoning(message, enabled=self._inline_reasoning)
         finish_reason = _coerce_finish_reason(choice.get("finish_reason"))
         native = _parse_native_tool_calls(message.get("tool_calls"))
         if native:
@@ -645,13 +659,17 @@ class LlamaServerClient:
     ) -> Iterator[str | ToolCallDelta | TokenUsage | StreamFinish]:
         """Open one SSE chat stream and yield its frames; raises before the first frame."""
         payload = self._chat_payload(messages, tools, tool_choice, options, stream=True)
+        inliner = _ThinkInliner(enabled=self._inline_reasoning)
         with (
             self._track(),
             self._http.stream("POST", _CHAT_PATH, json=payload) as resp,
         ):
             _raise_for_status(resp)
             for line in resp.iter_lines():
-                yield from _parse_sse_stream_items(line)
+                yield from _parse_sse_stream_items(line, inliner)
+            tail = inliner.finish()
+            if tail:
+                yield tail
 
     def _chat_payload(
         self,
@@ -992,21 +1010,70 @@ def _llm_rerank_score(top_logprobs: list[dict[str, Any]]) -> float:
     return yes_e / (yes_e + no_e)
 
 
-def _parse_sse_delta(line: str) -> str:
-    """Extract the content delta from one OpenAI SSE line, ``""`` if none."""
+def _parse_sse_deltas(line: str) -> tuple[str, str]:
+    """Extract the (reasoning, content) deltas from one OpenAI SSE line."""
     if not line.startswith(_DATA_PREFIX):
-        return ""
+        return "", ""
     body = line[len(_DATA_PREFIX) :].strip()
     if not body or body == _DONE_SENTINEL:
-        return ""
+        return "", ""
     try:
         obj = json.loads(body)
     except json.JSONDecodeError:
-        return ""
+        return "", ""
     choices = obj.get("choices") or []
     if not choices:
+        return "", ""
+    delta = choices[0].get("delta") or {}
+    return str(delta.get("reasoning_content") or ""), str(delta.get("content") or "")
+
+
+class _ThinkInliner:
+    """Re-inlines server-extracted reasoning deltas as inline ``<think>`` text.
+
+    The server parses each model's reasoning format natively (``--reasoning-format``)
+    and streams it as ``reasoning_content``; lilbee's pipeline speaks inline
+    ``<think>`` text, so the chat boundary opens the tag on the first reasoning
+    delta and closes it when the answer starts (or at end of stream). Disabled
+    (the non-chat roles), reasoning is dropped and content passes through, matching
+    the server-extracted default those roles already ran with.
+    """
+
+    def __init__(self, *, enabled: bool) -> None:
+        self._enabled = enabled
+        self._in_think = False
+
+    def feed(self, reasoning: str, content: str) -> str:
+        if not self._enabled:
+            return content
+        parts: list[str] = []
+        if reasoning:
+            if not self._in_think:
+                self._in_think = True
+                parts.append(THINK_OPEN_TAG)
+            parts.append(reasoning)
+        if content:
+            if self._in_think:
+                self._in_think = False
+                parts.append(THINK_CLOSE_TAG)
+            parts.append(content)
+        return "".join(parts)
+
+    def finish(self) -> str:
+        """Close an unterminated think block at end of stream."""
+        if self._in_think:
+            self._in_think = False
+            return THINK_CLOSE_TAG
         return ""
-    return str(choices[0].get("delta", {}).get("content") or "")
+
+
+def _inline_message_reasoning(message: Mapping[str, Any], *, enabled: bool) -> str:
+    """A non-streaming message's text with any extracted reasoning re-inlined."""
+    content = str(message.get("content") or "")
+    reasoning = str(message.get("reasoning_content") or "") if enabled else ""
+    if reasoning:
+        return f"{THINK_OPEN_TAG}{reasoning}{THINK_CLOSE_TAG}{content}"
+    return content
 
 
 def _usage_from_body(body: Mapping[str, Any]) -> TokenUsage | None:
@@ -1053,14 +1120,16 @@ def _tool_call_delta_from_chunk(call: Mapping[str, Any], *, fallback_index: int)
     )
 
 
-def _parse_sse_stream_items(line: str) -> Iterator[str | ToolCallDelta | TokenUsage | StreamFinish]:
+def _parse_sse_stream_items(
+    line: str, inliner: _ThinkInliner
+) -> Iterator[str | ToolCallDelta | TokenUsage | StreamFinish]:
     """Yield text tokens, tool-call deltas, and the finish frame from one SSE line.
 
-    A chunk can carry a ``content`` token, a ``tool_calls`` delta array, or
-    both; each is yielded as its own :data:`ChatStreamItem` frame. The chunk
-    that closes the turn carries ``choices[0].finish_reason``, surfaced as a
-    :class:`StreamFinish` so the dispatch reports ``length`` (and friends), not
-    just the default end-of-turn.
+    A chunk can carry a ``content`` token, a ``reasoning_content`` token (routed
+    through *inliner*), a ``tool_calls`` delta array, or a mix; each is yielded as
+    its own :data:`ChatStreamItem` frame. The chunk that closes the turn carries
+    ``choices[0].finish_reason``, surfaced as a :class:`StreamFinish` so the
+    dispatch reports ``length`` (and friends), not just the default end-of-turn.
     """
     if not line.startswith(_DATA_PREFIX):
         return
@@ -1081,9 +1150,11 @@ def _parse_sse_stream_items(line: str) -> Iterator[str | ToolCallDelta | TokenUs
             yield usage
         return
     delta = choices[0].get("delta") or {}
-    content = delta.get("content")
-    if content:
-        yield str(content)
+    text = inliner.feed(
+        str(delta.get("reasoning_content") or ""), str(delta.get("content") or "")
+    )
+    if text:
+        yield text
     raw_calls = delta.get("tool_calls") or []
     for i, call in enumerate(raw_calls):
         if isinstance(call, Mapping):

--- a/src/lilbee/providers/fleet/gpu_backends/amd.py
+++ b/src/lilbee/providers/fleet/gpu_backends/amd.py
@@ -7,6 +7,7 @@ import json
 from lilbee.providers.fleet.gpu_backends.base import (
     UtilSample,
     extract_int,
+    find_metric,
     parse_device_index,
     run_smi,
 )
@@ -44,20 +45,15 @@ def _rocm_smi_output() -> str:
     return run_smi(_TOOL_ROCM_SMI, list(_ROCM_SMI_ARGS), _TIMEOUT_S)
 
 
-def _nested_int(obj: dict[str, object], key: str, nested_key: str = "value") -> int | None:
-    """Extract an int from obj[key] when that value is a nested {"value": N} dict."""
-    val = obj.get(key)
-    if isinstance(val, dict):
-        return extract_int(val, (nested_key,))
-    return None
-
-
 def _parse_amd_smi(raw: str, indices: frozenset[int]) -> dict[int, UtilSample]:
     """Parse amd-smi JSON into UtilSample per index, or {} on failure.
 
-    Tolerates two shapes emitted by different amd-smi versions:
-    - Flat:   {"gfx_activity": 72, "temperature_c": 61}
-    - Nested: {"gfx_activity": {"value": 72, "unit": "%"}, "temperature": {"edge": 61}}
+    amd-smi nests the same readings differently across versions: flat
+    ({"gfx_activity": 72}), value-wrapped ({"gfx_activity": {"value": 72}}), or under
+    a block ({"usage": {"gfx_activity": {"value": 72}}, "temperature": {"edge":
+    {"value": 61}}}). ``find_metric`` reads any of these by key at any depth. The
+    index-carrying key ("gpu") is read at the top level so a nested "gpu" block
+    can't be mistaken for it.
     """
     if not raw:
         return {}
@@ -72,26 +68,15 @@ def _parse_amd_smi(raw: str, indices: frozenset[int]) -> dict[int, UtilSample]:
         if not isinstance(item, dict):
             continue
         raw_index = item.get("gpu") if "gpu" in item else item.get("id", -1)
-        try:
-            index = int(raw_index)  # type: ignore[arg-type]
-        except (ValueError, TypeError):
+        index = extract_int({"i": raw_index}, ("i",))
+        if index is None or index not in indices:
             continue
-        if index not in indices:
-            continue
-        # Util: try flat keys first, then nested {"value": N} form.
-        util = extract_int(item, ("gfx_activity", "gfx_busy_percent", "gpu_activity"))
-        if util is None:
-            util = (
-                _nested_int(item, "gfx_activity")
-                or _nested_int(item, "gfx_busy_percent")
-                or _nested_int(item, "gpu_activity")
-            )
-        # Temp: flat keys, then nested sensor dict {"edge": N} under "temperature".
-        temp = extract_int(item, ("temperature_c", "temp_edge", "edge"))
-        if temp is None:
-            temp_block = item.get("temperature")
-            if isinstance(temp_block, dict):
-                temp = extract_int(temp_block, ("edge", "junction", "mem"))
+        util = find_metric(item, ("gfx_activity", "gfx_busy_percent", "gpu_activity"))
+        temp_block = item.get("temperature")
+        if isinstance(temp_block, dict):
+            temp = find_metric(temp_block, ("edge", "junction", "hotspot"))
+        else:
+            temp = find_metric(item, ("temperature_c", "temp_edge"))
         # VRAM not reliably present in metric mode; leave 0 so the orchestrator
         # keeps structural VRAM.
         samples[index] = UtilSample(

--- a/src/lilbee/providers/fleet/gpu_backends/apple.py
+++ b/src/lilbee/providers/fleet/gpu_backends/apple.py
@@ -11,8 +11,11 @@ from lilbee.providers.fleet.gpu_backends.base import UtilSample, run_smi
 BACKEND_KEY = "MTL"
 
 _TOOL = "ioreg"
-# The GPU accelerator's PerformanceStatistics dict, readable without sudo.
-_ARGS = ("-r", "-d", "1", "-k", "PerformanceStatistics")
+# Root at the GPU accelerator (AGXAccelerator conforms to IOAccelerator on every
+# Apple Silicon generation) and read its properties. A plain "-d 1 -k
+# PerformanceStatistics" never reaches the GPU node -- it caps traversal at depth
+# 1 and matches a shallow always-zero entry, so the bar read 0% even under load.
+_ARGS = ("-r", "-c", "IOAccelerator", "-d", "1")
 _TIMEOUT_S = 5.0
 
 # Apple Silicon exposes one integrated GPU; its load is "Device Utilization %".

--- a/src/lilbee/providers/fleet/gpu_backends/base.py
+++ b/src/lilbee/providers/fleet/gpu_backends/base.py
@@ -71,3 +71,42 @@ def parse_device_index(key: str) -> int | None:
     """Extract a GPU index from keys like 'card0', 'GPU[0]', '0'."""
     m = re.search(r"\d+", key)
     return int(m.group()) if m else None
+
+
+def _coerce_metric(val: object) -> int | None:
+    """Coerce a metric value to int: a bare number, a decimal string, or {"value": N}."""
+    if isinstance(val, dict):
+        val = val.get("value")
+    if isinstance(val, bool):
+        return None
+    if isinstance(val, (int, float)):
+        return int(val)
+    if isinstance(val, str):
+        try:
+            return int(float(val))
+        except ValueError:
+            return None
+    return None
+
+
+def find_metric(obj: object, keys: tuple[str, ...]) -> int | None:
+    """Find the first of *keys* anywhere in a nested dict and coerce it to int.
+
+    SMI tools nest the same reading differently across versions -- flat
+    (``{"gfx_activity": 45}``), value-wrapped (``{"gfx_activity": {"value": 45}}``),
+    or under a block (``{"usage": {"gfx_activity": {"value": 45}}}``). Searching by
+    key at any depth reads all three without hard-coding one layout.
+    """
+    if not isinstance(obj, dict):
+        return None
+    for key in keys:
+        if key in obj:
+            found = _coerce_metric(obj[key])
+            if found is not None:
+                return found
+    for val in obj.values():
+        if isinstance(val, dict):
+            found = find_metric(val, keys)
+            if found is not None:
+                return found
+    return None

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -7,7 +7,7 @@ import os
 import re
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -597,7 +597,7 @@ def _server_model_inputs(
     *,
     unified_budget: int | None = None,
     device_count: int = 0,
-) -> tuple[list[ModelPlacementInput], dict[WorkerRole, str], int]:
+) -> tuple[list[ModelPlacementInput], dict[WorkerRole, str], int, dict[WorkerRole, str]]:
     """Build placement inputs for the configured server roles.
 
     The search and vision roles are estimated first; chat is then sized against the
@@ -605,13 +605,15 @@ def _server_model_inputs(
     starve embed/rerank on a shared-memory host. ``device_count`` resolves an auto
     replica knob to one per GPU. When *roles* is given, only those are considered.
     Skips an unconfigured optional role, a vision model with no resolvable mmproj
-    projector, and a role whose model is not installed on disk.
+    projector, and a role whose model is not installed on disk (the last returned as
+    ``skipped_not_installed`` so a surface can say so).
     """
     from lilbee.core.config import cfg
     from lilbee.providers.base import ProviderError, ProviderErrorKind
 
     inputs: dict[WorkerRole, ModelPlacementInput] = {}
     model_refs: dict[WorkerRole, str] = {}
+    skipped_not_installed: dict[WorkerRole, str] = {}
 
     def consider(role: WorkerRole, *, chat_reservation: int = 0) -> None:
         if roles is not None and role not in roles:
@@ -649,6 +651,7 @@ def _server_model_inputs(
             # debugging toward the registry.
             if isinstance(exc, ProviderError) and exc.kind is ProviderErrorKind.NOT_FOUND:
                 log.warning("Skipping %s server: model %r is not installed.", role.value, ref)
+                skipped_not_installed[role] = ref
             else:
                 log.warning(
                     "Skipping %s server: could not size model %r (%s).", role.value, ref, exc
@@ -667,7 +670,7 @@ def _server_model_inputs(
     consider(WorkerRole.CHAT, chat_reservation=reservation)
 
     ordered = [inputs[role] for role in ROLE_REGISTRY if role in inputs]
-    return ordered, model_refs, reservation
+    return ordered, model_refs, reservation, skipped_not_installed
 
 
 def _non_chat_reservation(
@@ -1042,6 +1045,10 @@ class ResolvedPlacement:
     instances: tuple[InstancePlan, ...]
     unplaceable_roles: tuple[WorkerRole, ...]
     model_refs: dict[WorkerRole, str]
+    # Roles configured but skipped because their model isn't installed (role -> ref).
+    # Distinct from unplaceable_roles (installed but won't fit); lets a surface show
+    # "not downloaded" instead of an empty table on a fresh install.
+    skipped_not_installed: dict[WorkerRole, str] = field(default_factory=dict)
 
 
 def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement:
@@ -1054,7 +1061,9 @@ def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement
     apply_cuda_runtime_env()
     devices = _read_device_cache.get(binary)
     unified_budget = _unified_memory_budget(devices)
-    inputs, model_refs, _ = _server_model_inputs(None, unified_budget=unified_budget)
+    inputs, model_refs, _, skipped_not_installed = _server_model_inputs(
+        None, unified_budget=unified_budget
+    )
     resolved = _resolve_placement(
         placement, inputs, model_refs, devices, unified_budget=unified_budget
     )
@@ -1063,6 +1072,7 @@ def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement
         instances=resolved.instances,
         unplaceable_roles=resolved.unplaceable_roles,
         model_refs=model_refs,
+        skipped_not_installed=skipped_not_installed,
     )
 
 
@@ -1076,7 +1086,7 @@ def plan_launches(
     from lilbee.core.config import cfg
 
     unified_budget = _unified_memory_budget(devices)
-    inputs, model_refs, reservation = _server_model_inputs(
+    inputs, model_refs, reservation, _ = _server_model_inputs(
         roles, unified_budget=unified_budget, device_count=len(devices)
     )
     spec = PlacementSpec.from_json(cfg.placement) if cfg.placement else None

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -602,6 +602,7 @@ class FleetProvider:
                 token_cap=launch.token_cap,
                 timeout=_request_timeout_s(launch.weights_bytes),
                 rerank_mode=launch.rerank_mode,
+                inline_reasoning=role is WorkerRole.CHAT,
             )
             for launch in launches
         ]

--- a/src/lilbee/retrieval/reasoning.py
+++ b/src/lilbee/retrieval/reasoning.py
@@ -21,35 +21,20 @@ from __future__ import annotations
 import contextlib
 import re
 from collections.abc import Callable, Generator, Iterator
-from dataclasses import dataclass, field
-from enum import StrEnum
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from lilbee.core.config import cfg
-from lilbee.providers.base import ClosableIterator
+from lilbee.providers.base import THINK_CLOSE_TAG, THINK_OPEN_TAG, ClosableIterator
 
 if TYPE_CHECKING:
     from lilbee.providers.base import LLMProvider
 
-_OPEN_TAG = "<think>"
-_CLOSE_TAG = "</think>"
-_THINK_BLOCK_RE = re.compile(r"<think>[\s\S]*?</think>\s*|<think>[\s\S]*$")
+_THINK_BLOCK_RE = re.compile(
+    rf"{THINK_OPEN_TAG}[\s\S]*?{THINK_CLOSE_TAG}\s*|{THINK_OPEN_TAG}[\s\S]*$"
+)
 _PROGRESS_TICK_CHARS = 256
 """Coarseness of the progress callback: fire when reasoning grows by at least this many chars."""
-
-# OpenAI harmony control tokens (gpt-oss). The stream leaks them as text because
-# the chat server runs with --reasoning-format none (keeps <think> inline); lilbee
-# classifies the channels itself, the same way it parses <think>.
-_HARMONY_OPEN = "<|"
-_HARMONY_CLOSE = "|>"
-_HARMONY_CHANNEL = "<|channel|>"
-_HARMONY_MESSAGE = "<|message|>"
-_HARMONY_START = "<|start|>"
-_HARMONY_END = "<|end|>"
-_HARMONY_RETURN = "<|return|>"
-_HARMONY_CALL = "<|call|>"
-_HARMONY_BODY_ENDERS = frozenset({_HARMONY_START, _HARMONY_END, _HARMONY_RETURN, _HARMONY_CALL})
-_FINAL_CHANNEL = "final"
 
 CAP_CONTINUATION_PROMPT = (
     "Stop thinking now. Give your final answer directly, without any further <think> blocks."
@@ -68,21 +53,6 @@ REASONING_EXHAUSTED_NOTICE = (
 
 Lets a caller tell "the model thought itself to death" apart from a genuine empty
 response, which an empty string alone cannot."""
-
-
-class _HarmonySection(StrEnum):
-    """Which part of a harmony message the parser is currently reading."""
-
-    HEADER = "header"  # role name after <|start|>; not emitted
-    CHANNEL = "channel"  # channel name after <|channel|>; captured, not emitted
-    BODY = "body"  # message text after <|message|>; classified by channel
-
-
-class _Route(StrEnum):
-    """Which stream dialect the dispatcher committed to."""
-
-    HARMONY = "harmony"  # gpt-oss channels
-    TAG = "tag"  # plain text or <think> reasoning
 
 
 @dataclass
@@ -131,9 +101,9 @@ class TagParser:
         return StreamToken(content=self.buf, is_reasoning=False)
 
     def _process_thinking(self) -> StreamToken | None:
-        close_idx = self.buf.find(_CLOSE_TAG)
+        close_idx = self.buf.find(THINK_CLOSE_TAG)
         if close_idx == -1:
-            if _could_be_partial(_CLOSE_TAG, self.buf):
+            if _could_be_partial(THINK_CLOSE_TAG, self.buf):
                 return None
             content = self.buf
             self.reasoning_chars += len(content)
@@ -145,160 +115,24 @@ class TagParser:
             )
         thinking_content = self.buf[:close_idx]
         self.reasoning_chars += len(thinking_content)
-        self.buf = self.buf[close_idx + len(_CLOSE_TAG) :]
+        self.buf = self.buf[close_idx + len(THINK_CLOSE_TAG) :]
         self.in_thinking = False
         if thinking_content and self.show:
             return StreamToken(content=thinking_content, is_reasoning=True)
         return StreamToken(content="", is_reasoning=True)
 
     def _process_normal(self) -> StreamToken | None:
-        open_idx = self.buf.find(_OPEN_TAG)
+        open_idx = self.buf.find(THINK_OPEN_TAG)
         if open_idx == -1:
-            if _could_be_partial(_OPEN_TAG, self.buf):
+            if _could_be_partial(THINK_OPEN_TAG, self.buf):
                 return None
             content = self.buf
             self.buf = ""
             return StreamToken(content=content, is_reasoning=False)
         before = self.buf[:open_idx]
-        self.buf = self.buf[open_idx + len(_OPEN_TAG) :]
+        self.buf = self.buf[open_idx + len(THINK_OPEN_TAG) :]
         self.in_thinking = True
         return StreamToken(content=before, is_reasoning=False)
-
-
-@dataclass
-class HarmonyParser:
-    """Stateful parser for gpt-oss harmony channels.
-
-    Emits the ``final`` channel as answer text and every other channel (analysis,
-    commentary) as reasoning, stripping all ``<|...|>`` control tokens. Mirrors
-    ``TagParser``'s ``feed`` / ``flush`` / ``reasoning_chars`` contract so the same
-    orchestrator and cap logic drive either dialect.
-    """
-
-    show: bool
-    buf: str = ""
-    section: _HarmonySection = _HarmonySection.HEADER
-    channel: str = ""
-    channel_buf: str = ""
-    reasoning_chars: int = 0
-
-    def feed(self, token: str) -> list[StreamToken]:
-        """Feed a token and return any complete StreamTokens."""
-        self.buf += token
-        result: list[StreamToken] = []
-        while self.buf:
-            emitted = self._step()
-            if emitted is None:
-                break
-            if emitted.content:
-                result.append(emitted)
-        return result
-
-    def flush(self) -> StreamToken | None:
-        """Bodies stream fully during feed; only a trailing partial token is left to drop."""
-        self.buf = ""
-        return None
-
-    def _step(self) -> StreamToken | None:
-        open_idx = self.buf.find(_HARMONY_OPEN)
-        if open_idx == -1:
-            return self._emit_plain()
-        if open_idx > 0:
-            text, self.buf = self.buf[:open_idx], self.buf[open_idx:]
-            return self._classify(text)
-        close_idx = self.buf.find(_HARMONY_CLOSE)
-        if close_idx == -1:
-            return None  # incomplete control token; wait for more
-        marker, self.buf = (
-            self.buf[: close_idx + len(_HARMONY_CLOSE)],
-            self.buf[close_idx + len(_HARMONY_CLOSE) :],
-        )
-        self._handle_marker(marker)
-        return StreamToken(content="", is_reasoning=False)
-
-    def _emit_plain(self) -> StreamToken | None:
-        """Consume buffered text with no control token, holding back a lone trailing '<'."""
-        if self.buf == _HARMONY_OPEN[0]:
-            return None  # could be the start of the next control token
-        if self.buf.endswith(_HARMONY_OPEN[0]):
-            text, self.buf = self.buf[:-1], _HARMONY_OPEN[0]
-            return self._classify(text)
-        text, self.buf = self.buf, ""
-        return self._classify(text)
-
-    def _classify(self, text: str) -> StreamToken:
-        """Route body text by channel; capture channel names; drop header text."""
-        if self.section is _HarmonySection.CHANNEL:
-            self.channel_buf += text
-            return StreamToken(content="", is_reasoning=False)
-        if self.section is not _HarmonySection.BODY:
-            return StreamToken(content="", is_reasoning=False)
-        if self.channel == _FINAL_CHANNEL:
-            return StreamToken(content=text, is_reasoning=False)
-        self.reasoning_chars += len(text)
-        return StreamToken(content=text if self.show else "", is_reasoning=True)
-
-    def _handle_marker(self, marker: str) -> None:
-        if marker == _HARMONY_CHANNEL:
-            self.section = _HarmonySection.CHANNEL
-            self.channel_buf = ""
-        elif marker == _HARMONY_MESSAGE:
-            if self.section is _HarmonySection.CHANNEL:
-                self.channel = self.channel_buf.strip()
-            self.section = _HarmonySection.BODY
-        elif marker in _HARMONY_BODY_ENDERS:
-            self.section = _HarmonySection.HEADER
-
-
-@dataclass
-class ReasoningParser:
-    """Routes a chat stream to harmony or ``<think>`` handling by its opening tokens.
-
-    A harmony stream (gpt-oss) opens with a ``<|`` control token; everything else,
-    plain text and ``<think>`` reasoning, is handled by ``TagParser``. The choice is
-    made from the leading bytes and never switches mid-stream.
-    """
-
-    show: bool
-    reasoning_chars: int = 0
-    _inner: TagParser | HarmonyParser | None = field(default=None, repr=False)
-    _probe: str = ""
-
-    def feed(self, token: str) -> list[StreamToken]:
-        if self._inner is None:
-            self._probe += token
-            route = _route_reasoning(self._probe)
-            if route is None:
-                return []  # ambiguous prefix; keep buffering until the dialect is clear
-            self._inner = (
-                HarmonyParser(show=self.show)
-                if route is _Route.HARMONY
-                else TagParser(show=self.show)
-            )
-            token, self._probe = self._probe, ""
-        out = self._inner.feed(token)
-        self.reasoning_chars = self._inner.reasoning_chars
-        return out
-
-    def flush(self) -> StreamToken | None:
-        if self._inner is not None:
-            tail = self._inner.flush()
-            self.reasoning_chars = self._inner.reasoning_chars
-            return tail
-        if self._probe:
-            tail, self._probe = StreamToken(content=self._probe, is_reasoning=False), ""
-            return tail
-        return None
-
-
-def _route_reasoning(probe: str) -> _Route | None:
-    """Pick the stream dialect from its leading bytes; None while still ambiguous."""
-    lead = probe.lstrip()
-    if lead.startswith(_HARMONY_OPEN):
-        return _Route.HARMONY
-    if lead in ("", _HARMONY_OPEN[0]):
-        return None  # could still become a "<|" control token
-    return _Route.TAG
 
 
 def filter_reasoning(
@@ -309,7 +143,7 @@ def filter_reasoning(
     on_cap: Callable[[], None] | None = None,
     on_progress: Callable[[int], None] | None = None,
 ) -> Iterator[StreamToken]:
-    """Classify reasoning tokens (``<think>`` or harmony) and stop past the cap.
+    """Classify ``<think>...</think>`` tokens and stop when reasoning exceeds the cap.
 
     *cap_chars* bounds reasoning content. When exceeded, ``on_cap`` is
     fired (no payload), the upstream iterator is closed, and iteration
@@ -318,7 +152,7 @@ def filter_reasoning(
     the running reasoning-chars count each time it grows by at least 256
     characters. A non-positive *cap_chars* disables the cap.
     """
-    parser = ReasoningParser(show=show)
+    parser = TagParser(show=show)
     last_progress_tick = 0
     try:
         for token in tokens:
@@ -447,21 +281,8 @@ def _close_iterator(tokens: Iterator[Any]) -> None:
 
 
 def strip_reasoning(text: str) -> str:
-    """Reduce a complete (non-streaming) string to its final-answer text.
-
-    Removes ``<think>...</think>`` blocks, and for gpt-oss harmony output keeps
-    only the ``final`` channel, stripping the analysis channel and every
-    ``<|...|>`` control token.
-    """
-    if _HARMONY_OPEN in text:
-        return _final_channel_text(text)
+    """Remove ``<think>...</think>`` blocks from a complete (non-streaming) string."""
     return _THINK_BLOCK_RE.sub("", text)
-
-
-def _final_channel_text(text: str) -> str:
-    """Run harmony *text* through the parser and keep only answer (final) tokens."""
-    parser = HarmonyParser(show=False)
-    return "".join(tok.content for tok in parser.feed(text) if not tok.is_reasoning)
 
 
 def _could_be_partial(tag: str, buf: str) -> bool:

--- a/src/lilbee/retrieval/reasoning.py
+++ b/src/lilbee/retrieval/reasoning.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 import contextlib
 import re
 from collections.abc import Callable, Generator, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from lilbee.core.config import cfg
@@ -35,6 +36,20 @@ _CLOSE_TAG = "</think>"
 _THINK_BLOCK_RE = re.compile(r"<think>[\s\S]*?</think>\s*|<think>[\s\S]*$")
 _PROGRESS_TICK_CHARS = 256
 """Coarseness of the progress callback: fire when reasoning grows by at least this many chars."""
+
+# OpenAI harmony control tokens (gpt-oss). The stream leaks them as text because
+# the chat server runs with --reasoning-format none (keeps <think> inline); lilbee
+# classifies the channels itself, the same way it parses <think>.
+_HARMONY_OPEN = "<|"
+_HARMONY_CLOSE = "|>"
+_HARMONY_CHANNEL = "<|channel|>"
+_HARMONY_MESSAGE = "<|message|>"
+_HARMONY_START = "<|start|>"
+_HARMONY_END = "<|end|>"
+_HARMONY_RETURN = "<|return|>"
+_HARMONY_CALL = "<|call|>"
+_HARMONY_BODY_ENDERS = frozenset({_HARMONY_START, _HARMONY_END, _HARMONY_RETURN, _HARMONY_CALL})
+_FINAL_CHANNEL = "final"
 
 CAP_CONTINUATION_PROMPT = (
     "Stop thinking now. Give your final answer directly, without any further <think> blocks."
@@ -53,6 +68,21 @@ REASONING_EXHAUSTED_NOTICE = (
 
 Lets a caller tell "the model thought itself to death" apart from a genuine empty
 response, which an empty string alone cannot."""
+
+
+class _HarmonySection(StrEnum):
+    """Which part of a harmony message the parser is currently reading."""
+
+    HEADER = "header"  # role name after <|start|>; not emitted
+    CHANNEL = "channel"  # channel name after <|channel|>; captured, not emitted
+    BODY = "body"  # message text after <|message|>; classified by channel
+
+
+class _Route(StrEnum):
+    """Which stream dialect the dispatcher committed to."""
+
+    HARMONY = "harmony"  # gpt-oss channels
+    TAG = "tag"  # plain text or <think> reasoning
 
 
 @dataclass
@@ -135,6 +165,142 @@ class TagParser:
         return StreamToken(content=before, is_reasoning=False)
 
 
+@dataclass
+class HarmonyParser:
+    """Stateful parser for gpt-oss harmony channels.
+
+    Emits the ``final`` channel as answer text and every other channel (analysis,
+    commentary) as reasoning, stripping all ``<|...|>`` control tokens. Mirrors
+    ``TagParser``'s ``feed`` / ``flush`` / ``reasoning_chars`` contract so the same
+    orchestrator and cap logic drive either dialect.
+    """
+
+    show: bool
+    buf: str = ""
+    section: _HarmonySection = _HarmonySection.HEADER
+    channel: str = ""
+    channel_buf: str = ""
+    reasoning_chars: int = 0
+
+    def feed(self, token: str) -> list[StreamToken]:
+        """Feed a token and return any complete StreamTokens."""
+        self.buf += token
+        result: list[StreamToken] = []
+        while self.buf:
+            emitted = self._step()
+            if emitted is None:
+                break
+            if emitted.content:
+                result.append(emitted)
+        return result
+
+    def flush(self) -> StreamToken | None:
+        """Bodies stream fully during feed; only a trailing partial token is left to drop."""
+        self.buf = ""
+        return None
+
+    def _step(self) -> StreamToken | None:
+        open_idx = self.buf.find(_HARMONY_OPEN)
+        if open_idx == -1:
+            return self._emit_plain()
+        if open_idx > 0:
+            text, self.buf = self.buf[:open_idx], self.buf[open_idx:]
+            return self._classify(text)
+        close_idx = self.buf.find(_HARMONY_CLOSE)
+        if close_idx == -1:
+            return None  # incomplete control token; wait for more
+        marker, self.buf = (
+            self.buf[: close_idx + len(_HARMONY_CLOSE)],
+            self.buf[close_idx + len(_HARMONY_CLOSE) :],
+        )
+        self._handle_marker(marker)
+        return StreamToken(content="", is_reasoning=False)
+
+    def _emit_plain(self) -> StreamToken | None:
+        """Consume buffered text with no control token, holding back a lone trailing '<'."""
+        if self.buf == _HARMONY_OPEN[0]:
+            return None  # could be the start of the next control token
+        if self.buf.endswith(_HARMONY_OPEN[0]):
+            text, self.buf = self.buf[:-1], _HARMONY_OPEN[0]
+            return self._classify(text)
+        text, self.buf = self.buf, ""
+        return self._classify(text)
+
+    def _classify(self, text: str) -> StreamToken:
+        """Route body text by channel; capture channel names; drop header text."""
+        if self.section is _HarmonySection.CHANNEL:
+            self.channel_buf += text
+            return StreamToken(content="", is_reasoning=False)
+        if self.section is not _HarmonySection.BODY:
+            return StreamToken(content="", is_reasoning=False)
+        if self.channel == _FINAL_CHANNEL:
+            return StreamToken(content=text, is_reasoning=False)
+        self.reasoning_chars += len(text)
+        return StreamToken(content=text if self.show else "", is_reasoning=True)
+
+    def _handle_marker(self, marker: str) -> None:
+        if marker == _HARMONY_CHANNEL:
+            self.section = _HarmonySection.CHANNEL
+            self.channel_buf = ""
+        elif marker == _HARMONY_MESSAGE:
+            if self.section is _HarmonySection.CHANNEL:
+                self.channel = self.channel_buf.strip()
+            self.section = _HarmonySection.BODY
+        elif marker in _HARMONY_BODY_ENDERS:
+            self.section = _HarmonySection.HEADER
+
+
+@dataclass
+class ReasoningParser:
+    """Routes a chat stream to harmony or ``<think>`` handling by its opening tokens.
+
+    A harmony stream (gpt-oss) opens with a ``<|`` control token; everything else,
+    plain text and ``<think>`` reasoning, is handled by ``TagParser``. The choice is
+    made from the leading bytes and never switches mid-stream.
+    """
+
+    show: bool
+    reasoning_chars: int = 0
+    _inner: TagParser | HarmonyParser | None = field(default=None, repr=False)
+    _probe: str = ""
+
+    def feed(self, token: str) -> list[StreamToken]:
+        if self._inner is None:
+            self._probe += token
+            route = _route_reasoning(self._probe)
+            if route is None:
+                return []  # ambiguous prefix; keep buffering until the dialect is clear
+            self._inner = (
+                HarmonyParser(show=self.show)
+                if route is _Route.HARMONY
+                else TagParser(show=self.show)
+            )
+            token, self._probe = self._probe, ""
+        out = self._inner.feed(token)
+        self.reasoning_chars = self._inner.reasoning_chars
+        return out
+
+    def flush(self) -> StreamToken | None:
+        if self._inner is not None:
+            tail = self._inner.flush()
+            self.reasoning_chars = self._inner.reasoning_chars
+            return tail
+        if self._probe:
+            tail, self._probe = StreamToken(content=self._probe, is_reasoning=False), ""
+            return tail
+        return None
+
+
+def _route_reasoning(probe: str) -> _Route | None:
+    """Pick the stream dialect from its leading bytes; None while still ambiguous."""
+    lead = probe.lstrip()
+    if lead.startswith(_HARMONY_OPEN):
+        return _Route.HARMONY
+    if lead in ("", _HARMONY_OPEN[0]):
+        return None  # could still become a "<|" control token
+    return _Route.TAG
+
+
 def filter_reasoning(
     tokens: Iterator[str],
     *,
@@ -143,7 +309,7 @@ def filter_reasoning(
     on_cap: Callable[[], None] | None = None,
     on_progress: Callable[[int], None] | None = None,
 ) -> Iterator[StreamToken]:
-    """Classify ``<think>...</think>`` tokens and stop when reasoning exceeds the cap.
+    """Classify reasoning tokens (``<think>`` or harmony) and stop past the cap.
 
     *cap_chars* bounds reasoning content. When exceeded, ``on_cap`` is
     fired (no payload), the upstream iterator is closed, and iteration
@@ -152,7 +318,7 @@ def filter_reasoning(
     the running reasoning-chars count each time it grows by at least 256
     characters. A non-positive *cap_chars* disables the cap.
     """
-    parser = TagParser(show=show)
+    parser = ReasoningParser(show=show)
     last_progress_tick = 0
     try:
         for token in tokens:
@@ -281,8 +447,21 @@ def _close_iterator(tokens: Iterator[Any]) -> None:
 
 
 def strip_reasoning(text: str) -> str:
-    """Remove ``<think>...</think>`` blocks from a complete (non-streaming) string."""
+    """Reduce a complete (non-streaming) string to its final-answer text.
+
+    Removes ``<think>...</think>`` blocks, and for gpt-oss harmony output keeps
+    only the ``final`` channel, stripping the analysis channel and every
+    ``<|...|>`` control token.
+    """
+    if _HARMONY_OPEN in text:
+        return _final_channel_text(text)
     return _THINK_BLOCK_RE.sub("", text)
+
+
+def _final_channel_text(text: str) -> str:
+    """Run harmony *text* through the parser and keep only answer (final) tokens."""
+    parser = HarmonyParser(show=False)
+    return "".join(tok.content for tok in parser.feed(text) if not tok.is_reasoning)
 
 
 def _could_be_partial(tag: str, buf: str) -> bool:

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -25,8 +25,8 @@ from lilbee.retrieval.reasoning import (
     CAP_NOTICE_TEMPLATE,
     REASONING_EXHAUSTED_NOTICE,
     CapNotice,
-    ReasoningParser,
     StreamToken,
+    TagParser,
     effective_reasoning_cap,
     stream_chat_with_cap,
     strip_reasoning,
@@ -457,7 +457,7 @@ async def _cap_aware_chat_events(
     show = cfg.show_reasoning
     answered = False
 
-    first_parser = ReasoningParser(show=show)
+    first_parser = TagParser(show=show)
     async for tok in _drive_stream(dispatch_chat_stream(req), first_parser, cap_chars):
         answered = answered or (not tok.is_reasoning and bool(tok.content))
         yield tok
@@ -465,7 +465,7 @@ async def _cap_aware_chat_events(
     if cap_chars > 0 and first_parser.reasoning_chars > cap_chars:
         yield CapNotice(cap_chars=cap_chars)
         nudged = _nudged_request(req)
-        cont_parser = ReasoningParser(show=show)
+        cont_parser = TagParser(show=show)
         async for tok in _drive_stream(dispatch_chat_stream(nudged), cont_parser, cap_chars=0):
             answered = answered or bool(tok.content)
             # Continuation tokens are always treated as final-answer text.
@@ -479,7 +479,7 @@ async def _cap_aware_chat_events(
 
 async def _drive_stream(
     stream: AsyncIterator[Any],
-    parser: ReasoningParser,
+    parser: TagParser,
     cap_chars: int,
 ) -> AsyncIterator[StreamToken]:
     """Feed *stream* through *parser*; yield ``StreamToken``s; stop on cap-fire."""

--- a/src/lilbee/server/handlers/rag.py
+++ b/src/lilbee/server/handlers/rag.py
@@ -25,8 +25,8 @@ from lilbee.retrieval.reasoning import (
     CAP_NOTICE_TEMPLATE,
     REASONING_EXHAUSTED_NOTICE,
     CapNotice,
+    ReasoningParser,
     StreamToken,
-    TagParser,
     effective_reasoning_cap,
     stream_chat_with_cap,
     strip_reasoning,
@@ -457,7 +457,7 @@ async def _cap_aware_chat_events(
     show = cfg.show_reasoning
     answered = False
 
-    first_parser = TagParser(show=show)
+    first_parser = ReasoningParser(show=show)
     async for tok in _drive_stream(dispatch_chat_stream(req), first_parser, cap_chars):
         answered = answered or (not tok.is_reasoning and bool(tok.content))
         yield tok
@@ -465,7 +465,7 @@ async def _cap_aware_chat_events(
     if cap_chars > 0 and first_parser.reasoning_chars > cap_chars:
         yield CapNotice(cap_chars=cap_chars)
         nudged = _nudged_request(req)
-        cont_parser = TagParser(show=show)
+        cont_parser = ReasoningParser(show=show)
         async for tok in _drive_stream(dispatch_chat_stream(nudged), cont_parser, cap_chars=0):
             answered = answered or bool(tok.content)
             # Continuation tokens are always treated as final-answer text.
@@ -479,7 +479,7 @@ async def _cap_aware_chat_events(
 
 async def _drive_stream(
     stream: AsyncIterator[Any],
-    parser: TagParser,
+    parser: ReasoningParser,
     cap_chars: int,
 ) -> AsyncIterator[StreamToken]:
     """Feed *stream* through *parser*; yield ``StreamToken``s; stop on cap-fire."""

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -598,6 +598,13 @@ class RolePlacementResponse(BaseModel):
     replicas: int
 
 
+class SkippedRoleResponse(BaseModel):
+    """A configured role left unplaced because its model isn't downloaded."""
+
+    role: WorkerRole
+    model: str
+
+
 class PlacementResponse(BaseModel):
     """Response for placement read, preview, set, and clear routes."""
 
@@ -606,6 +613,7 @@ class PlacementResponse(BaseModel):
     unplaceable: list[str]
     manual: bool
     spec_json: str | None
+    skipped_not_installed: list[SkippedRoleResponse] = []
 
     @classmethod
     def from_view(cls, view: PlacementView) -> PlacementResponse:
@@ -625,6 +633,9 @@ class PlacementResponse(BaseModel):
             unplaceable=[r.value for r in view.unplaceable],
             manual=view.manual,
             spec_json=view.spec_json,
+            skipped_not_installed=[
+                SkippedRoleResponse(role=s.role, model=s.model) for s in view.skipped_not_installed
+            ],
         )
 
 

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -22,6 +22,89 @@ def _resolved():
     )
 
 
+def _resolved_with_skipped():
+    from lilbee.providers.fleet.planning import ResolvedPlacement
+
+    return ResolvedPlacement(
+        devices=(FleetDevice("CUDA", 0, "NVIDIA A100", 80 * GIB, 72 * GIB),),
+        instances=(InstancePlan(role=WorkerRole.EMBED, devices=(0,), tensor_split=None),),
+        unplaceable_roles=(),
+        model_refs={WorkerRole.EMBED: "org/embed.gguf"},
+        skipped_not_installed={WorkerRole.CHAT: "org/Qwen3-4B.gguf"},
+    )
+
+
+def test_view_surfaces_skipped_not_installed(monkeypatch):
+    from lilbee.app.placement import SkippedRole
+
+    monkeypatch.setattr(
+        app_placement, "resolve_placement_plan", lambda spec: _resolved_with_skipped()
+    )
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    view = app_placement.get_placement()
+    assert view.skipped_not_installed == (
+        SkippedRole(role=WorkerRole.CHAT, model="org/Qwen3-4B.gguf"),
+    )
+    # The skipped role is absent from the placed roles (that is the bug it explains).
+    assert all(r.role is not WorkerRole.CHAT for r in view.roles)
+
+
+def test_view_has_no_skipped_when_all_installed(monkeypatch):
+    monkeypatch.setattr(app_placement, "resolve_placement_plan", lambda spec: _resolved())
+    monkeypatch.setattr(app_placement, "_active_spec", lambda: None)
+    assert app_placement.get_placement().skipped_not_installed == ()
+
+
+def _provider_with(role_ready, warm_phase):
+    import unittest.mock as m
+
+    from lilbee.providers.warm_progress import WarmProgress
+
+    provider = m.MagicMock()
+    provider.role_ready.return_value = role_ready
+    provider.warm_progress.return_value = (
+        WarmProgress(phase=warm_phase) if warm_phase is not None else None
+    )
+    services = m.MagicMock()
+    services.provider = provider
+    return services
+
+
+def test_warm_progress_none_without_services(monkeypatch):
+    monkeypatch.setattr(app_placement, "peek_services", lambda: None)
+    assert app_placement.active_chat_warm_progress() is None
+
+
+def test_warm_progress_none_when_role_ready(monkeypatch):
+    monkeypatch.setattr(app_placement, "peek_services", lambda: _provider_with(True, None))
+    assert app_placement.active_chat_warm_progress() is None
+
+
+def test_warm_progress_returns_snapshot_during_active_phase(monkeypatch):
+    from lilbee.providers.warm_progress import WarmPhase
+
+    monkeypatch.setattr(
+        app_placement, "peek_services", lambda: _provider_with(False, WarmPhase.READING_WEIGHTS)
+    )
+    snapshot = app_placement.active_chat_warm_progress()
+    assert snapshot is not None
+    assert snapshot.phase is WarmPhase.READING_WEIGHTS
+
+
+def test_warm_progress_none_when_not_warming(monkeypatch):
+    monkeypatch.setattr(app_placement, "peek_services", lambda: _provider_with(False, None))
+    assert app_placement.active_chat_warm_progress() is None
+
+
+def test_warm_progress_none_on_warm_error(monkeypatch):
+    from lilbee.providers.warm_progress import WarmPhase
+
+    monkeypatch.setattr(
+        app_placement, "peek_services", lambda: _provider_with(False, WarmPhase.ERROR)
+    )
+    assert app_placement.active_chat_warm_progress() is None
+
+
 def test_active_spec_reads_cfg(monkeypatch):
     monkeypatch.setattr(app_placement.cfg, "placement", None)
     assert app_placement._active_spec() is None

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -36,6 +36,38 @@ def test_show_renders_cards(monkeypatch: object) -> None:
     assert "chat" in result.stdout
 
 
+def _view_with_skipped() -> PlacementView:
+    from lilbee.app.placement import SkippedRole
+
+    return PlacementView(
+        gpus=(GpuInfo(0, "MTL", "MTL0", "Apple M3", 24 * _GIB, 20 * _GIB),),
+        roles=(RolePlacementView(WorkerRole.EMBED, "org/embed.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=False,
+        spec_json=None,
+        skipped_not_installed=(SkippedRole(WorkerRole.CHAT, "org/Qwen3-4B.gguf"),),
+    )
+
+
+def test_show_renders_not_downloaded_note(monkeypatch: object) -> None:
+    """A role skipped for a missing model prints a 'not downloaded' line."""
+    monkeypatch.setattr(cli_placement, "get_placement", _view_with_skipped)
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 0
+    assert "chat" in result.stdout
+    assert "not downloaded" in result.stdout
+
+
+def test_show_json_includes_skipped_not_installed(monkeypatch: object) -> None:
+    """The canonical JSON surfaces skipped-not-installed roles for HTTP/MCP/CLI parity."""
+    monkeypatch.setattr(cli_placement, "get_placement", _view_with_skipped)
+    monkeypatch.setattr(cfg, "json_mode", True)
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["skipped_not_installed"] == [{"role": "chat", "model": "org/Qwen3-4B.gguf"}]
+
+
 def test_show_json_mode_emits_valid_json(monkeypatch: object) -> None:
     """--json (global flag -> cfg.json_mode) makes placement emit machine-readable
     JSON instead of a Rich table, so scripts can consume it."""

--- a/tests/providers/fleet/gpu_backends/test_amd.py
+++ b/tests/providers/fleet/gpu_backends/test_amd.py
@@ -22,6 +22,16 @@ _AMD_SMI_JSON_NESTED = (
     '[{"gpu": 0, "gfx_activity": {"value": 72, "unit": "%"}, "temperature": {"edge": 61}}]'
 )
 
+# Real amd-smi 6.x `metric --usage --temperature --json`: readings live under
+# per-category blocks, so the util key is not at the item top level at all.
+_AMD_SMI_JSON_USAGE_BLOCK = (
+    '[{"gpu": 0,'
+    ' "usage": {"gfx_activity": {"value": 45, "unit": "%"},'
+    ' "umc_activity": {"value": 30, "unit": "%"}},'
+    ' "temperature": {"edge": {"value": 61, "unit": "C"},'
+    ' "hotspot": {"value": 68, "unit": "C"}}}]'
+)
+
 _ROCM_SMI_JSON = (
     '{"card0": {"GPU use (%)": "35", "Temperature (Sensor edge) (C)": "52"},'
     ' "card1": {"GPU use (%)": "80", "Temperature (Sensor edge) (C)": "67"}}'
@@ -70,6 +80,13 @@ def test_parse_amd_smi_gpu_dict_wrapper() -> None:
     raw = '{"gpu": [{"gpu": 0, "gfx_activity": 55, "temperature_c": 40}]}'
     result = _parse_amd_smi(raw, frozenset({0}))
     assert result[0].utilization_pct == 55
+
+
+def test_parse_amd_smi_usage_block_real_format() -> None:
+    """Real amd-smi 6.x nests util/temp under category blocks; both must be read."""
+    result = _parse_amd_smi(_AMD_SMI_JSON_USAGE_BLOCK, frozenset({0}))
+    assert result[0].utilization_pct == 45
+    assert result[0].temperature_c == 61
 
 
 def test_parse_amd_smi_vram_sentinel() -> None:

--- a/tests/providers/fleet/gpu_backends/test_apple.py
+++ b/tests/providers/fleet/gpu_backends/test_apple.py
@@ -53,6 +53,22 @@ def test_sample_empty_when_ioreg_absent(monkeypatch: pytest.MonkeyPatch) -> None
     assert AppleBackend().sample(_INDICES) == {}
 
 
+def test_ioreg_command_roots_at_gpu_accelerator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The probe must root at the GPU accelerator, not a depth-capped key match.
+
+    Regression: '-d 1 -k PerformanceStatistics' never reaches the GPU node and read
+    0% under load; the query must class-match IOAccelerator so utilization is live.
+    """
+    seen: dict[str, list[str]] = {}
+    monkeypatch.setattr(
+        apple_mod, "run_smi", lambda tool, args, timeout: seen.update(tool=tool, args=args) or ""
+    )
+    apple_mod._ioreg_output()
+    assert seen["tool"] == "ioreg"
+    assert "-c" in seen["args"]
+    assert "IOAccelerator" in seen["args"]
+
+
 def test_backend_key_is_mtl() -> None:
     assert BACKEND_KEY == "MTL"
 

--- a/tests/providers/fleet/gpu_backends/test_base.py
+++ b/tests/providers/fleet/gpu_backends/test_base.py
@@ -7,7 +7,12 @@ import subprocess
 import pytest
 
 from lilbee.providers.fleet.gpu_backends import base as base_mod
-from lilbee.providers.fleet.gpu_backends.base import extract_int, parse_device_index, run_smi
+from lilbee.providers.fleet.gpu_backends.base import (
+    extract_int,
+    find_metric,
+    parse_device_index,
+    run_smi,
+)
 
 # ---------------------------------------------------------------------------
 # extract_int
@@ -133,3 +138,54 @@ def test_run_smi_falls_back_to_tool_name_when_which_fails(monkeypatch: pytest.Mo
     monkeypatch.setattr(base_mod.subprocess, "run", _fake_run)
     run_smi("my-tool", ["--flag"])
     assert called_with[0][0] == "my-tool"
+
+
+# ---------------------------------------------------------------------------
+# find_metric -- reads a key at any nesting depth, across value shapes
+# ---------------------------------------------------------------------------
+
+
+def test_find_metric_flat_value() -> None:
+    assert find_metric({"gfx_activity": 45}, ("gfx_activity",)) == 45
+
+
+def test_find_metric_value_wrapped() -> None:
+    assert find_metric({"gfx_activity": {"value": 45, "unit": "%"}}, ("gfx_activity",)) == 45
+
+
+def test_find_metric_under_block() -> None:
+    obj = {"usage": {"gfx_activity": {"value": 45}}}
+    assert find_metric(obj, ("gfx_activity",)) == 45
+
+
+def test_find_metric_decimal_string() -> None:
+    assert find_metric({"temp": "61.0"}, ("temp",)) == 61
+
+
+def test_find_metric_first_key_wins() -> None:
+    assert find_metric({"b": 2, "a": 1}, ("a", "b")) == 1
+
+
+def test_find_metric_ignores_bool() -> None:
+    # A bool must not be read as 0/1 utilization.
+    assert (
+        find_metric({"gfx_activity": True, "gpu_activity": 33}, ("gfx_activity", "gpu_activity"))
+        == 33
+    )
+
+
+def test_find_metric_missing_returns_none() -> None:
+    assert find_metric({"other": 9}, ("gfx_activity",)) is None
+
+
+def test_find_metric_non_dict_returns_none() -> None:
+    assert find_metric([1, 2, 3], ("x",)) is None
+
+
+def test_find_metric_unparseable_string_returns_none() -> None:
+    assert find_metric({"x": "n/a"}, ("x",)) is None
+
+
+def test_find_metric_non_scalar_value_returns_none() -> None:
+    # A list value can't be coerced and isn't a dict to recurse into.
+    assert find_metric({"gfx_activity": [1, 2, 3]}, ("gfx_activity",)) is None

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -60,7 +60,7 @@ def test_resolve_placement_plan_uses_read_cache(monkeypatch):
     monkeypatch.setattr(cuda_runtime, "apply_cuda_runtime_env", lambda: None)
     monkeypatch.setattr(planning, "resolve_devices", counting)
     monkeypatch.setattr(
-        planning, "_server_model_inputs", lambda roles, *, unified_budget=None: ([], {}, 0)
+        planning, "_server_model_inputs", lambda roles, *, unified_budget=None: ([], {}, 0, {})
     )
     monkeypatch.setattr(
         planning,
@@ -91,7 +91,7 @@ def test_spec_branch_calls_placement_from_spec(monkeypatch):
     monkeypatch.setattr(
         planning,
         "_server_model_inputs",
-        lambda roles, *, unified_budget=None: ([], {WorkerRole.CHAT: "ref"}, 0),
+        lambda roles, *, unified_budget=None: ([], {WorkerRole.CHAT: "ref"}, 0, {}),
     )
     monkeypatch.setattr(planning, "_peak_estimator", lambda refs: lambda role, ratio: (GIB,))
     spec = PlacementSpec({WorkerRole.CHAT: RolePlacement(devices=(0,))})

--- a/tests/test_chat_input_wrap.py
+++ b/tests/test_chat_input_wrap.py
@@ -1,0 +1,79 @@
+"""ChatInput grows to show a wrapped prompt, not just on a literal newline."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from textual.app import ComposeResult
+
+from conftest import TEST_EMBED_REF, TEST_LOCAL_REF
+from lilbee.cli.tui.widgets.chat_input import ChatInput
+from lilbee.core.config import cfg
+from tests._lilbee_app_test_host import LilbeeAppHost
+
+_LONG_PROMPT = (
+    "What is the full pre-trip checklist for towing a 3,500 pound boat trailer "
+    "on the highway for several hours, covering tires, brakes, bearings, and the coupler?"
+)
+
+
+class _ChatHost(LilbeeAppHost):
+    """Mounts a real ChatScreen so chat.tcss height rules apply."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        from lilbee.cli.tui.widgets.task_bar_controller import TaskBarController
+
+        self.task_bar = TaskBarController(self)
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    def on_mount(self) -> None:
+        from lilbee.cli.tui.screens.chat import ChatScreen
+
+        self.push_screen(ChatScreen())
+
+
+@pytest.fixture(autouse=True)
+def _chat_ready_env():
+    cfg.chat_model = TEST_LOCAL_REF
+    cfg.embedding_model = TEST_EMBED_REF
+    cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
+    with (
+        mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=True),
+    ):
+        yield
+
+
+async def test_short_prompt_stays_single_row():
+    app = _ChatHost()
+    async with app.run_test(size=(80, 40)) as pilot:
+        await pilot.pause()
+        chat_input = app.screen.query_one("#chat-input", ChatInput)
+        chat_input.value = "hi"
+        await pilot.pause()
+        assert not chat_input.has_class("-multiline")
+
+
+async def test_long_prompt_wraps_and_grows_the_box():
+    app = _ChatHost()
+    async with app.run_test(size=(56, 40)) as pilot:
+        await pilot.pause()
+        chat_input = app.screen.query_one("#chat-input", ChatInput)
+        chat_input.value = _LONG_PROMPT
+        await pilot.pause()
+        assert chat_input.has_class("-multiline")
+        assert chat_input.size.height > 3
+
+
+async def test_literal_newline_still_grows():
+    app = _ChatHost()
+    async with app.run_test(size=(80, 40)) as pilot:
+        await pilot.pause()
+        chat_input = app.screen.query_one("#chat-input", ChatInput)
+        chat_input.value = "line one\nline two"
+        await pilot.pause()
+        assert chat_input.has_class("-multiline")

--- a/tests/test_chat_input_wrap.py
+++ b/tests/test_chat_input_wrap.py
@@ -69,6 +69,22 @@ async def test_long_prompt_wraps_and_grows_the_box():
         assert chat_input.size.height > 3
 
 
+async def test_grows_when_terminal_narrows_after_typing():
+    app = _ChatHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        chat_input = app.screen.query_one("#chat-input", ChatInput)
+        # Fits one row at 120 cols, so it starts single-row.
+        chat_input.value = "a prompt that comfortably fits on a single row at a wide terminal width"
+        await pilot.pause()
+        assert not chat_input.has_class("-multiline")
+        # Narrowing the terminal wraps it; the box must grow, not clip.
+        await pilot.resize_terminal(48, 40)
+        await pilot.pause()
+        await pilot.pause()
+        assert chat_input.has_class("-multiline")
+
+
 async def test_literal_newline_still_grows():
     app = _ChatHost()
     async with app.run_test(size=(80, 40)) as pilot:

--- a/tests/test_chat_startup_gating.py
+++ b/tests/test_chat_startup_gating.py
@@ -1,0 +1,93 @@
+"""The chat input is held until the model warms, not errored into a bubble."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from textual.app import ComposeResult
+
+from conftest import TEST_EMBED_REF, TEST_LOCAL_REF, make_mock_services
+from lilbee.app.services import set_services
+from lilbee.cli.tui import messages as msg
+from lilbee.cli.tui.widgets.chat_input import ChatInput
+from lilbee.core.config import cfg
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+from tests._lilbee_app_test_host import LilbeeAppHost
+
+
+class _ChatHost(LilbeeAppHost):
+    def __init__(self) -> None:
+        super().__init__()
+        from lilbee.cli.tui.widgets.task_bar_controller import TaskBarController
+
+        self.task_bar = TaskBarController(self)
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    def on_mount(self) -> None:
+        from lilbee.cli.tui.screens.chat import ChatScreen
+
+        self.push_screen(ChatScreen())
+
+
+@pytest.fixture
+def _warming_services():
+    """Mock services whose chat role is mid-warm (not ready)."""
+    cfg.chat_model = TEST_LOCAL_REF
+    cfg.embedding_model = TEST_EMBED_REF
+    cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
+    services = make_mock_services()
+    services.provider.role_ready.return_value = False
+    services.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.READING_WEIGHTS)
+    set_services(services)
+    with (
+        mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=True),
+    ):
+        yield services
+
+
+async def test_input_locked_and_submit_held_while_warming(_warming_services):
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert screen.chat_warming is True
+        assert screen._chat_input.disabled is True
+        with (
+            mock.patch.object(screen, "notify") as notify,
+            mock.patch.object(screen, "_send_message") as send,
+        ):
+            rejected = screen._reject_submit_when_busy()
+        assert rejected is True
+        send.assert_not_called()
+        assert notify.call_args[0][0] == msg.CHAT_WARMING
+
+
+async def test_ready_transition_unlocks_input(_warming_services):
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert screen._chat_input.disabled is True
+        # The model finishes warming and can serve.
+        _warming_services.provider.role_ready.return_value = True
+        screen._poll_chat_warming()
+        await pilot.pause()
+        assert screen.chat_warming is False
+        assert screen._chat_input.disabled is False
+
+
+async def test_not_installed_model_does_not_trap_input(_warming_services):
+    # No warm in flight (model not installed): input must stay usable, not locked.
+    _warming_services.provider.role_ready.return_value = False
+    _warming_services.provider.warm_progress.return_value = None
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert screen.chat_warming is False
+        assert screen._chat_input.disabled is False
+        assert app.screen.query_one("#chat-input", ChatInput) is screen._chat_input

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4117,7 +4117,8 @@ class TestSelfCheckHelpers:
         swap.endpoint.return_value = "http://127.0.0.1:5800"
         monkeypatch.setattr("lilbee.providers.fleet.swap_manager.SwapManager", lambda _d, _g: swap)
         monkeypatch.setattr(
-            "lilbee.providers.fleet.client.LlamaServerClient", lambda _endpoint, _model: client
+            "lilbee.providers.fleet.client.LlamaServerClient",
+            lambda _endpoint, _model, **_kw: client,
         )
 
     def test_self_check_chat_runs_completion(self, monkeypatch, tmp_path: Path) -> None:
@@ -4191,7 +4192,7 @@ class TestSelfCheckHelpers:
         seen: dict[str, str] = {}
         monkeypatch.setattr(
             "lilbee.providers.fleet.client.LlamaServerClient",
-            lambda _endpoint, model: seen.update(model=model) or mock.MagicMock(),
+            lambda _endpoint, model, **_kw: seen.update(model=model) or mock.MagicMock(),
         )
         setup._self_check_server(WorkerRole.CHAT, tmp_path / "chat.gguf")
         assert seen["model"] == "chat-0"

--- a/tests/test_dynamic_settings_eviction.py
+++ b/tests/test_dynamic_settings_eviction.py
@@ -36,6 +36,14 @@ class _RecordingProvider:
     def drop_loaded_models_async(self) -> None:
         self.dropped += 1
 
+    def role_ready(self, role: object) -> bool:
+        # The bottom TaskBar polls chat readiness on every screen; report ready so
+        # this settings-eviction host isn't treated as mid-warm.
+        return True
+
+    def warm_progress(self) -> None:
+        return None
+
 
 @pytest.fixture(autouse=True)
 def _isolated_cfg(tmp_path):

--- a/tests/test_fleet_adapters.py
+++ b/tests/test_fleet_adapters.py
@@ -197,17 +197,16 @@ def test_chat_server_spec_enables_jinja() -> None:
     assert "--jinja" in ROLE_SPECS[WorkerRole.CHAT].extra_args
 
 
-def test_chat_server_spec_keeps_reasoning_inline() -> None:
+def test_chat_server_spec_extracts_reasoning_server_side() -> None:
     from lilbee.providers.fleet.adapters import ROLE_SPECS
     from lilbee.providers.roles import WorkerRole
 
-    # Recent llama-server defaults to EXTRACTING reasoning into a separate
-    # reasoning_content field, which strips <think>...</think> out of content
-    # and leaves lilbee's <think>-based parser nothing to surface. Forcing
-    # --reasoning-format none keeps the tags inline so reasoning streams through.
+    # The server parses every model's native reasoning dialect (<think>, gpt-oss
+    # harmony) into reasoning_content; 'none' would leak raw dialect tokens into
+    # answers. The chat client re-inlines the extracted reasoning as <think>.
     extra_args = ROLE_SPECS[WorkerRole.CHAT].extra_args
     idx = extra_args.index("--reasoning-format")
-    assert extra_args[idx + 1] == "none"
+    assert extra_args[idx + 1] == "deepseek"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -14,7 +14,8 @@ from lilbee.providers.fleet.client import (
     LlamaServerClient,
     _first_token_top_logprobs,
     _llm_rerank_score,
-    _parse_sse_delta,
+    _parse_sse_deltas,
+    _ThinkInliner,
 )
 from lilbee.providers.roles import RerankMode
 
@@ -1042,21 +1043,26 @@ def test_close_leaves_injected_client_open() -> None:
     assert not http.is_closed
 
 
-class TestParseSseDelta:
+class TestParseSseDeltas:
     def test_non_data_line_is_empty(self) -> None:
-        assert _parse_sse_delta("event: message") == ""
+        assert _parse_sse_deltas("event: message") == ("", "")
 
     def test_done_sentinel_is_empty(self) -> None:
-        assert _parse_sse_delta("data: [DONE]") == ""
+        assert _parse_sse_deltas("data: [DONE]") == ("", "")
 
     def test_invalid_json_is_empty(self) -> None:
-        assert _parse_sse_delta("data: {not json") == ""
+        assert _parse_sse_deltas("data: {not json") == ("", "")
 
     def test_no_choices_is_empty(self) -> None:
-        assert _parse_sse_delta('data: {"choices": []}') == ""
+        assert _parse_sse_deltas('data: {"choices": []}') == ("", "")
 
     def test_extracts_content(self) -> None:
-        assert _parse_sse_delta('data: {"choices":[{"delta":{"content":"hi"}}]}') == "hi"
+        line = 'data: {"choices":[{"delta":{"content":"hi"}}]}'
+        assert _parse_sse_deltas(line) == ("", "hi")
+
+    def test_extracts_reasoning(self) -> None:
+        line = 'data: {"choices":[{"delta":{"reasoning_content":"hmm"}}]}'
+        assert _parse_sse_deltas(line) == ("hmm", "")
 
 
 def _tools() -> list[dict]:
@@ -1531,13 +1537,13 @@ def test_coerce_finish_reason_non_string_is_stop() -> None:
 def test_parse_sse_stream_items_skips_malformed_json() -> None:
     from lilbee.providers.fleet.client import _parse_sse_stream_items
 
-    assert list(_parse_sse_stream_items("data: {not json")) == []
+    assert list(_parse_sse_stream_items("data: {not json", _ThinkInliner(enabled=True))) == []
 
 
 def test_parse_sse_stream_items_skips_empty_choices() -> None:
     from lilbee.providers.fleet.client import _parse_sse_stream_items
 
-    assert list(_parse_sse_stream_items('data: {"choices": []}')) == []
+    assert list(_parse_sse_stream_items('data: {"choices": []}', _ThinkInliner(enabled=True))) == []
 
 
 def test_parse_sse_stream_items_emits_finish_frame_on_length() -> None:
@@ -1545,7 +1551,7 @@ def test_parse_sse_stream_items_emits_finish_frame_on_length() -> None:
     from lilbee.providers.fleet.client import _parse_sse_stream_items
 
     line = 'data: {"choices": [{"delta": {"content": "x"}, "finish_reason": "length"}]}'
-    items = list(_parse_sse_stream_items(line))
+    items = list(_parse_sse_stream_items(line, _ThinkInliner(enabled=True)))
     assert items == ["x", StreamFinish(reason=FinishReason.LENGTH)]
 
 
@@ -1554,7 +1560,7 @@ def test_parse_sse_stream_items_no_finish_frame_without_reason() -> None:
     from lilbee.providers.fleet.client import _parse_sse_stream_items
 
     line = 'data: {"choices": [{"delta": {"content": "x"}, "finish_reason": null}]}'
-    items = list(_parse_sse_stream_items(line))
+    items = list(_parse_sse_stream_items(line, _ThinkInliner(enabled=True)))
     assert not any(isinstance(i, StreamFinish) for i in items)
 
 
@@ -1692,3 +1698,108 @@ def test_chat_forwards_per_request_timeout() -> None:
 
     _client(handler).chat([{"role": "user", "content": "hi"}], timeout=7.5)
     assert seen["timeout"] == {"connect": 7.5, "read": 7.5, "write": 7.5, "pool": 7.5}
+
+
+class TestThinkInliner:
+    def test_wraps_reasoning_then_content(self) -> None:
+        inliner = _ThinkInliner(enabled=True)
+        out = (
+            inliner.feed("step one", "")
+            + inliner.feed(" step two", "")
+            + inliner.feed("", "answer")
+        )
+        out += inliner.finish()
+        assert out == "<think>step one step two</think>answer"
+
+    def test_mixed_delta_carries_both(self) -> None:
+        inliner = _ThinkInliner(enabled=True)
+        assert inliner.feed("thought", "answer") == "<think>thought</think>answer"
+
+    def test_unterminated_reasoning_closed_at_finish(self) -> None:
+        inliner = _ThinkInliner(enabled=True)
+        out = inliner.feed("endless thought", "") + inliner.finish()
+        assert out == "<think>endless thought</think>"
+
+    def test_disabled_drops_reasoning_and_passes_content(self) -> None:
+        inliner = _ThinkInliner(enabled=False)
+        assert inliner.feed("secret reasoning", "ocr text") == "ocr text"
+        assert inliner.finish() == ""
+
+    def test_no_reasoning_passthrough(self) -> None:
+        inliner = _ThinkInliner(enabled=True)
+        assert inliner.feed("", "plain") == "plain"
+        assert inliner.finish() == ""
+
+
+def _reasoning_handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "choices": [
+                {
+                    "message": {
+                        "content": "The answer.",
+                        "reasoning_content": "Let me think.",
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        },
+    )
+
+
+def test_chat_result_inlines_reasoning_for_chat_clients() -> None:
+    http = httpx.Client(transport=httpx.MockTransport(_reasoning_handler), base_url="http://gpu0")
+    c = LlamaServerClient("http://gpu0", "m", http=http, inline_reasoning=True)
+    result = c.chat_result([{"role": "user", "content": "q"}])
+    assert result.text == "<think>Let me think.</think>The answer."
+
+
+def test_chat_result_drops_reasoning_when_disabled() -> None:
+    http = httpx.Client(transport=httpx.MockTransport(_reasoning_handler), base_url="http://gpu0")
+    c = LlamaServerClient("http://gpu0", "m", http=http)
+    assert c.chat_result([{"role": "user", "content": "q"}]).text == "The answer."
+
+
+def _reasoning_sse_handler(request: httpx.Request) -> httpx.Response:
+    lines = (
+        'data: {"choices":[{"delta":{"reasoning_content":"hmm "}}]}\n\n'
+        'data: {"choices":[{"delta":{"reasoning_content":"ok"}}]}\n\n'
+        'data: {"choices":[{"delta":{"content":"4"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+    return httpx.Response(200, content=lines.encode())
+
+
+def test_chat_stream_inlines_reasoning_deltas() -> None:
+    http = httpx.Client(
+        transport=httpx.MockTransport(_reasoning_sse_handler), base_url="http://gpu0"
+    )
+    c = LlamaServerClient("http://gpu0", "m", http=http, inline_reasoning=True)
+    text = "".join(c.chat([{"role": "user", "content": "2+2?"}], stream=True))
+    assert text == "<think>hmm ok</think>4"
+
+
+def _unterminated_reasoning_sse_handler(request: httpx.Request) -> httpx.Response:
+    # Reasoning streams but the answer never starts (e.g. token budget exhausted).
+    lines = 'data: {"choices":[{"delta":{"reasoning_content":"endless"}}]}\n\ndata: [DONE]\n\n'
+    return httpx.Response(200, content=lines.encode())
+
+
+def test_chat_stream_closes_unterminated_reasoning() -> None:
+    http = httpx.Client(
+        transport=httpx.MockTransport(_unterminated_reasoning_sse_handler), base_url="http://gpu0"
+    )
+    c = LlamaServerClient("http://gpu0", "m", http=http, inline_reasoning=True)
+    text = "".join(c.chat([{"role": "user", "content": "q"}], stream=True))
+    assert text == "<think>endless</think>"
+
+
+def test_chat_stream_items_closes_unterminated_reasoning() -> None:
+    http = httpx.Client(
+        transport=httpx.MockTransport(_unterminated_reasoning_sse_handler), base_url="http://gpu0"
+    )
+    c = LlamaServerClient("http://gpu0", "m", http=http, inline_reasoning=True)
+    items = list(c.chat_stream_items([{"role": "user", "content": "q"}]))
+    text = "".join(i for i in items if isinstance(i, str))
+    assert text == "<think>endless</think>"

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -1002,6 +1002,39 @@ def test_close_closes_owned_client() -> None:
     assert c._http.is_closed
 
 
+def test_loopback_ssl_context_is_shared_and_unverified() -> None:
+    """Loopback clients reuse one minimal SSL context instead of rebuilding the
+    default (CA-loading) one on every reload."""
+    import ssl
+
+    from lilbee.providers.fleet.client import _LOOPBACK_SSL_CONTEXT
+
+    assert _LOOPBACK_SSL_CONTEXT.verify_mode == ssl.CERT_NONE
+    assert _LOOPBACK_SSL_CONTEXT.check_hostname is False
+
+
+def test_owned_client_uses_shared_context_not_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Creating a client must reuse the shared context and never call the expensive
+    create_default_context on the reload path."""
+    import lilbee.providers.fleet.client as client_mod
+
+    captured: dict[str, object] = {}
+    real_client = httpx.Client
+
+    def _spy_client(**kwargs: object) -> httpx.Client:
+        captured.update(kwargs)
+        return real_client(transport=httpx.MockTransport(_handler))
+
+    monkeypatch.setattr(client_mod.httpx, "Client", _spy_client)
+    monkeypatch.setattr(client_mod.ssl, "create_default_context", _boom_create_default_context)
+    LlamaServerClient("http://gpu0", "m")
+    assert captured["verify"] is client_mod._LOOPBACK_SSL_CONTEXT
+
+
+def _boom_create_default_context(*_a: object, **_k: object) -> object:
+    raise AssertionError("create_default_context must not be called on the reload path")
+
+
 def test_close_leaves_injected_client_open() -> None:
     http = httpx.Client(transport=httpx.MockTransport(_handler))
     c = LlamaServerClient("http://gpu0", "m", http=http)

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -368,7 +368,7 @@ def test_server_model_inputs_filters_to_requested_roles(monkeypatch) -> None:
     monkeypatch.setattr(cfg, "chat_model", "org/repo/chat.gguf")
     monkeypatch.setattr(cfg, "embedding_model", "org/repo/embed.gguf")
     # Only EMBED requested -> chat is filtered out even though it is configured.
-    _inputs, refs, _res = planning_mod._server_model_inputs((WorkerRole.EMBED,))
+    _inputs, refs, _res, _skipped = planning_mod._server_model_inputs((WorkerRole.EMBED,))
     assert set(refs) == {WorkerRole.EMBED}
 
 
@@ -388,7 +388,9 @@ def test_server_model_inputs_reserves_search_before_chat_on_shared_host(monkeypa
         return ModelPlacementInput(role, sizes.get(role, 10 * _GB))
 
     monkeypatch.setattr(planning_mod, "_estimate_role", _estimate)
-    _inputs, _refs, reservation = planning_mod._server_model_inputs(unified_budget=20 * _GB)
+    _inputs, _refs, reservation, _skipped = planning_mod._server_model_inputs(
+        unified_budget=20 * _GB
+    )
     assert reservation == 5 * _GB  # embed (2) + rerank (3)
     assert seen["chat_reservation"] == 5 * _GB
 
@@ -408,7 +410,7 @@ def test_server_model_inputs_no_reservation_on_discrete_gpu(monkeypatch) -> None
         return ModelPlacementInput(role, 2 * _GB)
 
     monkeypatch.setattr(planning_mod, "_estimate_role", _estimate)
-    _inputs, _refs, reservation = planning_mod._server_model_inputs(unified_budget=None)
+    _inputs, _refs, reservation, _skipped = planning_mod._server_model_inputs(unified_budget=None)
     assert reservation == 0
     assert seen["chat_reservation"] == 0
 
@@ -634,7 +636,7 @@ class TestBuildFleetWiring:
         )
         monkeypatch.setattr(cfg, "reranker_model", "")  # unconfigured -> skipped
         monkeypatch.setattr(cfg, "vision_model", "")
-        inputs, refs, _res = planning_mod._server_model_inputs()
+        inputs, refs, _res, _skipped = planning_mod._server_model_inputs()
         assert {i.role for i in inputs} == {WorkerRole.CHAT, WorkerRole.EMBED}
         assert set(refs) == {WorkerRole.CHAT, WorkerRole.EMBED}
 
@@ -642,11 +644,13 @@ class TestBuildFleetWiring:
         # Search-only indexing must not require an installed chat model: a
         # configured-but-missing chat model is skipped, not fatal, so the embed
         # server still gets planned.
-        from lilbee.providers.base import ProviderError
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
 
         def _estimate(role, ref, **_k):
             if role is WorkerRole.CHAT:
-                raise ProviderError("not installed", provider="llama-server")
+                raise ProviderError(
+                    "not installed", provider="llama-server", kind=ProviderErrorKind.NOT_FOUND
+                )
             return ModelPlacementInput(role, _GB)
 
         monkeypatch.setattr(planning_mod, "_estimate_role", _estimate)
@@ -654,9 +658,11 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(cfg, "embedding_model", "org/repo/embed.gguf")
         monkeypatch.setattr(cfg, "reranker_model", "")
         monkeypatch.setattr(cfg, "vision_model", "")
-        inputs, refs, _res = planning_mod._server_model_inputs()
+        inputs, refs, _res, skipped = planning_mod._server_model_inputs()
         assert WorkerRole.CHAT not in refs
         assert {i.role for i in inputs} == {WorkerRole.EMBED}
+        # The missing chat model is reported as not-installed so a surface can say so.
+        assert skipped == {WorkerRole.CHAT: "org/repo/missing-chat.gguf"}
 
     def test_server_model_inputs_distinguishes_sizing_failure_from_missing(
         self, monkeypatch, caplog
@@ -687,7 +693,7 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(cfg, "reranker_model", "")
         monkeypatch.setattr(cfg, "vision_model", "")
         with caplog.at_level(logging.WARNING):
-            inputs, refs, _res = planning_mod._server_model_inputs()
+            inputs, refs, _res, _skipped = planning_mod._server_model_inputs()
         assert not refs and not inputs
         # The genuinely-missing embed model says so; the chat sizing failure
         # names the estimator instead of misdirecting toward the registry.
@@ -702,7 +708,7 @@ class TestBuildFleetWiring:
         )
         monkeypatch.setattr(cfg, "reranker_model", "some/reranker.gguf")
         monkeypatch.setattr(cfg, "vision_model", "")
-        _inputs, refs, _res = planning_mod._server_model_inputs()
+        _inputs, refs, _res, _skipped = planning_mod._server_model_inputs()
         assert WorkerRole.RERANK in refs
 
     def test_server_model_inputs_includes_vision_only_with_mmproj(self, monkeypatch) -> None:
@@ -1185,6 +1191,7 @@ class TestBuildFleetWiring:
                 [ModelPlacementInput(WorkerRole.CHAT, 5 * _GB)],
                 {WorkerRole.CHAT: "ref"},
                 0,
+                {},
             ),
         )
         monkeypatch.setattr(
@@ -1213,6 +1220,7 @@ class TestBuildFleetWiring:
                 [ModelPlacementInput(WorkerRole.CHAT, 5 * _GB)],
                 {WorkerRole.CHAT: "ref"},
                 0,
+                {},
             ),
         )
 

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,6 +1,5 @@
 """Tests for reasoning token filter and cap-aware chat orchestrator."""
 
-from typing import ClassVar
 from unittest.mock import MagicMock
 
 import pytest
@@ -452,92 +451,6 @@ class TestStreamChatWithCap:
         assert second_closed["value"]
 
 
-class TestHarmonyChannels:
-    """gpt-oss harmony channels: render only 'final', strip control tokens."""
-
-    _ANALYSIS_FINAL: ClassVar[list[str]] = [
-        "<|channel|>analysis<|message|>Let's produce answer with citations.<|end|>",
-        "<|start|>assistant<|channel|>final<|message|>Pre-trip checklist: check tires.<|return|>",
-    ]
-
-    def test_final_channel_only_when_hidden(self):
-        out = _collect(self._ANALYSIS_FINAL, show=False)
-        text = "".join(t.content for t in out)
-        assert text == "Pre-trip checklist: check tires."
-        assert "<|" not in text
-        assert "analysis" not in text
-        assert "produce answer" not in text
-
-    def test_analysis_is_reasoning_when_shown(self):
-        out = _collect(self._ANALYSIS_FINAL, show=True)
-        reasoning = "".join(t.content for t in out if t.is_reasoning)
-        answer = "".join(t.content for t in out if not t.is_reasoning)
-        assert "Let's produce answer with citations." in reasoning
-        assert answer == "Pre-trip checklist: check tires."
-        assert "<|" not in reasoning + answer
-
-    def test_control_tokens_split_across_chunks(self):
-        chunks = ["<|chan", "nel|>fin", "al<|mess", "age|>Hi", " there<|ret", "urn|>"]
-        out = _collect(chunks, show=False)
-        assert "".join(t.content for t in out) == "Hi there"
-
-    def test_think_stream_unaffected_by_harmony_routing(self):
-        out = _collect(["<think>reason</think>answer"], show=False)
-        assert "".join(t.content for t in out) == "answer"
-
-    def test_start_role_header_dropped(self):
-        out = _collect(self._ANALYSIS_FINAL, show=True)
-        assert "assistant" not in "".join(t.content for t in out)
-
-    def test_commentary_channel_is_reasoning(self):
-        chunks = ["<|channel|>commentary<|message|>calling a tool<|end|>"]
-        out = _collect(chunks, show=False)
-        assert "".join(t.content for t in out) == ""
-        shown = _collect(chunks, show=True)
-        assert "calling a tool" in "".join(t.content for t in shown if t.is_reasoning)
-
-    def test_final_body_flushed_without_closing_token(self):
-        out = _collect(["<|channel|>final<|message|>partial answer"], show=False)
-        assert "".join(t.content for t in out) == "partial answer"
-
-    def test_trailing_partial_control_token_dropped_on_flush(self):
-        out = _collect(["<|channel|>final<|message|>done<|ret"], show=False)
-        assert "".join(t.content for t in out) == "done"
-
-    def test_literal_angle_bracket_in_final_answer_preserved(self):
-        chunks = ["<|channel|>final<|message|>a < b", "<|return|>"]
-        out = _collect(chunks, show=False)
-        assert "".join(t.content for t in out) == "a < b"
-
-    def test_leading_whitespace_before_harmony_token(self):
-        chunks = [" <|channel|>final<|message|>hi<|return|>"]
-        assert "".join(t.content for t in _collect(chunks, show=False)) == "hi"
-
-    def test_lone_angle_bracket_stream_is_plain_text(self):
-        assert "".join(t.content for t in _collect(["<"], show=False)) == "<"
-
-    def test_whitespace_prefix_then_think(self):
-        out = _collect(["  ", "<think>x</think>y"], show=False)
-        assert "".join(t.content for t in out) == "  y"
-
-    def test_final_body_lone_angle_bracket_token_held(self):
-        # A "<" arriving as its own chunk is held (could open <|return|>), then resolves.
-        chunks = ["<|channel|>final<|message|>a", "<", "|return|>tail"]
-        out = _collect(chunks, show=False)
-        assert "".join(t.content for t in out) == "a"
-
-    def test_final_body_trailing_angle_bracket_then_more(self):
-        chunks = ["<|channel|>final<|message|>b<", "c<|return|>"]
-        out = _collect(chunks, show=False)
-        assert "".join(t.content for t in out) == "b<c"
-
-    def test_cap_counts_harmony_analysis(self):
-        chunks = ["<|channel|>analysis<|message|>" + "z" * 50 + "<|end|>"]
-        out = _collect(chunks, show=True, cap_chars=10)
-        # The cap fires on the analysis channel, so no final answer is produced.
-        assert all(t.is_reasoning for t in out)
-
-
 class TestStripReasoning:
     def test_strips_think_block(self):
         assert strip_reasoning("<think>internal</think>answer") == "answer"
@@ -561,13 +474,6 @@ class TestStripReasoning:
 
     def test_unclosed_think_tag_stripped(self):
         assert strip_reasoning("answer<think>truncated reasoning") == "answer"
-
-    def test_strips_harmony_to_final_channel(self):
-        text = (
-            "<|channel|>analysis<|message|>thinking hard<|end|>"
-            "<|start|>assistant<|channel|>final<|message|>The answer.<|return|>"
-        )
-        assert strip_reasoning(text) == "The answer."
 
     def test_only_unclosed_think_tag(self):
         assert strip_reasoning("<think>all reasoning no answer") == ""

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,5 +1,6 @@
 """Tests for reasoning token filter and cap-aware chat orchestrator."""
 
+from typing import ClassVar
 from unittest.mock import MagicMock
 
 import pytest
@@ -451,6 +452,92 @@ class TestStreamChatWithCap:
         assert second_closed["value"]
 
 
+class TestHarmonyChannels:
+    """gpt-oss harmony channels: render only 'final', strip control tokens."""
+
+    _ANALYSIS_FINAL: ClassVar[list[str]] = [
+        "<|channel|>analysis<|message|>Let's produce answer with citations.<|end|>",
+        "<|start|>assistant<|channel|>final<|message|>Pre-trip checklist: check tires.<|return|>",
+    ]
+
+    def test_final_channel_only_when_hidden(self):
+        out = _collect(self._ANALYSIS_FINAL, show=False)
+        text = "".join(t.content for t in out)
+        assert text == "Pre-trip checklist: check tires."
+        assert "<|" not in text
+        assert "analysis" not in text
+        assert "produce answer" not in text
+
+    def test_analysis_is_reasoning_when_shown(self):
+        out = _collect(self._ANALYSIS_FINAL, show=True)
+        reasoning = "".join(t.content for t in out if t.is_reasoning)
+        answer = "".join(t.content for t in out if not t.is_reasoning)
+        assert "Let's produce answer with citations." in reasoning
+        assert answer == "Pre-trip checklist: check tires."
+        assert "<|" not in reasoning + answer
+
+    def test_control_tokens_split_across_chunks(self):
+        chunks = ["<|chan", "nel|>fin", "al<|mess", "age|>Hi", " there<|ret", "urn|>"]
+        out = _collect(chunks, show=False)
+        assert "".join(t.content for t in out) == "Hi there"
+
+    def test_think_stream_unaffected_by_harmony_routing(self):
+        out = _collect(["<think>reason</think>answer"], show=False)
+        assert "".join(t.content for t in out) == "answer"
+
+    def test_start_role_header_dropped(self):
+        out = _collect(self._ANALYSIS_FINAL, show=True)
+        assert "assistant" not in "".join(t.content for t in out)
+
+    def test_commentary_channel_is_reasoning(self):
+        chunks = ["<|channel|>commentary<|message|>calling a tool<|end|>"]
+        out = _collect(chunks, show=False)
+        assert "".join(t.content for t in out) == ""
+        shown = _collect(chunks, show=True)
+        assert "calling a tool" in "".join(t.content for t in shown if t.is_reasoning)
+
+    def test_final_body_flushed_without_closing_token(self):
+        out = _collect(["<|channel|>final<|message|>partial answer"], show=False)
+        assert "".join(t.content for t in out) == "partial answer"
+
+    def test_trailing_partial_control_token_dropped_on_flush(self):
+        out = _collect(["<|channel|>final<|message|>done<|ret"], show=False)
+        assert "".join(t.content for t in out) == "done"
+
+    def test_literal_angle_bracket_in_final_answer_preserved(self):
+        chunks = ["<|channel|>final<|message|>a < b", "<|return|>"]
+        out = _collect(chunks, show=False)
+        assert "".join(t.content for t in out) == "a < b"
+
+    def test_leading_whitespace_before_harmony_token(self):
+        chunks = [" <|channel|>final<|message|>hi<|return|>"]
+        assert "".join(t.content for t in _collect(chunks, show=False)) == "hi"
+
+    def test_lone_angle_bracket_stream_is_plain_text(self):
+        assert "".join(t.content for t in _collect(["<"], show=False)) == "<"
+
+    def test_whitespace_prefix_then_think(self):
+        out = _collect(["  ", "<think>x</think>y"], show=False)
+        assert "".join(t.content for t in out) == "  y"
+
+    def test_final_body_lone_angle_bracket_token_held(self):
+        # A "<" arriving as its own chunk is held (could open <|return|>), then resolves.
+        chunks = ["<|channel|>final<|message|>a", "<", "|return|>tail"]
+        out = _collect(chunks, show=False)
+        assert "".join(t.content for t in out) == "a"
+
+    def test_final_body_trailing_angle_bracket_then_more(self):
+        chunks = ["<|channel|>final<|message|>b<", "c<|return|>"]
+        out = _collect(chunks, show=False)
+        assert "".join(t.content for t in out) == "b<c"
+
+    def test_cap_counts_harmony_analysis(self):
+        chunks = ["<|channel|>analysis<|message|>" + "z" * 50 + "<|end|>"]
+        out = _collect(chunks, show=True, cap_chars=10)
+        # The cap fires on the analysis channel, so no final answer is produced.
+        assert all(t.is_reasoning for t in out)
+
+
 class TestStripReasoning:
     def test_strips_think_block(self):
         assert strip_reasoning("<think>internal</think>answer") == "answer"
@@ -474,6 +561,13 @@ class TestStripReasoning:
 
     def test_unclosed_think_tag_stripped(self):
         assert strip_reasoning("answer<think>truncated reasoning") == "answer"
+
+    def test_strips_harmony_to_final_channel(self):
+        text = (
+            "<|channel|>analysis<|message|>thinking hard<|end|>"
+            "<|start|>assistant<|channel|>final<|message|>The answer.<|return|>"
+        )
+        assert strip_reasoning(text) == "The answer."
 
     def test_only_unclosed_think_tag(self):
         assert strip_reasoning("<think>all reasoning no answer") == ""

--- a/tests/test_tui_fleet.py
+++ b/tests/test_tui_fleet.py
@@ -98,6 +98,61 @@ async def _step_until_generated(pilot, selector: str, app, predicate) -> None:  
     )  # pragma: no cover
 
 
+def _make_view_with_skipped():
+    from lilbee.app.placement import (
+        GpuInfo,
+        PlacementView,
+        RolePlacementView,
+        SkippedRole,
+    )
+    from lilbee.providers.roles import WorkerRole
+
+    return PlacementView(
+        gpus=(GpuInfo(0, "MTL", "MTL0", "Apple M3", 24 * GIB, 20 * GIB),),
+        roles=(RolePlacementView(WorkerRole.EMBED, "org/embed.gguf", (0,), None, 1),),
+        unplaceable=(),
+        manual=False,
+        spec_json=None,
+        skipped_not_installed=(SkippedRole(WorkerRole.CHAT, "Qwen/Qwen3-4B-GGUF/Q4.gguf"),),
+    )
+
+
+@pytest.mark.asyncio
+async def test_skipped_role_shows_not_downloaded_note(monkeypatch):
+    """A configured role skipped for a missing model shows a legible 'not downloaded'
+    line, not an unexplained empty table."""
+    from textual.widgets import Static
+
+    from lilbee.cli.tui.widgets import fleet_body as fbm
+
+    monkeypatch.setattr(fbm, "get_placement", _make_view_with_skipped)
+
+    app = FleetTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        note = app.screen.query_one("#placement-skipped", Static)
+        assert note.display is True
+        rendered = str(note.render())
+        assert "chat" in rendered
+        assert "not downloaded" in rendered
+        assert "Qwen3-4B" in rendered
+
+
+@pytest.mark.asyncio
+async def test_no_skipped_note_when_all_models_installed(monkeypatch):
+    """With every configured model installed the note stays hidden."""
+    from textual.widgets import Static
+
+    from lilbee.cli.tui.widgets import fleet_body as fbm
+
+    monkeypatch.setattr(fbm, "get_placement", lambda: _make_view())
+
+    app = FleetTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        assert app.screen.query_one("#placement-skipped", Static).display is False
+
+
 @pytest.mark.asyncio
 async def test_fleet_view_shows_live_rows_with_role_badges(monkeypatch):
     """Fleet view mounts FleetBody, which pushes role badges into GpuFleetPanel."""

--- a/tests/test_tui_gpu_fleet_panel.py
+++ b/tests/test_tui_gpu_fleet_panel.py
@@ -76,7 +76,7 @@ def test_panel_initial_content_is_loading_not_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_panel_renders_empty_state_with_no_devices(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Without any devices the panel shows the empty-state text."""
+    """A completed probe that finds no devices shows the empty-state text."""
     import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
     from lilbee.cli.tui import messages as msg
     from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
@@ -87,8 +87,48 @@ async def test_panel_renders_empty_state_with_no_devices(monkeypatch: pytest.Mon
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         panel = app.query_one(GpuFleetPanel)
+        panel.set_devices([], labels={})
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
         rendered = str(panel.render())
         assert msg.FLEET_NO_GPUS in rendered
+
+
+@pytest.mark.asyncio
+async def test_panel_holds_probing_until_devices_probed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The empty-GPUs text must not appear until the parent device probe completes.
+
+    Regression for the cold-probe flash: the panel's own stat probe returns {}
+    on a cold start (before set_devices runs), and that must keep the 'probing'
+    placeholder, not flash '(no GPUs detected)'.
+    """
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui import messages as msg
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {})
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        before_probe = str(panel.render())
+        assert msg.FLEET_GPU_PROBING in before_probe
+        assert msg.FLEET_NO_GPUS not in before_probe
+
+        # A completed probe that genuinely finds no devices does show the empty state.
+        panel.set_devices([], labels={})
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        after_probe = str(panel.render())
+        assert msg.FLEET_NO_GPUS in after_probe
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -472,13 +472,20 @@ class TestTaskBar:
         from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 
         assert _warm_detail(None) is None
-        assert _warm_detail(WarmProgress(phase=WarmPhase.STARTING)) == "starting"
-        assert _warm_detail(WarmProgress(phase=WarmPhase.LOADING_ENGINE)) == "loading engine"
         assert _warm_detail(WarmProgress(phase=WarmPhase.READY)) is None
-        reading = WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=42, bytes_total=100)
-        assert _warm_detail(reading) == "reading weights 42%"
+        # Each active phase carries a progress bar plus the phase word.
+        starting = _warm_detail(WarmProgress(phase=WarmPhase.STARTING))
+        assert "starting" in starting and "▓" in starting
+        loading = _warm_detail(WarmProgress(phase=WarmPhase.LOADING_ENGINE))
+        assert "loading engine" in loading and ("▓" in loading or "░" in loading)
+        reading = _warm_detail(
+            WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=42, bytes_total=100)
+        )
+        assert "reading weights 42%" in reading
+        assert reading.startswith("▓▓▓▓▓")  # round(0.42 * 12) = 5 filled cells
         # No total yet: percent floors to 0 instead of dividing by zero.
-        assert _warm_detail(WarmProgress(phase=WarmPhase.READING_WEIGHTS)) == "reading weights 0%"
+        zero = _warm_detail(WarmProgress(phase=WarmPhase.READING_WEIGHTS))
+        assert "reading weights 0%" in zero
 
     async def test_warm_line_shows_phase_when_chat_warming(self) -> None:
         from unittest import mock
@@ -498,10 +505,20 @@ class TestTaskBar:
         async with app.run_test() as pilot:
             await pilot.pause()
             bar = app.query_one(TaskBar)
-            assert bar._warm_line() == "loading chat · reading weights 25%"
+            warm = bar._warm_line()
+            assert warm.startswith("loading chat · ")
+            assert "reading weights 25%" in warm and "▓" in warm
             bar._refresh_display()
             await pilot.pause()
             assert bar.display is True
+
+    def test_sweep_bar_animates_and_keeps_width(self) -> None:
+        from lilbee.cli.tui.widgets.task_bar import _WARM_BAR_WIDTH, _sweep_bar
+
+        frames = [_sweep_bar(t) for t in range(_WARM_BAR_WIDTH + 4)]
+        assert all(len(f) == _WARM_BAR_WIDTH for f in frames)  # fixed width every frame
+        assert len({*frames}) > 1  # the lit window moves, so frames differ
+        assert all("▓" in f for f in frames)  # always shows a lit window
 
     async def test_warm_line_none_when_not_warming(self) -> None:
         from lilbee.cli.tui.widgets.task_bar import TaskBar

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -467,6 +467,52 @@ class TestTaskBar:
             out = bar._spawning_workers_template(["chat", "embed"])
             assert out == "Starting chat, embed workers..."
 
+    def test_warm_detail_phases(self) -> None:
+        from lilbee.cli.tui.widgets.task_bar import _warm_detail
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        assert _warm_detail(None) is None
+        assert _warm_detail(WarmProgress(phase=WarmPhase.STARTING)) == "starting"
+        assert _warm_detail(WarmProgress(phase=WarmPhase.LOADING_ENGINE)) == "loading engine"
+        assert _warm_detail(WarmProgress(phase=WarmPhase.READY)) is None
+        reading = WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=42, bytes_total=100)
+        assert _warm_detail(reading) == "reading weights 42%"
+        # No total yet: percent floors to 0 instead of dividing by zero.
+        assert _warm_detail(WarmProgress(phase=WarmPhase.READING_WEIGHTS)) == "reading weights 0%"
+
+    async def test_warm_line_shows_phase_when_chat_warming(self) -> None:
+        from unittest import mock
+
+        from lilbee.app.services import set_services
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+        from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+        services = mock.MagicMock()
+        services.provider.role_ready.return_value = False
+        services.provider.warm_progress.return_value = WarmProgress(
+            phase=WarmPhase.READING_WEIGHTS, bytes_done=1, bytes_total=4
+        )
+        set_services(services)
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            assert bar._warm_line() == "loading chat · reading weights 25%"
+            bar._refresh_display()
+            await pilot.pause()
+            assert bar.display is True
+
+    async def test_warm_line_none_when_not_warming(self) -> None:
+        from lilbee.cli.tui.widgets.task_bar import TaskBar
+
+        app = _TaskBarApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            bar = app.query_one(TaskBar)
+            # Default mock services report ready, so there is no warm line.
+            assert bar._warm_line() is None
+
     async def test_renders_spawning_summary_when_idle_with_spawn(self) -> None:
         """When idle except for in-flight worker spawns, the bar surfaces the
         'Starting <role> worker...' summary instead of hiding."""


### PR DESCRIPTION
## Problem

On a fresh install and during a cold start, the TUI showed alarming or blank states while the fleet was still coming up, and two chat rough edges surfaced while recording demos:

- Sending a prompt before the chat model finished warming reached a not-yet-ready fleet and rendered an error inside a chat bubble.
- The GPU fleet panel briefly flashed "(no GPUs detected)" before the device probe had finished, most visibly on Apple Silicon.
- With the chat model not downloaded, its role was silently absent from the placement panel, so a first-run user read the empty panel as "GPU placement is broken".
- Typing a long prompt did not wrap in the input box; it ran off the edge instead of growing.
- On Apple Silicon the GPU fleet panel's utilization bar read 0% even under load; the `ioreg` probe was rooted at the wrong node so it never saw the GPU.
- gpt-oss models leaked their harmony reasoning preamble and the control tokens (`<|channel|>`, `<|message|>`, `<|end|>`, ...) verbatim into the rendered answer.

## Solution

- **Chat startup.** The input now stays disabled while the chat model warms and re-enables on the ready transition, matching the convention every chat app uses (you can't send while the model is busy). The bottom status line shows the load phase with a byte percentage instead of a bare "starting worker" line, so a held input reads as "loading", not "stuck".
- **GPU panel.** It holds a "probing GPUs" placeholder until the device probe reports, so the empty "(no GPUs detected)" state only appears when there really are no GPUs.
- **Placement.** Roles skipped because their model isn't installed are carried through the placement plan and surfaced as a "not downloaded, pull it to place it" line. The state shows consistently across the TUI drawer, the `lilbee placement` CLI, and the HTTP/MCP placement responses.
- **Input box.** It grows to show the full wrapped prompt as it is typed, and re-grows if the terminal later narrows.
- **GPU utilization.** The fleet panel reads live activity on Apple Silicon (rooted at the GPU accelerator via `ioreg`) instead of a stuck 0%, and the AMD backend reads the real nested `amd-smi` format instead of a flat shape that would have read blank. Live AMD/Intel confirmation is tracked in #490.
- **Warm progress bar.** The chat cold-start line shows a real progress bar (a byte bar while weights page in, an animated sweep while the engine loads), not just phase text.
- **Fleet reload speed.** Fleet clients only reach a loopback llama-server over plain HTTP, but each reload rebuilt httpx clients that each construct a default SSL context (loads the system CA bundle). Reuse one minimal context so model switches don't pay that per-replica setup. (Found via a py-spy flame graph.)
- **gpt-oss output.** The chat server ran with `--reasoning-format none`, which leaks each model's raw reasoning dialect into answers (gpt-oss harmony control tokens appeared verbatim). The server now parses reasoning natively (llama.cpp handles harmony, `<think>`, and future dialects) and the fleet client re-inlines it as `<think>` at one boundary, so the downstream pipeline is unchanged and format-agnostic. Vision keeps dropping reasoning as before.
