### PR TITLE
TUI polish: full-surface QA sweep — reliable input, honest wizard, themed focus, human errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ You can also place it by hand. The placement editor pins each role to the cards 
 
 ![sweep through every TUI screen](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-tour.gif)
 
-`Ctrl+P` opens the Textual command palette, `?` toggles the keybinding cheat sheet, `/help` opens the slash-command catalog. Every action lilbee can take is reachable from one of those three.
+`Ctrl+P` opens the Textual command palette, `?` on an empty prompt (or `F1` anywhere) toggles the keybinding cheat sheet, `/help` opens the slash-command catalog. Every action lilbee can take is reachable from one of those three.
 
 ![command palette, keybinding cheat sheet, slash-command catalog](https://raw.githubusercontent.com/tobocop2/lilbee/gh-pages/demos/tui-palette.gif)
 

--- a/src/lilbee/catalog/featured.py
+++ b/src/lilbee/catalog/featured.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from lilbee.catalog.models import CatalogModel
-from lilbee.catalog.types import ModelTask
+from lilbee.catalog.types import ModelCompat, ModelTask
 
 
 def _load_featured() -> tuple[
@@ -31,6 +31,8 @@ def _load_featured() -> tuple[
                 downloads=0,
                 task=task,
                 recommended=m.get("recommended", False),
+                # Curated entries are hand-verified against the bundled engine.
+                compat=ModelCompat.SUPPORTED,
             )
             for m in data.get(task, [])
         )

--- a/src/lilbee/catalog/formatting.py
+++ b/src/lilbee/catalog/formatting.py
@@ -13,16 +13,27 @@ PARAM_COUNT_RE = re.compile(r"(\d+\.?\d*B)", re.IGNORECASE)
 # name suffixes (anywhere they precede ``-`` or end-of-string), trailing GGUF
 # quant tokens (``-Q4_K_M``, ``-F16`` ...), and trailing date stamps (``-2507``).
 _DISPLAY_NAME_NOISE = re.compile(
-    r"-(?:GGUF|Instruct|Chat|Embedding|Embed|qat)(?=-|$)"
+    r"-(?:GGUF|Instruct|Chat|Embedding|Embed|qat|it)(?=-|$)"
     r"|-(?:Q\d[A-Z0-9_]*|F16|F32)$"
     r"|-\d{4}$",
     re.IGNORECASE,
 )
 _DISPLAY_NAME_META_PREFIX = re.compile(r"^Meta-", re.IGNORECASE)
+# A bare parameter-count word (``300m``, ``0.6b``); rendered uppercase.
+_PARAM_COUNT_WORD = re.compile(r"\d+(?:\.\d+)?[bm]", re.IGNORECASE)
 
 # A native GGUF ref of the form ``<owner>/<repo>/<file>.gguf`` has at least
 # two ``/`` separators; one-slash refs are bare repo IDs.
 _NATIVE_GGUF_REF_MIN_SLASHES = 2
+
+
+def _prettify_word(word: str) -> str:
+    """Normalize one display-name word: uppercase param counts, capitalize lowercase words."""
+    if _PARAM_COUNT_WORD.fullmatch(word):
+        return word.upper()
+    if word.isalpha() and word.islower():
+        return word.capitalize()
+    return word
 
 
 def clean_display_name(repo_id: str) -> str:
@@ -31,8 +42,8 @@ def clean_display_name(repo_id: str) -> str:
     Examples:
         "Qwen/Qwen2.5-7B-Instruct-GGUF"           -> "Qwen2.5 7B"
         "meta-llama/Meta-Llama-3-8B"              -> "Llama 3 8B"
-        "unsloth/embeddinggemma-300M-qat-GGUF"    -> "embeddinggemma 300M"
-        "ggml-org/all-MiniLM-L6-v2-Embedding-Q8_0" -> "all MiniLM L6 v2"
+        "unsloth/embeddinggemma-300m-qat-GGUF"    -> "Embeddinggemma 300M"
+        "ggml-org/all-MiniLM-L6-v2-Embedding-Q8_0" -> "All MiniLM L6 v2"
     """
     name = repo_id.split("/")[-1]
     while True:
@@ -42,7 +53,8 @@ def clean_display_name(repo_id: str) -> str:
         name = stripped
     name = _DISPLAY_NAME_META_PREFIX.sub("", name)
     name = name.replace("-", " ").strip()
-    return re.sub(r"\s+", " ", name)
+    name = re.sub(r"\s+", " ", name)
+    return " ".join(_prettify_word(w) for w in name.split(" "))
 
 
 def download_task_name(ref: str) -> str:

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -420,15 +420,14 @@ class LilbeeApp(App[None]):
             self._theme_index = 0
 
     async def action_quit(self) -> None:
-        """Context-aware Ctrl+C: cancel active task > cancel stream > quit."""
+        """Context-aware Ctrl+C: cancel the foreground operation, else quit.
+
+        Only operations the user is actively watching (the setup wizard, an
+        in-flight chat stream) get the cancel-first treatment; a background
+        task like an engine warm or a sync never swallows a quit.
+        """
         get_services().cancel_inference()
 
-        if not self.task_bar.queue.is_empty:
-            active = self.task_bar.queue.active_task
-            if active:
-                self.task_bar.cancel_task(active.task_id)
-                self.notify(msg.APP_CANCELLED)
-                return
         from lilbee.cli.tui.screens.chat import ChatScreen
         from lilbee.cli.tui.screens.setup import SetupWizard
 
@@ -438,6 +437,7 @@ class LilbeeApp(App[None]):
             return
         if isinstance(screen, ChatScreen) and screen.streaming:
             screen.action_cancel_stream()
+            self.notify(msg.APP_QUIT_AGAIN_HINT)
             return
         self.exit()
 

--- a/src/lilbee/cli/tui/app.py
+++ b/src/lilbee/cli/tui/app.py
@@ -30,6 +30,7 @@ from lilbee.core.config import cfg
 from lilbee.providers.roles import WorkerRole
 
 if TYPE_CHECKING:
+    from lilbee.cli.tui.screens.chat import ChatScreen
     from lilbee.cli.tui.screens.startup_gate import StartupGate
 
 log = logging.getLogger(__name__)
@@ -578,6 +579,15 @@ class LilbeeApp(App[None]):
         if isinstance(self.screen, ChatScreen):
             self.screen.action_focus_commands()
 
+    def chat_screen(self) -> ChatScreen | None:
+        """The installed chat screen, or None before the startup gate installs it."""
+        from lilbee.cli.tui.screens.chat import ChatScreen
+
+        try:
+            return cast("ChatScreen", self.get_screen(_CHAT_SCREEN_NAME, ChatScreen))
+        except KeyError:
+            return None
+
     def action_run_sync(self) -> None:
         """Trigger an explicit document sync from any screen (S key).
 
@@ -591,9 +601,8 @@ class LilbeeApp(App[None]):
         if isinstance(self.screen, ChatScreen):
             self.screen._run_sync()
             return
-        try:
-            chat = self.get_screen(_CHAT_SCREEN_NAME, ChatScreen)
-        except KeyError:
+        chat = self.chat_screen()
+        if chat is None:
             return
 
         # switch_view drops the request outright while its re-entrancy guard is

--- a/src/lilbee/cli/tui/app.tcss
+++ b/src/lilbee/cli/tui/app.tcss
@@ -1,5 +1,23 @@
 /* lilbee TUI layout — colors come from Textual's built-in theme system */
 
+/* Textual's stock Button focus is bold-reverse: a flat light block with the
+ * label inverted into a dark box. Use the app's focus language instead:
+ * $primary border rails and a slight lift, like every other focused control. */
+Button.-style-default:focus {
+    text-style: bold;
+    background-tint: $foreground 10%;
+    border-top: tall $primary;
+    border-bottom: tall $primary;
+}
+
+/* A $primary rail is invisible on the $primary face, so the primary variant
+ * signals focus with a stronger lift plus its light rail on both edges. */
+Button.-style-default.-primary:focus {
+    background-tint: $foreground 25%;
+    border-top: tall $primary-lighten-3;
+    border-bottom: tall $primary-lighten-3;
+}
+
 ListView {
     height: 1fr;
 }

--- a/src/lilbee/cli/tui/command_registry.py
+++ b/src/lilbee/cli/tui/command_registry.py
@@ -150,6 +150,14 @@ def build_dispatch_dict() -> dict[str, str]:
     return dispatch
 
 
+def get_command(name: str) -> SlashCommand:
+    """Return the registry entry whose name is exactly *name* (aliases excluded)."""
+    for cmd in COMMANDS:
+        if cmd.name == name:
+            return cmd
+    raise KeyError(name)
+
+
 def completion_names() -> tuple[str, ...]:
     """All command names including aliases, for tab completion."""
     names: list[str] = []

--- a/src/lilbee/cli/tui/command_registry.py
+++ b/src/lilbee/cli/tui/command_registry.py
@@ -66,7 +66,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
         "_cmd_theme",
         aliases=(),
         args_hint="[name]",
-        help_text="Switch theme (no arg lists themes)",
+        help_text="Switch theme (no arg opens the theme list)",
         has_arg_completion=True,
     ),
     SlashCommand(

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, cast
 
 from textual.command import Hit, Hits, Provider
 
-from lilbee.app.services import get_services
 from lilbee.cli.tui import messages as msg
 from lilbee.core.config import cfg
 
@@ -51,6 +50,11 @@ class LilbeeCommandProvider(Provider):
                 "Re-attempt files that failed a previous sync",
                 self._action_retry_skipped,
             ),
+            (
+                "Delete document",
+                "Remove a file from the index (Tab completes names)",
+                self._action_delete_document,
+            ),
             ("Open wiki", "Browse and generate wiki pages", self._action_open_wiki),
             ("Show version", "Display lilbee version", self._action_version),
             (
@@ -62,7 +66,6 @@ class LilbeeCommandProvider(Provider):
         ]
 
         commands.extend(self._model_commands())
-        commands.extend(self._document_commands())
         return commands
 
     def _model_commands(self) -> list[tuple[str, str, Any]]:
@@ -84,24 +87,6 @@ class LilbeeCommandProvider(Provider):
 
         return commands
 
-    def _document_commands(self) -> list[tuple[str, str, Any]]:
-        """Generate commands for indexed documents."""
-        commands: list[tuple[str, str, Any]] = []
-        try:
-            for src in get_services().store.get_sources():
-                name = src.get("filename", src.get("source", ""))
-                if name:
-                    commands.append(
-                        (
-                            f"Delete document → {name}",
-                            f"Remove {name} from index",
-                            lambda n=name: self._delete_doc(n),
-                        )
-                    )
-        except Exception:
-            log.debug("Failed to list documents", exc_info=True)
-        return commands
-
     def _set_model(self, attr: str, value: str) -> None:
         # Route through LilbeeApp.set_active_model so model-bar / scope chip
         # / status bar subscribers (settings_changed_signal) refresh.
@@ -112,17 +97,17 @@ class LilbeeCommandProvider(Provider):
         if attr == "chat_model":
             app.title = msg.app_title(value)
 
-    def _delete_doc(self, name: str) -> None:
-        from lilbee.app.ingest import remove_documents_durably
-        from lilbee.cli.tui.widgets.autocomplete import invalidate_document_cache
+    def _action_delete_document(self) -> None:
+        """Jump to Chat with /delete prefilled; Tab there completes file names."""
+        from lilbee.cli.tui.screens.chat import ChatScreen
 
-        # Skip-mark so the next sync doesn't re-ingest the kept file (durable,
-        # non-destructive delete; the file stays on disk).
-        remove_documents_durably([name])
-        # Invalidate the document cache like the chat /delete path, so the
-        # deleted file stops being offered by autocomplete and the palette.
-        invalidate_document_cache()
-        self.screen.app.notify(msg.CMD_DELETE_SUCCESS.format(name=name))
+        app = self._app
+        chat = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
+        if chat is None:
+            app.notify("Open Chat to delete a document")
+            return
+        app.switch_view("Chat")
+        chat.prefill_prompt("/delete ")
 
     def _action_sync(self) -> None:
         self._app.action_run_sync()

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from textual.command import Hit, Hits, Provider
 
+from lilbee.catalog import display_label_for_ref
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.command_registry import COMMANDS, SlashCommand, get_command
 from lilbee.core.config import cfg
@@ -117,7 +118,7 @@ class LilbeeCommandProvider(Provider):
         # / status bar subscribers (settings_changed_signal) refresh.
         app = self._app
         app.set_active_model(attr, value)
-        display = value or "off"
+        display = display_label_for_ref(value) or "off"
         app.notify(f"{attr}: {display}")
         if attr == "chat_model":
             app.title = msg.app_title(value)

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -15,7 +15,6 @@ log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.app import LilbeeApp
-    from lilbee.cli.tui.screens.chat import ChatScreen
 
 
 class LilbeeCommandProvider(Provider):
@@ -74,27 +73,25 @@ class LilbeeCommandProvider(Provider):
     def _slash_commands(self) -> list[tuple[str, str, Any]]:
         """One palette entry per slash command, mirroring the chat surface."""
         return [
-            (cmd.name, cmd.help_text, lambda c=cmd: self._run_slash_command(c))
-            for cmd in COMMANDS
+            (cmd.name, cmd.help_text, lambda c=cmd: self._run_slash_command(c)) for cmd in COMMANDS
         ]
 
     def _run_slash_command(self, cmd: SlashCommand) -> None:
         """Run *cmd* through Chat: dispatch it, or prefill it when it needs arguments."""
         app = self._app
-        chat = self._chat_screen()
+        chat = app.chat_screen()
         if chat is None:
             app.notify(f"Open Chat to run {cmd.name}")
             return
-        app.switch_view("Chat")
         if cmd.args_hint.startswith("<"):
-            chat.prefill_prompt(f"{cmd.name} ")
+            # Needs an argument: land in the chat prompt for Tab completion.
+            app.switch_view("Chat")
+            chat.insert_slash_command(cmd.name)
         else:
+            # Complete as-is: dispatch like a submitted prompt. Handlers that
+            # navigate call switch_view themselves, and switch_view no-ops
+            # while another switch is in flight, so don't pre-switch to Chat.
             chat.run_command(cmd.name)
-
-    def _chat_screen(self) -> ChatScreen | None:
-        from lilbee.cli.tui.screens.chat import ChatScreen
-
-        return next((s for s in self._app.screen_stack if isinstance(s, ChatScreen)), None)
 
     def _model_commands(self) -> list[tuple[str, str, Any]]:
         """Generate commands for installed models."""
@@ -161,11 +158,4 @@ class LilbeeCommandProvider(Provider):
 
     def _action_reset(self) -> None:
         """Trigger /reset from the palette so the ConfirmDialog flow fires."""
-        from lilbee.cli.tui.screens.chat import ChatScreen
-
-        app = self._app
-        chat = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
-        if chat is None:
-            app.notify("Open Chat to run /reset")
-            return
-        chat.request_reset()
+        self._run_slash_command(get_command("/reset"))

--- a/src/lilbee/cli/tui/commands.py
+++ b/src/lilbee/cli/tui/commands.py
@@ -8,12 +8,14 @@ from typing import TYPE_CHECKING, Any, cast
 from textual.command import Hit, Hits, Provider
 
 from lilbee.cli.tui import messages as msg
+from lilbee.cli.tui.command_registry import COMMANDS, SlashCommand, get_command
 from lilbee.core.config import cfg
 
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.chat import ChatScreen
 
 
 class LilbeeCommandProvider(Provider):
@@ -65,8 +67,34 @@ class LilbeeCommandProvider(Provider):
             ("Quit", "Exit lilbee", app.action_quit),
         ]
 
+        commands.extend(self._slash_commands())
         commands.extend(self._model_commands())
         return commands
+
+    def _slash_commands(self) -> list[tuple[str, str, Any]]:
+        """One palette entry per slash command, mirroring the chat surface."""
+        return [
+            (cmd.name, cmd.help_text, lambda c=cmd: self._run_slash_command(c))
+            for cmd in COMMANDS
+        ]
+
+    def _run_slash_command(self, cmd: SlashCommand) -> None:
+        """Run *cmd* through Chat: dispatch it, or prefill it when it needs arguments."""
+        app = self._app
+        chat = self._chat_screen()
+        if chat is None:
+            app.notify(f"Open Chat to run {cmd.name}")
+            return
+        app.switch_view("Chat")
+        if cmd.args_hint.startswith("<"):
+            chat.prefill_prompt(f"{cmd.name} ")
+        else:
+            chat.run_command(cmd.name)
+
+    def _chat_screen(self) -> ChatScreen | None:
+        from lilbee.cli.tui.screens.chat import ChatScreen
+
+        return next((s for s in self._app.screen_stack if isinstance(s, ChatScreen)), None)
 
     def _model_commands(self) -> list[tuple[str, str, Any]]:
         """Generate commands for installed models."""
