### PR TITLE
Fix the chat engine idle-unload hang, keep_engine_warm semantics, and multi-instance config isolation

### DIFF
--- a/src/lilbee/core/config/model.py
+++ b/src/lilbee/core/config/model.py
@@ -366,13 +366,16 @@ class Config(BaseSettings):
     worker_pool_eager_start: bool = ConfigField(default=True, writable=True)
 
     # Leave the engine fleet running on quit so the next launch adopts it warm.
-    # Off is the on-demand default: the engine loads per launch and frees VRAM
-    # on close.
+    # On keeps the engine resident: it never idle-unloads and survives app close
+    # for the next launch to adopt. Off (default) is on-demand: the engine loads
+    # per launch, releases its weights after an idle window, and reloads on the
+    # next prompt.
     keep_engine_warm: bool = ConfigField(default=False, writable=True)
 
-    # Idle minutes before a warm fleet unloads its weights (llama-swap ttl), so
-    # a warm engine never holds VRAM past this window. 0 keeps weights loaded
-    # forever. Read only when keep_engine_warm is on.
+    # Idle minutes before an on-demand (not-warm) fleet unloads its weights
+    # (llama-swap ttl), so it never holds VRAM past this window. 0 keeps weights
+    # loaded until the app tears the fleet down. Read only when keep_engine_warm
+    # is off (a warm fleet stays resident regardless).
     engine_idle_ttl_minutes: int = ConfigField(default=5, writable=True)
 
     # Working n_ctx the dynamic picker aims for. Default scales with

--- a/src/lilbee/providers/fleet/planning.py
+++ b/src/lilbee/providers/fleet/planning.py
@@ -1210,6 +1210,10 @@ class FleetPlan:
 
     launches: tuple[InstanceLaunch, ...]
     co_tenants: frozenset[WorkerRole] = frozenset()
+    # Configured roles left unplaced because their model isn't installed (role ->
+    # ref), so the warm path can fail a not-installed chat with a named reason
+    # instead of spinning the warm line forever.
+    skipped_not_installed: dict[WorkerRole, str] = field(default_factory=dict)
 
 
 def _log_placement_findings(placement: Placement, model_refs: dict[WorkerRole, str]) -> None:
