### PR TITLE
Reap worker subprocesses on shutdown and harden parent-death watch

### DIFF
--- a/src/lilbee/parent_monitor.py
+++ b/src/lilbee/parent_monitor.py
@@ -34,14 +34,38 @@ def parse_parent_pid(env: dict[str, str] | None = None) -> int | None:
     return pid
 
 
+def _parent_start_time(pid: int) -> float | None:
+    """Process create-time for *pid*, or None if it is gone or unreadable."""
+    try:
+        return float(psutil.Process(pid).create_time())
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return None
+
+
+def _same_process(pid: int, start_time: float | None) -> bool:
+    """False when *pid* now belongs to a different process than *start_time*."""
+    if start_time is None:
+        return True
+    try:
+        return bool(psutil.Process(pid).create_time() == start_time)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return False
+
+
+def _parent_alive(pid: int, start_time: float | None) -> bool:
+    """True while *pid* still refers to the original parent process."""
+    return psutil.pid_exists(pid) and _same_process(pid, start_time)
+
+
 async def watch_parent_async(
     parent_pid: int,
     on_death: Callable[[], None],
     *,
     poll_interval_secs: float = POLL_INTERVAL_SECS,
 ) -> None:
-    """Poll *parent_pid* until it disappears, then call *on_death* once."""
-    while psutil.pid_exists(parent_pid):
+    """Poll *parent_pid* until it exits or its PID is recycled, then call *on_death* once."""
+    start_time = _parent_start_time(parent_pid)
+    while _parent_alive(parent_pid, start_time):
         await asyncio.sleep(poll_interval_secs)
     log.info("%s=%d is no longer alive; triggering shutdown", PARENT_PID_ENV, parent_pid)
     on_death()
@@ -53,10 +77,11 @@ def watch_parent_thread(
     *,
     poll_interval_secs: float = POLL_INTERVAL_SECS,
 ) -> threading.Thread:
-    """Spawn a daemon thread that fires *on_death* when *parent_pid* exits."""
+    """Daemon thread that fires *on_death* once *parent_pid* exits or its PID is recycled."""
 
     def _loop() -> None:
-        while psutil.pid_exists(parent_pid):
+        start_time = _parent_start_time(parent_pid)
+        while _parent_alive(parent_pid, start_time):
             time.sleep(poll_interval_secs)
         log.info("%s=%d is no longer alive; triggering shutdown", PARENT_PID_ENV, parent_pid)
         on_death()

--- a/src/lilbee/server/app.py
+++ b/src/lilbee/server/app.py
@@ -11,7 +11,7 @@ from litestar.config.cors import CORSConfig
 from litestar.middleware.base import DefineMiddleware
 from litestar.openapi import OpenAPIConfig
 
-from lilbee.app.services import get_services
+from lilbee.app.services import get_services, peek_services
 from lilbee.app.version import get_version
 from lilbee.core.config import cfg
 from lilbee.providers.sdk_llm_provider import inject_provider_keys
@@ -115,6 +115,11 @@ async def _lifespan(app: Litestar) -> AsyncIterator[None]:
         yield
     finally:
         session_manager.cleanup()
+        # Terminate the provider's worker/fleet subprocesses so they don't
+        # outlive the server (e.g. on parent-death shutdown in managed mode).
+        svc = peek_services()
+        if svc is not None:
+            svc.provider.shutdown()
 
 
 def create_app() -> Litestar:

--- a/tests/test_parent_monitor.py
+++ b/tests/test_parent_monitor.py
@@ -8,10 +8,13 @@ import threading
 from collections.abc import Iterator
 from unittest import mock
 
