### PR TITLE
Never refuse the vision model when only query-time models reserve VRAM

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -435,16 +435,21 @@ touching the running fleet.
   there; nothing is unloaded when an ingest finishes. If llama-swap is restarted or
   found dead, the fleet re-probes once and rebuilds its model config before
   reporting a failure.
-- **Swap tenancy**: when the chat model fits only if vision gives up its VRAM, the
-  two are not made unplaceable. They become co-tenants of a single llama-swap
-  group with `swap: true`, sharing one llama-swap process, and llama-swap evicts
-  one to load the other on demand. Only one is resident at a time, so the group is
-  charged the chat model's footprint alone, and a co-tenant role runs a single
-  instance (a `swap: true` group evicts same-group siblings, so a second vision
-  replica inside it would evict the first). Interleaving a chat turn with an ingest
-  costs a model reload each way. Everything else pins as before: with the VRAM to
-  hold both, chat and vision get their own groups and never evict. A role is
-  unplaceable only when it does not fit even alone beside the pinned search tier.
+- **Swap tenancy**: the planner matches the old in-process pool, where a role's
+  worker spawned lazily on first call, so ingest (embed + vision OCR) and a query
+  (embed + rerank + chat) never held each other's models in VRAM. Roles that share
+  no run **phase** (`RoleInfo.phases`) are never resident together, so when they
+  cannot all co-reside a role that does not fit **refunds** the already-charged
+  phase-disjoint roles and retries; the roles that let it in become co-tenants of a
+  single `swap: true` llama-swap group. On a tight card this pulls the query-only
+  rerank and chat into vision's swap group, so ingest's embed + vision fits exactly
+  as it did in-process. Only one member is resident at a time, so the group is
+  charged its largest member and each co-tenant runs a single instance (a
+  `swap: true` group evicts same-group siblings, so a second replica inside it would
+  evict the first). Interleaving a query with an ingest costs a model reload each
+  way. With the VRAM to hold everything at once, no swap group forms and every role
+  pins to its own group. A role is unplaceable only when it does not fit even beside
+  the one embedder its own phase needs (a genuine "use a smaller model").
 - **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
   vision roles can run as N independent servers, fanning embedding and OCR across
   the box during ingest. Setting either value to `0` (the default) means auto: one

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -435,9 +435,12 @@ touching the running fleet.
   there; nothing is unloaded when an ingest finishes. If llama-swap is restarted or
   found dead, the fleet re-probes once and rebuilds its model config before
   reporting a failure.
