### PR TITLE
Make ingest concurrency adapt to the hardware so full-corpus OCR stops starving the GPUs

### DIFF
--- a/src/lilbee/data/ingest/adaptive.py
+++ b/src/lilbee/data/ingest/adaptive.py
@@ -1,0 +1,419 @@
+"""Adaptive ingest concurrency: hill-climb to the hardware's throughput knee.
+
+The extraction-admission limit (how many documents are in their compute phase at
+once) can run in one of three modes, chosen by ``LILBEE_INGEST_CONCURRENCY``:
+
+- ``static`` -- a fixed limit (the pipeline's ``_max_concurrent()``); the proven
+  default and the guaranteed-safe fallback.
+- ``adaptive-conservative`` / ``adaptive-aggressive`` -- a background controller
+  resizes the limit every few seconds, climbing while throughput still improves
+  and backing off the instant a safety signal (CPU, free RAM, GPU temperature)
+  says the box is under pressure.
+
+The control law is a safety-gated AIMD hill-climb on smoothed throughput. The
+only thing that pushes the limit up is throughput still improving, so the fixed
+point is *this box's* real operating knee rather than a hardcoded utilization
+target (BBR / Kleinrock). GPU utilization is used only as a saturation veto, never
+as a setpoint. Multiplicative decrease on any danger signal is AIMD's proven
+fast-safe retreat; EWMA smoothing plus an asymmetric dead band and a one-step slew
+limit keep it from oscillating (CLR ThreadPool hill-climbing, TCP Vegas).
+
+``decide`` is a pure function -- the whole control law with no clock, asyncio, or
+hardware -- so the policy is unit-tested with plain numbers. ``ResizableGate`` and
+``AdaptiveController`` are the async machinery around it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import os
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lilbee.providers.fleet.gpu_stats import DeviceLike
+
+log = logging.getLogger(__name__)
+
+_MODE_ENV = "LILBEE_INGEST_CONCURRENCY"
+
+
+class ConcurrencyMode(StrEnum):
+    """How the extraction-admission limit is chosen for a sync run."""
+
+    STATIC = "static"
+    ADAPTIVE_CONSERVATIVE = "adaptive-conservative"
+    ADAPTIVE_AGGRESSIVE = "adaptive-aggressive"
+
+
+def resolve_mode() -> ConcurrencyMode:
+    """The concurrency mode from ``LILBEE_INGEST_CONCURRENCY``; ``static`` by default.
+
+    An unset or unrecognized value falls back to ``static`` (a warning is logged for
+    an unrecognized one), so a typo can never silently enable adaptive control.
+    """
+    raw = os.environ.get(_MODE_ENV, "").strip().lower()
+    if not raw:
+        return ConcurrencyMode.STATIC
+    try:
+        return ConcurrencyMode(raw)
+    except ValueError:
+        log.warning(
+            "Ignoring %s=%r: expected one of %s; using %s.",
+            _MODE_ENV,
+            raw,
+            [m.value for m in ConcurrencyMode],
+            ConcurrencyMode.STATIC.value,
+        )
+        return ConcurrencyMode.STATIC
+
+
+@dataclass(frozen=True)
+class SafetyLimits:
+    """Hard guardrails, identical across adaptive profiles -- safety is never relaxed.
+
+    Crossing a ``_crit`` line forces an immediate multiplicative backoff; a ``_warn``
+    / ``_soft`` line only vetoes further increases. Temperature and RAM are read raw
+    (never smoothed -- a fire alarm should not be averaged away).
+    """
+
+    gpu_sat_pct: float = 97.0
+    cpu_soft_pct: float = 90.0
+    cpu_crit_pct: float = 97.0
+    ram_soft_free: float = 0.20
+    ram_min_free: float = 0.10
+    temp_warn_c: float = 80.0
+    temp_crit_c: float = 85.0
+    decrease_factor: float = 0.5
+
+
+@dataclass(frozen=True)
+class ConcurrencyProfile:
+    """Climb-speed parameters for one adaptive profile (safety limits are shared)."""
+
+    name: str
+    interval_s: float
+    ewma_gamma: float
+    deadband_frac: float
+    cool_down_intervals: int
+    sqrt_step: bool
+    latency_veto_ratio: float  # veto increases once residence time inflates past baseline x this
+    safety: SafetyLimits = SafetyLimits()
+
+    def step(self, permits: int) -> int:
+        """Additive step size at the current limit; larger early when ``sqrt_step``."""
+        if self.sqrt_step:
+            return 1 + math.isqrt(max(0, permits)) // 4
+        return 1
+
+
+CONSERVATIVE = ConcurrencyProfile(
+    name="conservative",
+    interval_s=5.0,
+    ewma_gamma=0.3,
+    deadband_frac=0.05,
+    cool_down_intervals=3,
+    sqrt_step=False,
+    latency_veto_ratio=1.5,
+)
+AGGRESSIVE = ConcurrencyProfile(
+    name="aggressive",
+    interval_s=2.0,
+    ewma_gamma=0.5,
+    deadband_frac=0.03,
+    cool_down_intervals=2,
+    sqrt_step=True,
+    latency_veto_ratio=2.0,
+)
+
+
+def profile_for(mode: ConcurrencyMode) -> ConcurrencyProfile | None:
+    """The profile for an adaptive mode, or None for ``static``."""
+    return {
+        ConcurrencyMode.ADAPTIVE_CONSERVATIVE: CONSERVATIVE,
+        ConcurrencyMode.ADAPTIVE_AGGRESSIVE: AGGRESSIVE,
+    }.get(mode)
+
+
+@dataclass(frozen=True)
+class Signals:
+    """One tick's measured state. ``gpu_*`` are None when no GPU telemetry is available."""
+
+    throughput: float  # OCR pages completed since the previous tick (work done, not doc count)
+    gpu_util_pct: float | None
+    gpu_temp_c: float | None
+    cpu_pct: float
+    ram_free_frac: float
+
+
+@dataclass(frozen=True)
+class ControllerState:
+    """The controller's carried state between ticks."""
+
+    permits: int
+    ewma_tput: float | None  # smoothed throughput from the previous tick; None at start
+    direction: int  # +1 climbing, -1 backing off -- the last hill-climb step's sign
+    cool_down: int  # intervals remaining during which increases are suppressed
+    w_min: float | None = None  # smallest observed residence-time estimate (Little's Law baseline)
+
+
+def _is_critical(signals: Signals, s: SafetyLimits) -> bool:
+    """A signal that demands an immediate hard backoff (thermal / OOM / CPU meltdown)."""
+    temp = signals.gpu_temp_c
+    return (
+        (temp is not None and temp >= s.temp_crit_c)
+        or signals.ram_free_frac <= s.ram_min_free
+        or signals.cpu_pct >= s.cpu_crit_pct
+    )
+
+
+def _increase_vetoed(
+    profile: ConcurrencyProfile,
+    signals: Signals,
+    *,
+    cool_down: int,
+    gpu_saturated: bool,
+    w_est: float | None,
+    w_min: float | None,
+) -> bool:
+    """Whether soft pressure, saturation, cool-down, or inflating latency blocks a climb."""
+    s = profile.safety
+    temp = signals.gpu_temp_c
+    latency_inflated = (
+        w_est is not None and w_min is not None and w_est > w_min * profile.latency_veto_ratio
+    )
+    return (
+        cool_down > 0
+        or signals.cpu_pct >= s.cpu_soft_pct
+        or signals.ram_free_frac < s.ram_soft_free
+        or (temp is not None and temp >= s.temp_warn_c)
+        or gpu_saturated
+        or latency_inflated
+    )
+
+
+def _hill_climb(
+    profile: ConcurrencyProfile,
+    permits: int,
+    direction: int,
+    delta: float | None,
+    new_ewma: float,
+    clamp: Callable[[int], int],
+) -> tuple[int, int]:
+    """One dead-banded hill-climb step; returns the next (permits, direction).
+
+    No baseline yet -> a gentle probe up; a clear gain -> step in the same direction;
+    a clear loss -> reverse; inside the dead band -> hold.
+    """
+    if delta is None:
+        return clamp(permits + profile.step(permits)), 1
+    band = profile.deadband_frac * (new_ewma if new_ewma > 0 else 1.0)
+    if delta > band:
+        return clamp(permits + direction * profile.step(permits)), direction
+    if delta < -band:
+        direction = -direction
+        return clamp(permits + direction * profile.step(permits)), direction
+    return permits, direction
+
+
+def decide(
+    profile: ConcurrencyProfile,
+    state: ControllerState,
+    signals: Signals,
+    permit_min: int,
+    permit_max: int,
+) -> ControllerState:
+    """Pure control law: fold one tick of signals into the next permit target.
+
+    Priority: (1) any critical safety signal forces a multiplicative decrease and a
+    cool-down; (2) a soft-pressure, GPU-saturation, or latency-gradient signal vetoes
+    increases (with a single additive decrease when GPUs are saturated *and* throughput
+    is falling -- the Universal Scalability Law's retrograde region); (3) otherwise
+    hill-climb toward the knee. Always clamped to ``[permit_min, permit_max]``.
+
+    The latency veto is the leading knee indicator (TCP Vegas / Netflix Gradient2):
+    residence time ``W`` is estimated by Little's Law as ``permits / throughput``; once
+    ``W`` inflates past its observed minimum (the unloaded baseline) by the profile's
+    ratio, work is queueing at the bottleneck and increases stop -- before throughput
+    visibly rolls over.
+    """
+    if state.ewma_tput is None:
+        new_ewma: float = signals.throughput
+        delta: float | None = None
+    else:
+        gamma = profile.ewma_gamma
+        new_ewma = gamma * signals.throughput + (1.0 - gamma) * state.ewma_tput
+        delta = new_ewma - state.ewma_tput
+
+    permits = state.permits
+    cool_down = max(0, state.cool_down - 1)
+
+    # Little's Law residence-time estimate and its running minimum (the latency baseline).
+    w_est = permits / new_ewma if new_ewma > 0 else None
+    w_min = state.w_min if w_est is None else min(state.w_min or w_est, w_est)
+
+    def clamp(p: int) -> int:
+        return max(permit_min, min(permit_max, p))
+
+    def out(new_permits: int, new_direction: int, new_cool_down: int) -> ControllerState:
+        return ControllerState(new_permits, new_ewma, new_direction, new_cool_down, w_min)
+
+    if _is_critical(signals, profile.safety):
+        backoff = clamp(int(permits * profile.safety.decrease_factor))
+        return out(backoff, -1, profile.cool_down_intervals)
+
+    util = signals.gpu_util_pct
+    gpu_saturated = util is not None and util >= profile.safety.gpu_sat_pct
+    if gpu_saturated and delta is not None and delta < 0:
+        return out(clamp(permits - profile.step(permits)), -1, cool_down)  # USL retrograde
+
+    if _increase_vetoed(
+        profile, signals, cool_down=cool_down, gpu_saturated=gpu_saturated, w_est=w_est, w_min=w_min
+    ):
+        return out(permits, state.direction, cool_down)
+
+    permits, direction = _hill_climb(profile, permits, state.direction, delta, new_ewma, clamp)
+    return out(permits, direction, cool_down)
+
+
+class ResizableGate:
+    """An async admission gate whose permit ceiling can change while it is in use.
+
+    Same ``async with`` shape as ``asyncio.Semaphore``, plus ``set_limit``: growing
+    wakes blocked acquirers, shrinking lowers the ceiling and lets the surplus drain
+    as active holders release. The limit never drops below one, so a shrink can never
+    deadlock a run.
+    """
+
+    def __init__(self, limit: int) -> None:
+        self._limit = max(1, limit)
+        self._active = 0
+        self._cond = asyncio.Condition()
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    async def acquire(self) -> None:
+        async with self._cond:
+            await self._cond.wait_for(lambda: self._active < self._limit)
+            self._active += 1
+
+    async def release(self) -> None:
+        async with self._cond:
+            self._active -= 1
+            self._cond.notify_all()
+
+    async def __aenter__(self) -> ResizableGate:
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.release()
+
+    async def set_limit(self, new_limit: int) -> None:
+        async with self._cond:
+            self._limit = max(1, new_limit)
+            self._cond.notify_all()
+
+
+class AdaptiveController:
+    """Drives a :class:`ResizableGate`'s limit from live signals until cancelled.
+
+    ``sample(throughput)`` returns the current :class:`Signals`; ``completed()`` is a
+    monotonic count of finished documents, from which per-interval throughput is
+    derived. Both are injected so the controller runs in tests with no clock or GPU.
+    """
+
+    def __init__(
+        self,
+        gate: ResizableGate,
+        profile: ConcurrencyProfile,
+        sample: Callable[[float], Signals],
+        completed: Callable[[], int],
+        *,
+        permit_min: int,
+        permit_max: int,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._gate = gate
+        self._profile = profile
+        self._sample = sample
+        self._completed = completed
+        self._permit_min = permit_min
+        self._permit_max = permit_max
+        self._sleep = sleep
+
+    async def run(self) -> None:
+        """Sample-decide-resize loop. Runs until the task is cancelled.
+
+        A tuning tick is best-effort: a transient sampling/probe failure is logged and
+        skipped, never propagated, so the controller can never crash the ingest it is
+        only advising. Cancellation (``CancelledError``) still ends the loop cleanly.
+        """
+        state = ControllerState(self._gate.limit, None, 1, 0)
+        last_completed = self._completed()
+        while True:
+            await self._sleep(self._profile.interval_s)
+            try:
+                now_completed = self._completed()
+                throughput = float(max(0, now_completed - last_completed))
+                last_completed = now_completed
+                state = decide(
+                    self._profile,
+                    state,
+                    self._sample(throughput),
+                    self._permit_min,
+                    self._permit_max,
+                )
+                if state.permits != self._gate.limit:
+                    await self._gate.set_limit(state.permits)
+                    log.debug("adaptive ingest: limit -> %d", state.permits)
+            except Exception:
+                log.debug("adaptive ingest: tuning tick failed; skipping", exc_info=True)
+
+
+def enumerate_fleet_devices() -> Sequence[DeviceLike]:
+    """The GPU devices to read telemetry from, or empty when none can be enumerated.
+
+    Any failure (no engine binary, probe error) degrades to an empty list, which the
+    caller treats as "no fleet to feed" and falls back to the static limit.
+    """
+    try:
+        from lilbee.providers.fleet.binary import resolve_llama_server
+        from lilbee.providers.fleet.planning import resolve_devices
+
+        return resolve_devices(resolve_llama_server())
+    except Exception:
+        log.debug("adaptive ingest: device enumeration failed; using static limit", exc_info=True)
+        return []
+
+
+def make_signal_sampler(devices: Sequence[DeviceLike]) -> Callable[[float], Signals]:
+    """Build a sampler that reads mean GPU util, max GPU temp, CPU %, and free RAM.
+
+    GPU util/temp are None when no device reports them (the controller then relies on
+    the CPU and RAM guards alone); throughput is supplied by the controller.
+    """
+    import psutil
+
+    from lilbee.providers.fleet.gpu_stats import probe_gpu_stats
+
+    def sample(throughput: float) -> Signals:
+        stats = probe_gpu_stats(devices)
+        utils = [g.utilization_pct for g in stats.values() if g.utilization_pct is not None]
+        temps = [g.temperature_c for g in stats.values() if g.temperature_c is not None]
+        vm = psutil.virtual_memory()
+        return Signals(
+            throughput=throughput,
+            gpu_util_pct=(sum(utils) / len(utils)) if utils else None,
+            gpu_temp_c=float(max(temps)) if temps else None,
+            cpu_pct=psutil.cpu_percent(interval=None),
+            ram_free_frac=vm.available / vm.total,  # psutil total is always positive
+        )
+
+    return sample

--- a/src/lilbee/data/ingest/offload.py
+++ b/src/lilbee/data/ingest/offload.py
@@ -11,18 +11,45 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import functools
+import logging
 import os
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import ParamSpec, TypeVar
 
+log = logging.getLogger(__name__)
+
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
+_MAX_WORKERS_ENV = "LILBEE_INGEST_MAX_WORKERS"
+
 
 def _max_workers() -> int:
-    """Mirror the default-executor sizing; the point is isolation, not tuning."""
-    return min(32, (os.cpu_count() or 4) + 4)
+    """Concurrent slots for ingest offload work; honors ``LILBEE_INGEST_MAX_WORKERS``.
+
+    Extraction rasterizes PDFs and drives OCR on this pool, so its width caps how
+    many documents feed the GPU OCR/embed slots at once. The old fixed ``32``
+    ceiling left most cores idle on a many-vCPU box and pinned full-corpus
+    throughput below the vision fleet's capacity, so the default now scales with
+    the vCPU count (``os.cpu_count() + 4``, the ``+4`` headroom for threads
+    parked on OCR/embed I/O). The override accepts a positive integer; non-positive
+    or unparseable values fall back to the default and a warning is logged.
+    """
+    override = os.environ.get(_MAX_WORKERS_ENV)
+    if override is not None:
+        try:
+            value = int(override)
+            if value > 0:
+                return value
+        except ValueError:
+            pass  # bad override falls through to the warning + default below
+        log.warning(
+            "Ignoring %s=%r: must be a positive integer; using default.",
+            _MAX_WORKERS_ENV,
+            override,
+        )
+    return (os.cpu_count() or 4) + 4
 
 
 @functools.cache

--- a/src/lilbee/data/ingest/offload.py
+++ b/src/lilbee/data/ingest/offload.py
@@ -52,6 +52,15 @@ def _max_workers() -> int:
     return (os.cpu_count() or 4) + 4
 
 
+def max_workers() -> int:
+    """The ingest pool's worker count -- its hard concurrency ceiling.
+
+    The adaptive-concurrency controller uses this as the upper bound on in-flight
+    documents, since each one needs a pool thread to run its blocking extraction.
+    """
+    return _max_workers()
+
+
 @functools.cache
 def _ingest_executor() -> ThreadPoolExecutor:
     """The shared ingest pool, created on first use (cache makes it a singleton)."""

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -23,10 +23,18 @@ from rich.progress import (
 
 from lilbee.app.services import get_services
 from lilbee.core.config import active_config
+from lilbee.data.ingest.adaptive import (
+    AdaptiveController,
+    ResizableGate,
+    enumerate_fleet_devices,
+    make_signal_sampler,
+    profile_for,
+    resolve_mode,
+)
 from lilbee.data.ingest.code import ingest_code_sync
 from lilbee.data.ingest.discovery import classify_file, discover_files, file_hash
 from lilbee.data.ingest.extract import ingest_document, ingest_markdown
-from lilbee.data.ingest.offload import to_ingest_thread
+from lilbee.data.ingest.offload import max_workers, to_ingest_thread
 from lilbee.data.ingest.skip_marker import (
     clear_skip_markers,
     load_skip_markers,
@@ -517,6 +525,37 @@ def _phase_progress_callback(
 _TASK_WINDOW_MULTIPLIER = 2
 
 
+def _build_admission(
+    baseline: int, pages_done: list[int]
+) -> tuple[asyncio.Semaphore | ResizableGate, int, asyncio.Task[None] | None]:
+    """The batch's admission control, plus its task-window size and controller task.
+
+    Static mode (the default) returns a fixed semaphore and no controller. Adaptive
+    mode, when a GPU fleet is present to feed, returns a resizable gate and a running
+    :class:`AdaptiveController` that tunes it toward this box's throughput knee; with
+    no fleet it falls back to the static path so a GPU-less host is never affected.
+    """
+    profile = profile_for(resolve_mode())
+    devices = enumerate_fleet_devices() if profile is not None else []
+    if profile is None or not devices:
+        return asyncio.Semaphore(baseline), baseline * _TASK_WINDOW_MULTIPLIER, None
+    permit_max = max_workers()
+    gate = ResizableGate(min(baseline, permit_max))
+    controller = AdaptiveController(
+        gate,
+        profile,
+        make_signal_sampler(devices),
+        lambda: pages_done[0],
+        permit_min=1,
+        permit_max=permit_max,
+    )
+    task = asyncio.ensure_future(controller.run())
+    log.info(
+        "Adaptive ingest concurrency (%s): start %d, max %d", profile.name, gate.limit, permit_max
+    )
+    return gate, permit_max * _TASK_WINDOW_MULTIPLIER, task
+
+
 async def ingest_batch(
     files_to_process: list[FileToProcess],
     added: dict[str, None],
@@ -535,13 +574,16 @@ async def ingest_batch(
     ingesting new ones so the two operations are atomic per file.
     When *cancel* is set, pending files raise CancelledError before starting.
     """
-    semaphore = asyncio.Semaphore(_max_concurrent())
-    window = _max_concurrent() * _TASK_WINDOW_MULTIPLIER
+    # Throughput is measured in OCR pages, not documents: a document's cost scales
+    # with its page count (a 500-page scan is 500x a memo), so pages are the unbiased
+    # unit of GPU-feeding work for the adaptive controller to hill-climb on.
+    pages_done = [0]
+    admission, window, controller_task = _build_admission(_max_concurrent(), pages_done)
     total_files = len(files_to_process)
 
     async def _process_one(entry: FileToProcess, file_index: int) -> _IngestResult:
         name = entry.name
-        async with semaphore:
+        async with admission:
             if cancel and cancel.is_set():
                 raise asyncio.CancelledError
 
@@ -572,6 +614,7 @@ async def ingest_batch(
                     EventType.FILE_DONE,
                     FileDoneEvent(file=name, status="ok", chunks=len(records)),
                 )
+                pages_done[0] += max(1, len(page_texts))  # OCR pages cleared: the throughput signal
                 return _IngestResult(
                     name,
                     entry.path,
@@ -607,38 +650,12 @@ async def ingest_batch(
                         EventType.FILE_DONE,
                         FileDoneEvent(file=name, status="error", chunks=0),
                     )
+                pages_done[0] += 1  # cleared the gate (as a failure); still a throughput tick
                 return _IngestResult(name, entry.path, 0, error=exc)
 
     pending = (_process_one(entry, idx) for idx, entry in enumerate(files_to_process, 1))
-    if quiet:
-        await _collect_results(
-            pending,
-            total_files,
-            added,
-            updated,
-            failed,
-            skipped,
-            window=window,
-            on_progress=on_progress,
-            flush_failed=flush_failed,
-            reasons=reasons,
-        )
-    else:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("{task.description}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TimeElapsedColumn(),
-            transient=True,
-        ) as progress:
-            ptask = progress.add_task("Ingesting documents...", total=total_files)
-            # The bar advances once per file (in _collect_results), so a single
-            # multi-page scanned PDF would freeze at "0/1" through its whole
-            # OCR + embed phase. Drive the spinner's description off the same
-            # EXTRACT (OCR page i/N) and EMBED (chunk i/N) events the TUI uses
-            # so the row visibly moves while one file is being worked.
-            phase_progress = _phase_progress_callback(progress, ptask, on_progress)
+    try:
+        if quiet:
             await _collect_results(
                 pending,
                 total_files,
@@ -647,12 +664,47 @@ async def ingest_batch(
                 failed,
                 skipped,
                 window=window,
-                on_progress=phase_progress,
-                progress=progress,
-                ptask=ptask,
+                on_progress=on_progress,
                 flush_failed=flush_failed,
                 reasons=reasons,
             )
+        else:
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("{task.description}"),
+                BarColumn(),
+                MofNCompleteColumn(),
+                TimeElapsedColumn(),
+                transient=True,
+            ) as progress:
+                ptask = progress.add_task("Ingesting documents...", total=total_files)
+                # The bar advances once per file (in _collect_results), so a single
+                # multi-page scanned PDF would freeze at "0/1" through its whole
+                # OCR + embed phase. Drive the spinner's description off the same
+                # EXTRACT (OCR page i/N) and EMBED (chunk i/N) events the TUI uses
+                # so the row visibly moves while one file is being worked.
+                phase_progress = _phase_progress_callback(progress, ptask, on_progress)
+                await _collect_results(
+                    pending,
+                    total_files,
+                    added,
+                    updated,
+                    failed,
+                    skipped,
+                    window=window,
+                    on_progress=phase_progress,
+                    progress=progress,
+                    ptask=ptask,
+                    flush_failed=flush_failed,
+                    reasons=reasons,
+                )
+    finally:
+        # Stop the adaptive controller (if any) before returning: its background
+        # loop must not outlive the batch it was tuning.
+        if controller_task is not None:
+            controller_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await controller_task
 
 
 # Accumulate roughly this many chunks across documents before one batched

--- a/src/lilbee/data/ingest/pipeline.py
+++ b/src/lilbee/data/ingest/pipeline.py
@@ -378,6 +378,25 @@ def _force_rebuild_store(store: Any) -> None:
         store.rebuild_memory_embeddings(lambda texts: embedder.embed_batch(texts))
 
 
+def _reconcile_missing(
+    disk_files: dict[str, Path],
+    sources: list[SourceRecord],
+    failed: Iterable[str],
+    skipped: Iterable[str],
+) -> list[str]:
+    """On-disk document files absent from the store and not reported failed/skipped.
+
+    A file discovery found and classified that ended up in neither the sources table
+    nor the run's failed/skipped lists was dropped with no signal -- the silent
+    data-loss case (a scanned PDF that never made it into the index yet reported no
+    error). Everything legitimately not indexed is excluded: a failed extraction is in
+    ``failed``, a zero-text file is in ``skipped``, and an unsupported type was never
+    returned by discovery in the first place.
+    """
+    accounted = {s["filename"] for s in sources} | set(failed) | set(skipped)
+    return sorted(name for name in disk_files if name not in accounted)
+
+
 async def sync(
     force_rebuild: bool = False,
     quiet: bool = False,
@@ -472,6 +491,18 @@ async def sync(
         from lilbee.wiki.ingest import incremental_update
 
         await incremental_update(set(added) | set(updated) | set(removed))
+
+    # Reconciliation guard against silent data loss: any on-disk document file that
+    # ended up in neither the index nor the failed/skipped lists was dropped without
+    # a signal. Surface it loudly instead of letting a whole dataset vanish quietly.
+    missing = _reconcile_missing(disk_files, _store.get_sources(), failed, skipped)
+    if missing:
+        log.warning(
+            "Sync reconciliation: %d document file(s) on disk are absent from the index "
+            "with no failure reported (possible silent drop): %s",
+            len(missing),
+            ", ".join(missing[:20]),
+        )
 
     result = SyncResult(
         added=list(added),

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -178,6 +178,17 @@ def _make_empty_result():
     return result
 
 
+def test_reconcile_missing_flags_only_silent_drops():
+    from pathlib import Path
+
+    from lilbee.data.ingest.pipeline import _reconcile_missing
+
+    disk = {n: Path(n) for n in ("a.pdf", "b.pdf", "c.pdf", "d.pdf")}
+    # a indexed, b failed, c skipped, d dropped with no signal.
+    missing = _reconcile_missing(disk, [{"filename": "a.pdf"}], failed=["b.pdf"], skipped=["c.pdf"])
+    assert missing == ["d.pdf"]
+
+
 @mock.patch("kreuzberg.extract_file_sync", new_callable=Mock, return_value=_make_kreuzberg_result())
 class TestSync:
     async def test_empty_documents_dir(self, mock_extract_file, isolated_env):
@@ -212,6 +223,40 @@ class TestSync:
         )
         result = await sync(quiet=True)
         assert "adaptive.txt" in result.added
+
+    async def test_spaced_filename_ingests_without_silent_drop(
+        self, mock_extract_file, isolated_env, caplog
+    ):
+        # Regression for the silent drop of files with spaces in their names.
+        (isolated_env / "Request No. 1.txt").write_text("Maintenance request approved, page one.")
+        import logging
+
+        from lilbee.data.ingest import sync
+
+        with caplog.at_level(logging.WARNING, logger="lilbee.data.ingest.pipeline"):
+            result = await sync(quiet=True)
+        assert "Request No. 1.txt" in result.added
+        assert not any("reconciliation" in r.getMessage().lower() for r in caplog.records)
+
+    async def test_reconciliation_warns_on_silent_drop(
+        self, mock_extract_file, isolated_env, monkeypatch, caplog
+    ):
+        # A file discovered but never indexed, failed, or skipped is a silent drop.
+        (isolated_env / "ghost.txt").write_text("This file gets dropped by a broken ingest stage.")
+        import logging
+
+        from lilbee.data.ingest import pipeline, sync
+
+        async def _noop_ingest(*_a, **_k):
+            return None
+
+        monkeypatch.setattr(pipeline, "ingest_batch", _noop_ingest)
+        with caplog.at_level(logging.WARNING, logger="lilbee.data.ingest.pipeline"):
+            await sync(quiet=True)
+        assert any(
+            "reconciliation" in r.getMessage().lower() and "ghost.txt" in r.getMessage()
+            for r in caplog.records
+        )
 
     async def test_quiet_mode_suppresses_progress(self, mock_extract_file, isolated_env):
         (isolated_env / "quiet.txt").write_text("Quiet mode test content.")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -195,6 +195,24 @@ class TestSync:
         mock_extract_file.assert_called()
         assert any("test.txt" in str(call) for call in mock_extract_file.call_args_list)
 
+    async def test_adaptive_mode_ingests_and_stops_controller(
+        self, mock_extract_file, isolated_env, monkeypatch
+    ):
+        (isolated_env / "adaptive.txt").write_text("Adaptive-mode content for ingest.")
+        from lilbee.data.ingest import pipeline, sync
+        from lilbee.data.ingest.adaptive import Signals
+
+        monkeypatch.setenv("LILBEE_INGEST_CONCURRENCY", "adaptive-conservative")
+        # A fake fleet + sampler so the adaptive path engages without real GPU probing.
+        monkeypatch.setattr(pipeline, "enumerate_fleet_devices", lambda: [object()])
+        monkeypatch.setattr(
+            pipeline,
+            "make_signal_sampler",
+            lambda _devices: (lambda t: Signals(t, 50.0, 60.0, 50.0, 0.5)),
+        )
+        result = await sync(quiet=True)
+        assert "adaptive.txt" in result.added
+
     async def test_quiet_mode_suppresses_progress(self, mock_extract_file, isolated_env):
         (isolated_env / "quiet.txt").write_text("Quiet mode test content.")
         from lilbee.data.ingest import sync

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -219,7 +219,7 @@ class TestSync:
         monkeypatch.setattr(
             pipeline,
             "make_signal_sampler",
-            lambda _devices: (lambda t: Signals(t, 50.0, 60.0, 50.0, 0.5)),
+            lambda _devices: lambda t: Signals(t, 50.0, 60.0, 50.0, 0.5),
         )
         result = await sync(quiet=True)
         assert "adaptive.txt" in result.added

--- a/tests/test_ingest_adaptive.py
+++ b/tests/test_ingest_adaptive.py
@@ -1,0 +1,395 @@
+"""Adaptive ingest concurrency: mode resolution, the pure control law, the
+resizable gate, and the controller loop.
+
+The control law (:func:`decide`) is exercised with plain numbers -- no clock, no
+asyncio, no GPU -- since it is a pure function; the gate and controller get small
+asyncio tests with injected signals so they run without hardware.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from lilbee.data.ingest.adaptive import (
+    AGGRESSIVE,
+    CONSERVATIVE,
+    AdaptiveController,
+    ConcurrencyMode,
+    ControllerState,
+    ResizableGate,
+    Signals,
+    decide,
+    enumerate_fleet_devices,
+    make_signal_sampler,
+    profile_for,
+    resolve_mode,
+)
+
+MIN, MAX = 1, 100
+
+
+def _signals(throughput: float, **over: float | None) -> Signals:
+    """A tick with every safety signal comfortable, overridable per test."""
+    base: dict[str, float | None] = {
+        "gpu_util_pct": 50.0,
+        "gpu_temp_c": 60.0,
+        "cpu_pct": 50.0,
+        "ram_free_frac": 0.5,
+    }
+    base.update(over)
+    return Signals(throughput=throughput, **base)  # type: ignore[arg-type]
+
+
+def _state(
+    permits: int,
+    ewma: float | None = 100.0,
+    direction: int = 1,
+    cool_down: int = 0,
+    w_min: float | None = None,
+):
+    return ControllerState(
+        permits=permits, ewma_tput=ewma, direction=direction, cool_down=cool_down, w_min=w_min
+    )
+
+
+# --- mode resolution -------------------------------------------------------
+
+
+def test_mode_defaults_to_static(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LILBEE_INGEST_CONCURRENCY", raising=False)
+    assert resolve_mode() is ConcurrencyMode.STATIC
+
+
+@pytest.mark.parametrize(
+    ("value", "mode"),
+    [
+        ("static", ConcurrencyMode.STATIC),
+        ("adaptive-conservative", ConcurrencyMode.ADAPTIVE_CONSERVATIVE),
+        ("ADAPTIVE-AGGRESSIVE", ConcurrencyMode.ADAPTIVE_AGGRESSIVE),
+    ],
+)
+def test_mode_parses_known_values(monkeypatch: pytest.MonkeyPatch, value: str, mode) -> None:
+    monkeypatch.setenv("LILBEE_INGEST_CONCURRENCY", value)
+    assert resolve_mode() is mode
+
+
+def test_unknown_mode_falls_back_to_static(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LILBEE_INGEST_CONCURRENCY", "turbo")
+    assert resolve_mode() is ConcurrencyMode.STATIC
+
+
+def test_profile_for_maps_modes() -> None:
+    assert profile_for(ConcurrencyMode.STATIC) is None
+    assert profile_for(ConcurrencyMode.ADAPTIVE_CONSERVATIVE) is CONSERVATIVE
+    assert profile_for(ConcurrencyMode.ADAPTIVE_AGGRESSIVE) is AGGRESSIVE
+    assert CONSERVATIVE.step(100) == 1
+    assert AGGRESSIVE.step(100) == 3  # 1 + isqrt(100)//4
+
+
+# --- pure control law ------------------------------------------------------
+
+
+def test_first_tick_probes_upward() -> None:
+    out = decide(CONSERVATIVE, _state(10, ewma=None), _signals(100), MIN, MAX)
+    assert out.permits == 11
+    assert out.ewma_tput == 100
+    assert out.direction == 1
+
+
+def test_clear_throughput_gain_climbs_in_direction() -> None:
+    out = decide(CONSERVATIVE, _state(10, ewma=100, direction=1), _signals(200), MIN, MAX)
+    assert out.permits == 11  # new_ewma 130 > band -> +1
+
+
+def test_clear_throughput_loss_reverses_direction() -> None:
+    out = decide(CONSERVATIVE, _state(10, ewma=100, direction=1), _signals(0), MIN, MAX)
+    assert out.direction == -1
+    assert out.permits == 9
+
+
+def test_inside_dead_band_holds() -> None:
+    out = decide(CONSERVATIVE, _state(10, ewma=100, direction=1), _signals(101), MIN, MAX)
+    assert out.permits == 10
+
+
+@pytest.mark.parametrize("danger", ["gpu_temp_c", "cpu_pct", "ram_free_frac"])
+def test_critical_signal_forces_backoff_and_cooldown(danger: str) -> None:
+    crit = {"gpu_temp_c": 90.0, "cpu_pct": 98.0, "ram_free_frac": 0.05}[danger]
+    out = decide(CONSERVATIVE, _state(10, ewma=100), _signals(500, **{danger: crit}), MIN, MAX)
+    assert out.permits == 5  # halved
+    assert out.cool_down == CONSERVATIVE.cool_down_intervals
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("cpu_pct", 92.0), ("ram_free_frac", 0.15), ("gpu_temp_c", 82.0), ("gpu_util_pct", 98.0)],
+)
+def test_soft_pressure_vetoes_increase(field: str, value: float) -> None:
+    # Throughput is rising, so without the veto it would climb; the veto holds it.
+    out = decide(
+        CONSERVATIVE, _state(10, ewma=100, direction=1), _signals(500, **{field: value}), MIN, MAX
+    )
+    assert out.permits == 10
+
+
+def test_saturated_and_falling_steps_back() -> None:
+    # GPU saturated AND throughput slipping -> USL retrograde single step down.
+    out = decide(
+        CONSERVATIVE, _state(10, ewma=100, direction=1), _signals(0, gpu_util_pct=99.0), MIN, MAX
+    )
+    assert out.permits == 9
+    assert out.direction == -1
+
+
+def test_latency_gradient_vetoes_increase() -> None:
+    # An established low baseline (w_min) plus an inflated current residence time
+    # (permits high, throughput low) vetoes the climb before throughput rolls over.
+    out = decide(CONSERVATIVE, _state(20, ewma=100, direction=1, w_min=0.1), _signals(10), MIN, MAX)
+    assert out.permits == 20  # held: w_est 20/73 ~ 0.27 > 0.1 * 1.5
+
+
+def test_residence_baseline_is_tracked() -> None:
+    out = decide(CONSERVATIVE, _state(10, ewma=100, w_min=None), _signals(100), MIN, MAX)
+    assert out.w_min == pytest.approx(0.1)  # 10 / 100
+
+
+def test_cooldown_suppresses_increase_and_decrements() -> None:
+    out = decide(
+        CONSERVATIVE, _state(10, ewma=100, direction=1, cool_down=2), _signals(500), MIN, MAX
+    )
+    assert out.permits == 10
+    assert out.cool_down == 1
+
+
+def test_clamped_to_max() -> None:
+    out = decide(CONSERVATIVE, _state(MAX, ewma=100, direction=1), _signals(500), MIN, MAX)
+    assert out.permits == MAX
+
+
+def test_clamped_to_min_on_backoff() -> None:
+    out = decide(CONSERVATIVE, _state(1, ewma=100), _signals(500, cpu_pct=99.0), MIN, MAX)
+    assert out.permits == MIN
+
+
+# --- resizable gate --------------------------------------------------------
+
+
+async def test_gate_blocks_at_limit_and_release_admits() -> None:
+    gate = ResizableGate(1)
+    await gate.acquire()
+    admitted = asyncio.Event()
+
+    async def second() -> None:
+        await gate.acquire()
+        admitted.set()
+
+    task = asyncio.create_task(second())
+    await asyncio.sleep(0.01)
+    assert not admitted.is_set()
+    await gate.release()
+    await asyncio.wait_for(admitted.wait(), 1)
+    await task
+
+
+async def test_gate_grow_wakes_a_waiter() -> None:
+    gate = ResizableGate(1)
+    await gate.acquire()
+    got = asyncio.Event()
+
+    async def waiter() -> None:
+        await gate.acquire()
+        got.set()
+
+    task = asyncio.create_task(waiter())
+    await asyncio.sleep(0.01)
+    assert not got.is_set()
+    await gate.set_limit(2)
+    await asyncio.wait_for(got.wait(), 1)
+    await task
+
+
+async def test_gate_shrink_lowers_ceiling() -> None:
+    gate = ResizableGate(2)
+    await gate.acquire()
+    await gate.acquire()  # active == limit == 2
+    await gate.set_limit(1)  # over the new ceiling; must drain to below it
+    blocked = asyncio.Event()
+
+    async def waiter() -> None:
+        await gate.acquire()
+        blocked.set()
+
+    task = asyncio.create_task(waiter())
+    await gate.release()  # active 2 -> 1, still not < limit(1)
+    await asyncio.sleep(0.01)
+    assert not blocked.is_set()
+    await gate.release()  # active 1 -> 0 < 1
+    await asyncio.wait_for(blocked.wait(), 1)
+    await task
+
+
+# --- controller loop -------------------------------------------------------
+
+
+async def test_controller_climbs_on_rising_throughput() -> None:
+    gate = ResizableGate(10)
+    done = {"c": 0}
+    tick = {"n": 0}
+
+    def completed() -> int:
+        return done["c"]
+
+    def sample(throughput: float) -> Signals:
+        return _signals(throughput)
+
+    async def fake_sleep(_: float) -> None:
+        tick["n"] += 1
+        done["c"] += 100 * tick["n"]  # rising per-interval deltas
+        if tick["n"] >= 6:
+            raise asyncio.CancelledError
+
+    ctrl = AdaptiveController(
+        gate, CONSERVATIVE, sample, completed, permit_min=1, permit_max=50, sleep=fake_sleep
+    )
+    with contextlib.suppress(asyncio.CancelledError):
+        await ctrl.run()
+    assert gate.limit > 10
+
+
+async def test_controller_survives_a_sampler_failure() -> None:
+    gate = ResizableGate(10)
+    tick = {"n": 0}
+
+    def completed() -> int:
+        return 0
+
+    def sample(throughput: float) -> Signals:
+        raise RuntimeError("probe blew up")
+
+    async def fake_sleep(_: float) -> None:
+        tick["n"] += 1
+        if tick["n"] >= 3:
+            raise asyncio.CancelledError
+
+    ctrl = AdaptiveController(
+        gate, CONSERVATIVE, sample, completed, permit_min=1, permit_max=50, sleep=fake_sleep
+    )
+    with contextlib.suppress(asyncio.CancelledError):
+        await ctrl.run()
+    assert gate.limit == 10  # tick failures swallowed; the tuner never crashed
+
+
+async def test_controller_holds_and_skips_resize_when_flat() -> None:
+    gate = ResizableGate(10)
+    done = {"c": 0}
+    tick = {"n": 0}
+
+    def completed() -> int:
+        return done["c"]
+
+    def sample(throughput: float) -> Signals:
+        return _signals(throughput)
+
+    async def fake_sleep(_: float) -> None:
+        tick["n"] += 1
+        done["c"] += 100  # constant delta -> flat throughput after the first probe
+        if tick["n"] >= 4:
+            raise asyncio.CancelledError
+
+    ctrl = AdaptiveController(
+        gate, CONSERVATIVE, sample, completed, permit_min=1, permit_max=50, sleep=fake_sleep
+    )
+    with contextlib.suppress(asyncio.CancelledError):
+        await ctrl.run()
+    assert gate.limit == 11  # one probe up, then flat -> holds (no further resize)
+
+
+async def test_controller_backs_off_on_emergency() -> None:
+    gate = ResizableGate(20)
+    tick = {"n": 0}
+
+    def completed() -> int:
+        return 0
+
+    def sample(throughput: float) -> Signals:
+        return _signals(throughput, gpu_temp_c=90.0)  # over TEMP_CRIT
+
+    async def fake_sleep(_: float) -> None:
+        tick["n"] += 1
+        if tick["n"] >= 2:  # let one decide() run, then stop
+            raise asyncio.CancelledError
+
+    ctrl = AdaptiveController(
+        gate, CONSERVATIVE, sample, completed, permit_min=1, permit_max=50, sleep=fake_sleep
+    )
+    with contextlib.suppress(asyncio.CancelledError):
+        await ctrl.run()
+    assert gate.limit < 20
+
+
+async def test_gate_context_manager_admits_and_releases() -> None:
+    gate = ResizableGate(1)
+    async with gate:
+        blocked = asyncio.Event()
+
+        async def waiter() -> None:
+            async with gate:
+                blocked.set()
+
+        task = asyncio.create_task(waiter())
+        await asyncio.sleep(0.01)
+        assert not blocked.is_set()  # held inside the outer `async with`
+    await asyncio.wait_for(blocked.wait(), 1)  # released on exit
+    await task
+
+
+# --- real signal sampler ---------------------------------------------------
+
+
+def test_sampler_reports_mean_util_and_max_temp(monkeypatch: pytest.MonkeyPatch) -> None:
+    from lilbee.providers.fleet import gpu_stats
+
+    stats = {
+        0: gpu_stats.GpuStat(0, utilization_pct=40, free_bytes=1, total_bytes=2, temperature_c=70),
+        1: gpu_stats.GpuStat(1, utilization_pct=80, free_bytes=1, total_bytes=2, temperature_c=85),
+    }
+    monkeypatch.setattr(gpu_stats, "probe_gpu_stats", lambda _devices: stats)
+    signals = make_signal_sampler([object()])(throughput=12.0)
+    assert signals.throughput == 12.0
+    assert signals.gpu_util_pct == 60.0  # mean(40, 80)
+    assert signals.gpu_temp_c == 85.0  # max(70, 85)
+    assert 0.0 <= signals.ram_free_frac <= 1.0
+
+
+def test_sampler_without_gpu_telemetry_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    from lilbee.providers.fleet import gpu_stats
+
+    monkeypatch.setattr(gpu_stats, "probe_gpu_stats", lambda _devices: {})
+    signals = make_signal_sampler([])(throughput=0.0)
+    assert signals.gpu_util_pct is None
+    assert signals.gpu_temp_c is None
+
+
+# --- device enumeration ----------------------------------------------------
+
+
+def test_enumerate_devices_returns_probe_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    from lilbee.providers.fleet import binary, planning
+
+    sentinel = [object()]
+    monkeypatch.setattr(binary, "resolve_llama_server", lambda: "llama-server")
+    monkeypatch.setattr(planning, "resolve_devices", lambda _binary: sentinel)
+    assert enumerate_fleet_devices() == sentinel
+
+
+def test_enumerate_devices_degrades_to_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    from lilbee.providers.fleet import binary
+
+    def boom() -> str:
+        raise RuntimeError("no engine")
+
+    monkeypatch.setattr(binary, "resolve_llama_server", boom)
+    assert enumerate_fleet_devices() == []

--- a/tests/test_ingest_offload.py
+++ b/tests/test_ingest_offload.py
@@ -1,0 +1,46 @@
+"""Sizing of the dedicated ingest offload pool.
+
+Extraction (PDF rasterization + OCR) runs on this pool, so its width caps how
+many documents rasterize in parallel to feed the GPU OCR/embed slots on a
+full-corpus run. These lock in that the width scales with the vCPU count and is
+operator-overridable, rather than the old fixed 32-thread ceiling.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lilbee.data.ingest import offload
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LILBEE_INGEST_MAX_WORKERS", raising=False)
+
+
+def test_default_scales_past_the_old_32_ceiling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(offload.os, "cpu_count", lambda: 128)
+    assert offload._max_workers() == 132
+
+
+def test_default_keeps_headroom_on_a_small_box(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(offload.os, "cpu_count", lambda: 8)
+    assert offload._max_workers() == 12
+
+
+def test_default_falls_back_when_cpu_count_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(offload.os, "cpu_count", lambda: None)
+    assert offload._max_workers() == 8
+
+
+def test_env_override_wins_over_the_scaled_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(offload.os, "cpu_count", lambda: 8)
+    monkeypatch.setenv("LILBEE_INGEST_MAX_WORKERS", "200")
+    assert offload._max_workers() == 200
+
+
+@pytest.mark.parametrize("bad", ["nan", "0", "-4", "  "])
+def test_invalid_env_override_is_ignored(monkeypatch: pytest.MonkeyPatch, bad: str) -> None:
+    monkeypatch.setattr(offload.os, "cpu_count", lambda: 8)
+    monkeypatch.setenv("LILBEE_INGEST_MAX_WORKERS", bad)
+    assert offload._max_workers() == 12


### PR DESCRIPTION
## Problem

A full ~370k-file / ~590k-page OCR ingest on a 128-vCPU, 6-GPU pod ran the GPUs under 50% utilization while the machine swung between load 20 and 159. The pass is bottlenecked on CPU-side PDF rasterization, not the GPUs, and the pipeline had no way to match its concurrency to the box it was running on.

Two things were wrong. First, the ingest thread pool was hard-capped at `min(32, cpu_count + 4)`, so on a many-core box only 32 pages rasterized at once while the vision fleet's OCR slots sat idle, and throughput was pinned regardless of card. Second, even with the cap raised, the *right* number of in-flight documents is not a constant: it depends on the machine, the corpus, and how many GPUs are present. There is a real, hardware-specific operating point (the throughput knee), and no fixed default finds it on every box.

## Solution

Two changes, the second building on the first.

**Uncap the extraction pool.** Size it to `cpu_count + 4` instead of the fixed 32 ceiling, with a `LILBEE_INGEST_MAX_WORKERS` override, matching the existing `LILBEE_CPU_QUOTA` idiom. This alone removes the artificial floor that sat below the fleet's real slot capacity.

**Make the concurrency adapt to the hardware.** A new `LILBEE_INGEST_CONCURRENCY` selects the admission policy: `static` (the default, the fixed semaphore above, unchanged and always safe), or `adaptive-conservative` / `adaptive-aggressive`. In adaptive mode a background controller resizes the in-flight-document limit toward *this box's* actual throughput knee rather than any hardcoded utilization target.

The control law is a safety-gated AIMD hill-climb on smoothed per-page throughput, drawn from proven congestion-control and thread-pool autotuning practice (AIMD from Chiu & Jain; the knee/operating-point framing from TCP BBR and Kleinrock; throughput hill-climbing from the .NET CLR ThreadPool; the peak-exists intuition from the Universal Scalability Law). It climbs while pages-per-second keeps improving and settles at the knee. A Little's-Law residence-time estimate adds a TCP-Vegas / Netflix-Gradient2 style latency-gradient veto that stops increases *before* throughput visibly rolls over, since latency leads the knee. Throughput is measured in OCR pages, not documents, so a 500-page scan counts as 500 units of work rather than one and does not read as a throughput collapse.

Safety is never traded for speed. Hard guardrails on CPU load, free RAM, and GPU temperature force an immediate multiplicative backoff and a cool-down, so the controller cannot thrash the CPU, exhaust memory, or overheat a GPU; the two adaptive profiles differ only in climb speed, never in those limits. Adaptive engages only when a GPU fleet is present (a GPU-less host always uses static), and the tuner is best-effort: any sampling failure is logged and skipped, so it can never crash the ingest it is only advising.

This targets `main` (the kreuzberg trunk) rather than the xberg branch: the ingest pool and pipeline are shared, and on `main` rasterization runs on this pool, so both ingest paths benefit and the xberg branch inherits the change on its next merge from main.

The static path is byte-for-byte the prior behavior and remains the default, so nothing changes for anyone who does not opt in. The larger architectural split (separate CPU-extraction and GPU-OCR pods) and real-time per-page ticking are left as follow-ups.

## Also: surface silently dropped files

Separately, this fixes a silent data-loss path in the same pipeline. A document that discovery found but that never reached the index, and was never reported failed or skipped, vanished with the sync still reporting success, so an entire dataset could be missing from search with no error. After each sync we now reconcile the on-disk document files against the sources table and log a warning naming any that landed in neither the index nor the failed/skipped lists. Discovery, extraction, rasterization, the store round-trip, and skip markers all handle filenames with spaces correctly end-to-end, so this is the reconciliation guard plus a regression test rather than a change to a path that already works.
