### PR TITLE
Swap chat and vision on demand instead of dropping a role, and stop masking engine failures

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -263,7 +263,7 @@ flowchart LR
         provider["FleetProvider"]
         planner -->|"1: measure each GGUF"| gguf
     end
-    subgraph swaps ["llama-swap, one per role"]
+    subgraph swaps ["llama-swap, one per swap group"]
         sc["swap: chat<br/>own config, log, state"]
         se["swap: embed<br/>own config, log, state"]
     end
@@ -343,8 +343,9 @@ flowchart LR
   (`--parallel`) steps down the same way before refusing.
 
 - **Reload and the plan snapshot** (`planning.capture_plan_probe`,
-  `provider._reload_pass`): each role runs behind its own llama-swap process, and
-  a reload re-plans the whole fleet but restarts **only the roles whose launches
+  `provider._reload_pass`): each swap group runs behind its own llama-swap process
+  (one per role, except co-tenant chat and vision which share one), and a reload
+  re-plans the whole fleet but restarts **only the groups whose launches
   changed**. That diff is sound because launches are a pure function of config,
   hardware capacity, and a **clean-box memory snapshot**: devices, usable VRAM,
   and free system RAM are captured once per boot (right after stale-server
@@ -364,7 +365,7 @@ flowchart TB
     PLAN --> DIFF{per-role launch diff}
     DIFF -->|unchanged| KEEP[role keeps serving, model stays resident]
     DIFF -->|changed| RESTART[stop role's llama-swap, start with new argv]
-    subgraph fleet [one llama-swap per role]
+    subgraph fleet [one llama-swap per swap group]
         CHAT[chat group]
         EMBED[embed group xN]
         RERANK[rerank group]
@@ -421,18 +422,27 @@ what the auto planner would assign (or what a candidate spec would assign)
 including each card's backend+index label, name, and free/total VRAM, without
 touching the running fleet.
 
-- **Resident tiers and the elastic ingest pool**: placement reserves a persistent
-  query fleet first: chat, one embed server (`embed-0`), rerank, and one vision
-  server (`vision-0`). These stay resident so a chat request issued during ingest
-  always has capacity. This reservation applies to discrete-GPU placement; the
-  shared-memory path on a unified-memory or CPU host packs the same pool
-  differently and does not hold back the elastic replicas. Extra embed and vision
-  replicas (`embed-1..N`, additional
-  vision) are placed only into the VRAM that remains after the query fleet is
-  committed. When an ingest finishes, each extra replica is unloaded individually
-  via llama-swap's `POST /api/models/unload`, freeing its VRAM without disturbing
-  the resident servers. If llama-swap is restarted or found dead, the fleet
-  re-probes once and rebuilds its model config before reporting a failure.
+- **Resident tiers and the elastic ingest pool**: placement charges roles in the
+  registry's `placement_rank` order. The pinned tier goes first: one embed server
+  (`embed-0`), rerank, and one vision server (`vision-0`). Chat is charged last,
+  against what the pinned tier leaves, because chat's KV cache is the one footprint
+  that can shrink. Search therefore never loses its servers to a large chat model,
+  and vision is placeable whenever it fits beside the search tier, no matter how
+  large the chat model is. Extra embed and vision replicas (`embed-1..N`,
+  additional vision) are placed only into the VRAM that remains, and stay resident
+  there; nothing is unloaded when an ingest finishes. If llama-swap is restarted or
+  found dead, the fleet re-probes once and rebuilds its model config before
+  reporting a failure.
+- **Swap tenancy**: when the chat model fits only if vision gives up its VRAM, the
+  two are not made unplaceable. They become co-tenants of a single llama-swap
+  group with `swap: true`, sharing one llama-swap process, and llama-swap evicts
+  one to load the other on demand. Only one is resident at a time, so the group is
+  charged the chat model's footprint alone, and a co-tenant role runs a single
+  instance (a `swap: true` group evicts same-group siblings, so a second vision
+  replica inside it would evict the first). Interleaving a chat turn with an ingest
+  costs a model reload each way. Everything else pins as before: with the VRAM to
+  hold both, chat and vision get their own groups and never evict. A role is
+  unplaceable only when it does not fit even alone beside the pinned search tier.
 - **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
   vision roles can run as N independent servers, fanning embedding and OCR across
   the box during ingest. Setting either value to `0` (the default) means auto: one
@@ -461,11 +471,11 @@ touching the running fleet.
   setting deliberately not forwarded: it selects a single card by global index, which
   is meaningless once a server is pinned to a subset, and placement owns card choice
   in fleet mode.
-- **Lifecycle** (`swap_manager.py` / `provider.py`): each role runs behind its own llama-swap process
-  with its own config file, so restarting one role's group (a placement or
-  per-role model change) never touches another role's loaded servers. A reload
-  re-plans the whole fleet and diffs the fresh plan per role against the
-  running launches, restarting only the roles whose launches changed; an
+- **Lifecycle** (`swap_manager.py` / `provider.py`): each swap group runs behind its own
+  llama-swap process with its own config file, so restarting one group (a placement or
+  per-role model change) never touches another group's loaded servers. A reload
+  re-plans the whole fleet and diffs the fresh plan per group against the
+  running launches, restarting only the groups whose launches changed; an
   untouched 100GB chat model stays resident while the embedder moves. Each
   server runs in its own process group and claims
   its port at spawn (no racy batch allocation). Readiness is `/health` (200 only once

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -309,7 +309,9 @@ flowchart LR
   weights + KV-cache estimate that used discrete-GPU accounting and over-estimated
   ~3x on unified memory, which was crowding the co-resident embed/rerank servers out
   of the budget and 503-ing every search.
-- **Placement** (`placement.py`): first-fit-decreasing bin-pack with 90% headroom.
+- **Placement** (`placement.py`): bin-packed in `placement_rank` order (search roles,
+  then vision, then the elastic chat model), largest-first within a rank, with 90%
+  headroom.
   A model that fits one GPU is a single pinned instance; small models co-locate; a
   model too big for one GPU is tensor-split across enough cards that each card's
   per-device footprint fits, charged against each card's total VRAM capacity (so a
@@ -481,7 +483,7 @@ touching the running fleet.
   its port at spawn (no racy batch allocation). Readiness is `/health` (200 only once
   the model loads); the cold-load health timeout scales with the heaviest member's
   weights at a conservative disk rate (ten-minute floor), so a multi-hundred-GB model
-  on a slow volume isn't killed mid-load. Each owner lilbee writes one state file per role group
+  on a slow volume isn't killed mid-load. Each owner lilbee writes one state file per swap group
   (named with the group and its pid, written atomically so a concurrent scan never reads a torn
   file) recording that group's llama-swap pid, process group, and create time, the
   member servers' ports, plus the owner's pid and create time; before the next build

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -74,6 +74,9 @@ class PlacementView:
     # Configured roles absent from the plan because their model isn't installed,
     # so a surface can show "not downloaded" instead of an unexplained empty table.
     skipped_not_installed: tuple[SkippedRole, ...] = ()
+    # Roles sharing one swap group: each is placed, but only one is resident at a
+    # time, so their footprints do not sum against the card they name.
+    co_tenants: tuple[WorkerRole, ...] = ()
 
 
 def _active_spec() -> PlacementSpec | None:
@@ -117,6 +120,7 @@ def _view(resolved: ResolvedPlacement, *, manual: bool, spec_json: str | None) -
             SkippedRole(role=role, model=ref)
             for role, ref in resolved.skipped_not_installed.items()
         ),
+        co_tenants=tuple(sorted(resolved.co_tenants, key=lambda role: role.value)),
     )
 
 

--- a/src/lilbee/cli/commands/setup.py
+++ b/src/lilbee/cli/commands/setup.py
@@ -139,6 +139,7 @@ def _self_check_server(
         resolve_llama_server,
     )
     from lilbee.providers.fleet.client import LlamaServerClient
+    from lilbee.providers.fleet.groups import SwapGroup
     from lilbee.providers.fleet.launch import InstanceLaunch
     from lilbee.providers.fleet.swap_manager import SwapManager
     from lilbee.providers.gguf_meta import read_gguf_metadata
@@ -173,7 +174,7 @@ def _self_check_server(
         model=str(model_path),
         token_cap=ctx if is_embed else None,
     )
-    swap = SwapManager(work_dir, role.value)
+    swap = SwapManager(work_dir, SwapGroup(role.value))
     try:
         swap.start([launch])
     except BaseException:

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -47,10 +47,20 @@ def announce_cold_start(role: object, model: str) -> Console | None:
 
 
 def announce_ready(err: Console | None, role: object) -> None:
-    """Print the matching "<role> engine ready." stderr line, if cold-start announced."""
+    """Print the matching "<role> engine ready." stderr line, if cold-start announced.
+
+    Readiness is re-checked rather than inferred from output arriving: a grounded
+    refusal streams without the chat model, so a token is not evidence the engine
+    came up. A role that never loaded says so, and the engine log carries the
+    reason.
+    """
+    from lilbee.app.services import get_services
     from lilbee.providers.roles import WorkerRole
 
     if err is None or not isinstance(role, WorkerRole):
+        return
+    if not get_services().provider.role_ready(role):
+        err.print(f"[{theme.WARNING}]{role.value} engine did not load.[/{theme.WARNING}]")
         return
     err.print(f"[{theme.MUTED}]{role.value} engine ready.[/{theme.MUTED}]")
 

--- a/src/lilbee/cli/helpers.py
+++ b/src/lilbee/cli/helpers.py
@@ -49,20 +49,38 @@ def announce_cold_start(role: object, model: str) -> Console | None:
 def announce_ready(err: Console | None, role: object) -> None:
     """Print the matching "<role> engine ready." stderr line, if cold-start announced.
 
-    Readiness is re-checked rather than inferred from output arriving: a grounded
-    refusal streams without the chat model, so a token is not evidence the engine
-    came up. A role that never loaded says so, and the engine log carries the
-    reason.
+    A token arriving is not evidence the chat model came up: in RAG mode a grounded
+    refusal streams without it. When warm-up recorded a load failure, that reason is
+    printed instead of a readiness line.
     """
-    from lilbee.app.services import get_services
     from lilbee.providers.roles import WorkerRole
 
     if err is None or not isinstance(role, WorkerRole):
         return
-    if not get_services().provider.role_ready(role):
-        err.print(f"[{theme.WARNING}]{role.value} engine did not load.[/{theme.WARNING}]")
+    failure = _chat_warm_error(role)
+    if failure is not None:
+        err.print(f"[{theme.ERROR}]{failure}[/{theme.ERROR}]")
         return
     err.print(f"[{theme.MUTED}]{role.value} engine ready.[/{theme.MUTED}]")
+
+
+def _chat_warm_error(role: object) -> str | None:
+    """The chat warm-up's recorded failure, or None when it did not fail.
+
+    Read from the warm tracker rather than re-probing readiness: llama-swap can
+    report a freshly loaded model as not-yet-running, which would turn a healthy
+    engine into a spurious failure line.
+    """
+    from lilbee.app.services import get_services
+    from lilbee.providers.roles import WorkerRole
+    from lilbee.providers.warm_progress import WarmPhase
+
+    if role is not WorkerRole.CHAT:
+        return None
+    snapshot = get_services().provider.warm_progress()
+    if snapshot is None or snapshot.phase is not WarmPhase.ERROR:
+        return None
+    return snapshot.error or "The chat model did not finish loading."
 
 
 def render_status_result(status: StatusResult) -> Generator[RenderableType, None, None]:

--- a/src/lilbee/cli/placement.py
+++ b/src/lilbee/cli/placement.py
@@ -97,6 +97,12 @@ def _render_view(view: PlacementView) -> None:
             f" replicas={role_view.replicas}{split_info}  {role_view.model}"
         )
 
+    if view.co_tenants:
+        names = ", ".join(role.value for role in view.co_tenants)
+        console.print(
+            f"  [{theme.MUTED}]{names}: share memory, one loaded at a time[/{theme.MUTED}]"
+        )
+
     for role in view.unplaceable:
         console.print(f"  [{theme.ERROR}]{role.value}: does not fit, no server[/{theme.ERROR}]")
 

--- a/src/lilbee/cli/tui/widgets/fleet_body.py
+++ b/src/lilbee/cli/tui/widgets/fleet_body.py
@@ -255,6 +255,9 @@ class FleetBody(Widget):
         self._refresh_title(dirty=False)
         self._update_fleet_panel(view)
         self._render_skipped(view)
+        if view.co_tenants:
+            names = ", ".join(role.value for role in view.co_tenants)
+            self.notify(f"Sharing memory, one loaded at a time: {names}", severity="information")
         if view.unplaceable:
             names = ", ".join(role.value for role in view.unplaceable)
             self.notify(f"Does not fit: {names}", severity="warning")

--- a/src/lilbee/providers/fleet/groups.py
+++ b/src/lilbee/providers/fleet/groups.py
@@ -1,0 +1,27 @@
+"""Swap-group identity for the llama-swap processes that front the fleet."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from lilbee.providers.roles import WorkerRole
+
+
+class SwapGroup(StrEnum):
+    """One llama-swap process's group: a role's own, or the shared chat/vision pair."""
+
+    CHAT = "chat"
+    EMBED = "embed"
+    RERANK = "rerank"
+    VISION = "vision"
+    CO_TENANT = "co-tenant"
+
+    @property
+    def swaps(self) -> bool:
+        """Whether loading a member evicts its siblings (llama-swap ``swap: true``)."""
+        return self is SwapGroup.CO_TENANT
+
+
+def group_for(role: WorkerRole, co_tenants: frozenset[WorkerRole]) -> SwapGroup:
+    """The swap group *role* runs in: the shared co-tenant group, or its own."""
+    return SwapGroup.CO_TENANT if role in co_tenants else SwapGroup(role.value)

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -1,10 +1,12 @@
 """VRAM-aware placement planner for the multi-GPU llama-server fleet.
 
 Estimates each role-model's VRAM footprint from GGUF metadata and bin-packs
-instances across GPUs (first-fit-decreasing): a model that fits one GPU runs as a
-single pinned instance, small models co-locate on a GPU with spare VRAM, and a
-model too big for any single GPU is tensor-split across enough GPUs to fit. A role
-that fits nowhere gets no server (its calls error). See docs/architecture.md.
+instances across GPUs in ``placement_rank`` order, largest-first within a rank: a
+model that fits one GPU runs as a single pinned instance, small models co-locate
+on a GPU with spare VRAM, and a model too big for any single GPU is tensor-split
+across enough GPUs to fit. Chat and vision share a swap group when only one of
+them fits; a role that fits nowhere gets no server (its calls error). See
+docs/architecture.md.
 """
 
 from __future__ import annotations
@@ -83,9 +85,12 @@ def plan_placement(
 ) -> Placement:
     """Bin-pack *models* onto *devices* (``[(index, vram_bytes), ...]``).
 
-    First-fit-decreasing by footprint with a 90% headroom per GPU. A model that
-    fits one GPU takes a single instance; one too big for any single GPU is
-    tensor-split; a model that fits nowhere is an unplaceable role.
+    Roles are charged in ``placement_rank`` order, largest-first within a rank, with
+    a 90% headroom per GPU. A model that fits one GPU takes a single instance; one
+    too big for any single GPU is tensor-split. Chat is charged last: when it fits
+    only if vision's VRAM is refunded, the two become ``co_tenants`` of one swap
+    group instead of either becoming unplaceable. A model that fits nowhere, even
+    alone beside the pinned tier, is an unplaceable role.
 
     A chat split widens past the fewest fitting cards when ``chat_ctx_fit`` shows a
     tighter shard would starve its served context below ``chat_ctx_target``; the

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -16,11 +16,6 @@ from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec,
 from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION
 from lilbee.providers.roles import ROLE_REGISTRY, WorkerRole
 
-# Search-critical roles reserved ahead of the elastic chat model in a shared pool,
-# so a large chat can never crowd embed/rerank out (which would 503 every search).
-# The pooled search roles (embed/cross-encoder rerank), derived from the registry.
-_SEARCH_ROLES = tuple(role for role, info in ROLE_REGISTRY.items() if info.pooled)
-
 # (role, per-device tensor-split ratio) -> the instance's per-device VRAM footprint
 # vector aligned to that ratio. A split is accepted only when every card's entry
 # fits its own headroom, and each card is charged its own entry, not the sum.
@@ -63,14 +58,17 @@ class InstancePlan:
 
 @dataclass(frozen=True)
 class Placement:
-    """Planner output: server instances plus roles that fit on no device.
+    """Planner output: server instances, swap tenants, and roles that fit on no device.
 
     ``unplaceable_roles`` get no server, so a call to them surfaces a
-    ``ProviderError`` (there is no in-process fallback).
+    ``ProviderError`` (there is no in-process fallback). ``co_tenants`` share one
+    llama-swap group and evict each other on demand, so only one is resident at a
+    time; each runs a single instance.
     """
 
     instances: tuple[InstancePlan, ...]
     unplaceable_roles: tuple[WorkerRole, ...]
+    co_tenants: frozenset[WorkerRole] = frozenset()
 
 
 def plan_placement(
@@ -102,34 +100,23 @@ def plan_placement(
     host; ``None`` keeps the legacy ungated behavior.
     """
     if not devices:
