### PR TITLE
fix(opencode): route on the clean model id, not the full shard ref

### DIFF
--- a/src/lilbee/cli/agent_configs/opencode.py
+++ b/src/lilbee/cli/agent_configs/opencode.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from lilbee.catalog import display_label_for_ref
+from lilbee.catalog import agent_model_id, display_label_for_ref
 
 _OUTPUT_TOKEN_LIMIT = 8192
 """Per-response output cap reported to opencode (it reserves this from the context)."""
@@ -65,7 +65,11 @@ def opencode_config(
                     "baseURL": f"{base_url}/v1",
                     "apiKey": api_key,
                 },
-                "models": {ref: _model_entry(ref, chat_ctx) for ref in sorted(model_refs)},
+                # Key by the clean agent id (not the full ref) so opencode routes
+                # and shows a friendly id; lilbee's /v1 resolves it back to the ref.
+                "models": {
+                    agent_model_id(ref): _model_entry(ref, chat_ctx) for ref in sorted(model_refs)
+                },
             }
         },
     }
@@ -80,5 +84,5 @@ def opencode_config(
             }
         }
     if default_ref is not None:
-        config["model"] = f"lilbee/{default_ref}"
+        config["model"] = f"lilbee/{agent_model_id(default_ref)}"
     return config

--- a/tests/cli/test_agent_config_opencode.py
+++ b/tests/cli/test_agent_config_opencode.py
@@ -65,9 +65,10 @@ def test_opencode_config_prints_provider_with_real_port_and_token():
     options = payload["provider"]["lilbee"]["options"]
     assert options["baseURL"] == "http://127.0.0.1:8765/v1"
     assert options["apiKey"] == "test-token-abc"
-    assert set(payload["provider"]["lilbee"]["models"].keys()) == {_CHAT_REF_A}
-    # opencode picker shows a cleaned label rather than the full /-/-/.gguf ref.
-    assert payload["provider"]["lilbee"]["models"][_CHAT_REF_A] == {"name": "Qwen3 0.6B"}
+    # Keyed and routed by the clean agent id (not the full ref); lilbee's /v1
+    # resolves it back, so no surface leaks the shard path.
+    assert set(payload["provider"]["lilbee"]["models"].keys()) == {"Qwen3-0.6B"}
+    assert payload["provider"]["lilbee"]["models"]["Qwen3-0.6B"] == {"name": "Qwen3 0.6B"}
     mcp_block = payload["mcp"]["lilbee"]
     assert mcp_block["type"] == "remote"
     assert mcp_block["url"] == "http://127.0.0.1:8765/mcp"
@@ -89,8 +90,9 @@ def test_opencode_config_lists_all_chat_models_sorted():
 
     assert result.exit_code == 0, result.stderr
     payload = json.loads(result.stdout)
+    # Keys are the clean agent ids, in the same (ref-sorted) order the entries emit.
     model_keys = list(payload["provider"]["lilbee"]["models"].keys())
-    assert model_keys == sorted([_CHAT_REF_A, _CHAT_REF_B])
+    assert model_keys == ["Qwen3-0.6B", "SmolLM-135M"]
 
 
 def test_opencode_config_without_running_server_exits_1():

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
+from lilbee.catalog import agent_model_id
 from lilbee.catalog.types import ModelTask
 from lilbee.cli import app
 from lilbee.core.config import cfg
@@ -122,7 +123,7 @@ def test_launch_opencode_with_running_server_writes_provider_into_config(tmp_pat
     assert options["baseURL"] == f"http://127.0.0.1:{_PORT}/v1"
     assert options["apiKey"] == "{env:LILBEE_TOKEN}"  # reference, not the literal
     assert _TOKEN not in json.dumps(payload)  # no literal token on disk
-    assert _CHAT_REF in payload["provider"]["lilbee"]["models"]
+    assert agent_model_id(_CHAT_REF) in payload["provider"]["lilbee"]["models"]
     mcp_entry = payload["mcp"]["lilbee"]
     assert mcp_entry["type"] == "remote"
     assert mcp_entry["enabled"] is True
@@ -130,7 +131,7 @@ def test_launch_opencode_with_running_server_writes_provider_into_config(tmp_pat
     assert mcp_entry["headers"]["Authorization"] == "Bearer {env:LILBEE_TOKEN}"
     # Startup pin: without the top-level model key opencode boots on its own
     # default provider instead of the lilbee-served chat model.
-    assert payload["model"] == f"lilbee/{cfg.chat_model}"
+    assert payload["model"] == f"lilbee/{agent_model_id(cfg.chat_model)}"
 
 
 @pytest.mark.no_health_default
@@ -311,7 +312,7 @@ def test_opencode_config_sets_limit_context_when_known():
     block = opencode_config(
         base_url="http://127.0.0.1:9", api_key="k", model_refs=["a/M/m.gguf"], chat_ctx=32768
     )
-    entry = block["provider"]["lilbee"]["models"]["a/M/m.gguf"]
+    entry = block["provider"]["lilbee"]["models"]["M"]
     # Both keys required: opencode rejects a limit with only context (bb-c4t).
     assert entry["limit"] == {"context": 32768, "output": 8192}
 
@@ -322,7 +323,7 @@ def test_opencode_config_omits_limit_when_ctx_unknown():
     block = opencode_config(
         base_url="http://127.0.0.1:9", api_key="k", model_refs=["a/M/m.gguf"], chat_ctx=None
     )
-    assert "limit" not in block["provider"]["lilbee"]["models"]["a/M/m.gguf"]
+    assert "limit" not in block["provider"]["lilbee"]["models"]["M"]
 
 
 def test_opencode_config_pins_default_model_when_ref_given():
@@ -334,7 +335,7 @@ def test_opencode_config_pins_default_model_when_ref_given():
         model_refs=["a/M/m.gguf"],
         default_ref="a/M/m.gguf",
     )
-    assert block["model"] == "lilbee/a/M/m.gguf"
+    assert block["model"] == "lilbee/M"
 
 
 def test_opencode_config_includes_mcp_by_default():

--- a/tests/cli/test_opencode_display_name.py
+++ b/tests/cli/test_opencode_display_name.py
@@ -13,11 +13,14 @@ from lilbee.cli.agent_configs.opencode import opencode_config
 
 
 def _entry_name(ref: str) -> str:
+    from lilbee.catalog import agent_model_id
+
     cfg = opencode_config(base_url="http://127.0.0.1:8080", api_key="k", model_refs=[ref])
     models = cfg["provider"]["lilbee"]["models"]
-    # The entry key is the routing ref; its "name" is the picker label.
-    assert ref in models
-    return models[ref]["name"]
+    # The entry key is the clean agent id (the routing id); its "name" is the label.
+    key = agent_model_id(ref)
+    assert key in models
+    return models[key]["name"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

The earlier model-name fix only half-fixed opencode. It relabelled the picker (the model entry `name` became a clean label), but the models map was still keyed by the full GGUF ref and the top-level pin stayed `model: lilbee/<full shard ref>`. So opencode still routed on the whole shard path, and any surface that renders the model id rather than the entry name (for example opencode's task line) could still show the full path.

## Solution

Mirror what hermes already does: key opencode's models map by the clean agent id and pin that id. lilbee's chat endpoint resolves the clean id back to the installed ref, so opencode both shows and routes on the friendly id and no surface leaks the shard path. Model loading is unchanged — it still resolves to the real ref (including loading a split model from its first shard).