@@ -99,15 +127,7 @@ class LilbeeCommandProvider(Provider):
 
     def _action_delete_document(self) -> None:
         """Jump to Chat with /delete prefilled; Tab there completes file names."""
-        from lilbee.cli.tui.screens.chat import ChatScreen
-
-        app = self._app
-        chat = next((s for s in app.screen_stack if isinstance(s, ChatScreen)), None)
-        if chat is None:
-            app.notify("Open Chat to delete a document")
-            return
-        app.switch_view("Chat")
-        chat.prefill_prompt("/delete ")
+        self._run_slash_command(get_command("/delete"))
 
     def _action_sync(self) -> None:
         self._app.action_run_sync()

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -360,6 +360,10 @@ MEMORIES_COLUMN_TEXT = "Memory"
 MEMORIES_FLAG_YES = "yes"
 MEMORIES_FLAG_NO = "no"
 MEMORIES_SEARCH_PLACEHOLDER = "Filter memories..."
+MEMORIES_EMPTY_STATE = (
+    "Memories are notes lilbee keeps about you between chats. Use /remember to save one."
+)
+MEMORIES_NO_MATCHES = "No memories match this filter."
 MEMORIES_DELETE_CONFIRM_TITLE = "Delete memory?"
 MEMORIES_DELETE_CONFIRM_MESSAGE = "Delete this memory? This cannot be undone."
 MEMORIES_DELETED = "Deleted memory"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -130,7 +130,8 @@ CHAT_STACK_FAILED = "lilbee could not load its chat screen: {error}"
 # Engine-load status painted into the pending answer while a prompt waits on a
 # cold engine, and the failure that wait can end in.
 ENGINE_READING_WEIGHTS = "Reading {name} weights"
-ENGINE_LOADING = "Loading engine"
+ENGINE_WARMING = "Warming up the model"
+ENGINE_ALMOST_READY = "Almost ready"
 ENGINE_LOAD_FAILED = "The engine failed to load: {error}"
 ENGINE_FAILED_HINT = "Open Catalog or Settings to pick a different model."
 ENGINE_NOT_READY = "The engine is not ready yet. Send your prompt again in a moment."
@@ -472,10 +473,10 @@ TASKBAR_STARTING_WORKER = "Starting {labels} worker..."
 TASKBAR_STARTING_WORKERS = "Starting {labels} workers..."
 # Cold-start chat warm line: phase (and byte % while paging weights) so the held
 # input reads as "loading", not "stuck".
-TASKBAR_WARM = "loading chat · {detail}"
+TASKBAR_WARM = "warming up chat · {detail}"
 TASKBAR_WARM_STARTING = "starting"
 TASKBAR_WARM_READING = "reading weights {pct}%"
-TASKBAR_WARM_LOADING = "loading engine"
+TASKBAR_WARM_LOADING = "almost ready"
 
 TASK_CENTER_TITLE = "Background Tasks"
 TASK_CENTER_COUNTS = "{active} running  ·  {queued} queued  ·  {done} done"

--- a/src/lilbee/cli/tui/messages.py
+++ b/src/lilbee/cli/tui/messages.py
@@ -88,6 +88,7 @@ CMD_DELETE_NO_DOCS = "No documents indexed"
 CMD_DELETE_READ_FAILED = "Could not read the document list"
 CMD_DELETE_USAGE = "Documents: {names}\nUsage: /delete <filename>"
 CMD_DELETE_NOT_FOUND = "Not found: {name}"
+CMD_DELETE_SUGGESTION = "Did you mean {name}?"
 CMD_DELETE_SUCCESS = "Deleted {name}"
 CMD_REMEMBER_USAGE = "Usage: /remember <text>  (prefix with 'pref:' for a preference)"
 CMD_REMEMBER_SUCCESS = "Remembered ({kind})."
@@ -113,6 +114,8 @@ TASK_NAME_REBUILD = "Rebuild index"
 CMD_SET_UNKNOWN = "Unknown setting: {key}"
 CMD_SET_SUCCESS = "{key} = {value}"
 CMD_SET_INVALID = "Invalid value for {key}: {error}"
+CMD_SET_TYPE_HINT = "{key} needs {kind}"
+CMD_SET_CHOICES = "{key} must be one of {choices}"
 CMD_SET_READONLY = "{key} is read-only; use the Models screen"
 CMD_MODEL_SET = "Model set to {name}"
 # Shown while a model swap's fleet reload runs off the event loop, so the swap
@@ -143,7 +146,7 @@ CMD_REMOVE_SUCCESS = "Removed {name}"
 CMD_REMOVE_FAILED = "Failed to remove {name}"
 CMD_CANCEL = "Cancelled active operations"
 CMD_CLEAR = "Conversation cleared"
-CMD_THEME_LIST = "Themes: {names}"
+CMD_THEME_UNKNOWN = "No theme called {name}. Themes: {names}"
 CMD_WIKI_DISABLED = "Wiki is disabled (set wiki = true in settings)"
 TASK_NAME_CRAWL = "Crawl {url}"
 STREAM_ERROR = "\n\n*Error: {error}*"
@@ -371,7 +374,7 @@ MEMORIES_FLAG_FAILED = "Update failed: {error}"
 WIKI_TYPE_HEADINGS: dict[str, str] = {
     kind.value: label for kind, label in _WIKI_TYPE_HEADINGS.items()
 }
-APP_CANCELLED = "Cancelled"
+APP_QUIT_AGAIN_HINT = "Answer cancelled. Press Ctrl+C again to quit."
 SETUP_WELCOME = "Welcome to lilbee"
 SETUP_SUBTITLE = "Pick a chat model and an embedding model to get started."
 SETUP_INTRO = (
@@ -389,7 +392,7 @@ INSTALLED_CARD_HINT = "D / ⌫ to delete"
 # Architecture compatibility pill labels (catalog row).
 # SUPPORTED renders nothing to keep the row visually quiet for the common case.
 COMPAT_PILL_UNSUPPORTED = "unsupported"
-COMPAT_PILL_UNKNOWN = "?"
+COMPAT_PILL_UNKNOWN = "untested"
 
 # Architecture compatibility copy for the catalog detail view + confirm modal.
 COMPAT_DETAIL_SENTENCE_SUPPORTED = "Supported by your llama.cpp build."

--- a/src/lilbee/cli/tui/screens/catalog.py
+++ b/src/lilbee/cli/tui/screens/catalog.py
@@ -196,7 +196,7 @@ class CatalogScreen(Screen[None]):
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("q", "go_back", "Back", show=True, group=_ACTION_GROUP),
-        Binding("escape", "dismiss_filter", "", show=False),
+        Binding("escape", "go_back", "", show=False),
         # Surfaced outside _ACTION_GROUP so the "Grid/List" affordance prints
         # in full in the footer instead of collapsing into the compact pill.
         # Keep the label terse; the row of bindings runs out of space on
@@ -1925,27 +1925,13 @@ class CatalogScreen(Screen[None]):
 
     def action_go_back(self) -> None:
         # An open filter collapses to hidden (restoring grid/list focus);
-        # otherwise q leaves for Chat.
+        # otherwise q / Esc leaves for Chat.
         if self._filter_open:
             self._search_input.value = ""
             self._search_input.add_class(_HIDDEN_CLASS)
             self._focus_list_or_grid()
             return
         self.app.switch_view("Chat")
-
-    def action_dismiss_filter(self) -> None:
-        """Esc: hide the filter Input + restore grid/list focus; never dismiss.
-
-        Heavy-interaction QA showed a stray Esc (from info-modal-then-Esc
-        cycles, drawer thrash, filter typing chains) would dismiss the
-        catalog mid-task and leak subsequent keystrokes into the chat
-        Input on the next screen. Esc now only handles the filter; the
-        dismiss path is `q` (action_go_back) which still does both.
-        """
-        if self._filter_open:
-            self._search_input.value = ""
-            self._search_input.add_class(_HIDDEN_CLASS)
-            self._focus_list_or_grid()
 
     def _focus_list_or_grid(self) -> None:
         """Move focus from the filter input to the active view's list/grid."""

--- a/src/lilbee/cli/tui/screens/catalog_utils.py
+++ b/src/lilbee/cli/tui/screens/catalog_utils.py
@@ -275,6 +275,8 @@ def variant_to_row(v: ModelVariant, f: ModelFamily, installed: bool) -> LocalCat
         backend=NATIVE_BACKEND,
         variant=v,
         family=f,
+        # Families are built exclusively from the curated featured catalog.
+        compat=ModelCompat.SUPPORTED,
     )
 
 
@@ -295,7 +297,8 @@ def catalog_to_row(m: CatalogModel, installed: bool) -> LocalCatalogRow:
         ref=m.ref,
         backend=NATIVE_BACKEND,
         catalog_model=m,
-        compat=m.compat,
+        # An installed model demonstrably runs, whatever the catalog probe said.
+        compat=ModelCompat.SUPPORTED if installed else m.compat,
     )
 
 
@@ -320,6 +323,8 @@ def remote_to_row(rm: RemoteModel) -> LocalCatalogRow:
         ref=format_remote_ref(rm.name, rm.provider),
         backend=rm.provider.lower(),
         remote_model=rm,
+        # The model is live on the reporting server, so it demonstrably runs.
+        compat=ModelCompat.SUPPORTED,
     )
 
 

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -525,31 +525,9 @@ class ChatScreen(Screen[None]):
             # submitting whatever empty / stale text the input still holds.
             self._enter_insert_mode()
             return
-        if self._reject_submit_when_busy():
-            return
-        if self._dismiss_overlay_on_submit():
-            return
         text = event.value.strip()
-        if not text:
+        if not self._ready_to_submit(text):
             return
-        if text.startswith("/"):
-            if text.split()[0].lower() not in self._command_handlers:
-                # Keep the draft so a typo (or a stale leading slash) can be
-                # fixed in place instead of retyped.
-                self.notify(msg.CMD_UNKNOWN.format(cmd=text.split()[0].lower()), severity="warning")
-                return
-        else:
-            pending = self._pending_required_model_download()
-            if pending is not None:
-                # Keep the typed prompt in the input so the user can submit
-                # it again once the download finishes, instead of forcing
-                # them to retype.
-                self.notify(
-                    msg.CHAT_MODEL_DOWNLOADING.format(name=pending),
-                    severity="warning",
-                    timeout=5,
-                )
-                return
         event.chat_input.value = ""
         self._input_history.append(text)
         self._history_index = -1
@@ -558,6 +536,30 @@ class ChatScreen(Screen[None]):
             self._handle_slash(text)
             return
         self._send_message(text)
+
+    def _ready_to_submit(self, text: str) -> bool:
+        """Gate a submit: busy, consumed, empty, and keep-the-draft cases say no."""
+        if self._reject_submit_when_busy() or self._dismiss_overlay_on_submit() or not text:
+            return False
+        if text.startswith("/"):
+            cmd = text.split()[0].lower()
+            if cmd not in self._command_handlers:
+                # Keep the draft so a typo (or a stale leading slash) can be
+                # fixed in place instead of retyped.
+                self.notify(msg.CMD_UNKNOWN.format(cmd=cmd), severity="warning")
+                return False
+            return True
+        pending = self._pending_required_model_download()
+        if pending is not None:
+            # Keep the typed prompt in the input so the user can submit it
+            # again once the download finishes, instead of retyping it.
+            self.notify(
+                msg.CHAT_MODEL_DOWNLOADING.format(name=pending),
+                severity="warning",
+                timeout=5,
+            )
+            return False
+        return True
 
     def _reject_submit_when_busy(self) -> bool:
         """Toast and reject a submit while a swap is loading or a stream is in flight.

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -405,13 +405,6 @@ class ChatScreen(Screen[None]):
         """
         self._enter_insert_mode()
 
-    def prefill_prompt(self, text: str) -> None:
-        """Fill the prompt with *text* and focus it, cursor at the end."""
-        chat_input = self._chat_input
-        chat_input.text = text
-        chat_input.move_cursor(chat_input.document.end)
-        self.focus_prompt()
-
     def run_command(self, text: str) -> None:
         """Dispatch *text* as a slash command, as if submitted from the prompt."""
         if self._reject_submit_when_busy():

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -412,6 +412,12 @@ class ChatScreen(Screen[None]):
         chat_input.move_cursor(chat_input.document.end)
         self.focus_prompt()
 
+    def run_command(self, text: str) -> None:
+        """Dispatch *text* as a slash command, as if submitted from the prompt."""
+        if self._reject_submit_when_busy():
+            return
+        self._handle_slash(text)
+
     def _update_input_style(self) -> None:
         """Toggle input opacity and mode indicator based on current mode."""
         # Lifecycle interleaves (an installed-but-swapped-away screen during

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -133,7 +133,9 @@ def _engine_status_text(snapshot: WarmProgress) -> str:
         name = display_label_for_ref(snapshot.model_ref) if snapshot.model_ref else ""
         pct = snapshot.bytes_done * 100 // snapshot.bytes_total
         return f"{msg.ENGINE_READING_WEIGHTS.format(name=name)} {pct}%"
-    return msg.ENGINE_LOADING
+    if snapshot.phase is WarmPhase.LOADING_ENGINE:
+        return msg.ENGINE_ALMOST_READY
+    return msg.ENGINE_WARMING
 
 
 def _parse_add_paths(args: str) -> list[Path]:
@@ -402,6 +404,13 @@ class ChatScreen(Screen[None]):
         a prompt, so focus must not stay parked on the widget that opened it.
         """
         self._enter_insert_mode()
+
+    def prefill_prompt(self, text: str) -> None:
+        """Fill the prompt with *text* and focus it, cursor at the end."""
+        chat_input = self._chat_input
+        chat_input.text = text
+        chat_input.move_cursor(chat_input.document.end)
+        self.focus_prompt()
 
     def _update_input_style(self) -> None:
         """Toggle input opacity and mode indicator based on current mode."""
@@ -1365,7 +1374,7 @@ class ChatScreen(Screen[None]):
         # role loading first (embed on a cold start) leaves the tracker silent
         # for many seconds, and a bare scanner reads as a hang.
         with contextlib.suppress(Exception):
-            call_from_thread(self, widget.set_thinking_status, msg.ENGINE_LOADING)
+            call_from_thread(self, widget.set_thinking_status, msg.ENGINE_WARMING)
         if wait_chat_ready(on_progress=_paint, should_abort=lambda: worker.is_cancelled):
             with contextlib.suppress(Exception):
                 call_from_thread(self, widget.set_thinking_status, "")

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import difflib
 import logging
 import os
 import shlex
@@ -136,6 +137,24 @@ def _engine_status_text(snapshot: WarmProgress) -> str:
     if snapshot.phase is WarmPhase.LOADING_ENGINE:
         return msg.ENGINE_ALMOST_READY
     return msg.ENGINE_WARMING
+
+
+_SETTING_TYPE_HINTS: dict[type, str] = {int: "a whole number", float: "a number"}
+
+
+def _setting_type_hint(kind: type) -> str:
+    """Human phrase for what a settings value must be."""
+    return _SETTING_TYPE_HINTS.get(kind, f"a valid {kind.__name__} value")
+
+
+def _closest_source(name: str, known: set[str]) -> str | None:
+    """The indexed name most likely meant by *name*, or None when nothing is close."""
+    low = name.lower()
+    contains = [k for k in known if low in k.lower()]
+    if len(contains) == 1:
+        return contains[0]
+    matches = difflib.get_close_matches(name, sorted(known), n=1, cutoff=0.6)
+    return matches[0] if matches else None
 
 
 def _parse_add_paths(args: str) -> list[Path]:
@@ -508,16 +527,18 @@ class ChatScreen(Screen[None]):
             return
         if self._reject_submit_when_busy():
             return
-        # Enter when the completion dropdown is showing a different
-        # selection than the input itself: accept the highlight first
-        # (matches Tab's cycle-and-insert behavior) instead of submitting
-        # whatever bare prefix the user typed.
-        if self._accept_overlay_selection_on_enter():
+        if self._dismiss_overlay_on_submit():
             return
         text = event.value.strip()
         if not text:
             return
-        if not text.startswith("/"):
+        if text.startswith("/"):
+            if text.split()[0].lower() not in self._command_handlers:
+                # Keep the draft so a typo (or a stale leading slash) can be
+                # fixed in place instead of retyped.
+                self.notify(msg.CMD_UNKNOWN.format(cmd=text.split()[0].lower()), severity="warning")
+                return
+        else:
             pending = self._pending_required_model_download()
             if pending is not None:
                 # Keep the typed prompt in the input so the user can submit
@@ -572,28 +593,22 @@ class ChatScreen(Screen[None]):
                 return label
         return None
 
-    def _accept_overlay_selection_on_enter(self) -> bool:
-        """Accept the highlighted completion on Enter; True if Enter was consumed.
+    def _dismiss_overlay_on_submit(self) -> bool:
+        """Close the dropdown on Enter; consume only a bare slash, never a message.
 
-        If the input already holds the highlighted candidate (the user cycled
-        to it), Enter falls through to submit. Otherwise the candidate is
-        filled in and Enter is consumed so a second Enter submits.
+        Enter submits exactly what was typed. Tab and the arrow keys are the
+        completion gestures, and a previewed candidate is already in the input,
+        so a highlighted-but-unaccepted suggestion must never rewrite or swallow
+        a submission.
         """
         overlay = self._completion_overlay
