### PR TITLE
fix(rerank): LLM rerankers silently left results unranked

### DIFF
--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -390,7 +390,9 @@ class LLMProvider(Protocol):
         Returns: list of floats in input order, higher = more relevant.
         Empty ``candidates`` returns ``[]``.
         Raises :class:`ProviderError` when the backend does not support
-        reranking or ``cfg.reranker_model`` is empty.
+        reranking, ``cfg.reranker_model`` is empty, or the model scored no
+        candidate. A backend must raise rather than return uniform scores,
+        which would silently preserve the caller's input order.
         """
         ...
 

--- a/src/lilbee/providers/fleet/client.py
+++ b/src/lilbee/providers/fleet/client.py
@@ -54,6 +54,12 @@ _LLM_RERANK_PROMPT = (
 _LLM_RERANK_TOP_LOGPROBS = 20
 _YES_LABEL = "yes"
 _NO_LABEL = "no"
+_LLM_RERANK_NO_VERDICT_ERROR = (
+    "The reranker model never answered 'yes' or 'no', so its relevance scores are "
+    "unusable. Its chat template does not fit the relevance prompt. Choose a GGUF "
+    "built for reranking, set reranker_type to cross_encoder, or adapt "
+    "reranker_prompt to the model's expected format."
+)
 # Max sequences per /v1/embeddings request. Like the in-process backstop, a
 # batch is bounded by BOTH the token budget (the server's n_batch, == token_cap)
 # and this sequence count: a corpus of many tiny chunks would otherwise pack one
@@ -830,13 +836,19 @@ class LlamaServerClient:
         return scores
 
     def _rerank_llm(self, query: str, candidates: list[str]) -> list[float]:
-        """Score each candidate by an LLM's yes/no first-token logprob."""
+        """Score each candidate by an LLM's yes/no first-token logprob.
+
+        Raises ``ProviderError`` when no candidate yields a verdict.
+        """
         template = cfg.reranker_prompt or _LLM_RERANK_PROMPT
         workers = min(LLM_RERANK_CONCURRENCY, len(candidates))
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            return list(pool.map(lambda c: self._llm_rerank_one(template, query, c), candidates))
+            scores = list(pool.map(lambda c: self._llm_rerank_one(template, query, c), candidates))
+        if all(score is None for score in scores):
+            raise ProviderError(_LLM_RERANK_NO_VERDICT_ERROR, provider=_PROVIDER_NAME)
+        return [0.0 if score is None else score for score in scores]
 
-    def _llm_rerank_one(self, template: str, query: str, candidate: str) -> float:
+    def _llm_rerank_one(self, template: str, query: str, candidate: str) -> float | None:
         """One chat request scoring a single candidate's relevance to the query."""
         content = template.format(query=query, document=candidate)
         payload = {
@@ -847,6 +859,9 @@ class LlamaServerClient:
             "logprobs": True,
             "top_logprobs": _LLM_RERANK_TOP_LOGPROBS,
             "stream": False,
+            # Scoring reads the first generated token; a thinking template would
+            # spend it opening a <think> block instead of answering.
+            "chat_template_kwargs": {"enable_thinking": False},
         }
 
         def _call() -> dict[str, Any]:
@@ -1008,8 +1023,11 @@ def _first_token_top_logprobs(response: dict[str, Any]) -> list[dict[str, Any]]:
     return list(content[0].get("top_logprobs") or [])
 
 
-def _llm_rerank_score(top_logprobs: list[dict[str, Any]]) -> float:
-    """Softmax of the yes vs no logprobs in a token's top_logprobs (case/space-insensitive)."""
+def _llm_rerank_score(top_logprobs: list[dict[str, Any]]) -> float | None:
+    """Softmax of the yes vs no logprobs in a token's top_logprobs (case/space-insensitive).
+
+    ``None`` when neither verdict appears, distinct from the 0.0 of a confident "no".
+    """
     yes_lp: float | None = None
     no_lp: float | None = None
     for entry in top_logprobs:
@@ -1020,7 +1038,7 @@ def _llm_rerank_score(top_logprobs: list[dict[str, Any]]) -> float:
         elif token == _NO_LABEL and (no_lp is None or logprob > no_lp):
             no_lp = logprob
     if yes_lp is None:
-        return 0.0
+        return None if no_lp is None else 0.0
     if no_lp is None:
         return math.exp(yes_lp)
     yes_e, no_e = math.exp(yes_lp), math.exp(no_lp)

--- a/tests/test_fleet_client.py
+++ b/tests/test_fleet_client.py
@@ -301,8 +301,13 @@ def test_llm_rerank_score_only_yes_present() -> None:
     assert _llm_rerank_score([{"token": "yes", "logprob": -0.5}]) > 0.0
 
 