@@ -1253,7 +1257,7 @@ def plan_launches(
     from lilbee.core.config import cfg
 
     unified_budget = _unified_memory_budget(devices)
-    inputs, model_refs, reservation, _ = _server_model_inputs(
+    inputs, model_refs, reservation, skipped_not_installed = _server_model_inputs(
         roles,
         unified_budget=unified_budget,
         device_count=len(devices),
@@ -1277,6 +1281,7 @@ def plan_launches(
             for plan in placement.instances
         ),
         co_tenants=placement.co_tenants,
+        skipped_not_installed=skipped_not_installed,
     )
 
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -560,8 +560,15 @@ def _adoptable_launches(state: _SwapState) -> list[InstanceLaunch] | None:
 
 
 def _warm_ttl_seconds() -> int:
-    """llama-swap idle-unload timer: the user's warm ttl, or 0 when warm is off."""
-    if not cfg.keep_engine_warm:
+    """llama-swap idle-unload timer in seconds for the spawned fleet.
+
+    ``keep_engine_warm`` keeps the fleet resident: ttl 0, so llama-swap never
+    idle-unloads it. With warm off the engine is on-demand and releases its
+    weights after ``engine_idle_ttl_minutes`` of inactivity to free VRAM; the
+    next prompt reloads transparently. A ttl of 0 there disables the idle unload
+    entirely (weights stay until the app tears the fleet down).
+    """
+    if cfg.keep_engine_warm:
         return 0
     return cfg.engine_idle_ttl_minutes * 60
 

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -24,6 +24,7 @@ from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar, overload
 
+from lilbee.catalog import clean_display_name
 from lilbee.core.config import cfg
 from lilbee.modelhub.registry import ModelRegistry
 from lilbee.providers.base import ProviderError, ProviderErrorKind
@@ -627,6 +628,10 @@ class FleetProvider:
         # The engine's own reason a role's model failed to warm, so the launcher and
         # the TUI report the real cause instead of a generic "did not load".
         self._warm_errors: dict[WorkerRole, str] = {}
+        # Configured roles the last plan left unplaced because their model isn't
+        # installed (role -> ref). The warm finalizer reads it to fail a not-installed
+        # chat with a named reason instead of clearing to a silent "not ready" retry.
+        self._skipped_not_installed: dict[WorkerRole, str] = {}
         # Single-flight guard for the off-thread warm-up: True from the moment a
         # warm thread is dispatched until it finishes, so a second warm_up_pool
         # never starts a second swap and double-allocates GPU memory.
@@ -693,6 +698,7 @@ class FleetProvider:
         except ProviderError:
             log.debug("Engine binary unavailable; no swap started")
             plan = None
+        self._skipped_not_installed = dict(plan.skipped_not_installed) if plan else {}
         if plan is None or not plan.launches:
             # No engine binary, or no installed/configured model: serve nothing.
             return False
@@ -1426,7 +1432,7 @@ class FleetProvider:
             self._warm_tracker.begin(str(cfg.chat_model))
             self._ensure_fleet()
             self._preload_roles()
-            self._clear_warm_if_chat_never_ran()
+            self._finalize_warm_if_chat_never_ran()
         except Exception as exc:
             if isinstance(exc, RuntimeError) and sys.is_finalizing():
                 # A fast CLI exit can tear down the interpreter while this daemon
@@ -1458,17 +1464,24 @@ class FleetProvider:
         if snapshot is None or snapshot.phase is not WarmPhase.READY:
             self._warm_tracker.fail(message)
 
-    def _clear_warm_if_chat_never_ran(self) -> None:
-        """Drop the early STARTING stamp when no chat role was placed to warm.
+    def _finalize_warm_if_chat_never_ran(self) -> None:
+        """Terminate the early STARTING stamp when no chat instance was placed.
 
-        ``_warm_chat_role`` always ends in READY or ERROR when it runs; a
-        snapshot still on STARTING after a successful preload means the plan
-        had no chat instances (model not installed), and leaving it would spin
-        the warm line forever.
+        ``_warm_chat_role`` always ends in READY or ERROR when it runs, so a
+        snapshot still on STARTING after a successful preload means the plan had
+        no chat instance. A chat model that isn't installed fails the warm with a
+        user-facing reason so the prompt path renders "failed to load" instead of
+        spinning a "not ready" retry that can never succeed; any other reason (a
+        remote-routed chat has no local server to warm) clears the stamp.
         """
         snapshot = self._warm_tracker.snapshot()
-        if snapshot is not None and snapshot.phase is WarmPhase.STARTING:
+        if snapshot is None or snapshot.phase is not WarmPhase.STARTING:
+            return
+        missing = self._skipped_not_installed.get(WorkerRole.CHAT)
+        if missing is None:
             self._warm_tracker.clear()
+        else:
+            self._warm_tracker.fail(f"chat model {clean_display_name(missing)} is not installed")
 
     def _preload_roles(self, roles: frozenset[WorkerRole] | None = None) -> None:
         """Issue a cheap request per replica so llama-swap loads each upstream now.

--- a/src/lilbee/providers/fleet/provider.py
+++ b/src/lilbee/providers/fleet/provider.py
@@ -1375,7 +1375,19 @@ class FleetProvider:
         (or once the fleet is up) is a no-op.
         """
         with self._lock:
-            if self._swaps or self._warming:
+            if self._warming:
+                return
+            fleet_up = bool(self._swaps)
+        # A live swap whose model llama-swap idle-unloaded (its ttl stops only the
+        # llama-server child, leaving the swap handle in _swaps) reports its role
+        # cold. Re-warm so a prompt sent into that gap drives llama-swap's
+        # on-demand reload; bailing on "swaps exist" alone stranded every later
+        # prompt on a stale not-ready. A fully-loaded fleet still short-circuits.
+        # The probe runs off the lock (role_ready may hit the proxy).
+        if fleet_up and self._roles_ready():
+            return
+        with self._lock:
+            if self._warming:
                 return
             self._warming = True
         threading.Thread(
@@ -1383,6 +1395,12 @@ class FleetProvider:
             name="fleet-warm-up",
             daemon=True,
         ).start()
+
+    def _roles_ready(self) -> bool:
+        """Whether every configured role's upstream is loaded (fleet fully warm)."""
+        with self._lock:
+            roles = list(self._role_group)
+        return bool(roles) and all(self.role_ready(role) for role in roles)
 
     def _warm_up_blocking(self) -> None:
         """Start the fleet and pre-load every role on a background thread.

--- a/src/lilbee/providers/fleet/swap_manager.py
+++ b/src/lilbee/providers/fleet/swap_manager.py
@@ -40,7 +40,11 @@ _HOST = "127.0.0.1"
 # One llama-swap per swap group: the group name lands in the config filename so
 # each group's processes are identified (and stopped) by their own config path,
 # and a placement change can restart one group without touching the others.
-_CONFIG_FILENAME_TEMPLATE = "llama-swap-{group}.json"
+# Per owner-pid (the last dotted segment, matching the state-file scheme) so two
+# lilbee instances at one data_dir never write the same config file. A shared
+# name let a sibling's write flip the ports/ttl a later restart would re-read.
+_CONFIG_FILENAME_TEMPLATE = "llama-swap-{group}.{pid}.json"
+# Matches every owner's group configs; the per-owner glob narrows to one pid.
 _CONFIG_FILE_GLOB = "llama-swap-*.json"
 # llama-swap's own stdout/stderr (its HTTP access log) is captured to a file under
 # the data root's ``logs/`` (beside server.log etc.) instead of inherited from the
@@ -141,7 +145,7 @@ class SwapManager:
     def __init__(self, data_dir: Path, group: SwapGroup) -> None:
         self._data_dir = data_dir
         self._group = group
-        self._config_path = data_dir / _CONFIG_FILENAME_TEMPLATE.format(group=group.value)
+        self._config_path = data_dir / _config_filename(os.getpid(), group.value)
         self._log_path = data_dir / _LOGS_SUBDIR / _LOG_FILENAME_TEMPLATE.format(group=group.value)
         self._state_path = data_dir / _state_filename(os.getpid(), group.value)
         self._proc: subprocess.Popen[bytes] | None = None
@@ -500,6 +504,7 @@ def reap_stale(data_dir: Path, *, keep_detached: bool = False) -> None:
     which role groups exist, when no per-group manager has been built yet.
     """
     _clean_stale_tmp_files(data_dir)
+    _clean_stale_configs(data_dir)
     for state_path in sorted(data_dir.glob(_STATE_FILE_GLOB)):
         state = _load_state(state_path)
         if state is None:
@@ -525,15 +530,30 @@ def _clean_stale_tmp_files(data_dir: Path) -> None:
             tmp_path.unlink(missing_ok=True)
 
 
+def _clean_stale_configs(data_dir: Path) -> None:
+    """Remove per-owner config files whose owner lilbee is gone.
+
+    The swaps themselves are reaped from the state files; these leftover config
+    files are just clutter once their writer pid is dead. A live owner's config
+    (pid still exists) and a pid-less legacy name are left untouched; skipping on
+    pid reuse only leaves harmless clutter, never deletes a live owner's config.
+    """
+    for config_path in data_dir.glob(_CONFIG_FILE_GLOB):
+        owner = _config_owner_pid(config_path.name)
+        if owner is not None and not psutil.pid_exists(owner):
+            config_path.unlink(missing_ok=True)
+
+
 def sweep_owned(data_dir: Path) -> None:
     """Stop every llama-swap this process owns at *data_dir*, across all groups.
 
     The provider's fallback teardown path: when it holds no tracked managers, an
-    in-flight build may still have spawned swaps it never adopted. Each group's
-    config file identifies that group's processes, so every group config present
-    is swept. Cross-run leftovers are ``reap_stale``'s job, not this sweep's.
+    in-flight build may still have spawned swaps it never adopted. Config files
+    are per owner-pid, so this sweeps only this process's group configs; a
+    sibling lilbee's swaps are its own to stop. Cross-run leftovers are
+    ``reap_stale``'s job, not this sweep's.
     """
-    for config_path in sorted(data_dir.glob(_CONFIG_FILE_GLOB)):
+    for config_path in sorted(data_dir.glob(_own_config_glob(os.getpid()))):
         _stop_own_fleet(config_path, ())
 
 
@@ -726,6 +746,25 @@ def _state_owner_pid(name: str) -> int | None:
     """
     stem = name.removeprefix(_STATE_TMP_PREFIX).removesuffix(_STATE_TMP_SUFFIX)
     stem = stem.removeprefix(_STATE_FILENAME_PREFIX).removesuffix(_STATE_FILENAME_SUFFIX)
+    try:
+        return int(stem.rsplit(".", 1)[-1])
+    except ValueError:
+        return None
+
+
+def _config_filename(pid: int, group: str) -> str:
+    """This owner's config filename for *group* (``llama-swap-<group>.<pid>.json``)."""
+    return _CONFIG_FILENAME_TEMPLATE.format(group=group, pid=pid)
+
+
+def _own_config_glob(pid: int) -> str:
+    """Glob matching only *pid*'s per-group config files."""
+    return f"llama-swap-*.{pid}.json"
+
+
+def _config_owner_pid(name: str) -> int | None:
+    """Owner pid embedded in a config filename, ``None`` for a legacy pid-less name."""
+    stem = name.removeprefix("llama-swap-").removesuffix(".json")
     try:
         return int(stem.rsplit(".", 1)[-1])
     except ValueError:

--- a/tests/test_fleet_planning.py
+++ b/tests/test_fleet_planning.py
@@ -1271,6 +1271,33 @@ class TestBuildFleetWiring:
         monkeypatch.setattr(planning_mod, "_launch_for", lambda *a, **kw: sentinel)
         assert planning_mod.plan_all_launches() == planning_mod.FleetPlan((sentinel,))
 
+    def test_plan_all_launches_carries_skipped_not_installed(self, monkeypatch) -> None:
+        # The plan surfaces a configured-but-missing chat model so the provider's
+        # warm path can fail with a named reason instead of spinning.
+        device = FleetDevice("CUDA", 0, "gpu", 24 * _GB, 23 * _GB)
+        monkeypatch.setattr(planning_mod, "resolve_llama_server", lambda: Path("/bin/llama-server"))
+        monkeypatch.setattr(planning_mod, "probe_devices", lambda _binary: [device])
+        monkeypatch.setattr(
+            planning_mod,
+            "_server_model_inputs",
+            lambda *_roles, **_kw: (
+                [ModelPlacementInput(WorkerRole.EMBED, 1 * _GB)],
+                {WorkerRole.EMBED: "eref"},
+                0,
+                {WorkerRole.CHAT: "org/repo/missing-chat.gguf"},
+            ),
+        )
+        monkeypatch.setattr(
+            planning_mod,
+            "plan_placement",
+            lambda inputs, devices, *, estimate_peak, unified_budget=None, **_kw: Placement(
+                instances=(InstancePlan(WorkerRole.EMBED, (0,)),), unplaceable_roles=()
+            ),
+        )
+        monkeypatch.setattr(planning_mod, "_launch_for", lambda *a, **kw: MagicMock())
+        plan = planning_mod.plan_all_launches()
+        assert plan.skipped_not_installed == {WorkerRole.CHAT: "org/repo/missing-chat.gguf"}
+
     def test_plan_launches_reports_co_tenant_roles(self, monkeypatch, caplog) -> None:
         # Co-tenancy changes how the box behaves (one model resident at a time), so it
         # is stated in the log rather than being inferred from a silent plan.

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -119,6 +119,26 @@ def _provider_with_clients(clients: dict[WorkerRole, list[MagicMock]]) -> FleetP
     return p
 
 
+def test_warm_up_pool_rechecks_warming_after_readiness_probe(monkeypatch) -> None:
+    # The readiness probe runs off the lock; if a concurrent warm starts during
+    # it, the re-check under the lock abandons this dispatch so no second warm
+    # thread spawns.
+    p = FleetProvider()
+    group = SwapGroup(WorkerRole.CHAT.value)
+    p._role_group = {WorkerRole.CHAT: group}
+    p._swaps = {group: _FakeSwap()}  # fleet up, role cold
+    kicked = _stub_warm_thread(monkeypatch)
+
+    def _probe_then_a_warm_wins_the_race() -> bool:
+        p._warming = True  # a sibling warm started while we were probing
+        return False
+
+    monkeypatch.setattr(p, "_roles_ready", _probe_then_a_warm_wins_the_race)
+    p.warm_up_pool()
+
+    assert not kicked, "the re-check must abandon this dispatch, not start a second warm"
+
+
 def _stub_warm_thread(monkeypatch) -> list[dict]:
     """Replace the warm-up daemon thread with a recorder; return the kicked list."""
     kicked: list[dict] = []
@@ -216,6 +236,24 @@ def test_adopt_group_builds_a_client_per_replica(monkeypatch) -> None:
     p = FleetProvider()
     p._ensure_fleet()
     assert len(p._clients[WorkerRole.EMBED]) == 2  # one client per replica launch
+
+
+def test_ensure_fleet_records_skipped_not_installed_from_plan(monkeypatch) -> None:
+    # The plan reports a configured-but-missing chat model; _plan_and_spawn records
+    # it so the warm finalizer can fail chat with a named reason. The installed embed
+    # role still starts.
+    _install_engine(monkeypatch, launches=[_fake_launch(WorkerRole.EMBED)])
+    monkeypatch.setattr(
+        planning_mod,
+        "plan_all_launches",
+        lambda: planning_mod.FleetPlan(
+            (_fake_launch(WorkerRole.EMBED),),
+            skipped_not_installed={WorkerRole.CHAT: "org/repo/missing-chat.gguf"},
+        ),
+    )
+    p = FleetProvider()
+    p._ensure_fleet()
+    assert p._skipped_not_installed == {WorkerRole.CHAT: "org/repo/missing-chat.gguf"}
 
 
 def test_ensure_fleet_refused_after_shutdown(monkeypatch) -> None:
@@ -1458,14 +1496,37 @@ def test_warm_up_blocking_reports_starting_before_fleet_spawn(monkeypatch) -> No
     assert seen == [WarmPhase.STARTING]
 
 
-def test_warm_up_blocking_clears_stamp_when_chat_never_warms(monkeypatch) -> None:
-    """No chat instance placed (model not installed): the early STARTING stamp
-    is dropped so the warm line cannot spin forever."""
+def test_warm_up_blocking_clears_stamp_when_chat_absent_for_other_reasons(monkeypatch) -> None:
+    """No chat instance placed for a non-install reason (a remote-routed chat has
+    no local server to warm): the early STARTING stamp is dropped so the warm line
+    cannot spin forever, and no spurious failure is stamped."""
     p = FleetProvider()
     monkeypatch.setattr(p, "_ensure_fleet", lambda: None)
     monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
     p._warm_up_blocking()
     assert p.warm_progress() is None
+
+
+def test_warm_up_blocking_fails_when_chat_model_not_installed(monkeypatch) -> None:
+    """Chat model configured but not installed: the warm ends in a terminal ERROR
+    naming the cause, so the prompt path renders 'failed to load' instead of an
+    endless 'not ready, send again' bounce that retrying can never resolve."""
+    from lilbee.providers.warm_progress import WarmPhase
+
+    p = FleetProvider()
+
+    def _plan_skips_chat() -> None:
+        # _ensure_fleet records what the plan left unplaced; a not-installed chat
+        # model is skipped here, as _plan_and_spawn would record it.
+        p._skipped_not_installed = {WorkerRole.CHAT: "Qwen/Qwen3-8B-GGUF"}
+
+    monkeypatch.setattr(p, "_ensure_fleet", _plan_skips_chat)
+    monkeypatch.setattr(p, "_preload_roles", lambda roles=None: None)
+    p._warm_up_blocking()
+    snap = p.warm_progress()
+    assert snap is not None
+    assert snap.phase is WarmPhase.ERROR
+    assert (snap.error or "") == "chat model Qwen3 8B is not installed"
 
 
 def test_warm_up_blocking_swallows_interpreter_shutdown_race(monkeypatch, caplog) -> None:

--- a/tests/test_fleet_provider.py
+++ b/tests/test_fleet_provider.py
@@ -8,6 +8,7 @@ import os
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -116,6 +117,34 @@ def _provider_with_clients(clients: dict[WorkerRole, list[MagicMock]]) -> FleetP
     p._swaps = {SwapGroup(role.value): _FakeSwap() for role in roles}
     p._clients = {role: list(cs) for role, cs in clients.items() if cs}
     return p
+
+
+def _stub_warm_thread(monkeypatch) -> list[dict]:
+    """Replace the warm-up daemon thread with a recorder; return the kicked list."""
+    kicked: list[dict] = []
+    monkeypatch.setattr(
+        prov_mod.threading,
+        "Thread",
+        lambda **kw: SimpleNamespace(start=lambda: kicked.append(kw)),
+    )
+    return kicked
+
+
+def test_warm_up_pool_rewarms_when_fleet_up_but_role_unloaded(monkeypatch) -> None:
+    # llama-swap idle-unloads a model (ttl) by stopping only the llama-server
+    # child; the swap handle stays in _swaps while the role goes cold. A prompt
+    # sent into that gap must re-warm so llama-swap reloads on demand, not bounce
+    # forever on a stale "swap exists therefore ready" assumption.
+    p = FleetProvider()
+    group = SwapGroup(WorkerRole.CHAT.value)
+    p._role_group = {WorkerRole.CHAT: group}
+    p._swaps = {group: _FakeSwap()}  # ready set empty -> role_ready False
+    kicked = _stub_warm_thread(monkeypatch)
+
+    p.warm_up_pool()
+
+    assert kicked, "warm_up_pool must re-warm a cold role even while its swap is up"
+    assert p._warming is True
 
 
 def test_least_in_flight_picks_minimum() -> None:
@@ -1341,15 +1370,23 @@ def test_warm_up_pool_single_flight_does_not_double_start(monkeypatch) -> None:
     assert starts["n"] == 1
 
 
-def test_warm_up_pool_noop_when_swap_already_up(monkeypatch) -> None:
+def test_warm_up_pool_noop_when_swap_already_up_and_ready(monkeypatch) -> None:
+    # A fully-loaded fleet (swap up AND its role ready) short-circuits: no swap
+    # restart and no re-warm thread. The cold-role counterpart, where the swap is
+    # up but the model idle-unloaded, is covered by the rewarm test above.
     starts = {"n": 0}
     swap = _install_engine(monkeypatch, launches=[])
     monkeypatch.setattr(swap, "start", lambda launches: starts.__setitem__("n", starts["n"] + 1))
+    ready_swap = _FakeSwap()
+    ready_swap.ready = {WorkerRole.CHAT}
     p = FleetProvider()
-    p._swaps = {SwapGroup.CHAT: _FakeSwap()}  # already up
+    p._swaps = {SwapGroup.CHAT: ready_swap}  # up and loaded
     p._role_group = {WorkerRole.CHAT: SwapGroup.CHAT}
+    kicked = _stub_warm_thread(monkeypatch)
     p.warm_up_pool()
     assert starts["n"] == 0  # no start dispatched
+    assert not kicked  # no re-warm thread dispatched
+    assert p._warming is False
 
 
 def test_warm_up_blocking_logs_and_clears_guard_on_failure(monkeypatch, caplog) -> None:

--- a/tests/test_fleet_swap_config.py
+++ b/tests/test_fleet_swap_config.py
@@ -212,26 +212,29 @@ class TestHealthCheckTimeoutScaling:
 
 
 class TestWarmTtlSeconds:
-    def test_off_pins_zero_regardless_of_ttl(self, monkeypatch) -> None:
+    def test_warm_keeps_weights_resident_regardless_of_ttl(self, monkeypatch) -> None:
+        # keep_engine_warm means resident: ttl 0, so llama-swap never idle-unloads.
+        from lilbee.core.config import cfg
+        from lilbee.providers.fleet.provider import _warm_ttl_seconds
+
+        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 15)
+        assert _warm_ttl_seconds() == 0
+
+    def test_on_demand_unloads_after_idle_ttl(self, monkeypatch) -> None:
+        # Warm off: the fleet releases its weights after the idle window.
         from lilbee.core.config import cfg
         from lilbee.providers.fleet.provider import _warm_ttl_seconds
 
         monkeypatch.setattr(cfg, "keep_engine_warm", False)
         monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 15)
