### PR TITLE
Serialize fleet warm-up for roles sharing a device; document tested model families

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,60 @@ Retrieval returns things that make sense on their own, not fragments cut through
 
 ### Pick and tune your models
 
-Chat, embedding, vision, and reranking models are installed and switched from inside the terminal: browse the catalog, pull a model, pick a role. Retrieval and generation expose 50+ settings (chunk size, search strictness, reranker depth, and more), editable from the TUI, env vars, or a project-local config file. Sane defaults. [docs/tested-models.md](docs/tested-models.md) lists the architecture families verified end to end on real GPUs for every role.
+Chat, embedding, vision, and reranking models are installed and switched from inside the terminal: browse the catalog, pull a model, pick a role. Retrieval and generation expose 50+ settings (chunk size, search strictness, reranker depth, and more), editable from the TUI, env vars, or a project-local config file. Sane defaults.
+
+<details>
+<summary><b>Model families tested end to end on real GPUs, per role. Click to expand.</b></summary>
+
+### Tested model families
+
+One representative per architecture family, pulled with `lilbee model pull` and run through the full pipeline (index, search, answer; OCR for vision) on consumer hardware. [docs/tested-models.md](docs/tested-models.md) has the details and method.
+
+**Vision** (all on a single 12 GB card, projector fetched by the pull itself):
+
+| Family | Projector type |
+|--------|----------------|
+| LightOnOCR | lightonocr |
+| Qwen2.5-VL | qwen2.5vl merger |
+| Qwen3-VL | qwen3vl |
+| Gemma 3 | gemma3 |
+| SmolVLM2 | idefics3 |
+| MiniCPM-V | resampler |
+| InternVL3 | internvl |
+| LLaVA 1.6 | mlp |
+| Gemma 4 | mixed vision+audio |
+| dots.ocr | dots.ocr |
+
+**Chat** (one per memory-architecture class):
+
+| Class | Representative |
+|-------|----------------|
+| Dense GQA | Llama 3.2 |
+| Dense | Qwen3 |
+| Sliding-window attention | Gemma 3 |
+| Multi-head latent attention | DeepSeek V2 Lite |
+| Mixture of experts | OLMoE |
+| Hybrid SSM | LFM2 |
+
+**Embedding:**
+
+| Class | Representative |
+|-------|----------------|
+| BERT encoder | all-MiniLM-L6-v2 |
+| nomic-bert | nomic-embed-text v1.5 |
+| Decoder-pooled | Qwen3-Embedding 0.6B |
+| Decoder-pooled, large | Qwen3-Embedding 8B |
+| XLM-RoBERTa | bge-m3 |
+
+**Rerank:**
+
+| Class | Representative |
+|-------|----------------|
+| Cross-encoder | bge-reranker-v2-m3 |
+| LLM reranker | Qwen3-Reranker 0.6B |
+
+</details>
+
 
 ![browse the model catalog, search Hugging Face Hub, pull a model live](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-catalog.gif)
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Retrieval returns things that make sense on their own, not fragments cut through
 
 ### Pick and tune your models
 
-Chat, embedding, vision, and reranking models are installed and switched from inside the terminal: browse the catalog, pull a model, pick a role. Retrieval and generation expose 50+ settings (chunk size, search strictness, reranker depth, and more), editable from the TUI, env vars, or a project-local config file. Sane defaults.
+Chat, embedding, vision, and reranking models are installed and switched from inside the terminal: browse the catalog, pull a model, pick a role. Retrieval and generation expose 50+ settings (chunk size, search strictness, reranker depth, and more), editable from the TUI, env vars, or a project-local config file. Sane defaults. [docs/tested-models.md](docs/tested-models.md) lists the architecture families verified end to end on real GPUs for every role.
 
 ![browse the model catalog, search Hugging Face Hub, pull a model live](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-catalog.gif)
 