-        if not overlay.is_visible:
-            return False
-        display = overlay.get_current()
-        if display is None:
+        if overlay.is_visible:
             overlay.hide()
             self._completion_origin = None
-            return False
-        target = self._completion_value(display)
-        consumed = self._chat_input.value != target
-        if consumed:
-            self._set_input(target)
-        overlay.hide()
-        self._completion_origin = None
-        return consumed
+        if self._chat_input.value.strip() == "/":
+            self._set_input("")
+            return True
+        return False
 
     def _handle_slash(self, text: str) -> None:
         """Dispatch slash commands via the per-instance handler registry."""
@@ -968,12 +983,11 @@ class ChatScreen(Screen[None]):
             return
 
         if name not in known:
-            call_from_thread(
-                self,
-                self.notify,
-                msg.CMD_DELETE_NOT_FOUND.format(name=name),
-                severity="error",
-            )
+            message = msg.CMD_DELETE_NOT_FOUND.format(name=name)
+            suggestion = _closest_source(name, known)
+            if suggestion is not None:
+                message = f"{message}. {msg.CMD_DELETE_SUGGESTION.format(name=suggestion)}"
+            call_from_thread(self, self.notify, message, severity="error")
             return
 
         from lilbee.app.ingest import remove_documents_durably
@@ -1082,9 +1096,11 @@ class ChatScreen(Screen[None]):
 
     def _cmd_model(self, args: str) -> None:
         if args:
+            from lilbee.catalog.formatting import display_label_for_ref
+
             apply_active_model(self.app, "chat_model", args)
             self.app.title = msg.app_title(cfg.chat_model)
-            self.notify(msg.CMD_MODEL_SET.format(name=cfg.chat_model))
+            self.notify(msg.CMD_MODEL_SET.format(name=display_label_for_ref(cfg.chat_model)))
             self.apply_model_change()
             self.refresh_model_bar()
         else:
@@ -1194,7 +1210,20 @@ class ChatScreen(Screen[None]):
             elif defn.nullable and value.lower() in ("none", "null", ""):
                 parsed = None
             else:
-                parsed = defn.type(value)
+                if defn.choices and value not in defn.choices:
+                    self.notify(
+                        msg.CMD_SET_CHOICES.format(key=key, choices=", ".join(defn.choices)),
+                        severity="error",
+                    )
+                    return
+                try:
+                    parsed = defn.type(value)
+                except (ValueError, TypeError):
+                    self.notify(
+                        msg.CMD_SET_TYPE_HINT.format(key=key, kind=_setting_type_hint(defn.type)),
+                        severity="error",
+                    )
+                    return
             # Route through set_setting so settings_changed_signal subscribers
             # (model bar, scope chip, status bar) refresh. The boundary's
             # _invalidate_caches now handles llm_provider service reset.
@@ -1230,12 +1259,18 @@ class ChatScreen(Screen[None]):
         self.app.switch_view("Status")
 
     def _cmd_theme(self, args: str) -> None:
-        if args:
-            self.app.set_theme(args)
-            self.notify(msg.THEME_SET.format(name=args))
-        else:
-            theme_list = msg.CMD_THEME_LIST.format(names=", ".join(DARK_THEMES))
-            self.notify(theme_list, severity="information")
+        if not args:
+            # Land in the prompt with the dropdown listing every theme.
+            self.insert_slash_command("/theme")
+            return
+        if args not in DARK_THEMES:
+            self.notify(
+                msg.CMD_THEME_UNKNOWN.format(name=args, names=", ".join(DARK_THEMES)),
+                severity="warning",
+            )
+            return
+        self.app.set_theme(args)
+        self.notify(msg.THEME_SET.format(name=args))
 
     def _cmd_version(self, _args: str) -> None:
         self.notify(msg.CHAT_VERSION.format(version=get_version()))
@@ -1602,6 +1637,10 @@ class ChatScreen(Screen[None]):
                 self._set_input(self._completion_origin)
             self._completion_origin = None
             overlay.hide()
+            # Backing out of the command list leaves nothing worth keeping in
+            # a lone slash, and it would hijack the next message as /word.
+            if self._chat_input.value.strip() == "/":
+                self._set_input("")
             return
         if isinstance(self.focused, (Select, ModelPickerButton)):
             # Returning from a model picker should put us back in INSERT

--- a/src/lilbee/cli/tui/screens/chat.py
+++ b/src/lilbee/cli/tui/screens/chat.py
@@ -470,6 +470,10 @@ class ChatScreen(Screen[None]):
             if self._focus_in_fleet_drawer():
                 return
             self._enter_insert_mode()
+            if event.key == "enter" and inp.value.strip():
+                # Enter meant "send": submit the draft the user Esc'd over
+                # instead of stranding it invisibly in the dimmed input.
+                self._submit_draft(inp, inp.value)
             event.prevent_default()
             event.stop()
             return
@@ -525,10 +529,14 @@ class ChatScreen(Screen[None]):
             # submitting whatever empty / stale text the input still holds.
             self._enter_insert_mode()
             return
-        text = event.value.strip()
+        self._submit_draft(event.chat_input, event.value)
+
+    def _submit_draft(self, chat_input: ChatInput, value: str) -> None:
+        """Send *value* as a command or message once the submit gate allows it."""
+        text = value.strip()
         if not self._ready_to_submit(text):
             return
-        event.chat_input.value = ""
+        chat_input.value = ""
         self._input_history.append(text)
         self._history_index = -1
 
@@ -536,6 +544,7 @@ class ChatScreen(Screen[None]):
             self._handle_slash(text)
             return
         self._send_message(text)
+
 
     def _ready_to_submit(self, text: str) -> bool:
         """Gate a submit: busy, consumed, empty, and keep-the-draft cases say no."""

--- a/src/lilbee/cli/tui/screens/memories.py
+++ b/src/lilbee/cli/tui/screens/memories.py
@@ -17,7 +17,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical
 from textual.screen import Screen
-from textual.widgets import DataTable, Input
+from textual.widgets import DataTable, Input, Static
 
 from lilbee.app.memory import forget, list_memories, memory_enabled, set_memory_shared
 from lilbee.cli.tui import messages as msg
@@ -72,6 +72,7 @@ class MemoriesScreen(Screen[None]):
         yield Vertical(
             Input(placeholder=msg.MEMORIES_SEARCH_PLACEHOLDER, id="memories-search"),
             table,
+            Static("", id="memories-empty"),
             id="memories-layout",
         )
         with BottomBars():
@@ -91,6 +92,7 @@ class MemoriesScreen(Screen[None]):
         """Fetch memories and populate the table, respecting the active filter."""
         table = self.query_one("#memories-table", DataTable)
         table.clear()
+        self._set_empty_state(None)
         if not memory_enabled():
             self.notify(msg.MEMORIES_DISABLED, severity="warning")
             self._memories = []
@@ -105,6 +107,9 @@ class MemoriesScreen(Screen[None]):
 
         visible = self._visible_memories()
         if not visible:
+            self._set_empty_state(
+                msg.MEMORIES_NO_MATCHES if self._filter else msg.MEMORIES_EMPTY_STATE
+            )
             self.notify(msg.MEMORIES_EMPTY)
             return
         for m in visible:
@@ -114,6 +119,16 @@ class MemoriesScreen(Screen[None]):
                 m.text,
                 key=m.id,
             )
+
+    def _set_empty_state(self, text: str | None) -> None:
+        """Show the under-table hint line with *text*, or hide it when None."""
+        empty = self.query_one("#memories-empty", Static)
+        self.query_one("#memories-layout", Vertical).set_class(text is not None, "-empty")
+        if text is None:
+            empty.remove_class("-visible")
+            return
+        empty.update(text)
+        empty.add_class("-visible")
 
     def _visible_memories(self) -> list[MemoryRow]:
         """Apply the current text filter to the loaded memory list."""

--- a/src/lilbee/cli/tui/screens/memories.tcss
+++ b/src/lilbee/cli/tui/screens/memories.tcss
@@ -9,3 +9,20 @@
 #memories-table {
     height: 1fr;
 }
+
+#memories-layout.-empty #memories-table {
+    height: auto;
+}
+
+#memories-empty {
+    display: none;
+    width: 100%;
+    height: auto;
+    margin-top: 1;
+    text-align: center;
+    color: $text-muted;
+}
+
+#memories-empty.-visible {
+    display: block;
+}

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -36,7 +36,7 @@ from lilbee.catalog import (
     display_label_for_ref,
     extract_quant,
 )
-from lilbee.catalog.types import ModelTask
+from lilbee.catalog.types import ModelCompat, ModelTask
 from lilbee.cli.tui import messages as msg
 from lilbee.cli.tui.app import apply_active_model
 from lilbee.cli.tui.screens.catalog_utils import (
@@ -93,6 +93,7 @@ def _installed_name_to_row(name: str, task: str) -> LocalCatalogRow:
         sort_downloads=0,
         sort_size=0.0,
         ref=name,
+        compat=ModelCompat.SUPPORTED,
     )
 
 
@@ -182,8 +183,8 @@ class SetupWizard(Screen[str | None]):
             yield Footer()
 
     def _initial_hint_text(self) -> str:
-        """Return SETUP_RETURN_HINT when both roles already resolve, else SETUP_ENTER_HINT."""
-        if self._chat_installed and self._embed_installed:
+        """Return SETUP_RETURN_HINT only when the configured refs are installed role-correctly."""
+        if cfg.chat_model in self._chat_installed and cfg.embedding_model in self._embed_installed:
             return msg.SETUP_RETURN_HINT
         return msg.SETUP_ENTER_HINT
 
@@ -282,7 +283,10 @@ class SetupWizard(Screen[str | None]):
             return
         pending = _pending_download(card)
         if pending is None:
-            self._apply_selection(task, ref)
+            row = card.row
+            # Only a ref that is already on disk may be written without a download.
+            if row.kind == CatalogRowKind.LOCAL and row.installed:
+                self._apply_selection(task, ref)
             return
         if pending.ref in self._submitted:
             return

--- a/src/lilbee/cli/tui/screens/setup.py
+++ b/src/lilbee/cli/tui/screens/setup.py
@@ -56,6 +56,14 @@ log = logging.getLogger(__name__)
 SETUP_CHAT_GRID_ID = "setup-chat-grid"
 
 
+def _exact_installed_ref(installed: list[str], ref: str) -> str | None:
+    """The exact installed ref for *ref*, expanding a repo-level ref to its file."""
+    if ref in installed:
+        return ref
+    matches = [r for r in installed if r.startswith(f"{ref}/")]
+    return matches[0] if matches else None
+
+
 def _scan_installed_models() -> tuple[list[str], list[str]]:
     """List installed models from the registry, split into chat vs embedding."""
     try:
@@ -284,9 +292,17 @@ class SetupWizard(Screen[str | None]):
         pending = _pending_download(card)
         if pending is None:
             row = card.row
-            # Only a ref that is already on disk may be written without a download.
+            # Only a ref that is already on disk may be written without a
+            # download, and always as the exact installed file ref: featured
+            # rows carry the repo-level ref, which the display label and the
+            # ready check cannot resolve.
             if row.kind == CatalogRowKind.LOCAL and row.installed:
-                self._apply_selection(task, ref)
+                installed = (
+                    self._chat_installed if task == ModelTask.CHAT else self._embed_installed
+                )
+                exact = _exact_installed_ref(installed, ref)
+                if exact is not None:
+                    self._apply_selection(task, exact)
             return
         if pending.ref in self._submitted:
             return

--- a/src/lilbee/cli/tui/screens/setup.tcss
+++ b/src/lilbee/cli/tui/screens/setup.tcss
@@ -30,23 +30,19 @@
     padding: 0 2;
 }
 
