### PR TITLE
Let the lilbee-compat formula publish its first release

### DIFF
--- a/.github/actions/publish-homebrew-formula/action.yml
+++ b/.github/actions/publish-homebrew-formula/action.yml
@@ -30,6 +30,20 @@ runs:
         git config --global user.name "lilbee-bot"
         git config --global user.email "lilbee-bot@users.noreply.github.com"
         git clone "https://x-access-token:${TAP_TOKEN}@github.com/tobocop2/homebrew-lilbee.git" /tmp/tap
+        # render_formula.py rewrites a formula in place, so a channel whose formula was
+        # never created in the tap can never publish its first release: lilbee-compat
+        # failed this way on every run. Seed it from the copy this repo keeps, which is
+        # also where the formula stays reviewable.
+        if [ ! -f "/tmp/tap/${FORMULA_PATH}" ]; then
+          seed="packaging/homebrew/$(basename "${FORMULA_PATH}")"
+          [ -f "${seed}" ] || {
+            echo "${FORMULA_PATH} is not in the tap and there is no seed at ${seed}" >&2
+            exit 1
+          }
+          mkdir -p "$(dirname "/tmp/tap/${FORMULA_PATH}")"
+          cp "${seed}" "/tmp/tap/${FORMULA_PATH}"
+          echo "seeded ${FORMULA_PATH} from ${seed}"
+        fi
         # shellcheck disable=SC2086
         python3 packaging/tools/render_formula.py "/tmp/tap/${FORMULA_PATH}" ${RENDER_ARGS}
         cd /tmp/tap

--- a/packaging/homebrew/lilbee-compat.rb
+++ b/packaging/homebrew/lilbee-compat.rb
@@ -1,0 +1,44 @@
+class LilbeeCompat < Formula
+  desc "Run local AI models, search your files and code, and crawl the web (pre-Haswell CPU build)"
+  homepage "https://github.com/tobocop2/lilbee"
+  version "0.0.0"
+  license "Elastic-2.0"
+
+  conflicts_with "tobocop2/lilbee/lilbee", because: "both install the lilbee binary"
+  conflicts_with "tobocop2/lilbee/lilbee-cuda", because: "both install the lilbee binary"
+
+  on_linux do
+    on_intel do
+      url "https://github.com/tobocop2/lilbee/releases/download/v#{version}/lilbee-compat-linux-x86_64"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  def install
+    binary = Dir["lilbee-*"].first
+    bin.install binary => "lilbee"
+  end
+
+  service do
+    run [opt_bin/"lilbee", "serve", "--host", "127.0.0.1", "--port", "42697"]
+    keep_alive true
+    log_path var/"log/lilbee/serve.log"
+    error_log_path var/"log/lilbee/serve.err.log"
+  end
+
+  def caveats
+    <<~EOS
+      lilbee-compat installs the same `lilbee` binary as the regular `lilbee` formula,
+      held to an x86-64-v2 baseline so it runs on pre-Haswell CPUs (Sandy Bridge,
+      Bulldozer). Only pick it if `lilbee` crashes with an illegal instruction. If you
+      previously had `lilbee` installed, uninstall it first:
+
+        brew uninstall lilbee
+        brew install tobocop2/lilbee/lilbee-compat
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/lilbee --version")
+  end
+end


### PR DESCRIPTION
Stacked on #507, which touches the same action. Retarget to `main` once that merges.

## Problem

`render_formula.py` rewrites a formula in place. The tap holds `lilbee.rb` and `lilbee-cuda.rb`; nobody ever wrote `lilbee-compat.rb`. So the compat homebrew job has failed on every dispatch with `FileNotFoundError: /tmp/tap/Formula/lilbee-compat.rb`, and the compat channel has never shipped a single release. It failed again publishing `dev712`.

## Solution

- Keep `lilbee-compat.rb` in `packaging/homebrew/`, where it is reviewable.
- The publish action seeds the tap from it when the formula is absent; later releases find it and update in place as before.
- A formula with neither a tap copy nor a seed now fails with a clear message instead of a traceback.

Verified against the real renderer and `dev712`'s published digest: the seed's placeholders match `render_formula.py`'s patterns, a first publish seeds then renders, a second updates in place without reseeding, and an unknown formula errors.