--- a/docs/tested-models.md
+++ b/docs/tested-models.md
@@ -1,0 +1,54 @@
+# Model families tested
+
+lilbee's placement planner and engine are exercised against real models on real GPUs, one representative per architecture family, covering every role a model can hold: chat, embedding, vision, and rerank. Every family below was pulled with `lilbee model pull` and run through the full pipeline on consumer hardware, with nothing staged by hand. For chat families verified against coding agents and tool calling, see [agent-models](agent-models.md).
+
+The vision families ran on a single 12 GB RTX 3080 Ti with the chat and embed defaults resident beside them: the model indexed an image-only scanned PDF through OCR and answered a question whose answer exists only in the scanned text. The text families ran the same pipeline (index a document, search it, answer from it) with each candidate swapped into its role next to the other defaults.
+
+## Vision
+
+| Family | Projector type | Tested with |
+|--------|----------------|-------------|
+| LightOnOCR | lightonocr | `noctrex/LightOnOCR-2-1B-GGUF` |
+| Qwen2.5-VL | qwen2.5vl merger | `ggml-org/Qwen2.5-VL-3B-Instruct-GGUF` |
+| Qwen3-VL | qwen3vl | `Qwen/Qwen3-VL-4B-Instruct-GGUF` |
+| Gemma 3 | gemma3 | `ggml-org/gemma-3-4b-it-GGUF` |
+| SmolVLM2 | idefics3 | `ggml-org/SmolVLM2-2.2B-Instruct-GGUF` |
+| MiniCPM-V | resampler | `openbmb/MiniCPM-V-2_6-gguf` |
+| InternVL3 | internvl | `ggml-org/InternVL3-2B-Instruct-GGUF` |
+| LLaVA 1.6 | mlp | `cjpais/llava-1.6-mistral-7b-gguf` |
+| Gemma 4 | mixed vision+audio | `ggml-org/gemma-4-12B-it-GGUF` |
+| dots.ocr | dots.ocr | `ggml-org/dots.ocr-GGUF` |
+
+Every family's pull fetched the multimodal projector on its own, placement never refused, and OCR plus the grounded answer completed on the 12 GB card. Beyond these live loads, the placement decision layer is swept against a corpus of 947 unique text-model and projector pairs spanning 34 projector types, checking that the corrected estimate never undercuts the model's own floor and that no model is refused on estimate alone.
+
+## Chat
+
+One representative per memory-architecture class, since context sizing and KV behavior differ by attention design, not by parameter count.
+
+| Class | Tested with |
+|-------|-------------|
+| Dense GQA | `hugging-quants/Llama-3.2-3B-Instruct-Q4_K_M-GGUF` |
+| Dense (Qwen3) | `Qwen/Qwen3-4B-GGUF` |
+| Sliding-window attention | `ggml-org/gemma-3-4b-it-GGUF` |
+| Multi-head latent attention | `mradermacher/DeepSeek-V2-Lite-Chat-GGUF` |
+| Mixture of experts | `bartowski/OLMoE-1B-7B-0924-Instruct-GGUF` |
+| Hybrid SSM | `LiquidAI/LFM2-1.2B-GGUF` |
+
+## Embedding
+
+| Class | Tested with |
+|-------|-------------|
+| BERT encoder | `second-state/All-MiniLM-L6-v2-Embedding-GGUF` |
+| nomic-bert | `nomic-ai/nomic-embed-text-v1.5-GGUF` |
+| Decoder-pooled | `Qwen/Qwen3-Embedding-0.6B-GGUF` |
+| Decoder-pooled, large | `Qwen/Qwen3-Embedding-8B-GGUF` |
+| XLM-RoBERTa | `gpustack/bge-m3-GGUF` |
+
+## Rerank
+
+| Class | Tested with |
+|-------|-------------|
+| Cross-encoder | `gpustack/bge-reranker-v2-m3-GGUF` |
+| LLM reranker | `mradermacher/Qwen3-Reranker-0.6B-GGUF` |
+
+A family listed here means the architecture loads, places, and completes its role's pipeline. Model quality within a family still varies by size and training; a 2B vision model can read a scan yet answer thinly where a 4B one answers well.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -51,7 +51,7 @@ from lilbee.providers.warm_progress import WarmPhase, WarmProgress, WarmProgress
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Mapping, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 
     from lilbee.providers.base import (
         ChatMessage,
@@ -197,6 +197,66 @@ def _no_healthy_replica_error() -> ProviderError:
         provider=_PROVIDER_NAME,
         kind=ProviderErrorKind.CONNECTION,
     )