-- **Swap tenancy**: the planner matches the old in-process pool, where a role's
-  worker spawned lazily on first call, so ingest (embed + vision OCR) and a query
-  (embed + rerank + chat) never held each other's models in VRAM. Roles that share
+- **Swap tenancy**: the planner matches the old in-process pool (last shipped in
+  v0.6.66b507; see its
+  [Inference Worker Pool](https://github.com/tobocop2/lilbee/blob/v0.6.66b507/docs/architecture.md#inference-worker-pool)
+  section), where a role's worker spawned lazily on first call, so ingest
+  (embed + vision OCR) and a query (embed + rerank + chat) never held each
+  other's models in VRAM. Roles that share
   no run **phase** (`RoleInfo.phases`) are never resident together, so when they
   cannot all co-reside a role that does not fit **refunds** the already-charged
   phase-disjoint roles and retries; the roles that let it in become co-tenants of a

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -4,8 +4,9 @@ Estimates each role-model's VRAM footprint from GGUF metadata and bin-packs
 instances across GPUs in ``placement_rank`` order, largest-first within a rank: a
 model that fits one GPU runs as a single pinned instance, small models co-locate
 on a GPU with spare VRAM, and a model too big for any single GPU is tensor-split
-across enough GPUs to fit. Chat and vision share a swap group when only one of
-them fits; a role that fits nowhere gets no server (its calls error). See
+across enough GPUs to fit. Roles that never run in the same phase (ingest OCR vs a
+query) share one swap group when they cannot all co-reside, so only the phase in
+use is charged; a role that fits nowhere gets no server (its calls error). See
 docs/architecture.md.
 """
 
@@ -130,10 +131,7 @@ def plan_placement(
             free_headroom=free_headroom,
         )
 
-    instances, unplaceable, charges = _place_pinned(persistent_singles, place)
-    co_tenants = _place_chat_last(
-        _chat_of(persistent_singles), place, remaining, charges, instances, unplaceable
-    )
+    instances, unplaceable, co_tenants = _place_persistent(persistent_singles, place, remaining)
     instances.extend(_place_elastic(replicated, instances, remaining, co_tenants))
 
     return Placement(
@@ -155,44 +153,69 @@ def _place_ungated(models: list[ModelPlacementInput]) -> Placement:
     )
 
 
-def _place_pinned(
+def _place_persistent(
     persistent_singles: list[ModelPlacementInput],
     place: Callable[[ModelPlacementInput], _Placed | None],
-) -> tuple[list[InstancePlan], list[WorkerRole], dict[WorkerRole, dict[int, float]]]:
-    """Charge every persistent single except chat, in ``placement_rank`` order."""
+    remaining: dict[int, float],
+) -> tuple[list[InstancePlan], list[WorkerRole], frozenset[WorkerRole]]:
+    """Charge every persistent single in ``placement_rank`` order.
+
+    A role that does not fit refunds every already-charged role it is phase-disjoint
+    from (never co-resident with) and retries; the roles that let it in become one
+    swap group. This restores the in-process pool's behavior, where a role loaded
+    only when its phase ran, so ingest never paid for the query models or vice versa.
+    """
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
     charges: dict[WorkerRole, dict[int, float]] = {}
-    for model in sorted(_pinned(persistent_singles), key=_shared_pool_order):
+    co_tenants: set[WorkerRole] = set()
+    for model in sorted(persistent_singles, key=_shared_pool_order):
         placed = place(model)
+        if placed is None:
+            placed, group = _place_beside_disjoint(model, place, remaining, charges)
+            co_tenants |= group
         if placed is None:
             unplaceable.append(model.role)
         else:
             instances.append(placed.plan)
             charges[model.role] = placed.charges
-    return instances, unplaceable, charges
+    return instances, unplaceable, frozenset(co_tenants)
 
 
-def _place_chat_last(
-    chat: ModelPlacementInput | None,
+def _place_beside_disjoint(
+    model: ModelPlacementInput,
     place: Callable[[ModelPlacementInput], _Placed | None],
     remaining: dict[int, float],
     charges: dict[WorkerRole, dict[int, float]],
-    instances: list[InstancePlan],
-    unplaceable: list[WorkerRole],
-) -> frozenset[WorkerRole]:
-    """Charge chat against what the pinned tier left, co-tenanting with vision if needed."""
-    if chat is None:
-        return frozenset()
-    placed = place(chat)
-    co_tenants: frozenset[WorkerRole] = frozenset()
-    if placed is None:
-        placed, co_tenants = _chat_beside_vision(chat, place, remaining, charges)
-    if placed is None:
-        unplaceable.append(chat.role)
-    else:
-        instances.append(placed.plan)
-    return co_tenants
+) -> tuple[_Placed | None, frozenset[WorkerRole]]:
+    """Retry *model* with every phase-disjoint charged role's VRAM refunded.
+
+    Phase-disjoint roles are never resident together, so they can share one swap
+    group: only the resident one is charged. On success *model* and the refunded
+    roles form the group and the refunded roles drop out of ``charges`` (their VRAM
+    is now the group's shared budget). On failure every refund is rolled back and
+    *model* is genuinely oversize.
+    """
+    refunds = {r: c for r, c in charges.items() if _phase_disjoint(r, model.role)}
+    if not refunds:
+        return None, frozenset()
+    for charged in refunds.values():
+        for idx, held in charged.items():
+            remaining[idx] += held
+    placed = place(model)
+    if placed is not None:
+        for role in refunds:
+            del charges[role]
+        return placed, frozenset(refunds) | {model.role}
+    for charged in refunds.values():
+        for idx, held in charged.items():
+            remaining[idx] -= held
+    return None, frozenset()
+
+
+def _phase_disjoint(a: WorkerRole, b: WorkerRole) -> bool:
+    """True when *a* and *b* share no run phase, so they are never co-resident."""
+    return ROLE_REGISTRY[a].phases.isdisjoint(ROLE_REGISTRY[b].phases)
 
 
 def _place_elastic(
@@ -209,41 +232,6 @@ def _place_elastic(
             continue  # unplaceable, or a co-tenant capped to its single instance
         elastic.extend(_place_replicas(model, remaining, start=1))
     return elastic
-
-
-def _pinned(models: list[ModelPlacementInput]) -> list[ModelPlacementInput]:
-    """The persistent singles that are charged before chat."""
-    return [m for m in models if m.role is not WorkerRole.CHAT]
-
-
-def _chat_of(models: list[ModelPlacementInput]) -> ModelPlacementInput | None:
-    """The chat model among *models*, or None when chat is unconfigured."""
-    return next((m for m in models if m.role is WorkerRole.CHAT), None)
-
-
-def _chat_beside_vision(
-    chat: ModelPlacementInput,
-    place: Callable[[ModelPlacementInput], _Placed | None],
-    remaining: dict[int, float],
-    charges: dict[WorkerRole, dict[int, float]],
-) -> tuple[_Placed | None, frozenset[WorkerRole]]:
-    """Retry a chat model that did not fit, with vision's VRAM refunded.
-
-    On success the pair are swap tenants: only one is resident, so the group is
-    charged the chat model's footprint alone. On failure vision keeps its VRAM and
-    chat is the genuinely oversize role.
-    """
-    refund = charges.get(WorkerRole.VISION)
-    if refund is None:
-        return None, frozenset()
-    for idx, charged in refund.items():
-        remaining[idx] += charged
-    placed = place(chat)
-    if placed is not None:
-        return placed, frozenset({WorkerRole.CHAT, WorkerRole.VISION})
-    for idx, charged in refund.items():
-        remaining[idx] -= charged
-    return None, frozenset()
 
 
 def _persistent_single(model: ModelPlacementInput) -> ModelPlacementInput:
@@ -373,17 +361,18 @@ def _place_replicas(
 def _place_shared_memory(models: list[ModelPlacementInput], budget: int) -> Placement:
     """Fit un-pinned roles into one shared RAM *budget*.
 
-    Roles pack in ``placement_rank`` order, so the elastic chat model is charged
-    last and can never crowd out search or vision. Replicas run as N co-resident
-    processes against the shared pool (no per-GPU spread without GPUs). A chat
-    model that fits only without vision makes the pair swap tenants; a role with no
-    instance placed is unplaceable (gets no server, its calls error).
+    Roles pack in ``placement_rank`` order (the elastic chat model last). Replicas
+    run as N co-resident processes against the shared pool (no per-GPU spread without
+    GPUs). A role that does not fit refunds every already-charged phase-disjoint role
+    (never resident with it), which caps those roles to a single instance and makes
+    the set one swap group; a role that still fits nowhere is unplaceable.
     """
     remaining = budget
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
     charged: dict[WorkerRole, int] = {}
-    for model in sorted(_pinned(models), key=_shared_pool_order):
+    co_tenants: set[WorkerRole] = set()
+    for model in sorted(models, key=_shared_pool_order):
         placed = 0
         for _ in range(model.replicas):
             if model.est_vram_bytes > remaining:
@@ -391,45 +380,45 @@ def _place_shared_memory(models: list[ModelPlacementInput], budget: int) -> Plac
             remaining -= model.est_vram_bytes
             instances.append(InstancePlan(role=model.role, devices=(), replica=placed))
             placed += 1
-        if placed == 0:
-            unplaceable.append(model.role)
-        else:
+        if placed:
             charged[model.role] = placed * model.est_vram_bytes
-
-    chat = _chat_of(models)
-    co_tenants: frozenset[WorkerRole] = frozenset()
-    if chat is not None:
-        co_tenants = _place_shared_chat(chat, instances, unplaceable, remaining, charged)
+            continue
+        remaining, group = _shared_beside_disjoint(model, remaining, charged, instances)
+        if group:
+            instances.append(InstancePlan(role=model.role, devices=()))
+            charged[model.role] = model.est_vram_bytes
+            co_tenants |= group
+        else:
+            unplaceable.append(model.role)
     return Placement(
         instances=tuple(instances),
         unplaceable_roles=tuple(unplaceable),
-        co_tenants=co_tenants,
+        co_tenants=frozenset(co_tenants),
     )
 
 
-def _place_shared_chat(
-    chat: ModelPlacementInput,
-    instances: list[InstancePlan],
-    unplaceable: list[WorkerRole],
+def _shared_beside_disjoint(
+    model: ModelPlacementInput,
     remaining: int,
     charged: dict[WorkerRole, int],
-) -> frozenset[WorkerRole]:
-    """Charge chat last against the shared pool, refunding vision if that is what it takes.
+    instances: list[InstancePlan],
+) -> tuple[int, frozenset[WorkerRole]]:
+    """Refund the shared-pool roles phase-disjoint from *model* and cap them to one instance.
 
-    Refunding vision makes the pair swap tenants, so only chat's footprint is held
-    and vision drops to its single instance.
+    The refunded roles and *model* become one swap group: only one is resident, so
+    each keeps a single instance and only *model*'s footprint is charged. Returns the
+    budget after reclaiming their VRAM and charging *model*, plus the group; on a
+    genuinely oversize *model* the budget is unchanged and the group empty.
     """
-    if chat.est_vram_bytes <= remaining:
-        instances.append(InstancePlan(role=chat.role, devices=()))
-        return frozenset()
-    vision_bytes = charged.get(WorkerRole.VISION)
-    if vision_bytes is None or chat.est_vram_bytes > remaining + vision_bytes:
-        unplaceable.append(chat.role)
-        return frozenset()
-    instances[:] = [plan for plan in instances if plan.role is not WorkerRole.VISION]
-    instances.append(InstancePlan(role=WorkerRole.VISION, devices=(), replica=0))
-    instances.append(InstancePlan(role=chat.role, devices=()))
-    return frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+    refunds = [r for r in list(charged) if _phase_disjoint(r, model.role)]
+    reclaim = sum(charged[r] for r in refunds)
+    if not refunds or model.est_vram_bytes > remaining + reclaim:
+        return remaining, frozenset()
+    for role in refunds:
+        del charged[role]
+        instances[:] = [plan for plan in instances if plan.role is not role]
+        instances.append(InstancePlan(role=role, devices=(), replica=0))
+    return remaining + reclaim - model.est_vram_bytes, frozenset(refunds) | {model.role}
 
 
 def _shared_pool_order(model: ModelPlacementInput) -> tuple[int, int]:

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -204,13 +204,37 @@ def _place_beside_disjoint(
             remaining[idx] += held
     placed = place(model)
     if placed is not None:
+        slot = _group_slot(placed.charges, refunds, remaining)
         for role in refunds:
             del charges[role]
-        return placed, frozenset(refunds) | {model.role}
+        return _Placed(plan=placed.plan, charges=slot), frozenset(refunds) | {model.role}
     for charged in refunds.values():
         for idx, held in charged.items():
             remaining[idx] -= held
     return None, frozenset()
+
+
+def _group_slot(
+    trigger: dict[int, float],
+    refunds: dict[WorkerRole, dict[int, float]],
+    remaining: dict[int, float],
+) -> dict[int, float]:
+    """Charge each device the swap group's largest member, not just the trigger.
+
+    Only one member is resident at a time, but every evicted member must be able to
+    swap back in, so the group's per-device slot is the max across members. The
+    shortfall beyond the trigger's own charge is deducted from *remaining* here so
+    the elastic replica tier cannot claim VRAM an evicted member needs to return to.
+    The returned slot is recorded as the trigger's charge, so a later trigger that
+    refunds this group reclaims the whole slot.
+    """
+    slot = dict(trigger)
+    for charged in refunds.values():
+        for idx, held in charged.items():
+            need = max(slot.get(idx, 0.0), held)
+            remaining[idx] -= need - slot.get(idx, 0.0)
+            slot[idx] = need
+    return slot
 
 
 def _phase_disjoint(a: WorkerRole, b: WorkerRole) -> bool:
@@ -371,6 +395,9 @@ def _place_shared_memory(models: list[ModelPlacementInput], budget: int) -> Plac
     instances: list[InstancePlan] = []
     unplaceable: list[WorkerRole] = []
     charged: dict[WorkerRole, int] = {}
+    # A charged role's swap-back need: its single-instance footprint, or, for the
+    # role holding a swap group's budget, the whole group slot.
+    swap_need = {m.role: m.est_vram_bytes for m in models}
     co_tenants: set[WorkerRole] = set()
     for model in sorted(models, key=_shared_pool_order):
         placed = 0
@@ -383,10 +410,9 @@ def _place_shared_memory(models: list[ModelPlacementInput], budget: int) -> Plac
         if placed:
             charged[model.role] = placed * model.est_vram_bytes
             continue
-        remaining, group = _shared_beside_disjoint(model, remaining, charged, instances)
+        remaining, group = _shared_beside_disjoint(model, remaining, charged, swap_need, instances)
         if group:
             instances.append(InstancePlan(role=model.role, devices=()))
-            charged[model.role] = model.est_vram_bytes
             co_tenants |= group
         else:
             unplaceable.append(model.role)
@@ -401,29 +427,44 @@ def _shared_beside_disjoint(
     model: ModelPlacementInput,
     remaining: int,
     charged: dict[WorkerRole, int],
+    swap_need: dict[WorkerRole, int],
     instances: list[InstancePlan],
 ) -> tuple[int, frozenset[WorkerRole]]:
     """Refund the shared-pool roles phase-disjoint from *model* and cap them to one instance.
 
-    The refunded roles and *model* become one swap group: only one is resident, so
-    each keeps a single instance and only *model*'s footprint is charged. Returns the
-    budget after reclaiming their VRAM and charging *model*, plus the group; on a
-    genuinely oversize *model* the budget is unchanged and the group empty.
+    The refunded roles and *model* become one swap group: only one member is resident
+    at a time, but every member must be able to swap back in, so the group is charged
+    its largest member's footprint (the slot), recorded under *model*'s role so a
+    later trigger reclaims the whole slot. Returns the budget after reclaiming the
+    refunded VRAM and charging the slot, plus the group; when even the slot does not
+    fit the reclaimed budget the group is empty and the budget unchanged.
     """
     refunds = [r for r in list(charged) if _phase_disjoint(r, model.role)]
+    if not refunds:
+        return remaining, frozenset()
     reclaim = sum(charged[r] for r in refunds)
-    if not refunds or model.est_vram_bytes > remaining + reclaim:
+    slot = max(model.est_vram_bytes, *(swap_need[r] for r in refunds))
+    if slot > remaining + reclaim:
         return remaining, frozenset()
     for role in refunds:
         del charged[role]
         instances[:] = [plan for plan in instances if plan.role is not role]
         instances.append(InstancePlan(role=role, devices=(), replica=0))
-    return remaining + reclaim - model.est_vram_bytes, frozenset(refunds) | {model.role}
+    charged[model.role] = slot
+    swap_need[model.role] = slot
+    return remaining + reclaim - slot, frozenset(refunds) | {model.role}
 
 
-def _shared_pool_order(model: ModelPlacementInput) -> tuple[int, int]:
-    """Sort key: by the role's placement rank, then largest-first within a rank."""
-    return (ROLE_REGISTRY[model.role].placement_rank, -model.est_vram_bytes)
+def _shared_pool_order(model: ModelPlacementInput) -> tuple[int, int, int]:
+    """Sort key: placement rank, then most-phases-first, then largest-first.
+
+    A role in more phases is co-resident with more of the fleet and can never make
+    room by swapping (nothing is phase-disjoint from it), so it charges before a
+    same-rank single-phase sibling: a large LLM reranker must not crowd out the
+    embedder that both ingest and query need.
+    """
+    info = ROLE_REGISTRY[model.role]
+    return (info.placement_rank, -len(info.phases), -model.est_vram_bytes)
 
 
 def _best_single_device(need: int, remaining: dict[int, float]) -> int | None:

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -683,14 +683,18 @@ def _non_chat_reservation(
     A tensor-split chat shard must size its KV against the headroom left after the
     embed/rerank/vision servers on the same card, not the card's raw free VRAM, or
     it over-commits and OOMs at launch. Chat is excluded because it sizes its own
-    weights, and so are chat's co-tenants: they are evicted while chat is resident,
-    so their VRAM is chat's to use. Non-chat roles are single-device, so each
-    charges its full footprint (once per replica) to its card.
+    weights. Chat's own swap-group siblings are excluded too: they are evicted while
+    chat is resident, so their VRAM is chat's to use. That only holds when chat is
+    itself a co-tenant; a co-tenant group that does not include chat runs behind its
+    own swap process and can be resident beside chat, so it is charged normally.
+    Non-chat roles are single-device, so each charges its full footprint (once per
+    replica) to its card.
     """
+    chat_siblings = co_tenants if WorkerRole.CHAT in co_tenants else frozenset()
     charge_by_role = {inp.role: inp.est_vram_bytes for inp in inputs}
     reserved: dict[int, int] = {}
     for inst in instances:
-        if inst.role is WorkerRole.CHAT or inst.role in co_tenants:
+        if inst.role is WorkerRole.CHAT or inst.role in chat_siblings:
             continue
         charge = charge_by_role[inst.role]
         for device in inst.devices:

--- a/src/lilbee/providers/roles.py
+++ b/src/lilbee/providers/roles.py
@@ -22,6 +22,18 @@ class WorkerRole(StrEnum):
     VISION = "vision"
 
 
+class Phase(StrEnum):
+    """A run phase whose roles are loaded together on demand.
+
+    Ingest OCRs and embeds (vision + embed); a query embeds, reranks, and generates
+    (embed + rerank + chat). Roles sharing no phase are never co-resident, so on a
+    tight host they may share one swap group instead of both reserving VRAM.
+    """
+
+    INGEST = "ingest"
+    QUERY = "query"
+
+
 class RerankMode(StrEnum):
     """Resolved reranker serving mode for one RERANK server.
 
@@ -49,6 +61,7 @@ class RoleInfo:
     flash_attn: bool  # runs with flash attention (chat/vision)
     pooled: bool  # pooled single-slot search role (embed/cross-encoder rerank)
     placement_rank: int  # placement order; the elastic chat model is charged last
+    phases: frozenset[Phase]  # run phases that load this role (co-residency model)
 
 
 ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
@@ -61,6 +74,7 @@ ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
         flash_attn=True,
         pooled=False,
         placement_rank=2,
+        phases=frozenset({Phase.QUERY}),
     ),
     WorkerRole.EMBED: RoleInfo(
         role=WorkerRole.EMBED,
@@ -71,6 +85,7 @@ ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
         flash_attn=False,
         pooled=True,
         placement_rank=0,
+        phases=frozenset({Phase.INGEST, Phase.QUERY}),
     ),
     WorkerRole.RERANK: RoleInfo(
         role=WorkerRole.RERANK,
@@ -81,6 +96,7 @@ ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
         flash_attn=False,
         pooled=True,
         placement_rank=0,
+        phases=frozenset({Phase.QUERY}),
     ),
     WorkerRole.VISION: RoleInfo(
         role=WorkerRole.VISION,
@@ -91,6 +107,7 @@ ROLE_REGISTRY: dict[WorkerRole, RoleInfo] = {
         flash_attn=True,
         pooled=False,
         placement_rank=1,
+        phases=frozenset({Phase.INGEST}),
     ),
 }
 """Single source of truth for per-role fleet configuration, ordered chat/embed/rerank/vision."""

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -582,8 +582,25 @@ class TestChatVisionCoTenancy:
         assert plan.unplaceable_roles == ()
         assert plan.co_tenants == frozenset()
 
-    def test_vision_too_big_for_the_search_tier_is_still_unplaceable(self) -> None:
-        # Vision does not fit even before chat is charged: a real "use a smaller model".
+    def test_vision_too_big_even_for_ingest_alone_is_unplaceable(self) -> None:
+        # Vision does not fit even beside the embedder alone (its ingest working set):
+        # a real "use a smaller model", not a co-residency conflict. 8GB card is 7.2
+        # usable; embed 1 + vision 8 overflows even with rerank and chat refunded.
+        models = [
+            ModelPlacementInput(WorkerRole.CHAT, 3 * _GB),
+            *self._search(),
+            ModelPlacementInput(WorkerRole.VISION, 8 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 8 * _GB)], estimate_peak=_never)
+
+        assert plan.unplaceable_roles == (WorkerRole.VISION,)
+        assert plan.co_tenants == frozenset()
+
+    def test_vision_that_fits_ingest_pulls_rerank_into_the_swap_group(self) -> None:
+        # 8GB card (7.2 usable): embed 1 + rerank 1 + vision 6 = 8 overflows, but the
+        # ingest working set embed 1 + vision 6 = 7 fits. The in-process pool served
+        # this ingest (chat/rerank never loaded), so the planner must not refuse
+        # vision: rerank (query-only) and chat join vision's swap group.
         models = [
             ModelPlacementInput(WorkerRole.CHAT, 3 * _GB),
             *self._search(),
@@ -591,8 +608,28 @@ class TestChatVisionCoTenancy:
         ]
         plan = plan_placement(models, [(0, 8 * _GB)], estimate_peak=_never)
 
-        assert plan.unplaceable_roles == (WorkerRole.VISION,)
-        assert plan.co_tenants == frozenset()
+        assert plan.unplaceable_roles == ()
+        assert self._roles(plan) == {
+            WorkerRole.CHAT,
+            WorkerRole.EMBED,
+            WorkerRole.RERANK,
+            WorkerRole.VISION,
+        }
+        assert plan.co_tenants == frozenset(
+            {WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION}
+        )
+
+    def test_vision_swap_group_forms_without_chat_when_chat_is_disabled(self) -> None:
+        # No chat model configured: on a tight card vision still cannot sit beside the
+        # full search tier, so it co-tenants with the query-only rerank alone.
+        models = [
+            *self._search(),
+            ModelPlacementInput(WorkerRole.VISION, 6 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 8 * _GB)], estimate_peak=_never)
+
+        assert plan.unplaceable_roles == ()
+        assert plan.co_tenants == frozenset({WorkerRole.RERANK, WorkerRole.VISION})
 
     def test_co_tenant_vision_runs_a_single_replica(self) -> None:
         # swap:true evicts same-group siblings, so a second vision replica in the

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -619,6 +619,39 @@ class TestChatVisionCoTenancy:
             {WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION}
         )
 
