### PR TITLE
Fix a catalog crash when a scheduled refresh fires during screen dismissal

### DIFF
--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -814,8 +814,6 @@ class CatalogScreen(Screen[None]):
         # A fast worker can complete before TabbedContent finishes mounting
         # its panes; tolerate that and let the deferred _refresh_grid that
         # _activate_initial_tab schedules rebuild against the applied state.
-        from textual.css.query import NoMatches
-
         with contextlib.suppress(NoMatches):
             # FETCH_MORE_HF appends to the active view's tail; skip the full
             # _refresh_view rebuild so scroll position and focus are preserved.
@@ -1696,8 +1694,6 @@ class CatalogScreen(Screen[None]):
         new screen's ``compose`` has finished mounting ``#sort-label``.
         On Windows that race lands often enough to fail CI.
         """
-        from textual.css.query import NoMatches
-
         try:
             label = self.query_one("#sort-label", Static)
         except NoMatches:
@@ -2244,8 +2240,6 @@ class CatalogScreen(Screen[None]):
 
     def _first_grid_or_none(self) -> ModelGrid | None:
         """Return the first ModelGrid in the active tab's container, or None."""
-        from textual.css.query import NoMatches
-
         try:
             return self._grid_container.query(ModelGrid).first()
         except NoMatches:

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -12,6 +12,7 @@ from textual import getters, on, work
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Horizontal, VerticalScroll
+from textual.css.query import NoMatches
 from textual.events import Click, Key, MouseScrollDown
 from textual.message import Message
 from textual.screen import Screen
@@ -337,6 +338,22 @@ class CatalogScreen(Screen[None]):
         widget = self.query_one(f"#{_LIST_ID_PREFIX}{target}", ModelList)
         self._tab_list_cache[target] = widget
         return widget
+
+    def _grid_mounted(self) -> bool:
+        """Whether the active tab's grid container exists to paint into."""
+        try:
+            self._grid_for_tab(self._active_tab_id_cache)
+        except NoMatches:
+            return False
+        return True
+
+    def _list_mounted(self) -> bool:
+        """Whether the active tab's list widget exists to paint into."""
+        try:
+            self._list_for_tab(self._active_tab_id_cache)
+        except NoMatches:
+            return False
+        return True
 
     @property
     def _grid_container(self) -> VerticalScroll:
@@ -1128,7 +1145,14 @@ class CatalogScreen(Screen[None]):
         update each existing ModelGrid via set_rows rather than tearing
         the container down and re-mounting from scratch. Avoids a 100%
         CPU spike on every "Browse more" return.
+
+        A scheduled refresh can fire while the screen is composing or being
+        dismissed, when the tab containers aren't mounted; there is nothing
+        to paint then, and the guard runs before the row-cache update so the
+        next mounted refresh still repaints.
         """
+        if not self._grid_mounted():
+            return
         prep = self._prepare_grid_refresh()
         if prep is None:
             self._update_sort_label()
@@ -1566,6 +1590,8 @@ class CatalogScreen(Screen[None]):
 
     def _refresh_list(self) -> None:
         """Rebuild the list view for the active tab; per-tab cache key skips no-op rebuilds."""
+        if not self._list_mounted():
+            return
         active_tab = self._active_tab_id_cache
         all_rows = self._sort_rows(self._build_rows())
         if active_tab in TASK_TAB_IDS:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -386,6 +386,50 @@ class TestChatScreenAsync:
                 mock_send.assert_not_called()
 
 
+class TestStatusStorageEntities:
+    def test_storage_panel_shows_entities_when_enabled(self):
+        from lilbee.app.status import EntityStatus
+        from lilbee.cli.tui.screens.status import _build_storage_content
+        from lilbee.core.config import cfg
+
+        old_flag = cfg.entity_extraction
+        cfg.entity_extraction = True
+        try:
+            with mock.patch(
+                "lilbee.app.status.entity_status",
+                return_value=EntityStatus(types=["part_number"], rows=4),
+            ):
+                content = _build_storage_content(doc_count=1)
+        finally:
+            cfg.entity_extraction = old_flag
+        assert "4 extracted (part_number)" in content.plain
+
+    def test_storage_panel_omits_entities_when_off(self):
+        from lilbee.cli.tui.screens.status import _build_storage_content
+        from lilbee.core.config import cfg
+
+        old_flag = cfg.entity_extraction
+        cfg.entity_extraction = False
+        try:
+            content = _build_storage_content(doc_count=1)
+        finally:
+            cfg.entity_extraction = old_flag
+        assert "extracted" not in content.plain
+
+
+class TestCatalogRefreshGuards:
+    def test_unmounted_refreshes_are_noops(self):
+        """A scheduled refresh landing while the screen is composing or being
+        dismissed has no containers to paint into and must not crash."""
+        from lilbee.cli.tui.screens.catalog import CatalogScreen
+
+        screen = CatalogScreen()
+        screen._refresh_grid()
+        screen._refresh_list()
+        assert not screen._grid_mounted()
+        assert not screen._list_mounted()
+
+
 class TestCatalogScreenAsync:
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
     async def test_catalog_shows_featured(self, mock_catalog: mock.MagicMock) -> None:
@@ -415,9 +459,19 @@ class TestCatalogScreenAsync:
             await pilot.pause()
             catalog = CatalogScreen()
             app.push_screen(catalog)
-            await pilot.pause()
+            # Fixed single pauses race a loaded xdist worker: the key must not
+            # fire before the catalog is the active screen, and the dismissal
+            # needs time to process. Bounded condition loops on both sides.
+            for _ in range(40):
+                if app.screen is catalog:
+                    break
+                await pilot.pause(0.05)
+            assert app.screen is catalog
             await pilot.press("q")
-            await pilot.pause()
+            for _ in range(40):
+                if not isinstance(app.screen, CatalogScreen):
+                    break
+                await pilot.pause(0.05)
             # Catalog should be gone, chat screen visible
             assert not isinstance(app.screen, CatalogScreen)
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -386,37 +386,6 @@ class TestChatScreenAsync:
                 mock_send.assert_not_called()
 
 
-class TestStatusStorageEntities:
-    def test_storage_panel_shows_entities_when_enabled(self):
-        from lilbee.app.status import EntityStatus
-        from lilbee.cli.tui.screens.status import _build_storage_content
-        from lilbee.core.config import cfg
-
-        old_flag = cfg.entity_extraction
-        cfg.entity_extraction = True
-        try:
-            with mock.patch(
-                "lilbee.app.status.entity_status",
-                return_value=EntityStatus(types=["part_number"], rows=4),
-            ):
-                content = _build_storage_content(doc_count=1)
-        finally:
-            cfg.entity_extraction = old_flag
-        assert "4 extracted (part_number)" in content.plain
-
-    def test_storage_panel_omits_entities_when_off(self):
-        from lilbee.cli.tui.screens.status import _build_storage_content
-        from lilbee.core.config import cfg
-
-        old_flag = cfg.entity_extraction
-        cfg.entity_extraction = False
-        try:
-            content = _build_storage_content(doc_count=1)
-        finally:
-            cfg.entity_extraction = old_flag
-        assert "extracted" not in content.plain
-
-
 class TestCatalogRefreshGuards:
     def test_unmounted_refreshes_are_noops(self):
         """A scheduled refresh landing while the screen is composing or being

