### PR TITLE
Stop the package fan-out losing a push race

### DIFF
--- a/.github/actions/publish-flake-sources/action.yml
+++ b/.github/actions/publish-flake-sources/action.yml
@@ -52,4 +52,5 @@ runs:
           exit 0
         fi
         git commit -m "${COMMIT_MESSAGE}"
-        git push origin main
+        # scoop and the CUDA/compat flake jobs commit to this same branch in parallel.
+        bash "${GITHUB_WORKSPACE}/tools/ci/git_push_retry.sh"

--- a/.github/actions/publish-flatpak/action.yml
+++ b/.github/actions/publish-flatpak/action.yml
@@ -141,6 +141,10 @@ runs:
           exit 0
         fi
         git commit -m "lilbee ${VERSION} (flatpak)"
+        # Deliberately a plain push, not tools/ci/git_push_retry.sh: build-update-repo
+        # regenerates this repo's summary and static deltas wholesale, so rebasing onto
+        # a sibling's commit would drop the app it just published. The flatpak jobs
+        # serialize on a shared `concurrency` group instead, so there is no race to retry.
         git push
 
     - name: Attach the bundle to the release

--- a/.github/actions/publish-homebrew-formula/action.yml
+++ b/.github/actions/publish-homebrew-formula/action.yml
@@ -39,4 +39,5 @@ runs:
           exit 0
         fi
         git commit -m "${COMMIT_MESSAGE}"
-        git push
+        # The CUDA and compat jobs push their own formula to this tap in parallel.
+        bash "${GITHUB_WORKSPACE}/tools/ci/git_push_retry.sh"

--- a/.github/workflows/publish-compat-packages.yml
+++ b/.github/workflows/publish-compat-packages.yml
@@ -161,6 +161,10 @@ jobs:
 
   flatpak:
     needs: resolve
+    # Serialized against the regular and CUDA flatpak jobs; see publish-packages.yml.
+    concurrency:
+      group: flatpak-lilbee-repo
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -220,8 +224,5 @@ jobs:
             exit 0
           fi
           git commit -m "lilbee-compat ${VERSION} (scoop)"
-          for _ in 1 2 3; do
-            if git push origin main; then exit 0; fi
-            git pull --rebase origin main
-          done
-          echo "push failed after retries"; exit 1
+          # nix-flake commits to main from a sibling job; rebase-retry on a race.
+          bash tools/ci/git_push_retry.sh

--- a/.github/workflows/publish-cuda-packages.yml
+++ b/.github/workflows/publish-cuda-packages.yml
@@ -155,6 +155,10 @@ jobs:
 
   flatpak:
     needs: resolve
+    # Serialized against the regular and compat flatpak jobs; see publish-packages.yml.
+    concurrency:
+      group: flatpak-lilbee-repo
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -117,6 +117,14 @@ jobs:
   flatpak:
     needs: resolve
     if: inputs.channels == 'all' || contains(inputs.channels, 'flatpak')
+    # One writer at a time for the shared OSTree pages repo. The regular, CUDA and
+    # compat fan-outs run concurrently and each regenerates the repo's summary and
+    # static deltas wholesale, so the rebase-retry the text-file channels use would
+    # drop whichever app a sibling had just published. Group name is shared across
+    # all three workflows on purpose.
+    concurrency:
+      group: flatpak-lilbee-repo
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -252,8 +260,4 @@ jobs:
           fi
           git commit -m "lilbee ${VERSION} (scoop)"
           # nix-flake commits to main from a sibling job; rebase-retry on a race.
-          for _ in 1 2 3; do
-            if git push origin main; then exit 0; fi
-            git pull --rebase origin main
-          done
-          echo "push failed after retries"; exit 1
+          bash tools/ci/git_push_retry.sh

--- a/tools/ci/git_push_retry.sh
+++ b/tools/ci/git_push_retry.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Push the current branch, rebasing onto whatever landed first when a sibling job
+# beat us to the remote.
+#
+# The package fan-out runs homebrew / scoop / nix-flake / flatpak in parallel, and
+# the regular, CUDA and compat workflows run at the same time as each other. Several
+# of those jobs commit to the same branch of the same repository, so whoever loses
+# the race gets a non-fast-forward rejection and the channel silently goes unpublished
+# until someone re-runs the job by hand.
+#
+# Only safe for text files that different jobs touch independently (a formula, a
+# manifest, a flake source). A repository whose content is regenerated wholesale --
+# the flatpak OSTree repo -- must serialize its writers instead: rebasing a commit
+# that rewrites `summary` and the static deltas would drop whatever the sibling
+# published.
+#
+# Reads:
+#   PUSH_REMOTE   remote to push to (default: origin)
+#   PUSH_BRANCH   branch to push (default: the checked-out branch, as bare `git push`)
+#   PUSH_ATTEMPTS how many times to try (default: 5)
+
+set -euo pipefail
+
+remote="${PUSH_REMOTE:-origin}"
+# Not hardcoded to main: the homebrew tap and the flatpak pages repo are separate
+# repositories whose default branch is theirs to choose, and the callers reached
+# them with a bare `git push`, which follows the checked-out branch.
+branch="${PUSH_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
+attempts="${PUSH_ATTEMPTS:-5}"
+
+for attempt in $(seq 1 "${attempts}"); do
+  if git push "${remote}" "HEAD:${branch}"; then
+    exit 0
+  fi
+  if [ "${attempt}" -eq "${attempts}" ]; then
+    break
+  fi
+  echo "push rejected (attempt ${attempt}/${attempts}); rebasing onto ${remote}/${branch}" >&2
+  # A rebase that stops on a conflict would leave the tree mid-rebase and the next
+  # push would send the wrong thing. Abort and fail loudly instead: a conflict here
+  # means two jobs edited the same file, which this script is not the fix for.
+  if ! git pull --rebase "${remote}" "${branch}"; then
+    git rebase --abort || true
+    echo "rebase onto ${remote}/${branch} conflicted; two jobs are writing the same file" >&2
+    exit 1
+  fi
+  sleep "${attempt}"
+done
+
+echo "push to ${remote}/${branch} failed after ${attempts} attempts" >&2
+exit 1


### PR DESCRIPTION
## Problem

The regular, CUDA and compat publish workflows run concurrently, and homebrew, scoop, nix-flake and flatpak run in parallel within each. Several push to the same branch of the same repo, so the loser gets a non-fast-forward rejection and that channel goes unpublished until someone re-runs it.

`dev712` hit it twice: `nix-flake` was rejected in the regular workflow but succeeded in the CUDA one; `flatpak` did the reverse. The scoop and compat-scoop jobs already had copy-pasted rebase-retry loops naming nix-flake as the racer. The two pushes that lost had none.

## Solution

- `tools/ci/git_push_retry.sh`: one rebase-retry, called from the flake sources, homebrew formula, and both scoop manifests. They write different files, so rebasing keeps both edits.
- Follows the checked-out branch, not `main`: the tap and pages repo are separate repositories.
- Aborts a conflicted rebase rather than leaving a half-rebased tree for the next push.
- flatpak is excluded: `build-update-repo` regenerates the summary and static deltas wholesale, so rebasing would drop the app a sibling just published. Its three jobs serialize on a shared `concurrency` group.

Verified against real repos: two clones racing a shared remote reproduce the rejection; the helper resolves it with both edits intact on `main`, `master` and `trunk`; a same-file conflict exits non-zero without clobbering the winner.