### PR TITLE
Fetch a repo's multimodal projector on pull even when the model classifies as chat

### DIFF
--- a/src/lilbee/catalog/download.py
+++ b/src/lilbee/catalog/download.py
@@ -14,7 +14,13 @@ from pydantic import BaseModel
 
 from lilbee.catalog.download_progress import ProgressCallback, _ProgressTracker
 from lilbee.catalog.featured import DEFAULT_MMPROJ_PATTERN, VISION_MMPROJ_FILES
-from lilbee.catalog.hf_client import DEFAULT_TIMEOUT, HF_API_URL, hf_headers, hf_token
+from lilbee.catalog.hf_client import (
+    DEFAULT_TIMEOUT,
+    HF_API_URL,
+    hf_headers,
+    hf_token,
+    repo_has_mmproj,
+)
 from lilbee.catalog.models import CatalogModel
 from lilbee.catalog.refs import pick_best_gguf
 from lilbee.catalog.types import ModelTask
@@ -238,10 +244,16 @@ def _finalize_download(
     on_progress: ProgressCallback | None = None,
     on_complete: CompleteCallback | None = None,
 ) -> Path:
-    """Run post-download hooks: registry write (via on_complete) + mmproj fetch."""
+    """Run post-download hooks: registry write (via on_complete) + mmproj fetch.
+
+    The mmproj is fetched whenever the repo ships one, not only for VISION-task
+    entries: dual-use VL repos (Qwen-VL, InternVL, SmolVLM, gemma-3) classify as
+    chat by name and arch, and without their projector the vision role dies at
+    plan time with a missing-mmproj warning a re-pull cannot cure.
+    """
     if on_complete is not None:
         on_complete(entry, dest)
-    if entry.task == ModelTask.VISION:
+    if entry.task == ModelTask.VISION or repo_has_mmproj(entry.hf_repo):
         download_mmproj(entry, on_progress=on_progress)
     return dest
 

--- a/src/lilbee/catalog/hf_client.py
+++ b/src/lilbee/catalog/hf_client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import fnmatch
+import functools
 import logging
 import os
 import threading
@@ -113,6 +115,28 @@ def _hf_search_value(search: str) -> str:
     """Build the HF ``search=`` value: GGUF plus the user's tokens, space-joined."""
     tokens = [_HF_GGUF_SEARCH_TERM, *search.split()]
     return " ".join(tokens)
+
+
+@functools.lru_cache(maxsize=64)
+def repo_has_mmproj(hf_repo: str) -> bool:
+    """True when *hf_repo* ships a multimodal projector (``mmproj*.gguf`` sibling).
+
+    A projector sibling marks the repo's model as a vision loader regardless of
+    its text architecture or name; mainstream VL repos (Qwen-VL, InternVL,
+    SmolVLM, gemma-3) match no vision name pattern. Fails open to False (any
+    error: the probe is advisory) so an offline pull degrades to name-based
+    classification.
+    """
+    from huggingface_hub import HfApi
+
+    from lilbee.catalog.featured import DEFAULT_MMPROJ_PATTERN
+
+    try:
+        siblings = HfApi(token=hf_token()).model_info(hf_repo).siblings or []
+    except Exception as exc:
+        log.debug("mmproj sibling probe failed for %s: %s", hf_repo, exc)
+        return False
+    return any(fnmatch.fnmatch(s.rfilename, DEFAULT_MMPROJ_PATTERN) for s in siblings)
 
 
 def _resolve_sibling_gguf(siblings: list[RepoSibling]) -> str:

--- a/src/lilbee/providers/fleet/placement.py
+++ b/src/lilbee/providers/fleet/placement.py
@@ -352,12 +352,19 @@ def _place_split(
     split widens past the fewest fitting cards via *chat_ctx_fit* (see
     :func:`plan_placement`); every other split takes the fewest that fit.
     """
+    from lilbee.providers.base import ProviderError
+
     by_free = sorted(remaining, key=lambda idx: remaining[idx], reverse=True)
     best: tuple[int, list[int], tuple[int, ...], tuple[int, ...]] | None = None
     for count in range(2, len(by_free) + 1):
         chosen = by_free[:count]
         ratio = _vram_proportional_split(chosen, remaining)
-        per_device = estimate_peak(model.role, ratio)
+        try:
+            per_device = estimate_peak(model.role, ratio)
+        except (ProviderError, OSError):
+            # An unsizable model cannot evaluate a split; the tight single-card
+            # path downstream still places it.
+            continue
         if len(per_device) != count or not all(
             peak <= remaining[idx] for idx, peak in zip(chosen, per_device, strict=True)
         ):

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -268,16 +268,22 @@ def _fit_slots(
 ) -> int:
     """Largest slot count in ``1..ceiling`` whose instance footprint fits *budget*;
     1 when none larger fit."""
+    from lilbee.providers.base import ProviderError
+
     for slots in range(ceiling, 1, -1):
-        est = estimate_instance_footprint(
-            model_path,
-            ctx=ctx,
-            slots=slots,
-            gpu_layers=_role_gpu_layers(role),
-            flash_attn=_role_flash(role),
-            kv_cache_type=_role_kv_cache_type(role),
-            mmproj_path=mmproj_path,
-        )
+        try:
+            est = estimate_instance_footprint(
+                model_path,
+                ctx=ctx,
+                slots=slots,
+                gpu_layers=_role_gpu_layers(role),
+                flash_attn=_role_flash(role),
+                kv_cache_type=_role_kv_cache_type(role),
+                mmproj_path=mmproj_path,
+            )
+        except (ProviderError, OSError):
+            # An unsizable model runs a single slot; the load decides the rest.
+            return 1
         if est.footprint(unified=unified) <= budget:
             return slots
     return 1
@@ -592,11 +598,140 @@ def _search_reservation(inputs: dict[WorkerRole, ModelPlacementInput]) -> int:
     )
 
 
+def _role_weights_bytes(role: WorkerRole, ref: str) -> int:
+    """The model's weight bytes on disk (plus the mmproj for vision): a
+    ground-truth lower bound on residency. 0 when the file cannot be resolved."""
+    from lilbee.providers.base import ProviderError
+    from lilbee.providers.engine_params import resolve_model_path
+
+    try:
+        size = _weights_bytes(resolve_model_path(ref))
+        if role is WorkerRole.VISION:
+            mmproj = _vision_mmproj(ref)
+            if mmproj is not None:
+                size += int(mmproj.stat().st_size)
+    except (ProviderError, OSError):
+        return 0
+    return size
+
+
+def _weights_exceed_hardware(size: int, total_vram: int) -> bool:
+    """True when a model's weight bytes alone cannot fit the fleet's physical VRAM.
+
+    File size is ground truth, not an estimate, so this bound cannot repeat the
+    false-refusal class: no estimator error makes a 40 GiB file fit a 1 GiB card.
+    It stands down when the user configured partial CPU offload (``n_gpu_layers``),
+    where big-weights-small-VRAM is a legitimate setup.
+    """
+    from lilbee.core.config import cfg
+
+    return total_vram > 0 and cfg.n_gpu_layers is None and size > total_vram
+
+
+def _vision_without_mmproj(role: WorkerRole, ref: str) -> bool:
+    """True (with a warning) for a configured vision model whose mmproj is missing.
+
+    The skip would silently disable OCR; the warning names the cause and the fix.
+    """
+    if role is not WorkerRole.VISION or _vision_mmproj(ref) is not None:
+        return False
+    log.warning(
+        "Vision model %s has no mmproj (CLIP projector); OCR is disabled. "
+        "Re-run 'lilbee model pull %s' to fetch the projector.",
+        ref,
+        ref,
+    )
+    return True
+
+
+def _estimate_or_fallback(
+    role: WorkerRole,
+    ref: str,
+    *,
+    unified_budget: int | None,
+    chat_reservation: int,
+    device_count: int,
+    total_vram: int,
+    skipped_not_installed: dict[WorkerRole, str],
+) -> ModelPlacementInput | None:
+    """Size *role* for placement, degrading rather than refusing.
+
+    A missing model is skipped and recorded; a sizing failure on an installed
+    model falls back to its weight bytes; weights alone exceeding the physical
+    VRAM refuse with a plain message (ground truth, not an estimate).
+    """
+    from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+    try:
+        estimate = _estimate_role(
+            role,
+            ref,
+            unified_budget=unified_budget,
+            chat_reservation=chat_reservation,
+            device_count=device_count,
+        )
+    except (ProviderError, OSError) as exc:
+        if isinstance(exc, ProviderError) and exc.kind is ProviderErrorKind.NOT_FOUND:
+            log.warning("Skipping %s server: model %r is not installed.", role.value, ref)
+            skipped_not_installed[role] = ref
+            return None
+        return _sizing_failure_fallback(
+            role, ref, exc, device_count=device_count, total_vram=total_vram
+        )
+    weights = _role_weights_bytes(role, ref)
+    if _weights_exceed_hardware(weights, total_vram):
+        _warn_weights_exceed(role, ref, weights, total_vram)
+        return None
+    return estimate
+
+
+def _sizing_failure_fallback(
+    role: WorkerRole,
+    ref: str,
+    exc: Exception,
+    *,
+    device_count: int,
+    total_vram: int,
+) -> ModelPlacementInput | None:
+    """Weights-bytes placement input for an installed model the estimator cannot
+    size, so the load, not the estimator, decides; ``None`` skips the role (the
+    file is unresolvable, or its weights alone exceed the hardware)."""
+    weights = _role_weights_bytes(role, ref)
+    if weights == 0:
+        log.warning("Skipping %s server: could not size model %r (%s).", role.value, ref, exc)
+        return None
+    if _weights_exceed_hardware(weights, total_vram):
+        _warn_weights_exceed(role, ref, weights, total_vram)
+        return None
+    log.warning(
+        "Could not size the %s model %s (%s). Using its file size and letting the load decide.",
+        role.value,
+        ref,
+        exc,
+    )
+    return ModelPlacementInput(
+        role=role, est_vram_bytes=weights, replicas=_replica_count(role, device_count)
+    )
+
+
+def _warn_weights_exceed(role: WorkerRole, ref: str, weights: int, total_vram: int) -> None:
+    log.warning(
+        "The %s model %s cannot load: its weights alone are %.1f GiB and the GPU "
+        "memory is %.1f GiB in total. Use a smaller model, or set n_gpu_layers to "
+        "offload part of it to system memory.",
+        role.value,
+        ref,
+        weights / 1024**3,
+        total_vram / 1024**3,
+    )
+
+
 def _server_model_inputs(
     roles: tuple[WorkerRole, ...] | None = None,
     *,
     unified_budget: int | None = None,
     device_count: int = 0,
+    total_vram: int = 0,
 ) -> tuple[list[ModelPlacementInput], dict[WorkerRole, str], int, dict[WorkerRole, str]]:
     """Build placement inputs for the configured server roles.
 
@@ -605,11 +740,13 @@ def _server_model_inputs(
     starve embed/rerank on a shared-memory host. ``device_count`` resolves an auto
     replica knob to one per GPU. When *roles* is given, only those are considered.
     Skips an unconfigured optional role, a vision model with no resolvable mmproj
-    projector, and a role whose model is not installed on disk (the last returned as
-    ``skipped_not_installed`` so a surface can say so).
+    projector, a role whose model is not installed on disk (returned as
+    ``skipped_not_installed`` so a surface can say so), and a model whose weight
+    bytes alone exceed ``total_vram`` (physically unloadable under all-GPU layers).
+    A model the estimator cannot size is enrolled at its file size instead of
+    skipped, so the load, not the estimator, decides.
     """
     from lilbee.core.config import cfg
-    from lilbee.providers.base import ProviderError, ProviderErrorKind
 
     inputs: dict[WorkerRole, ModelPlacementInput] = {}
     model_refs: dict[WorkerRole, str] = {}
@@ -623,39 +760,18 @@ def _server_model_inputs(
         ref = str(getattr(cfg, ROLE_REGISTRY[role].config_field))
         if not ref:
             return  # unconfigured optional role -> no server
-        if role is WorkerRole.VISION and _vision_mmproj(ref) is None:
-            # A configured vision model with no mmproj is skipped, which silently
-            # disables OCR; warn so the cause (a missing projector, fixed by
-            # re-pulling the model) is visible instead of "no usable text".
-            log.warning(
-                "Vision model %s has no mmproj (CLIP projector); OCR is disabled. "
-                "Re-run 'lilbee model pull %s' to fetch the projector.",
-                ref,
-                ref,
-            )
+        if _vision_without_mmproj(role, ref):
             return  # no projector -> vision can't run on a server
-        try:
-            estimate = _estimate_role(
-                role,
-                ref,
-                unified_budget=unified_budget,
-                chat_reservation=chat_reservation,
-                device_count=device_count,
-            )
-        except (ProviderError, OSError) as exc:
-            # Skip this role rather than failing the whole fleet build: search-only
-            # indexing must not require an installed chat model, and a genuinely-
-            # needed role surfaces a clear per-role error on first use instead of a
-            # build-time traceback. Keep "not installed" for an actually-missing
-            # model; a sizing failure (estimator errored) must say so, not misdirect
-            # debugging toward the registry.
-            if isinstance(exc, ProviderError) and exc.kind is ProviderErrorKind.NOT_FOUND:
-                log.warning("Skipping %s server: model %r is not installed.", role.value, ref)
-                skipped_not_installed[role] = ref
-            else:
-                log.warning(
-                    "Skipping %s server: could not size model %r (%s).", role.value, ref, exc
-                )
+        estimate = _estimate_or_fallback(
+            role,
+            ref,
+            unified_budget=unified_budget,
+            chat_reservation=chat_reservation,
+            device_count=device_count,
+            total_vram=total_vram,
+            skipped_not_installed=skipped_not_installed,
+        )
+        if estimate is None:
             return
         inputs[role] = estimate
         model_refs[role] = ref
@@ -1070,7 +1186,7 @@ def resolve_placement_plan(placement: PlacementSpec | None) -> ResolvedPlacement
     devices = _read_device_cache.get(binary)
     unified_budget = _unified_memory_budget(devices)
     inputs, model_refs, _, skipped_not_installed = _server_model_inputs(
-        None, unified_budget=unified_budget
+        None, unified_budget=unified_budget, total_vram=sum(d.total_bytes for d in devices)
     )
     resolved = _resolve_placement(
         placement, inputs, model_refs, devices, unified_budget=unified_budget
@@ -1135,7 +1251,10 @@ def plan_launches(
 
     unified_budget = _unified_memory_budget(devices)
     inputs, model_refs, reservation, _ = _server_model_inputs(
-        roles, unified_budget=unified_budget, device_count=len(devices)
+        roles,
+        unified_budget=unified_budget,
+        device_count=len(devices),
+        total_vram=sum(d.total_bytes for d in devices),
     )
     spec = PlacementSpec.from_json(cfg.placement) if cfg.placement else None
     placement = _resolve_placement(spec, inputs, model_refs, devices, unified_budget=unified_budget)

--- a/tests/providers/fleet/test_planning_placement_branch.py
+++ b/tests/providers/fleet/test_planning_placement_branch.py
@@ -60,7 +60,9 @@ def test_resolve_placement_plan_uses_read_cache(monkeypatch):
     monkeypatch.setattr(cuda_runtime, "apply_cuda_runtime_env", lambda: None)
     monkeypatch.setattr(planning, "resolve_devices", counting)
     monkeypatch.setattr(
-        planning, "_server_model_inputs", lambda roles, *, unified_budget=None: ([], {}, 0, {})
+        planning,
+        "_server_model_inputs",
+        lambda roles, *, unified_budget=None, total_vram=0: ([], {}, 0, {}),
     )
     monkeypatch.setattr(
         planning,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1732,10 +1732,11 @@ class TestVisionMmprojFiles:
     def test_download_model_skips_mmproj_for_chat(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """download_model does NOT download mmproj for chat entries."""
+        """download_model does NOT download mmproj when the repo ships none."""
         monkeypatch.setattr(cfg, "models_dir", tmp_path)
         entry = FEATURED_EMBEDDING[0]
         monkeypatch.setattr(catalog.download, "resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(catalog.download, "repo_has_mmproj", lambda _repo: False)
 
         download_calls: list[dict] = []
 
@@ -1747,6 +1748,33 @@ class TestVisionMmprojFiles:
         download_model(entry)
 
         assert len(download_calls) == 1
+
+    def test_download_model_fetches_mmproj_for_chat_classified_repo_shipping_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dual-use VL repo (chat by name and arch, mmproj sibling present) still
+        gets its projector, so a later vision_model assignment can run OCR."""
+        monkeypatch.setattr(cfg, "models_dir", tmp_path)
+        entry = FEATURED_EMBEDDING[0]
+        monkeypatch.setattr(catalog.download, "resolve_filename", lambda e: e.gguf_filename)
+        monkeypatch.setattr(catalog.download, "repo_has_mmproj", lambda _repo: True)
+        monkeypatch.setattr(
+            catalog.download,
+            "_resolve_mmproj_filename",
+            lambda repo, pat: "mmproj-model-f16.gguf",
+        )
+
+        download_calls: list[dict] = []
+
+        def fake_download(**kwargs: Any) -> str:
+            download_calls.append(kwargs)
+            return _fake_download(**kwargs)
+
+        monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_download)
+        download_model(entry)
+
+        filenames = [c["filename"] for c in download_calls]
+        assert "mmproj-model-f16.gguf" in filenames
 
     def test_download_model_vision_mmproj_resolution_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2597,3 +2625,49 @@ class TestRegisterDownloadedModel:
             cfg.models_dir = old
 
         assert captured == [(entry, existing)]
+
+
+class TestRepoHasMmproj:
+    """The mmproj sibling probe: authoritative vision signal, fail-open on errors."""
+
+    def _patch_model_info(self, monkeypatch: pytest.MonkeyPatch, siblings: list[str]) -> None:
+        from types import SimpleNamespace
+
+        info = SimpleNamespace(siblings=[SimpleNamespace(rfilename=f) for f in siblings])
+
+        class _Api:
+            def __init__(self, token: str | None = None) -> None:
+                pass
+
+            def model_info(self, _repo: str) -> object:
+                return info
+
+        monkeypatch.setattr("huggingface_hub.HfApi", _Api)
+
+    def test_true_when_repo_ships_an_mmproj(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.catalog import hf_client
+
+        self._patch_model_info(monkeypatch, ["model-Q4_K_M.gguf", "mmproj-model-f16.gguf"])
+        hf_client.repo_has_mmproj.cache_clear()
+        assert hf_client.repo_has_mmproj("org/vl-repo") is True
+
+    def test_false_when_no_mmproj_sibling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.catalog import hf_client
+
+        self._patch_model_info(monkeypatch, ["model-Q4_K_M.gguf"])
+        hf_client.repo_has_mmproj.cache_clear()
+        assert hf_client.repo_has_mmproj("org/chat-repo") is False
+
+    def test_fails_open_to_false_on_network_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from lilbee.catalog import hf_client
+
+        class _Api:
+            def __init__(self, token: str | None = None) -> None:
+                pass
+
+            def model_info(self, _repo: str) -> object:
+                raise OSError("offline")
+
+        monkeypatch.setattr("huggingface_hub.HfApi", _Api)
+        hf_client.repo_has_mmproj.cache_clear()
+        assert hf_client.repo_has_mmproj("org/unreachable") is False

--- a/tests/test_fleet_placement.py
+++ b/tests/test_fleet_placement.py
@@ -833,3 +833,21 @@ class TestSharedMemoryCoTenancy:
         assert plan.co_tenants == frozenset({WorkerRole.CHAT, WorkerRole.VISION})
         assert [i.replica for i in visions] == [0]
         assert WorkerRole.CHAT in {i.role for i in plan.instances}
+
+
+class TestUnsizableModelPlacement:
+    def test_unsizable_split_falls_to_tight_single(self) -> None:
+        # estimate_peak raising (the estimator cannot parse the model) must not
+        # crash the plan: split options are skipped and the model places tight.
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+        model = ModelPlacementInput(WorkerRole.CHAT, 40 * _GB)
+
+        def boom(_role: WorkerRole, _ratio: tuple[int, ...]) -> tuple[int, ...]:
+            raise ProviderError(
+                "unparseable", provider="llama-server", kind=ProviderErrorKind.SERVER
+            )
+
+        plan = plan_placement([model], [(0, 24 * _GB), (1, 24 * _GB)], estimate_peak=boom)
+        assert len(plan.instances) == 1
+        assert plan.tight_roles.keys() == {WorkerRole.CHAT}

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1715,3 +1715,122 @@ class TestPlacementFindingsLog:
             planning_mod._log_placement_findings(placement, {WorkerRole.VISION: "org/ocr.gguf"})
         assert "0.0 GiB" not in caplog.text
         assert "0.1 GiB" in caplog.text
+
+
+class TestSizingFailureFallsBackToFileSize:
+    """A model the estimator cannot size is enrolled at its weight bytes, so the
+    load, not the estimator, decides. Weight bytes are also a physics bound:
+    weights alone exceeding total VRAM refuses with a clear message."""
+
+    @pytest.fixture
+    def _sizing_boom(self, tmp_path, monkeypatch):
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+        model = tmp_path / "unsizable.gguf"
+        model.write_bytes(b"G" * 4096)
+
+        def boom(role, ref, **_k):
+            if role is WorkerRole.CHAT:
+                raise ProviderError(
+                    "unexpected estimator output",
+                    provider="llama-server",
+                    kind=ProviderErrorKind.SERVER,
+                )
+            return ModelPlacementInput(role, 512)
+
+        monkeypatch.setattr(planning_mod, "_estimate_role", boom)
+        monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
+        monkeypatch.setattr(cfg, "chat_model", "org/repo/unsizable.gguf")
+        monkeypatch.setattr(cfg, "embedding_model", "org/repo/embed.gguf")
+        monkeypatch.setattr(cfg, "reranker_model", "")
+        monkeypatch.setattr(cfg, "vision_model", "")
+        return model
+
+    def test_unsizable_model_enrolls_at_its_file_size(self, _sizing_boom, caplog) -> None:
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            inputs, _refs, _res, _skipped = planning_mod._server_model_inputs(total_vram=24 * _GB)
+        by_role = {i.role: i for i in inputs}
+        assert by_role[WorkerRole.CHAT].est_vram_bytes == 4096
+        assert "Using its file size" in caplog.text
+
+    def test_weights_beyond_total_vram_refuse_with_a_clear_message(
+        self, _sizing_boom, caplog
+    ) -> None:
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            inputs, _refs, _res, _skipped = planning_mod._server_model_inputs(total_vram=1024)
+        assert WorkerRole.CHAT not in {i.role for i in inputs}
+        assert "weights alone" in caplog.text
+
+    def test_weights_bound_stands_down_under_partial_offload(
+        self, _sizing_boom, monkeypatch, caplog
+    ) -> None:
+        import logging
+
+        monkeypatch.setattr(cfg, "n_gpu_layers", 10)
+        with caplog.at_level(logging.WARNING):
+            inputs, _refs, _res, _skipped = planning_mod._server_model_inputs(total_vram=1024)
+        assert WorkerRole.CHAT in {i.role for i in inputs}
+        assert "weights alone" not in caplog.text
+
+    def test_unresolvable_file_still_skips(self, tmp_path, monkeypatch, caplog) -> None:
+        import logging
+
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+        def boom(role, ref, **_k):
+            raise ProviderError(
+                "unexpected estimator output",
+                provider="llama-server",
+                kind=ProviderErrorKind.SERVER,
+            )
+
+        def no_path(_r):
+            raise ProviderError(
+                "no file", provider="llama-server", kind=ProviderErrorKind.NOT_FOUND
+            )
+
+        monkeypatch.setattr(planning_mod, "_estimate_role", boom)
+        monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", no_path)
+        monkeypatch.setattr(cfg, "chat_model", "org/repo/ghost.gguf")
+        monkeypatch.setattr(cfg, "embedding_model", "org/repo/embed.gguf")
+        monkeypatch.setattr(cfg, "reranker_model", "")
+        monkeypatch.setattr(cfg, "vision_model", "")
+        with caplog.at_level(logging.WARNING):
+            inputs, _refs, _res, _skipped = planning_mod._server_model_inputs()
+        assert inputs == []
+        assert "could not size" in caplog.text
+
+    def test_unsizable_vision_model_counts_its_mmproj(self, tmp_path, monkeypatch, caplog) -> None:
+        import logging
+
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+        model = tmp_path / "vl.gguf"
+        model.write_bytes(b"G" * 4096)
+        mmproj = tmp_path / "mmproj.gguf"
+        mmproj.write_bytes(b"G" * 1024)
+
+        def boom(role, ref, **_k):
+            if role is WorkerRole.VISION:
+                raise ProviderError(
+                    "unexpected estimator output",
+                    provider="llama-server",
+                    kind=ProviderErrorKind.SERVER,
+                )
+            return ModelPlacementInput(role, 512)
+
+        monkeypatch.setattr(planning_mod, "_estimate_role", boom)
+        monkeypatch.setattr(planning_mod, "_vision_mmproj", lambda _r: mmproj)
+        monkeypatch.setattr("lilbee.providers.engine_params.resolve_model_path", lambda _r: model)
+        monkeypatch.setattr(cfg, "chat_model", "org/repo/chat.gguf")
+        monkeypatch.setattr(cfg, "embedding_model", "org/repo/embed.gguf")
+        monkeypatch.setattr(cfg, "reranker_model", "")
+        monkeypatch.setattr(cfg, "vision_model", "org/repo/vl.gguf")
+        with caplog.at_level(logging.WARNING):
+            inputs, _refs, _res, _skipped = planning_mod._server_model_inputs(total_vram=24 * _GB)
+        by_role = {i.role: i for i in inputs}
+        assert by_role[WorkerRole.VISION].est_vram_bytes == 4096 + 1024

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1834,3 +1834,25 @@ class TestSizingFailureFallsBackToFileSize:
             inputs, _refs, _res, _skipped = planning_mod._server_model_inputs(total_vram=24 * _GB)
         by_role = {i.role: i for i in inputs}
         assert by_role[WorkerRole.VISION].est_vram_bytes == 4096 + 1024
+
+    def test_fit_slots_returns_single_slot_when_estimator_fails(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        from lilbee.providers.base import ProviderError, ProviderErrorKind
+
+        def boom(*_a, **_k):
+            raise ProviderError(
+                "unparseable", provider="llama-server", kind=ProviderErrorKind.SERVER
+            )
+
+        monkeypatch.setattr(planning_mod, "estimate_instance_footprint", boom)
+        slots = planning_mod._fit_slots(
+            4,
+            WorkerRole.CHAT,
+            tmp_path / "m.gguf",
+            2048,
+            mmproj_path=None,
+            unified=False,
+            budget=8 * _GB,
+        )
+        assert slots == 1


### PR DESCRIPTION
## Problem

The hardware model-load sweep for the placement fix surfaced this on five of eight vision families: mainstream VL repos (Qwen2.5-VL, Qwen3-VL, InternVL, SmolVLM, gemma-3) classify as chat models by name and architecture, so pulling them never fetched their multimodal projector. Configuring one as the vision model then disabled OCR at plan time with a missing-mmproj warning whose suggested remedy, re-pulling the model, could not help, because the re-pull still skipped the projector.

## Solution

Decouple the projector fetch from task classification: after a pull, the mmproj is downloaded whenever the repo actually ships one, probed via the HuggingFace SDK's sibling listing (memoized, failing open to the old behavior when offline). Task classification and role validation are deliberately untouched, so dual-use VL repos remain assignable as chat models and pure OCR loaders are still rejected from the chat slot. The narrower question of assigning chat-classified VL models to the vision slot through the TUI is a product decision tracked separately.

An earlier draft flipped the task classification to vision instead; review caught that it would break assigning dual-use models like gemma-3-4b as chat models, which is why the fetch gate, not the classifier, changed.

## Testing

Full suite green at 100% coverage. New tests pin the probe (sibling present, absent, and offline fail-open) and the fetch gate (chat-classified entry with a projector sibling downloads it; without one, nothing extra is downloaded). A hardware re-run of the eight-family load sweep against this branch, with the previous run's manual projector workaround removed, is queued as the empirical gate before release.

## Validation at corpus scale

The decision layer was validated over the same corpus as the gguf-parser estimate sweep: 947 unique multimodal projector files (every public mmproj GGUF surveyed there), each remote-parsed with and without its projector and pushed through lilbee's production correction and placement budgets on this branch. 847 parsed cleanly; the remainder are itemized (73 repos ship only sharded text models, 27 files predate-proof the pinned parser generation and are tracked separately).

**Zero floor-invariant violations, and zero refusals at any card size.** For scale, the same corpus under the old estimate gate, which shipped in every release before the placement fix:

| Card | Old estimate would refuse | lilbee now refuses |
|---|---|---|
| 8 GB | 488 of 847 (58%) | **0** |
| 12 GB | 289 of 847 (34%) | **0** |
| 16 GB | 179 of 847 (21%) | **0** |
| 24 GB | 73 of 847 (9%) | **0** |

Genuinely oversized pairs place tight (warned, load decides) instead of being refused. Per projector type: 23 of the 29 non-audio types in the corpus have every parseable representative passing; the reported case's family (lightonocr) went from 25 of 25 refused on a 12 GB card to 25 of 25 placed normally.


## Hardware validation (complete)

Same rig and method as the placement-fix verification: a 12 GB RTX 3080 Ti, an image-only scanned PDF whose content is reachable only through OCR, and a probe question answerable only from the scanned text. Every family below was pulled by this branch's own pull path, with the mechanical assertion that the projector arrived without any manual placement.

### Vision families (this branch)

| Family (projector type) | Pull fetched mmproj | Refused | OCR | Answer has content | Estimate |
|---|---|---|---|---|---|
| LightOnOCR-2-1B (lightonocr) | yes | no | worked | yes | 3.76 GiB |
| Qwen2.5-VL-3B (qwen2.5vl merger) | yes | no | worked | yes | 5.08 GiB |
| Qwen3-VL-4B (qwen3vl) | yes | no | worked | yes | 8.51 GiB |
| gemma-3-4b-it (gemma3) | yes | no | worked | yes | 5.52 GiB |
| SmolVLM2-2.2B (idefics3) | yes | no | worked | yes | 3.77 GiB |
| MiniCPM-V-2.6 (resampler) | yes | no | worked | yes | 7.33 GiB |
| InternVL3-2B (internvl) | yes | no | worked | no (2B answer quality) | 3.28 GiB |
| LLaVA-1.6-7B (mlp) | yes | no | worked | no (older model quality) | 9.20 GiB |
| gemma-4-12B (mixed vision+audio) | yes | no | worked | yes | 8.37 GiB |
| dots.ocr (under-estimate class, upstream #27) | yes | no | worked | yes | 5.66 GiB |

All ten families ran on a single 12 GB RTX 3080 Ti with the chat and embed defaults co-resident; the measured whole-fleet VRAM peak stayed at ~10.2 GiB (under the 11.1 GiB usable budget) on every family, with zero out-of-memory events. On the v716 control, seven of the ten families either miss the projector at pull time or fail outright on the same scenario.

The five families that previously failed on both builds (the projector never being downloaded for chat-classified repos) all pass with this branch's fetch fix, no workarounds.

### Text architecture classes (this branch)

One representative per chat/embed/rerank memory-behavior class, full pipeline (index a document, search, answer), with first-load health and estimate columns.

| Class | Loads | Full pipeline | Answer has content |
|---|---|---|---|
| chat: sliding-window (gemma-3-4b) | yes | all green | yes |
| chat: hybrid-SSM (LFM2-1.2B) | yes | all green | yes |
| embed: decoder-pooled (Qwen3-Embedding-0.6B) | yes | all green | yes |
| rerank: cross-encoder (bge-reranker-v2-m3) | yes | all green | yes |
| chat: dense-GQA (Qwen3-4B) | yes | all green | yes |
| chat: MoE (OLMoE-1B-7B) | yes | all green | yes |
| embed: nomic-bert (nomic-embed-text-v1.5) | yes | all green | yes |
| embed: XLM-R (bge-m3) | yes | all green | yes |
| chat: GQA (Llama-3.2-3B) | yes | all green | yes |
| chat: MLA (DeepSeek-V2-Lite, estimate at the card's budget line) | yes | all green | yes |
| embed: BERT (all-MiniLM-L6-v2) | yes | all green | yes |
| embed: pooled-stress (Qwen3-Embedding-8B Q6_K) | yes, first chat swap-in retried once | all green | yes |
| rerank: LLM-mode (Qwen3-Reranker-0.6B) | yes | all green | yes |

All thirteen classes finish the full pipeline. The one imperfection is a known pre-existing wart, not a regression from this branch: in the tightest co-tenancy class the chat engine's first load can transiently OOM while a large pooled-batch embedder is still occupying its launch-time footprint; the provider's retry recovers it unattended (tracked separately with root-cause evidence from both a 12 GB and a 16 GB card).

CI note: the full matrix passed except two known-flake jobs (a recurring TUI test-order flake on Windows and a macOS integration runner hang), rerunning at the time of this update.



