### PR TITLE
Bump soupsieve to 2.8.4 to clear two high-severity CVEs

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3814,11 +3814,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627 }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016 },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

GitHub is reporting two high-severity CVEs against `soupsieve` 2.8.3, and both the `pip-audit` and `OSV-Scanner` jobs in Security Scan have been failing on main because of them.

`CVE-2026-49476` lets a crafted comma-separated selector list allocate unbounded memory, roughly 244 MB from a 500 KB input. `CVE-2026-49477` is catastrophic regex backtracking in the attribute-selector parser, where a 300-byte unterminated quoted value hangs the regex engine for over three seconds. Both are reachable through `soupsieve.compile()` and Beautiful Soup's `.select()` / `.select_one()`, and both are fixed in 2.8.4.

The same two CVEs account for all four open alerts: two Dependabot alerts and two code-scanning alerts that OSV-Scanner raises off `uv.lock`.

## Solution

Bump `soupsieve` to 2.8.4 in the lockfile.

It is a transitive dependency, `beautifulsoup4` pulled in by `crawl4ai`, which only the `crawler` and `release` extras install. Nothing under `src/` imports `bs4` or `soupsieve` directly, so this is a lockfile-only change: the default runtime resolution is byte-for-byte identical before and after, and only the crawler extra moves from 2.8.3 to 2.8.4.

Verified that `ruff`, the style-rule check, `ruff format`, and `mypy` all pass, and that Beautiful Soup's selector path still parses correctly against 2.8.4.
