### PR TITLE
Bundle the CUDA runtime on Linux, and gate every CUDA wheel on carrying it

### DIFF
--- a/.github/workflows/build-cuda-executables.yml
+++ b/.github/workflows/build-cuda-executables.yml
@@ -177,6 +177,33 @@ jobs:
           CXXFLAGS: ${{ matrix.march && format('-march={0}', matrix.march) || '' }}
         run: bash tools/wheel-build/build_lilbee_binary.sh
 
+      # The wheel gate can't cover the executable: Nuitka rebundles the engine, and on
+      # Linux it takes the .so files through --include-package-data rather than the
+      # verbatim --include-data-files path (build_lilbee_binary.sh skips *.so there).
+      # If it ever drops them the onefile ships a CUDA engine with no CUDA runtime, and
+      # a driverless runner can't tell by executing it. Assert against the standalone
+      # tree Nuitka leaves under dist/ before it is packed into the onefile.
+      - name: The CUDA executable bundles the runtime it links
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Nuitka names the standalone tree after the entry module (__main__.dist);
+          # find it by shape rather than by that name.
+          bin_dir=$(find dist -type d -path '*lilbee_engine/bin' | head -1)
+          [ -n "${bin_dir}" ] || { echo "no bundled engine found under dist/" >&2; exit 1; }
+          if [ "${RUNNER_OS}" = "Windows" ]; then
+            required="cudart64_*.dll cublas64_*.dll cublasLt64_*.dll"
+          else
+            required="libcudart.so.* libcublas.so.* libcublasLt.so.*"
+          fi
+          for pattern in ${required}; do
+            compgen -G "${bin_dir}/${pattern}" >/dev/null || {
+              echo "${pattern} missing from the engine Nuitka bundled into ${{ matrix.asset_name }}" >&2
+              exit 1
+            }
+          done
+          echo "the bundled engine carries its CUDA runtime"
+
       - name: Smoke test
         # CUDA cells run on GPU-less runners: the bundled server links the CUDA
         # driver (libcuda.so.1), so it cannot run inference here. The full