-        if unified_budget is None:
-            return Placement(
-                instances=tuple(
-                    InstancePlan(role=m.role, devices=(), replica=r)
-                    for m in models
-                    for r in range(m.replicas)
-                ),
-                unplaceable_roles=(),
-            )
-        return _place_shared_memory(models, unified_budget)
+        return (
+            _place_ungated(models)
+            if unified_budget is None
+            else _place_shared_memory(models, unified_budget)
+        )
     remaining: dict[int, float] = {idx: vram * USABLE_VRAM_FRACTION for idx, vram in devices}
-    instances: list[InstancePlan] = []
-    unplaceable: list[WorkerRole] = []
 
-    # Reserve the persistent query fleet first, then fill residual VRAM with the
-    # elastic ingest pool. The persistent singles are: every replicas<=1 role plus
-    # replica 0 of each replicated role (the query embedder / vision that a search
-    # issued during ingest must always reach). Within the singles, place the
-    # search-critical roles (embed/rerank) before chat: chat tensor-splits across
-    # cards and, placed first, can claim them all and leave an essential search role
-    # unplaceable. Search-first here mirrors the shared-memory path's reservation.
-    # The extra replicas (1..N-1) are placed only into what VRAM remains, so a chat
-    # issued during ingest always fits and the query embedder always exists.
-    singles = [m for m in models if m.replicas <= 1]
+    # The persistent singles are every replicas<=1 role plus replica 0 of each
+    # replicated role. They are charged before the elastic replicas, and the chat
+    # model is charged last of all (``placement_rank``).
     replicated = [m for m in models if m.replicas > 1]
-    persistent_singles = singles + [_persistent_single(m) for m in replicated]
-    for model in sorted(persistent_singles, key=_shared_pool_order):
-        plan = _place_single(
+    persistent_singles = [m for m in models if m.replicas <= 1] + [
+        _persistent_single(m) for m in replicated
+    ]
+
+    def place(model: ModelPlacementInput) -> _Placed | None:
+        return _place_single(
             model,
             remaining,
             estimate_peak,
@@ -137,22 +124,134 @@ def plan_placement(
             chat_ctx_target=chat_ctx_target,
             free_headroom=free_headroom,
         )
-        if plan is None:
+
+    instances, unplaceable, charges = _place_pinned(persistent_singles, place)
+    co_tenants = _place_chat_last(
+        _chat_of(persistent_singles), place, remaining, charges, instances, unplaceable
+    )
+    instances.extend(_place_elastic(replicated, instances, remaining, co_tenants))
+
+    return Placement(
+        instances=tuple(instances),
+        unplaceable_roles=tuple(unplaceable),
+        co_tenants=co_tenants,
+    )
+
+
+def _place_ungated(models: list[ModelPlacementInput]) -> Placement:
+    """Every role as a single un-pinned instance: no GPU and no measured RAM budget."""
+    return Placement(
+        instances=tuple(
+            InstancePlan(role=m.role, devices=(), replica=r)
+            for m in models
+            for r in range(m.replicas)
+        ),
+        unplaceable_roles=(),
+    )
+
+
+def _place_pinned(
+    persistent_singles: list[ModelPlacementInput],
+    place: Callable[[ModelPlacementInput], _Placed | None],
+) -> tuple[list[InstancePlan], list[WorkerRole], dict[WorkerRole, dict[int, float]]]:
+    """Charge every persistent single except chat, in ``placement_rank`` order."""
+    instances: list[InstancePlan] = []
+    unplaceable: list[WorkerRole] = []
+    charges: dict[WorkerRole, dict[int, float]] = {}
+    for model in sorted(_pinned(persistent_singles), key=_shared_pool_order):
+        placed = place(model)
+        if placed is None:
             unplaceable.append(model.role)
         else:
-            instances.append(plan)
-    placed_roles = {plan.role for plan in instances}
-    for model in replicated:
-        if model.role not in placed_roles:
-            continue  # the persistent single did not fit -> already unplaceable
-        instances.extend(_place_replicas(model, remaining, start=1))
+            instances.append(placed.plan)
+            charges[model.role] = placed.charges
+    return instances, unplaceable, charges
 
-    return Placement(instances=tuple(instances), unplaceable_roles=tuple(unplaceable))
+
+def _place_chat_last(
+    chat: ModelPlacementInput | None,
+    place: Callable[[ModelPlacementInput], _Placed | None],
+    remaining: dict[int, float],
+    charges: dict[WorkerRole, dict[int, float]],
+    instances: list[InstancePlan],
+    unplaceable: list[WorkerRole],
+) -> frozenset[WorkerRole]:
+    """Charge chat against what the pinned tier left, co-tenanting with vision if needed."""
+    if chat is None:
+        return frozenset()
+    placed = place(chat)
+    co_tenants: frozenset[WorkerRole] = frozenset()
+    if placed is None:
+        placed, co_tenants = _chat_beside_vision(chat, place, remaining, charges)
+    if placed is None:
+        unplaceable.append(chat.role)
+    else:
+        instances.append(placed.plan)
+    return co_tenants
+
+
+def _place_elastic(
+    replicated: list[ModelPlacementInput],
+    instances: list[InstancePlan],
+    remaining: dict[int, float],
+    co_tenants: frozenset[WorkerRole],
+) -> list[InstancePlan]:
+    """Fill the residual VRAM with replicas 1..N-1 of each placed, non-co-tenant role."""
+    placed_roles = {plan.role for plan in instances}
+    elastic: list[InstancePlan] = []
+    for model in replicated:
+        if model.role not in placed_roles or model.role in co_tenants:
+            continue  # unplaceable, or a co-tenant capped to its single instance
+        elastic.extend(_place_replicas(model, remaining, start=1))
+    return elastic
+
+
+def _pinned(models: list[ModelPlacementInput]) -> list[ModelPlacementInput]:
+    """The persistent singles that are charged before chat."""
+    return [m for m in models if m.role is not WorkerRole.CHAT]
+
+
+def _chat_of(models: list[ModelPlacementInput]) -> ModelPlacementInput | None:
+    """The chat model among *models*, or None when chat is unconfigured."""
+    return next((m for m in models if m.role is WorkerRole.CHAT), None)
+
+
+def _chat_beside_vision(
+    chat: ModelPlacementInput,
+    place: Callable[[ModelPlacementInput], _Placed | None],
+    remaining: dict[int, float],
+    charges: dict[WorkerRole, dict[int, float]],
+) -> tuple[_Placed | None, frozenset[WorkerRole]]:
+    """Retry a chat model that did not fit, with vision's VRAM refunded.
+
+    On success the pair are swap tenants: only one is resident, so the group is
+    charged the chat model's footprint alone. On failure vision keeps its VRAM and
+    chat is the genuinely oversize role.
+    """
+    refund = charges.get(WorkerRole.VISION)
+    if refund is None:
+        return None, frozenset()
+    for idx, charged in refund.items():
+        remaining[idx] += charged
+    placed = place(chat)
+    if placed is not None:
+        return placed, frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+    for idx, charged in refund.items():
+        remaining[idx] -= charged
+    return None, frozenset()
 
 
 def _persistent_single(model: ModelPlacementInput) -> ModelPlacementInput:
     """The replica-0 persistent instance of a replicated role, sized as one server."""
     return ModelPlacementInput(role=model.role, est_vram_bytes=model.est_vram_bytes, replicas=1)
+
+
+@dataclass(frozen=True)
+class _Placed:
+    """One placed instance and the per-device VRAM it was charged."""
+
+    plan: InstancePlan
+    charges: dict[int, float]
 
 
 def _place_single(
@@ -163,12 +262,15 @@ def _place_single(
     chat_ctx_fit: SplitCtxFitter | None = None,
     chat_ctx_target: int = 0,
     free_headroom: dict[int, int] | None = None,
-) -> InstancePlan | None:
+) -> _Placed | None:
     """Place one instance: a single GPU when it fits, else a tensor-split, else None."""
     single = _best_single_device(model.est_vram_bytes, remaining)
     if single is not None:
         remaining[single] -= model.est_vram_bytes
-        return InstancePlan(role=model.role, devices=(single,))
+        return _Placed(
+            plan=InstancePlan(role=model.role, devices=(single,)),
+            charges={single: float(model.est_vram_bytes)},
+        )
     return _place_split(
         model,
         remaining,
@@ -187,7 +289,7 @@ def _place_split(
     chat_ctx_fit: SplitCtxFitter | None = None,
     chat_ctx_target: int = 0,
     free_headroom: dict[int, int] | None = None,
-) -> InstancePlan | None:
+) -> _Placed | None:
     """Tensor-split across the most-free GPUs whose per-device share each fits.
 
     Charges each chosen card its own entry from *estimate_peak*'s vector, so the
@@ -226,11 +328,14 @@ def _charge_split(
     ratio: tuple[int, ...],
     per_device: tuple[int, ...],
     remaining: dict[int, float],
-) -> InstancePlan:
+) -> _Placed:
     """Debit each chosen card its own per-device share and return the split plan."""
     for idx, peak in zip(chosen, per_device, strict=True):
         remaining[idx] -= peak
-    return InstancePlan(role=model.role, devices=tuple(chosen), tensor_split=ratio)
+    return _Placed(
+        plan=InstancePlan(role=model.role, devices=tuple(chosen), tensor_split=ratio),
+        charges={idx: float(peak) for idx, peak in zip(chosen, per_device, strict=True)},
+    )
 
 
 def _place_replicas(
@@ -263,15 +368,17 @@ def _place_replicas(
 def _place_shared_memory(models: list[ModelPlacementInput], budget: int) -> Placement:
     """Fit un-pinned roles into one shared RAM *budget*.
 
-    Search-critical roles (embed/rerank) are reserved first so the elastic chat
-    model can never crowd them out; the rest pack largest-first. Replicas run as N
-    co-resident processes against the shared pool (no per-GPU spread without GPUs).
-    A role with no instance placed is unplaceable (gets no server, its calls error).
+    Roles pack in ``placement_rank`` order, so the elastic chat model is charged
+    last and can never crowd out search or vision. Replicas run as N co-resident
+    processes against the shared pool (no per-GPU spread without GPUs). A chat
+    model that fits only without vision makes the pair swap tenants; a role with no
+    instance placed is unplaceable (gets no server, its calls error).
     """
     remaining = budget
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
-    for model in sorted(models, key=_shared_pool_order):
+    charged: dict[WorkerRole, int] = {}
+    for model in sorted(_pinned(models), key=_shared_pool_order):
         placed = 0
         for _ in range(model.replicas):
             if model.est_vram_bytes > remaining:
@@ -281,13 +388,48 @@ def _place_shared_memory(models: list[ModelPlacementInput], budget: int) -> Plac
             placed += 1
         if placed == 0:
             unplaceable.append(model.role)
-    return Placement(instances=tuple(instances), unplaceable_roles=tuple(unplaceable))
+        else:
+            charged[model.role] = placed * model.est_vram_bytes
+
+    chat = _chat_of(models)
+    co_tenants: frozenset[WorkerRole] = frozenset()
+    if chat is not None:
+        co_tenants = _place_shared_chat(chat, instances, unplaceable, remaining, charged)
+    return Placement(
+        instances=tuple(instances),
+        unplaceable_roles=tuple(unplaceable),
+        co_tenants=co_tenants,
+    )
+
+
+def _place_shared_chat(
+    chat: ModelPlacementInput,
+    instances: list[InstancePlan],
+    unplaceable: list[WorkerRole],
+    remaining: int,
+    charged: dict[WorkerRole, int],
+) -> frozenset[WorkerRole]:
+    """Charge chat last against the shared pool, refunding vision if that is what it takes.
+
+    Refunding vision makes the pair swap tenants, so only chat's footprint is held
+    and vision drops to its single instance.
+    """
+    if chat.est_vram_bytes <= remaining:
+        instances.append(InstancePlan(role=chat.role, devices=()))
+        return frozenset()
+    vision_bytes = charged.get(WorkerRole.VISION)
+    if vision_bytes is None or chat.est_vram_bytes > remaining + vision_bytes:
+        unplaceable.append(chat.role)
+        return frozenset()
+    instances[:] = [plan for plan in instances if plan.role is not WorkerRole.VISION]
+    instances.append(InstancePlan(role=WorkerRole.VISION, devices=(), replica=0))
+    instances.append(InstancePlan(role=chat.role, devices=()))
+    return frozenset({WorkerRole.CHAT, WorkerRole.VISION})
 
 
 def _shared_pool_order(model: ModelPlacementInput) -> tuple[int, int]:
-    """Sort key: search roles first, then everything else largest-first."""
-    is_search = 0 if model.role in _SEARCH_ROLES else 1
-    return (is_search, -model.est_vram_bytes)
+    """Sort key: by the role's placement rank, then largest-first within a rank."""
+    return (ROLE_REGISTRY[model.role].placement_rank, -model.est_vram_bytes)
 
 
 def _best_single_device(need: int, remaining: dict[int, float]) -> int | None:

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -1048,6 +1048,7 @@ class ResolvedPlacement:
     instances: tuple[InstancePlan, ...]
     unplaceable_roles: tuple[WorkerRole, ...]
     model_refs: dict[WorkerRole, str]
+    co_tenants: frozenset[WorkerRole] = frozenset()
     # Roles configured but skipped because their model isn't installed (role -> ref).
     # Distinct from unplaceable_roles (installed but won't fit); lets a surface show
     # "not downloaded" instead of an empty table on a fresh install.
@@ -1075,6 +1076,7 @@ def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement
         instances=resolved.instances,
         unplaceable_roles=resolved.unplaceable_roles,
         model_refs=model_refs,
+        co_tenants=resolved.co_tenants,
         skipped_not_installed=skipped_not_installed,
     )
 

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -1076,12 +1076,20 @@ def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement
     )
 
 
+@dataclass(frozen=True)
+class FleetPlan:
+    """The servers to start, and the roles that share one swap group."""
+
+    launches: tuple[InstanceLaunch, ...]
+    co_tenants: frozenset[WorkerRole] = frozenset()
+
+
 def plan_launches(
     roles: tuple[WorkerRole, ...] | None,
     binary: Path,
     by_index: dict[int, FleetDevice],
     devices: list[FleetDevice],
-) -> list[InstanceLaunch]:
+) -> FleetPlan:
     """Plan placement for *roles* (``None`` = all configured) and build their launches."""
     from lilbee.core.config import cfg
 
@@ -1098,22 +1106,30 @@ def plan_launches(
             role.value,
             model_refs[role],
         )
