### PR TITLE
Stop the chat server from prefilling a trailing assistant message

### DIFF
--- a/src/lilbee/cli/commands/agent_config.py
+++ b/src/lilbee/cli/commands/agent_config.py
@@ -16,9 +16,9 @@ from lilbee.cli.launchers.hermes import _MCP_CONTAINER_KEY
 from lilbee.cli.launchers.hermes_mcp import MCP_EXTRA_HINT
 from lilbee.cli.launchers.server import (
     LOOPBACK,
+    client_chat_ctx,
     installed_chat_model_refs,
     running_server_session,
-    served_chat_ctx,
 )
 from lilbee.core.config import cfg
 from lilbee.providers.model_ref import with_configured_remote_chat
@@ -44,7 +44,7 @@ def _emit_block(builder: _JsonBuilder | _TextBuilder, **kwargs: Any) -> None:
         # context window, so the pasted config opens on a lilbee model and trims
         # history to the right limit.
         extra.setdefault("default_ref", str(cfg.chat_model))
-        extra.setdefault("chat_ctx", served_chat_ctx(port))
+        extra.setdefault("chat_ctx", client_chat_ctx(port))
     block = builder(
         base_url=f"http://{LOOPBACK}:{port}",
         api_key=token,

--- a/src/lilbee/cli/launchers/hermes.py
+++ b/src/lilbee/cli/launchers/hermes.py
@@ -14,7 +14,7 @@ from lilbee.cli.agent_configs.hermes import hermes_config
 from lilbee.cli.agent_configs.merge import deep_merge, prune_lilbee
 from lilbee.cli.launchers.hermes_mcp import ensure_hermes_http_mcp
 from lilbee.cli.launchers.launcher import LILBEE_TOKEN_ENV_VAR, run_launcher
-from lilbee.cli.launchers.server import LOOPBACK, served_chat_ctx
+from lilbee.cli.launchers.server import LOOPBACK, client_chat_ctx
 from lilbee.cli.launchers.skill_install import install_bundled_skill
 from lilbee.core.config import cfg
 
@@ -24,6 +24,9 @@ _HERMES_INSTALL_HINT = (
 _TOKEN_REF = "${" + LILBEE_TOKEN_ENV_VAR + "}"
 _MCP_CONTAINER_KEY = "mcp_servers"
 _CONFIG_LABEL = "hermes config (config.yaml)"
+# hermes refuses to start against a model whose window is under this, so a smaller
+# one is worth naming here rather than leaving hermes to fail after the handoff.
+_HERMES_MIN_CTX = 64_000
 # hermes config keys gating its own auto-installs (security.allow_lazy_installs).
 _SECURITY_KEY = "security"
 _ALLOW_LAZY_INSTALLS_KEY = "allow_lazy_installs"
@@ -56,6 +59,19 @@ def _upsert_env_token(path: Path, token: str) -> None:
         path.chmod(0o600)
 
 
+def warn_if_below_hermes_minimum(chat_ctx: int | None) -> None:
+    """Tell the user up front when hermes will reject the window lilbee serves."""
+    if chat_ctx is None or chat_ctx >= _HERMES_MIN_CTX:
+        return
+    typer.secho(
+        f"Warning: hermes requires at least a {_HERMES_MIN_CTX:,}-token context and "
+        f"lilbee serves {chat_ctx:,}, so hermes will refuse to start. Chat with a "
+        "longer-context model, a smaller quantization, or a higher gpu_memory_fraction.",
+        err=True,
+        fg=typer.colors.YELLOW,
+    )
+
+
 class HermesLauncher:
     """``Launcher`` implementation for hermes-agent."""
 
@@ -79,12 +95,14 @@ class HermesLauncher:
             parse_error=yaml.YAMLError,
             label=_CONFIG_LABEL,
         )
+        chat_ctx = client_chat_ctx(port)
+        warn_if_below_hermes_minimum(chat_ctx)
         fragment = hermes_config(
             base_url=f"http://{LOOPBACK}:{port}",
             api_key=_TOKEN_REF,
             model_refs=model_refs,
             default_ref=str(cfg.chat_model),
-            chat_ctx=served_chat_ctx(port),
+            chat_ctx=chat_ctx,
             include_mcp=self._include_mcp,
         )
         deep_merge(config, fragment)

--- a/src/lilbee/cli/launchers/opencode.py
+++ b/src/lilbee/cli/launchers/opencode.py
@@ -15,7 +15,7 @@ from lilbee.cli.agent_configs import config_file
 from lilbee.cli.agent_configs.merge import deep_merge, prune_lilbee
 from lilbee.cli.agent_configs.opencode import opencode_config
 from lilbee.cli.launchers.launcher import LILBEE_TOKEN_ENV_VAR, run_launcher
-from lilbee.cli.launchers.server import LOOPBACK, served_chat_ctx
+from lilbee.cli.launchers.server import LOOPBACK, client_chat_ctx
 from lilbee.cli.launchers.skill_install import install_bundled_skill
 from lilbee.core.config import cfg
 
@@ -133,7 +133,7 @@ class OpencodeLauncher:
             base_url=f"http://{LOOPBACK}:{port}",
             api_key=_TOKEN_REF,
             model_refs=model_refs,
-            chat_ctx=served_chat_ctx(port),
+            chat_ctx=client_chat_ctx(port),
             default_ref=str(cfg.chat_model),
             include_mcp=self._include_mcp,
         )