-        assert _warm_ttl_seconds() == 0
-
-    def test_warm_converts_minutes_to_llama_swap_seconds(self, monkeypatch) -> None:
-        from lilbee.core.config import cfg
-        from lilbee.providers.fleet.provider import _warm_ttl_seconds
-
-        monkeypatch.setattr(cfg, "keep_engine_warm", True)
-        monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 15)
         assert _warm_ttl_seconds() == 900
 
-    def test_warm_with_zero_ttl_keeps_weights_forever(self, monkeypatch) -> None:
+    def test_on_demand_with_zero_ttl_keeps_weights_until_teardown(self, monkeypatch) -> None:
+        # 0 disables the idle unload even for an on-demand fleet.
         from lilbee.core.config import cfg
         from lilbee.providers.fleet.provider import _warm_ttl_seconds
 
-        monkeypatch.setattr(cfg, "keep_engine_warm", True)
+        monkeypatch.setattr(cfg, "keep_engine_warm", False)
         monkeypatch.setattr(cfg, "engine_idle_ttl_minutes", 0)
         assert _warm_ttl_seconds() == 0

--- a/tests/test_fleet_swap_manager.py
+++ b/tests/test_fleet_swap_manager.py
@@ -85,7 +85,7 @@ class TestStart:
         mgr = SwapManager(tmp_path, _GROUP)
         mgr.start([_launch(WorkerRole.CHAT), _launch(WorkerRole.EMBED)])
         # Config was written and the endpoint is live.
