### PR TITLE
Stop the blank startup screen, the too-early chat input, and engine processes that outlive the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,27 +94,31 @@ CLI, the HTTP API, env vars, and `config.toml` are there for scripting, headless
 
 ## Startup and the engine lifecycle
 
-The first thing you should know before launching lilbee: the engine is a real
-llama.cpp server that loads your model into memory, and by default it lives and
-dies with lilbee. Launch starts it, quit frees everything. That on-demand default
-is deliberate, no VRAM or RAM is held while lilbee is closed, but it means every
-launch pays the engine load before chat opens. You will watch a progress bar, not
-a frozen screen, and chat stays out of reach until the model can actually answer.
+lilbee opens fast and loads the model lazily, the way Ollama and LM Studio do.
+The TUI is on screen within a couple of seconds of launch; the engine, a real
+llama.cpp server, starts loading your model in the background at the same
+moment. Ask something before it's ready and the answer bubble shows the load
+itself, weights read as a live percentage, then your answer streams in. Nothing
+freezes and nothing is silently queued.
 
-Measured on real builds with a small chat model (Qwen3 0.6B):
+By default the engine lives and dies with lilbee: launch starts it, quit frees
+all of its memory. That on-demand default is deliberate, no VRAM or RAM is held
+while lilbee is closed, but it means the first answer of a session waits out the
+engine load. Measured on real builds with a small chat model (Qwen3 0.6B):
 
-| Launch | Apple Silicon Mac | Linux + CUDA |
+| | Apple Silicon Mac | Linux + CUDA |
 |---|---|---|
-| Very first run (one-time unpack + engine load) | ~22s | ~33s |
-| Later launches (engine load only) | ~15s | ~20s |
-| `lilbee --version` and other quick commands | ~1s | ~2s |
+| Launch to a usable TUI | ~2s | ~2s |
+| First answer, very first run (one-time unpack + load) | ~22s | ~33s |
+| First answer, later sessions (engine load only) | ~15s | ~20s |
+| Answers after the engine is loaded | model speed | model speed |
 
-Bigger models load longer; the bar shows real progress while weights are read.
+Bigger models load longer; the bubble shows real progress while weights are read.
 
 If you relaunch lilbee often, opt into a persistent engine in Settings:
 
 - **Keep engine warm** leaves the engine running when you quit, and the next
-  launch connects to it in about two seconds instead of reloading the model.
+  session's first answer skips the load entirely.
 - **Engine idle ttl minutes** bounds how long idle weights stay in memory,
   five minutes by default (the same idea as Ollama's keep_alive). The memory
   frees itself after that many idle minutes; a small proxy process stays behind,

--- a/README.md
+++ b/README.md
@@ -115,10 +115,12 @@ If you relaunch lilbee often, opt into a persistent engine in Settings:
 
 - **Keep engine warm** leaves the engine running when you quit, and the next
   launch connects to it in about two seconds instead of reloading the model.
-- **Engine idle ttl minutes** bounds how long idle weights stay in memory. `0`
-  keeps them loaded until you turn the setting off; any other value frees the
-  memory after that many idle minutes (a small proxy process stays behind, a few
-  tens of MB and no VRAM).
+- **Engine idle ttl minutes** bounds how long idle weights stay in memory,
+  five minutes by default (the same idea as Ollama's keep_alive). The memory
+  frees itself after that many idle minutes; a small proxy process stays behind,
+  a few tens of MB and no VRAM. `0` keeps weights loaded until you stop them.
+- **`lilbee engine stop`** frees everything immediately from any terminal, no
+  TUI needed.
 
 Turning the setting off returns to the on-demand default and stops the engine at
 the next opportunity. Both knobs live in the TUI Settings screen,

--- a/README.md
+++ b/README.md
@@ -92,30 +92,47 @@ Defaults are sane for chatting with code, documentation, crawled sites, and long
 
 CLI, the HTTP API, env vars, and `config.toml` are there for scripting, headless runs, and custom integrations. See the [usage guide](docs/usage.md).
 
-## Startup and the engine lifecycle
+## First start
 
-lilbee opens fast and loads the model lazily, the way Ollama and LM Studio do.
-The TUI is on screen within a couple of seconds of launch; the engine, a real
-llama.cpp server, starts loading your model in the background at the same
-moment. Ask something before it's ready and the answer bubble shows the load
-itself, weights read as a live percentage, then your answer streams in. Nothing
-freezes and nothing is silently queued.
+The very first launch does one-time work: the executable unpacks itself behind
+a progress bar, and the model loads before your first answer, shown live inside
+the answer bubble. Every launch after that opens straight to chat in a couple
+of seconds.
+
+<table>
+  <tr>
+    <th align="center">Very first launch</th>
+    <th align="center">Every launch after</th>
+  </tr>
+  <tr>
+    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/first-start.gif" alt="First launch: a one-time unpack bar, chat opens, the first answer shows the engine loading in its bubble, then streams" width="420"></td>
+    <td><img src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/later-start.gif" alt="Every later launch: chat opens in about two seconds and the answer follows" width="420"></td>
+  </tr>
+</table>
+
+Measured with a small chat model (Qwen3 0.6B):
+
+| | Very first launch | Every launch after |
+|---|---|---|
+| Chat on screen | 15 to 20s, one-time unpack | 2 to 3s |
+| First answer of the session | 10 to 20s, the engine load plays in the bubble | the same, or instant with **Keep engine warm** |
+| Answers after that | model speed | model speed |
+
+Bigger models load longer; the bubble shows real progress while weights are read.
+
+## The engine lifecycle
+
+lilbee loads the model lazily, the way Ollama and LM Studio do: the TUI never
+waits for the engine, a real llama.cpp server that starts loading in the
+background the moment the app opens. Ask something before it's ready and the
+answer bubble carries the load until your answer streams. Nothing freezes and
+nothing is silently queued.
 
 By default the engine lives and dies with lilbee: launch starts it, quit frees
 all of its memory. That on-demand default is deliberate, no VRAM or RAM is held
 while lilbee is closed, but it means the first answer of a session waits out the
-engine load. Measured on real builds with a small chat model (Qwen3 0.6B):
-
-| | Apple Silicon Mac | Linux + CUDA |
-|---|---|---|
-| Launch to a usable TUI | ~2s | ~2s |
-| First answer, very first run (one-time unpack + load) | ~22s | ~33s |
-| First answer, later sessions (engine load only) | ~15s | ~20s |
-| Answers after the engine is loaded | model speed | model speed |
-
-Bigger models load longer; the bubble shows real progress while weights are read.
-
-If you relaunch lilbee often, opt into a persistent engine in Settings:
+engine load. If you relaunch lilbee often, opt into a persistent engine in
+Settings:
 
 - **Keep engine warm** leaves the engine running when you quit, and the next
   session's first answer skips the load entirely.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ If you relaunch lilbee often, opt into a persistent engine in Settings:
   tens of MB and no VRAM).
 
 Turning the setting off returns to the on-demand default and stops the engine at
-the next opportunity. Both knobs live in the TUI Settings screen, `lilbee set`,
+the next opportunity. Both knobs live in the TUI Settings screen,
 MCP `lilbee_settings_set`, the HTTP config API, and `config.toml`. The first
 launch after a reboot is always a cold one.
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,39 @@ Defaults are sane for chatting with code, documentation, crawled sites, and long
 
 CLI, the HTTP API, env vars, and `config.toml` are there for scripting, headless runs, and custom integrations. See the [usage guide](docs/usage.md).
 
+## Startup and the engine lifecycle
+
+The first thing you should know before launching lilbee: the engine is a real
+llama.cpp server that loads your model into memory, and by default it lives and
+dies with lilbee. Launch starts it, quit frees everything. That on-demand default
+is deliberate, no VRAM or RAM is held while lilbee is closed, but it means every
+launch pays the engine load before chat opens. You will watch a progress bar, not
+a frozen screen, and chat stays out of reach until the model can actually answer.
+
+Measured on real builds with a small chat model (Qwen3 0.6B):
+
+| Launch | Apple Silicon Mac | Linux + CUDA |
+|---|---|---|
+| Very first run (one-time unpack + engine load) | ~22s | ~33s |
+| Later launches (engine load only) | ~15s | ~20s |
+| `lilbee --version` and other quick commands | ~1s | ~2s |
+
+Bigger models load longer; the bar shows real progress while weights are read.
+
+If you relaunch lilbee often, opt into a persistent engine in Settings:
+
+- **Keep engine warm** leaves the engine running when you quit, and the next
+  launch connects to it in about two seconds instead of reloading the model.
+- **Engine idle ttl minutes** bounds how long idle weights stay in memory. `0`
+  keeps them loaded until you turn the setting off; any other value frees the
+  memory after that many idle minutes (a small proxy process stays behind, a few
+  tens of MB and no VRAM).
+
+Turning the setting off returns to the on-demand default and stops the engine at
+the next opportunity. Both knobs live in the TUI Settings screen, `lilbee set`,
+MCP `lilbee_settings_set`, the HTTP config API, and `config.toml`. The first
+launch after a reboot is always a cold one.
+
 ## Highlights
 
 - **Answers cite the source line.** Click a citation, jump to the file at the exact line. When the answer isn't in your library, lilbee says so instead of inventing one.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -519,6 +519,62 @@ touching the running fleet.
 - **Hardware QA:** `tools/qa/multi_gpu_smoke.py` validates enumeration, placement,
   concurrency, restart, and orphan cleanup on a real multi-GPU host.
 
+### Startup sequence and engine lifecycle
+
+The TUI opens the way Ollama and LM Studio do: the app is usable within a
+couple of seconds and the model loads in the background. The launcher never
+blocks on the engine; the same amber wordmark carries every stage. The onefile
+bootstrap paints an unpack progress bar (one-time; later launches skip it via
+the extraction stamp), parks the wordmark for the Python start, and the startup
+gate (`cli/tui/screens/startup_gate.py`) holds only while the services
+container builds. Nothing slower than widget mounting runs on the mount path:
+model canonicalization (disk reads, server probes) lives in the gate's boot
+worker, off the event loop. A prompt sent before the engine is ready waits
+inside its own answer bubble, whose thinking row renders the live load phase
+(`wait_chat_ready(on_progress=...)` in `app/placement.py`), byte progress
+included; a failed load lands there with the model hint.
+
+```mermaid
+flowchart TD
+    A([launch]) --> C["unpack progress bar<br/><i>first run only; later runs skip in ~1s</i>"]
+    C --> D["bee splash<br/>while Python starts"]
+    D --> E(["chat opens, ~2s<br/>engine loads in the background"])
+    E --> F{"prompt sent before<br/>the engine is ready?"}
+    F -- yes --> G["answer bubble shows the load<br/>live weight-read percentage"]
+    G --> H([answer streams])
+    F -- no --> H
+```
+
+By default the engine lives and dies with lilbee. With `keep_engine_warm` on,
+terminal shutdown detaches instead: the fleet state file gains a `detached`
+marker (owner-PID state files in `providers/fleet/swap_manager.py`) and the
+next launch adopts the running fleet after a health, version, and model match,
+skipping planning and the load entirely. llama-swap's per-model `ttl`
+(`engine_idle_ttl_minutes`, default five minutes) frees idle GPU memory on its
+own; `lilbee engine stop` frees everything from any terminal. `reap_stale`
+spares detached fleets only while the setting is on, so toggling it off cleans
+up at the next start of any lilbee process.
+
+```mermaid
+flowchart TD
+    subgraph OFF ["default: on-demand"]
+        q1["quit, kill, or terminal close"] --> s1["engine stopped<br/>GPU memory freed"]
+    end
+    subgraph ON ["keep_engine_warm on"]
+        q2[quit] --> d["fleet keeps running,<br/>state file marked detached"]
+        d --> l2([next launch]) --> ok{"healthy, same lilbee<br/>version, same models?"}
+        ok -- yes --> a["adopt: bind to the running fleet<br/>first answer immediate"]
+        ok -- no --> r["reap it, start fresh"]
+        d --> i["idle past the ttl<br/>default five minutes"] --> u["weights unloaded<br/>GPU memory freed"]
+        t["setting turned off"] --> r
+        e["lilbee engine stop"] --> s2["everything freed now"]
+    end
+```
+
+There is no background daemon: the only processes that outlive a session are
+the engine's own, and only when the user opted in. A crashed or force-killed
+session's engine is reclaimed at the next launch.
+
 ### Chat context-window management
 
 The fleet provider windows the request messages to fit the served chat

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -216,6 +216,30 @@ per sync) so day-to-day re-ingest never churns existing concept slugs. Rebuild
 from scratch, lint, drafts review, and prune are also available as CLI
 commands (see [Wiki commands](#wiki-1)) and as MCP tools.
 
+## The warm engine
+
+By default the engine lives and dies with lilbee: launch loads the model, quit
+frees the GPU. Every launch pays the model load before chat opens.
+
+If you relaunch often, turn on **Keep engine warm** (Settings, MCP
+`lilbee_settings_set`, the HTTP config API, or `config.toml`). Quitting then
+leaves the engine running, and the next launch connects to it in a couple of
+seconds. **Engine idle ttl minutes** bounds how long idle weights stay in GPU
+memory, five minutes by default, the same idea as Ollama's `keep_alive`. After
+that the memory is freed on its own; a small proxy process (a few tens of MB, no
+GPU memory) stays behind until reuse or stop. Set the ttl to `0` only if you
+want the model resident until you say otherwise.
+
+To stop a warm engine without opening the TUI:
+
+```bash
+lilbee engine stop
+```
+
+It reports whether anything was running, frees the GPU immediately, and is safe
+to run at any time. Turning **Keep engine warm** off also cleans the engine up
+at the next launch of any lilbee command.
+
 ## Memory
 
 lilbee can remember durable facts about you and standing preferences for how

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -218,13 +218,16 @@ commands (see [Wiki commands](#wiki-1)) and as MCP tools.
 
 ## The warm engine
 
-By default the engine lives and dies with lilbee: launch loads the model, quit
-frees the GPU. Every launch pays the model load before chat opens.
+By default the engine lives and dies with lilbee: launch starts loading the
+model in the background, quit frees the GPU. The TUI opens right away either
+way; a question asked before the engine is ready shows the load's progress in
+its answer bubble and streams the answer once loaded, so only the session's
+first answer waits out the load.
 
 If you relaunch often, turn on **Keep engine warm** (Settings, MCP
 `lilbee_settings_set`, the HTTP config API, or `config.toml`). Quitting then
-leaves the engine running, and the next launch connects to it in a couple of
-seconds. **Engine idle ttl minutes** bounds how long idle weights stay in GPU
+leaves the engine running, the next launch connects to it, and even that first
+answer skips the load. **Engine idle ttl minutes** bounds how long idle weights stay in GPU
 memory, five minutes by default, the same idea as Ollama's `keep_alive`. After
 that the memory is freed on its own; a small proxy process (a few tens of MB, no
 GPU memory) stays behind until reuse or stop. Set the ttl to `0` only if you

--- a/site/index.html
+++ b/site/index.html
@@ -104,6 +104,7 @@
         <div class="tutorialtabs" role="tablist" aria-label="Tutorial reel">
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-whatis"   aria-controls="tutorial-pane-whatis"   aria-selected="true"  tabindex="0">what is lilbee</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-setup"    aria-controls="tutorial-pane-setup"    aria-selected="false" tabindex="-1">first run</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-startup"  aria-controls="tutorial-pane-startup"  aria-selected="false" tabindex="-1">startup</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-tour"     aria-controls="tutorial-pane-tour"     aria-selected="false" tabindex="-1">tui-tour</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-chat"     aria-controls="tutorial-pane-chat"     aria-selected="false" tabindex="-1">chat</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-add"      aria-controls="tutorial-pane-add"      aria-selected="false" tabindex="-1">add files</button>
@@ -133,6 +134,13 @@
             <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-setup.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
           <p class="tutorial-caption">First run: a setup wizard pulls a chat model and an embedder, then drops you straight into chat.</p>
+        </div>
+
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-startup" aria-labelledby="tutorial-tab-startup" hidden>
+          <div class="tutorial-clip">
+            <video src="https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/cold-start.mp4" controls loop muted autoplay playsinline preload="metadata"></video>
+          </div>
+          <p class="tutorial-caption">A cold start, end to end: the one-time unpack behind the wordmark, chat on screen in seconds, and the first answer showing the engine load inside its own bubble.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-tour" aria-labelledby="tutorial-tab-tour" hidden>

--- a/site/style.css
+++ b/site/style.css
@@ -475,16 +475,17 @@ h2.label { font-size: inherit; font-weight: inherit; }
   font-family: var(--mono);
   font-size: 13px;
   letter-spacing: 0.05em;
-  background: transparent;
-  border: none;
+  background: rgba(57, 53, 82, 0.35);
+  border: 1px solid var(--rule-2);
   border-bottom: 2px solid transparent;
-  color: var(--ink-3);
+  border-radius: 3px 3px 0 0;
+  color: var(--ink-2);
   padding: 0.5rem 0.85rem;
   margin-bottom: -1px;
   cursor: pointer;
-  transition: color 140ms, border-color 140ms;
+  transition: color 140ms, background-color 140ms, border-color 140ms;
 }
-.installtabs .tab:hover { color: var(--ink-2); }
+.installtabs .tab:hover { color: var(--ink); border-color: var(--ink-3); }
 .installtabs .tab[aria-selected="true"] {
   color: var(--accent);
   border-bottom-color: var(--accent);
@@ -756,11 +757,13 @@ footer .meta { text-align: right; font-size: 12px; }
   font-family: var(--mono);
   font-size: 13px;
   letter-spacing: 0.04em;
-  background: transparent;
-  border: 1px solid transparent;
+  /* Resting chip: a visible border and a faint fill so the row reads as
+     buttons, not labels. Hover and the selected highlight stay as they were. */
+  background: rgba(57, 53, 82, 0.35);
+  border: 1px solid var(--rule-2);
   border-bottom: 2px solid transparent;
   border-radius: 3px 3px 0 0;
-  color: var(--ink-3);
+  color: var(--ink-2);
   padding: 0.5rem 0.9rem;
   margin-bottom: -1px;
   cursor: pointer;
@@ -769,6 +772,7 @@ footer .meta { text-align: right; font-size: 12px; }
 .tutorialtabs .tutorialtab:hover {
   color: var(--ink);
   background: rgba(235, 188, 186, 0.05);
+  border-color: var(--ink-3);
 }
 .tutorialtabs .tutorialtab:focus-visible {
   outline: 2px solid var(--accent);

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -26,7 +26,7 @@ _PLACEMENT_KEY = "placement"
 _CHAT_READY_TIMEOUT_S = 1800.0
 _CHAT_READY_POLL_S = 0.5
 _CHAT_READY_GRACE_S = 3.0
-_ACTIVE_WARM_PHASES = frozenset(
+ACTIVE_WARM_PHASES = frozenset(
     {WarmPhase.STARTING, WarmPhase.READING_WEIGHTS, WarmPhase.LOADING_ENGINE}
 )
 
@@ -197,11 +197,24 @@ def wait_chat_ready(timeout_s: float = _CHAT_READY_TIMEOUT_S) -> bool:
         if provider.role_ready(WorkerRole.CHAT):
             return True
         snapshot = provider.warm_progress()
-        warm_in_flight = snapshot is not None and snapshot.phase in _ACTIVE_WARM_PHASES
+        warm_in_flight = snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES
         if not warm_in_flight and time.monotonic() > grace_deadline:
             return False
         time.sleep(_CHAT_READY_POLL_S)
     return False
+
+
+def chat_engine_ready() -> bool:
+    """Whether a chat prompt can be served right now.
+
+    Positive readiness, not absence-of-warm: before the services container is
+    built nothing is loading yet and nothing can answer, which a warm snapshot
+    cannot distinguish from a finished load.
+    """
+    services = peek_services()
+    if services is None:
+        return False
+    return services.provider.role_ready(WorkerRole.CHAT)
 
 
 def active_chat_warm_progress() -> WarmProgress | None:
@@ -218,6 +231,6 @@ def active_chat_warm_progress() -> WarmProgress | None:
     if provider.role_ready(WorkerRole.CHAT):
         return None
     snapshot = provider.warm_progress()
-    if snapshot is not None and snapshot.phase in _ACTIVE_WARM_PHASES:
+    if snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES:
         return snapshot
     return None

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 
 from lilbee.app.services import peek_services
@@ -184,8 +185,13 @@ def warm_is_reporting(snapshot: WarmProgress | None) -> bool:
     return snapshot is not None and snapshot.phase in _ACTIVE_WARM_PHASES
 
 
-def wait_chat_ready(timeout_s: float = _CHAT_READY_TIMEOUT_S) -> bool:
-    """Block while a chat warm is in flight after a placement change; True when ready.
+def wait_chat_ready(
+    timeout_s: float = _CHAT_READY_TIMEOUT_S,
+    *,
+    on_progress: Callable[[WarmProgress], None] | None = None,
+    should_abort: Callable[[], bool] | None = None,
+) -> bool:
+    """Block while a chat warm is in flight; True once a prompt can be served.
 
     ``reload_placement(wait=True)`` returns once the proxies are healthy while the
     restarted model still warms off-thread, so a chat request sent right after an
@@ -194,6 +200,10 @@ def wait_chat_ready(timeout_s: float = _CHAT_READY_TIMEOUT_S) -> bool:
     actively in flight: with no fleet, no warm, or a failed/finished warm it
     returns at once, so a change that never restarts chat cannot stall the caller.
     The brief grace covers the reload kicking its warm on a separate thread.
+
+    ``on_progress`` receives each actively-reporting warm snapshot so the caller
+    can render the load. ``should_abort`` is polled every cycle; True ends the
+    wait at once, so a cancelled prompt never pins its worker thread.
     """
     services = peek_services()
     if services is None:
@@ -205,10 +215,16 @@ def wait_chat_ready(timeout_s: float = _CHAT_READY_TIMEOUT_S) -> bool:
     while time.monotonic() < deadline:
         if provider.role_ready(WorkerRole.CHAT):
             return True
+        if should_abort is not None and should_abort():
+            return False
         snapshot = provider.warm_progress()
         # A requested warm counts as in flight before it stamps a phase: the fleet
         # spawns and health-checks llama-swap first, which takes seconds.
-        if warm_is_reporting(snapshot) or provider.warm_pending():
+        if warm_is_reporting(snapshot):
+            if on_progress is not None and snapshot is not None:
+                on_progress(snapshot)
+            grace_deadline = time.monotonic() + _CHAT_READY_GRACE_S
+        elif provider.warm_pending():
             grace_deadline = time.monotonic() + _CHAT_READY_GRACE_S
         elif time.monotonic() > grace_deadline:
             return False
@@ -244,3 +260,14 @@ def active_chat_warm_progress() -> WarmProgress | None:
         return None
     snapshot = provider.warm_progress()
     return snapshot if warm_is_reporting(snapshot) else None
+
+
+def chat_warm_error() -> str | None:
+    """The failed chat warm's error text, or None when no failure is on record."""
+    services = peek_services()
+    if services is None:
+        return None
+    snapshot = services.provider.warm_progress()
+    if snapshot is not None and snapshot.phase is WarmPhase.ERROR:
+        return snapshot.error or ""
+    return None

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -26,7 +26,7 @@ _PLACEMENT_KEY = "placement"
 _CHAT_READY_TIMEOUT_S = 1800.0
 _CHAT_READY_POLL_S = 0.5
 _CHAT_READY_GRACE_S = 3.0
-ACTIVE_WARM_PHASES = frozenset(
+_ACTIVE_WARM_PHASES = frozenset(
     {WarmPhase.STARTING, WarmPhase.READING_WEIGHTS, WarmPhase.LOADING_ENGINE}
 )
 
@@ -175,6 +175,11 @@ def set_placement(spec: PlacementSpec | None) -> PlacementView:
     return _view(resolved, manual=spec is not None, spec_json=spec.to_json() if spec else None)
 
 
+def warm_is_reporting(snapshot: WarmProgress | None) -> bool:
+    """Whether *snapshot* is a warm that is actively loading, rather than idle or done."""
+    return snapshot is not None and snapshot.phase in _ACTIVE_WARM_PHASES
+
+
 def wait_chat_ready(timeout_s: float = _CHAT_READY_TIMEOUT_S) -> bool:
     """Block while a chat warm is in flight after a placement change; True when ready.
 
@@ -197,10 +202,9 @@ def wait_chat_ready(timeout_s: float = _CHAT_READY_TIMEOUT_S) -> bool:
         if provider.role_ready(WorkerRole.CHAT):
             return True
         snapshot = provider.warm_progress()
-        reporting = snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES
         # A requested warm counts as in flight before it stamps a phase: the fleet
         # spawns and health-checks llama-swap first, which takes seconds.
-        if reporting or provider.warm_pending():
+        if warm_is_reporting(snapshot) or provider.warm_pending():
             grace_deadline = time.monotonic() + _CHAT_READY_GRACE_S
         elif time.monotonic() > grace_deadline:
             return False
@@ -235,6 +239,4 @@ def active_chat_warm_progress() -> WarmProgress | None:
     if provider.role_ready(WorkerRole.CHAT):
         return None
     snapshot = provider.warm_progress()
-    if snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES:
-        return snapshot
-    return None
+    return snapshot if warm_is_reporting(snapshot) else None

--- a/src/lilbee/app/placement.py
+++ b/src/lilbee/app/placement.py
@@ -197,8 +197,12 @@ def wait_chat_ready(timeout_s: float = _CHAT_READY_TIMEOUT_S) -> bool:
         if provider.role_ready(WorkerRole.CHAT):
             return True
         snapshot = provider.warm_progress()
-        warm_in_flight = snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES
-        if not warm_in_flight and time.monotonic() > grace_deadline:
+        reporting = snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES
+        # A requested warm counts as in flight before it stamps a phase: the fleet
+        # spawns and health-checks llama-swap first, which takes seconds.
+        if reporting or provider.warm_pending():
+            grace_deadline = time.monotonic() + _CHAT_READY_GRACE_S
+        elif time.monotonic() > grace_deadline:
             return False
         time.sleep(_CHAT_READY_POLL_S)
     return False

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import signal
+import sys
 import threading
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -42,6 +44,9 @@ if TYPE_CHECKING:
     from lilbee.retrieval.query import Searcher
     from lilbee.retrieval.reranker import Reranker
     from lilbee.runtime.ingest_lock import IngestLockRegistry
+
+
+_SIGNAL_EXIT_BASE = 128
 
 
 @dataclass
@@ -318,6 +323,49 @@ def reset_store() -> None:
         searcher=searcher,
     )
     old_store.close()
+
+
+class _EngineLifecycle:
+    """Owns the hard-exit hooks that stop the engine fleet."""
+
+    def __init__(self) -> None:
+        self._installed = False
+
+    @staticmethod
+    def _hard_exit_signals() -> tuple[signal.Signals, ...]:
+        """Signals whose default disposition kills us without running atexit."""
+        if sys.platform == "win32":  # pragma: no cover - Windows has no SIGHUP
+            return (signal.SIGTERM,)
+        return (signal.SIGTERM, signal.SIGHUP)
+
+    def install(self) -> None:
+        """Route hard-exit signals through teardown. Idempotent; no-op off the main thread."""
+        if self._installed:
+            return
+        try:
+            for sig in self._hard_exit_signals():
+                signal.signal(sig, self._on_hard_exit)
+        except ValueError:
+            return
+        self._installed = True
+
+    def reset(self) -> None:
+        """Forget that handlers were installed."""
+        self._installed = False
+
+    def _on_hard_exit(self, signum: int, frame: object) -> None:
+        """Stop the fleet, then exit with the conventional signal status."""
+        del frame
+        reset_services()
+        raise SystemExit(_SIGNAL_EXIT_BASE + signum)
+
+
+_lifecycle = _EngineLifecycle()
+
+
+def install_engine_lifecycle_hooks() -> None:
+    """Make a terminal close or ``kill`` stop the engine fleet instead of orphaning it."""
+    _lifecycle.install()
 
 
 atexit.register(reset_services)

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -275,16 +275,25 @@ def peek_services() -> Services | None:
     return _state.singleton
 
 
+# Serializes the singleton swap in reset_services: the hard-exit teardown
+# thread and the atexit hook can race, and both tearing down the same container
+# would double-close the store.
+_reset_swap_lock = threading.Lock()
+
+
 def reset_services() -> None:
     """Shut down and discard all cached instances.
 
     Swap the module reference to ``None`` *before* tearing the old instances
-    down, so a new caller never observes a half-closed container. On the shared
-    HTTP daemon every entry point that would call this mid-flight is refused, so
-    it only ever runs single-client (CLI, TUI, stdio MCP).
+    down, so a new caller never observes a half-closed container. The swap is
+    locked so concurrent callers (the hard-exit teardown thread plus atexit)
+    tear the container down exactly once. On the shared HTTP daemon every entry
+    point that would call this mid-flight is refused, so it only ever runs
+    single-client (CLI, TUI, stdio MCP).
     """
-    old = _state.singleton
-    _state.singleton = None
+    with _reset_swap_lock:
+        old = _state.singleton
+        _state.singleton = None
     if old is not None:
         old.provider.shutdown()
         old.store.close()
@@ -354,9 +363,18 @@ class _EngineLifecycle:
         self._installed = False
 
     def _on_hard_exit(self, signum: int, frame: object) -> None:
-        """Stop the fleet, then exit with the conventional signal status."""
+        """Stop the fleet on its own thread, then exit with the signal status.
+
+        Signal handlers all run on the main thread, and a second signal can
+        interrupt this one mid-teardown: the kernel pairs SIGCONT with SIGHUP
+        for an orphaned process group, and Textual's SIGCONT handler raises
+        once the event loop is gone, which aborted the reap half-done and
+        orphaned a loaded fleet. A dedicated non-daemon thread cannot be
+        interrupted by signals, and the interpreter waits for it even as the
+        SystemExit unwinds the main thread.
+        """
         del frame
-        reset_services()
+        threading.Thread(target=reset_services, name="hard-exit-teardown").start()
         raise SystemExit(_SIGNAL_EXIT_BASE + signum)
 
 

--- a/src/lilbee/app/services.py
+++ b/src/lilbee/app/services.py
@@ -332,9 +332,9 @@ class _EngineLifecycle:
         self._installed = False
 
     @staticmethod
-    def _hard_exit_signals() -> tuple[signal.Signals, ...]:
+    def _hard_exit_signals() -> tuple[signal.Signals, ...]:  # pragma: no cover - platform split
         """Signals whose default disposition kills us without running atexit."""
-        if sys.platform == "win32":  # pragma: no cover - Windows has no SIGHUP
+        if sys.platform == "win32":  # Windows has no SIGHUP
             return (signal.SIGTERM,)
         return (signal.SIGTERM, signal.SIGHUP)
 

--- a/src/lilbee/app/settings.py
+++ b/src/lilbee/app/settings.py
@@ -198,6 +198,9 @@ def _validate(updates: dict[str, Any]) -> None:
             raise ValueError(f"Unknown or read-only setting: {key}")
         if value is None and not _is_nullable(key):
             raise ValueError(f"Setting '{key}' does not accept null")
+    new_ttl = _as_int_setting(updates.get("engine_idle_ttl_minutes"))
+    if new_ttl is not None and new_ttl < 0:
+        raise ValueError("engine_idle_ttl_minutes must be >= 0 (0 keeps weights loaded)")
     new_chunk_size = _as_int_setting(updates.get("chunk_size"))
     if new_chunk_size is not None and new_chunk_size < _MIN_CHUNK_SIZE:
         raise ValueError(f"chunk_size must be >= {_MIN_CHUNK_SIZE}")

--- a/src/lilbee/app/settings_map.py
+++ b/src/lilbee/app/settings_map.py
@@ -739,6 +739,18 @@ SETTINGS_MAP: dict[str, SettingDef] = {
             "Trades cold-start time per role for first-call latency"
         ),
     ),
+    "keep_engine_warm": SettingDef(
+        bool,
+        nullable=False,
+        group=SettingGroup.SYSTEM,
+        help_text="Keep the engine running after quit so the next launch starts warm",
+    ),
+    "engine_idle_ttl_minutes": SettingDef(
+        int,
+        nullable=False,
+        group=SettingGroup.SYSTEM,
+        help_text="Idle minutes before a warm engine unloads its weights; 0 keeps them loaded",
+    ),
     "agent_mcp_enabled": SettingDef(
         bool,
         nullable=False,

--- a/src/lilbee/app/setup_state.py
+++ b/src/lilbee/app/setup_state.py
@@ -1,0 +1,39 @@
+"""Whether the first-run setup wizard has to run before anything can load."""
+
+from __future__ import annotations
+
+import logging
+
+from lilbee.core.config import cfg
+from lilbee.providers.model_ref import parse_model_ref
+
+log = logging.getLogger(__name__)
+
+
+def needs_setup() -> bool:
+    """True when the setup wizard should run: fresh data dir or unresolved models.
+
+    Remote-prefixed refs (ollama/lm_studio/API) are validated against current
+    state instead of probed on disk: an ``ollama/`` ref whose litellm extra is
+    missing or whose server is down is unusable and must route the user to
+    setup, not be assumed live.
+    """
+    if not cfg.lancedb_dir.is_dir():
+        log.debug("needs_setup: lancedb_dir missing (%s)", cfg.lancedb_dir)
+        return True
+    from lilbee.modelhub.model_manager import ValidationResult, validate_persisted_model
+    from lilbee.providers.base import ProviderError
+    from lilbee.providers.engine_params import resolve_model_path
+
+    for label, model in (("chat", cfg.chat_model), ("embedding", cfg.embedding_model)):
+        if parse_model_ref(model).is_remote:
+            if validate_persisted_model(model) != ValidationResult.OK:
+                log.debug("needs_setup: remote %s model %r not usable", label, model)
+                return True
+            continue
+        try:
+            resolve_model_path(model)
+        except (ProviderError, KeyError, ValueError) as exc:
+            log.debug("needs_setup: %s model %r unresolved: %s", label, model, exc)
+            return True
+    return False

--- a/src/lilbee/cli/__init__.py
+++ b/src/lilbee/cli/__init__.py
@@ -5,9 +5,11 @@
 # happens in the right order even though `app` is listed below alphabetically.
 from lilbee.cli import commands as _commands  # noqa: F401  side-effect: command registration
 from lilbee.cli.app import app, apply_overrides, console
+from lilbee.cli.engine import engine_app
 from lilbee.cli.model import model_app
 from lilbee.cli.placement import placement_app
 
+app.add_typer(engine_app)
 app.add_typer(model_app)
 app.add_typer(placement_app)
 

--- a/src/lilbee/cli/app.py
+++ b/src/lilbee/cli/app.py
@@ -9,6 +9,7 @@ from typing import Any
 import typer
 from rich.console import Console
 
+from lilbee.app.services import install_engine_lifecycle_hooks
 from lilbee.app.version import get_version
 from lilbee.cli.helpers import json_output as json_out
 from lilbee.core.config import cfg, config_load_error
@@ -172,6 +173,10 @@ def _default(
     from lilbee.data.store import install_lancedb_thread_error_suppressor
 
     install_lancedb_thread_error_suppressor()
+
+    # A terminal close or `kill` otherwise leaves the engine fleet running and its
+    # VRAM pinned, because the default disposition skips the atexit teardown.
+    install_engine_lifecycle_hooks()
 
     cfg.json_mode = json_output
     # Typer binds options placed before the subcommand name to this callback;

--- a/src/lilbee/cli/engine.py
+++ b/src/lilbee/cli/engine.py
@@ -1,0 +1,34 @@
+"""Engine lifecycle commands: manage a warm fleet without opening the TUI."""
+
+from __future__ import annotations
+
+import typer
+
+from lilbee.cli.app import console, json_out
+from lilbee.core.config import cfg
+from lilbee.providers.fleet.groups import SwapGroup
+from lilbee.providers.fleet.swap_manager import find_detached_state, reap_stale
+
+engine_app = typer.Typer(
+    name="engine",
+    help="Manage the local inference engine.",
+    no_args_is_help=True,
+)
+
+_STOPPED = "Stopped the warm engine and freed its memory."
+_NOTHING_RUNNING = "No warm engine is running."
+
+
+@engine_app.command("stop")
+def stop() -> None:
+    """Stop a warm engine left running by keep_engine_warm."""
+    detached = [
+        group.value
+        for group in SwapGroup
+        if find_detached_state(cfg.data_dir, group) is not None
+    ]
+    reap_stale(cfg.data_dir)
+    if cfg.json_mode:
+        json_out({"command": "engine stop", "stopped": detached})
+        return
+    console.print(_STOPPED if detached else _NOTHING_RUNNING)

--- a/src/lilbee/cli/engine.py
+++ b/src/lilbee/cli/engine.py
@@ -23,9 +23,7 @@ _NOTHING_RUNNING = "No warm engine is running."
 def stop() -> None:
     """Stop a warm engine left running by keep_engine_warm."""
     detached = [
-        group.value
-        for group in SwapGroup
-        if find_detached_state(cfg.data_dir, group) is not None
+        group.value for group in SwapGroup if find_detached_state(cfg.data_dir, group) is not None
     ]
     reap_stale(cfg.data_dir)
     if cfg.json_mode:

--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -99,17 +99,12 @@ def run_tui(*, initial_view: str | None = None) -> None:
     # cold-start on bare runners); only needed at TUI shutdown. (bb-oae5)
     from lilbee.cli.sync import shutdown_executor
     from lilbee.cli.tui.app import LilbeeApp
-    from lilbee.runtime.splash import dismiss
 
     log_path = setup_tui_log_file()
     _silence_stderr_log_handlers()
     stderr_redirect = _redirect_native_stderr_to(log_path)
 
     app = LilbeeApp(initial_view=initial_view)
-    # The launcher's splash animates until here, covering this module's own
-    # heavy imports; it must be gone before Textual claims the terminal, or
-    # its frames would land on the alt-screen.
-    dismiss()
     try:
         app.run()
     except KeyboardInterrupt:

--- a/src/lilbee/cli/tui/__init__.py
+++ b/src/lilbee/cli/tui/__init__.py
@@ -99,12 +99,17 @@ def run_tui(*, initial_view: str | None = None) -> None:
     # cold-start on bare runners); only needed at TUI shutdown. (bb-oae5)
     from lilbee.cli.sync import shutdown_executor
     from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.runtime.splash import dismiss
 
     log_path = setup_tui_log_file()
     _silence_stderr_log_handlers()
     stderr_redirect = _redirect_native_stderr_to(log_path)
 
     app = LilbeeApp(initial_view=initial_view)
+    # The launcher's splash animates until here, covering this module's own
+    # heavy imports; it must be gone before Textual claims the terminal, or
+    # its frames would land on the alt-screen.
+    dismiss()
     try:
         app.run()
     except KeyboardInterrupt:

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -174,6 +174,14 @@ class LilbeeApp(App[None]):
     async def on_mount(self) -> None:
         if self._test_skip_auto_init:
             return
+        # Paint the gate before any awaiting work so the terminal is never blank
+        # between the splash handing over and the first screen appearing.
+        from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+        gate = StartupGate()
+        # Awaited: the gate's boot worker treats an unmounted gate as "torn down",
+        # so it must be mounted before start_boot can hand over.
+        await self.push_screen(gate)
         await self._canonicalize_persisted_models()
         self.title = msg.app_title(cfg.chat_model)
         # Restore the persisted theme so the TUI opens in whatever the user
@@ -189,7 +197,11 @@ class LilbeeApp(App[None]):
 
         chat = ChatScreen()
         self.install_screen(chat, name=_CHAT_SCREEN_NAME)
-        self.push_screen(_CHAT_SCREEN_NAME)
+        gate.start_boot()
+
+    def reveal_chat(self) -> None:
+        """Swap the startup gate for the chat screen once the engine has settled."""
+        self.switch_screen(_CHAT_SCREEN_NAME)
         if self._initial_view and self._initial_view != msg.DEFAULT_VIEW:
             self.switch_view(self._initial_view)
         # Cheap detection only: filesystem walk + hash compare. The user
@@ -239,7 +251,7 @@ class LilbeeApp(App[None]):
 
             if canon.original == canon.effective:
                 # Nothing to fall back to: keep the ref and let the chat screen's
-                # _needs_setup open the SetupWizard, which is the single voice for
+                # needs_setup open the SetupWizard, which is the single voice for
                 # "pick a model." A toast here just duplicates the wizard (on first
                 # launch the default refs aren't downloaded yet), so log the reason
                 # as a breadcrumb but don't surface it.

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -6,8 +6,9 @@ import contextlib
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
+from textual import work
 from textual.app import App, ComposeResult
 from textual.await_complete import AwaitComplete
 from textual.binding import Binding, BindingType
@@ -26,6 +27,9 @@ from lilbee.cli.tui.widgets.status_bar import ViewTabs
 from lilbee.config_meta import MODEL_ROLE_FIELDS
 from lilbee.core.config import cfg
 from lilbee.providers.roles import WorkerRole
+
+if TYPE_CHECKING:
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
 
 log = logging.getLogger(__name__)
 
@@ -194,7 +198,23 @@ class LilbeeApp(App[None]):
 
         self.settings_changed_signal.subscribe(self, self._fan_out_provider_availability)
         self._wire_worker_pool_notifications()
+        # Chat's import graph is the TUI's heaviest; loading it here would hold
+        # the first frame back for seconds on a cold disk, leaving the terminal
+        # blank exactly where the gate should be. Paint first, then load.
+        self.call_after_refresh(self._load_chat_screen, gate)
 
+    def _load_chat_screen(self, gate: StartupGate) -> None:
+        """Import the chat stack off-thread after the first frame, then boot."""
+        self._chat_import_worker(gate)
+
+    @work(thread=True, name="chat_import", exit_on_error=False)
+    def _chat_import_worker(self, gate: StartupGate) -> None:
+        import lilbee.cli.tui.screens.chat  # noqa: F401 - imported for its side effect
+
+        self.call_from_thread(self._install_chat_screen, gate)
+
+    def _install_chat_screen(self, gate: StartupGate) -> None:
+        """Install chat and start the gate's boot; runs once chat's modules exist."""
         from lilbee.cli.tui.screens.chat import ChatScreen
 
         chat = ChatScreen()

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
@@ -209,7 +210,15 @@ class LilbeeApp(App[None]):
         self.call_after_refresh(self._load_chat_screen, gate)
 
     def _load_chat_screen(self, gate: StartupGate) -> None:
-        """Import the chat stack off-thread after the first frame, then boot."""
+        """Install chat after the first frame, importing off-thread only when cold.
+
+        The worker exists for the cold-disk case where chat's module graph takes
+        seconds to read; once the modules are in sys.modules the import is free,
+        and the extra thread hop would only delay the handover.
+        """
+        if "lilbee.cli.tui.screens.chat" in sys.modules:
+            self._install_chat_screen(gate)
+            return
         self._chat_import_worker(gate)
 
     @work(thread=True, name="chat_import", exit_on_error=False)

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -595,15 +595,18 @@ class LilbeeApp(App[None]):
             chat = self.get_screen(_CHAT_SCREEN_NAME, ChatScreen)
         except KeyError:
             return
-        self.switch_view("Chat")
 
-        # The switch is guarded and lands over several message-pump slots; a
-        # single deferred check silently dropped the sync when it fired early.
+        # switch_view drops the request outright while its re-entrancy guard is
+        # held (an earlier switch still in flight), so the retry must re-attempt
+        # the switch itself, not just wait for one that may never have started.
         def _start(attempts: int = 600) -> None:
+            if not self.screen_stack:
+                return  # the app is tearing down; nothing left to sync
             if isinstance(self.screen, ChatScreen):
                 chat._run_sync()
                 return
             if attempts > 0:
+                self.switch_view("Chat")
                 self.set_timer(0.05, lambda: _start(attempts - 1))
 
         self.call_later(_start)

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
 from collections.abc import Callable
@@ -22,6 +21,7 @@ from lilbee.app.settings import apply_settings_update
 from lilbee.app.themes import DARK_THEMES
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.commands import LilbeeCommandProvider
+from lilbee.cli.tui.thread_safe import call_from_thread
 from lilbee.cli.tui.widgets.status_bar import ViewTabs
 from lilbee.config_meta import MODEL_ROLE_FIELDS
 from lilbee.core.config import cfg
@@ -174,15 +174,17 @@ class LilbeeApp(App[None]):
     async def on_mount(self) -> None:
         if self._test_skip_auto_init:
             return
-        # Paint the gate before any awaiting work so the terminal is never blank
-        # between the splash handing over and the first screen appearing.
+        # Paint the gate before any other work so the terminal is never blank
+        # between the splash handing over and the first screen appearing. Nothing
+        # slower than widget mounting may run before the first frame: model
+        # canonicalization does disk and network probes, so it lives in the
+        # gate's boot worker, off this thread.
         from lilbee.cli.tui.screens.startup_gate import StartupGate
 
         gate = StartupGate()
         # Awaited: the gate's boot worker treats an unmounted gate as "torn down",
         # so it must be mounted before start_boot can hand over.
         await self.push_screen(gate)
-        await self._canonicalize_persisted_models()
         self.title = msg.app_title(cfg.chat_model)
         # Restore the persisted theme so the TUI opens in whatever the user
         # picked last session, not always the default.
@@ -226,12 +228,14 @@ class LilbeeApp(App[None]):
 
         get_services().add_pool_listener(on_spawning=_on_spawning, on_spawned=_on_spawned)
 
-    async def _canonicalize_persisted_models(self) -> None:
+    def canonicalize_persisted_models(self) -> None:
         """Swap stale persisted refs to a working fallback, persist, and log once.
 
-        Canonicalization can probe local model servers over HTTP/DNS, so it runs
-        off the event loop to keep the TUI from freezing at mount. The probes
-        finish before the chat screen installs, so it still sees a settled ref.
+        Canonicalization reads model files and can probe local model servers
+        over HTTP/DNS, so the startup gate's boot worker calls this off the
+        event loop before the services container builds; anything slower than
+        widget mounting on the mount path delays the TUI's first frame. UI
+        updates marshal back to the main thread.
         """
         from lilbee.modelhub.model_manager import (
             ValidationResult,
@@ -239,8 +243,8 @@ class LilbeeApp(App[None]):
             canonicalize_embedding_model,
         )
 
-        chat_canon = await asyncio.to_thread(canonicalize_chat_model)
-        embedding_canon = await asyncio.to_thread(canonicalize_embedding_model)
+        chat_canon = canonicalize_chat_model()
+        embedding_canon = canonicalize_embedding_model()
         for canon, field, label in (
             (chat_canon, "chat_model", "Chat"),
             (embedding_canon, "embedding_model", "Embedding"),
@@ -280,7 +284,14 @@ class LilbeeApp(App[None]):
                 label=label, original=canon.original, effective=canon.effective, reason=reason
             )
             log.warning(notice)
-            self.notify(notice, severity="warning", timeout=_FALLBACK_TOAST_TIMEOUT_S)
+            call_from_thread(
+                self, self.notify, notice, severity="warning", timeout=_FALLBACK_TOAST_TIMEOUT_S
+            )
+        call_from_thread(self, self._refresh_title)
+
+    def _refresh_title(self) -> None:
+        """Re-derive the window title after canonicalization may have swapped the ref."""
+        self.title = msg.app_title(cfg.chat_model)
 
     def _fan_out_provider_availability(self, payload: tuple[str, object]) -> None:
         """Republish on provider_availability_changed_signal when an API key changes."""

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -599,7 +599,7 @@ class LilbeeApp(App[None]):
 
         # The switch is guarded and lands over several message-pump slots; a
         # single deferred check silently dropped the sync when it fired early.
-        def _start(attempts: int = 40) -> None:
+        def _start(attempts: int = 600) -> None:
             if isinstance(self.screen, ChatScreen):
                 chat._run_sync()
                 return

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -597,9 +597,14 @@ class LilbeeApp(App[None]):
             return
         self.switch_view("Chat")
 
-        def _start() -> None:
+        # The switch is guarded and lands over several message-pump slots; a
+        # single deferred check silently dropped the sync when it fired early.
+        def _start(attempts: int = 40) -> None:
             if isinstance(self.screen, ChatScreen):
                 chat._run_sync()
+                return
+            if attempts > 0:
+                self.set_timer(0.05, lambda: _start(attempts - 1))
 
         self.call_later(_start)
 

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -93,6 +93,11 @@ _VIEW_FACTORIES: dict[str, Callable[[], Screen]] = {
 }
 
 
+def _import_chat_stack() -> None:
+    """Pull in the chat screen's module graph, the TUI's heaviest import."""
+    import lilbee.cli.tui.screens.chat  # noqa: F401 - imported for its side effect
+
+
 def get_views() -> dict[str, Callable[[], Screen]]:
     """Return the active view factories, derived from the nav view list."""
     return {name: _VIEW_FACTORIES[name] for name in msg.get_nav_views() if name in _VIEW_FACTORIES}
@@ -209,9 +214,19 @@ class LilbeeApp(App[None]):
 
     @work(thread=True, name="chat_import", exit_on_error=False)
     def _chat_import_worker(self, gate: StartupGate) -> None:
-        import lilbee.cli.tui.screens.chat  # noqa: F401 - imported for its side effect
+        try:
+            _import_chat_stack()
+        except Exception as exc:
+            # Without chat the app has no home screen; exit loudly like the old
+            # inline import did rather than stranding the user on the gate.
+            log.exception("the chat screen failed to import")
+            call_from_thread(self, self._exit_on_chat_import_failure, str(exc))
+            return
+        call_from_thread(self, self._install_chat_screen, gate)
 
-        self.call_from_thread(self._install_chat_screen, gate)
+    def _exit_on_chat_import_failure(self, error: str) -> None:
+        """Leave the TUI with the import error where the user can read it."""
+        self.exit(return_code=1, message=msg.CHAT_STACK_FAILED.format(error=error))
 
     def _install_chat_screen(self, gate: StartupGate) -> None:
         """Install chat and start the gate's boot; runs once chat's modules exist."""

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -123,6 +123,12 @@ MODEL_SWAP_FAILED = "Could not switch model: {error}"
 # Shown when the user tries to send a prompt while the new chat model is still loading.
 CHAT_MODEL_SWITCHING = "Still switching model. One moment, then send your prompt."
 FLEET_RELOADING = "Applying placement, reloading the fleet. One moment, then send your prompt."
+# Startup gate: shown from the moment the TUI paints until the chat engine answers.
+STARTUP_PREPARING = "Preparing lilbee"
+STARTUP_READING_WEIGHTS = "Reading {name} weights"
+STARTUP_LOADING_ENGINE = "Loading engine"
+STARTUP_FAILED = "The chat model failed to load: {error}"
+STARTUP_FAILED_HINT = "Open Catalog or Settings to pick a different model."
 CMD_REMOVE_USAGE = "Usage: /remove <model_name>"
 CMD_REMOVE_NOT_FOUND = "{name} is not installed"
 CMD_REMOVE_SUCCESS = "Removed {name}"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -126,6 +126,7 @@ FLEET_RELOADING = "Applying placement, reloading the fleet. One moment, then sen
 # Startup gate: shown from the moment the TUI paints until the app can serve.
 STARTUP_PREPARING = "Preparing lilbee"
 STARTUP_FAILED = "lilbee could not start: {error}"
+CHAT_STACK_FAILED = "lilbee could not load its chat screen: {error}"
 # Engine-load status painted into the pending answer while a prompt waits on a
 # cold engine, and the failure that wait can end in.
 ENGINE_READING_WEIGHTS = "Reading {name} weights"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -129,6 +129,8 @@ STARTUP_READING_WEIGHTS = "Reading {name} weights"
 STARTUP_LOADING_ENGINE = "Loading engine"
 STARTUP_FAILED = "The chat model failed to load: {error}"
 STARTUP_FAILED_HINT = "Open Catalog or Settings to pick a different model."
+# Shown while a cold engine load runs and keep_engine_warm is off.
+STARTUP_WARM_TIP = "Tip: Settings > Keep engine warm makes the next launch fast"
 CMD_REMOVE_USAGE = "Usage: /remove <model_name>"
 CMD_REMOVE_NOT_FOUND = "{name} is not installed"
 CMD_REMOVE_SUCCESS = "Removed {name}"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -123,14 +123,18 @@ MODEL_SWAP_FAILED = "Could not switch model: {error}"
 # Shown when the user tries to send a prompt while the new chat model is still loading.
 CHAT_MODEL_SWITCHING = "Still switching model. One moment, then send your prompt."
 FLEET_RELOADING = "Applying placement, reloading the fleet. One moment, then send your prompt."
-# Startup gate: shown from the moment the TUI paints until the chat engine answers.
+# Startup gate: shown from the moment the TUI paints until the app can serve.
 STARTUP_PREPARING = "Preparing lilbee"
-STARTUP_READING_WEIGHTS = "Reading {name} weights"
-STARTUP_LOADING_ENGINE = "Loading engine"
-STARTUP_FAILED = "The chat model failed to load: {error}"
-STARTUP_FAILED_HINT = "Open Catalog or Settings to pick a different model."
-# Shown while a cold engine load runs and keep_engine_warm is off.
-STARTUP_WARM_TIP = "Tip: Settings > Keep engine warm makes the next launch fast"
+STARTUP_FAILED = "lilbee could not start: {error}"
+# Engine-load status painted into the pending answer while a prompt waits on a
+# cold engine, and the failure that wait can end in.
+ENGINE_READING_WEIGHTS = "Reading {name} weights"
+ENGINE_LOADING = "Loading engine"
+ENGINE_LOAD_FAILED = "The engine failed to load: {error}"
+ENGINE_FAILED_HINT = "Open Catalog or Settings to pick a different model."
+ENGINE_NOT_READY = "The engine is not ready yet. Send your prompt again in a moment."
+# Shown once when a prompt first waits on a cold engine and keep_engine_warm is off.
+ENGINE_WARM_TIP = "Tip: Settings > Keep engine warm makes the next launch fast"
 CMD_REMOVE_USAGE = "Usage: /remove <model_name>"
 CMD_REMOVE_NOT_FOUND = "{name} is not installed"
 CMD_REMOVE_SUCCESS = "Removed {name}"
@@ -219,7 +223,6 @@ SCOPE_PILL_BOTH = "Both"
 SCOPE_PILL_WIKI = "Wiki"
 SCOPE_PILL_RAW = "Raw"
 CHAT_BUSY = "Already answering. Press Ctrl+C to cancel, then submit your next prompt."
-CHAT_WARMING = "Loading the chat model. One moment, then send your prompt."
 CHAT_MODEL_DOWNLOADING = "{name} is still downloading. Wait for it to finish, then submit."
 MODEL_BEING_DOWNLOADED = (
     "{name} is still downloading. Wait for it to finish before setting it active."

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -32,6 +32,7 @@ from textual.worker import get_current_worker as _get_worker
 
 from lilbee.app.services import get_services, reset_store
 from lilbee.app.settings_map import SETTINGS_MAP
+from lilbee.app.setup_state import needs_setup
 from lilbee.app.themes import DARK_THEMES
 from lilbee.app.version import get_version
 from lilbee.cli.tui import messages as msg
@@ -65,7 +66,6 @@ from lilbee.core.config import cfg
 from lilbee.core.config.enums import ChatMode, CrawlRenderMode
 from lilbee.crawler import crawler_available, is_url, require_valid_crawl_url
 from lilbee.data.store import ChunkType, EmbeddingModelMismatchError, scope_to_chunk_type
-from lilbee.providers.model_ref import parse_model_ref
 from lilbee.providers.roles import WorkerRole
 from lilbee.retrieval.embedder import is_model_available
 from lilbee.retrieval.query import ChatMessage
@@ -329,8 +329,8 @@ class ChatScreen(Screen[None]):
 
     @work(thread=True, name="chat_setup_check", exit_on_error=False)
     def _setup_check_worker(self) -> None:
-        """Run ``_needs_setup`` off the UI thread; push the wizard if needed."""
-        if not self._needs_setup():
+        """Run ``needs_setup`` off the UI thread; push the wizard if needed."""
+        if not needs_setup():
             return
         call_from_thread(self, self._push_setup_wizard)
 
@@ -358,34 +358,6 @@ class ChatScreen(Screen[None]):
                 self._enter_insert_mode()
             else:
                 self._chat_log.focus()
-
-    def _needs_setup(self) -> bool:
-        """True when the setup wizard should run: fresh data dir or unresolved models.
-
-        Remote-prefixed refs (ollama/lm_studio/API) are validated against
-        current state instead of probed on disk: an ``ollama/`` ref whose
-        litellm extra is missing or whose server is down is unusable and
-        must route the user to setup, not be assumed live.
-        """
-        if not cfg.lancedb_dir.is_dir():
-            log.debug("_needs_setup: lancedb_dir missing (%s)", cfg.lancedb_dir)
-            return True
-        from lilbee.modelhub.model_manager import ValidationResult, validate_persisted_model
-        from lilbee.providers.base import ProviderError
-        from lilbee.providers.engine_params import resolve_model_path
-
-        for label, model in (("chat", cfg.chat_model), ("embedding", cfg.embedding_model)):
-            if parse_model_ref(model).is_remote:
-                if validate_persisted_model(model) != ValidationResult.OK:
-                    log.debug("_needs_setup: remote %s model %r not usable", label, model)
-                    return True
-                continue
-            try:
-                resolve_model_path(model)
-            except (ProviderError, KeyError, ValueError) as exc:
-                log.debug("_needs_setup: %s model %r unresolved: %s", label, model, exc)
-                return True
-        return False
 
     def _embedding_ready(self) -> bool:
         """Quick check if the embedding model resolves (no network calls)."""

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -393,11 +393,14 @@ class ChatScreen(Screen[None]):
 
     def _update_input_style(self) -> None:
         """Toggle input opacity and mode indicator based on current mode."""
-        inp = self._chat_input
-        if self._insert_mode:
-            inp.remove_class("normal-mode")
-        else:
-            inp.add_class("normal-mode")
+        # Lifecycle interleaves (an installed-but-swapped-away screen during
+        # app teardown) can invoke this before or after the input exists.
+        with contextlib.suppress(NoMatches):
+            inp = self._chat_input
+            if self._insert_mode:
+                inp.remove_class("normal-mode")
+            else:
+                inp.add_class("normal-mode")
         self._update_mode_indicator()
 
     def _update_mode_indicator(self) -> None:

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1300,6 +1300,11 @@ class ChatScreen(Screen[None]):
         """
         from lilbee.app.placement import chat_engine_ready, chat_warm_error, wait_chat_ready
 
+        # Build the container if nothing holds it (a settings change resets it);
+        # readiness is probed via peek_services, which never builds, so without
+        # this a prompt sent into the gap would report a dead engine instead of
+        # lazily rebuilding the way ask_stream always has.
+        get_services()
         if chat_engine_ready():
             return True
         self._show_warm_tip_once()

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -1309,6 +1309,11 @@ class ChatScreen(Screen[None]):
             with contextlib.suppress(Exception):
                 call_from_thread(self, widget.set_thinking_status, _engine_status_text(snapshot))
 
+        # Label the wait before the chat warm stamps its first phase: another
+        # role loading first (embed on a cold start) leaves the tracker silent
+        # for many seconds, and a bare scanner reads as a hang.
+        with contextlib.suppress(Exception):
+            call_from_thread(self, widget.set_thinking_status, msg.ENGINE_LOADING)
         if wait_chat_ready(on_progress=_paint, should_abort=lambda: worker.is_cancelled):
             with contextlib.suppress(Exception):
                 call_from_thread(self, widget.set_thinking_status, "")

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -67,6 +67,7 @@ from lilbee.core.config.enums import ChatMode, CrawlRenderMode
 from lilbee.crawler import crawler_available, is_url, require_valid_crawl_url
 from lilbee.data.store import ChunkType, EmbeddingModelMismatchError, scope_to_chunk_type
 from lilbee.providers.roles import WorkerRole
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 from lilbee.retrieval.embedder import is_model_available
 from lilbee.retrieval.query import ChatMessage
 from lilbee.retrieval.query.history_window import windowed_history
@@ -122,8 +123,16 @@ _CRAWL_FLAG_RENDER = "--render"
 # event loop.
 _MODEL_SWAP_WORKER = "model_swap_reset"
 
-# Cadence for polling whether the chat model is still warming on a cold start.
-_WARM_POLL_INTERVAL_S = 0.3
+
+def _engine_status_text(snapshot: WarmProgress) -> str:
+    """One status line for an engine-load snapshot: byte progress or the phase."""
+    if snapshot.phase is WarmPhase.READING_WEIGHTS and snapshot.bytes_total:
+        from lilbee.catalog.formatting import display_label_for_ref
+
+        name = display_label_for_ref(snapshot.model_ref) if snapshot.model_ref else ""
+        pct = snapshot.bytes_done * 100 // snapshot.bytes_total
+        return f"{msg.ENGINE_READING_WEIGHTS.format(name=name)} {pct}%"
+    return msg.ENGINE_LOADING
 
 
 def _parse_add_paths(args: str) -> list[Path]:
@@ -184,10 +193,6 @@ class ChatScreen(Screen[None]):
     # True while a placement apply/clear reloads the fleet (from the Fleet drawer);
     # holds chat submissions so they don't race the reload into a 429.
     reloading_placement: reactive[bool] = reactive(False)
-    # True while the chat model is warming on a cold start. Disables the input and
-    # holds submits until the model can serve, so a prompt can't land on a not-yet-warm
-    # fleet and render an error inside a chat bubble; cleared on the ready transition.
-    chat_warming: reactive[bool] = reactive(False)
 
     HELP = (
         "# Chat\n\n"
@@ -271,6 +276,9 @@ class ChatScreen(Screen[None]):
         self._history_index: int = -1
         self._tail_scroll_y: float = 0.0
         self._auto_follow: bool = True
+        # The warm tip is worth one toast per session, on the first prompt that
+        # has to wait out a cold engine load.
+        self._warm_tip_shown: bool = False
         self._command_handlers: dict[str, Callable[[str], None]] = self._build_command_handlers()
 
     def _build_command_handlers(self) -> dict[str, Callable[[str], None]]:
@@ -324,8 +332,6 @@ class ChatScreen(Screen[None]):
         self._update_input_style()
         self.app.settings_changed_signal.subscribe(self, self._on_settings_changed)
         self._setup_check_worker()
-        self._poll_chat_warming()
-        self.set_interval(_WARM_POLL_INTERVAL_S, self._poll_chat_warming)
 
     @work(thread=True, name="chat_setup_check", exit_on_error=False)
     def _setup_check_worker(self) -> None:
@@ -520,11 +526,6 @@ class ChatScreen(Screen[None]):
             return True
         if self.reloading_placement:
             self.notify(msg.FLEET_RELOADING, severity="warning", timeout=3)
-            return True
-        if self.chat_warming:
-            # The model is still warming; hold the prompt (input keeps the typed text)
-            # rather than firing it into a not-warm fleet and erroring in a bubble.
-            self.notify(msg.CHAT_WARMING, severity="warning", timeout=3)
             return True
         if self.streaming:
             # Only one chat message may be in flight at a time; surface a toast
@@ -1268,6 +1269,8 @@ class ChatScreen(Screen[None]):
         sources: list[str] = []
         stream: Any = None
         try:
+            if not self._await_chat_engine(widget):
+                return
             with self._history_lock:
                 history_snapshot = self._history[:-1]
             stream = get_services().searcher.ask_stream(
@@ -1285,6 +1288,50 @@ class ChatScreen(Screen[None]):
             close_stream(stream)
             self._finalize_stream(widget, sources, response_parts)
             call_from_thread(self, self._maybe_extract_memories, question, "".join(response_parts))
+
+    def _await_chat_engine(self, widget: AssistantMessage) -> bool:
+        """Hold the stream until the engine can serve, painting the load into *widget*.
+
+        The default lifecycle loads the engine on demand, so the first prompt of
+        a session usually lands here: the answer bubble's thinking row carries the
+        live load phase instead of the input locking up. Worker thread. Returns
+        False once the wait was cancelled or the load failed, with any failure
+        already rendered into the bubble.
+        """
+        from lilbee.app.placement import chat_engine_ready, chat_warm_error, wait_chat_ready
+
+        if chat_engine_ready():
+            return True
+        self._show_warm_tip_once()
+        worker = _get_worker()
+
+        def _paint(snapshot: WarmProgress) -> None:
+            with contextlib.suppress(Exception):
+                call_from_thread(self, widget.set_thinking_status, _engine_status_text(snapshot))
+
+        if wait_chat_ready(on_progress=_paint, should_abort=lambda: worker.is_cancelled):
+            with contextlib.suppress(Exception):
+                call_from_thread(self, widget.set_thinking_status, "")
+            return True
+        if worker.is_cancelled:
+            return False
+        error = chat_warm_error()
+        text = (
+            f"{msg.ENGINE_LOAD_FAILED.format(error=error)}\n{msg.ENGINE_FAILED_HINT}"
+            if error is not None
+            else msg.ENGINE_NOT_READY
+        )
+        with contextlib.suppress(Exception):
+            call_from_thread(self, widget.append_content, text)
+        return False
+
+    def _show_warm_tip_once(self) -> None:
+        """Toast the keep-warm tip on the session's first cold-engine wait. Worker thread."""
+        if cfg.keep_engine_warm or self._warm_tip_shown:
+            return
+        self._warm_tip_shown = True
+        with contextlib.suppress(Exception):
+            call_from_thread(self, self.notify, msg.ENGINE_WARM_TIP, timeout=8)
 
     def _maybe_extract_memories(self, question: str, answer: str) -> None:
         """Spawn auto-extraction for the finished turn, when enabled and idle.
@@ -1557,7 +1604,7 @@ class ChatScreen(Screen[None]):
         because the unblock can fire (via ``call_from_thread`` or a bubbled
         message) after the user navigated away and the input is no longer mounted.
         """
-        busy = self.swapping_model or self.reloading_placement or self.chat_warming
+        busy = self.swapping_model or self.reloading_placement
         with contextlib.suppress(NoMatches):
             self._chat_input.disabled = busy
             if not busy and self._insert_mode:
@@ -1568,15 +1615,6 @@ class ChatScreen(Screen[None]):
 
     def watch_reloading_placement(self, reloading: bool) -> None:
         self._apply_input_busy_state()
-
-    def watch_chat_warming(self, warming: bool) -> None:
-        self._apply_input_busy_state()
-
-    def _poll_chat_warming(self) -> None:
-        """Track whether the chat model is still warming so input stays held until ready."""
-        from lilbee.app.placement import active_chat_warm_progress
-
-        self.chat_warming = active_chat_warm_progress() is not None
 
     def on_fleet_body_placement_reloading(self, event: FleetBody.PlacementReloading) -> None:
         """Hold chat submissions while the Fleet drawer reloads the fleet."""

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -1,0 +1,145 @@
+"""Blocking startup screen: the lilbee wordmark and the chat model's real load progress."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+
+from textual import work
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import ProgressBar, Static
+from textual.worker import get_current_worker
+
+from lilbee.app.placement import ACTIVE_WARM_PHASES, chat_engine_ready
+from lilbee.app.services import get_services
+from lilbee.app.setup_state import needs_setup
+from lilbee.catalog.formatting import display_label_for_ref
+from lilbee.cli.tui import messages as msg
+from lilbee.cli.tui.app import LilbeeApp
+from lilbee.core.config import cfg
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+from lilbee.runtime.bee_logo import BEE_LINES
+
+log = logging.getLogger(__name__)
+
+_POLL_INTERVAL_S = 0.1
+# Covers get_services kicking its warm on a separate thread before a phase is stamped.
+_WARM_START_GRACE_S = 3.0
+_LOGO = "\n".join(BEE_LINES)
+
+
+class StartupGate(Screen[None]):
+    """Holds the screen until the chat engine can answer, or has failed trying."""
+
+    CSS_PATH = "startup_gate.tcss"
+
+    # Lilbee always hosts screens on a LilbeeApp, so narrowing the type lets
+    # reveal_chat resolve without reflection.
+    app: LilbeeApp  # type: ignore[assignment]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="gate-body"):
+            yield Static(_LOGO, id="gate-logo")
+            yield ProgressBar(total=None, show_eta=False, id="gate-bar")
+            yield Static(msg.STARTUP_PREPARING, id="gate-status")
+
+    def start_boot(self) -> None:
+        """Reveal chat at once when a prompt can already be served, else warm off-thread.
+
+        A fleet that is already up (a second TUI against a live engine) has nothing
+        to wait for, so painting a loading screen would be a lie.
+        """
+        if chat_engine_ready():
+            self._release()
+            return
+        self._boot_worker()
+
+    @work(thread=True, name="startup_gate", exit_on_error=False)
+    def _boot_worker(self) -> None:
+        """Build services (which warms the fleet), then track the warm to completion."""
+        if needs_setup():
+            self._marshal(self._release)
+            return
+
+        try:
+            provider = get_services().provider
+        except Exception as exc:
+            # Any failure to build the container leaves the user with no engine.
+            # Show it and hand them the rest of the TUI rather than a dead screen.
+            log.exception("startup gate could not build the services container")
+            self._marshal(self._fail, str(exc))
+            return
+
+        if not cfg.worker_pool_eager_start:
+            self._marshal(self._release)
+            return
+
+        # The grace covers get_services kicking its warm on a separate thread. With
+        # no fleet, no warm, or a model that was never installed, nothing will ever
+        # stamp a phase, and holding the screen forever would be worse than the
+        # blank terminal this gate replaces.
+        grace_deadline = time.monotonic() + _WARM_START_GRACE_S
+        while not chat_engine_ready():
+            if self._stopping():
+                return
+            snapshot = provider.warm_progress()
+            if snapshot is not None and snapshot.phase is WarmPhase.ERROR:
+                self._marshal(self._fail, snapshot.error or "")
+                return
+            warm_in_flight = snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES
+            if warm_in_flight:
+                self._marshal(self._apply_snapshot, snapshot)
+            elif time.monotonic() > grace_deadline:
+                break
+            time.sleep(_POLL_INTERVAL_S)
+
+        self._marshal(self._release)
+
+    def _stopping(self) -> bool:
+        """True once the worker was cancelled or the gate left the screen."""
+        worker = get_current_worker()
+        return worker.is_cancelled or not self.is_mounted
+
+    def _marshal(self, callback: Callable[..., None], *args: object) -> None:
+        """Hop to the UI thread, unless the app is already tearing down."""
+        if self._stopping():
+            return
+        self.app.call_from_thread(callback, *args)
+
+    def _apply_snapshot(self, snapshot: WarmProgress) -> None:
+        """Reflect one warm snapshot onto the bar and the status line."""
+        bar = self.query_one("#gate-bar", ProgressBar)
+        status = self.query_one("#gate-status", Static)
+        if snapshot.phase is WarmPhase.READING_WEIGHTS and snapshot.bytes_total:
+            bar.update(total=snapshot.bytes_total, progress=snapshot.bytes_done)
+            status.update(msg.STARTUP_READING_WEIGHTS.format(name=_model_label(snapshot)))
+            return
+        # No byte signal outside the read phase, so the bar stays indeterminate.
+        bar.update(total=None)
+        status.update(
+            msg.STARTUP_LOADING_ENGINE
+            if snapshot.phase is WarmPhase.LOADING_ENGINE
+            else msg.STARTUP_PREPARING
+        )
+
+    def _fail(self, error: str) -> None:
+        """Surface a failed load and hand the user to the rest of the TUI to fix it."""
+        self.app.notify(msg.STARTUP_FAILED.format(error=error), severity="error", timeout=8)
+        self.app.notify(msg.STARTUP_FAILED_HINT, severity="error", timeout=8)
+        self._release()
+
+    def _release(self) -> None:
+        """Reveal the chat screen.
+
+        No widget lookup here: the gate can resolve before compose has mounted its
+        children, and a missed query would strand the user on the loading screen.
+        """
+        self.app.reveal_chat()
+
+
+def _model_label(snapshot: WarmProgress) -> str:
+    """The name to show while reading weights."""
+    return display_label_for_ref(snapshot.model_ref) if snapshot.model_ref else ""

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -58,16 +58,23 @@ class StartupGate(Screen[None]):
 
     @work(thread=True, name="startup_gate", exit_on_error=False)
     def _boot_worker(self) -> None:
-        """Build the services container (which kicks the engine warm), then hand over."""
-        if needs_setup():
-            self._marshal(self._release)
-            return
+        """Settle the model refs, build the services container, then hand over.
+
+        Canonicalization runs first (it can swap a stale ref to a working
+        fallback, which decides whether setup is needed) and runs here rather
+        than on the mount path: its disk reads and server probes would sit
+        between the terminal handover and the TUI's first frame.
+        """
         try:
+            self.app.canonicalize_persisted_models()
+            if needs_setup():
+                self._marshal(self._release)
+                return
             get_services()
         except Exception as exc:
-            # Any failure to build the container leaves the user with no engine.
+            # Any failure to prepare the app leaves the user with no engine.
             # Show it and hand them the rest of the TUI rather than a dead screen.
-            log.exception("startup gate could not build the services container")
+            log.exception("startup gate could not prepare the app")
             self._marshal(self._fail, str(exc))
             return
         self._marshal(self._release)

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -13,7 +13,7 @@ from textual.screen import Screen
 from textual.widgets import ProgressBar, Static
 from textual.worker import get_current_worker
 
-from lilbee.app.placement import ACTIVE_WARM_PHASES, chat_engine_ready
+from lilbee.app.placement import chat_engine_ready, warm_is_reporting
 from lilbee.app.services import get_services
 from lilbee.app.setup_state import needs_setup
 from lilbee.catalog.formatting import display_label_for_ref
@@ -92,7 +92,7 @@ class StartupGate(Screen[None]):
             if snapshot is not None and snapshot.phase is WarmPhase.ERROR:
                 self._marshal(self._fail, snapshot.error or "")
                 return
-            if snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES:
+            if warm_is_reporting(snapshot):
                 self._marshal(self._apply_snapshot, snapshot)
             elif provider.warm_pending():
                 grace_deadline = time.monotonic() + _WARM_START_GRACE_S

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -43,7 +43,7 @@ class StartupGate(Screen[None]):
     def compose(self) -> ComposeResult:
         with Vertical(id="gate-body"):
             yield Static(_LOGO, id="gate-logo")
-            yield ProgressBar(total=None, show_eta=False, id="gate-bar")
+            yield ProgressBar(total=None, show_eta=False, show_percentage=False, id="gate-bar")
             yield Static(msg.STARTUP_PREPARING, id="gate-status")
 
     def start_boot(self) -> None:
@@ -118,10 +118,13 @@ class StartupGate(Screen[None]):
         bar = self.query_one("#gate-bar", ProgressBar)
         status = self.query_one("#gate-status", Static)
         if snapshot.phase is WarmPhase.READING_WEIGHTS and snapshot.bytes_total:
+            bar.show_percentage = True
             bar.update(total=snapshot.bytes_total, progress=snapshot.bytes_done)
             status.update(msg.STARTUP_READING_WEIGHTS.format(name=_model_label(snapshot)))
             return
-        # No byte signal outside the read phase, so the bar stays indeterminate.
+        # No byte signal outside the read phase, so the bar stays indeterminate and
+        # shows no percentage rather than a placeholder.
+        bar.show_percentage = False
         bar.update(total=None)
         status.update(
             msg.STARTUP_LOADING_ENGINE

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -45,6 +45,10 @@ class StartupGate(Screen[None]):
             yield Static(_LOGO, id="gate-logo")
             yield ProgressBar(total=None, show_eta=False, show_percentage=False, id="gate-bar")
             yield Static(msg.STARTUP_PREPARING, id="gate-status")
+            yield Static(
+                msg.STARTUP_WARM_TIP if not cfg.keep_engine_warm else "",
+                id="gate-tip",
+            )
 
     def start_boot(self) -> None:
         """Reveal chat at once when a prompt can already be served, else warm off-thread.

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -77,10 +77,13 @@ class StartupGate(Screen[None]):
             self._marshal(self._release)
             return
 
-        # The grace covers get_services kicking its warm on a separate thread. With
-        # no fleet, no warm, or a model that was never installed, nothing will ever
-        # stamp a phase, and holding the screen forever would be worse than the
-        # blank terminal this gate replaces.
+        # Hold while a warm is pending, which covers the seconds between requesting
+        # one and the tracker stamping its first phase (the fleet spawns llama-swap
+        # and waits on its health check before the chat role starts loading). The
+        # grace only applies once nothing is pending and nothing is reporting: a
+        # remote chat model, an uninstalled one, or a warm that already gave up.
+        # Holding the screen forever would be worse than the blank terminal this
+        # gate replaces.
         grace_deadline = time.monotonic() + _WARM_START_GRACE_S
         while not chat_engine_ready():
             if self._stopping():
@@ -89,9 +92,10 @@ class StartupGate(Screen[None]):
             if snapshot is not None and snapshot.phase is WarmPhase.ERROR:
                 self._marshal(self._fail, snapshot.error or "")
                 return
-            warm_in_flight = snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES
-            if warm_in_flight:
+            if snapshot is not None and snapshot.phase in ACTIVE_WARM_PHASES:
                 self._marshal(self._apply_snapshot, snapshot)
+            elif provider.warm_pending():
+                grace_deadline = time.monotonic() + _WARM_START_GRACE_S
             elif time.monotonic() > grace_deadline:
                 break
             time.sleep(_POLL_INTERVAL_S)

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -50,10 +50,12 @@ class StartupGate(Screen[None]):
         """Reveal chat at once when a prompt can already be served, else warm off-thread.
 
         A fleet that is already up (a second TUI against a live engine) has nothing
-        to wait for, so painting a loading screen would be a lie.
+        to wait for, so painting a loading screen would be a lie. The handover is
+        deferred a frame because start_boot runs at the tail of the app's on_mount,
+        and switching screens from inside on_mount stalls Textual.
         """
         if chat_engine_ready():
-            self._release()
+            self.call_after_refresh(self._release)
             return
         self._boot_worker()
 
@@ -139,11 +141,15 @@ class StartupGate(Screen[None]):
         self._release()
 
     def _release(self) -> None:
-        """Reveal the chat screen.
+        """Hand the screen to chat, unless something else has taken it.
 
-        No widget lookup here: the gate can resolve before compose has mounted its
-        children, and a missed query would strand the user on the loading screen.
+        reveal_chat switches whatever screen is on top, so a gate that resolved
+        after another screen opened above it would replace that screen instead of
+        itself. No widget lookup here either: the gate can resolve before compose
+        has mounted its children, and a missed query would strand the user.
         """
+        if self.app.screen is not self:
+            return
         self.app.reveal_chat()
 
 

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -42,6 +42,27 @@ class StartupGate(Screen[None]):
             yield ProgressBar(total=None, show_eta=False, show_percentage=False, id="gate-bar")
             yield Static(msg.STARTUP_PREPARING, id="gate-status")
 
+    def on_mount(self) -> None:
+        """Retire the launcher's splash now that Textual is painting.
+
+        The splash animates over the blank alt-screen right up to this moment,
+        so the wordmark never leaves the terminal. Dismissal waits on the
+        subprocess, so it runs off-thread; the refresh afterwards repaints
+        anything a final splash frame may have touched.
+        """
+        self._retire_splash()
+
+    @work(thread=True, name="splash_retire", exit_on_error=False)
+    def _retire_splash(self) -> None:
+        from lilbee.runtime.splash import dismiss
+
+        dismiss()
+        self._marshal(self._repaint)
+
+    def _repaint(self) -> None:
+        """Repaint anything a final splash frame may have scribbled over."""
+        self.refresh()
+
     def start_boot(self) -> None:
         """Reveal chat at once when services already exist, else build them off-thread.
 

--- a/src/lilbee/cli/tui/screens/startup_gate.py
+++ b/src/lilbee/cli/tui/screens/startup_gate.py
@@ -1,9 +1,8 @@
-"""Blocking startup screen: the lilbee wordmark and the chat model's real load progress."""
+"""Startup splash: the lilbee wordmark while the services container builds."""
 
 from __future__ import annotations
 
 import logging
-import time
 from collections.abc import Callable
 
 from textual import work
@@ -13,26 +12,23 @@ from textual.screen import Screen
 from textual.widgets import ProgressBar, Static
 from textual.worker import get_current_worker
 
-from lilbee.app.placement import chat_engine_ready, warm_is_reporting
-from lilbee.app.services import get_services
+from lilbee.app.services import get_services, peek_services
 from lilbee.app.setup_state import needs_setup
-from lilbee.catalog.formatting import display_label_for_ref
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import LilbeeApp
-from lilbee.core.config import cfg
-from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 from lilbee.runtime.bee_logo import BEE_LINES
 
 log = logging.getLogger(__name__)
 
-_POLL_INTERVAL_S = 0.1
-# Covers get_services kicking its warm on a separate thread before a phase is stamped.
-_WARM_START_GRACE_S = 3.0
 _LOGO = "\n".join(BEE_LINES)
 
 
 class StartupGate(Screen[None]):
-    """Holds the screen until the chat engine can answer, or has failed trying."""
+    """Holds the screen until the app can serve, then hands over to chat.
+
+    The engine itself loads in the background after the handover; a prompt sent
+    before it is ready waits inside its own answer bubble with live progress.
+    """
 
     CSS_PATH = "startup_gate.tcss"
 
@@ -45,67 +41,35 @@ class StartupGate(Screen[None]):
             yield Static(_LOGO, id="gate-logo")
             yield ProgressBar(total=None, show_eta=False, show_percentage=False, id="gate-bar")
             yield Static(msg.STARTUP_PREPARING, id="gate-status")
-            yield Static(
-                msg.STARTUP_WARM_TIP if not cfg.keep_engine_warm else "",
-                id="gate-tip",
-            )
 
     def start_boot(self) -> None:
-        """Reveal chat at once when a prompt can already be served, else warm off-thread.
+        """Reveal chat at once when services already exist, else build them off-thread.
 
-        A fleet that is already up (a second TUI against a live engine) has nothing
-        to wait for, so painting a loading screen would be a lie. The handover is
-        deferred a frame because start_boot runs at the tail of the app's on_mount,
-        and switching screens from inside on_mount stalls Textual.
+        A container that is already built (a second TUI in the same process, a
+        test host) has nothing to wait for, so painting a loading screen would be
+        a lie. The handover is deferred a frame because start_boot runs at the
+        tail of the app's on_mount, and switching screens from inside on_mount
+        stalls Textual.
         """
-        if chat_engine_ready():
+        if peek_services() is not None:
             self.call_after_refresh(self._release)
             return
         self._boot_worker()
 
     @work(thread=True, name="startup_gate", exit_on_error=False)
     def _boot_worker(self) -> None:
-        """Build services (which warms the fleet), then track the warm to completion."""
+        """Build the services container (which kicks the engine warm), then hand over."""
         if needs_setup():
             self._marshal(self._release)
             return
-
         try:
-            provider = get_services().provider
+            get_services()
         except Exception as exc:
             # Any failure to build the container leaves the user with no engine.
             # Show it and hand them the rest of the TUI rather than a dead screen.
             log.exception("startup gate could not build the services container")
             self._marshal(self._fail, str(exc))
             return
-
-        if not cfg.worker_pool_eager_start:
-            self._marshal(self._release)
-            return
-
-        # Hold while a warm is pending, which covers the seconds between requesting
-        # one and the tracker stamping its first phase (the fleet spawns llama-swap
-        # and waits on its health check before the chat role starts loading). The
-        # grace only applies once nothing is pending and nothing is reporting: a
-        # remote chat model, an uninstalled one, or a warm that already gave up.
-        # Holding the screen forever would be worse than the blank terminal this
-        # gate replaces.
-        grace_deadline = time.monotonic() + _WARM_START_GRACE_S
-        while not chat_engine_ready():
-            if self._stopping():
-                return
-            snapshot = provider.warm_progress()
-            if snapshot is not None and snapshot.phase is WarmPhase.ERROR:
-                self._marshal(self._fail, snapshot.error or "")
-                return
-            if warm_is_reporting(snapshot):
-                self._marshal(self._apply_snapshot, snapshot)
-            elif provider.warm_pending():
-                grace_deadline = time.monotonic() + _WARM_START_GRACE_S
-            elif time.monotonic() > grace_deadline:
-                break
-            time.sleep(_POLL_INTERVAL_S)
-
         self._marshal(self._release)
 
     def _stopping(self) -> bool:
@@ -119,29 +83,9 @@ class StartupGate(Screen[None]):
             return
         self.app.call_from_thread(callback, *args)
 
-    def _apply_snapshot(self, snapshot: WarmProgress) -> None:
-        """Reflect one warm snapshot onto the bar and the status line."""
-        bar = self.query_one("#gate-bar", ProgressBar)
-        status = self.query_one("#gate-status", Static)
-        if snapshot.phase is WarmPhase.READING_WEIGHTS and snapshot.bytes_total:
-            bar.show_percentage = True
-            bar.update(total=snapshot.bytes_total, progress=snapshot.bytes_done)
-            status.update(msg.STARTUP_READING_WEIGHTS.format(name=_model_label(snapshot)))
-            return
-        # No byte signal outside the read phase, so the bar stays indeterminate and
-        # shows no percentage rather than a placeholder.
-        bar.show_percentage = False
-        bar.update(total=None)
-        status.update(
-            msg.STARTUP_LOADING_ENGINE
-            if snapshot.phase is WarmPhase.LOADING_ENGINE
-            else msg.STARTUP_PREPARING
-        )
-
     def _fail(self, error: str) -> None:
-        """Surface a failed load and hand the user to the rest of the TUI to fix it."""
+        """Surface a failed start and hand the user to the rest of the TUI to fix it."""
         self.app.notify(msg.STARTUP_FAILED.format(error=error), severity="error", timeout=8)
-        self.app.notify(msg.STARTUP_FAILED_HINT, severity="error", timeout=8)
         self._release()
 
     def _release(self) -> None:
@@ -155,8 +99,3 @@ class StartupGate(Screen[None]):
         if self.app.screen is not self:
             return
         self.app.reveal_chat()
-
-
-def _model_label(snapshot: WarmProgress) -> str:
-    """The name to show while reading weights."""
-    return display_label_for_ref(snapshot.model_ref) if snapshot.model_ref else ""

--- a/src/lilbee/cli/tui/screens/startup_gate.tcss
+++ b/src/lilbee/cli/tui/screens/startup_gate.tcss
@@ -1,0 +1,29 @@
+StartupGate {
+    align: center middle;
+}
+
+#gate-body {
+    width: auto;
+    height: auto;
+    align: center middle;
+}
+
+/* Bright amber, xterm-256 index 214 (AMBER_BRIGHT_XTERM in runtime/bee_logo.py).
+   The wordmark warms from the bootstrap's dim amber to this once the TUI owns
+   the screen. tests/test_startup_gate.py pins the two together. */
+#gate-logo {
+    width: auto;
+    color: #ffaf00;
+    text-style: bold;
+}
+
+#gate-bar {
+    width: 55;
+    margin: 1 0 0 0;
+}
+
+#gate-status {
+    width: auto;
+    margin: 1 0 0 0;
+    color: $text-muted;
+}

--- a/src/lilbee/cli/tui/screens/startup_gate.tcss
+++ b/src/lilbee/cli/tui/screens/startup_gate.tcss
@@ -45,3 +45,9 @@ StartupGate {
     margin: 1 0 0 0;
     color: $text-muted;
 }
+
+#gate-tip {
+    width: auto;
+    margin: 1 0 0 0;
+    color: #875f00;
+}

--- a/src/lilbee/cli/tui/screens/startup_gate.tcss
+++ b/src/lilbee/cli/tui/screens/startup_gate.tcss
@@ -17,9 +17,30 @@ StartupGate {
     text-style: bold;
 }
 
+/* The bar carries the same amber ramp as the bootstrap's blocks: bright fill,
+   mid-amber sweep while indeterminate, dim remainder. Textual's default accent
+   is the theme's pink, which fights the wordmark. */
 #gate-bar {
     width: 55;
     margin: 1 0 0 0;
+}
+
+#gate-bar Bar > .bar--bar {
+    color: #ffaf00;
+    background: #5f3f00;
+}
+
+#gate-bar Bar > .bar--indeterminate {
+    color: #d78700;
+    background: #5f3f00;
+}
+
+#gate-bar PercentageStatus {
+    color: #d78700;
+}
+
+#gate-bar ETAStatus {
+    display: none;
 }
 
 #gate-status {

--- a/src/lilbee/cli/tui/screens/startup_gate.tcss
+++ b/src/lilbee/cli/tui/screens/startup_gate.tcss
@@ -17,9 +17,10 @@ StartupGate {
     text-style: bold;
 }
 
-/* The bar carries the same amber ramp as the bootstrap's blocks: bright fill,
-   mid-amber sweep while indeterminate, dim remainder. Textual's default accent
-   is the theme's pink, which fights the wordmark. */
+/* The bar carries the same amber ramp as the bootstrap's blocks: a bright fill,
+   a mid-amber sweep while indeterminate, and a dim-amber trough. Every hex is the
+   xterm index in runtime/bee_logo.py; tests/test_startup_gate.py pins them.
+   Textual's default accent is the theme's pink, which fights the wordmark. */
 #gate-bar {
     width: 55;
     margin: 1 0 0 0;
@@ -27,20 +28,16 @@ StartupGate {
 
 #gate-bar Bar > .bar--bar {
     color: #ffaf00;
-    background: #5f3f00;
+    background: #875f00;
 }
 
 #gate-bar Bar > .bar--indeterminate {
     color: #d78700;
-    background: #5f3f00;
+    background: #875f00;
 }
 
 #gate-bar PercentageStatus {
     color: #d78700;
-}
-
-#gate-bar ETAStatus {
-    display: none;
 }
 
 #gate-status {

--- a/src/lilbee/cli/tui/screens/startup_gate.tcss
+++ b/src/lilbee/cli/tui/screens/startup_gate.tcss
@@ -45,9 +45,3 @@ StartupGate {
     margin: 1 0 0 0;
     color: $text-muted;
 }
-
-#gate-tip {
-    width: auto;
-    margin: 1 0 0 0;
-    color: #875f00;
-}

--- a/src/lilbee/cli/tui/widgets/message.py
+++ b/src/lilbee/cli/tui/widgets/message.py
@@ -130,6 +130,11 @@ class AssistantMessage(Vertical):
             self._last_reasoning_update = now
             self._reasoning_static.update(Content("".join(self._reasoning_parts)))
 
+    def set_thinking_status(self, detail: str) -> None:
+        """Show *detail* beside the thinking animator (e.g. an engine-load phase)."""
+        if self._thinking_header is not None:
+            self._thinking_header.set_status(detail)
+
     def append_content(self, text: str) -> None:
         """Append response content token (debounced markdown updates)."""
         first_token = not self._content_parts

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -565,13 +565,23 @@ class ModelBar(Widget, can_focus=False):
             opts = scope_to_options.get(row.scope, [])
             fingerprint = tuple((o.label, o.ref) for o in opts)
             if self._options_cache.get(row.scope) != fingerprint:
-                row.query_one(ModelPickerButton).set_options(opts)
+                try:
+                    row.query_one(ModelPickerButton).set_options(opts)
+                except NoMatches:
+                    # The scan can land while a row is still composing; the next
+                    # scan repopulates against the mounted picker.
+                    continue
                 self._options_cache[row.scope] = fingerprint
         self._refresh_cloud_warning()
 
     def _refresh_cloud_warning(self) -> None:
         """Show a warning if the active chat model routes to a cloud provider."""
-        warning = self.query_one(f"#{_CLOUD_WARNING_ID}", Static)
+        try:
+            warning = self.query_one(f"#{_CLOUD_WARNING_ID}", Static)
+        except NoMatches:
+            # A scan worker can finish before compose mounts the warning row;
+            # the next refresh runs against the mounted bar.
+            return
         label = _cloud_provider_label(cfg.chat_model)
         if label is None:
             warning.remove_class("-visible")

--- a/src/lilbee/cli/tui/widgets/scope_chip.py
+++ b/src/lilbee/cli/tui/widgets/scope_chip.py
@@ -101,7 +101,9 @@ class ScopeChip(Widget):
 
     def on_mount(self) -> None:
         self._refresh_visibility()
-        self._refresh()
+        # _refresh queries the pills this widget composes, which are not guaranteed
+        # to be mounted yet when on_mount runs. Defer it a frame.
+        self.call_after_refresh(self._refresh)
         self.app.settings_changed_signal.subscribe(self, self._on_settings_changed)
 
     def _refresh_visibility(self) -> None:

--- a/src/lilbee/cli/tui/widgets/thinking_header.py
+++ b/src/lilbee/cli/tui/widgets/thinking_header.py
@@ -38,8 +38,8 @@ def _bounce_position(frame: int) -> int:
     return cycle - step
 
 
-def _frame_content(frame: int) -> Content:
-    """Render the bouncing-block track for *frame* as styled content."""
+def _frame_content(frame: int, detail: str = "") -> Content:
+    """Render the bouncing-block track for *frame*, with an optional detail suffix."""
     pos = _bounce_position(frame)
     parts: list[Content] = []
     for i in range(_TRACK_CELLS):
@@ -47,6 +47,8 @@ def _frame_content(frame: int) -> Content:
             parts.append(Content.styled(_BLOCK_FILLED, _FILL_STYLE))
         else:
             parts.append(Content.styled(_BLOCK_EMPTY, _DIM_STYLE))
+    if detail:
+        parts.append(Content.styled(f"  {detail}", _DIM_STYLE))
     return Content.assemble(*parts)
 
 
@@ -58,6 +60,7 @@ class ThinkingHeader(Static):
     def __init__(self) -> None:
         super().__init__(_frame_content(0), classes="thinking-header")
         self._frame: int = 0
+        self._detail: str = ""
         self._timer: Timer | None = None
         self._target: Callable[[Content], None] | None = None
 
@@ -77,9 +80,13 @@ class ThinkingHeader(Static):
         """Send each frame's content to *target* instead of painting self."""
         self._target = target
 
+    def set_status(self, detail: str) -> None:
+        """Show *detail* beside the scanner track from the next frame on."""
+        self._detail = detail
+
     def _tick(self) -> None:
         self._frame += 1
-        content = _frame_content(self._frame)
+        content = _frame_content(self._frame, self._detail)
         if self._target is not None:
             self._target(content)
         else:

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -365,6 +365,15 @@ class Config(BaseSettings):
     # for headless / scripted use where the first call doesn't need to be fast.
     worker_pool_eager_start: bool = ConfigField(default=True, writable=True)
 
+    # Leave the engine fleet running on quit so the next launch adopts it warm.
+    # Off is the on-demand default: the engine loads per launch and frees VRAM
+    # on close.
+    keep_engine_warm: bool = ConfigField(default=False, writable=True)
+
+    # Idle minutes before a warm fleet unloads its weights (llama-swap ttl).
+    # 0 keeps them loaded forever. Read only when keep_engine_warm is on.
+    engine_idle_ttl_minutes: int = ConfigField(default=0, writable=True)
+
     # Working n_ctx the dynamic picker aims for. Default scales with
     # total host RAM (see core.system.chat_ctx_target_for_total_bytes):
     # <16 GiB -> 8192, 16-32 -> 12288, 32-64 -> 16384, >=64 -> 24576.

--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -370,9 +370,10 @@ class Config(BaseSettings):
     # on close.
     keep_engine_warm: bool = ConfigField(default=False, writable=True)
 
-    # Idle minutes before a warm fleet unloads its weights (llama-swap ttl).
-    # 0 keeps them loaded forever. Read only when keep_engine_warm is on.
-    engine_idle_ttl_minutes: int = ConfigField(default=0, writable=True)
+    # Idle minutes before a warm fleet unloads its weights (llama-swap ttl), so
+    # a warm engine never holds VRAM past this window. 0 keeps weights loaded
+    # forever. Read only when keep_engine_warm is on.
+    engine_idle_ttl_minutes: int = ConfigField(default=5, writable=True)
 
     # Working n_ctx the dynamic picker aims for. Default scales with
     # total host RAM (see core.system.chat_ctx_target_for_total_bytes):

--- a/src/lilbee/providers/base.py
+++ b/src/lilbee/providers/base.py
@@ -494,6 +494,15 @@ class LLMProvider(Protocol):
         """
         return None
 
+    def warm_pending(self) -> bool:
+        """Whether a warm has been requested and has not finished.
+
+        True from the moment ``warm_up_pool`` accepts a warm until its background
+        work ends, so a surface can hold before the first phase is stamped. Default
+        ``False``: providers without managed servers never warm.
+        """
+        return False
+
     def warm_progress(self) -> WarmProgress | None:
         """Snapshot of the chat model's cold-load progress, or None when idle.
 

--- a/src/lilbee/providers/fleet/launch.py
+++ b/src/lilbee/providers/fleet/launch.py
@@ -30,6 +30,38 @@ class InstanceLaunch:
     replica: int = 0  # index within the role's data-parallel pool (0 = single server)
     rerank_mode: RerankMode | None = None  # set only for RERANK; picks the client scoring path
 
+    def to_state(self) -> dict:
+        """JSON-safe form persisted in a detached fleet's state file."""
+        return {
+            "role": self.role.value,
+            "argv": list(self.argv),
+            "env_overrides": dict(self.env_overrides),
+            "model": self.model,
+            "token_cap": self.token_cap,
+            "weights_bytes": self.weights_bytes,
+            "slots": self.slots,
+            "ctx": self.ctx,
+            "replica": self.replica,
+            "rerank_mode": self.rerank_mode.value if self.rerank_mode else None,
+        }
+
+    @classmethod
+    def from_state(cls, payload: dict) -> InstanceLaunch:
+        """Rebuild a launch from :meth:`to_state` output; raises on a foreign shape."""
+        raw_mode = payload.get("rerank_mode")
+        return cls(
+            role=WorkerRole(payload["role"]),
+            argv=list(payload["argv"]),
+            env_overrides=dict(payload.get("env_overrides") or {}),
+            model=str(payload["model"]),
+            token_cap=payload.get("token_cap"),
+            weights_bytes=int(payload.get("weights_bytes") or 0),
+            slots=int(payload.get("slots") or 1),
+            ctx=int(payload.get("ctx") or 0),
+            replica=int(payload.get("replica") or 0),
+            rerank_mode=RerankMode(raw_mode) if raw_mode else None,
+        )
+
     @property
     def model_id(self) -> str:
         """The llama-swap model id for this instance: ``<role>-<replica>``."""

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -803,6 +803,21 @@ class FleetProvider:
 
                 sweep_owned(cfg.data_dir)
 
+    def _detach_swap(self) -> None:
+        """Terminal shutdown with keep_engine_warm on: mark and leave the fleet running.
+
+        Latches like ``_shutdown_swap`` so a discarded provider's in-flight warm
+        cannot spawn an orphan, but the running swaps are handed to the next
+        launch instead of being stopped, and no ownership sweep runs.
+        """
+        with self._build_lock:
+            with self._lock:
+                swaps = dict(self._swaps)
+                self._shut_down = True
+            self._drop_swap_refs()
+            for swap in swaps.values():
+                swap.detach()
+
     def _drop_swap_refs(self) -> None:
         """Clear every group's swap/clients and the chat capacity so the next call rebuilds."""
         with self._lock:
@@ -1579,4 +1594,7 @@ class FleetProvider:
         ).start()
 
     def shutdown(self) -> None:
+        if cfg.keep_engine_warm:
+            self._detach_swap()
+            return
         self._shutdown_swap()

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -711,6 +711,16 @@ class FleetProvider:
         with self._lock:
             return self._chat_ctx if WorkerRole.CHAT in self._swaps else None
 
+    def warm_pending(self) -> bool:
+        """Whether a requested warm is still running.
+
+        The tracker only stamps a phase once the chat role starts loading, which is
+        seconds after the swap is spawned, so ``warm_progress`` alone cannot tell a
+        not-yet-started warm from no warm at all.
+        """
+        with self._lock:
+            return self._warming
+
     def warm_progress(self) -> WarmProgress | None:
         """Live cold-load progress for the chat role, or None before warm begins."""
         return self._warm_tracker.snapshot()

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -20,6 +20,7 @@ import threading
 import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import contextmanager
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar, overload
 
@@ -34,10 +35,17 @@ from lilbee.providers.fleet.client import (
     retry_on_busy,
 )
 from lilbee.providers.fleet.groups import SwapGroup, group_for
+from lilbee.providers.fleet.launch import InstanceLaunch
 from lilbee.providers.fleet.swap_config import cold_load_timeout_s
-from lilbee.providers.fleet.swap_manager import SwapManager, reap_stale, sweep_owned
+from lilbee.providers.fleet.swap_manager import (
+    SwapManager,
+    _SwapState,
+    find_detached_state,
+    reap_stale,
+    sweep_owned,
+)
 from lilbee.providers.fleet.windowing import window_messages
-from lilbee.providers.roles import WorkerRole, configured_model_message
+from lilbee.providers.roles import MODEL_FIELD_TO_ROLE, WorkerRole, configured_model_message
 from lilbee.providers.warm_progress import WarmProgress, WarmProgressTracker
 
 log = logging.getLogger(__name__)
@@ -54,7 +62,6 @@ if TYPE_CHECKING:
         OcrBackend,
         PageText,
     )
-    from lilbee.providers.fleet.launch import InstanceLaunch
 
 # User-facing name for this engine in error messages.
 _PROVIDER_NAME = "llama-server"
@@ -468,6 +475,30 @@ def _ocr_deadline(per_page_timeout_s: float | None) -> float | None:
     return None if budget is None else time.monotonic() + budget
 
 
+_ROLE_TO_MODEL_FIELD = {role: field for field, role in MODEL_FIELD_TO_ROLE.items()}
+
+
+def _configured_model_for(role: WorkerRole) -> str:
+    """The cfg model ref for *role*, empty when the role is unset."""
+    field = _ROLE_TO_MODEL_FIELD.get(role)
+    return getattr(cfg, field) or "" if field else ""
+
+
+def _adoptable_launches(state: _SwapState) -> list[InstanceLaunch] | None:
+    """Decode a detached fleet's launches when it matches this build and config."""
+    if state.lilbee_version != _pkg_version("lilbee"):
+        return None
+    try:
+        launches = [InstanceLaunch.from_state(item) for item in state.launches]
+    except (KeyError, TypeError, ValueError):
+        return None
+    if not launches:
+        return None
+    if any(launch.model != _configured_model_for(launch.role) for launch in launches):
+        return None
+    return launches
+
+
 def _warm_ttl_seconds() -> int:
     """llama-swap idle-unload timer: the user's warm ttl, or 0 when warm is off."""
     if not cfg.keep_engine_warm:
@@ -574,35 +605,92 @@ class FleetProvider:
             # A dead owner's surviving llama-swap holds VRAM; reap it before the
             # snapshot so the cards are actually free for this fleet (and the
             # context sizer reads true clean-box memory).
-            reap_stale(cfg.data_dir, keep_detached=cfg.keep_engine_warm)
-            try:
-                # Snapshot the clean box; this plan and every later reload size
-                # ctx, slots, and budgets against it (a live probe under a loaded
-                # fleet would report our own residency as unavailable). Inside the
-                # try: capturing resolves the engine binary, and a binary-less
-                # host must serve nothing, not raise.
-                planning.capture_plan_probe()
-                plan = planning.plan_all_launches()
-            except ProviderError:
-                log.debug("Engine binary unavailable; no swap started")
+            if self._reap_and_maybe_adopt(cfg.data_dir):
+                return True
+            return self._plan_and_spawn(cfg.data_dir)
+
+    def _plan_and_spawn(self, data_dir: Path) -> bool:
+        """Plan placement against the clean box and start one swap per group.
+
+        Caller holds the build lock. False when the engine binary is missing or
+        nothing is installed/configured, so the provider serves nothing.
+        """
+        try:
+            # Snapshot the clean box; this plan and every later reload size
+            # ctx, slots, and budgets against it (a live probe under a loaded
+            # fleet would report our own residency as unavailable). Inside the
+            # try: capturing resolves the engine binary, and a binary-less
+            # host must serve nothing, not raise.
+            planning.capture_plan_probe()
+            plan = planning.plan_all_launches()
+        except ProviderError:
+            log.debug("Engine binary unavailable; no swap started")
+            plan = None
+        if plan is None or not plan.launches:
+            # No engine binary, or no installed/configured model: serve nothing.
+            return False
+        by_group = _launches_by_group(plan)
+        started: dict[SwapGroup, SwapManager] = {}
+        try:
+            for group, group_launches in by_group.items():
+                swap = SwapManager(data_dir, group)
+                swap.start(list(group_launches), ttl_seconds=_warm_ttl_seconds())
+                started[group] = swap
+        except BaseException:
+            for swap in started.values():
+                swap.shutdown()
+            raise
+        with self._lock:
+            for group, swap in started.items():
+                self._adopt_group(group, swap, list(by_group[group]))
+        return True
+
+    def _reap_and_maybe_adopt(self, data_dir: Path) -> bool:
+        """Reap dead fleets (sparing warm ones), then adopt a matching warm fleet."""
+        reap_stale(data_dir, keep_detached=cfg.keep_engine_warm)
+        return cfg.keep_engine_warm and self._try_adopt_detached(data_dir)
+
+    def _try_adopt_detached(self, data_dir: Path) -> bool:
+        """Bind to a warm detached fleet when it matches this version and config.
+
+        All or nothing: any unhealthy group, version drift, undecodable launch
+        record, or a configured role the detached fleet does not serve reaps the
+        leftovers and falls back to a fresh spawn. Caller holds the build lock.
+        """
+        found = [
+            (group, *hit)
+            for group in SwapGroup
+            if (hit := find_detached_state(data_dir, group)) is not None
+        ]
+        if not found:
+            return False
+        adopted: dict[SwapGroup, tuple[SwapManager, list[InstanceLaunch]]] = {}
+        for group, state, state_path in found:
+            launches = _adoptable_launches(state)
+            swap = SwapManager(data_dir, group)
+            if launches is None or not swap.adopt(state, state_path):
+                self._abandon_adoption(adopted, data_dir)
                 return False
-            if not plan.launches:
-                return False  # no installed/configured model -> serve nothing, spawn nothing
-            by_group = _launches_by_group(plan)
-            started: dict[SwapGroup, SwapManager] = {}
-            try:
-                for group, group_launches in by_group.items():
-                    swap = SwapManager(cfg.data_dir, group)
-                    swap.start(list(group_launches), ttl_seconds=_warm_ttl_seconds())
-                    started[group] = swap
-            except BaseException:
-                for swap in started.values():
-                    swap.shutdown()
-                raise
-            with self._lock:
-                for group, swap in started.items():
-                    self._adopt_group(group, swap, list(by_group[group]))
-            return True
+            adopted[group] = (swap, launches)
+        served = {launch.role for _, launches in adopted.values() for launch in launches}
+        configured = {role for role in WorkerRole if _configured_model_for(role)}
+        if not configured <= served:
+            self._abandon_adoption(adopted, data_dir)
+            return False
+        with self._lock:
+            for group, (swap, launches) in adopted.items():
+                self._adopt_group(group, swap, launches)
+        log.info("Adopted the warm engine fleet left by a previous session")
+        return True
+
+    @staticmethod
+    def _abandon_adoption(
+        adopted: dict[SwapGroup, tuple[SwapManager, list[InstanceLaunch]]], data_dir: Path
+    ) -> None:
+        """Stop half-adopted swaps and reap every remaining detached fleet."""
+        for swap, _launches in adopted.values():
+            swap.shutdown()
+        reap_stale(data_dir)
 
     def _adopt_group(
         self, group: SwapGroup, swap: SwapManager, launches: list[InstanceLaunch]
@@ -813,10 +901,12 @@ class FleetProvider:
         with self._build_lock:
             with self._lock:
                 swaps = dict(self._swaps)
+                launches = dict(self._launches)
                 self._shut_down = True
             self._drop_swap_refs()
-            for swap in swaps.values():
-                swap.detach()
+            for group, swap in swaps.items():
+                payload = [launch.to_state() for launch in launches.get(group, ())]
+                swap.detach(payload)
 
     def _drop_swap_refs(self) -> None:
         """Clear every group's swap/clients and the chat capacity so the next call rebuilds."""

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -574,7 +574,7 @@ class FleetProvider:
             # A dead owner's surviving llama-swap holds VRAM; reap it before the
             # snapshot so the cards are actually free for this fleet (and the
             # context sizer reads true clean-box memory).
-            reap_stale(cfg.data_dir)
+            reap_stale(cfg.data_dir, keep_detached=cfg.keep_engine_warm)
             try:
                 # Snapshot the clean box; this plan and every later reload size
                 # ctx, slots, and budgets against it (a live probe under a loaded
@@ -1519,7 +1519,7 @@ class FleetProvider:
                 running = set(self._swaps)
                 old = dict(self._launches)
             # Reap dead owners' swaps before re-planning, same as the first build.
-            reap_stale(cfg.data_dir)
+            reap_stale(cfg.data_dir, keep_detached=cfg.keep_engine_warm)
             if not running:
                 # Nothing loaded (a resurrect after a failed pass): the box is
                 # clean, so refresh the plan snapshot like a first build would.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -468,6 +468,13 @@ def _ocr_deadline(per_page_timeout_s: float | None) -> float | None:
     return None if budget is None else time.monotonic() + budget
 
 
+def _warm_ttl_seconds() -> int:
+    """llama-swap idle-unload timer: the user's warm ttl, or 0 when warm is off."""
+    if not cfg.keep_engine_warm:
+        return 0
+    return cfg.engine_idle_ttl_minutes * 60
+
+
 class FleetProvider:
     """Routes every role to the managed llama-server fleet (a fleet-of-one on one box)."""
 
@@ -586,7 +593,7 @@ class FleetProvider:
             try:
                 for group, group_launches in by_group.items():
                     swap = SwapManager(cfg.data_dir, group)
-                    swap.start(list(group_launches))
+                    swap.start(list(group_launches), ttl_seconds=_warm_ttl_seconds())
                     started[group] = swap
             except BaseException:
                 for swap in started.values():
@@ -1524,7 +1531,7 @@ class FleetProvider:
             for group in sorted(changed & set(new), key=lambda g: g.value):
                 group_launches = list(new[group])
                 swap = SwapManager(cfg.data_dir, group)
-                swap.start(group_launches)
+                swap.start(group_launches, ttl_seconds=_warm_ttl_seconds())
                 with self._lock:
                     self._adopt_group(group, swap, group_launches)
                 restarted.extend(_by_role(group_launches))

--- a/src/lilbee/providers/fleet/swap_config.py
+++ b/src/lilbee/providers/fleet/swap_config.py
@@ -32,7 +32,6 @@ _PROXY_URL_TEMPLATE = "http://127.0.0.1:{port}"
 # Shared with the swap manager, whose orphan-server sweep matches this flag's
 # value in survivor cmdlines.
 PORT_FLAG = "--port"
-_TTL_KEEP = 0  # no idle timeout; a member leaves memory only when a sibling evicts it
 
 # llama-swap config keys.
 _KEY_HEALTH_TIMEOUT = "healthCheckTimeout"
@@ -50,7 +49,11 @@ _KEY_MEMBERS = "members"
 
 
 def build_swap_config(
-    launches: list[InstanceLaunch], member_ports: Mapping[str, int], *, swap: bool = False
+    launches: list[InstanceLaunch],
+    member_ports: Mapping[str, int],
+    *,
+    swap: bool = False,
+    ttl_seconds: int = 0,
 ) -> str:
     """Render a llama-swap config (JSON, which is valid YAML) for *launches*.
 
@@ -58,7 +61,8 @@ def build_swap_config(
     command is the llama-server argv plus the explicit port from *member_ports*;
     one group holds them behind this group's proxy endpoint. ``swap`` makes the
     members evict each other on load, so only one is resident at a time; the
-    default keeps them co-resident. Ports are allocated fresh per start (never
+    default keeps them co-resident. ``ttl_seconds`` is llama-swap's idle unload
+    timer per member; 0 keeps weights loaded forever. Ports are allocated fresh per start (never
     llama-swap's fixed ``startPort`` range) so a previous instance's lingering
     server can't collide with the new fleet's bind.
     """
@@ -68,7 +72,7 @@ def build_swap_config(
         entry: dict[str, object] = {
             _KEY_CMD: _command_line(launch.argv, port),
             _KEY_PROXY: _PROXY_URL_TEMPLATE.format(port=port),
-            _KEY_TTL: _TTL_KEEP,
+            _KEY_TTL: ttl_seconds,
         }
         if launch.env_overrides:
             entry[_KEY_ENV] = [f"{key}={value}" for key, value in launch.env_overrides.items()]

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -140,7 +140,7 @@ class SwapManager:
         self._port: int | None = None
         self._member_ports: list[int] = []
 
-    def start(self, launches: list[InstanceLaunch]) -> None:
+    def start(self, launches: list[InstanceLaunch], *, ttl_seconds: int = 0) -> None:
         """Write the config and spawn llama-swap, waiting for its proxy to answer.
 
         The proxy and every member get a freshly allocated free port; a fixed
@@ -161,7 +161,7 @@ class SwapManager:
         self._member_ports = sorted(member_ports.values())
         self._config_path.parent.mkdir(parents=True, exist_ok=True)
         self._config_path.write_text(
-            build_swap_config(launches, member_ports, swap=self._group.swaps)
+            build_swap_config(launches, member_ports, swap=self._group.swaps, ttl_seconds=ttl_seconds)
         )
         self._port = ports[0]
         # Capture llama-swap's stdout/stderr to a file so its access log never

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -195,9 +195,9 @@ class SwapManager:
         self._write_state()
         self._await_health()
 
-    def reap_stale(self) -> None:
+    def reap_stale(self, *, keep_detached: bool = False) -> None:
         """Kill every dead owner's surviving llama-swap; see :func:`reap_stale`."""
-        reap_stale(self._data_dir)
+        reap_stale(self._data_dir, keep_detached=keep_detached)
 
     def _write_state(self, *, detached: bool = False) -> None:
         """Record the swap's pid/pgid/create time, member ports, and our identity.
@@ -418,7 +418,7 @@ def _live_sibling_swap_pids(data_dir: Path) -> set[int]:
     return protected
 
 
-def reap_stale(data_dir: Path) -> None:
+def reap_stale(data_dir: Path, *, keep_detached: bool = False) -> None:
     """Kill every dead owner's surviving llama-swap at *data_dir*.
 
     An OOM-killed lilbee leaves llama-swap (and its servers) holding VRAM,
@@ -445,6 +445,9 @@ def reap_stale(data_dir: Path) -> None:
         if state is None:
             continue
         if _owner_alive(state.owner_pid, state.owner_created_at):
+            continue
+        if state.detached and keep_detached:
+            # A deliberately-left warm fleet; the next launch adopts or replaces it.
             continue
         if _is_live_llama_swap(state):
             _stop_stale_swap(state)

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -161,7 +161,9 @@ class SwapManager:
         self._member_ports = sorted(member_ports.values())
         self._config_path.parent.mkdir(parents=True, exist_ok=True)
         self._config_path.write_text(
-            build_swap_config(launches, member_ports, swap=self._group.swaps, ttl_seconds=ttl_seconds)
+            build_swap_config(
+                launches, member_ports, swap=self._group.swaps, ttl_seconds=ttl_seconds
+            )
         )
         self._port = ports[0]
         # Capture llama-swap's stdout/stderr to a file so its access log never
@@ -246,11 +248,6 @@ class SwapManager:
         except (OSError, httpx.HTTPError):
             return False
         return resp.status_code < httpx.codes.BAD_REQUEST
-
-    def reload(self, launches: list[InstanceLaunch]) -> None:
-        """Apply a changed model set by restarting llama-swap with a fresh config."""
-        self.shutdown()
-        self.start(launches)
 
     @property
     def running(self) -> bool:

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -17,10 +17,9 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
-
-from importlib.metadata import version as _pkg_version
 
 import httpx
 import psutil
@@ -68,6 +67,7 @@ _STATE_KEY_MEMBER_PORTS = "member_ports"
 _STATE_KEY_PROXY_PORT = "proxy_port"
 _STATE_KEY_LILBEE_VERSION = "lilbee_version"
 _STATE_KEY_DETACHED = "detached"
+_STATE_KEY_LAUNCHES = "launches"
 # Atomic state writes: the dot prefix keeps half-written tmp files out of the
 # reap scan's glob.
 _STATE_TMP_PREFIX = "."
@@ -128,6 +128,7 @@ class _SwapState:
     proxy_port: int | None = None
     lilbee_version: str | None = None
     detached: bool = False
+    launches: tuple[dict, ...] = ()
 
 
 class SwapManager:
@@ -144,6 +145,7 @@ class SwapManager:
         self._log_path = data_dir / _LOGS_SUBDIR / _LOG_FILENAME_TEMPLATE.format(group=group.value)
         self._state_path = data_dir / _state_filename(os.getpid(), group.value)
         self._proc: subprocess.Popen[bytes] | None = None
+        self._adopted: _SwapState | None = None
         self._log_file: BinaryIO | None = None
         self._port: int | None = None
         self._member_ports: list[int] = []
@@ -199,24 +201,34 @@ class SwapManager:
         """Kill every dead owner's surviving llama-swap; see :func:`reap_stale`."""
         reap_stale(self._data_dir, keep_detached=keep_detached)
 
-    def _write_state(self, *, detached: bool = False) -> None:
+    def _process_identity(self) -> tuple[int, int | None, float | None] | None:
+        """(pid, pgid, create time) of the swap this manager runs or adopted."""
+        if self._proc is not None:
+            pid = self._proc.pid
+            pgid: int | None = None
+            if sys.platform != "win32":
+                with contextlib.suppress(ProcessLookupError):
+                    pgid = os.getpgid(pid)
+            created_at: float | None = None
+            with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                created_at = psutil.Process(pid).create_time()
+            return pid, pgid, created_at
+        if self._adopted is not None:
+            return self._adopted.pid, self._adopted.pgid, self._adopted.created_at
+        return None
+
+    def _write_state(self, *, detached: bool = False, launches: list[dict] | None = None) -> None:
         """Record the swap's pid/pgid/create time, member ports, and our identity.
 
         The write is atomic (tmp file then ``os.replace``) so a sibling's reap
         scan can never read a torn file and mistake this live record for junk.
         """
-        proc = self._proc
-        if proc is None:
+        identity = self._process_identity()
+        if identity is None:
             return
-        pgid: int | None = None
-        if sys.platform != "win32":
-            with contextlib.suppress(ProcessLookupError):
-                pgid = os.getpgid(proc.pid)
-        created_at: float | None = None
-        with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
-            created_at = psutil.Process(proc.pid).create_time()
+        swap_pid, pgid, created_at = identity
         state = {
-            _STATE_KEY_PID: proc.pid,
+            _STATE_KEY_PID: swap_pid,
             _STATE_KEY_PGID: pgid,
             _STATE_KEY_CREATED_AT: created_at,
             _STATE_KEY_OWNER_PID: os.getpid(),
@@ -226,6 +238,7 @@ class SwapManager:
             _STATE_KEY_PROXY_PORT: self._port,
             _STATE_KEY_LILBEE_VERSION: _pkg_version("lilbee"),
             _STATE_KEY_DETACHED: detached,
+            _STATE_KEY_LAUNCHES: launches or [],
         }
         tmp_path = self._state_path.with_name(
             f"{_STATE_TMP_PREFIX}{self._state_path.name}{_STATE_TMP_SUFFIX}"
@@ -265,11 +278,39 @@ class SwapManager:
         """Whether this manager currently has a spawned llama-swap process."""
         return self._proc is not None
 
-    def detach(self) -> None:
+    def detach(self, launches: list[dict]) -> None:
         """Leave llama-swap running for the next launch to adopt; mark the state file."""
-        self._write_state(detached=True)
+        self._write_state(detached=True, launches=launches)
         self._close_log()
         self._proc = None
+
+    def adopt(self, state: _SwapState, state_path: Path) -> bool:
+        """Bind to a detached fleet's running proxy; False leaves this manager unbound.
+
+        Success rewrites ownership under this process (its own state file) and
+        removes the detached record so the fleet cannot be adopted twice.
+        """
+        if state.proxy_port is None:
+            return False
+        self._port = state.proxy_port
+        self._member_ports = list(state.member_ports)
+        if not self._proxy_answers():
+            self._port = None
+            self._member_ports = []
+            return False
+        self._adopted = state
+        self._write_state()
+        if state_path != self._state_path:
+            state_path.unlink(missing_ok=True)
+        return True
+
+    def _proxy_answers(self) -> bool:
+        """Whether the bound proxy port serves llama-swap's running endpoint."""
+        try:
+            resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_HTTP_TIMEOUT_S)
+        except (OSError, httpx.HTTPError):
+            return False
+        return resp.status_code < httpx.codes.BAD_REQUEST
 
     def shutdown(self) -> None:
         """Stop every llama-swap this lilbee owns at our config and reap servers.
@@ -418,6 +459,20 @@ def _live_sibling_swap_pids(data_dir: Path) -> set[int]:
     return protected
 
 
+def find_detached_state(data_dir: Path, group: SwapGroup) -> tuple[_SwapState, Path] | None:
+    """The newest detached state for *group*, or None when nothing was left warm."""
+    best: tuple[_SwapState, Path] | None = None
+    for state_path in sorted(data_dir.glob(_STATE_FILE_GLOB)):
+        if f".{group.value}." not in f".{state_path.name}":
+            continue
+        state = _load_state(state_path)
+        if state is None or not state.detached:
+            continue
+        if best is None or (state.created_at or 0) > (best[0].created_at or 0):
+            best = (state, state_path)
+    return best
+
+
 def reap_stale(data_dir: Path, *, keep_detached: bool = False) -> None:
     """Kill every dead owner's surviving llama-swap at *data_dir*.
 
@@ -550,6 +605,7 @@ def _load_state(path: Path) -> _SwapState | None:
             proxy_port=int(raw_proxy) if raw_proxy is not None else None,
             lilbee_version=payload.get(_STATE_KEY_LILBEE_VERSION),
             detached=bool(payload.get(_STATE_KEY_DETACHED, False)),
+            launches=tuple(payload.get(_STATE_KEY_LAUNCHES) or ()),
         )
     except (OSError, ValueError, KeyError, TypeError):
         return None

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
+from importlib.metadata import version as _pkg_version
+
 import httpx
 import psutil
 
@@ -63,6 +65,9 @@ _STATE_KEY_OWNER_PID = "owner_pid"
 _STATE_KEY_OWNER_CREATED_AT = "owner_created_at"
 _STATE_KEY_NAME = "name"
 _STATE_KEY_MEMBER_PORTS = "member_ports"
+_STATE_KEY_PROXY_PORT = "proxy_port"
+_STATE_KEY_LILBEE_VERSION = "lilbee_version"
+_STATE_KEY_DETACHED = "detached"
 # Atomic state writes: the dot prefix keeps half-written tmp files out of the
 # reap scan's glob.
 _STATE_TMP_PREFIX = "."
@@ -120,6 +125,9 @@ class _SwapState:
     owner_created_at: float | None
     created_at: float | None = None
     member_ports: tuple[int, ...] = ()
+    proxy_port: int | None = None
+    lilbee_version: str | None = None
+    detached: bool = False
 
 
 class SwapManager:
@@ -191,7 +199,7 @@ class SwapManager:
         """Kill every dead owner's surviving llama-swap; see :func:`reap_stale`."""
         reap_stale(self._data_dir)
 
-    def _write_state(self) -> None:
+    def _write_state(self, *, detached: bool = False) -> None:
         """Record the swap's pid/pgid/create time, member ports, and our identity.
 
         The write is atomic (tmp file then ``os.replace``) so a sibling's reap
@@ -215,6 +223,9 @@ class SwapManager:
             _STATE_KEY_OWNER_CREATED_AT: psutil.Process().create_time(),
             _STATE_KEY_NAME: _LLAMA_SWAP_PROCESS_NAME,
             _STATE_KEY_MEMBER_PORTS: self._member_ports,
+            _STATE_KEY_PROXY_PORT: self._port,
+            _STATE_KEY_LILBEE_VERSION: _pkg_version("lilbee"),
+            _STATE_KEY_DETACHED: detached,
         }
         tmp_path = self._state_path.with_name(
             f"{_STATE_TMP_PREFIX}{self._state_path.name}{_STATE_TMP_SUFFIX}"
@@ -519,6 +530,7 @@ def _load_state(path: Path) -> _SwapState | None:
         raw_owner_created = payload.get(_STATE_KEY_OWNER_CREATED_AT)
         raw_created = payload.get(_STATE_KEY_CREATED_AT)
         raw_ports = payload.get(_STATE_KEY_MEMBER_PORTS) or []
+        raw_proxy = payload.get(_STATE_KEY_PROXY_PORT)
         return _SwapState(
             pid=int(payload[_STATE_KEY_PID]),
             pgid=int(raw_pgid) if raw_pgid is not None else None,
@@ -526,6 +538,9 @@ def _load_state(path: Path) -> _SwapState | None:
             owner_created_at=float(raw_owner_created) if raw_owner_created is not None else None,
             created_at=float(raw_created) if raw_created is not None else None,
             member_ports=tuple(int(port) for port in raw_ports),
+            proxy_port=int(raw_proxy) if raw_proxy is not None else None,
+            lilbee_version=payload.get(_STATE_KEY_LILBEE_VERSION),
+            detached=bool(payload.get(_STATE_KEY_DETACHED, False)),
         )
     except (OSError, ValueError, KeyError, TypeError):
         return None

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -265,6 +265,12 @@ class SwapManager:
         """Whether this manager currently has a spawned llama-swap process."""
         return self._proc is not None
 
+    def detach(self) -> None:
+        """Leave llama-swap running for the next launch to adopt; mark the state file."""
+        self._write_state(detached=True)
+        self._close_log()
+        self._proc = None
+
     def shutdown(self) -> None:
         """Stop every llama-swap this lilbee owns at our config and reap servers.
 

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -429,9 +429,16 @@ def _swaps_for_config(config_path: Path) -> list[psutil.Process]:
     for proc in psutil.process_iter():
         try:
             cmdline = proc.cmdline()
-        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess, OSError):
-            # OSError: macOS psutil can leak a raw PermissionError for
-            # entitlement-protected binaries instead of wrapping it.
+        except (
+            psutil.NoSuchProcess,
+            psutil.AccessDenied,
+            psutil.ZombieProcess,
+            OSError,
+            SystemError,
+        ):
+            # OSError/SystemError: macOS psutil mishandles entitlement-protected
+            # binaries (sysctl KERN_PROCARGS2), leaking a raw PermissionError or a
+            # C-extension SystemError instead of an AccessDenied.
             continue
         binary = Path(next(iter(cmdline), "")).name
         if _LLAMA_SWAP_PROCESS_NAME in binary and target in cmdline:

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -429,7 +429,9 @@ def _swaps_for_config(config_path: Path) -> list[psutil.Process]:
     for proc in psutil.process_iter():
         try:
             cmdline = proc.cmdline()
-        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess, OSError):
+            # OSError: macOS psutil can leak a raw PermissionError for
+            # entitlement-protected binaries instead of wrapping it.
             continue
         binary = Path(next(iter(cmdline), "")).name
         if _LLAMA_SWAP_PROCESS_NAME in binary and target in cmdline:

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -267,11 +267,7 @@ class SwapManager:
             return False
         if self._port is None:
             return False
-        try:
-            resp = httpx.get(f"{self.endpoint()}{_RUNNING_PATH}", timeout=_HTTP_TIMEOUT_S)
-        except (OSError, httpx.HTTPError):
-            return False
-        return resp.status_code < httpx.codes.BAD_REQUEST
+        return self._proxy_answers()
 
     @property
     def running(self) -> bool:

--- a/src/lilbee/providers/routing_provider.py
+++ b/src/lilbee/providers/routing_provider.py
@@ -342,6 +342,10 @@ class RoutingProvider(LLMProvider):
             return None
         return self._local.served_chat_ctx()
 
+    def warm_pending(self) -> bool:
+        """Forward to the native side; the SDK side never warms."""
+        return self._get_local().warm_pending()
+
     def warm_progress(self) -> WarmProgress | None:
         """Cold-load progress of the local engine, or None when none exists yet."""
         if self._local is None:

--- a/src/lilbee/runtime/_splash_runner.py
+++ b/src/lilbee/runtime/_splash_runner.py
@@ -1,4 +1,4 @@
-"""Standalone splash animation process: zero lilbee imports, stdlib only.
+"""Standalone splash animation process: stdlib plus the shared wordmark.
 
 Launched as a subprocess by ``splash.start()``. Reads a pipe fd from argv
 and animates until the pipe signals EOF (parent closed its write end, or
@@ -14,14 +14,23 @@ import signal
 import sys
 import time
 
+from lilbee.runtime.bee_logo import (
+    AMBER_BRIGHT_XTERM,
+    AMBER_DIM_XTERM,
+    AMBER_MID_XTERM,
+    BEE_LINES,
+    LOGO_WIDTH,
+    xterm_fg,
+)
+
 HIDE_CURSOR = "\033[?25l"
 SHOW_CURSOR = "\033[?25h"
 CLEAR_LINE = "\033[2K"
 MOVE_UP = "\033[A"
 
-AMBER_BRIGHT = "\033[38;5;214m"
-AMBER_MID = "\033[38;5;172m"
-AMBER_DIM = "\033[38;5;94m"
+AMBER_BRIGHT = xterm_fg(AMBER_BRIGHT_XTERM)
+AMBER_MID = xterm_fg(AMBER_MID_XTERM)
+AMBER_DIM = xterm_fg(AMBER_DIM_XTERM)
 RESET = "\033[0m"
 
 FRAME_INTERVAL = 0.15
@@ -34,23 +43,6 @@ _BAR_FALLOFF_LIGHT = 2
 
 # Subprocess entry point expects exactly ``python -m ... <pipe_fd>`` (script name + 1 arg).
 _EXPECTED_ARGV_LEN = 2
-
-BEE_LINES = [
-    "                                                       ",
-    "@@@       @@@  @@@       @@@@@@@   @@@@@@@@  @@@@@@@@  ",
-    "@@@       @@@  @@@       @@@@@@@@  @@@@@@@@  @@@@@@@@  ",
-    "@@@       @@@  @@@       @@!  @@@  @@!       @@!       ",
-    "@!       !@!  !@!       !@   @!@  !@!       !@!       ",
-    "@!!       !!@  @!!       @!@!@!@   @!!!:!    @!!!:!    ",
-    "!!!       !!!  !!!       !!!@!!!!  !!!!!:    !!!!!:    ",
-    "!!:       !!:  !!:       !!:  !!!  !!:       !!:       ",
-    " :!:      :!:   :!:      :!:  !:!  :!:       :!:       ",
-    " :: ::::   ::   :: ::::   :: ::::   :: ::::   :: ::::  ",
-    ": :: : :  :    : :: : :  :: : ::   : :: ::   : :: ::   ",
-    "                                                       ",
-]
-
-LOGO_WIDTH = len(BEE_LINES[1])
 
 COLOR_SEQUENCE = [AMBER_BRIGHT, AMBER_MID, AMBER_DIM, AMBER_MID]
 

--- a/src/lilbee/runtime/_splash_runner.py
+++ b/src/lilbee/runtime/_splash_runner.py
@@ -84,9 +84,25 @@ def build_knight_rider_frames() -> list[str]:
     return frames
 
 
-def render_frame(logo_lines: list[str], loading_bar: str) -> bytes:
+def left_pad() -> int:
+    """Columns needed to centre the wordmark, matching the C bootstrap's formula.
+
+    The bootstrap frame this animation repaints in place is centred with
+    ``(columns - LILBEE_LOGO_WIDTH) / 2``; diverging here would draw the two
+    stages at different offsets and break the one-continuous-logo illusion.
+    """
+    try:
+        columns = os.get_terminal_size(2).columns
+    except OSError:
+        return 0
+    return max((columns - LOGO_WIDTH) // 2, 0)
+
+
+def render_frame(logo_lines: list[str], loading_bar: str, pad: int = 0) -> bytes:
     """Build a single frame as raw bytes for os.write()."""
-    all_lines = [*logo_lines, "", f"  {loading_bar}"]
+    margin = " " * pad
+    all_lines = [margin + line for line in logo_lines]
+    all_lines += ["", f"{margin}  {loading_bar}"]
     return ("\n".join(all_lines) + "\n").encode()
 
 
@@ -157,6 +173,7 @@ def animation_loop(pipe_fd: int) -> None:
 
     logo_frames = build_logo_frames()
     knight_frames = build_knight_rider_frames()
+    pad = left_pad()
     frame_height = len(BEE_LINES) + 2
 
     got_signal = False
@@ -182,7 +199,7 @@ def animation_loop(pipe_fd: int) -> None:
         while not got_signal and not pipe_closed(pipe_fd):
             logo = logo_frames[frame_idx % len(logo_frames)]
             knight = knight_frames[knight_idx % len(knight_frames)]
-            rendered = render_frame(logo, knight)
+            rendered = render_frame(logo, knight, pad)
             os.write(fd, rendered)
 
             for _ in range(int(FRAME_INTERVAL / POLL_INTERVAL)):

--- a/src/lilbee/runtime/bee_logo.py
+++ b/src/lilbee/runtime/bee_logo.py
@@ -1,0 +1,32 @@
+"""The lilbee wordmark, shared by every loading surface."""
+
+from __future__ import annotations
+
+BEE_LINES = [
+    "                                                       ",
+    "@@@       @@@  @@@       @@@@@@@   @@@@@@@@  @@@@@@@@  ",
+    "@@@       @@@  @@@       @@@@@@@@  @@@@@@@@  @@@@@@@@  ",
+    "@@@       @@@  @@@       @@!  @@@  @@!       @@!       ",
+    "@!       !@!  !@!       !@   @!@  !@!       !@!       ",
+    "@!!       !!@  @!!       @!@!@!@   @!!!:!    @!!!:!    ",
+    "!!!       !!!  !!!       !!!@!!!!  !!!!!:    !!!!!:    ",
+    "!!:       !!:  !!:       !!:  !!!  !!:       !!:       ",
+    " :!:      :!:   :!:      :!:  !:!  :!:       :!:       ",
+    " :: ::::   ::   :: ::::   :: ::::   :: ::::   :: ::::  ",
+    ": :: : :  :    : :: : :  :: : ::   : :: ::   : :: ::   ",
+    "                                                       ",
+]
+
+LOGO_WIDTH = len(BEE_LINES[1])
+
+# xterm-256 indexes. The logo warms from dim to bright as startup advances:
+# dim while the bootstrap unpacks, pulsing while Python imports, bright once
+# the engine is warm.
+AMBER_DIM_XTERM = 94
+AMBER_MID_XTERM = 172
+AMBER_BRIGHT_XTERM = 214
+
+
+def xterm_fg(index: int) -> str:
+    """The ANSI escape that sets *index* as the foreground color."""
+    return f"\033[38;5;{index}m"

--- a/src/lilbee/runtime/launcher.py
+++ b/src/lilbee/runtime/launcher.py
@@ -38,7 +38,11 @@ def main() -> None:
     """Entry point for the ``lilbee`` console script."""
     _force_utf8_stdio()
     args = sys.argv[1:]
-    is_interactive = (not args or args[0] in ("chat", "")) and not _shell_completion_active()
+    # Help exits before the TUI, so it must not print through the animation.
+    wants_help = any(arg in ("--help", "-h") for arg in args)
+    is_interactive = (
+        (not args or args[0] in ("chat", "")) and not wants_help and not _shell_completion_active()
+    )
 
     if not is_interactive:
         from lilbee.cli import app
@@ -55,11 +59,10 @@ def main() -> None:
     except BaseException:
         stop(handle)
         raise
-    else:
-        # Stop the splash BEFORE the TUI takes over the terminal so the
-        # subprocess's final writes don't land on Textual's alt-screen.
-        stop(handle)
 
+    # The splash keeps animating through the CLI dispatch and the TUI stack's
+    # own imports (Textual and every screen), which on a cold disk take seconds;
+    # run_tui dismisses it right before Textual takes over the terminal.
     try:
         app()
     except KeyboardInterrupt:

--- a/tests/_lilbee_app_test_host.py
+++ b/tests/_lilbee_app_test_host.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+
 from lilbee.cli.tui.app import LilbeeApp
 
 
@@ -9,3 +11,45 @@ class LilbeeAppHost(LilbeeApp):
     """LilbeeApp subclass that skips the heavyweight on_mount work for tests."""
 
     _test_skip_auto_init = True
+
+
+_GATE_HANDOVER_TIMEOUT_S = 20.0
+_GATE_POLL_S = 0.02
+
+
+async def await_chat(app, pilot) -> object:
+    """Wait for the startup gate to hand the screen over to chat, and return it.
+
+    Production pushes a blocking StartupGate before the chat screen exists, and its
+    boot worker runs on a real thread, so a bare ``pilot.pause()`` no longer lands
+    on chat.
+    """
+    import asyncio
+    import time
+
+    from lilbee.cli.tui.screens.chat import ChatScreen
+
+    deadline = time.monotonic() + _GATE_HANDOVER_TIMEOUT_S
+    while time.monotonic() < deadline:
+        chat = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        if chat is not None:
+            return chat
+        await pilot.pause()
+        await asyncio.sleep(_GATE_POLL_S)
+    raise AssertionError("the startup gate never revealed the chat screen")
+
+
+@contextmanager
+def ready_services():
+    """Bind a mock container whose chat role is ready, so the startup gate releases at once."""
+    from unittest.mock import MagicMock
+
+    from lilbee.app.services import set_services
+
+    services = MagicMock()
+    services.provider.role_ready.return_value = True
+    set_services(services)
+    try:
+        yield services
+    finally:
+        set_services(None)

--- a/tests/_lilbee_app_test_host.py
+++ b/tests/_lilbee_app_test_host.py
@@ -18,11 +18,12 @@ _GATE_POLL_S = 0.02
 
 
 async def await_chat(app, pilot) -> object:
-    """Wait for the startup gate to hand the screen over to chat, and return it.
+    """Wait for the startup gate to hand over a fully composed chat screen, and return it.
 
     Production pushes a blocking StartupGate before the chat screen exists, and its
     boot worker runs on a real thread, so a bare ``pilot.pause()`` no longer lands
-    on chat.
+    on chat. Waiting for the screen alone races its children: a caller that queries
+    a widget the instant the screen appears can miss it on a slow runner.
     """
     import asyncio
     import time
@@ -32,11 +33,11 @@ async def await_chat(app, pilot) -> object:
     deadline = time.monotonic() + _GATE_HANDOVER_TIMEOUT_S
     while time.monotonic() < deadline:
         chat = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
-        if chat is not None:
+        if chat is not None and chat.is_mounted and chat.query("#chat-input"):
             return chat
         await pilot.pause()
         await asyncio.sleep(_GATE_POLL_S)
-    raise AssertionError("the startup gate never revealed the chat screen")
+    raise AssertionError("the startup gate never revealed a composed chat screen")
 
 
 @contextmanager

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -273,11 +273,12 @@ def test_view_multi_replica_unions_devices():
 
 
 class _WaitProvider:
-    """Provider stub scripting role_ready / warm_progress across polls."""
+    """Provider stub scripting role_ready / warm_progress / warm_pending across polls."""
 
-    def __init__(self, ready_after: int, snapshots: list) -> None:
+    def __init__(self, ready_after: int, snapshots: list, *, pending: bool = False) -> None:
         self._ready_after = ready_after
         self._snapshots = snapshots
+        self._pending = pending
         self.polls = 0
 
     def role_ready(self, role: WorkerRole) -> bool:
@@ -287,6 +288,9 @@ class _WaitProvider:
     def warm_progress(self):
         idx = min(self.polls - 1, len(self._snapshots) - 1)
         return self._snapshots[idx] if self._snapshots else None
+
+    def warm_pending(self) -> bool:
+        return self._pending
 
 
 class _WaitServices:
@@ -322,6 +326,16 @@ def test_wait_chat_ready_stops_when_no_warm_in_flight(monkeypatch):
     monkeypatch.setattr(app_placement, "_CHAT_READY_POLL_S", 0.01)
     monkeypatch.setattr(app_placement, "_CHAT_READY_GRACE_S", 0.0)
     assert app_placement.wait_chat_ready(timeout_s=5) is False
+
+
+def test_wait_chat_ready_holds_while_a_warm_is_pending(monkeypatch):
+    """A requested warm has no phase yet while the fleet spawns; hold anyway."""
+    provider = _WaitProvider(ready_after=3, snapshots=[], pending=True)
+    monkeypatch.setattr(app_placement, "peek_services", lambda: _WaitServices(provider))
+    monkeypatch.setattr(app_placement, "_CHAT_READY_POLL_S", 0.0)
+    monkeypatch.setattr(app_placement, "_CHAT_READY_GRACE_S", 0.0)
+    # A zero grace would give up on the first poll if pending were ignored.
+    assert app_placement.wait_chat_ready(timeout_s=5) is True
 
 
 def test_wait_chat_ready_stops_on_warm_error(monkeypatch):

--- a/tests/app/test_placement.py
+++ b/tests/app/test_placement.py
@@ -362,3 +362,64 @@ def test_wait_chat_ready_times_out_while_warm_never_finishes(monkeypatch):
     monkeypatch.setattr(app_placement, "peek_services", lambda: _WaitServices(provider))
     monkeypatch.setattr(app_placement, "_CHAT_READY_POLL_S", 0.005)
     assert app_placement.wait_chat_ready(timeout_s=0.02) is False
+
+
+def test_wait_chat_ready_reports_progress_to_the_caller(monkeypatch):
+    """Each actively-loading snapshot reaches on_progress, so a caller can render it."""
+    from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+    loading = WarmProgress(phase=WarmPhase.LOADING_ENGINE)
+    provider = _WaitProvider(ready_after=2, snapshots=[loading, loading])
+    monkeypatch.setattr(app_placement, "peek_services", lambda: _WaitServices(provider))
+    monkeypatch.setattr(app_placement, "_CHAT_READY_POLL_S", 0.0)
+    seen: list = []
+    assert app_placement.wait_chat_ready(timeout_s=5, on_progress=seen.append) is True
+    assert seen == [loading, loading]
+
+
+def test_wait_chat_ready_aborts_when_asked(monkeypatch):
+    """should_abort ends the wait at once, before any grace or timeout."""
+    from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+    loading = WarmProgress(phase=WarmPhase.LOADING_ENGINE)
+    provider = _WaitProvider(ready_after=10_000, snapshots=[loading])
+    monkeypatch.setattr(app_placement, "peek_services", lambda: _WaitServices(provider))
+    monkeypatch.setattr(app_placement, "_CHAT_READY_POLL_S", 0.0)
+    assert app_placement.wait_chat_ready(timeout_s=5, should_abort=lambda: True) is False
+    assert provider.polls == 1  # one readiness check, then straight out
+
+
+def test_chat_warm_error_reports_the_failure(monkeypatch):
+    from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+    failed = WarmProgress(phase=WarmPhase.ERROR, error="boom")
+    provider = _WaitProvider(ready_after=10_000, snapshots=[failed])
+    provider.polls = 1  # warm_progress indexes off the poll count
+    monkeypatch.setattr(app_placement, "peek_services", lambda: _WaitServices(provider))
+    assert app_placement.chat_warm_error() == "boom"
+
+
+def test_chat_warm_error_none_without_a_failure(monkeypatch):
+    from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+    loading = WarmProgress(phase=WarmPhase.LOADING_ENGINE)
+    provider = _WaitProvider(ready_after=10_000, snapshots=[loading])
+    provider.polls = 1
+    monkeypatch.setattr(app_placement, "peek_services", lambda: _WaitServices(provider))
+    assert app_placement.chat_warm_error() is None
+
+
+def test_chat_warm_error_none_without_services(monkeypatch):
+    monkeypatch.setattr(app_placement, "peek_services", lambda: None)
+    assert app_placement.chat_warm_error() is None
+
+
+def test_chat_warm_error_empty_string_when_error_text_is_missing(monkeypatch):
+    """An ERROR phase with no message still reads as a failure, not as None."""
+    from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+    failed = WarmProgress(phase=WarmPhase.ERROR)
+    provider = _WaitProvider(ready_after=10_000, snapshots=[failed])
+    provider.polls = 1
+    monkeypatch.setattr(app_placement, "peek_services", lambda: _WaitServices(provider))
+    assert app_placement.chat_warm_error() == ""

--- a/tests/cli/test_engine_stop.py
+++ b/tests/cli/test_engine_stop.py
@@ -22,9 +22,7 @@ def _data_args(tmp_path) -> list[str]:
 def _write_detached(tmp_path) -> object:
     (tmp_path / "data").mkdir(exist_ok=True)
     path = tmp_path / "data" / sm._state_filename(999_999, SwapGroup.CHAT.value)
-    path.write_text(
-        json.dumps({"pid": 999_998, "owner_pid": 999_999, "detached": True})
-    )
+    path.write_text(json.dumps({"pid": 999_998, "owner_pid": 999_999, "detached": True}))
     return path
 
 

--- a/tests/cli/test_engine_stop.py
+++ b/tests/cli/test_engine_stop.py
@@ -1,0 +1,51 @@
+"""lilbee engine stop kills a warm fleet without the TUI."""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from lilbee.cli import app
+from lilbee.providers.fleet import swap_manager as sm
+from lilbee.providers.fleet.groups import SwapGroup
+
+runner = CliRunner()
+
+
+def _data_args(tmp_path) -> list[str]:
+    """--data-dir wins the CLI's data-root resolution, unlike a cfg monkeypatch."""
+    (tmp_path / "data").mkdir(exist_ok=True)
+    return ["--data-dir", str(tmp_path)]
+
+
+def _write_detached(tmp_path) -> object:
+    (tmp_path / "data").mkdir(exist_ok=True)
+    path = tmp_path / "data" / sm._state_filename(999_999, SwapGroup.CHAT.value)
+    path.write_text(
+        json.dumps({"pid": 999_998, "owner_pid": 999_999, "detached": True})
+    )
+    return path
+
+
+def test_stop_reaps_a_detached_fleet(tmp_path):
+    path = _write_detached(tmp_path)
+    result = runner.invoke(app, [*_data_args(tmp_path), "engine", "stop"])
+    assert result.exit_code == 0
+    assert "Stopped the warm engine" in result.output
+    assert not path.exists()
+
+
+def test_stop_reports_when_nothing_is_running(tmp_path):
+    result = runner.invoke(app, [*_data_args(tmp_path), "engine", "stop"])
+    assert result.exit_code == 0
+    assert "No warm engine is running" in result.output
+
+
+def test_stop_emits_json_in_json_mode(tmp_path):
+    _write_detached(tmp_path)
+    result = runner.invoke(app, [*_data_args(tmp_path), "--json", "engine", "stop"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["command"] == "engine stop"
+    assert payload["stopped"] == ["chat"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,24 +87,35 @@ def pytest_configure(config: pytest.Config) -> None:
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> None:  # type: ignore[type-arg]
-    """Downgrade asyncio event loop teardown errors to xfail.
+    """Downgrade asyncio event loop self-pipe corruption to xfail.
 
     Textual's @work(thread=True) workers can corrupt the event loop's
-    self-pipe socket during teardown. pytest-asyncio's Runner fixture
-    then raises OSError when closing the loop. This is not a real test
-    failure.
+    self-pipe socket: a worker leaked by an earlier test writes to its
+    closed loop's fd after the OS has reused the number for the current
+    test's selector. pytest-asyncio's Runner then raises OSError from the
+    loop's own selector, at close (teardown) or mid-poll (call), depending
+    on when the stray write lands. Neither is a real test failure. The
+    call-phase downgrade only applies when the error comes out of the
+    selector itself, so a genuine EBADF raised by product code still fails.
     """
     outcome = yield
     report = outcome.get_result()
     if (
-        report.when == "teardown"
+        report.when in ("call", "teardown")
         and report.failed
         and call.excinfo is not None
         and call.excinfo.errisinstance(OSError)
         and "Bad file descriptor" in str(call.excinfo.value)
+        and (report.when == "teardown" or _raised_in_loop_selector(call.excinfo))
     ):
         report.outcome = "passed"
-        report.wasxfail = "asyncio loop teardown noise (Textual worker thread)"
+        report.wasxfail = "asyncio loop self-pipe noise (Textual worker thread)"
+
+
+def _raised_in_loop_selector(excinfo: pytest.ExceptionInfo) -> bool:  # type: ignore[type-arg]
+    """Whether the OSError came out of the event loop's selector poll."""
+    tail = excinfo.traceback[-1]
+    return str(tail.path).endswith("selectors.py")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_bootstrap_patch.py
+++ b/tests/test_bootstrap_patch.py
@@ -1,0 +1,79 @@
+"""The onefile bootstrap patch must stay in step with the shared wordmark."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from lilbee.runtime.bee_logo import AMBER_DIM_XTERM, BEE_LINES
+
+_PATCH = (
+    pathlib.Path(__file__).resolve().parents[1] / "tools/wheel-build/onefile-bootstrap-lilbee.patch"
+)
+
+_ADDED_PREFIX = "+"
+
+
+@pytest.fixture(scope="module")
+def added_lines() -> list[str]:
+    """The lines the patch adds to the Nuitka bootstrap."""
+    text = _PATCH.read_text()
+    return [line[1:] for line in text.splitlines() if line.startswith(_ADDED_PREFIX)]
+
+
+def test_patch_exists():
+    """The build script applies this patch by path; a rename must fail loudly here."""
+    assert _PATCH.is_file()
+
+
+def test_c_logo_matches_the_python_wordmark(added_lines):
+    """Every non-blank wordmark row must appear verbatim as a C string literal."""
+    body = "\n".join(added_lines)
+    for row in BEE_LINES:
+        if not row.strip():
+            continue
+        assert f'"{row}",' in body, f"wordmark row missing from the C bootstrap: {row!r}"
+
+
+def test_c_logo_has_no_extra_rows(added_lines):
+    """The C array must hold exactly the non-blank wordmark rows, in order."""
+    row_starts = ('"@', '"!', '" :', '": ')
+    literals = [
+        line.strip().removeprefix('"').removesuffix('",')
+        for line in added_lines
+        if line.strip().startswith(row_starts)
+    ]
+    expected = [row for row in BEE_LINES if row.strip()]
+    assert literals == expected
+
+
+def test_bootstrap_uses_the_shared_dim_amber(added_lines):
+    """The bootstrap paints the dim-amber stage of the wordmark."""
+    body = "\n".join(added_lines)
+    assert f"38;5;{AMBER_DIM_XTERM}m" in body
+
+
+def test_progress_is_suppressed_off_a_terminal(added_lines):
+    """A piped or redirected launch must not emit escape codes."""
+    body = "\n".join(added_lines)
+    assert "isatty(STDERR_FILENO)" in body
+
+
+def test_stamp_fast_path_is_guarded_by_payload_size(added_lines):
+    """A stamp from a different payload must not be trusted."""
+    body = "\n".join(added_lines)
+    assert "_NUITKA_ONEFILE_PAYLOAD_SIZE_INT" in body
+    assert "stamped_size !=" in body
+
+
+def test_stamp_fast_path_requires_an_executable_entry_point(added_lines):
+    """A stamp naming a missing binary must fall back to a full extraction."""
+    body = "\n".join(added_lines)
+    assert "access(stamped_main, X_OK)" in body
+
+
+def test_patch_is_posix_guarded(added_lines):
+    """Windows keeps Nuitka's stock bootstrap, which has its own splash support."""
+    body = "\n".join(added_lines)
+    assert "#if !defined(_WIN32) && !defined(__MSYS__)" in body

--- a/tests/test_bootstrap_patch.py
+++ b/tests/test_bootstrap_patch.py
@@ -91,3 +91,22 @@ def test_patch_is_posix_guarded(added_lines):
     """Windows keeps Nuitka's stock bootstrap, which has its own splash support."""
     body = "\n".join(added_lines)
     assert "#if !defined(_WIN32) && !defined(__MSYS__)" in body
+
+
+def test_bootstrap_frame_matches_the_splash_frame_geometry(added_lines):
+    """The splash repaints the bootstrap's frame in place, so the row counts must agree.
+
+    The splash writes len(BEE_LINES) wordmark rows, a separator, and the bar. The
+    bootstrap parks the cursor that many rows above the bar. A mismatch would draw
+    the splash over the wrong lines.
+    """
+    body = "\n".join(added_lines)
+    expected = len(BEE_LINES) + 1
+    assert f"#define LILBEE_FRAME_ROWS_ABOVE_BAR {expected}" in body
+
+
+def test_interactive_launch_keeps_the_wordmark_on_screen(added_lines):
+    """Erasing the frame before exec left the terminal blank until the splash started."""
+    body = "\n".join(added_lines)
+    assert "lilbee_progress_end(argc == 1)" in body
+    assert "keep_logo ? " in body

--- a/tests/test_bootstrap_patch.py
+++ b/tests/test_bootstrap_patch.py
@@ -110,3 +110,12 @@ def test_interactive_launch_keeps_the_wordmark_on_screen(added_lines):
     body = "\n".join(added_lines)
     assert "lilbee_progress_end(argc == 1)" in body
     assert "keep_logo ? " in body
+
+
+def test_bootstrap_centres_on_the_python_wordmark_width(added_lines):
+    """Both stages centre with (columns - width) / 2; a drifting width constant
+    would draw the bootstrap and the splash at different offsets."""
+    from lilbee.runtime.bee_logo import LOGO_WIDTH
+
+    assert f"#define LILBEE_LOGO_WIDTH {LOGO_WIDTH}" in added_lines
+    assert any("TIOCGWINSZ" in line for line in added_lines)

--- a/tests/test_bootstrap_patch.py
+++ b/tests/test_bootstrap_patch.py
@@ -6,7 +6,12 @@ import pathlib
 
 import pytest
 
-from lilbee.runtime.bee_logo import AMBER_DIM_XTERM, BEE_LINES
+from lilbee.runtime.bee_logo import (
+    AMBER_BRIGHT_XTERM,
+    AMBER_DIM_XTERM,
+    AMBER_MID_XTERM,
+    BEE_LINES,
+)
 
 _PATCH = (
     pathlib.Path(__file__).resolve().parents[1] / "tools/wheel-build/onefile-bootstrap-lilbee.patch"
@@ -48,10 +53,19 @@ def test_c_logo_has_no_extra_rows(added_lines):
     assert literals == expected
 
 
-def test_bootstrap_uses_the_shared_dim_amber(added_lines):
-    """The bootstrap paints the dim-amber stage of the wordmark."""
+def test_bootstrap_uses_the_shared_amber_ramp(added_lines):
+    """The bootstrap paints the wordmark and bar from the shared palette."""
     body = "\n".join(added_lines)
-    assert f"38;5;{AMBER_DIM_XTERM}m" in body
+    for index in (AMBER_DIM_XTERM, AMBER_MID_XTERM, AMBER_BRIGHT_XTERM):
+        assert f"38;5;{index}m" in body, f"xterm index {index} missing from the C bootstrap"
+
+
+def test_bootstrap_bar_uses_the_splash_block_glyphs(added_lines):
+    """The bar reads as the same surface as the splash, not an ASCII fallback."""
+    body = "\n".join(added_lines)
+    for glyph in ("\\u2593", "\\u2592", "\\u2591"):
+        assert glyph in body, f"block glyph {glyph} missing from the bootstrap bar"
+    assert "'='" not in body, "the bar should not fall back to ASCII"
 
 
 def test_progress_is_suppressed_off_a_terminal(added_lines):

--- a/tests/test_bottom_bar_affordances.py
+++ b/tests/test_bottom_bar_affordances.py
@@ -60,7 +60,7 @@ def _mock_services():
 def _patch_chat_setup():
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
+            "lilbee.cli.tui.screens.chat.needs_setup",
             return_value=False,
         ),
         mock.patch(

--- a/tests/test_bottom_bar_affordances.py
+++ b/tests/test_bottom_bar_affordances.py
@@ -15,7 +15,7 @@ from lilbee.cli.tui.screens.chat import ChatScreen
 from lilbee.cli.tui.screens.setup import SetupWizard
 from lilbee.cli.tui.widgets.status_bar import ViewTabs
 from lilbee.core.config import cfg
-from tests._lilbee_app_test_host import LilbeeAppHost
+from tests._lilbee_app_test_host import LilbeeAppHost, await_chat
 
 _ALT_CHAT_REF = "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf"
 _TEST_LOCAL_LABEL = display_label_for_ref(TEST_LOCAL_REF)
@@ -93,6 +93,7 @@ async def test_view_tabs_hides_model_pill_on_chat(_patch_chat_setup) -> None:
     cfg.chat_model = TEST_LOCAL_REF
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert isinstance(app.screen, ChatScreen)
         tabs = app.screen.query_one(ViewTabs)
@@ -105,6 +106,7 @@ async def test_view_tabs_renders_active_chat_model_on_settings(_patch_chat_setup
     cfg.chat_model = TEST_LOCAL_REF
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         await pilot.press("escape")
         await pilot.pause()
@@ -124,6 +126,7 @@ async def test_view_tabs_refreshes_model_pill_on_settings_change(_patch_chat_set
     cfg.chat_model = TEST_LOCAL_REF
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         await pilot.press("escape")
         await pilot.pause()
@@ -151,6 +154,7 @@ async def test_view_tabs_ignores_non_model_settings_changes(_patch_chat_setup) -
     cfg.chat_model = TEST_LOCAL_REF
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         await pilot.press("escape")
         await pilot.pause()
@@ -275,6 +279,7 @@ async def test_cycle_theme_persists_to_config(_patch_chat_setup) -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         before = app.theme
 
@@ -293,6 +298,7 @@ async def test_set_theme_persists_to_config(_patch_chat_setup) -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
 
         app.set_theme("dracula")
@@ -309,6 +315,7 @@ async def test_app_restores_persisted_theme_on_startup(_patch_chat_setup) -> Non
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert app.theme == "nord"
 
@@ -319,6 +326,7 @@ async def test_app_falls_back_when_persisted_theme_invalid(_patch_chat_setup) ->
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         # Falls back to the module-level default, not the bad value.
         from lilbee.cli.tui.app import _DEFAULT_THEME
@@ -333,6 +341,7 @@ async def test_sync_theme_index_handles_non_dark_theme(_patch_chat_setup) -> Non
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         # Pick any Textual theme that is intentionally NOT in DARK_THEMES.
         non_dark = next(

--- a/tests/test_bottom_bars_stacking.py
+++ b/tests/test_bottom_bars_stacking.py
@@ -54,7 +54,7 @@ def _mock_services():
 @pytest.fixture(autouse=True)
 def _patch_chat_setup():
     with (
-        patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
         patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,

--- a/tests/test_chat_embedder_adopt.py
+++ b/tests/test_chat_embedder_adopt.py
@@ -50,6 +50,9 @@ class TestStreamResponseDispatch:
         screen._history_lock.__exit__ = MagicMock(return_value=False)
         screen._on_embedding_mismatch = MagicMock()  # type: ignore[method-assign]
         screen._finalize_stream = MagicMock()  # type: ignore[method-assign]
+        # The engine wait is its own unit (test_chat_startup_gating); here the
+        # engine is ready so the dispatch under test runs unconditionally.
+        screen._await_chat_engine = MagicMock(return_value=True)  # type: ignore[method-assign]
         return screen
 
     def test_mismatch_routes_to_adopt_prompt(self):
@@ -67,6 +70,22 @@ class TestStreamResponseDispatch:
             screen._do_stream_response("q", widget, None)
         screen._on_embedding_mismatch.assert_called_once()
         widget.append_content.assert_not_called()
+
+    def test_failed_engine_wait_skips_the_ask_and_still_finalizes(self):
+        screen = self._screen()
+        screen._await_chat_engine = MagicMock(return_value=False)  # type: ignore[method-assign]
+        widget = MagicMock()
+        services = MagicMock()
+        with (
+            patch("lilbee.cli.tui.screens.chat.get_services", return_value=services),
+            patch(
+                "lilbee.cli.tui.screens.chat.call_from_thread",
+                side_effect=lambda _node, fn, *a, **k: fn(*a, **k),
+            ),
+        ):
+            screen._do_stream_response("q", widget, None)
+        services.searcher.ask_stream.assert_not_called()
+        screen._finalize_stream.assert_called_once()
 
     def test_other_error_shows_stream_error(self):
         screen = self._screen()

--- a/tests/test_chat_input_wrap.py
+++ b/tests/test_chat_input_wrap.py
@@ -42,7 +42,7 @@ def _chat_ready_env():
     cfg.embedding_model = TEST_EMBED_REF
     cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     with (
-        mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
         mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=True),
     ):
         yield

--- a/tests/test_chat_memory_commands.py
+++ b/tests/test_chat_memory_commands.py
@@ -46,7 +46,7 @@ def _patch_chat_setup():
     from lilbee.cli.tui.widgets.model_bar import ModelBar
 
     with (
-        patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
         patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=False),
         patch.object(ModelBar, "_scan_models"),
     ):

--- a/tests/test_chat_setup_detection.py
+++ b/tests/test_chat_setup_detection.py
@@ -1,4 +1,4 @@
-"""Tests for ChatScreen._needs_setup: wizard shows on fresh data dirs."""
+"""Tests for needs_setup: the wizard shows on fresh data dirs."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 
+from lilbee.app.setup_state import needs_setup
 from lilbee.cli.tui.screens.chat import ChatScreen
 from lilbee.core.config import cfg
 
@@ -25,10 +26,6 @@ def isolated_data_dir(tmp_path):
             setattr(cfg, field_name, getattr(snapshot, field_name))
 
 
-def _make_screen() -> ChatScreen:
-    return ChatScreen.__new__(ChatScreen)
-
-
 def test_needs_setup_true_when_lancedb_dir_missing(isolated_data_dir):
     """Fresh data dir must trigger the wizard even when models resolve globally."""
     assert not cfg.lancedb_dir.exists()
@@ -36,7 +33,7 @@ def test_needs_setup_true_when_lancedb_dir_missing(isolated_data_dir):
         "lilbee.providers.engine_params.resolve_model_path",
         return_value="/some/resolved/path",
     ) as resolve:
-        assert _make_screen()._needs_setup() is True
+        assert needs_setup() is True
         resolve.assert_not_called()
 
 
@@ -67,7 +64,7 @@ def test_needs_setup_false_when_initialized_and_models_resolve(isolated_data_dir
         "lilbee.providers.engine_params.resolve_model_path",
         return_value="/some/resolved/path",
     ):
-        assert _make_screen()._needs_setup() is False
+        assert needs_setup() is False
 
 
 def test_needs_setup_true_when_initialized_but_model_missing(isolated_data_dir):
@@ -81,7 +78,7 @@ def test_needs_setup_true_when_initialized_but_model_missing(isolated_data_dir):
         "lilbee.providers.engine_params.resolve_model_path",
         side_effect=ProviderError("no such model", provider="llama-cpp"),
     ):
-        assert _make_screen()._needs_setup() is True
+        assert needs_setup() is True
 
 
 def test_needs_setup_skips_native_probe_for_usable_remote_models(isolated_data_dir):
@@ -103,7 +100,7 @@ def test_needs_setup_skips_native_probe_for_usable_remote_models(isolated_data_d
         ),
         mock.patch("lilbee.providers.engine_params.resolve_model_path") as resolve,
     ):
-        assert _make_screen()._needs_setup() is False
+        assert needs_setup() is False
         resolve.assert_not_called()
 
 
@@ -123,7 +120,7 @@ def test_needs_setup_true_when_remote_model_unusable(isolated_data_dir):
         "lilbee.modelhub.model_manager.validate_persisted_model",
         return_value=ValidationResult.UNKNOWN,
     ):
-        assert _make_screen()._needs_setup() is True
+        assert needs_setup() is True
 
 
 def test_needs_setup_true_when_lancedb_path_is_a_file(isolated_data_dir):
@@ -136,7 +133,7 @@ def test_needs_setup_true_when_lancedb_path_is_a_file(isolated_data_dir):
         "lilbee.providers.engine_params.resolve_model_path",
         return_value="/some/resolved/path",
     ):
-        assert _make_screen()._needs_setup() is True
+        assert needs_setup() is True
 
 
 @pytest.fixture
@@ -156,7 +153,7 @@ def mock_services():
 async def test_chat_screen_cached_across_navigation(isolated_data_dir, mock_services):
     """Navigating away from Chat and back reuses the same instance.
     ChatScreen is installed via install_screen, so on_mount (and therefore
-    _needs_setup) runs only on first mount, not on every revisit."""
+    the setup check) runs only on first mount, not on every revisit."""
     from lilbee.cli.tui.app import LilbeeApp
     from lilbee.cli.tui.screens.catalog import CatalogScreen
     from lilbee.cli.tui.screens.chat import ChatScreen
@@ -165,7 +162,7 @@ async def test_chat_screen_cached_across_navigation(isolated_data_dir, mock_serv
 
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
+            "lilbee.cli.tui.screens.chat.needs_setup",
             return_value=False,
         ),
         mock.patch(

--- a/tests/test_chat_setup_detection.py
+++ b/tests/test_chat_setup_detection.py
@@ -9,6 +9,7 @@ import pytest
 from lilbee.app.setup_state import needs_setup
 from lilbee.cli.tui.screens.chat import ChatScreen
 from lilbee.core.config import cfg
+from tests._lilbee_app_test_host import await_chat
 
 
 @pytest.fixture
@@ -172,6 +173,7 @@ async def test_chat_screen_cached_across_navigation(isolated_data_dir, mock_serv
     ):
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             chat = app.screen
             assert isinstance(chat, ChatScreen)

--- a/tests/test_chat_startup_gating.py
+++ b/tests/test_chat_startup_gating.py
@@ -43,7 +43,7 @@ def _warming_services():
     services.provider.warm_progress.return_value = WarmProgress(phase=WarmPhase.READING_WEIGHTS)
     set_services(services)
     with (
-        mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
         mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready", return_value=True),
     ):
         yield services

--- a/tests/test_chat_startup_gating.py
+++ b/tests/test_chat_startup_gating.py
@@ -116,6 +116,7 @@ async def test_await_engine_paints_progress_then_proceeds(_warming_services):
         ):
             assert await asyncio.to_thread(screen._await_chat_engine, widget) is True
         painted = [c.args[0] for c in widget.set_thinking_status.call_args_list]
+        assert painted[0] == msg.ENGINE_LOADING  # labelled before the first snapshot
         assert _engine_status_text(snapshot) in painted
         assert painted[-1] == ""  # the status clears once the engine is ready
 

--- a/tests/test_chat_startup_gating.py
+++ b/tests/test_chat_startup_gating.py
@@ -213,3 +213,19 @@ def test_engine_status_text_reports_bytes_or_phase():
     assert _engine_status_text(WarmProgress(phase=WarmPhase.LOADING_ENGINE)) == msg.ENGINE_LOADING
     no_bytes = WarmProgress(phase=WarmPhase.READING_WEIGHTS)
     assert _engine_status_text(no_bytes) == msg.ENGINE_LOADING
+
+
+async def test_await_engine_builds_services_when_none_exist(_warming_services):
+    """A prompt right after a settings reset must rebuild the container rather
+    than reporting a dead engine; readiness probes never build on their own."""
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        widget = mock.MagicMock()
+        with (
+            mock.patch("lilbee.cli.tui.screens.chat.get_services") as build,
+            mock.patch("lilbee.app.placement.chat_engine_ready", return_value=True),
+        ):
+            assert await asyncio.to_thread(screen._await_chat_engine, widget) is True
+        build.assert_called_once()

--- a/tests/test_chat_startup_gating.py
+++ b/tests/test_chat_startup_gating.py
@@ -1,7 +1,8 @@
-"""The chat input is held until the model warms, not errored into a bubble."""
+"""A prompt sent before the engine is ready waits inside its bubble, input stays live."""
 
 from __future__ import annotations
 
+import asyncio
 from unittest import mock
 
 import pytest
@@ -10,6 +11,7 @@ from textual.app import ComposeResult
 from conftest import TEST_EMBED_REF, TEST_LOCAL_REF, make_mock_services
 from lilbee.app.services import set_services
 from lilbee.cli.tui import messages as msg
+from lilbee.cli.tui.screens.chat import _engine_status_text
 from lilbee.cli.tui.widgets.chat_input import ChatInput
 from lilbee.core.config import cfg
 from lilbee.providers.warm_progress import WarmPhase, WarmProgress
@@ -49,35 +51,17 @@ def _warming_services():
         yield services
 
 
-async def test_input_locked_and_submit_held_while_warming(_warming_services):
+async def test_input_stays_live_and_submits_while_warming(_warming_services):
+    """A cold engine no longer locks the input; the prompt goes through."""
     app = _ChatHost()
     async with app.run_test(size=(100, 40)) as pilot:
         await pilot.pause()
         screen = app.screen
-        assert screen.chat_warming is True
-        assert screen._chat_input.disabled is True
-        with (
-            mock.patch.object(screen, "notify") as notify,
-            mock.patch.object(screen, "_send_message") as send,
-        ):
-            rejected = screen._reject_submit_when_busy()
-        assert rejected is True
-        send.assert_not_called()
-        assert notify.call_args[0][0] == msg.CHAT_WARMING
-
-
-async def test_ready_transition_unlocks_input(_warming_services):
-    app = _ChatHost()
-    async with app.run_test(size=(100, 40)) as pilot:
-        await pilot.pause()
-        screen = app.screen
-        assert screen._chat_input.disabled is True
-        # The model finishes warming and can serve.
-        _warming_services.provider.role_ready.return_value = True
-        screen._poll_chat_warming()
-        await pilot.pause()
-        assert screen.chat_warming is False
         assert screen._chat_input.disabled is False
+        with mock.patch.object(screen, "notify") as notify:
+            rejected = screen._reject_submit_when_busy()
+        assert rejected is False
+        notify.assert_not_called()
 
 
 async def test_not_installed_model_does_not_trap_input(_warming_services):
@@ -88,6 +72,143 @@ async def test_not_installed_model_does_not_trap_input(_warming_services):
     async with app.run_test(size=(100, 40)) as pilot:
         await pilot.pause()
         screen = app.screen
-        assert screen.chat_warming is False
         assert screen._chat_input.disabled is False
         assert app.screen.query_one("#chat-input", ChatInput) is screen._chat_input
+
+
+async def test_await_engine_returns_at_once_when_ready(_warming_services):
+    """A ready engine costs the stream worker nothing."""
+    _warming_services.provider.role_ready.return_value = True
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        widget = mock.MagicMock()
+        with mock.patch("lilbee.app.placement.wait_chat_ready") as waited:
+            assert await asyncio.to_thread(screen._await_chat_engine, widget) is True
+        waited.assert_not_called()
+        widget.set_thinking_status.assert_not_called()
+
+
+async def test_await_engine_paints_progress_then_proceeds(_warming_services):
+    """The load's snapshots land in the bubble's thinking row, then clear."""
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        widget = mock.MagicMock()
+        snapshot = WarmProgress(
+            phase=WarmPhase.READING_WEIGHTS, bytes_done=1, bytes_total=4, model_ref="a/b/c.gguf"
+        )
+
+        def _wait(*, on_progress, should_abort):
+            assert should_abort() is False
+            on_progress(snapshot)
+            return True
+
+        with (
+            mock.patch("lilbee.app.placement.chat_engine_ready", return_value=False),
+            mock.patch("lilbee.app.placement.wait_chat_ready", side_effect=_wait),
+            mock.patch(
+                "lilbee.cli.tui.screens.chat._get_worker",
+                return_value=mock.MagicMock(is_cancelled=False),
+            ),
+        ):
+            assert await asyncio.to_thread(screen._await_chat_engine, widget) is True
+        painted = [c.args[0] for c in widget.set_thinking_status.call_args_list]
+        assert _engine_status_text(snapshot) in painted
+        assert painted[-1] == ""  # the status clears once the engine is ready
+
+
+async def test_await_engine_cancelled_wait_stays_silent(_warming_services):
+    """A cancelled prompt ends the wait without painting an error."""
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        widget = mock.MagicMock()
+        with (
+            mock.patch("lilbee.app.placement.chat_engine_ready", return_value=False),
+            mock.patch("lilbee.app.placement.wait_chat_ready", return_value=False),
+            mock.patch(
+                "lilbee.cli.tui.screens.chat._get_worker",
+                return_value=mock.MagicMock(is_cancelled=True),
+            ),
+        ):
+            assert await asyncio.to_thread(screen._await_chat_engine, widget) is False
+        widget.append_content.assert_not_called()
+
+
+async def test_await_engine_failure_lands_in_the_bubble(_warming_services):
+    """A failed load renders its reason and the model hint where the answer would be."""
+    _warming_services.provider.warm_progress.return_value = WarmProgress(
+        phase=WarmPhase.ERROR, error="out of memory"
+    )
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        widget = mock.MagicMock()
+        with (
+            mock.patch("lilbee.app.placement.chat_engine_ready", return_value=False),
+            mock.patch("lilbee.app.placement.wait_chat_ready", return_value=False),
+            mock.patch(
+                "lilbee.cli.tui.screens.chat._get_worker",
+                return_value=mock.MagicMock(is_cancelled=False),
+            ),
+        ):
+            assert await asyncio.to_thread(screen._await_chat_engine, widget) is False
+        rendered = widget.append_content.call_args[0][0]
+        assert msg.ENGINE_LOAD_FAILED.format(error="out of memory") in rendered
+        assert msg.ENGINE_FAILED_HINT in rendered
+
+
+async def test_await_engine_stall_reports_not_ready(_warming_services):
+    """A wait that ends with no failure on record still explains itself."""
+    _warming_services.provider.warm_progress.return_value = None
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        widget = mock.MagicMock()
+        with (
+            mock.patch("lilbee.app.placement.chat_engine_ready", return_value=False),
+            mock.patch("lilbee.app.placement.wait_chat_ready", return_value=False),
+            mock.patch(
+                "lilbee.cli.tui.screens.chat._get_worker",
+                return_value=mock.MagicMock(is_cancelled=False),
+            ),
+        ):
+            assert await asyncio.to_thread(screen._await_chat_engine, widget) is False
+        assert widget.append_content.call_args[0][0] == msg.ENGINE_NOT_READY
+
+
+async def test_warm_tip_shows_once_and_only_when_warm_is_off(_warming_services, monkeypatch):
+    """The keep-warm tip toasts on the first cold wait, never again, never when warm."""
+    app = _ChatHost()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        monkeypatch.setattr(cfg, "keep_engine_warm", False)
+        with mock.patch.object(screen, "notify") as notify:
+            await asyncio.to_thread(screen._show_warm_tip_once)
+            await asyncio.to_thread(screen._show_warm_tip_once)
+        assert notify.call_count == 1
+        assert notify.call_args[0][0] == msg.ENGINE_WARM_TIP
+
+        screen._warm_tip_shown = False
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        with mock.patch.object(screen, "notify") as notify:
+            await asyncio.to_thread(screen._show_warm_tip_once)
+        notify.assert_not_called()
+
+
+def test_engine_status_text_reports_bytes_or_phase():
+    """Byte progress renders as a percentage; other phases fall back to the label."""
+    reading = WarmProgress(
+        phase=WarmPhase.READING_WEIGHTS, bytes_done=1, bytes_total=2, model_ref="a/b/c.gguf"
+    )
+    assert "50%" in _engine_status_text(reading)
+    assert _engine_status_text(WarmProgress(phase=WarmPhase.LOADING_ENGINE)) == msg.ENGINE_LOADING
+    no_bytes = WarmProgress(phase=WarmPhase.READING_WEIGHTS)
+    assert _engine_status_text(no_bytes) == msg.ENGINE_LOADING

--- a/tests/test_chat_wiki_controller_integration.py
+++ b/tests/test_chat_wiki_controller_integration.py
@@ -17,6 +17,14 @@ from lilbee.catalog import CatalogModel
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.task_queue import TaskStatus, TaskType
 from lilbee.cli.tui.widgets.task_bar_controller import ProgressReporter, TaskBarController
+from tests._lilbee_app_test_host import await_chat, ready_services
+
+
+@pytest.fixture(autouse=True)
+def _gate_releases_at_once():
+    """Bind a ready chat role so the startup gate hands over on mount."""
+    with ready_services():
+        yield
 
 
 def _fake_model() -> CatalogModel:
@@ -82,14 +90,13 @@ async def test_queue_unsubscribe_removes_callback() -> None:
 @pytest.mark.asyncio
 async def test_do_add_reports_progress_and_runs_sync(tmp_path: Path) -> None:
     """_do_add copies files, reports indeterminate progress, and runs sync."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     src = tmp_path / "doc.pdf"
     src.write_bytes(b"x")
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
 
         reporter = MagicMock(spec=ProgressReporter)
@@ -130,14 +137,13 @@ async def test_do_add_reports_progress_and_runs_sync(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_do_add_force_propagates_to_copy_files(tmp_path: Path) -> None:
     """After overwrite-confirm ``_do_add`` must pass ``force=True`` through."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     src = tmp_path / "doc.pdf"
     src.write_bytes(b"x")
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
 
         reporter = MagicMock(spec=ProgressReporter)
@@ -183,14 +189,13 @@ async def test_do_add_force_propagates_to_copy_files(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_do_add_passes_skipped_files_through_copy_result(tmp_path: Path) -> None:
     """_do_add observes copy_files' skipped list and keeps running."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     src = tmp_path / "doc.pdf"
     src.write_bytes(b"x")
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
 
         reporter = MagicMock(spec=ProgressReporter)
@@ -554,12 +559,11 @@ def test_do_sync_translates_cancellation() -> None:
 @pytest.mark.asyncio
 async def test_cmd_add_missing_path_notifies(tmp_path: Path) -> None:
     """_cmd_add on a non-existent path shows an error."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
         notified: list[str] = []
         screen.notify = lambda *a, **kw: notified.append(str(a[0]))  # type: ignore[assignment]
@@ -570,14 +574,13 @@ async def test_cmd_add_missing_path_notifies(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_cmd_add_submits_task_to_controller(tmp_path: Path) -> None:
     """_cmd_add routes real work through TaskBarController.start_task."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     src = tmp_path / "doc.pdf"
     src.write_bytes(b"x")
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
         with patch.object(app.task_bar, "start_task", return_value="tid") as mock_start:
             screen._cmd_add(str(src))
@@ -589,7 +592,6 @@ async def test_cmd_add_submits_task_to_controller(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_cmd_add_prompts_before_overwriting_existing_file(tmp_path: Path) -> None:
     """A duplicate in documents_dir opens ConfirmDialog; confirm spawns the task."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.core.config import cfg as _cfg
 
     # Seed a copy already in documents_dir so _cmd_add detects a duplicate.
@@ -602,7 +604,7 @@ async def test_cmd_add_prompts_before_overwriting_existing_file(tmp_path: Path) 
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
 
         captured_callbacks: list[object] = []
@@ -630,7 +632,6 @@ async def test_cmd_add_prompts_before_overwriting_existing_file(tmp_path: Path) 
 @pytest.mark.asyncio
 async def test_cmd_add_overwrite_rejected_keeps_existing_copy(tmp_path: Path) -> None:
     """When the user answers No to the overwrite dialog, no task is spawned."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.core.config import cfg as _cfg
 
     _cfg.documents_dir.mkdir(parents=True, exist_ok=True)
@@ -642,7 +643,7 @@ async def test_cmd_add_overwrite_rejected_keeps_existing_copy(tmp_path: Path) ->
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
 
         captured_callbacks: list[object] = []
@@ -671,14 +672,13 @@ async def test_cmd_add_overwrite_rejected_keeps_existing_copy(tmp_path: Path) ->
 @pytest.mark.asyncio
 async def test_cmd_add_rejects_when_sync_active(tmp_path: Path) -> None:
     """_cmd_add refuses when another sync is already running."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     src = tmp_path / "doc.pdf"
     src.write_bytes(b"x")
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
         screen._sync_active = True
         notified: list[str] = []
@@ -696,12 +696,11 @@ async def test_start_crawl_submits_task_to_controller() -> None:
     ensure_chromium short-circuits and the subsequent start_task call
     lands with the CRAWL type.
     """
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
         with (
             patch(
@@ -718,12 +717,11 @@ async def test_start_crawl_submits_task_to_controller() -> None:
 @pytest.mark.asyncio
 async def test_run_sync_submits_task_to_controller() -> None:
     """_run_sync routes through TaskBarController.start_task with SYNC type."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
         with patch.object(app.task_bar, "start_task", return_value="tid") as mock_start:
             screen._run_sync()
@@ -734,12 +732,11 @@ async def test_run_sync_submits_task_to_controller() -> None:
 @pytest.mark.asyncio
 async def test_run_sync_rejects_when_already_active() -> None:
     """_run_sync refuses when another sync is already running."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
         screen._sync_active = True
         notified: list[str] = []
@@ -1043,12 +1040,11 @@ def test_do_add_raises_on_skipped(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_cmd_crawl_with_valid_url_routes_to_start_crawl() -> None:
     """/crawl with a valid URL (explicit https) triggers _start_crawl."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     app = LilbeeApp()
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        screen = await await_chat(app, pilot)
         assert screen is not None
         with (
             patch("lilbee.cli.tui.screens.chat.crawler_available", return_value=True),

--- a/tests/test_chat_wiki_controller_integration.py
+++ b/tests/test_chat_wiki_controller_integration.py
@@ -56,6 +56,7 @@ async def test_on_success_exception_is_swallowed() -> None:
     """An exception raised inside on_success must not propagate."""
     app = LilbeeApp()
     async with app.run_test() as pilot:
+        await await_chat(app, pilot)
         controller = TaskBarController(app)
 
         def _oops() -> None:

--- a/tests/test_controller_downloads.py
+++ b/tests/test_controller_downloads.py
@@ -24,7 +24,7 @@ from lilbee.catalog import CatalogModel
 from lilbee.cli.tui.task_queue import TaskStatus, TaskType
 from lilbee.cli.tui.widgets.task_bar_controller import ProgressReporter, TaskBarController
 from lilbee.runtime.cancellation import TaskCancelledError
-from tests._lilbee_app_test_host import LilbeeAppHost
+from tests._lilbee_app_test_host import LilbeeAppHost, await_chat, ready_services
 
 
 def _make_model(slug: str = "test", display: str = "Test Model") -> CatalogModel:
@@ -320,16 +320,13 @@ async def test_notify_model_installed_refreshes_chat_screen() -> None:
     """When a DOWNLOAD finalizes DONE the ChatScreen's model bar is refreshed."""
     from lilbee.cli.tui.app import LilbeeApp
 
-    app = LilbeeApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        from lilbee.cli.tui.screens.chat import ChatScreen
-
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
-        assert screen is not None
-        with patch.object(screen, "refresh_model_bar") as mock_refresh:
-            app.task_bar._notify_model_installed()
-            assert mock_refresh.called
+    with ready_services():
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            screen = await await_chat(app, pilot)
+            with patch.object(screen, "refresh_model_bar") as mock_refresh:
+                app.task_bar._notify_model_installed()
+                assert mock_refresh.called
 
 
 @pytest.mark.asyncio
@@ -338,16 +335,14 @@ async def test_notify_model_installed_swallows_query_error() -> None:
     from textual.css.query import NoMatches
 
     from lilbee.cli.tui.app import LilbeeApp
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
-    app = LilbeeApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        screen = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
-        assert screen is not None
-        # NoMatches is a QueryError subclass; simulates the query miss path.
-        with patch.object(screen, "refresh_model_bar", side_effect=NoMatches("no bar")):
-            app.task_bar._notify_model_installed()  # must not raise
+    with ready_services():
+        app = LilbeeApp()
+        async with app.run_test() as pilot:
+            screen = await await_chat(app, pilot)
+            # NoMatches is a QueryError subclass; simulates the query miss path.
+            with patch.object(screen, "refresh_model_bar", side_effect=NoMatches("no bar")):
+                app.task_bar._notify_model_installed()  # must not raise
 
 
 @pytest.mark.asyncio

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -622,7 +622,7 @@ class TestAppCanonicalizeFallbackNotice:
 
         This is the first-launch case: the default refs aren't downloaded
         yet and there's nothing to fall back to. The chat screen's
-        ``_needs_setup`` keys off the same unresolved state and opens the
+        ``needs_setup`` keys off the same unresolved state and opens the
         SetupWizard, which is the single voice for "pick a model." A toast
         here just duplicates the wizard (its text literally says "Opening
         setup"), so it's suppressed; the WARNING log stays as a breadcrumb.

--- a/tests/test_coverage_supplement.py
+++ b/tests/test_coverage_supplement.py
@@ -510,8 +510,10 @@ class TestStatusFetchSourcesDistinguishesFailureFromEmpty:
 
 
 class TestAppCanonicalizeFallbackNotice:
-    """`LilbeeApp._canonicalize_persisted_models` setattrs a fallback
-    when canonicalize returns a different effective ref."""
+    """`LilbeeApp.canonicalize_persisted_models` setattrs a fallback
+    when canonicalize returns a different effective ref. It runs on the gate's
+    boot worker thread, so UI updates route through call_from_thread (run
+    inline here)."""
 
     async def test_fallback_writes_cfg_persists_and_toasts_the_reason(self, caplog) -> None:
         """Fallback writes cfg, persists via settings, logs WARNING, and toasts why.
@@ -557,11 +559,15 @@ class TestAppCanonicalizeFallbackNotice:
                     app, "notify", side_effect=lambda *a, **kw: notifications.append(a)
                 ),
                 mock.patch(
+                    "lilbee.cli.tui.app.call_from_thread",
+                    side_effect=lambda _node, fn, *a, **k: fn(*a, **k),
+                ),
+                mock.patch(
                     "lilbee.app.settings.persistent_settings.update_values"
                 ) as mock_update_values,
                 caplog.at_level(logging.WARNING, logger="lilbee.cli.tui.app"),
             ):
-                await app._canonicalize_persisted_models()
+                app.canonicalize_persisted_models()
                 mock_update_values.assert_called_once()
                 persisted_args = mock_update_values.call_args.args
                 assert persisted_args[0] == cfg.data_root
@@ -608,10 +614,11 @@ class TestAppCanonicalizeFallbackNotice:
                 "lilbee.cli.tui.app.apply_settings_update",
                 side_effect=ValueError("is a chat model, not embedding"),
             ),
+            mock.patch("lilbee.cli.tui.app.call_from_thread"),
             caplog.at_level(logging.WARNING, logger="lilbee.cli.tui.app"),
         ):
             # Must not raise.
-            await app._canonicalize_persisted_models()
+            app.canonicalize_persisted_models()
         assert any("ollama/nomic-embed-text" in r.getMessage() for r in caplog.records), (
             "a rejected swap must be logged at WARNING"
         )
@@ -656,10 +663,14 @@ class TestAppCanonicalizeFallbackNotice:
                 mock.patch.object(
                     app, "notify", side_effect=lambda *a, **kw: notifications.append(a)
                 ),
+                mock.patch(
+                    "lilbee.cli.tui.app.call_from_thread",
+                    side_effect=lambda _node, fn, *a, **k: fn(*a, **k),
+                ),
                 mock.patch("lilbee.cli.tui.app.apply_settings_update") as mock_apply,
                 caplog.at_level(logging.WARNING, logger="lilbee.cli.tui.app"),
             ):
-                await app._canonicalize_persisted_models()
+                app.canonicalize_persisted_models()
                 mock_apply.assert_not_called()
             assert cfg.embedding_model == snapshot_embed, "an un-fallbackable ref is left intact"
             assert not notifications, "no toast: the SetupWizard is the single voice"

--- a/tests/test_dynamic_settings_eviction.py
+++ b/tests/test_dynamic_settings_eviction.py
@@ -356,7 +356,7 @@ def test_protocol_defaults_for_drop_and_role_ready():
 def _patch_chat_setup():
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
+            "lilbee.cli.tui.screens.chat.needs_setup",
             return_value=False,
         ),
         mock.patch(

--- a/tests/test_dynamic_settings_eviction.py
+++ b/tests/test_dynamic_settings_eviction.py
@@ -12,6 +12,7 @@ from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.screens.chat import ChatScreen
 from lilbee.core.config import cfg
 from lilbee.providers.base import LLMProvider
+from tests._lilbee_app_test_host import await_chat
 
 
 class _RecordingProvider:
@@ -373,6 +374,7 @@ async def test_app_set_setting_evicts_via_boundary(_patch_chat_setup):
     try:
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             assert isinstance(app.screen, ChatScreen)
 
@@ -392,6 +394,7 @@ async def test_provider_availability_signal_fires_for_api_keys(_patch_chat_setup
     """Adding an API key republishes on provider_availability_changed_signal."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         received: list[tuple[str, object]] = []
         app.provider_availability_changed_signal.subscribe(app, received.append)
@@ -411,6 +414,7 @@ async def test_provider_availability_signal_fires_for_each_provider_key(_patch_c
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         received: list[tuple[str, object]] = []
         app.provider_availability_changed_signal.subscribe(app, received.append)

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -54,7 +54,7 @@ class _FakeSwap:
     def reap_stale(self) -> None:
         self.reaps += 1
 
-    def start(self, launches: list) -> None:
+    def start(self, launches: list, *, ttl_seconds: int = 0) -> None:
         self.started.append(launches)
         self.running = True
 
@@ -1099,7 +1099,7 @@ def test_ensure_fleet_spawns_nothing_when_no_models(monkeypatch) -> None:
     started = {"swaps": 0}
 
     class _CountingSwap(_FakeSwap):
-        def start(self, launches: list) -> None:
+        def start(self, launches: list, *, ttl_seconds: int = 0) -> None:
             started["swaps"] += 1
             super().start(launches)
 
@@ -1204,7 +1204,7 @@ def test_concurrent_first_requests_start_swap_once(monkeypatch) -> None:
     starts = {"n": 0}
 
     class _SlowSwap(_FakeSwap):
-        def start(self, launches: list) -> None:
+        def start(self, launches: list, *, ttl_seconds: int = 0) -> None:
             starts["n"] += 1
             time.sleep(0.05)  # widen the race window
             super().start(launches)
@@ -1303,7 +1303,7 @@ def test_warm_up_pool_starts_swap_off_thread(monkeypatch) -> None:
     release = threading.Event()
 
     class _SlowSwap(_FakeSwap):
-        def start(self, launches: list) -> None:
+        def start(self, launches: list, *, ttl_seconds: int = 0) -> None:
             started.set()
             release.wait(timeout=5.0)
             super().start(launches)
@@ -1323,7 +1323,7 @@ def test_warm_up_pool_single_flight_does_not_double_start(monkeypatch) -> None:
     release = threading.Event()
 
     class _GatedSwap(_FakeSwap):
-        def start(self, launches: list) -> None:
+        def start(self, launches: list, *, ttl_seconds: int = 0) -> None:
             starts["n"] += 1
             in_start.set()
             release.wait(timeout=5.0)
@@ -2136,7 +2136,7 @@ class TestReloadSingleFlight:
 
     def test_reload_pass_failure_clears_guards_and_propagates(self, monkeypatch) -> None:
         class _ExplodingSwap(_FakeSwap):
-            def start(self, launches: list) -> None:
+            def start(self, launches: list, *, ttl_seconds: int = 0) -> None:
                 raise RuntimeError("respawn failed")
 
         plans: list[int] = []
@@ -2163,7 +2163,7 @@ class TestReloadSingleFlight:
         built: list[_FakeSwap] = []
 
         class _FlakyFirstSwap(_FakeSwap):
-            def start(self, launches: list) -> None:
+            def start(self, launches: list, *, ttl_seconds: int = 0) -> None:
                 if len(built) == 1:  # only the first fresh manager fails its spawn
                     raise RuntimeError("first pass failed")
                 super().start(launches)
@@ -2194,7 +2194,7 @@ class TestReloadSingleFlight:
 
     def test_final_pass_failure_drops_the_dead_swap(self, monkeypatch) -> None:
         class _ExplodingSwap(_FakeSwap):
-            def start(self, launches: list) -> None:
+            def start(self, launches: list, *, ttl_seconds: int = 0) -> None:
                 self.running = False  # the failed restart tore the process down
                 raise RuntimeError("respawn failed")
 
@@ -2560,7 +2560,7 @@ def test_ensure_fleet_partial_failure_tears_down_started_groups(monkeypatch) -> 
     built: list[_FakeSwap] = []
 
     class _SecondExplodes(_FakeSwap):
-        def start(self, launches: list) -> None:
+        def start(self, launches: list, *, ttl_seconds: int = 0) -> None:
             if len(built) > 1:
                 raise RuntimeError("second group failed")
             super().start(launches)

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -93,7 +93,7 @@ def _install_engine(monkeypatch, *, launches: list, swap: _FakeSwap | None = Non
     """Patch the swap, client, and planner so _ensure_fleet builds controllable fakes."""
     swap = swap or _FakeSwap()
     monkeypatch.setattr(prov_mod, "SwapManager", lambda _data_dir, _group: swap)
-    monkeypatch.setattr(prov_mod, "reap_stale", lambda _data_dir: None)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _data_dir, **_kw: None)
     monkeypatch.setattr(prov_mod, "sweep_owned", lambda _data_dir: None)
     monkeypatch.setattr(planning_mod, "capture_plan_probe", lambda: None)
     monkeypatch.setattr(
@@ -1068,7 +1068,7 @@ def test_ensure_fleet_reaps_stale_swaps_before_planning(monkeypatch) -> None:
     # the device probe see artificially reduced free memory and misplace.
     order: list[str] = []
     monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _FakeSwap())
-    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: order.append("reap"))
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: order.append("reap"))
     monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
     monkeypatch.setattr(
         planning_mod, "plan_all_launches", _ordered_planner(order, [_fake_launch(WorkerRole.CHAT)])
@@ -1081,7 +1081,7 @@ def test_reload_pass_reaps_stale_swaps_before_planning(monkeypatch) -> None:
     order: list[str] = []
     swap = _FakeSwap()
     monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: swap)
-    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: order.append("reap"))
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: order.append("reap"))
     monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
     monkeypatch.setattr(
         planning_mod, "plan_all_launches", _ordered_planner(order, [_fake_launch(WorkerRole.CHAT)])
@@ -1688,7 +1688,7 @@ class TestLifecycleMethods:
         monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
         fresh = _FakeSwap()
         monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: fresh)
-        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
         p = FleetProvider()
         stale = _FakeSwap()
         p._swaps = {SwapGroup.CHAT: stale}
@@ -2103,7 +2103,7 @@ class TestReloadSingleFlight:
 
         monkeypatch.setattr(planning_mod, "plan_all_launches", _plan)
         monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _FakeSwap())
-        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
         monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
         p = FleetProvider()
         monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
@@ -2147,7 +2147,7 @@ class TestReloadSingleFlight:
 
         monkeypatch.setattr(planning_mod, "plan_all_launches", _plan)
         monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _ExplodingSwap())
-        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
         p = FleetProvider()
         p._swaps = {SwapGroup.CHAT: _FakeSwap()}
         p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
@@ -2173,7 +2173,7 @@ class TestReloadSingleFlight:
             return built[-1]
 
         monkeypatch.setattr(prov_mod, "SwapManager", _factory)
-        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
         monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
         monkeypatch.setattr(
             planning_mod,
@@ -2199,7 +2199,7 @@ class TestReloadSingleFlight:
                 raise RuntimeError("respawn failed")
 
         monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _ExplodingSwap())
-        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
         monkeypatch.setattr(
             planning_mod,
             "plan_all_launches",
@@ -2235,7 +2235,7 @@ class TestReloadSingleFlight:
         p._swaps = {SwapGroup.CHAT: swap}
         p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
         p._reloading = True
-        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
         monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan(()))
         p._reload_blocking()
         assert swap.shutdowns == 1  # nothing planned -> the running group stops
@@ -2246,7 +2246,7 @@ class TestReloadSingleFlight:
         # Nothing running and nothing planned: the pass replans (a resurrect
         # would start whatever the fresh plan holds), finds nothing, and the
         # guard is still released.
-        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
         monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: planning_mod.FleetPlan(()))
         p = FleetProvider()
         p._reloading = True
@@ -2276,7 +2276,7 @@ class TestReloadSingleFlight:
             gate.wait(5.0)
             return planning_mod.FleetPlan(())
 
-        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
         monkeypatch.setattr(prov_mod, "sweep_owned", lambda _d: None)
         monkeypatch.setattr(planning_mod, "plan_all_launches", _slow_plan)
         reloader = threading.Thread(target=p._reload_blocking)
@@ -2490,7 +2490,7 @@ def test_rebuild_role_restarts_only_that_role(monkeypatch) -> None:
     """A dead group's rebuild replaces just that role's swap; the live one stays."""
     fresh = _FakeSwap()
     monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: fresh)
-    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
     monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
     chat_launch, embed_launch = _fake_launch(WorkerRole.CHAT), _fake_launch(WorkerRole.EMBED)
     monkeypatch.setattr(
@@ -2527,7 +2527,7 @@ def test_co_tenant_roles_share_one_swap_process(monkeypatch) -> None:
     chat, vision = _fake_launch(WorkerRole.CHAT), _fake_launch(WorkerRole.VISION)
     embed = _fake_launch(WorkerRole.EMBED)
     monkeypatch.setattr(prov_mod, "SwapManager", _factory)
-    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
     monkeypatch.setattr(prov_mod, "sweep_owned", lambda _d: None)
     monkeypatch.setattr(planning_mod, "capture_plan_probe", lambda: None)
     monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
@@ -2570,7 +2570,7 @@ def test_ensure_fleet_partial_failure_tears_down_started_groups(monkeypatch) -> 
         return built[-1]
 
     monkeypatch.setattr(prov_mod, "SwapManager", _factory)
-    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
     monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
     monkeypatch.setattr(
         planning_mod,
@@ -2609,7 +2609,7 @@ def test_reload_pass_refuses_after_terminal_shutdown(monkeypatch) -> None:
     """A reload queued behind a terminal shutdown must not resurrect the fleet."""
     plans: list[int] = []
     monkeypatch.setattr(planning_mod, "plan_all_launches", lambda: plans.append(1) or [])
-    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: None)
+    monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: None)
     p = FleetProvider()
     p._shut_down = True
     p._reload_pass(force=frozenset((WorkerRole.CHAT,)))
@@ -2621,7 +2621,7 @@ class TestPlanProbeLifecycle:
 
     def _wire(self, monkeypatch, order: list[str]) -> None:
         monkeypatch.setattr(prov_mod, "SwapManager", lambda _d, _g: _FakeSwap())
-        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d: order.append("reap"))
+        monkeypatch.setattr(prov_mod, "reap_stale", lambda _d, **_kw: order.append("reap"))
         monkeypatch.setattr(planning_mod, "capture_plan_probe", lambda: order.append("capture"))
         monkeypatch.setattr(prov_mod, "LlamaServerClient", lambda _e, _m, **_kw: _fake_client())
         monkeypatch.setattr(

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -16,7 +16,9 @@ from lilbee.core.config import cfg
 from lilbee.providers.fleet import planning as planning_mod
 from lilbee.providers.fleet import provider as prov_mod
 from lilbee.providers.fleet.groups import SwapGroup
+from lilbee.providers.fleet.launch import InstanceLaunch
 from lilbee.providers.fleet.provider import FleetProvider, _least_in_flight
+from lilbee.providers.fleet.swap_manager import SwapManager
 from lilbee.providers.roles import RerankMode, WorkerRole
 
 _GB = 1024**3
@@ -2729,7 +2731,7 @@ class TestWarmDetachOnShutdown:
         provider, fakes = self._provider_with_fake_swaps()
         provider.shutdown()
         for fake in fakes:
-            fake.detach.assert_called_once_with()
+            fake.detach.assert_called_once()
             fake.shutdown.assert_not_called()
 
     def test_warm_shutdown_still_latches(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2755,3 +2757,163 @@ class TestWarmDetachOnShutdown:
         for fake in fakes:
             fake.shutdown.assert_called_once_with()
             fake.detach.assert_not_called()
+
+
+class TestAdoptDetachedFleet:
+    """Adoption binds to a warm fleet only when version, health, and models match."""
+
+    def _detached_fleet(self, tmp_path, **chat_kwargs):
+        """Detached chat + embed groups matching the configured models."""
+        self._detached_state(tmp_path, **chat_kwargs)
+        self._detached_state(
+            tmp_path,
+            group=SwapGroup.EMBED,
+            proxy_port=4199,
+            launches=[
+                InstanceLaunch(
+                    role=WorkerRole.EMBED,
+                    argv=["/bin/llama-server"],
+                    env_overrides={},
+                    model=cfg.embedding_model,
+                ).to_state()
+            ],
+        )
+
+    def _detached_state(
+        self, tmp_path, *, version=None, launches=None, group=SwapGroup.CHAT, proxy_port=4099
+    ):
+        import json as _json
+        from importlib.metadata import version as _pkg_version
+
+        from lilbee.providers.fleet import swap_manager as sm
+
+        payload = {
+            "pid": 999_998,
+            "owner_pid": 999_999,
+            "member_ports": [proxy_port + 1],
+            "proxy_port": proxy_port,
+            "lilbee_version": version or _pkg_version("lilbee"),
+            "detached": True,
+            "launches": launches
+            if launches is not None
+            else [
+                InstanceLaunch(
+                    role=WorkerRole.CHAT,
+                    argv=["/bin/llama-server"],
+                    env_overrides={},
+                    model=cfg.chat_model,
+                    slots=4,
+                    ctx=8192,
+                ).to_state()
+            ],
+        }
+        path = tmp_path / sm._state_filename(999_999, group.value)
+        path.write_text(_json.dumps(payload))
+        return path
+
+    def _adopting_provider(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        monkeypatch.setattr(cfg, "data_dir", tmp_path)
+        # chat + embed configured (embed can never be empty); optional roles off.
+        monkeypatch.setattr(cfg, "vision_model", "")
+        monkeypatch.setattr(cfg, "reranker_model", "")
+        provider = FleetProvider()
+        monkeypatch.setattr(SwapManager, "_proxy_answers", lambda self: True)
+        return provider
+
+    def test_adopts_a_matching_fleet_without_planning(self, monkeypatch, tmp_path) -> None:
+        self._detached_fleet(tmp_path)
+        provider = self._adopting_provider(monkeypatch, tmp_path)
+        planned = MagicMock()
+        monkeypatch.setattr(prov_mod.planning, "plan_all_launches", planned)
+        assert provider._ensure_fleet() is True
+        planned.assert_not_called()
+        assert provider.role_ready is not None  # fleet bound
+        assert provider._chat_slots == 4
+        assert provider._chat_ctx == 8192
+
+    def test_version_drift_reaps_and_falls_through(self, monkeypatch, tmp_path) -> None:
+        path = self._detached_state(tmp_path, version="0.0.0+stale")  # stale chat
+        provider = self._adopting_provider(monkeypatch, tmp_path)
+        assert provider._try_adopt_detached(tmp_path) is False
+        assert not path.exists()
+
+    def test_model_mismatch_reaps_and_falls_through(self, monkeypatch, tmp_path) -> None:
+        launches = [
+            InstanceLaunch(
+                role=WorkerRole.CHAT,
+                argv=["/bin/llama-server"],
+                env_overrides={},
+                model="somebody/else-GGUF/else.gguf",
+            ).to_state()
+        ]
+        path = self._detached_state(tmp_path, launches=launches)
+        provider = self._adopting_provider(monkeypatch, tmp_path)
+        assert provider._try_adopt_detached(tmp_path) is False
+        assert not path.exists()
+
+    def test_dead_proxy_reaps_and_falls_through(self, monkeypatch, tmp_path) -> None:
+        path = self._detached_state(tmp_path)
+        self._detached_fleet(tmp_path)
+        provider = self._adopting_provider(monkeypatch, tmp_path)
+        monkeypatch.setattr(SwapManager, "_proxy_answers", lambda self: False)
+        assert provider._try_adopt_detached(tmp_path) is False
+        assert not path.exists()
+
+    def test_missing_configured_role_aborts(self, monkeypatch, tmp_path) -> None:
+        self._detached_state(tmp_path)  # serves CHAT only, but embed is configured
+        provider = self._adopting_provider(monkeypatch, tmp_path)
+        assert provider._try_adopt_detached(tmp_path) is False
+
+
+class TestLaunchStateRoundTrip:
+    def test_round_trips_every_field(self) -> None:
+        launch = InstanceLaunch(
+            role=WorkerRole.RERANK,
+            argv=["/bin/llama-server", "--flag"],
+            env_overrides={"CUDA_VISIBLE_DEVICES": "1"},
+            model="o/r-GGUF/r.gguf",
+            token_cap=512,
+            weights_bytes=123,
+            slots=2,
+            ctx=4096,
+            replica=1,
+            rerank_mode=RerankMode.LLM,
+        )
+        rebuilt = InstanceLaunch.from_state(launch.to_state())
+        assert rebuilt == launch
+
+
+class TestAdoptableLaunchGuards:
+    def test_undecodable_launch_record_is_rejected(self, monkeypatch) -> None:
+        from importlib.metadata import version as _pkg_version
+
+        from lilbee.providers.fleet import swap_manager as sm
+
+        state = sm._SwapState(
+            pid=1,
+            pgid=None,
+            owner_pid=None,
+            owner_created_at=None,
+            lilbee_version=_pkg_version("lilbee"),
+            launches=({"garbage": True},),
+        )
+        assert prov_mod._adoptable_launches(state) is None
+
+    def test_empty_launch_record_is_rejected(self) -> None:
+        from importlib.metadata import version as _pkg_version
+
+        from lilbee.providers.fleet import swap_manager as sm
+
+        state = sm._SwapState(
+            pid=1,
+            pgid=None,
+            owner_pid=None,
+            owner_created_at=None,
+            lilbee_version=_pkg_version("lilbee"),
+            launches=(),
+        )
+        assert prov_mod._adoptable_launches(state) is None
+
+    def test_no_detached_states_means_no_adoption(self, tmp_path) -> None:
+        assert FleetProvider()._try_adopt_detached(tmp_path) is False

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -2712,3 +2712,46 @@ class TestWarmErrorsClearedOnTeardown:
         p._drop_swap_refs()
         assert p._warm_errors == {}
         assert "did not finish loading" in p._chat_load_failure()
+
+
+class TestWarmDetachOnShutdown:
+    def _provider_with_fake_swaps(self, count: int = 2):
+        provider = FleetProvider()
+        fakes = []
+        for group in list(SwapGroup)[:count]:
+            fake = MagicMock()
+            provider._swaps[group] = fake
+            fakes.append(fake)
+        return provider, fakes
+
+    def test_warm_shutdown_detaches_and_never_kills(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        provider, fakes = self._provider_with_fake_swaps()
+        provider.shutdown()
+        for fake in fakes:
+            fake.detach.assert_called_once_with()
+            fake.shutdown.assert_not_called()
+
+    def test_warm_shutdown_still_latches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        provider, _ = self._provider_with_fake_swaps()
+        provider.shutdown()
+        assert provider._shut_down is True
+
+    def test_default_shutdown_kills_exactly_as_before(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cfg, "keep_engine_warm", False)
+        provider, fakes = self._provider_with_fake_swaps()
+        provider.shutdown()
+        for fake in fakes:
+            fake.shutdown.assert_called_once_with()
+            fake.detach.assert_not_called()
+
+    def test_cache_drop_kills_even_when_warm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        provider, fakes = self._provider_with_fake_swaps()
+        provider._shutdown_swap(latch=False)
+        for fake in fakes:
+            fake.shutdown.assert_called_once_with()
+            fake.detach.assert_not_called()

--- a/tests/test_fleet_swap_config.py
+++ b/tests/test_fleet_swap_config.py
@@ -163,6 +163,13 @@ class TestBuildSwapConfig:
         cfg = _config([_launch(WorkerRole.CHAT, ["/bin/llama-server"])])
         assert cfg["models"][_mid(WorkerRole.CHAT)]["ttl"] == 0
 
+    def test_ttl_seconds_flows_to_every_member(self) -> None:
+        """llama-swap's ttl is in seconds; a warm fleet unloads idle weights after it."""
+        launches = [_launch(WorkerRole.CHAT, ["/bin/llama-server"])]
+        ports = {launch.model_id: _BASE_PORT + i for i, launch in enumerate(launches)}
+        cfg = json.loads(build_swap_config(launches, ports, ttl_seconds=900))
+        assert cfg["models"][_mid(WorkerRole.CHAT)]["ttl"] == 900
+
 
 class TestHealthCheckTimeoutScaling:
     def test_small_model_gets_the_floor(self) -> None:
@@ -202,3 +209,29 @@ class TestHealthCheckTimeoutScaling:
 
         weights = 300 * 1024**3
         assert cold_load_timeout_s(weights) == weights // swap_config_mod._COLD_LOAD_BYTES_PER_S
+
+
+class TestWarmTtlSeconds:
+    def test_off_pins_zero_regardless_of_ttl(self, monkeypatch) -> None:
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet.provider import _warm_ttl_seconds
+
+        monkeypatch.setattr(cfg, "keep_engine_warm", False)
+        monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 15)
+        assert _warm_ttl_seconds() == 0
+
+    def test_warm_converts_minutes_to_llama_swap_seconds(self, monkeypatch) -> None:
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet.provider import _warm_ttl_seconds
+
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 15)
+        assert _warm_ttl_seconds() == 900
+
+    def test_warm_with_zero_ttl_keeps_weights_forever(self, monkeypatch) -> None:
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet.provider import _warm_ttl_seconds
+
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 0)
+        assert _warm_ttl_seconds() == 0

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1367,3 +1367,56 @@ class TestReapSparesDetached:
         path = self._write_detached_state(tmp_path, detached=False)
         sm.reap_stale(tmp_path, keep_detached=True)
         assert not path.exists()
+
+
+class TestDetachAdoptUnits:
+    def test_detach_marks_state_and_keeps_the_process(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        proc = _FakeProc(poll_result=None)
+        _patch_spawn(monkeypatch, proc)
+        _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
+        mgr = SwapManager(tmp_path, _GROUP)
+        mgr.start([_launch(WorkerRole.CHAT)])
+        mgr.detach([{"role": "chat"}])
+        state = sm._load_state(mgr._state_path)
+        assert state is not None and state.detached is True
+        assert state.launches == ({"role": "chat"},)
+        assert proc.terminated is False and proc.killed is False  # never signaled
+
+    def test_adopt_rejects_a_state_without_a_proxy_port(self, tmp_path: Path) -> None:
+        mgr = SwapManager(tmp_path, _GROUP)
+        state = sm._SwapState(pid=1, pgid=None, owner_pid=None, owner_created_at=None)
+        assert mgr.adopt(state, tmp_path / "x.json") is False
+
+    def test_adopt_probes_the_real_proxy_endpoint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
+        mgr = SwapManager(tmp_path, _GROUP)
+        state = sm._SwapState(
+            pid=1, pgid=None, owner_pid=None, owner_created_at=None, proxy_port=4321
+        )
+        old = tmp_path / "old-state.json"
+        old.write_text("{}")
+        assert mgr.adopt(state, old) is True
+        assert not old.exists()
+
+    def test_adopt_unbinds_when_the_proxy_is_dead(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _refuse(_url, **_kw):
+            raise OSError("refused")
+
+        monkeypatch.setattr(sm.httpx, "get", _refuse)
+        mgr = SwapManager(tmp_path, _GROUP)
+        state = sm._SwapState(
+            pid=1, pgid=None, owner_pid=None, owner_created_at=None, proxy_port=4321
+        )
+        assert mgr.adopt(state, tmp_path / "x.json") is False
+        assert mgr._port is None
+
+    def test_find_detached_state_skips_owned_files(self, tmp_path: Path) -> None:
+        owned = tmp_path / sm._state_filename(1, _GROUP.value)
+        owned.write_text(json.dumps({"pid": 2, "detached": False}))
+        assert sm.find_detached_state(tmp_path, _GROUP) is None

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -238,20 +238,6 @@ class TestLifecycle:
         with pytest.raises(ProviderError):
             mgr.endpoint()  # port cleared after shutdown
 
-    def test_reload_restarts_with_new_config(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        starts: list[int] = []
-        _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
-        _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        mgr = SwapManager(tmp_path, _GROUP)
-        mgr.start([_launch(WorkerRole.CHAT)])
-        monkeypatch.setattr(
-            SwapManager, "start", lambda self, launches: starts.append(len(launches))
-        )
-        mgr.reload([_launch(WorkerRole.CHAT), _launch(WorkerRole.EMBED)])
-        assert starts == [2]  # restarted with the new launch set
-
 
 class _FakeChild:
     """A stand-in psutil.Process that records the signals it receives."""

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1431,19 +1431,19 @@ def test_owned_swap_scan_skips_processes_that_deny_inspection(monkeypatch, leak)
     """macOS psutil mishandles entitlement-protected binaries (sysctl
     KERN_PROCARGS2), leaking raw PermissionError or C-extension SystemError;
     one such process must not break the sweep."""
+    from pathlib import Path
     from unittest import mock
 
     import psutil
 
     from lilbee.providers.fleet import swap_manager
 
+    config_path = Path("/tmp/x.json")
     denied = mock.MagicMock()
     denied.cmdline.side_effect = leak
     visible = mock.MagicMock()
-    visible.cmdline.return_value = ["/opt/bin/llama-swap", "-config", "/tmp/x.json"]
+    visible.cmdline.return_value = ["/opt/bin/llama-swap", "-config", str(config_path)]
     monkeypatch.setattr(psutil, "process_iter", lambda: [denied, visible])
 
-    from pathlib import Path
-
-    swaps = swap_manager._swaps_for_config(Path("/tmp/x.json"))
+    swaps = swap_manager._swaps_for_config(config_path)
     assert swaps == [visible]

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1336,3 +1336,34 @@ class TestStateFilePersistenceKeys:
         assert state.proxy_port is None
         assert state.lilbee_version is None
         assert state.detached is False
+
+
+class TestReapSparesDetached:
+    def _write_detached_state(self, tmp_path: Path, *, detached: bool) -> Path:
+        path = tmp_path / sm._state_filename(999_999, _GROUP.value)
+        path.write_text(
+            json.dumps(
+                {
+                    "pid": 999_998,
+                    "owner_pid": 999_999,
+                    "member_ports": [4000],
+                    "detached": detached,
+                }
+            )
+        )
+        return path
+
+    def test_detached_is_spared_while_warm_is_on(self, tmp_path: Path) -> None:
+        path = self._write_detached_state(tmp_path, detached=True)
+        sm.reap_stale(tmp_path, keep_detached=True)
+        assert path.exists()
+
+    def test_detached_is_reaped_once_warm_is_off(self, tmp_path: Path) -> None:
+        path = self._write_detached_state(tmp_path, detached=True)
+        sm.reap_stale(tmp_path, keep_detached=False)
+        assert not path.exists()
+
+    def test_dead_owner_without_marker_is_reaped_regardless(self, tmp_path: Path) -> None:
+        path = self._write_detached_state(tmp_path, detached=False)
+        sm.reap_stale(tmp_path, keep_detached=True)
+        assert not path.exists()

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1301,3 +1301,38 @@ class TestSweepOwned:
         monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: swept.append(cfg))
         sm.sweep_owned(tmp_path)
         assert swept == []
+
+
+class TestStateFilePersistenceKeys:
+    def test_round_trips_proxy_port_version_and_detached(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
+        _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
+        mgr = SwapManager(tmp_path, _GROUP)
+        mgr.start([_launch(WorkerRole.CHAT)])
+        mgr._write_state(detached=True)
+        state = sm._load_state(mgr._state_path)
+        assert state is not None
+        assert state.proxy_port == mgr._port
+        assert state.lilbee_version
+        assert state.detached is True
+
+    def test_start_writes_an_owned_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
+        _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
+        mgr = SwapManager(tmp_path, _GROUP)
+        mgr.start([_launch(WorkerRole.CHAT)])
+        state = sm._load_state(mgr._state_path)
+        assert state is not None and state.detached is False
+
+    def test_old_format_files_parse_with_defaults(self, tmp_path: Path) -> None:
+        legacy = tmp_path / "legacy.json"
+        legacy.write_text(json.dumps({"pid": 123, "member_ports": [4000]}))
+        state = sm._load_state(legacy)
+        assert state is not None
+        assert state.proxy_port is None
+        assert state.lilbee_version is None
+        assert state.detached is False

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1422,9 +1422,15 @@ class TestDetachAdoptUnits:
         assert sm.find_detached_state(tmp_path, _GROUP) is None
 
 
-def test_owned_swap_scan_skips_processes_that_deny_inspection(monkeypatch):
-    """macOS psutil can leak a raw PermissionError for entitlement-protected
-    binaries (sysctl KERN_PROCARGS2); one such process must not break the sweep."""
+@pytest.mark.parametrize(
+    "leak",
+    [PermissionError(13, "force permission denied"), SystemError("result with an exception set")],
+    ids=["permission-error", "system-error"],
+)
+def test_owned_swap_scan_skips_processes_that_deny_inspection(monkeypatch, leak):
+    """macOS psutil mishandles entitlement-protected binaries (sysctl
+    KERN_PROCARGS2), leaking raw PermissionError or C-extension SystemError;
+    one such process must not break the sweep."""
     from unittest import mock
 
     import psutil
@@ -1432,7 +1438,7 @@ def test_owned_swap_scan_skips_processes_that_deny_inspection(monkeypatch):
     from lilbee.providers.fleet import swap_manager
 
     denied = mock.MagicMock()
-    denied.cmdline.side_effect = PermissionError(13, "force permission denied")
+    denied.cmdline.side_effect = leak
     visible = mock.MagicMock()
     visible.cmdline.return_value = ["/opt/bin/llama-swap", "-config", "/tmp/x.json"]
     monkeypatch.setattr(psutil, "process_iter", lambda: [denied, visible])

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -1420,3 +1420,24 @@ class TestDetachAdoptUnits:
         owned = tmp_path / sm._state_filename(1, _GROUP.value)
         owned.write_text(json.dumps({"pid": 2, "detached": False}))
         assert sm.find_detached_state(tmp_path, _GROUP) is None
+
+
+def test_owned_swap_scan_skips_processes_that_deny_inspection(monkeypatch):
+    """macOS psutil can leak a raw PermissionError for entitlement-protected
+    binaries (sysctl KERN_PROCARGS2); one such process must not break the sweep."""
+    from unittest import mock
+
+    import psutil
+
+    from lilbee.providers.fleet import swap_manager
+
+    denied = mock.MagicMock()
+    denied.cmdline.side_effect = PermissionError(13, "force permission denied")
+    visible = mock.MagicMock()
+    visible.cmdline.return_value = ["/opt/bin/llama-swap", "-config", "/tmp/x.json"]
+    monkeypatch.setattr(psutil, "process_iter", lambda: [denied, visible])
+
+    from pathlib import Path
+
+    swaps = swap_manager._swaps_for_config(Path("/tmp/x.json"))
+    assert swaps == [visible]

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -79,6 +79,34 @@ def test_shell_completion_skips_splash(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_app.assert_called_once()
 
 
+def test_help_flag_skips_splash(monkeypatch: pytest.MonkeyPatch, _no_completion_env: None) -> None:
+    """``lilbee chat --help`` prints and exits before the TUI, so animating
+    through it would mangle the help text."""
+    fake_app, start_spy, _ = _patch_app_and_splash(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lilbee", "chat", "--help"])
+
+    launcher.main()
+
+    start_spy.assert_not_called()
+    fake_app.assert_called_once()
+
+
+def test_successful_launch_leaves_the_splash_to_run_tui(
+    monkeypatch: pytest.MonkeyPatch, _no_completion_env: None
+) -> None:
+    """The splash animates through the CLI dispatch and the TUI stack's own
+    imports; stopping it at import time re-opens seconds of blank terminal on
+    a cold disk. run_tui dismisses it right before Textual takes over."""
+    fake_app, start_spy, stop_spy = _patch_app_and_splash(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lilbee"])
+
+    launcher.main()
+
+    start_spy.assert_called_once()
+    fake_app.assert_called_once()
+    stop_spy.assert_not_called()
+
+
 def test_app_import_failure_stops_splash(
     monkeypatch: pytest.MonkeyPatch, _no_completion_env: None
 ) -> None:

--- a/tests/test_persistent_engine_settings.py
+++ b/tests/test_persistent_engine_settings.py
@@ -25,7 +25,7 @@ def _isolated_cfg(tmp_path):
 def test_defaults_are_on_demand():
     """Off by default: today's teardown-on-quit behavior is the shipped default."""
     assert cfg.model_fields["keep_engine_warm"].default is False
-    assert cfg.model_fields["engine_idle_ttl_minutes"].default == 0
+    assert cfg.model_fields["engine_idle_ttl_minutes"].default == 5
 
 
 @pytest.mark.parametrize("name", ["keep_engine_warm", "engine_idle_ttl_minutes"])

--- a/tests/test_persistent_engine_settings.py
+++ b/tests/test_persistent_engine_settings.py
@@ -1,0 +1,55 @@
+"""The persistent-engine settings exist, default off, and round-trip every surface."""
+
+from __future__ import annotations
+
+import pytest
+
+from lilbee.app.settings import apply_settings_update, list_settings
+from lilbee.app.settings_map import SETTINGS_MAP
+from lilbee.config_meta import WRITABLE_CONFIG_FIELDS
+from lilbee.core.config import cfg
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cfg(tmp_path):
+    """Point cfg at a per-test data root and restore the full snapshot."""
+    snapshot = cfg.model_copy()
+    cfg.data_root = tmp_path
+    cfg.data_dir = tmp_path / "data"
+    cfg.data_dir.mkdir(parents=True, exist_ok=True)
+    yield
+    for field_name in type(snapshot).model_fields:
+        setattr(cfg, field_name, getattr(snapshot, field_name))
+
+
+def test_defaults_are_on_demand():
+    """Off by default: today's teardown-on-quit behavior is the shipped default."""
+    assert cfg.model_fields["keep_engine_warm"].default is False
+    assert cfg.model_fields["engine_idle_ttl_minutes"].default == 0
+
+
+@pytest.mark.parametrize("name", ["keep_engine_warm", "engine_idle_ttl_minutes"])
+def test_exposed_in_the_settings_map(name):
+    """The TUI settings screen renders from SETTINGS_MAP."""
+    assert name in SETTINGS_MAP
+    assert SETTINGS_MAP[name].help_text
+
+
+@pytest.mark.parametrize("name", ["keep_engine_warm", "engine_idle_ttl_minutes"])
+def test_writable_for_http_and_mcp(name):
+    """HTTP and MCP writes are gated on the derived writable set."""
+    assert name in WRITABLE_CONFIG_FIELDS
+
+
+def test_round_trip_through_apply_settings_update():
+    """The choke point every surface uses accepts and persists both fields."""
+    apply_settings_update({"keep_engine_warm": True, "engine_idle_ttl_minutes": 15})
+    listed = {s.key: s.value for s in list_settings()}
+    assert listed["keep_engine_warm"] is True
+    assert listed["engine_idle_ttl_minutes"] == 15
+
+
+def test_negative_ttl_is_rejected():
+    """A negative idle ttl has no meaning; the update must refuse it."""
+    with pytest.raises(ValueError, match="engine_idle_ttl_minutes"):
+        apply_settings_update({"engine_idle_ttl_minutes": -5})

--- a/tests/test_screen_navigation_repaint.py
+++ b/tests/test_screen_navigation_repaint.py
@@ -50,7 +50,7 @@ def _mock_services():
 @pytest.fixture(autouse=True)
 def _patch_chat_setup():
     with (
-        patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
         patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,

--- a/tests/test_screen_navigation_repaint.py
+++ b/tests/test_screen_navigation_repaint.py
@@ -17,6 +17,7 @@ from lilbee.cli.tui.widgets.bottom_bars import BottomBars
 from lilbee.cli.tui.widgets.model_bar import ModelBar
 from lilbee.cli.tui.widgets.task_bar import TaskBar
 from lilbee.core.config import cfg
+from tests._lilbee_app_test_host import await_chat
 
 
 @pytest.fixture(autouse=True)
@@ -70,6 +71,7 @@ async def test_chat_task_center_chat_task_center_cycle_has_no_leftovers() -> Non
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert isinstance(app.screen, ChatScreen)
 
@@ -106,6 +108,7 @@ async def test_footer_row_is_not_shared_with_other_bottom_widgets() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.action_open_tasks()
         await pilot.pause()

--- a/tests/test_services_lifecycle.py
+++ b/tests/test_services_lifecycle.py
@@ -1,0 +1,126 @@
+"""Hard-exit signals must tear the engine fleet down, not orphan it."""
+
+from __future__ import annotations
+
+import signal
+from unittest.mock import MagicMock
+
+import pytest
+
+from lilbee.app import services as services_mod
+from lilbee.app.services import (
+    install_engine_lifecycle_hooks,
+    peek_services,
+    reset_services,
+    set_services,
+)
+
+_HARD_EXIT_SIGNALS = [
+    pytest.param(signal.SIGTERM, id="sigterm"),
+    pytest.param(signal.SIGHUP, id="sighup-terminal-close"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_handlers():
+    """Snapshot and restore the real signal table around every test."""
+    saved = {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGHUP)}
+    services_mod._lifecycle.reset()
+    yield
+    for sig, handler in saved.items():
+        signal.signal(sig, handler)
+    services_mod._lifecycle.reset()
+    reset_services()
+
+
+def _install_stub_services() -> MagicMock:
+    """Bind a mock container whose provider records shutdown()."""
+    provider = MagicMock()
+    container = MagicMock()
+    container.provider = provider
+    set_services(container)
+    return provider
+
+
+@pytest.mark.parametrize("sig", _HARD_EXIT_SIGNALS)
+def test_hard_exit_signal_shuts_down_the_provider(sig):
+    """SIGTERM / SIGHUP must run teardown before the process dies."""
+    provider = _install_stub_services()
+    install_engine_lifecycle_hooks()
+
+    handler = signal.getsignal(sig)
+    assert callable(handler), f"{sig!r} still has its default disposition"
+
+    with pytest.raises(SystemExit):
+        handler(sig, None)
+
+    provider.shutdown.assert_called_once()
+    assert peek_services() is None
+
+
+def test_install_is_idempotent():
+    """Installing twice must not stack handlers or double-shutdown."""
+    provider = _install_stub_services()
+    install_engine_lifecycle_hooks()
+    first = signal.getsignal(signal.SIGTERM)
+    install_engine_lifecycle_hooks()
+    assert signal.getsignal(signal.SIGTERM) is first
+
+    with pytest.raises(SystemExit):
+        first(signal.SIGTERM, None)
+    provider.shutdown.assert_called_once()
+
+
+def test_teardown_runs_once_when_signal_and_atexit_both_fire():
+    """The atexit hook after a signal handler must not shut down twice."""
+    provider = _install_stub_services()
+    install_engine_lifecycle_hooks()
+
+    with pytest.raises(SystemExit):
+        signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+    reset_services()
+
+    provider.shutdown.assert_called_once()
+
+
+def test_signal_without_services_still_exits():
+    """A hard exit before any container was built must not raise."""
+    install_engine_lifecycle_hooks()
+    with pytest.raises(SystemExit):
+        signal.getsignal(signal.SIGHUP)(signal.SIGHUP, None)
+
+
+def test_cli_entry_point_installs_the_hooks():
+    """Every surface enters through the Typer callback, so the hooks install there."""
+    import inspect
+
+    from lilbee.cli.app import _default
+
+    assert "install_engine_lifecycle_hooks()" in inspect.getsource(_default)
+
+
+def test_mounting_the_tui_does_not_touch_the_signal_table():
+    """Installing from on_mount would leave real handlers behind in every TUI test."""
+    import inspect
+
+    from lilbee.cli.tui.app import LilbeeApp
+
+    assert "install_engine_lifecycle_hooks" not in inspect.getsource(LilbeeApp.on_mount)
+
+
+def test_install_off_main_thread_is_a_noop():
+    """signal.signal raises off the main thread; installing there must not crash."""
+    import threading
+
+    errors: list[BaseException] = []
+
+    def _worker() -> None:
+        try:
+            install_engine_lifecycle_hooks()
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    assert errors == []

--- a/tests/test_services_lifecycle.py
+++ b/tests/test_services_lifecycle.py
@@ -15,16 +15,21 @@ from lilbee.app.services import (
     set_services,
 )
 
+# The exact signals production installs: (SIGTERM, SIGHUP) on POSIX, SIGTERM alone
+# on Windows, which has no SIGHUP. Deriving from the helper keeps this file
+# collectable on every platform and pins the test set to what install() really does.
 _HARD_EXIT_SIGNALS = [
-    pytest.param(signal.SIGTERM, id="sigterm"),
-    pytest.param(signal.SIGHUP, id="sighup-terminal-close"),
+    pytest.param(sig, id=sig.name.lower())
+    for sig in services_mod._EngineLifecycle._hard_exit_signals()
 ]
 
 
 @pytest.fixture(autouse=True)
 def _restore_handlers():
     """Snapshot and restore the real signal table around every test."""
-    saved = {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGHUP)}
+    saved = {
+        sig: signal.getsignal(sig) for sig in services_mod._EngineLifecycle._hard_exit_signals()
+    }
     services_mod._lifecycle.reset()
     yield
     for sig, handler in saved.items():
@@ -87,7 +92,7 @@ def test_signal_without_services_still_exits():
     """A hard exit before any container was built must not raise."""
     install_engine_lifecycle_hooks()
     with pytest.raises(SystemExit):
-        signal.getsignal(signal.SIGHUP)(signal.SIGHUP, None)
+        signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
 
 
 def test_cli_entry_point_installs_the_hooks():

--- a/tests/test_services_lifecycle.py
+++ b/tests/test_services_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import signal
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -38,6 +39,13 @@ def _restore_handlers():
     reset_services()
 
 
+def _join_teardown() -> None:
+    """Wait out the handler's teardown thread so assertions don't race it."""
+    for thread in threading.enumerate():
+        if thread.name == "hard-exit-teardown":
+            thread.join(timeout=5)
+
+
 def _install_stub_services() -> MagicMock:
     """Bind a mock container whose provider records shutdown()."""
     provider = MagicMock()
@@ -58,6 +66,7 @@ def test_hard_exit_signal_shuts_down_the_provider(sig):
 
     with pytest.raises(SystemExit):
         handler(sig, None)
+    _join_teardown()
 
     provider.shutdown.assert_called_once()
     assert peek_services() is None
@@ -73,6 +82,7 @@ def test_install_is_idempotent():
 
     with pytest.raises(SystemExit):
         first(signal.SIGTERM, None)
+    _join_teardown()
     provider.shutdown.assert_called_once()
 
 
@@ -83,9 +93,27 @@ def test_teardown_runs_once_when_signal_and_atexit_both_fire():
 
     with pytest.raises(SystemExit):
         signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+    _join_teardown()
     reset_services()
 
     provider.shutdown.assert_called_once()
+
+
+def test_teardown_runs_off_the_main_thread():
+    """Regression: a second signal (the kernel pairs SIGCONT with SIGHUP for an
+    orphaned process group) interrupts the main thread mid-handler; a teardown
+    running there was aborted half-done, orphaning a loaded fleet. The reap
+    must run on its own thread, out of any signal handler's reach."""
+    provider = _install_stub_services()
+    teardown_threads: list[str] = []
+    provider.shutdown.side_effect = lambda: teardown_threads.append(threading.current_thread().name)
+    install_engine_lifecycle_hooks()
+
+    with pytest.raises(SystemExit):
+        signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+    _join_teardown()
+
+    assert teardown_threads == ["hard-exit-teardown"]
 
 
 def test_signal_without_services_still_exits():

--- a/tests/test_setup_task_routing.py
+++ b/tests/test_setup_task_routing.py
@@ -8,6 +8,8 @@ the download to the app-level controller.
 
 from __future__ import annotations
 
+import asyncio
+import time
 from unittest.mock import patch
 
 import pytest
@@ -57,15 +59,18 @@ class _PlainApp(LilbeeAppHost):
         self.push_screen(SetupWizard())
 
 
-# Generous ceiling: slow Windows CI runners need many pauses before the wizard's
-# model cards finish mounting; waiting for the screen alone races the cards.
-_WIZARD_WAIT_PAUSES = 60
+# Generous ceiling: the startup gate decides on a real thread before chat mounts and
+# pushes the wizard, and slow CI runners need time before its model cards exist.
+_WIZARD_WAIT_TIMEOUT_S = 20.0
+_WIZARD_POLL_S = 0.02
 
 
 async def _wait_for_wizard_cards(app: LilbeeApp, pilot) -> SetupWizard:
     """Wait until the SetupWizard is the active screen and its model cards exist."""
-    for _ in range(_WIZARD_WAIT_PAUSES):
+    deadline = time.monotonic() + _WIZARD_WAIT_TIMEOUT_S
+    while time.monotonic() < deadline:
         await pilot.pause()
+        await asyncio.sleep(_WIZARD_POLL_S)
         screen = app.screen
         if isinstance(screen, SetupWizard) and list(screen.query(ModelCard)):
             return screen

--- a/tests/test_setup_task_routing.py
+++ b/tests/test_setup_task_routing.py
@@ -59,9 +59,10 @@ class _PlainApp(LilbeeAppHost):
         self.push_screen(SetupWizard())
 
 
-# Generous ceiling: the startup gate decides on a real thread before chat mounts and
-# pushes the wizard, and slow CI runners need time before its model cards exist.
-_WIZARD_WAIT_TIMEOUT_S = 20.0
+# Generous ceiling: the gate paints, the chat screen installs after the first
+# frame, its setup worker runs real disk checks on a thread, and only then does
+# the wizard push and compose its cards; loaded CI runners take a while.
+_WIZARD_WAIT_TIMEOUT_S = 60.0
 _WIZARD_POLL_S = 0.02
 
 

--- a/tests/test_splash_runner.py
+++ b/tests/test_splash_runner.py
@@ -46,6 +46,37 @@ def test_render_frame():
     assert b"bar" in result
 
 
+def test_render_frame_centres_every_row_by_the_same_margin():
+    from lilbee.runtime._splash_runner import render_frame
+
+    lines = render_frame(["line1", "line2"], "bar", pad=4).decode().splitlines()
+    assert lines[0] == "    line1"
+    assert lines[1] == "    line2"
+    assert lines[-1] == "      bar"  # margin plus the bar's own two-space indent
+
+
+def test_left_pad_matches_the_bootstrap_formula(monkeypatch):
+    import os
+
+    from lilbee.runtime import _splash_runner
+    from lilbee.runtime.bee_logo import LOGO_WIDTH
+
+    monkeypatch.setattr(os, "get_terminal_size", lambda fd=1: os.terminal_size((121, 40)))
+    assert _splash_runner.left_pad() == (121 - LOGO_WIDTH) // 2
+
+
+def test_left_pad_is_zero_when_the_terminal_size_is_unknown(monkeypatch):
+    import os
+
+    from lilbee.runtime import _splash_runner
+
+    def _raise(fd=1):
+        raise OSError("not a tty")
+
+    monkeypatch.setattr(os, "get_terminal_size", _raise)
+    assert _splash_runner.left_pad() == 0
+
+
 def test_move_up_and_clear():
     from lilbee.runtime._splash_runner import move_up_and_clear
 

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -1,0 +1,349 @@
+"""The startup gate holds the screen until the chat engine can serve a prompt."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from lilbee.app.placement import chat_engine_ready
+from lilbee.app.services import set_services
+from lilbee.catalog.formatting import display_label_for_ref
+from lilbee.cli.tui import messages as msg
+from lilbee.providers.roles import WorkerRole
+from lilbee.providers.warm_progress import WarmPhase, WarmProgress
+
+
+@pytest.fixture
+def _no_services():
+    """Leave the singleton empty, as it is before the container is built."""
+    set_services(None)
+    yield
+    set_services(None)
+
+
+def test_chat_engine_not_ready_before_services_exist(_no_services):
+    """The pre-services window must read as not-ready, not as ready."""
+    assert chat_engine_ready() is False
+
+
+def test_chat_engine_ready_tracks_the_chat_role():
+    """Readiness is the chat role's own readiness, asked positively."""
+    services = mock.MagicMock()
+    services.provider.role_ready.return_value = True
+    set_services(services)
+    try:
+        assert chat_engine_ready() is True
+        services.provider.role_ready.assert_called_once_with(WorkerRole.CHAT)
+    finally:
+        set_services(None)
+
+
+def test_chat_engine_not_ready_while_the_role_is_cold():
+    """A spawned-but-cold chat role still cannot serve a prompt."""
+    services = mock.MagicMock()
+    services.provider.role_ready.return_value = False
+    set_services(services)
+    try:
+        assert chat_engine_ready() is False
+    finally:
+        set_services(None)
+
+
+def _xterm_to_hex(index: int) -> str:
+    """The 6x6x6 colour-cube hex for an xterm-256 index in 16..231."""
+    levels = (0, 95, 135, 175, 215, 255)
+    offset = index - 16
+    red = levels[offset // 36]
+    green = levels[(offset % 36) // 6]
+    blue = levels[offset % 6]
+    return f"#{red:02x}{green:02x}{blue:02x}"
+
+
+def test_gate_logo_colour_matches_the_shared_bright_amber():
+    """The stylesheet's hex must stay in step with the palette the splash uses."""
+    import pathlib
+
+    from lilbee.runtime.bee_logo import AMBER_BRIGHT_XTERM
+
+    tcss = pathlib.Path("src/lilbee/cli/tui/screens/startup_gate.tcss")
+    stylesheet = (pathlib.Path(__file__).resolve().parents[1] / tcss).read_text()
+    assert _xterm_to_hex(AMBER_BRIGHT_XTERM) in stylesheet
+
+
+def _snapshot(phase: WarmPhase, **kwargs) -> WarmProgress:
+    return WarmProgress(phase=phase, **kwargs)
+
+
+async def test_gate_shows_a_byte_bar_while_reading_weights():
+    """READING_WEIGHTS carries byte counts, so the bar is determinate."""
+    from textual.widgets import ProgressBar
+
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    with mock.patch.object(StartupGate, "query_one") as query:
+        bar, status = mock.MagicMock(spec=ProgressBar), mock.MagicMock()
+        query.side_effect = lambda selector, _kind=None: bar if "bar" in selector else status
+        gate._apply_snapshot(
+            _snapshot(
+                WarmPhase.READING_WEIGHTS, bytes_done=512, bytes_total=1024, model_ref="a/b/c.gguf"
+            )
+        )
+    bar.update.assert_called_once_with(total=1024, progress=512)
+
+
+async def test_gate_bar_is_indeterminate_while_loading_the_engine():
+    """The VRAM upload emits no byte signal, so the bar must not fake one."""
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    with mock.patch.object(StartupGate, "query_one") as query:
+        bar, status = mock.MagicMock(), mock.MagicMock()
+        query.side_effect = lambda selector, _kind=None: bar if "bar" in selector else status
+        gate._apply_snapshot(_snapshot(WarmPhase.LOADING_ENGINE))
+    bar.update.assert_called_once_with(total=None)
+    status.update.assert_called_once_with(msg.STARTUP_LOADING_ENGINE)
+
+
+async def test_gate_release_reveals_chat():
+    """Reaching ready hands the screen to chat."""
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    app = mock.MagicMock()
+    with (
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+    ):
+        gate._release()
+    app.reveal_chat.assert_called_once_with()
+
+
+async def test_gate_releases_when_nothing_is_warming(monkeypatch):
+    """No fleet, no warm, or an uninstalled model must not hold the screen forever."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    monkeypatch.setattr(gate_mod, "_WARM_START_GRACE_S", 0.0)
+
+    provider = mock.MagicMock()
+    provider.role_ready.return_value = False
+    provider.warm_progress.return_value = None
+    services = mock.MagicMock()
+    services.provider = provider
+    set_services(services)
+    try:
+        gate = StartupGate()
+        app = mock.MagicMock()
+        with (
+            mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+            mock.patch.object(gate_mod, "needs_setup", return_value=False),
+            mock.patch.object(StartupGate, "_stopping", return_value=False),
+        ):
+            app.call_from_thread.side_effect = lambda fn, *a: fn(*a)
+            with mock.patch.object(StartupGate, "query_one"):
+                StartupGate._boot_worker.__wrapped__(gate)
+        app.reveal_chat.assert_called_once_with()
+    finally:
+        set_services(None)
+
+
+async def test_gate_failure_surfaces_the_error_and_still_reveals_chat():
+    """A failed load must not lock the user out of Catalog and Settings."""
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    app = mock.MagicMock()
+    status = mock.MagicMock()
+    with (
+        mock.patch.object(StartupGate, "query_one", return_value=status),
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+    ):
+        gate._fail("no such file")
+    notified = [c.args[0] for c in app.notify.call_args_list if c.args]
+    assert msg.STARTUP_FAILED.format(error="no such file") in notified
+    assert msg.STARTUP_FAILED_HINT in notified
+    app.reveal_chat.assert_called_once_with()
+
+
+def _gate_with_app():
+    """A gate whose call_from_thread runs inline, so the worker body is testable.
+
+    ``_stopping`` needs a live worker context and a mounted screen, neither of
+    which a direct call to the worker body has, so it is stubbed to "keep going".
+    """
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    app = mock.MagicMock()
+    app.call_from_thread.side_effect = lambda fn, *a: fn(*a)
+    return gate, app
+
+
+async def test_gate_reveals_chat_when_setup_is_required(monkeypatch):
+    """With no models installed the wizard owns the flow, so the gate steps aside."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate, app = _gate_with_app()
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: True)
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(StartupGate, "_stopping", return_value=False),
+    ):
+        StartupGate._boot_worker.__wrapped__(gate)
+    app.reveal_chat.assert_called_once_with()
+
+
+async def test_gate_surfaces_a_failure_to_build_services(monkeypatch):
+    """A container that cannot be built must show the error, not hang the screen."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate, app = _gate_with_app()
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
+    monkeypatch.setattr(gate_mod, "get_services", mock.Mock(side_effect=OSError("disk gone")))
+    status = mock.MagicMock()
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "query_one", return_value=status),
+        mock.patch.object(StartupGate, "_stopping", return_value=False),
+    ):
+        StartupGate._boot_worker.__wrapped__(gate)
+    notified = [c.args[0] for c in app.notify.call_args_list if c.args]
+    assert msg.STARTUP_FAILED.format(error="disk gone") in notified
+    app.reveal_chat.assert_called_once_with()
+
+
+async def test_gate_does_not_wait_when_eager_start_is_disabled(monkeypatch):
+    """With eager start off nothing warms, so holding the screen would never end."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+    from lilbee.core.config import cfg
+
+    gate, app = _gate_with_app()
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
+    monkeypatch.setattr(cfg, "worker_pool_eager_start", False)
+    provider = mock.MagicMock()
+    provider.role_ready.return_value = False
+    services = mock.MagicMock()
+    services.provider = provider
+    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(StartupGate, "_stopping", return_value=False),
+    ):
+        StartupGate._boot_worker.__wrapped__(gate)
+    app.reveal_chat.assert_called_once_with()
+
+
+async def test_gate_renders_progress_then_fails_on_an_error_phase(monkeypatch):
+    """An in-flight warm renders, and a later ERROR phase surfaces the reason."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+    from lilbee.core.config import cfg
+
+    gate, app = _gate_with_app()
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
+    monkeypatch.setattr(cfg, "worker_pool_eager_start", True)
+    monkeypatch.setattr(gate_mod, "_POLL_INTERVAL_S", 0.0)
+
+    provider = mock.MagicMock()
+    provider.role_ready.return_value = False
+    provider.warm_progress.side_effect = [
+        _snapshot(WarmPhase.READING_WEIGHTS, bytes_done=1, bytes_total=2, model_ref="a/b/c.gguf"),
+        _snapshot(WarmPhase.ERROR, error="out of memory"),
+    ]
+    services = mock.MagicMock()
+    services.provider = provider
+    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
+    set_services(services)
+    try:
+        status = mock.MagicMock()
+        with (
+            mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+            mock.patch.object(StartupGate, "query_one", return_value=status),
+            mock.patch.object(StartupGate, "_stopping", return_value=False),
+        ):
+            StartupGate._boot_worker.__wrapped__(gate)
+        status.update.assert_any_call(
+            msg.STARTUP_READING_WEIGHTS.format(name=display_label_for_ref("a/b/c.gguf"))
+        )
+        notified = [c.args[0] for c in app.notify.call_args_list if c.args]
+        assert msg.STARTUP_FAILED.format(error="out of memory") in notified
+    finally:
+        set_services(None)
+
+
+async def test_marshal_skips_the_ui_hop_once_the_app_is_tearing_down():
+    """A gate worker that outlives the app must not touch a shutting-down UI thread."""
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    app = mock.MagicMock()
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "_stopping", return_value=True),
+    ):
+        gate._marshal(gate._release)
+    app.call_from_thread.assert_not_called()
+    app.reveal_chat.assert_not_called()
+
+
+async def test_stopping_is_true_when_the_gate_is_unmounted():
+    """An unmounted gate must report that the worker should stop."""
+    from textual.worker import Worker
+
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    worker = mock.MagicMock(spec=Worker)
+    worker.is_cancelled = False
+    with mock.patch("lilbee.cli.tui.screens.startup_gate.get_current_worker", return_value=worker):
+        assert gate._stopping() is True
+
+
+async def test_stopping_is_true_when_the_worker_is_cancelled():
+    """A cancelled worker must stop even while the gate is still mounted."""
+    from textual.worker import Worker
+
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    worker = mock.MagicMock(spec=Worker)
+    worker.is_cancelled = True
+    with (
+        mock.patch("lilbee.cli.tui.screens.startup_gate.get_current_worker", return_value=worker),
+        mock.patch.object(type(gate), "is_mounted", new=mock.PropertyMock(return_value=True)),
+    ):
+        assert gate._stopping() is True
+
+
+async def test_first_run_hands_over_when_setup_is_required(tmp_path, monkeypatch):
+    """Regression: an unmounted gate must not be mistaken for a torn-down one.
+
+    ``push_screen`` returns an AwaitMount. Left unawaited, the boot worker could
+    reach ``_stopping`` before the gate mounted, silently drop the handover, and
+    strand a first-run user on the loading screen forever.
+    """
+    import asyncio
+    import time
+
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.core.config import cfg
+
+    monkeypatch.setattr(cfg, "lancedb_dir", tmp_path / "missing")  # forces needs_setup
+    revealed = mock.MagicMock()
+    monkeypatch.setattr(LilbeeApp, "reveal_chat", revealed)
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not revealed.called:
+            await pilot.pause()
+            await asyncio.sleep(0.02)
+
+    revealed.assert_called_once_with()

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -390,3 +390,41 @@ async def test_start_boot_builds_services_when_none_exist(monkeypatch):
 
     assert worker_calls == [True]
     assert deferred == []
+
+
+async def test_boot_worker_canonicalizes_before_the_setup_check(monkeypatch):
+    """Canonicalization can swap a stale ref to a working one, which is exactly
+    what decides whether setup is needed, so it must run first."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate, app = _gate_with_app()
+    order: list[str] = []
+    app.canonicalize_persisted_models.side_effect = lambda: order.append("canonicalize")
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: order.append("setup") or True)
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(StartupGate, "_stopping", return_value=False),
+    ):
+        StartupGate._boot_worker.__wrapped__(gate)
+    assert order == ["canonicalize", "setup"]
+
+
+async def test_boot_worker_surfaces_a_canonicalization_failure(monkeypatch):
+    """A crash while settling the refs shows the error instead of hanging the gate."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate, app = _gate_with_app()
+    app.canonicalize_persisted_models.side_effect = OSError("registry unreadable")
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(StartupGate, "_stopping", return_value=False),
+    ):
+        StartupGate._boot_worker.__wrapped__(gate)
+    notified = [c.args[0] for c in app.notify.call_args_list if c.args]
+    assert msg.STARTUP_FAILED.format(error="registry unreadable") in notified
+    app.reveal_chat.assert_called_once_with()

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -129,6 +129,7 @@ async def test_gate_release_reveals_chat():
 
     gate = StartupGate()
     app = mock.MagicMock()
+    app.screen = gate
     with (
         mock.patch.object(StartupGate, "query_one"),
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
@@ -154,6 +155,7 @@ async def test_gate_releases_when_nothing_is_warming(monkeypatch):
     try:
         gate = StartupGate()
         app = mock.MagicMock()
+        app.screen = gate
         with (
             mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
             mock.patch.object(gate_mod, "needs_setup", return_value=False),
@@ -173,6 +175,7 @@ async def test_gate_failure_surfaces_the_error_and_still_reveals_chat():
 
     gate = StartupGate()
     app = mock.MagicMock()
+    app.screen = gate
     status = mock.MagicMock()
     with (
         mock.patch.object(StartupGate, "query_one", return_value=status),
@@ -196,6 +199,7 @@ def _gate_with_app():
     gate = StartupGate()
     app = mock.MagicMock()
     app.call_from_thread.side_effect = lambda fn, *a: fn(*a)
+    app.screen = gate  # the gate owns the screen, as it does in production
     return gate, app
 
 
@@ -477,3 +481,68 @@ async def test_gate_composes_and_styles_its_widgets(monkeypatch):
         assert msg.STARTUP_PREPARING in str(status.render())
         assert logo.styles.color.hex.lower() == _xterm_to_hex(AMBER_BRIGHT_XTERM)
         assert gate_mod._LOGO.splitlines()[1].strip().startswith("@@@")
+
+
+async def test_gate_does_not_steal_a_screen_pushed_over_it(monkeypatch):
+    """Regression: reveal_chat switches the *current* screen, whichever it is.
+
+    A slow warm let another screen open above the gate; when the warm finished the
+    gate replaced that screen instead of itself, throwing the user out of it.
+    """
+    from textual.app import ComposeResult
+    from textual.screen import Screen
+    from textual.widgets import Static
+
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    class _Other(Screen[None]):
+        def compose(self) -> ComposeResult:
+            yield Static("other")
+
+    gate = StartupGate()
+    app = mock.MagicMock()
+    app.screen = _Other()  # something else owns the screen now
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "query_one"),
+    ):
+        gate._release()
+    app.reveal_chat.assert_not_called()
+
+
+async def test_gate_hands_over_when_it_still_owns_the_screen():
+    """The ordinary path: the gate is on top, so it reveals chat."""
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    app = mock.MagicMock()
+    app.screen = gate
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "query_one"),
+    ):
+        gate._release()
+    app.reveal_chat.assert_called_once_with()
+
+
+async def test_ready_fleet_defers_the_handover_off_on_mount(monkeypatch):
+    """Regression: switching screens inside on_mount stalled Textual.
+
+    start_boot runs at the tail of LilbeeApp.on_mount. Calling reveal_chat straight
+    from there switches screens mid-mount; defer it a frame instead.
+    """
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    monkeypatch.setattr(gate_mod, "chat_engine_ready", lambda: True)
+
+    deferred: list = []
+    released: list = []
+    monkeypatch.setattr(gate, "call_after_refresh", deferred.append, raising=False)
+    monkeypatch.setattr(gate, "_release", lambda: released.append(True), raising=False)
+
+    gate.start_boot()
+
+    assert released == [], "the handover must not run inside on_mount"
+    assert deferred == [gate._release]

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -546,3 +546,35 @@ async def test_ready_fleet_defers_the_handover_off_on_mount(monkeypatch):
 
     assert released == [], "the handover must not run inside on_mount"
     assert deferred == [gate._release]
+
+
+async def test_gate_tip_points_at_the_warm_setting_only_when_off(monkeypatch):
+    """The tip renders during a cold load and disappears once warm is enabled."""
+    from textual.app import App, ComposeResult
+    from textual.widgets import Static
+
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+    from lilbee.core.config import cfg
+
+    monkeypatch.setattr(StartupGate, "start_boot", lambda self: None)
+
+    class _Host(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Static("host")
+
+        def on_mount(self) -> None:
+            self.push_screen(StartupGate())
+
+    monkeypatch.setattr(cfg, "keep_engine_warm", False)
+    app = _Host()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        tip = app.screen.query_one("#gate-tip", Static)
+        assert msg.STARTUP_WARM_TIP in str(tip.render())
+
+    monkeypatch.setattr(cfg, "keep_engine_warm", True)
+    app = _Host()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        tip = app.screen.query_one("#gate-tip", Static)
+        assert msg.STARTUP_WARM_TIP not in str(tip.render())

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -428,3 +428,20 @@ async def test_boot_worker_surfaces_a_canonicalization_failure(monkeypatch):
     notified = [c.args[0] for c in app.notify.call_args_list if c.args]
     assert msg.STARTUP_FAILED.format(error="registry unreadable") in notified
     app.reveal_chat.assert_called_once_with()
+
+
+async def test_gate_mount_retires_the_splash_then_repaints(monkeypatch):
+    """The splash animates over the blank alt-screen until the gate paints;
+    the dismissal then repaints anything a final frame touched."""
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate, app = _gate_with_app()
+    order: list[str] = []
+    monkeypatch.setattr("lilbee.runtime.splash.dismiss", lambda: order.append("dismiss"))
+    monkeypatch.setattr(gate, "_repaint", lambda: order.append("refresh"), raising=False)
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "_stopping", return_value=False),
+    ):
+        StartupGate._retire_splash.__wrapped__(gate)
+    assert order == ["dismiss", "refresh"]

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -1,4 +1,4 @@
-"""The startup gate holds the screen until the chat engine can serve a prompt."""
+"""The startup gate holds the screen only while the services container builds."""
 
 from __future__ import annotations
 
@@ -8,10 +8,8 @@ import pytest
 
 from lilbee.app.placement import chat_engine_ready
 from lilbee.app.services import set_services
-from lilbee.catalog.formatting import display_label_for_ref
 from lilbee.cli.tui import messages as msg
 from lilbee.providers.roles import WorkerRole
-from lilbee.providers.warm_progress import WarmPhase, WarmProgress
 
 
 @pytest.fixture
@@ -88,106 +86,6 @@ def test_gate_stylesheet_has_no_colour_outside_the_palette():
     assert found <= allowed, f"colours outside the palette: {sorted(found - allowed)}"
 
 
-def _snapshot(phase: WarmPhase, **kwargs) -> WarmProgress:
-    return WarmProgress(phase=phase, **kwargs)
-
-
-async def test_gate_shows_a_byte_bar_while_reading_weights():
-    """READING_WEIGHTS carries byte counts, so the bar is determinate."""
-    from textual.widgets import ProgressBar
-
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-
-    gate = StartupGate()
-    with mock.patch.object(StartupGate, "query_one") as query:
-        bar, status = mock.MagicMock(spec=ProgressBar), mock.MagicMock()
-        query.side_effect = lambda selector, _kind=None: bar if "bar" in selector else status
-        gate._apply_snapshot(
-            _snapshot(
-                WarmPhase.READING_WEIGHTS, bytes_done=512, bytes_total=1024, model_ref="a/b/c.gguf"
-            )
-        )
-    bar.update.assert_called_once_with(total=1024, progress=512)
-
-
-async def test_gate_bar_is_indeterminate_while_loading_the_engine():
-    """The VRAM upload emits no byte signal, so the bar must not fake one."""
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-
-    gate = StartupGate()
-    with mock.patch.object(StartupGate, "query_one") as query:
-        bar, status = mock.MagicMock(), mock.MagicMock()
-        query.side_effect = lambda selector, _kind=None: bar if "bar" in selector else status
-        gate._apply_snapshot(_snapshot(WarmPhase.LOADING_ENGINE))
-    bar.update.assert_called_once_with(total=None)
-    status.update.assert_called_once_with(msg.STARTUP_LOADING_ENGINE)
-
-
-async def test_gate_release_reveals_chat():
-    """Reaching ready hands the screen to chat."""
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-
-    gate = StartupGate()
-    app = mock.MagicMock()
-    app.screen = gate
-    with (
-        mock.patch.object(StartupGate, "query_one"),
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-    ):
-        gate._release()
-    app.reveal_chat.assert_called_once_with()
-
-
-async def test_gate_releases_when_nothing_is_warming(monkeypatch):
-    """No fleet, no warm, or an uninstalled model must not hold the screen forever."""
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-
-    monkeypatch.setattr(gate_mod, "_WARM_START_GRACE_S", 0.0)
-
-    provider = mock.MagicMock()
-    provider.role_ready.return_value = False
-    provider.warm_progress.return_value = None
-    provider.warm_pending.return_value = False
-    services = mock.MagicMock()
-    services.provider = provider
-    set_services(services)
-    try:
-        gate = StartupGate()
-        app = mock.MagicMock()
-        app.screen = gate
-        with (
-            mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-            mock.patch.object(gate_mod, "needs_setup", return_value=False),
-            mock.patch.object(StartupGate, "_stopping", return_value=False),
-        ):
-            app.call_from_thread.side_effect = lambda fn, *a: fn(*a)
-            with mock.patch.object(StartupGate, "query_one"):
-                StartupGate._boot_worker.__wrapped__(gate)
-        app.reveal_chat.assert_called_once_with()
-    finally:
-        set_services(None)
-
-
-async def test_gate_failure_surfaces_the_error_and_still_reveals_chat():
-    """A failed load must not lock the user out of Catalog and Settings."""
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-
-    gate = StartupGate()
-    app = mock.MagicMock()
-    app.screen = gate
-    status = mock.MagicMock()
-    with (
-        mock.patch.object(StartupGate, "query_one", return_value=status),
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-    ):
-        gate._fail("no such file")
-    notified = [c.args[0] for c in app.notify.call_args_list if c.args]
-    assert msg.STARTUP_FAILED.format(error="no such file") in notified
-    assert msg.STARTUP_FAILED_HINT in notified
-    app.reveal_chat.assert_called_once_with()
-
-
 def _gate_with_app():
     """A gate whose call_from_thread runs inline, so the worker body is testable.
 
@@ -203,13 +101,39 @@ def _gate_with_app():
     return gate, app
 
 
-async def test_gate_reveals_chat_when_setup_is_required(monkeypatch):
-    """With no models installed the wizard owns the flow, so the gate steps aside."""
+async def test_gate_release_reveals_chat():
+    """A built container hands the screen to chat."""
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    app = mock.MagicMock()
+    app.screen = gate
+    with (
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+    ):
+        gate._release()
+    app.reveal_chat.assert_called_once_with()
+
+
+async def test_gate_releases_once_services_build_even_with_a_cold_engine(monkeypatch):
+    """The gate waits for the container, never for the model load.
+
+    The engine loads in the background after the handover; a prompt that arrives
+    first waits inside its own answer bubble. Holding the screen for the load
+    would re-block every launch that the lazy path exists to unblock.
+    """
     from lilbee.cli.tui.screens import startup_gate as gate_mod
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
     gate, app = _gate_with_app()
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: True)
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
+
+    provider = mock.MagicMock()
+    provider.role_ready.return_value = False  # engine is stone cold
+    services = mock.MagicMock()
+    services.provider = provider
+    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
     with (
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
@@ -217,6 +141,43 @@ async def test_gate_reveals_chat_when_setup_is_required(monkeypatch):
     ):
         StartupGate._boot_worker.__wrapped__(gate)
     app.reveal_chat.assert_called_once_with()
+    provider.role_ready.assert_not_called()
+
+
+async def test_gate_failure_surfaces_the_error_and_still_reveals_chat():
+    """A failed start must not lock the user out of Catalog and Settings."""
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate = StartupGate()
+    app = mock.MagicMock()
+    app.screen = gate
+    with (
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+    ):
+        gate._fail("no such file")
+    notified = [c.args[0] for c in app.notify.call_args_list if c.args]
+    assert msg.STARTUP_FAILED.format(error="no such file") in notified
+    app.reveal_chat.assert_called_once_with()
+
+
+async def test_gate_reveals_chat_when_setup_is_required(monkeypatch):
+    """With no models installed the wizard owns the flow, so the gate steps aside."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+
+    gate, app = _gate_with_app()
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: True)
+    built = mock.Mock()
+    monkeypatch.setattr(gate_mod, "get_services", built)
+    with (
+        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+        mock.patch.object(StartupGate, "query_one"),
+        mock.patch.object(StartupGate, "_stopping", return_value=False),
+    ):
+        StartupGate._boot_worker.__wrapped__(gate)
+    app.reveal_chat.assert_called_once_with()
+    built.assert_not_called()
 
 
 async def test_gate_surfaces_a_failure_to_build_services(monkeypatch):
@@ -227,77 +188,15 @@ async def test_gate_surfaces_a_failure_to_build_services(monkeypatch):
     gate, app = _gate_with_app()
     monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
     monkeypatch.setattr(gate_mod, "get_services", mock.Mock(side_effect=OSError("disk gone")))
-    status = mock.MagicMock()
-    with (
-        mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-        mock.patch.object(StartupGate, "query_one", return_value=status),
-        mock.patch.object(StartupGate, "_stopping", return_value=False),
-    ):
-        StartupGate._boot_worker.__wrapped__(gate)
-    notified = [c.args[0] for c in app.notify.call_args_list if c.args]
-    assert msg.STARTUP_FAILED.format(error="disk gone") in notified
-    app.reveal_chat.assert_called_once_with()
-
-
-async def test_gate_does_not_wait_when_eager_start_is_disabled(monkeypatch):
-    """With eager start off nothing warms, so holding the screen would never end."""
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-    from lilbee.core.config import cfg
-
-    gate, app = _gate_with_app()
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
-    monkeypatch.setattr(cfg, "worker_pool_eager_start", False)
-    provider = mock.MagicMock()
-    provider.role_ready.return_value = False
-    services = mock.MagicMock()
-    services.provider = provider
-    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
     with (
         mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
         mock.patch.object(StartupGate, "query_one"),
         mock.patch.object(StartupGate, "_stopping", return_value=False),
     ):
         StartupGate._boot_worker.__wrapped__(gate)
+    notified = [c.args[0] for c in app.notify.call_args_list if c.args]
+    assert msg.STARTUP_FAILED.format(error="disk gone") in notified
     app.reveal_chat.assert_called_once_with()
-
-
-async def test_gate_renders_progress_then_fails_on_an_error_phase(monkeypatch):
-    """An in-flight warm renders, and a later ERROR phase surfaces the reason."""
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-    from lilbee.core.config import cfg
-
-    gate, app = _gate_with_app()
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
-    monkeypatch.setattr(cfg, "worker_pool_eager_start", True)
-    monkeypatch.setattr(gate_mod, "_POLL_INTERVAL_S", 0.0)
-
-    provider = mock.MagicMock()
-    provider.role_ready.return_value = False
-    provider.warm_progress.side_effect = [
-        _snapshot(WarmPhase.READING_WEIGHTS, bytes_done=1, bytes_total=2, model_ref="a/b/c.gguf"),
-        _snapshot(WarmPhase.ERROR, error="out of memory"),
-    ]
-    services = mock.MagicMock()
-    services.provider = provider
-    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
-    set_services(services)
-    try:
-        status = mock.MagicMock()
-        with (
-            mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-            mock.patch.object(StartupGate, "query_one", return_value=status),
-            mock.patch.object(StartupGate, "_stopping", return_value=False),
-        ):
-            StartupGate._boot_worker.__wrapped__(gate)
-        status.update.assert_any_call(
-            msg.STARTUP_READING_WEIGHTS.format(name=display_label_for_ref("a/b/c.gguf"))
-        )
-        notified = [c.args[0] for c in app.notify.call_args_list if c.args]
-        assert msg.STARTUP_FAILED.format(error="out of memory") in notified
-    finally:
-        set_services(None)
 
 
 async def test_marshal_skips_the_ui_hop_once_the_app_is_tearing_down():
@@ -371,80 +270,6 @@ async def test_first_run_hands_over_when_setup_is_required(tmp_path, monkeypatch
     revealed.assert_called_once_with()
 
 
-async def test_gate_holds_while_a_warm_is_pending_but_unreported(monkeypatch):
-    """Regression: the fleet spawns for seconds before the tracker stamps a phase.
-
-    Releasing on "warm_progress() is None" dropped the user into chat while
-    llama-server had not been launched, which is the bug this screen exists for.
-    """
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-    from lilbee.core.config import cfg
-
-    gate, app = _gate_with_app()
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
-    monkeypatch.setattr(cfg, "worker_pool_eager_start", True)
-    monkeypatch.setattr(gate_mod, "_POLL_INTERVAL_S", 0.0)
-    monkeypatch.setattr(gate_mod, "_WARM_START_GRACE_S", 0.0)
-
-    provider = mock.MagicMock()
-    provider.warm_progress.return_value = None
-    # Pending for the first polls, then the role comes up ready.
-    provider.warm_pending.side_effect = [True] * 5 + [False]
-    provider.role_ready.side_effect = [False] * 5 + [True]
-
-    services = mock.MagicMock()
-    services.provider = provider
-    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
-    set_services(services)
-    try:
-        with (
-            mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-            mock.patch.object(StartupGate, "query_one"),
-            mock.patch.object(StartupGate, "_stopping", return_value=False),
-        ):
-            StartupGate._boot_worker.__wrapped__(gate)
-    finally:
-        set_services(None)
-
-    # A zero grace would have released on the first poll had warm_pending been ignored.
-    assert provider.warm_pending.call_count >= 5
-    app.reveal_chat.assert_called_once_with()
-
-
-async def test_gate_releases_when_no_warm_is_pending_and_none_reported(monkeypatch):
-    """A remote or uninstalled chat model never warms, so the gate must step aside."""
-    from lilbee.cli.tui.screens import startup_gate as gate_mod
-    from lilbee.cli.tui.screens.startup_gate import StartupGate
-    from lilbee.core.config import cfg
-
-    gate, app = _gate_with_app()
-    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
-    monkeypatch.setattr(cfg, "worker_pool_eager_start", True)
-    monkeypatch.setattr(gate_mod, "_POLL_INTERVAL_S", 0.0)
-    monkeypatch.setattr(gate_mod, "_WARM_START_GRACE_S", 0.0)
-
-    provider = mock.MagicMock()
-    provider.warm_progress.return_value = None
-    provider.warm_pending.return_value = False
-    provider.role_ready.return_value = False
-
-    services = mock.MagicMock()
-    services.provider = provider
-    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
-    set_services(services)
-    try:
-        with (
-            mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
-            mock.patch.object(StartupGate, "query_one"),
-            mock.patch.object(StartupGate, "_stopping", return_value=False),
-        ):
-            StartupGate._boot_worker.__wrapped__(gate)
-    finally:
-        set_services(None)
-    app.reveal_chat.assert_called_once_with()
-
-
 async def test_gate_composes_and_styles_its_widgets(monkeypatch):
     """Render the gate for real: a bad CSS selector must fail here, not at launch.
 
@@ -477,7 +302,7 @@ async def test_gate_composes_and_styles_its_widgets(monkeypatch):
         status = gate.query_one("#gate-status", Static)
         logo = gate.query_one("#gate-logo", Static)
 
-        assert bar.show_percentage is False  # no placeholder before a byte signal
+        assert bar.show_percentage is False  # the build has no byte signal to fake
         assert msg.STARTUP_PREPARING in str(status.render())
         assert logo.styles.color.hex.lower() == _xterm_to_hex(AMBER_BRIGHT_XTERM)
         assert gate_mod._LOGO.splitlines()[1].strip().startswith("@@@")
@@ -486,8 +311,8 @@ async def test_gate_composes_and_styles_its_widgets(monkeypatch):
 async def test_gate_does_not_steal_a_screen_pushed_over_it(monkeypatch):
     """Regression: reveal_chat switches the *current* screen, whichever it is.
 
-    A slow warm let another screen open above the gate; when the warm finished the
-    gate replaced that screen instead of itself, throwing the user out of it.
+    A slow build let another screen open above the gate; when the build finished
+    the gate replaced that screen instead of itself, throwing the user out of it.
     """
     from textual.app import ComposeResult
     from textual.screen import Screen
@@ -525,7 +350,7 @@ async def test_gate_hands_over_when_it_still_owns_the_screen():
     app.reveal_chat.assert_called_once_with()
 
 
-async def test_ready_fleet_defers_the_handover_off_on_mount(monkeypatch):
+async def test_built_services_defer_the_handover_off_on_mount(monkeypatch):
     """Regression: switching screens inside on_mount stalled Textual.
 
     start_boot runs at the tail of LilbeeApp.on_mount. Calling reveal_chat straight
@@ -535,7 +360,7 @@ async def test_ready_fleet_defers_the_handover_off_on_mount(monkeypatch):
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
     gate = StartupGate()
-    monkeypatch.setattr(gate_mod, "chat_engine_ready", lambda: True)
+    monkeypatch.setattr(gate_mod, "peek_services", lambda: mock.MagicMock())
 
     deferred: list = []
     released: list = []
@@ -548,33 +373,20 @@ async def test_ready_fleet_defers_the_handover_off_on_mount(monkeypatch):
     assert deferred == [gate._release]
 
 
-async def test_gate_tip_points_at_the_warm_setting_only_when_off(monkeypatch):
-    """The tip renders during a cold load and disappears once warm is enabled."""
-    from textual.app import App, ComposeResult
-    from textual.widgets import Static
-
+async def test_start_boot_builds_services_when_none_exist(monkeypatch):
+    """Without a container the gate takes the worker path, not the fast path."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
     from lilbee.cli.tui.screens.startup_gate import StartupGate
-    from lilbee.core.config import cfg
 
-    monkeypatch.setattr(StartupGate, "start_boot", lambda self: None)
+    gate = StartupGate()
+    monkeypatch.setattr(gate_mod, "peek_services", lambda: None)
 
-    class _Host(App[None]):
-        def compose(self) -> ComposeResult:
-            yield Static("host")
+    worker_calls: list = []
+    deferred: list = []
+    monkeypatch.setattr(gate, "_boot_worker", lambda: worker_calls.append(True), raising=False)
+    monkeypatch.setattr(gate, "call_after_refresh", deferred.append, raising=False)
 
-        def on_mount(self) -> None:
-            self.push_screen(StartupGate())
+    gate.start_boot()
 
-    monkeypatch.setattr(cfg, "keep_engine_warm", False)
-    app = _Host()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        tip = app.screen.query_one("#gate-tip", Static)
-        assert msg.STARTUP_WARM_TIP in str(tip.render())
-
-    monkeypatch.setattr(cfg, "keep_engine_warm", True)
-    app = _Host()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        tip = app.screen.query_one("#gate-tip", Static)
-        assert msg.STARTUP_WARM_TIP not in str(tip.render())
+    assert worker_calls == [True]
+    assert deferred == []

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -60,15 +60,32 @@ def _xterm_to_hex(index: int) -> str:
     return f"#{red:02x}{green:02x}{blue:02x}"
 
 
-def test_gate_logo_colour_matches_the_shared_bright_amber():
-    """The stylesheet's hex must stay in step with the palette the splash uses."""
+def _gate_stylesheet() -> str:
     import pathlib
 
-    from lilbee.runtime.bee_logo import AMBER_BRIGHT_XTERM
+    return (
+        pathlib.Path(__file__).resolve().parents[1] / "src/lilbee/cli/tui/screens/startup_gate.tcss"
+    ).read_text()
 
-    tcss = pathlib.Path("src/lilbee/cli/tui/screens/startup_gate.tcss")
-    stylesheet = (pathlib.Path(__file__).resolve().parents[1] / tcss).read_text()
-    assert _xterm_to_hex(AMBER_BRIGHT_XTERM) in stylesheet
+
+def test_gate_colours_match_the_shared_amber_palette():
+    """Every hex in the stylesheet must be an xterm index from runtime/bee_logo."""
+    from lilbee.runtime.bee_logo import AMBER_BRIGHT_XTERM, AMBER_DIM_XTERM, AMBER_MID_XTERM
+
+    stylesheet = _gate_stylesheet()
+    for index in (AMBER_BRIGHT_XTERM, AMBER_MID_XTERM, AMBER_DIM_XTERM):
+        assert _xterm_to_hex(index) in stylesheet, f"xterm {index} missing from the gate CSS"
+
+
+def test_gate_stylesheet_has_no_colour_outside_the_palette():
+    """A hand-picked hex would drift from the bootstrap and the splash."""
+    import re
+
+    from lilbee.runtime.bee_logo import AMBER_BRIGHT_XTERM, AMBER_DIM_XTERM, AMBER_MID_XTERM
+
+    allowed = {_xterm_to_hex(i) for i in (AMBER_BRIGHT_XTERM, AMBER_MID_XTERM, AMBER_DIM_XTERM)}
+    found = set(re.findall(r"#[0-9a-fA-F]{6}", _gate_stylesheet()))
+    assert found <= allowed, f"colours outside the palette: {sorted(found - allowed)}"
 
 
 def _snapshot(phase: WarmPhase, **kwargs) -> WarmProgress:
@@ -422,3 +439,41 @@ async def test_gate_releases_when_no_warm_is_pending_and_none_reported(monkeypat
     finally:
         set_services(None)
     app.reveal_chat.assert_called_once_with()
+
+
+async def test_gate_composes_and_styles_its_widgets(monkeypatch):
+    """Render the gate for real: a bad CSS selector must fail here, not at launch.
+
+    Every other gate test stubs query_one, so nothing else parses the stylesheet
+    or mounts the ProgressBar's component classes.
+    """
+    from textual.app import App, ComposeResult
+    from textual.widgets import ProgressBar, Static
+
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+    from lilbee.runtime.bee_logo import AMBER_BRIGHT_XTERM
+
+    monkeypatch.setattr(StartupGate, "start_boot", lambda self: None)
+
+    class _Host(App[None]):
+        def compose(self) -> ComposeResult:
+            yield Static("host")
+
+        def on_mount(self) -> None:
+            self.push_screen(StartupGate())
+
+    app = _Host()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        gate = app.screen
+        assert isinstance(gate, StartupGate)
+
+        bar = gate.query_one("#gate-bar", ProgressBar)
+        status = gate.query_one("#gate-status", Static)
+        logo = gate.query_one("#gate-logo", Static)
+
+        assert bar.show_percentage is False  # no placeholder before a byte signal
+        assert msg.STARTUP_PREPARING in str(status.render())
+        assert logo.styles.color.hex.lower() == _xterm_to_hex(AMBER_BRIGHT_XTERM)
+        assert gate_mod._LOGO.splitlines()[1].strip().startswith("@@@")

--- a/tests/test_startup_gate.py
+++ b/tests/test_startup_gate.py
@@ -130,6 +130,7 @@ async def test_gate_releases_when_nothing_is_warming(monkeypatch):
     provider = mock.MagicMock()
     provider.role_ready.return_value = False
     provider.warm_progress.return_value = None
+    provider.warm_pending.return_value = False
     services = mock.MagicMock()
     services.provider = provider
     set_services(services)
@@ -347,3 +348,77 @@ async def test_first_run_hands_over_when_setup_is_required(tmp_path, monkeypatch
             await asyncio.sleep(0.02)
 
     revealed.assert_called_once_with()
+
+
+async def test_gate_holds_while_a_warm_is_pending_but_unreported(monkeypatch):
+    """Regression: the fleet spawns for seconds before the tracker stamps a phase.
+
+    Releasing on "warm_progress() is None" dropped the user into chat while
+    llama-server had not been launched, which is the bug this screen exists for.
+    """
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+    from lilbee.core.config import cfg
+
+    gate, app = _gate_with_app()
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
+    monkeypatch.setattr(cfg, "worker_pool_eager_start", True)
+    monkeypatch.setattr(gate_mod, "_POLL_INTERVAL_S", 0.0)
+    monkeypatch.setattr(gate_mod, "_WARM_START_GRACE_S", 0.0)
+
+    provider = mock.MagicMock()
+    provider.warm_progress.return_value = None
+    # Pending for the first polls, then the role comes up ready.
+    provider.warm_pending.side_effect = [True] * 5 + [False]
+    provider.role_ready.side_effect = [False] * 5 + [True]
+
+    services = mock.MagicMock()
+    services.provider = provider
+    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
+    set_services(services)
+    try:
+        with (
+            mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+            mock.patch.object(StartupGate, "query_one"),
+            mock.patch.object(StartupGate, "_stopping", return_value=False),
+        ):
+            StartupGate._boot_worker.__wrapped__(gate)
+    finally:
+        set_services(None)
+
+    # A zero grace would have released on the first poll had warm_pending been ignored.
+    assert provider.warm_pending.call_count >= 5
+    app.reveal_chat.assert_called_once_with()
+
+
+async def test_gate_releases_when_no_warm_is_pending_and_none_reported(monkeypatch):
+    """A remote or uninstalled chat model never warms, so the gate must step aside."""
+    from lilbee.cli.tui.screens import startup_gate as gate_mod
+    from lilbee.cli.tui.screens.startup_gate import StartupGate
+    from lilbee.core.config import cfg
+
+    gate, app = _gate_with_app()
+    monkeypatch.setattr(gate_mod, "needs_setup", lambda: False)
+    monkeypatch.setattr(cfg, "worker_pool_eager_start", True)
+    monkeypatch.setattr(gate_mod, "_POLL_INTERVAL_S", 0.0)
+    monkeypatch.setattr(gate_mod, "_WARM_START_GRACE_S", 0.0)
+
+    provider = mock.MagicMock()
+    provider.warm_progress.return_value = None
+    provider.warm_pending.return_value = False
+    provider.role_ready.return_value = False
+
+    services = mock.MagicMock()
+    services.provider = provider
+    monkeypatch.setattr(gate_mod, "get_services", lambda: services)
+    set_services(services)
+    try:
+        with (
+            mock.patch.object(type(gate), "app", new=mock.PropertyMock(return_value=app)),
+            mock.patch.object(StartupGate, "query_one"),
+            mock.patch.object(StartupGate, "_stopping", return_value=False),
+        ):
+            StartupGate._boot_worker.__wrapped__(gate)
+    finally:
+        set_services(None)
+    app.reveal_chat.assert_called_once_with()

--- a/tests/test_tab_navigation.py
+++ b/tests/test_tab_navigation.py
@@ -64,7 +64,7 @@ def _mock_services() -> Any:
 def _patch_chat_setup() -> Any:
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
+            "lilbee.cli.tui.screens.chat.needs_setup",
             return_value=False,
         ),
         mock.patch(

--- a/tests/test_tab_navigation.py
+++ b/tests/test_tab_navigation.py
@@ -24,6 +24,14 @@ import pytest
 from conftest import TEST_EMBED_REF, TEST_LOCAL_REF
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.core.config import cfg
+from tests._lilbee_app_test_host import ready_services as _ready_services
+
+
+@pytest.fixture(autouse=True)
+def _gate_releases_at_once():
+    """Bind a ready chat role so the startup gate hands over on mount."""
+    with _ready_services():
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_tab_navigation.py
+++ b/tests/test_tab_navigation.py
@@ -147,6 +147,7 @@ async def test_chat_input_tab_inserts_literal_tab() -> None:
         assert app.focused is inp, "Focus moved away from chat input on Tab"
 
 
+@pytest.mark.timeout(120)
 async def test_settings_tab_chain_visits_group_tabs_widget() -> None:
     """Tab from SettingsScreen visits the group Tabs strip."""
     app = LilbeeApp()

--- a/tests/test_tab_navigation.py
+++ b/tests/test_tab_navigation.py
@@ -24,6 +24,7 @@ import pytest
 from conftest import TEST_EMBED_REF, TEST_LOCAL_REF
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.core.config import cfg
+from tests._lilbee_app_test_host import await_chat
 from tests._lilbee_app_test_host import ready_services as _ready_services
 
 
@@ -117,10 +118,15 @@ async def test_chat_tab_chain_includes_view_tabs() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(160, 48)) as pilot:
-        await pilot.pause(0.2)
+        await await_chat(app, pilot)
         view_tabs = app.screen.query_one(ViewTabs)
-        view_tabs.query_one("#view-tab-chat").focus()
-        await pilot.pause()
+        # Chat's auto-focus lands on the input around the handover; pin the
+        # walk's starting point or Tab becomes a literal character immediately.
+        for _ in range(20):
+            view_tabs.query_one("#view-tab-chat").focus()
+            await pilot.pause()
+            if app.focused is not None and app.focused.id == "view-tab-chat":
+                break
         chain = await _walk_tab_chain(app, pilot, max_presses=40)
         for view in ("view-tab-chat", "view-tab-catalog", "view-tab-settings"):
             assert view in chain, f"Tab walk missed {view}: {chain}"
@@ -136,6 +142,7 @@ async def test_chat_input_tab_inserts_literal_tab() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(160, 48)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause(0.2)
         inp = app.screen.query_one("#chat-input", ChatInput)
         inp.focus()
@@ -152,6 +159,7 @@ async def test_settings_tab_chain_visits_group_tabs_widget() -> None:
     """Tab from SettingsScreen visits the group Tabs strip."""
     app = LilbeeApp()
     async with app.run_test(size=(160, 48)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Settings")
         await pilot.pause(0.2)
@@ -169,6 +177,7 @@ async def test_settings_tab_rolls_over_to_next_pane() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(160, 48)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Settings")
         await pilot.pause(0.2)
@@ -205,6 +214,7 @@ async def test_settings_tab_advances_within_pane() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(160, 48)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Settings")
         await pilot.pause(0.2)
@@ -241,6 +251,7 @@ async def test_catalog_tab_chain_visits_search() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(160, 48)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Catalog")
         await pilot.pause(0.3)

--- a/tests/test_task_bar_per_screen.py
+++ b/tests/test_task_bar_per_screen.py
@@ -53,7 +53,7 @@ def _mock_services():
 @pytest.fixture(autouse=True)
 def _patch_chat_setup():
     with (
-        patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
         patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,

--- a/tests/test_task_bar_per_screen.py
+++ b/tests/test_task_bar_per_screen.py
@@ -19,7 +19,7 @@ from lilbee.app.services import set_services
 from lilbee.cli.tui.widgets.task_bar import TaskBar
 from lilbee.cli.tui.widgets.task_bar_controller import TaskBarController
 from lilbee.core.config import cfg
-from tests._lilbee_app_test_host import LilbeeAppHost
+from tests._lilbee_app_test_host import LilbeeAppHost, await_chat
 
 
 @pytest.fixture(autouse=True)
@@ -212,6 +212,7 @@ async def test_action_open_tasks_switches_to_task_center() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.action_open_tasks()
         await pilot.pause()

--- a/tests/test_task_center_polling.py
+++ b/tests/test_task_center_polling.py
@@ -12,15 +12,15 @@ from unittest.mock import patch
 
 import pytest
 
-from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.screens.task_center import TaskCenter
 from lilbee.cli.tui.task_queue import TaskType
 from lilbee.cli.tui.widgets.task_row import TaskRow
+from tests._lilbee_app_test_host import LilbeeAppHost
 
 
 @pytest.mark.asyncio
 async def test_poll_mounts_new_row_for_enqueued_task() -> None:
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -40,7 +40,7 @@ async def test_poll_mounts_new_row_for_enqueued_task() -> None:
 
 @pytest.mark.asyncio
 async def test_poll_updates_existing_row() -> None:
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -64,7 +64,7 @@ async def test_poll_updates_existing_row() -> None:
 
 @pytest.mark.asyncio
 async def test_poll_removes_rows_for_removed_tasks() -> None:
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -87,7 +87,7 @@ async def test_poll_removes_rows_for_removed_tasks() -> None:
 
 @pytest.mark.asyncio
 async def test_poll_updates_counts_strip() -> None:
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -112,7 +112,7 @@ async def test_poll_updates_counts_strip() -> None:
 @pytest.mark.asyncio
 async def test_poll_counts_strip_has_no_spinner_when_idle() -> None:
     """bb-18y3: spinner only shows while tasks are active, not when idle."""
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -130,7 +130,7 @@ async def test_poll_counts_strip_has_no_spinner_when_idle() -> None:
 @pytest.mark.asyncio
 async def test_action_cancel_hits_active_when_no_focus() -> None:
     """``c`` with no row focused cancels the first active task."""
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -148,7 +148,7 @@ async def test_action_cancel_hits_active_when_no_focus() -> None:
 @pytest.mark.asyncio
 async def test_clear_history_action_drops_finished_rows() -> None:
     """Shift+C clears DONE/FAILED/CANCELLED rows and leaves active ones alone."""
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -177,7 +177,7 @@ async def test_empty_state_visibility_follows_queue() -> None:
     """
     from textual.containers import VerticalScroll
 
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -204,7 +204,7 @@ async def test_empty_state_visibility_follows_queue() -> None:
 
 @pytest.mark.asyncio
 async def test_refresh_action_is_safe_on_empty_queue() -> None:
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -216,7 +216,7 @@ async def test_refresh_action_is_safe_on_empty_queue() -> None:
 
 @pytest.mark.asyncio
 async def test_cursor_actions_move_focus() -> None:
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -230,25 +230,38 @@ async def test_cursor_actions_move_focus() -> None:
 
 @pytest.mark.asyncio
 async def test_go_back_switches_to_chat_on_lilbee_app() -> None:
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        app.push_screen(TaskCenter())
-        await pilot.pause()
-        screen = app.screen
-        assert isinstance(screen, TaskCenter)
-        screen.action_go_back()
-        for _ in range(5):
+    """go-back returns to chat, so this one needs the real app with a chat screen.
+
+    ready_services + needs_setup=False make the startup gate hand over to chat
+    deterministically, without the setup wizard racing the pushed TaskCenter.
+    """
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.chat import ChatScreen
+    from tests._lilbee_app_test_host import await_chat, ready_services
+
+    with (
+        ready_services(),
+        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
+    ):
+        app = LilbeeApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
+            app.push_screen(TaskCenter())
             await pilot.pause()
-            if not isinstance(app.screen, TaskCenter):
-                break
-        assert not isinstance(app.screen, TaskCenter)
+            screen = app.screen
+            assert isinstance(screen, TaskCenter)
+            screen.action_go_back()
+            for _ in range(5):
+                await pilot.pause()
+                if isinstance(app.screen, ChatScreen):
+                    break
+            assert isinstance(app.screen, ChatScreen)
 
 
 @pytest.mark.asyncio
 async def test_action_cancel_task_uses_focused_task_row() -> None:
     """``c`` with a TaskRow focused cancels that specific task."""
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -274,7 +287,7 @@ async def test_action_cancel_task_uses_focused_task_row() -> None:
 async def test_initial_focus_lands_on_first_active_row() -> None:
     """entering Task Center focuses the first active/queued row,
     not whatever DONE row happens to be at position 0."""
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         done_id = app.task_bar.queue.enqueue(lambda: None, "old", TaskType.SYNC.value)
@@ -303,7 +316,7 @@ async def test_initial_focus_lands_on_first_active_row() -> None:
 async def test_initial_focus_prefers_queued_when_no_active() -> None:
     """if the only live row is QUEUED, focus lands there instead
     of on a DONE history row."""
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         done_id = app.task_bar.queue.enqueue(lambda: None, "old", TaskType.SYNC.value)
@@ -327,7 +340,7 @@ async def test_initial_focus_prefers_queued_when_no_active() -> None:
 async def test_initial_focus_noop_when_no_tasks() -> None:
     """with an empty queue there is no row to focus -- the
     on_mount focus step must not raise."""
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())
@@ -343,7 +356,7 @@ async def test_initial_focus_falls_back_when_only_history_present() -> None:
     """no active/queued work means _focus_initial_row is a no-op
     and AUTO_FOCUS's row-1 landing (a history row) still holds. The
     cancel action is a no-op on that focused terminal row."""
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         done_id = app.task_bar.queue.enqueue(lambda: None, "old", TaskType.SYNC.value)
@@ -369,7 +382,7 @@ async def test_initial_focus_falls_back_when_only_history_present() -> None:
 @pytest.mark.asyncio
 async def test_poll_swallows_row_remove_exception() -> None:
     """If a row's ``remove`` raises during reconciliation, the poll survives."""
-    app = LilbeeApp()
+    app = LilbeeAppHost()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         app.push_screen(TaskCenter())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -17,6 +17,14 @@ from lilbee.catalog import CatalogResult
 from lilbee.cli.tui.screens.catalog_utils import catalog_to_row, remote_to_row
 from lilbee.cli.tui.widgets.message import AssistantMessage, UserMessage
 from lilbee.core.config import cfg
+from tests._lilbee_app_test_host import ready_services as _ready_services
+
+
+@pytest.fixture(autouse=True)
+def _gate_releases_at_once():
+    """Bind a ready chat role so the startup gate hands over on mount."""
+    with _ready_services():
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -35,7 +43,7 @@ def _isolated_cfg(tmp_path):
 def _patch_chat_setup():
     """Patch out embedding model checks and model scanning so ChatScreen mounts cleanly."""
     with (
-        mock.patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
         mock.patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -74,6 +74,22 @@ class TestRunTui:
             run_tui(initial_view="Catalog")
         init.assert_called_once_with(initial_view="Catalog")
 
+    @mock.patch("lilbee.cli.tui.app.LilbeeApp.run")
+    def test_run_tui_dismisses_the_splash_before_textual_starts(
+        self, mock_run: mock.MagicMock
+    ) -> None:
+        """The launcher's splash animates until here; a frame written after
+        Textual claims the terminal would land on the alt-screen."""
+        from lilbee.cli.tui import run_tui
+
+        order: list[str] = []
+        mock_run.side_effect = lambda: order.append("run")
+        with mock.patch(
+            "lilbee.runtime.splash.dismiss", side_effect=lambda: order.append("dismiss")
+        ):
+            run_tui()
+        assert order == ["dismiss", "run"]
+
     @pytest.mark.asyncio
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
     async def test_initial_view_switches_to_catalog(self, mock_catalog: mock.MagicMock) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -17,6 +17,7 @@ from lilbee.catalog import CatalogResult
 from lilbee.cli.tui.screens.catalog_utils import catalog_to_row, remote_to_row
 from lilbee.cli.tui.widgets.message import AssistantMessage, UserMessage
 from lilbee.core.config import cfg
+from tests._lilbee_app_test_host import await_chat
 from tests._lilbee_app_test_host import ready_services as _ready_services
 
 
@@ -215,6 +216,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             assert app.title.startswith("lilbee")
 
@@ -225,6 +227,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             await pilot.pause()
             inp = app.screen.query_one("#chat-input")
@@ -237,6 +240,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             with mock.patch.object(app, "exit") as mock_exit:
                 await pilot.press("ctrl+q")
                 await pilot.pause()
@@ -249,6 +253,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             # Escape out of the chat Input so ? routes to the binding instead
             # of being typed as a character.
@@ -266,6 +271,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Catalog")
             await pilot.pause()
@@ -278,6 +284,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             inp = app.screen.query_one("#chat-input")
             inp.value = "/help"
@@ -292,6 +299,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             inp = app.screen.query_one("#chat-input")
             inp.value = "/badcommand"
@@ -314,6 +322,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             inp = app.screen.query_one("#chat-input")
             new_ref = "ollama/new-model:latest"
@@ -330,6 +339,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             inp = app.screen.query_one("#chat-input")
             inp.value = "/set top_k 10"
@@ -344,6 +354,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             inp = app.screen.query_one("#chat-input")
             inp.value = "/set nonexistent 42"
@@ -360,6 +371,7 @@ class TestChatScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             inp = app.screen.query_one("#chat-input")
             inp.value = ""
@@ -378,6 +390,7 @@ class TestCatalogScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.push_screen(CatalogScreen())
             await pilot.pause()
@@ -393,6 +406,7 @@ class TestCatalogScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             catalog = CatalogScreen()
             app.push_screen(catalog)
@@ -416,6 +430,7 @@ class TestCatalogScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             catalog = CatalogScreen()
             app.push_screen(catalog)
@@ -445,6 +460,7 @@ class TestCatalogScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             catalog = CatalogScreen()
             app.push_screen(catalog)
@@ -469,6 +485,7 @@ class TestCatalogScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             catalog = CatalogScreen()
             app.push_screen(catalog)
@@ -498,6 +515,7 @@ class TestSettingsScreenAsync:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.push_screen(SettingsScreen())
             await pilot.pause()
@@ -522,6 +540,7 @@ class TestStatusScreenAsync:
         try:
             app = LilbeeApp()
             async with app.run_test() as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.push_screen(StatusScreen())
                 await pilot.pause()
@@ -585,6 +604,7 @@ class TestThemes:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             before = app.theme
             app.action_cycle_theme()
@@ -597,6 +617,7 @@ class TestThemes:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.set_theme("dracula")
             assert app.theme == "dracula"
@@ -614,6 +635,7 @@ class TestThemes:
         mock_catalog.return_value = _EMPTY_CATALOG
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             with pytest.raises(SkipAction):
                 app.action_dismiss_help_if_open()
@@ -628,6 +650,7 @@ class TestThemes:
         mock_catalog.return_value = _EMPTY_CATALOG
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.action_show_help_panel()
             await pilot.pause()
@@ -649,6 +672,7 @@ class TestThemes:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             target = "dracula" if app.theme != "dracula" else "gruvbox"
             app.set_setting("theme", target)
@@ -667,6 +691,7 @@ class TestThemes:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             with (
                 mock.patch("lilbee.app.settings.persistent_settings.update_values") as mock_update,
@@ -687,6 +712,7 @@ class TestThemes:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             with mock.patch("lilbee.app.settings.persistent_settings.update_values") as mock_update:
                 app.set_setting("crawl_exclude_patterns", ["foo", "bar"])
@@ -701,6 +727,7 @@ class TestThemes:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             original = app.theme
             app.set_theme("nonexistent_theme_xyz")
@@ -753,6 +780,7 @@ class TestSetupWizard:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             await app.push_screen(SetupWizard())
             await pilot.pause()
@@ -776,6 +804,7 @@ class TestSetupWizard:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             wizard = SetupWizard()
             await app.push_screen(wizard)
@@ -866,6 +895,7 @@ class TestContextAwareQuit:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             task_bar = app.task_bar
             task_bar.add_task("Test download", "download")
@@ -883,6 +913,7 @@ class TestContextAwareQuit:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             screen = app.screen
             screen.streaming = True
@@ -899,6 +930,7 @@ class TestContextAwareQuit:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             await app.action_quit()
             await pilot.pause()
@@ -1079,6 +1111,7 @@ class TestLoginCommand:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             inp = app.screen.query_one("#chat-input")
             inp.value = "/login"
@@ -1100,6 +1133,7 @@ class TestAppSignals:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             assert hasattr(app, "settings_changed_signal")
 
@@ -1115,6 +1149,7 @@ class TestAppSignals:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             received: list[tuple[str, object]] = []
             app.settings_changed_signal.subscribe(app, lambda val: received.append(val))
@@ -1138,6 +1173,7 @@ class TestSyncHint:
         ):
             app = LilbeeApp()
             async with app.run_test() as pilot:
+                await await_chat(app, pilot)
                 # detect runs on a daemon thread; pause until the count lands.
                 for _ in range(50):
                     if app.task_bar.pending_sync_count == 3:
@@ -1156,6 +1192,7 @@ class TestSyncHint:
         with mock.patch("lilbee.data.ingest.detect_pending", return_value=0):
             app = LilbeeApp()
             async with app.run_test() as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 bar = app.screen.query_one(TaskBar)
                 bar._refresh_display()
@@ -1174,6 +1211,7 @@ class TestSyncHint:
         with mock.patch("lilbee.data.ingest.detect_pending", return_value=0):
             app = LilbeeApp()
             async with app.run_test() as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.task_bar.set_pending_sync(3)
                 bar = app.screen.query_one(TaskBar)
@@ -1201,6 +1239,7 @@ class TestSyncHint:
         ):
             app = LilbeeApp()
             async with app.run_test() as pilot:
+                await await_chat(app, pilot)
                 # Wait until detection has populated the count.
                 for _ in range(50):
                     if app.task_bar.pending_sync_count == 2:
@@ -1221,6 +1260,7 @@ class TestSyncHint:
         with mock.patch("lilbee.data.ingest.detect_pending", return_value=0):
             app = LilbeeApp()
             async with app.run_test() as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 with mock.patch.object(app.task_bar, "start_detect_pending") as start:
                     app.screen._on_setup_complete("done")
@@ -1248,11 +1288,14 @@ class TestSyncHint:
                         break
                     await pilot.pause()
                 assert app.active_view == "Catalog"
+                import asyncio
+                import time
+
                 app.action_run_sync()
-                for _ in range(50):
-                    if run_sync.called:
-                        break
+                deadline = time.monotonic() + 20
+                while time.monotonic() < deadline and not run_sync.called:
                     await pilot.pause()
+                    await asyncio.sleep(0.02)
                 run_sync.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1293,6 +1336,7 @@ class TestSyncHint:
         ):
             app = LilbeeApp()
             async with app.run_test() as pilot:
+                await await_chat(app, pilot)
                 for _ in range(50):
                     if app.task_bar.pending_sync_count == 4:
                         break
@@ -1359,3 +1403,48 @@ class TestChatImportWorker:
         ):
             LilbeeApp._chat_import_worker.__wrapped__(app, gate)
         assert installed == [gate]
+
+
+class TestLoadChatScreen:
+    def test_already_imported_chat_installs_synchronously(self) -> None:
+        """With chat's modules warm the worker hop would only delay the handover."""
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp.__new__(LilbeeApp)
+        gate = mock.MagicMock()
+        with (
+            mock.patch.object(LilbeeApp, "_install_chat_screen") as install,
+            mock.patch.object(LilbeeApp, "_chat_import_worker") as worker,
+        ):
+            app._load_chat_screen(gate)
+        install.assert_called_once_with(gate)
+        worker.assert_not_called()
+
+    def test_cold_import_goes_through_the_worker(self, monkeypatch) -> None:
+        """A cold disk pays seconds for chat's module graph; keep it off the loop."""
+        import sys as real_sys
+
+        from lilbee.cli.tui import app as app_mod
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp.__new__(LilbeeApp)
+        gate = mock.MagicMock()
+        pruned = {k: v for k, v in real_sys.modules.items() if k != "lilbee.cli.tui.screens.chat"}
+        with (
+            mock.patch.object(app_mod.sys, "modules", pruned),
+            mock.patch.object(LilbeeApp, "_install_chat_screen") as install,
+            mock.patch.object(LilbeeApp, "_chat_import_worker") as worker,
+        ):
+            app._load_chat_screen(gate)
+        worker.assert_called_once_with(gate)
+        install.assert_not_called()
+
+
+def test_import_chat_stack_pulls_the_module_in() -> None:
+    """The seam the cold-start worker wraps really imports the chat module."""
+    import sys
+
+    from lilbee.cli.tui.app import _import_chat_stack
+
+    _import_chat_stack()
+    assert "lilbee.cli.tui.screens.chat" in sys.modules

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1448,3 +1448,31 @@ def test_import_chat_stack_pulls_the_module_in() -> None:
 
     _import_chat_stack()
     assert "lilbee.cli.tui.screens.chat" in sys.modules
+
+
+class TestRunSyncRetry:
+    def test_run_sync_retries_until_the_switch_lands_and_gives_up_cleanly(self) -> None:
+        """The view switch is deferred; a single early check silently dropped
+        the sync. The retry keeps polling and stops after the budget."""
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp.__new__(LilbeeApp)
+        chat = mock.MagicMock()
+        timers: list = []
+        laters: list = []
+        with (
+            mock.patch.object(LilbeeApp, "screen", new=mock.PropertyMock(return_value=object())),
+            mock.patch.object(LilbeeApp, "get_screen", return_value=chat),
+            mock.patch.object(LilbeeApp, "switch_view"),
+            mock.patch.object(LilbeeApp, "call_later", side_effect=lambda fn: laters.append(fn)),
+            mock.patch.object(LilbeeApp, "set_timer", side_effect=lambda _d, fn: timers.append(fn)),
+        ):
+            app.action_run_sync()
+            start = laters[0]
+            start(attempts=2)  # screen never becomes chat: schedules a retry
+            assert len(timers) == 1
+            timers[0]()  # attempts=1: schedules once more
+            assert len(timers) == 2
+            timers[1]()  # attempts=0: gives up without scheduling
+            assert len(timers) == 2
+        chat._run_sync.assert_not_called()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -83,7 +83,12 @@ class TestRunTui:
 
         app = LilbeeApp(initial_view="Catalog")
         async with app.run_test() as pilot:
-            await pilot.pause()
+            # The chat install and the initial-view switch land after the gate's
+            # first frame; poll them in rather than assuming one pause.
+            for _ in range(200):
+                if app.active_view == "Catalog":
+                    break
+                await pilot.pause()
             assert app.active_view == "Catalog"
 
 
@@ -1310,7 +1315,13 @@ class TestSyncHint:
         with mock.patch("lilbee.data.ingest.detect_pending", return_value=0):
             app = LilbeeApp(initial_view="Catalog")
             async with app.run_test() as pilot:
-                await pilot.pause()
+                # Let the boot chain finish its own screen switches first: the
+                # KeyError mock below would otherwise sabotage reveal_chat's
+                # switch_screen, which resolves screens through get_screen too.
+                for _ in range(200):
+                    if app.active_view == "Catalog":
+                        break
+                    await pilot.pause()
                 with mock.patch.object(app, "get_screen", side_effect=KeyError("chat")):
                     # Should return without raising or attempting a switch.
                     app.action_run_sync()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1462,28 +1462,53 @@ def test_import_chat_stack_pulls_the_module_in() -> None:
 
 
 class TestRunSyncRetry:
-    def test_run_sync_retries_until_the_switch_lands_and_gives_up_cleanly(self) -> None:
-        """The view switch is deferred; a single early check silently dropped
-        the sync. The retry keeps polling and stops after the budget."""
+    def test_run_sync_retries_the_switch_itself_and_gives_up_cleanly(self) -> None:
+        """switch_view drops requests while its guard is held, so each retry
+        must re-attempt the switch, and the budget bounds the loop."""
         from lilbee.cli.tui.app import LilbeeApp
 
         app = LilbeeApp.__new__(LilbeeApp)
         chat = mock.MagicMock()
         timers: list = []
         laters: list = []
+        switches: list = []
         with (
             mock.patch.object(LilbeeApp, "screen", new=mock.PropertyMock(return_value=object())),
+            mock.patch.object(
+                LilbeeApp, "screen_stack", new=mock.PropertyMock(return_value=[object()])
+            ),
             mock.patch.object(LilbeeApp, "get_screen", return_value=chat),
-            mock.patch.object(LilbeeApp, "switch_view"),
+            mock.patch.object(LilbeeApp, "switch_view", side_effect=switches.append),
             mock.patch.object(LilbeeApp, "call_later", side_effect=lambda fn: laters.append(fn)),
             mock.patch.object(LilbeeApp, "set_timer", side_effect=lambda _d, fn: timers.append(fn)),
         ):
             app.action_run_sync()
             start = laters[0]
-            start(attempts=2)  # screen never becomes chat: schedules a retry
-            assert len(timers) == 1
-            timers[0]()  # attempts=1: schedules once more
-            assert len(timers) == 2
+            start(attempts=2)  # screen never becomes chat: re-switches and retries
+            assert len(timers) == 1 and switches == ["Chat"]
+            timers[0]()  # attempts=1: switches and schedules once more
+            assert len(timers) == 2 and switches == ["Chat", "Chat"]
             timers[1]()  # attempts=0: gives up without scheduling
             assert len(timers) == 2
+        chat._run_sync.assert_not_called()
+
+    def test_run_sync_retry_stops_when_the_app_is_tearing_down(self) -> None:
+        """A pending retry firing after the screens are gone must do nothing."""
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp.__new__(LilbeeApp)
+        chat = mock.MagicMock()
+        laters: list = []
+        with (
+            mock.patch.object(LilbeeApp, "screen_stack", new=mock.PropertyMock(return_value=[])),
+            mock.patch.object(LilbeeApp, "screen", new=mock.PropertyMock(return_value=object())),
+            mock.patch.object(LilbeeApp, "get_screen", return_value=chat),
+            mock.patch.object(LilbeeApp, "switch_view") as switch,
+            mock.patch.object(LilbeeApp, "call_later", side_effect=lambda fn: laters.append(fn)),
+            mock.patch.object(LilbeeApp, "set_timer") as timer,
+        ):
+            app.action_run_sync()
+            laters[0]()  # fires with an empty stack: returns immediately
+        switch.assert_not_called()
+        timer.assert_not_called()
         chat._run_sync.assert_not_called()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1241,7 +1241,12 @@ class TestSyncHint:
         ):
             app = LilbeeApp(initial_view="Catalog")
             async with app.run_test() as pilot:
-                await pilot.pause()
+                # The chat install and the initial-view switch now happen after
+                # the gate's first frame, so poll rather than assume one pause.
+                for _ in range(100):
+                    if app.active_view == "Catalog":
+                        break
+                    await pilot.pause()
                 assert app.active_view == "Catalog"
                 app.action_run_sync()
                 for _ in range(50):
@@ -1312,3 +1317,45 @@ class TestSyncHint:
                     await pilot.pause()
                 assert observed == [0]
                 assert len(start_calls) >= 1
+
+
+class TestChatImportWorker:
+    def test_import_failure_exits_with_the_error(self) -> None:
+        """An unimportable chat stack must exit loudly, not strand the gate."""
+        from lilbee.cli.tui import messages as msg
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp.__new__(LilbeeApp)
+        gate = mock.MagicMock()
+        with (
+            mock.patch("lilbee.cli.tui.app._import_chat_stack", side_effect=ImportError("boom")),
+            mock.patch(
+                "lilbee.cli.tui.app.call_from_thread",
+                side_effect=lambda _node, fn, *a, **k: fn(*a, **k),
+            ),
+            mock.patch.object(LilbeeApp, "exit") as mock_exit,
+        ):
+            LilbeeApp._chat_import_worker.__wrapped__(app, gate)
+        mock_exit.assert_called_once_with(
+            return_code=1, message=msg.CHAT_STACK_FAILED.format(error="boom")
+        )
+
+    def test_successful_import_installs_chat_and_boots(self) -> None:
+        """The worker hands over to the installer once the modules exist."""
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp.__new__(LilbeeApp)
+        gate = mock.MagicMock()
+        installed: list = []
+        with (
+            mock.patch("lilbee.cli.tui.app._import_chat_stack"),
+            mock.patch(
+                "lilbee.cli.tui.app.call_from_thread",
+                side_effect=lambda _node, fn, *a, **k: fn(*a, **k),
+            ),
+            mock.patch.object(
+                LilbeeApp, "_install_chat_screen", side_effect=lambda g: installed.append(g)
+            ),
+        ):
+            LilbeeApp._chat_import_worker.__wrapped__(app, gate)
+        assert installed == [gate]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -74,22 +74,6 @@ class TestRunTui:
             run_tui(initial_view="Catalog")
         init.assert_called_once_with(initial_view="Catalog")
 
-    @mock.patch("lilbee.cli.tui.app.LilbeeApp.run")
-    def test_run_tui_dismisses_the_splash_before_textual_starts(
-        self, mock_run: mock.MagicMock
-    ) -> None:
-        """The launcher's splash animates until here; a frame written after
-        Textual claims the terminal would land on the alt-screen."""
-        from lilbee.cli.tui import run_tui
-
-        order: list[str] = []
-        mock_run.side_effect = lambda: order.append("run")
-        with mock.patch(
-            "lilbee.runtime.splash.dismiss", side_effect=lambda: order.append("dismiss")
-        ):
-            run_tui()
-        assert order == ["dismiss", "run"]
-
     @pytest.mark.asyncio
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
     async def test_initial_view_switches_to_catalog(self, mock_catalog: mock.MagicMock) -> None:

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -21,6 +21,7 @@ from lilbee.cli.tui import messages as msg_module
 from lilbee.cli.tui.widgets.chat_input import ChatInput
 from lilbee.core.config import cfg
 from tests._lilbee_app_test_host import LilbeeAppHost
+from tests._lilbee_app_test_host import await_chat as _await_chat
 
 
 @pytest.fixture(autouse=True)
@@ -37,7 +38,7 @@ def _isolated_cfg(tmp_path):
     cfg.data_dir.mkdir(parents=True, exist_ok=True)
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
     cfg.models_dir.mkdir(parents=True, exist_ok=True)
-    # Simulate "already-initialized" state so ChatScreen._needs_setup()
+    # Simulate "already-initialized" state so needs_setup()
     # doesn't push the SetupWizard during tests that exercise chat.
     cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     yield
@@ -241,7 +242,7 @@ class TestViewTabsPresence:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
+            await _await_chat(app, pilot)
 
             # Chat screen
             bar = app.screen.query_one(ViewTabs)
@@ -2434,7 +2435,7 @@ class TestAppQuit:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
+            await _await_chat(app, pilot)
             app.screen.streaming = True
             with (
                 mock.patch.object(app.screen, "action_cancel_stream") as mock_cancel,
@@ -2606,7 +2607,7 @@ class TestChatSlashCommands:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
+            await _await_chat(app, pilot)
             from lilbee.cli.tui.screens.chat import ChatScreen
 
             screen = app.screen
@@ -2621,7 +2622,7 @@ class TestChatSlashCommands:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
+            await _await_chat(app, pilot)
             from lilbee.cli.tui.screens.chat import ChatScreen
 
             screen = app.screen
@@ -3039,7 +3040,7 @@ class TestQuestionMarkBehavior:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
+            await _await_chat(app, pilot)
             inp = app.screen.query_one("#chat-input", ChatInput)
             inp.focus()
             await pilot.pause()
@@ -3058,7 +3059,7 @@ class TestQuestionMarkBehavior:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
+            await _await_chat(app, pilot)
             inp = app.screen.query_one("#chat-input", ChatInput)
             inp.focus()
             await pilot.pause()
@@ -3257,9 +3258,7 @@ class TestChatEmbeddingReadyCoverage:
         try:
             app = ChatTestApp()
             # Keep the ChatScreen mounted; wizard routing is covered separately.
-            with mock.patch(
-                "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False
-            ):
+            with mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False):
                 async with app.run_test(size=(120, 40)) as pilot:
                     await pilot.pause()
                     screen = app.screen
@@ -3284,9 +3283,7 @@ class TestChatEmbeddingReadyCoverage:
         try:
             app = ChatTestApp()
             # Keep the ChatScreen mounted; wizard routing is covered separately.
-            with mock.patch(
-                "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False
-            ):
+            with mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False):
                 async with app.run_test(size=(120, 40)) as pilot:
                     await pilot.pause()
                     screen = app.screen

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -20,8 +20,7 @@ from lilbee.catalog.types import ModelTask
 from lilbee.cli.tui import messages as msg_module
 from lilbee.cli.tui.widgets.chat_input import ChatInput
 from lilbee.core.config import cfg
-from tests._lilbee_app_test_host import LilbeeAppHost
-from tests._lilbee_app_test_host import await_chat as _await_chat
+from tests._lilbee_app_test_host import LilbeeAppHost, await_chat
 
 
 @pytest.fixture(autouse=True)
@@ -242,7 +241,7 @@ class TestViewTabsPresence:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await _await_chat(app, pilot)
+            await await_chat(app, pilot)
 
             # Chat screen
             bar = app.screen.query_one(ViewTabs)
@@ -290,6 +289,7 @@ class TestViewCycling:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 assert app.active_view == "Chat"
 
@@ -472,6 +472,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 assert app.active_view == "Chat"
 
@@ -495,6 +496,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 # Blur the chat input so the app-level ] binding fires.
                 await pilot.press("escape")
@@ -512,6 +514,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -536,6 +539,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -555,6 +559,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 assert app.active_view == "Chat"
                 # Blur the chat input so the app-level ] binding fires.
@@ -573,6 +578,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 assert app.active_view == "Chat"
                 # Blur the chat input so the app-level [ binding fires.
@@ -599,6 +605,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 sequence = ["Catalog", "Status", "Settings", "Catalog", "Status"]
                 for view in sequence:
@@ -613,6 +620,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 for view in ["Chat", "Catalog", "Status", "Settings", "Tasks"]:
                     app.switch_view(view)
@@ -637,6 +645,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -657,6 +666,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Status")
                 # Two pauses: first lets the screen mount and on_mount run,
@@ -681,6 +691,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Settings")
                 await pilot.pause()
@@ -700,6 +711,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Tasks")
                 await pilot.pause()
@@ -720,6 +732,7 @@ class TestScreenTransitions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 for view in ["Catalog", "Status", "Settings", "Tasks"]:
                     app.switch_view(view)
@@ -740,6 +753,7 @@ class TestScreenTransitions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             initial_theme = app.theme
             await pilot.press("ctrl+t")
@@ -1052,6 +1066,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1072,6 +1087,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1120,6 +1136,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 # ChatScreen auto-focuses the insert-mode input; leave it
                 # before reaching for the screen-level nav keys.
@@ -1158,6 +1175,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1198,6 +1216,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1228,6 +1247,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1253,6 +1273,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1281,6 +1302,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1329,6 +1351,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1372,6 +1395,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1440,6 +1464,7 @@ class TestCatalogInteractions:
         ):
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1480,6 +1505,7 @@ class TestCatalogInteractions:
         ):
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1515,6 +1541,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1540,6 +1567,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1568,6 +1596,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1598,6 +1627,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1641,6 +1671,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1669,6 +1700,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1721,6 +1753,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1766,6 +1799,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1801,6 +1835,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1853,6 +1888,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1878,6 +1914,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1897,6 +1934,7 @@ class TestCatalogInteractions:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -1925,6 +1963,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -1938,6 +1977,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -1961,6 +2001,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 60)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -1981,6 +2022,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 60)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -2000,6 +2042,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 60)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -2027,6 +2070,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 120)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -2053,6 +2097,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -2073,6 +2118,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -2091,6 +2137,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -2110,6 +2157,7 @@ class TestSettingsInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -2130,6 +2178,7 @@ class TestSettingsInteractions:
         received = []
 
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.settings_changed_signal.subscribe(app, lambda data: received.append(data))
             app.switch_view("Settings")
@@ -2160,6 +2209,7 @@ class TestStatusInteractions:
         with _mock_status_deps():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Status")
                 # Two pauses: first lets the screen mount and on_mount run,
@@ -2177,6 +2227,7 @@ class TestStatusInteractions:
         with _mock_status_deps():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Status")
                 # Two pauses: first lets the screen mount and on_mount run,
@@ -2196,6 +2247,7 @@ class TestStatusInteractions:
         with _mock_status_deps():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Status")
                 # Two pauses: first lets the screen mount and on_mount run,
@@ -2214,6 +2266,7 @@ class TestStatusInteractions:
         with _mock_status_deps():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Status")
                 # Two pauses: first lets the screen mount and on_mount run,
@@ -2234,6 +2287,7 @@ class TestStatusInteractions:
         with _mock_status_deps():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Status")
                 # Two pauses: first lets the screen mount and on_mount run,
@@ -2255,6 +2309,7 @@ class TestStatusInteractions:
         with _mock_status_deps():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Status")
                 # Two pauses: first lets the screen mount and on_mount run,
@@ -2287,6 +2342,7 @@ class TestStatusInteractions:
         ):
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Status")
                 # Documents/Architecture/Storage collapsibles mount via
@@ -2316,6 +2372,7 @@ class TestTaskCenterInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.task_bar.add_task("Task 1", "download")
             app.task_bar.add_task("Task 2", "sync")
@@ -2334,6 +2391,7 @@ class TestTaskCenterInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.task_bar.add_task("Cancel Me", "download")
 
@@ -2350,6 +2408,7 @@ class TestTaskCenterInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Tasks")
             await pilot.pause()
@@ -2363,6 +2422,7 @@ class TestTaskCenterInteractions:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Tasks")
             await pilot.pause()
@@ -2409,6 +2469,7 @@ class TestAppQuit:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             with mock.patch.object(app, "exit") as mock_exit:
                 await pilot.press("ctrl+c")
@@ -2421,6 +2482,7 @@ class TestAppQuit:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.task_bar.add_task("Active Task", "download")
             app.task_bar.queue.advance("download")
@@ -2435,7 +2497,7 @@ class TestAppQuit:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await _await_chat(app, pilot)
+            await await_chat(app, pilot)
             app.screen.streaming = True
             with (
                 mock.patch.object(app.screen, "action_cancel_stream") as mock_cancel,
@@ -2607,7 +2669,7 @@ class TestChatSlashCommands:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await _await_chat(app, pilot)
+            await await_chat(app, pilot)
             from lilbee.cli.tui.screens.chat import ChatScreen
 
             screen = app.screen
@@ -2622,7 +2684,7 @@ class TestChatSlashCommands:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await _await_chat(app, pilot)
+            await await_chat(app, pilot)
             from lilbee.cli.tui.screens.chat import ChatScreen
 
             screen = app.screen
@@ -2839,6 +2901,7 @@ class TestCatalogViewToggle:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -2862,6 +2925,7 @@ class TestCatalogViewToggle:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -2894,6 +2958,7 @@ class TestCatalogPickBadge:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()
@@ -2930,6 +2995,7 @@ class TestCatalogAutoLoad:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 for _ in range(20):
@@ -2957,6 +3023,7 @@ class TestCatalogGridFocus:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 for _ in range(20):
@@ -2986,6 +3053,7 @@ class TestCatalogGridFocus:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 for _ in range(20):
@@ -3019,6 +3087,7 @@ class TestGlobalSlashRoutesToChat:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             app.switch_view("Settings")
             await pilot.pause()
@@ -3048,7 +3117,7 @@ class TestQuestionMarkBehavior:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await _await_chat(app, pilot)
+            await await_chat(app, pilot)
             inp = app.screen.query_one("#chat-input", ChatInput)
             inp.focus()
             await pilot.pause()
@@ -3067,7 +3136,7 @@ class TestQuestionMarkBehavior:
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
-            await _await_chat(app, pilot)
+            await await_chat(app, pilot)
             inp = app.screen.query_one("#chat-input", ChatInput)
             inp.focus()
             await pilot.pause()
@@ -3202,6 +3271,7 @@ class TestSetupWizardGrid:
         with _mock_catalog_deps(), _mock_remote_models():
             app = LilbeeApp()
             async with app.run_test(size=(120, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 app.switch_view("Catalog")
                 await pilot.pause()

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2940,7 +2940,15 @@ class TestCatalogAutoLoad:
 
 
 class TestCatalogGridFocus:
-    """Catalog grid Tab/G key behavior (bb-zp4o, bb-8kxf)."""
+    """Catalog grid Tab/G key behavior."""
+
+    @pytest.fixture(autouse=True)
+    def _gate_releases_at_once(self):
+        """Bind a ready chat role so the startup gate hands over on mount."""
+        from tests._lilbee_app_test_host import ready_services
+
+        with ready_services():
+            yield
 
     async def test_grid_focus_auto_highlights_first_card(self, _mock_resolve):
         """A focused ModelGrid must auto-highlight a card so users see Tab feedback."""

--- a/tests/test_tui_fleet_drawer.py
+++ b/tests/test_tui_fleet_drawer.py
@@ -311,7 +311,7 @@ async def test_normal_tab_focuses_drawer_and_enter_toggles(monkeypatch) -> None:
     try:
         cs = "lilbee.cli.tui.screens.chat.ChatScreen"
         with (
-            mock.patch(f"{cs}._needs_setup", return_value=False),
+            mock.patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
             mock.patch(f"{cs}._embedding_ready", return_value=True),
         ):
             app = LilbeeApp()

--- a/tests/test_tui_fleet_drawer.py
+++ b/tests/test_tui_fleet_drawer.py
@@ -6,7 +6,7 @@ import pytest
 from textual.app import ComposeResult
 from textual.widgets import Input
 
-from tests._lilbee_app_test_host import LilbeeAppHost
+from tests._lilbee_app_test_host import LilbeeAppHost, await_chat
 
 GIB = 1024**3
 
@@ -316,6 +316,7 @@ async def test_normal_tab_focuses_drawer_and_enter_toggles(monkeypatch) -> None:
         ):
             app = LilbeeApp()
             async with app.run_test(size=(140, 40)) as pilot:
+                await await_chat(app, pilot)
                 await pilot.pause()
                 await pilot.press("ctrl+g")
                 await pilot.pause()

--- a/tests/test_tui_model_bar.py
+++ b/tests/test_tui_model_bar.py
@@ -399,14 +399,15 @@ class _ChatTestApp(LilbeeAppHost):
 @pytest.fixture
 def _seeded_models(monkeypatch):
     """Pre-populate chat/embedding and skip the SetupWizard pop so the bar is reachable."""
-    from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.core.config import cfg
 
     monkeypatch.setattr(cfg, "chat_model", "fake/chat-model")
     monkeypatch.setattr(cfg, "embedding_model", "fake/embed-model")
     monkeypatch.setattr(cfg, "vision_model", "")
     monkeypatch.setattr(cfg, "reranker_model", "")
-    monkeypatch.setattr(ChatScreen, "_needs_setup", lambda self: False)
+    from lilbee.cli.tui.screens import chat as chat_screen_mod
+
+    monkeypatch.setattr(chat_screen_mod, "needs_setup", lambda: False)
 
 
 async def test_chat_screen_mounts_with_bar_present(_seeded_models) -> None:

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -38,7 +38,7 @@ def _isolated_cfg(tmp_path):
     cfg.data_dir.mkdir(parents=True, exist_ok=True)
     cfg.documents_dir.mkdir(parents=True, exist_ok=True)
     cfg.models_dir.mkdir(parents=True, exist_ok=True)
-    # Simulate "already-initialized" state so ChatScreen._needs_setup()
+    # Simulate "already-initialized" state so needs_setup()
     # doesn't push the SetupWizard during tests that exercise chat.
     cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     yield
@@ -64,7 +64,7 @@ def _mock_services():
 def _patch_chat_setup():
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
+            "lilbee.cli.tui.screens.chat.needs_setup",
             return_value=False,
         ),
         mock.patch(

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -22,6 +22,7 @@ from lilbee.cli.tui.screens.status import StatusScreen
 from lilbee.cli.tui.screens.task_center import TaskCenter
 from lilbee.cli.tui.widgets.chat_input import ChatInput
 from lilbee.core.config import cfg
+from tests._lilbee_app_test_host import await_chat
 
 
 @pytest.fixture(autouse=True)
@@ -79,6 +80,7 @@ async def test_bracket_keys_cycle_all_screens():
     """Press ] through all 6 views from normal mode (Escape first on Chat)."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert isinstance(app.screen, ChatScreen)
 
@@ -96,7 +98,11 @@ async def test_bracket_keys_cycle_all_screens():
         ]
         for screen_type in expected:
             await pilot.press("right_square_bracket")
-            await pilot.pause()
+            # Switches are deferred behind the view-switch guard; poll them in.
+            for _ in range(40):
+                await pilot.pause()
+                if isinstance(app.screen, screen_type):
+                    break
             assert isinstance(app.screen, screen_type), (
                 f"Expected {screen_type.__name__}, got {type(app.screen).__name__}"
             )
@@ -109,6 +115,7 @@ async def test_view_switch_guard_held_until_transition_completes():
     """
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
 
         app.switch_view("Catalog")
@@ -131,6 +138,7 @@ async def test_bracket_keys_typed_literally_when_chat_input_focused():
     """Pressing [ or ] with the chat input focused must insert text, not switch screens."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert isinstance(app.screen, ChatScreen)
 
@@ -156,6 +164,7 @@ async def test_bracket_keys_cycle_backward():
     """Press [ to go backward through views."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         # Escape to normal mode so ] works
         await pilot.press("escape")
@@ -174,6 +183,7 @@ async def test_bracket_keys_work_from_settings():
     """Navigate to Settings, press ], verify screen changes to Tasks."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Settings")
         await pilot.pause()
@@ -188,6 +198,7 @@ async def test_bracket_keys_typed_literally_when_catalog_search_focused():
     """Brackets in catalog search input must insert text, not switch screens."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Catalog")
         await pilot.pause()
@@ -217,6 +228,7 @@ async def test_settings_escape_returns_to_chat():
     """Escape on Settings switches back to Chat (no filter input to blur)."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Settings")
         await pilot.pause()
@@ -241,6 +253,7 @@ async def test_rapid_fleet_back_does_not_corrupt_screen_stack():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         for _ in range(5):
             app.switch_view("Fleet")
@@ -264,6 +277,7 @@ async def test_slash_catalog_routes_through_switch_view_under_lilbee_app():
     """/models from Chat under LilbeeApp must use switch_view, not push_screen."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         chat = app.screen
         assert isinstance(chat, ChatScreen)
@@ -276,6 +290,7 @@ async def test_slash_settings_routes_through_switch_view_under_lilbee_app():
     """/settings under LilbeeApp must use switch_view, not push_screen."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         chat = app.screen
         assert isinstance(chat, ChatScreen)
@@ -288,6 +303,7 @@ async def test_slash_status_routes_through_switch_view_under_lilbee_app():
     """/status under LilbeeApp must use switch_view, not push_screen."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         chat = app.screen
         assert isinstance(chat, ChatScreen)
@@ -300,6 +316,7 @@ async def test_grid_arrows_stay_on_catalog():
     """Right arrow in catalog grid mode should move grid cursor, not switch screens."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Catalog")
         await pilot.pause()
@@ -313,6 +330,7 @@ async def test_footer_present_on_screens():
     """Every screen should have a Footer widget."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
 
         views = ["Chat", "Catalog", "Status", "Settings", "Tasks"]
@@ -334,6 +352,7 @@ async def test_help_panel_toggle():
     """? opens HelpPanel, ? again closes it."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         # Escape to normal mode so ? isn't typed into Input
         await pilot.press("escape")
@@ -355,6 +374,7 @@ async def test_catalog_nav_noop_when_search_focused():
     """Navigation actions are no-ops when catalog search input is focused."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Catalog")
         await pilot.pause()
@@ -381,6 +401,7 @@ async def test_chat_tab_outside_input_advances_focus():
     """Tab from outside the chat input advances the focus chain."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         # Escape to normal mode: input loses focus
         await pilot.press("escape")
@@ -398,6 +419,7 @@ async def test_chat_escape_from_model_picker_button():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         screen = app.screen
 
@@ -419,6 +441,7 @@ async def test_app_footer_hides_tasks_hint_when_text_input_focused():
     focused Input/TextArea swallows `t` as a literal character."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         # Chat boots in INSERT mode with the prompt (a TextArea) focused.
         assert app.check_action("open_tasks", ()) is False
@@ -441,6 +464,7 @@ async def test_backward_nav_from_catalog_after_visiting_tasks():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert isinstance(app.screen, ChatScreen)
         await pilot.press("escape")
@@ -475,6 +499,7 @@ async def test_switching_guard_blocks_concurrent_switch():
     """The _switching guard drops a second switch_view call while one is pending."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         await pilot.press("escape")
         await pilot.pause()
@@ -519,6 +544,7 @@ async def test_lilbee_app_wires_worker_pool_notifications_on_mount() -> None:
     try:
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             on_spawning = captured.get("on_spawning")
             on_spawned = captured.get("on_spawned")

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -66,7 +66,7 @@ def _isolated_cfg(tmp_path):
     cfg.chat_model = TEST_LOCAL_REF
     cfg.embedding_model = TEST_EMBED_REF
     cfg.chunk_size = 512
-    # Simulate "already-initialized" state so ChatScreen._needs_setup()
+    # Simulate "already-initialized" state so needs_setup()
     # doesn't push the SetupWizard during tests that exercise chat.
     cfg.lancedb_dir.mkdir(parents=True, exist_ok=True)
     yield
@@ -99,7 +99,7 @@ def _patch_chat_setup():
     from lilbee.cli.tui.widgets.model_bar import ModelBar
 
     with (
-        patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False),
+        patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False),
         patch(
             "lilbee.cli.tui.screens.chat.ChatScreen._embedding_ready",
             return_value=False,
@@ -3457,10 +3457,16 @@ async def test_chat_vim_j_k_skips_in_insert_mode():
 
 
 async def test_chat_needs_setup_false_when_models_exist():
-    app = ChatTestApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        with patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=False):
-            assert not app.screen._needs_setup()
+    """Resolvable models must leave the chat screen up, with no setup wizard."""
+    from lilbee.cli.tui.screens.chat import ChatScreen
+    from lilbee.cli.tui.screens.setup import SetupWizard
+
+    with patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=False):
+        app = ChatTestApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert isinstance(app.screen, ChatScreen)
+            assert not isinstance(app.screen, SetupWizard)
 
 
 async def test_chat_refresh_model_bar():
@@ -6060,7 +6066,7 @@ async def test_chat_cancel_stream_with_streaming_workers(mock_svc):
 
 
 async def test_chat_needs_setup_true_pushes_wizard():
-    """Verify _needs_setup=True pushes SetupWizard on mount."""
+    """Verify needs_setup() returning True pushes SetupWizard on mount."""
     from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.cli.tui.screens.setup import SetupWizard
 
@@ -6074,7 +6080,7 @@ async def test_chat_needs_setup_true_pushes_wizard():
             self.push_screen(ChatScreen())
 
     app = SetupTestApp()
-    with patch("lilbee.cli.tui.screens.chat.ChatScreen._needs_setup", return_value=True):
+    with patch("lilbee.cli.tui.screens.chat.needs_setup", return_value=True):
         async with app.run_test(size=(120, 40)) as _pilot:
             await _pilot.pause()
             assert isinstance(app.screen, SetupWizard)

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -46,7 +46,7 @@ from lilbee.core.config import cfg
 from lilbee.core.config.enums import CrawlRenderMode
 from lilbee.modelhub.model_manager import RemoteModel
 from lilbee.wiki.shared import PENDING_MARKER_KEYWORD_COLLISION
-from tests._lilbee_app_test_host import LilbeeAppHost
+from tests._lilbee_app_test_host import LilbeeAppHost, await_chat
 
 _EMPTY_CATALOG = CatalogResult(total=0, limit=25, offset=0, models=[])
 
@@ -2407,7 +2407,8 @@ async def test_app_mounts_chat_screen():
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.screens.chat import ChatScreen
 
-        assert isinstance(app.screen, ChatScreen)
+        chat = await await_chat(app, _pilot)
+        assert isinstance(chat, ChatScreen)
 
 
 async def test_app_title_has_model():
@@ -2504,6 +2505,7 @@ async def test_app_push_help():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         app.action_push_help()
         await _pilot.pause()
         assert app.screen.query("HelpPanel")
@@ -2701,6 +2703,7 @@ async def test_chat_slash_theme_with_arg():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         with patch.object(app.screen, "notify") as mock_notify:
             app.screen._handle_slash("/theme dracula")
             mock_notify.assert_called_once()
@@ -2712,6 +2715,7 @@ async def test_chat_slash_theme_no_arg():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         with patch.object(app.screen, "notify") as mock_notify:
             app.screen._handle_slash("/theme")
             mock_notify.assert_called_once()
@@ -4060,13 +4064,12 @@ async def test_command_provider_action_version():
 async def test_command_provider_action_reset_pushes_confirm():
     """Palette 'Reset knowledge base' invokes ChatScreen.request_reset (the public entry)."""
     from lilbee.cli.tui.app import LilbeeApp
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
-        chat = next(s for s in app.screen_stack if isinstance(s, ChatScreen))
+        chat = await await_chat(app, pilot)
         with patch.object(chat, "request_reset") as mock_reset:
             provider = LilbeeCommandProvider(app.screen, match_style=None)
             provider._action_reset()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2020,6 +2020,7 @@ async def test_reset_all_publishes_signals_on_lilbee_app():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.push_screen(SettingsScreen())
         await pilot.pause()
@@ -2416,6 +2417,7 @@ async def test_app_title_has_model():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         assert TEST_LOCAL_REF in app.title
 
 
@@ -2425,6 +2427,7 @@ async def test_app_cycle_theme():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         # Cycle starts from whatever theme on_mount restored, not from
         # index 0, so the next theme is the one AFTER the active theme.
         start_idx = DARK_THEMES.index(app.theme)
@@ -2443,6 +2446,7 @@ async def test_app_toggle_lilbee_path_flips_setting():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         start = cfg.show_lilbee_path
         app.action_toggle_lilbee_path()
         assert cfg.show_lilbee_path is not start
@@ -2455,6 +2459,7 @@ async def test_app_set_theme():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         app.set_theme("dracula")
         assert app.theme == "dracula"
         app.set_theme("nonexistent-theme-xyz")
@@ -2467,6 +2472,7 @@ async def test_app_switch_to_catalog():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         with (
             patch("lilbee.catalog.get_catalog", return_value=_EMPTY_CATALOG),
             patch("lilbee.modelhub.model_manager.classify_all_remote_models", return_value=[]),
@@ -2481,6 +2487,7 @@ async def test_app_switch_to_status():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         app.switch_view("Status")
         await _pilot.pause()
         from lilbee.cli.tui.screens.status import StatusScreen
@@ -2493,6 +2500,7 @@ async def test_app_switch_to_settings():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         app.switch_view("Settings")
         await _pilot.pause()
         from lilbee.cli.tui.screens.settings import SettingsScreen
@@ -3931,6 +3939,7 @@ async def test_command_provider_discover():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -3945,6 +3954,7 @@ async def test_command_provider_search():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -3957,6 +3967,7 @@ async def test_command_provider_search_no_match():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -3969,6 +3980,7 @@ async def test_command_provider_set_model():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -3984,6 +3996,7 @@ async def test_command_provider_open_wiki_action():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -4002,6 +4015,7 @@ async def test_command_provider_retry_skipped_action(tmp_path):
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -4016,6 +4030,7 @@ async def test_command_provider_delete_doc(mock_svc):
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         # Re-inject mock after mount (model bar events may call reset_services)
         set_services(mock_svc)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
@@ -4036,6 +4051,7 @@ async def test_command_provider_action_sync():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -4049,6 +4065,7 @@ async def test_command_provider_action_version():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -4083,6 +4100,7 @@ async def test_command_provider_action_reset_no_chat_screen():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -4102,6 +4120,7 @@ async def test_command_provider_model_commands():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -4119,6 +4138,7 @@ async def test_command_provider_model_commands_error():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -4135,6 +4155,7 @@ async def test_command_provider_document_commands(mock_svc):
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         # Re-inject mock after mount (model bar events may call reset_services)
         set_services(mock_svc)
         mock_svc.store.get_sources.return_value = [
@@ -4153,6 +4174,7 @@ async def test_command_provider_document_commands_error(mock_svc):
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         # Re-inject mock after mount (model bar events may call reset_services)
         set_services(mock_svc)
         mock_svc.store.get_sources.side_effect = Exception("no store")
@@ -4168,6 +4190,7 @@ async def test_command_provider_document_commands_empty_name(mock_svc):
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         # Re-inject mock after mount (model bar events may call reset_services)
         set_services(mock_svc)
         mock_svc.store.get_sources.return_value = [{"source": ""}]
@@ -7513,6 +7536,7 @@ async def test_app_nav_prev_cycles_views():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert app.active_view == "Chat"
 
@@ -7533,6 +7557,7 @@ async def test_app_nav_next_cycles_views():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert app.active_view == "Chat"
 
@@ -7553,6 +7578,7 @@ async def test_app_nav_switches_all_views():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
 
         app.switch_view("Chat")
@@ -7619,6 +7645,7 @@ async def test_task_center_pop_screen():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         app.push_screen(TaskCenter())
         await pilot.pause()
         app.screen.action_go_back()
@@ -7630,6 +7657,7 @@ async def test_chat_input_history_up_down():
     """Up/down arrows cycle through input history when input focused."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         inp = app.screen.query_one("#chat-input")
         inp.focus()
         await pilot.pause()
@@ -7832,6 +7860,7 @@ async def test_app_switch_to_tasks():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         app.switch_view("Tasks")
         await pilot.pause()
         assert isinstance(app.screen, TaskCenter)
@@ -7843,6 +7872,7 @@ async def test_chat_mode_indicator_shows_normal():
     cfg.embedding_model = TEST_EMBED_REF
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         from lilbee.cli.tui import messages as msg
         from lilbee.cli.tui.widgets.status_bar import ViewTabs
 
@@ -8109,6 +8139,7 @@ async def test_settings_group_titles_present():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         app.push_screen(SettingsScreen())
         await pilot.pause()
         titles = app.screen.query("Tab")
@@ -9433,6 +9464,7 @@ class TestWikiCoverageEdgeCases:
         _create_wiki_page(wiki_root, "summaries", "test", "Test")
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
             app.switch_view("Wiki")
             await pilot.pause()
             from lilbee.cli.tui.screens.wiki import WikiScreen
@@ -10924,6 +10956,7 @@ async def test_app_action_quit_when_streaming():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         screen = app.screen
         assert isinstance(screen, ChatScreen)
@@ -10940,6 +10973,7 @@ async def test_app_action_quit_routes_to_wizard_cancel():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         wizard = SetupWizard()
         with _patch_setup_scan(), _patch_setup_ram(16.0):
@@ -10963,6 +10997,7 @@ async def test_action_quit_calls_cancel_inference_before_exit():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         parent = MagicMock()
 
@@ -11006,6 +11041,7 @@ async def test_no_force_quit_attribute():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert not hasattr(app, "_force_quit")
 
@@ -11021,6 +11057,7 @@ async def test_action_quit_no_double_ctrl_c_window():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         # No state should track press timing any more.
         assert not hasattr(app, "last_quit_time")
@@ -11072,6 +11109,7 @@ async def test_app_switch_view_unknown():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Nonexistent")
         await pilot.pause()
@@ -11086,6 +11124,7 @@ async def test_app_switch_view_chat_when_already_chat():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert isinstance(app.screen, ChatScreen)
         app.switch_view("Chat")
@@ -11100,6 +11139,7 @@ async def test_app_switch_view_non_chat():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         app.switch_view("Settings")
         await pilot.pause()
@@ -11119,6 +11159,7 @@ async def test_command_provider_action_setup():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
@@ -11468,6 +11509,7 @@ async def test_chat_cmd_wiki_navigates_to_wiki_screen():
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
         await _pilot.pause()
         with (
             patch("lilbee.cli.tui.screens.chat.cfg") as mock_cfg,

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -25,6 +25,14 @@ from lilbee.cli.tui.screens.catalog_utils import (
 from lilbee.cli.tui.widgets.model_bar import ModelOption
 from lilbee.core.config import cfg
 from tests._lilbee_app_test_host import LilbeeAppHost
+from tests._lilbee_app_test_host import ready_services as _ready_services
+
+
+@pytest.fixture(autouse=True)
+def _gate_releases_at_once():
+    """Bind a ready chat role so the startup gate hands over on mount."""
+    with _ready_services():
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1399,6 +1399,12 @@ class TestScopeChip:
             await pilot.pause()
             chip = app.query_one(ScopeChip)
             both = chip.query_one("#scope-pill-both", Static)
+            # The initial paint is deferred a frame (on_mount cannot query the
+            # pills it composes); give the scheduled refresh time to land.
+            for _ in range(20):
+                if "-active" in both.classes:
+                    break
+                await pilot.pause()
             wiki = chip.query_one("#scope-pill-wiki", Static)
             raw = chip.query_one("#scope-pill-raw", Static)
             assert "-active" in both.classes

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -115,6 +115,23 @@ class TestAssistantMessageAsync:
             assert isinstance(am._thinking_header, ThinkingHeader)
             assert am._thinking_header.is_mounted
 
+    async def test_thinking_status_renders_beside_the_scanner(self) -> None:
+        """set_thinking_status reaches the header and lands in the next frame."""
+        from lilbee.cli.tui.widgets.thinking_header import _frame_content
+
+        app = _MsgApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            am = app._am
+            am.set_thinking_status("Loading engine")
+            header = am._thinking_header
+            assert header is not None
+            header._tick()
+            assert "Loading engine" in str(_frame_content(header._frame, header._detail))
+            # A dismissed header makes the setter a no-op, not a crash.
+            am._dismiss_thinking_header()
+            am.set_thinking_status("gone")
+
     async def test_first_reasoning_token_mounts_streaming_collapsible(self) -> None:
         """The Collapsible appears only when the first reasoning token arrives,
         carrying the ``-streaming`` modifier so the toggle row is hidden by CSS.

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -1354,6 +1354,28 @@ class TestScopeChip:
             chip = app.query_one(ScopeChip)
             assert "-hidden" in chip.classes
 
+    async def test_mount_does_not_query_pills_before_they_exist(self) -> None:
+        """Regression: on_mount ran _refresh, which queries children that may not be mounted.
+
+        A slow runner mounted the chip before its pills, and the query raised
+        NoMatches. The refresh is deferred a frame instead.
+        """
+        import inspect
+
+        from lilbee.cli.tui.widgets.scope_chip import ScopeChip
+
+        source = inspect.getsource(ScopeChip.on_mount)
+        assert "call_after_refresh(self._refresh)" in source
+        assert "self._refresh()" not in source
+
+        cfg.chat_mode = "search"
+        cfg.wiki = True
+        app = _ScopeChipApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chip = app.query_one(ScopeChip)
+            assert len(chip.query(".scope-pill")) == 3
+
     async def test_scope_property_defaults_to_both(self) -> None:
         from lilbee.cli.tui.widgets.scope_chip import ScopeChip
         from lilbee.data.store import SearchScope

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -6795,3 +6795,38 @@ class TestPathExists:
 
         with mock.patch.object(autocomplete, "Path", side_effect=OSError("boom")):
             assert autocomplete._path_exists("~/whatever") is False
+
+
+class TestModelBarScanRaces:
+    """A scan worker can land while the bar or a row is still composing."""
+
+    def test_populate_skips_rows_whose_picker_is_not_mounted(self) -> None:
+        from unittest import mock
+
+        from textual.css.query import NoMatches
+
+        from lilbee.cli.tui.widgets.model_bar import ModelBar, ModelOption
+
+        bar = ModelBar.__new__(ModelBar)
+        bar._options_cache = {}
+        row = mock.MagicMock()
+        row.scope = "chat"
+        row.query_one.side_effect = NoMatches("not composed")
+        with (
+            mock.patch.object(ModelBar, "query", return_value=[row]),
+            mock.patch.object(ModelBar, "_refresh_cloud_warning") as refresh,
+        ):
+            bar._populate({"chat": [ModelOption(label="m", ref="a/b/c.gguf")]})
+        assert bar._options_cache == {}  # nothing cached; the next scan retries
+        refresh.assert_called_once()
+
+    def test_cloud_warning_refresh_survives_an_unmounted_bar(self) -> None:
+        from unittest import mock
+
+        from textual.css.query import NoMatches
+
+        from lilbee.cli.tui.widgets.model_bar import ModelBar
+
+        bar = ModelBar.__new__(ModelBar)
+        with mock.patch.object(ModelBar, "query_one", side_effect=NoMatches("no warning row")):
+            bar._refresh_cloud_warning()  # must not raise

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -24,7 +24,7 @@ from lilbee.cli.tui.screens.catalog_utils import (
 )
 from lilbee.cli.tui.widgets.model_bar import ModelOption
 from lilbee.core.config import cfg
-from tests._lilbee_app_test_host import LilbeeAppHost
+from tests._lilbee_app_test_host import LilbeeAppHost, await_chat
 from tests._lilbee_app_test_host import ready_services as _ready_services
 
 
@@ -3599,6 +3599,7 @@ class TestViewTabsWikiVisibility:
         cfg.wiki = True
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             wiki_tab = app.screen.query_one("#view-tab-wiki", ViewTab)
             assert wiki_tab.display is True
@@ -3626,6 +3627,7 @@ class TestViewTabsWikiVisibility:
         cfg.wiki = False
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             wiki_tab = app.screen.query_one("#view-tab-wiki", ViewTab)
             wiki_sep = app.screen.query_one("#view-tab-sep-wiki")
@@ -3767,6 +3769,7 @@ class TestViewTabs:
         app = LilbeeApp()
         switch_calls: list[str] = []
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             tabs = list(app.screen.query(ViewTab))
             assert len(tabs) >= 2
@@ -3803,6 +3806,7 @@ class LilbeeAppHostSettingWriter:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             with (
                 mock.patch("lilbee.app.settings.persistent_settings.update_values") as mock_set,
@@ -3821,6 +3825,7 @@ class LilbeeAppHostSettingWriter:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             with mock.patch.object(app, "set_setting") as mock_set_setting:
                 apply_setting(app, "chat_mode", "chat")
@@ -3837,6 +3842,7 @@ class LilbeeAppHostViewTabs:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             while not isinstance(app.screen, ChatScreen):
                 app.pop_screen()
@@ -3853,6 +3859,7 @@ class LilbeeAppHostViewTabs:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             while not isinstance(app.screen, ChatScreen):
                 app.pop_screen()
@@ -3870,6 +3877,7 @@ class LilbeeAppHostViewTabs:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             while not isinstance(app.screen, ChatScreen):
                 app.pop_screen()
@@ -3892,6 +3900,7 @@ class LilbeeAppHostViewTabs:
 
         app = LilbeeApp()
         async with app.run_test() as pilot:
+            await await_chat(app, pilot)
             await pilot.pause()
             while not isinstance(app.screen, ChatScreen):
                 app.pop_screen()

--- a/tests/test_view_tabs_visibility.py
+++ b/tests/test_view_tabs_visibility.py
@@ -50,7 +50,7 @@ def _mock_services():
 def _patch_chat_setup():
     with (
         mock.patch(
-            "lilbee.cli.tui.screens.chat.ChatScreen._needs_setup",
+            "lilbee.cli.tui.screens.chat.needs_setup",
             return_value=False,
         ),
         mock.patch(

--- a/tests/test_view_tabs_visibility.py
+++ b/tests/test_view_tabs_visibility.py
@@ -10,6 +10,7 @@ from conftest import TEST_EMBED_REF, TEST_LOCAL_REF
 from lilbee.cli.tui.app import LilbeeApp
 from lilbee.cli.tui.widgets.status_bar import ViewTabs
 from lilbee.core.config import cfg
+from tests._lilbee_app_test_host import await_chat
 
 
 @pytest.fixture(autouse=True)
@@ -66,6 +67,7 @@ async def test_view_tabs_visible_on_screen(view_name: str) -> None:
     """ViewTabs must be mounted and occupy a non-zero region on every main screen."""
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         # Chat starts in insert mode; escape to normal so [/] navigation works.
         await pilot.press("escape")
@@ -86,6 +88,7 @@ async def test_view_tabs_visible_on_chat() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert isinstance(app.screen, ChatScreen)
         tabs = app.screen.query_one(ViewTabs)
@@ -102,6 +105,7 @@ async def test_view_tabs_docks_at_top_not_bottom() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         assert isinstance(app.screen, ChatScreen)
         tabs = app.screen.query_one(ViewTabs)
@@ -122,6 +126,7 @@ async def test_view_tabs_no_stale_pill_after_navigation() -> None:
     cfg.chat_model = TEST_LOCAL_REF
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         await pilot.press("escape")
         await pilot.pause()
@@ -153,6 +158,7 @@ async def test_view_tabs_active_view_tracks_screen_changes() -> None:
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
         await pilot.pause()
         await pilot.press("escape")
         await pilot.pause()

--- a/tests/test_warm_pending.py
+++ b/tests/test_warm_pending.py
@@ -1,0 +1,51 @@
+"""A warm is in flight from the moment it is requested, not from its first phase."""
+
+from __future__ import annotations
+
+import threading
+from unittest import mock
+
+from lilbee.providers.base import LLMProvider
+
+
+def test_base_provider_reports_no_pending_warm():
+    """Providers without managed servers have nothing to wait for."""
+    assert LLMProvider.warm_pending(mock.MagicMock()) is False
+
+
+def test_fleet_reports_a_pending_warm_before_any_phase_is_stamped():
+    """Regression: warm_up_pool spawns the fleet before the tracker stamps STARTING.
+
+    A surface that gates on warm_progress() alone sees None during the spawn and
+    concludes nothing is warming, which is how the startup gate stepped aside
+    while llama-server had not even been launched.
+    """
+    from lilbee.providers.fleet.provider import FleetProvider
+
+    provider = FleetProvider.__new__(FleetProvider)
+    provider._lock = threading.RLock()
+    provider._swaps = {}
+    provider._warming = False
+    provider._warm_tracker = mock.MagicMock()
+    provider._warm_tracker.snapshot.return_value = None
+
+    assert provider.warm_pending() is False
+
+    released = threading.Event()
+    with mock.patch.object(FleetProvider, "_warm_up_blocking", lambda self: released.wait(5)):
+        provider.warm_up_pool()
+        # The tracker has stamped nothing yet, exactly as in production.
+        assert provider.warm_progress() is None
+        assert provider.warm_pending() is True, "a requested warm must read as pending"
+        released.set()
+
+
+def test_routing_provider_forwards_pending_warm_to_the_local_engine():
+    """The routing wrapper must not hide the native side's pending warm."""
+    from lilbee.providers.routing_provider import RoutingProvider
+
+    provider = RoutingProvider.__new__(RoutingProvider)
+    local = mock.MagicMock()
+    local.warm_pending.return_value = True
+    with mock.patch.object(RoutingProvider, "_get_local", return_value=local):
+        assert provider.warm_pending() is True

--- a/tools/wheel-build/build_lilbee_binary.sh
+++ b/tools/wheel-build/build_lilbee_binary.sh
@@ -17,6 +17,24 @@ PRODUCT_VERSION="${PRODUCT_VERSION:?PRODUCT_VERSION is required (int-tuple, e.g.
 # it so litestar gets the real module. Idempotent.
 uv pip uninstall python-multipart >/dev/null 2>&1 || true
 
+# Nuitka's onefile bootstrap CRC32s every cached file on every launch, which costs
+# seconds of pure CPU before Python starts and cannot be covered by our splash.
+# The patch adds a stamp fast path and renders the lilbee wordmark plus a real
+# progress bar while unpacking. --forward under `set -e` fails the build if a
+# Nuitka upgrade moves the source, rather than silently shipping a slow binary.
+NUITKA_ROOT=$(uv run --no-sync python -c "import nuitka, pathlib; print(pathlib.Path(nuitka.__file__).parent.parent)")
+BOOTSTRAP_PATCH="$PWD/tools/wheel-build/onefile-bootstrap-lilbee.patch"
+if ! patch --forward --dry-run -p1 -d "$NUITKA_ROOT" <"$BOOTSTRAP_PATCH" >/dev/null 2>&1; then
+    if patch --reverse --dry-run -p1 -d "$NUITKA_ROOT" <"$BOOTSTRAP_PATCH" >/dev/null 2>&1; then
+        echo "onefile bootstrap patch already applied"
+    else
+        echo "ERROR: onefile bootstrap patch does not apply to Nuitka at $NUITKA_ROOT" >&2
+        exit 1
+    fi
+else
+    patch --forward -p1 -d "$NUITKA_ROOT" <"$BOOTSTRAP_PATCH"
+fi
+
 # Bundle en_core_web_sm so concept extraction works in the frozen binary.
 # It is loaded by name (spacy.load), never imported, so the Nuitka run below
 # pulls in the package, its model data, and its distribution metadata.
@@ -96,6 +114,7 @@ uv run --no-sync python -m nuitka \
     --mode=onefile \
     --user-plugin=tools/wheel-build/playwright_node_verbatim.py \
     --no-deployment-flag=self-execution \
+    --onefile-as-archive \
     --onefile-cache-mode=cached \
     --onefile-tempdir-spec='{CACHE_DIR}/lilbee/{VERSION}' \
     --product-name=lilbee \

--- a/tools/wheel-build/onefile-bootstrap-lilbee.patch
+++ b/tools/wheel-build/onefile-bootstrap-lilbee.patch
@@ -1,0 +1,195 @@
+--- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-09 21:37:40
++++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-09 21:37:40
+@@ -446,6 +446,137 @@
+ 
+ #if _NUITKA_ONEFILE_TEMP_BOOL
+ static bool payload_created = false;
++#endif
++
++// lilbee: cold-start feedback and a warm-start fast path.
++//
++// The onefile cache is keyed on {VERSION}, so a populated payload directory whose
++// stamp records this payload's size was written by this exact binary. Trusting it
++// skips the per-file CRC32 of the whole payload, which otherwise costs seconds of
++// pure CPU on every launch. Cold starts still verify normally.
++#if !defined(_WIN32) && !defined(__MSYS__)
++#include <unistd.h>
++
++#define LILBEE_STAMP_NAME ".lilbee-bootstrap-stamp"
++#define LILBEE_BAR_CELLS 40
++#define LILBEE_AMBER_DIM "\033[38;5;94m"
++#define LILBEE_RESET "\033[0m"
++
++static char const *lilbee_logo_lines[] = {
++    "@@@       @@@  @@@       @@@@@@@   @@@@@@@@  @@@@@@@@  ",
++    "@@@       @@@  @@@       @@@@@@@@  @@@@@@@@  @@@@@@@@  ",
++    "@@@       @@@  @@@       @@!  @@@  @@!       @@!       ",
++    "@!       !@!  !@!       !@   @!@  !@!       !@!       ",
++    "@!!       !!@  @!!       @!@!@!@   @!!!:!    @!!!:!    ",
++    "!!!       !!!  !!!       !!!@!!!!  !!!!!:    !!!!!:    ",
++    "!!:       !!:  !!:       !!:  !!!  !!:       !!:       ",
++    " :!:      :!:   :!:      :!:  !:!  :!:       :!:       ",
++    " :: ::::   ::   :: ::::   :: ::::   :: ::::   :: ::::  ",
++    ": :: : :  :    : :: : :  :: : ::   : :: ::   : :: ::   ",
++    NULL,
++};
++
++static bool lilbee_progress_on = false;
++static int lilbee_last_percent = -1;
++
++static void lilbee_stamp_path(filename_char_t *buffer, size_t size) {
++    buffer[0] = 0;
++    appendStringSafeFilename(buffer, payload_path, size);
++    appendCharSafeFilename(buffer, FILENAME_SEP_CHAR, size);
++    appendStringSafeFilename(buffer, LILBEE_STAMP_NAME, size);
++}
++
++// True when the stamp records this payload's size; fills first_filename from it.
++static bool lilbee_stamp_matches(filename_char_t *first_filename, size_t size) {
++    static filename_char_t stamp[4096];
++    lilbee_stamp_path(stamp, sizeof(stamp) / sizeof(filename_char_t));
++
++    FILE *handle = fopen(stamp, "rb");
++    if (handle == NULL) {
++        return false;
++    }
++
++    unsigned long long stamped_size = 0;
++    static char stamped_main[4096];
++    stamped_main[0] = 0;
++
++    bool ok = fscanf(handle, "%llu\n", &stamped_size) == 1 &&
++              fgets(stamped_main, sizeof(stamped_main), handle) != NULL;
++    fclose(handle);
++
++    if (!ok || stamped_size != (unsigned long long)_NUITKA_ONEFILE_PAYLOAD_SIZE_INT) {
++        return false;
++    }
++
++    size_t length = strlen(stamped_main);
++    while (length > 0 && (stamped_main[length - 1] == '\n' || stamped_main[length - 1] == '\r')) {
++        stamped_main[--length] = 0;
++    }
++    if (length == 0 || access(stamped_main, X_OK) != 0) {
++        return false;
++    }
++
++    first_filename[0] = 0;
++    appendStringSafeFilename(first_filename, stamped_main, size);
++    return true;
++}
++
++static void lilbee_stamp_write(filename_char_t const *first_filename) {
++    static filename_char_t stamp[4096];
++    lilbee_stamp_path(stamp, sizeof(stamp) / sizeof(filename_char_t));
++
++    FILE *handle = fopen(stamp, "wb");
++    if (handle == NULL) {
++        return;
++    }
++    fprintf(handle, "%llu\n%s\n", (unsigned long long)_NUITKA_ONEFILE_PAYLOAD_SIZE_INT, first_filename);
++    fclose(handle);
++}
++
++static void lilbee_progress_begin(void) {
++    lilbee_progress_on = isatty(STDERR_FILENO) != 0;
++    if (!lilbee_progress_on) {
++        return;
++    }
++    fputs(LILBEE_AMBER_DIM, stderr);
++    for (int i = 0; lilbee_logo_lines[i] != NULL; i += 1) {
++        fputs(lilbee_logo_lines[i], stderr);
++        fputc('\n', stderr);
++    }
++    fputs(LILBEE_RESET "\n", stderr);
++}
++
++static void lilbee_progress_update(unsigned long long done, unsigned long long total) {
++    if (!lilbee_progress_on || total == 0) {
++        return;
++    }
++    int percent = (int)((done * 100ULL) / total);
++    if (percent == lilbee_last_percent) {
++        return;
++    }
++    lilbee_last_percent = percent;
++
++    int filled = (percent * LILBEE_BAR_CELLS) / 100;
++    fputs("\r  " LILBEE_AMBER_DIM "bootstrapping " LILBEE_RESET "[", stderr);
++    for (int i = 0; i < LILBEE_BAR_CELLS; i += 1) {
++        fputc(i < filled ? '=' : ' ', stderr);
++    }
++    fprintf(stderr, "] %3d%%", percent);
++    fflush(stderr);
++}
++
++static void lilbee_progress_end(void) {
++    if (!lilbee_progress_on) {
++        return;
++    }
++    // Erase the frame so the Python splash draws onto a clean terminal.
++    fputs("\r\033[2K", stderr);
++    for (int i = 0; lilbee_logo_lines[i] != NULL; i += 1) {
++        fputs("\033[A\033[2K", stderr);
++    }
++    fputs("\033[A\033[2K", stderr);
++    fflush(stderr);
++}
+ #endif
+ 
+ #define MAX_CREATED_DIRS 1024
+@@ -1151,6 +1282,13 @@
+     wprintf(L"payload path: '" FILENAME_FORMAT_STR "'\n", payload_path);
+ #endif
+ 
++#if !defined(_WIN32) && !defined(__MSYS__)
++    bool const lilbee_warm_start =
++        lilbee_stamp_matches(first_filename, sizeof(first_filename) / sizeof(filename_char_t));
++#else
++    bool const lilbee_warm_start = false;
++#endif
++
+     if (process_role == NULL) {
+ #if defined(_WIN32)
+         bool_res = SetConsoleCtrlHandler(ourConsoleCtrlHandler, true);
+@@ -1169,6 +1307,7 @@
+ #endif
+ 
+ #if _NUITKA_ONEFILE_HAS_PAYLOAD_BOOL == 1
++    if (!lilbee_warm_start) {
+     NUITKA_PRINT_TIMING("ONEFILE: Checking header for compression.");
+ 
+     char header[3];
+@@ -1202,6 +1341,11 @@
+ 
+     NUITKA_PRINT_TIMING("ONEFILE: Entering decompression.");
+ 
++#if !defined(_WIN32) && !defined(__MSYS__)
++    unsigned char const *lilbee_payload_start = payload_current;
++    lilbee_progress_begin();
++#endif
++
+ #if _NUITKA_ONEFILE_TEMP_BOOL
+     payload_created = true;
+ #endif
+@@ -1336,10 +1480,20 @@
+                 fatalErrorTempFiles();
+             }
+         }
++
++#if !defined(_WIN32) && !defined(__MSYS__)
++        lilbee_progress_update((unsigned long long)(payload_current - lilbee_payload_start), payload_size);
++#endif
+     }
+ 
+     NUITKA_PRINT_TIMING("ONEFILE: Finishing decompression, cleanup payload.");
+ 
++#if !defined(_WIN32) && !defined(__MSYS__)
++    lilbee_progress_end();
++    lilbee_stamp_write(first_filename);
++#endif
++    }
++
+     closePayloadData();
+ #endif
+ 

--- a/tools/wheel-build/onefile-bootstrap-lilbee.patch
+++ b/tools/wheel-build/onefile-bootstrap-lilbee.patch
@@ -1,9 +1,10 @@
---- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-10 05:02:20
-+++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-10 05:02:20
-@@ -447,7 +447,165 @@
+--- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-11 00:33:34
++++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-11 00:33:34
+@@ -446,6 +446,175 @@
+ 
  #if _NUITKA_ONEFILE_TEMP_BOOL
  static bool payload_created = false;
- #endif
++#endif
 +
 +// lilbee: cold-start feedback and a warm-start fast path.
 +//
@@ -12,9 +13,13 @@
 +// skips the per-file CRC32 of the whole payload, which otherwise costs seconds of
 +// pure CPU on every launch. Cold starts still verify normally.
 +#if !defined(_WIN32) && !defined(__MSYS__)
++#include <sys/ioctl.h>
 +#include <unistd.h>
 +
 +#define LILBEE_STAMP_NAME ".lilbee-bootstrap-stamp"
++// Mirrors bee_logo.LOGO_WIDTH so this frame and the Python splash centre on the
++// same column and the splash can repaint over it in place.
++#define LILBEE_LOGO_WIDTH 55
 +#define LILBEE_BAR_CELLS 40
 +#define LILBEE_AMBER_BRIGHT "\033[38;5;214m"
 +#define LILBEE_AMBER_MID "\033[38;5;172m"
@@ -24,7 +29,7 @@
 +#define LILBEE_CELL_FULL "\u2593"
 +#define LILBEE_CELL_EDGE "\u2592"
 +#define LILBEE_CELL_EMPTY "\u2591"
- 
++
 +static char const *lilbee_logo_lines[] = {
 +    "@@@       @@@  @@@       @@@@@@@   @@@@@@@@  @@@@@@@@  ",
 +    "@@@       @@@  @@@       @@@@@@@@  @@@@@@@@  @@@@@@@@  ",
@@ -41,6 +46,7 @@
 +
 +static bool lilbee_progress_on = false;
 +static int lilbee_last_percent = -1;
++static int lilbee_pad = 0;
 +
 +static void lilbee_stamp_path(filename_char_t *buffer, size_t size) {
 +    buffer[0] = 0;
@@ -106,9 +112,14 @@
 +    if (!lilbee_progress_on) {
 +        return;
 +    }
++    struct winsize lilbee_ws;
++    if (ioctl(STDERR_FILENO, TIOCGWINSZ, &lilbee_ws) == 0 && lilbee_ws.ws_col > LILBEE_LOGO_WIDTH) {
++        lilbee_pad = (lilbee_ws.ws_col - LILBEE_LOGO_WIDTH) / 2;
++    }
 +    fputc('\n', stderr);
 +    fputs(LILBEE_AMBER_DIM, stderr);
 +    for (int i = 0; lilbee_logo_lines[i] != NULL; i += 1) {
++        fprintf(stderr, "%*s", lilbee_pad, "");
 +        fputs(lilbee_logo_lines[i], stderr);
 +        fputc('\n', stderr);
 +    }
@@ -129,8 +140,9 @@
 +
 +    int filled = (percent * LILBEE_BAR_CELLS) / 100;
 +
-+    // Indent to sit under the wordmark, which is LILBEE_LOGO_WIDTH columns wide.
-+    fputs("\r  " LILBEE_AMBER_DIM "bootstrapping" LILBEE_RESET "  ", stderr);
++    // Sit under the centred wordmark.
++    fprintf(stderr, "\r%*s", lilbee_pad, "");
++    fputs("  " LILBEE_AMBER_DIM "bootstrapping" LILBEE_RESET "  ", stderr);
 +
 +    fputs(LILBEE_AMBER_BRIGHT, stderr);
 +    for (int i = 0; i < filled; i += 1) {
@@ -161,12 +173,10 @@
 +    fputc('\r', stderr);
 +    fflush(stderr);
 +}
-+#endif
-+
+ #endif
+ 
  #define MAX_CREATED_DIRS 1024
- static filename_char_t *created_dir_paths[MAX_CREATED_DIRS];
- int created_dir_count = 0;
-@@ -1151,6 +1309,13 @@
+@@ -1151,6 +1320,13 @@
      wprintf(L"payload path: '" FILENAME_FORMAT_STR "'\n", payload_path);
  #endif
  
@@ -180,7 +190,7 @@
      if (process_role == NULL) {
  #if defined(_WIN32)
          bool_res = SetConsoleCtrlHandler(ourConsoleCtrlHandler, true);
-@@ -1169,6 +1334,7 @@
+@@ -1169,6 +1345,7 @@
  #endif
  
  #if _NUITKA_ONEFILE_HAS_PAYLOAD_BOOL == 1
@@ -188,7 +198,7 @@
      NUITKA_PRINT_TIMING("ONEFILE: Checking header for compression.");
  
      char header[3];
-@@ -1202,6 +1368,11 @@
+@@ -1202,6 +1379,11 @@
  
      NUITKA_PRINT_TIMING("ONEFILE: Entering decompression.");
  
@@ -200,7 +210,7 @@
  #if _NUITKA_ONEFILE_TEMP_BOOL
      payload_created = true;
  #endif
-@@ -1336,10 +1507,22 @@
+@@ -1336,10 +1518,22 @@
                  fatalErrorTempFiles();
              }
          }

--- a/tools/wheel-build/onefile-bootstrap-lilbee.patch
+++ b/tools/wheel-build/onefile-bootstrap-lilbee.patch
@@ -1,10 +1,9 @@
---- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-09 21:37:40
-+++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-09 21:37:40
-@@ -446,6 +446,137 @@
- 
+--- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-10 02:44:52
++++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-10 02:44:52
+@@ -447,7 +447,155 @@
  #if _NUITKA_ONEFILE_TEMP_BOOL
  static bool payload_created = false;
-+#endif
+ #endif
 +
 +// lilbee: cold-start feedback and a warm-start fast path.
 +//
@@ -17,8 +16,14 @@
 +
 +#define LILBEE_STAMP_NAME ".lilbee-bootstrap-stamp"
 +#define LILBEE_BAR_CELLS 40
++#define LILBEE_AMBER_BRIGHT "\033[38;5;214m"
++#define LILBEE_AMBER_MID "\033[38;5;172m"
 +#define LILBEE_AMBER_DIM "\033[38;5;94m"
 +#define LILBEE_RESET "\033[0m"
++// Same block glyphs the Python splash bar uses, so the two read as one surface.
++#define LILBEE_CELL_FULL "\u2593"
++#define LILBEE_CELL_EDGE "\u2592"
++#define LILBEE_CELL_EMPTY "\u2591"
 +
 +static char const *lilbee_logo_lines[] = {
 +    "@@@       @@@  @@@       @@@@@@@   @@@@@@@@  @@@@@@@@  ",
@@ -33,7 +38,7 @@
 +    ": :: : :  :    : :: : :  :: : ::   : :: ::   : :: ::   ",
 +    NULL,
 +};
-+
+ 
 +static bool lilbee_progress_on = false;
 +static int lilbee_last_percent = -1;
 +
@@ -115,11 +120,22 @@
 +    lilbee_last_percent = percent;
 +
 +    int filled = (percent * LILBEE_BAR_CELLS) / 100;
-+    fputs("\r  " LILBEE_AMBER_DIM "bootstrapping " LILBEE_RESET "[", stderr);
-+    for (int i = 0; i < LILBEE_BAR_CELLS; i += 1) {
-+        fputc(i < filled ? '=' : ' ', stderr);
++
++    // Indent to sit under the wordmark, which is LILBEE_LOGO_WIDTH columns wide.
++    fputs("\r  " LILBEE_AMBER_DIM "bootstrapping" LILBEE_RESET "  ", stderr);
++
++    fputs(LILBEE_AMBER_BRIGHT, stderr);
++    for (int i = 0; i < filled; i += 1) {
++        fputs(LILBEE_CELL_FULL, stderr);
 +    }
-+    fprintf(stderr, "] %3d%%", percent);
++    if (filled < LILBEE_BAR_CELLS) {
++        fputs(LILBEE_AMBER_MID LILBEE_CELL_EDGE, stderr);
++        fputs(LILBEE_AMBER_DIM, stderr);
++        for (int i = filled + 1; i < LILBEE_BAR_CELLS; i += 1) {
++            fputs(LILBEE_CELL_EMPTY, stderr);
++        }
++    }
++    fprintf(stderr, LILBEE_RESET "  " LILBEE_AMBER_MID "%3d%%" LILBEE_RESET, percent);
 +    fflush(stderr);
 +}
 +
@@ -135,24 +151,26 @@
 +    fputs("\033[A\033[2K", stderr);
 +    fflush(stderr);
 +}
- #endif
- 
++#endif
++
  #define MAX_CREATED_DIRS 1024
-@@ -1151,6 +1282,13 @@
-     wprintf(L"payload path: '" FILENAME_FORMAT_STR "'\n", payload_path);
- #endif
+ static filename_char_t *created_dir_paths[MAX_CREATED_DIRS];
+ int created_dir_count = 0;
+@@ -1149,6 +1297,13 @@
  
+ #if defined(_NUITKA_EXPERIMENTAL_DEBUG_ONEFILE_HANDLING)
+     wprintf(L"payload path: '" FILENAME_FORMAT_STR "'\n", payload_path);
++#endif
++
 +#if !defined(_WIN32) && !defined(__MSYS__)
 +    bool const lilbee_warm_start =
 +        lilbee_stamp_matches(first_filename, sizeof(first_filename) / sizeof(filename_char_t));
 +#else
 +    bool const lilbee_warm_start = false;
-+#endif
-+
+ #endif
+ 
      if (process_role == NULL) {
- #if defined(_WIN32)
-         bool_res = SetConsoleCtrlHandler(ourConsoleCtrlHandler, true);
-@@ -1169,6 +1307,7 @@
+@@ -1169,6 +1324,7 @@
  #endif
  
  #if _NUITKA_ONEFILE_HAS_PAYLOAD_BOOL == 1
@@ -160,19 +178,19 @@
      NUITKA_PRINT_TIMING("ONEFILE: Checking header for compression.");
  
      char header[3];
-@@ -1202,6 +1341,11 @@
+@@ -1201,6 +1357,11 @@
+ #endif
  
      NUITKA_PRINT_TIMING("ONEFILE: Entering decompression.");
- 
++
 +#if !defined(_WIN32) && !defined(__MSYS__)
 +    unsigned char const *lilbee_payload_start = payload_current;
 +    lilbee_progress_begin();
 +#endif
-+
+ 
  #if _NUITKA_ONEFILE_TEMP_BOOL
      payload_created = true;
- #endif
-@@ -1336,10 +1480,20 @@
+@@ -1336,10 +1497,20 @@
                  fatalErrorTempFiles();
              }
          }

--- a/tools/wheel-build/onefile-bootstrap-lilbee.patch
+++ b/tools/wheel-build/onefile-bootstrap-lilbee.patch
@@ -1,6 +1,6 @@
---- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-10 02:44:52
-+++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-10 02:44:52
-@@ -447,7 +447,155 @@
+--- a/nuitka/build/static_src/OnefileBootstrap.c	2026-07-10 05:02:20
++++ b/nuitka/build/static_src/OnefileBootstrap.c	2026-07-10 05:02:20
+@@ -447,7 +447,165 @@
  #if _NUITKA_ONEFILE_TEMP_BOOL
  static bool payload_created = false;
  #endif
@@ -24,7 +24,7 @@
 +#define LILBEE_CELL_FULL "\u2593"
 +#define LILBEE_CELL_EDGE "\u2592"
 +#define LILBEE_CELL_EMPTY "\u2591"
-+
+ 
 +static char const *lilbee_logo_lines[] = {
 +    "@@@       @@@  @@@       @@@@@@@   @@@@@@@@  @@@@@@@@  ",
 +    "@@@       @@@  @@@       @@@@@@@@  @@@@@@@@  @@@@@@@@  ",
@@ -38,7 +38,7 @@
 +    ": :: : :  :    : :: : :  :: : ::   : :: ::   : :: ::   ",
 +    NULL,
 +};
- 
++
 +static bool lilbee_progress_on = false;
 +static int lilbee_last_percent = -1;
 +
@@ -96,17 +96,25 @@
 +    fclose(handle);
 +}
 +
++// The frame occupies exactly the rows the Python splash redraws: a blank row, the
++// ten wordmark rows, a blank row, a separator, and the bar. Matching that geometry
++// lets the splash repaint over this frame in place instead of below it.
++#define LILBEE_FRAME_ROWS_ABOVE_BAR 13
++
 +static void lilbee_progress_begin(void) {
 +    lilbee_progress_on = isatty(STDERR_FILENO) != 0;
 +    if (!lilbee_progress_on) {
 +        return;
 +    }
++    fputc('\n', stderr);
 +    fputs(LILBEE_AMBER_DIM, stderr);
 +    for (int i = 0; lilbee_logo_lines[i] != NULL; i += 1) {
 +        fputs(lilbee_logo_lines[i], stderr);
 +        fputc('\n', stderr);
 +    }
-+    fputs(LILBEE_RESET "\n", stderr);
++    fputs(LILBEE_RESET, stderr);
++    fputc('\n', stderr);
++    fputc('\n', stderr);
 +}
 +
 +static void lilbee_progress_update(unsigned long long done, unsigned long long total) {
@@ -139,16 +147,18 @@
 +    fflush(stderr);
 +}
 +
-+static void lilbee_progress_end(void) {
++// keep_logo: park the cursor on the wordmark instead of erasing it, so an
++// interactive launch never shows a blank terminal between this frame and the
++// Python splash. A launch with arguments prints its own output, so erase.
++static void lilbee_progress_end(bool keep_logo) {
 +    if (!lilbee_progress_on) {
 +        return;
 +    }
-+    // Erase the frame so the Python splash draws onto a clean terminal.
 +    fputs("\r\033[2K", stderr);
-+    for (int i = 0; lilbee_logo_lines[i] != NULL; i += 1) {
-+        fputs("\033[A\033[2K", stderr);
++    for (int i = 0; i < LILBEE_FRAME_ROWS_ABOVE_BAR; i += 1) {
++        fputs(keep_logo ? "\033[A" : "\033[A\033[2K", stderr);
 +    }
-+    fputs("\033[A\033[2K", stderr);
++    fputc('\r', stderr);
 +    fflush(stderr);
 +}
 +#endif
@@ -156,21 +166,21 @@
  #define MAX_CREATED_DIRS 1024
  static filename_char_t *created_dir_paths[MAX_CREATED_DIRS];
  int created_dir_count = 0;
-@@ -1149,6 +1297,13 @@
- 
- #if defined(_NUITKA_EXPERIMENTAL_DEBUG_ONEFILE_HANDLING)
+@@ -1151,6 +1309,13 @@
      wprintf(L"payload path: '" FILENAME_FORMAT_STR "'\n", payload_path);
-+#endif
-+
+ #endif
+ 
 +#if !defined(_WIN32) && !defined(__MSYS__)
 +    bool const lilbee_warm_start =
 +        lilbee_stamp_matches(first_filename, sizeof(first_filename) / sizeof(filename_char_t));
 +#else
 +    bool const lilbee_warm_start = false;
- #endif
- 
++#endif
++
      if (process_role == NULL) {
-@@ -1169,6 +1324,7 @@
+ #if defined(_WIN32)
+         bool_res = SetConsoleCtrlHandler(ourConsoleCtrlHandler, true);
+@@ -1169,6 +1334,7 @@
  #endif
  
  #if _NUITKA_ONEFILE_HAS_PAYLOAD_BOOL == 1
@@ -178,19 +188,19 @@
      NUITKA_PRINT_TIMING("ONEFILE: Checking header for compression.");
  
      char header[3];
-@@ -1201,6 +1357,11 @@
- #endif
+@@ -1202,6 +1368,11 @@
  
      NUITKA_PRINT_TIMING("ONEFILE: Entering decompression.");
-+
+ 
 +#if !defined(_WIN32) && !defined(__MSYS__)
 +    unsigned char const *lilbee_payload_start = payload_current;
 +    lilbee_progress_begin();
 +#endif
- 
++
  #if _NUITKA_ONEFILE_TEMP_BOOL
      payload_created = true;
-@@ -1336,10 +1497,20 @@
+ #endif
+@@ -1336,10 +1507,22 @@
                  fatalErrorTempFiles();
              }
          }
@@ -203,7 +213,9 @@
      NUITKA_PRINT_TIMING("ONEFILE: Finishing decompression, cleanup payload.");
  
 +#if !defined(_WIN32) && !defined(__MSYS__)
-+    lilbee_progress_end();
++    // argc == 1 means no user arguments: the child launches the TUI, whose splash
++    // repaints this wordmark in place.
++    lilbee_progress_end(argc == 1);
 +    lilbee_stamp_write(first_filename);
 +#endif
 +    }


### PR DESCRIPTION
## Problem

Opening the downloaded executable looked broken. The terminal stayed completely blank for about 16 seconds on every launch. A chat box then appeared and accepted questions long before the model was loaded, so a first prompt sat behind a spinner for close to a minute with no explanation. And closing the terminal did not stop the engine: the llama-server processes survived, holding about 7GB of GPU memory until killed by hand.

## Solution

lilbee now opens the way Ollama and LM Studio do: the app is on screen and usable within a couple of seconds, and the model loads in the background. Something is visible from the first second, always in the same lilbee wordmark: a progress bar while the executable unpacks (a one-time cost, later launches skip it in about a second), the bee splash while Python starts, then chat. The engine starts loading the moment the app opens. Ask something before it's ready and the answer bubble itself shows the load, weights read as a live percentage, until the answer streams in. Nothing is silently queued, a failed load explains itself right where the answer would have been, and the input is never dead.

Quitting, being killed, or losing the terminal always shuts the engine down and frees the GPU.

Because the model load is real work (~19s even for a small model) and is paid once per session, there is also an opt-in way to skip it: a keep_engine_warm setting (TUI settings, MCP, HTTP, config.toml) leaves the engine running on quit so the next session's first answer is immediate. An idle timeout frees the GPU memory after five minutes by default, the same idea as Ollama's keep_alive (0 keeps it loaded), and `lilbee engine stop` frees everything from any terminal. Turning the setting off cleans the engine up. The default is unchanged: on-demand, nothing left running. The README states the startup costs plainly, with measured times, and how to opt into faster relaunches.

## The startup sequence

```mermaid
flowchart TD
    A([launch]) --> C[progress bar<br/>while the executable unpacks<br/><i>first run only, later runs skip in ~1s</i>]
    C --> D[bee splash<br/>while Python starts]
    D --> E([chat opens, ~2s<br/>engine loads in the background])
    E --> F{prompt sent<br/>before the engine<br/>is ready?}
    F -- yes --> G[answer bubble shows the load<br/>live weight-read percentage]
    G --> H([answer streams])
    F -- no --> H
```

The screen is never blank, the input is never locked, and a prompt that has to wait shows exactly what it is waiting for.

## The engine lifecycle

```mermaid
flowchart TD
    subgraph OFF [default: on-demand]
        q1[quit, kill, or terminal close] --> s1[engine stopped<br/>GPU memory freed]
    end
    subgraph ON [keep_engine_warm on]
        q2[quit] --> d[engine keeps running,<br/>marked as left-on-purpose]
        d --> l2([next launch]) --> ok{healthy, same lilbee<br/>version, same models?}
        ok -- yes --> a[connect to it<br/>first answer immediate]
        ok -- no --> r[stop it, start fresh]
        d --> i[idle five minutes<br/>ttl setting, default 5] --> u[weights unloaded<br/>GPU memory freed]
        t[setting turned off] --> r
        e[lilbee engine stop] --> s2[everything freed now]
    end
```

There is no background daemon: the only processes left running are the engine itself, and only when the user opted in. A crashed or force-killed session's engine is reclaimed at the next launch, same as before.

## The cold start, on film

![The very first launch: the one-time unpack behind the wordmark, chat opens, and the first answer carries the engine load inside its own bubble before streaming a cited answer](https://raw.githubusercontent.com/tobocop2/lilbee/demo-startup-reels/demos/first-start.gif)

## Verified

The full QA matrix drives the real TUI over tmux against fresh builds and asserts every promise above. On the Linux CUDA pod (A40, compat build): 41 of 41 checks pass, including bootstrap stamp and bar, the TUI usable at 12.2s cold with the one-time unpack, load progress rendered in the answer bubble, first answer 17.7s after submit and the second in 2.1s, all three quit paths reaping the engine (a SIGHUP orphan this matrix caught was root-caused to a second signal interrupting the teardown and fixed), the warm engine surviving quit with relaunch to chat in 3.9s and the adopted first answer in 3.6s with no reload, the five-minute ttl in the llama-swap config with VRAM freed on idle while the proxy stays adoptable, lilbee engine stop freeing everything, serve adopting the warm fleet with no second load, and the authenticated HTTP config round-trip.

On the Mac (Apple Silicon build): the same matrix passes, chat usable at ~3s warm-cache, the warm relaunch at 2.8s, and an instrumented cold-start probe shows the wordmark continuous from the first second to the gate with a single sub-second handover blink, versus about sixteen seconds of black at the branch point. Measured numbers live in the README's First start table.