--- a/tests/test_tui_navigation.py
+++ b/tests/test_tui_navigation.py
@@ -76,6 +76,20 @@ def _patch_chat_setup():
         yield
 
 
+async def _wait_for_screen(app, pilot, screen_type):
+    """Wait (bounded) for a view transition to land on *screen_type*.
+
+    The view-switch guard deliberately drops a switch while the previous
+    transition is still in flight, so pressing again after one fixed pause
+    races a loaded worker; each press must wait for its transition.
+    """
+    for _ in range(40):
+        if isinstance(app.screen, screen_type):
+            return
+        await pilot.pause(0.05)
+    raise AssertionError(f"Expected {screen_type.__name__}, got {type(app.screen).__name__}")
+
+
 async def test_bracket_keys_cycle_all_screens():
     """Press ] through all 6 views from normal mode (Escape first on Chat)."""
     app = LilbeeApp()
@@ -98,14 +112,7 @@ async def test_bracket_keys_cycle_all_screens():
         ]
         for screen_type in expected:
             await pilot.press("right_square_bracket")
-            # Switches are deferred behind the view-switch guard; poll them in.
-            for _ in range(40):
-                await pilot.pause()
-                if isinstance(app.screen, screen_type):
-                    break
-            assert isinstance(app.screen, screen_type), (
-                f"Expected {screen_type.__name__}, got {type(app.screen).__name__}"
-            )
+            await _wait_for_screen(app, pilot, screen_type)
 
 
 async def test_view_switch_guard_held_until_transition_completes():
@@ -171,12 +178,10 @@ async def test_bracket_keys_cycle_backward():
         await pilot.pause()
 
         await pilot.press("left_square_bracket")
-        await pilot.pause()
-        assert isinstance(app.screen, FleetScreen)
+        await _wait_for_screen(app, pilot, FleetScreen)
 
         await pilot.press("left_square_bracket")
-        await pilot.pause()
-        assert isinstance(app.screen, TaskCenter)
+        await _wait_for_screen(app, pilot, TaskCenter)
 
 
 async def test_bracket_keys_work_from_settings():


### PR DESCRIPTION
## Problem

The catalog screen schedules grid/list refreshes that can fire while the screen is still composing or is being dismissed. At that moment the tab containers don't exist, the refresh's `query_one` raises `NoMatches`, and the whole app crashes. In the test suite this surfaced as the long-standing intermittent TUI failures: the catalog-quit test only ever passed by racing out before the refresh fired, and under a loaded parallel test worker a random screen test failed each full-suite run.

The bracket-key navigation tests had a related timing hole: they pressed through six screens with single fixed pauses, but the view-switch guard deliberately drops a switch while the previous transition is in flight, so under load a keypress vanished and a random screen assertion failed.

## Solution

Both catalog refresh entrypoints now no-op when there is nothing mounted to paint into, with the guard placed before the row-cache update so a skipped refresh never marks itself as done and the next mounted refresh still repaints. The catalog-quit test waits on conditions instead of fixed pauses, and the screen-cycling tests wait for each transition to land before pressing again (superseding the inline poll loop the forward test already had).