-/* Setup-wizard cards inherit ModelCard's catalog styling (tall $secondary 50%
- * border, $accent focus/hover) verbatim; only the wizard-specific "-selected"
- * state overlays an extra cue so the picked card reads as committed. */
+/* Exactly one treatment means "Enter acts here": the focused grid's
+ * highlighted card gets the strong filled+accent look (see the GridSelect
+ * block below). A remembered pick ("-selected") in any grid keeps only a
+ * dimmed accent border so it never competes with the cursor. */
 
 ModelCard.-selected {
-    background: $primary 30%;
-    border: tall $accent;
+    background: transparent;
+    border: tall $accent 50%;
 }
 
 GridSelect:focus ModelCard.-highlight.-selected {
     background: $primary 30%;
     border: tall $accent;
-}
-
-GridSelect:focus ModelCard.-highlight #card-hint {
-    color: $primary;
-    text-style: bold italic;
 }
 
 .section-heading {
@@ -64,15 +60,10 @@ GridSelect {
     border: round $secondary 50%;
     keyline: none;
 
-    &.-highlight {
-        background: $surface;
-        border: tall $primary 30%;
-    }
-
     &:focus * {
         &.-highlight {
-            background: $surface;
-            border: tall $primary;
+            background: $primary 30%;
+            border: tall $accent;
         }
     }
 }

--- a/src/lilbee/cli/tui/screens/status.py
+++ b/src/lilbee/cli/tui/screens/status.py
@@ -195,7 +195,12 @@ class StatusScreen(Screen[None]):
         # cost of mounting all four under a single VerticalScroll spiked
         # screen-switch latency to ~1s on cold caches.
         yield VerticalScroll(
-            Collapsible(Static(id="config-info"), title="Configuration", id="config-section"),
+            Collapsible(
+                Static(id="config-info"),
+                title="Configuration",
+                id="config-section",
+                collapsed=False,
+            ),
             id="status-scroll",
         )
         with BottomBars():
@@ -221,10 +226,23 @@ class StatusScreen(Screen[None]):
         await scroll.mount_all(
             [
                 Collapsible(
-                    DataTable(id="docs-table"), title=msg.STATUS_DOCS_TITLE, id="docs-section"
+                    DataTable(id="docs-table"),
+                    title=msg.STATUS_DOCS_TITLE,
+                    id="docs-section",
+                    collapsed=False,
                 ),
-                Collapsible(Static(id="arch-info"), title="Model Architecture", id="arch-section"),
-                Collapsible(Static(id="storage-info"), title="Storage", id="storage-section"),
+                Collapsible(
+                    Static(id="arch-info"),
+                    title="Model Architecture",
+                    id="arch-section",
+                    collapsed=False,
+                ),
+                Collapsible(
+                    Static(id="storage-info"),
+                    title="Storage",
+                    id="storage-section",
+                    collapsed=False,
+                ),
             ]
         )
         self._sections_mounted = True
@@ -381,7 +399,7 @@ class StatusScreen(Screen[None]):
         self.query_one("#status-scroll", VerticalScroll).scroll_up()
 
     def action_jump_top(self) -> None:
-        self.query_one("#status-scroll", VerticalScroll).scroll_home()
+        self.query_one("#status-scroll", VerticalScroll).scroll_home(animate=False)
 
     def action_jump_bottom(self) -> None:
-        self.query_one("#status-scroll", VerticalScroll).scroll_end()
+        self.query_one("#status-scroll", VerticalScroll).scroll_end(animate=False)

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -11,10 +11,9 @@ from typing import ClassVar
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical
+from textual.content import Content
 from textual.widgets import OptionList
 from textual.widgets.option_list import Option
-
-from textual.content import Content
 
 from lilbee.app.services import get_services
 from lilbee.app.settings import _is_settable

--- a/src/lilbee/cli/tui/widgets/autocomplete.py
+++ b/src/lilbee/cli/tui/widgets/autocomplete.py
@@ -14,15 +14,30 @@ from textual.containers import Vertical
 from textual.widgets import OptionList
 from textual.widgets.option_list import Option
 
+from textual.content import Content
+
 from lilbee.app.services import get_services
 from lilbee.app.settings import _is_settable
 from lilbee.app.settings_map import SETTINGS_MAP
 from lilbee.app.themes import DARK_THEMES
-from lilbee.cli.tui.command_registry import completion_names
+from lilbee.cli.tui.command_registry import COMMANDS, completion_names
 
 log = logging.getLogger(__name__)
 
 _SLASH_COMMANDS = completion_names()
+_COMMAND_HELP: dict[str, str] = {
+    name: cmd.help_text for cmd in COMMANDS for name in (cmd.name, *cmd.aliases)
+}
+
+
+def _option_prompt(value: str) -> Content:
+    """Render a dropdown row: bare *value*, plus dim registry help for commands."""
+    help_text = _COMMAND_HELP.get(value, "")
+    if not help_text:
+        return Content(value)
+    return Content.assemble(value, Content.styled(f"  {help_text}", "$text-muted"))
+
+
 _MAX_VISIBLE = 8  # max dropdown items shown at once
 # Hard cap on path completions surfaced for /add so a deep directory doesn't
 # stall the dropdown rebuild.
@@ -69,8 +84,12 @@ def _get_arg_completions(cmd: str, partial: str) -> list[str]:
     else:
         options = sources()
         if partial:
+            # Substring match so a model's human name ("smol") finds its full
+            # ref without the HF org; prefix matches keep first place.
             low = partial.lower()
-            options = [o for o in options if o.lower().startswith(low)]
+            prefixed = [o for o in options if o.lower().startswith(low)]
+            contained = [o for o in options if low in o.lower() and not o.lower().startswith(low)]
+            options = prefixed + contained
     return [o for o in options if o.lower() != partial.lower()]
 
 
@@ -220,7 +239,7 @@ class CompletionOverlay(Vertical):
         ol = self.query_one("#completion-list", OptionList)
         ol.clear_options()
         for opt in self._options:
-            ol.add_option(Option(opt))
+            ol.add_option(Option(_option_prompt(opt)))
         if self._options:
             ol.highlighted = 0
             self.display = True

--- a/src/lilbee/cli/tui/widgets/chat_input.py
+++ b/src/lilbee/cli/tui/widgets/chat_input.py
@@ -78,6 +78,16 @@ class ChatInput(TextArea):
             return False
         return super().check_consume_key(key, character)
 
+    async def _on_key(self, event: events.Key) -> None:
+        if event.key == "question_mark" and not self.text:
+            # An empty prompt can't be mid-typing, so ? opens the help panel;
+            # with any text present it stays a literal character.
+            event.prevent_default()
+            event.stop()
+            await self.app.run_action("push_help")
+            return
+        await super()._on_key(event)
+
     def action_submit(self) -> None:
         # Enter is a priority binding; when a drawer toggle holds focus, yield so
         # Enter reaches that widget instead of submitting the prompt.

--- a/src/lilbee/cli/tui/widgets/crawl_dialog.py
+++ b/src/lilbee/cli/tui/widgets/crawl_dialog.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding, BindingType
-from textual.containers import Center, VerticalScroll
+from textual.containers import Center, Horizontal, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Input, Label, Static
 
@@ -82,7 +82,7 @@ class CrawlDialog(ModalScreen[CrawlParams | None]):
                 id="crawl-depth-input",
             )
             yield Static("", id="crawl-error")
-            with Center():
+            with Center(), Horizontal(id="crawl-buttons"):
                 yield Button(msg.CRAWL_DIALOG_SUBMIT, variant="primary", id="crawl-submit")
                 yield Button(msg.CRAWL_DIALOG_CANCEL, variant="default", id="crawl-cancel")
 

--- a/src/lilbee/cli/tui/widgets/crawl_dialog.tcss
+++ b/src/lilbee/cli/tui/widgets/crawl_dialog.tcss
@@ -41,6 +41,11 @@ CrawlDialog Center {
     margin-top: 1;
 }
 
+CrawlDialog #crawl-buttons {
+    width: auto;
+    height: auto;
+}
+
 CrawlDialog Button {
     margin: 0 1;
 }

--- a/src/lilbee/cli/tui/widgets/model_bar.py
+++ b/src/lilbee/cli/tui/widgets/model_bar.py
@@ -223,6 +223,11 @@ _CSS_FILE = Path(__file__).parent / "model_bar.tcss"
 
 _CLOUD_WARNING_ID = "model-bar-cloud-warning"
 