-def test_llm_rerank_score_neither_present_is_zero() -> None:
-    assert _llm_rerank_score([{"token": "maybe", "logprob": -0.1}]) == 0.0
+def test_llm_rerank_score_only_no_present_is_zero() -> None:
+    assert _llm_rerank_score([{"token": "no", "logprob": -0.5}]) == 0.0
+
+
+def test_llm_rerank_score_neither_present_is_none() -> None:
+    assert _llm_rerank_score([{"token": "maybe", "logprob": -0.1}]) is None
+    assert _llm_rerank_score([]) is None
 
 
 def test_first_token_top_logprobs_empty_on_missing_fields() -> None:
@@ -314,6 +319,22 @@ def test_first_token_top_logprobs_empty_on_missing_fields() -> None:
 def _llm_rerank_client(handler) -> LlamaServerClient:
     http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://gpu0")
     return LlamaServerClient("http://gpu0", "rerank-0", http=http, rerank_mode=RerankMode.LLM)
+
+
+def _think_token_response() -> httpx.Response:
+    """What a thinking-capable chat template yields: the verdict is not token 0."""
+    return httpx.Response(
+        200,
+        json={
+            "choices": [
+                {
+                    "logprobs": {
+                        "content": [{"top_logprobs": [{"token": "<think>", "logprob": -0.01}]}]
+                    }
+                }
+            ]
+        },
+    )
 
 
 def _chat_logprobs_response(yes_lp: float, no_lp: float) -> httpx.Response:
@@ -354,6 +375,37 @@ def test_llm_rerank_routes_to_chat_and_ranks_relevant_higher() -> None:
     scores = _llm_rerank_client(handler).rerank("q", ["relevant doc", "off-topic"])
     assert seen_paths == ["/v1/chat/completions", "/v1/chat/completions"]
     assert scores[0] > scores[1]
+
+
+def test_llm_rerank_request_disables_template_thinking() -> None:
+    captured: list[object] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content)["chat_template_kwargs"])
+        return _chat_logprobs_response(0.0, -1.0)
+
+    _llm_rerank_client(handler).rerank("q", ["doc"])
+    assert captured == [{"enable_thinking": False}]
+
+
+def test_llm_rerank_raises_when_no_candidate_yields_a_verdict() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _think_token_response()
+
+    with pytest.raises(ProviderError, match=r"yes.*no"):
+        _llm_rerank_client(handler).rerank("q", ["one", "two"])
+
+
+def test_llm_rerank_scores_a_verdictless_candidate_zero_without_raising() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if "answered" in body["messages"][0]["content"]:
+            return _chat_logprobs_response(0.0, -4.0)
+        return _think_token_response()
+
+    scores = _llm_rerank_client(handler).rerank("q", ["answered", "silent"])
+    assert scores[0] > 0.5
+    assert scores[1] == 0.0
 
 
 def test_llm_rerank_uses_prompt_override(monkeypatch) -> None:


### PR DESCRIPTION
## Problem

Set an LLM reranker (Qwen3-Reranker, mxbai-rerank-v2) and reranking silently does nothing. Results come back in the same order retrieval produced them, with no error and no warning.

These models score a candidate by generating one token and reading how likely "yes" was versus "no". But their chat template lets the model open a `<think>` block first, so the one token we generate is `<think>`, not a verdict. Every candidate then scores 0.0, the scores tie, and the original order survives.

Setting `--reasoning-format none` does not help. It only moves the thinking text to a different response field. The token we read is the same either way.

## Solution

Send `chat_template_kwargs: {"enable_thinking": false}` with each rerank request. The template then answers immediately instead of thinking first, so the token we score is the verdict. This is what Qwen's own reranker code does.

Also stop failing quietly. If no candidate produces a yes or no, the reranker now raises instead of returning zeros. Search still answers, and the skipped rerank shows up as a warning that names the problem, rather than as quietly worse results.

## Validation

Unit tests cover the scoring and the raise-on-no-verdict path. Benched end to end on an A100 through `provider.rerank` with a real Qwen3-Reranker-8B GGUF (`dean2155/Qwen3-Reranker-8B-Q8_0-GGUF`):

- **With the fix:** scores spread. The relevant passage ("Paris is the capital of France") scores 0.77 and the two irrelevant candidates 0.0, so it sorts to the top instead of collapsing to a flat tie.
- **With `enable_thinking` stripped from the request** (the pre-fix behavior): the same model opens with reasoning ("Okay, the user is asking...") instead of a verdict, no candidate answers yes or no, and the guard raises `ProviderError`. No silent no-op. So `enable_thinking: false` is load-bearing, not cosmetic.
- A separately mis-converted 8B GGUF that emits code-token garbage for every prompt also trips the guard with a clear error instead of quietly returning the input order, which is exactly the failure this PR is meant to surface.
