### PR TITLE
Fix formatting drift that fails lint on main

### DIFF
--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -1167,9 +1167,7 @@ def _parse_sse_stream_items(
             yield usage
         return
     delta = choices[0].get("delta") or {}
-    text = inliner.feed(
-        str(delta.get("reasoning_content") or ""), str(delta.get("content") or "")
-    )
+    text = inliner.feed(str(delta.get("reasoning_content") or ""), str(delta.get("content") or ""))
     if text:
         yield text
     raw_calls = delta.get("tool_calls") or []


### PR DESCRIPTION
## Problem

The merge of #489 landed with one call in the fleet client wrapped across lines that ruff format wants on a single line, so the lint job fails on main.

## Solution

Fold the call onto one line. Whitespace only, no behavior change.