+# Below this width the bar degrades: disabled role rows hide, picker labels
+# compact, and the mode toggle docks right so it never clips off-screen.
+_NARROW_BAR_WIDTH = 100
+_NARROW_CLASS = "-narrow"
+
 _SCOPE_TO_LABEL: dict[str, str] = {
     "chat": msg.MODEL_BAR_CHAT_LABEL,
     "embed": msg.MODEL_BAR_EMBED_LABEL,
@@ -543,6 +548,10 @@ class ModelBar(Widget, can_focus=False):
         self._refresh_cloud_warning()
         self._scan_models()
         self.app.settings_changed_signal.subscribe(self, self._on_settings_changed)
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Toggle the narrow-layout class so the bar degrades instead of clipping."""
+        self.set_class(event.size.width < _NARROW_BAR_WIDTH, _NARROW_CLASS)
 
     def _on_settings_changed(self, payload: tuple[str, object]) -> None:
         key, _ = payload

--- a/src/lilbee/cli/tui/widgets/model_bar.tcss
+++ b/src/lilbee/cli/tui/widgets/model_bar.tcss
@@ -40,6 +40,18 @@ RoleRow ModelPickerButton:focus {
     text-style: bold;
 }
 
+ModelBar.-narrow RoleRow.-off {
+    display: none;
+}
+
+ModelBar.-narrow RoleRow ModelPickerButton {
+    max-width: 12;
+}
+
+ModelBar.-narrow #chat-mode-toggle {
+    dock: right;
+}
+
 ModelBar #chat-mode-toggle {
     width: auto;
     height: 1;

--- a/src/lilbee/cli/tui/widgets/slash_command_catalog.py
+++ b/src/lilbee/cli/tui/widgets/slash_command_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import textwrap
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -28,8 +29,15 @@ class CatalogGroup:
 # Visual layout constants for ``_render_row``: align the command name +
 # args column at this width, with at least this much gutter before the
 # help text starts. Picked to fit the longest /set <key> <value> entry.
+# Help text wraps at the row width with a hanging indent so wrapped
+# lines stay in the description column; the fallback width matches the
+# option area of the default 70-col modal before layout has run.
 _ROW_NAME_COLUMN_WIDTH = 28
 _ROW_HELP_GUTTER_MIN = 2
+_ROW_HELP_MIN_WIDTH = 16
+_ROW_FALLBACK_WIDTH = 64
+# Horizontal padding the .option-list--option rule adds around each row.
+_ROW_OPTION_PADDING = 2
 
 
 CATALOG_GROUPS: tuple[CatalogGroup, ...] = (
@@ -132,6 +140,10 @@ class SlashCommandCatalog(ModalScreen[str | None]):
                 self.dismiss(opt.id)
                 return
 
+    def on_resize(self) -> None:
+        """Re-render rows so help wrapping tracks the option list's width."""
+        self._rebuild(self.query_one("#catalog-filter", Input).value)
+
     def _rebuild(self, query: str) -> None:
         ol = self.query_one("#catalog-list", OptionList)
         ol.clear_options()
@@ -139,9 +151,15 @@ class SlashCommandCatalog(ModalScreen[str | None]):
         if not groups:
             ol.add_option(Option(msg.SLASH_CATALOG_NO_MATCH, id=None, disabled=True))
             return
-        first_runnable = _populate_options(ol, groups)
+        first_runnable = _populate_options(ol, groups, _row_width(ol))
         if first_runnable is not None:
             ol.highlighted = first_runnable
+
+
+def _row_width(ol: OptionList) -> int:
+    """Usable text width of one option row, before layout the fallback width."""
+    width = ol.scrollable_content_region.width - _ROW_OPTION_PADDING
+    return width if width > 0 else _ROW_FALLBACK_WIDTH
 
 
 def _filter_groups(query: str) -> list[tuple[str, list[SlashCommand]]]:
@@ -159,7 +177,9 @@ def _filter_groups(query: str) -> list[tuple[str, list[SlashCommand]]]:
     return out
 
 
-def _populate_options(ol: OptionList, groups: list[tuple[str, list[SlashCommand]]]) -> int | None:
+def _populate_options(
+    ol: OptionList, groups: list[tuple[str, list[SlashCommand]]], width: int
+) -> int | None:
     """Add header + command rows for each group, return the first runnable row index."""
     first_runnable: int | None = None
     for title, commands in groups:
@@ -167,7 +187,7 @@ def _populate_options(ol: OptionList, groups: list[tuple[str, list[SlashCommand]
         for cmd in commands:
             if first_runnable is None:
                 first_runnable = ol.option_count
-            ol.add_option(Option(_render_row(cmd), id=cmd.name))
+            ol.add_option(Option(_render_row(cmd, width), id=cmd.name))
     return first_runnable
 
 
@@ -175,10 +195,16 @@ def _render_header(title: str) -> Content:
     return Content.styled(title, "bold $primary")
 
 
-def _render_row(cmd: SlashCommand) -> Content:
-    name_part = Content.styled(f"  {cmd.name}", "$success bold")
-    args_part = Content.styled(f" {cmd.args_hint}", "$text-muted") if cmd.args_hint else Content("")
-    visible_len = len(f"  {cmd.name}") + (len(f" {cmd.args_hint}") if cmd.args_hint else 0)
-    pad = " " * max(_ROW_HELP_GUTTER_MIN, _ROW_NAME_COLUMN_WIDTH - visible_len)
-    help_part = Content.styled(f"{pad}{cmd.help_text}", "$text-muted")
+def _render_row(cmd: SlashCommand, width: int) -> Content:
+    """One row at *width* cols: name + args column, help with a hanging indent."""
+    lead = f"  {cmd.name}"
+    args = f" {cmd.args_hint}" if cmd.args_hint else ""
+    help_col = max(_ROW_NAME_COLUMN_WIDTH, len(lead) + len(args) + _ROW_HELP_GUTTER_MIN)
+    help_width = max(_ROW_HELP_MIN_WIDTH, width - help_col)
+    wrapped = textwrap.wrap(cmd.help_text, help_width) or [""]
+    first_pad = " " * (help_col - len(lead) - len(args))
+    help_block = first_pad + ("\n" + " " * help_col).join(wrapped)
+    name_part = Content.styled(lead, "$success bold")
+    args_part = Content.styled(args, "$text-muted") if args else Content("")
+    help_part = Content.styled(help_block, "$text-muted")
     return Content.assemble(name_part, args_part, help_part)

--- a/src/lilbee/cli/tui/widgets/task_bar.py
+++ b/src/lilbee/cli/tui/widgets/task_bar.py
@@ -38,7 +38,7 @@ _DOT_GLYPH = "●"
 _WARM_BAR_FILL = "▓"
 _WARM_BAR_TRACK = "░"
 _WARM_BAR_WIDTH = 12
-# Indeterminate sweep (loading engine has no byte signal): a lit window that walks
+# Indeterminate sweep (the engine-load phase has no byte signal): a lit window that walks
 # the track so the bar reads as "working", not stalled. Advanced by the poll tick.
 _WARM_SWEEP_WIDTH = 3
 

--- a/tests/test_bottom_bar_affordances.py
+++ b/tests/test_bottom_bar_affordances.py
@@ -230,10 +230,16 @@ async def test_setup_wizard_hint_when_no_models_installed() -> None:
 
 
 async def test_setup_wizard_hint_when_models_already_installed() -> None:
-    """Models present -> hint shifts to 'Esc to return' so the wizard reads as a review."""
+    """Configured refs installed -> hint shifts to 'Esc to return' (a review, not setup)."""
+    from lilbee.core.config import cfg
+
+    chat_ref = "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q8_0.gguf"
+    embed_ref = "nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q4_K_M.gguf"
+    cfg.chat_model = chat_ref
+    cfg.embedding_model = embed_ref
     with mock.patch(
         "lilbee.cli.tui.screens.setup._scan_installed_models",
-        return_value=(["qwen3:8b"], ["nomic-embed-text"]),
+        return_value=([chat_ref], [embed_ref]),
     ):
         app = _SetupHostApp()
         async with app.run_test(size=(120, 40)) as pilot:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -350,7 +350,7 @@ class TestFetchHfModels:
         models = page.models
         assert len(models) == 2
         assert models[0].hf_repo == "user/model-7b-gguf"
-        assert models[0].display_name == "model 7b"
+        assert models[0].display_name == "Model 7B"
         assert models[0].downloads == 5000
         assert models[0].featured is False
         assert models[0].task == "chat"
@@ -842,7 +842,7 @@ class TestBuildAdhocEntry:
         entry = build_adhoc_entry("bartowski/gemma-2-2b-it-GGUF")
         assert entry.hf_repo == "bartowski/gemma-2-2b-it-GGUF"
         assert entry.gguf_filename == "*.gguf"
-        assert entry.display_name == "gemma 2 2b it"
+        assert entry.display_name == "Gemma 2 2B"
         assert entry.featured is False
         assert entry.task == ModelTask.CHAT
 
@@ -2190,18 +2190,31 @@ class TestCleanDisplayName:
         assert result == "Mistral 7B v0.3"
 
     def test_strips_qat_marker(self) -> None:
-        assert clean_display_name("unsloth/embeddinggemma-300M-qat-GGUF") == "embeddinggemma 300M"
+        assert clean_display_name("unsloth/embeddinggemma-300M-qat-GGUF") == "Embeddinggemma 300M"
 
     def test_strips_embedding_suffix(self) -> None:
-        assert clean_display_name("ggml-org/all-MiniLM-L6-v2-Embedding-GGUF") == "all MiniLM L6 v2"
+        assert clean_display_name("ggml-org/all-MiniLM-L6-v2-Embedding-GGUF") == "All MiniLM L6 v2"
 
     def test_strips_trailing_quant(self) -> None:
-        assert clean_display_name("ggml-org/all-MiniLM-L6-v2-Q8_0") == "all MiniLM L6 v2"
+        assert clean_display_name("ggml-org/all-MiniLM-L6-v2-Q8_0") == "All MiniLM L6 v2"
 
     def test_strips_combined_quant_and_qat(self) -> None:
         assert (
-            clean_display_name("unsloth/embeddinggemma-300M-qat-Q8_0-GGUF") == "embeddinggemma 300M"
+            clean_display_name("unsloth/embeddinggemma-300M-qat-Q8_0-GGUF") == "Embeddinggemma 300M"
         )
+
+    def test_capitalizes_lowercase_words_and_strips_it_suffix(self) -> None:
+        assert clean_display_name("unsloth/gemma-4-E2B-it-GGUF") == "Gemma 4 E2B"
+
+    def test_uppercases_lowercase_param_count(self) -> None:
+        assert (
+            clean_display_name("ggml-org/embeddinggemma-300m-qat-q8_0-GGUF")
+            == "Embeddinggemma 300M"
+        )
+
+    def test_mixed_case_words_are_preserved(self) -> None:
+        result = clean_display_name("unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF")
+        assert result == "Qwen3 Coder 30B A3B"
 
 
 class TestDownloadTaskName:

--- a/tests/test_catalog_actions.py
+++ b/tests/test_catalog_actions.py
@@ -1,5 +1,5 @@
 """Coverage for new catalog actions: select_tab, cycle_source, toggle_drawer,
-on_key digit intercept, dismiss_filter, discover-rail population edges."""
+on_key digit intercept, Esc back-navigation, discover-rail population edges."""
 
 from __future__ import annotations
 
@@ -202,7 +202,7 @@ async def test_action_toggle_drawer_flips_collapsed_class() -> None:
         assert drawer.has_class("-collapsed")
 
 
-async def test_dismiss_filter_closes_revealed_bar_when_unfocused() -> None:
+async def test_escape_closes_revealed_bar_when_unfocused() -> None:
     """Esc closes an open filter even when focus has raced off the Input."""
     async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
         await pilot.pause()
@@ -245,16 +245,37 @@ async def test_go_back_closes_revealed_bar_when_unfocused() -> None:
         assert pilot.app.query_one(CatalogScreen) is screen
 
 
-async def test_action_dismiss_filter_no_op_outside_input() -> None:
-    """Esc outside the filter Input must not dismiss; the screen stays put."""
+async def test_escape_without_filter_switches_to_chat() -> None:
+    """Esc with no filter open leaves the catalog for the Chat view, like q."""
+    from unittest.mock import patch
+
     async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         screen = pilot.app.query_one(CatalogScreen)
-        # Focus the toggle (NOT the filter Input).
-        screen.action_dismiss_filter()
+        screen._activation_settled = True
+        assert not screen._filter_open
+        with patch.object(pilot.app, "switch_view") as switch:
+            await pilot.press("escape")
+            await pilot.pause()
+            switch.assert_called_once_with("Chat")
+
+
+async def test_escape_with_open_filter_stays_on_catalog() -> None:
+    """The first Esc only collapses the filter; it must not leave the screen."""
+    from unittest.mock import patch
+
+    async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        # Screen still mounted.
-        assert pilot.app.query_one(CatalogScreen) is screen
+        screen = pilot.app.query_one(CatalogScreen)
+        screen._activation_settled = True
+        await pilot.press("slash")
+        await pilot.pause()
+        assert screen._filter_open
+        with patch.object(pilot.app, "switch_view") as switch:
+            await pilot.press("escape")
+            await pilot.pause()
+            switch.assert_not_called()
+        assert not screen._filter_open
 
 
 def test_row_cache_signature_keys_frontier_rows_as_uninstalled() -> None:
@@ -390,7 +411,7 @@ async def test_action_select_tab_idempotent_when_already_active() -> None:
         assert tabs.active == "rerank"
 
 
-async def test_action_dismiss_filter_clears_input_value() -> None:
+async def test_escape_on_open_filter_clears_input_value() -> None:
     """Esc on an open filter clears its value and hides the box."""
     async with _CatalogTestApp().run_test(size=(120, 40)) as pilot:
         await pilot.pause()

--- a/tests/test_catalog_hf_client_compat.py
+++ b/tests/test_catalog_hf_client_compat.py
@@ -57,10 +57,10 @@ def test_fetch_populates_arch_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client.get_cached_arch("acme/test-GGUF") == "qwen3"
 
 
-def test_featured_catalog_models_default_to_unknown_compat() -> None:
-    """TOML-loaded featured entries default to UNKNOWN; probe at pull catches mismatch."""
+def test_featured_catalog_models_are_supported_compat() -> None:
+    """Curated featured entries carry SUPPORTED; the pull-time probe still re-checks arch."""
     from lilbee.catalog.featured import FEATURED_ALL
 
     for entry in FEATURED_ALL:
-        assert entry.compat is ModelCompat.UNKNOWN
+        assert entry.compat is ModelCompat.SUPPORTED
         assert entry.architecture == ""

--- a/tests/test_chat_startup_gating.py
+++ b/tests/test_chat_startup_gating.py
@@ -140,7 +140,7 @@ async def test_await_engine_paints_progress_then_proceeds(_warming_services):
         ):
             assert await asyncio.to_thread(screen._await_chat_engine, widget) is True
         painted = [c.args[0] for c in widget.set_thinking_status.call_args_list]
-        assert painted[0] == msg.ENGINE_LOADING  # labelled before the first snapshot
+        assert painted[0] == msg.ENGINE_WARMING  # labelled before the first snapshot
         assert _engine_status_text(snapshot) in painted
         assert painted[-1] == ""  # the status clears once the engine is ready
 
@@ -234,9 +234,12 @@ def test_engine_status_text_reports_bytes_or_phase():
         phase=WarmPhase.READING_WEIGHTS, bytes_done=1, bytes_total=2, model_ref="a/b/c.gguf"
     )
     assert "50%" in _engine_status_text(reading)
-    assert _engine_status_text(WarmProgress(phase=WarmPhase.LOADING_ENGINE)) == msg.ENGINE_LOADING
+    almost = _engine_status_text(WarmProgress(phase=WarmPhase.LOADING_ENGINE))
+    assert almost == msg.ENGINE_ALMOST_READY
     no_bytes = WarmProgress(phase=WarmPhase.READING_WEIGHTS)
-    assert _engine_status_text(no_bytes) == msg.ENGINE_LOADING
+    assert _engine_status_text(no_bytes) == msg.ENGINE_WARMING
+    starting = _engine_status_text(WarmProgress(phase=WarmPhase.STARTING))
+    assert starting == msg.ENGINE_WARMING
 
 
 async def test_await_engine_builds_services_when_none_exist(_warming_services):

--- a/tests/test_model_card_compat_pill.py
+++ b/tests/test_model_card_compat_pill.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from lilbee.catalog.types import ModelCompat
+from lilbee.catalog.types import ModelCompat, ModelTask
 from lilbee.cli.tui.messages import COMPAT_PILL_UNKNOWN, COMPAT_PILL_UNSUPPORTED
 from lilbee.cli.tui.screens.catalog_utils import LocalCatalogRow
 from lilbee.cli.tui.widgets.model_card import _compat_pill, _render_local
@@ -87,6 +87,72 @@ def test_grid_card_lines_omit_compat_pill_for_supported() -> None:
     joined = "\n".join(line.plain for line in lines)
     assert COMPAT_PILL_UNSUPPORTED not in joined
     assert COMPAT_PILL_UNKNOWN not in joined
+
+
+def test_unknown_pill_text_is_self_explanatory() -> None:
+    """A bare '?' pill explains nothing; the copy must name the state."""
+    assert COMPAT_PILL_UNKNOWN == "untested"
+
+
+def test_featured_entries_carry_supported_compat() -> None:
+    """Curated featured models are known to run; none may render an unknown pill."""
+    from lilbee.catalog import FEATURED_ALL
+
+    assert FEATURED_ALL
+    assert all(m.compat is ModelCompat.SUPPORTED for m in FEATURED_ALL)
+
+
+def test_catalog_to_row_marks_installed_rows_supported() -> None:
+    """An installed model demonstrably runs, whatever the catalog probe said."""
+    from lilbee.catalog.models import CatalogModel
+    from lilbee.cli.tui.screens.catalog_utils import catalog_to_row
+
+    model = CatalogModel(
+        hf_repo="acme/foo-GGUF",
+        gguf_filename="foo-Q8_0.gguf",
+        size_gb=0.5,
+        min_ram_gb=2.0,
+        description="",
+        featured=False,
+        downloads=0,
+        task=ModelTask.CHAT,
+        compat=ModelCompat.UNKNOWN,
+    )
+    assert catalog_to_row(model, installed=True).compat is ModelCompat.SUPPORTED
+    assert catalog_to_row(model, installed=False).compat is ModelCompat.UNKNOWN
+
+
+def test_installed_registry_row_is_supported() -> None:
+    """Wizard/library rows built from an installed registry ref carry SUPPORTED."""
+    from lilbee.cli.tui.screens.setup import _installed_name_to_row
+
+    row = _installed_name_to_row("acme/foo-GGUF/foo-Q8_0.gguf", "chat")
+    assert row.compat is ModelCompat.SUPPORTED
+
+
+def test_remote_row_is_supported() -> None:
+    """Rows for models a live local server reports are running are SUPPORTED."""
+    from lilbee.cli.tui.screens.catalog_utils import remote_to_row
+    from lilbee.modelhub.model_manager import RemoteModel
+
+    rm = RemoteModel(
+        name="llama3:latest",
+        task=ModelTask.CHAT,
+        family="llama",
+        parameter_size="8B",
+        provider="Ollama",
+    )
+    assert remote_to_row(rm).compat is ModelCompat.SUPPORTED
+
+
+def test_variant_row_is_supported() -> None:
+    """Family rows come from the curated featured catalog, so they are SUPPORTED."""
+    from lilbee.catalog import get_families
+    from lilbee.cli.tui.screens.catalog_utils import variant_to_row
+
+    family = get_families()[0]
+    row = variant_to_row(family.variants[0], family, installed=False)
+    assert row.compat is ModelCompat.SUPPORTED
 
 
 def test_native_backend_pill_is_dropped() -> None:

--- a/tests/test_setup_task_routing.py
+++ b/tests/test_setup_task_routing.py
@@ -272,3 +272,62 @@ async def test_escape_with_selection_dismisses_completed() -> None:
                         break
             assert not isinstance(app.screen, SetupWizard)
             mock_reset.assert_called_once()
+
+
+_INSTALLED_CHAT_REF = "org/Other-Chat-GGUF/Other-Chat-Q8_0.gguf"
+_INSTALLED_EMBED_REF = "Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf"
+
+
+def test_ready_hint_requires_configured_chat_ref_installed() -> None:
+    """Other installed chat models don't make an uninstalled configured ref 'ready'."""
+    from lilbee.cli.tui import messages as msg
+    from lilbee.core.config import cfg
+
+    cfg.chat_model = "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf"
+    cfg.embedding_model = _INSTALLED_EMBED_REF
+    with _patch_setup_scan(chat=[_INSTALLED_CHAT_REF], embed=[_INSTALLED_EMBED_REF]):
+        wizard = SetupWizard()
+    assert wizard._initial_hint_text() == msg.SETUP_ENTER_HINT
+
+
+def test_ready_hint_requires_configured_embedding_ref_installed() -> None:
+    """A configured embedding ref that isn't installed keeps the install hint."""
+    from lilbee.cli.tui import messages as msg
+    from lilbee.core.config import cfg
+
+    cfg.chat_model = _INSTALLED_CHAT_REF
+    cfg.embedding_model = "nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q4_K_M.gguf"
+    with _patch_setup_scan(chat=[_INSTALLED_CHAT_REF], embed=[_INSTALLED_EMBED_REF]):
+        wizard = SetupWizard()
+    assert wizard._initial_hint_text() == msg.SETUP_ENTER_HINT
+
+
+def test_ready_hint_when_both_configured_refs_installed() -> None:
+    """The ready hint shows only when both configured refs resolve to installs."""
+    from lilbee.cli.tui import messages as msg
+    from lilbee.core.config import cfg
+
+    cfg.chat_model = _INSTALLED_CHAT_REF
+    cfg.embedding_model = _INSTALLED_EMBED_REF
+    with _patch_setup_scan(chat=[_INSTALLED_CHAT_REF], embed=[_INSTALLED_EMBED_REF]):
+        wizard = SetupWizard()
+    assert wizard._initial_hint_text() == msg.SETUP_RETURN_HINT
+
+
+@pytest.mark.asyncio
+async def test_commit_selection_never_writes_a_ref_it_cannot_install() -> None:
+    """A non-installed card with no downloadable catalog model writes nothing."""
+    from lilbee.cli.tui.screens.setup import _installed_name_to_row
+
+    app = _PlainApp()
+    with _patch_setup_scan(), _patch_setup_ram():
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            wizard = app.screen
+            assert isinstance(wizard, SetupWizard)
+            row = _installed_name_to_row(_INSTALLED_CHAT_REF, "chat")
+            row.installed = False
+            card = ModelCard(row)
+            with patch.object(wizard, "_apply_selection") as mock_apply:
+                wizard._commit_selection(card, "chat")
+            mock_apply.assert_not_called()

--- a/tests/test_setup_task_routing.py
+++ b/tests/test_setup_task_routing.py
@@ -315,6 +315,33 @@ def test_ready_hint_when_both_configured_refs_installed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_commit_selection_resolves_repo_ref_to_installed_file_ref() -> None:
+    """Picking an installed featured card writes the exact installed file ref.
+
+    Featured rows carry the repo-level ref (org/Repo-GGUF); persisting that
+    breaks the display label and the ready check, which compare full file refs.
+    """
+    from lilbee.cli.tui.screens.setup import _installed_name_to_row
+
+    app = _PlainApp()
+    with (
+        _patch_setup_scan(chat=["Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf"]),
+        _patch_setup_ram(),
+    ):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            wizard = app.screen
+            assert isinstance(wizard, SetupWizard)
+            row = _installed_name_to_row("Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf", "chat")
+            row.ref = "Qwen/Qwen3-8B-GGUF"
+            row.installed = True
+            card = ModelCard(row)
+            with patch.object(wizard, "_apply_selection") as mock_apply:
+                wizard._commit_selection(card, "chat")
+            mock_apply.assert_called_once_with("chat", "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf")
+
+
+@pytest.mark.asyncio
 async def test_commit_selection_never_writes_a_ref_it_cannot_install() -> None:
     """A non-installed card with no downloadable catalog model writes nothing."""
     from lilbee.cli.tui.screens.setup import _installed_name_to_row

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -415,9 +415,7 @@ class TestCatalogScreenAsync:
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
     async def test_catalog_quit(self, mock_catalog: mock.MagicMock) -> None:
-        """`q` dismisses the catalog (Escape no longer dismisses; see
-        action_dismiss_filter).
-        """
+        """`q` leaves the catalog for the Chat view."""
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
         from lilbee.cli.tui.screens.catalog import CatalogScreen
@@ -913,11 +911,11 @@ class TestSlashSuggester:
 
 
 class TestContextAwareQuit:
-    """Test that action_quit cancels tasks/stream before quitting."""
+    """Test that action_quit cancels foreground work but never background tasks."""
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
-    async def test_quit_cancels_active_task(self, mock_catalog: mock.MagicMock) -> None:
-        """Ctrl+C cancels active TaskBar task when one exists."""
+    async def test_quit_exits_despite_active_task(self, mock_catalog: mock.MagicMock) -> None:
+        """Ctrl+C exits on the first press even with a background task running."""
         mock_catalog.return_value = _EMPTY_CATALOG
         from lilbee.cli.tui.app import LilbeeApp
 
@@ -928,10 +926,10 @@ class TestContextAwareQuit:
             task_bar = app.task_bar
             task_bar.add_task("Test download", "download")
             task_bar.queue.advance()
-            await app.action_quit()
-            await pilot.pause()
-            # Task should have been cancelled, app still running
-            assert app.is_running
+            with mock.patch.object(app, "exit") as mock_exit:
+                await app.action_quit()
+                await pilot.pause()
+            mock_exit.assert_called_once()
 
     @mock.patch("lilbee.cli.tui.screens.catalog.get_catalog")
     async def test_quit_cancels_streaming(self, mock_catalog: mock.MagicMock) -> None:

--- a/tests/test_tui_e2e.py
+++ b/tests/test_tui_e2e.py
@@ -2476,8 +2476,8 @@ class TestAppQuit:
                 await pilot.pause()
                 mock_exit.assert_called_once()
 
-    async def test_quit_cancels_active_task_first(self, _mock_resolve):
-        """Ctrl+C with active task cancels it instead of exiting."""
+    async def test_quit_exits_despite_active_task(self, _mock_resolve):
+        """Ctrl+C quits on the first press; a background task never swallows it."""
         from lilbee.cli.tui.app import LilbeeApp
 
         app = LilbeeApp()
@@ -2489,7 +2489,7 @@ class TestAppQuit:
             with mock.patch.object(app, "exit") as mock_exit:
                 await pilot.press("ctrl+c")
                 await pilot.pause()
-                mock_exit.assert_not_called()
+                mock_exit.assert_called_once()
 
     async def test_quit_cancels_stream_if_on_chat(self, _mock_resolve):
         """Ctrl+C cancels stream before exiting when streaming."""
@@ -2710,8 +2710,9 @@ class TestChatSlashCommands:
             assert app.theme == "monokai"
 
     async def test_cmd_theme_without_name(self, _mock_resolve):
-        """/theme with no args lists themes."""
+        """/theme with no args lands in the prompt with the theme dropdown open."""
         from lilbee.cli.tui.app import LilbeeApp
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
         app = LilbeeApp()
         async with app.run_test(size=(120, 40)) as pilot:
@@ -2722,7 +2723,27 @@ class TestChatSlashCommands:
             assert isinstance(screen, ChatScreen)
             screen._handle_slash("/theme")
             await pilot.pause()
-            assert app.screen.is_current
+            assert screen.query_one("#chat-input").value == "/theme "
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            assert overlay.is_visible
+            assert "monokai" in overlay.options
+
+    async def test_cmd_theme_unknown_name_notifies(self, _mock_resolve):
+        """/theme with a bogus name warns with the valid list instead of raising."""
+        from lilbee.cli.tui.app import LilbeeApp
+
+        app = LilbeeApp()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await await_chat(app, pilot)
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            with mock.patch.object(screen, "notify") as mock_notify:
+                screen._handle_slash("/theme not-a-theme")
+                await pilot.pause()
+            mock_notify.assert_called_once()
+            assert "monokai" in mock_notify.call_args[0][0]
 
     async def test_cmd_delete_no_docs(self, _mock_resolve):
         """/delete with no docs shows warning."""
@@ -3144,6 +3165,7 @@ class TestQuestionMarkBehavior:
     """
 
     async def test_question_mark_types_literal_into_focused_chat_input(self, _mock_resolve):
+        """With text in the prompt, ? stays a literal character (no help popup)."""
         from lilbee.cli.tui.app import LilbeeApp
 
         app = LilbeeApp()
@@ -3151,15 +3173,16 @@ class TestQuestionMarkBehavior:
             await await_chat(app, pilot)
             inp = app.screen.query_one("#chat-input", ChatInput)
             inp.focus()
+            inp.value = "what is this"
             await pilot.pause()
             assert app.focused is inp
             await pilot.press("?")
             await pilot.pause()
-            assert "?" in inp.value, (
-                f"? must land as a literal character in chat input, got {inp.value!r}"
+            assert inp.value == "what is this?", (
+                f"? must land as a literal character mid-typing, got {inp.value!r}"
             )
             assert not app.screen.query("HelpPanel"), (
-                "? must not open help while the chat input has focus"
+                "? must not open help while the user is mid-typing"
             )
 
     async def test_f1_opens_help_even_with_chat_input_focused(self, _mock_resolve):

--- a/tests/test_tui_memories.py
+++ b/tests/test_tui_memories.py
@@ -101,6 +101,42 @@ async def test_empty_notifies(store, notes):
         assert msg.MEMORIES_EMPTY in notes
 
 
+async def test_empty_state_line_shown_when_no_memories(store):
+    from textual.widgets import Static
+
+    app = MemoriesTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        empty = app.screen.query_one("#memories-empty", Static)
+        assert empty.has_class("-visible")
+        assert str(empty.render()) == msg.MEMORIES_EMPTY_STATE
+
+
+async def test_empty_state_line_hidden_when_memories_exist(store):
+    from textual.widgets import Static
+
+    store.get_memories.return_value = [_row("uses rust")]
+    app = MemoriesTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert not app.screen.query_one("#memories-empty", Static).has_class("-visible")
+
+
+async def test_filter_with_no_matches_says_no_matches(store):
+    from textual.widgets import Input, Static
+
+    store.get_memories.return_value = [_row("uses rust")]
+    app = MemoriesTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        search = app.screen.query_one("#memories-search", Input)
+        search.value = "zzz"
+        await pilot.pause()
+        empty = app.screen.query_one("#memories-empty", Static)
+        assert empty.has_class("-visible")
+        assert str(empty.render()) == msg.MEMORIES_NO_MATCHES
+
+
 async def test_disabled_notifies(store, notes):
     cfg.memory_enabled = False
     app = MemoriesTestApp()

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2726,8 +2726,10 @@ async def test_chat_slash_theme_no_arg():
         await await_chat(app, _pilot)
         with patch.object(app.screen, "notify") as mock_notify:
             app.screen._handle_slash("/theme")
-            mock_notify.assert_called_once()
-            assert "Themes:" in mock_notify.call_args[0][0]
+            await _pilot.pause()
+            mock_notify.assert_not_called()
+        # No-arg /theme lands in the prompt with the theme dropdown open.
+        assert app.screen.query_one("#chat-input").value == "/theme "
 
 
 async def test_chat_slash_delete_with_match(mock_svc):
@@ -2761,6 +2763,25 @@ async def test_chat_slash_delete_not_found(mock_svc):
             await _pilot.pause()
             mock_notify.assert_called_once()
             assert "Not found" in mock_notify.call_args[0][0]
+
+
+async def test_chat_slash_delete_not_found_suggests_near_match(mock_svc):
+    """A miss that is a substring of exactly one indexed name offers it back."""
+    mock_svc.store.get_sources.return_value = [
+        {"filename": "qa-corpus/tested-models.md", "source": "qa-corpus/tested-models.md"},
+        {"filename": "qa-corpus/usage.md", "source": "qa-corpus/usage.md"},
+    ]
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        set_services(mock_svc)
+        with patch.object(app.screen, "notify") as mock_notify:
+            app.screen._cmd_delete("tested")
+            await app.screen.workers.wait_for_complete()
+            await _pilot.pause()
+            mock_notify.assert_called_once()
+            message = mock_notify.call_args[0][0]
+            assert "Not found" in message
+            assert "qa-corpus/tested-models.md" in message
 
 
 async def test_chat_slash_delete_no_arg(mock_svc):
@@ -3024,12 +3045,24 @@ async def test_chat_slash_set_unknown_key():
 
 
 async def test_chat_slash_set_invalid_value():
+    """A type mismatch reads as human copy, never a raw Python exception."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         with patch.object(app.screen, "notify") as mock_notify:
             app.screen._cmd_set("top_k not-a-number")
             mock_notify.assert_called_once()
-            assert "Invalid value" in mock_notify.call_args[0][0]
+            message = mock_notify.call_args[0][0]
+            assert "whole number" in message
+            assert "invalid literal" not in message
+
+
+async def test_chat_slash_set_enum_mismatch_lists_choices():
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with patch.object(app.screen, "notify") as mock_notify:
+            app.screen._cmd_set("reranker_type bogus")
+            mock_notify.assert_called_once()
+            assert "one of" in mock_notify.call_args[0][0]
 
 
 async def test_chat_slash_set_no_value():
@@ -3037,11 +3070,11 @@ async def test_chat_slash_set_no_value():
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         # top_k is writable but int-typed; empty string fails int() conversion
-        # and surfaces as CMD_SET_INVALID, covering the no-value branch.
+        # and surfaces as the human type hint, covering the no-value branch.
         with patch.object(app.screen, "notify") as mock_notify:
             app.screen._cmd_set("top_k")
             mock_notify.assert_called_once()
-            assert "Invalid value" in mock_notify.call_args[0][0]
+            assert "whole number" in mock_notify.call_args[0][0]
 
 
 async def test_chat_slash_set_readonly_key():
@@ -3706,18 +3739,28 @@ async def test_chat_tab_completes_alias_prefix():
         assert inp.value == "/catalog"
 
 
-async def test_chat_accept_on_enter_with_no_highlight_hides():
-    """Enter on a visible overlay whose highlight is None hides it and falls through to submit."""
+async def test_chat_dismiss_overlay_on_submit_never_consumes_a_message():
+    """Enter on a visible overlay hides it and falls through to submit."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
 
+        app.screen._set_input("hello")
         overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
         overlay.show_completions(["a", "b"])
-        with patch.object(overlay, "get_current", return_value=None):
-            consumed = app.screen._accept_overlay_selection_on_enter()
+        consumed = app.screen._dismiss_overlay_on_submit()
         assert consumed is False
         assert not overlay.is_visible
+
+
+async def test_chat_dismiss_overlay_on_submit_consumes_bare_slash():
+    """Submitting a lone slash clears it instead of dispatching an unknown command."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        app.screen._set_input("/")
+        consumed = app.screen._dismiss_overlay_on_submit()
+        assert consumed is True
+        assert app.screen.query_one("#chat-input").value == ""
 
 
 async def test_chat_completion_value_preserves_windows_directory():
@@ -3746,12 +3789,8 @@ async def test_chat_completion_value_preserves_posix_directory():
         )
 
 
-async def test_chat_accept_on_enter_falls_through_for_full_windows_path():
-    """A fully-typed backslash /add path must not be consumed by the overlay.
-
-    The highlighted completion (basename) rebuilds to the same full path, so
-    Enter falls through to submit the command rather than re-filling the input.
-    """
+async def test_chat_enter_falls_through_for_full_windows_path():
+    """A fully-typed backslash /add path must never be consumed or rewritten."""
     app = ChatTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -3761,8 +3800,9 @@ async def test_chat_accept_on_enter_falls_through_for_full_windows_path():
         overlay = app.screen.query_one("#completion-overlay", CompletionOverlay)
         app.screen._completion_origin = full_path
         overlay.show_completions(["quantum_test.md"])
-        consumed = app.screen._accept_overlay_selection_on_enter()
+        consumed = app.screen._dismiss_overlay_on_submit()
         assert consumed is False
+        assert app.screen.query_one("#chat-input").value == full_path
 
 
 async def test_chat_send_message():
@@ -4019,6 +4059,26 @@ async def test_command_provider_set_model():
             provider._set_model("chat_model", "ollama/new-model:latest")
             assert cfg.chat_model == "ollama/new-model:latest"
             assert "ollama/new-model:latest" in app.title
+
+
+async def test_command_provider_set_model_toast_uses_display_label():
+    """The model-switch toast shows the display label, not the raw GGUF ref."""
+    from lilbee.cli.tui.app import LilbeeApp
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        await await_chat(app, _pilot)
+        from lilbee.cli.tui.commands import LilbeeCommandProvider
+
+        provider = LilbeeCommandProvider(app.screen, match_style=None)
+        ref = "unsloth/SmolLM2-360M-Instruct-GGUF/SmolLM2-360M-Instruct-Q8_0.gguf"
+        with (
+            patch("lilbee.app.settings.persistent_settings.update_values"),
+            patch.object(app, "notify") as mock_notify,
+        ):
+            provider._set_model("chat_model", ref)
+        toast = mock_notify.call_args[0][0]
+        assert toast == "chat_model: SmolLM2 360M"
 
 
 async def test_command_provider_open_wiki_action():
@@ -11006,7 +11066,7 @@ async def test_task_center_go_back_invokes_switch_view():
 
 
 async def test_app_action_quit_when_streaming():
-    """action_quit cancels stream instead of exiting when streaming."""
+    """action_quit cancels the stream instead of exiting, and says how to quit."""
     from lilbee.cli.tui.app import LilbeeApp
     from lilbee.cli.tui.screens.chat import ChatScreen
 
@@ -11017,9 +11077,34 @@ async def test_app_action_quit_when_streaming():
         screen = app.screen
         assert isinstance(screen, ChatScreen)
         screen.streaming = True
-        with patch.object(screen, "action_cancel_stream") as mock_cancel:
+        with (
+            patch.object(screen, "action_cancel_stream") as mock_cancel,
+            patch.object(app, "notify") as mock_notify,
+        ):
             await app.action_quit()
             mock_cancel.assert_called_once()
+        # The two-step is discoverable: the cancel toast says how to quit.
+        assert any("Ctrl+C" in str(c.args[0]) for c in mock_notify.call_args_list)
+
+
+async def test_app_action_quit_ignores_background_tasks():
+    """A background task in the task bar must not swallow the first Ctrl+C."""
+    from lilbee.cli.tui.app import LilbeeApp
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
+        await pilot.pause()
+        app.task_bar.add_task("Warming chat model", "warm", indeterminate=True)
+        await pilot.pause()
+        assert not app.task_bar.queue.is_empty
+        with (
+            patch.object(app, "exit") as mock_exit,
+            patch.object(type(app.task_bar), "cancel_task") as mock_cancel,
+        ):
+            await app.action_quit()
+        mock_exit.assert_called_once()
+        mock_cancel.assert_not_called()
 
 
 async def test_app_action_quit_routes_to_wizard_cancel():

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4214,8 +4214,9 @@ async def test_command_provider_single_delete_entry_regardless_of_index_size(moc
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
         cmds = provider._get_commands()
-        delete_cmds = [c for c in cmds if "delete" in c[0].lower()]
-        assert len(delete_cmds) == 1
+        assert [c[0] for c in cmds].count("Delete document") == 1
+        # No per-file entries are materialized for the 10k indexed sources.
+        assert not any("doc-" in c[0] for c in cmds)
         # Palette cost stays constant: the store is never asked for sources.
         mock_svc.store.get_sources.assert_not_called()
 

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4072,6 +4072,42 @@ async def test_command_provider_delete_document_prefills_prompt(mock_svc):
         assert chat._chat_input.has_focus
 
 
+async def test_command_provider_delete_document_prefills_from_other_view():
+    """A required-arg palette command lands back in Chat with the prompt filled."""
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.screens.chat import ChatScreen
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        chat = await await_chat(app, pilot)
+        from lilbee.cli.tui.commands import LilbeeCommandProvider
+
+        app.switch_view("Status")
+        await pilot.pause()
+        assert not isinstance(app.screen, ChatScreen)
+        provider = LilbeeCommandProvider(app.screen, match_style=None)
+        provider._action_delete_document()
+        await pilot.pause()
+        assert isinstance(app.screen, ChatScreen)
+        assert chat._chat_input.text == "/delete "
+
+
+async def test_command_provider_slash_command_navigates_to_catalog():
+    """A palette command whose handler navigates must actually switch views."""
+    from lilbee.cli.tui.app import LilbeeApp
+    from lilbee.cli.tui.command_registry import get_command
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await await_chat(app, pilot)
+        from lilbee.cli.tui.commands import LilbeeCommandProvider
+
+        provider = LilbeeCommandProvider(app.screen, match_style=None)
+        provider._run_slash_command(get_command("/models"))
+        await pilot.pause()
+        assert app.active_view == "Catalog"
+
+
 async def test_command_provider_delete_document_no_chat_screen():
     """Palette delete falls back to notify when ChatScreen isn't in the stack."""
     from lilbee.cli.tui.app import LilbeeApp
@@ -4082,9 +4118,9 @@ async def test_command_provider_delete_document_no_chat_screen():
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
-        # Stand-in app whose screen_stack contains no ChatScreen.
+        # Stand-in app that has no chat screen installed yet.
         fake_app = MagicMock()
-        fake_app.screen_stack = []
+        fake_app.chat_screen.return_value = None
         with patch.object(
             LilbeeCommandProvider, "_app", new_callable=PropertyMock, return_value=fake_app
         ):
@@ -4152,9 +4188,9 @@ async def test_command_provider_action_reset_no_chat_screen():
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
-        # Stand-in app whose screen_stack contains no ChatScreen.
+        # Stand-in app that has no chat screen installed yet.
         fake_app = MagicMock()
-        fake_app.screen_stack = []
+        fake_app.chat_screen.return_value = None
         with patch.object(
             LilbeeCommandProvider, "_app", new_callable=PropertyMock, return_value=fake_app
         ):

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -4056,24 +4056,41 @@ async def test_command_provider_retry_skipped_action(tmp_path):
         assert load_skip_markers(tmp_path) == {}
 
 
-async def test_command_provider_delete_doc(mock_svc):
+async def test_command_provider_delete_document_prefills_prompt(mock_svc):
+    """Palette 'Delete document' lands in Chat with /delete ready to complete."""
+    from lilbee.cli.tui.app import LilbeeApp
+
+    app = LilbeeApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        chat = await await_chat(app, pilot)
+        from lilbee.cli.tui.commands import LilbeeCommandProvider
+
+        provider = LilbeeCommandProvider(app.screen, match_style=None)
+        provider._action_delete_document()
+        await pilot.pause()
+        assert chat._chat_input.text == "/delete "
+        assert chat._chat_input.has_focus
+
+
+async def test_command_provider_delete_document_no_chat_screen():
+    """Palette delete falls back to notify when ChatScreen isn't in the stack."""
     from lilbee.cli.tui.app import LilbeeApp
 
     app = LilbeeApp()
     async with app.run_test(size=(120, 40)) as _pilot:
         await await_chat(app, _pilot)
-        # Re-inject mock after mount (model bar events may call reset_services)
-        set_services(mock_svc)
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
-        with patch(
-            "lilbee.cli.tui.widgets.autocomplete.invalidate_document_cache"
-        ) as mock_invalidate:
-            provider._delete_doc("notes.md")
-        mock_svc.store.remove_documents.assert_called_once_with(["notes.md"])
-        # Palette delete invalidates the doc cache like the chat /delete path.
-        mock_invalidate.assert_called_once()
+        # Stand-in app whose screen_stack contains no ChatScreen.
+        fake_app = MagicMock()
+        fake_app.screen_stack = []
+        with patch.object(
+            LilbeeCommandProvider, "_app", new_callable=PropertyMock, return_value=fake_app
+        ):
+            provider._action_delete_document()
+        fake_app.notify.assert_called_once()
+        assert "chat" in fake_app.notify.call_args[0][0].lower()
 
 
 async def test_command_provider_action_sync():
@@ -4181,7 +4198,8 @@ async def test_command_provider_model_commands_error():
             assert cmds == []
 
 
-async def test_command_provider_document_commands(mock_svc):
+async def test_command_provider_single_delete_entry_regardless_of_index_size(mock_svc):
+    """The palette carries one delete command and never enumerates the index."""
     from lilbee.cli.tui.app import LilbeeApp
 
     app = LilbeeApp()
@@ -4190,46 +4208,16 @@ async def test_command_provider_document_commands(mock_svc):
         # Re-inject mock after mount (model bar events may call reset_services)
         set_services(mock_svc)
         mock_svc.store.get_sources.return_value = [
-            {"filename": "notes.md", "source": "notes.md"},
+            {"filename": f"doc-{i}.md", "source": f"doc-{i}.md"} for i in range(10_000)
         ]
         from lilbee.cli.tui.commands import LilbeeCommandProvider
 
         provider = LilbeeCommandProvider(app.screen, match_style=None)
-        cmds = provider._document_commands()
-        assert len(cmds) == 1
-        assert "notes.md" in cmds[0][0]
-
-
-async def test_command_provider_document_commands_error(mock_svc):
-    from lilbee.cli.tui.app import LilbeeApp
-
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        await await_chat(app, _pilot)
-        # Re-inject mock after mount (model bar events may call reset_services)
-        set_services(mock_svc)
-        mock_svc.store.get_sources.side_effect = Exception("no store")
-        from lilbee.cli.tui.commands import LilbeeCommandProvider
-
-        provider = LilbeeCommandProvider(app.screen, match_style=None)
-        cmds = provider._document_commands()
-        assert cmds == []
-
-
-async def test_command_provider_document_commands_empty_name(mock_svc):
-    from lilbee.cli.tui.app import LilbeeApp
-
-    app = LilbeeApp()
-    async with app.run_test(size=(120, 40)) as _pilot:
-        await await_chat(app, _pilot)
-        # Re-inject mock after mount (model bar events may call reset_services)
-        set_services(mock_svc)
-        mock_svc.store.get_sources.return_value = [{"source": ""}]
-        from lilbee.cli.tui.commands import LilbeeCommandProvider
-
-        provider = LilbeeCommandProvider(app.screen, match_style=None)
-        cmds = provider._document_commands()
-        assert cmds == []
+        cmds = provider._get_commands()
+        delete_cmds = [c for c in cmds if "delete" in c[0].lower()]
+        assert len(delete_cmds) == 1
+        # Palette cost stays constant: the store is never asked for sources.
+        mock_svc.store.get_sources.assert_not_called()
 
 
 class CatalogTestApp(LilbeeAppHost):

--- a/tests/test_tui_screens.py
+++ b/tests/test_tui_screens.py
@@ -2092,6 +2092,18 @@ async def test_status_screen_has_collapsible_sections(mock_svc):
         assert len(sections) == 4
 
 
+async def test_status_screen_sections_start_expanded(mock_svc):
+    """All four sections open expanded so the screen shows content immediately."""
+    app = StatusTestApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        from textual.widgets import Collapsible
+
+        await pilot.pause()
+        sections = list(app.screen.query(Collapsible))
+        assert len(sections) == 4
+        assert all(not section.collapsed for section in sections)
+
+
 async def test_status_screen_config_shows_models(mock_svc):
     app = StatusTestApp()
     async with app.run_test(size=(120, 40)) as _pilot:
@@ -3063,6 +3075,18 @@ async def test_chat_slash_set_enum_mismatch_lists_choices():
             app.screen._cmd_set("reranker_type bogus")
             mock_notify.assert_called_once()
             assert "one of" in mock_notify.call_args[0][0]
+
+
+async def test_chat_slash_set_downstream_validation_error_stays_human():
+    """A cross-field validation error surfaces its own human message."""
+    app = ChatTestApp()
+    async with app.run_test(size=(120, 40)) as _pilot:
+        with patch.object(app.screen, "notify") as mock_notify:
+            app.screen._cmd_set("chunk_size 10")
+            mock_notify.assert_called_once()
+            message = mock_notify.call_args[0][0]
+            assert "chunk_size" in message
+            assert "Traceback" not in message
 
 
 async def test_chat_slash_set_no_value():

--- a/tests/test_tui_slash_discoverability.py
+++ b/tests/test_tui_slash_discoverability.py
@@ -96,9 +96,12 @@ class _ChatHostApp(LilbeeAppHost):
         yield from ()
 
     def on_mount(self) -> None:
+        from lilbee.cli.tui.app import _CHAT_SCREEN_NAME
         from lilbee.cli.tui.screens.chat import ChatScreen
 
-        self.push_screen(ChatScreen())
+        # Install under the production name so app.chat_screen() resolves.
+        self.install_screen(ChatScreen(), name=_CHAT_SCREEN_NAME)
+        self.push_screen(_CHAT_SCREEN_NAME)
 
 
 class TestArgHintHelper:
@@ -1182,7 +1185,7 @@ class TestPaletteSlashCommandsAsync:
             await pilot.pause()
             provider = LilbeeCommandProvider(app.screen, match_style=None)
             fake_app = mock.MagicMock()
-            fake_app.screen_stack = []
+            fake_app.chat_screen.return_value = None
             with mock.patch.object(
                 LilbeeCommandProvider,
                 "_app",

--- a/tests/test_tui_slash_discoverability.py
+++ b/tests/test_tui_slash_discoverability.py
@@ -506,6 +506,37 @@ class TestChatScreenIntegrationAsync:
             assert not isinstance(bare.screen, SlashCommandCatalog)
 
 
+class TestQuestionMarkHelpAsync:
+    """? opens help on an empty prompt; mid-typing it stays a literal character."""
+
+    async def test_question_mark_on_empty_input_opens_help(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            inp = app.screen.query_one("#chat-input")
+            assert inp.value == ""
+            with mock.patch.object(app, "action_push_help") as push_help:
+                await pilot.press("question_mark")
+                await pilot.pause()
+            push_help.assert_called_once()
+            assert inp.value == ""
+
+    async def test_question_mark_mid_typing_stays_literal(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            inp = app.screen.query_one("#chat-input")
+            inp.value = "what does this do"
+            await pilot.pause()
+            with mock.patch.object(app, "action_push_help") as push_help:
+                await pilot.press("question_mark")
+                await pilot.pause()
+            push_help.assert_not_called()
+            assert inp.value == "what does this do?"
+
+
 class TestPlaceholderCopy:
     def test_placeholder_advertises_three_discovery_keys(self) -> None:
         text = msg.CHAT_INPUT_PLACEHOLDER_DEFAULT
@@ -721,16 +752,38 @@ class TestDropdownNavigationAsync:
             assert isinstance(screen, ChatScreen)
             inp = screen.query_one("#chat-input")
             overlay = screen.query_one("#completion-overlay", CompletionOverlay)
-            inp.value = "/"
+            inp.value = "/add "
+            await pilot.pause()
+            overlay.show_completions(["mydir/"])
             await pilot.pause()
             await pilot.press("ctrl+n")
             await pilot.pause()
-            assert inp.value != "/"
+            assert inp.value != "/add "
             await pilot.press("escape")
             await pilot.pause()
             # Esc restores exactly what the user had typed and closes the menu.
-            assert inp.value == "/"
+            assert inp.value == "/add "
             assert not overlay.is_visible
+
+    async def test_esc_clears_a_bare_slash(self, _mock_resolve, _mock_services) -> None:
+        """Backing out of the dropdown must not leave a "/" to hijack the next message."""
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            inp = screen.query_one("#chat-input")
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            inp.value = "/"
+            await pilot.pause()
+            assert overlay.is_visible
+            await pilot.press("escape")
+            await pilot.pause()
+            assert not overlay.is_visible
+            assert inp.value == ""
 
     async def test_ctrl_p_opens_palette_when_overlay_hidden(
         self, _mock_resolve, _mock_services
@@ -775,9 +828,55 @@ class TestDropdownNavigationAsync:
 
 
 class TestEnterAcceptsHighlightAsync:
-    """Pressing Enter on a visible dropdown must accept the highlighted command."""
+    """Enter submits exactly what was typed; Tab and the arrows do completion."""
 
-    async def test_enter_accepts_highlight_when_input_differs(
+    async def test_enter_never_rewrites_typed_input(self, _mock_resolve, _mock_services) -> None:
+        """ "/model" must dispatch /model even while the dropdown highlights /models."""
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            inp = screen.query_one("#chat-input")
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            with mock.patch.object(screen, "_handle_slash") as dispatch:
+                inp.value = "/model"
+                await pilot.pause()
+                assert overlay.is_visible
+                assert overlay.get_current() == "/models"
+                await pilot.press("enter")
+                await pilot.pause()
+            dispatch.assert_called_once_with("/model")
+            assert not overlay.is_visible
+
+    async def test_prose_submits_even_with_stale_overlay(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        """A leftover visible dropdown must not swallow a plain message."""
+        from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            inp = screen.query_one("#chat-input")
+            overlay = screen.query_one("#completion-overlay", CompletionOverlay)
+            with mock.patch.object(screen, "_send_message") as send:
+                inp.value = "hello world"
+                await pilot.pause()
+                overlay.show_completions(["/model"])
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+            send.assert_called_once_with("hello world")
+            assert not overlay.is_visible
+
+    async def test_bare_slash_enter_clears_without_unknown_toast(
         self, _mock_resolve, _mock_services
     ) -> None:
         from lilbee.cli.tui.widgets.autocomplete import CompletionOverlay
@@ -790,18 +889,58 @@ class TestEnterAcceptsHighlightAsync:
             assert isinstance(screen, ChatScreen)
             inp = screen.query_one("#chat-input")
             overlay = screen.query_one("#completion-overlay", CompletionOverlay)
-            inp.value = "/"
-            await pilot.pause()
-            assert overlay.is_visible
-            highlighted = overlay.get_current()
-            assert highlighted is not None and highlighted.startswith("/")
-            await pilot.press("enter")
-            await pilot.pause()
-            # Enter fills the highlighted command (nothing was previewed yet)
-            # and is consumed, so the message is NOT submitted; a second Enter
-            # would submit.
-            assert inp.value == highlighted
+            with (
+                mock.patch.object(screen, "_handle_slash") as dispatch,
+                mock.patch.object(screen, "notify") as notify,
+            ):
+                inp.value = "/"
+                await pilot.pause()
+                assert overlay.is_visible
+                await pilot.press("enter")
+                await pilot.pause()
+            dispatch.assert_not_called()
+            notify.assert_not_called()
+            assert inp.value == ""
             assert not overlay.is_visible
+
+    async def test_unknown_command_keeps_typed_text(self, _mock_resolve, _mock_services) -> None:
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            inp = screen.query_one("#chat-input")
+            with mock.patch.object(screen, "notify") as notify:
+                inp.value = "/what is a search engine"
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+            notify.assert_called_once()
+            assert "/what" in notify.call_args[0][0]
+            assert inp.value == "/what is a search engine"
+
+    async def test_history_recall_replaces_input(self, _mock_resolve, _mock_services) -> None:
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            inp = screen.query_one("#chat-input")
+            with mock.patch.object(screen, "_send_message"):
+                inp.value = "hello there"
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+            await pilot.press("up")
+            await pilot.pause()
+            assert inp.value == "hello there"
+            await pilot.press("up")
+            await pilot.pause()
+            # Recall replaces the buffer wholesale; it never stacks lines.
+            assert inp.value == "hello there"
+            assert inp.document.line_count == 1
 
     async def test_enter_submits_when_selection_matches_input(
         self, _mock_resolve, _mock_services
@@ -1053,17 +1192,18 @@ class TestCompletionOpenAndAcceptAsync:
             assert isinstance(screen, ChatScreen)
             overlay = screen.query_one("#completion-overlay", CompletionOverlay)
             inp = screen.query_one("#chat-input")
-            inp.value = "/"
+            inp.value = "/m"
             await pilot.pause()
             await pilot.press("escape")
             await pilot.pause()
             assert not overlay.is_visible
+            assert inp.value == "/m"
             await pilot.press("tab")
             await pilot.pause()
             assert overlay.is_visible
-            # Commands share only "/", so Tab previews the first match.
+            # The /m commands share only that prefix, so Tab previews the first match.
             assert inp.value == overlay.get_current()
-            assert inp.value != "/"
+            assert inp.value != "/m"
 
     async def test_ctrl_n_opens_closed_overlay_and_previews_first(
         self, _mock_resolve, _mock_services
@@ -1078,16 +1218,17 @@ class TestCompletionOpenAndAcceptAsync:
             assert isinstance(screen, ChatScreen)
             overlay = screen.query_one("#completion-overlay", CompletionOverlay)
             inp = screen.query_one("#chat-input")
-            inp.value = "/"
+            inp.value = "/m"
             await pilot.pause()
             await pilot.press("escape")
             await pilot.pause()
             assert not overlay.is_visible
+            assert inp.value == "/m"
             await pilot.press("ctrl+n")
             await pilot.pause()
             assert overlay.is_visible
             assert inp.value == overlay.get_current()
-            assert inp.value != "/"
+            assert inp.value != "/m"
 
     async def test_directory_accept_omits_trailing_space(
         self, _mock_resolve, _mock_services

--- a/tests/test_tui_slash_discoverability.py
+++ b/tests/test_tui_slash_discoverability.py
@@ -182,7 +182,47 @@ class TestArgHintWidgetAsync:
             assert hint.display is False
 
 
+def test_render_row_wraps_help_with_hanging_indent() -> None:
+    """Wrapped help lines stay in the description column, never the name column."""
+    from lilbee.cli.tui.widgets.slash_command_catalog import (
+        _ROW_NAME_COLUMN_WIDTH,
+        _render_row,
+    )
+
+    cmd = next(c for c in COMMANDS if c.name == "/model")
+    lines = _render_row(cmd, width=64).plain.splitlines()
+    assert len(lines) > 1
+    for continuation in lines[1:]:
+        assert continuation.startswith(" " * _ROW_NAME_COLUMN_WIDTH)
+    assert all(len(line) <= 64 for line in lines)
+
+
+def test_render_row_short_help_stays_single_line() -> None:
+    from lilbee.cli.tui.widgets.slash_command_catalog import _render_row
+
+    cmd = next(c for c in COMMANDS if c.name == "/quit")
+    assert "\n" not in _render_row(cmd, width=64).plain
+
+
 class TestSlashCommandCatalogAsync:
+    async def test_rows_never_leak_help_into_name_column(self) -> None:
+        """At the modal's real width every wrapped help line keeps the hanging indent."""
+        from lilbee.cli.tui.widgets.slash_command_catalog import _ROW_NAME_COLUMN_WIDTH
+
+        app = _CatalogOnlyApp()
+        async with app.run_test(size=(90, 30)) as pilot:
+            await pilot.pause()
+            ol = app.screen.query_one("#catalog-list", OptionList)
+            width = ol.scrollable_content_region.width
+            for i in range(ol.option_count):
+                opt = ol.get_option_at_index(i)
+                if opt.id is None:
+                    continue
+                lines = str(opt.prompt).splitlines()
+                assert all(len(line) <= width for line in lines)
+                for continuation in lines[1:]:
+                    assert continuation.startswith(" " * _ROW_NAME_COLUMN_WIDTH)
+
     async def test_lists_every_registry_command(self) -> None:
         app = _CatalogOnlyApp()
         async with app.run_test() as pilot:

--- a/tests/test_tui_slash_discoverability.py
+++ b/tests/test_tui_slash_discoverability.py
@@ -1087,6 +1087,47 @@ class TestOverlayBackoutAsync:
             await pilot.pause()
             assert screen._insert_mode is False
 
+    async def test_enter_in_normal_mode_submits_waiting_draft(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        """Esc after typing must not strand the draft: NORMAL-mode Enter sends it."""
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            inp = screen.query_one("#chat-input")
+            with mock.patch.object(screen, "_send_message") as send:
+                inp.value = "hello draft"
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                assert screen._insert_mode is False
+                await pilot.press("enter")
+                await pilot.pause()
+            send.assert_called_once_with("hello draft")
+            assert screen._insert_mode is True
+            assert inp.value == ""
+
+    async def test_enter_in_normal_mode_with_empty_input_returns_to_insert(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            from lilbee.cli.tui.screens.chat import ChatScreen
+
+            screen = app.screen
+            assert isinstance(screen, ChatScreen)
+            with mock.patch.object(screen, "_send_message") as send:
+                await pilot.press("escape")
+                await pilot.pause()
+                assert screen._insert_mode is False
+                await pilot.press("enter")
+                await pilot.pause()
+            send.assert_not_called()
+            assert screen._insert_mode is True
+
 
 _LIVE_FILTER_MODELS = ["qwen3:8b", "mistral:7b"]
 

--- a/tests/test_tui_slash_discoverability.py
+++ b/tests/test_tui_slash_discoverability.py
@@ -1112,6 +1112,103 @@ class TestCompletionOpenAndAcceptAsync:
             assert not overlay.is_visible
 
 
+def test_get_command_returns_exact_entry_and_raises_on_unknown():
+    from lilbee.cli.tui.command_registry import get_command
+
+    assert get_command("/crawl").handler == "_cmd_crawl"
+    with pytest.raises(KeyError):
+        get_command("/nope")
+
+
+class TestPaletteSlashCommandsAsync:
+    """Every slash command is reachable from the Ctrl+P command palette."""
+
+    async def test_palette_lists_every_registry_command(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        from lilbee.cli.tui.commands import LilbeeCommandProvider
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            provider = LilbeeCommandProvider(app.screen, match_style=None)
+            labels = [c[0] for c in provider._get_commands()]
+            for cmd in COMMANDS:
+                assert cmd.name in labels
+
+    async def test_optional_arg_command_runs_immediately(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        """/version needs no argument, so picking it dispatches through chat."""
+        from lilbee.cli.tui.command_registry import get_command
+        from lilbee.cli.tui.commands import LilbeeCommandProvider
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat = app.screen
+            provider = LilbeeCommandProvider(app.screen, match_style=None)
+            with mock.patch.object(chat, "notify") as notify:
+                provider._run_slash_command(get_command("/version"))
+                await pilot.pause()
+            assert "lilbee" in notify.call_args[0][0]
+
+    async def test_required_arg_command_prefills_prompt(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        """/remove requires a name, so picking it lands in the prompt instead."""
+        from lilbee.cli.tui.command_registry import get_command
+        from lilbee.cli.tui.commands import LilbeeCommandProvider
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat = app.screen
+            provider = LilbeeCommandProvider(app.screen, match_style=None)
+            provider._run_slash_command(get_command("/remove"))
+            await pilot.pause()
+            chat_input = chat.query_one("#chat-input")
+            assert chat_input.value == "/remove "
+            assert chat_input.has_focus
+
+    async def test_slash_command_without_chat_screen_notifies(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        from lilbee.cli.tui.command_registry import get_command
+        from lilbee.cli.tui.commands import LilbeeCommandProvider
+
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            provider = LilbeeCommandProvider(app.screen, match_style=None)
+            fake_app = mock.MagicMock()
+            fake_app.screen_stack = []
+            with mock.patch.object(
+                LilbeeCommandProvider,
+                "_app",
+                new_callable=mock.PropertyMock,
+                return_value=fake_app,
+            ):
+                provider._run_slash_command(get_command("/crawl"))
+            fake_app.notify.assert_called_once()
+            assert "chat" in fake_app.notify.call_args[0][0].lower()
+
+    async def test_run_command_rejected_while_streaming(
+        self, _mock_resolve, _mock_services
+    ) -> None:
+        """run_command respects the busy gate like a prompt-submitted command."""
+        app = _ChatHostApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            chat = app.screen
+            chat.streaming = True
+            await pilot.pause()
+            with mock.patch.object(chat, "notify") as notify:
+                chat.run_command("/version")
+            notify.assert_called_once()
+            assert notify.call_args[0][0] == msg.CHAT_BUSY
+
+
 def test_setting_options_exclude_non_settable_keys():
     """Autocomplete offers only settable keys (wiki_dir is read-only)."""
     from lilbee.cli.tui.widgets.autocomplete import _setting_options

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -749,6 +749,43 @@ class TestModelBar:
             assert app.query_one("#model-pick-chat", ModelPickerButton) is not None
             assert app.query_one("#model-pick-embed", ModelPickerButton) is not None
 
+    async def test_mode_toggle_visible_at_80_columns(self) -> None:
+        """At 80 cols the Search/Chat toggle still renders fully inside the screen."""
+        from lilbee.cli.tui.widgets.model_bar import ChatModeToggle
+
+        cfg.chat_model = TEST_LOCAL_REF
+        cfg.embedding_model = TEST_EMBED_REF
+        cfg.vision_model = ""
+        cfg.reranker_model = ""
+        app = _ModelBarApp()
+        async with app.run_test(size=(80, 30)) as pilot:
+            await pilot.pause()
+            toggle = app.query_one(ChatModeToggle)
+            assert toggle.display
+            assert toggle.region.width > 0
+            assert toggle.region.right <= 80
+
+    async def test_narrow_bar_hides_disabled_roles_wide_shows_them(self) -> None:
+        """Disabled role pills drop out at narrow widths and return on wide bars."""
+        from lilbee.cli.tui.widgets.model_bar import RoleRow
+
+        cfg.chat_model = TEST_LOCAL_REF
+        cfg.embedding_model = TEST_EMBED_REF
+        cfg.vision_model = ""
+        cfg.reranker_model = ""
+        app = _ModelBarApp()
+        async with app.run_test(size=(80, 30)) as pilot:
+            await pilot.pause()
+            off_rows = [row for row in app.query(RoleRow) if row.has_class("-off")]
+            assert off_rows
+            assert all(row.region.width == 0 for row in off_rows)
+        app = _ModelBarApp()
+        async with app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause()
+            off_rows = [row for row in app.query(RoleRow) if row.has_class("-off")]
+            assert off_rows
+            assert all(row.region.width > 0 for row in off_rows)
+
     async def test_chat_mode_toggle_renders_search_when_embedding_ready(self) -> None:
         from lilbee.cli.tui.widgets.model_bar import ChatModeToggle
 
@@ -5422,6 +5459,17 @@ class CrawlDialogTestApp(LilbeeAppHost):
         from lilbee.cli.tui.widgets.crawl_dialog import CrawlDialog
 
         self.push_screen(CrawlDialog(), self.results.append)
+
+
+async def test_crawl_dialog_buttons_render_side_by_side():
+    """Crawl and Cancel sit on one row, like ConfirmDialog's yes/no pills."""
+    app = CrawlDialogTestApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        await pilot.pause()
+        submit = app.screen.query_one("#crawl-submit", Button)
+        cancel = app.screen.query_one("#crawl-cancel", Button)
+        assert submit.region.y == cancel.region.y
+        assert submit.region.x < cancel.region.x
 
 
 async def test_crawl_dialog_button_focus_uses_themed_highlight():

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -2561,12 +2561,46 @@ class TestGetCompletions:
         r = get_completions("/model ")
         assert "qwen3:8b" in r
 
+    @mock.patch(
+        "lilbee.modelhub.models.list_installed_models",
+        return_value=[
+            "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf",
+            "bartowski/SmolLM2-360M-Instruct-GGUF/SmolLM2-360M-Instruct-Q4_K_M.gguf",
+        ],
+    )
+    def test_model_arg_substring_matches_display_words(self, _mock: mock.MagicMock) -> None:
+        """Typing a model's human name must match even mid-ref (no HF org needed)."""
+        from lilbee.cli.tui.widgets.autocomplete import get_completions
+
+        r = get_completions("/model smol")
+        assert r == ["bartowski/SmolLM2-360M-Instruct-GGUF/SmolLM2-360M-Instruct-Q4_K_M.gguf"]
+
+    @mock.patch(
+        "lilbee.modelhub.models.list_installed_models",
+        return_value=["qwen3:8b", "abc-qwen-mix:1b"],
+    )
+    def test_model_arg_prefix_matches_rank_first(self, _mock: mock.MagicMock) -> None:
+        from lilbee.cli.tui.widgets.autocomplete import get_completions
+
+        r = get_completions("/model qwen")
+        assert r == ["qwen3:8b", "abc-qwen-mix:1b"]
+
     def test_slash_prefix_includes_aliases(self) -> None:
         """/cat expands via the /catalog alias for /models."""
         from lilbee.cli.tui.widgets.autocomplete import get_completions
 
         r = get_completions("/cat")
         assert "/catalog" in r
+
+    def test_command_option_prompt_carries_help_text(self) -> None:
+        """Dropdown rows for commands show the registry help beside the name."""
+        from lilbee.cli.tui.widgets.autocomplete import _option_prompt
+
+        prompt = str(_option_prompt("/crawl"))
+        assert "/crawl" in prompt
+        assert "Crawl a URL" in prompt
+        # Non-command options (model names, paths) stay bare.
+        assert str(_option_prompt("qwen3:8b")) == "qwen3:8b"
 
     def test_unknown_command_arg_returns_empty(self) -> None:
         from lilbee.cli.tui.widgets.autocomplete import get_completions
@@ -3422,7 +3456,7 @@ class TestSetupWizard:
 
         ref = "unsloth/embeddinggemma-300M-qat-GGUF/embeddinggemma-300M-qat-Q8_0.gguf"
         row = _installed_name_to_row(ref, "embedding")
-        assert row.name == "embeddinggemma 300M"
+        assert row.name == "Embeddinggemma 300M"
         assert row.quant == "Q8_0"
         assert row.ref == ref
 

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -123,11 +123,11 @@ class TestAssistantMessageAsync:
         async with app.run_test() as pilot:
             await pilot.pause()
             am = app._am
-            am.set_thinking_status("Loading engine")
+            am.set_thinking_status("Warming up the model")
             header = am._thinking_header
             assert header is not None
             header._tick()
-            assert "Loading engine" in str(_frame_content(header._frame, header._detail))
+            assert "Warming up the model" in str(_frame_content(header._frame, header._detail))
             # A dismissed header makes the setter a no-op, not a crash.
             am._dismiss_thinking_header()
             am.set_thinking_status("gone")
@@ -502,7 +502,7 @@ class TestTaskBar:
         starting = _warm_detail(WarmProgress(phase=WarmPhase.STARTING))
         assert "starting" in starting and "▓" in starting
         loading = _warm_detail(WarmProgress(phase=WarmPhase.LOADING_ENGINE))
-        assert "loading engine" in loading and ("▓" in loading or "░" in loading)
+        assert "almost ready" in loading and ("▓" in loading or "░" in loading)
         reading = _warm_detail(
             WarmProgress(phase=WarmPhase.READING_WEIGHTS, bytes_done=42, bytes_total=100)
         )
@@ -531,7 +531,7 @@ class TestTaskBar:
             await pilot.pause()
             bar = app.query_one(TaskBar)
             warm = bar._warm_line()
-            assert warm.startswith("loading chat · ")
+            assert warm.startswith("warming up chat · ")
             assert "reading weights 25%" in warm and "▓" in warm
             bar._refresh_display()
             await pilot.pause()
@@ -5388,6 +5388,23 @@ class CrawlDialogTestApp(LilbeeAppHost):
         from lilbee.cli.tui.widgets.crawl_dialog import CrawlDialog
 
         self.push_screen(CrawlDialog(), self.results.append)
+
+
+async def test_crawl_dialog_button_focus_uses_themed_highlight():
+    """Focused dialog buttons pick up the app's focus styling, not reverse video."""
+    app = CrawlDialogTestApp()
+    async with app.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        for button_id in ("#crawl-submit", "#crawl-cancel"):
+            button = app.screen.query_one(button_id, Button)
+            unfocused_rails = (button.styles.border_top, button.styles.border_bottom)
+            button.focus()
+            await pilot.pause()
+            text_style = button.styles.text_style
+            assert text_style is None or text_style.reverse is not True
+            # Focus rides the border rails (the theme's focus language), so at
+            # least one rail color must change from the resting state.
+            assert (button.styles.border_top, button.styles.border_bottom) != unfocused_rails
 
 
 async def test_crawl_dialog_submit_valid():


### PR DESCRIPTION
## Problem

A full QA pass over the TUI, driven end to end as a first-time user (fresh data dir, real first-run wizard, real engine loads, every view and slash command), turned up a long list of bugs and papercuts: Enter could silently eat or even rewrite what you typed, the first-run wizard could configure a model that isn't installed, focused buttons rendered in raw reverse video, error toasts leaked Python exceptions, and a dozen smaller rough edges across the catalog, status, memories, and dialogs.

## Solution

Every finding that belongs to the TUI is fixed on this branch and re-verified by driving the whole surface again on the fixed build. The retrieval-side findings (empty-library guidance, unreachable grounded refusal) land in #508 and the engine-side not-ready loop in #526.

| Area | Before | After |
|---|---|---|
| Chat input | Enter was consumed by the completion dropdown and could rewrite the command (`/model` ran `/models`) | Enter submits exactly what was typed; Tab and the arrows do completion |
| Chat input | Esc after typing dropped to NORMAL invisibly and the next Enter was swallowed, stranding the draft | Enter in NORMAL submits the waiting draft; empty input just returns to INSERT |
| Chat input | Backing out of the dropdown left a stale `/` that turned the next message into `Unknown command: /what` and discarded it | Esc clears a bare slash; unknown commands keep the draft in the input |
| Chat input | Up-arrow history recall was unpinned by tests | Recall replaces the buffer wholesale, pinned by a regression test |
| First-run wizard | "Your existing models are ready" without checking the configured refs, then persisted an uninstalled chat model whose first prompt could never answer | The ready hint requires the configured chat and embedding refs themselves, role-correct; the wizard never writes a ref it cannot install |
| First-run wizard | Picking an installed featured card persisted the repo-level ref, breaking the display label and the ready check | The commit path expands to the exact installed file ref |
| First-run wizard | Three cards could look selected at once | One strong treatment marks the card Enter acts on |
| Model catalog | Every wizard/Picks/Installed card wore a bare `?` compat pill | Curated and installed rows are SUPPORTED (no pill); unprobed HF rows say `untested` |
| Model catalog | Esc did nothing; only `q` went back | Esc leaves the catalog (an open filter closes first), matching every other surface |
| Model names | `embeddinggemma 300m` next to `All MiniLM L6 v2`; toasts showed raw refs (`…t-Q4_K_M.gguf`) | Display labels normalize casing and instruct tags; toasts use them everywhere |
| Completion | Arg completion matched raw ref prefixes only, so typing `smol` or a filename found nothing | Substring matching with prefix-first ranking for models, documents, settings, and themes |
| Completion | The `/` dropdown listed bare names | Each command row carries its one-line help |
| Errors | `/set top_k abc` toasted `invalid literal for int() with base 10` | Human copy: `top_k needs a whole number`; selects list their valid choices |
| Errors | `/delete tested` said only `Not found: tested` | Offers the closest indexed name: `Did you mean qa-corpus/tested-models.md?` |
| /theme | Listed 11 themes in a fading toast you could not pick from | No-arg `/theme` lands in the prompt with the theme dropdown open; unknown names list the valid ones |
| Help | README claimed `?` toggles the cheat sheet, but it typed a literal character | `?` on an empty prompt opens help; mid-typing it stays literal; README updated |
| Quit | Ctrl+C needed two presses because a background engine warm swallowed the first | Only a foreground stream or the wizard gets cancel-first (with a "press Ctrl+C again to quit" toast); background tasks never block quit |
| Engine status | Raw "Loading engine" in the bubble and "loading chat · loading engine" in the task bar | "Warming up the model" → "Reading {name} weights NN%" → "Almost ready", mirrored in the task bar |
| Buttons | Focused buttons rendered Textual's stock reverse-video flat block | Themed focus: primary border rails plus a background lift, app-wide |
| Command palette | One `Delete document → name` entry per indexed file (thousands on a real corpus), and curated actions only | Constant-cost palette; every slash command is reachable from Ctrl+P from any view (`/crawl` opens its dialog) |
| Status screen | Opened with all four sections collapsed | Sections start expanded; vim-style jumps are instant |
| Memories screen | Blank void under the column headers when empty | Explains what memories are and that `/remember` saves one; distinguishes no-matches from empty |
| Slash catalog (F2) | Long help texts wrapped into the command-name column | Hanging indent keeps continuation lines in the description column at any width |
| Crawl dialog | Crawl and Cancel stacked vertically | Side by side, like the confirm dialog |
| Model bar | 84-column terminals clipped it mid-word and hid the Search/Chat toggle | Below 100 columns disabled roles hide, labels compact, and the toggle docks right, staying visible at 80 columns |

Verified with the full gate after every change (lint, format, typecheck, full suite with the 100% coverage gate) and a second live end-to-end drive of the entire TUI on the fixed build, which itself surfaced and fixed the NORMAL-mode Enter and wizard-ref rows above.