-        config = json.loads((tmp_path / "llama-swap-chat.json").read_text())
+        config = json.loads(mgr._config_path.read_text())
         assert mgr.endpoint().startswith("http://127.0.0.1:")
         # Each member got its own freshly allocated port, distinct from the proxy's.
         member_ports = {
@@ -1069,8 +1069,9 @@ class TestOrphanServerReaping:
     ) -> None:
         _patch_spawn(monkeypatch, _FakeProc(poll_result=None))
         _patch_http(monkeypatch, lambda _url: _fake_response(status=200))
-        SwapManager(tmp_path, _GROUP).start([_launch(WorkerRole.CHAT), _launch(WorkerRole.EMBED)])
-        config = json.loads((tmp_path / "llama-swap-chat.json").read_text())
+        mgr = SwapManager(tmp_path, _GROUP)
+        mgr.start([_launch(WorkerRole.CHAT), _launch(WorkerRole.EMBED)])
+        config = json.loads(mgr._config_path.read_text())
         expected = sorted(
             int(entry["cmd"].rsplit(" ", 1)[-1]) for entry in config["models"].values()
         )
@@ -1267,8 +1268,8 @@ class TestPerGroupNaming:
         embed.start([_launch(WorkerRole.EMBED)])
         # Each group runs against its own config, so stopping one group's fleet
         # (keyed on config-path identity) can never touch the other's servers.