-    reserved_by_device = _non_chat_reservation(placement.instances, inputs)
-    return [
-        _launch_for(
-            plan,
-            model_refs[plan.role],
-            binary,
-            by_index,
-            unified_budget=unified_budget,
-            chat_reservation=reservation,
-            reserved_by_device=reserved_by_device,
+    if placement.co_tenants:
+        log.info(
+            "%s share GPU memory and load on demand; only one is resident at a time.",
+            ", ".join(sorted(role.value for role in placement.co_tenants)),
         )
-        for plan in placement.instances
-    ]
+    reserved_by_device = _non_chat_reservation(placement.instances, inputs)
+    return FleetPlan(
+        launches=tuple(
+            _launch_for(
+                plan,
+                model_refs[plan.role],
+                binary,
+                by_index,
+                unified_budget=unified_budget,
+                chat_reservation=reservation,
+                reserved_by_device=reserved_by_device,
+            )
+            for plan in placement.instances
+        ),
+        co_tenants=placement.co_tenants,
+    )
 
 
-def plan_all_launches() -> list[InstanceLaunch]:
+def plan_all_launches() -> FleetPlan:
     """Apply GPU env, probe devices, and plan launches for every configured role.
 
     Disables crash-prone Vulkan layers / dual-vendor ICDs and applies any

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -674,20 +674,23 @@ def _server_model_inputs(
 
 
 def _non_chat_reservation(
-    instances: Sequence[InstancePlan], inputs: Sequence[ModelPlacementInput]
+    instances: Sequence[InstancePlan],
+    inputs: Sequence[ModelPlacementInput],
+    co_tenants: frozenset[WorkerRole] = frozenset(),
 ) -> dict[int, int]:
     """Per-device VRAM the non-chat role servers occupy, keyed by device index.
 
     A tensor-split chat shard must size its KV against the headroom left after the
     embed/rerank/vision servers on the same card, not the card's raw free VRAM, or
-    it over-commits and OOMs at launch. Chat is excluded because it sizes
-    its own weights; non-chat roles are single-device, so each charges its full
-    footprint (once per replica) to its card.
+    it over-commits and OOMs at launch. Chat is excluded because it sizes its own
+    weights, and so are chat's co-tenants: they are evicted while chat is resident,
+    so their VRAM is chat's to use. Non-chat roles are single-device, so each
+    charges its full footprint (once per replica) to its card.
     """
     charge_by_role = {inp.role: inp.est_vram_bytes for inp in inputs}
     reserved: dict[int, int] = {}
     for inst in instances:
-        if inst.role is WorkerRole.CHAT:
+        if inst.role is WorkerRole.CHAT or inst.role in co_tenants:
             continue
         charge = charge_by_role[inst.role]
         for device in inst.devices:
@@ -1111,7 +1114,7 @@ def plan_launches(
             "%s share GPU memory and load on demand; only one is resident at a time.",
             ", ".join(sorted(role.value for role in placement.co_tenants)),
         )
-    reserved_by_device = _non_chat_reservation(placement.instances, inputs)
+    reserved_by_device = _non_chat_reservation(placement.instances, inputs, placement.co_tenants)
     return FleetPlan(
         launches=tuple(
             _launch_for(

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -799,6 +799,9 @@ class FleetProvider:
             self._retiring_clients = []
             self._chat_slots = 1
             self._chat_ctx = None
+            # A torn-down fleet's load failures describe servers that no longer
+            # exist; the next warm records its own.
+            self._warm_errors = {}
         # Full teardown: the next build starts from a clean box, so it must
         # re-snapshot memory rather than plan against this boot's probe.
         planning.clear_plan_probe()

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -1,13 +1,13 @@
 """FleetProvider: the local llama-server engine for every role.
 
-On first use it plans GPU placement and starts one llama-swap process per
-configured role (chat/embed/rerank/vision), each fronting that role's
-llama-server(s); each call routes to its role's proxy by replica model id.
-Per-role processes let a reload restart only the roles whose launches changed,
-so a placement or model change never unloads an untouched role's model. There
-is no in-process fallback, so a missing role surfaces a user-facing
-``ProviderError``. Model management (list/show/capabilities) reads the registry
-and GGUF headers directly and needs no running server.
+On first use it plans GPU placement and starts one llama-swap process per swap
+group, each fronting that group's llama-server(s); each call routes to its role's
+proxy by replica model id. Per-group processes let a reload restart only the
+groups whose launches changed, so a placement or model change never unloads an
+untouched group's model. There is no in-process fallback, so a missing role
+surfaces a user-facing ``ProviderError``. Model management
+(list/show/capabilities) reads the registry and GGUF headers directly and needs no
+running server. See docs/architecture.md for swap tenancy.
 """
 
 from __future__ import annotations
@@ -33,6 +33,7 @@ from lilbee.providers.fleet.client import (
     is_connection_failure,
     retry_on_busy,
 )
+from lilbee.providers.fleet.groups import SwapGroup, group_for
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
 from lilbee.providers.fleet.swap_manager import SwapManager, reap_stale, sweep_owned
 from lilbee.providers.fleet.windowing import window_messages
@@ -106,14 +107,26 @@ def _request_timeout_s(weights_bytes: int) -> float:
     )
 
 
-def _launches_by_role(
-    launches: list[InstanceLaunch],
-) -> dict[WorkerRole, tuple[InstanceLaunch, ...]]:
-    """Group a plan's launches by role, replica order preserved within each role."""
+def _launches_by_group(
+    plan: planning.FleetPlan,
+) -> dict[SwapGroup, tuple[InstanceLaunch, ...]]:
+    """Group a plan's launches by swap group, replica order preserved within each group.
+
+    Co-tenant roles land in one group, so llama-swap evicts between them rather
+    than holding both resident.
+    """
+    grouped: dict[SwapGroup, list[InstanceLaunch]] = {}
+    for launch in plan.launches:
+        grouped.setdefault(group_for(launch.role, plan.co_tenants), []).append(launch)
+    return {group: tuple(group_launches) for group, group_launches in grouped.items()}
+
+
+def _by_role(launches: list[InstanceLaunch]) -> dict[WorkerRole, list[InstanceLaunch]]:
+    """Split one group's launches per role, replica order preserved."""
     grouped: dict[WorkerRole, list[InstanceLaunch]] = {}
     for launch in launches:
         grouped.setdefault(launch.role, []).append(launch)
-    return {role: tuple(role_launches) for role, role_launches in grouped.items()}
+    return grouped
 
 
 def _least_in_flight(clients: list[LlamaServerClient]) -> LlamaServerClient:
@@ -459,14 +472,18 @@ class FleetProvider:
     """Routes every role to the managed llama-server fleet (a fleet-of-one on one box)."""
 
     def __init__(self) -> None:
-        # One llama-swap per placed role, so restarting one role's servers (a
-        # placement or per-role model change) never unloads another role's.
-        self._swaps: dict[WorkerRole, SwapManager] = {}
+        # One llama-swap per placed group, so restarting one group's servers (a
+        # placement or per-role model change) never unloads another group's. A
+        # co-tenant group holds chat and vision, which evict each other on load.
+        self._swaps: dict[SwapGroup, SwapManager] = {}
+        # The group each placed role runs in, so a role's clients and its swap
+        # process can be reached from the role alone.
+        self._role_group: dict[WorkerRole, SwapGroup] = {}
         # The launches each running group was started with, kept so a reload can
-        # diff the fresh plan against what is running and restart only the roles
+        # diff the fresh plan against what is running and restart only the groups
         # whose launches actually changed. Launch argv is port-free (ports are
         # injected at config render), so the comparison is stable across starts.
-        self._launches: dict[WorkerRole, tuple[InstanceLaunch, ...]] = {}
+        self._launches: dict[SwapGroup, tuple[InstanceLaunch, ...]] = {}
         # Latched once shutdown runs. A discarded provider (reset_services swaps
         # in a new one) can still have an in-flight warm-up or reload daemon
         # thread; without this latch that thread could start a llama-swap after
@@ -555,77 +572,99 @@ class FleetProvider:
                 # try: capturing resolves the engine binary, and a binary-less
                 # host must serve nothing, not raise.
                 planning.capture_plan_probe()
-                launches = planning.plan_all_launches()
+                plan = planning.plan_all_launches()
             except ProviderError:
                 log.debug("Engine binary unavailable; no swap started")
                 return False
-            if not launches:
+            if not plan.launches:
                 return False  # no installed/configured model -> serve nothing, spawn nothing
-            by_role = _launches_by_role(launches)
-            started: dict[WorkerRole, SwapManager] = {}
+            by_group = _launches_by_group(plan)
+            started: dict[SwapGroup, SwapManager] = {}
             try:
-                for role, role_launches in by_role.items():
-                    swap = SwapManager(cfg.data_dir, role.value)
-                    swap.start(list(role_launches))
-                    started[role] = swap
+                for group, group_launches in by_group.items():
+                    swap = SwapManager(cfg.data_dir, group)
+                    swap.start(list(group_launches))
+                    started[group] = swap
             except BaseException:
                 for swap in started.values():
                     swap.shutdown()
                 raise
             with self._lock:
-                for role, swap in started.items():
-                    self._adopt_role(role, swap, list(by_role[role]))
+                for group, swap in started.items():
+                    self._adopt_group(group, swap, list(by_group[group]))
             return True
 
-    def _adopt_role(
-        self, role: WorkerRole, swap: SwapManager, launches: list[InstanceLaunch]
+    def _adopt_group(
+        self, group: SwapGroup, swap: SwapManager, launches: list[InstanceLaunch]
     ) -> None:
-        """Record *role*'s freshly started swap and build its client pool.
+        """Record *group*'s freshly started swap and build a client pool per role.
 
         Caller holds ``self._lock``. Each launch (one per replica) becomes a client
         keyed by its replica model id against this group's own proxy endpoint;
         the chat launch carries the slots/ctx so the capacity and served context
         come from the launch, not a probe.
         """
-        # Retire the role's previous clients (a reload re-adopts over an existing
-        # pool): closing them now would error a reader still mid-call on an old
-        # client snapshot, and never closing leaks an httpx pool per replica.
-        old_clients = list(self._clients.get(role, []))
-        self._swaps[role] = swap
-        self._launches[role] = tuple(launches)
+        self._swaps[group] = swap
+        self._launches[group] = tuple(launches)
         endpoint = swap.endpoint()
-        # token_cap truncates oversize embed/rerank inputs to the per-slot context
-        # (the in-process backstop); the longer timeout covers a cold upstream load.
-        self._clients[role] = [
-            LlamaServerClient(
-                endpoint,
-                launch.model_id,
-                token_cap=launch.token_cap,
-                timeout=_request_timeout_s(launch.weights_bytes),
-                rerank_mode=launch.rerank_mode,
-                inline_reasoning=role is WorkerRole.CHAT,
-            )
-            for launch in launches
-        ]
-        if role is WorkerRole.CHAT:
-            chat = launches[0]
-            self._chat_slots = chat.slots
-            self._chat_ctx = chat.ctx
-        self._retire_clients(old_clients)
+        for role, role_launches in _by_role(launches).items():
+            # Retire the role's previous clients (a reload re-adopts over an existing
+            # pool): closing them now would error a reader still mid-call on an old
+            # client snapshot, and never closing leaks an httpx pool per replica.
+            old_clients = list(self._clients.get(role, []))
+            self._role_group[role] = group
+            # token_cap truncates oversize embed/rerank inputs to the per-slot context
+            # (the in-process backstop); the longer timeout covers a cold upstream load.
+            self._clients[role] = [
+                LlamaServerClient(
+                    endpoint,
+                    launch.model_id,
+                    token_cap=launch.token_cap,
+                    timeout=_request_timeout_s(launch.weights_bytes),
+                    rerank_mode=launch.rerank_mode,
+                    inline_reasoning=role is WorkerRole.CHAT,
+                )
+                for launch in role_launches
+            ]
+            if role is WorkerRole.CHAT:
+                self._chat_slots = role_launches[0].slots
+                self._chat_ctx = role_launches[0].ctx
+            self._retire_clients(old_clients)
 
-    def _drop_role(self, role: WorkerRole) -> SwapManager | None:
-        """Forget *role*'s swap/launches/clients; return the swap for teardown.
+    def _swap_for(self, role: WorkerRole) -> SwapManager | None:
+        """The swap process serving *role*, or None when the role has no server.
 
-        Caller holds ``self._lock``. The role's clients are retired (closed at a
-        later reload or shutdown, never while a reader could still hold one) and
-        the chat capacity falls back to its defaults when chat itself is dropped.
+        Caller holds ``self._lock``.
         """
-        swap = self._swaps.pop(role, None)
-        self._launches.pop(role, None)
-        self._retire_clients(self._clients.pop(role, []))
-        if role is WorkerRole.CHAT:
-            self._chat_slots = 1
-            self._chat_ctx = None
+        group = self._role_group.get(role)
+        return None if group is None else self._swaps.get(group)
+
+    def _role_launches(self, role: WorkerRole) -> tuple[InstanceLaunch, ...]:
+        """*role*'s launch snapshot, empty when it has no server.
+
+        A co-tenant group holds more than one role's launches, so the group's
+        snapshot is filtered down to this role's replicas.
+        """
+        group = self._role_group.get(role)
+        if group is None:
+            return ()
+        return tuple(launch for launch in self._launches.get(group, ()) if launch.role is role)
+
+    def _drop_group(self, group: SwapGroup) -> SwapManager | None:
+        """Forget *group*'s swap/launches and every member role's clients.
+
+        Caller holds ``self._lock``. Member clients are retired (closed at a later
+        reload or shutdown, never while a reader could still hold one) and the chat
+        capacity falls back to its defaults when chat's group is dropped.
+        """
+        swap = self._swaps.pop(group, None)
+        self._launches.pop(group, None)
+        for role in [r for r, g in self._role_group.items() if g is group]:
+            del self._role_group[role]
+            self._retire_clients(self._clients.pop(role, []))
+            if role is WorkerRole.CHAT:
+                self._chat_slots = 1
+                self._chat_ctx = None
         return swap
 
     def _retire_clients(self, old_clients: list[LlamaServerClient]) -> None:
@@ -661,7 +700,7 @@ class FleetProvider:
         self._ensure_fleet()
         with self._lock:
             clients = self._clients.get(role)
-            swap = self._swaps.get(role)
+            swap = self._swap_for(role)
         if not clients and swap is not None and not swap.is_live():
             self._rebuild_role(role)
             with self._lock:
@@ -691,7 +730,7 @@ class FleetProvider:
         is up or while the role's upstream is still loading.
         """
         with self._lock:
-            swap = self._swaps.get(role)
+            swap = self._swap_for(role)
         return swap is not None and swap.role_ready(role)
 
     def max_concurrent_chats(self) -> int:
@@ -702,14 +741,14 @@ class FleetProvider:
         client connects, so the real capacity is in effect by the first chat).
         """
         with self._lock:
-            if WorkerRole.CHAT not in self._swaps:
+            if WorkerRole.CHAT not in self._role_group:
                 return 1
             return self._chat_slots
 
     def served_chat_ctx(self) -> int | None:
         """Per-slot context the chat server runs with, or None if not up."""
         with self._lock:
-            return self._chat_ctx if WorkerRole.CHAT in self._swaps else None
+            return self._chat_ctx if WorkerRole.CHAT in self._role_group else None
 
     def warm_progress(self) -> WarmProgress | None:
         """Live cold-load progress for the chat role, or None before warm begins."""
@@ -752,6 +791,7 @@ class FleetProvider:
             clients.extend(self._retiring_clients)
             self._swaps = {}
             self._launches = {}
+            self._role_group = {}
             self._clients = {}
             self._retiring_clients = []
             self._chat_slots = 1
@@ -769,8 +809,8 @@ class FleetProvider:
         a live engine is never abandoned unstopped.
         """
         with self._build_lock, self._lock:
-            for role in [r for r, swap in self._swaps.items() if not swap.running]:
-                self._drop_role(role)
+            for group in [g for g, swap in self._swaps.items() if not swap.running]:
+                self._drop_group(group)
 
     def _require_configured_model(
         self, model: str | None, configured: str, role: WorkerRole
@@ -932,7 +972,7 @@ class FleetProvider:
         card that fit fewer slots than requested reports the smaller real number,
         so the fan-out never queues more pages than the servers can serve.
         """
-        launches = self._launches.get(WorkerRole.VISION)
+        launches = self._role_launches(WorkerRole.VISION)
         if not launches:
             return None
         return max(1, sum(launch.slots for launch in launches))
@@ -947,7 +987,7 @@ class FleetProvider:
         drop it between two reads).
         """
         clients = self._require_clients(WorkerRole.VISION)
-        launches = self._launches.get(WorkerRole.VISION)
+        launches = self._role_launches(WorkerRole.VISION)
         if launches and len(launches) == len(clients):
             return [
                 _VisionReplica(client, max(1, launch.slots))
@@ -1395,16 +1435,16 @@ class FleetProvider:
                 self._reload_pending = False
 
     def _reload_pass(self, force: frozenset[WorkerRole] = frozenset()) -> None:
-        """One re-plan from current cfg, restarting only the roles that changed.
+        """One re-plan from current cfg, restarting only the groups that changed.
 
-        The fresh plan is diffed per role against the launches each running group
-        was started with; a role restarts only when its launches differ (covers
-        added and removed roles too), so an untouched role's loaded model stays
-        resident through a placement or per-role model change. *force* adds roles
-        to the restart set even when their plan is unchanged (dead-swap recovery).
-        Changed groups stop before the new ones start, so the planned VRAM is
-        actually free when the new servers spawn. Runs under the build lock so a
-        racing shutdown/build can't interleave with the restart and leak a live
+        The fresh plan is diffed per swap group against the launches each running
+        group was started with; a group restarts only when its launches differ
+        (covers added and removed groups too), so an untouched group's loaded model
+        stays resident through a placement or per-role model change. *force* adds a
+        role's group to the restart set even when its plan is unchanged (dead-swap
+        recovery). Changed groups stop before the new ones start, so the planned
+        VRAM is actually free when the new servers spawn. Runs under the build lock
+        so a racing shutdown/build can't interleave with the restart and leak a live
         llama-swap holding GPU memory.
         """
         from lilbee.core.config import cfg
@@ -1423,31 +1463,32 @@ class FleetProvider:
                 # Nothing loaded (a resurrect after a failed pass): the box is
                 # clean, so refresh the plan snapshot like a first build would.
                 planning.capture_plan_probe()
-            new = _launches_by_role(planning.plan_all_launches())
-            # A role restarts when its launches changed OR its running/planned
+            plan = planning.plan_all_launches()
+            new = _launches_by_group(plan)
+            # A group restarts when its launches changed OR its running/planned
             # presence disagrees (covers a group the new plan drops or adds).
             changed = {
-                role
-                for role in running | set(new)
-                if (role in running) != (role in new) or old.get(role, ()) != new.get(role, ())
+                group
+                for group in running | set(new)
+                if (group in running) != (group in new) or old.get(group, ()) != new.get(group, ())
             }
-            changed |= set(force)
-            # Stop phase: free the changed roles' VRAM before their replacements
-            # (or another role's grown plan) spawn against it.
-            for role in sorted(changed, key=lambda r: r.value):
+            changed |= {group_for(role, plan.co_tenants) for role in force}
+            # Stop phase: free the changed groups' VRAM before their replacements
+            # (or another group's grown plan) spawn against it.
+            for group in sorted(changed, key=lambda g: g.value):
                 with self._lock:
-                    swap = self._drop_role(role)
+                    swap = self._drop_group(group)
                 if swap is not None:
                     swap.shutdown()
-            # Start phase: spawn the changed roles present in the new plan.
+            # Start phase: spawn the changed groups present in the new plan.
             restarted: list[WorkerRole] = []
-            for role in sorted(changed & set(new), key=lambda r: r.value):
-                role_launches = list(new[role])
-                swap = SwapManager(cfg.data_dir, role.value)
-                swap.start(role_launches)
+            for group in sorted(changed & set(new), key=lambda g: g.value):
+                group_launches = list(new[group])
+                swap = SwapManager(cfg.data_dir, group)
+                swap.start(group_launches)
                 with self._lock:
-                    self._adopt_role(role, swap, role_launches)
-                restarted.append(role)
+                    self._adopt_group(group, swap, group_launches)
+                restarted.extend(_by_role(group_launches))
         if restarted:
             # Load the restarted roles' models off-thread (llama-swap spawns an
             # upstream on its first request): the reload returns once the proxies

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -502,6 +502,9 @@ class FleetProvider:
         # Granular cold-load progress for the chat role, streamed to a launcher so
         # the user sees real read/engine-load progress instead of a frozen spinner.
         self._warm_tracker = WarmProgressTracker()
+        # The engine's own reason a role's model failed to warm, so the launcher and
+        # the TUI report the real cause instead of a generic "did not load".
+        self._warm_errors: dict[WorkerRole, str] = {}
         # Single-flight guard for the off-thread warm-up: True from the moment a
         # warm thread is dispatched until it finishes, so a second warm_up_pool
         # never starts a second swap and double-allocates GPU memory.
@@ -1223,14 +1226,30 @@ class FleetProvider:
                 future.result()
 
     def _warm_role_clients(self, role: WorkerRole, clients: list[LlamaServerClient]) -> bool:
-        """Warm every replica of *role*; return whether at least one loaded."""
+        """Warm every replica of *role*; return whether at least one loaded.
+
+        A replica that fails to load is reported at warning level with the engine's
+        own message (an unsupported architecture, a corrupt file). Warm-up stays
+        best-effort, but the failure must not be silent: the role then serves
+        nothing, and a caller that never reaches it would otherwise see only an
+        unexplained empty answer.
+        """
         warmed = False
+        self._warm_errors.pop(role, None)
         for client in clients:
             try:
                 _warm_role(role, client)
                 warmed = True
-            except Exception:
-                log.debug("Warm-up request for %s failed.", role.value, exc_info=True)
+            except Exception as exc:
+                self._warm_errors[role] = str(exc)
+                log.warning(
+                    "The %s model failed to load: %s",
+                    role.value,
+                    exc,
+                    exc_info=log.isEnabledFor(logging.DEBUG),
+                )
+        if warmed:
+            self._warm_errors.pop(role, None)
         return warmed
 
     def _warm_chat_role(self, clients: list[LlamaServerClient]) -> None:
@@ -1251,7 +1270,14 @@ class FleetProvider:
             if warmed:
                 self._warm_tracker.ready()
             else:
-                self._warm_tracker.fail("The chat model did not finish loading.")
+                self._warm_tracker.fail(self._chat_load_failure())
+
+    def _chat_load_failure(self) -> str:
+        """The engine's own reason the chat model did not load, when it gave one."""
+        reason = self._warm_errors.get(WorkerRole.CHAT)
+        if not reason:
+            return "The chat model did not finish loading."
+        return f"The chat model did not load: {reason}"
 
     def _prewarm_chat_weights(self) -> None:
         """Page the chat model's GGUF shards into the OS cache, reporting byte progress.

--- a/src/lilbee/providers/fleet/swap_config.py
+++ b/src/lilbee/providers/fleet/swap_config.py
@@ -1,7 +1,7 @@
-"""Generate one role group's llama-swap config (all its replicas co-resident).
+"""Generate one swap group's llama-swap config.
 
-Each role runs behind its own llama-swap process with its own config, so a
-reload of one role never touches another's loaded servers. See
+Each group runs behind its own llama-swap process with its own config, so a
+reload of one group never touches another's loaded servers. See
 docs/architecture.md (llama-swap) for the supervisor/proxy design.
 """
 
@@ -18,9 +18,8 @@ if TYPE_CHECKING:
 
     from lilbee.providers.fleet.launch import InstanceLaunch
 
-# One group holds the role's members with swap disabled, so llama-swap brings
-# them all up and never evicts one to load another (the co-residency the fleet
-# needs across a role's replicas).
+# One group holds this process's members. Swap disabled keeps them co-resident (a
+# role's replicas); enabled makes llama-swap evict one to load another.
 _GROUP_NAME = "lilbee"
 # Cold-load ceiling floor; the heaviest member's weights scale it up from here.
 _HEALTH_CHECK_TIMEOUT_FLOOR_S = 600
@@ -33,7 +32,7 @@ _PROXY_URL_TEMPLATE = "http://127.0.0.1:{port}"
 # Shared with the swap manager, whose orphan-server sweep matches this flag's
 # value in survivor cmdlines.
 PORT_FLAG = "--port"
-_TTL_KEEP = 0  # never time a member out; the group keeps it resident
+_TTL_KEEP = 0  # no idle timeout; a member leaves memory only when a sibling evicts it
 
 # llama-swap config keys.
 _KEY_HEALTH_TIMEOUT = "healthCheckTimeout"
@@ -50,15 +49,18 @@ _KEY_PERSISTENT = "persistent"
 _KEY_MEMBERS = "members"
 
 
-def build_swap_config(launches: list[InstanceLaunch], member_ports: Mapping[str, int]) -> str:
+def build_swap_config(
+    launches: list[InstanceLaunch], member_ports: Mapping[str, int], *, swap: bool = False
+) -> str:
     """Render a llama-swap config (JSON, which is valid YAML) for *launches*.
 
     Each launch becomes a model whose id is its replica model id and whose
     command is the llama-server argv plus the explicit port from *member_ports*;
-    one ``swap: false`` group holds them all co-resident behind this role's
-    proxy endpoint. Ports are allocated fresh per start (never llama-swap's fixed
-    ``startPort`` range) so a previous instance's lingering server can't collide
-    with the new fleet's bind.
+    one group holds them behind this group's proxy endpoint. ``swap`` makes the
+    members evict each other on load, so only one is resident at a time; the
+    default keeps them co-resident. Ports are allocated fresh per start (never
+    llama-swap's fixed ``startPort`` range) so a previous instance's lingering
+    server can't collide with the new fleet's bind.
     """
     models: dict[str, object] = {}
     for launch in launches:
@@ -77,7 +79,7 @@ def build_swap_config(launches: list[InstanceLaunch], member_ports: Mapping[str,
         _KEY_MODELS: models,
         _KEY_GROUPS: {
             _GROUP_NAME: {
-                _KEY_SWAP: False,
+                _KEY_SWAP: swap,
                 _KEY_EXCLUSIVE: False,
                 _KEY_PERSISTENT: True,
                 _KEY_MEMBERS: [launch.model_id for launch in launches],

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -25,6 +25,7 @@ import psutil
 
 from lilbee.providers.base import ProviderError, ProviderErrorKind
 from lilbee.providers.fleet.binary import resolve_llama_swap
+from lilbee.providers.fleet.groups import SwapGroup
 from lilbee.providers.fleet.launch import role_model_prefix
 from lilbee.providers.fleet.swap_config import PORT_FLAG, build_swap_config
 
@@ -128,12 +129,12 @@ class SwapManager:
     or model change) never touches another group's loaded servers.
     """
 
-    def __init__(self, data_dir: Path, group: str) -> None:
+    def __init__(self, data_dir: Path, group: SwapGroup) -> None:
         self._data_dir = data_dir
         self._group = group
-        self._config_path = data_dir / _CONFIG_FILENAME_TEMPLATE.format(group=group)
-        self._log_path = data_dir / _LOGS_SUBDIR / _LOG_FILENAME_TEMPLATE.format(group=group)
-        self._state_path = data_dir / _state_filename(os.getpid(), group)
+        self._config_path = data_dir / _CONFIG_FILENAME_TEMPLATE.format(group=group.value)
+        self._log_path = data_dir / _LOGS_SUBDIR / _LOG_FILENAME_TEMPLATE.format(group=group.value)
+        self._state_path = data_dir / _state_filename(os.getpid(), group.value)
         self._proc: subprocess.Popen[bytes] | None = None
         self._log_file: BinaryIO | None = None
         self._port: int | None = None
@@ -159,7 +160,9 @@ class SwapManager:
         member_ports = dict(zip([launch.model_id for launch in launches], ports[1:], strict=True))
         self._member_ports = sorted(member_ports.values())
         self._config_path.parent.mkdir(parents=True, exist_ok=True)
-        self._config_path.write_text(build_swap_config(launches, member_ports))
+        self._config_path.write_text(
+            build_swap_config(launches, member_ports, swap=self._group.swaps)
+        )
         self._port = ports[0]
         # Capture llama-swap's stdout/stderr to a file so its access log never
         # reaches an inherited terminal (a TUI/CLI parent) and garbles the screen.

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _HOST = "127.0.0.1"
-# One llama-swap per role group: the group name lands in the config filename so
+# One llama-swap per swap group: the group name lands in the config filename so
 # each group's processes are identified (and stopped) by their own config path,
 # and a placement change can restart one group without touching the others.
 _CONFIG_FILENAME_TEMPLATE = "llama-swap-{group}.json"

--- a/src/lilbee/providers/roles.py
+++ b/src/lilbee/providers/roles.py
@@ -48,6 +48,7 @@ class RoleInfo:
     offload_all_layers: bool  # loader offloads every layer, ignoring cfg.n_gpu_layers
     flash_attn: bool  # runs with flash attention (chat/vision)
     pooled: bool  # pooled single-slot search role (embed/cross-encoder rerank)
+    placement_rank: int  # placement order; the elastic chat model is charged last
 
 
 ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
@@ -59,6 +60,7 @@ ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
         offload_all_layers=False,
         flash_attn=True,
         pooled=False,
+        placement_rank=2,
     ),
     WorkerRole.EMBED: RoleInfo(
         role=WorkerRole.EMBED,
@@ -68,6 +70,7 @@ ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
         offload_all_layers=True,
         flash_attn=False,
         pooled=True,
+        placement_rank=0,
     ),
     WorkerRole.RERANK: RoleInfo(
         role=WorkerRole.RERANK,
@@ -77,6 +80,7 @@ ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
         offload_all_layers=True,
         flash_attn=False,
         pooled=True,
+        placement_rank=0,
     ),
     WorkerRole.VISION: RoleInfo(
         role=WorkerRole.VISION,
@@ -86,6 +90,7 @@ ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
         offload_all_layers=True,
         flash_attn=True,
         pooled=False,
+        placement_rank=1,
     ),
 }
 """Single source of truth for per-role fleet configuration, ordered chat/embed/rerank/vision."""

--- a/src/lilbee/retrieval/reasoning.py
+++ b/src/lilbee/retrieval/reasoning.py
@@ -285,6 +285,21 @@ def strip_reasoning(text: str) -> str:
     return _THINK_BLOCK_RE.sub("", text)
 
 
+def split_reasoning(text: str) -> tuple[str, str]:
+    """Split a complete string into its reasoning and its answer.
+
+    An unterminated ``<think>`` block means the model never reached an answer, so
+    everything after the tag is reasoning. Surfaces that must not leak lilbee's
+    inline ``<think>`` convention (the OpenAI-compatible API) use this to report
+    reasoning in its own field.
+    """
+    blocks = [
+        match.group(0).strip().removeprefix(THINK_OPEN_TAG).removesuffix(THINK_CLOSE_TAG).strip()
+        for match in _THINK_BLOCK_RE.finditer(text)
+    ]
+    return "".join(blocks), strip_reasoning(text)
+
+
 def _could_be_partial(tag: str, buf: str) -> bool:
     """Check if the end of buf could be the start of the given tag."""
     return any(buf.endswith(tag[:length]) for length in range(1, len(tag)))

--- a/src/lilbee/server/chat_completions_api/models.py
+++ b/src/lilbee/server/chat_completions_api/models.py
@@ -140,6 +140,8 @@ class CompletionsResponseToolCall(BaseModel):
 class CompletionsResponseMessage(BaseModel):
     role: Literal["assistant"] = "assistant"
     content: str | None = None
+    # A reasoning model's thinking, reported separately so ``content`` stays clean.
+    reasoning_content: str | None = None
     tool_calls: list[CompletionsResponseToolCall] | None = None
 
 
@@ -181,6 +183,7 @@ class CompletionsStreamToolCall(BaseModel):
 class CompletionsStreamDelta(BaseModel):
     role: Literal["assistant"] | None = None
     content: str | None = None
+    reasoning_content: str | None = None
     tool_calls: list[CompletionsStreamToolCall] | None = None
 
 

--- a/src/lilbee/server/chat_completions_api/translate.py
+++ b/src/lilbee/server/chat_completions_api/translate.py
@@ -50,6 +50,7 @@ from lilbee.server.chat_dispatch.canonical import (
     ToolUseBlock,
     ToolUseDelta,
 )
+from lilbee.retrieval.reasoning import StreamToken, TagParser, split_reasoning
 from lilbee.server.chat_dispatch.tool_args import parse_tool_arguments
 
 _TOOL_CHOICE_MODES: dict[ToolChoiceMode, Literal["auto", "any", "none"]] = {
@@ -103,8 +104,10 @@ def canonical_to_completions_response(
     """Translate a canonical chat response to the OpenAI ``chat.completion`` model."""
     text_parts = [b.text for b in resp.content if isinstance(b, TextBlock)]
     tool_calls = [_response_tool_call(b) for b in resp.content if isinstance(b, ToolUseBlock)]
-    joined = "".join(text_parts)
-    content: str | None = joined if joined or not tool_calls else None
+    # lilbee carries a reasoning model's thinking inline as <think>...</think>; the
+    # OpenAI surface reports it in its own field so agents render a clean answer.
+    reasoning, answer = split_reasoning("".join(text_parts))
+    content: str | None = answer if answer or not tool_calls else None
 
     total = resp.usage.input_tokens + resp.usage.output_tokens
     return CompletionsResponse(
@@ -116,6 +119,7 @@ def canonical_to_completions_response(
                 index=0,
                 message=CompletionsResponseMessage(
                     content=content,
+                    reasoning_content=reasoning or None,
                     tool_calls=tool_calls or None,
                 ),
                 finish_reason=_STOP_REASON_TO_FINISH[resp.stop_reason],
@@ -136,6 +140,9 @@ class _StreamMapper:
         self._role_emitted = False
         self._tool_index_for_block: dict[int, int] = {}
         self._next_tool_index = 0
+        # Splits lilbee's inline <think> text into its own delta field. Stateful
+        # because a tag can arrive split across deltas.
+        self._reasoning = TagParser(show=True)
 
     def block_start(self, event: ContentBlockStart) -> CompletionsStreamDelta | None:
         # The first delta must carry role:assistant for OpenAI-SDK accumulation,
@@ -158,13 +165,29 @@ class _StreamMapper:
 
     def block_delta(self, event: ContentBlockDelta) -> CompletionsStreamDelta | None:
         if isinstance(event.delta, TextDelta):
-            return CompletionsStreamDelta(content=event.delta.text)
+            return self._text_delta(self._reasoning.feed(event.delta.text))
         if isinstance(event.delta, ToolUseDelta):
             tool_index = self._tool_index_for_block[event.index]
             return CompletionsStreamDelta(
                 tool_calls=[_tool_call_args(tool_index, event.delta.partial_json)],
             )
         return None
+
+    def block_stop(self) -> CompletionsStreamDelta | None:
+        """Emit whatever the reasoning splitter still holds (a partial or unclosed tag)."""
+        remaining = self._reasoning.flush()
+        return self._text_delta([remaining] if remaining else [])
+
+    def _text_delta(self, tokens: list[StreamToken]) -> CompletionsStreamDelta | None:
+        """One delta carrying the reasoning and answer text split out of *tokens*."""
+        reasoning = "".join(t.content for t in tokens if t.is_reasoning)
+        answer = "".join(t.content for t in tokens if not t.is_reasoning)
+        if not reasoning and not answer:
+            return None
+        return CompletionsStreamDelta(
+            content=answer or None,
+            reasoning_content=reasoning or None,
+        )
 
 
 def _tool_call_open(index: int, call_id: str, name: str) -> CompletionsStreamToolCall:
@@ -224,12 +247,17 @@ async def canonical_stream_to_completions_chunks(
                 # hang because the provider streamed no usage frame.
                 usage = event.usage or CanonicalUsage(input_tokens=0, output_tokens=0)
                 yield _usage_chunk(model, response_id, usage)
-        elif isinstance(event, MessageStart | ContentBlockStop | MessageStop):
+        elif isinstance(event, ContentBlockStop):
+            # Closing a text block flushes any text the reasoning splitter still
+            # buffers (an unclosed <think>, or a tag that never completed).
+            delta = mapper.block_stop()
+            if delta is not None:
+                yield _chunk(model, response_id, delta)
+        elif isinstance(event, MessageStart | MessageStop):
             # OpenAI's wire format has no equivalent for these canonical events:
             # MessageStart carries metadata we already encoded in the chunk header,
-            # ContentBlockStop is implicit (the next block opens), and MessageStop
-            # is replaced by the final chunk's finish_reason. Explicit branch so
-            # a new event type added later forces a translation decision.
+            # and MessageStop is replaced by the final chunk's finish_reason.
+            # Explicit branch so a new event type added later forces a decision.
             continue
 
 

--- a/src/lilbee/server/chat_completions_api/translate.py
+++ b/src/lilbee/server/chat_completions_api/translate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import AsyncIterator
-from typing import Literal
+from typing import Literal, assert_never
 
 from lilbee.retrieval.reasoning import StreamToken, TagParser, split_reasoning
 from lilbee.server.chat_completions_api.models import (
@@ -256,10 +256,9 @@ def _chunks_for_event(
     if isinstance(event, MessageStart | MessageStop):
         # OpenAI's wire format has no equivalent: MessageStart carries metadata
         # already encoded in the chunk header, and MessageStop is replaced by the
-        # final chunk's finish_reason. Explicit branch so a new event type added
-        # later forces a translation decision.
+        # final chunk's finish_reason.
         return []
-    return []
+    assert_never(event)  # a new canonical event must choose its translation
 
 
 def _message_delta_chunks(

--- a/src/lilbee/server/chat_completions_api/translate.py
+++ b/src/lilbee/server/chat_completions_api/translate.py
@@ -258,7 +258,9 @@ def _chunks_for_event(
         # already encoded in the chunk header, and MessageStop is replaced by the
         # final chunk's finish_reason.
         return []
-    assert_never(event)  # a new canonical event must choose its translation
+    # Unreachable: the branches above exhaust CanonicalStreamEvent. This makes a new
+    # event type a type error rather than a silently dropped frame.
+    assert_never(event)  # pragma: no cover
 
 
 def _message_delta_chunks(

--- a/src/lilbee/server/chat_completions_api/translate.py
+++ b/src/lilbee/server/chat_completions_api/translate.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import AsyncIterator
 from typing import Literal
 
+from lilbee.retrieval.reasoning import StreamToken, TagParser, split_reasoning
 from lilbee.server.chat_completions_api.models import (
     CompletionsImageContent,
     CompletionsMessage,
@@ -50,7 +51,6 @@ from lilbee.server.chat_dispatch.canonical import (
     ToolUseBlock,
     ToolUseDelta,
 )
-from lilbee.retrieval.reasoning import StreamToken, TagParser, split_reasoning
 from lilbee.server.chat_dispatch.tool_args import parse_tool_arguments
 
 _TOOL_CHOICE_MODES: dict[ToolChoiceMode, Literal["auto", "any", "none"]] = {
@@ -226,39 +226,65 @@ async def canonical_stream_to_completions_chunks(
     """
     mapper = _StreamMapper()
     async for event in events:
-        if isinstance(event, ContentBlockStart):
-            delta = mapper.block_start(event)
-            if delta is not None:
-                yield _chunk(model, response_id, delta)
-        elif isinstance(event, ContentBlockDelta):
-            delta = mapper.block_delta(event)
-            if delta is not None:
-                yield _chunk(model, response_id, delta)
-        elif isinstance(event, MessageDelta):
-            yield _chunk(
-                model,
-                response_id,
-                CompletionsStreamDelta(),
-                finish_reason=_finish_reason_for(event),
-            )
-            if include_usage:
-                # OpenAI's contract sends the usage-only chunk unconditionally
-                # when include_usage is set; a client blocking on it must not
-                # hang because the provider streamed no usage frame.
-                usage = event.usage or CanonicalUsage(input_tokens=0, output_tokens=0)
-                yield _usage_chunk(model, response_id, usage)
-        elif isinstance(event, ContentBlockStop):
-            # Closing a text block flushes any text the reasoning splitter still
-            # buffers (an unclosed <think>, or a tag that never completed).
-            delta = mapper.block_stop()
-            if delta is not None:
-                yield _chunk(model, response_id, delta)
-        elif isinstance(event, MessageStart | MessageStop):
-            # OpenAI's wire format has no equivalent for these canonical events:
-            # MessageStart carries metadata we already encoded in the chunk header,
-            # and MessageStop is replaced by the final chunk's finish_reason.
-            # Explicit branch so a new event type added later forces a decision.
-            continue
+        for chunk in _chunks_for_event(
+            event, mapper, model=model, response_id=response_id, include_usage=include_usage
+        ):
+            yield chunk
+
+
+def _chunks_for_event(
+    event: CanonicalStreamEvent,
+    mapper: _StreamMapper,
+    *,
+    model: str,
+    response_id: str,
+    include_usage: bool,
+) -> list[CompletionsStreamChunk]:
+    """The OpenAI chunks one canonical event translates to; empty for a no-op event."""
+    if isinstance(event, ContentBlockStart):
+        return _maybe_chunk(model, response_id, mapper.block_start(event))
+    if isinstance(event, ContentBlockDelta):
+        return _maybe_chunk(model, response_id, mapper.block_delta(event))
+    if isinstance(event, ContentBlockStop):
+        # Closing a text block flushes any text the reasoning splitter still
+        # buffers (an unclosed <think>, or a tag that never completed).
+        return _maybe_chunk(model, response_id, mapper.block_stop())
+    if isinstance(event, MessageDelta):
+        return _message_delta_chunks(
+            event, model=model, response_id=response_id, include_usage=include_usage
+        )
+    if isinstance(event, MessageStart | MessageStop):
+        # OpenAI's wire format has no equivalent: MessageStart carries metadata
+        # already encoded in the chunk header, and MessageStop is replaced by the
+        # final chunk's finish_reason. Explicit branch so a new event type added
+        # later forces a translation decision.
+        return []
+    return []
+
+
+def _message_delta_chunks(
+    event: MessageDelta, *, model: str, response_id: str, include_usage: bool
+) -> list[CompletionsStreamChunk]:
+    """The finish chunk, plus the usage-only chunk when the client asked for it."""
+    chunks = [
+        _chunk(
+            model, response_id, CompletionsStreamDelta(), finish_reason=_finish_reason_for(event)
+        )
+    ]
+    if include_usage:
+        # OpenAI's contract sends the usage-only chunk unconditionally when
+        # include_usage is set; a client blocking on it must not hang because the
+        # provider streamed no usage frame.
+        usage = event.usage or CanonicalUsage(input_tokens=0, output_tokens=0)
+        chunks.append(_usage_chunk(model, response_id, usage))
+    return chunks
+
+
+def _maybe_chunk(
+    model: str, response_id: str, delta: CompletionsStreamDelta | None
+) -> list[CompletionsStreamChunk]:
+    """Wrap a delta in a chunk, or nothing when the event produced no delta."""
+    return [] if delta is None else [_chunk(model, response_id, delta)]
 
 
 def _chunk(

--- a/src/lilbee/server/handlers/__init__.py
+++ b/src/lilbee/server/handlers/__init__.py
@@ -97,8 +97,9 @@ def _chat_status(provider: LLMProvider) -> Literal["ready", "loading", "not_star
     """Classify the chat engine's readiness for /api/health.
 
     ``ready`` once the role serves; ``error`` when warm-up failed; ``loading``
-    while a warm is in flight; ``not_started`` when nothing is warming and the
-    role isn't up (no chat model planned, so the fleet won't come up on its own).
+    while a warm is in flight; ``not_started`` when nothing is warming and the role
+    isn't up (no chat model planned, or chat is swapped out for its co-tenant; the
+    next chat request loads it).
     """
     if provider.role_ready(WorkerRole.CHAT):
         return "ready"

--- a/src/lilbee/server/models.py
+++ b/src/lilbee/server/models.py
@@ -614,6 +614,7 @@ class PlacementResponse(BaseModel):
     manual: bool
     spec_json: str | None
     skipped_not_installed: list[SkippedRoleResponse] = []
+    co_tenants: list[str] = []
 
     @classmethod
     def from_view(cls, view: PlacementView) -> PlacementResponse:
@@ -636,6 +637,7 @@ class PlacementResponse(BaseModel):
             skipped_not_installed=[
                 SkippedRoleResponse(role=s.role, model=s.model) for s in view.skipped_not_installed
             ],
+            co_tenants=[r.value for r in view.co_tenants],
         )
 
 

--- a/tests/cli/test_placement_cli.py
+++ b/tests/cli/test_placement_cli.py
@@ -166,6 +166,24 @@ def test_show_unplaceable_role(monkeypatch: object) -> None:
     assert "embed" in result.stdout
 
 
+def test_show_reports_co_tenant_roles(monkeypatch: object) -> None:
+    """Co-tenants are placed but never co-resident, so the card they name is not
+    over-committed; show says so instead of listing two roles on one GPU."""
+    view = PlacementView(
+        gpus=(GpuInfo(0, "CUDA", "CUDA0", "A100", 80 * _GIB, 72 * _GIB),),
+        roles=(),
+        unplaceable=(),
+        manual=False,
+        spec_json=None,
+        co_tenants=(WorkerRole.CHAT, WorkerRole.VISION),
+    )
+    monkeypatch.setattr(cli_placement, "get_placement", lambda: view)
+    result = runner.invoke(placement_app, ["show"])
+    assert result.exit_code == 0
+    assert "chat, vision" in result.stdout
+    assert "one loaded at a time" in result.stdout
+
+
 def test_preview_with_spec_file(tmp_path: object, monkeypatch: object) -> None:
     """preview --spec FILE parses the JSON and passes PlacementSpec to preview_placement."""
     seen: dict[str, object] = {}

--- a/tests/server/chat_completions_api/test_translate.py
+++ b/tests/server/chat_completions_api/test_translate.py
@@ -11,6 +11,7 @@ from lilbee.server.chat_completions_api.models import (
     CompletionsRequest,
     CompletionsResponse,
     CompletionsStreamChunk,
+    CompletionsStreamDelta,
 )
 from lilbee.server.chat_completions_api.translate import (
     canonical_stream_to_completions_chunks,
@@ -697,6 +698,84 @@ async def _drain(
 async def _async_iter(items: list[CanonicalStreamEvent]) -> AsyncIterator[CanonicalStreamEvent]:
     for item in items:
         yield item
+
+
+class TestReasoningLeavesContentClean:
+    """Reasoning models wrap thinking in <think>; agents on /v1 must never see it."""
+
+    def _resp(self, text: str) -> CanonicalResponse:
+        return CanonicalResponse(
+            id="msg_abc",
+            model="m",
+            content=[TextBlock(text=text)],
+            stop_reason=StopReason.END_TURN,
+            usage=CanonicalUsage(input_tokens=0, output_tokens=0),
+        )
+
+    def test_think_block_moves_to_reasoning_content(self) -> None:
+        body = canonical_to_completions_response(
+            self._resp("<think>weighing options</think>The answer is 4."),
+            response_id=_RESPONSE_ID,
+        )
+        message = body.choices[0].message
+        assert message.content == "The answer is 4."
+        assert message.reasoning_content == "weighing options"
+
+    def test_plain_answer_has_no_reasoning_content(self) -> None:
+        body = canonical_to_completions_response(
+            self._resp("just an answer"), response_id=_RESPONSE_ID
+        )
+        message = body.choices[0].message
+        assert message.content == "just an answer"
+        assert message.reasoning_content is None
+
+    def test_unterminated_think_block_is_all_reasoning(self) -> None:
+        # A model that spends its whole budget thinking must not dump the raw tag.
+        body = canonical_to_completions_response(
+            self._resp("<think>still thinking"), response_id=_RESPONSE_ID
+        )
+        message = body.choices[0].message
+        assert message.reasoning_content == "still thinking"
+        assert not message.content
+
+
+class TestReasoningStreamSplitsDeltas:
+    async def _deltas(self, texts: list[str]) -> list[CompletionsStreamDelta]:
+        events: list[CanonicalStreamEvent] = [
+            MessageStart(id="msg_x", model="m"),
+            ContentBlockStart(index=0, block=TextBlock(text="")),
+            *[ContentBlockDelta(index=0, delta=TextDelta(text=t)) for t in texts],
+            ContentBlockStop(index=0),
+            MessageDelta(stop_reason=StopReason.END_TURN),
+            MessageStop(),
+        ]
+        chunks = await _drain(
+            canonical_stream_to_completions_chunks(
+                _async_iter(events), model="m", response_id="msg_x"
+            )
+        )
+        return [c.choices[0].delta for c in chunks if c.choices]
+
+    async def test_streamed_think_tokens_go_to_reasoning_content(self) -> None:
+        deltas = await self._deltas(["<think>", "why", "</think>", "hi"])
+        content = "".join(d.content or "" for d in deltas)
+        reasoning = "".join(d.reasoning_content or "" for d in deltas)
+        assert content == "hi"
+        assert reasoning == "why"
+
+    async def test_think_tag_split_across_deltas_is_not_leaked(self) -> None:
+        # The open tag arrives in pieces; a naive per-delta check would emit "<thi".
+        deltas = await self._deltas(["<thi", "nk>", "hm", "</th", "ink>", "done"])
+        content = "".join(d.content or "" for d in deltas)
+        reasoning = "".join(d.reasoning_content or "" for d in deltas)
+        assert content == "done"
+        assert reasoning == "hm"
+        assert "<think" not in content
+
+    async def test_stream_without_reasoning_is_unchanged(self) -> None:
+        deltas = await self._deltas(["he", "llo"])
+        assert "".join(d.content or "" for d in deltas) == "hello"
+        assert all(d.reasoning_content is None for d in deltas)
 
 
 class TestCanonicalStreamToCompletionsChunks:

--- a/tests/test_cli_cold_start.py
+++ b/tests/test_cli_cold_start.py
@@ -41,7 +41,8 @@ def test_announce_cold_start_silent_in_json_mode(monkeypatch) -> None:
     services.provider.role_ready.assert_not_called()
 
 
-def test_announce_ready_prints_through_returned_console() -> None:
+def test_announce_ready_prints_through_returned_console(monkeypatch) -> None:
+    monkeypatch.setattr("lilbee.app.services.get_services", lambda: _services_with_role_ready(True))
     err = mock.MagicMock()
     helpers.announce_ready(err, WorkerRole.CHAT)
     assert err.print.call_count == 1
@@ -51,3 +52,17 @@ def test_announce_ready_prints_through_returned_console() -> None:
 def test_announce_ready_noop_when_no_console() -> None:
     # When cold-start was never announced (role warm), announce_ready is a no-op.
     helpers.announce_ready(None, WorkerRole.CHAT)  # must not raise
+
+
+def test_announce_ready_does_not_claim_ready_when_the_model_never_loaded(monkeypatch) -> None:
+    # A chat model whose llama-server died on load leaves the role not ready. The RAG
+    # path can still stream a grounded refusal, so a token arriving is not evidence the
+    # engine came up: announcing "ready" there is how a load failure got masked.
+    monkeypatch.setattr(
+        "lilbee.app.services.get_services", lambda: _services_with_role_ready(False)
+    )
+    err = mock.MagicMock()
+    helpers.announce_ready(err, WorkerRole.CHAT)
+    printed = " ".join(str(call.args[0]) for call in err.print.call_args_list).lower()
+    assert "ready" not in printed
+    assert "did not load" in printed

--- a/tests/test_cli_cold_start.py
+++ b/tests/test_cli_cold_start.py
@@ -8,6 +8,7 @@ from rich.console import Console
 
 from lilbee.cli import helpers
 from lilbee.providers.roles import WorkerRole
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 
 
 def _services_with_role_ready(ready: bool) -> mock.MagicMock:
@@ -41,8 +42,14 @@ def test_announce_cold_start_silent_in_json_mode(monkeypatch) -> None:
     services.provider.role_ready.assert_not_called()
 
 
+def _services_with_warm(snapshot: object) -> mock.MagicMock:
+    services = mock.MagicMock()
+    services.provider.warm_progress.return_value = snapshot
+    return services
+
+
 def test_announce_ready_prints_through_returned_console(monkeypatch) -> None:
-    monkeypatch.setattr("lilbee.app.services.get_services", lambda: _services_with_role_ready(True))
+    monkeypatch.setattr("lilbee.app.services.get_services", lambda: _services_with_warm(None))
     err = mock.MagicMock()
     helpers.announce_ready(err, WorkerRole.CHAT)
     assert err.print.call_count == 1
@@ -54,15 +61,36 @@ def test_announce_ready_noop_when_no_console() -> None:
     helpers.announce_ready(None, WorkerRole.CHAT)  # must not raise
 
 
-def test_announce_ready_does_not_claim_ready_when_the_model_never_loaded(monkeypatch) -> None:
-    # A chat model whose llama-server died on load leaves the role not ready. The RAG
-    # path can still stream a grounded refusal, so a token arriving is not evidence the
-    # engine came up: announcing "ready" there is how a load failure got masked.
-    monkeypatch.setattr(
-        "lilbee.app.services.get_services", lambda: _services_with_role_ready(False)
-    )
+def test_announce_ready_reports_the_engines_reason_when_the_model_failed_to_load(
+    monkeypatch,
+) -> None:
+    # A chat model whose llama-server died on load must not be announced as ready. In
+    # RAG mode a grounded refusal still streams, so a token is not evidence of a load.
+    snapshot = WarmProgress(phase=WarmPhase.ERROR, error="unknown model architecture: qwen35moe")
+    monkeypatch.setattr("lilbee.app.services.get_services", lambda: _services_with_warm(snapshot))
     err = mock.MagicMock()
     helpers.announce_ready(err, WorkerRole.CHAT)
-    printed = " ".join(str(call.args[0]) for call in err.print.call_args_list).lower()
-    assert "ready" not in printed
-    assert "did not load" in printed
+    printed = " ".join(str(call.args[0]) for call in err.print.call_args_list)
+    assert "ready" not in printed.lower()
+    assert "unknown model architecture: qwen35moe" in printed
+
+
+def test_announce_ready_is_not_fooled_by_a_transient_not_running_probe(monkeypatch) -> None:
+    # llama-swap can report a freshly loaded model as not running. Readiness must not be
+    # re-probed here, or a healthy engine prints a spurious failure line.
+    services = _services_with_warm(WarmProgress(phase=WarmPhase.READY))
+    services.provider.role_ready.return_value = False
+    monkeypatch.setattr("lilbee.app.services.get_services", lambda: services)
+    err = mock.MagicMock()
+    helpers.announce_ready(err, WorkerRole.CHAT)
+    assert "ready" in err.print.call_args.args[0].lower()
+    services.provider.role_ready.assert_not_called()
+
+
+def test_announce_ready_for_a_non_chat_role_ignores_the_chat_warm_tracker(monkeypatch) -> None:
+    # The warm tracker only tracks chat; embed must not inherit a chat load failure.
+    snapshot = WarmProgress(phase=WarmPhase.ERROR, error="chat blew up")
+    monkeypatch.setattr("lilbee.app.services.get_services", lambda: _services_with_warm(snapshot))
+    err = mock.MagicMock()
+    helpers.announce_ready(err, WorkerRole.EMBED)
+    assert "ready" in err.print.call_args.args[0].lower()

--- a/tests/test_fleet_groups.py
+++ b/tests/test_fleet_groups.py
@@ -1,0 +1,34 @@
+"""Tests for swap-group identity and the role-to-group mapping."""
+
+from __future__ import annotations
+
+from lilbee.providers.fleet.groups import SwapGroup, group_for
+from lilbee.providers.roles import WorkerRole
+
+
+class TestSwapGroupPolicy:
+    def test_only_the_co_tenant_group_evicts_its_members(self) -> None:
+        assert SwapGroup.CO_TENANT.swaps is True
+        for group in (SwapGroup.CHAT, SwapGroup.EMBED, SwapGroup.RERANK, SwapGroup.VISION):
+            assert group.swaps is False
+
+    def test_every_role_has_a_group_of_its_own(self) -> None:
+        # group_for falls back to the role's own group, so the name must resolve.
+        for role in WorkerRole:
+            assert SwapGroup(role.value).value == role.value
+
+
+class TestGroupFor:
+    def test_a_role_outside_the_co_tenants_keeps_its_own_group(self) -> None:
+        co_tenants = frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+        assert group_for(WorkerRole.EMBED, co_tenants) is SwapGroup.EMBED
+        assert group_for(WorkerRole.RERANK, co_tenants) is SwapGroup.RERANK
+
+    def test_co_tenants_share_one_group(self) -> None:
+        co_tenants = frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+        assert group_for(WorkerRole.CHAT, co_tenants) is SwapGroup.CO_TENANT
+        assert group_for(WorkerRole.VISION, co_tenants) is SwapGroup.CO_TENANT
+
+    def test_no_co_tenancy_leaves_chat_and_vision_pinned_apart(self) -> None:
+        assert group_for(WorkerRole.CHAT, frozenset()) is SwapGroup.CHAT
+        assert group_for(WorkerRole.VISION, frozenset()) is SwapGroup.VISION

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -171,6 +171,21 @@ class TestPlanPlacement:
         assert plan.instances == ()
         assert plan.unplaceable_roles == (WorkerRole.CHAT,)
 
+    def test_unified_budget_marks_an_oversize_pinned_role_unplaceable(self) -> None:
+        # Chat is charged last through its own path, so the pinned tier needs its own
+        # oversize case: an embedder larger than free RAM gets no server either.
+        plan = plan_placement(
+            [
+                ModelPlacementInput(WorkerRole.CHAT, 2 * _GB),
+                ModelPlacementInput(WorkerRole.EMBED, 20 * _GB),
+            ],
+            [],
+            estimate_peak=_never,
+            unified_budget=11 * _GB,
+        )
+        assert plan.unplaceable_roles == (WorkerRole.EMBED,)
+        assert {i.role for i in plan.instances} == {WorkerRole.CHAT}
+
     def test_shared_pool_reserves_search_roles_before_chat(self) -> None:
         # Search-first: embed is reserved before the elastic chat, so a chat that
         # would consume the whole 12 GB pool is dropped instead of starving search

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -622,3 +622,18 @@ class TestSharedMemoryCoTenancy:
 
         assert plan.unplaceable_roles == ()
         assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+
+    def test_co_tenant_vision_drops_to_one_replica_in_shared_memory(self) -> None:
+        # The elastic vision replicas are refunded with the rest of vision's pool;
+        # a swap:true group would evict them anyway.
+        models = [
+            ModelPlacementInput(WorkerRole.CHAT, 18 * _GB),
+            ModelPlacementInput(WorkerRole.EMBED, 1 * _GB),
+            ModelPlacementInput(WorkerRole.VISION, 2 * _GB, replicas=3),
+        ]
+        plan = plan_placement(models, [], estimate_peak=_never, unified_budget=22 * _GB)
+
+        visions = [i for i in plan.instances if i.role is WorkerRole.VISION]
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+        assert [i.replica for i in visions] == [0]
+        assert WorkerRole.CHAT in {i.role for i in plan.instances}

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -225,26 +225,23 @@ class TestPerDeviceSplit:
         assert plan.instances[0].devices == (0, 1, 2)
 
     def test_charges_each_card_its_own_share(self) -> None:
-        # Chat splits with an uneven per-device charge (10 GiB, 5 GiB). A following
-        # single role that fits only the less-charged card proves the debit is
-        # per-device, not the proportional/summed charge the old planner applied.
-        # Vision (a non-search single) is placed after chat, so it exercises the
-        # post-chat fit; a search role would be placed first (bb-7jg1.6).
+        # Chat splits with an uneven per-device charge (20 GiB, 2 GiB). The elastic
+        # vision replica, placed after chat, fits only the less-charged card. A summed
+        # charge (22 GiB on both) would leave it nowhere to go.
         chat = ModelPlacementInput(WorkerRole.CHAT, 30 * _GB)
-        vision = ModelPlacementInput(WorkerRole.VISION, 12 * _GB)
+        vision = ModelPlacementInput(WorkerRole.VISION, 6 * _GB, replicas=2)
 
         def peak(_role: WorkerRole, _ratio: tuple[int, ...]) -> tuple[int, ...]:
-            return (10 * _GB, 5 * _GB)
+            return (20 * _GB, 2 * _GB)
 
         plan = plan_placement(
             [chat, vision],
             [(0, 24 * _GB), (1, 24 * _GB)],
             estimate_peak=peak,
         )
-        vision_inst = next(i for i in plan.instances if i.role is WorkerRole.VISION)
-        assert vision_inst.devices == (
-            1,
-        )  # card 1 (charged 5) has room; card 0 (charged 10) does not
+        elastic = next(i for i in plan.instances if i.role is WorkerRole.VISION and i.replica == 1)
+        assert elastic.devices == (0,)  # card 0 (charged 2) has room; card 1 (charged 20) does not
+        assert plan.co_tenants == frozenset()
 
     def test_unplaceable_when_per_device_never_fits(self) -> None:
         model = ModelPlacementInput(WorkerRole.CHAT, 40 * _GB)
@@ -525,3 +522,103 @@ class TestPersistentSingleElasticSplit:
         embeds = self._embeds(plan)
         assert len(embeds) == 1
         assert embeds[0].replica == 0
+
+
+class TestChatVisionCoTenancy:
+    """A chat model that crowds out vision makes the pair swap tenants, not unplaceable."""
+
+    def _search(self) -> list[ModelPlacementInput]:
+        return [
+            ModelPlacementInput(WorkerRole.EMBED, 1 * _GB),
+            ModelPlacementInput(WorkerRole.RERANK, 1 * _GB),
+        ]
+
+    def _roles(self, plan: Placement) -> set[WorkerRole]:
+        return {i.role for i in plan.instances}
+
+    def test_chat_giant_makes_vision_a_co_tenant_instead_of_unplaceable(self) -> None:
+        # One 24GB card (21.6 usable): embed+rerank pin 2GB, vision needs 4, chat 18.
+        # Chat alone leaves no room for vision, so the pair share a swap group.
+        models = [
+            ModelPlacementInput(WorkerRole.CHAT, 18 * _GB),
+            *self._search(),
+            ModelPlacementInput(WorkerRole.VISION, 4 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 24 * _GB)], estimate_peak=_never)
+
+        assert plan.unplaceable_roles == ()
+        assert self._roles(plan) == {
+            WorkerRole.CHAT,
+            WorkerRole.EMBED,
+            WorkerRole.RERANK,
+            WorkerRole.VISION,
+        }
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+
+    def test_chat_and_vision_that_both_fit_stay_pinned(self) -> None:
+        # An 80GB card holds everything at once: no swap group, no eviction.
+        models = [
+            ModelPlacementInput(WorkerRole.CHAT, 18 * _GB),
+            *self._search(),
+            ModelPlacementInput(WorkerRole.VISION, 4 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 80 * _GB)], estimate_peak=_never)
+
+        assert plan.unplaceable_roles == ()
+        assert plan.co_tenants == frozenset()
+
+    def test_vision_too_big_for_the_search_tier_is_still_unplaceable(self) -> None:
+        # Vision does not fit even before chat is charged: a real "use a smaller model".
+        models = [
+            ModelPlacementInput(WorkerRole.CHAT, 3 * _GB),
+            *self._search(),
+            ModelPlacementInput(WorkerRole.VISION, 6 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 8 * _GB)], estimate_peak=_never)
+
+        assert plan.unplaceable_roles == (WorkerRole.VISION,)
+        assert plan.co_tenants == frozenset()
+
+    def test_co_tenant_vision_runs_a_single_replica(self) -> None:
+        # swap:true evicts same-group siblings, so a second vision replica in the
+        # co-tenant group would evict the first. The planner must not emit one.
+        models = [
+            ModelPlacementInput(WorkerRole.CHAT, 18 * _GB),
+            *self._search(),
+            ModelPlacementInput(WorkerRole.VISION, 4 * _GB, replicas=2),
+        ]
+        plan = plan_placement(models, [(0, 24 * _GB)], estimate_peak=_never)
+
+        visions = [i for i in plan.instances if i.role is WorkerRole.VISION]
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+        assert len(visions) == 1
+        assert visions[0].replica == 0
+
+    def test_chat_that_fits_nowhere_is_unplaceable_and_vision_stays_pinned(self) -> None:
+        # Refunding vision still does not make room: chat is the genuinely oversize one.
+        models = [
+            ModelPlacementInput(WorkerRole.CHAT, 200 * _GB),
+            *self._search(),
+            ModelPlacementInput(WorkerRole.VISION, 4 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 24 * _GB)], estimate_peak=_never)
+
+        assert plan.unplaceable_roles == (WorkerRole.CHAT,)
+        assert plan.co_tenants == frozenset()
+        assert WorkerRole.VISION in self._roles(plan)
+
+
+class TestSharedMemoryCoTenancy:
+    """The unified-memory path reaches the same verdict as the discrete-GPU path."""
+
+    def test_chat_giant_co_tenants_with_vision_in_shared_memory(self) -> None:
+        models = [
+            ModelPlacementInput(WorkerRole.CHAT, 18 * _GB),
+            ModelPlacementInput(WorkerRole.EMBED, 1 * _GB),
+            ModelPlacementInput(WorkerRole.RERANK, 1 * _GB),
+            ModelPlacementInput(WorkerRole.VISION, 4 * _GB),
+        ]
+        plan = plan_placement(models, [], estimate_peak=_never, unified_budget=22 * _GB)
+
+        assert plan.unplaceable_roles == ()
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1203,7 +1203,7 @@ class TestBuildFleetWiring:
         )
         sentinel = MagicMock()
         monkeypatch.setattr(planning_mod, "_launch_for", lambda *a, **kw: sentinel)
-        assert planning_mod.plan_all_launches() == [sentinel]
+        assert planning_mod.plan_all_launches() == planning_mod.FleetPlan((sentinel,))
 
     def test_plan_all_launches_falls_back_to_vulkan_probe(self, monkeypatch) -> None:
         monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -980,6 +980,24 @@ class TestBuildFleetWiring:
         # Chat is excluded (it sizes its own weights); two embed replicas stack on card 0.
         assert reserved == {0: 6 * _GB, 1: 2 * _GB}
 
+    def test_non_chat_reservation_excludes_chats_co_tenants(self) -> None:
+        # A co-tenant vision is evicted while chat is resident, so its VRAM must not
+        # be held back from the chat shard's KV; only the pinned embed is reserved.
+        instances = [
+            InstancePlan(role=WorkerRole.CHAT, devices=(0,)),
+            InstancePlan(role=WorkerRole.VISION, devices=(0,)),
+            InstancePlan(role=WorkerRole.EMBED, devices=(0,)),
+        ]
+        inputs = [
+            ModelPlacementInput(WorkerRole.CHAT, 40 * _GB),
+            ModelPlacementInput(WorkerRole.VISION, 6 * _GB),
+            ModelPlacementInput(WorkerRole.EMBED, 3 * _GB),
+        ]
+        reserved = planning_mod._non_chat_reservation(
+            instances, inputs, frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+        )
+        assert reserved == {0: 3 * _GB}
+
     def test_launch_for_pinned_multi_card_chat_runs_one_slot(self, tmp_path, monkeypatch) -> None:
         # A cfg.num_ctx pin skips the fit, but a multi-card chat still serves one slot
         # so --ctx-size matches the single-sequence footprint the planner reserved.

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1223,6 +1223,42 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(planning_mod, "_launch_for", lambda *a, **kw: sentinel)
         assert planning_mod.plan_all_launches() == planning_mod.FleetPlan((sentinel,))
 
+    def test_plan_launches_reports_co_tenant_roles(self, monkeypatch, caplog) -> None:
+        # Co-tenancy changes how the box behaves (one model resident at a time), so it
+        # is stated in the log rather than being inferred from a silent plan.
+        import logging
+
+        device = FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB)
+        monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))
+        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [device])
+        monkeypatch.setattr(
+            planning_mod,
+            "_server_model_inputs",
+            lambda *_roles, **_kw: (
+                [ModelPlacementInput(WorkerRole.CHAT, 5 * _GB)],
+                {WorkerRole.CHAT: "ref", WorkerRole.VISION: "vref"},
+                0,
+                {},
+            ),
+        )
+        monkeypatch.setattr(
+            planning_mod,
+            "plan_placement",
+            lambda inputs, devices, *, estimate_peak, unified_budget=None, **_kw: Placement(
+                instances=(InstancePlan(WorkerRole.CHAT, (0,)),),
+                unplaceable_roles=(),
+                co_tenants=frozenset({WorkerRole.CHAT, WorkerRole.VISION}),
+            ),
+        )
+        monkeypatch.setattr(planning_mod, "_launch_for", lambda *a, **kw: MagicMock())
+
+        with caplog.at_level(logging.INFO):
+            plan = planning_mod.plan_all_launches()
+
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+        assert "chat, vision" in caplog.text
+        assert "only one is resident" in caplog.text
+
     def test_plan_all_launches_falls_back_to_vulkan_probe(self, monkeypatch) -> None:
         monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))
         monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [])  # can't enumerate

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -14,6 +14,7 @@ import pytest
 from lilbee.core.config import cfg
 from lilbee.providers.fleet import planning as planning_mod
 from lilbee.providers.fleet import provider as prov_mod