--- a/.github/workflows/build-multigpu.yml
+++ b/.github/workflows/build-multigpu.yml
@@ -157,6 +157,17 @@ jobs:
           python -m build --wheel
           python -m wheel tags --remove --platform-tag "${{ matrix.wheel-plat }}" dist/*.whl
 
+      # Hard gate for the CUDA cells, which the exec smoke below cannot cover: a
+      # driverless runner has no libcuda/nvcuda, so the engine never loads its CUDA
+      # backend and the binary starts clean with or without its runtime. Read the
+      # wheel instead and fail here, where the diagnosis is cheap.
+      # `python`, not `python3`: setup-python does not put a python3 on PATH for the
+      # Windows cells, which are exactly the ones this gate exists for.
+      - name: The CUDA wheel carries the runtime it links
+        if: ${{ startsWith(matrix.backend, 'cu') }}
+        shell: bash
+        run: python tools/qa/assert_cuda_bundle.py "${PKG_DIR}"/dist/*.whl
+
       # Hard gate: a lib-less bundle fails at exec with a loader error. This
       # step swallowing failures (continue-on-error) is how a broken metal
       # bundle once shipped. Skipped for GPU-driver backends, whose binaries

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -45,6 +45,53 @@ jobs:
           TAG: ${{ inputs.tag || github.event.workflow_run.head_branch }}
         run: echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
+  # The CUDA artifacts can't be exercised here: a driverless runner has no
+  # libcuda/nvcuda, so the engine never loads its CUDA backend and a run proves
+  # nothing. Check them structurally instead. Every CUDA engine wheel must carry the
+  # cudart/cublas/cublasLt it links, and every CUDA asset the matrices build must be
+  # on the release: those build cells are continue-on-error, so a dropped cell
+  # otherwise leaves the release quietly missing an artifact and still reports green.
+  verify-cuda-bundles:
+    needs: [resolve]
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download every engine wheel from the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern 'lilbee_engine-*.whl' --dir engine/
+      - name: Every CUDA engine wheel carries the runtime it links
+        shell: bash
+        run: python3 tools/qa/assert_cuda_bundle.py engine/*.whl
+      - name: Every CUDA asset the matrices build is on the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+            --jq '.assets[].name' > assets.txt
+          missing=0
+          while read -r expected; do
+            [ -n "${expected}" ] || continue
+            # -x: an exact line. A substring match would let lilbee-linux-x86_64-cu125.snap
+            # satisfy the check for the lilbee-linux-x86_64-cu125 binary.
+            grep -qxF "${expected}" assets.txt || { echo "missing from the release: ${expected}"; missing=1; }
+          done <<'EOF'
+          lilbee-linux-x86_64-cu121
+          lilbee-linux-x86_64-cu124
+          lilbee-linux-x86_64-cu125
+          lilbee-compat-linux-x86_64-cu124
+          lilbee-windows-x86_64-cu124.exe
+          lilbee-windows-x86_64-cu125.exe
+          EOF
+          [ "${missing}" -eq 0 ] || { echo "a continue-on-error CUDA build cell dropped its artifact"; exit 1; }
+          echo "every expected CUDA asset is present"
+
   verify-executables:
     needs: [resolve]
     timeout-minutes: 45

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -53,7 +53,9 @@ jobs:
   # otherwise leaves the release quietly missing an artifact and still reports green.
   verify-cuda-bundles:
     needs: [resolve]
-    timeout-minutes: 20
+    # The eleven engine wheels are several GB together, most of it the CUDA fatbins
+    # and cublasLt; the download dominates this job.
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,6 +442,13 @@ closure. These rules exist because each one shipped a broken artifact once.
   nondeterministic. SONAME symlinks (`libllama.0.dylib`) are copied as real
   files under the names the binary loads. The script execs the bundled binary
   at build time so a missing lib fails on the builder, not the user.
+- **A CUDA build bundles its CUDA runtime too.** `cudart`, `cublas` and `cublasLt`
+  live in the toolkit, not the build tree, and only `libcuda` / `nvcuda` comes from
+  the driver, so `build_llama_server.sh` copies them beside the binary on Linux and
+  Windows and fails the build when one is missing. The exec gate above proves nothing
+  here — a driverless runner never loads the CUDA backend — so read the artifact
+  instead: `tools/qa/assert_cuda_bundle.py` checks the wheel in the build cells and
+  again in `verify-release`, which also asserts every CUDA asset reached the release.
 - **Every release channel has a real-inference gate.** `tools/qa/artifact_smoke.sh`
   runs `self-check` (real chat + embedding), ingest, search, a RAG ask, and an
   http crawl, sourcing models from the `ci-models` mirror (no HuggingFace).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,11 @@ dependencies = [
 litellm = ["litellm>=1.84.0,<1.92"]
 graph = ["spacy>=3.8", "graspologic-native>=1.2"]
 crawler = ["crawl4ai>=0.9.0"]
-# The CUDA 12 runtime the bundled llama-server links, from NVIDIA's official PyPI
-# wheels; fleet.cuda_runtime adds their lib dirs to the engine's LD_LIBRARY_PATH.
-# Linux x86_64 only: macOS and aarch64 have no CUDA build to feed, and the Windows
-# engine wheel ships the toolkit's redistributable DLLs beside llama-server.exe
-# (build_llama_server.sh), which is where Windows looks for a process's imports.
+# A fallback source of the CUDA 12 runtime, from NVIDIA's official PyPI wheels;
+# fleet.cuda_runtime adds their lib dirs to the engine's LD_LIBRARY_PATH. The engine
+# wheel now ships cudart/cublas/cublasLt beside llama-server on both Linux and Windows
+# (build_llama_server.sh), so this is only needed for an engine built elsewhere.
+# Linux x86_64 only: macOS and aarch64 have no CUDA build to feed.
 cuda12 = [
     "nvidia-cuda-runtime-cu12; platform_system=='Linux' and platform_machine=='x86_64'",
     "nvidia-cublas-cu12; platform_system=='Linux' and platform_machine=='x86_64'",

--- a/src/lilbee/providers/fleet/cuda_runtime.py
+++ b/src/lilbee/providers/fleet/cuda_runtime.py
@@ -1,14 +1,15 @@
 """Put the CUDA 12 runtime wheels on the engine's library search path.
 
-Driver-only GPU images (common on RunPod) ship ``libcuda.so`` from the kernel
-driver but not the CUDA 12 runtime that llama-server links (``libcudart.so.12``,
-``libcublas.so.12``, ``libnvrtc.so.12``); without them llama-server exits before
-binding its port. Installing lilbee with the ``cuda12`` extra pulls the
-``nvidia-cuda-runtime-cu12`` / ``nvidia-cublas-cu12`` / ``nvidia-cuda-nvrtc-cu12``
-wheels, which carry those libraries under ``site-packages/nvidia``.
-:func:`cuda_runtime_env` adds their ``lib`` directories to the spawned server's
-``LD_LIBRARY_PATH`` so GPU ingest works without a system CUDA toolkit -- the path
-can't be a baked rpath because the wheels' location is only known at install time.
+Driver-only GPU images (common on RunPod) ship ``libcuda.so`` from the kernel driver
+but not the CUDA 12 runtime that llama-server links (``libcudart.so.12``,
+``libcublas.so.12``, ``libnvrtc.so.12``). The bundled engine now carries those beside
+the binary and resolves them through its baked ``$ORIGIN`` rpath, so this module is
+the fallback for an engine built elsewhere: installing lilbee with the ``cuda12``
+extra pulls the ``nvidia-cuda-runtime-cu12`` / ``nvidia-cublas-cu12`` /
+``nvidia-cuda-nvrtc-cu12`` wheels, which carry those libraries under
+``site-packages/nvidia``. :func:`cuda_runtime_env` adds their ``lib`` directories to
+the spawned server's ``LD_LIBRARY_PATH`` -- the path can't be a baked rpath because
+the wheels' location is only known at install time.
 """
 
 from __future__ import annotations

--- a/tests/test_assert_cuda_bundle.py
+++ b/tests/test_assert_cuda_bundle.py
@@ -1,0 +1,156 @@
+"""Tests for the CUDA-bundle gate that keeps a runtime-less engine wheel off a release."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import zipfile
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "qa" / "assert_cuda_bundle.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("assert_cuda_bundle", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+acb = _load()
+
+_LINUX_RUNTIME = ("libcudart.so.12", "libcublas.so.12", "libcublasLt.so.12")
+_WINDOWS_RUNTIME = ("cudart64_12.dll", "cublas64_12.dll", "cublasLt64_12.dll")
+
+
+def _wheel(tmp_path: Path, name: str, bin_files: tuple[str, ...]) -> Path:
+    path = tmp_path / name
+    with zipfile.ZipFile(path, "w") as zf:
+        for entry in bin_files:
+            zf.writestr(f"lilbee_engine/bin/{entry}", b"x")
+    return path
+
+
+def test_linux_cuda_wheel_without_runtime_is_rejected(tmp_path: Path) -> None:
+    # The shipped-broken shape: ggml-cuda present, the runtime it links absent.
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cu125-py3-none-manylinux_2_17_x86_64.whl",
+        ("llama-server", "libggml-cuda.so"),
+    )
+    problems = acb.check(wheel)
+    assert len(problems) == 3
+    assert any("libcudart.so" in p for p in problems)
+    assert any("libcublasLt.so" in p for p in problems)
+
+
+def test_linux_cuda_wheel_with_runtime_passes(tmp_path: Path) -> None:
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cu125-py3-none-manylinux_2_17_x86_64.whl",
+        ("llama-server", "libggml-cuda.so", *_LINUX_RUNTIME),
+    )
+    assert acb.check(wheel) == []
+
+
+def test_windows_cuda_wheel_without_runtime_is_rejected(tmp_path: Path) -> None:
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cu125-py3-none-win_amd64.whl",
+        ("llama-server.exe", "ggml-cuda.dll"),
+    )
+    assert len(acb.check(wheel)) == 3
+
+
+def test_windows_cuda_wheel_with_runtime_passes(tmp_path: Path) -> None:
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cu125-py3-none-win_amd64.whl",
+        ("llama-server.exe", "ggml-cuda.dll", *_WINDOWS_RUNTIME),
+    )
+    assert acb.check(wheel) == []
+
+
+def test_cuda_detected_from_payload_not_filename(tmp_path: Path) -> None:
+    # A freshly built wheel has no -1.cu125- build tag; that is added at attach time.
+    # Detection must still fire, or the gate silently passes every build artifact.
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-py3-none-win_amd64.whl",
+        ("llama-server.exe", "ggml-cuda.dll"),
+    )
+    assert len(acb.check(wheel)) == 3
+
+
+def test_non_cuda_wheel_passes(tmp_path: Path) -> None:
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cpu-py3-none-manylinux_2_17_x86_64.whl",
+        ("llama-server", "libggml-cpu.so"),
+    )
+    assert acb.check(wheel) == []
+
+
+def test_non_cuda_wheel_carrying_cuda_runtime_is_rejected(tmp_path: Path) -> None:
+    # Guards the other direction: the copy step must stay scoped to CUDA backends.
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.vulkan-py3-none-win_amd64.whl",
+        ("llama-server.exe", "ggml-vulkan.dll", "cudart64_12.dll"),
+    )
+    problems = acb.check(wheel)
+    assert len(problems) == 1
+    assert "non-CUDA wheel ships CUDA runtime" in problems[0]
+
+
+def test_empty_bin_dir_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "lilbee_engine-1.0-py3-none-win_amd64.whl"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("lilbee_engine/__init__.py", b"")
+    assert acb.check(path) == [f"{path.name}: no lilbee_engine/bin/ payload at all"]
+
+
+def test_macos_cuda_payload_asserts_nothing(tmp_path: Path) -> None:
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-py3-none-macosx_11_0_arm64.whl",
+        ("llama-server", "libggml-cuda.so"),
+    )
+    assert acb.check(wheel) == []
+
+
+def test_main_returns_nonzero_and_names_the_wheel(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cu125-py3-none-manylinux_2_17_x86_64.whl",
+        ("llama-server", "libggml-cuda.so"),
+    )
+    assert acb.main([str(wheel)]) == 1
+    assert "libcudart.so" in capsys.readouterr().err
+
+
+def test_main_returns_zero_on_a_good_wheel(tmp_path: Path) -> None:
+    wheel = _wheel(
+        tmp_path,
+        "lilbee_engine-1.0-1.cu125-py3-none-manylinux_2_17_x86_64.whl",
+        ("llama-server", "libggml-cuda.so", *_LINUX_RUNTIME),
+    )
+    assert acb.main([str(wheel)]) == 0
+
+
+def test_main_rejects_a_missing_file(tmp_path: Path) -> None:
+    assert acb.main([str(tmp_path / "nope.whl")]) == 1
+
+
+def test_main_with_no_arguments_is_a_usage_error() -> None:
+    assert acb.main([]) == 2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/tools/qa/assert_cuda_bundle.py
+++ b/tools/qa/assert_cuda_bundle.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Assert a lilbee-engine wheel carries the CUDA runtime its engine links.
+
+A CUDA build of llama-server links cudart, cublas and cublasLt dynamically. Only
+libcuda / nvcuda comes from the NVIDIA driver, so the rest have to ship inside the
+wheel beside the binary. When they are missing the failure is invisible on a
+driverless CI runner: Windows dies at process start on a user's machine, and Linux
+silently falls back to CPU. Neither shows up in a build log, so check the wheel.
+
+Non-CUDA wheels are checked the other way, that they carry no CUDA runtime at all,
+so a copy step can't quietly bloat every backend.
+
+Usage:
+    assert_cuda_bundle.py <wheel> [<wheel> ...]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+BIN_DIR = "lilbee_engine/bin/"
+
+# The SONAME / import names the engine loads by, per wheel platform tag. Named so a
+# failure names the file a user would look for, not the pattern that matched it.
+REQUIRED = {
+    "win_amd64": (
+        ("cudart64_<major>.dll", r"cudart64_\d+\.dll"),
+        ("cublas64_<major>.dll", r"cublas64_\d+\.dll"),
+        ("cublasLt64_<major>.dll", r"cublasLt64_\d+\.dll"),
+    ),
+    "linux": (
+        ("libcudart.so.<major>", r"libcudart\.so\.\d+"),
+        ("libcublas.so.<major>", r"libcublas\.so\.\d+"),
+        ("libcublasLt.so.<major>", r"libcublasLt\.so\.\d+"),
+    ),
+}
+# Any CUDA runtime library, used to assert non-CUDA wheels stay clean.
+ANY_CUDA_RUNTIME = re.compile(r"(cudart|cublas|cublasLt|nvrtc)", re.IGNORECASE)
+# The ggml CUDA backend. Its presence is what makes a wheel a CUDA build. Read the
+# payload rather than the filename: the ``-1.cu125-`` build tag is added when the
+# wheel is attached to the release, so a freshly built artifact does not carry it.
+GGML_CUDA = re.compile(r"(lib)?ggml-cuda\.(so|dll)")
+
+
+def _platform_of(wheel_name: str) -> str:
+    if "win_amd64" in wheel_name:
+        return "win_amd64"
+    if "manylinux" in wheel_name or "linux_x86_64" in wheel_name:
+        return "linux"
+    return "other"
+
+
+def _bin_entries(wheel: Path) -> list[str]:
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+    return [n[len(BIN_DIR) :] for n in names if n.startswith(BIN_DIR) and not n.endswith("/")]
+
+
+def check(wheel: Path) -> list[str]:
+    """Return a list of problems with *wheel*; empty means it is correct."""
+    name = wheel.name
+    entries = _bin_entries(wheel)
+    if not entries:
+        return [f"{name}: no {BIN_DIR} payload at all"]
+
+    is_cuda = any(GGML_CUDA.fullmatch(e) for e in entries)
+    platform = _platform_of(name)
+
+    if not is_cuda:
+        stowaways = sorted(e for e in entries if ANY_CUDA_RUNTIME.search(e))
+        if stowaways:
+            return [f"{name}: non-CUDA wheel ships CUDA runtime libraries: {', '.join(stowaways)}"]
+        return []
+
+    if platform == "other":
+        return []  # A CUDA engine on a platform we ship no CUDA runtime for.
+
+    return [
+        f"{name}: CUDA wheel is missing {display} from {BIN_DIR} "
+        f"(ggml-cuda links it; only libcuda/nvcuda comes from the driver)"
+        for display, pattern in REQUIRED[platform]
+        if not any(re.fullmatch(pattern, e) for e in entries)
+    ]
+
+
+def main(argv: list[str]) -> int:
+    wheels = [Path(a) for a in argv]
+    if not wheels:
+        print("usage: assert_cuda_bundle.py <wheel> [<wheel> ...]", file=sys.stderr)
+        return 2
+
+    problems: list[str] = []
+    for wheel in wheels:
+        if not wheel.is_file():
+            problems.append(f"{wheel}: not a file")
+            continue
+        problems.extend(check(wheel))
+        print(f"checked {wheel.name}")
+
+    for problem in problems:
+        print(f"FAIL: {problem}", file=sys.stderr)
+    if problems:
+        return 1
+    print(f"all {len(wheels)} wheel(s) carry the CUDA runtime they link")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/wheel-build/build_llama_server.sh
+++ b/tools/wheel-build/build_llama_server.sh
@@ -138,40 +138,78 @@ while IFS= read -r -d '' lib; do
 done < <(find "${src}/server-build" \( -name CMakeFiles -o -name CMakeScratch -o -path '*vulkan-shaders-gen-prefix*' \) -prune -o \
   \( -type f -o -type l \) \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -print0)
 
-# A CUDA build links the CUDA 12 runtime dynamically, and those libraries live in
-# the toolkit, never in the build output copied above. Linux finds them at runtime
-# from the nvidia-*-cu12 wheels (fleet.cuda_runtime puts them on LD_LIBRARY_PATH);
-# Windows has no equivalent hook, so the toolkit's redistributables must sit beside
-# llama-server.exe, which is the first directory Windows searches for a process's
-# imports. Without them the server dies before binding its port, with a "cudart64_12.dll
-# was not found" dialog and no healthy replica for lilbee to route to.
+# A CUDA build links the CUDA 12 runtime dynamically, and those libraries live in the
+# toolkit, never in the build output copied above. Only libcuda / nvcuda comes from the
+# driver; cudart, cublas and cublasLt do not, so they ship beside the binary like every
+# other lib here. The baked $ORIGIN runpath resolves them on Linux, and on Windows the
+# executable's own directory is the first place the loader looks.
+#
+# Both platforms broke without this, in different ways. On Windows cudart is a hard
+# import of the process, so llama-server.exe died before binding its port with a
+# "cudart64_12.dll was not found" dialog. On Linux ggml dlopens libggml-cuda.so and
+# tolerates the failure, so the GPU silently disappeared and work fell back to CPU.
 case "${backend}_$(uname -s)" in
-  cu12*_MINGW* | cu12*_MSYS* | cu12*_CYGWIN*)
-    cuda_bin="$(cygpath -u "${CUDA_PATH:?CUDA_PATH must be set for a Windows CUDA build}")/bin"
-    shopt -s nullglob
-    # nvrtc only matters for runtime kernel compilation and the CI toolkit install
-    # omits it; copy it when present. The other three are hard requirements.
-    cuda_libs=(
-      "${cuda_bin}"/cudart64_*.dll
-      "${cuda_bin}"/cublas64_*.dll
-      "${cuda_bin}"/cublasLt64_*.dll
-      "${cuda_bin}"/nvrtc64_*.dll
-    )
-    shopt -u nullglob
-    for lib in ${cuda_libs[@]+"${cuda_libs[@]}"}; do
-      cp "${lib}" "${pkg_bin_dir}/"
-    done
-    # The bundle is unverifiable by exec here (a driverless build host loads no CUDA
-    # backend at all, so the server would start clean with or without these), so gate
-    # on the copy itself: every required redistributable must have landed.
-    for required in cudart64 cublas64 cublasLt64; do
-      compgen -G "${pkg_bin_dir}/${required}_*.dll" >/dev/null || {
-        echo "no ${required}_*.dll under ${cuda_bin}: the Windows CUDA bundle is incomplete" >&2
-        exit 1
-      }
-    done
-    ;;
+  cu12*_MINGW* | cu12*_MSYS* | cu12*_CYGWIN*) cuda_platform="windows" ;;
+  cu12*_Linux)                                cuda_platform="linux" ;;
+  *)                                          cuda_platform="" ;;
 esac
+
+if [ -n "${cuda_platform}" ]; then
+  # nvrtc is optional: nothing in the current ggml links it (readelf shows no
+  # DT_NEEDED for it), and the Windows toolkit install omits the sub-package.
+  # Copy it when the toolkit provides it; the other three are hard requirements.
+  case "${cuda_platform}" in
+    windows)
+      cuda_lib_dir="$(cygpath -u "${CUDA_PATH:?CUDA_PATH must be set for a Windows CUDA build}")/bin"
+      required_libs=(cudart64 cublas64 cublasLt64)
+      shopt -s nullglob
+      cuda_libs=(
+        "${cuda_lib_dir}"/cudart64_*.dll
+        "${cuda_lib_dir}"/cublas64_*.dll
+        "${cuda_lib_dir}"/cublasLt64_*.dll
+        "${cuda_lib_dir}"/nvrtc64_*.dll
+      )
+      shopt -u nullglob
+      ;;
+    linux)
+      # install_gpu_toolkit.sh exports CUDA_HOME; fall back to the versionless symlink.
+      cuda_lib_dir="${CUDA_HOME:-/usr/local/cuda}/lib64"
+      [ -d "${cuda_lib_dir}" ] || cuda_lib_dir="${CUDA_HOME:-/usr/local/cuda}/targets/x86_64-linux/lib"
+      required_libs=(libcudart.so.12 libcublas.so.12 libcublasLt.so.12)
+      # Copy the SONAME names the binary loads by. These are symlinks to the versioned
+      # files in the toolkit; cp dereferences each into a real file under the loadable
+      # name, as the ggml libs above are handled.
+      shopt -s nullglob
+      cuda_libs=(
+        "${cuda_lib_dir}"/libcudart.so.12
+        "${cuda_lib_dir}"/libcublas.so.12
+        "${cuda_lib_dir}"/libcublasLt.so.12
+        "${cuda_lib_dir}"/libnvrtc.so.12
+      )
+      shopt -u nullglob
+      ;;
+  esac
+
+  [ -d "${cuda_lib_dir}" ] || { echo "CUDA library dir ${cuda_lib_dir} does not exist" >&2; exit 1; }
+  for lib in ${cuda_libs[@]+"${cuda_libs[@]}"}; do
+    cp -L "${lib}" "${pkg_bin_dir}/"
+  done
+
+  # The bundle can't be verified by exec here: a driverless build host has no
+  # libcuda/nvcuda, so the CUDA backend never loads and the server starts clean
+  # whether or not these are present. Gate on the copy instead, and fail the build
+  # rather than ship a bundle that only breaks on a user's machine.
+  for required in "${required_libs[@]}"; do
+    case "${cuda_platform}" in
+      windows) pattern="${pkg_bin_dir}/${required}_*.dll" ;;
+      linux)   pattern="${pkg_bin_dir}/${required}" ;;
+    esac
+    compgen -G "${pattern}" >/dev/null || {
+      echo "no ${required} under ${cuda_lib_dir}: the ${cuda_platform} CUDA bundle is incomplete" >&2
+      exit 1
+    }
+  done
+fi
 
 # The copied closure must actually resolve: exec the bundled binary from the
 # bundle dir. A missing bundled lib fails here, at build time, instead of on a


### PR DESCRIPTION
## Problem

The Linux CUDA build has the same defect the Windows one just did. `readelf -d` on the `libggml-cuda.so` we shipped in `v0.6.90b420.dev711` lists `libcudart.so.12`, `libcublas.so.12` and `libcuda.so.1` as needed. Only `libcuda` comes from the NVIDIA driver. The engine wheel bundles neither of the other two, declares no dependencies at all, and the `cuda12` extra that `fleet.cuda_runtime` relies on appears in no install command in the README or the docs. So on a machine with just the driver, which is what we tell people is enough, nothing supplies them.

The symptom is what kept it hidden. ggml dlopens the CUDA backend and tolerates the failure, so a Linux user's GPU quietly disappears and the work falls back to CPU. On Windows `cudart` is a hard import of the process, so the identical omission killed `llama-server.exe` before it could bind a port and was reported within a day.

Neither could be caught by the build. A driverless CI runner has no `libcuda` / `nvcuda`, so the engine never loads its CUDA backend and the binary starts clean whether or not its runtime is there. `--version` and `--help` pass either way. On top of that the CUDA build cells are `continue-on-error`, so a cell that drops its artifact leaves the release missing a binary and still reports green.

## Solution

Copy `cudart`, `cublas` and `cublasLt` out of the toolkit on Linux as well. Both `llama-server` and `libggml-cuda.so` bake an `$ORIGIN` runpath, so they resolve beside the ggml libraries already bundled there, with no loader configuration and nothing for the user to install. `nvrtc` is copied when the toolkit provides it; nothing links it today. The build now fails outright when a required library is missing, rather than producing a bundle that only breaks on someone else's machine.

Because a driverless runner cannot validate this by execution, check the artifact instead of running it. `tools/qa/assert_cuda_bundle.py` reads a wheel's payload and asserts a CUDA engine carries the runtime it links, and that a non-CUDA engine carries none so the copy step cannot quietly bloat every backend. A wheel counts as CUDA by the presence of `ggml-cuda` in its `bin/`, not by its filename, because the `-1.cu125-` build tag is only added when the wheel is attached to the release.

That check runs in the build cells, where a failure is cheap to diagnose, and again in `verify-release` against the published assets, which is the gate `make release-promote` refuses to bypass. `verify-release` also now asserts that every CUDA asset the matrices build actually landed on the release, closing the `continue-on-error` hole.

Verified against the real `dev711` artifacts: the checker passes the fixed Windows wheel, fails the Linux one on all three libraries, and the asset-presence check passes the live release. The Linux libraries total 526 MiB, so the wheel and the standalone binary stay well inside GitHub's 2 GB per-asset limit.

README's claim that the CUDA runtime is bundled and you only need the driver is now true on both platforms.