-        assert (tmp_path / "llama-swap-chat.json").exists()
-        assert (tmp_path / "llama-swap-embed.json").exists()
+        assert (tmp_path / sm._config_filename(os.getpid(), "chat")).exists()
+        assert (tmp_path / sm._config_filename(os.getpid(), "embed")).exists()
         state_names = {path.name for path in tmp_path.glob("llama-swap.state.*")}
         assert sm._state_filename(os.getpid(), "chat") in state_names
         assert sm._state_filename(os.getpid(), "embed") in state_names
@@ -1277,22 +1278,45 @@ class TestPerGroupNaming:
         assert sm._state_owner_pid("llama-swap.state.chat.123.json") == 123
         assert sm._state_owner_pid(".llama-swap.state.embed.456.json.tmp") == 456
 
+    def test_config_owner_pid_parses_and_rejects_legacy(self) -> None:
+        assert sm._config_owner_pid("llama-swap-chat.123.json") == 123
+        assert sm._config_owner_pid("llama-swap-embed.456.json") == 456
+        # A pid-less legacy name has no owner pid.
+        assert sm._config_owner_pid("llama-swap-chat.json") is None
+
+    def test_reap_removes_dead_owner_configs_keeps_live_and_legacy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pid = os.getpid()
+        live = tmp_path / sm._config_filename(pid, "chat")
+        legacy = tmp_path / "llama-swap-embed.json"
+        dead = tmp_path / sm._config_filename(pid + 1, "chat")
+        for path in (live, legacy, dead):
+            path.write_text("{}")
+        monkeypatch.setattr(sm.psutil, "pid_exists", lambda p: p == pid)
+        sm._clean_stale_configs(tmp_path)
+        assert live.exists()  # this owner is alive
+        assert legacy.exists()  # pid-less name is left alone
+        assert not dead.exists()  # dead owner's orphan config removed
+
 
 class TestSweepOwned:
-    def test_sweeps_every_group_config_present(
+    def test_sweeps_only_this_owners_group_configs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         swept: list[Path] = []
         monkeypatch.setattr(sm, "_stop_own_fleet", lambda cfg, ports: swept.append(cfg))
-        (tmp_path / "llama-swap-chat.json").write_text("{}")
-        (tmp_path / "llama-swap-embed.json").write_text("{}")
-        # State files match "llama-swap*" but not the group-config glob: never swept.
+        pid = os.getpid()
+        (tmp_path / sm._config_filename(pid, "chat")).write_text("{}")
+        (tmp_path / sm._config_filename(pid, "embed")).write_text("{}")
+        # A sibling lilbee's config (a different owner pid) must never be swept here.
+        (tmp_path / sm._config_filename(pid + 1, "chat")).write_text("{}")
+        # State files share the "llama-swap" stem but not the config glob: never swept.
         (tmp_path / "llama-swap.state.chat.1.json").write_text("{}")
         sm.sweep_owned(tmp_path)
-        assert [path.name for path in swept] == [
-            "llama-swap-chat.json",
-            "llama-swap-embed.json",
-        ]
+        assert sorted(path.name for path in swept) == sorted(
+            [sm._config_filename(pid, "chat"), sm._config_filename(pid, "embed")]
+        )
 
     def test_noop_when_no_group_configs_exist(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Problem

Three engine-lifecycle issues, all reachable from the same "the engine died while I was using it" report:

1. **The chat sticks on "engine is not ready" after an idle unload.** With keep-engine-warm on, llama-swap unloads the chat model after its idle TTL, stopping only the model subprocess while the llama-swap parent stays alive. On the next prompt the readiness path calls `warm_up_pool()`, whose guard was `if self._swaps or self._warming: return` — the swap handle is still present, so it returned without starting a warm and nothing reloaded the model. The wait fell through to the not-ready message and every retry repeated it, permanently. The request was never sent to llama-swap, which would have reloaded on demand if it had received one.

2. **keep_engine_warm read backwards.** On mapped to a finite idle TTL (unload after `engine_idle_ttl_minutes`), off mapped to a TTL of 0 (never unload) — the opposite of what the name promises. Turning the setting on is what made the engine unload sooner.

3. **Two lilbee instances at one data_dir clobbered each other's engine config.** The per-group llama-swap config file was a fixed shared path (`llama-swap-<group>.json`). A second instance overwrote it, so a later restart re-read the sibling's ports and TTL. State files were already PID-namespaced; the config file was not.

## Solution

1. `warm_up_pool()` now treats "a swap process exists" and "the engine can serve" as different things. When the fleet is up but a configured role's model was unloaded, it starts a warm (which sends a request per replica — exactly what drives llama-swap's on-demand reload) instead of bailing. A fully-loaded fleet still short-circuits, so a healthy prompt path is unchanged. A prompt after any unload (idle TTL, a crashed backend, an OOM) now reloads transparently; the not-ready message only appears on a genuine load failure, which carries its own error.

2. Flip the TTL mapping: on keeps the engine resident (ttl 0, never idle-unloads), off loads on demand and releases its weights after the idle window, reloading transparently on the next prompt. Config docs updated to match.

3. PID-namespace the config path (`llama-swap-<group>.<pid>.json`) like the state files. `sweep_owned` scopes to this owner's pid so a sibling's swaps are its own to stop, and `reap_stale` cleans dead owners' orphan config files. A live sibling is never touched.

## Verification

Unit coverage pins each change: a test asserts a warm is started when the swap is up but the role is cold (and the "no-op when fleet up" test is tightened to a genuinely-ready fleet); the TTL tests are rewritten for the flipped mapping; a sweep test asserts a sibling owner's config is never swept, and a reap test asserts dead owners' configs are cleaned while a live owner's and a legacy name are left alone. Full fleet/placement/config suites pass; lint, style, format, and mypy are clean.

**End-to-end idle-unload, before/after** — run as a real TUI (`uv run lilbee`, SmolLM2-360M chat, keep-engine-warm on with a 1-minute idle TTL), identical steps on the base build and this branch:

- Before (base): baseline prompt answered; idled 60s; llama-swap unloaded the chat backend, swap parent stayed alive; next prompt → "The engine is not ready yet. Send your prompt again in a moment."; retry → same message; backend never reloaded. Permanent hang.
- After (this branch): same steps; next prompt answered normally, no not-ready message; the swap reloaded a fresh backend on demand.

**Two concurrent instances at one data_dir** — started instance A, then instance B against the same data dir:

- Each wrote its own config (`llama-swap-chat.<pidA>.json`, `llama-swap-chat.<pidB>.json`); A's file was untouched when B started.
- Both engines ran at once (two live backends) — no cross-kill.
- Quitting B left A's engine running; quitting A left zero llama-swap and zero llama-server processes. No orphaned VRAM from either exit.

## Also on this branch

A separate fix shares this branch: a missing chat model now fails the warm with a named reason instead of clearing to a silent "not ready" retry (`FleetPlan.skipped_not_installed`, surfaced by the warm finalizer).

## Known-flaky checks at merge

Two checks are red and were confirmed unrelated to this change:

- `test (windows-latest, 3.12)` — `tests/test_catalog_actions.py` fails with a `MagicMock` leaking into a search string / `coroutine raised StopIteration`. Catalog TUI test pollution; passes on windows 3.13 and every other platform.
- `integration (macos-latest, 3.13)` — `pytest-timeout (>180s)` on the first ask tests, a cold model load on a slow runner. Integration flakes on a *different* job every run, including `windows 3.11` on the commit before the TTL change existed, so it is pre-existing intermittent timeout flakiness rather than a regression.

Coverage reaches 100%, lint passes, and every other test and integration job is green.