+    def test_swap_group_slot_holds_vram_for_its_largest_member(self) -> None:
+        # 6GB card (5.4 usable): embed 0.4 (2 replicas), vision 5.0 fits exactly,
+        # chat 3.0 joins by refunding vision. The group must stay charged at vision's
+        # 5.0 (its largest member), not chat's 3.0, or the elastic embed replica
+        # claims the difference and vision OOMs when it swaps back in.
+        models = [
+            ModelPlacementInput(WorkerRole.EMBED, int(0.4 * _GB), replicas=2),
+            ModelPlacementInput(WorkerRole.VISION, 5 * _GB),
+            ModelPlacementInput(WorkerRole.CHAT, 3 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 6 * _GB)], estimate_peak=_never)
+
+        embeds = [i for i in plan.instances if i.role is WorkerRole.EMBED]
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+        assert len(embeds) == 1
+
+    def test_large_llm_reranker_cannot_crowd_out_the_embedder(self) -> None:
+        # The embedder runs in every phase, so nothing can swap with it; it charges
+        # before same-rank single-phase roles. A 5GB LLM reranker on a 6GB card is
+        # the genuinely unservable role (query needs embed+rerank co-resident);
+        # embed, vision, and chat all still get servers.
+        models = [
+            ModelPlacementInput(WorkerRole.EMBED, int(0.6 * _GB)),
+            ModelPlacementInput(WorkerRole.RERANK, 5 * _GB),
+            ModelPlacementInput(WorkerRole.VISION, 2 * _GB),
+            ModelPlacementInput(WorkerRole.CHAT, 3 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 6 * _GB)], estimate_peak=_never)
+
+        assert plan.unplaceable_roles == (WorkerRole.RERANK,)
+        assert self._roles(plan) == {WorkerRole.EMBED, WorkerRole.VISION, WorkerRole.CHAT}
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+
     def test_vision_swap_group_forms_without_chat_when_chat_is_disabled(self) -> None:
         # No chat model configured: on a tight card vision still cannot sit beside the
         # full search tier, so it co-tenants with the query-only rerank alone.
