### PR TITLE
Fix vision OCR refused on consumer GPUs: correct the projector estimate and load tight models best-effort

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -305,7 +305,12 @@ flowchart LR
   whichever GPU is fullest, not on the summed total. The estimate also carries the
   same `--batch-size`/`--ubatch-size` the launch will use (pooled embed/rerank raise
   them to the full context), so the compute-buffer estimate matches what the server
-  actually allocates. This replaced a hand-rolled
+  actually allocates. For a vision model the discrete-GPU number is corrected on
+  lilbee's side: gguf-parser's `nonuma` merge charges any multimodal projector
+  roughly 10 GiB of phantom compute buffer (a 1.2 GiB OCR model plus its 0.9 GiB
+  projector came back as 12.7 GiB), so the projector is instead charged at its
+  unified-memory delta, floored at the projector's own weights. This replaced a
+  hand-rolled
   weights + KV-cache estimate that used discrete-GPU accounting and over-estimated
   ~3x on unified memory, which was crowding the co-resident embed/rerank servers out
   of the budget and 503-ing every search.
@@ -451,8 +456,13 @@ touching the running fleet.
   `swap: true` group evicts same-group siblings, so a second replica inside it would
   evict the first). Interleaving a query with an ingest costs a model reload each
   way. With the VRAM to hold everything at once, no swap group forms and every role
-  pins to its own group. A role is unplaceable only when it does not fit even beside
-  the one embedder its own phase needs (a genuine "use a smaller model").
+  pins to its own group. On GPUs the estimate advises but never refuses: a role that
+  does not fit even beside the one embedder its own phase needs is still **placed
+  tight** (best-effort) on the emptiest card, anchoring the swap group so the load
+  starts against as much free VRAM as possible, with a memory-is-tight warning
+  carrying the estimated shortfall. The in-process pool never gated a load on an
+  estimate, and the load itself is the only reliable arbiter (the estimate can be
+  high, and some drivers page into shared memory rather than fail).
 - **Data-parallel replicas** (`embed_replicas` / `vision_replicas`): the embed and
   vision roles can run as N independent servers, fanning embedding and OCR across
   the box during ingest. Setting either value to `0` (the default) means auto: one

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -6,14 +6,14 @@ model that fits one GPU runs as a single pinned instance, small models co-locate
 on a GPU with spare VRAM, and a model too big for any single GPU is tensor-split
 across enough GPUs to fit. Roles that never run in the same phase (ingest OCR vs a
 query) share one swap group when they cannot all co-reside, so only the phase in
-use is charged; a role that fits nowhere gets no server (its calls error). See
-docs/architecture.md.
+use is charged. On GPUs the estimate advises but never refuses: a role that fits
+nowhere is placed tight (best-effort, with a warning). See docs/architecture.md.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from lilbee.providers.fleet.placement_spec import PlacementError, PlacementSpec, RolePlacement
 from lilbee.providers.fleet.vram import USABLE_VRAM_FRACTION
@@ -61,17 +61,21 @@ class InstancePlan:
 
 @dataclass(frozen=True)
 class Placement:
-    """Planner output: server instances, swap tenants, and roles that fit on no device.
+    """Planner output: server instances, swap tenants, and best-effort placements.
 
     ``unplaceable_roles`` get no server, so a call to them surfaces a
-    ``ProviderError`` (there is no in-process fallback). ``co_tenants`` share one
-    llama-swap group and evict each other on demand, so only one is resident at a
-    time; each runs a single instance.
+    ``ProviderError`` (there is no in-process fallback); only the shared-memory
+    path produces them (an oversize load there OOM-livelocks the host). On GPUs
+    a role that fits nowhere is placed anyway and listed in ``tight_roles`` with
+    its estimated shortfall in bytes. ``co_tenants`` share one llama-swap group
+    and evict each other on demand, so only one is resident at a time; each runs
+    a single instance.
     """
 
     instances: tuple[InstancePlan, ...]
     unplaceable_roles: tuple[WorkerRole, ...]
     co_tenants: frozenset[WorkerRole] = frozenset()
+    tight_roles: dict[WorkerRole, int] = field(default_factory=dict)
 
 
 def plan_placement(
@@ -91,7 +95,8 @@ def plan_placement(
     too big for any single GPU is tensor-split. Chat is charged last: when it fits
     only if vision's VRAM is refunded, the two become ``co_tenants`` of one swap
     group instead of either becoming unplaceable. A model that fits nowhere, even
-    alone beside the pinned tier, is an unplaceable role.
+    alone beside the pinned tier, is still placed tight and reported in
+    ``tight_roles``.
 
     A chat split widens past the fewest fitting cards when ``chat_ctx_fit`` shows a
     tighter shard would starve its served context below ``chat_ctx_target``; the
@@ -131,13 +136,14 @@ def plan_placement(
             free_headroom=free_headroom,
         )
 
-    instances, unplaceable, co_tenants = _place_persistent(persistent_singles, place, remaining)
+    instances, co_tenants, tight = _place_persistent(persistent_singles, place, remaining)
     instances.extend(_place_elastic(replicated, instances, remaining, co_tenants))
 
     return Placement(
         instances=tuple(instances),
-        unplaceable_roles=tuple(unplaceable),
+        unplaceable_roles=(),
         co_tenants=co_tenants,
+        tight_roles=tight,
     )
 
 
@@ -157,29 +163,32 @@ def _place_persistent(
     persistent_singles: list[ModelPlacementInput],
     place: Callable[[ModelPlacementInput], _Placed | None],
     remaining: dict[int, float],
-) -> tuple[list[InstancePlan], list[WorkerRole], frozenset[WorkerRole]]:
+) -> tuple[list[InstancePlan], frozenset[WorkerRole], dict[WorkerRole, int]]:
     """Charge every persistent single in ``placement_rank`` order.
 
     A role that does not fit refunds every already-charged role it is phase-disjoint
     from (never co-resident with) and retries; the roles that let it in become one
     swap group. This restores the in-process pool's behavior, where a role loaded
     only when its phase ran, so ingest never paid for the query models or vice versa.
