### PR TITLE
Make Intel GPU utilization work, including consumer iGPUs

### DIFF
--- a/scripts/qa/gpu_util_qa.py
+++ b/scripts/qa/gpu_util_qa.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Live GPU-utilization QA harness.
+
+Verifies the per-vendor live-util backends against real hardware. It drives the
+exact path the fleet panel uses -- probe the engine's devices, then
+``probe_gpu_stats`` -- so a green run here means the panel reads live util on this
+box. It also captures the raw vendor-tool JSON so it can be saved as a fixture,
+and offers a watch mode to confirm the bar moves under load.
+
+Why this exists: every backend's unit test mocks an *assumed* tool format, so a
+passing suite never proves the assumption matches the real tool. That is how the
+Apple backend shipped reading a stuck 0%. Only real hardware settles it, and this
+harness is how you settle it in ~10 minutes on a rented box.
+
+Usage on the box::
+
+    # one-shot: probe + parse + PASS/FAIL, and print the raw tool JSON
+    uv run python scripts/qa/gpu_util_qa.py
+
+    # capture the raw JSON to turn into a test fixture
+    uv run python scripts/qa/gpu_util_qa.py --capture /tmp/amd_metric.json
+
+    # watch util for 30s while a job runs, to confirm it tracks load
+    uv run python scripts/qa/gpu_util_qa.py --watch 30
+
+    # skip device probe (no engine binary); force a backend + indices
+    uv run python scripts/qa/gpu_util_qa.py --backend SYCL --indices 0,1
+
+PASS when at least one GPU reports an integer utilization in [0, 100].
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+from lilbee.providers.fleet.devices import FleetDevice
+from lilbee.providers.fleet.gpu_backends.base import run_smi
+from lilbee.providers.fleet.gpu_stats import probe_gpu_stats
+
+# The exact command each backend runs, for raw capture. Mirrors the backend
+# modules (nvidia._QUERY, amd._AMD_SMI_ARGS, intel._xpu_smi_output); keep in step
+# with them. {i} is filled per device index.
+_RAW_COMMANDS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "CUDA": (
+        "nvidia-smi",
+        (
+            "--query-gpu=index,utilization.gpu,memory.used,memory.total",
+            "--format=csv,noheader,nounits",
+        ),
+    ),
+    "ROCm": ("amd-smi", ("metric", "--usage", "--temperature", "--json")),
+    "HIP": ("amd-smi", ("metric", "--usage", "--temperature", "--json")),
+    "SYCL": ("xpu-smi", ("stats", "-d", "{i}", "-j")),
+}
+
+
+def _probe_real_devices() -> list[FleetDevice]:
+    """Probe the engine's devices, or [] when no engine binary resolves."""
+    try:
+        from lilbee.providers.fleet.binary import resolve_llama_server
+        from lilbee.providers.fleet.devices import probe_devices
+    except ImportError:
+        return []
+    try:
+        return list(probe_devices(resolve_llama_server()))
+    except Exception as exc:
+        print(f"  device probe unavailable ({exc}); use --backend/--indices")
+        return []
+
+
+def _forced_devices(backend: str, indices: list[int]) -> list[FleetDevice]:
+    """Synthesize FleetDevices for a forced backend + indices (structural VRAM 0)."""
+    return [FleetDevice(backend, i, f"{backend} device {i}", 0, 0) for i in indices]
+
+
+def _capture_raw(backend: str, indices: list[int]) -> str:
+    """Run the vendor tool exactly as the backend does; return concatenated stdout."""
+    spec = _RAW_COMMANDS.get(backend)
+    if spec is None:
+        return ""
+    tool, arg_template = spec
+    if "{i}" in arg_template:
+        chunks = []
+        for i in indices:
+            args = [a.format(i=i) for a in arg_template]
+            chunks.append(f"# {tool} {' '.join(args)}\n{run_smi(tool, args)}")
+        return "\n".join(chunks)
+    return run_smi(tool, list(arg_template))
+
+
+def _print_stats(devices: list[FleetDevice]) -> dict[int, int | None]:
+    """Print per-GPU stats via the real orchestrator; return index -> util."""
+    stats = probe_gpu_stats(devices)
+    utils: dict[int, int | None] = {}
+    for index in sorted(stats):
+        s = stats[index]
+        utils[index] = s.utilization_pct
+        util = "--" if s.utilization_pct is None else f"{s.utilization_pct}%"
+        temp = "--" if s.temperature_c is None else f"{s.temperature_c}C"
+        gib = 1024**3
+        vram = (
+            "structural"
+            if s.total_bytes == 0
+            else f"{s.free_bytes / gib:.1f}/{s.total_bytes / gib:.1f} GiB free"
+        )
+        print(f"  gpu {index}: util={util:>5}  temp={temp:>5}  vram={vram}")
+    return utils
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--backend", help="Force a backend (CUDA/ROCm/HIP/SYCL/Metal/MTL)")
+    ap.add_argument("--indices", help="Comma-separated device indices for --backend")
+    ap.add_argument("--capture", type=Path, help="Write raw vendor-tool JSON to this path")
+    ap.add_argument("--watch", type=int, default=0, help="Re-probe every second for N seconds")
+    args = ap.parse_args()
+
+    if args.backend:
+        indices = [int(x) for x in (args.indices or "0").split(",")]
+        devices = _forced_devices(args.backend, indices)
+    else:
+        devices = _probe_real_devices()
+
+    if not devices:
+        print("FAIL: no GPU devices to probe (pass --backend and --indices to force)")
+        return 1
+
+    backend = devices[0].backend
+    indices = [d.index for d in devices]
+    print(f"backend={backend} indices={indices}")
+
+    raw = _capture_raw(backend, indices)
+    if args.capture and raw:
+        args.capture.write_text(raw)
+        print(f"  raw tool output -> {args.capture}")
+    else:
+        print("--- raw vendor-tool output ---")
+        print(raw or "  (no raw output; tool absent or non-zero exit)")
+        print("--- end raw ---")
+
+    print("parsed via probe_gpu_stats (the fleet-panel path):")
+    utils = _print_stats(devices)
+
+    if args.watch:
+        print(f"watching util for {args.watch}s (run a GPU job now to see it move):")
+        for _ in range(args.watch):
+            time.sleep(1)
+            snapshot = probe_gpu_stats(devices)
+            cells = []
+            for i in sorted(snapshot):
+                util = snapshot[i].utilization_pct
+                cells.append(f"gpu{i}={'--' if util is None else f'{util}%'}")
+            print("  " + "  ".join(cells))
+
+    live = [u for u in utils.values() if isinstance(u, int) and 0 <= u <= 100]
+    if not live:
+        print("FAIL: no GPU reported an integer utilization in [0,100]")
+        return 1
+    print(f"PASS: {len(live)}/{len(utils)} GPU(s) report live utilization")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -402,6 +402,12 @@ FLEET_NO_GPUS = "(no GPUs detected)"
 # Shown for a role that has no placement because its model isn't downloaded, so the
 # empty slot reads as a fixable state instead of "GPU placement is broken".
 FLEET_MODEL_NOT_DOWNLOADED = "{role}: {model} not downloaded, pull it to place it"
+# Shown when an Intel GPU's utilization is unreadable only because intel_gpu_top
+# lacks the CAP_PERFMON grant, so the muted "--" reads as a fixable state.
+FLEET_INTEL_UTIL_GRANT = (
+    "Intel GPU utilization needs a one-time grant: "
+    "sudo setcap cap_perfmon+ep {binary}  (or Linux 6.2+ reads it with no setup)"
+)
 FLEET_CMD_PREVIEW = "Preview"
 FLEET_CMD_APPLY = "Apply"
 FLEET_CMD_AUTO = "Auto"

--- a/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
+++ b/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
@@ -18,7 +18,7 @@ from textual.widgets import Static
 
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.thread_safe import call_from_thread
-from lilbee.providers.fleet.gpu_stats import GpuStat, probe_gpu_stats
+from lilbee.providers.fleet.gpu_stats import GpuStat, probe_gpu_stats, util_notice
 
 if TYPE_CHECKING:
     from lilbee.providers.fleet.gpu_stats import DeviceLike
@@ -251,4 +251,8 @@ class GpuFleetPanel(Static):
         """Update the rendered content with fresh stat data (main thread)."""
         theme = self._resolve_theme()
         markup = _render_stats(stats, labels, roles, theme, probed=self._probed)
+        notice = util_notice(self._devices, stats)
+        if notice:
+            muted = _theme_color(theme, "text-muted")
+            markup += f"\n[{muted}]  {notice}[/]"
         self.update(markup)

--- a/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
+++ b/src/lilbee/cli/tui/widgets/gpu_fleet_panel.py
@@ -18,7 +18,7 @@ from textual.widgets import Static
 
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.thread_safe import call_from_thread
-from lilbee.providers.fleet.gpu_stats import GpuStat, probe_gpu_stats, util_notice
+from lilbee.providers.fleet.gpu_stats import GpuStat, intel_grant_binary, probe_gpu_stats
 
 if TYPE_CHECKING:
     from lilbee.providers.fleet.gpu_stats import DeviceLike
@@ -251,8 +251,9 @@ class GpuFleetPanel(Static):
         """Update the rendered content with fresh stat data (main thread)."""
         theme = self._resolve_theme()
         markup = _render_stats(stats, labels, roles, theme, probed=self._probed)
-        notice = util_notice(self._devices, stats)
-        if notice:
+        binary = intel_grant_binary(self._devices, stats)
+        if binary:
             muted = _theme_color(theme, "text-muted")
-            markup += f"\n[{muted}]  {notice}[/]"
+            hint = msg.FLEET_INTEL_UTIL_GRANT.format(binary=binary)
+            markup += f"\n[{muted}]  {hint}[/]"
         self.update(markup)

--- a/src/lilbee/providers/fleet/gpu_backends/__init__.py
+++ b/src/lilbee/providers/fleet/gpu_backends/__init__.py
@@ -14,7 +14,7 @@ from lilbee.providers.fleet.gpu_backends.amd import AmdBackend
 from lilbee.providers.fleet.gpu_backends.apple import BACKEND_KEY as _APPLE_KEY
 from lilbee.providers.fleet.gpu_backends.apple import AppleBackend
 from lilbee.providers.fleet.gpu_backends.base import UtilBackend, UtilSample
-from lilbee.providers.fleet.gpu_backends.intel import IntelBackend
+from lilbee.providers.fleet.gpu_backends.intel import IntelBackend, intel_util_hint
 from lilbee.providers.fleet.gpu_backends.nvidia import NvidiaBackend
 
 # Maps the backend string that llama-server --list-devices emits to the backend
@@ -69,6 +69,7 @@ def util_backend_name(backend: str, name: str) -> str:
 __all__ = [
     "UtilBackend",
     "UtilSample",
+    "intel_util_hint",
     "resolve_backend",
     "util_backend_name",
 ]

--- a/src/lilbee/providers/fleet/gpu_backends/__init__.py
+++ b/src/lilbee/providers/fleet/gpu_backends/__init__.py
@@ -14,7 +14,7 @@ from lilbee.providers.fleet.gpu_backends.amd import AmdBackend
 from lilbee.providers.fleet.gpu_backends.apple import BACKEND_KEY as _APPLE_KEY
 from lilbee.providers.fleet.gpu_backends.apple import AppleBackend
 from lilbee.providers.fleet.gpu_backends.base import UtilBackend, UtilSample
-from lilbee.providers.fleet.gpu_backends.intel import IntelBackend, intel_util_hint
+from lilbee.providers.fleet.gpu_backends.intel import IntelBackend, intel_gpu_top_grant_binary
 from lilbee.providers.fleet.gpu_backends.nvidia import NvidiaBackend
 
 # Maps the backend string that llama-server --list-devices emits to the backend