+import psutil
 import pytest
 
 from lilbee.parent_monitor import (
     PARENT_PID_ENV,
+    _parent_start_time,
+    _same_process,
     parse_parent_pid,
     watch_parent_async,
     watch_parent_thread,
@@ -63,6 +66,53 @@ class TestParseParentPid:
             os.environ.pop(PARENT_PID_ENV, None)
 
 
+class TestParentIdentity:
+    def test_start_time_returns_create_time(self):
+        proc = mock.MagicMock()
+        proc.create_time.return_value = 100.0
+        with mock.patch("lilbee.parent_monitor.psutil.Process", return_value=proc):
+            assert _parent_start_time(123) == 100.0
+
+    def test_start_time_none_when_process_gone(self):
+        with mock.patch(
+            "lilbee.parent_monitor.psutil.Process", side_effect=psutil.NoSuchProcess(123)
+        ):
+            assert _parent_start_time(123) is None
+
+    def test_start_time_none_when_access_denied(self):
+        with mock.patch(
+            "lilbee.parent_monitor.psutil.Process", side_effect=psutil.AccessDenied(123)
+        ):
+            assert _parent_start_time(123) is None
+
+    def test_same_process_true_when_identity_unknown(self):
+        assert _same_process(123, None) is True
+
+    def test_same_process_true_when_create_time_matches(self):
+        proc = mock.MagicMock()
+        proc.create_time.return_value = 100.0
+        with mock.patch("lilbee.parent_monitor.psutil.Process", return_value=proc):
+            assert _same_process(123, 100.0) is True
+
+    def test_same_process_false_when_pid_recycled(self):
+        proc = mock.MagicMock()
+        proc.create_time.return_value = 200.0
+        with mock.patch("lilbee.parent_monitor.psutil.Process", return_value=proc):
+            assert _same_process(123, 100.0) is False
+
+    def test_same_process_false_when_process_vanished(self):
+        with mock.patch(
+            "lilbee.parent_monitor.psutil.Process", side_effect=psutil.NoSuchProcess(123)
+        ):
+            assert _same_process(123, 100.0) is False
+
+    def test_same_process_false_when_access_denied(self):
+        with mock.patch(
+            "lilbee.parent_monitor.psutil.Process", side_effect=psutil.AccessDenied(123)
+        ):
+            assert _same_process(123, 100.0) is False
+
+
 class TestWatchParentAsync:
     async def test_invokes_callback_when_pid_disappears(self):
         events = [True, True, False]
@@ -90,6 +140,18 @@ class TestWatchParentAsync:
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
+
+    async def test_fires_when_pid_is_recycled(self):
+        # PID stays alive, but create-time changes: a different process took it.
+        proc = mock.MagicMock()
+        proc.create_time.side_effect = [100.0, 100.0, 200.0]
+        called: list[bool] = []
+        with (
+            mock.patch("lilbee.parent_monitor.psutil.pid_exists", return_value=True),
+            mock.patch("lilbee.parent_monitor.psutil.Process", return_value=proc),
+        ):
+            await watch_parent_async(123, lambda: called.append(True), poll_interval_secs=0)
+        assert called == [True]
 
 
 class TestWatchParentThread:

--- a/tests/test_server_litestar.py
+++ b/tests/test_server_litestar.py
@@ -1458,6 +1458,18 @@ class TestLifespan:
             pass
         mock_get_svc.assert_called()
 
+    @mock.patch("lilbee.server.app.peek_services")
+    @mock.patch("lilbee.server.app.get_services")
+    async def test_shuts_down_worker_pool_on_exit(self, mock_get_svc, mock_peek):
+        mock_get_svc.return_value = mock.MagicMock()
+        svc = mock.MagicMock()
+        mock_peek.return_value = svc
+        from lilbee.server.app import _lifespan
+
+        async with _lifespan(mock.MagicMock()):
+            svc.provider.shutdown.assert_not_called()
+        svc.provider.shutdown.assert_called_once()
+
 
 class TestSessionManagerPersistence:
     """Cover SessionManager.load_or_generate token-reuse semantics."""


### PR DESCRIPTION
## Problem

Two ways the managed server can leave processes behind, paired with the plugin-side fix for the same class of bug:

- The server's worker/fleet subprocesses aren't torn down on shutdown. The HTTP lifespan only cleaned up the session manager, so when the server exits — including the parent-death shutdown that fires when the plugin's Obsidian process goes away — the worker processes it spawned keep running.
- The parent-death watcher polls only `psutil.pid_exists(parent_pid)`. If the parent's PID is recycled by an unrelated process after Obsidian exits, the watcher thinks the parent is still alive and never shuts the server down.

## Solution

- The lifespan shutdown now calls the provider's `shutdown()` after cleaning up the session, so the worker/fleet subprocesses exit with the server.
- The parent watcher records the parent's process create-time when it starts and treats "same PID, different create-time" as death, so a recycled PID can't keep the server running. When the create-time can't be read it falls back to the previous existence check.

Full suite passes at 100% coverage.