+
+
+# Env vars a launch pins its devices with, one per backend (Metal has none).
+_VISIBLE_DEVICE_ENV_VARS = (
+    "CUDA_VISIBLE_DEVICES",
+    "ROCR_VISIBLE_DEVICES",
+    "HIP_VISIBLE_DEVICES",
+    "GGML_VK_VISIBLE_DEVICES",
+    "ONEAPI_DEVICE_SELECTOR",
+)
+
+
+def _role_device_sets(
+    launches: Iterable[InstanceLaunch],
+) -> dict[WorkerRole, frozenset[str]]:
+    """Backend-qualified device tokens each role's launches pin, by role.
+
+    A role's set is the union across its replicas. Roles whose launches carry
+    no visibility env (Metal, or an unpinned backend) are absent: without
+    pinning there is no proof of sharing, so they keep the concurrent warm.
+    """
+    sets: dict[WorkerRole, set[str]] = {}
+    for launch in launches:
+        for var in _VISIBLE_DEVICE_ENV_VARS:
+            value = launch.env_overrides.get(var)
+            if value:
+                sets.setdefault(launch.role, set()).update(
+                    f"{var}={part.strip()}" for part in value.split(",")
+                )
+    return {role: frozenset(tokens) for role, tokens in sets.items()}
+
+
+def _warm_chains(
+    warm_roles: list[WorkerRole], device_sets: dict[WorkerRole, frozenset[str]]
+) -> list[list[WorkerRole]]:
+    """Group *warm_roles* into chains warmed sequentially; chains run in parallel.
+
+    Roles with overlapping device sets land in one chain, merged transitively.
+    Within a chain chat goes last: it sizes its KV against the headroom the
+    settled residents leave, so it must not race their loads. A role with no
+    device set shares nothing provable and gets its own chain.
+    """
+    chains: list[tuple[set[str], list[WorkerRole]]] = []
+    ordered = sorted(warm_roles, key=lambda r: (r is WorkerRole.CHAT, list(WorkerRole).index(r)))
+    for role in ordered:
+        tokens = device_sets.get(role)
+        if not tokens:
+            chains.append((set(), [role]))
+            continue
+        merged_tokens, merged_roles = set(tokens), [role]
+        kept: list[tuple[set[str], list[WorkerRole]]] = []
+        for chain_tokens, chain_roles in chains:
+            if chain_tokens & merged_tokens:
+                merged_tokens |= chain_tokens
+                merged_roles = chain_roles + merged_roles
+            else:
+                kept.append((chain_tokens, chain_roles))
+        kept.append((merged_tokens, merged_roles))
+        chains = kept
+    return [roles for _tokens, roles in chains]
 
 
 def _warm_role(role: WorkerRole, client: LlamaServerClient) -> None:
@@ -1395,8 +1455,12 @@ class FleetProvider:
         :meth:`_warm_chat_role` so a launcher gets granular progress. *roles*
         narrows the warm to just those roles (a reload warms only what restarted).
 