@@ -674,6 +707,26 @@ class TestSharedMemoryCoTenancy:
 
         assert plan.unplaceable_roles == ()
         assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+
+    def test_shared_swap_group_is_charged_at_its_largest_member(self) -> None:
+        # 6GB budget: a 5GB LLM reranker is refunded by a 2GB vision trigger. The
+        # group must hold the reranker's 5GB slot, which forces the 3GB chat to join
+        # the group as well instead of pinning persistently in VRAM the evicted
+        # reranker needs to swap back into.
+        models = [
+            ModelPlacementInput(WorkerRole.EMBED, int(0.6 * _GB)),
+            ModelPlacementInput(WorkerRole.RERANK, 5 * _GB),
+            ModelPlacementInput(WorkerRole.VISION, 2 * _GB),
+            ModelPlacementInput(WorkerRole.CHAT, 3 * _GB),
+        ]
+        plan = plan_placement(models, [], estimate_peak=_never, unified_budget=6 * _GB)
+
+        assert plan.unplaceable_roles == ()
+        assert plan.co_tenants == frozenset(
+            {WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION}
+        )
+        persistent = [i.role for i in plan.instances if i.role not in plan.co_tenants]
+        assert persistent == [WorkerRole.EMBED]
 
     def test_co_tenant_vision_drops_to_one_replica_in_shared_memory(self) -> None:
         # The elastic vision replicas are refunded with the rest of vision's pool;

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -615,9 +615,7 @@ class TestChatVisionCoTenancy:
             WorkerRole.RERANK,
             WorkerRole.VISION,
         }