+from lilbee.providers.fleet.groups import SwapGroup
 from lilbee.providers.fleet.provider import FleetProvider, _least_in_flight
 from lilbee.providers.roles import RerankMode, WorkerRole
 
@@ -97,7 +98,9 @@ def _install_engine(monkeypatch, *, launches: list, swap: _FakeSwap | None = Non
     monkeypatch.setattr(
         prov_mod, "LlamaServerClient", lambda _endpoint, _model, **_kw: _fake_client()
     )
-    monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: launches)
+    monkeypatch.setattr(
+        planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan(tuple(launches))
+    )
     return swap
 
 
@@ -105,7 +108,9 @@ def _provider_with_clients(clients: dict[WorkerRole, list[MagicMock]]) -> FleetP
     """A provider with a fake swap already up and a client pool per role (no real start)."""
     p = FleetProvider()
     # Non-empty so _ensure_fleet short-circuits; roles without clients still error.
-    p._swaps = {role: _FakeSwap() for role in clients} or {WorkerRole.CHAT: _FakeSwap()}
+    roles = list(clients) or [WorkerRole.CHAT]
+    p._role_group = {role: SwapGroup(role.value) for role in roles}
+    p._swaps = {SwapGroup(role.value): _FakeSwap() for role in roles}
     p._clients = {role: list(cs) for role, cs in clients.items() if cs}
     return p
 
