### PR TITLE
fix(fleet): retry transient gateway errors instead of dropping the call

### DIFF
--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -191,21 +191,28 @@ def _raise_for_status(resp: httpx.Response) -> None:
     raise ProviderError(
         f"llama-server returned HTTP {resp.status_code}{detail}",
         provider=_PROVIDER_NAME,
-        kind=_classify_error_body(body),
+        kind=_classify_error(resp.status_code, body),
     )
 
 
-def _classify_error_body(body: str) -> ProviderErrorKind:
-    """Error kind from a llama-server/llama-swap error body.
+def _classify_error(status_code: int, body: str) -> ProviderErrorKind:
+    """Error kind from a llama-server/llama-swap error status and body.
 
     An input past the server's n_batch is a 500 whose body says "too large to
     process" (CONTEXT_OVERFLOW, so the embed path re-truncates exactly); a dead
-    upstream is CONNECTION, so the router can mark the replica unhealthy.
+    upstream is CONNECTION, so the router can mark the replica unhealthy. The
+    body markers win over the status: llama-swap reports a died upstream under
+    gateway statuses too, and that case needs the failover path, not a retry
+    against the same dead server. A bare gateway error (502/503/504) is a
+    momentarily-unreachable upstream -- restarting, OOM-killed, mid-swap -- so
+    it is SERVER, which the busy retry treats as transient.
     """
     if _BATCH_OVERFLOW_MARKER in body:
         return ProviderErrorKind.CONTEXT_OVERFLOW
     if _UPSTREAM_DIED_MARKER in body:
         return ProviderErrorKind.CONNECTION
+    if status_code in _TRANSIENT_GATEWAY_STATUSES:
+        return ProviderErrorKind.SERVER
     return ProviderErrorKind.UNKNOWN
 
 
@@ -218,12 +225,13 @@ def is_connection_failure(exc: Exception) -> bool:
 
 
 def _is_transient_probe_failure(exc: Exception) -> bool:
-    """Whether a probe failure is transient (dead replica or a busy 429), not a
-    template verdict. A cold replica 429s its first traffic, so a busy response
-    must not be read as the template rejecting the exchange."""
+    """Whether a probe failure is transient (dead replica, busy 429, gateway
+    error), not a template verdict. A cold replica 429s or 502s its first
+    traffic, so neither response must be read as the template rejecting the
+    exchange."""
     if is_connection_failure(exc):
         return True
-    return isinstance(exc, ProviderError) and exc.kind is ProviderErrorKind.RATE_LIMIT
+    return isinstance(exc, ProviderError) and exc.kind in _TRANSIENT_KINDS
 
 
 def _upstream_failure_tail(resp: httpx.Response) -> str:
@@ -278,6 +286,14 @@ _TOKENIZE_PARSE_SPECIAL = False
 _HTTP_OK = 200
 _HTTP_BAD_REQUEST = 400
 _HTTP_TOO_MANY_REQUESTS = 429
+# Gateway statuses llama-swap returns while an upstream is unreachable
+# (502 crashing/restarting, 503 unavailable, 504 gateway timeout). The request
+# succeeds once the upstream is back, so these must never terminalize a call.
+_TRANSIENT_GATEWAY_STATUSES = frozenset({502, 503, 504})
+# Error kinds the busy retry treats as transient: a 429 (slots still loading)
+# and a bare gateway error (upstream momentarily unreachable) both clear on
+# their own once the server is ready again.
+_TRANSIENT_KINDS = frozenset({ProviderErrorKind.RATE_LIMIT, ProviderErrorKind.SERVER})
 _DONE_SENTINEL = "[DONE]"
 _DATA_PREFIX = "data:"
 _DEFAULT_TIMEOUT_S = 300.0
@@ -315,14 +331,15 @@ class ChatDeadlineError(ProviderError):
 def retry_on_busy(
     call: Callable[[], _T], *, retries: int = _BUSY_RETRIES, deadline: float | None = None
 ) -> _T:
-    """Run *call*, retrying a transient server-busy (RATE_LIMIT) with capped backoff.
+    """Run *call*, retrying transient failures (429, gateway errors) with capped backoff.
 
-    A cold replica fleet 429s the first fan-out until its slots load; backing
-    off and retrying turns those drops into successes. With a *deadline*
-    (``time.monotonic`` epoch) the retry waits out a busy server until that
+    A cold replica fleet 429s the first fan-out until its slots load, and a
+    replica restarting mid-run answers 502 until it is back; backing off and
+    retrying turns both drops into successes. With a *deadline*
+    (``time.monotonic`` epoch) the retry waits out the server until that
     deadline -- a page on a deep OCR queue keeps waiting for a genuinely free
     slot instead of dropping after a fixed budget. Without one, *retries* bounds
-    the attempts. Non-RATE_LIMIT errors (and the final still-busy response)
+    the attempts. Non-transient errors (and the final still-failing response)
     propagate.
     """
     delay = _BUSY_BACKOFF_BASE_S