-        assert plan.co_tenants == frozenset(
-            {WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION}
-        )
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION})
 
     def test_swap_group_slot_holds_vram_for_its_largest_member(self) -> None:
         # 6GB card (5.4 usable): embed 0.4 (2 replicas), vision 5.0 fits exactly,
@@ -722,9 +720,7 @@ class TestSharedMemoryCoTenancy:
         plan = plan_placement(models, [], estimate_peak=_never, unified_budget=6 * _GB)
 
         assert plan.unplaceable_roles == ()
-        assert plan.co_tenants == frozenset(
-            {WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION}
-        )
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION})
         persistent = [i.role for i in plan.instances if i.role not in plan.co_tenants]
         assert persistent == [WorkerRole.EMBED]
 

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -998,6 +998,27 @@ class TestBuildFleetWiring:
         )
         assert reserved == {0: 3 * _GB}
 
+    def test_non_chat_reservation_charges_a_co_tenant_group_without_chat(self) -> None:
+        # A vision/rerank swap group that excludes chat runs behind its own process
+        # and can be resident beside a chat shard, so its members are charged (not
+        # treated as chat's to reclaim); only chat itself is excluded.
+        instances = [
+            InstancePlan(role=WorkerRole.CHAT, devices=(0,)),
+            InstancePlan(role=WorkerRole.VISION, devices=(0,)),
+            InstancePlan(role=WorkerRole.RERANK, devices=(0,)),
+            InstancePlan(role=WorkerRole.EMBED, devices=(0,)),
+        ]
+        inputs = [
+            ModelPlacementInput(WorkerRole.CHAT, 40 * _GB),
+            ModelPlacementInput(WorkerRole.VISION, 6 * _GB),
+            ModelPlacementInput(WorkerRole.RERANK, 2 * _GB),
+            ModelPlacementInput(WorkerRole.EMBED, 3 * _GB),
+        ]
+        reserved = planning_mod._non_chat_reservation(
+            instances, inputs, frozenset({WorkerRole.VISION, WorkerRole.RERANK})
+        )
+        assert reserved == {0: (6 + 2 + 3) * _GB}
+
     def test_launch_for_pinned_multi_card_chat_runs_one_slot(self, tmp_path, monkeypatch) -> None:
         # A cfg.num_ctx pin skips the fit, but a multi-card chat still serves one slot
         # so --ctx-size matches the single-sequence footprint the planner reserved.