@@ -173,7 +178,7 @@ def test_embed_routes_to_least_busy_replica() -> None:
     busy.embed.assert_not_called()
 
 
-def test_adopt_role_builds_a_client_per_replica(monkeypatch) -> None:
+def test_adopt_group_builds_a_client_per_replica(monkeypatch) -> None:
     launches = [_fake_launch(WorkerRole.EMBED), _fake_launch(WorkerRole.EMBED)]
     _install_engine(monkeypatch, launches=launches)
     p = FleetProvider()
@@ -192,7 +197,7 @@ def test_ensure_fleet_refused_after_shutdown(monkeypatch) -> None:
     assert swap.started == []  # no swap started after shutdown
 
 
-def test_adopt_role_retires_old_clients_without_closing(monkeypatch) -> None:
+def test_adopt_group_retires_old_clients_without_closing(monkeypatch) -> None:
     # Re-adopting (a reload) must not close old clients in place (a
     # reader may still hold one); they are retired for deferred close.
     launch = _fake_launch(WorkerRole.EMBED)
@@ -202,7 +207,7 @@ def test_adopt_role_retires_old_clients_without_closing(monkeypatch) -> None:
     p._clients = {WorkerRole.EMBED: old}
 
     with p._lock:
-        p._adopt_role(WorkerRole.EMBED, swap, [launch])
+        p._adopt_group(SwapGroup.EMBED, swap, [launch])
 
     assert p._retiring_clients == old  # retired, not closed yet
     for client in old:
@@ -252,7 +257,7 @@ def test_drop_swap_refs_closes_retiring_clients() -> None:
     assert p._retiring_clients == []
 
 
-def test_adopt_role_threads_rerank_mode(monkeypatch) -> None:
+def test_adopt_group_threads_rerank_mode(monkeypatch) -> None:
     launch = _fake_launch(WorkerRole.RERANK)
     launch.rerank_mode = RerankMode.LLM
     captured: dict[str, object] = {}
@@ -263,7 +268,9 @@ def test_adopt_role_threads_rerank_mode(monkeypatch) -> None:
 
     monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir, _group: _FakeSwap())
     monkeypatch.setattr(prov_mod, "LlamaServerClient", _capture)
-    monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [launch])
+    monkeypatch.setattr(
+        planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan((launch,))
+    )
     FleetProvider()._ensure_fleet()
     assert captured["rerank_mode"] is RerankMode.LLM
 
@@ -490,7 +497,8 @@ def test_vision_pool_pairs_each_replica_with_its_fitted_slots(monkeypatch) -> No
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 16)
     first_client, second_client = _fake_client(), _fake_client()
     p = _provider_with_clients({WorkerRole.VISION: [first_client, second_client]})
-    p._launches[WorkerRole.VISION] = (
+    p._role_group[WorkerRole.VISION] = SwapGroup.VISION
+    p._launches[SwapGroup.VISION] = (
         _fake_launch(WorkerRole.VISION, slots=3),
         _fake_launch(WorkerRole.VISION, slots=2, replica=1),
     )
@@ -514,14 +522,16 @@ def test_vision_pool_falls_back_on_launch_client_mismatch(monkeypatch) -> None:
     monkeypatch.setattr(cfg, "vision_ocr_concurrency", 4)
     clients = [_fake_client(), _fake_client()]
     p = _provider_with_clients({WorkerRole.VISION: clients})
-    p._launches[WorkerRole.VISION] = (_fake_launch(WorkerRole.VISION, slots=3),)
+    p._role_group[WorkerRole.VISION] = SwapGroup.VISION
+    p._launches[SwapGroup.VISION] = (_fake_launch(WorkerRole.VISION, slots=3),)
     assert [replica.slots for replica in p._vision_pool()] == [4, 4]
 
 
 def test_vision_slot_capacity_sums_fitted_launch_slots() -> None:
     # The ingest fan-out sizes to this: the sum of the running servers' fitted slots.
     p = _provider_with_clients({WorkerRole.VISION: [_fake_client(), _fake_client()]})
-    p._launches[WorkerRole.VISION] = (
+    p._role_group[WorkerRole.VISION] = SwapGroup.VISION
+    p._launches[SwapGroup.VISION] = (
         _fake_launch(WorkerRole.VISION, slots=3),
         _fake_launch(WorkerRole.VISION, slots=2, replica=1),
     )
@@ -1045,9 +1055,9 @@ class _OrderedReapSwap(_FakeSwap):
 def _ordered_planner(order: list[str], launches: list) -> object:
     """A plan_all_launches stand-in appending to the shared order log."""
 
-    def _plan() -> list:
+    def _plan() -> planning_mod.FleetPlan:
         order.append("plan")
-        return launches
+        return planning_mod.FleetPlan(tuple(launches))
 
     return _plan
 
@@ -1076,7 +1086,8 @@ def test_reload_pass_reaps_stale_swaps_before_planning(monkeypatch) -> None:
         planning_mod, "plan_all_launches", _ordered_planner(order, [_fake_launch(WorkerRole.CHAT)])
     )
     p = FleetProvider()
-    p._swaps = {WorkerRole.CHAT: swap}
+    p._swaps = {SwapGroup.CHAT: swap}
+    p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
     p._reload_pass()
     assert order == ["reap", "plan"]
 
@@ -1117,7 +1128,9 @@ def test_ensure_fleet_returns_none_when_engine_binary_unavailable(monkeypatch) -
 def _captured_client_kwargs(monkeypatch, launch) -> dict:
     """Build the engine around *launch* and return the client constructor kwargs."""
     monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _FakeSwap())