@@ -331,7 +348,7 @@ def retry_on_busy(
         try:
             return call()
         except ProviderError as exc:
-            if exc.kind is not ProviderErrorKind.RATE_LIMIT:
+            if exc.kind not in _TRANSIENT_KINDS:
                 raise
             attempt += 1
             exhausted = (

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -366,11 +366,12 @@ def _ocr_dispatch(
     messages: Sequence[Mapping[str, Any]],
     deadline: float | None,
 ) -> str:
-    """OCR *messages* on a free replica slot, retrying a busy server until *deadline*.
+    """OCR *messages* on a free replica slot, retrying transient failures until *deadline*.
 
     Backpressure (the dispatcher blocking until a slot frees) makes a
     self-inflicted 429 unreachable; a residual busy response is a still-warming
-    server or foreign traffic. The retry is deadline-bound rather than
+    server or foreign traffic, and a gateway error is a replica restarting
+    mid-run. The retry is deadline-bound rather than
     attempt-bound so a page on a deep queue waits for a genuinely free slot until
     its own budget passes instead of dropping after a fixed count. Each attempt
     is bounded by the budget remaining before *deadline*; an exhausted budget

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -79,6 +79,71 @@ def test_raise_for_status_maps_429_to_rate_limit() -> None:
     assert excinfo.value.kind is ProviderErrorKind.RATE_LIMIT
 
 
+@pytest.mark.parametrize("status", [502, 503, 504])
+def test_raise_for_status_maps_gateway_errors_to_server(status: int) -> None:
+    # llama-swap answers for a momentarily-unreachable upstream (restarting,
+    # OOM-killed, mid-swap) with a gateway error; the kind must be retryable,
+    # not terminal.
+    from lilbee.providers.base import ProviderErrorKind
+    from lilbee.providers.fleet.client import _raise_for_status
+
+    with pytest.raises(ProviderError) as excinfo:
+        _raise_for_status(httpx.Response(status, text="Bad Gateway"))
+    assert excinfo.value.kind is ProviderErrorKind.SERVER
+
+
+def test_raise_for_status_gateway_premature_exit_stays_connection(monkeypatch) -> None:
+    # A 502 whose body carries the died marker keeps its CONNECTION kind (and
+    # with it the replica failover path); the gateway status must not shadow it.
+    import lilbee.providers.fleet.client as client_mod
+    from lilbee.providers.base import ProviderErrorKind
+    from lilbee.providers.fleet.client import _raise_for_status
+
+    monkeypatch.setattr(client_mod, "_upstream_failure_tail", lambda _resp: "")
+    with pytest.raises(ProviderError) as excinfo:
+        _raise_for_status(
+            httpx.Response(502, text='{"error": "upstream command exited prematurely"}')
+        )
+    assert excinfo.value.kind is ProviderErrorKind.CONNECTION
+
+
+def test_embed_retries_transient_gateway_error_then_succeeds(monkeypatch) -> None:
+    # A 502 while the upstream restarts is retried like a busy 429 instead of
+    # dropping the input.
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    calls = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return httpx.Response(502, text="Bad Gateway")
+        return httpx.Response(200, json={"data": [{"embedding": [0.1, 0.2]}]})
+
+    assert _client(handler).embed(["hello"]) == [[0.1, 0.2]]
+    assert calls["n"] == 3
+
+
+def test_retry_on_busy_deadline_retries_gateway_error(monkeypatch) -> None:
+    # The deadline-bound OCR retry rides out a transient 502 the same way it
+    # rides out a busy 429: the page is re-attempted, not dropped.
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+    from lilbee.providers.fleet.client import retry_on_busy
+
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
+    monkeypatch.setattr("lilbee.providers.fleet.client.time.monotonic", lambda: 0.0)
+    gateway = ProviderError("HTTP 502", provider="llama-server", kind=ProviderErrorKind.SERVER)
+    calls = {"n": 0}
+
+    def _call() -> str:
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise gateway
+        return "ok"
+
+    assert retry_on_busy(_call, deadline=100.0) == "ok"
+    assert calls["n"] == 3
+
+
 def test_embed_retries_on_busy_then_succeeds(monkeypatch) -> None:
     monkeypatch.setattr("lilbee.providers.fleet.client.time.sleep", lambda _s: None)
     calls = {"n": 0}


### PR DESCRIPTION
## Problem

On a clean 23k-page vision-OCR run, 16 pages failed with `llama-server returned HTTP 502` even though every input decoded fine. llama-swap returns a gateway error while an upstream is momentarily unreachable (a replica restarting, OOM-killed, or mid-swap), but the fleet client only treated a busy 429 as retryable. A bare 502/503/504 was classified as an unknown, terminal error, so a single transient blip permanently dropped the page.

## Solution

Classify bare 502/503/504 responses as transient server errors and let the busy retry ride them out the same way it rides out a 429: deadline-bound for OCR pages, attempt-bound for embed and rerank. The chat-template probe also treats them as inconclusive rather than as a template verdict. A 502 whose body reports the upstream exited prematurely keeps its connection classification, so the existing replica-failover path is unchanged, and the OpenAI-compatible API now surfaces an exhausted gateway error as 502 instead of a generic 500.