--- a/tests/test_placement_oracle_parity.py
+++ b/tests/test_placement_oracle_parity.py
@@ -98,6 +98,20 @@ _STACK = {
     WorkerRole.RERANK: _gb(0.6),
 }
 _BIG_VISION = {**_STACK, WorkerRole.VISION: _gb(7.0)}
+# An LLM reranker larger than the embedder: must never crowd embed out of the plan.
+_LLM_RERANK = {
+    WorkerRole.CHAT: _gb(3.0),
+    WorkerRole.VISION: _gb(2.0),
+    WorkerRole.EMBED: _gb(0.6),
+    WorkerRole.RERANK: _gb(5.0),
+}
+# Chat smaller than vision: the swap group must be charged at vision's footprint.
+_SMALL_CHAT = {
+    WorkerRole.CHAT: _gb(3.0),
+    WorkerRole.VISION: _gb(5.0),
+    WorkerRole.EMBED: _gb(0.4),
+    WorkerRole.RERANK: _gb(0.6),
+}
 
 SCENARIOS = [
     Scenario("gpu-24gb-roomy", dict(_STACK), devices=[(0, _gb(24))]),
@@ -105,10 +119,14 @@ SCENARIOS = [
     Scenario("gpu-8gb-one-big-at-a-time", dict(_STACK), devices=[(0, _gb(8))]),
     Scenario("gpu-6gb-embed-rerank-vision-overflow", dict(_STACK), devices=[(0, _gb(6))]),
     Scenario("gpu-8gb-big-vision", dict(_BIG_VISION), devices=[(0, _gb(8))]),
+    Scenario("gpu-6gb-llm-rerank", dict(_LLM_RERANK), devices=[(0, _gb(6))]),
+    Scenario("gpu-6gb-small-chat-big-vision", dict(_SMALL_CHAT), devices=[(0, _gb(6))]),
+    Scenario("unified-6gb-llm-rerank", dict(_LLM_RERANK), unified_budget=_gb(6)),
     Scenario("unified-6gb-embed-rerank-vision-overflow", dict(_STACK), unified_budget=_gb(6)),
     Scenario("unified-8gb", dict(_STACK), unified_budget=_gb(8)),
     Scenario("unified-12gb", dict(_STACK), unified_budget=_gb(12)),
     Scenario("unified-8gb-big-vision", dict(_BIG_VISION), unified_budget=_gb(8)),
+    Scenario("unified-6gb-big-vision", dict(_BIG_VISION), unified_budget=_gb(6)),
 ]
 
 

--- a/tests/test_placement_oracle_parity.py
+++ b/tests/test_placement_oracle_parity.py
@@ -74,8 +74,7 @@ def _oracle_servable(sc: Scenario) -> set[WorkerRole]:
 
 def _planner_servable(sc: Scenario) -> tuple[set[WorkerRole], frozenset[WorkerRole]]:
     models = [
-        ModelPlacementInput(role=role, est_vram_bytes=vram)
-        for role, vram in sc.footprints.items()
+        ModelPlacementInput(role=role, est_vram_bytes=vram) for role, vram in sc.footprints.items()
     ]
     placement = plan_placement(
         models,
@@ -183,8 +182,10 @@ def _print_diff_table() -> int:
             hw = f"unified {sc.unified_budget // GB}GB"
         print(f"[{'BUG' if refused else 'OK '}] {sc.name}  ({hw})")
         print(f"        oracle  : {sorted(r.value for r in oracle)}")
-        print(f"        planner : {sorted(r.value for r in servable)}"
-              f"  swap-group={sorted(r.value for r in co)}")
+        print(
+            f"        planner : {sorted(r.value for r in servable)}"
+            f"  swap-group={sorted(r.value for r in co)}"
+        )
         if refused:
             print(f"        >>> REGRESSION: planner refuses {refused}")
     print(f"\n=== {regressions} scenario(s) regress vs the in-process oracle ===")

--- a/tests/test_placement_oracle_parity.py
+++ b/tests/test_placement_oracle_parity.py
@@ -1,0 +1,177 @@
+"""Differential regression: the fleet planner must serve every role the b507
+in-process pool would have served on demand.
+
+The in-process ``WorkerPool`` had no VRAM admission and no idle reaping: a role's
+worker spawned lazily on first call, so only the roles a single operation used were
+ever co-resident. Ingest loaded embed+vision; query loaded embed+chat+rerank. Peak
+was ``embed + max(vision, chat+rerank)``, never the sum. This suite feeds low-RAM /
+on-the-cusp conditions into the real :func:`plan_placement` and asserts it never
+refuses a role that lazy per-phase residency would have served.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from lilbee.providers.fleet.placement import ModelPlacementInput, plan_placement
+from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION
+from lilbee.providers.roles import WorkerRole
+
+GB = 1024**3
+
+# Roles co-resident during each operation, per the in-process lazy-load reality.
+_WORKING_SETS: tuple[frozenset[WorkerRole], ...] = (
+    frozenset({WorkerRole.EMBED, WorkerRole.VISION}),  # ingest: OCR + chunk embed
+    frozenset({WorkerRole.CHAT, WorkerRole.EMBED, WorkerRole.RERANK}),  # query
+)
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    footprints: dict[WorkerRole, int]  # role -> footprint bytes
+    devices: list[tuple[int, int]] = field(default_factory=list)  # (index, total vram)
+    unified_budget: int | None = None  # free RAM bytes when devices is empty
+
+
+def _gb(x: float) -> int:
+    return int(x * GB)
+
+
+def _budget(sc: Scenario) -> int:
+    """The usable budget the planner charges against, per path.
+
+    The GPU path applies the 90% ``USABLE_VRAM_FRACTION`` headroom; the unified path
+    charges the raw free-RAM budget it is given. The oracle is gated at the same
+    basis so the comparison isolates the co-residency policy, not the headroom.
+    """
+    if sc.devices:
+        return int(sum(v for _, v in sc.devices) * USABLE_VRAM_FRACTION)
+    assert sc.unified_budget is not None
+    return sc.unified_budget
+
+
+def _estimate(footprints: dict[WorkerRole, int]):
+    def estimate(role: WorkerRole, ratio: tuple[int, ...]) -> tuple[int, ...]:
+        denom = sum(ratio) or 1
+        return tuple(int(footprints[role] * r / denom) for r in ratio)
+
+    return estimate
+
+
+def _oracle_servable(sc: Scenario) -> set[WorkerRole]:
+    """Every role in a working set that fits: what the lazy pool would serve."""
+    budget = _budget(sc)
+    servable: set[WorkerRole] = set()
+    for roles in _WORKING_SETS:
+        present = [r for r in roles if r in sc.footprints]
+        if sum(sc.footprints[r] for r in present) <= budget:
+            servable.update(present)
+    return servable
+
+
+def _planner_servable(sc: Scenario) -> tuple[set[WorkerRole], frozenset[WorkerRole]]:
+    models = [
+        ModelPlacementInput(role=role, est_vram_bytes=vram)
+        for role, vram in sc.footprints.items()
+    ]
+    placement = plan_placement(
+        models,
+        sc.devices,
+        estimate_peak=_estimate(sc.footprints),
+        unified_budget=sc.unified_budget,
+    )
+    servable = set(sc.footprints) - set(placement.unplaceable_roles)
+    return servable, placement.co_tenants
+
+
+# Footprints modeled on the friend's stack: a ~4B chat, nomic embed, a small
+# cross-encoder rerank, and a ~4B vision OCR model. Cusp scenarios vary only the
+# budget so the planner's co-residency policy is the lone variable. The "big vision"
+# rows show the regression is not unique to 6GB: a larger OCR model reaches it at 8GB.
+_STACK = {
+    WorkerRole.CHAT: _gb(4.5),
+    WorkerRole.VISION: _gb(4.5),
+    WorkerRole.EMBED: _gb(0.6),
+    WorkerRole.RERANK: _gb(0.6),
+}
+_BIG_VISION = {**_STACK, WorkerRole.VISION: _gb(7.0)}
+
+SCENARIOS = [
+    Scenario("gpu-24gb-roomy", dict(_STACK), devices=[(0, _gb(24))]),
+    Scenario("gpu-12gb-cusp", dict(_STACK), devices=[(0, _gb(12))]),
+    Scenario("gpu-8gb-one-big-at-a-time", dict(_STACK), devices=[(0, _gb(8))]),
+    Scenario("gpu-6gb-embed-rerank-vision-overflow", dict(_STACK), devices=[(0, _gb(6))]),
+    Scenario("gpu-8gb-big-vision", dict(_BIG_VISION), devices=[(0, _gb(8))]),
+    Scenario("unified-6gb-embed-rerank-vision-overflow", dict(_STACK), unified_budget=_gb(6)),
+    Scenario("unified-8gb", dict(_STACK), unified_budget=_gb(8)),
+    Scenario("unified-12gb", dict(_STACK), unified_budget=_gb(12)),
+    Scenario("unified-8gb-big-vision", dict(_BIG_VISION), unified_budget=_gb(8)),
+]
+
+
+def _charged_total(sc: Scenario, servable: set[WorkerRole], swap: frozenset[WorkerRole]) -> int:
+    """The VRAM the plan reserves: every persistent role, plus one swap-group member.
+
+    Swap-group members never co-reside (llama-swap loads one at a time), so the group
+    is charged its largest member; every other served role is charged in full.
+    """
+    persistent = [r for r in servable if r not in swap]
+    total = sum(sc.footprints[r] for r in persistent)
+    members = [sc.footprints[r] for r in swap if r in servable]
+    if members:
+        total += max(members)
+    return total
+
+
+@pytest.mark.parametrize("sc", SCENARIOS, ids=lambda s: s.name)
+def test_planner_serves_every_role_the_oracle_would(sc: Scenario) -> None:
+    oracle = _oracle_servable(sc)
+    servable, _co = _planner_servable(sc)
+    refused = {r.value for r in oracle if r not in servable}
+    assert not refused, (
+        f"{sc.name}: planner refuses {sorted(refused)} that the in-process oracle "
+        f"would serve on demand (oracle={sorted(r.value for r in oracle)}, "
+        f"planner={sorted(r.value for r in servable)})"
+    )
+
+
+@pytest.mark.parametrize("sc", SCENARIOS, ids=lambda s: s.name)
+def test_plan_fits_its_own_budget(sc: Scenario) -> None:
+    """Serving a role is not enough: the plan's reservation must fit the budget."""
+    servable, swap = _planner_servable(sc)
+    reserved = _charged_total(sc, servable, swap)
+    budget = _budget(sc)
+    assert reserved <= budget, (
+        f"{sc.name}: plan reserves {reserved / GB:.2f}GB > budget {budget / GB:.2f}GB "
+        f"(served={sorted(r.value for r in servable)}, swap-group={sorted(r.value for r in swap)})"
+    )
+
+
+def _print_diff_table() -> int:
+    """Print the oracle-vs-planner diff for every scenario; return the regression count."""
+    regressions = 0
+    for sc in SCENARIOS:
+        oracle = _oracle_servable(sc)
+        servable, co = _planner_servable(sc)
+        refused = sorted(r.value for r in oracle if r not in servable)
+        regressions += bool(refused)
+        if sc.devices:
+            hw = f"{len(sc.devices)}xGPU {[v // GB for _, v in sc.devices]}GB"
+        else:
+            assert sc.unified_budget is not None
+            hw = f"unified {sc.unified_budget // GB}GB"
+        print(f"[{'BUG' if refused else 'OK '}] {sc.name}  ({hw})")
+        print(f"        oracle  : {sorted(r.value for r in oracle)}")
+        print(f"        planner : {sorted(r.value for r in servable)}"
+              f"  swap-group={sorted(r.value for r in co)}")
+        if refused:
+            print(f"        >>> REGRESSION: planner refuses {refused}")
+    print(f"\n=== {regressions} scenario(s) regress vs the in-process oracle ===")
+    return regressions
+
+
+if __name__ == "__main__":
+    raise SystemExit(1 if _print_diff_table() else 0)


### PR DESCRIPTION
## Problem

Since the move to the llama-server/llama-swap fleet, ingest fails on tight GPUs with the vision model refused "because the chat model is there." The in-process pool that preceded the fleet loaded each role lazily on first call, so ingest (embed + vision OCR) and a query (embed + rerank + chat) never held each other's models in VRAM; peak was embed + max(vision, chat+rerank), never the sum of all four. The fleet planner instead reserves every role at once, pinning embed + rerank and then trying vision on the leftover, so on any box where embed+rerank+vision overflows but embed+vision fits, vision gets no server and OCR hard-fails. The earlier co-tenancy fix (#506) only refunded vision for chat, so the query-only reranker still tipped vision out.

## Solution

The planner now models the two run phases explicitly (`RoleInfo.phases`: ingest loads embed+vision, a query loads embed+rerank+chat). Roles that share no phase are never resident together, so a role that does not fit refunds the already-charged phase-disjoint roles and retries; the roles that make room become one `swap: true` llama-swap group. On a tight card this pulls the query-only rerank and chat into vision's swap group, so ingest's embed + vision fits exactly as it did in-process, and llama-swap evicts across the phase boundary at runtime. Roomy hardware forms no swap group and pins every role. A role is unplaceable only when it does not fit even beside the one embedder its own phase needs.

This also fixes a reservation bug the generalization exposed: a co-tenant group that does not include chat runs behind its own process and can be resident beside a tensor-split chat shard, so its members are charged against the shard's KV headroom instead of being treated as chat's to reclaim.

## Evidence

A committed differential harness (`tests/test_placement_oracle_parity.py`) drives the real planner across GPU and unified low-RAM / on-the-cusp conditions and asserts two things per scenario: the planner serves every role the in-process pool would have served on demand, and the resulting plan fits its own budget. It reproduced the regression before the fix (a single 6GB GPU served embed+rerank and refused vision, where the in-process pool served embed+vision) and shows zero regressions across all scenarios after.