-    monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [launch])
+    monkeypatch.setattr(
+        planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan((launch,))
+    )
     captured: list[dict] = []
 
     def _capture(_endpoint, _model, **kwargs):
@@ -1176,7 +1189,11 @@ def test_chat_starts_swap_on_first_use(monkeypatch) -> None:
     swap = _FakeSwap()
     monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: swap)
     monkeypatch.setattr(prov_mod, "LlamaServerClient", _make_client)
-    monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [_fake_launch(WorkerRole.CHAT)])
+    monkeypatch.setattr(
+        planning_mod,
+        "plan_all_launches",
+        lambda: planning_mod.FleetPlan((_fake_launch(WorkerRole.CHAT),)),
+    )
     p = FleetProvider()
     assert p.chat([{"role": "user", "content": "hi"}]).text == "ok"
     assert len(swap.started) == 1  # routing the first chat started the swap
@@ -1200,7 +1217,11 @@ def test_concurrent_first_requests_start_swap_once(monkeypatch) -> None:
         return client
 
     monkeypatch.setattr(prov_mod, "LlamaServerClient", _make_client)
-    monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [_fake_launch(WorkerRole.CHAT)])
+    monkeypatch.setattr(
+        planning_mod,
+        "plan_all_launches",
+        lambda: planning_mod.FleetPlan((_fake_launch(WorkerRole.CHAT),)),
+    )
     p = FleetProvider()
     barrier = threading.Barrier(8)
 
@@ -1322,7 +1343,8 @@ def test_warm_up_pool_noop_when_swap_already_up(monkeypatch) -> None:
     swap = _install_engine(monkeypatch, launches=[])
     monkeypatch.setattr(swap, "start", lambda launches: starts.__setitem__("n", starts["n"] + 1))
     p = FleetProvider()
-    p._swaps = {WorkerRole.CHAT: _FakeSwap()}  # already up
+    p._swaps = {SwapGroup.CHAT: _FakeSwap()}  # already up
+    p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
     p.warm_up_pool()
     assert starts["n"] == 0  # no start dispatched
 
@@ -1482,7 +1504,8 @@ def test_role_ready_reflects_swap_running_state() -> None:
     p = FleetProvider()
     swap = _FakeSwap()
     swap.ready = {WorkerRole.CHAT}
-    p._swaps = {WorkerRole.CHAT: swap}
+    p._swaps = {SwapGroup.CHAT: swap}
+    p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
     assert p.role_ready(WorkerRole.CHAT) is True
     assert p.role_ready(WorkerRole.EMBED) is False
 
@@ -1650,21 +1673,25 @@ class TestLifecycleMethods:
     def test_reload_role_dispatches_background_restart(self) -> None:
         done = threading.Event()
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}  # non-None so reload dispatches
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}  # non-None so reload dispatches
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reload_blocking = lambda: done.set()  # type: ignore[method-assign]
         p.reload_role(WorkerRole.EMBED)
         assert done.wait(timeout=2.0)  # the spawned thread ran the blocking restart
 
     def test_reload_blocking_restarts_swap_and_readopts(self, monkeypatch) -> None:
         launches = [_fake_launch(WorkerRole.CHAT, slots=2, ctx=4096)]
-        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: launches)
+        monkeypatch.setattr(
+            planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan(tuple(launches))
+        )
         monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
         fresh = _FakeSwap()
         monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: fresh)
         monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
         p = FleetProvider()
         stale = _FakeSwap()
-        p._swaps = {WorkerRole.CHAT: stale}
+        p._swaps = {SwapGroup.CHAT: stale}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reload_blocking()
         # The chat launches changed (old running set unknown -> differs), so the
         # old group was stopped and a fresh one started and adopted.
@@ -1675,7 +1702,7 @@ class TestLifecycleMethods:
         assert set(p._clients) == {WorkerRole.CHAT}
 
     def test_reload_blocking_noop_when_swap_cleared(self, monkeypatch) -> None:
-        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [])
+        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan(()))
         p = FleetProvider()  # _swap stays None
         p._reload_blocking()  # must not raise
 
@@ -1683,7 +1710,8 @@ class TestLifecycleMethods:
         spawned = {"thread": False}
         monkeypatch.setattr("threading.Thread", lambda *a, **k: spawned.__setitem__("thread", True))
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         ran = {"blocking": False}
         p._reload_blocking = lambda: ran.__setitem__("blocking", True)  # type: ignore[method-assign]
         p.reload_role(WorkerRole.CHAT, wait=True)
@@ -1692,7 +1720,8 @@ class TestLifecycleMethods:
 
     def test_reload_role_wait_propagates_failure(self) -> None:
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
 
         def boom() -> None:
             raise RuntimeError("reload failed")
@@ -1703,7 +1732,8 @@ class TestLifecycleMethods:
 
     def test_reload_role_wait_blocks_until_in_flight_done(self) -> None:
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         with p._lock:
             p._reloading = True  # simulate a reload already in flight
         returned = threading.Event()
@@ -1776,7 +1806,8 @@ class TestChatCapacityAndCtxGetters:
 
     def test_max_concurrent_chats_reads_chat_slots_when_up(self) -> None:
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._chat_slots = 4
         assert p.max_concurrent_chats() == 4
 
@@ -1785,7 +1816,8 @@ class TestChatCapacityAndCtxGetters:
 
     def test_served_chat_ctx_reads_chat_ctx_when_up(self) -> None:
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._chat_ctx = 32768
         assert p.served_chat_ctx() == 32768
 
@@ -2063,9 +2095,10 @@ class TestReloadSingleFlight:
     def test_reload_requested_mid_flight_runs_a_second_pass(self, monkeypatch) -> None:
         plans: list[int] = []
 
-        def _plan() -> list:
+        def _plan() -> planning_mod.FleetPlan:
             plans.append(len(plans))
-            return [_fake_launch(WorkerRole.CHAT)]  # fresh object -> differs -> restarts
+            # fresh object -> differs -> restarts
+            return planning_mod.FleetPlan((_fake_launch(WorkerRole.CHAT),))
 
         monkeypatch.setattr(planning_mod, "plan_all_launches", _plan)
         monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _FakeSwap())
@@ -2073,7 +2106,8 @@ class TestReloadSingleFlight:
         monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
         p = FleetProvider()
         monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reloading = True  # an in-flight reload that already snapshotted its plan
         p.reload_role(WorkerRole.EMBED)  # the second settings change arrives mid-flight
         assert p._reload_pending is True
@@ -2106,15 +2140,16 @@ class TestReloadSingleFlight:
 
         plans: list[int] = []
 
-        def _plan() -> list:
+        def _plan() -> planning_mod.FleetPlan:
             plans.append(len(plans))
-            return [_fake_launch(WorkerRole.CHAT)]
+            return planning_mod.FleetPlan((_fake_launch(WorkerRole.CHAT),))
 
         monkeypatch.setattr(planning_mod, "plan_all_launches", _plan)
         monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _ExplodingSwap())
         monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reloading = True
         p._reload_pending = True
         with pytest.raises(RuntimeError, match="respawn failed"):
@@ -2140,11 +2175,14 @@ class TestReloadSingleFlight:
         monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
         monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
         monkeypatch.setattr(
-            planning_mod, "plan_all_launches", lambda: [_fake_launch(WorkerRole.CHAT)]
+            planning_mod,
+            "plan_all_launches",
+            lambda: planning_mod.FleetPlan((_fake_launch(WorkerRole.CHAT),)),
         )
         p = FleetProvider()
         monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reloading = True
         p._reload_pending = True  # a settings change arrived during the failing pass
         p._reload_blocking()  # must not raise: the pending pass succeeded
@@ -2162,10 +2200,13 @@ class TestReloadSingleFlight:
         monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _ExplodingSwap())
         monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
         monkeypatch.setattr(
-            planning_mod, "plan_all_launches", lambda: [_fake_launch(WorkerRole.CHAT)]
+            planning_mod,
+            "plan_all_launches",
+            lambda: planning_mod.FleetPlan((_fake_launch(WorkerRole.CHAT),)),
         )
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reloading = True
         with pytest.raises(RuntimeError, match="respawn failed"):
             p._reload_blocking()
@@ -2174,7 +2215,8 @@ class TestReloadSingleFlight:
     def test_planning_failure_keeps_a_live_swap(self, monkeypatch) -> None:
         swap = _FakeSwap()
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: swap}
+        p._swaps = {SwapGroup.CHAT: swap}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reloading = True
 
         def _broken_plan() -> list:
@@ -2189,10 +2231,11 @@ class TestReloadSingleFlight:
     def test_reload_clears_the_guard_when_done(self, monkeypatch) -> None:
         swap = _FakeSwap()
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: swap}
+        p._swaps = {SwapGroup.CHAT: swap}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reloading = True
         monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
-        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [])
+        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan(()))
         p._reload_blocking()
         assert swap.shutdowns == 1  # nothing planned -> the running group stops
         assert p._reloading is False
@@ -2203,7 +2246,7 @@ class TestReloadSingleFlight:
         # would start whatever the fresh plan holds), finds nothing, and the
         # guard is still released.
         monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
-        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [])
+        monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan(()))
         p = FleetProvider()
         p._reloading = True
         p._reload_blocking()
@@ -2221,15 +2264,16 @@ class TestReloadSingleFlight:
 
         swap = _OrderedSwap()
         p = FleetProvider()
-        p._swaps = {WorkerRole.CHAT: swap}
+        p._swaps = {SwapGroup.CHAT: swap}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reloading = True
 
         reload_entered = threading.Event()
 
-        def _slow_plan() -> list:
+        def _slow_plan() -> planning_mod.FleetPlan:
             reload_entered.set()
             gate.wait(5.0)
-            return []
+            return planning_mod.FleetPlan(())
 
         monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
         monkeypatch.setattr(prov_mod, "sweep_owned", lambda _d: None)
@@ -2386,7 +2430,8 @@ def test_require_clients_reprobes_dead_swap(monkeypatch) -> None:
     p._clients = {}
     dead = mock.Mock()
     dead.is_live.return_value = False
-    p._swaps = {WorkerRole.CHAT: dead}
+    p._swaps = {SwapGroup.CHAT: dead}
+    p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
     rebuilt = {"called": False}
 
     def fake_rebuild(role: WorkerRole) -> None:
@@ -2431,7 +2476,8 @@ def test_require_clients_no_reprobe_when_swap_live(monkeypatch) -> None:
     p = FleetProvider()
     live = mock.Mock()
     live.is_live.return_value = True
-    p._swaps = {WorkerRole.CHAT: live}
+    p._swaps = {SwapGroup.CHAT: live}
+    p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
     p._clients = {}
     monkeypatch.setattr(p, "_rebuild_role", fake_rebuild, raising=False)
     with pytest.raises(ProviderError, match="No chat model server is running"):
@@ -2446,7 +2492,11 @@ def test_rebuild_role_restarts_only_that_role(monkeypatch) -> None:
     monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
     monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
     chat_launch, embed_launch = _fake_launch(WorkerRole.CHAT), _fake_launch(WorkerRole.EMBED)
-    monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: [chat_launch, embed_launch])
+    monkeypatch.setattr(
+        planning_mod,
+        "plan_all_launches",
+        lambda: planning_mod.FleetPlan((chat_launch, embed_launch)),
+    )
     p = FleetProvider()
     monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
     dead, live = _FakeSwap(), _FakeSwap()