--- a/src/lilbee/cli/launchers/server.py
+++ b/src/lilbee/cli/launchers/server.py
@@ -127,6 +127,65 @@ def served_chat_ctx(port: int) -> int | None:
     return ctx if isinstance(ctx, int) and ctx > 0 else None
 
 
+def planned_chat_ctx() -> int | None:
+    """The per-slot window the fleet will serve the configured chat model, or None.
+
+    Mirrors the fleet's own single-GPU chat sizing, so it answers before the
+    engine is up: the same ``cfg.num_ctx`` short-circuit, then the same
+    :func:`resolve_chat_ctx` against the same memory read the fleet's plan
+    snapshot holds (both scale total VRAM by ``cfg.gpu_memory_fraction``, so
+    neither moves with what is currently resident).
+
+    A tensor-split chat is sized by the fleet against per-device headroom
+    instead, so this can over-report there; it is only a fallback for a chat
+    engine that is not up yet, and the served window wins once it is. A
+    remote-served chat model has no local window to compute.
+    """
+    from lilbee.providers.base import ProviderError
+    from lilbee.providers.engine_params import resolve_chat_ctx, resolve_model_path
+    from lilbee.providers.gguf_meta import read_gguf_metadata
+    from lilbee.providers.model_ref import parse_model_ref
+
+    ref = str(cfg.chat_model)
+    if not parse_model_ref(ref).is_local:
+        return None
+    if cfg.num_ctx is not None:
+        return cfg.num_ctx
+    try:
+        path = resolve_model_path(ref)
+        return resolve_chat_ctx(path, read_gguf_metadata(path))
+    except (ProviderError, OSError, ValueError):
+        # Sizing needs the model file and its GGUF header; an absent or unreadable
+        # one leaves the window unknown rather than failing the launch.
+        log.debug("planned_chat_ctx failed for %s", ref, exc_info=True)
+        return None
+
+
+def client_chat_ctx(port: int) -> int | None:
+    """The chat window to advertise to a launched client, warning when it is small.
+
+    The chat role builds lazily, so a launcher that hands off before the engine
+    is warm gets nothing from ``/api/health``; fall back to the window the fleet
+    plans to serve rather than leaving the client with no window at all. A window
+    below ``cfg.chat_n_ctx_target`` means the host could not back what was asked
+    for, which changes how much history an agent can keep, so say so.
+    """
+    ctx = served_chat_ctx(port)
+    if ctx is None:
+        ctx = planned_chat_ctx()
+    if ctx is not None and ctx < cfg.chat_n_ctx_target:
+        typer.secho(
+            f"Warning: the chat model is served with a {ctx:,}-token context, below the "
+            f"configured chat_n_ctx_target of {cfg.chat_n_ctx_target:,}. Either the model "
+            "was trained on a smaller window, or its weights leave too little of the "
+            "memory budget for the KV cache. A longer-context model, a smaller "
+            "quantization, or a higher gpu_memory_fraction raises it.",
+            err=True,
+            fg=typer.colors.YELLOW,
+        )
+    return ctx
+
+
 def chat_warm_budget_s() -> float:
     """Warm wait scaled to the chat model's on-disk weights at the engine's cold-load rate."""
     try:

--- a/src/lilbee/providers/fleet/adapters.py
+++ b/src/lilbee/providers/fleet/adapters.py
@@ -46,7 +46,11 @@ ROLE_SPECS: dict[WorkerRole, RoleServerSpec] = {
         # reasoning dialect (<think>, gpt-oss harmony, ...) into reasoning_content;
         # the chat client re-inlines it as <think> so downstream parsing stays
         # format-agnostic and control tokens never leak into answers.
-        extra_args=("--jinja", "--reasoning-format", "deepseek"),
+        # --no-prefill-assistant keeps a trailing assistant message a finished turn:
+        # by default the server continues its text instead of answering, and rejects
+        # two trailing assistant messages with a 400. Agents compacting their history
+        # send both shapes, and OpenAI's API accepts them.
+        extra_args=("--jinja", "--reasoning-format", "deepseek", "--no-prefill-assistant"),
         server_capable=True,
     ),
     WorkerRole.EMBED: RoleServerSpec(

--- a/tests/cli/test_agent_config_hermes.py
+++ b/tests/cli/test_agent_config_hermes.py
@@ -143,7 +143,7 @@ def _write_server_session() -> None:
 
 def test_agent_config_hermes_prints_yaml_block(monkeypatch):
     _write_server_session()
-    monkeypatch.setattr("lilbee.cli.commands.agent_config.served_chat_ctx", lambda _p: None)
+    monkeypatch.setattr("lilbee.cli.commands.agent_config.client_chat_ctx", lambda _p: None)
     result = runner.invoke(app, ["agent-config", "hermes"])
     assert result.exit_code == 0
     block = yaml.safe_load(result.stdout)
@@ -157,7 +157,7 @@ def test_agent_config_hermes_notes_mcp_extra(monkeypatch):
     # Entry-point parity with `lilbee launch hermes`: the paste path can't install
     # hermes's `mcp` extra, so it must at least tell the user it's needed.
     _write_server_session()
-    monkeypatch.setattr("lilbee.cli.commands.agent_config.served_chat_ctx", lambda _p: None)
+    monkeypatch.setattr("lilbee.cli.commands.agent_config.client_chat_ctx", lambda _p: None)
     result = runner.invoke(app, ["agent-config", "hermes"])
     assert result.exit_code == 0
     assert "hermes-agent[mcp]" in result.stderr
@@ -168,3 +168,14 @@ def test_agent_config_hermes_requires_running_server():
     result = runner.invoke(app, ["agent-config", "hermes"])
     assert result.exit_code == 1
     assert "lilbee serve" in result.stderr
+
+
+def test_agent_config_hermes_carries_the_advertised_context_window(monkeypatch):
+    # Entry-point parity with `lilbee launch hermes`: the pasted block must carry the
+    # window a launcher would advertise, not omit it.
+    _write_server_session()
+    monkeypatch.setattr("lilbee.cli.commands.agent_config.client_chat_ctx", lambda _p: 40960)
+    result = runner.invoke(app, ["agent-config", "hermes"])
+    assert result.exit_code == 0
+    block = yaml.safe_load(result.stdout)
+    assert block["providers"]["lilbee"]["context_length"] == 40960

--- a/tests/cli/test_launch_hermes.py
+++ b/tests/cli/test_launch_hermes.py
@@ -48,7 +48,7 @@ def _stub_registry():
 def _healthy_and_warm(monkeypatch):
     monkeypatch.setattr("lilbee.cli.launchers.server.health_ok", lambda _port: True)
     monkeypatch.setattr("lilbee.cli.launchers.launcher.wait_for_chat_warm", lambda _port: True)
-    monkeypatch.setattr("lilbee.cli.launchers.hermes.served_chat_ctx", lambda _port: None)
+    monkeypatch.setattr("lilbee.cli.launchers.hermes.client_chat_ctx", lambda _port: None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/test_launch_opencode.py
+++ b/tests/cli/test_launch_opencode.py
@@ -66,7 +66,7 @@ def _warm_by_default(request, monkeypatch):
     monkeypatch.setattr("lilbee.cli.launchers.launcher.wait_for_chat_warm", lambda _port: True)
     # opencode's prepare() reads the served window over HTTP; default it to
     # unknown so tests do not hit the network. The limit.context test overrides.
-    monkeypatch.setattr("lilbee.cli.launchers.opencode.served_chat_ctx", lambda _port: None)
+    monkeypatch.setattr("lilbee.cli.launchers.opencode.client_chat_ctx", lambda _port: None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/test_launch_server_ctx.py
+++ b/tests/cli/test_launch_server_ctx.py
@@ -1,0 +1,155 @@
+"""The chat window a launcher advertises to the client it starts."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lilbee.core.config import cfg
+
+
+def _health(monkeypatch, body: dict) -> None:
+    from lilbee.cli.launchers import server as launch_mod
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = body
+    monkeypatch.setattr(launch_mod.httpx, "get", lambda url, timeout: resp)
+
+
+@pytest.mark.no_warm_default
+def test_client_chat_ctx_prefers_the_window_the_server_reports(monkeypatch):
+    from lilbee.cli.launchers import server as launch_mod
+
+    _health(monkeypatch, {"chat_ready": True, "chat_ctx": 40960})
+    monkeypatch.setattr(launch_mod, "planned_chat_ctx", lambda: 65536)
+    assert launch_mod.client_chat_ctx(8765) == 40960
+
+
+@pytest.mark.no_warm_default
+def test_client_chat_ctx_falls_back_to_planned_window_when_engine_is_cold(monkeypatch):
+    # The chat role builds lazily, so a launcher that hands off before the engine
+    # is up would otherwise write a config with no context window at all.
+    from lilbee.cli.launchers import server as launch_mod
+
+    _health(monkeypatch, {"chat_ready": False, "chat_ctx": None})
+    monkeypatch.setattr(launch_mod, "planned_chat_ctx", lambda: 65536)
+    assert launch_mod.client_chat_ctx(8765) == 65536
+
+
+@pytest.mark.no_warm_default
+def test_client_chat_ctx_is_none_when_no_local_window_can_be_planned(monkeypatch):
+    from lilbee.cli.launchers import server as launch_mod
+
+    _health(monkeypatch, {"chat_ready": False})
+    monkeypatch.setattr(launch_mod, "planned_chat_ctx", lambda: None)
+    assert launch_mod.client_chat_ctx(8765) is None
+
+
+@pytest.mark.no_warm_default
+def test_client_chat_ctx_warns_when_the_window_is_below_the_configured_target(monkeypatch, capsys):
+    from lilbee.cli.launchers import server as launch_mod
+
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 65536)
+    _health(monkeypatch, {"chat_ready": True, "chat_ctx": 32768})
+    assert launch_mod.client_chat_ctx(8765) == 32768
+    err = capsys.readouterr().err
+    assert "32,768" in err
+    assert "65,536" in err
+
+
+@pytest.mark.no_warm_default
+def test_client_chat_ctx_is_quiet_when_the_target_is_met(monkeypatch, capsys):
+    from lilbee.cli.launchers import server as launch_mod
+
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 32768)
+    _health(monkeypatch, {"chat_ready": True, "chat_ctx": 32768})
+    assert launch_mod.client_chat_ctx(8765) == 32768
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.no_warm_default
+def test_planned_chat_ctx_is_none_for_a_remote_chat_model(monkeypatch):
+    from lilbee.cli.launchers import server as launch_mod
+
+    monkeypatch.setattr(cfg, "chat_model", "ollama/qwen3:4b")
+    assert launch_mod.planned_chat_ctx() is None
+
+
+@pytest.mark.no_warm_default
+def test_planned_chat_ctx_honors_an_explicit_num_ctx_pin(monkeypatch):
+    from lilbee.cli.launchers import server as launch_mod
+
+    monkeypatch.setattr(cfg, "chat_model", "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf")
+    monkeypatch.setattr(cfg, "num_ctx", 12288)
+    assert launch_mod.planned_chat_ctx() == 12288
+
+
+@pytest.mark.no_warm_default
+def test_hermes_warns_when_the_window_is_below_its_hard_minimum(capsys):
+    from lilbee.cli.launchers.hermes import warn_if_below_hermes_minimum
+
+    warn_if_below_hermes_minimum(32768)
+    err = capsys.readouterr().err
+    assert "32,768" in err
+    assert "64,000" in err
+
+
+@pytest.mark.no_warm_default
+def test_hermes_is_quiet_when_the_window_clears_its_minimum(capsys):
+    from lilbee.cli.launchers.hermes import warn_if_below_hermes_minimum
+
+    warn_if_below_hermes_minimum(65536)
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.no_warm_default
+def test_hermes_is_quiet_when_the_window_is_unknown(capsys):
+    from lilbee.cli.launchers.hermes import warn_if_below_hermes_minimum
+
+    warn_if_below_hermes_minimum(None)
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.no_warm_default
+def test_planned_chat_ctx_sizes_a_local_model_the_way_the_fleet_does(monkeypatch, tmp_path):
+    # Exercises the real sizing path: only the model file and its GGUF header are
+    # faked, so resolve_chat_ctx does the arithmetic the fleet's planner does.
+    from lilbee.cli.launchers import server as launch_mod
+
+    gguf = tmp_path / "chat.gguf"
+    gguf.write_bytes(b"0" * 1024)
+    meta = {
+        "architecture": "qwen3",
+        "block_count": "36",
+        "head_count": "32",
+        "head_count_kv": "8",
+        "key_length": "128",
+        "value_length": "128",
+        "context_length": "40960",
+    }
+    monkeypatch.setattr(cfg, "chat_model", "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf")
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr(cfg, "num_ctx_max", None)
+    monkeypatch.setattr(cfg, "chat_n_ctx_target", 65536)
+    monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _ref: gguf)
+    monkeypatch.setattr("lilbee.providers.gguf_meta.read_gguf_metadata", lambda _p: meta)
+
+    # A 40,960-token trained window caps the 65,536 target.
+    assert launch_mod.planned_chat_ctx() == 40960
+
+
+@pytest.mark.no_warm_default
+def test_planned_chat_ctx_is_none_when_the_model_file_is_missing(monkeypatch):
+    from lilbee.cli.launchers import server as launch_mod
+    from lilbee.providers.base import ProviderError
+
+    def _missing(_ref):
+        raise ProviderError("not installed")
+
+    monkeypatch.setattr(cfg, "chat_model", "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf")
+    monkeypatch.setattr(cfg, "num_ctx", None)
+    monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", _missing)
+
+    assert launch_mod.planned_chat_ctx() is None

--- a/tests/test_fleet_adapters.py
+++ b/tests/test_fleet_adapters.py
@@ -209,6 +209,29 @@ def test_chat_server_spec_extracts_reasoning_server_side() -> None:
     assert extra_args[idx + 1] == "deepseek"
 
 
+def test_chat_server_spec_disables_assistant_prefill() -> None:
+    from lilbee.providers.fleet.adapters import ROLE_SPECS
+    from lilbee.providers.roles import WorkerRole
+
+    # With prefill on, the server treats a trailing assistant message as text to
+    # continue, and rejects two of them outright. Agents send both shapes, so the
+    # chat server must read a trailing assistant message as a finished turn.
+    assert "--no-prefill-assistant" in ROLE_SPECS[WorkerRole.CHAT].extra_args
+
+
+def test_build_argv_chat_launches_without_assistant_prefill() -> None:
+    argv = build_server_argv(
+        binary=Path("/bin/llama-server"),
+        spec=ROLE_SPECS[WorkerRole.CHAT],
+        model_path=Path("/models/chat.gguf"),
+        devices=(0,),
+        n_gpu_layers=-1,
+        slots=1,
+        ctx_per_slot=4096,
+    )
+    assert "--no-prefill-assistant" in argv
+
+
 @pytest.mark.parametrize(
     ("reranker_type", "arch", "expected"),
     [

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1413,6 +1413,7 @@ _NON_SIZING_LAUNCH_FLAGS = {
     "--cont-batching",
     "--jinja",
     "--no-mmap",
+    "--no-prefill-assistant",
     "--reasoning-format",
     "--embeddings",
     "--pooling",


### PR DESCRIPTION
## Problem

Two defects on the agent-facing path.

llama-server treats a trailing assistant message as a prefill: it continues that text instead of answering it, and rejects two trailing assistant messages with an HTTP 400. `/v1/chat/completions` forwarded both shapes through, and the 400 reached the caller as a 500 mid-stream. hermes compacts history into an assistant summary and keeps going, which produces two trailing assistant messages, so it died after three retries without finishing its work. OpenAI's API accepts both shapes.

Launchers read the context window from `/api/health`, which reports nothing until the chat role is built. Handing off before then wrote an agent config with no window at all: hermes fell back to a 20k cap on context files, opencode got no `limit.context`. A window smaller than `chat_n_ctx_target` was never mentioned either, and hermes refuses to start below 64,000 tokens.

## Solution

Launch the chat server with `--no-prefill-assistant`, so a trailing assistant message is a finished turn. The flag does not affect memory sizing, so it joins the non-sizing set in the launch/estimator parity test.

Add `planned_chat_ctx()`, which mirrors the fleet's chat sizing and answers before the engine is up, and `client_chat_ctx()`, which prefers the served window and falls back to the planned one. Both report 40960 for Qwen3-8B at a 65536 target. A window below `chat_n_ctx_target` now warns, and `lilbee launch hermes` names hermes's 64,000-token minimum before the handoff. `lilbee agent-config` moves to the same helper.

Verified on an A100 with Qwen3.6-35B-A3B: two trailing assistant messages return 200 instead of 500, one starts a new turn instead of being continued, and hermes completed the Godot pathfinding task with `godot --headless` green. opencode completed a coding task against the same build with no server errors.
