### PR TITLE
fix(tui): stop redundant model toasts on first launch

### DIFF
--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -238,12 +238,16 @@ class LilbeeApp(App[None]):
             reason = canon.reason or msg.MODEL_REASON_DEFAULT
 
             if canon.original == canon.effective:
-                # Nothing to fall back to: keep the ref; the chat screen opens the wizard.
-                notice = msg.MODEL_UNUSABLE_OPENING_SETUP.format(
-                    label=label, original=canon.original, reason=reason
+                # Nothing to fall back to: keep the ref and let the chat screen's
+                # _needs_setup open the SetupWizard, which is the single voice for
+                # "pick a model." A toast here just duplicates the wizard (on first
+                # launch the default refs aren't downloaded yet), so log the reason
+                # as a breadcrumb but don't surface it.
+                log.warning(
+                    msg.MODEL_UNUSABLE_OPENING_SETUP.format(
+                        label=label, original=canon.original, reason=reason
+                    )
                 )
-                log.warning(notice)
-                self.notify(notice, severity="warning", timeout=_FALLBACK_TOAST_TIMEOUT_S)
                 continue
 
             # A rejected swap (validation or disk error) must not be fatal at startup.

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -616,9 +616,17 @@ class TestAppCanonicalizeFallbackNotice:
             "a rejected swap must be logged at WARNING"
         )
 
-    async def test_no_fallback_toasts_reason_and_leaves_ref(self, caplog) -> None:
+    async def test_no_fallback_logs_but_does_not_toast(self, caplog) -> None:
         """When nothing is installed to fall back to, the ref is left intact
-        and a toast explains why (the chat screen then opens the wizard)."""
+        and the reason is logged, but no toast fires.
+
+        This is the first-launch case: the default refs aren't downloaded
+        yet and there's nothing to fall back to. The chat screen's
+        ``_needs_setup`` keys off the same unresolved state and opens the
+        SetupWizard, which is the single voice for "pick a model." A toast
+        here just duplicates the wizard (its text literally says "Opening
+        setup"), so it's suppressed; the WARNING log stays as a breadcrumb.
+        """
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.core.config import cfg
         from lilbee.modelhub.model_manager import CanonicalRef, ValidationResult
@@ -654,9 +662,10 @@ class TestAppCanonicalizeFallbackNotice:
                 await app._canonicalize_persisted_models()
                 mock_apply.assert_not_called()
             assert cfg.embedding_model == snapshot_embed, "an un-fallbackable ref is left intact"
-            assert notifications, "the user must be told why before the wizard opens"
-            toast = notifications[0][0]
-            assert "litellm" in toast and "setup" in toast.lower()
+            assert not notifications, "no toast: the SetupWizard is the single voice"
+            assert any("litellm" in r.getMessage() for r in caplog.records), (
+                "the reason must still be logged at WARNING as a breadcrumb"
+            )
         finally:
             cfg.embedding_model = snapshot_embed
 


### PR DESCRIPTION
## Problem

On the very first launch (single-GPU, nothing downloaded yet), two warning toasts flash up naming the default models as unavailable, e.g.:

- `Chat model 'Qwen/Qwen3-0.6B-GGUF/...' is unavailable (...) and nothing is installed to fall back to. Opening setup so you can pick one.`
- `Embedding model 'nomic-ai/nomic-embed-text-v1.5-GGUF/...' is unavailable (...). Opening setup so you can pick one.`

They fire from the mount-time canonicalization of the persisted chat/embedding refs. On a fresh install the config still holds the built-in defaults, nothing is on disk, and there's no fallback, so the "nothing to fall back to" branch toasts once per role. The chat screen then opens the SetupWizard for that same unresolved state, so the toast just narrates what the wizard is about to do. First impression is two error-looking toasts before anything has gone wrong.

## Solution

Drop the toast in the no-fallback branch and keep the WARNING log line as a breadcrumb. That branch always coincides with `_needs_setup` returning True and the SetupWizard opening, so the wizard becomes the single voice for "pick a model" instead of competing with a redundant toast.

The genuine swap notice, which fires only when a working fallback is actually applied and the wizard does not open, is left untouched. The existing coverage test for the no-fallback path is updated to assert the ref is left intact and the reason is still logged, but no toast surfaces.