@@ -2462,6 +2512,45 @@ def test_rebuild_role_restarts_only_that_role(monkeypatch) -> None:
     assert p._swaps[WorkerRole.EMBED] is fresh  # ...and replaced from the fresh plan
     assert p._swaps[WorkerRole.CHAT] is live  # the healthy group was never touched
     assert live.shutdowns == 0
+
+
+def test_co_tenant_roles_share_one_swap_process(monkeypatch) -> None:
+    """Chat and vision must land in the same llama-swap process; only a shared process
+    can evict one to load the other. Separate processes would hold both resident."""
+    groups: list[SwapGroup] = []
+
+    def _factory(_d: object, group: SwapGroup) -> _FakeSwap:
+        groups.append(group)
+        return _FakeSwap()
+
+    chat, vision = _fake_launch(WorkerRole.CHAT), _fake_launch(WorkerRole.VISION)
+    embed = _fake_launch(WorkerRole.EMBED)
+    monkeypatch.setattr(prov_mod, "SwapManager", _factory)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+    monkeypatch.setattr(prov_mod, "sweep_owned", lambda _d: None)
+    monkeypatch.setattr(planning_mod, "capture_plan_probe", lambda: None)
+    monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
+    monkeypatch.setattr(
+        planning_mod,
+        "plan_all_launches",
+        lambda: planning_mod.FleetPlan(
+            (chat, vision, embed),
+            co_tenants=frozenset({WorkerRole.CHAT, WorkerRole.VISION}),
+        ),
+    )
+
+    p = FleetProvider()
+    assert p._ensure_fleet() is True
+
+    assert sorted(groups) == sorted([SwapGroup.CO_TENANT, SwapGroup.EMBED])
+    assert p._role_group[WorkerRole.CHAT] is SwapGroup.CO_TENANT
+    assert p._role_group[WorkerRole.VISION] is SwapGroup.CO_TENANT
+    assert p._role_group[WorkerRole.EMBED] is SwapGroup.EMBED
+    # Both roles keep their own client pool even though they share a process.
+    assert len(p._clients[WorkerRole.CHAT]) == 1
+    assert len(p._clients[WorkerRole.VISION]) == 1
+    # The shared group's launches are filtered down to the role's own replicas.
+    assert p._role_launches(WorkerRole.VISION) == (vision,)
 
 
 def test_ensure_fleet_partial_failure_tears_down_started_groups(monkeypatch) -> None:
@@ -2485,7 +2574,9 @@ def test_ensure_fleet_partial_failure_tears_down_started_groups(monkeypatch) -> 
     monkeypatch.setattr(
         planning_mod,
         "plan_all_launches",
-        lambda: [_fake_launch(WorkerRole.CHAT), _fake_launch(WorkerRole.EMBED)],
+        lambda: planning_mod.FleetPlan(
+            (_fake_launch(WorkerRole.CHAT), _fake_launch(WorkerRole.EMBED))
+        ),
     )
     p = FleetProvider()
     with pytest.raises(RuntimeError, match="second group failed"):
@@ -2506,7 +2597,8 @@ def test_drop_dead_swaps_drops_only_dead_groups() -> None:
 def test_reload_placement_dispatches_the_diff_reload(monkeypatch) -> None:
     passes: list[bool] = []
     p = FleetProvider()
-    p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+    p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+    p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
     monkeypatch.setattr(p, "_reload_pass", lambda force=frozenset(): passes.append(True))
     p.reload_placement(wait=True)
     assert passes == [True]
@@ -2534,7 +2626,9 @@ class TestPlanProbeLifecycle:
         monkeypatch.setattr(
             planning_mod,
             "plan_all_launches",
-            lambda: order.append("plan") or [_fake_launch(WorkerRole.CHAT)],
+            lambda: (
+                order.append("plan") or planning_mod.FleetPlan((_fake_launch(WorkerRole.CHAT),))
+            ),
         )
 
     def test_first_build_snapshots_after_reaping(self, monkeypatch) -> None:
@@ -2553,7 +2647,8 @@ class TestPlanProbeLifecycle:
         self._wire(monkeypatch, order)
         p = FleetProvider()
         monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
-        p._swaps = {WorkerRole.CHAT: _FakeSwap()}
+        p._swaps = {SwapGroup.CHAT: _FakeSwap()}
+        p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reload_pass()
         assert "capture" not in order
         assert "plan" in order

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -2701,3 +2701,14 @@ class TestChatLoadFailureMessage:
 
     def test_failure_message_falls_back_when_the_engine_said_nothing(self) -> None:
         assert "did not finish loading" in FleetProvider()._chat_load_failure()
+
+
+class TestWarmErrorsClearedOnTeardown:
+    def test_dropping_the_fleet_forgets_its_load_failures(self) -> None:
+        # The errors describe servers that no longer exist; a rebuilt fleet must not
+        # inherit them.
+        p = FleetProvider()
+        p._warm_errors[WorkerRole.CHAT] = "unknown model architecture: qwen35moe"
+        p._drop_swap_refs()
+        assert p._warm_errors == {}
+        assert "did not finish loading" in p._chat_load_failure()

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import threading
 import time
@@ -2571,3 +2572,37 @@ class TestPlanProbeLifecycle:
         monkeypatch.setattr(planning_mod, "clear_plan_probe", lambda: cleared.append(True))
         FleetProvider()._drop_swap_refs()
         assert cleared == [True]
+
+
+class TestWarmFailureIsSurfaced:
+    """A model that cannot load must not fail silently at debug level."""
+
+    def test_warm_failure_logs_the_underlying_error_at_warning(self, caplog) -> None:
+        p = FleetProvider()
+        client = _fake_client()
+        client.chat.side_effect = RuntimeError("unknown model architecture: qwen35moe")
+
+        with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.provider"):
+            warmed = p._warm_role_clients(WorkerRole.CHAT, [client])
+
+        assert warmed is False
+        assert "unknown model architecture: qwen35moe" in caplog.text
+        assert "chat" in caplog.text
+
+    def test_successful_warm_logs_nothing(self, caplog) -> None:
+        p = FleetProvider()
+        with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.provider"):
+            assert p._warm_role_clients(WorkerRole.EMBED, [_fake_client()]) is True
+        assert caplog.text == ""
+
+
+class TestChatLoadFailureMessage:
+    """The launcher and the TUI must see the engine's real reason, not a generic one."""
+
+    def test_failure_message_carries_the_engine_error(self) -> None:
+        p = FleetProvider()
+        p._warm_errors[WorkerRole.CHAT] = "unknown model architecture: qwen35moe"
+        assert "unknown model architecture: qwen35moe" in p._chat_load_failure()
+
+    def test_failure_message_falls_back_when_the_engine_said_nothing(self) -> None:
+        assert "did not finish loading" in FleetProvider()._chat_load_failure()

--- a/tests/test_fleet_swap_config.py
+++ b/tests/test_fleet_swap_config.py
@@ -92,6 +92,22 @@ class TestBuildSwapConfig:
             _mid(WorkerRole.RERANK),
         }
 
+    def test_co_tenant_group_evicts_between_its_members(self) -> None:
+        # swap=True is what makes llama-swap unload chat to load vision, and back.
+        cfg = json.loads(
+            build_swap_config(
+                [
+                    _launch(WorkerRole.CHAT, ["/bin/llama-server"]),
+                    _launch(WorkerRole.VISION, ["/bin/llama-server"]),
+                ],
+                {_mid(WorkerRole.CHAT): 1, _mid(WorkerRole.VISION): 2},
+                swap=True,
+            )
+        )
+        (group,) = cfg["groups"].values()
+        assert group["swap"] is True
+        assert set(group["members"]) == {_mid(WorkerRole.CHAT), _mid(WorkerRole.VISION)}
+
     def test_command_carries_explicit_port_and_role_argv(self) -> None:
         cfg = _config([_launch(WorkerRole.CHAT, ["/bin/llama-server", "--jinja"])])
         cmd = cfg["models"][_mid(WorkerRole.CHAT)]["cmd"]

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -15,12 +15,13 @@ import pytest
 
 from lilbee.providers.base import ProviderError
 from lilbee.providers.fleet import swap_manager as sm
+from lilbee.providers.fleet.groups import SwapGroup
 from lilbee.providers.fleet.launch import InstanceLaunch
 from lilbee.providers.fleet.swap_manager import SwapManager
 from lilbee.providers.roles import WorkerRole
 
 # All lifecycle tests run one manager for the chat group unless stated otherwise.
-_GROUP = "chat"
+_GROUP = SwapGroup.CHAT
 
 
 class _FakeProc:
@@ -1274,8 +1275,8 @@ class TestPerGroupNaming:
     ) -> None:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        chat = SwapManager(tmp_path, "chat")
-        embed = SwapManager(tmp_path, "embed")
+        chat = SwapManager(tmp_path, SwapGroup.CHAT)
+        embed = SwapManager(tmp_path, SwapGroup.EMBED)
         chat.start([_launch(WorkerRole.CHAT)])
         embed.start([_launch(WorkerRole.EMBED)])
         # Each group runs against its own config, so stopping one group's fleet

--- a/tests/test_server_handlers.py
+++ b/tests/test_server_handlers.py
@@ -4474,6 +4474,25 @@ class TestPlacementHandlers:
         assert resp.gpus == []
         assert resp.roles == []
 
+    async def test_placement_surfaces_co_tenant_roles(self):
+        # Co-tenants are placed but not co-resident; a surface that omits them
+        # reads as an over-committed card.
+        from lilbee.app.placement import PlacementView
+        from lilbee.providers.roles import WorkerRole
+
+        view = PlacementView(
+            gpus=(),
+            roles=(),
+            unplaceable=(),
+            manual=False,
+            spec_json=None,
+            co_tenants=(WorkerRole.CHAT, WorkerRole.VISION),
+        )
+        with patch("lilbee.app.placement.get_placement", return_value=view):
+            resp = await handlers.placement()
+        assert resp.co_tenants == ["chat", "vision"]
+        assert resp.unplaceable == []
+
     async def test_placement_preview_without_spec(self):
         view = _stub_placement_view()
         with patch("lilbee.app.placement.preview_placement", return_value=view):

--- a/tests/test_tui_fleet.py
+++ b/tests/test_tui_fleet.py
@@ -17,7 +17,9 @@ from tests._lilbee_app_test_host import LilbeeAppHost
 GIB = 1024**3
 
 
-def _make_view(*, manual: bool = False, unplaceable: tuple = (), spec_json=None):  # type: ignore[type-arg]
+def _make_view(  # type: ignore[type-arg]
+    *, manual: bool = False, unplaceable: tuple = (), spec_json=None, co_tenants: tuple = ()
+):
     from lilbee.app.placement import GpuInfo, PlacementView, RolePlacementView
     from lilbee.providers.roles import WorkerRole
 
@@ -32,6 +34,7 @@ def _make_view(*, manual: bool = False, unplaceable: tuple = (), spec_json=None)
         unplaceable=unplaceable,
         manual=manual,
         spec_json=spec_json,
+        co_tenants=co_tenants,
     )
 
 
@@ -449,6 +452,29 @@ async def test_unplaceable_warns(monkeypatch):
         await pilot.pause()
 
     assert any("vision" in n.lower() for n in notes)
+
+
+@pytest.mark.asyncio
+async def test_co_tenant_roles_are_surfaced(monkeypatch):
+    """Co-tenants are placed but share memory, so the drawer says so rather than
+    letting two roles on one card read as an over-committed plan."""
+    from lilbee.cli.tui.widgets import fleet_body as fbm
+    from lilbee.providers.roles import WorkerRole
+
+    view = _make_view(co_tenants=(WorkerRole.CHAT, WorkerRole.VISION))
+    monkeypatch.setattr(fbm, "get_placement", lambda: view)
+
+    notes: list[str] = []
+    app = FleetTestApp()
+    async with app.run_test(size=(140, 44)) as pilot:
+        body = app.screen.query_one("FleetBody")
+        body.notify = lambda msg, **k: notes.append(msg)  # type: ignore[method-assign]
+        body._load_worker()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert any("one loaded at a time" in n for n in notes)
+    assert any("chat, vision" in n for n in notes)
 
 
 @pytest.mark.asyncio

--- a/tools/qa/multi_gpu_smoke.py
+++ b/tools/qa/multi_gpu_smoke.py
@@ -98,10 +98,14 @@ def _check_placement() -> None:
     """
     from lilbee.providers.fleet.planning import plan_all_launches
 
-    launches = plan_all_launches()
+    plan = plan_all_launches()
+    launches = plan.launches
     _require(bool(launches), "planner produced no servers (every role unplaceable)")
     roles = {launch.role for launch in launches}
     print(f"[2] planned {len(launches)} server(s) across roles {sorted(r.value for r in roles)}")
+    if plan.co_tenants:
+        shared = ", ".join(sorted(role.value for role in plan.co_tenants))
+        print(f"      {shared} share a swap group (one resident at a time)")
     for launch in launches:
         env = launch.env_overrides
         pinned = env.get("CUDA_VISIBLE_DEVICES") or env.get("ROCR_VISIBLE_DEVICES") or "(host)"


### PR DESCRIPTION
Three engine bugs, all in the llama-server fleet and the surfaces in front of it.

## Problem

### A role gets dropped when chat and vision cannot both fit

The placement planner reserved VRAM for every configured role permanently and up front. Only the pooled search roles (embed, rerank) were charged before chat, so vision sorted after the chat giant and lost whatever memory was left.

The role then got no server. Ingesting a scanned PDF or an image failed with "No vision model server is running", while search kept working, so the failure looked arbitrary. On a box where the chat model is the smaller of the two, chat is the role that gets dropped instead.

`docs/architecture.md` already claimed vision was part of the reserved persistent tier. The code did not honor it.

This worked before the llama-server migration because the old worker pool spawned a role's process on first use and had no admission control at all. Nothing reserved memory, so vision simply loaded when ingest needed it.

### Reasoning models leak raw think tags to agents through /v1

lilbee runs the chat server with `--reasoning-format deepseek`, then re-inlines the extracted reasoning as `<think>...</think>` text, because its own TUI parser reads that inline form.

The OpenAI-compatible endpoint served that internal representation verbatim, so an agent connected to `/v1/chat/completions` rendered the raw tags as literal text.

Changing the server's reasoning format never helped. The re-inlining happens after the server has already extracted the reasoning.

### A model-load failure is reported as "chat engine ready"

When llama-server could not load the chat model, warm-up caught the error and logged it at debug level, so the reason never reached anyone.

The CLI then printed "chat engine ready." on the first streamed token. In RAG mode that token is the grounded refusal, which streams without ever calling the chat model.

A user whose model failed to load saw a confident readiness line followed by an unexplained no-answer.

## Solution

### Swap tenancy instead of an unplaceable role

Roles now charge in an order declared on the role registry. The pinned tier (embed, rerank, vision) goes first, and the chat model is charged last against what the pinned tier leaves, because chat's KV cache is the one footprint that can shrink.

When chat fits only if vision gives up its VRAM, neither role becomes unplaceable. The two become co-tenants of a single llama-swap group with `swap: true`, sharing one llama-swap process, and llama-swap evicts one to load the other on demand.

Consequences of only one being resident:

- The group is charged the chat model's footprint alone.
- A co-tenant role is capped to a single instance, since a `swap: true` group evicts its own siblings.
- The context reservation no longer holds back memory for a server that is evicted while chat runs.

A role is unplaceable only when it does not fit alone beside the pinned search tier. That is a genuine "use a smaller model" condition.

llama-swap can only evict between models inside one process, so the provider's swap and launch maps are keyed by swap group rather than by role. Embed and rerank keep their own processes, so reloading the embedder still never touches a resident chat model.

Every placement surface (CLI, HTTP, MCP, TUI) reports the pair as sharing memory, so a card holding both no longer reads as over-committed.

### Reasoning reported in its own field

The OpenAI translation layer, which exists to convert lilbee's shapes to OpenAI's, now splits the thinking out of the answer and reports it in `reasoning_content` on both the response message and the stream delta.

Streaming reuses the existing tag parser, so a tag arriving split across two deltas is never emitted as text. Clients of non-reasoning models see an unchanged wire format.

### Load failures surfaced

Warm-up reports a load failure with the engine's own message instead of discarding it, so the launcher and the TUI show the real reason rather than a generic "did not finish loading".

The CLI consults the warm tracker before announcing readiness, because output arriving is not evidence that the chat model came up. Readiness is not re-probed, since llama-swap can report a freshly loaded model as not yet running.

## Verification

Reproduced and fixed on an Apple M1 Pro with 21 GiB of usable VRAM, running a chat model, a vision model and an embedder that together exceed the card.

- On `main`, `lilbee placement show` reports `chat: does not fit, no server`.
- On this branch, all three roles place, and the pair is reported as sharing memory.
- Driving lilbee's own provider, llama-swap evicts `chat-0` to load `vision-0` for an OCR call, then reloads `chat-0` for the next chat turn.
- A real scanned PDF (595 pages, no text layer) ingests through the vision server.

Windows and CUDA paths were not exercised locally and rely on CI.