+    A role that still fits nowhere is placed tight (:func:`_place_tight`) instead
+    of refused.
     """
     instances: list[InstancePlan] = []
-    unplaceable: list[WorkerRole] = []
     charges: dict[WorkerRole, dict[int, float]] = {}
     co_tenants: set[WorkerRole] = set()
+    tight: dict[WorkerRole, int] = {}
     for model in sorted(persistent_singles, key=_shared_pool_order):
         placed = place(model)
         if placed is None:
             placed, group = _place_beside_disjoint(model, place, remaining, charges)
             co_tenants |= group
         if placed is None:
-            unplaceable.append(model.role)
-        else:
-            instances.append(placed.plan)
-            charges[model.role] = placed.charges
-    return instances, unplaceable, frozenset(co_tenants)
+            placed, group, shortfall = _place_tight(model, remaining, charges)
+            co_tenants |= group
+            tight[model.role] = shortfall
+        instances.append(placed.plan)
+        charges[model.role] = placed.charges
+    return instances, frozenset(co_tenants), tight
 
 
 def _place_beside_disjoint(
@@ -212,6 +221,35 @@ def _place_beside_disjoint(
         for idx, held in charged.items():
             remaining[idx] -= held
     return None, frozenset()
+
+
+def _place_tight(
+    model: ModelPlacementInput,
+    remaining: dict[int, float],
+    charges: dict[WorkerRole, dict[int, float]],
+) -> tuple[_Placed, frozenset[WorkerRole], int]:
+    """Place an oversize *model* best-effort instead of refusing it.
+
+    Refunds every phase-disjoint charged role (they become *model*'s swap group),
+    pins *model* to the card with the most headroom, and drains that card so the
+    elastic tier places nothing on it. Returns the estimated shortfall in bytes.
+    """
+    refunds = {r: c for r, c in charges.items() if _phase_disjoint(r, model.role)}
+    for charged in refunds.values():
+        for idx, held in charged.items():
+            remaining[idx] += held
+    device = max(remaining, key=lambda idx: remaining[idx])
+    available = remaining[device]
+    remaining[device] = 0.0
+    slot = _group_slot({device: available}, refunds, remaining)
+    for role in refunds:
+        del charges[role]
+    placed = _Placed(
+        plan=InstancePlan(role=model.role, devices=(device,)),
+        charges=slot,
+    )
+    group = frozenset(refunds) | {model.role} if refunds else frozenset()
+    return placed, group, int(model.est_vram_bytes - available)
 
 
 def _group_slot(

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -1114,7 +1114,8 @@ def _log_placement_findings(placement: Placement, model_refs: dict[WorkerRole, s
             "load or runs slowly, free up GPU memory or use a smaller model.",
             role.value,
             model_refs[role],
-            shortfall / 1024**3,
+            # A sub-0.05 GiB shortfall would render as "0.0 GiB more".
+            max(shortfall / 1024**3, 0.1),
         )
     if placement.co_tenants:
         log.info(

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -1093,6 +1093,36 @@ class FleetPlan:
     co_tenants: frozenset[WorkerRole] = frozenset()
 
 
+def _log_placement_findings(placement: Placement, model_refs: dict[WorkerRole, str]) -> None:
+    """Warn about placements that exceed the memory budget.
+
+    Shared-memory roles that fit nowhere get no server (loading them would OOM the
+    host). GPU roles are never refused: one whose estimate exceeds the free VRAM
+    still loads on demand, with a warning carrying the shortfall.
+    """
+    for role in placement.unplaceable_roles:
+        log.warning(
+            "%s model %s does not fit available memory and will not be served; "
+            "free up memory or use a smaller model.",
+            role.value,
+            model_refs[role],
+        )
+    for role, shortfall in placement.tight_roles.items():
+        log.warning(
+            "Memory is tight for the %s model %s: it is estimated to need %.1f GiB more "
+            "GPU memory than is available. It will still load on demand; if it fails to "
+            "load or runs slowly, free up GPU memory or use a smaller model.",
+            role.value,
+            model_refs[role],
+            shortfall / 1024**3,
+        )
+    if placement.co_tenants:
+        log.info(
+            "%s share GPU memory and load on demand; only one is resident at a time.",
+            ", ".join(sorted(role.value for role in placement.co_tenants)),
+        )
+
+
 def plan_launches(
     roles: tuple[WorkerRole, ...] | None,
     binary: Path,
@@ -1108,18 +1138,7 @@ def plan_launches(
     )
     spec = PlacementSpec.from_json(cfg.placement) if cfg.placement else None
     placement = _resolve_placement(spec, inputs, model_refs, devices, unified_budget=unified_budget)
-    for role in placement.unplaceable_roles:
-        log.warning(
-            "%s model %s does not fit available memory and will not be served; "
-            "free up memory or use a smaller model.",
-            role.value,
-            model_refs[role],
-        )
-    if placement.co_tenants:
-        log.info(
-            "%s share GPU memory and load on demand; only one is resident at a time.",
-            ", ".join(sorted(role.value for role in placement.co_tenants)),
-        )
+    _log_placement_findings(placement, model_refs)
     reserved_by_device = _non_chat_reservation(placement.instances, inputs, placement.co_tenants)
     return FleetPlan(
         launches=tuple(

--- a/src/lilbee/providers/fleet/vram.py
+++ b/src/lilbee/providers/fleet/vram.py
@@ -104,21 +104,54 @@ def estimate_instance_footprint(
     estimate is single-device and the per-GPU peak that actually OOMs is invisible.
     Pass *batch_size* when the launch raises ``--batch-size``/``--ubatch-size``
     (pooled embed/rerank), so the compute-buffer estimate matches the launch.
+
+    With an *mmproj_path* the discrete-GPU number is corrected: gguf-parser's
+    nonuma merge overcharges a multimodal projector by roughly 10 GiB of compute
+    buffer (v0.24.x and current main), while its unified-memory accounting stays
+    accurate, so the projector is re-charged from that side
+    (:func:`_corrected_projector_estimate`).
     """
-    mmproj = str(mmproj_path) if mmproj_path is not None else None
-    mmproj_mtime = mmproj_path.stat().st_mtime_ns if mmproj_path is not None else 0
-    return _cached_footprint(
-        str(model_path),
-        model_path.stat().st_mtime_ns,
-        ctx,
-        slots,
-        gpu_layers,
-        flash_attn,
-        kv_cache_type.value,
-        mmproj,
-        mmproj_mtime,
-        tensor_split,
-        batch_size,
+
+    def run(mmproj: Path | None) -> GgufVramEstimate:
+        return _cached_footprint(
+            str(model_path),
+            model_path.stat().st_mtime_ns,
+            ctx,
+            slots,
+            gpu_layers,
+            flash_attn,
+            kv_cache_type.value,
+            str(mmproj) if mmproj is not None else None,
+            mmproj.stat().st_mtime_ns if mmproj is not None else 0,
+            tensor_split,
+            batch_size,
+        )
+
+    if mmproj_path is None:
+        return run(None)
+    with_projector = run(mmproj_path)
+    return _corrected_projector_estimate(run(None), with_projector, mmproj_path.stat().st_size)
+
+
+def _corrected_projector_estimate(
+    base: GgufVramEstimate, with_projector: GgufVramEstimate, mmproj_bytes: int
+) -> GgufVramEstimate:
+    """Charge the projector at its unified-memory delta, floored at its weights.
+
+    The floor covers a mmap-shared projector whose uma delta hides weights that
+    still occupy VRAM once offloaded. The charge lands on the first device:
+    llama.cpp loads the projector on the main GPU, not across a split.
+    """
+    projector = max(with_projector.unified_bytes - base.unified_bytes, mmproj_bytes)
+    per_device_vram = tuple(
+        vram + (projector if i == 0 else 0) for i, vram in enumerate(base.per_device_vram)
+    )
+    return GgufVramEstimate(
+        vram_bytes=base.vram_bytes + projector,
+        ram_bytes=with_projector.ram_bytes,
+        unified_bytes=with_projector.unified_bytes,
+        per_device_vram=per_device_vram,
+        per_device_unified=with_projector.per_device_unified,
     )
 
 

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -75,11 +75,13 @@ class TestPlanPlacement:
         placed first (bb-7jg1.6)."""
         chat = ModelPlacementInput(WorkerRole.CHAT, 20 * _GB)
         embed = ModelPlacementInput(WorkerRole.EMBED, 18 * _GB)
-        # One 24 GB card (21.6 GB usable): either model fits alone, not both.
+        # One 24 GB card (21.6 GB usable): either model fits alone, not both. Embed
+        # keeps its full charge; chat (never phase-disjoint from embed, so nothing
+        # to swap with) loads tight into the leftover instead of being refused.
         plan = plan_placement([chat, embed], [(0, 24 * _GB)], estimate_peak=_even(chat, embed))
         placed = {i.role for i in plan.instances}
-        assert WorkerRole.EMBED in placed
-        assert WorkerRole.CHAT in plan.unplaceable_roles
+        assert placed == {WorkerRole.EMBED, WorkerRole.CHAT}
+        assert plan.tight_roles.keys() == {WorkerRole.CHAT}
 
     def test_colocates_small_models_on_one_gpu(self) -> None:
         plan = plan_placement(
@@ -118,15 +120,20 @@ class TestPlanPlacement:
         assert plan.instances[0].devices == (0, 1)
         assert plan.instances[0].tensor_split == (21, 14)
 
-    def test_unplaceable_when_model_fits_nowhere(self) -> None:
+    def test_model_that_fits_nowhere_loads_tight_on_one_card(self) -> None:
+        # An oversize model still gets a server: placed tight on one card.
         model = ModelPlacementInput(WorkerRole.CHAT, 100 * _GB)
         plan = plan_placement(
             [model],
             [(0, 24 * _GB), (1, 24 * _GB)],
             estimate_peak=_even(model),
         )
-        assert plan.instances == ()
-        assert plan.unplaceable_roles == (WorkerRole.CHAT,)
+        assert len(plan.instances) == 1
+        assert plan.instances[0].role is WorkerRole.CHAT
+        assert len(plan.instances[0].devices) == 1
+        assert plan.unplaceable_roles == ()
+        # Short by its estimate minus one card's 90% headroom.
+        assert plan.tight_roles == {WorkerRole.CHAT: int(100 * _GB - 24 * _GB * 0.9)}
 
     def test_no_gpu_devices_places_every_role_on_cpu(self) -> None:
         # A GPU-less host (or a probe that found nothing): each role runs as a
@@ -258,7 +265,7 @@ class TestPerDeviceSplit:
         assert elastic.devices == (0,)  # card 0 (charged 2) has room; card 1 (charged 20) does not
         assert plan.co_tenants == frozenset()
 
-    def test_unplaceable_when_per_device_never_fits(self) -> None:
+    def test_loads_tight_when_per_device_never_fits(self) -> None:
         model = ModelPlacementInput(WorkerRole.CHAT, 40 * _GB)
 
         def peak(_role: WorkerRole, ratio: tuple[int, ...]) -> tuple[int, ...]:
@@ -269,8 +276,8 @@ class TestPerDeviceSplit:
             [(0, 24 * _GB), (1, 24 * _GB)],
             estimate_peak=peak,
         )
-        assert plan.instances == ()
-        assert plan.unplaceable_roles == (WorkerRole.CHAT,)
+        assert len(plan.instances) == 1
+        assert plan.tight_roles.keys() == {WorkerRole.CHAT}
 
     def test_skips_count_when_estimator_returns_wrong_cardinality(self) -> None:
         # A malformed estimate (cardinality != device count) is skipped, not crashed.
@@ -284,7 +291,7 @@ class TestPerDeviceSplit:
             [(0, 24 * _GB), (1, 24 * _GB)],
             estimate_peak=peak,
         )
-        assert plan.unplaceable_roles == (WorkerRole.CHAT,)
+        assert plan.tight_roles.keys() == {WorkerRole.CHAT}
 
 
 class TestContextAwareChatSplit:
@@ -402,14 +409,16 @@ class TestReplicas:
         assert sorted(i.devices[0] for i in embeds) == [0, 0, 1, 1]
         assert {i.replica for i in embeds} == {0, 1, 2, 3}
 
-    def test_replicated_role_unplaceable_when_no_gpu_fits_one(self) -> None:
+    def test_oversize_replicated_role_loads_one_tight_instance(self) -> None:
+        # The persistent single loads tight; the drained card leaves the elastic
+        # replica nowhere to go, so exactly one instance serves the role.
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.EMBED, 100 * _GB, replicas=2)],
             [(0, 24 * _GB)],
             estimate_peak=_never,
         )
-        assert plan.instances == ()
-        assert plan.unplaceable_roles == (WorkerRole.EMBED,)
+        assert [i.role for i in plan.instances] == [WorkerRole.EMBED]
+        assert plan.tight_roles.keys() == {WorkerRole.EMBED}
 
     def test_chat_placed_before_replicas_then_replicas_fill_remaining(self) -> None:
         plan = plan_placement(
@@ -517,15 +526,18 @@ class TestPersistentSingleElasticSplit:
         assert len(embeds) < 4  # capped by residual, not all 4 requested
         assert plan.unplaceable_roles == ()
 
-    def test_replicated_role_unplaceable_when_persistent_single_does_not_fit(self) -> None:
-        # If replica 0 (the persistent single) fits nowhere, the role is unplaceable.
+    def test_oversize_persistent_single_loads_tight_without_elastic_replicas(self) -> None:
+        # Replica 0 (the persistent single) fits nowhere: it loads tight and drains
+        # the card, so the elastic batch places nothing on top of it.
         plan = plan_placement(
             [ModelPlacementInput(WorkerRole.EMBED, 100 * _GB, replicas=2)],
             [(0, 24 * _GB)],
             estimate_peak=_never,
         )
-        assert self._embeds(plan) == []
-        assert plan.unplaceable_roles == (WorkerRole.EMBED,)
+        embeds = self._embeds(plan)
+        assert len(embeds) == 1
+        assert embeds[0].replica == 0
+        assert plan.tight_roles.keys() == {WorkerRole.EMBED}
 
     def test_single_replica_role_is_unchanged(self) -> None:
         # replicas=1 still places exactly one replica-0 single, no elastic batch.
@@ -582,10 +594,10 @@ class TestChatVisionCoTenancy:
         assert plan.unplaceable_roles == ()
         assert plan.co_tenants == frozenset()
 
-    def test_vision_too_big_even_for_ingest_alone_is_unplaceable(self) -> None:
-        # Vision does not fit even beside the embedder alone (its ingest working set):
-        # a real "use a smaller model", not a co-residency conflict. 8GB card is 7.2
+    def test_vision_too_big_even_for_ingest_alone_loads_tight(self) -> None:
+        # Vision does not fit even beside the embedder alone: 8GB card is 7.2
         # usable; embed 1 + vision 8 overflows even with rerank and chat refunded.
+        # Vision anchors the swap group tight (short by 1.8) instead of refused.
         models = [
             ModelPlacementInput(WorkerRole.CHAT, 3 * _GB),
             *self._search(),
@@ -593,8 +605,16 @@ class TestChatVisionCoTenancy:
         ]
         plan = plan_placement(models, [(0, 8 * _GB)], estimate_peak=_never)
 
-        assert plan.unplaceable_roles == (WorkerRole.VISION,)
-        assert plan.co_tenants == frozenset()
+        assert plan.unplaceable_roles == ()
+        assert self._roles(plan) == {
+            WorkerRole.CHAT,
+            WorkerRole.EMBED,
+            WorkerRole.RERANK,
+            WorkerRole.VISION,
+        }
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION})
+        # Short by its 8GB estimate minus what refunding rerank freed (7.2 - embed 1).
+        assert plan.tight_roles == {WorkerRole.VISION: int(8 * _GB - (8 * _GB * 0.9 - 1 * _GB))}
 
     def test_vision_that_fits_ingest_pulls_rerank_into_the_swap_group(self) -> None:
         # 8GB card (7.2 usable): embed 1 + rerank 1 + vision 6 = 8 overflows, but the
@@ -635,9 +655,9 @@ class TestChatVisionCoTenancy:
 
     def test_large_llm_reranker_cannot_crowd_out_the_embedder(self) -> None:
         # The embedder runs in every phase, so nothing can swap with it; it charges
-        # before same-rank single-phase roles. A 5GB LLM reranker on a 6GB card is
-        # the genuinely unservable role (query needs embed+rerank co-resident);
-        # embed, vision, and chat all still get servers.
+        # before same-rank single-phase roles. A 5GB LLM reranker on a 6GB card
+        # cannot take the embedder's charge: it loads tight into the leftover
+        # (short by 0.2) and every role still gets a server.
         models = [
             ModelPlacementInput(WorkerRole.EMBED, int(0.6 * _GB)),
             ModelPlacementInput(WorkerRole.RERANK, 5 * _GB),
@@ -646,9 +666,15 @@ class TestChatVisionCoTenancy:
         ]
         plan = plan_placement(models, [(0, 6 * _GB)], estimate_peak=_never)
 
-        assert plan.unplaceable_roles == (WorkerRole.RERANK,)
-        assert self._roles(plan) == {WorkerRole.EMBED, WorkerRole.VISION, WorkerRole.CHAT}
-        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
+        assert plan.unplaceable_roles == ()
+        assert self._roles(plan) == {
+            WorkerRole.EMBED,
+            WorkerRole.RERANK,
+            WorkerRole.VISION,
+            WorkerRole.CHAT,
+        }
+        assert plan.tight_roles.keys() == {WorkerRole.RERANK}
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION})
 
     def test_vision_swap_group_forms_without_chat_when_chat_is_disabled(self) -> None:
         # No chat model configured: on a tight card vision still cannot sit beside the
@@ -677,8 +703,9 @@ class TestChatVisionCoTenancy:
         assert len(visions) == 1
         assert visions[0].replica == 0
 
-    def test_chat_that_fits_nowhere_is_unplaceable_and_vision_stays_pinned(self) -> None:
-        # Refunding vision still does not make room: chat is the genuinely oversize one.
+    def test_chat_that_fits_nowhere_loads_tight_in_visions_swap_group(self) -> None:
+        # Refunding vision still does not make room: chat is genuinely oversize.
+        # Chat loads tight; the refunded vision shares its swap group.
         models = [
             ModelPlacementInput(WorkerRole.CHAT, 200 * _GB),
             *self._search(),
@@ -686,9 +713,77 @@ class TestChatVisionCoTenancy:
         ]
         plan = plan_placement(models, [(0, 24 * _GB)], estimate_peak=_never)
 
-        assert plan.unplaceable_roles == (WorkerRole.CHAT,)
-        assert plan.co_tenants == frozenset()
+        assert plan.unplaceable_roles == ()
+        assert plan.tight_roles.keys() == {WorkerRole.CHAT}
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
         assert WorkerRole.VISION in self._roles(plan)
+
+
+class TestTightPlacement:
+    """The estimate never refuses a role: a model that fits nowhere loads tight
+    (best-effort) on the emptiest card with its shortfall reported."""
+
+    def test_inflated_vision_estimate_still_gets_a_server(self) -> None:
+        # Vision's estimate exceeds the whole card and embed (same phase) cannot
+        # be refunded: vision anchors the swap group tight; chat joins by
+        # refunding that slot.
+        models = [
+            ModelPlacementInput(WorkerRole.CHAT, 3 * _GB),
+            ModelPlacementInput(WorkerRole.EMBED, int(0.5 * _GB)),
+            ModelPlacementInput(WorkerRole.RERANK, 1 * _GB),
+            ModelPlacementInput(WorkerRole.VISION, 18 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 16 * _GB)], estimate_peak=_never)
+
+        assert plan.unplaceable_roles == ()
+        assert {i.role for i in plan.instances} == {
+            WorkerRole.CHAT,
+            WorkerRole.EMBED,
+            WorkerRole.RERANK,
+            WorkerRole.VISION,
+        }
+        assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.RERANK, WorkerRole.VISION})
+        # Short by the estimate minus the card's headroom less the embedder's charge.
+        assert plan.tight_roles == {WorkerRole.VISION: int(18 * _GB - (16 * _GB * 0.9 - 0.5 * _GB))}
+
+    def test_lone_tight_role_forms_no_swap_group(self) -> None:
+        # Nothing charged is phase-disjoint from vision (the embedder shares ingest):
+        # the tight role stays a plain pinned instance, no co-tenancy.
+        models = [
+            ModelPlacementInput(WorkerRole.EMBED, int(0.5 * _GB)),
+            ModelPlacementInput(WorkerRole.VISION, 18 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 16 * _GB)], estimate_peak=_never)
+
+        assert {i.role for i in plan.instances} == {WorkerRole.EMBED, WorkerRole.VISION}
+        assert plan.co_tenants == frozenset()
+        assert plan.tight_roles.keys() == {WorkerRole.VISION}
+
+    def test_tight_role_lands_on_the_emptiest_card(self) -> None:
+        # Two unequal cards: the tight model takes the one with the most headroom.
+        models = [
+            ModelPlacementInput(WorkerRole.EMBED, 4 * _GB),
+            ModelPlacementInput(WorkerRole.VISION, 40 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 8 * _GB), (1, 24 * _GB)], estimate_peak=_even(*models))
+
+        vision = next(i for i in plan.instances if i.role is WorkerRole.VISION)
+        embed = next(i for i in plan.instances if i.role is WorkerRole.EMBED)
+        assert embed.devices == (1,)  # most-free single placement charges card 1 first
+        assert vision.devices == (1,)  # 24GB minus embed still beats the empty 8GB card
+        assert plan.tight_roles.keys() == {WorkerRole.VISION}
+
+    def test_tight_role_drains_its_card_so_replicas_cannot_pile_on(self) -> None:
+        # The tight slot consumes the card's whole headroom: no room remains for
+        # an elastic embed replica.
+        models = [
+            ModelPlacementInput(WorkerRole.EMBED, 1 * _GB, replicas=2),
+            ModelPlacementInput(WorkerRole.VISION, 40 * _GB),
+        ]
+        plan = plan_placement(models, [(0, 16 * _GB)], estimate_peak=_never)
+
+        embeds = [i for i in plan.instances if i.role is WorkerRole.EMBED]
+        assert len(embeds) == 1
 
 
 class TestSharedMemoryCoTenancy:

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1673,3 +1673,32 @@ class TestPlanProbe:
         monkeypatch.setattr("lilbee.providers.model_cache.free_system_memory", lambda: 5 * _GB)
         assert planning_mod._plan_available_memory() == 7 * _GB
         assert planning_mod._plan_free_system_memory() == 5 * _GB
+
+
+class TestPlacementFindingsLog:
+    """plan_launches tells the user about tight and unservable placements."""
+
+    def test_tight_role_logs_a_memory_is_tight_warning(self, caplog) -> None:
+        import logging
+
+        placement = Placement(
+            instances=(InstancePlan(role=WorkerRole.VISION, devices=(0,)),),
+            unplaceable_roles=(),
+            tight_roles={WorkerRole.VISION: int(4.1 * _GB)},
+        )
+        with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.planning"):
+            planning_mod._log_placement_findings(placement, {WorkerRole.VISION: "org/ocr.gguf"})
+        assert "Memory is tight for the vision model org/ocr.gguf" in caplog.text
+        assert "4.1 GiB" in caplog.text
+        assert "will still load on demand" in caplog.text
+
+    def test_unplaceable_shared_memory_role_still_warns_it_gets_no_server(self, caplog) -> None:
+        import logging
+
+        placement = Placement(
+            instances=(),
+            unplaceable_roles=(WorkerRole.CHAT,),
+        )
+        with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.planning"):
+            planning_mod._log_placement_findings(placement, {WorkerRole.CHAT: "org/chat.gguf"})
+        assert "will not be served" in caplog.text

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1702,3 +1702,16 @@ class TestPlacementFindingsLog:
         with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.planning"):
             planning_mod._log_placement_findings(placement, {WorkerRole.CHAT: "org/chat.gguf"})
         assert "will not be served" in caplog.text
+
+    def test_tiny_shortfall_never_reads_as_zero(self, caplog) -> None:
+        import logging
+
+        placement = Placement(
+            instances=(InstancePlan(role=WorkerRole.VISION, devices=(0,)),),
+            unplaceable_roles=(),
+            tight_roles={WorkerRole.VISION: 10 * 1024 * 1024},
+        )
+        with caplog.at_level(logging.WARNING, logger="lilbee.providers.fleet.planning"):
+            planning_mod._log_placement_findings(placement, {WorkerRole.VISION: "org/ocr.gguf"})
+        assert "0.0 GiB" not in caplog.text
+        assert "0.1 GiB" in caplog.text

--- a/tests/test_fleet_vram.py
+++ b/tests/test_fleet_vram.py
@@ -348,3 +348,104 @@ class TestBatchSizeFlags:
         estimate_instance_footprint(model_file, **common)
         estimate_instance_footprint(model_file, **common, batch_size=2048)
         assert len(recorder) == 2  # a different batch size is a different estimate
+
+
+class TestProjectorCorrection:
+    """A multimodal projector is charged at its unified-memory delta, floored at its
+    weights, instead of gguf-parser's inflated discrete-GPU merge (v0.24.x adds ~10
+    GiB of phantom compute buffer to any model+mmproj estimate)."""
+
+    _GB = 1024**3
+
+    def _patch_two_run_parser(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        base_json: str,
+        mmproj_json: str,
+        recorder: list[list[str]] | None = None,
+    ) -> None:
+        monkeypatch.setattr(vram_mod, "resolve_gguf_parser", lambda: Path("/fake/gguf-parser"))
+
+        def fake_run(argv: list[str], **_kwargs: object) -> SimpleNamespace:
+            if recorder is not None:
+                recorder.append(argv)
+            return SimpleNamespace(stdout=mmproj_json if "--mmproj-path" in argv else base_json)
+
+        monkeypatch.setattr(vram_mod.subprocess, "run", fake_run)
+
+    def _estimate(self, model_file: Path, mmproj: Path) -> GgufVramEstimate:
+        return estimate_instance_footprint(
+            model_file,
+            ctx=2048,
+            slots=1,
+            gpu_layers=-1,
+            flash_attn=True,
+            kv_cache_type=KvCacheType.F16,
+            mmproj_path=mmproj,
+        )
+
+    def test_projector_vram_is_the_uma_delta_not_the_nonuma_merge(
+        self, model_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Without the projector: 3GB nonuma / 2GB uma. With it the parser claims
+        # 13GB nonuma but a sane 2.8GB uma. The projector must cost the 0.8GB the
+        # unified model attributes to it, not the 10GB phantom.
+        mmproj = tmp_path / "mmproj.gguf"
+        mmproj.write_bytes(b"G" * 1024)  # far below the uma delta
+        self._patch_two_run_parser(
+            monkeypatch,
+            base_json=_sample_json(ram_uma=0, ram_nonuma=0, vrams=[(2 * self._GB, 3 * self._GB)]),
+            mmproj_json=_sample_json(
+                ram_uma=0, ram_nonuma=0, vrams=[(int(2.8 * self._GB), 13 * self._GB)]
+            ),
+        )
+        est = self._estimate(model_file, mmproj)
+        assert est.vram_bytes == 3 * self._GB + int(0.8 * self._GB)
+        # The unified estimate was never inflated; it passes through untouched.
+        assert est.unified_bytes == int(2.8 * self._GB)
+
+    def test_projector_charge_is_floored_at_its_weights(
+        self, model_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A projector whose weights are mmap-shared can show a near-zero uma delta,
+        # but offloaded weights still occupy VRAM: floor the charge at the file size.
+        mmproj = tmp_path / "mmproj.gguf"
+        mmproj.write_bytes(b"G" * 4096)  # weights larger than the 1000-byte uma delta
+        self._patch_two_run_parser(
+            monkeypatch,
+            base_json=_sample_json(ram_uma=0, ram_nonuma=0, vrams=[(2_000, 3_000)]),
+            mmproj_json=_sample_json(ram_uma=0, ram_nonuma=0, vrams=[(3_000, 13_000)]),
+        )
+        est = self._estimate(model_file, mmproj)
+        assert est.vram_bytes == 3_000 + 4096  # base plus the projector weights floor
+
+    def test_projector_lands_on_the_first_device_of_a_split(
+        self, model_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mmproj = tmp_path / "mmproj.gguf"
+        mmproj.write_bytes(b"G" * 4096)
+        self._patch_two_run_parser(
+            monkeypatch,
+            base_json=_sample_json(
+                ram_uma=0,
+                ram_nonuma=0,
+                vrams=[(2_000, 3_000), (2_000, 3_000)],
+            ),
+            mmproj_json=_sample_json(
+                ram_uma=0,
+                ram_nonuma=0,
+                vrams=[(2_000, 9_000), (2_000, 9_000)],
+            ),
+        )
+        est = estimate_instance_footprint(
+            model_file,
+            ctx=2048,
+            slots=1,
+            gpu_layers=-1,
+            flash_attn=True,
+            kv_cache_type=KvCacheType.F16,
+            mmproj_path=mmproj,
+            tensor_split=(1, 1),
+        )
+        assert est.per_device_vram == (3_000 + 4096, 3_000)

--- a/tests/test_placement_oracle_parity.py
+++ b/tests/test_placement_oracle_parity.py
@@ -4,9 +4,13 @@ in-process pool would have served on demand.
 The in-process ``WorkerPool`` had no VRAM admission and no idle reaping: a role's
 worker spawned lazily on first call, so only the roles a single operation used were
 ever co-resident. Ingest loaded embed+vision; query loaded embed+chat+rerank. Peak
-was ``embed + max(vision, chat+rerank)``, never the sum. This suite feeds low-RAM /
-on-the-cusp conditions into the real :func:`plan_placement` and asserts it never
-refuses a role that lazy per-phase residency would have served.
+was ``embed + max(vision, chat+rerank)``, never the sum, and no load was ever
+gated on an estimate. This suite feeds low-RAM / on-the-cusp conditions into the
+real :func:`plan_placement` and asserts three properties: the GPU path never
+refuses a role, tight (best-effort) placement fires only for roles whose working
+set exceeds the budget by estimate, and the normally-placed tier fits the budget
+it claims. The shared-memory path keeps its deliberate divergence: a role larger
+than free system RAM is refused rather than OOM-livelocking the host.
 """
 
 from __future__ import annotations
@@ -62,7 +66,15 @@ def _estimate(footprints: dict[WorkerRole, int]):
 
 
 def _oracle_servable(sc: Scenario) -> set[WorkerRole]:
-    """Every role in a working set that fits: what the lazy pool would serve."""
+    """What the b507 lazy pool would serve: everything on GPUs (no estimate
+    gate); on shared memory, every role in a working set that fits the budget."""
+    if sc.devices:
+        return set(sc.footprints)
+    return _working_set_servable(sc)
+
+
+def _working_set_servable(sc: Scenario) -> set[WorkerRole]:
+    """Every role in a working set that fits the budget by estimate."""
     budget = _budget(sc)
     servable: set[WorkerRole] = set()
     for roles in _WORKING_SETS:
@@ -72,7 +84,9 @@ def _oracle_servable(sc: Scenario) -> set[WorkerRole]:
     return servable
 
 
-def _planner_servable(sc: Scenario) -> tuple[set[WorkerRole], frozenset[WorkerRole]]:
+def _planner_servable(
+    sc: Scenario,
+) -> tuple[set[WorkerRole], frozenset[WorkerRole], dict[WorkerRole, int]]:
     models = [
         ModelPlacementInput(role=role, est_vram_bytes=vram) for role, vram in sc.footprints.items()
     ]
@@ -83,7 +97,7 @@ def _planner_servable(sc: Scenario) -> tuple[set[WorkerRole], frozenset[WorkerRo
         unified_budget=sc.unified_budget,
     )
     servable = set(sc.footprints) - set(placement.unplaceable_roles)
-    return servable, placement.co_tenants
+    return servable, placement.co_tenants, placement.tight_roles
 
 
 # Footprints modeled on the friend's stack: a ~4B chat, nomic embed, a small
@@ -112,6 +126,9 @@ _SMALL_CHAT = {
     WorkerRole.RERANK: _gb(0.6),
 }
 
+# A vision estimate larger than the whole card (the inflated-projector case).
+_INFLATED_VISION = {**_STACK, WorkerRole.VISION: _gb(18.0)}
+
 SCENARIOS = [
     Scenario("gpu-24gb-roomy", dict(_STACK), devices=[(0, _gb(24))]),
     Scenario("gpu-12gb-cusp", dict(_STACK), devices=[(0, _gb(12))]),
@@ -120,6 +137,7 @@ SCENARIOS = [
     Scenario("gpu-8gb-big-vision", dict(_BIG_VISION), devices=[(0, _gb(8))]),
     Scenario("gpu-6gb-llm-rerank", dict(_LLM_RERANK), devices=[(0, _gb(6))]),
     Scenario("gpu-6gb-small-chat-big-vision", dict(_SMALL_CHAT), devices=[(0, _gb(6))]),
+    Scenario("gpu-16gb-inflated-vision-estimate", dict(_INFLATED_VISION), devices=[(0, _gb(16))]),
     Scenario("unified-6gb-llm-rerank", dict(_LLM_RERANK), unified_budget=_gb(6)),
     Scenario("unified-6gb-embed-rerank-vision-overflow", dict(_STACK), unified_budget=_gb(6)),
     Scenario("unified-8gb", dict(_STACK), unified_budget=_gb(8)),
@@ -146,7 +164,7 @@ def _charged_total(sc: Scenario, servable: set[WorkerRole], swap: frozenset[Work
 @pytest.mark.parametrize("sc", SCENARIOS, ids=lambda s: s.name)
 def test_planner_serves_every_role_the_oracle_would(sc: Scenario) -> None:
     oracle = _oracle_servable(sc)
-    servable, _co = _planner_servable(sc)
+    servable, _co, _tight = _planner_servable(sc)
     refused = {r.value for r in oracle if r not in servable}
     assert not refused, (
         f"{sc.name}: planner refuses {sorted(refused)} that the in-process oracle "
@@ -156,10 +174,23 @@ def test_planner_serves_every_role_the_oracle_would(sc: Scenario) -> None:
 
 
 @pytest.mark.parametrize("sc", SCENARIOS, ids=lambda s: s.name)
+def test_tight_is_reserved_for_genuinely_oversize_working_sets(sc: Scenario) -> None:
+    """A memory-is-tight warning must not fire for a placement the budget affords."""
+    _servable, _co, tight = _planner_servable(sc)
+    affordable = _working_set_servable(sc)
+    spurious = {r.value for r in tight if r in affordable}
+    assert not spurious, (
+        f"{sc.name}: planner marks {sorted(spurious)} tight although their working "
+        f"sets fit the budget by estimate"
+    )
+
+
+@pytest.mark.parametrize("sc", SCENARIOS, ids=lambda s: s.name)
 def test_plan_fits_its_own_budget(sc: Scenario) -> None:
-    """Serving a role is not enough: the plan's reservation must fit the budget."""
-    servable, swap = _planner_servable(sc)
-    reserved = _charged_total(sc, servable, swap)
+    """The normally-placed tier must fit the budget; tight roles are excluded
+    (their slot is clamped to the leftover headroom)."""
+    servable, swap, tight = _planner_servable(sc)
+    reserved = _charged_total(sc, servable - set(tight), swap)
     budget = _budget(sc)
     assert reserved <= budget, (
         f"{sc.name}: plan reserves {reserved / GB:.2f}GB > budget {budget / GB:.2f}GB "
@@ -172,7 +203,7 @@ def _print_diff_table() -> int:
     regressions = 0
     for sc in SCENARIOS:
         oracle = _oracle_servable(sc)
-        servable, co = _planner_servable(sc)
+        servable, co, tight = _planner_servable(sc)
         refused = sorted(r.value for r in oracle if r not in servable)
         regressions += bool(refused)
         if sc.devices:
@@ -185,6 +216,7 @@ def _print_diff_table() -> int:
         print(
             f"        planner : {sorted(r.value for r in servable)}"
             f"  swap-group={sorted(r.value for r in co)}"
+            f"  tight={sorted(r.value for r in tight)}"
         )
         if refused:
             print(f"        >>> REGRESSION: planner refuses {refused}")


### PR DESCRIPTION
## Problem

Ingest OCR still fails on consumer GPUs after the last placement fix: lilbee refuses to serve the vision model with "does not fit available memory", so scanned documents come back empty. Two defects stack.

### The vision memory estimate is wrong

The memory estimator overstates any vision model's GPU footprint by about 10 GiB. A 1.2 GB OCR model is estimated at 12.7 GiB, larger than most consumer cards, so vision can never pass the fit check no matter how small the model really is.

Root-causing this exposed a bug in gguf-parser itself: its discrete-GPU accounting for multimodal projectors of unrecognized types skips the spatial-merge reduction and sizes a quadratic attention buffer against the full-resolution patch grid. Reported upstream with a reproducer and analysis: gpustack/gguf-parser-go#21.

### One bad estimate kills the role

Placement treats the estimate as a hard gate: a model that does not fit by estimate gets no server at all. The pre-fleet engine never refused a load. It tried, and the load itself decided.

## Solution

### Work around the estimator bug

Until gguf-parser fixes the projector accounting upstream, this PR carries a workaround: the vision estimate is rebuilt from the accounting the estimator gets right (its unified-memory figures), with the projector's own file size as a floor. The same OCR model now estimates 3.8 GiB, matching its real usage. Once the upstream fix ships and the pin is bumped, the workaround can be re-evaluated; it stays accurate either way.

### Warn instead of refuse

On GPUs the estimate now only advises. A model that does not fit by estimate still gets a server: it is placed on the card with the most free memory and lilbee logs a warning that memory is tight and the load may be slow or fail. If the load truly fails, the existing per-page OCR skip handling applies, so the worst case is no worse than today's refusal. This also means any future estimator error degrades to a warning instead of a dead role.

CPU and Apple Silicon hosts keep the strict check, since an oversize load on shared memory can freeze the whole machine. Manually pinned layouts are also still validated strictly.

### No change on larger machines

The warn-instead-of-refuse path only triggers where today's code refuses outright. A regression test proves the warning can never fire for a placement the memory budget affords.

## Testing

The oracle parity harness now asserts the GPU planner never refuses a role, across 14 low-memory and on-the-cusp scenarios including this exact failure. The full suite is green at 100% coverage, and the estimate fix is verified against the real gguf-parser and a real vision model.

Verified end to end on real hardware: a rented 12 GB RTX 3080 Ti ran the same scanned-PDF ingest and query on v0.6.66b507 (the pre-fleet baseline), the current release, and this branch. The current release reproduces the refusal verbatim; this branch serves every scenario the baseline served, including a forced memory-is-tight case where the warned load succeeds and OCR completes.