@@ -69,7 +69,7 @@ def util_backend_name(backend: str, name: str) -> str:
 __all__ = [
     "UtilBackend",
     "UtilSample",
-    "intel_util_hint",
+    "intel_gpu_top_grant_binary",
     "resolve_backend",
     "util_backend_name",
 ]

--- a/src/lilbee/providers/fleet/gpu_backends/__init__.py
+++ b/src/lilbee/providers/fleet/gpu_backends/__init__.py
@@ -37,8 +37,38 @@ def resolve_backend(device_backend: str) -> UtilBackend | None:
     return _REGISTRY.get(device_backend)
 
 
+_VULKAN = "Vulkan"
+# Vulkan is vendor-agnostic, and a consumer GPU is often only exposed to the
+# engine via Vulkan. Map a Vulkan device to a vendor's util backend by the vendor
+# named in its device string so its utilization still reads.
+_VENDOR_KEYS: tuple[tuple[str, str], ...] = (
+    ("intel", "SYCL"),
+    ("nvidia", "CUDA"),
+    ("radeon", "ROCm"),
+    ("amd", "ROCm"),
+)
+
+
+def util_backend_name(backend: str, name: str) -> str:
+    """Registry key for a device's util backend.
+
+    A recognized inference backend already implies the vendor. Vulkan does not, so
+    a Vulkan device is mapped by the vendor named in *name*; anything unrecognized
+    is returned unchanged (and resolves to no backend, i.e. structural fallback).
+    """
+    if backend in _REGISTRY:
+        return backend
+    if backend == _VULKAN:
+        lowered = name.lower()
+        for hint, key in _VENDOR_KEYS:
+            if hint in lowered:
+                return key
+    return backend
+
+
 __all__ = [
     "UtilBackend",
     "UtilSample",
     "resolve_backend",
+    "util_backend_name",
 ]

--- a/src/lilbee/providers/fleet/gpu_backends/fdinfo.py
+++ b/src/lilbee/providers/fleet/gpu_backends/fdinfo.py
@@ -1,0 +1,126 @@
+"""Generic DRM fdinfo GPU-utilization reader (no root, no vendor tool).
+
+Modern kernels publish per-client GPU engine-busy counters under
+``/proc/<pid>/fdinfo/<fd>`` for any DRM driver (i915, xe, amdgpu, ...). Each open
+DRM file reports monotonic nanosecond counters per engine::
+
+    drm-driver:	i915
+    drm-pdev:	0000:00:02.0
+    drm-engine-render:	9288864723 ns
+    drm-engine-video:	0 ns
+
+Utilization is the busiest engine's share of wall-clock time over a short window:
+we snapshot the counters, wait, snapshot again, and divide the delta by the
+elapsed time. Counters are summed across every DRM client of the matching driver,
+so a workload split across processes still reads correctly.
+
+This needs no elevated privileges (a process can read its own and same-user
+clients' fdinfo) and no extra tool, but the engine counters only exist on kernels
+new enough to publish them (i915 landed them in ~6.2); older kernels omit the
+``drm-engine-*`` lines and this reader reports nothing, letting a caller fall back.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+_PROC = Path("/proc")
+_ENGINE_PREFIX = "drm-engine-"
+_DRIVER_KEY = "drm-driver"
+_DEFAULT_INTERVAL_S = 0.2
+
+
+def read_drm_util(
+    driver: str,
+    interval_s: float = _DEFAULT_INTERVAL_S,
+    proc: Path = _PROC,
+) -> int | None:
+    """Busiest-engine utilization percent for *driver*'s GPU, or None.
+
+    Returns None when the kernel publishes no engine counters for this driver
+    (too old, or no active DRM clients), so the caller can fall back to a tool.
+    """
+    first = _snapshot(driver, proc)
+    if first is None:
+        return None
+    time.sleep(interval_s)
+    second = _snapshot(driver, proc)
+    if second is None:
+        return None
+    busy1, wall1 = first
+    busy2, wall2 = second
+    elapsed = wall2 - wall1
+    if elapsed <= 0:
+        return None
+    peak = 0.0
+    for engine, ns2 in busy2.items():
+        delta = ns2 - busy1.get(engine, 0)
+        if delta > 0:
+            peak = max(peak, delta / elapsed)
+    return round(min(peak, 1.0) * 100)
+
+
+def _snapshot(driver: str, proc: Path) -> tuple[dict[str, int], int] | None:
+    """Sum engine-busy ns per engine across all DRM clients of *driver*.
+
+    Returns (totals_by_engine, monotonic_ns), or None when no client publishes
+    engine counters for this driver.
+    """
+    totals: dict[str, int] = {}
+    found = False
+    try:
+        pids = [entry for entry in proc.iterdir() if entry.name.isdigit()]
+    except OSError:
+        return None
+    for pid in pids:
+        for engine, ns in _client_engine_ns(pid, driver):
+            totals[engine] = totals.get(engine, 0) + ns
+            found = True
+    if not found:
+        return None
+    return totals, time.monotonic_ns()
+
+
+def _client_engine_ns(pid: Path, driver: str) -> list[tuple[str, int]]:
+    """(engine, ns) pairs from every *driver* DRM client fd under this pid."""
+    pairs: list[tuple[str, int]] = []
+    try:
+        entries = list((pid / "fdinfo").iterdir())
+    except OSError:
+        return pairs
+    for entry in entries:
+        try:
+            text = entry.read_text()
+        except OSError:
+            continue
+        if not _driver_matches(text, driver):
+            continue
+        for line in text.splitlines():
+            if line.startswith(_ENGINE_PREFIX):
+                engine, ns = _parse_engine_line(line)
+                if ns is not None:
+                    pairs.append((engine, ns))
+    return pairs
+
+
+def _driver_matches(text: str, driver: str) -> bool:
+    """True when the fdinfo names *driver* on its drm-driver line."""
+    for line in text.splitlines():
+        if line.startswith(_DRIVER_KEY):
+            _, _, val = line.partition(":")
+            return val.strip() == driver
+    return False
+
+
+def _parse_engine_line(line: str) -> tuple[str, int | None]:
+    """Parse 'drm-engine-render:\\t123 ns' into ('render', 123)."""
+    key, _, val = line.partition(":")
+    engine = key[len(_ENGINE_PREFIX) :]
+    fields = val.split()
+    if not fields:
+        return engine, None
+    try:
+        return engine, int(fields[0])
+    except ValueError:
+        return engine, None

--- a/src/lilbee/providers/fleet/gpu_backends/intel.py
+++ b/src/lilbee/providers/fleet/gpu_backends/intel.py
@@ -20,6 +20,7 @@ as the 0/0 structural sentinel since none of these report an iGPU's total memory
 
 from __future__ import annotations
 
+import functools
 import json
 import shutil
 import subprocess
@@ -43,6 +44,15 @@ _IGT_CAPTURE_S = 0.6
 
 # The i915 DRM driver name, for the fdinfo reader.
 _I915 = "i915"
+
+# intel_gpu_top needs CAP_PERFMON to read the i915 PMU. When it is installed but
+# unprivileged, the util reads back empty; this hint tells the user the one-time
+# fix. A working PMU streams, so the check hits the timeout and reports usable.
+_IGT_PERM_CHECK_S = 1.0
+_SETCAP_HINT = (
+    "Intel GPU utilization needs a one-time grant: "
+    "sudo setcap cap_perfmon+ep {binary}  (or Linux 6.2+ reads it with no setup)"
+)
 
 
 class IntelBackend:
@@ -205,3 +215,38 @@ def _single(indices: frozenset[int], util: int) -> dict[int, UtilSample]:
     return {
         idx: UtilSample(idx, utilization_pct=util, temperature_c=None, free_bytes=0, total_bytes=0)
     }
+
+
+@functools.cache
+def intel_util_hint() -> str | None:
+    """Actionable one-liner when Intel util is missing only for a fixable reason.
+
+    Returns the setcap command when intel_gpu_top is installed but the i915 PMU is
+    permission-blocked, so a surface shows it only when it will actually help;
+    None when the tool is absent or already usable. Cached: the permission state
+    does not change within a run (and the notice is gated on util being missing,
+    so it disappears on its own once a grant makes util read).
+    """
+    binary = shutil.which(_TOOL_IGT)
+    if binary is None:
+        return None
+    if _igt_permission_denied(binary):
+        return _SETCAP_HINT.format(binary=binary)
+    return None
+
+
+def _igt_permission_denied(binary: str) -> bool:
+    """True when intel_gpu_top reports the i915 PMU is permission-blocked."""
+    try:
+        proc = subprocess.run(  # noqa: S603 - resolved binary, fixed args
+            [binary, "-J", "-s", str(_IGT_SAMPLE_MS)],
+            capture_output=True,
+            text=True,
+            timeout=_IGT_PERM_CHECK_S,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False  # it streamed rather than erroring out, so the PMU is usable
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "CAP_PERFMON" in proc.stderr or "Permission denied" in proc.stderr

--- a/src/lilbee/providers/fleet/gpu_backends/intel.py
+++ b/src/lilbee/providers/fleet/gpu_backends/intel.py
@@ -1,44 +1,64 @@
-"""SYCL/Intel GPU utilization via xpu-smi.
+"""Intel GPU utilization from the first available source.
 
-`xpu-smi stats -d <id> -j` reports device metrics as a ``device_level`` array of
-``{"metrics_type": "XPUM_STATS_...", "value": N}`` objects (one metric per entry),
-not the flat ``gpu_utilization`` keys an earlier parser assumed. The metrics_type
-strings are the names of xpum_stats_type_enum; utilization is a percentage and
-memory-used is in bytes. Total VRAM is not reported by stats, so VRAM is left as
-the 0/0 sentinel and the orchestrator falls back to structural VRAM.
+Intel exposes GPU activity three different ways depending on the GPU class,
+kernel, and privileges. We try them in order and take the first that reports:
 
-stats reports one device per call, so we run it once per requested index.
+1. ``xpu-smi`` (Intel XPU Manager) -- Data Center GPU Max/Flex and Arc only.
+   Reads a ``device_level`` array of {metrics_type, value} objects keyed by the
+   xpum_stats_type_enum names. One device per call, no root.
+2. DRM ``fdinfo`` -- the kernel's per-client engine-busy counters. Covers
+   consumer iGPUs with no root and no extra tool, but only on kernels new enough
+   to publish i915 engine stats (~6.2+).
+3. ``intel_gpu_top`` (Intel GPU Tools) -- reads the i915 PMU, so it covers
+   essentially every consumer iGPU on kernel 4.16+, but needs CAP_PERFMON (or
+   root); it falls through cleanly when the permission isn't granted.
+
+The fdinfo and intel_gpu_top sources report one device (the consumer case is a
+single iGPU); their reading is keyed to the lowest requested index. VRAM is left
+as the 0/0 structural sentinel since none of these report an iGPU's total memory.
 """
 
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 
+from lilbee.providers.fleet.gpu_backends import fdinfo
 from lilbee.providers.fleet.gpu_backends.base import UtilSample, extract_int, run_smi
 
-_TOOL = "xpu-smi"
+_TOOL_XPU_SMI = "xpu-smi"
+_TOOL_IGT = "intel_gpu_top"
 _TIMEOUT_S = 5.0
 
-# xpum_stats_type_enum names, as emitted verbatim in the device_level "metrics_type".
+# xpu-smi device_level metrics_type names (xpum_stats_type_enum).
 _METRIC_UTIL = "XPUM_STATS_GPU_UTILIZATION"
 _METRIC_TEMP = "XPUM_STATS_GPU_CORE_TEMPERATURE"
 
+# intel_gpu_top streams JSON samples forever; run it for one short window and
+# read the partial output. A couple of 200ms periods lands a fresh per-interval
+# reading while keeping the (synchronous) probe from stalling the caller long.
+_IGT_SAMPLE_MS = 200
+_IGT_CAPTURE_S = 0.6
+
+# The i915 DRM driver name, for the fdinfo reader.
+_I915 = "i915"
+
 
 class IntelBackend:
-    """SYCL util via xpu-smi, one `stats -d <id>` call per device."""
+    """Intel util from xpu-smi, then DRM fdinfo, then intel_gpu_top."""
 
     def sample(self, indices: frozenset[int]) -> dict[int, UtilSample]:
-        samples: dict[int, UtilSample] = {}
-        for index in sorted(indices):
-            sample = _parse_xpu_smi(_xpu_smi_output(index), index)
-            if sample is not None:
-                samples[index] = sample
-        return samples
+        for source in (_xpu_smi_samples, _fdinfo_samples, _intel_gpu_top_samples):
+            result = source(indices)
+            if result:
+                return result
+        return {}
 
 
 def _xpu_smi_output(index: int) -> str:
     """xpu-smi stats JSON stdout for one device, or "" when it can't run."""
-    return run_smi(_TOOL, ["stats", "-d", str(index), "-j"], _TIMEOUT_S)
+    return run_smi(_TOOL_XPU_SMI, ["stats", "-d", str(index), "-j"], _TIMEOUT_S)
 
 
 def _device_level(data: object) -> list[object]:
@@ -87,3 +107,101 @@ def _parse_xpu_smi(raw: str, index: int) -> UtilSample | None:
         free_bytes=0,
         total_bytes=0,
     )
+
+
+def _xpu_smi_samples(indices: frozenset[int]) -> dict[int, UtilSample]:
+    samples: dict[int, UtilSample] = {}
+    for index in sorted(indices):
+        sample = _parse_xpu_smi(_xpu_smi_output(index), index)
+        if sample is not None:
+            samples[index] = sample
+    return samples
+
+
+def _fdinfo_samples(indices: frozenset[int]) -> dict[int, UtilSample]:
+    if not indices:
+        return {}
+    util = fdinfo.read_drm_util(_I915)
+    if util is None:
+        return {}
+    return _single(indices, util)
+
+
+def _intel_gpu_top_output() -> str:
+    """intel_gpu_top -J partial stdout over one short window, or "" on failure.
+
+    intel_gpu_top streams until killed, so it always hits the timeout on success;
+    a permission failure exits fast with empty stdout. Both yield the right thing.
+    """
+    binary = shutil.which(_TOOL_IGT)
+    if binary is None:
+        return ""
+    try:
+        proc = subprocess.run(  # noqa: S603 - fixed args, resolved binary
+            [binary, "-J", "-s", str(_IGT_SAMPLE_MS)],
+            capture_output=True,
+            text=True,
+            timeout=_IGT_CAPTURE_S,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        out = exc.stdout
+        if out is None:
+            return ""
+        return out if isinstance(out, str) else out.decode(errors="replace")
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return proc.stdout
+
+
+def _last_json_object(raw: str) -> dict[str, object] | None:
+    """Parse the last complete sample from intel_gpu_top's streamed JSON array."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    # The stream is an unclosed '[ {..}, {..},' -- close it and take the last item.
+    if raw.startswith("[") and not raw.endswith("]"):
+        raw = raw.rstrip().rstrip(",") + "]"
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(data, list):
+        last = data[-1] if data else None
+        return last if isinstance(last, dict) else None
+    return data if isinstance(data, dict) else None
+
+
+def _igt_max_busy(raw: str) -> int | None:
+    """Busiest engine's busy percent from an intel_gpu_top sample, or None."""
+    obj = _last_json_object(raw)
+    if obj is None:
+        return None
+    engines = obj.get("engines")
+    if not isinstance(engines, dict):
+        return None
+    busies = [
+        float(eng["busy"])
+        for eng in engines.values()
+        if isinstance(eng, dict) and isinstance(eng.get("busy"), (int, float))
+    ]
+    if not busies:
+        return None
+    return round(max(busies))
+
+
+def _intel_gpu_top_samples(indices: frozenset[int]) -> dict[int, UtilSample]:
+    if not indices:
+        return {}
+    util = _igt_max_busy(_intel_gpu_top_output())
+    if util is None:
+        return {}
+    return _single(indices, util)
+
+
+def _single(indices: frozenset[int], util: int) -> dict[int, UtilSample]:
+    """One device-level reading keyed to the lowest requested index (iGPU case)."""
+    idx = min(indices)
+    return {
+        idx: UtilSample(idx, utilization_pct=util, temperature_c=None, free_bytes=0, total_bytes=0)
+    }

--- a/src/lilbee/providers/fleet/gpu_backends/intel.py
+++ b/src/lilbee/providers/fleet/gpu_backends/intel.py
@@ -1,64 +1,89 @@
-"""SYCL/Intel GPU utilization via xpu-smi."""
+"""SYCL/Intel GPU utilization via xpu-smi.
+
+`xpu-smi stats -d <id> -j` reports device metrics as a ``device_level`` array of
+``{"metrics_type": "XPUM_STATS_...", "value": N}`` objects (one metric per entry),
+not the flat ``gpu_utilization`` keys an earlier parser assumed. The metrics_type
+strings are the names of xpum_stats_type_enum; utilization is a percentage and
+memory-used is in bytes. Total VRAM is not reported by stats, so VRAM is left as
+the 0/0 sentinel and the orchestrator falls back to structural VRAM.
+
+stats reports one device per call, so we run it once per requested index.
+"""
 
 from __future__ import annotations
 
 import json
 
-from lilbee.providers.fleet.devices import MIB
 from lilbee.providers.fleet.gpu_backends.base import UtilSample, extract_int, run_smi
 
 _TOOL = "xpu-smi"
-_ARGS = ("stats", "--json")
 _TIMEOUT_S = 5.0
+
+# xpum_stats_type_enum names, as emitted verbatim in the device_level "metrics_type".
+_METRIC_UTIL = "XPUM_STATS_GPU_UTILIZATION"
+_METRIC_TEMP = "XPUM_STATS_GPU_CORE_TEMPERATURE"
 
 
 class IntelBackend:
-    """SYCL util via xpu-smi."""
+    """SYCL util via xpu-smi, one `stats -d <id>` call per device."""
 
     def sample(self, indices: frozenset[int]) -> dict[int, UtilSample]:
-        return _xpu_smi_samples(indices)
+        samples: dict[int, UtilSample] = {}
+        for index in sorted(indices):
+            sample = _parse_xpu_smi(_xpu_smi_output(index), index)
+            if sample is not None:
+                samples[index] = sample
+        return samples
 
 
-def _xpu_smi_output() -> str:
-    """xpu-smi JSON stdout, or "" when it can't run."""
-    return run_smi(_TOOL, list(_ARGS), _TIMEOUT_S)
+def _xpu_smi_output(index: int) -> str:
+    """xpu-smi stats JSON stdout for one device, or "" when it can't run."""
+    return run_smi(_TOOL, ["stats", "-d", str(index), "-j"], _TIMEOUT_S)
 
 
-def _parse_xpu_smi(raw: str, indices: frozenset[int]) -> dict[int, UtilSample]:
-    """Parse xpu-smi JSON into UtilSample per index, or {} on failure."""
+def _device_level(data: object) -> list[object]:
+    """Return the device_level metric array from parsed stats JSON, or []."""
+    # stats -d <id> -j emits a single device object with a "device_level" array.
+    # Tolerate a bare list or a {"device_list": [...]} wrapper defensively.
+    if isinstance(data, dict):
+        top_level = data.get("device_level")
+        if isinstance(top_level, list):
+            return top_level
+        wrapped = data.get("device_list")
+        if isinstance(wrapped, list) and wrapped and isinstance(wrapped[0], dict):
+            inner = wrapped[0].get("device_level")
+            return inner if isinstance(inner, list) else []
+    if isinstance(data, list) and data and isinstance(data[0], dict):
+        inner = data[0].get("device_level")
+        return inner if isinstance(inner, list) else []
+    return []
+
+
+def _metric_int(entries: list[object], metrics_type: str) -> int | None:
+    """First device_level entry with this metrics_type, coerced to int, or None."""
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("metrics_type") == metrics_type:
+            return extract_int(entry, ("value",))
+    return None
+
+
+def _parse_xpu_smi(raw: str, index: int) -> UtilSample | None:
+    """Parse one device's xpu-smi stats JSON into a UtilSample, or None on failure."""
     if not raw:
-        return {}
+        return None
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
-        return {}
-    # xpu-smi stats --json emits a list of device objects or {"device_list": [...]}.
-    items: list[object] = data if isinstance(data, list) else data.get("device_list", [])
-    samples: dict[int, UtilSample] = {}
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        try:
-            index = int(item.get("device_id", -1))
-        except (ValueError, TypeError):
-            continue
-        if index not in indices:
-            continue
-        util = extract_int(item, ("gpu_utilization", "eu_active", "xe_eu_active"))
-        temp = extract_int(item, ("gpu_temperature", "temperature"))
-        used_mib = extract_int(item, ("gpu_memory_used_in_mb", "mem_used"))
-        total_mib = extract_int(item, ("gpu_memory_size_in_mb", "mem_total"))
-        free = max((total_mib or 0) - (used_mib or 0), 0) * MIB if total_mib else 0
-        total = (total_mib or 0) * MIB
-        samples[index] = UtilSample(
-            index=index,
-            utilization_pct=util,
-            temperature_c=temp,
-            free_bytes=free,
-            total_bytes=total,
-        )
-    return samples
-
-
-def _xpu_smi_samples(indices: frozenset[int]) -> dict[int, UtilSample]:
-    return _parse_xpu_smi(_xpu_smi_output(), indices)
+        return None
+    entries = _device_level(data)
+    if not entries:
+        return None
+    return UtilSample(
+        index=index,
+        utilization_pct=_metric_int(entries, _METRIC_UTIL),
+        temperature_c=_metric_int(entries, _METRIC_TEMP),
+        # stats reports memory-used but not total; leave the 0/0 sentinel so the
+        # orchestrator keeps structural VRAM.
+        free_bytes=0,
+        total_bytes=0,
+    )

--- a/src/lilbee/providers/fleet/gpu_backends/intel.py
+++ b/src/lilbee/providers/fleet/gpu_backends/intel.py
@@ -46,13 +46,9 @@ _IGT_CAPTURE_S = 0.6
 _I915 = "i915"
 
 # intel_gpu_top needs CAP_PERFMON to read the i915 PMU. When it is installed but
-# unprivileged, the util reads back empty; this hint tells the user the one-time
-# fix. A working PMU streams, so the check hits the timeout and reports usable.
+# unprivileged, the util reads back empty. A working PMU streams, so the check
+# hits the timeout and reports usable.
 _IGT_PERM_CHECK_S = 1.0
-_SETCAP_HINT = (
-    "Intel GPU utilization needs a one-time grant: "
-    "sudo setcap cap_perfmon+ep {binary}  (or Linux 6.2+ reads it with no setup)"
-)
 
 
 class IntelBackend:
@@ -218,21 +214,18 @@ def _single(indices: frozenset[int], util: int) -> dict[int, UtilSample]:
 
 
 @functools.cache
-def intel_util_hint() -> str | None:
-    """Actionable one-liner when Intel util is missing only for a fixable reason.
+def intel_gpu_top_grant_binary() -> str | None:
+    """The intel_gpu_top path a CAP_PERFMON grant would unblock, or None.
 
-    Returns the setcap command when intel_gpu_top is installed but the i915 PMU is
-    permission-blocked, so a surface shows it only when it will actually help;
-    None when the tool is absent or already usable. Cached: the permission state
-    does not change within a run (and the notice is gated on util being missing,
-    so it disappears on its own once a grant makes util read).
+    Returns the binary when it is installed but the i915 PMU is permission-blocked
+    (the caller turns this into a user-facing grant hint); None when the tool is
+    absent or already usable. Cached: the permission state does not change within
+    a run.
     """
     binary = shutil.which(_TOOL_IGT)
     if binary is None:
         return None
-    if _igt_permission_denied(binary):
-        return _SETCAP_HINT.format(binary=binary)
-    return None
+    return binary if _igt_permission_denied(binary) else None
 
 
 def _igt_permission_denied(binary: str) -> bool:

--- a/src/lilbee/providers/fleet/gpu_stats.py
+++ b/src/lilbee/providers/fleet/gpu_stats.py
@@ -79,8 +79,9 @@ def probe_gpu_stats(devices: Sequence[DeviceLike]) -> dict[int, GpuStat]:
             if index not in stats:
                 continue
             base = stats[index]
-            # Keep structural VRAM when the backend returns 0/0 (amd-smi metric
-            # mode omits VRAM; xpu-smi populates it so it takes precedence).
+            # Keep structural VRAM when the backend returns the 0/0 sentinel
+            # (amd-smi metric mode and xpu-smi stats both omit total VRAM); a
+            # backend that does report memory takes precedence.
             free = sample.free_bytes if sample.free_bytes or sample.total_bytes else base.free_bytes
             total = sample.total_bytes if sample.total_bytes else base.total_bytes
             stats[index] = GpuStat(

--- a/src/lilbee/providers/fleet/gpu_stats.py
+++ b/src/lilbee/providers/fleet/gpu_stats.py
@@ -16,7 +16,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
-from lilbee.providers.fleet.gpu_backends import UtilSample, resolve_backend, util_backend_name
+from lilbee.providers.fleet.gpu_backends import (
+    UtilSample,
+    intel_util_hint,
+    resolve_backend,
+    util_backend_name,
+)
 
 
 class DeviceLike(Protocol):
@@ -97,3 +102,22 @@ def probe_gpu_stats(devices: Sequence[DeviceLike]) -> dict[int, GpuStat]:
             )
 
     return {i: stats[i] for i in sorted(stats)}
+
+
+def util_notice(devices: Sequence[DeviceLike], stats: dict[int, GpuStat]) -> str | None:
+    """An actionable hint when a GPU's utilization is missing but fixable, else None.
+
+    Surfaces the Intel setcap hint when an Intel GPU reports no utilization and the
+    only thing in the way is the one-time permission grant. Modern kernels read util
+    with no grant, so this stays silent there (and once util reads, the None gate
+    below drops the notice on its own).
+    """
+    for d in devices:
+        if util_backend_name(d.backend, d.name) != "SYCL":
+            continue
+        stat = stats.get(d.index)
+        if stat is not None and stat.utilization_pct is None:
+            hint = intel_util_hint()
+            if hint is not None:
+                return hint
+    return None

--- a/src/lilbee/providers/fleet/gpu_stats.py
+++ b/src/lilbee/providers/fleet/gpu_stats.py
@@ -16,7 +16,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
-from lilbee.providers.fleet.gpu_backends import UtilSample, resolve_backend
+from lilbee.providers.fleet.gpu_backends import UtilSample, resolve_backend, util_backend_name
 
 
 class DeviceLike(Protocol):
@@ -26,6 +26,8 @@ class DeviceLike(Protocol):
     def index(self) -> int: ...
     @property
     def backend(self) -> str: ...
+    @property
+    def name(self) -> str: ...
     @property
     def total_bytes(self) -> int: ...
     @property
@@ -69,9 +71,11 @@ def probe_gpu_stats(devices: Sequence[DeviceLike]) -> dict[int, GpuStat]:
         d.index: GpuStat(d.index, None, d.free_bytes, d.total_bytes) for d in devices
     }
 
+    # Group by the util backend, not the raw inference backend: a Vulkan-exposed
+    # consumer GPU routes to its vendor's util source by name.
     by_backend: dict[str, list[DeviceLike]] = {}
     for d in devices:
-        by_backend.setdefault(d.backend, []).append(d)
+        by_backend.setdefault(util_backend_name(d.backend, d.name), []).append(d)
 
     for backend_name, group in by_backend.items():
         indices = frozenset(d.index for d in group)

--- a/src/lilbee/providers/fleet/gpu_stats.py
+++ b/src/lilbee/providers/fleet/gpu_stats.py
@@ -18,7 +18,7 @@ from typing import Protocol
 
 from lilbee.providers.fleet.gpu_backends import (
     UtilSample,
-    intel_util_hint,
+    intel_gpu_top_grant_binary,
     resolve_backend,
     util_backend_name,
 )
@@ -104,20 +104,20 @@ def probe_gpu_stats(devices: Sequence[DeviceLike]) -> dict[int, GpuStat]:
     return {i: stats[i] for i in sorted(stats)}
 
 
-def util_notice(devices: Sequence[DeviceLike], stats: dict[int, GpuStat]) -> str | None:
-    """An actionable hint when a GPU's utilization is missing but fixable, else None.
+def intel_grant_binary(devices: Sequence[DeviceLike], stats: dict[int, GpuStat]) -> str | None:
+    """The intel_gpu_top path a grant would unblock when an Intel GPU's util is
+    missing only for that reason, else None.
 
-    Surfaces the Intel setcap hint when an Intel GPU reports no utilization and the
-    only thing in the way is the one-time permission grant. Modern kernels read util
-    with no grant, so this stays silent there (and once util reads, the None gate
-    below drops the notice on its own).
+    A surface turns the binary into the localized grant hint. Modern kernels read
+    util with no grant, so this stays silent there, and the None-util gate clears
+    it once a grant makes util read.
     """
     for d in devices:
         if util_backend_name(d.backend, d.name) != "SYCL":
             continue
         stat = stats.get(d.index)
         if stat is not None and stat.utilization_pct is None:
-            hint = intel_util_hint()
-            if hint is not None:
-                return hint
+            binary = intel_gpu_top_grant_binary()
+            if binary is not None:
+                return binary
     return None

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -164,13 +164,16 @@ async def gpu_stats_stream(
     A heartbeat is emitted every ``cfg.sse_heartbeat_interval`` seconds of idle so
     clients don't time out.
     """
-    from lilbee.providers.fleet.gpu_stats import probe_gpu_stats
+    from lilbee.providers.fleet.gpu_stats import probe_gpu_stats, util_notice
 
     last_heartbeat = time.monotonic()
     tick = 0
     while max_ticks is None or tick < max_ticks:
         stats = probe_gpu_stats(devices)  # type: ignore[arg-type]
-        payload = {"gpus": [dataclasses.asdict(s) for s in stats.values()]}
+        payload: dict[str, object] = {"gpus": [dataclasses.asdict(s) for s in stats.values()]}
+        notice = util_notice(devices, stats)  # type: ignore[arg-type]
+        if notice:
+            payload["notice"] = notice
         yield sse_event(SseEvent.GPU_STATS, payload)
         tick += 1
         if max_ticks is None or tick < max_ticks:

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -159,9 +159,10 @@ async def gpu_stats_stream(
 
     Devices are resolved by the caller before the stream starts so a ProviderError
     surfaces as a 503 at route time, not mid-stream. Each tick only runs the light
-    ``nvidia-smi`` query. The client keeps the stream open while visible;
-    ``max_ticks`` bounds it for tests. A heartbeat is emitted every
-    ``cfg.sse_heartbeat_interval`` seconds of idle so clients don't time out.
+    per-vendor utilization probe (nvidia-smi, amd-smi, xpu-smi, or ioreg). The
+    client keeps the stream open while visible; ``max_ticks`` bounds it for tests.
+    A heartbeat is emitted every ``cfg.sse_heartbeat_interval`` seconds of idle so
+    clients don't time out.
     """
     from lilbee.providers.fleet.gpu_stats import probe_gpu_stats
 

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -164,16 +164,17 @@ async def gpu_stats_stream(
     A heartbeat is emitted every ``cfg.sse_heartbeat_interval`` seconds of idle so
     clients don't time out.
     """
-    from lilbee.providers.fleet.gpu_stats import probe_gpu_stats, util_notice
+    from lilbee.cli.tui import messages as msg
+    from lilbee.providers.fleet.gpu_stats import intel_grant_binary, probe_gpu_stats
 
     last_heartbeat = time.monotonic()
     tick = 0
     while max_ticks is None or tick < max_ticks:
         stats = probe_gpu_stats(devices)  # type: ignore[arg-type]
         payload: dict[str, object] = {"gpus": [dataclasses.asdict(s) for s in stats.values()]}
-        notice = util_notice(devices, stats)  # type: ignore[arg-type]
-        if notice:
-            payload["notice"] = notice
+        binary = intel_grant_binary(devices, stats)  # type: ignore[arg-type]
+        if binary:
+            payload["notice"] = msg.FLEET_INTEL_UTIL_GRANT.format(binary=binary)
         yield sse_event(SseEvent.GPU_STATS, payload)
         tick += 1
         if max_ticks is None or tick < max_ticks:

--- a/tests/providers/fleet/gpu_backends/test_fdinfo.py
+++ b/tests/providers/fleet/gpu_backends/test_fdinfo.py
@@ -1,0 +1,136 @@
+"""Tests for the generic DRM fdinfo utilization reader.
+
+The fdinfo fixtures below mirror the kernel's drm-usage-stats format. Live capture
+on a modern-kernel box (kernel 6.2+, e.g. an amdgpu or i915 GPU under load)
+confirms the real counters; these tests pin the parsing and delta math.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lilbee.providers.fleet.gpu_backends import fdinfo
+
+_S = 1_000_000_000  # one second in nanoseconds
+
+
+def _write_fdinfo(proc: Path, pid: int, fd: int, body: str) -> None:
+    d = proc / str(pid) / "fdinfo"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / str(fd)).write_text(body)
+
+
+# ---------------------------------------------------------------------------
+# read_drm_util: delta math (snapshots stubbed)
+# ---------------------------------------------------------------------------
+
+
+def _stub_snapshots(monkeypatch: pytest.MonkeyPatch, snaps: list[object]) -> None:
+    monkeypatch.setattr(fdinfo, "_snapshot", lambda *_a: snaps.pop(0))
+    monkeypatch.setattr(fdinfo.time, "sleep", lambda _s: None)
+
+
+def test_read_drm_util_busiest_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_snapshots(
+        monkeypatch,
+        [
+            ({"render": 1000, "video": 500}, _S),
+            ({"render": 1000 + 850_000_000, "video": 500}, 2 * _S),
+        ],
+    )
+    assert fdinfo.read_drm_util("i915") == 85
+
+
+def test_read_drm_util_caps_at_100_and_ignores_negative(monkeypatch: pytest.MonkeyPatch) -> None:
+    # render counter dropped (client left) -> ignored; copy exceeds wall -> capped.
+    _stub_snapshots(
+        monkeypatch,
+        [({"render": 9_000, "copy": 0}, _S), ({"render": 10, "copy": 3 * _S}, 2 * _S)],
+    )
+    assert fdinfo.read_drm_util("i915") == 100
+
+
+def test_read_drm_util_none_when_no_first_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_snapshots(monkeypatch, [None])
+    assert fdinfo.read_drm_util("i915") is None
+
+
+def test_read_drm_util_none_when_no_second_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_snapshots(monkeypatch, [({"render": 1}, _S), None])
+    assert fdinfo.read_drm_util("i915") is None
+
+
+def test_read_drm_util_none_when_no_elapsed_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_snapshots(monkeypatch, [({"render": 1}, _S), ({"render": 999}, _S)])
+    assert fdinfo.read_drm_util("i915") is None
+
+
+# ---------------------------------------------------------------------------
+# _snapshot: /proc scanning (tmp_path fixtures)
+# ---------------------------------------------------------------------------
+
+_I915_FD = "drm-driver:\ti915\ndrm-engine-render:\t500 ns\ndrm-engine-video:\t0 ns\n"
+
+
+def test_snapshot_sums_engines_across_clients(tmp_path: Path) -> None:
+    _write_fdinfo(tmp_path, 100, 3, _I915_FD)
+    _write_fdinfo(tmp_path, 200, 4, "drm-driver:\ti915\ndrm-engine-render:\t250 ns\n")
+    result = fdinfo._snapshot("i915", tmp_path)
+    assert result is not None
+    totals, wall = result
+    assert totals["render"] == 750
+    assert isinstance(wall, int)
+
+
+def test_snapshot_skips_other_driver(tmp_path: Path) -> None:
+    _write_fdinfo(tmp_path, 100, 3, "drm-driver:\tamdgpu\ndrm-engine-gfx:\t500 ns\n")
+    assert fdinfo._snapshot("i915", tmp_path) is None
+
+
+def test_snapshot_none_when_no_engine_lines(tmp_path: Path) -> None:
+    _write_fdinfo(tmp_path, 100, 3, "drm-driver:\ti915\ndrm-pdev:\t0000:00:02.0\n")
+    assert fdinfo._snapshot("i915", tmp_path) is None
+
+
+def test_snapshot_none_when_proc_unreadable(tmp_path: Path) -> None:
+    assert fdinfo._snapshot("i915", tmp_path / "does-not-exist") is None
+
+
+def test_snapshot_skips_pid_without_fdinfo(tmp_path: Path) -> None:
+    (tmp_path / "100").mkdir()  # a pid dir with no fdinfo subdir
+    _write_fdinfo(tmp_path, 200, 4, _I915_FD)
+    result = fdinfo._snapshot("i915", tmp_path)
+    assert result is not None and result[0]["render"] == 500
+
+
+def test_snapshot_skips_non_pid_entries(tmp_path: Path) -> None:
+    (tmp_path / "cpuinfo").write_text("x")  # non-numeric /proc entry
+    _write_fdinfo(tmp_path, 200, 4, _I915_FD)
+    assert fdinfo._snapshot("i915", tmp_path) is not None
+
+
+def test_snapshot_skips_unreadable_entry(tmp_path: Path) -> None:
+    # An fdinfo entry that is a directory -> read_text raises OSError -> skipped.
+    (tmp_path / "100" / "fdinfo" / "3").mkdir(parents=True)
+    _write_fdinfo(tmp_path, 200, 4, _I915_FD)
+    result = fdinfo._snapshot("i915", tmp_path)
+    assert result is not None and result[0]["render"] == 500
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def test_driver_matches() -> None:
+    assert fdinfo._driver_matches("drm-driver:\ti915\n", "i915") is True
+    assert fdinfo._driver_matches("drm-driver:\tamdgpu\n", "i915") is False
+    assert fdinfo._driver_matches("pos:\t0\n", "i915") is False
+
+
+def test_parse_engine_line() -> None:
+    assert fdinfo._parse_engine_line("drm-engine-render:\t123 ns") == ("render", 123)
+    assert fdinfo._parse_engine_line("drm-engine-x:\tabc ns") == ("x", None)
+    assert fdinfo._parse_engine_line("drm-engine-y:") == ("y", None)

--- a/tests/providers/fleet/gpu_backends/test_intel.py
+++ b/tests/providers/fleet/gpu_backends/test_intel.py
@@ -1,13 +1,13 @@
-"""Tests for the SYCL/Intel utilization backend (xpu-smi).
+"""Tests for the Intel utilization backend (xpu-smi -> fdinfo -> intel_gpu_top).
 
-The fixture below mirrors the real `xpu-smi stats -d <id> -j` shape derived from
-the xpumanager CLI source (a ``device_level`` array of {metrics_type, value}
-objects keyed by the xpum_stats_type_enum names). Live capture on Intel Data
-Center GPU Max / Arc hardware confirms the numeric scaling and swaps this fixture
-for real tool output.
+The xpu-smi and intel_gpu_top fixtures mirror the real tool output (xpu-smi from
+the xpumanager CLI source; intel_gpu_top captured live from a CometLake iGPU).
+Live capture confirms the numbers; these tests pin the parsing and source order.
 """
 
 from __future__ import annotations
+
+import subprocess
 
 import pytest
 
@@ -15,22 +15,34 @@ from lilbee.providers.fleet import gpu_backends
 from lilbee.providers.fleet.gpu_backends import intel as intel_mod
 from lilbee.providers.fleet.gpu_backends.intel import IntelBackend, _parse_xpu_smi
 
-# Real device_level shape: one {metrics_type, value} entry per metric.
+# Real xpu-smi device_level shape.
 _XPU_JSON = """\
 {
   "device_id": 0,
   "device_level": [
     {"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": 88},
-    {"metrics_type": "XPUM_STATS_EU_ACTIVE", "value": 60},
-    {"metrics_type": "XPUM_STATS_GPU_CORE_TEMPERATURE", "value": 73},
-    {"metrics_type": "XPUM_STATS_MEMORY_USED", "value": 1073741824}
+    {"metrics_type": "XPUM_STATS_GPU_CORE_TEMPERATURE", "value": 73}
   ]
 }
 """
 
+# Real intel_gpu_top -J shape: an unclosed, comma-terminated array of samples,
+# each with an "engines" map of {"busy": pct}. Last sample peaks Render/3D at 85.
+_IGT_STREAM = (
+    "[\n"
+    '{"engines":{"Render/3D":{"busy":1.6,"unit":"%"},"Video":{"busy":0.0,"unit":"%"}}},\n'
+    '{"engines":{"Render/3D":{"busy":85.0,"unit":"%"},"Video":{"busy":12.0,"unit":"%"}}},\n'
+)
+
+
+def _no_fallbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize the fdinfo + intel_gpu_top sources so xpu-smi tests are hermetic."""
+    monkeypatch.setattr(intel_mod.fdinfo, "read_drm_util", lambda *_a, **_k: None)
+    monkeypatch.setattr(intel_mod, "_intel_gpu_top_output", lambda: "")
+
 
 # ---------------------------------------------------------------------------
-# _parse_xpu_smi
+# xpu-smi parsing
 # ---------------------------------------------------------------------------
 
 
@@ -39,38 +51,25 @@ def test_parse_xpu_smi_happy_path() -> None:
     assert sample is not None
     assert sample.utilization_pct == 88
     assert sample.temperature_c == 73
-
-
-def test_parse_xpu_smi_keys_sample_by_requested_index() -> None:
-    """The sample's index is the requested device, not any id parsed from output."""
-    sample = _parse_xpu_smi(_XPU_JSON, 3)
-    assert sample is not None
-    assert sample.index == 3
-
-
-def test_parse_xpu_smi_vram_is_sentinel() -> None:
-    """stats reports memory-used but no total; VRAM stays the 0/0 structural sentinel."""
-    sample = _parse_xpu_smi(_XPU_JSON, 0)
-    assert sample is not None
     assert sample.free_bytes == 0
     assert sample.total_bytes == 0
 
 
+def test_parse_xpu_smi_keys_sample_by_requested_index() -> None:
+    sample = _parse_xpu_smi(_XPU_JSON, 3)
+    assert sample is not None and sample.index == 3
+
+
 def test_parse_xpu_smi_decimal_string_value() -> None:
-    """A metric value emitted as a decimal string is coerced to int."""
     raw = '{"device_level": [{"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": "55.0"}]}'
     sample = _parse_xpu_smi(raw, 0)
-    assert sample is not None
-    assert sample.utilization_pct == 55
+    assert sample is not None and sample.utilization_pct == 55
 
 
 def test_parse_xpu_smi_missing_util_metric_leaves_none() -> None:
-    """A device_level without the utilization metric yields util None, not a crash."""
     raw = '{"device_level": [{"metrics_type": "XPUM_STATS_GPU_CORE_TEMPERATURE", "value": 50}]}'
     sample = _parse_xpu_smi(raw, 0)
-    assert sample is not None
-    assert sample.utilization_pct is None
-    assert sample.temperature_c == 50
+    assert sample is not None and sample.utilization_pct is None and sample.temperature_c == 50
 
 
 def test_parse_xpu_smi_device_list_wrapper() -> None:
@@ -79,15 +78,13 @@ def test_parse_xpu_smi_device_list_wrapper() -> None:
         '[{"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": 42}]}]}'
     )
     sample = _parse_xpu_smi(raw, 0)
-    assert sample is not None
-    assert sample.utilization_pct == 42
+    assert sample is not None and sample.utilization_pct == 42
 
 
 def test_parse_xpu_smi_bare_list_wrapper() -> None:
     raw = '[{"device_level": [{"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": 17}]}]'
     sample = _parse_xpu_smi(raw, 0)
-    assert sample is not None
-    assert sample.utilization_pct == 17
+    assert sample is not None and sample.utilization_pct == 17
 
 
 def test_parse_xpu_smi_empty_string() -> None:
@@ -103,28 +100,24 @@ def test_parse_xpu_smi_no_device_level_returns_none() -> None:
 
 
 def test_parse_xpu_smi_skips_non_dict_entries() -> None:
-    """Non-dict device_level entries are skipped, not crashed on."""
     raw = '{"device_level": [1, "x", {"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": 22}]}'
     sample = _parse_xpu_smi(raw, 0)
-    assert sample is not None
-    assert sample.utilization_pct == 22
+    assert sample is not None and sample.utilization_pct == 22
 
 
 # ---------------------------------------------------------------------------
-# IntelBackend.sample
-# run_smi is imported by name into intel_mod; patch there, not in base.
+# Source order: xpu-smi -> fdinfo -> intel_gpu_top
 # ---------------------------------------------------------------------------
 
 
-def test_sample_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sample_prefers_xpu_smi(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(intel_mod, "run_smi", lambda *_a, **_k: _XPU_JSON)
+    monkeypatch.setattr(intel_mod.fdinfo, "read_drm_util", lambda *_a, **_k: 99)
     result = IntelBackend().sample(frozenset({0}))
-    assert result[0].utilization_pct == 88
-    assert result[0].temperature_c == 73
+    assert result[0].utilization_pct == 88  # xpu-smi won, not fdinfo
 
 
-def test_sample_runs_stats_per_index_with_device_flag(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Each requested index runs `xpu-smi stats -d <index> -j` once."""
+def test_sample_runs_xpu_smi_per_index_with_device_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[list[str]] = []
 
     def _run_smi(_tool: str, args: list[str], *_a: object, **_k: object) -> str:
@@ -136,9 +129,144 @@ def test_sample_runs_stats_per_index_with_device_flag(monkeypatch: pytest.Monkey
     assert calls == [["stats", "-d", "0", "-j"], ["stats", "-d", "1", "-j"]]
 
 
-def test_sample_tool_absent_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sample_falls_back_to_fdinfo(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(intel_mod, "run_smi", lambda *_a, **_k: "")
+    monkeypatch.setattr(intel_mod.fdinfo, "read_drm_util", lambda *_a, **_k: 42)
+    monkeypatch.setattr(intel_mod, "_intel_gpu_top_output", lambda: _IGT_STREAM)
+    result = IntelBackend().sample(frozenset({0}))
+    assert result[0].utilization_pct == 42  # fdinfo won, not intel_gpu_top
+
+
+def test_sample_falls_back_to_intel_gpu_top(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intel_mod, "run_smi", lambda *_a, **_k: "")
+    monkeypatch.setattr(intel_mod.fdinfo, "read_drm_util", lambda *_a, **_k: None)
+    monkeypatch.setattr(intel_mod, "_intel_gpu_top_output", lambda: _IGT_STREAM)
+    result = IntelBackend().sample(frozenset({0}))
+    assert result[0].utilization_pct == 85  # busiest engine in the last sample
+
+
+def test_sample_all_sources_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intel_mod, "run_smi", lambda *_a, **_k: "")
+    _no_fallbacks(monkeypatch)
     assert IntelBackend().sample(frozenset({0})) == {}
+
+
+def test_fdinfo_sample_empty_indices(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intel_mod.fdinfo, "read_drm_util", lambda *_a, **_k: 50)
+    assert intel_mod._fdinfo_samples(frozenset()) == {}
+
+
+def test_intel_gpu_top_sample_empty_indices() -> None:
+    assert intel_mod._intel_gpu_top_samples(frozenset()) == {}
+
+
+# ---------------------------------------------------------------------------
+# intel_gpu_top parsing
+# ---------------------------------------------------------------------------
+
+
+def test_igt_max_busy_from_stream() -> None:
+    assert intel_mod._igt_max_busy(_IGT_STREAM) == 85
+
+
+def test_igt_max_busy_closed_array() -> None:
+    assert intel_mod._igt_max_busy('[{"engines":{"Render/3D":{"busy":30.0}}}]') == 30
+
+
+def test_igt_max_busy_empty_string() -> None:
+    assert intel_mod._igt_max_busy("") is None
+
+
+def test_igt_max_busy_malformed() -> None:
+    assert intel_mod._igt_max_busy("{bad") is None
+
+
+def test_igt_max_busy_no_engines() -> None:
+    assert intel_mod._igt_max_busy('{"frequency": {"actual": 300}}') is None
+
+
+def test_igt_max_busy_engines_not_dict() -> None:
+    assert intel_mod._igt_max_busy('{"engines": []}') is None
+
+
+def test_igt_max_busy_no_numeric_busy() -> None:
+    assert intel_mod._igt_max_busy('{"engines": {"Render/3D": {"busy": "n/a"}}}') is None
+
+
+def test_last_json_object_empty_list() -> None:
+    assert intel_mod._last_json_object("[]") is None
+
+
+def test_last_json_object_non_dict_last() -> None:
+    assert intel_mod._last_json_object("[1, 2]") is None
+
+
+def test_last_json_object_bare_dict() -> None:
+    assert intel_mod._last_json_object('{"engines": {}}') == {"engines": {}}
+
+
+def test_last_json_object_non_container() -> None:
+    assert intel_mod._last_json_object("5") is None
+
+
+# ---------------------------------------------------------------------------
+# intel_gpu_top invocation (subprocess)
+# ---------------------------------------------------------------------------
+
+
+def test_intel_gpu_top_output_tool_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: None)
+    assert intel_mod._intel_gpu_top_output() == ""
+
+
+def test_intel_gpu_top_output_clean_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
+
+    class _Proc:
+        stdout = "err-exit-output"
+
+    monkeypatch.setattr(intel_mod.subprocess, "run", lambda *_a, **_k: _Proc())
+    assert intel_mod._intel_gpu_top_output() == "err-exit-output"
+
+
+def test_intel_gpu_top_output_timeout_str_partial(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
+
+    def _raise(*_a: object, **_k: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="intel_gpu_top", timeout=1.3, output=_IGT_STREAM)
+
+    monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
+    assert intel_mod._intel_gpu_top_output() == _IGT_STREAM
+
+
+def test_intel_gpu_top_output_timeout_bytes_partial(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
+
+    def _raise(*_a: object, **_k: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="x", timeout=1.3, output=b"[\n{}")
+
+    monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
+    assert intel_mod._intel_gpu_top_output() == "[\n{}"
+
+
+def test_intel_gpu_top_output_timeout_no_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
+
+    def _raise(*_a: object, **_k: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="x", timeout=1.3)
+
+    monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
+    assert intel_mod._intel_gpu_top_output() == ""
+
+
+def test_intel_gpu_top_output_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
+
+    def _raise(*_a: object, **_k: object) -> None:
+        raise OSError("boom")
+
+    monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
+    assert intel_mod._intel_gpu_top_output() == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/fleet/gpu_backends/test_intel.py
+++ b/tests/providers/fleet/gpu_backends/test_intel.py
@@ -1,24 +1,31 @@
-"""Tests for the SYCL/Intel utilization backend (xpu-smi)."""
+"""Tests for the SYCL/Intel utilization backend (xpu-smi).
+
+The fixture below mirrors the real `xpu-smi stats -d <id> -j` shape derived from
+the xpumanager CLI source (a ``device_level`` array of {metrics_type, value}
+objects keyed by the xpum_stats_type_enum names). Live capture on Intel Data
+Center GPU Max / Arc hardware confirms the numeric scaling and swaps this fixture
+for real tool output.
+"""
 
 from __future__ import annotations
 
 import pytest
 
 from lilbee.providers.fleet import gpu_backends
-from lilbee.providers.fleet.devices import MIB
 from lilbee.providers.fleet.gpu_backends import intel as intel_mod
 from lilbee.providers.fleet.gpu_backends.intel import IntelBackend, _parse_xpu_smi
 
-_INDICES = frozenset({0})
-
+# Real device_level shape: one {metrics_type, value} entry per metric.
 _XPU_JSON = """\
-[{
+{
   "device_id": 0,
-  "gpu_utilization": 88,
-  "gpu_temperature": 73,
-  "gpu_memory_used_in_mb": 1024,
-  "gpu_memory_size_in_mb": 16384
-}]
+  "device_level": [
+    {"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": 88},
+    {"metrics_type": "XPUM_STATS_EU_ACTIVE", "value": 60},
+    {"metrics_type": "XPUM_STATS_GPU_CORE_TEMPERATURE", "value": 73},
+    {"metrics_type": "XPUM_STATS_MEMORY_USED", "value": 1073741824}
+  ]
+}
 """
 
 
@@ -28,37 +35,79 @@ _XPU_JSON = """\
 
 
 def test_parse_xpu_smi_happy_path() -> None:
-    result = _parse_xpu_smi(_XPU_JSON, _INDICES)
-    assert result[0].utilization_pct == 88
-    assert result[0].temperature_c == 73
-    assert result[0].total_bytes == 16384 * MIB
-    assert result[0].free_bytes == (16384 - 1024) * MIB
+    sample = _parse_xpu_smi(_XPU_JSON, 0)
+    assert sample is not None
+    assert sample.utilization_pct == 88
+    assert sample.temperature_c == 73
+
+
+def test_parse_xpu_smi_keys_sample_by_requested_index() -> None:
+    """The sample's index is the requested device, not any id parsed from output."""
+    sample = _parse_xpu_smi(_XPU_JSON, 3)
+    assert sample is not None
+    assert sample.index == 3
+
+
+def test_parse_xpu_smi_vram_is_sentinel() -> None:
+    """stats reports memory-used but no total; VRAM stays the 0/0 structural sentinel."""
+    sample = _parse_xpu_smi(_XPU_JSON, 0)
+    assert sample is not None
+    assert sample.free_bytes == 0
+    assert sample.total_bytes == 0
+
+
+def test_parse_xpu_smi_decimal_string_value() -> None:
+    """A metric value emitted as a decimal string is coerced to int."""
+    raw = '{"device_level": [{"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": "55.0"}]}'
+    sample = _parse_xpu_smi(raw, 0)
+    assert sample is not None
+    assert sample.utilization_pct == 55
+
+
+def test_parse_xpu_smi_missing_util_metric_leaves_none() -> None:
+    """A device_level without the utilization metric yields util None, not a crash."""
+    raw = '{"device_level": [{"metrics_type": "XPUM_STATS_GPU_CORE_TEMPERATURE", "value": 50}]}'
+    sample = _parse_xpu_smi(raw, 0)
+    assert sample is not None
+    assert sample.utilization_pct is None
+    assert sample.temperature_c == 50
 
 
 def test_parse_xpu_smi_device_list_wrapper() -> None:
-    raw = '{"device_list": [{"device_id": 0, "gpu_utilization": 55}]}'
-    result = _parse_xpu_smi(raw, _INDICES)
-    assert result[0].utilization_pct == 55
+    raw = (
+        '{"device_list": [{"device_id": 0, "device_level": '
+        '[{"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": 42}]}]}'
+    )
+    sample = _parse_xpu_smi(raw, 0)
+    assert sample is not None
+    assert sample.utilization_pct == 42
+
+
+def test_parse_xpu_smi_bare_list_wrapper() -> None:
+    raw = '[{"device_level": [{"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": 17}]}]'
+    sample = _parse_xpu_smi(raw, 0)
+    assert sample is not None
+    assert sample.utilization_pct == 17
 
 
 def test_parse_xpu_smi_empty_string() -> None:
-    assert _parse_xpu_smi("", _INDICES) == {}
+    assert _parse_xpu_smi("", 0) is None
 
 
 def test_parse_xpu_smi_malformed_json() -> None:
-    assert _parse_xpu_smi("{bad", _INDICES) == {}
+    assert _parse_xpu_smi("{bad", 0) is None
 
 
-def test_parse_xpu_smi_skips_out_of_range_indices() -> None:
-    result = _parse_xpu_smi(_XPU_JSON, frozenset({5}))
-    assert result == {}
+def test_parse_xpu_smi_no_device_level_returns_none() -> None:
+    assert _parse_xpu_smi('{"device_id": 0}', 0) is None
 
 
-def test_parse_xpu_smi_no_vram_gives_zero() -> None:
-    raw = '[{"device_id": 0, "gpu_utilization": 10}]'
-    result = _parse_xpu_smi(raw, _INDICES)
-    assert result[0].free_bytes == 0
-    assert result[0].total_bytes == 0
+def test_parse_xpu_smi_skips_non_dict_entries() -> None:
+    """Non-dict device_level entries are skipped, not crashed on."""
+    raw = '{"device_level": [1, "x", {"metrics_type": "XPUM_STATS_GPU_UTILIZATION", "value": 22}]}'
+    sample = _parse_xpu_smi(raw, 0)
+    assert sample is not None
+    assert sample.utilization_pct == 22
 
 
 # ---------------------------------------------------------------------------
@@ -69,19 +118,27 @@ def test_parse_xpu_smi_no_vram_gives_zero() -> None:
 
 def test_sample_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(intel_mod, "run_smi", lambda *_a, **_k: _XPU_JSON)
-    result = IntelBackend().sample(_INDICES)
+    result = IntelBackend().sample(frozenset({0}))
     assert result[0].utilization_pct == 88
     assert result[0].temperature_c == 73
 
 
+def test_sample_runs_stats_per_index_with_device_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each requested index runs `xpu-smi stats -d <index> -j` once."""
+    calls: list[list[str]] = []
+
+    def _run_smi(_tool: str, args: list[str], *_a: object, **_k: object) -> str:
+        calls.append(args)
+        return _XPU_JSON
+
+    monkeypatch.setattr(intel_mod, "run_smi", _run_smi)
+    IntelBackend().sample(frozenset({0, 1}))
+    assert calls == [["stats", "-d", "0", "-j"], ["stats", "-d", "1", "-j"]]
+
+
 def test_sample_tool_absent_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(intel_mod, "run_smi", lambda *_a, **_k: "")
-    assert IntelBackend().sample(_INDICES) == {}
-
-
-def test_sample_nonzero_exit_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(intel_mod, "run_smi", lambda *_a, **_k: "")
-    assert IntelBackend().sample(_INDICES) == {}
+    assert IntelBackend().sample(frozenset({0})) == {}
 
 
 # ---------------------------------------------------------------------------
@@ -91,21 +148,3 @@ def test_sample_nonzero_exit_returns_empty(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_registry_maps_sycl_to_intel_backend() -> None:
     assert isinstance(gpu_backends.resolve_backend("SYCL"), IntelBackend)
-
-
-# ---------------------------------------------------------------------------
-# Defensive branches (malformed CLI output)
-# ---------------------------------------------------------------------------
-
-
-def test_parse_xpu_smi_skips_non_dict_items() -> None:
-    """Non-dict list entries are skipped, not crashed on."""
-    raw = '[1, "x", {"device_id": 0, "gpu_utilization": 22}]'
-    result = _parse_xpu_smi(raw, frozenset({0}))
-    assert list(result) == [0]
-    assert result[0].utilization_pct == 22
-
-
-def test_parse_xpu_smi_skips_non_int_device_id() -> None:
-    """A non-integer device_id is skipped."""
-    assert _parse_xpu_smi('[{"device_id": "abc", "gpu_utilization": 5}]', frozenset({0})) == {}

--- a/tests/providers/fleet/gpu_backends/test_intel.py
+++ b/tests/providers/fleet/gpu_backends/test_intel.py
@@ -279,60 +279,58 @@ def test_registry_maps_sycl_to_intel_backend() -> None:
 
 
 # ---------------------------------------------------------------------------
-# intel_util_hint (the "grant this to enable utilization" one-liner)
+# intel_gpu_top_grant_binary (the binary a CAP_PERFMON grant would unblock)
 # ---------------------------------------------------------------------------
 
 _PMU_DENIED = "Failed to initialize PMU! (Permission denied)\nCAP_PERFMON is required\n"
 
 
-def test_intel_util_hint_tool_absent(monkeypatch: pytest.MonkeyPatch) -> None:
-    intel_mod.intel_util_hint.cache_clear()
+def test_grant_binary_tool_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_gpu_top_grant_binary.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: None)
-    assert intel_mod.intel_util_hint() is None
+    assert intel_mod.intel_gpu_top_grant_binary() is None
 
 
-def test_intel_util_hint_permission_denied_returns_setcap(monkeypatch: pytest.MonkeyPatch) -> None:
-    intel_mod.intel_util_hint.cache_clear()
+def test_grant_binary_permission_denied_returns_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_gpu_top_grant_binary.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
 
     class _Proc:
         stderr = _PMU_DENIED
 
     monkeypatch.setattr(intel_mod.subprocess, "run", lambda *_a, **_k: _Proc())
-    hint = intel_mod.intel_util_hint()
-    assert hint is not None
-    assert "setcap cap_perfmon+ep /usr/bin/intel_gpu_top" in hint
+    assert intel_mod.intel_gpu_top_grant_binary() == "/usr/bin/intel_gpu_top"
 
 
-def test_intel_util_hint_usable_when_streaming(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A working PMU streams, so the probe times out and reports usable (no hint)."""
-    intel_mod.intel_util_hint.cache_clear()
+def test_grant_binary_none_when_streaming(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A working PMU streams, so the probe times out and reports usable (no grant)."""
+    intel_mod.intel_gpu_top_grant_binary.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
 
     def _raise(*_a: object, **_k: object) -> None:
         raise subprocess.TimeoutExpired(cmd="intel_gpu_top", timeout=1.0)
 
     monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
-    assert intel_mod.intel_util_hint() is None
+    assert intel_mod.intel_gpu_top_grant_binary() is None
 
 
-def test_intel_util_hint_no_permission_marker(monkeypatch: pytest.MonkeyPatch) -> None:
-    intel_mod.intel_util_hint.cache_clear()
+def test_grant_binary_no_permission_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_gpu_top_grant_binary.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
 
     class _Proc:
         stderr = "some unrelated diagnostic"
 
     monkeypatch.setattr(intel_mod.subprocess, "run", lambda *_a, **_k: _Proc())
-    assert intel_mod.intel_util_hint() is None
+    assert intel_mod.intel_gpu_top_grant_binary() is None
 
 
-def test_intel_util_hint_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    intel_mod.intel_util_hint.cache_clear()
+def test_grant_binary_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_gpu_top_grant_binary.cache_clear()
     monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
 
     def _raise(*_a: object, **_k: object) -> None:
         raise OSError("boom")
 
     monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
-    assert intel_mod.intel_util_hint() is None
+    assert intel_mod.intel_gpu_top_grant_binary() is None

--- a/tests/providers/fleet/gpu_backends/test_intel.py
+++ b/tests/providers/fleet/gpu_backends/test_intel.py
@@ -276,3 +276,63 @@ def test_intel_gpu_top_output_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_registry_maps_sycl_to_intel_backend() -> None:
     assert isinstance(gpu_backends.resolve_backend("SYCL"), IntelBackend)
+
+
+# ---------------------------------------------------------------------------
+# intel_util_hint (the "grant this to enable utilization" one-liner)
+# ---------------------------------------------------------------------------
+
+_PMU_DENIED = "Failed to initialize PMU! (Permission denied)\nCAP_PERFMON is required\n"
+
+
+def test_intel_util_hint_tool_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_util_hint.cache_clear()
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: None)
+    assert intel_mod.intel_util_hint() is None
+
+
+def test_intel_util_hint_permission_denied_returns_setcap(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_util_hint.cache_clear()
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
+
+    class _Proc:
+        stderr = _PMU_DENIED
+
+    monkeypatch.setattr(intel_mod.subprocess, "run", lambda *_a, **_k: _Proc())
+    hint = intel_mod.intel_util_hint()
+    assert hint is not None
+    assert "setcap cap_perfmon+ep /usr/bin/intel_gpu_top" in hint
+
+
+def test_intel_util_hint_usable_when_streaming(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A working PMU streams, so the probe times out and reports usable (no hint)."""
+    intel_mod.intel_util_hint.cache_clear()
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
+
+    def _raise(*_a: object, **_k: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="intel_gpu_top", timeout=1.0)
+
+    monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
+    assert intel_mod.intel_util_hint() is None
+
+
+def test_intel_util_hint_no_permission_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_util_hint.cache_clear()
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
+
+    class _Proc:
+        stderr = "some unrelated diagnostic"
+
+    monkeypatch.setattr(intel_mod.subprocess, "run", lambda *_a, **_k: _Proc())
+    assert intel_mod.intel_util_hint() is None
+
+
+def test_intel_util_hint_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    intel_mod.intel_util_hint.cache_clear()
+    monkeypatch.setattr(intel_mod.shutil, "which", lambda _t: "/usr/bin/intel_gpu_top")
+
+    def _raise(*_a: object, **_k: object) -> None:
+        raise OSError("boom")
+
+    monkeypatch.setattr(intel_mod.subprocess, "run", _raise)
+    assert intel_mod.intel_util_hint() is None

--- a/tests/providers/fleet/test_gpu_stats.py
+++ b/tests/providers/fleet/test_gpu_stats.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from lilbee.providers.fleet import gpu_stats as stats_mod
 from lilbee.providers.fleet.devices import MIB, FleetDevice
+from lilbee.providers.fleet.gpu_backends import util_backend_name
 from lilbee.providers.fleet.gpu_backends.base import UtilSample
 from lilbee.providers.fleet.gpu_stats import GpuStat, probe_gpu_stats
 
@@ -191,3 +192,44 @@ def test_safe_sample_returns_empty_on_exception() -> None:
         mock_resolve.return_value.sample.side_effect = OSError("boom")
         result = stats_mod._safe_sample("CUDA", frozenset({0}))
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Vendor-based util routing (a Vulkan-exposed consumer GPU)
+# ---------------------------------------------------------------------------
+
+_VULKAN_INTEL = (
+    FleetDevice("Vulkan", 0, "Intel(R) UHD Graphics (CML GT2)", 12 * 1024 * MIB, 11 * 1024 * MIB),
+)
+
+
+def test_vulkan_intel_device_routes_to_intel_util() -> None:
+    """A Vulkan device named Intel dispatches to the Intel (SYCL) util backend."""
+    live = {0: _sample(0, util=77)}
+    with patch("lilbee.providers.fleet.gpu_stats.resolve_backend") as mock_resolve:
+        mock_resolve.return_value.sample.return_value = live
+        result = probe_gpu_stats(_VULKAN_INTEL)
+    mock_resolve.assert_called_once_with("SYCL")
+    assert result[0].utilization_pct == 77
+    # structural VRAM is kept (the util backend reports 0/0 for an iGPU)
+    assert result[0].total_bytes == 12 * 1024 * MIB
+
+
+def test_util_backend_name_recognized_backend_unchanged() -> None:
+    assert util_backend_name("CUDA", "NVIDIA A40") == "CUDA"
+    assert util_backend_name("SYCL", "Intel Arc") == "SYCL"
+
+
+def test_util_backend_name_vulkan_maps_by_vendor() -> None:
+    assert util_backend_name("Vulkan", "Intel(R) UHD Graphics") == "SYCL"
+    assert util_backend_name("Vulkan", "NVIDIA GeForce GTX 1650 Ti") == "CUDA"
+    assert util_backend_name("Vulkan", "AMD Radeon RX 7900") == "ROCm"
+    assert util_backend_name("Vulkan", "Radeon Graphics") == "ROCm"
+
+
+def test_util_backend_name_vulkan_unknown_vendor_unchanged() -> None:
+    assert util_backend_name("Vulkan", "Some Mystery Accelerator") == "Vulkan"
+
+
+def test_util_backend_name_unknown_backend_unchanged() -> None:
+    assert util_backend_name("OpenCL", "whatever") == "OpenCL"

--- a/tests/providers/fleet/test_gpu_stats.py
+++ b/tests/providers/fleet/test_gpu_stats.py
@@ -15,7 +15,7 @@ from lilbee.providers.fleet import gpu_stats as stats_mod
 from lilbee.providers.fleet.devices import MIB, FleetDevice
 from lilbee.providers.fleet.gpu_backends import util_backend_name
 from lilbee.providers.fleet.gpu_backends.base import UtilSample
-from lilbee.providers.fleet.gpu_stats import GpuStat, probe_gpu_stats, util_notice
+from lilbee.providers.fleet.gpu_stats import GpuStat, intel_grant_binary, probe_gpu_stats
 
 _CUDA = (
     FleetDevice("CUDA", 0, "NVIDIA A40", 48 * 1024 * MIB, 47 * 1024 * MIB),
@@ -238,45 +238,47 @@ def test_util_backend_name_unknown_backend_unchanged() -> None:
 
 
 # ---------------------------------------------------------------------------
-# util_notice (actionable hint when Intel util is missing but fixable)
+# intel_grant_binary (the binary a grant would unblock, for the surfaces to format)
 # ---------------------------------------------------------------------------
 
 
 def _hint(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
-    monkeypatch.setattr(stats_mod, "intel_util_hint", lambda: value)
+    monkeypatch.setattr(stats_mod, "intel_gpu_top_grant_binary", lambda: value)
 
 
-def test_util_notice_intel_missing_util_returns_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_intel_grant_binary_intel_missing_util_returns_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _hint(monkeypatch, "GRANT ME")
     dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
-    assert util_notice([dev], {0: GpuStat(0, None, 0, 0)}) == "GRANT ME"
+    assert intel_grant_binary([dev], {0: GpuStat(0, None, 0, 0)}) == "GRANT ME"
 
 
-def test_util_notice_vulkan_intel_routes_to_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_intel_grant_binary_vulkan_intel_routes_to_hint(monkeypatch: pytest.MonkeyPatch) -> None:
     _hint(monkeypatch, "GRANT ME")
     dev = FleetDevice("Vulkan", 0, "Intel(R) UHD Graphics", 0, 0)
-    assert util_notice([dev], {0: GpuStat(0, None, 0, 0)}) == "GRANT ME"
+    assert intel_grant_binary([dev], {0: GpuStat(0, None, 0, 0)}) == "GRANT ME"
 
 
-def test_util_notice_silent_when_util_present(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_intel_grant_binary_silent_when_util_present(monkeypatch: pytest.MonkeyPatch) -> None:
     _hint(monkeypatch, "GRANT ME")
     dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
-    assert util_notice([dev], {0: GpuStat(0, 50, 0, 0)}) is None
+    assert intel_grant_binary([dev], {0: GpuStat(0, 50, 0, 0)}) is None
 
 
-def test_util_notice_silent_for_non_intel(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_intel_grant_binary_silent_for_non_intel(monkeypatch: pytest.MonkeyPatch) -> None:
     _hint(monkeypatch, "GRANT ME")
     dev = FleetDevice("CUDA", 0, "NVIDIA A40", 0, 0)
-    assert util_notice([dev], {0: GpuStat(0, None, 0, 0)}) is None
+    assert intel_grant_binary([dev], {0: GpuStat(0, None, 0, 0)}) is None
 
 
-def test_util_notice_silent_when_no_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_intel_grant_binary_silent_when_no_hint(monkeypatch: pytest.MonkeyPatch) -> None:
     _hint(monkeypatch, None)
     dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
-    assert util_notice([dev], {0: GpuStat(0, None, 0, 0)}) is None
+    assert intel_grant_binary([dev], {0: GpuStat(0, None, 0, 0)}) is None
 
 
-def test_util_notice_skips_index_absent_from_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_intel_grant_binary_skips_index_absent_from_stats(monkeypatch: pytest.MonkeyPatch) -> None:
     _hint(monkeypatch, "GRANT ME")
     dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
-    assert util_notice([dev], {}) is None
+    assert intel_grant_binary([dev], {}) is None

--- a/tests/providers/fleet/test_gpu_stats.py
+++ b/tests/providers/fleet/test_gpu_stats.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from lilbee.providers.fleet import gpu_stats as stats_mod
 from lilbee.providers.fleet.devices import MIB, FleetDevice
 from lilbee.providers.fleet.gpu_backends import util_backend_name
 from lilbee.providers.fleet.gpu_backends.base import UtilSample
-from lilbee.providers.fleet.gpu_stats import GpuStat, probe_gpu_stats
+from lilbee.providers.fleet.gpu_stats import GpuStat, probe_gpu_stats, util_notice
 
 _CUDA = (
     FleetDevice("CUDA", 0, "NVIDIA A40", 48 * 1024 * MIB, 47 * 1024 * MIB),
@@ -233,3 +235,48 @@ def test_util_backend_name_vulkan_unknown_vendor_unchanged() -> None:
 
 def test_util_backend_name_unknown_backend_unchanged() -> None:
     assert util_backend_name("OpenCL", "whatever") == "OpenCL"
+
+
+# ---------------------------------------------------------------------------
+# util_notice (actionable hint when Intel util is missing but fixable)
+# ---------------------------------------------------------------------------
+
+
+def _hint(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    monkeypatch.setattr(stats_mod, "intel_util_hint", lambda: value)
+
+
+def test_util_notice_intel_missing_util_returns_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, "GRANT ME")
+    dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
+    assert util_notice([dev], {0: GpuStat(0, None, 0, 0)}) == "GRANT ME"
+
+
+def test_util_notice_vulkan_intel_routes_to_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, "GRANT ME")
+    dev = FleetDevice("Vulkan", 0, "Intel(R) UHD Graphics", 0, 0)
+    assert util_notice([dev], {0: GpuStat(0, None, 0, 0)}) == "GRANT ME"
+
+
+def test_util_notice_silent_when_util_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, "GRANT ME")
+    dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
+    assert util_notice([dev], {0: GpuStat(0, 50, 0, 0)}) is None
+
+
+def test_util_notice_silent_for_non_intel(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, "GRANT ME")
+    dev = FleetDevice("CUDA", 0, "NVIDIA A40", 0, 0)
+    assert util_notice([dev], {0: GpuStat(0, None, 0, 0)}) is None
+
+
+def test_util_notice_silent_when_no_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, None)
+    dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
+    assert util_notice([dev], {0: GpuStat(0, None, 0, 0)}) is None
+
+
+def test_util_notice_skips_index_absent_from_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hint(monkeypatch, "GRANT ME")
+    dev = FleetDevice("SYCL", 0, "Intel Arc A770", 0, 0)
+    assert util_notice([dev], {}) is None

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4547,7 +4547,7 @@ class TestPlacementHandlers:
         }
         assert probe.call_count == 2
 
-    async def test_gpu_stats_stream_includes_util_notice(self):
+    async def test_gpu_stats_stream_includes_intel_grant_notice(self):
         from lilbee.app.placement import GpuInfo
         from lilbee.providers.fleet.gpu_stats import GpuStat
 
@@ -4562,7 +4562,10 @@ class TestPlacementHandlers:
         stat = {0: GpuStat(0, None, 200, 200)}
         with (
             patch("lilbee.providers.fleet.gpu_stats.probe_gpu_stats", return_value=stat),
-            patch("lilbee.providers.fleet.gpu_stats.util_notice", return_value="grant me"),
+            patch(
+                "lilbee.providers.fleet.gpu_stats.intel_grant_binary",
+                return_value="/usr/bin/intel_gpu_top",
+            ),
         ):
             chunks = [c async for c in handlers.gpu_stats_stream((gpu,), interval_s=0, max_ticks=1)]
         events = [
@@ -4571,7 +4574,7 @@ class TestPlacementHandlers:
             for line in chunk.splitlines()
             if line.startswith("data:")
         ]
-        assert events[0]["notice"] == "grant me"
+        assert "setcap cap_perfmon+ep /usr/bin/intel_gpu_top" in events[0]["notice"]
 
     async def test_gpu_stats_stream_emits_heartbeat_when_interval_elapsed(self):
         """A heartbeat event is emitted when the configured interval elapses."""

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4547,6 +4547,32 @@ class TestPlacementHandlers:
         }
         assert probe.call_count == 2
 
+    async def test_gpu_stats_stream_includes_util_notice(self):
+        from lilbee.app.placement import GpuInfo
+        from lilbee.providers.fleet.gpu_stats import GpuStat
+
+        gpu = GpuInfo(
+            index=0,
+            backend="SYCL",
+            label="SYCL0",
+            name="Intel Arc",
+            total_bytes=200,
+            free_bytes=200,
+        )
+        stat = {0: GpuStat(0, None, 200, 200)}
+        with (
+            patch("lilbee.providers.fleet.gpu_stats.probe_gpu_stats", return_value=stat),
+            patch("lilbee.providers.fleet.gpu_stats.util_notice", return_value="grant me"),
+        ):
+            chunks = [c async for c in handlers.gpu_stats_stream((gpu,), interval_s=0, max_ticks=1)]
+        events = [
+            json.loads(line[len("data:") :].strip())
+            for chunk in chunks
+            for line in chunk.splitlines()
+            if line.startswith("data:")
+        ]
+        assert events[0]["notice"] == "grant me"
+
     async def test_gpu_stats_stream_emits_heartbeat_when_interval_elapsed(self):
         """A heartbeat event is emitted when the configured interval elapses."""
         from lilbee.app.placement import GpuInfo

--- a/tests/test_tui_gpu_fleet_panel.py
+++ b/tests/test_tui_gpu_fleet_panel.py
@@ -161,24 +161,26 @@ async def test_panel_renders_card_label_and_vram(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
-async def test_panel_shows_util_notice_when_present(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A pending util_notice (e.g. the Intel setcap hint) renders under the rows."""
+async def test_panel_shows_intel_grant_hint_when_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An Intel GPU needing the CAP_PERFMON grant renders the localized setcap line."""
     import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
     from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
 
     stat = _make_stat(0, utilization_pct=None)
     monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {0: stat})
-    monkeypatch.setattr(panel_mod, "util_notice", lambda devices, stats: "grant me: setcap ...")
+    monkeypatch.setattr(
+        panel_mod, "intel_grant_binary", lambda devices, stats: "/usr/bin/intel_gpu_top"
+    )
 
     app = _PanelHost()
-    async with app.run_test(size=(80, 24)) as pilot:
+    async with app.run_test(size=(120, 24)) as pilot:
         await pilot.pause()
         panel = app.query_one(GpuFleetPanel)
         panel.set_devices([_make_device(0, backend="SYCL")], labels={0: "SYCL0"})
         panel._request_stats()
         await app.workers.wait_for_complete()
         await pilot.pause()
-        assert "grant me: setcap" in str(panel.render())
+        assert "setcap cap_perfmon+ep /usr/bin/intel_gpu_top" in str(panel.render())
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui_gpu_fleet_panel.py
+++ b/tests/test_tui_gpu_fleet_panel.py
@@ -25,6 +25,7 @@ class _FakeDevice:
     backend: str
     total_bytes: int
     free_bytes: int
+    name: str = "Test GPU"
 
 
 def _make_stat(
@@ -157,6 +158,27 @@ async def test_panel_renders_card_label_and_vram(monkeypatch: pytest.MonkeyPatch
         # VRAM numerics: 10.0/24G
         assert "10.0" in rendered
         assert "24" in rendered
+
+
+@pytest.mark.asyncio
+async def test_panel_shows_util_notice_when_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pending util_notice (e.g. the Intel setcap hint) renders under the rows."""
+    import lilbee.cli.tui.widgets.gpu_fleet_panel as panel_mod
+    from lilbee.cli.tui.widgets.gpu_fleet_panel import GpuFleetPanel
+
+    stat = _make_stat(0, utilization_pct=None)
+    monkeypatch.setattr(panel_mod, "probe_gpu_stats", lambda devices: {0: stat})
+    monkeypatch.setattr(panel_mod, "util_notice", lambda devices, stats: "grant me: setcap ...")
+
+    app = _PanelHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        panel = app.query_one(GpuFleetPanel)
+        panel.set_devices([_make_device(0, backend="SYCL")], labels={0: "SYCL0"})
+        panel._request_stats()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "grant me: setcap" in str(panel.render())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

On Intel GPUs the fleet panel's utilization bar was blank, for a few different reasons:

- On data-center Intel GPUs the code read the numbers in the wrong place, so it never found them.
- On ordinary Intel laptops and desktops (integrated graphics) there was no support at all — a core case for a local search engine meant to run on consumer hardware.
- Even once a consumer GPU is detected, utilization was tied to how the model is *run* (the inference backend). A GPU that the engine only exposes over Vulkan — common for consumer parts — had no utilization source and showed a blank bar, even though its vendor telemetry reads fine.

It's the same trap that recently hid utilization on Apple machines: each reader is tested against a made-up sample of what we assume the tool prints, so tests pass even when the real tool prints something different. Only real hardware settles it.

## Solution

Read Intel GPU activity the way the tools actually report it, and separate *measuring* the GPU from *running* on it:

- **Data-center / Arc:** read the real output shape of Intel's management tool (confirmed against Intel's own CLI source).
- **Consumer integrated GPUs, no setup:** on current kernels, read the GPU's activity straight from the kernel (per-process counters under `/proc`) with no extra tool and no root. This reader is vendor-neutral.
- **Consumer integrated GPUs, older kernels:** fall back to Intel's GPU monitor, which covers essentially every Intel iGPU but needs a one-time permission grant.
- **Pick the utilization source by the GPU's vendor, not the inference backend.** A recognized backend (CUDA/ROCm/SYCL/Metal) already implies the vendor and is unchanged; a Vulkan-exposed GPU is mapped to its vendor's telemetry by name. So an Intel iGPU that the engine drives over Vulkan still reports real utilization.

Sources are tried in order and the first that reports wins; when none can, the bar degrades to blank exactly as before, so there's no regression. NVIDIA is unaffected: recognized-backend routing is byte-for-byte identical.

Verified live on a real Intel laptop iGPU: the actual lilbee TUI fleet panel tracks utilization from idle to ~90% under load, the same real-time behavior as NVIDIA and Metal. The utilization value also flows unchanged to the CLI and the HTTP/MCP responses.

When an Intel GPU needs the one-time permission grant, the panel and the HTTP stream show a copy-pasteable `setcap` line instead of a mute bar (and only when it will actually help; modern kernels never see it). Confirming the no-setup kernel path and the AMD reader on live modern-kernel hardware is the remaining step, tracked in #490.