### PR TITLE
Ship the CUDA runtime DLLs beside llama-server.exe so the Windows CUDA build starts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,10 @@ litellm = ["litellm>=1.84.0,<1.92"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
 crawler = ["crawl4ai>=0.9.0"]
 # The CUDA 12 runtime the bundled llama-server links, from NVIDIA's official PyPI
-# wheels. Markers keep it a no-op off Linux x86_64 (no wheel exists elsewhere);
-# fleet.cuda_runtime adds their lib dirs to the engine's LD_LIBRARY_PATH.
+# wheels; fleet.cuda_runtime adds their lib dirs to the engine's LD_LIBRARY_PATH.
+# Linux x86_64 only: macOS and aarch64 have no CUDA build to feed, and the Windows
+# engine wheel ships the toolkit's redistributable DLLs beside llama-server.exe
+# (build_llama_server.sh), which is where Windows looks for a process's imports.
 cuda12 = [
     "nvidia-cuda-runtime-cu12; platform_system=='Linux' and platform_machine=='x86_64'",
     "nvidia-cublas-cu12; platform_system=='Linux' and platform_machine=='x86_64'",

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -138,6 +138,41 @@ while IFS= read -r -d '' lib; do
 done < <(find "${src}/server-build" \( -name CMakeFiles -o -name CMakeScratch -o -path '*vulkan-shaders-gen-prefix*' \) -prune -o \
   \( -type f -o -type l \) \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -print0)
 
+# A CUDA build links the CUDA 12 runtime dynamically, and those libraries live in
+# the toolkit, never in the build output copied above. Linux finds them at runtime
+# from the nvidia-*-cu12 wheels (fleet.cuda_runtime puts them on LD_LIBRARY_PATH);
+# Windows has no equivalent hook, so the toolkit's redistributables must sit beside
+# llama-server.exe, which is the first directory Windows searches for a process's
+# imports. Without them the server dies before binding its port, with a "cudart64_12.dll
+# was not found" dialog and no healthy replica for lilbee to route to.
+case "${backend}_$(uname -s)" in
+  cu12*_MINGW* | cu12*_MSYS* | cu12*_CYGWIN*)
+    cuda_bin="$(cygpath -u "${CUDA_PATH:?CUDA_PATH must be set for a Windows CUDA build}")/bin"
+    shopt -s nullglob
+    # nvrtc only matters for runtime kernel compilation and the CI toolkit install
+    # omits it; copy it when present. The other three are hard requirements.
+    cuda_libs=(
+      "${cuda_bin}"/cudart64_*.dll
+      "${cuda_bin}"/cublas64_*.dll
+      "${cuda_bin}"/cublasLt64_*.dll
+      "${cuda_bin}"/nvrtc64_*.dll
+    )
+    shopt -u nullglob
+    for lib in ${cuda_libs[@]+"${cuda_libs[@]}"}; do
+      cp "${lib}" "${pkg_bin_dir}/"
+    done
+    # The bundle is unverifiable by exec here (a driverless build host loads no CUDA
+    # backend at all, so the server would start clean with or without these), so gate
+    # on the copy itself: every required redistributable must have landed.
+    for required in cudart64 cublas64 cublasLt64; do
+      compgen -G "${pkg_bin_dir}/${required}_*.dll" >/dev/null || {
+        echo "no ${required}_*.dll under ${cuda_bin}: the Windows CUDA bundle is incomplete" >&2
+        exit 1
+      }
+    done
+    ;;
+esac
+
 # The copied closure must actually resolve: exec the bundled binary from the
 # bundle dir. A missing bundled lib fails here, at build time, instead of on a
 # user's machine. Skipped when cross-compiling (the host can't exec the target)


### PR DESCRIPTION
## Problem

On Windows, the CUDA build of the engine never starts. `llama-server.exe` dies before it binds its port with a `The code execution cannot proceed because cudart64_12.dll was not found` dialog, and lilbee then reports `The model server is not responding and no healthy replica is available` for every chat turn.

The engine bundle step copies every shared library CMake produces, which is ggml, llama, and mtmd. A CUDA build also links the CUDA 12 runtime dynamically, and those libraries live in the CUDA toolkit's own `bin/`, so they were never copied. Linux gets away with it: `fleet.cuda_runtime` puts the `nvidia-*-cu12` wheel directories on `LD_LIBRARY_PATH` at launch. Windows has no equivalent hook, so the libraries have to be on disk next to the binary.

This reached a user because CI cannot catch it by running the binary. The CUDA smoke tests are skipped on the build runners, since a driverless host loads no CUDA backend at all and `llama-server --version` succeeds whether or not the runtime is present.

## Solution

Copy the toolkit's redistributables into the engine bundle for Windows CUDA builds, next to `llama-server.exe`, which is the first directory Windows searches when resolving a process's imports. That covers both distribution channels, since the standalone executable and the `--extra-index-url https://lilbee.sh/cu125/` install are built from the same bundle.

`cudart64`, `cublas64`, and `cublasLt64` are required, and the build now fails if any of them is missing rather than producing a bundle that only breaks on a user's machine. `nvrtc64` is copied when the toolkit installs it. Since the copy cannot be verified by executing the binary on a driverless runner, the check is on the copy itself.

Both engine cache keys already hash this script, so warm caches rebuild rather than restoring a bundle without the libraries.

This grows the Windows CUDA executable by a few hundred megabytes, almost all of it `cublasLt`. The wheel indexes link to release assets rather than hosting wheels, so the site's size limit is unaffected.

Confirming this end to end needs an NVIDIA Windows machine. CI proves the libraries are in the bundle; it cannot prove the server starts.