-        Roles warm concurrently: chat is the long pole (a large model's load
-        dominates), so the light roles load alongside it instead of before it.
+        Roles on separate devices warm concurrently: chat is the long pole (a
+        large model's load dominates), so the light roles load alongside it
+        instead of before it. Roles whose launches pin overlapping devices warm
+        one at a time instead, chat last: two engines loading into the same
+        card at once race each other for VRAM, and the loser's first load can
+        OOM even though both fit once settled.
         """
         with self._lock:
             pools = {
@@ -1405,23 +1469,49 @@ class FleetProvider:
                 if roles is None or role in roles
             }
             on_spawning, on_spawned = self._on_spawning, self._on_spawned
-
-        def _warm_one(role: WorkerRole, clients: list[LlamaServerClient]) -> None:
-            if on_spawning is not None:
-                on_spawning(role)
-            if role is WorkerRole.CHAT:
-                self._warm_chat_role(clients)
-            else:
-                self._warm_role_clients(role, clients)
-            if on_spawned is not None:
-                on_spawned(role)
+            device_sets = _role_device_sets(
+                launch for launches in self._launches.values() for launch in launches
+            )
 
         if not pools:
             return
-        with ThreadPoolExecutor(max_workers=len(pools), thread_name_prefix="fleet-preload") as pool:
-            futures = [pool.submit(_warm_one, role, clients) for role, clients in pools.items()]
+        listeners = (on_spawning, on_spawned)
+        chains = _warm_chains(list(pools), device_sets)
+        with ThreadPoolExecutor(
+            max_workers=len(chains), thread_name_prefix="fleet-preload"
+        ) as pool:
+            futures = [pool.submit(self._warm_chain, chain, pools, listeners) for chain in chains]
             for future in futures:
                 future.result()
+
+    def _warm_chain(
+        self,
+        chain: list[WorkerRole],
+        pools: dict[WorkerRole, list[LlamaServerClient]],
+        listeners: tuple[Callable[[WorkerRole], None] | None, Callable[[WorkerRole], None] | None],
+    ) -> None:
+        """Warm *chain*'s roles one at a time; every role gets its attempt.
+
+        An unexpected error warming one role (a listener blowing up) must not rob
+        the roles behind it of their warm, so the first error is re-raised only
+        after the chain finishes.
+        """
+        on_spawning, on_spawned = listeners
+        first_exc: Exception | None = None
+        for role in chain:
+            try:
+                if on_spawning is not None:
+                    on_spawning(role)
+                if role is WorkerRole.CHAT:
+                    self._warm_chat_role(pools[role])
+                else:
+                    self._warm_role_clients(role, pools[role])
+                if on_spawned is not None:
+                    on_spawned(role)
+            except Exception as exc:  # noqa: BLE001 - every role gets its warm attempt
+                first_exc = first_exc or exc
+        if first_exc is not None:
+            raise first_exc
 
     def _warm_role_clients(self, role: WorkerRole, clients: list[LlamaServerClient]) -> bool:
         """Warm every replica of *role*; return whether at least one loaded.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -1508,7 +1508,7 @@ class FleetProvider:
                     self._warm_role_clients(role, pools[role])
                 if on_spawned is not None:
                     on_spawned(role)
-            except Exception as exc:  # noqa: BLE001 - every role gets its warm attempt
+            except Exception as exc:
                 first_exc = first_exc or exc
         if first_exc is not None:
             raise first_exc

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -1499,6 +1499,104 @@ def test_preload_roles_warms_roles_concurrently(monkeypatch) -> None:
     assert not preload.is_alive()
 
 
+def _pinned_launch(role: WorkerRole, devices: str, replica: int = 0) -> InstanceLaunch:
+    return InstanceLaunch(
+        role=role,
+        argv=[],
+        env_overrides={"CUDA_VISIBLE_DEVICES": devices},
+        model=f"{role.value}-{replica}",
+        replica=replica,
+    )
+
+
+def test_warm_chains_serializes_shared_device_chat_last() -> None:
+    sets = {
+        WorkerRole.CHAT: frozenset({"CUDA_VISIBLE_DEVICES=0"}),
+        WorkerRole.EMBED: frozenset({"CUDA_VISIBLE_DEVICES=0"}),
+    }
+    chains = prov_mod._warm_chains([WorkerRole.CHAT, WorkerRole.EMBED], sets)
+    assert chains == [[WorkerRole.EMBED, WorkerRole.CHAT]]
+
+
+def test_warm_chains_keeps_disjoint_devices_parallel() -> None:
+    sets = {
+        WorkerRole.CHAT: frozenset({"CUDA_VISIBLE_DEVICES=0"}),
+        WorkerRole.EMBED: frozenset({"CUDA_VISIBLE_DEVICES=1"}),
+    }
+    chains = prov_mod._warm_chains([WorkerRole.CHAT, WorkerRole.EMBED], sets)
+    assert {tuple(c) for c in chains} == {(WorkerRole.EMBED,), (WorkerRole.CHAT,)}
+
+
+def test_warm_chains_unpinned_role_stays_parallel() -> None:
+    # No pinning info (Metal, or a launch without visibility env) keeps today's
+    # concurrent warm; only proven device sharing serializes.
+    sets = {WorkerRole.CHAT: frozenset({"CUDA_VISIBLE_DEVICES=0"})}
+    chains = prov_mod._warm_chains([WorkerRole.CHAT, WorkerRole.EMBED], sets)
+    assert {tuple(c) for c in chains} == {(WorkerRole.EMBED,), (WorkerRole.CHAT,)}
+
+
+def test_warm_chains_transitive_overlap_merges() -> None:
+    sets = {
+        WorkerRole.CHAT: frozenset({"CUDA_VISIBLE_DEVICES=0", "CUDA_VISIBLE_DEVICES=1"}),
+        WorkerRole.EMBED: frozenset({"CUDA_VISIBLE_DEVICES=1", "CUDA_VISIBLE_DEVICES=2"}),
+        WorkerRole.RERANK: frozenset({"CUDA_VISIBLE_DEVICES=2"}),
+    }
+    chains = prov_mod._warm_chains([WorkerRole.CHAT, WorkerRole.EMBED, WorkerRole.RERANK], sets)
+    assert chains == [[WorkerRole.EMBED, WorkerRole.RERANK, WorkerRole.CHAT]]
+
+
+def test_role_device_sets_unions_replicas_and_skips_unpinned() -> None:
+    launches = [
+        _pinned_launch(WorkerRole.EMBED, "0", replica=0),
+        _pinned_launch(WorkerRole.EMBED, "1", replica=1),
+        InstanceLaunch(role=WorkerRole.VISION, argv=[], env_overrides={}, model="vision-0"),
+    ]
+    sets = prov_mod._role_device_sets(launches)
+    assert sets == {
+        WorkerRole.EMBED: frozenset({"CUDA_VISIBLE_DEVICES=0", "CUDA_VISIBLE_DEVICES=1"})
+    }
+
+
+def test_preload_serializes_roles_sharing_a_device(monkeypatch) -> None:
+    # Chat and embed pinned to the same card must warm one at a time, embed
+    # first: concurrent loads on a shared device race each other for VRAM and
+    # the loser OOMs its first attempt.
+    order: list[str] = []
+    chat, embed = _fake_client(), _fake_client()
+    chat.chat.side_effect = lambda *a, **k: (order.append("chat"), MagicMock())[1]
+    embed.embed.side_effect = lambda *a, **k: (order.append("embed"), [[0.1]])[1]
+    p = _provider_with_clients({WorkerRole.CHAT: [chat], WorkerRole.EMBED: [embed]})
+    p._launches = {
+        SwapGroup.CHAT: (_pinned_launch(WorkerRole.CHAT, "0"),),
+        SwapGroup.EMBED: (_pinned_launch(WorkerRole.EMBED, "0"),),
+    }
+    monkeypatch.setattr(p, "_prewarm_chat_weights", lambda: None)
+    p._preload_roles()
+    assert order == ["embed", "chat"]
+
+
+def test_preload_chain_gives_every_role_its_warm_attempt(monkeypatch) -> None:
+    # An unexpected error warming one chain role (a listener blowing up) must
+    # not rob the roles behind it of their warm; it surfaces after the chain.
+    chat, embed = _fake_client(), _fake_client()
+    embed.embed.return_value = [[0.1]]
+    p = _provider_with_clients({WorkerRole.CHAT: [chat], WorkerRole.EMBED: [embed]})
+    p._launches = {
+        SwapGroup.CHAT: (_pinned_launch(WorkerRole.CHAT, "0"),),
+        SwapGroup.EMBED: (_pinned_launch(WorkerRole.EMBED, "0"),),
+    }
+    monkeypatch.setattr(p, "_prewarm_chat_weights", lambda: None)
+
+    def _blowing_listener(role: WorkerRole) -> None:
+        if role is WorkerRole.EMBED:
+            raise RuntimeError("listener broke")
+
+    p.add_spawn_listener(on_spawning=_blowing_listener)
+    with pytest.raises(RuntimeError, match="listener broke"):
+        p._preload_roles()
+    chat.chat.assert_called_once()  # chat still warmed behind the failed embed
+
+
 def _registry_with_shards(monkeypatch, shards: list[Path]) -> None:
     registry = MagicMock()
     registry.shard_paths.return_value = shards


### PR DESCRIPTION
## Problem

The placement-estimation campaign that closed with the last two merged PRs left two follow-ups. First, the model families it verified (ten vision projector families, six chat memory-architecture classes, five embedders, two rerankers, all loaded end to end on real GPUs) were documented only in PR descriptions, not in the repo. Second, the campaign reproduced a known wart on a second card size: on a GPU shared by chat and a heavy pooled embedder, the chat engine's first load can fail with a transient CUDA out-of-memory and recover on retry, surfacing a scary warning for a failure the system heals on its own.

The root cause of that transient is startup ordering, not estimation. Fleet warm-up spawns one thread per role and warms them all concurrently, so two engines that share a device allocate VRAM at the same instant; whoever loses the race dies once, and the retry succeeds because the surviving tenant has settled by then. Both recorded incidents (a 12 GB card with a pooled 0.6B embedder, a 16 GB card with an 8B one) happened in exactly this window.

## Solution

Warm-up now serializes roles that share a device and keeps device-disjoint roles concurrent. Launches already carry their device pinning, so the provider derives per-role device sets from them, chains overlapping roles into one sequential warm (chat last, since chat sizes its context into the headroom the settled residents leave), and runs disjoint chains in parallel as before. Multi-GPU startups keep their concurrent warm; single-GPU and unified-memory boxes get a deterministic load order instead of a race. Roles with no pinning information are treated as sharing, which is the safe default.

The docs gain `docs/tested-models.md`, the per-role table of every architecture family the campaign verified, linked from the README.

## Validation

The campaign evidence behind both changes: 10/10 vision families, 13/13 text classes, and the 947-pair decision-corpus sweep, all green, with the one transient above as the only defect observed anywhere. The warm-ordering change is covered by unit tests over the chain-building logic and the preload path; the existing test asserting concurrent warm-up for disjoint roles keeps passing.
